### PR TITLE
[202511][backport#23302] xfail test_decap and test_vnet_decap on SN5640

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -802,6 +802,12 @@ decap/test_decap.py:
     reason: 'Skip on t1-isolated-d32/128 topos'
     conditions:
       - "topo_name in ['t1-isolated-d128', 't1-isolated-d32']"
+  xfail:
+    reason: "Xfail due to github issue 20982. Or decap is not supported on x86_64-nvidia_sn5640-r0."
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20982 and asic_type in ['mellanox', 'nvidia']"
+      - "platform in ['x86_64-nvidia_sn5640-r0']"
 
 decap/test_decap.py::test_decap[ttl=pipe, dscp=pipe, vxlan=disable]:
   skip:
@@ -4978,6 +4984,12 @@ vxlan/test_vnet_bgp_route_precedence.py:
     reason: "Testcase ignored due to github issue: https://github.com/sonic-net/sonic-buildimage/issues/23824"
     conditions:
       - "https://github.com/sonic-net/sonic-buildimage/issues/23824"
+
+vxlan/test_vnet_decap.py::test_vnet_decap:
+  xfail:
+    reason: "Decap is not supported on x86_64-nvidia_sn5640-r0."
+    conditions:
+      - "platform in ['x86_64-nvidia_sn5640-r0']"
 
 vxlan/test_vnet_route_leak.py:
   skip:


### PR DESCRIPTION
### Description of PR

Summary: Backport of PR #23302 to 202511 branch. Add xfail conditions for decap tests on x86_64-nvidia_sn5640-r0 platform where decap is not supported.

Original PR: https://github.com/sonic-net/sonic-mgmt/pull/23302

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Decap tests fail on x86_64-nvidia_sn5640-r0 because decap is not supported on this platform. These tests should be marked as xfail.

#### How did you do it?
Manual backport (auto cherry-pick failed due to line number context differences in tests_mark_conditions.yaml between master and 202511):
1. Added xfail block to `decap/test_decap.py` entry with platform check for SN5640 and existing issue #20982
2. Added new `vxlan/test_vnet_decap.py::test_vnet_decap` xfail entry for SN5640

#### How did you verify/test it?
YAML syntax validation passed.

#### Any platform specific information?
x86_64-nvidia_sn5640-r0

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A