### PR TITLE
Suppress CredScan false positives in tests and ansible files

### DIFF
--- a/ansible/roles/vm_set/tasks/start_8000e_sonic.yml
+++ b/ansible/roles/vm_set/tasks/start_8000e_sonic.yml
@@ -36,6 +36,7 @@
        CISCO_NPSUITE_VER: "{{ hostvars[dut_name]['cisco_npsuite_ver'] | default(omit) }}"
        MGMT_GATEWAY: "{{ mgmt_gw }}"
        SONIC_LOGIN: "cisco"
+       # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Test placeholder password")]
        SONIC_PASSWORD: "cisco123"
        # 8000e device requires eth4 interface to be configured for for proper device operation (simulation artifact).
        # Disable route check to prevent eth4 route check error ("missed_ROUTE_TABLE_routes": [ "192.168.123.0/24"])

--- a/tests/bgp/test_passive_peering.py
+++ b/tests/bgp/test_passive_peering.py
@@ -19,6 +19,7 @@ pytestmark = [
 
 BGP_WAIT_TIMEOUT = 90
 BGP_WAIT_INTERVAL = 10
+# [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Test placeholder password")]
 peer_password = "sonic.123"
 wrong_password = "wrong-password"
 EOS_BACKUP_CONFIG_FILE = "/tmp/eos_neighbor_test_passive_peering_backup_config_{}"


### PR DESCRIPTION
### Description of PR
Suppress CredScan false positives for test placeholder passwords in tests and ansible files.

Files changed:
- `ansible/roles/vm_set/tasks/start_8000e_sonic.yml` - SONIC_PASSWORD for 8000e simulation (`cisco123`)
- `tests/bgp/test_passive_peering.py` - peer_password for BGP passive peering test (`sonic.123`)

All flagged values are test placeholder passwords used in simulation/test environments, not real credentials.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(Scripts) change

### Back port request
- [ ] N/A

### Approach
#### What is the motivation for this PR?
CredScan flags these test placeholder passwords as credential findings. Adding SuppressMessage comments to mark them as acknowledged false positives.

#### How did you do it?
Added inline `[SuppressMessage]` comments with appropriate justification on the flagged lines.

#### How did you verify/test it?
Ran CredScan locally and verified the findings are suppressed after adding the comments.