### PR TITLE
Xfail test_ecn_config_updates[None-replace-green_max_threshold]

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2629,6 +2629,12 @@ generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates:
       - "release in ['202211']"
       - "https://github.com/sonic-net/sonic-buildimage/issues/22295 and platform in ['x86_64-nvidia_sn5600-r0', 'x86_64-nvidia_sn5640-r0']"
 
+generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[None-replace-green_max_threshold]:
+  xfail:
+    reason: "Xfail due to GH issue: https://github.com/sonic-net/sonic-mgmt/issues/23597"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23597 and platform in ['x86_64-nvidia_sn5640-r0']"
+
 generic_config_updater/test_eth_interface.py::test_port_speed_change_oper_status:
   skip:
     reason: 'Skip this test due to misleading StateDB output for valid speed, same known issue as test_update_speed'


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Xfail test_ecn_config_updates[None-replace-green_max_threshold] on platform x86_64-nvidia_sn5640-r0 due to github issue https://github.com/sonic-net/sonic-mgmt/issues/23597


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Due to github issue https://github.com/sonic-net/sonic-mgmt/issues/23597, the case test_ecn_config_updates[None-replace-green_max_threshold] is keep failing on mellanox sn5640 platform.
#### How did you do it?
Skip the case
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
