### PR TITLE
Fix flaky everflow IPv6 test on dualtor by fixing fixture ordering

### DIFF
--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -117,7 +117,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     @pytest.fixture(scope='function', autouse=True)
     def background_traffic(self, ptfadapter, everflow_direction, setup_info, everflow_dut,  # noqa F811
-                           setup_standby_ports_on_rand_unselected_tor_unconditionally):     # noqa F811
+                           setup_standby_ports_on_rand_unselected_tor_unconditionally,      # noqa F811
+                           toggle_all_simulator_ports_to_rand_selected_tor):                # noqa F811
         stop_thread = threading.Event()
         src_port = EverflowIPv6Tests.rx_port_ptf_id
 
@@ -250,9 +251,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
         return 6
 
     def test_src_ipv6_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,       # noqa F811
-                                setup_standby_ports_on_rand_unselected_tor_unconditionally,             # noqa F811
-                                everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,    # noqa F811
-                                erspan_ip_ver):                                                         # noqa F811
+                                everflow_direction, erspan_ip_ver):                                     # noqa F811
         """Verify that we can match on Source IPv6 addresses."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -270,9 +269,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_dst_ipv6_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,       # noqa F811
-                                setup_standby_ports_on_rand_unselected_tor_unconditionally,             # noqa F811
-                                everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,    # noqa F811
-                                erspan_ip_ver):                                                         # noqa F811
+                                everflow_direction, erspan_ip_ver):                                     # noqa F811
         """Verify that we can match on Destination IPv6 addresses."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -290,9 +287,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_next_header_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
-                                   setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
-                                   everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
-                                   erspan_ip_ver):                                                          # noqa F811
+                                   everflow_direction, erspan_ip_ver):                                      # noqa F811
         """Verify that we can match on the Next Header field."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, next_header=0x7E)
 
@@ -305,9 +300,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_l4_src_port_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
-                                   setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
-                                   everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
-                                   erspan_ip_ver):                                                          # noqa F811
+                                   everflow_direction, erspan_ip_ver):                                      # noqa F811
         """Verify that we can match on the L4 Source Port."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, sport=9000)
 
@@ -320,9 +313,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_l4_dst_port_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
-                                   setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
-                                   everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
-                                   erspan_ip_ver):                                                          # noqa F811
+                                   everflow_direction, erspan_ip_ver):                                      # noqa F811
         """Verify that we can match on the L4 Destination Port."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, dport=9001)
 
@@ -336,8 +327,6 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     def test_l4_src_port_range_mirroring(self, setup_info, setup_mirror_session,                      # noqa F811
                                          ptfadapter, everflow_dut, everflow_direction,
-                                         setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
-                                         toggle_all_simulator_ports_to_rand_selected_tor,             # noqa F811
                                          erspan_ip_ver):                                              # noqa F811
         """Verify that we can match on a range of L4 Source Ports."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, sport=10200)
@@ -352,8 +341,6 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     def test_l4_dst_port_range_mirroring(self, setup_info, setup_mirror_session,                      # noqa F811
                                          ptfadapter, everflow_dut, everflow_direction,
-                                         setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
-                                         toggle_all_simulator_ports_to_rand_selected_tor,             # noqa F811
                                          erspan_ip_ver):                                              # noqa F811
         """Verify that we can match on a range of L4 Destination Ports."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, dport=10700)
@@ -367,9 +354,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_tcp_flags_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,          # noqa F811
-                                 setup_standby_ports_on_rand_unselected_tor_unconditionally,                # noqa F811
-                                 everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,       # noqa F811
-                                 erspan_ip_ver):                                                            # noqa F811
+                                 everflow_direction, erspan_ip_ver):                                        # noqa F811
         """Verify that we can match on TCP Flags."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, flags=0x1B)
 
@@ -382,9 +367,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_dscp_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,               # noqa F811
-                            setup_standby_ports_on_rand_unselected_tor_unconditionally,                     # noqa F811
-                            everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,            # noqa F811
-                            erspan_ip_ver):                                                                 # noqa F811
+                            everflow_direction, erspan_ip_ver):                                             # noqa F811
         """Verify that we can match on DSCP."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, dscp=37)
 
@@ -397,9 +380,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_l4_range_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,           # noqa F811
-                                setup_standby_ports_on_rand_unselected_tor_unconditionally,                 # noqa F811
-                                everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,        # noqa F811
-                                erspan_ip_ver):                                                             # noqa F811
+                                everflow_direction, erspan_ip_ver):                                         # noqa F811
         """Verify that we can match from a source port to a range of destination ports and vice-versa."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -438,9 +419,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_tcp_response_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,       # noqa F811
