### PR TITLE
Fixing 64 Port t2 topology:topo_t2_single_node_max_64p.yml

### DIFF
--- a/ansible/vars/topo_t2_single_node_max_64p.yml
+++ b/ansible/vars/topo_t2_single_node_max_64p.yml
@@ -336,7 +336,7 @@ configuration_properties:
     tor_subnet_size: 128
     dut_asn: 66000
     dut_confed_asn: 65100
-    dut_config_peers: 65200
+    dut_confed_peers: 65200
     dut_type: UpperSpineRouter
     nhipv4: 10.10.246.254
     nhipv6: fc0a::ff

--- a/ansible/vars/topo_t2_single_node_max_64p.yml
+++ b/ansible/vars/topo_t2_single_node_max_64p.yml
@@ -334,9 +334,7 @@ configuration_properties:
     tor_subnet_number: 8
     max_tor_subnet_number: 32
     tor_subnet_size: 128
-    dut_asn: 66000
-    dut_confed_asn: 65100
-    dut_confed_peers: 65200
+    dut_asn: 65100
     dut_type: UpperSpineRouter
     nhipv4: 10.10.246.254
     nhipv6: fc0a::ff
@@ -351,7 +349,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -375,7 +372,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -399,7 +395,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -423,7 +418,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -447,7 +441,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -471,7 +464,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -495,7 +487,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -519,7 +510,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -543,7 +533,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -567,7 +556,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -591,7 +579,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -615,7 +602,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -639,7 +625,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -663,7 +648,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -687,7 +671,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -711,7 +694,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -735,7 +717,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -759,7 +740,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -783,7 +763,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -807,7 +786,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -831,7 +809,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -855,7 +832,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -879,7 +855,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -903,7 +878,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -927,7 +901,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -951,7 +924,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -975,7 +947,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -999,7 +970,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1023,7 +993,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1047,7 +1016,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1071,7 +1039,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1095,7 +1062,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1119,11 +1085,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64600
       peers:
-        66000:
+        65100:
         - 10.0.0.128
         - fc00::101
     interfaces:
@@ -1142,11 +1106,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64610
       peers:
-        66000:
+        65100:
         - 10.0.0.130
         - fc00::105
     interfaces:
@@ -1165,11 +1127,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64620
       peers:
-        66000:
+        65100:
         - 10.0.0.132
         - fc00::109
     interfaces:
@@ -1188,11 +1148,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64630
       peers:
-        66000:
+        65100:
         - 10.0.0.134
         - fc00::10d
     interfaces:
@@ -1211,11 +1169,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64640
       peers:
-        66000:
+        65100:
         - 10.0.0.136
         - fc00::111
     interfaces:
@@ -1234,11 +1190,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64650
       peers:
-        66000:
+        65100:
         - 10.0.0.138
         - fc00::115
     interfaces:
@@ -1257,11 +1211,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64660
       peers:
-        66000:
+        65100:
         - 10.0.0.140
         - fc00::119
     interfaces:
@@ -1280,11 +1232,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64670
       peers:
-        66000:
+        65100:
         - 10.0.0.142
         - fc00::11d
     interfaces:
@@ -1303,11 +1253,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64680
       peers:
-        66000:
+        65100:
         - 10.0.0.144
         - fc00::121
     interfaces:
@@ -1326,11 +1274,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64690
       peers:
-        66000:
+        65100:
         - 10.0.0.146
         - fc00::125
     interfaces:
@@ -1349,11 +1295,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64700
       peers:
-        66000:
+        65100:
         - 10.0.0.148
         - fc00::129
     interfaces:
@@ -1372,11 +1316,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64710
       peers:
-        66000:
+        65100:
         - 10.0.0.150
         - fc00::12d
     interfaces:
@@ -1395,11 +1337,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64720
       peers:
-        66000:
+        65100:
         - 10.0.0.152
         - fc00::131
     interfaces:
@@ -1418,11 +1358,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64730
       peers:
-        66000:
+        65100:
         - 10.0.0.154
         - fc00::135
     interfaces:
@@ -1441,11 +1379,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64740
       peers:
-        66000:
+        65100:
         - 10.0.0.156
         - fc00::139
     interfaces:
@@ -1464,11 +1400,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64750
       peers:
-        66000:
+        65100:
         - 10.0.0.158
         - fc00::13d
     interfaces:
@@ -1487,11 +1421,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64760
       peers:
