### PR TITLE
Skip the warm reboot test in test_static_route on dualtor setup

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4849,11 +4849,23 @@ route/test_static_route.py::test_static_route_ecmp_ipv6:
       - "release in ['201811', '201911']"
       - "'standalone' in topo_name"
 
+route/test_static_route.py::test_static_route_ecmp_warmboot:
+  skip:
+    reason: "Dualtor topology doesn't support warm reboot on mellanox platform"
+    conditions:
+      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout'] and asic_type in ['mellanox', 'nvidia']"
+
 route/test_static_route.py::test_static_route_ipv6:
   xfail:
     reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
     conditions:
       - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
+
+route/test_static_route.py::test_static_route_ipv6_warmboot:
+  skip:
+    reason: "Dualtor topology doesn't support warm reboot on mellanox platform"
+    conditions:
+      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout'] and asic_type in ['mellanox', 'nvidia']"
 
 #######################################
 #####           sai_qualify       #####


### PR DESCRIPTION

### Description of PR
Skip the warm reboot test in test_static_route on dualtor setup 
Currently warm reboot is not supported on dualtor setup


Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
- master: test pass

### Approach
#### What is the motivation for this PR?
The warm reboot test in test_static_route are failing on dualtor setup.
#### How did you do it?
Skip the warm reboot test in test_static_route on dualtor setup 
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

