### PR TITLE
Guard fanouthost.facts access in drop_packets tests (#22343)

### DIFF
--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -104,7 +104,7 @@ def fanouthost(duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts,
             fanout.restore_drop_counter_config()
 
     if fanout:
-        if fanout.facts["asic_type"] == "marvell-teralynx":
+        if hasattr(fanout, "facts") and fanout.facts.get("asic_type") == "marvell-teralynx":
             # Check and clean up existing REDIRECT_VLAN ACL table if present.
             check_output = fanout.shell("show acl table", module_ignore_errors=True)
             if "REDIRECT_VLAN" in check_output["stdout"]:
@@ -663,7 +663,7 @@ def test_equal_smac_dmac_drop(do_test, ptfadapter, setup, fanouthost,
     src_mac = ports_info["dst_mac"]
 
     # Marvell ASIC specific ACL rule injection
-    if fanouthost.facts["asic_type"] == "marvell-teralynx":
+    if hasattr(fanouthost, "facts") and fanouthost.facts.get("asic_type") == "marvell-teralynx":
         drop_counter_config(fanouthost)
 
     if fanouthost.os == 'onyx':
@@ -712,7 +712,7 @@ def test_multicast_smac_drop(do_test, ptfadapter, setup, fanouthost,
                    pkt_fields["ipv4_dst"], pkt_fields["ipv4_src"])
 
     # Marvell ASIC specific ACL rule injection
-    if fanouthost.facts["asic_type"] == "marvell-teralynx":
+    if hasattr(fanouthost, "facts") and fanouthost.facts.get("asic_type") == "marvell-teralynx":
         drop_counter_config(fanouthost)
 
     if fanouthost.os == 'onyx':

--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -361,7 +361,7 @@ def test_reserved_dmac_drop(do_test, ptfadapter, duthosts, enum_rand_one_per_hws
         pytest.skip("Test case requires explicit fanout support")
 
     # Marvell ASIC specific ACL rule injection
-    if fanouthost.facts["asic_type"] == "marvell-teralynx":
+    if hasattr(fanouthost, "facts") and fanouthost.facts.get("asic_type") == "marvell-teralynx":
         drop_counter_config(fanouthost)
 
     reserved_mac_addr = ["01:80:C2:00:00:05", "01:80:C2:00:00:08"]


### PR DESCRIPTION
### Description of PR
Guard `fanouthost.facts` access with `hasattr()` and `dict.get()` to prevent `AttributeError` when the fanout device does not expose a `facts` attribute (e.g., Mellanox Onyx fanout devices).

### Summary:
PR #22257 added Marvell-Teralynx-specific ACL rule injection that unconditionally accesses `fanouthost.facts["asic_type"]` in four locations. This raises `AttributeError` on fanout devices that lack the `facts` attribute.

**Fix:** All four call sites now use `hasattr(fanouthost, "facts") and fanouthost.facts.get("asic_type")` for safe access.

Fixes #22343

### Type of change
- [x] Bug fix

### Back port request
- [ ] 202411
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Tests `test_reserved_dmac_drop`, `test_equal_smac_dmac_drop`, `test_multicast_smac_drop`, and the `fanouthost` fixture teardown all crash with `AttributeError` when the fanout is an Onyx device without a `facts` attribute.

#### How did you do it?
Added `hasattr()` guards and `dict.get()` for safe key lookup at all four access sites.

#### How did you verify/test it?
Code review of all `fanouthost.facts` access paths in the changed files. The fix is a defensive guard that preserves existing behavior for Marvell-Teralynx fanouts while preventing crashes on other platforms.

---
> **Note:** This PR was generated with assistance from an AI agent and has been reviewed for correctness.