-        66000:
+        65100:
         - 10.0.0.160
         - fc00::141
     interfaces:
@@ -1510,11 +1442,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64770
       peers:
-        66000:
+        65100:
         - 10.0.0.162
         - fc00::145
     interfaces:
@@ -1533,11 +1463,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64780
       peers:
-        66000:
+        65100:
         - 10.0.0.164
         - fc00::149
     interfaces:
@@ -1556,11 +1484,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64790
       peers:
-        66000:
+        65100:
         - 10.0.0.166
         - fc00::14d
     interfaces:
@@ -1579,11 +1505,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64800
       peers:
-        66000:
+        65100:
         - 10.0.0.168
         - fc00::151
     interfaces:
@@ -1602,11 +1526,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64810
       peers:
-        66000:
+        65100:
         - 10.0.0.170
         - fc00::155
     interfaces:
@@ -1625,11 +1547,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64820
       peers:
-        66000:
+        65100:
         - 10.0.0.172
         - fc00::159
     interfaces:
@@ -1648,11 +1568,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64830
       peers:
-        66000:
+        65100:
         - 10.0.0.174
         - fc00::15d
     interfaces:
@@ -1671,11 +1589,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64840
       peers:
-        66000:
+        65100:
         - 10.0.0.176
         - fc00::161
     interfaces:
@@ -1694,11 +1610,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64850
       peers:
-        66000:
+        65100:
         - 10.0.0.178
         - fc00::165
     interfaces:
@@ -1717,11 +1631,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64860
       peers:
-        66000:
+        65100:
         - 10.0.0.180
         - fc00::169
     interfaces:
@@ -1740,11 +1652,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64870
       peers:
-        66000:
+        65100:
         - 10.0.0.182
         - fc00::16d
     interfaces:
@@ -1763,11 +1673,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64880
       peers:
-        66000:
+        65100:
         - 10.0.0.184
         - fc00::171
     interfaces:
@@ -1786,11 +1694,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64890
       peers:
-        66000:
+        65100:
         - 10.0.0.186
         - fc00::175
     interfaces:
@@ -1809,11 +1715,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64900
       peers:
-        66000:
+        65100:
         - 10.0.0.188
         - fc00::179
     interfaces:
@@ -1832,11 +1736,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64910
       peers:
-        66000:
+        65100:
         - 10.0.0.190
         - fc00::17d
     interfaces:

--- a/ansible/vars/topo_t2_single_node_max_64p.yml
+++ b/ansible/vars/topo_t2_single_node_max_64p.yml
@@ -329,15 +329,17 @@ topology:
 
 configuration_properties:
   common:
-    dut_asn: 65100
-    dut_type: SpineRouter
     podset_number: 400
     tor_number: 16
     tor_subnet_number: 8
     max_tor_subnet_number: 32
     tor_subnet_size: 128
-    nhipv4: 10.10.48.254
-    nhipv6: fc30::ff
+    dut_asn: 66000
+    dut_confed_asn: 65100
+    dut_config_peers: 65200
+    dut_type: UpperSpineRouter
+    nhipv4: 10.10.246.254
+    nhipv6: fc0a::ff
   core:
     swrole: core
   leaf:
@@ -349,6 +351,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -364,14 +367,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.1/24
-      ipv6: fc30::2/64
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
 
   VM02T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -387,14 +391,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.2/24
-      ipv6: fc30::3/64
+      ipv4: 10.10.246.2/24
+      ipv6: fc0a::3/64
 
   VM03T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -410,14 +415,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.3/24
-      ipv6: fc30::4/64
+      ipv4: 10.10.246.3/24
+      ipv6: fc0a::4/64
 
   VM04T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -433,14 +439,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.4/24
-      ipv6: fc30::5/64
+      ipv4: 10.10.246.4/24
+      ipv6: fc0a::5/64
 
   VM05T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -456,14 +463,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.5/24
-      ipv6: fc30::6/64
+      ipv4: 10.10.246.5/24
+      ipv6: fc0a::6/64
 
   VM06T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -479,14 +487,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.6/24
-      ipv6: fc30::7/64
+      ipv4: 10.10.246.6/24
+      ipv6: fc0a::7/64
 
   VM07T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -502,14 +511,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.7/24
-      ipv6: fc30::8/64
+      ipv4: 10.10.246.7/24
+      ipv6: fc0a::8/64
 
   VM08T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -525,14 +535,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.8/24
