### PR TITLE
[202511][backport#21634] Remove default golden config of high frequency telemetry

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -590,19 +590,6 @@ class GenerateGoldenConfigDBModule(object):
 
         return json.dumps({'PORT': golden_config['PORT']}, indent=4)
 
-    def generate_dummy_hft_config_db(self, config):
-        json_config = json.loads(config)
-        json_config["HIGH_FREQUENCY_TELEMETRY_PROFILE"] = {
-            "default": {
-                "stream_state": "disabled",
-                "poll_interval": "10000"
-            }
-        }
-        json_config["HIGH_FREQUENCY_TELEMETRY_GROUP"] = {
-            "default|PORT": {}
-        }
-        return json.dumps(json_config, indent=4)
-
     def generate(self):
         module_msg = "Success to generate golden_config_db.json"
         # topo check
@@ -659,10 +646,6 @@ class GenerateGoldenConfigDBModule(object):
                     "has_per_asic_scope": "True",
                 }
             })
-
-        # Generate dummy table for HFT
-        if not multi_asic.is_multi_asic():
-            config = self.generate_dummy_hft_config_db(config)
 
         with open(GOLDEN_CONFIG_DB_PATH, "w") as temp_file:
             temp_file.write(config)


### PR DESCRIPTION
### Description of PR

Summary: Backport of PR #21634 to 202511 branch. Remove the default HFT golden configuration since GCU does not require an existing table.

Fixes #21634

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The default HFT configuration is not needed because the GCU does not require an existing table. This was already merged to master via PR #21634 but the automatic backport to 202511 failed due to merge conflicts caused by diverged code context in `generate_golden_config_db.py`.

#### How did you do it?
Manually applied the same changes as PR #21634:
1. Removed `generate_dummy_hft_config_db()` method
2. Removed the call to `self.generate_dummy_hft_config_db(config)` in `generate()`

#### How did you verify/test it?
- Python syntax validation passed
- Verified no remaining references to `generate_dummy_hft_config_db` or `HIGH_FREQUENCY_TELEMETRY` in the file

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A