### PR TITLE
Fix `test_everflow_fwd_recircle_port_queue_check` for multi-asic

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -743,11 +743,11 @@ def verify_mirror_packets_on_recircle_port(self, ptfadapter, setup, mirror_sessi
     # Number of packets to send
     packet_count = {"iteration-1": 10, "iteration-2": 50, "iteration-3": 100}
     for iteration, count in list(packet_count.items()):
-        pkts_sent = 0
+        total_pkts_sent = {}
         clear_queue_counters(duthost, asic_ns)
         for i in range(1, count + 1):
             logging.info("Sending packet {} to DUT for {}".format(i, iteration))
-            pkts_sent += self.send_and_check_mirror_packets(
+            num_pkts_sent = self.send_and_check_mirror_packets(
                 setup,
                 mirror_session,
                 ptfadapter,
@@ -760,12 +760,19 @@ def verify_mirror_packets_on_recircle_port(self, ptfadapter, setup, mirror_sessi
                 valid_across_namespace=valid_across_namespace,
                 erspan_ip_ver=erspan_ip_ver
             )
+            total_pkts_sent = { k: total_pkts_sent.get(k, 0) + num_pkts_sent.get(k, 0)
+                                for k in total_pkts_sent.keys() | num_pkts_sent.keys() }
 
+        if duthost.is_multi_asic:
+            expected_pkts = total_pkts_sent[(duthost, asic_ns)]
+        else:
+            # Handle asic as both None or '' on single-asic
+            expected_pkts = total_pkts_sent.get((duthost, None), 0) + total_pkts_sent.get((duthost, ''), 0)
         # Assert the specific asic recircle port's queue
         # Make sure mirrored packets are sent via specific queue configured
         for q in range(1, 8):
             if str(q) == queue:
-                assert wait_until(30, 1, 0, check_queue_counters, duthost, asic_ns, recircle_port, q, pkts_sent), \
+                assert wait_until(30, 1, 0, check_queue_counters, duthost, asic_ns, recircle_port, q, expected_pkts), \
                     "Recircle port {} queue{} counter value is not same as packets sent".format(recircle_port, q)
             else:
                 assert (get_queue_counters(duthost, asic_ns, recircle_port, q) == 0)
@@ -1329,17 +1336,22 @@ class BaseEverflowTest(object):
 
         if 't2' in setup['topo'] and 'lt2' not in setup['topo'] and 'ft2' not in setup['topo']:
             src_port_set.add(src_port)
-            src_port_metadata_map[src_port] = (None, 1)
+            src_port_metadata_map[src_port] = (None, 1, setup[direction]['everflow_dut'],
+                                               setup[direction]['everflow_namespace'])
             if valid_across_namespace is True:
                 # Add the dest_port to src_port_set only in non MACSEC testbed scenarios
                 if not MACSEC_INFO:
                     if duthost.facts['switch_type'] == "voq":
                         if self.mirror_type() != "egress":  # no egress route on the other node/namespace
                             src_port_set.add(dest_ports[0])
-                            src_port_metadata_map[dest_ports[0]] = (setup[direction]["egress_router_mac"], 1)
+                            src_port_metadata_map[dest_ports[0]] = (setup[direction]["egress_router_mac"], 1,
+                                                                    setup[direction]['remote_dut'],
+                                                                    setup[direction]['remote_namespace'])
                     else:
                         src_port_set.add(dest_ports[0])
-                        src_port_metadata_map[dest_ports[0]] = (setup[direction]["egress_router_mac"], 0)
+                        src_port_metadata_map[dest_ports[0]] = (setup[direction]["egress_router_mac"], 0,
+                                                                setup[direction]['remote_dut'],
+                                                                setup[direction]['remote_namespace'])
 
         else:
             src_port_namespace = setup[direction]["everflow_namespace"]
@@ -1347,15 +1359,15 @@ class BaseEverflowTest(object):
 
             if valid_across_namespace is True or src_port_namespace == dest_ports_namespace:
                 src_port_set.add(src_port)
-                src_port_metadata_map[src_port] = (None, 0)
+                src_port_metadata_map[src_port] = (None, 0, setup[direction]['everflow_dut'], src_port_namespace)
 
             # To verify same namespace mirroring we will add destination port also to the Source Port Set
             if src_port_namespace != dest_ports_namespace:
                 src_port_set.add(dest_ports[0])
-                src_port_metadata_map[dest_ports[0]] = (None, 2)
+                src_port_metadata_map[dest_ports[0]] = (None, 2, setup[direction]['remote_dut'], dest_ports_namespace)
 
         # Loop through Source Port Set and send traffic on each source port of the set
-        num_pkts_sent = 0
+        num_pkts_sent = {}
         for src_port in src_port_set:
             expected_mirror_packet = BaseEverflowTest.get_expected_mirror_packet(mirror_session,
                                                                                  setup,
@@ -1370,7 +1382,8 @@ class BaseEverflowTest(object):
             if src_port_metadata_map[src_port][0]:
                 mirror_packet_sent[packet.Ether].dst = src_port_metadata_map[src_port][0]
             ptfadapter.dataplane.flush()
-            num_pkts_sent += 1
+            src_port_dut_namespace = ( src_port_metadata_map[src_port][2], src_port_metadata_map[src_port][3] )
+            num_pkts_sent[src_port_dut_namespace] = num_pkts_sent.get(src_port_dut_namespace, 0) + 1
             testutils.send(ptfadapter, src_port, mirror_packet_sent)
 
             if expect_recv:

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -760,8 +760,8 @@ def verify_mirror_packets_on_recircle_port(self, ptfadapter, setup, mirror_sessi
                 valid_across_namespace=valid_across_namespace,
                 erspan_ip_ver=erspan_ip_ver
             )
-            total_pkts_sent = { k: total_pkts_sent.get(k, 0) + num_pkts_sent.get(k, 0)
-                                for k in total_pkts_sent.keys() | num_pkts_sent.keys() }
+            total_pkts_sent = {k: total_pkts_sent.get(k, 0) + num_pkts_sent.get(k, 0)
+                               for k in total_pkts_sent.keys() | num_pkts_sent.keys()}
 
         if duthost.is_multi_asic:
             expected_pkts = total_pkts_sent[(duthost, asic_ns)]
@@ -1382,7 +1382,7 @@ class BaseEverflowTest(object):
             if src_port_metadata_map[src_port][0]:
                 mirror_packet_sent[packet.Ether].dst = src_port_metadata_map[src_port][0]
             ptfadapter.dataplane.flush()
-            src_port_dut_namespace = ( src_port_metadata_map[src_port][2], src_port_metadata_map[src_port][3] )
+            src_port_dut_namespace = (src_port_metadata_map[src_port][2], src_port_metadata_map[src_port][3])
             num_pkts_sent[src_port_dut_namespace] = num_pkts_sent.get(src_port_dut_namespace, 0) + 1
             testutils.send(ptfadapter, src_port, mirror_packet_sent)
 


### PR DESCRIPTION
### Description of PR

In https://github.com/sonic-net/sonic-mgmt/pull/21942 we fixed `test_everflow_fwd_recircle_port_queue_check` to return the total number of packets sent by `send_and_check_mirror_packets` and use that value as the expected number of packets seen on the `Ethernet-Rec` interface.

The problem is on multi-asic skus `send_and_check_mirror_packets` might use 2 src_ports, one on ASIC0 and the other on ASIC1. This results in half the packets utilizing `Ethernet-Rec0` and the other half using `Ethernet-Rec1`.

This change will update the return value of `send_and_check_mirror_packets` to be a dictionary instead of an integer.
The dictionary will be key'd on `(dut, asic)` and the value will be the number of packets sent.
With this return value `test_everflow_fwd_recircle_port_queue_check` can just look at how many packets were sent on the `(dut, asic)` belonging to the `Ethernet-Rec` port we're checking.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fix `test_everflow_fwd_recircle_port_queue_check` for multi-asic SKUs

#### How did you do it?
Track packets per `(dut, asic)` to only assert on the packets sent on our `Ethernet-Rec`'s `(dut, asic)`

#### How did you verify/test it?
Ran `test_everflow_fwd_recircle_port_queue_check` on the following SKUs:
single-asic fixedsystem
multi-asic fixedsystem
single-asic chassis
multi-asic chassis

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
