### PR TITLE
Increase timeout for the console line tests.

### DIFF
--- a/tests/console/test_console_loopback.py
+++ b/tests/console/test_console_loopback.py
@@ -23,7 +23,7 @@ def test_console_loopback_echo(duthost, creds, target_line):
     packet_size = 64
     delay_factor = 2.0
     if "arm64-c8220tg_48a_o" in duthost.facts['platform']:
-        delay_factor = 40.0
+        delay_factor = 50.0
 
     # Estimate a reasonable data transfer time based on configured baud rate
     if target_line not in console_facts['lines']:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The console loopback tests calculate the time required for the message to come back using message length and baudrate. But in addition, we need time to process the packet in socat in the remote device as well. Considering these, we are increasing the time in this PR.

Summary:
Fixing the flaky-test-fail issue with loopback tests.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
The loopback test kept failing in c0 topology.

#### How did you do it?
Increased the multiplier value for C8220TG platform.

#### How did you verify/test it?
Ran it on c0 topo.
```
_______________________________________________________________________________________________________ test_console_loopback_echo[115200-47] _______________________________________________________________________________________________________
_______________________________________________________________________________________________________ test_console_loopback_echo[115200-48] _______________________________________________________________________________________________________
----------------------------------------------- generated xml file: /run_logs/tb3/copy-socat/2026-04-03-03-20-40/console/test_console_loopback.py::test_console_loopback_echo_2026-04-03-03-20-40.xml -----------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
============================================================================================================== short test summary info ==============================================================================================================
PASSED console/test_console_loopback.py::test_console_loopback_echo[9600-1]
PASSED console/test_console_loopback.py::test_console_loopback_echo[9600-2]
PASSED console/test_console_loopback.py::test_console_loopback_echo[9600-3]

...

PASSED console/test_console_loopback.py::test_console_loopback_echo[115200-45]
PASSED console/test_console_loopback.py::test_console_loopback_echo[115200-46]
PASSED console/test_console_loopback.py::test_console_loopback_echo[115200-47]
PASSED console/test_console_loopback.py::test_console_loopback_echo[115200-48]
==================================================================================================== 96 passed, 1 warning in 4619.86s (1:16:59) =====================================================================================================
sonic@arctos_cicd_TB3_double_console_202511:/data/tests$ 
```

#### Any platform specific information?
Specific to C8220TG only.