### PR TITLE
Tag the Set default dut index step to always run to cover the separate DPU minigraph case

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -142,6 +142,7 @@
     - name: Set default dut index
       set_fact:
         dut_index: "{{ testbed_facts['duts_map'][inventory_hostname]|int }}"
+      tags: always
 
     - name: set testbed_type
       set_fact:


### PR DESCRIPTION
### Description of PR
A fix for the case of the HA or multi DUT setup when DPUs are configured in a separate minigraph run.
A follow-up on the https://github.com/sonic-net/sonic-mgmt/pull/22142

Summary:
Fixes the situation when the DPUs on the DUTs with index > 0 are not configured correctly



### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
Fix the HA deployment

#### How did you do it?
Tag the "Set default dut index step" to make sure it runs when the DPUs are configured

#### How did you verify/test it?
Deployment on HA testbed, manual check for the DPU configuration applied.

#### Any platform specific information?
Smartswitch/DPU

#### Supported testbed topology if it's a new test case?
HA

### Documentation
