### PR TITLE
ignore superfluous sonic_yang logs on all DUTs

### DIFF
--- a/tests/generic_config_updater/test_multiasic_addcluster.py
+++ b/tests/generic_config_updater/test_multiasic_addcluster.py
@@ -78,6 +78,7 @@ LOGANALYZER_IGNORE_REGEX = [
     ".*Unable to find key NPU_SI_SETTINGS_SYNC_STATUS.*",
 ]
 
+
 @support_ignore_loganalyzer
 def apply_patch_with_log_ignore(duthost, json_data, dest_file):
     """Apply GCU patch with loganalyzer temporarily muted.


### PR DESCRIPTION
### Description of PR

Summary:
Add `sonic_yang` error pattern to loganalyzer ignore list for `test_multiasic_addcluster` test to prevent false test failures from expected transient YANG validation errors.

Fixes # N/A (test reliability improvement)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?

The `test_multiasic_addcluster` test was failing due to `sonic_yang` YANG validation errors being caught by the loganalyzer. These errors are **expected transient failures** that occur during GCU (Generic Config Updater) patch application.

When GCU applies JSON patches, it tries multiple orderings of patch operations to find one that passes YANG validation. During these intermediate attempts:
- PORT entries may temporarily be missing the required `lanes` field
- Tables like `PORT_QOS_MAP`, `QUEUE`, `BUFFER_PG` may reference ports that don't exist yet

Example errors:
```
ERR sonic_yang: Data Loading Failed:Missing required element "lanes" in "PORT_LIST"
ERR sonic_yang: Data Loading Failed:Invalid value "Ethernet0" in "ifname" element
ERR sonic_yang: Data Loading Failed:Leafref...points to a non-existing leaf
```

The `conftest.py` in `tests/generic_config_updater/` has an ignore pattern `".*ERR sonic_yang.*"` but it only applies to ONE host. The test's own `LOGANALYZER_IGNORE_REGEX` (which applies to ALL hosts via `ignore_expected_loganalyzer_errors` fixture) was missing this pattern.

#### How did you do it?

Added `".*ERR sonic_yang.*"` to `LOGANALYZER_IGNORE_REGEX` in `test_multiasic_addcluster.py`, which is applied to all DUT hosts via the `ignore_expected_loganalyzer_errors` fixture.

#### How did you verify/test it?

- Verified the error pattern matches the observed syslog entries
- Confirmed the fixture applies ignore patterns to all hosts in `duthosts`
- Cross-referenced with existing ignore pattern in `conftest.py` (line 93)

#### Any platform specific information?

N/A - applies to all multi-ASIC platforms running GCU operations.

#### Supported testbed topology if it's a new test case?

N/A - this is an improvement to an existing t2 topology test.

### Documentation

N/A - no new features or test cases added.
