### PR TITLE
[deploy-mg] Add BMC topology support

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -148,6 +148,11 @@
         topo: "{{ testbed_facts['topo'] }}"
       tags: always
 
+    - name: set BMC mode flag
+      set_fact:
+        is_bmc_topo: "{{ 'bmc' in topo }}"
+      tags: always
+
     - name: set lit mode
       set_fact:
         is_lit_mode: "{{ testbed_facts.get('is_lit_mode', topo in ['t1-smartswitch-ha', 't1-28-lag', 'smartswitch-t1', 't1-48-lag']) }}"
@@ -234,7 +239,7 @@
       switchids: "{{ switchids | default([]) }}"
       num_asic: "{{ num_asics }}"
       sort_by_index: "{{ sort_by_index | default(true) }}"
-    when: deploy is defined and deploy|bool == true
+    when: deploy is defined and deploy|bool == true and not (is_bmc_topo | bool)
 
   - name: find interface name mapping and individual interface speed if defined with local data
     port_alias:
@@ -246,7 +251,7 @@
       slotid: "{{ slot_num | default(None) }}"
       sort_by_index: "{{ sort_by_index | default(true) }}"
     delegate_to: localhost
-    when: deploy is not defined or deploy|bool == false
+    when: (deploy is not defined or deploy|bool == false) and not (is_bmc_topo | bool)
 
   - name: find and generate fabric ASIC information
     fabric_info:
@@ -388,13 +393,13 @@
     set_fact:
       interface_to_vms: "{{ interface_to_vms|default([]) + [ {'name': item.key, 'ports': item.value['interface_indexes'][dut_index|int] }] }}"
     with_dict: "{{ vm_topo_config['vm'] }}"
-    when: "'cable' not in topo"
+    when: "'cable' not in topo and not (is_bmc_topo | bool)"
 
   - name: find all interface indexes connecting to VM
     set_fact:
       ifindex_to_vms: "{{ ifindex_to_vms|default([]) + item.value['interface_indexes'][dut_index|int] }}"
     with_dict: "{{ vm_topo_config['vm'] }}"
-    when: "'cable' not in topo"
+    when: "'cable' not in topo and not (is_bmc_topo | bool)"
 
   - name: find all interface names
     set_fact:
@@ -402,7 +407,7 @@
     with_subelements:
       - "{{ interface_to_vms | default([]) }}"
       - "ports"
-    when: "'cable' not in topo"
+    when: "'cable' not in topo and not (is_bmc_topo | bool)"
 
   # create map of VM to asic interface names
   - name: find all interface asic names

--- a/ansible/library/topo_facts.py
+++ b/ansible/library/topo_facts.py
@@ -332,6 +332,12 @@ class ParseTestbedTopoinfo():
             elif 't0' in topo_name:
                 vm_topo_config['dut_type'] = "BackEndToRRouter"
 
+        # Fallback: read dut_type from configuration_properties when no VMs (e.g., BMC topo)
+        if 'dut_type' not in vm_topo_config and 'configuration_properties' in topo_definition:
+            common = topo_definition['configuration_properties'].get('common', {})
+            if 'dut_type' in common:
+                vm_topo_config['dut_type'] = common['dut_type']
+
         for slot, asic_definition in slot_definition.items():
             asic_topo_config[slot] = dict()
             for asic in asic_definition:

--- a/ansible/templates/minigraph_cpg.j2
+++ b/ansible/templates/minigraph_cpg.j2
@@ -154,7 +154,7 @@
 {% endif %}
     </PeeringSessions>
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-{% if ((card_type is not defined or card_type != 'supervisor') and vm_topo_config['topo_type'] != 'wan') %}
+{% if ((card_type is not defined or card_type != 'supervisor') and vm_topo_config['topo_type'] != 'wan') and 'dut_asn' in vm_topo_config %}
       <a:BGPRouterDeclaration>
         <a:ASN>{{ vm_topo_config['dut_asn'] }}</a:ASN>
         <a:Hostname>{{ inventory_hostname }}</a:Hostname>

