### PR TITLE
[BGP] Fix ImportError in test_bgp_aggregate_address_resilience

### DIFF
--- a/tests/bgp/test_bgp_aggregate_address_resilience.py
+++ b/tests/bgp/test_bgp_aggregate_address_resilience.py
@@ -23,10 +23,8 @@ import pytest
 
 from bgp_bbr_helpers import config_bbr_by_gcu, get_bbr_default_state, is_bbr_enabled
 
-from test_bgp_aggregate_address import (
+from bgp_aggregate_helpers import (
     AggregateCfg,
-    AGGR_V4,
-    AGGR_V6,
     BGP_AGGREGATE_ADDRESS,
     PLACEHOLDER_PREFIX,
     dump_db,
@@ -35,6 +33,11 @@ from test_bgp_aggregate_address import (
     gcu_remove_aggregate,
     verify_bgp_aggregate_consistence,
     verify_bgp_aggregate_cleanup,
+)
+
+from test_bgp_aggregate_address import (
+    AGGR_V4,
+    AGGR_V6,
 )
 
 from tests.common.config_reload import config_reload


### PR DESCRIPTION
### Description of PR

Summary: Fix `ImportError: cannot import name 'BGP_AGGREGATE_ADDRESS'` in `test_bgp_aggregate_address_resilience.py`.

The symbols `BGP_AGGREGATE_ADDRESS`, `PLACEHOLDER_PREFIX`, `dump_db`, and `gcu_add_placeholder_aggregate` are defined in `bgp_aggregate_helpers.py`, not in `test_bgp_aggregate_address.py`. The resilience test was importing them from the wrong module.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

`test_bgp_aggregate_address_resilience.py` fails to import with:
```
ImportError: cannot import name 'BGP_AGGREGATE_ADDRESS' from 'test_bgp_aggregate_address'
```
This blocks the "Validate Test Cases" CI check for all PRs.

#### How did you do it?

Changed the import to source symbols from their actual definition module (`bgp_aggregate_helpers`), keeping only `AGGR_V4`/`AGGR_V6` imported from `test_bgp_aggregate_address`.

#### How did you verify/test it?

Verified the symbols exist in `bgp_aggregate_helpers.py` and do not exist in `test_bgp_aggregate_address.py`.

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
