### PR TITLE
Suppress CredScan false positives in spytest sample/test files

### DIFF
--- a/spytest/Doc/intro.md
+++ b/spytest/Doc/intro.md
@@ -200,6 +200,7 @@ testbed file content for this topology is given below.
             credentials: {username: admin, password: password, altpassword: YourPaSsWoRd}
             properties: {config: default, build: default, services: default, speed: default}
             breakout: {Ethernet0: 4x10, Ethernet8: 4x10}
+            # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Sample placeholder password")]
             rps: {model: Raritan, ip: 1.2.3.5, outlet: 10, username: admin, password: admin}
         DUT-02:
             device_type: sonic
@@ -207,6 +208,7 @@ testbed file content for this topology is given below.
             credentials: {username: admin, password: password, altpassword: YourPaSsWoRd}
             properties: {config: default, build: default, services: default, speed: default}
             breakout: {}
+            # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Sample placeholder password")]
             rps: {model: Raritan, ip: 1.2.3.5, outlet: 11, username: admin, password: admin}
         ixia-01:
             device_type: TGEN

--- a/spytest/apis/security/user.py
+++ b/spytest/apis/security/user.py
@@ -123,13 +123,13 @@ def config(dut, **kwargs):
     :param :no_form: 0[False] | 1[True]
 
     :Usage:
-    config(vars.D1, username='test', password='test123', role='operator', cli_type='kilsh')
-    config(vars.D1, username='test', cli_type='kilsh', no_form=True)
+    config(vars.D1, username='test', password='test123', role='operator', cli_type='kilsh')  # [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Sample placeholder password in docstring")]
+    config(vars.D1, username='test', cli_type='kilsh', no_form=True)  # [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Sample placeholder password in docstring")]
     config(vars.D1, username='test', password='test123', role='admin', cli_type='click', no_form=0)
     config(vars.D1, username='test', password_update='test1234', cli_type='click', no_form=0)
     config(vars.D1, group='admin_test', cli_type='click', no_form=0)
     config(vars.D1, group='admin_test', cli_type='click', no_form=1)
