### PR TITLE
Fix DUT VM crash with >128 ports by using virtio NIC model

### DIFF
--- a/ansible/roles/vm_set/templates/sonic.xml.j2
+++ b/ansible/roles/vm_set/templates/sonic.xml.j2
@@ -85,6 +85,8 @@
         <target dev='{{ dut_name }}-0' />
     {% if asic_type == 'vpp' %}
         <model type='virtio-net-pci' />
+    {% elif port_alias|length > 128 %}
+        <model type='virtio' />
     {% else %}
         <model type='e1000' />
     {% endif %}
@@ -94,6 +96,8 @@
         <target dev='{{ dut_name }}-{{ i + 1 }}' />
     {% if asic_type == 'vpp' %}
         <model type='virtio-net-pci' />
+    {% elif port_alias|length > 128 %}
+        <model type='virtio' />
     {% else %}
         <model type='e1000' />
     {% endif %}


### PR DESCRIPTION
### Description of PR

Summary:
Fix DUT VM crash when deploying virtual testbeds with more than 128 front-panel ports (e.g., hwsku `ACS-SN6600_LD` with 130 ports).

The `sonic.xml.j2` template uses the `e1000` NIC model for DUT interfaces. Each e1000 NIC registers multiple devices on the KVM I/O bus. The Linux kernel has a hard-coded per-VM limit of `NR_IOBUS_DEVS = 1000` (`include/linux/kvm_host.h`). With 131+ e1000 NICs (1 mgmt + 130 front-panel), the total I/O bus device registrations exceed this limit, causing QEMU to crash with:
```
kvm_mem_ioeventfd_add: error adding ioeventfd: No space left on device (28)
```

This PR switches to the `virtio` NIC model when `port_alias|length > 128`. Virtio uses fewer ioeventfd registrations per device and works within the KVM limit. Existing topologies with ≤128 ports remain on `e1000` and are unaffected.

Fixes #23529

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Deploying a T2 virtual testbed with 130 front-panel ports fails because the DUT KVM VM crashes immediately on start. The root cause is the `e1000` NIC model exhausting the KVM kernel's per-VM I/O bus device limit (`NR_IOBUS_DEVS = 1000`). This limit is a compile-time `#define` in the kernel and cannot be changed via `ulimit`, `sysctl`, or KVM module parameters.

#### How did you do it?

Added a condition in `sonic.xml.j2` to use the `virtio` NIC model when the number of ports exceeds 128. The threshold of 128 was determined by binary search testing — 131 e1000 NICs consistently crashes, while 131 virtio NICs works fine.

The change applies to both the management interface and the front-panel interfaces in the template. The existing `e1000` model is preserved for topologies with ≤128 ports to maintain backward compatibility.

#### How did you verify/test it?

1. **Binary search test:** Tested e1000 NICs from 64 to 131 — all counts up to ~128 work, 131 crashes. Same counts with virtio all work.
2. **Full topology deployment:** Successfully deployed `t2-isolated-d128s2` topology (130 front-panel ports, 3 converged cEOS peers) with the fix applied. DUT VM boots, all 130 interfaces come up, SSH accessible.
3. **Backward compatibility:** The change only affects VMs with >128 ports. Existing topologies (t0, t1, t2 with ≤128 ports) are completely unaffected.

#### Any platform specific information?

Tested on Ubuntu with kernel 6.8.0-106-generic. The `NR_IOBUS_DEVS = 1000` limit has been the same value in mainline Linux for many years, so this affects all standard Linux kernels.

#### Supported testbed topology if it's a new test case?

N/A (not a new test case)

### Documentation

N/A
