### PR TITLE
Add C0 topology support to golden_config_db generation

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -832,6 +832,7 @@
           vm_configuration: "{{ configuration if topo == 't1-filterleaf-lag' else omit }}"
           is_lit_mode: "{{ is_lit_mode | default(true) }}"
           npu_index: "{{ dut_index | default(0) | int }}"
+          console_ports: "{{ device_serial_link[inventory_hostname] | default(omit) if 'c0' in topo else omit }}"
         become: true
 
       - name: Copy macsec profile json to dut

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -61,7 +61,8 @@ class GenerateGoldenConfigDBModule(object):
                                     hwsku=dict(required=False, type='str', default=None),
                                     vm_configuration=dict(required=False, type='dict', default={}),
                                     is_lit_mode=dict(required=False, type='bool', default=True),
-                                    npu_index=dict(required=False, type='int', default=0)),
+                                    npu_index=dict(required=False, type='int', default=0),
+                                    console_ports=dict(required=False, type='dict', default=None)),
                                     supports_check_mode=True)
         self.topo_name = self.module.params['topo_name']
         self.port_index_map = self.module.params['port_index_map']
@@ -73,6 +74,7 @@ class GenerateGoldenConfigDBModule(object):
         self.vm_configuration = self.module.params['vm_configuration']
         self.is_lit_mode = self.module.params['is_lit_mode']
         self.npu_index = self.module.params['npu_index']
+        self.console_ports = self.module.params['console_ports']
 
     def generate_mgfx_golden_config_db(self):
         rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
@@ -705,6 +707,39 @@ class GenerateGoldenConfigDBModule(object):
 
         return json.dumps({'PORT': golden_config['PORT']}, indent=4)
 
+    def generate_c0_golden_config_db(self):
+        """
+        Generate golden_config_db for C0 topology.
+        Add CONSOLE_PORT and CONSOLE_SWITCH config based on serial_links data
+        passed via the console_ports parameter from device_serial_link fact.
+        """
+        rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
+        if rc != 0:
+            self.module.fail_json(msg="Failed to get config from minigraph: {}".format(err))
+
+        ori_config_db = json.loads(out)
+
+        golden_config_db = {}
+        if "DEVICE_METADATA" in ori_config_db:
+            golden_config_db["DEVICE_METADATA"] = ori_config_db["DEVICE_METADATA"]
+
+        if self.console_ports:
+            console_port_config = {}
+            for port, link_info in self.console_ports.items():
+                console_port_config[str(port)] = {
+                    "baud_rate": str(link_info.get("baud_rate", "9600")),
+                    "flow_control": str(link_info.get("flow_control", "0")),
+                    "remote_device": link_info.get("peerdevice", "")
+                }
+            golden_config_db["CONSOLE_PORT"] = console_port_config
+            golden_config_db["CONSOLE_SWITCH"] = {
+                "console_mgmt": {
+                    "enabled": "yes"
+                }
+            }
+
+        return json.dumps(golden_config_db, indent=4)
+
     def generate(self):
         module_msg = "Success to generate golden_config_db.json"
         # topo check
@@ -732,6 +767,9 @@ class GenerateGoldenConfigDBModule(object):
             config = self.generate_full_lossy_golden_config_db()
         elif self.topo_name in ["t1-filterleaf-lag"]:
             config = self.generate_filterleaf_golden_config_db()
+        elif "c0" in self.topo_name:
+            config = self.generate_c0_golden_config_db()
+            module_msg = module_msg + " for c0"
         else:
             config = self.generate_default_init_config_db()
 


### PR DESCRIPTION
### Description of PR

Summary:
Add CONSOLE_PORT and CONSOLE_SWITCH configuration to `golden_config_db.json` when the topology is C0. This enables console management on C0 topology devices during deploy-mg.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
C0 topology devices (e.g., Cisco-8220) have serial console ports that need to be configured in config_db via `CONSOLE_PORT` and `CONSOLE_SWITCH` tables. Currently, `generate_golden_config_db.py` has no handler for C0 topology, so these tables are missing after deploy-mg.

#### How did you do it?
1. Added a `console_ports` parameter to the `generate_golden_config_db` Ansible module.
2. In the playbook, pass `device_serial_link[inventory_hostname]` (from `conn_graph_facts`, which parses `serial_links.csv`) as the `console_ports` parameter when the topology contains "c0".
3. Added `generate_c0_golden_config_db()` method that transforms the serial link data into `CONSOLE_PORT` entries (with `baud_rate`, `flow_control`, `remote_device`) and adds `CONSOLE_SWITCH` with `console_mgmt` enabled.
4. Added `"c0" in topo_name` dispatch in the `generate()` method.

#### How did you verify/test it?
Ran deploy-mg on a Cisco-8220 testbed with c0-lo topology. Verified:
- Deploy completed with 0 failures
- `CONSOLE_PORT` (48 entries) and `CONSOLE_SWITCH` present in `/etc/sonic/golden_config_db.json`
- `CONSOLE_PORT` keys confirmed in running config_db via `sonic-db-cli`

#### Any platform specific information?
Tested on Cisco-C8220TG-48A-O (arm64) with c0-lo topology.

#### Supported testbed topology if it's a new test case?
N/A (framework change, not a new test case)

### Documentation
N/A