### PR TITLE
Add tests for static route removal after config reload (#18882)

### DIFF
--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -679,3 +679,264 @@ def test_static_route_config_reload_with_traffic(rand_selected_dut, rand_unselec
             duthost.shell('config mux mode auto all')
             unselected_duthost.shell('config mux mode auto all')
             unselected_duthost.shell('config save -y')
+
+
+def check_static_route_removed(duthost, prefix, ipv6):
+    """Verify that a static route is no longer present in the routing table.
+
+    Args:
+        duthost: DUT host object
+        prefix: Route prefix to check
+        ipv6: Whether this is an IPv6 route
+
+    Returns:
+        bool: True if route is removed (not found), False if still present
+    """
+    if ipv6:
+        cmd = "show ipv6 route {}".format(prefix)
+    else:
+        cmd = "show ip route {}".format(prefix)
+    output = duthost.shell(cmd, module_ignore_errors=True)["stdout"]
+    # Route should not appear with "S" (static) protocol marker
+    return prefix not in output or "Network not in table" in output
+
+
+@pytest.mark.disable_loganalyzer
+def test_static_route_removal_after_config_reload(rand_selected_dut, rand_unselected_dut, ptfadapter, ptfhost, tbinfo,
+                                                  setup_standby_ports_on_rand_unselected_tor,  # noqa F811
+                                                  toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
+                                                  is_route_flow_counter_supported):  # noqa F811
+    """
+    Test that removing a static route from CONFIG_DB and performing config reload
+    actually clears the route from kernel/FIB.
+
+    Addresses: https://github.com/sonic-net/sonic-buildimage/issues/21423
+    Addresses: https://github.com/sonic-net/sonic-mgmt/issues/18882
+
+    This test validates that:
+    1. A static route is added and persisted (config save)
+    2. The route is removed from CONFIG_DB
+    3. After config reload, the route is no longer in the kernel routing table
+    4. The route is no longer advertised to BGP neighbors
+    """
+    duthost = rand_selected_dut
+    unselected_duthost = rand_unselected_dut
+    is_dual_tor = 'dualtor' in tbinfo['topo']['name'] and unselected_duthost is not None
+    prefix = "6.6.6.0/24"
+
+    prefix_len, nexthop_addrs, nexthop_devs, nexthop_interfaces = get_nexthops(
+        duthost, tbinfo, ipv6=False, count=1
+    )
+
+    # Setup: Add IP addresses on PTF
+    add_ipaddr(ptfadapter, ptfhost, nexthop_addrs, prefix_len, nexthop_interfaces, ipv6=False)
+
+    try:
+        # Step 1: Add static route and save config
+        apply_static_route_config(duthost, unselected_duthost if is_dual_tor else None,
+                                  prefix, nexthop_addrs, op="add")
+        time.sleep(5)
+        check_static_route(duthost, prefix, nexthop_addrs, ipv6=False)
+        duthost.shell('config save -y')
+
+        # Step 2: Remove static route from CONFIG_DB (without saving yet)
+        apply_static_route_config(duthost, unselected_duthost if is_dual_tor else None,
+                                  prefix, op="del")
+        # Save config so the removal is persisted
+        duthost.shell('config save -y')
+
+        # Step 3: Config reload
+        config_reload(duthost, wait=450)
+
+        # Wait for system to stabilize
+        wait_all_bgp_up(duthost)
+
+        # Step 4: Verify route is removed from kernel
+        pytest_assert(
+            wait_until(60, 10, 0, check_static_route_removed, duthost, prefix, False),
+            "Static route {} still present in kernel after removal and config reload".format(prefix)
+        )
+
+        # Step 5: Verify route is no longer advertised via BGP
+        check_route_redistribution(duthost, prefix, ipv6=False, removed=True)
+
+    finally:
+        # Cleanup: Ensure route is removed
+        apply_static_route_config(duthost, unselected_duthost if is_dual_tor else None,
+                                  prefix, op="del")
+        del_ipaddr(ptfhost, nexthop_addrs, prefix_len, nexthop_devs, ipv6=False)
+        duthost.shell('config save -y')
+        clear_arp_ndp(duthost, ipv6=False)
+        if is_dual_tor:
+            clear_arp_ndp(unselected_duthost, ipv6=False)
+
+
+@pytest.mark.disable_loganalyzer
+def test_static_route_removal_after_config_reload_ipv6(rand_selected_dut, rand_unselected_dut, ptfadapter, ptfhost,
+                                                       tbinfo,
+                                                       setup_standby_ports_on_rand_unselected_tor,  # noqa F811
+                                                       toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
+                                                       is_route_flow_counter_supported):  # noqa F811
+    """
+    Test that removing an IPv6 static route from CONFIG_DB and performing config reload
+    actually clears the route from kernel/FIB.
+
+    Addresses: https://github.com/sonic-net/sonic-buildimage/issues/21423
+    Addresses: https://github.com/sonic-net/sonic-mgmt/issues/18882
+
+    This test validates the same removal-after-config-reload scenario for IPv6 routes.
+    """
+    duthost = rand_selected_dut
+    unselected_duthost = rand_unselected_dut
+    is_dual_tor = 'dualtor' in tbinfo['topo']['name'] and unselected_duthost is not None
+    prefix = "2000:6::/64"
+
+    prefix_len, nexthop_addrs, nexthop_devs, nexthop_interfaces = get_nexthops(
+        duthost, tbinfo, ipv6=True, count=1
+    )
+
+    # Setup: Add IP addresses on PTF
+    add_ipaddr(ptfadapter, ptfhost, nexthop_addrs, prefix_len, nexthop_interfaces, ipv6=True)
+
+    try:
+        # Step 1: Add static route and save config
+        apply_static_route_config(duthost, unselected_duthost if is_dual_tor else None,
+                                  prefix, nexthop_addrs, op="add")
+        time.sleep(5)
+        check_static_route(duthost, prefix, nexthop_addrs, ipv6=True)
+        duthost.shell('config save -y')
+
+        # Step 2: Remove static route and save
+        apply_static_route_config(duthost, unselected_duthost if is_dual_tor else None,
+                                  prefix, op="del")
+        duthost.shell('config save -y')
+
+        # Step 3: Config reload
+        config_reload(duthost, wait=450)
+
+        # Wait for system to stabilize
+        wait_all_bgp_up(duthost)
+
+        # Step 4: Verify route is removed from kernel
+        pytest_assert(
+            wait_until(60, 10, 0, check_static_route_removed, duthost, prefix, True),
+            "IPv6 static route {} still present in kernel after removal and config reload".format(prefix)
+        )
+
+        # Step 5: Verify route is no longer advertised via BGP
+        check_route_redistribution(duthost, prefix, ipv6=True, removed=True)
+
+    finally:
+        # Cleanup
+        apply_static_route_config(duthost, unselected_duthost if is_dual_tor else None,
+                                  prefix, op="del")
+        del_ipaddr(ptfhost, nexthop_addrs, prefix_len, nexthop_devs, ipv6=True)
+        duthost.shell('config save -y')
+        clear_arp_ndp(duthost, ipv6=True)
+        if is_dual_tor:
+            clear_arp_ndp(unselected_duthost, ipv6=True)
+
+
+@pytest.mark.disable_loganalyzer
+def test_static_route_blackhole_removal_after_config_reload(rand_selected_dut, rand_unselected_dut, tbinfo):
+    """
+    Test that removing a blackhole static route from CONFIG_DB and performing config reload
+    actually clears the route from kernel/FIB.
+
+    This is the exact scenario reported in:
+    https://github.com/sonic-net/sonic-buildimage/issues/21423
+    https://github.com/sonic-net/sonic-mgmt/issues/18882
+
+    The bug: when a blackhole static route in config_db.json is removed and config reload
+    is performed, the route still exists in the kernel because no daemon clears it.
+
+    This test validates both IPv4 and IPv6 blackhole routes.
+    """
+    duthost = rand_selected_dut
+    unselected_duthost = rand_unselected_dut
+    is_dual_tor = 'dualtor' in tbinfo['topo']['name'] and unselected_duthost is not None
+
+    ipv4_prefix = "7.7.7.0/24"
+    ipv6_prefix = "1000::/120"
+
+    def add_blackhole_route(prefix, ipv6=False):
+        """Add a blackhole static route via CONFIG_DB."""
+        duthost.shell(
+            'sonic-db-cli CONFIG_DB hmset "STATIC_ROUTE|{}" '
+            'blackhole true distance 0 ifname "" nexthop blackhole nexthop-vrf ""'.format(prefix)
+        )
+        if is_dual_tor and unselected_duthost:
+            unselected_duthost.shell(
+                'sonic-db-cli CONFIG_DB hmset "STATIC_ROUTE|{}" '
+                'blackhole true distance 0 ifname "" nexthop blackhole nexthop-vrf ""'.format(prefix)
+            )
+
+    def remove_blackhole_route(prefix):
+        """Remove a blackhole static route from CONFIG_DB."""
+        duthost.shell(
+            'sonic-db-cli CONFIG_DB del "STATIC_ROUTE|{}"'.format(prefix)
+        )
+        if is_dual_tor and unselected_duthost:
+            unselected_duthost.shell(
+                'sonic-db-cli CONFIG_DB del "STATIC_ROUTE|{}"'.format(prefix)
+            )
+
+    def check_blackhole_route_present(prefix, ipv6=False):
+        """Verify blackhole route is present in the routing table."""
+        if ipv6:
+            cmd = "show ipv6 route {}".format(prefix)
+        else:
+            cmd = "show ip route {}".format(prefix)
+        output = duthost.shell(cmd, module_ignore_errors=True)["stdout"]
+        return prefix in output
+
+    try:
+        # Step 1: Add blackhole routes and save config
+        add_blackhole_route(ipv4_prefix, ipv6=False)
+        add_blackhole_route(ipv6_prefix, ipv6=True)
+        time.sleep(5)
+
+        # Verify routes are present
+        pytest_assert(
+            wait_until(30, 5, 0, check_blackhole_route_present, ipv4_prefix, False),
+            "IPv4 blackhole route {} not found after adding".format(ipv4_prefix)
+        )
+        pytest_assert(
+            wait_until(30, 5, 0, check_blackhole_route_present, ipv6_prefix, True),
+            "IPv6 blackhole route {} not found after adding".format(ipv6_prefix)
+        )
+
+        duthost.shell('config save -y')
+
+        # Step 2: Remove blackhole routes and save
+        remove_blackhole_route(ipv4_prefix)
+        remove_blackhole_route(ipv6_prefix)
+        duthost.shell('config save -y')
+
+        # Step 3: Config reload
+        config_reload(duthost, wait=450)
+
+        # Wait for system to stabilize
+        wait_all_bgp_up(duthost)
+
+        # Step 4: Verify routes are removed from kernel
+        pytest_assert(
+            wait_until(60, 10, 0, check_static_route_removed, duthost, ipv4_prefix, False),
+            "IPv4 blackhole route {} still present in kernel after removal and config reload "
+            "(see sonic-buildimage#21423)".format(ipv4_prefix)
+        )
+        pytest_assert(
+            wait_until(60, 10, 0, check_static_route_removed, duthost, ipv6_prefix, True),
+            "IPv6 blackhole route {} still present in kernel after removal and config reload "
+            "(see sonic-buildimage#21423)".format(ipv6_prefix)
+        )
+
+        # Step 5: Verify routes are not advertised
+        check_route_redistribution(duthost, ipv4_prefix, ipv6=False, removed=True)
+        check_route_redistribution(duthost, ipv6_prefix, ipv6=True, removed=True)
+
+    finally:
+        # Cleanup: Ensure routes are removed
+        remove_blackhole_route(ipv4_prefix)
+        remove_blackhole_route(ipv6_prefix)
+        duthost.shell('config save -y')


### PR DESCRIPTION
### Description of PR

Summary:
Add test cases verifying that static route removal from CONFIG_DB is properly cleared from kernel/FIB after config reload.

Addresses #18882 and sonic-net/sonic-buildimage#21423.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Existing static route tests verify route **persistence** through warmboot and config reload, but there is no test verifying that **removing** a static route from CONFIG_DB and performing config reload actually clears the route from the kernel/FIB.

The specific bug (sonic-buildimage#21423): when a blackhole static route in config_db.json is removed and config reload is performed, the route still exists in the kernel because no daemon clears it.

#### How did you do it?

Added three new test cases to `tests/route/test_static_route.py`:

1. **`test_static_route_removal_after_config_reload`** — Adds an IPv4 static route with nexthop, saves config, removes it from CONFIG_DB, saves again, does config reload, and verifies the route is gone from both kernel and BGP advertisements.

2. **`test_static_route_removal_after_config_reload_ipv6`** — Same scenario for IPv6 routes.

3. **`test_static_route_blackhole_removal_after_config_reload`** — Tests blackhole route removal (both IPv4 and IPv6), which is the exact scenario reported in sonic-buildimage#21423.

All tests follow the existing pattern in the file and reuse existing helpers (`apply_static_route_config`, `check_route_redistribution`, `wait_all_bgp_up`, etc.).

#### How did you verify/test it?

- flake8 passes with max-line-length=120
- Tests follow existing patterns and use established fixtures/helpers
- Ready for CI validation

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

T0 (any)

### Documentation

N/A

---
*This PR was generated with the assistance of an AI agent on behalf of @yxieca.*