--- a/ansible/templates/minigraph_device.j2
+++ b/ansible/templates/minigraph_device.j2
@@ -2,6 +2,7 @@
     <DeviceInfo>
       <EthernetInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
 {% if switch_type is not defined or switch_type != 'fabric' %}
+{% if port_alias is defined and port_alias | length > 0 %}
 {% set num_of_intf = port_alias | length %}
 {% for index in range(num_of_intf) %}
         <a:EthernetInterface>
@@ -33,6 +34,7 @@
 {% endif %}
         </a:EthernetInterface>
 {% endfor %}
+{% endif %}
 {% endif %}
       </EthernetInterfaces>
 {% if switch_type is defined and switch_type == 'voq' %}

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -1,6 +1,7 @@
   <DpgDec>
     <DeviceDataPlaneInfo>
       <IPSecTunnels/>
+{% if not (is_bmc_topo | bool) %}
       <LoopbackIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
 {% if card_type is not defined or card_type != 'supervisor' %}
         <a:LoopbackIPInterface>
@@ -62,6 +63,9 @@
       {%- endif -%}
 {% endif %}
 </LoopbackIPInterfaces>
+{% else %}
+      <LoopbackIPInterfaces i:nil="true" />
+{% endif %}
       <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
 {% if use_ipv6_mgmt is not defined or not use_ipv6_mgmt|bool %}
         <a:ManagementIPInterface>
@@ -292,7 +296,7 @@
           <InAcl>ssh-only</InAcl>
           <Type>SSH</Type>
         </AclInterface>
-{% if card_type is not defined or card_type != 'supervisor' %}
+{% if (card_type is not defined or card_type != 'supervisor') and not (is_bmc_topo | bool) %}
         <AclInterface>
           <AttachTo>ERSPAN</AttachTo>
           <InAcl>Everflow</InAcl>

--- a/ansible/templates/minigraph_meta.j2
+++ b/ansible/templates/minigraph_meta.j2
@@ -6,7 +6,7 @@
 {% set snmp_servers_str = ';'.join(snmp_servers) %}
 {% set tacacs_servers_str = ';'.join(tacacs_servers) %}
 {% set radius_servers_str = ';'.join(radius_servers) %}
-{% set erspan_dest_str = ';'.join(erspan_dest) %}
+{% set erspan_dest_str = ';'.join(erspan_dest | default([])) %}
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
         <a:Name>{{ inventory_hostname }}</a:Name>
@@ -21,11 +21,13 @@
             <a:Reference i:nil="true"/>
             <a:Value>Public</a:Value>
           </a:DeviceProperty>
+{% if not (is_bmc_topo | bool) %}
           <a:DeviceProperty>
             <a:Name>QosProfile</a:Name>
             <a:Reference i:nil="true"/>
             <a:Value>Profile0</a:Value>
           </a:DeviceProperty>
+{% endif %}
 {% if sonic_qos_profile is defined and sonic_qos_profile != "DEFAULT" %}
           <a:DeviceProperty>
             <a:Name>SonicQosProfile</a:Name>
@@ -86,7 +88,7 @@
             <a:Value>ComputeAI</a:Value>
           </a:DeviceProperty>
 {% endif %}
-{% if dhcp_servers %}
+{% if dhcp_servers and not (is_bmc_topo | bool) %}
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>
             <a:Reference i:nil="true"/>
@@ -121,7 +123,7 @@
             <a:Value>{{ syslog_servers_str }}</a:Value>
           </a:DeviceProperty>
 {% endif %}
-{% if tacacs_group %}
+{% if tacacs_group is defined and tacacs_group %}
           <a:DeviceProperty>
             <a:Name>TacacsGroup</a:Name>
             <a:Reference i:nil="true"/>
@@ -142,7 +144,7 @@
             <a:Value>{{ forced_mgmt_routes_str }}</a:Value>
           </a:DeviceProperty>
 {% endif %}
-{% if erspan_dest %}
+{% if erspan_dest is defined and erspan_dest %}
           <a:DeviceProperty>
             <a:Name>ErspanDestinationIpv4</a:Name>
             <a:Reference i:nil="true"/>

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -100,6 +100,7 @@
 {% endfor %}
 {% endfor %}
 {% endif %}