-                                    setup_standby_ports_on_rand_unselected_tor_unconditionally,             # noqa F811
-                                    everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,    # noqa F811
-                                    erspan_ip_ver):                                                         # noqa F811
+                                    everflow_direction, erspan_ip_ver):                                     # noqa F811
         """Verify that we can match a SYN -> SYN-ACK pattern."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -478,8 +457,6 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     def test_tcp_application_mirroring(self, setup_info, setup_mirror_session,                      # noqa F811
                                        ptfadapter, everflow_dut, everflow_direction,
-                                       setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
-                                       toggle_all_simulator_ports_to_rand_selected_tor,             # noqa F811
                                        erspan_ip_ver):                                              # noqa F811
         """Verify that we can match a TCP handshake between a client and server."""
         test_packet = self._base_tcpv6_packet(
@@ -522,8 +499,6 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     def test_udp_application_mirroring(self, setup_info, setup_mirror_session,                      # noqa F811
                                        ptfadapter, everflow_dut, everflow_direction,
-                                       setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
-                                       toggle_all_simulator_ports_to_rand_selected_tor,             # noqa F811
                                        erspan_ip_ver):                                              # noqa F811
         """Verify that we can match UDP traffic between a client and server application."""
         test_packet = self._base_udpv6_packet(
@@ -564,9 +539,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_any_protocol(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,         # noqa F811
-                          setup_standby_ports_on_rand_unselected_tor_unconditionally,               # noqa F811
-                          everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,      # noqa F811
-                          erspan_ip_ver):                                                           # noqa F811
+                          everflow_direction, erspan_ip_ver):                                       # noqa F811
         """Verify that the protocol number is ignored if it is not specified in the ACL rule."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -619,8 +592,6 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     def test_any_transport_protocol(self, setup_info, setup_mirror_session,                      # noqa F811
                                     ptfadapter, everflow_dut, everflow_direction,
-                                    setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
-                                    toggle_all_simulator_ports_to_rand_selected_tor,             # noqa F811
                                     erspan_ip_ver):                                              # noqa F811
         """Verify that src port and dst port rules match regardless of whether TCP or UDP traffic is sent."""
         test_packet = self._base_tcpv6_packet(
@@ -660,8 +631,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_invalid_tcp_rule(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,         # noqa F811
-                              setup_standby_ports_on_rand_unselected_tor_unconditionally,               # noqa F811
-                              everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):     # noqa F811
+                              everflow_direction):
         """Verify that the ASIC does not reject rules with TCP flags if the protocol is not TCP."""
         pass
 
@@ -671,9 +641,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
         # suite + loganaylzer + the sanity check to fail.
 
     def test_source_subnet(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,            # noqa F811
-                           setup_standby_ports_on_rand_unselected_tor_unconditionally,                  # noqa F811
-                           everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,         # noqa F811
-                           erspan_ip_ver):                                                              # noqa F811
+                           everflow_direction, erspan_ip_ver):                                          # noqa F811
         """Verify that we can match packets with a Source IPv6 Subnet."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -694,9 +662,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_dest_subnet(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,          # noqa F811
-                         setup_standby_ports_on_rand_unselected_tor_unconditionally,                # noqa F811
-                         everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,       # noqa F811
-                         erspan_ip_ver):                                                            # noqa F811
+                         everflow_direction, erspan_ip_ver):                                        # noqa F811
         """Verify that we can match packets with a Destination IPv6 Subnet."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -717,9 +683,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_both_subnets(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,         # noqa F811
-                          setup_standby_ports_on_rand_unselected_tor_unconditionally,               # noqa F811
-                          everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,      # noqa F811
-                          erspan_ip_ver):                                                           # noqa F811
+                          everflow_direction, erspan_ip_ver):                                       # noqa F811
         """Verify that we can match packets with both source and destination subnets."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -740,9 +704,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_fuzzy_subnets(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
-                           setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
-                           everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
-                           erspan_ip_ver):                                                          # noqa F811
+                           everflow_direction, erspan_ip_ver):                                      # noqa F811
         """Verify that we can match packets with non-standard subnet sizes."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -763,9 +725,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_icmpv6_type(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
-                         setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
-                         everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
-                         erspan_ip_ver):                                                          # noqa F811
+                         everflow_direction, erspan_ip_ver):                                      # noqa F811
         """Verify that we can match packets with icmp type field"""
         test_packet = self._base_icmpv6_packet(
             everflow_direction,
@@ -783,9 +743,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_icmpv6_code(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,       # noqa F811
-                         setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
-                         everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
-                         erspan_ip_ver):                                                          # noqa F811
+                         everflow_direction, erspan_ip_ver):                                     # noqa F811
         """Verify that we can match packets with icmp code field"""
         test_packet = self._base_icmpv6_packet(
             everflow_direction,
@@ -804,9 +762,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_ip_type_any(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,       # noqa F811
-                         setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
-                         everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
-                         erspan_ip_ver):                                                          # noqa F811
+                         everflow_direction, erspan_ip_ver):                                     # noqa F811
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
             ptfadapter,
@@ -823,9 +779,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_ip_type_ip(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
-                        setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
-                        everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
-                        erspan_ip_ver):                                                          # noqa F811
+                        everflow_direction, erspan_ip_ver):                                      # noqa F811
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
             ptfadapter,
@@ -842,9 +796,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_ip_type_ipv6any(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
-                             setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
-                             everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
-                             erspan_ip_ver):                                                          # noqa F811
+                             everflow_direction, erspan_ip_ver):                                      # noqa F811
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
             ptfadapter,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The `background_traffic` fixture runs before `toggle_all_simulator_ports_to_rand_selected_tor` since it has no dependency on it. This causes the background traffic verification to fail when the randomly selected DUT happens to be the `standby` ToR, as standby mux ports drop server-ingress packets.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # https://github.com/aristanetworks/sonic-qual.msft/issues/1197

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
`everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6` is flaky, its failing at background traffic verification. 

#### How did you do it?
Fix by adding `toggle_all_simulator_ports_to_rand_selected_tor` as a dependency of `background_traffic`, ensuring mux cables are toggled to the selected ToR before any traffic is sent. Since background_traffic is autouse, the per-test-method parameters for both toggle and setup_standby fixtures are now redundant and removed.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