-    config(vars.D1, username='test', password='test123', role='admin', cli_type='click', no_form=1)
+    config(vars.D1, username='test', password='test123', role='admin', cli_type='click', no_form=1)  # [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Sample placeholder password in docstring")]
     """
     skip_error_check = kwargs.get("skip_error_check", False)
     cli_type = kwargs.get("cli_type", "")

--- a/spytest/apis/system/config_replace.py
+++ b/spytest/apis/system/config_replace.py
@@ -85,7 +85,7 @@ def copy_running_config_to_config_db_json(dut, src_path, **kwargs):
     :return:
     Example:
     copy_running_config_to_config_db_json(dut,"config://filename")
-    copy_running_config_to_config_db_json(dut,"ftp://userid:passwd@hostip/filepath")
+    copy_running_config_to_config_db_json(dut,"ftp://userid:passwd@hostip/filepath")  # [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Sample placeholder password in docstring")]
     copy_running_config_to_config_db_json(dut,"home://filename")
     copy_running_config_to_config_db_json(dut,"http://hostip/filepath")
     copy_running_config_to_config_db_json(dut,"scp://userid:passwd@hostip/filepath")

--- a/spytest/spytest/net.py
+++ b/spytest/spytest/net.py
@@ -5185,6 +5185,7 @@ class Net(object):
 
         for _ in range(0, 3):
             delay_factor = 3  # so that --faster-cli is not used
+            # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a password, regex pattern matching password prompt")]
             prompt_terminator = r"Enter new UNIX password:\s*$|New password:\s*$|{}\s*$".format(cli_prompt)
             output = self._send_command(access, "sudo passwd {}".format(username), prompt_terminator,
                                         delay_factor=delay_factor, use_cache=False)

--- a/spytest/spytest/tgen/scapy/unit_test.py
+++ b/spytest/spytest/tgen/scapy/unit_test.py
@@ -417,9 +417,9 @@ def test_dot1x(ipaddr, port=8009):
     tg = TGScapyTest(ipaddr, port, ["1/1", "1/2"], False)
     tg_ph_1 = list(tg.tg_port_handle.values())[0]
     res1 = tg.tg_emulation_dot1x_config(username='userp11', eap_auth_method='md5', local_ip_addr='192.168.1.10', port_handle=tg_ph_1,
-                                        mode='create', gateway_ip_addr='192.168.1.1', ip_version='ipv4', encapsulation='ethernet_ii', password='userp11', mac_addr='00:00:00:A1:A1:A1')
+                                        mode='create', gateway_ip_addr='192.168.1.1', ip_version='ipv4', encapsulation='ethernet_ii', password='userp11', mac_addr='00:00:00:A1:A1:A1')  # [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Test placeholder password")]
     res2 = tg.tg_emulation_dot1x_config(username='userp12', eap_auth_method='md5', local_ip_addr='192.168.2.10', port_handle=tg_ph_1,
-                                        mode='create', gateway_ip_addr='192.168.2.1', ip_version='ipv4', encapsulation='ethernet_ii', password='userp12', mac_addr='00:00:00:A2:A2:A2')
+                                        mode='create', gateway_ip_addr='192.168.2.1', ip_version='ipv4', encapsulation='ethernet_ii', password='userp12', mac_addr='00:00:00:A2:A2:A2')  # [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Test placeholder password")]
     tg.tg_emulation_dot1x_control(handle=res1["handle"], mode="start")
     tg.tg_emulation_dot1x_control(handle=res2["handle"], mode="start")
     time.sleep(10)

--- a/spytest/testbeds/sample_sonic_2d_tgen.yaml
+++ b/spytest/testbeds/sample_sonic_2d_tgen.yaml
@@ -16,12 +16,14 @@ devices:
     s6100-01:
         device_type: DevSonic
         access: {protocol: telnet, ip: 1.2.3.4, port: 2000}
+        # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Sample placeholder password")]
         rps: {model: Raritan, ip: 2.3.4.5, outlet: 10, username: admin, password: admin}
         credentials: {username: admin, password: YourPaSsWoRd, altpassword: company}
         properties: {config: default, build: default, services: default, params: def_dut, speed: default}
     s6100-02:
         device_type: DevSonic
         access: {protocol: telnet, ip: 1.2.3.4, port: 2001}
+        # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Sample placeholder password")]
         rps: {model: Raritan, ip: 2.3.4.5, outlet: 11, username: admin, password: admin}
         credentials: {username: admin, password: YourPaSsWoRd, altpassword: company}
         properties: {config: default, build: default, services: default, params: def_dut, speed: default}

--- a/spytest/testbeds/sample_sonic_ssh_1d.yaml
+++ b/spytest/testbeds/sample_sonic_ssh_1d.yaml
@@ -16,18 +16,21 @@ devices:
     s6100-01:
         device_type: DevSonic
         access: {protocol: ssh, ip: 1.2.3.4, port: 22}
+        # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Sample placeholder password")]
         rps: {model: None, ip: 2.3.4.5, outlet: 10, username: admin, password: admin}
         credentials: {username: admin, password: YourPaSsWoRd, altpassword: company}
         properties: {config: default, build: default, services: default, params: def_dut, speed: default}
     s6100-02:
         device_type: DevSonic
         access: {protocol: telnet, ip: 1.2.3.4, port: 2001}
+        # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Sample placeholder password")]
         rps: {model: Raritan, ip: 2.3.4.5, outlet: 11, username: admin, password: admin}
         credentials: {username: admin, password: YourPaSsWoRd, altpassword: company}
         properties: {config: default, build: default, services: default, params: def_dut, speed: default}
     s6100-03:
         device_type: DevSonic
         access: {protocol: telnet, ip: 1.2.3.4, port: 2002}
+        # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Sample placeholder password")]
         rps: {model: Avocent, ip: 2.3.4.5, outlet: 12, username: admin, password: admin}
         credentials: {username: admin, password: YourPaSsWoRd, altpassword: company}
         properties: {config: default, build: default, services: default, params: def_dut, speed: default}

--- a/spytest/testbeds/sample_sonic_terminal_3d.yaml
+++ b/spytest/testbeds/sample_sonic_terminal_3d.yaml
@@ -16,19 +16,25 @@ devices:
     s6100-01:
         device_type: DevSonic
         access: {protocol: telnet, ip: 1.2.3.4, port: 2000}
+        # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Sample placeholder password")]
         rps: {model: Raritan, ip: 2.3.4.5, outlet: 10, username: admin, password: admin}
+        # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Sample placeholder password")]
         credentials: {username: admin, password: YourPaSsWoRd, altpassword: company}
         properties: {config: default, build: default, services: default, params: def_dut, speed: default}
     s6100-02:
         device_type: DevSonic
         access: {protocol: telnet, ip: 1.2.3.4, port: 2001}
+        # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Sample placeholder password")]
         rps: {model: Raritan, ip: 2.3.4.5, outlet: 11, username: admin, password: admin}
+        # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Sample placeholder password")]
         credentials: {username: admin, password: YourPaSsWoRd, altpassword: company}
         properties: {config: default, build: default, services: default, params: def_dut, speed: default}
     s6100-03:
         device_type: DevSonic
         access: {protocol: telnet, ip: 1.2.3.4, port: 2002}
+        # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Sample placeholder password")]
         rps: {model: Raritan, ip: 2.3.4.5, outlet: 12, username: admin, password: admin}
+        # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Sample placeholder password")]
         credentials: {username: admin, password: YourPaSsWoRd, altpassword: company}
         properties: {config: default, build: default, services: default, params: def_dut, speed: default}
     ixia-01:

--- a/spytest/tests/routing/BGP/bgplib.py
+++ b/spytest/tests/routing/BGP/bgplib.py
@@ -29,7 +29,7 @@ static_rt_info = SpyTestDict()
 fixed_nw_info = SpyTestDict()
 tg_connected_routers = []
 as_info = SpyTestDict()
-bgp_password = 'Test_127'
+bgp_password = 'Test_127'  # [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Test placeholder password")]
 underlay_info = SpyTestDict()
 
 


### PR DESCRIPTION
### Description of PR
Suppress CredScan false positives for sample placeholder passwords and test credentials in spytest files.

Files changed:
- `spytest/testbeds/sample_sonic_terminal_3d.yaml` - sample RPS/credentials passwords
- `spytest/testbeds/sample_sonic_2d_tgen.yaml` - sample RPS passwords
- `spytest/testbeds/sample_sonic_ssh_1d.yaml` - sample RPS passwords
- `spytest/Doc/intro.md` - sample RPS passwords in documentation
- `spytest/apis/security/user.py` - test credentials in docstring examples
- `spytest/apis/system/config_replace.py` - sample FTP password in docstring
- `spytest/spytest/tgen/scapy/unit_test.py` - test dot1x passwords
- `spytest/spytest/net.py` - regex pattern matching password prompt (not a real password)
- `spytest/tests/routing/BGP/bgplib.py` - test BGP password

All flagged values are sample/test placeholder passwords, not real credentials.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(Scripts) change

### Back port request
- [ ] N/A

### Approach
#### What is the motivation for this PR?
CredScan flags these sample/test placeholder passwords as credential findings. Adding SuppressMessage comments to mark them as acknowledged false positives.

#### How did you do it?
Added `[SuppressMessage]` comments (inline or on preceding line) with appropriate justification on the flagged lines.

#### How did you verify/test it?
Ran CredScan locally and verified the findings are suppressed after adding the comments.