### PR TITLE
Fix ECN config update test skipping WRED profile validation (#23597)

### DIFF
--- a/tests/generic_config_updater/test_ecn_config_update.py
+++ b/tests/generic_config_updater/test_ecn_config_update.py
@@ -223,6 +223,8 @@ def test_ecn_config_updates(duthost, ensure_dut_readiness, configdb_field, opera
         delta = determine_delta_values(ecn_data, fields)
         if all(delta[f] == 0 for f in fields):
             logger.info(f"Skipping WRED profile {wred_profile}: all deltas are 0, no real value change possible.")
+            # Still track current values so ASIC DB validation includes this profile
+            new_values[wred_profile] = {field: int(ecn_data[field]) for field in fields}
             continue
         new_values[wred_profile] = {}
         for field in fields:


### PR DESCRIPTION
### Description of PR

Summary:
Fix `test_ecn_config_updates[None-replace-green_max_threshold]` failure introduced by PR #23319. When WRED profiles have zero deltas, their expected values were excluded from ASIC DB validation, causing sorted comparison to fail due to list length mismatch.

Fixes #23597

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

PR #23319 introduced ECN config update tests that generate JSON patches for WRED profile modifications. When a WRED profile has zero deltas (current value is already at the boundary, so no change is possible), it is correctly skipped during patch generation. However, the expected values dict (`new_values`) also excluded these profiles. Since ASIC DB contains entries for **all** WRED profiles, the sorted comparison between ASIC DB values and expected values fails — the lists have different lengths.

#### How did you do it?

Include skipped profiles' current (unchanged) values in `new_values` so the ASIC DB comparison accounts for all WRED profiles, not just the modified ones.

#### How did you verify/test it?

Tested on local KVM T0 testbed — `test_ecn_config_updates[None-replace-green_max_threshold]` passes with the fix.

#### Any platform specific information?

N/A — generic test framework fix.

#### Supported testbed topology if it's a new test case?

N/A — bug fix.

### Documentation

N/A

---
*This PR was generated with the assistance of an AI agent on behalf of @yxieca.*