### PR TITLE
Revert "[action] [PR:23201] [dut_console] Fix fixture conflict in test_idle_timeout"

### DIFF
--- a/tests/dut_console/test_idle_timeout.py
+++ b/tests/dut_console/test_idle_timeout.py
@@ -15,8 +15,8 @@ pytestmark = [
 ]
 
 
-def test_timeout(duthost_console, duthosts, enum_rand_one_per_hwsku_hostname):
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+def test_timeout(duthost_console, duthosts, enum_supervisor_dut_hostname):
+    duthost = duthosts[enum_supervisor_dut_hostname]
     logger.info("Get default session idle timeout")
     default_tmout = duthost_console.send_command('echo $TMOUT').strip().splitlines()[0].strip()
     pytest_assert(default_tmout == DEFAULT_TMOUT, "default timeout on dut is not {} seconds".format(DEFAULT_TMOUT))


### PR DESCRIPTION
### Description of PR

Reverts sonic-net/sonic-mgmt#23434

#### Why I did it

PR #23434 (auto cherry-pick of #23201 to 202511) was applied **without its prerequisite PR #21587**, breaking `test_idle_timeout.py` on the 202511 branch.

**PR Dependency Chain:**



**Why #23201 is needed on master but NOT on 202511:**
- On **master**: PR #21587 changed `test_timeout` to use `enum_supervisor_dut_hostname` for modular chassis support. This conflicted with `duthost_console`'s dependency on `enum_rand_one_per_hwsku_hostname` (mutually exclusive in `pytest_generate_tests`'s `elif` chain). PR #23201 fixed this.
- On **202511**: PR #21587 was never applied — the test was already working with `enum_supervisor_dut_hostname`. Cherry-picking just the fix without the prerequisite changed working code into the broken state.

#### How I did it

Revert commit from PR #23434.

#### How did you verify/test it

Ran `dut_console/test_idle_timeout.py` on `testbed-bjw2-can-t1-7260-11` (Arista-7260CX3-C64, `internal-202511` branch):

| Run | Code State | Result |
|---|---|---|
| Before revert | `enum_rand_one_per_hwsku_hostname` (from #23434) | ❌ `AttributeError: 'SubRequest' object has no attribute 'param'` |
| After revert | `enum_supervisor_dut_hostname` (original 202511 code) | ✅ **1 passed, 36 warnings in 99.43s** |

Fixes https://msazure.visualstudio.com/One/_workitems/edit/36796668
