### PR TITLE
[202511] Fix test_service_warm_restart dead loop in advanced-reboot (#10362)

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1656,6 +1656,11 @@ class ReloadTest(BaseTest):
 
         else:
             self.restart_service()
+            self.finalizer_state = "inactive"
+            if not self.kvm_test:
+                self.sniffer_started = threading.Event()
+                self.sniff_thr.start()
+                self.sender_thr.start()
             return
 
         if not self.kvm_test and\


### PR DESCRIPTION
### Description of PR

Summary:
Fixes #10362

test_service_warm_restart gets stuck in a dead loop and eventually times out. PR #8089 added a while loop in handle_advanced_reboot_health_check() that waits for sniff_thr and sender_thr to start. PR #8993 then moved the logic to start those threads inside reboot_dut(), but placed it after an early return in the service-warm-restart branch. So for service-warm-restart, the threads are never started and the while loop spins forever.

This only affects per-service container restart (service-warm-restart), not full system warm-reboot or fast-reboot.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

In reboot_dut(), when reboot_type is service-warm-restart, the function calls restart_service() and returns before reaching the code that starts sniff_thr and sender_thr. This causes the while loop in handle_advanced_reboot_health_check() to wait forever for threads that will never be alive.

There is also a second issue: the sender thread exits its loop only when finalizer_state == "inactive", but check_warmboot_finalizer (which sets that value) is only launched for warm-reboot/fast-reboot. Without handling this, starting the threads alone would just move the hang to sender_thr.join().

#### How did you do it?

In the service-warm-restart branch of reboot_dut(), before the early return:
- Set finalizer_state to "inactive" since there is no warmboot-finalizer service for container restarts
- Start sniff_thr and sender_thr (guarded by not self.kvm_test, same as the other reboot paths)

#### How did you verify/test it?

Code review tracing the full threading flow for service-warm-restart. Needs test_service_warm_restart run on a t0 testbed.

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?