-      ipv6: fc30::9/64
+      ipv4: 10.10.246.8/24
+      ipv6: fc0a::9/64
 
   VM09T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -548,14 +559,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.9/24
-      ipv6: fc30::a/64
+      ipv4: 10.10.246.9/24
+      ipv6: fc0a::a/64
 
   VM10T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -571,14 +583,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.10/24
-      ipv6: fc30::b/64
+      ipv4: 10.10.246.10/24
+      ipv6: fc0a::b/64
 
   VM11T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -594,14 +607,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.11/24
-      ipv6: fc30::c/64
+      ipv4: 10.10.246.11/24
+      ipv6: fc0a::c/64
 
   VM12T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -617,14 +631,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.12/24
-      ipv6: fc30::d/64
+      ipv4: 10.10.246.12/24
+      ipv6: fc0a::d/64
 
   VM13T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -640,14 +655,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.13/24
-      ipv6: fc30::e/64
+      ipv4: 10.10.246.13/24
+      ipv6: fc0a::e/64
 
   VM14T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -663,14 +679,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.14/24
-      ipv6: fc30::f/64
+      ipv4: 10.10.246.14/24
+      ipv6: fc0a::f/64
 
   VM15T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -686,14 +703,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.15/24
-      ipv6: fc30::10/64
+      ipv4: 10.10.246.15/24
+      ipv6: fc0a::10/64
 
   VM16T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -709,14 +727,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.16/24
-      ipv6: fc30::11/64
+      ipv4: 10.10.246.16/24
+      ipv6: fc0a::11/64
 
   VM17T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -732,14 +751,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.17/24
-      ipv6: fc30::12/64
+      ipv4: 10.10.246.17/24
+      ipv6: fc0a::12/64
 
   VM18T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -755,14 +775,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.18/24
-      ipv6: fc30::13/64
+      ipv4: 10.10.246.18/24
+      ipv6: fc0a::13/64
 
   VM19T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -778,14 +799,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.19/24
-      ipv6: fc30::14/64
+      ipv4: 10.10.246.19/24
+      ipv6: fc0a::14/64
 
   VM20T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -801,14 +823,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.20/24
-      ipv6: fc30::15/64
+      ipv4: 10.10.246.20/24
+      ipv6: fc0a::15/64
 
   VM21T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -824,14 +847,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.21/24
-      ipv6: fc30::16/64
+      ipv4: 10.10.246.21/24
+      ipv6: fc0a::16/64
 
   VM22T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -847,14 +871,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.22/24
-      ipv6: fc30::17/64
+      ipv4: 10.10.246.22/24
+      ipv6: fc0a::17/64
 
   VM23T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -870,14 +895,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.23/24
-      ipv6: fc30::18/64
+      ipv4: 10.10.246.23/24
+      ipv6: fc0a::18/64
 
   VM24T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -893,14 +919,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.24/24
-      ipv6: fc30::19/64
+      ipv4: 10.10.246.24/24
+      ipv6: fc0a::19/64
 
   VM25T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -916,14 +943,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.25/24
-      ipv6: fc30::1a/64
+      ipv4: 10.10.246.25/24
+      ipv6: fc0a::1a/64
 
   VM26T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -939,14 +967,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.26/24
-      ipv6: fc30::1b/64
+      ipv4: 10.10.246.26/24
+      ipv6: fc0a::1b/64
 
   VM27T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -962,14 +991,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.27/24
-      ipv6: fc30::1c/64
+      ipv4: 10.10.246.27/24
+      ipv6: fc0a::1c/64
 
   VM28T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -985,14 +1015,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.28/24
-      ipv6: fc30::1d/64
+      ipv4: 10.10.246.28/24
+      ipv6: fc0a::1d/64
 
   VM29T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1008,14 +1039,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.29/24
-      ipv6: fc30::1e/64
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::1e/64
 
   VM30T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1031,14 +1063,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.30/24
-      ipv6: fc30::1f/64
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::1f/64
 
   VM31T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1054,14 +1087,15 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.31/24
-      ipv6: fc30::20/64
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::20/64
 
   VM32T3:
     properties:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1077,17 +1111,19 @@ configuration:
       Ethernet1:
         lacp: 1
     bp_interface:
-      ipv4: 10.10.48.32/24
-      ipv6: fc30::21/64
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::21/64
 
   VM01LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64600
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.128
         - fc00::101
     interfaces:
