### PR TITLE
Ignore internal ports in `test_route_perf.py`

### DIFF
--- a/tests/route/utils.py
+++ b/tests/route/utils.py
@@ -24,8 +24,8 @@ def generate_intf_neigh(asichost, num_neigh, ip_version, mg_facts=None, is_backe
     else:
         interfaces = asichost.show_interface(command="status")["ansible_facts"]["int_status"]
         for intf, values in list(interfaces.items()):
-            if values["admin_state"] == "up" and values["oper_state"] == "up" and values["type"] != "DPU-NPU Data Port" and\
-                  (mg_facts==None or intf in mg_facts['minigraph_ports']):
+            if values["admin_state"] == "up" and values["oper_state"] == "up" and values["type"] != "DPU-NPU Data Port"\
+                  and (mg_facts is None or intf in mg_facts['minigraph_ports']):
                 up_interfaces.append(intf)
         if not up_interfaces:
             raise Exception("DUT does not have up interfaces")


### PR DESCRIPTION
Without this change we see ports like 'Ethernet-Rec0' used on single-asic VOQ systems.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
`route/test_route_perf.py` is currently failing on single-asic VOQ systems.

An example of one of the failures is:
```
"29/03/2026 09:35:43 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):\n",
"  File \"/opt/venv/lib/python3.12/site-packages/_pytest/python.py\", line 1720, in runtest\n",
"    self.ihook.pytest_pyfunc_call(pyfuncitem=self)\n",
"  File \"/opt/venv/lib/python3.12/site-packages/pluggy/_hooks.py\", line 512, in __call__\n",
"    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)\n",
"           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
"  File \"/opt/venv/lib/python3.12/site-packages/pluggy/_manager.py\", line 120, in _hookexec\n",
"    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)\n",
"           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
"  File \"/opt/venv/lib/python3.12/site-packages/pluggy/_callers.py\", line 167, in _multicall\n",
"    raise exception\n",
"  File \"/opt/venv/lib/python3.12/site-packages/pluggy/_callers.py\", line 121, in _multicall\n",
"    res = hook_impl.function(*args)\n",
"          ^^^^^^^^^^^^^^^^^^^^^^^^^\n",
"  File \"/opt/venv/lib/python3.12/site-packages/_pytest/python.py\", line 166, in pytest_pyfunc_call\n",
"    result = testfunction(**testargs)\n",
"             ^^^^^^^^^^^^^^^^^^^^^^^^\n",
"  File \"/data/tests/route/test_route_perf.py\", line 395, in test_perf_add_remove_routes\n",
"    ptf_dst_ports.append(port_indices[nh_ports])\n",
"                         ~~~~~~~~~~~~^^^^^^^^^^\n",
"KeyError: 'Ethernet-Rec0'\n",
```

The problem is that the test relies on querying `show interface status` to gather the list of interfaces.
But on single-asic VOQ systems the internal ports are included in that output (not the same on multi-asic).
See https://github.com/sonic-net/sonic-mgmt/issues/18249 for further details on this behavior.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fix `route/test_route_perf.py` on single-asic VOQ systems

#### How did you do it?
Filter out internal ports from the `show interface status` output

#### How did you verify/test it?
Ran `route/test_route_perf.py` and it's now passing on single-asic VOQ systems
Also ran `route/test_duplicate_route.py` which uses the same `generate_intf_neigh` function and confirmed it still passes.

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
