### PR TITLE
[ci] Fix markers_check.py break bug and improve logging

### DIFF
--- a/.azure-pipelines/markers_check/markers_check.py
+++ b/.azure-pipelines/markers_check/markers_check.py
@@ -5,60 +5,91 @@ import logging
 
 from natsort import natsorted
 
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+# Subfolders under tests/ whose scripts are exempt from the topology marker requirement.
+EXCLUDED_SUBFOLDERS = {"transceiver", "saitests"}
+
+
+def _is_excluded(script_path, location):
+    """Check whether *script_path* falls under one of the excluded subfolders."""
+    rel = os.path.relpath(script_path, location)
+    parts = rel.replace("\\", "/").split("/")
+    return any(part in EXCLUDED_SUBFOLDERS for part in parts)
+
 
 def collect_scripts_without_topology_markers():
     """
-    This function collects all test scripts under the folder 'tests/' and check the topology type marked in the script.
+    Collect all ``test_*.py`` scripts under *location* and verify that each
+    one contains a ``pytest.mark.topology`` marker.
 
     Returns:
-        List: A list of test scripts without the topology type marker.
+        tuple: (scripts_without_marker, total_checked, skipped_scripts)
     """
     location = sys.argv[1]
 
     # Recursively find all scripts starting with "test_" and ending with ".py"
-    # Note: The full path and name of files are stored in a list named "scripts"
     scripts = []
-    for root, dirs, script in os.walk(location):
-        for s in script:
-            if s.startswith("test_") and s.endswith(".py"):
-                scripts.append(os.path.join(root, s))
+    for root, dirs, filenames in os.walk(location):
+        for f in filenames:
+            if f.startswith("test_") and f.endswith(".py"):
+                scripts.append(os.path.join(root, f))
     scripts = natsorted(scripts)
 
-    # Open each script and search for regex pattern
+    logger.info("Found %d test scripts under '%s'", len(scripts), location)
+
     pattern = re.compile(r"[^@]pytest\.mark\.topology\(([^\)]*)\)")
 
     scripts_without_marker = []
+    skipped_scripts = []
 
     for s in scripts:
-        has_markers = False
-        # Remove prefix from file name:
         script_name = s[len(location) + 1:]
+
+        if _is_excluded(s, location):
+            skipped_scripts.append(script_name)
+            continue
+
         try:
-            with open(s, 'r') as script:
-                match = pattern.search(script.read())
-                if match:
-                    has_markers = True
-                    break
-
-            if not has_markers:
+            with open(s, 'r') as fh:
+                content = fh.read()
+                if pattern.search(content):
+                    continue
                 scripts_without_marker.append(script_name)
-
         except Exception as e:
             raise Exception('Exception occurred while trying to get marker in {}, error {}'.format(s, e))
 
-    return scripts_without_marker
+    return scripts_without_marker, len(scripts), skipped_scripts
 
 
 def main():
     try:
-        scripts_without_marker = collect_scripts_without_topology_markers()
+        scripts_without_marker, total, skipped = collect_scripts_without_topology_markers()
+
+        checked = total - len(skipped)
+
+        # --- Summary -----------------------------------------------------------
+        logger.info("----------- Markers Check Summary -----------")
+        logger.info("Total scripts found  : %d", total)
+        logger.info("Scripts checked      : %d", checked)
+        logger.info("Scripts skipped      : %d", len(skipped))
+        logger.info("Scripts with marker  : %d", checked - len(scripts_without_marker))
+        logger.info("Scripts WITHOUT marker: %d", len(scripts_without_marker))
+
+        if skipped:
+            logger.info("Skipped subfolders   : %s", ", ".join(sorted(EXCLUDED_SUBFOLDERS)))
 
         if scripts_without_marker:
+            logger.info("---------------------------------------------")
             for script in scripts_without_marker:
-                print("\033[31mPlease add mark `pytest.mark.topology` in script {}\033[0m".format(script))
+                logger.error("Please add `pytest.mark.topology` in script %s", script)
+            logger.info("---------------------------------------------")
             sys.exit(1)
 
+        logger.info("All checked scripts have topology markers. PASSED.")
         sys.exit(0)
+
     except Exception as e:
         logging.error(e)
         sys.exit(2)

--- a/tests/performance_meter/test_performance.py
+++ b/tests/performance_meter/test_performance.py
@@ -14,6 +14,7 @@ from success_criteria import filter_vars
 
 
 pytestmark = [
+    pytest.mark.topology('any'),
     pytest.mark.sanity_check(skip_sanity=True),  # will be invoked manually in test
     pytest.mark.disable_loganalyzer
 ]


### PR DESCRIPTION
### Description of PR

Summary:
Fix a bug in `markers_check.py` introduced by https://github.com/sonic-net/sonic-mgmt/pull/16571 where a `break` statement on line 41 exits the entire script loop after the first script with a topology marker is found, causing all remaining scripts to be skipped from the check. Also improve logging/summarization and add exclusion support for subfolders that don't use topology markers.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

PR https://github.com/sonic-net/sonic-mgmt/pull/16571 introduced a bug in `.azure-pipelines/markers_check/markers_check.py`. On line 41, a `break` statement was used inside the loop that iterates over all test scripts. When the first script with a `pytest.mark.topology` marker is found, `break` exits the entire `for` loop instead of continuing to the next script. This means only scripts alphabetically before the first marked script are actually checked — all remaining scripts are silently skipped.

#### How did you do it?

1. **Fixed the break bug**: Replaced the `break` with `continue` so all scripts are checked.
2. **Added structured logging**: The script now prints a summary showing total scripts found, checked, skipped, passing, and failing counts.
3. **Added exclusion support**: Scripts under `transceiver/` and `saitests/` subfolders are excluded from the topology marker requirement, as they use different testing patterns.
4. **Added missing marker**: Added `pytest.mark.topology('any')` to `tests/performance_meter/test_performance.py`.

#### How did you verify/test it?

Ran the script locally against the `tests/` directory. All 617 checked scripts pass (27 skipped from excluded subfolders).

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation
N/A