@@ -1098,17 +1134,19 @@ configuration:
         ipv4: 10.0.0.129/31
         ipv6: fc00::102/126
     bp_interface:
-      ipv4: 10.10.48.65/24
-      ipv6: fc30::42/64
+      ipv4: 10.10.246.65/24
+      ipv6: fc0a::42/64
 
   VM02LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64610
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.130
         - fc00::105
     interfaces:
@@ -1119,17 +1157,19 @@ configuration:
         ipv4: 10.0.0.131/31
         ipv6: fc00::106/126
     bp_interface:
-      ipv4: 10.10.48.66/24
-      ipv6: fc30::43/64
+      ipv4: 10.10.246.66/24
+      ipv6: fc0a::43/64
 
   VM03LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64620
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.132
         - fc00::109
     interfaces:
@@ -1140,17 +1180,19 @@ configuration:
         ipv4: 10.0.0.133/31
         ipv6: fc00::10a/126
     bp_interface:
-      ipv4: 10.10.48.67/24
-      ipv6: fc30::44/64
+      ipv4: 10.10.246.67/24
+      ipv6: fc0a::44/64
 
   VM04LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64630
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.134
         - fc00::10d
     interfaces:
@@ -1161,17 +1203,19 @@ configuration:
         ipv4: 10.0.0.135/31
         ipv6: fc00::10e/126
     bp_interface:
-      ipv4: 10.10.48.68/24
-      ipv6: fc30::45/64
+      ipv4: 10.10.246.68/24
+      ipv6: fc0a::45/64
 
   VM05LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64640
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.136
         - fc00::111
     interfaces:
@@ -1182,17 +1226,19 @@ configuration:
         ipv4: 10.0.0.137/31
         ipv6: fc00::112/126
     bp_interface:
-      ipv4: 10.10.48.69/24
-      ipv6: fc30::46/64
+      ipv4: 10.10.246.69/24
+      ipv6: fc0a::46/64
 
   VM06LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64650
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.138
         - fc00::115
     interfaces:
@@ -1203,17 +1249,19 @@ configuration:
         ipv4: 10.0.0.139/31
         ipv6: fc00::116/126
     bp_interface:
-      ipv4: 10.10.48.70/24
-      ipv6: fc30::47/64
+      ipv4: 10.10.246.70/24
+      ipv6: fc0a::47/64
 
   VM07LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64660
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.140
         - fc00::119
     interfaces:
@@ -1224,17 +1272,19 @@ configuration:
         ipv4: 10.0.0.141/31
         ipv6: fc00::11a/126
     bp_interface:
-      ipv4: 10.10.48.71/24
-      ipv6: fc30::48/64
+      ipv4: 10.10.246.71/24
+      ipv6: fc0a::48/64
 
   VM08LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64670
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.142
         - fc00::11d
     interfaces:
@@ -1245,17 +1295,19 @@ configuration:
         ipv4: 10.0.0.143/31
         ipv6: fc00::11e/126
     bp_interface:
-      ipv4: 10.10.48.72/24
-      ipv6: fc30::49/64
+      ipv4: 10.10.246.72/24
+      ipv6: fc0a::49/64
 
   VM09LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64680
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.144
         - fc00::121
     interfaces:
@@ -1266,17 +1318,19 @@ configuration:
         ipv4: 10.0.0.145/31
         ipv6: fc00::122/126
     bp_interface:
-      ipv4: 10.10.48.73/24
-      ipv6: fc30::4a/64
+      ipv4: 10.10.246.73/24
+      ipv6: fc0a::4a/64
 
   VM10LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64690
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.146
         - fc00::125
     interfaces:
@@ -1287,17 +1341,19 @@ configuration:
         ipv4: 10.0.0.147/31
         ipv6: fc00::126/126
     bp_interface:
-      ipv4: 10.10.48.74/24
-      ipv6: fc30::4b/64
+      ipv4: 10.10.246.74/24
+      ipv6: fc0a::4b/64
 
   VM11LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64700
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.148
         - fc00::129
     interfaces:
@@ -1308,17 +1364,19 @@ configuration:
         ipv4: 10.0.0.149/31
         ipv6: fc00::12a/126
     bp_interface:
-      ipv4: 10.10.48.75/24
-      ipv6: fc30::4c/64
+      ipv4: 10.10.246.75/24
+      ipv6: fc0a::4c/64
 
   VM12LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64710
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.150
         - fc00::12d
     interfaces:
