### PR TITLE
Fix test test_pfcwd_timer_accuracy

### DIFF
--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -11,6 +11,8 @@ from tests.ptf_runner import ptf_runner
 from tests.common import constants
 from tests.common.cisco_data import is_cisco_device
 from tests.common.mellanox_data import is_mellanox_device
+from tests.common.utilities import wait_until
+from tests.common.helpers.assertions import pytest_assert
 
 # If the version of the Python interpreter is greater or equal to 3, set the unicode variable to the str class.
 if sys.version_info[0] >= 3:
@@ -429,6 +431,52 @@ def fetch_vendor_specific_diagnosis_re(duthost):
         return ""
 
     return VENDOR_SPEC_ADDITIONAL_INFO_RE.get(duthost.facts["asic_type"], "")
+
+
+def pfcwd_stats(dut):
+    result = dut.shell("show pfcwd stats", module_ignore_errors=True, verbose=False)
+    if result['rc'] != 0:
+        return {}
+    return parse_pfcwd_stats(result['stdout_lines'])
+
+
+def parse_pfcwd_stats(lines):
+    stats = {}
+    for line in lines:
+        tokens = line.split()
+        queue = tokens[0]
+        if queue.startswith('Ether'):
+            status = tokens[1]
+            stats[queue] = status
+    return stats
+
+
+def is_pfcwd_port_restored(dut, storm_port):
+    stats = pfcwd_stats(dut)
+    for queue, status in stats.items():
+        if queue.startswith(storm_port) and status == 'operational':
+            return True
+    return False
+
+
+def wait_until_pfcwd_restored(dut, storm_port):
+    is_restored = wait_until(10 * 60, 5, 0, is_pfcwd_port_restored, dut, storm_port)
+    pytest_assert(is_restored, f"Port {storm_port} did not restore storm!")
+
+
+def get_storm_detected_count(dut):
+    result = dut.shell("show pfcwd stats", module_ignore_errors=True, verbose=False)
+    if result['rc'] != 0:
+        return 0
+    lines = result['stdout_lines']
+    for line in lines:
+        tokens = line.split()
+        queue = tokens[0]
+        if queue.startswith('Ether'):
+            storm_detected_restored_count = tokens[2]
+            storm_detected_count = storm_detected_restored_count.split('/')[0]
+            return int(storm_detected_count)
+    return 0
 
 
 @pytest.fixture(scope='class', autouse=False)

--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -433,49 +433,37 @@ def fetch_vendor_specific_diagnosis_re(duthost):
     return VENDOR_SPEC_ADDITIONAL_INFO_RE.get(duthost.facts["asic_type"], "")
 
 
-def pfcwd_stats(dut):
-    result = dut.shell("show pfcwd stats", module_ignore_errors=True, verbose=False)
-    if result['rc'] != 0:
-        return {}
-    return parse_pfcwd_stats(result['stdout_lines'])
-
-
-def parse_pfcwd_stats(lines):
-    stats = {}
-    for line in lines:
-        tokens = line.split()
-        queue = tokens[0]
-        if queue.startswith('Ether'):
-            status = tokens[1]
-            stats[queue] = status
-    return stats
-
-
 def is_pfcwd_port_restored(dut, storm_port):
-    stats = pfcwd_stats(dut)
-    for queue, status in stats.items():
-        if queue.startswith(storm_port) and status == 'operational':
+    pfcwd_stat_output = dut.show_and_parse('show pfcwd stat')
+    for item in pfcwd_stat_output:
+        port = item['queue'].split(':')[0]
+        if port == storm_port and item['status'] == 'operational':
             return True
     return False
 
 
 def wait_until_pfcwd_restored(dut, storm_port):
-    is_restored = wait_until(10 * 60, 5, 0, is_pfcwd_port_restored, dut, storm_port)
+    is_restored = wait_until(120, 5, 0, is_pfcwd_port_restored, dut, storm_port)
     pytest_assert(is_restored, f"Port {storm_port} did not restore storm!")
 
 
