### PR TITLE
Fix missing PLACEHOLDER_PREFIX import in BGP aggregate tests

### DIFF
--- a/tests/bgp/bgp_aggregate_helpers.py
+++ b/tests/bgp/bgp_aggregate_helpers.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 # ---- Constants ----
 BGP_AGGREGATE_ADDRESS = "BGP_AGGREGATE_ADDRESS"
+PLACEHOLDER_PREFIX = "192.0.2.0/32"
 
 # Convergence wait times
 ROUTE_PROPAGATION_WAIT = 10


### PR DESCRIPTION
### Description of PR

Summary:
Add `PLACEHOLDER_PREFIX = "192.0.2.0/32"` constant to `tests/bgp/bgp_aggregate_helpers.py`.

**⚠️ This is the critical fix for the current CI "Validate Test Cases" failure.** The missing `PLACEHOLDER_PREFIX` causes an `ImportError` during pytest collection, which is the actual blocker for all PRs on master. This should be merged first/urgently.

Related to #23614

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

`test_bgp_aggregate_address_dual_stack.py` and `test_bgp_aggregate_address_negative.py` import `PLACEHOLDER_PREFIX` from `bgp_aggregate_helpers`, but it was never defined there. This causes an `ImportError` during pytest collection, which **breaks the CI "Validate Test Cases" pre-check for all PRs**.

This is the actual root cause of the current CI failures — not the invalid escape sequences (which are `SyntaxWarning` on CI's Python 3.12, not `SyntaxError`).

#### How did you do it?

Added `PLACEHOLDER_PREFIX = "192.0.2.0/32"` to the constants section of `bgp_aggregate_helpers.py`.

#### How did you verify/test it?

Verified that the import resolves correctly and pytest collection succeeds for the affected test files.

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A