### PR TITLE
[loganalyzer] Fix end marker lost during rsyslog reload (#23562)

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
@@ -188,12 +188,26 @@ class AnsibleLogAnalyzer:
         '''
         @summary: Place marker into '/dev/log'.
         @param marker: Marker to be placed into syslog.
+
+        Flush rsyslog's internal queues *before* writing the marker so that
+        the reload (which briefly closes and reopens log files) does not race
+        with the marker message sitting in rsyslog's buffer.  After the marker
+        is sent we only need a short sleep for rsyslog to write it out under
+        normal (non-reload) conditions.
         '''
+
+        # Flush any previously buffered messages first, so the reload
+        # does not interfere with the marker we are about to write.
+        self.flush_rsyslogd()
 
         syslogger = self.init_sys_logger()
         syslogger.info(marker)
         syslogger.info('\n')
-        self.flush_rsyslogd()
+
+        # Give rsyslog time to write the marker to disk.
+        # Do NOT call flush_rsyslogd() here — a reload right after writing
+        # can cause the marker message to be dropped (see #23562).
+        time.sleep(2)
 
     def wait_for_marker(self, marker, timeout=120, polling_interval=10):
         '''


### PR DESCRIPTION
### Description of PR
Fixes #23562

#### Summary
The `place_marker_to_syslog()` method called `flush_rsyslogd()` (`systemctl reload rsyslog`) immediately after writing the marker to syslog. The reload briefly closes and reopens log files, which can race with the marker message still sitting in rsyslog's internal buffer, causing the marker to be silently dropped.

**Root cause:** PR #22447 replaced `kill -HUP` with `systemctl reload rsyslog` to avoid syslog message loss during the *previous* flush. However, calling the reload *right after* writing a new marker creates a new race — the just-written marker can be dropped during the reload's file close/reopen cycle.

**Fix:** Flush rsyslog *before* writing the marker (to drain old buffers), then after writing the marker, use a simple `time.sleep(2)` instead of a reload to let rsyslog write the marker to disk naturally.

### Type of change
- [x] Bug fix

### Back port request
- [ ] N/A

### Approach
#### What is the motivation for this PR?
LogAnalyzer's `add_end_marker` action fails intermittently with `RuntimeError: cannot find marker end-LogAnalyzer-... in /var/log/syslog`, causing test failures across all platforms.

#### How did you do it?
Moved the `flush_rsyslogd()` call to *before* writing the syslog marker and replaced the post-write flush with a 2-second sleep. This ensures:
1. Pre-existing buffered messages are flushed before the marker is written
2. The marker itself is not disrupted by a concurrent rsyslog reload
3. rsyslog has time to naturally write the marker to disk

#### How did you verify/test it?
- Code review of the race condition timeline
- The fix eliminates the problematic pattern (write then immediate reload) identified in the issue

---
> [!NOTE]
> This PR was generated with the assistance of an AI agent.
