### PR TITLE
[ACL] Fix missing upstream ports in ACL table for topologies with a mix of LAG and non-LAG upstream ports

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -509,6 +509,16 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_selected_front_end_dut, ran
             # In multi-asic we need config both in host and namespace.
             if v['namespace']:
                 acl_table_ports[''].append(k)
+        # Add upstream ports not covered by any PortChannel
+        pc_members = set()
+        for pc in port_channels.values():
+            pc_members.update(pc.get('members', []))
+        for namespace, port in list(upstream_ports.items()):
+            non_pc_ports = [p for p in port if p not in pc_members]
+            acl_table_ports[namespace] += non_pc_ports
+            # In multi-asic we need config both in host and namespace.
+            if namespace:
+                acl_table_ports[''] += non_pc_ports
     elif topo == "t2":
         acl_table_ports = t2_info['acl_table_ports']
     elif topo == "lt2":


### PR DESCRIPTION
### Description of PR
For topologies like t1-isolated-d448u15-lag, most upstream (T2) connections are individual ports rather than PortChannels. The ACL table port binding logic adds downstream individual ports as well as PortChannels, but skips upstream individual ports because the logic for adding PortChannels and upstream-ports is mutually exclusive.

This causes ingress ACL rules to not be applied on non-PortChannel upstream ports, so packets that should be dropped are forwarded, producing "Received packet that we expected not to receive" assertion errors on uplink->downlink ACL tests.

Fix by also adding upstream ports that are not members of any PortChannel to the ACL table, even when PortChannels for other ports are present.

Summary:
Fixes #25647

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
To fix the AssertionError "Received packet that we expected not to receive..." associated with the non-ACL'd non-PortChannel ports that cause the uplink->downlink ACL tests to fail.

#### How did you do it?
Add upstream ports that are not members of any PortChannel to the ACL table, even when PortChannels are present for other ports.

#### How did you verify/test it?
Ran the acl package on a t1-isolated-d448u15-lag setup and confirmed that the tests no longer fail with this AssertionError.