+{% if front_panel_asic_ifnames is defined and front_panel_asic_ifnames | length > 0 %}
 {% for if_index in range(front_panel_asic_ifnames | length) %}
       <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
@@ -121,6 +122,7 @@
         <Validate>true</Validate>
       </DeviceLinkBase>
 {% endfor %}
+{% endif %}
 {% endif %}
     </DeviceInterfaceLinks>
     <Devices>

--- a/ansible/templates/minigraph_template.j2
+++ b/ansible/templates/minigraph_template.j2
@@ -1,15 +1,15 @@
 <DeviceMiniGraph xmlns="Microsoft.Search.Autopilot.Evolution" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
-{% if 'cable' not in topo %}
+{% if 'cable' not in topo and 'vm' in vm_topo_config %}
 {% set vms=vm_topo_config['vm'].keys() | sort %}
 {% endif %}
-{% if 'cable' in topo %}
+{% if 'cable' in topo or vms is not defined %}
 {% set vms_number = 0 %}
 {% set enable_data_plane_acl = false %}
 {% set neighbor_eosvm_mgmt = {} %}
 {% else %}
 {% set vms_number = vms | length %}
 {% endif %}
-{% if 'loopback' in vm_topo_config['DUT'] %}
+{% if not (is_bmc_topo | bool) and 'loopback' in vm_topo_config['DUT'] %}
 {% if card_type is not defined or card_type != 'supervisor' %}
 {% set lp_ipv4 = vm_topo_config['DUT']['loopback']['ipv4'][dut_index|int] %}
 {% set lp_ipv4_addr = lp_ipv4.split('/')[0] %}
@@ -18,7 +18,7 @@
 {% set lp_ipv6 = vm_topo_config['DUT']['loopback']['ipv6'][dut_index|int] %}
 {% set lp_ipv6_addr = lp_ipv6.split('/')[0] %}
 {% endif %}
-{% else %}
+{% elif not (is_bmc_topo | bool) %}
 {% set lp_ipv4 = '10.1.0.32/32' %}
 {% set lp_ipv4_addr = '10.1.0.32' %}
 {% set lp_ipv6 = 'FC00:1::32/128' %}


### PR DESCRIPTION
### Description of PR

Summary: Add BMC (Baseboard Management Controller) topology support to the deploy-mg playbook and minigraph templates, enabling `config_sonic_basedon_testbed.yml` to work with port-less BMC devices.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
BMC devices run SONiC but have no data ports, no VMs, no BGP, no syncd/swss. The existing deploy-mg playbook and minigraph templates assume all devices have ports and VM topology, causing failures when deploying to BMC.

#### How did you do it?
- Added `is_bmc_topo` flag to detect BMC topologies (`bmc-dual-mgmt`)
- Skipped `port_alias` and VM-interface mapping tasks for BMC (no ports/VMs to map)
- Modified `topo_facts.py` to read `dut_type` from `configuration_properties` for topos without VMs (sets `NetworkBmc`)
- Modified minigraph templates to handle empty port/VM data:
  - `minigraph_template.j2`: skip loopback variable setup for BMC
  - `minigraph_dpg.j2`: emit nil `LoopbackIPInterfaces`, skip Everflow ACL for BMC
  - `minigraph_cpg.j2`: guard BGP router block
  - `minigraph_png.j2`: guard front-panel port links
  - `minigraph_device.j2`: guard port iteration
  - `minigraph_meta.j2`: skip QosProfile/DhcpResources, guard undefined `erspan_dest`

#### How did you verify/test it?
- Tested deploy-mg on a BMC board
- Verified: minigraph.xml generated and loaded, hostname set correctly, all containers running, config_db.json saved, DEVICE_METADATA type = NetworkBmc

#### Any platform specific information?
Tested on physical BMC

#### Supported testbed topology if it's a new test case?
N/A - this is a framework improvement for `bmc-dual-mgmt` topology.

### Documentation
N/A