### PR TITLE
refactor: extract syslog drain wait into common utility (follow-up to #23291)

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1749,3 +1749,49 @@ def group_interfaces_by_asic(duthost, interfaces: list) -> dict:
         namespace = duthost.get_port_asic_instance(interface).get_asic_namespace()
         asic_interface_map["-n {}".format(namespace)].append(interface)
     return dict(asic_interface_map)
+
+
+def wait_for_syslog_stable(duthost, interval=10, stable_count=2, max_iterations=30):
+    """Wait for /var/log/syslog to stop growing, indicating rsyslogd has drained its buffer.
+
+    Under heavy syslog load (e.g. after config_reload with CPU stress), rsyslogd may
+    have a large backlog in its socket buffer.  This function polls the syslog file size
+    and waits until it remains unchanged for ``stable_count`` consecutive checks spaced
+    ``interval`` seconds apart.
+
+    This is useful before placing loganalyzer end markers to avoid marker loss caused
+    by rsyslogd buffer overflow.
+
+    Args:
+        duthost: DUT host object.
+        interval: Seconds between consecutive size checks (default 10).
+        stable_count: Number of consecutive unchanged checks required (default 2).
+        max_iterations: Maximum number of polling iterations (default 30).
+
+    Returns:
+        True if syslog stabilized within the limit, False otherwise.
+    """
+    import time
+    import logging
+
+    logger = logging.getLogger(__name__)
+    prev_size = None
+    unchanged = 0
+
+    for i in range(max_iterations):
+        result = duthost.shell("stat -c %s /var/log/syslog", module_ignore_errors=True)
+        curr_size = result.get('stdout', '').strip()
+
+        if curr_size == prev_size:
+            unchanged += 1
+            if unchanged >= stable_count:
+                logger.info("Syslog stable after %d checks (size=%s)", i + 1, curr_size)
+                return True
+        else:
+            unchanged = 0
+
+        prev_size = curr_size
+        time.sleep(interval)
+
+    logger.warning("Syslog did not stabilize after %d iterations", max_iterations)
+    return False

--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -1,10 +1,9 @@
-import time
 import pytest
 import logging
 
 from tests.common.fixtures.duthost_utils import stop_route_checker_on_duthost
 from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
-from tests.common.utilities import wait_until
+from tests.common.utilities import wait_until, wait_for_syslog_stable
 from tests.common import config_reload
 from tests.common.plugins.loganalyzer.loganalyzer import DisableLogrotateCronContext, LogAnalyzer
 
@@ -155,20 +154,8 @@ def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_host
                     # the marker.
                     duthost.shell("killall yes", module_ignore_errors=True)
                     # Wait for rsyslogd to drain the /dev/log socket buffer
-                    # backlog.  Under CPU stress, config_reload floods the socket
-                    # and the backlog can take minutes to drain even after the
-                    # stress ends.  Poll until /var/log/syslog stops growing
-                    # (stable for two consecutive 10-second intervals), meaning
-                    # rsyslogd has caught up and it is safe to place the end marker.
-                    prev_size = None
-                    for _ in range(30):
-                        result = duthost.shell("stat -c %s /var/log/syslog",
-                                               module_ignore_errors=True)
-                        curr_size = result.get('stdout', '').strip()
-                        if curr_size == prev_size:
-                            break
-                        prev_size = curr_size
-                        time.sleep(10)
+                    # backlog before loganalyzer places the end marker.
+                    wait_for_syslog_stable(duthost)
         # Cancel the watchdog so it doesn't fire during later tests
         if watchdog_pid:
             duthost.shell("kill {} 2>/dev/null || true".format(watchdog_pid), module_ignore_errors=True)


### PR DESCRIPTION
### Description of PR

Summary: Follow-up to PR #23291 per [reviewer feedback](https://github.com/sonic-net/sonic-mgmt/pull/23291#issuecomment-4133002498) from @yenlu-keith. Extracts the syslog drain wait logic into a common utility function `wait_for_syslog_stable()` in `tests/common/utilities.py` so other test cases with similar `config_reload` behavior can reuse it (e.g. PR #22776).

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The syslog stabilization polling logic in `test_po_cleanup.py` (from PR #23291) is useful for any test that performs `config_reload` under heavy syslog load. Per reviewer feedback, it should be a common utility.

#### How did you do it?
1. Added `wait_for_syslog_stable(duthost, interval=10, stable_count=2, max_iterations=30)` to `tests/common/utilities.py`
2. Replaced the inline polling loop in `test_po_cleanup.py` with a call to `wait_for_syslog_stable(duthost)`
3. Removed unused `import time` from `test_po_cleanup.py`

#### How did you verify/test it?
Python syntax validation passed.

#### Any platform specific information?
N/A

### Documentation
N/A

**Note:** This PR depends on PR #23291 being merged first (it builds on that branch).