### PR TITLE
Skip dhcp_relay tests on sn5640 platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1048,10 +1048,11 @@ decap/test_subnet_decap.py::test_vlan_subnet_decap:
 #######################################
 dhcp_relay:
   skip:
-    reason: "It is skipped for '202412' for now"
+    reason: "It is skipped for '202412' for now; Or skip on sn5640 platform"
     conditions_logical_operator: or
     conditions:
       - "release in ['202412']"
+      - "platform in ['x86_64-nvidia_sn5640-r0']"
       - "'bmc' in topo_type"
 
 dhcp_relay/test_dhcp_counter_stress.py::test_dhcpmon_relay_counters_stress:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Skip dhcp_relay tests on sn5640 platform, currently it does not support on Mellanox sn5640 platform.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Dhcp relay function is not supported on Mellanox sn5640 platform.
#### How did you do it?
Skip the dhcp_relay tests on Mellanox sn5640 platform
#### How did you verify/test it?
Run it locally
#### Any platform specific information?
Mellanox sn5640 platform.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
