### PR TITLE
Adding c0 support to common/helpers/constants.py

### DIFF
--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -53,8 +53,7 @@ DOWNSTREAM_NEIGHBOR_MAP = {
     "m0_vlan": "server",
     "m0_l3": "mx",
     "ft2": "lt2",
-    "lt2": "t1",
-    "c0": "c1"
+    "lt2": "t1"
 }
 
 # Describe downstream neighbor of dut in different topos
@@ -68,6 +67,5 @@ DOWNSTREAM_ALL_NEIGHBOR_MAP = {
     "m0_vlan": ["mx", "server"],
     "m0_l3": ["mx", "server"],
     "ft2": "lt2",
-    "lt2": "t1",
-    "c0": "c1"
+    "lt2": "t1"
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Adding c0 support in common/helpers/constants.py. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
To allow the scripts that use the constants.py to run for c0 topology.

#### How did you do it?
Added defined constants for the c0 topology.

#### How did you verify/test it?
Ran a set of tests(ip folder), and verified that they are not skipped anymore.

#### Supported testbed topology if it's a new test case?
C0