### PR TITLE
Fix `test_lo_interface.py` on t2/voq systems

### DIFF
--- a/tests/generic_config_updater/test_lo_interface.py
+++ b/tests/generic_config_updater/test_lo_interface.py
@@ -97,6 +97,8 @@ def setup_env(duthosts, rand_one_dut_front_end_hostname, lo_intf):
 def cleanup_lo_interface_config(duthost, cfg_facts):
     lo_interfaces = cfg_facts.get('LOOPBACK_INTERFACE', {})
     for lo_interface in lo_interfaces:
+        if lo_interface != DEFAULT_LOOPBACK:
+            continue
         del_loopback_interface = duthost.shell(
             "sudo config loopback del {}".format(lo_interface),
             module_ignore_errors=True)


### PR DESCRIPTION
### Description of PR
T2/VOQ systems have a Loopback4096 interface which returns an error when `generic_config_updater/test_lo_interface.py` tries to delete it.
```
> sudo config loopback del Loopback4096
Usage: config loopback del [OPTIONS] <loopback_name>
Try 'config loopback del -h' for help.

Error: Loopback4096 is invalid, name should have prefix 'Loopback' and suffix '<0-999>'
```

The test doesn't need to delete this interface so skip it.
More details in https://github.com/sonic-net/sonic-mgmt/issues/23586

Summary:
Fixes #23586 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fix `generic_config_updater/test_lo_interface.py` on T2/VOQ systems

#### How did you do it?
Don't delete Loopback4096

#### How did you verify/test it?
Ran `generic_config_updater/test_lo_interface.py` on a T2/VOQ system and saw it passed

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
