### PR TITLE
Update the balance_range for mellanox platform during ecmp inner hash

### DIFF
--- a/tests/ecmp/inner_hashing/test_inner_hashing_lag.py
+++ b/tests/ecmp/inner_hashing/test_inner_hashing_lag.py
@@ -52,6 +52,8 @@ class TestDynamicInnerHashingLag():
             else:
                 balancing_test_times = 20
                 balancing_range = 0.5
+                if "mellanox" in duthost.facts['asic_type'].lower():
+                    balancing_range = 0.7
 
             ptf_runner(ptfhost,
                        "ptftests",


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
There is a very low chance that the test_inner_hashing would failed on Mellanox SN4600C due to unbalanced hash result.
Checked with design team, and update the balance_range for mellanox platform.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
There is a very low chance that the test_inner_hashing would failed on Mellanox SN4600C due to unbalanced hash result
#### How did you do it?
Update the balance_range for mellanox platform.
#### How did you verify/test it?
Run the test locally
#### Any platform specific information?
Mellanox platform
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