-def get_storm_detected_count(dut):
-    result = dut.shell("show pfcwd stats", module_ignore_errors=True, verbose=False)
-    if result['rc'] != 0:
-        return 0
-    lines = result['stdout_lines']
-    for line in lines:
-        tokens = line.split()
-        queue = tokens[0]
-        if queue.startswith('Ether'):
-            storm_detected_restored_count = tokens[2]
-            storm_detected_count = storm_detected_restored_count.split('/')[0]
-            return int(storm_detected_count)
+def get_storm_detected_count(dut, storm_port):
+    pfcwd_stat_output = dut.show_and_parse('show pfcwd stat')
+    for item in pfcwd_stat_output:
+        port = item['queue'].split(':')[0]
+        if port == storm_port:
+            storm_detect_count = item['storm detected/restored'].split('/')[0]
+            return int(storm_detect_count)
+    return 0
+
+
+def get_storm_restored_count(dut, storm_port):
+    pfcwd_stat_output = dut.show_and_parse('show pfcwd stat')
+    for item in pfcwd_stat_output:
+        port = item['queue'].split(':')[0]
+        if port == storm_port:
+            storm_restored_count = item['storm detected/restored'].split('/')[1]
+            return int(storm_restored_count)
     return 0
 
 

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -7,7 +7,8 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.pfc_storm import PFCStorm
 from tests.common.helpers.pfcwd_helper import start_wd_on_ports, start_background_traffic     # noqa: F401
 from tests.common.helpers.pfcwd_helper import calculate_pfcwd_default_timers
-from tests.common.helpers.pfcwd_helper import get_storm_detected_count, wait_until_pfcwd_restored
+from tests.common.helpers.pfcwd_helper import get_storm_detected_count, get_storm_restored_count
+from tests.common.helpers.pfcwd_helper import wait_until_pfcwd_restored
 
 from tests.common.plugins.loganalyzer import DisableLogrotateCronContext
 from tests.common.helpers.pfcwd_helper import send_background_traffic
@@ -102,7 +103,6 @@ def pfcwd_timer_setup_restore(setup_pfc_test, enum_fanout_graph_facts, duthosts,
            'storm_handle': storm_handle,
            'test_ports': test_ports,
            'test_port': pfc_wd_test_port,
-           'selected_test_port': pfc_wd_test_port
            }
 
     logger.info("--- Pfcwd timer test cleanup ---")
@@ -178,13 +178,19 @@ class TestPfcwdAllTimer(object):
             self.dut.shell("logrotate -f /etc/logrotate.conf")
         # Retry logic as workaround for issue #10848
         num_tries = 3
-        storm_detected_count = get_storm_detected_count(self.dut)
+        storm_port = setup_info['test_port']
+        storm_detected_count = get_storm_detected_count(self.dut, storm_port)
+        storm_restored_count = get_storm_restored_count(self.dut, storm_port)
 
         def check_stormed(storm_detected_count_prev):
-            storm_detected_count_latest = get_storm_detected_count(self.dut)
+            storm_detected_count_latest = get_storm_detected_count(self.dut, storm_port)
             return storm_detected_count_latest > storm_detected_count_prev
 
-        selected_test_ports = [setup_info['selected_test_port']]
+        def check_restored(storm_restored_count_prev):
+            storm_restored_count_latest = get_storm_restored_count(self.dut, storm_port)
+            return storm_restored_count_latest > storm_restored_count_prev
+
+        selected_test_ports = [storm_port]
         test_ports_info = setup_info['test_ports']
         queues = [self.storm_handle.pfc_queue_idx]
 
@@ -203,9 +209,11 @@ class TestPfcwdAllTimer(object):
             self.storm_handle.stop_storm()
             logger.info("Wait for PFC storm restored marker to appear in logs")
             for _ in range(num_tries):
-                stormed = wait_until(3, 1, 1, check_stormed, storm_detected_count)
-                if stormed:
+                restored = wait_until(3, 1, 1, check_restored, storm_restored_count)
+                if restored:
                     break
+            else:
+                pytest.fail("Could not detect storm restoration on port even after {} retries".format(num_tries))
 
         if self.dut.facts['asic_type'] == 'vs':
             logger.info("Skip time detect for VS")

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -176,6 +176,11 @@ class TestPfcwdAllTimer(object):
         with DisableLogrotateCronContext(self.dut):
             logger.info("Flush logs")
             self.dut.shell("logrotate -f /etc/logrotate.conf")
+
+        if self.dut.facts['asic_type'] == 'vs':
+            logger.info("Skip run_test for VS")
+            return
+
         # Retry logic as workaround for issue #10848
         num_tries = 3
         storm_port = setup_info['test_port']
@@ -214,10 +219,6 @@ class TestPfcwdAllTimer(object):
                     break
             else:
                 pytest.fail("Could not detect storm restoration on port even after {} retries".format(num_tries))
