### PR TITLE
[202511][backport#21865] Add hft test cases for Queue, IPG and Buffer Pool

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2950,6 +2950,11 @@ high_frequency_telemetry:
     conditions:
       - "platform not in ['x86_64-nvidia_sn5600-r0', 'x86_64-nvidia_sn5640-r0', 'x86_64-arista_7060x6_64pe_b']"
 
+high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_full_counters:
+  skip:
+    reason: "In SN5640 platform, it doesn't support multiple types in one session. In 7060X6 platform, it hasn't supported any HFT tests yet."
+
+#######################################
 #####          http              #####
 #######################################
 http:

--- a/tests/high_frequency_telemetry/counter_profiles.py
+++ b/tests/high_frequency_telemetry/counter_profiles.py
@@ -1,0 +1,99 @@
+"""High frequency telemetry counter configuration keyed by platform and object type.
+
+Each platform maps to counter definitions grouped by `CounterObjectType`.  Tests
+should call `get_support_counter_list(duthost, counter_type)` so they always get
+the counters that are supported on the current DUT platform.  New platforms can
+reference the same sequence by reusing the tuple constant defined above.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Mapping, Sequence
+
+
+class CounterObjectType(Enum):
+    PORT = "port"
+    BUFFER_POOL = "buffer_pool"
+    INGRESS_PRIORITY_GROUP = "ingress_priority_group"
+    QUEUE = "queue"
+
+
+_DEFAULT_PLATFORM = "default"
+
+_PORT_COUNTERS_SN5640 = (
+    "IF_IN_OCTETS",
+    # "IF_IN_UCAST_PKTS",
+    "IF_IN_DISCARDS",
+    "IF_OUT_OCTETS",
+    # "IF_OUT_ERRORS",
+    # "IF_OUT_UCAST_PKTS",
+    # "TRIM_PACKETS"
+)
+
+_QUEUE_COUNTERS_SN5640 = (
+    # "PACKETS",
+    "BYTES",
+    # "DROPPED_PACKETS",
+    "CURR_OCCUPANCY_CELLS",
+    "WATERMARK_CELLS",
+    "WRED_ECN_MARKED_PACKETS",
+)
+
+_INGRESS_PRIORITY_GROUP_COUNTERS_SN5640 = (
+    # "PACKETS",
+    # "BYTES",
+    "CURR_OCCUPANCY_CELLS",
+    "WATERMARK_CELLS",
+)
+
+_BUFFER_POOL_COUNTERS_SN5640 = (
+    # "CURR_OCCUPANCY_CELLS",
+    # "WATERMARK_CELLS",
+)
+
+SUPPORTED_STATS: Mapping[str, Mapping[CounterObjectType, Sequence[str]]] = {
+    "x86_64-nvidia_sn5640-r0": {
+        CounterObjectType.PORT: _PORT_COUNTERS_SN5640,
+        CounterObjectType.QUEUE: _QUEUE_COUNTERS_SN5640,
+        CounterObjectType.INGRESS_PRIORITY_GROUP: _INGRESS_PRIORITY_GROUP_COUNTERS_SN5640,
+        CounterObjectType.BUFFER_POOL: _BUFFER_POOL_COUNTERS_SN5640,
+    },
+    "x86_64-arista_7060x6_64pe_b": {
+        CounterObjectType.PORT: (),
+        CounterObjectType.QUEUE: (),
+    },
+    _DEFAULT_PLATFORM: {
+        CounterObjectType.PORT: (),
+        CounterObjectType.QUEUE: (),
+        CounterObjectType.BUFFER_POOL: (),
+        CounterObjectType.INGRESS_PRIORITY_GROUP: (),
+    },
+}
+
+
+def _normalize_platform(platform: str | None) -> str:
+    if not platform:
+        return _DEFAULT_PLATFORM
+    return platform.strip().lower()
+
+
+def _get_platform(duthost) -> str:
+    facts = getattr(duthost, "facts", {})
+    return facts.get("platform", "")
+
+
+def get_support_counter_list(duthost, counter_type: CounterObjectType) -> Sequence[str]:
+    """Return the list of supported counters for `counter_type` on the DUT platform."""
+
+    platform_key = _normalize_platform(_get_platform(duthost))
+    platform_defs = SUPPORTED_STATS.get(platform_key)
+
+    if not platform_defs:
+        platform_defs = SUPPORTED_STATS.get(_DEFAULT_PLATFORM, {})
+
+    counters = platform_defs.get(counter_type)
+    if counters is None:
+        return ()
+
+    return counters

--- a/tests/high_frequency_telemetry/test_high_frequency_telemetry.py
+++ b/tests/high_frequency_telemetry/test_high_frequency_telemetry.py
@@ -3,6 +3,10 @@ import logging
 import time
 
 from tests.common.helpers.assertions import pytest_assert
+from tests.high_frequency_telemetry.counter_profiles import (
+    CounterObjectType,
+    get_support_counter_list,
+)
 from tests.high_frequency_telemetry.utilities import (
     setup_hft_profile,
     setup_hft_group,
@@ -15,7 +19,10 @@ from tests.high_frequency_telemetry.utilities import (
     validate_config_state_transitions,
     validate_port_state_transitions,
     validate_counter_output,
-    get_available_ports
+    get_available_ports,
+    get_configured_queue_objects,
+    get_configured_buffer_queue_objects,
+    get_configured_buffer_pools
 )
 
 logger = logging.getLogger(__name__)
@@ -96,25 +103,28 @@ def test_hft_port_counters(duthosts, enum_rand_one_per_hwsku_hostname,
         cleanup_hft_config(duthost, profile_name, [group_name])
 
 
-@pytest.mark.skip(reason="Queue-based high frequency telemetry "
-                         "not yet supported")
-def test_hft_queue_counters(duthosts, enum_rand_one_per_hwsku_hostname,
-                            disable_flex_counters, tbinfo):
+def test_hft_full_queue_counters(duthosts, enum_rand_one_per_hwsku_hostname,
+                                 disable_flex_counters):
     """
-    Test high frequency telemetry for queue counters.
+    Test high frequency telemetry for every configured queue.
 
-    This test demonstrates a different configuration with queue objects.
+    This test derives queue objects directly from the DUT config facts so
+    it exercises all queues that are defined on the device.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     profile_name = "queue_profile"
     group_name = "QUEUE"
 
-    # Get available ports from topology (try for 2 ports, min 1 required)
-    test_ports = get_available_ports(duthost, tbinfo, desired_ports=2,
-                                     min_ports=1)
-    # Format queue objects with index
-    queue_objects = [f"{port}|0" for port in test_ports]
+    queue_objects = get_configured_queue_objects(duthost)
+    if not queue_objects:
+        pytest.skip("No queue objects defined in CONFIG_DB; can't run queue telemetry test")
 
+    object_counters = get_support_counter_list(
+        duthost,
+        CounterObjectType.QUEUE
+    )
+    if not object_counters:
+        pytest.skip("No queue counters supported on this platform")
     logger.info(f"Using queue objects for testing: {queue_objects}")
 
     try:
@@ -132,7 +142,7 @@ def test_hft_queue_counters(duthosts, enum_rand_one_per_hwsku_hostname,
             profile_name=profile_name,
             group_name=group_name,
             object_names=queue_objects,  # Queue objects with index
-            object_counters=["QUEUE_STAT_PACKETS"]
+            object_counters=object_counters
         )
 
         logger.info("Queue high frequency telemetry configuration completed")
@@ -154,7 +164,154 @@ def test_hft_queue_counters(duthosts, enum_rand_one_per_hwsku_hostname,
         cleanup_hft_config(duthost, profile_name)
 
 
-@pytest.mark.skip(reason="Some PORT stats haven't been supported yet")
+def test_hft_full_ingress_priority_group_counters(duthosts, enum_rand_one_per_hwsku_hostname,
+                                                  disable_flex_counters):
+    """Test high frequency telemetry for all configured buffer queues (ingress priority groups)."""
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    profile_name = "ingress_pg_profile"
+    group_name = "INGRESS_PRIORITY_GROUP"
+
+    buffer_queue_objects = get_configured_buffer_queue_objects(duthost)
+    if not buffer_queue_objects:
+        pytest.skip("No BUFFER_QUEUE entries defined in CONFIG_DB; can't run ingress PG telemetry test")
+
+    object_counters = get_support_counter_list(
+        duthost,
+        CounterObjectType.INGRESS_PRIORITY_GROUP
+    )
+    if not object_counters:
+        pytest.skip("No ingress priority group counters supported on this platform")
+
+    try:
+        setup_hft_profile(
+            duthost=duthost,
+            profile_name=profile_name,
+            poll_interval=10000,
+            stream_state="enabled"
+        )
+
+        setup_hft_group(
+            duthost=duthost,
+            profile_name=profile_name,
+            group_name=group_name,
+            object_names=buffer_queue_objects,
+            object_counters=object_counters
+        )
+
+        result = run_countersyncd_and_capture_output(duthost, timeout=360)
+        validate_counter_output(
+            output=result['stdout'],
+            min_counter_value=0,
+            expected_poll_interval=10000
+        )
+    finally:
+        cleanup_hft_config(duthost, profile_name)
+
+
+def test_hft_full_buffer_pool_counters(duthosts, enum_rand_one_per_hwsku_hostname,
+                                       disable_flex_counters):
+    """Test high frequency telemetry for all configured buffer pools."""
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    profile_name = "buffer_pool_profile"
+    group_name = "BUFFER_POOL"
+
+    buffer_pools = get_configured_buffer_pools(duthost)
+    if not buffer_pools:
+        pytest.skip("No BUFFER_POOL entries defined in CONFIG_DB; can't run buffer pool telemetry test")
+
+    object_counters = get_support_counter_list(
+        duthost,
+        CounterObjectType.BUFFER_POOL
+    )
+    if not object_counters:
+        pytest.skip("No buffer pool counters supported on this platform")
+
+    try:
+        setup_hft_profile(
+            duthost=duthost,
+            profile_name=profile_name,
+            poll_interval=10000,
+            stream_state="enabled"
+        )
+
+        setup_hft_group(
+            duthost=duthost,
+            profile_name=profile_name,
+            group_name=group_name,
+            object_names=buffer_pools,
+            object_counters=object_counters
+        )
+
+        result = run_countersyncd_and_capture_output(duthost, timeout=360)
+        validate_counter_output(
+            output=result['stdout'],
+            min_counter_value=0,
+            expected_poll_interval=10000
+        )
+    finally:
+        cleanup_hft_config(duthost, profile_name)
+
+
+@pytest.mark.skip(reason="Full counters HFT isn't supported")
+def test_hft_full_counters(duthosts, enum_rand_one_per_hwsku_hostname,
+                           disable_flex_counters, tbinfo):
+    """Test high frequency telemetry for all supported object types in one profile."""
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    profile_name = "full_hft_profile"
+
+    # Collect objects and counters per type
+    port_objects = get_available_ports(duthost, tbinfo, desired_ports=None, min_ports=1)
+    port_counters = get_support_counter_list(duthost, CounterObjectType.PORT)
+
+    queue_objects = get_configured_queue_objects(duthost)
+    queue_counters = get_support_counter_list(duthost, CounterObjectType.QUEUE)
+
+    pg_objects = get_configured_buffer_queue_objects(duthost)
+    pg_counters = get_support_counter_list(duthost, CounterObjectType.INGRESS_PRIORITY_GROUP)
+
+    pool_objects = get_configured_buffer_pools(duthost)
+    pool_counters = get_support_counter_list(duthost, CounterObjectType.BUFFER_POOL)
+
+    groups_to_configure = []
+    if port_objects and port_counters:
+        groups_to_configure.append(("PORT", port_objects, port_counters))
+    if queue_objects and queue_counters:
+        groups_to_configure.append(("QUEUE", queue_objects, queue_counters))
+    if pg_objects and pg_counters:
+        groups_to_configure.append(("INGRESS_PRIORITY_GROUP", pg_objects, pg_counters))
+    if pool_objects and pool_counters:
+        groups_to_configure.append(("BUFFER_POOL", pool_objects, pool_counters))
+
+    if not groups_to_configure:
+        pytest.skip("No counters or objects available for any HFT group")
+
+    try:
+        setup_hft_profile(
+            duthost=duthost,
+            profile_name=profile_name,
+            poll_interval=10000,
+            stream_state="enabled"
+        )
+
+        for group_name, objects, counters in groups_to_configure:
+            setup_hft_group(
+                duthost=duthost,
+                profile_name=profile_name,
+                group_name=group_name,
+                object_names=objects,
+                object_counters=counters
+            )
+
+        result = run_countersyncd_and_capture_output(duthost, timeout=360)
+        validate_counter_output(
+            output=result['stdout'],
+            min_counter_value=0,
+            expected_poll_interval=10000
+        )
+    finally:
+        cleanup_hft_config(duthost, profile_name)
+
+
 def test_hft_full_port_counters(duthosts, enum_rand_one_per_hwsku_hostname,
                                 disable_flex_counters, tbinfo):
     """
@@ -178,19 +335,12 @@ def test_hft_full_port_counters(duthosts, enum_rand_one_per_hwsku_hostname,
     )
 
     # All available port counters
-    all_port_counters = [
-        "IF_IN_OCTETS",
-        "IF_IN_UCAST_PKTS",
-        "IF_IN_DISCARDS",
-        "IF_IN_ERRORS",
-        "IN_CURR_OCCUPANCY_BYTES",
-        "IF_OUT_OCTETS",
-        "IF_OUT_DISCARDS",
-        "IF_OUT_ERRORS",
-        "IF_OUT_UCAST_PKTS",
-        "OUT_CURR_OCCUPANCY_BYTES",
-        "TRIM_PACKETS"
-    ]
+    all_port_counters = get_support_counter_list(
+        duthost,
+        CounterObjectType.PORT
+    )
+    if not all_port_counters:
+        pytest.skip("No port counters supported on this platform")
 
     logger.info(
             f"Testing all {len(all_available_ports)} available ports: "
@@ -295,7 +445,15 @@ def test_hft_disabled_stream(duthosts, enum_rand_one_per_hwsku_hostname,
     logger.info(f"Using ports for testing: {test_ports}")
 
     try:
-        # Initial setup: Configure the telemetry group (starts disabled, will be enabled in first phase)
+        # Initial setup: Create profile first (default disabled), then configure group
+        logger.info("Setting up high frequency telemetry profile configuration")
+        setup_hft_profile(
+            duthost=duthost,
+            profile_name=profile_name,
+            poll_interval=10000,
+            stream_state="disabled"
+        )
+
         logger.info("Setting up high frequency telemetry group configuration")
         setup_hft_group(
             duthost=duthost,

--- a/tests/high_frequency_telemetry/utilities.py
+++ b/tests/high_frequency_telemetry/utilities.py
@@ -11,6 +11,7 @@ import re
 import threading
 import time
 from datetime import datetime, timedelta, timezone
+from collections.abc import Iterable
 
 import pytest
 import ptf.testutils as testutils
@@ -108,8 +109,74 @@ def get_available_ports(duthost, tbinfo, desired_ports=2, min_ports=None):
         return available_ports
 
 
+def _format_counter_db_name_map_keys(name_map_keys):
+    """Return sorted, de-duplicated object names as <port>|<queue_id> strings."""
+    objects = [key.replace(":", "|") for key in natsorted(name_map_keys)]
+    return list(dict.fromkeys(objects))
+
+
+def _get_counter_db_name_map_keys(duthost, name_map):
+    """Return list of keys from COUNTERS_DB name map hash table."""
+    cmd = f'redis-cli -n 2 --raw hgetall "{name_map}"'
+    result = duthost.shell(cmd, module_ignore_errors=True)
+
+    if result.get("rc", 1) != 0:
+        logger.warning("Failed to read %s from COUNTERS_DB: %s", name_map, result.get("stderr"))
+        return []
+
+    lines = [line for line in (result.get("stdout", "") or "").splitlines() if line]
+    if not lines:
+        logger.info("No entries found in COUNTERS_DB %s", name_map)
+        return []
+
+    # redis-cli --raw hgetall returns alternating lines: key, value, key, value...
+    keys = lines[0::2]
+    return keys
+
+
+def get_configured_queue_objects(duthost):
+    """Return all queue objects from COUNTERS_DB as <port>|<queue_id> strings."""
+    name_map_keys = _get_counter_db_name_map_keys(duthost, "COUNTERS_QUEUE_NAME_MAP")
+
+    if not name_map_keys:
+        logger.info("No queue entries found in COUNTERS_QUEUE_NAME_MAP")
+        return []
+
+    queue_objects = _format_counter_db_name_map_keys(name_map_keys)
+    logger.info(f"Found {len(queue_objects)} queue objects: {queue_objects}")
+    return queue_objects
+
+
+def get_configured_buffer_queue_objects(duthost):
+    """Return all buffer queue objects as <port>|<queue_id> strings."""
+    name_map_keys = _get_counter_db_name_map_keys(duthost, "COUNTERS_PG_NAME_MAP")
+
+    if not name_map_keys:
+        logger.info("No buffer queue entries found in COUNTERS_PG_NAME_MAP")
+        return []
+
+    buffer_queue_objects = _format_counter_db_name_map_keys(name_map_keys)
+    logger.info(f"Found {len(buffer_queue_objects)} buffer queue objects: {buffer_queue_objects}")
+    return buffer_queue_objects
+
+
+def get_configured_buffer_pools(duthost, source="persistent"):
+    """Return all buffer pool names from CONFIG_DB."""
+    cfg_facts = duthost.config_facts(
+        host=duthost.hostname, source=source)['ansible_facts']
+    buffer_pools = natsorted(cfg_facts.get('BUFFER_POOL', {}).keys())
+    buffer_pools = list(dict.fromkeys(buffer_pools))
+
+    if not buffer_pools:
+        logger.info("No BUFFER_POOL entries found in config facts")
+    else:
+        logger.info(f"Found {len(buffer_pools)} buffer pools: {buffer_pools}")
+
+    return buffer_pools
+
+
 def setup_hft_profile(duthost, profile_name, poll_interval=10000,
-                      stream_state="enabled", otel_endpoint=None,
+                      stream_state="disabled", otel_endpoint=None,
                       otel_certs=None):
     """
     Set up a high frequency telemetry profile.
@@ -117,35 +184,71 @@ def setup_hft_profile(duthost, profile_name, poll_interval=10000,
     Args:
         duthost: DUT host object
         profile_name: Name of the profile
-        poll_interval: Polling interval in microseconds (default: 30000)
-        stream_state: enabled/disabled (default: enabled)
+        poll_interval: Polling interval in microseconds (default: 10000)
+        stream_state: enabled/disabled (default: disabled)
         otel_endpoint: OpenTelemetry endpoint (optional)
         otel_certs: Path to certificates (optional)
     """
-    profile_config = {
-        "poll_interval": str(poll_interval),
-        "stream_state": stream_state
-    }
+    stream_state = (stream_state or "").strip().lower()
+    if stream_state not in {"enabled", "disabled"}:
+        pytest_assert(
+            False,
+            f"Invalid stream_state '{stream_state}'. Expected 'enabled' or 'disabled'."
+        )
 
-    if otel_endpoint:
-        profile_config["otel_endpoint"] = otel_endpoint
-    if otel_certs:
-        profile_config["otel_certs"] = otel_certs
-
-    # Build the HSET command
-    config_parts = []
-    for key, value in profile_config.items():
-        config_parts.extend([f'"{key}"', f'"{value}"'])
+    if otel_endpoint or otel_certs:
+        logger.warning(
+            "otel_endpoint/otel_certs are not supported by 'config hft add profile' yet. "
+            "Ignoring these parameters."
+        )
 
     profile_cmd = (
-        f'redis-cli -n 4 HSET "HIGH_FREQUENCY_TELEMETRY_PROFILE|'
-        f'{profile_name}" {" ".join(config_parts)}'
+        f"sudo config hft add profile {profile_name} "
+        f"--poll_interval {poll_interval} "
+        f"--stream_state {stream_state}"
     )
 
     result = duthost.shell(profile_cmd, module_ignore_errors=False)
-    logger.info(f"Created high frequency telemetry profile '{profile_name}': "
-                f"{profile_config}")
+    logger.info(
+        "Created high frequency telemetry profile '%s' with poll_interval=%s, stream_state=%s",
+        profile_name,
+        poll_interval,
+        stream_state,
+    )
     return result
+
+
+def _stringify_sequence(value):
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Iterable):
+        return ",".join(str(item) for item in value)
+    return str(value)
+
+
+def _normalize_hft_group_type(group_name):
+    if not group_name:
+        pytest_assert(False, "group_name must not be empty")
+
+    key = re.sub(r"[\s\-]+", "_", str(group_name).strip()).upper()
+    mapping = {
+        "PORT": "PORT",
+        "QUEUE": "QUEUE",
+        "BUFFER": "BUFFER_POOL",
+        "BUFFER_POOL": "BUFFER_POOL",
+        "INGRESS_PRIORITY_GROUP": "INGRESS_PRIORITY_GROUP",
+        "PG": "INGRESS_PRIORITY_GROUP",
+        "IPG": "INGRESS_PRIORITY_GROUP",
+    }
+    group_type = mapping.get(key, key)
+    allowed = {"PORT", "BUFFER_POOL", "INGRESS_PRIORITY_GROUP", "QUEUE"}
+    if group_type not in allowed:
+        pytest_assert(
+            False,
+            f"Unsupported HFT group type '{group_name}'. "
+            f"Expected one of: {sorted(allowed)}"
+        )
+    return group_type
 
 
 def setup_hft_group(duthost, profile_name, group_name,
@@ -160,22 +263,54 @@ def setup_hft_group(duthost, profile_name, group_name,
         object_names: List of object names or comma-separated string
         object_counters: List of counter names or comma-separated string
     """
-    if isinstance(object_names, list):
-        object_names = ",".join(object_names)
-    if isinstance(object_counters, list):
-        object_counters = ",".join(object_counters)
+    object_names = _stringify_sequence(object_names)
+    object_counters = _stringify_sequence(object_counters)
+
+    group_type = _normalize_hft_group_type(group_name)
 
     group_cmd = (
-        f'redis-cli -n 4 HSET "HIGH_FREQUENCY_TELEMETRY_GROUP|'
-        f'{profile_name}|{group_name}" '
-        f'"object_names" "{object_names}" '
-        f'"object_counters" "{object_counters}"'
+        f"sudo config hft add group {profile_name} "
+        f"--group_type {group_type} "
+        f"--object_names \"{object_names}\" "
+        f"--object_counters \"{object_counters}\""
     )
 
     result = duthost.shell(group_cmd, module_ignore_errors=False)
-    logger.info(f"Created high frequency telemetry group '{group_name}' "
-                f"for profile '{profile_name}': "
-                f"objects={object_names}, counters={object_counters}")
+    logger.info(
+        "Created high frequency telemetry group '%s' (type=%s) for profile '%s': "
+        "objects=%s, counters=%s",
+        group_name,
+        group_type,
+        profile_name,
+        object_names,
+        object_counters,
+    )
+    return result
+
+
+def setup_hft_stream_state(duthost, profile_name, stream_state):
+    """
+    Enable or disable an HFT stream for a profile.
+
+    Args:
+        duthost: DUT host object
+        profile_name: Name of the profile
+        stream_state: enabled/disabled/enable/disable
+    """
+    state = (stream_state or "").strip().lower()
+    if state in {"enabled", "enable"}:
+        action = "enable"
+    elif state in {"disabled", "disable"}:
+        action = "disable"
+    else:
+        pytest_assert(
+            False,
+            f"Invalid stream_state '{stream_state}'. Expected 'enabled' or 'disabled'."
+        )
+
+    cmd = f"sudo config hft {action} {profile_name}"
+    result = duthost.shell(cmd, module_ignore_errors=False)
+    logger.info("Set HFT stream state to '%s' for profile '%s'", action, profile_name)
     return result
 
 
@@ -191,40 +326,52 @@ def cleanup_hft_config(duthost, profile_name, group_names=None):
     """
     cleanup_commands = []
 
-    # Clean up profile
-    cleanup_commands.append(
-        f'redis-cli -n 4 DEL "HIGH_FREQUENCY_TELEMETRY_PROFILE|{profile_name}"'
-    )
-
-    # Clean up groups
+    # Clean up groups first
     if group_names:
         if isinstance(group_names, str):
             group_names = [group_names]
         for group_name in group_names:
+            group_type = _normalize_hft_group_type(group_name)
             cleanup_commands.append(
-                f'redis-cli -n 4 DEL "HIGH_FREQUENCY_TELEMETRY_GROUP|'
-                f'{profile_name}|{group_name}"'
+                f"sudo config hft del group {profile_name} {group_type}"
             )
     else:
-        # Clean up all groups for this profile (use pattern matching)
+        # Query all groups for this profile (use redis-cli for discovery only)
         pattern_cmd = (
             f'redis-cli -n 4 KEYS "HIGH_FREQUENCY_TELEMETRY_GROUP|'
             f'{profile_name}|*"'
         )
         result = duthost.shell(pattern_cmd, module_ignore_errors=True)
-        if result['rc'] == 0 and result['stdout_lines']:
+        if result.get('rc') == 0 and result.get('stdout_lines'):
             for key in result['stdout_lines']:
-                if key.strip():
-                    cleanup_commands.append(
-                        f'redis-cli -n 4 DEL "{key.strip()}"'
-                    )
+                key = (key or "").strip()
+                if not key:
+                    continue
+                parts = key.split("|", 2)
+                if len(parts) != 3:
+                    logger.warning("Unexpected HFT group key format: %s", key)
+                    continue
+                _, key_profile, key_group = parts
+                if key_profile != profile_name:
+                    continue
+                group_type = _normalize_hft_group_type(key_group)
+                cleanup_commands.append(
+                    f"sudo config hft del group {profile_name} {group_type}"
+                )
+
+    # Clean up profile last
+    cleanup_commands.append(
+        f"sudo config hft del profile {profile_name}"
+    )
 
     # Execute cleanup commands
     for cmd in cleanup_commands:
         duthost.shell(cmd, module_ignore_errors=True)
 
-    logger.info(f"Cleaned up high frequency telemetry configuration "
-                f"for profile '{profile_name}'")
+    logger.info(
+        "Cleaned up high frequency telemetry configuration for profile '%s'",
+        profile_name,
+    )
 
 
 def run_countersyncd_and_capture_output(duthost, timeout=120, stats_interval=60):
@@ -406,11 +553,10 @@ def run_continuous_countersyncd_with_state_changes(duthost, profile_name,
             phase_start_position = monitor.get_current_file_size()
 
             # Change stream state
-            setup_hft_profile(
+            setup_hft_stream_state(
                 duthost=duthost,
                 profile_name=profile_name,
-                poll_interval=10000,
-                stream_state=state
+                stream_state=state,
             )
 
             # Wait for the state change to take effect
@@ -1292,17 +1438,29 @@ def analyze_counter_trend(output):
     first_val = sample_values[0]
     last_val = sample_values[-1]
 
-    # Calculate the difference and percentage change
-    diff = last_val - first_val
-    pct_change = (diff / first_val * 100) if first_val > 0 else 0
+    # Analyze per-sample direction without percentage thresholds
+    diffs = [b - a for a, b in zip(sample_values, sample_values[1:])]
+    pos_changes = sum(1 for d in diffs if d > 0)
+    neg_changes = sum(1 for d in diffs if d < 0)
+    non_zero_changes = pos_changes + neg_changes
 
-    logger.info(f"Counter trend analysis: first={first_val}, last={last_val}, "
-                f"diff={diff}, pct_change={pct_change: .2f}%")
+    logger.info(
+        "Counter trend analysis: first=%s, last=%s, diffs=%s, +changes=%s, -changes=%s",
+        first_val,
+        last_val,
+        diffs,
+        pos_changes,
+        neg_changes,
+    )
 
-    # Determine trend based on percentage change
-    if pct_change > 5:  # More than 5% increase
-        return 'increasing'
-    elif pct_change < -5:  # More than 5% decrease
-        return 'decreasing'
-    else:  # Within 5% change
+    # Stable means the sequence changes at most once across all samples
+    if non_zero_changes <= 1:
         return 'stable'
+
+    # Determine overall trend by dominant direction
+    if pos_changes > neg_changes:
+        return 'increasing'
+    if neg_changes > pos_changes:
+        return 'decreasing'
+
+    return 'stable'


### PR DESCRIPTION
### Description of PR

Summary: Backport of PR #21865 to 202511 branch. Add HFT test cases for Queue, Ingress Priority Group, and Buffer Pool counters, and refactor HFT setup utilities from redis-cli to config hft CLI.

Original PR: https://github.com/sonic-net/sonic-mgmt/pull/21865

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Improving the coverage of HFT tests.

#### How did you do it?
Manual backport of PR #21865 (automatic cherry-pick failed due to context conflicts from diverged code in `utilities.py` and `test_high_frequency_telemetry.py`). Changes include:
- Add `counter_profiles.py` for per-platform counter definitions (new file)
- Add `test_hft_full_queue_counters`, `test_hft_full_ingress_priority_group_counters`, `test_hft_full_buffer_pool_counters`, `test_hft_full_counters` test cases
- Refactor `setup_hft_profile/group/cleanup` from redis-cli to `config hft` CLI commands
- Add `get_configured_queue_objects`, `get_configured_buffer_queue_objects`, `get_configured_buffer_pools` utility functions
- Add `setup_hft_stream_state` utility for enable/disable
- Improve `analyze_counter_trend` logic
- Add skip mark for `test_hft_full_counters` in `tests_mark_conditions.yaml`

#### How did you verify/test it?
- Python syntax validation passed for all modified files
- YAML syntax validation passed for tests_mark_conditions.yaml

#### Any platform specific information?
SN5640

#### Supported testbed topology if it's a new test case?
any

### Documentation
N/A