### PR TITLE
Revert "Ignore pmon DomInfoUpdateTask VDM basic real values error in loganalyzer (#22905)"

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -430,8 +430,6 @@ r, ".*ERR pmon.*Failed to freeze VDM stats in contextmanager for port.*"
 r, ".*ERR pmon.*Failed to freeze VDM stats for port.*"
 r, ".*ERR pmon.*Failed to confirm VDM unfreeze status for port.*"
 r, ".*ERR pmon.*Failed to unfreeze VDM stats in contextmanager for port.*"
-# https://github.com/aristanetworks/sonic-qual.msft/issues/1156
-r, ".*ERR pmon#DomInfoUpdateTask.*Failed to get VDM basic real values for port.*"
 
 # Ignore PIE port error log on set pfc mode
 r, ".* ERR syncd#syncd: :- sendApiResponse: api SAI_COMMON_API_SET failed in syncd mode: SAI_STATUS_NOT_SUPPORTED.*"


### PR DESCRIPTION
### Description of PR
Summary:
Revert the loganalyzer ignore added by #22905 because the image-side fix is now available in sonic-net/sonic-platform-common#624.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
PR #22905 added a LogAnalyzer ignore for `ERR pmon#DomInfoUpdateTask.*Failed to get VDM basic real values for port.*` as a temporary workaround. Since the underlying image-side issue is fixed by sonic-net/sonic-platform-common#624, the ignore is no longer needed and should be removed.

#### How did you do it?
Reverted the change from #22905 that added the ignore entry in `ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt`.

#### How did you verify/test it?
Verified the revert cleanly removes the ignore entry from `ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt`.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
N/A.

### Documentation
Not needed.