-
-        if self.dut.facts['asic_type'] == 'vs':
-            logger.info("Skip time detect for VS")
-            return
 
         wait_until_pfcwd_restored(self.dut, setup_info['test_port'])
 

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -1,6 +1,5 @@
 import logging
 import pytest
-import time
 import re
 
 from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts      # noqa: F401
@@ -8,10 +7,12 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.pfc_storm import PFCStorm
 from tests.common.helpers.pfcwd_helper import start_wd_on_ports, start_background_traffic     # noqa: F401
 from tests.common.helpers.pfcwd_helper import calculate_pfcwd_default_timers
+from tests.common.helpers.pfcwd_helper import get_storm_detected_count, wait_until_pfcwd_restored
 
 from tests.common.plugins.loganalyzer import DisableLogrotateCronContext
 from tests.common.helpers.pfcwd_helper import send_background_traffic
 from tests.common import config_reload
+from tests.common.utilities import wait_until
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -100,6 +101,7 @@ def pfcwd_timer_setup_restore(setup_pfc_test, enum_fanout_graph_facts, duthosts,
     yield {'timers': timers,
            'storm_handle': storm_handle,
            'test_ports': test_ports,
+           'test_port': pfc_wd_test_port,
            'selected_test_port': pfc_wd_test_port
            }
 
@@ -174,21 +176,42 @@ class TestPfcwdAllTimer(object):
         with DisableLogrotateCronContext(self.dut):
             logger.info("Flush logs")
             self.dut.shell("logrotate -f /etc/logrotate.conf")
+        # Retry logic as workaround for issue #10848
+        num_tries = 3
+        storm_detected_count = get_storm_detected_count(self.dut)
+
+        def check_stormed(storm_detected_count_prev):
+            storm_detected_count_latest = get_storm_detected_count(self.dut)
+            return storm_detected_count_latest > storm_detected_count_prev
 
         selected_test_ports = [setup_info['selected_test_port']]
         test_ports_info = setup_info['test_ports']
         queues = [self.storm_handle.pfc_queue_idx]
 
         with send_background_traffic(self.dut, self.ptf, queues, selected_test_ports, test_ports_info, pkt_count=500):
-            self.storm_handle.start_storm()
-            logger.info("Wait for queue to recover from PFC storm")
-            time.sleep(32)
+            for _ in range(num_tries):
+                self.storm_handle.start_storm()
+                logger.info("Wait for PFC storm detected marker to appear in logs")
+                stormed = wait_until(25, 5, 5, check_stormed, storm_detected_count)
+                if stormed:
+                    break
+                logger.info("Storm not detected on port, trying again...")
+                self.storm_handle.stop_storm()
+            else:
+                pytest.fail("Could not detect storm on port even after {} retries".format(num_tries))
+
             self.storm_handle.stop_storm()
-            time.sleep(16)
+            logger.info("Wait for PFC storm restored marker to appear in logs")
+            for _ in range(num_tries):
+                stormed = wait_until(3, 1, 1, check_stormed, storm_detected_count)
+                if stormed:
+                    break
 
         if self.dut.facts['asic_type'] == 'vs':
             logger.info("Skip time detect for VS")
             return
+
+        wait_until_pfcwd_restored(self.dut, setup_info['test_port'])
 
         skip_this_loop = False
         if self.dut.topo_type == 't2' and self.storm_handle.peer_device.os == 'sonic':
@@ -196,9 +219,6 @@ class TestPfcwdAllTimer(object):
         else:
             storm_start_ms = self.retrieve_timestamp("[P]FC_STORM_START")
             storm_detect_ms = self.retrieve_timestamp("[d]etected PFC storm")
-
-        logger.info("Wait for PFC storm end marker to appear in logs")
-        time.sleep(16)
 
         if self.dut.topo_type == 't2' and self.storm_handle.peer_device.os == 'sonic':
             storm_restore_ms = self.retrieve_timestamp("[s]torm restored")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Intermittent failure with `Too many iterations failed to collect PFCWD timestamps (0/20)` due to `PFC_STORM_END` not appearing in syslog within the fixed sleep window.

#### How did you do it?
- Added `pfcwd_stats`, `parse_pfcwd_stats`, `get_storm_detected_count`,
   `is_pfcwd_port_restored`, `wait_until_pfcwd_restored` to `pfcwd_helper.py`
- Replaced `time.sleep()` calls with active polling using `wait_until()` and
   `wait_until_pfcwd_restored()` to ensure `PFC_STORM_END` is in syslog before
    timestamp retrieval.

#### How did you verify/test it?
Verified on Arista-7260CX3 running dualtor-120 topology

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