@@ -1329,17 +1387,19 @@ configuration:
         ipv4: 10.0.0.151/31
         ipv6: fc00::12e/126
     bp_interface:
-      ipv4: 10.10.48.76/24
-      ipv6: fc30::4d/64
+      ipv4: 10.10.246.76/24
+      ipv6: fc0a::4d/64
 
   VM13LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64720
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.152
         - fc00::131
     interfaces:
@@ -1350,17 +1410,19 @@ configuration:
         ipv4: 10.0.0.153/31
         ipv6: fc00::132/126
     bp_interface:
-      ipv4: 10.10.48.77/24
-      ipv6: fc30::4e/64
+      ipv4: 10.10.246.77/24
+      ipv6: fc0a::4e/64
 
   VM14LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64730
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.154
         - fc00::135
     interfaces:
@@ -1371,17 +1433,19 @@ configuration:
         ipv4: 10.0.0.155/31
         ipv6: fc00::136/126
     bp_interface:
-      ipv4: 10.10.48.78/24
-      ipv6: fc30::4f/64
+      ipv4: 10.10.246.78/24
+      ipv6: fc0a::4f/64
 
   VM15LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64740
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.156
         - fc00::139
     interfaces:
@@ -1392,17 +1456,19 @@ configuration:
         ipv4: 10.0.0.157/31
         ipv6: fc00::13a/126
     bp_interface:
-      ipv4: 10.10.48.79/24
-      ipv6: fc30::50/64
+      ipv4: 10.10.246.79/24
+      ipv6: fc0a::50/64
 
   VM16LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64750
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.158
         - fc00::13d
     interfaces:
@@ -1413,17 +1479,19 @@ configuration:
         ipv4: 10.0.0.159/31
         ipv6: fc00::13e/126
     bp_interface:
-      ipv4: 10.10.48.80/24
-      ipv6: fc30::51/64
+      ipv4: 10.10.246.80/24
+      ipv6: fc0a::51/64
 
   VM17LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64760
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.160
         - fc00::141
     interfaces:
@@ -1434,17 +1502,19 @@ configuration:
         ipv4: 10.0.0.161/31
         ipv6: fc00::142/126
     bp_interface:
-      ipv4: 10.10.48.81/24
-      ipv6: fc30::52/64
+      ipv4: 10.10.246.81/24
+      ipv6: fc0a::52/64
 
   VM18LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64770
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.162
         - fc00::145
     interfaces:
@@ -1455,17 +1525,19 @@ configuration:
         ipv4: 10.0.0.163/31
         ipv6: fc00::146/126
     bp_interface:
-      ipv4: 10.10.48.82/24
-      ipv6: fc30::53/64
+      ipv4: 10.10.246.82/24
+      ipv6: fc0a::53/64
 
   VM19LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64780
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.164
         - fc00::149
     interfaces:
@@ -1476,17 +1548,19 @@ configuration:
         ipv4: 10.0.0.165/31
         ipv6: fc00::14a/126
     bp_interface:
-      ipv4: 10.10.48.83/24
-      ipv6: fc30::54/64
+      ipv4: 10.10.246.83/24
+      ipv6: fc0a::54/64
 
   VM20LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64790
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.166
         - fc00::14d
     interfaces:
@@ -1497,17 +1571,19 @@ configuration:
         ipv4: 10.0.0.167/31
         ipv6: fc00::14e/126
     bp_interface:
-      ipv4: 10.10.48.84/24
-      ipv6: fc30::55/64
+      ipv4: 10.10.246.84/24
+      ipv6: fc0a::55/64
 
   VM21LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64800
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.168
         - fc00::151
     interfaces:
@@ -1518,17 +1594,19 @@ configuration:
         ipv4: 10.0.0.169/31
         ipv6: fc00::152/126
     bp_interface:
-      ipv4: 10.10.48.85/24
-      ipv6: fc30::56/64
+      ipv4: 10.10.246.85/24
+      ipv6: fc0a::56/64
 
   VM22LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64810
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.170
         - fc00::155
     interfaces:
@@ -1539,17 +1617,19 @@ configuration:
         ipv4: 10.0.0.171/31
         ipv6: fc00::156/126
     bp_interface:
-      ipv4: 10.10.48.86/24
-      ipv6: fc30::57/64
+      ipv4: 10.10.246.86/24
+      ipv6: fc0a::57/64
 
   VM23LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64820
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.172
         - fc00::159
     interfaces:
