### PR TITLE
Use get method for PORTCHANNEL keys access in Dynamic ACL GCU Test

### DIFF
--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -1442,7 +1442,7 @@ def test_gcu_acl_dualtor_standby_drop_takes_priority_across_tables(rand_selected
 
     if not setup["is_dualtor"]:
         pytest.skip("Test only valid for active-standby dual ToR setups, skipping on non dual ToR device.")
-    if "dualtor-aa" in setup["topo"]:
+    if "dualtor-aa" in tbinfo["topo"]["name"]:
         pytest.skip("Test not valid for dualtor active-active setups, skipping on dualtor active-active device.")
 
     itfs, _ = rand_selected_interface

--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -225,7 +225,7 @@ def setup(rand_selected_dut, rand_unselected_dut, tbinfo, vlan_name, topo_scenar
 
     # Get the PTF portchannel ports connected to the T1 switchs.
     t1_pc_ports = {}
-    for pc in list(config_facts['PORTCHANNEL'].keys()):
+    for pc in list(config_facts.get('PORTCHANNEL', {}).keys()):
         t1_pc_ports[pc] = []
         for intf in config_facts["PORTCHANNEL"][pc]["members"]:
             ptf_port_index = mg_facts["minigraph_ptf_indices"][intf]


### PR DESCRIPTION
### Description of PR

Summary:

Safeguard against topologies that do not have portchannels.  This fixes bug #23546.


### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fixing bug #23546 
#### How did you do it?
Switched to a .get lookup that will just return an empty dict if the key is not found.  This is intended on these platforms as the only test that uses these values will be skipped anyways.
