### PR TITLE
Upload a topo file designed for OCS testing

### DIFF
--- a/ansible/testbed_ocs.yaml
+++ b/ansible/testbed_ocs.yaml
@@ -1,0 +1,16 @@
+---
+
+- conf-name: single-dut-ocs-testbed-demo
+  group-name: ptf_2
+  topo: ocs
+  ptf_image_name: docker-ptf
+  ptf: ptf_2
+  ptf_ip: 10.250.0.189/24
+  ptf_ipv6: 2001:db8:1::189
+  mgmt_gw: 10.250.0.1
+  server: vm_host
+  dut:
+    - mgmt141
+  inv_name: ocs
+  vm_type: vsonic
+  comment: used to test ocs device


### PR DESCRIPTION
## Summary
Add a new topology configuration file `topo_ocs.yml` for OCS (Open Compute System) testing.

## Description
This topology configuration file defines the host interfaces available for OCS device testing:

- **Host Interfaces**: 0-63 (64 interfaces total)

This configuration can be used with the SONiC testbed deployment to set up OCS test environments.

## Files Added
- `ansible/vars/topo_ocs.yml`