@@ -1560,17 +1640,19 @@ configuration:
         ipv4: 10.0.0.173/31
         ipv6: fc00::15a/126
     bp_interface:
-      ipv4: 10.10.48.87/24
-      ipv6: fc30::58/64
+      ipv4: 10.10.246.87/24
+      ipv6: fc0a::58/64
 
   VM24LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64830
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.174
         - fc00::15d
     interfaces:
@@ -1581,17 +1663,19 @@ configuration:
         ipv4: 10.0.0.175/31
         ipv6: fc00::15e/126
     bp_interface:
-      ipv4: 10.10.48.88/24
-      ipv6: fc30::59/64
+      ipv4: 10.10.246.88/24
+      ipv6: fc0a::59/64
 
   VM25LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64840
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.176
         - fc00::161
     interfaces:
@@ -1602,17 +1686,19 @@ configuration:
         ipv4: 10.0.0.177/31
         ipv6: fc00::162/126
     bp_interface:
-      ipv4: 10.10.48.89/24
-      ipv6: fc30::5a/64
+      ipv4: 10.10.246.89/24
+      ipv6: fc0a::5a/64
 
   VM26LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64850
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.178
         - fc00::165
     interfaces:
@@ -1623,17 +1709,19 @@ configuration:
         ipv4: 10.0.0.179/31
         ipv6: fc00::166/126
     bp_interface:
-      ipv4: 10.10.48.90/24
-      ipv6: fc30::5b/64
+      ipv4: 10.10.246.90/24
+      ipv6: fc0a::5b/64
 
   VM27LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64860
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.180
         - fc00::169
     interfaces:
@@ -1644,17 +1732,19 @@ configuration:
         ipv4: 10.0.0.181/31
         ipv6: fc00::16a/126
     bp_interface:
-      ipv4: 10.10.48.91/24
-      ipv6: fc30::5c/64
+      ipv4: 10.10.246.91/24
+      ipv6: fc0a::5c/64
 
   VM28LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64870
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.182
         - fc00::16d
     interfaces:
@@ -1665,17 +1755,19 @@ configuration:
         ipv4: 10.0.0.183/31
         ipv6: fc00::16e/126
     bp_interface:
-      ipv4: 10.10.48.92/24
-      ipv6: fc30::5d/64
+      ipv4: 10.10.246.92/24
+      ipv6: fc0a::5d/64
 
   VM29LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64880
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.184
         - fc00::171
     interfaces:
@@ -1686,17 +1778,19 @@ configuration:
         ipv4: 10.0.0.185/31
         ipv6: fc00::172/126
     bp_interface:
-      ipv4: 10.10.48.93/24
-      ipv6: fc30::5e/64
+      ipv4: 10.10.246.93/24
+      ipv6: fc0a::5e/64
 
   VM30LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64890
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.186
         - fc00::175
     interfaces:
@@ -1707,17 +1801,19 @@ configuration:
         ipv4: 10.0.0.187/31
         ipv6: fc00::176/126
     bp_interface:
-      ipv4: 10.10.48.94/24
-      ipv6: fc30::5f/64
+      ipv4: 10.10.246.94/24
+      ipv6: fc0a::5f/64
 
   VM31LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64900
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.188
         - fc00::179
     interfaces:
@@ -1728,17 +1824,19 @@ configuration:
         ipv4: 10.0.0.189/31
         ipv6: fc00::17a/126
     bp_interface:
-      ipv4: 10.10.48.95/24
-      ipv6: fc30::60/64
+      ipv4: 10.10.246.95/24
+      ipv6: fc0a::60/64
 
   VM32LT2:
     properties:
     - common
     - leaf
     bgp:
-      asn: 64910
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.190
         - fc00::17d
     interfaces:
@@ -1749,5 +1847,5 @@ configuration:
         ipv4: 10.0.0.191/31
         ipv6: fc00::17e/126
     bp_interface:
-      ipv4: 10.10.48.96/24
-      ipv6: fc30::61/64
+      ipv4: 10.10.246.96/24
+      ipv6: fc0a::61/64


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Updated the Dut Role and changed the nhipv4 and nhipv6 in topo_t2_single_node_max_64p.yml

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
To have correct role for the dut in the topology file and to update the nh ips.
#### How did you do it?
By modifying the topology file.
#### How did you verify/test it?
By doing add-topo
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
