### PR TITLE
Revert "[vxlan] Mark test_vxlan_ecmp as xfail on VPP platform"

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5774,10 +5774,6 @@ vxlan/test_vxlan_ecmp.py:
     reason: "VxLAN ECMP test is not yet supported on multi-ASIC platform. Also this test can only run on some platforms."
     conditions:
       - "(is_multi_asic == True) or (platform not in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn2700-r0', 'x86_64-mlnx_msn2700a1-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn4280-r0', 'x86_64-8102_28fh_dpu_o-r0'])"
-  xfail:
-    reason: "xfail due to consistent VPP failures https://github.com/sonic-net/sonic-mgmt/issues/22659"
-    conditions:
-      - "asic_type == 'vpp'"
 
 vxlan/test_vxlan_ecmp_switchover.py:
   skip:


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#22966
The issue has been fixed by PR https://github.com/sonic-net/sonic-mgmt/pull/22644. Here is the latest nightly run to prove that: https://dev.azure.com/mssonic/build/_build/results?buildId=1077180&view=results