### PR TITLE
Fix ValueError in everflow case

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -462,7 +462,10 @@ def assert_no_tx_queue_drops_on_mirror_port(duthost, mirror_port):
         if "Ethernet" not in line or "cached" in line:
             continue
         queue = line.split()[1]
-        drop = int(line.split()[4].replace(',', ''))
+        drop_str = line.split()[4].replace(',', '')
+        if drop_str == 'N/A':
+            continue
+        drop = int(drop_str)
         if drop > 30:
             queues_with_drops.append((queue, drop))
     msg = f"Expected no tx drops on mirror port {mirror_port}, found drops on queues: {queues_with_drops}"


### PR DESCRIPTION
Summary: Fix ValueError in everflow case
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
PR https://github.com/sonic-net/sonic-mgmt/pull/23269 update `tests/everflow/everflow_test_utilities.py`

```
    for line in output:
        if "Ethernet" not in line or "cached" in line:
            continue
        queue = line.split()[1]
        drop = int(line.split()[4].replace(',', ''))        <<<<<<
        if drop > 30:
            queues_with_drops.append((queue, drop))
```

If the `Drop/pkts` field is "N/A", case will fail with error `ValueError: invalid literal for int() with base 10: 'N/A'`
```
CMD: show queue counters Ethernet76
STDOUT:
Last cached time was 2026-04-02T13:37:46.210355
Ethernet76 Last cached time was 2026-04-02T13:37:46.210355
        Port    TxQ    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
----------  -----  --------------  ---------------  -----------  ------------
Ethernet76    UC0           8,666        1,421,224            0           N/A
Ethernet76    UC1               0                0            0           N/A
Ethernet76    UC2               0                0            0           N/A
Ethernet76    UC3               0                0            0           N/A
Ethernet76    UC4               0                0            0           N/A
Ethernet76    UC5               0                0            0           N/A
Ethernet76    UC6               0                0            0           N/A
Ethernet76    UC7              12            1,782            0           N/A
Ethernet76    UC8             N/A              N/A          N/A           N/A    <<<
Ethernet76    UC9             N/A              N/A          N/A           N/A
Ethernet76   UC10             N/A              N/A          N/A           N/A
Ethernet76   UC11             N/A              N/A          N/A           N/A
Ethernet76   UC12             N/A              N/A          N/A           N/A
Ethernet76   UC13             N/A              N/A          N/A           N/A
Ethernet76   UC14             N/A              N/A          N/A           N/A
Ethernet76   UC15             N/A              N/A          N/A           N/A
```

#### How did you do it?
Fix ValueError in everflow case

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
