### PR TITLE
[hft] Add Arista 7060X6 platform support for high frequency telemetry tests

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3298,7 +3298,7 @@ high_frequency_telemetry:
     reason: "High frequency telemetry isn't supported in this platform"
     conditions_logical_operator: or
     conditions:
-      - "platform not in ['x86_64-nvidia_sn5600-r0', 'x86_64-nvidia_sn5640-r0', 'x86_64-arista_7060x6_64pe_b']"
+      - "platform not in ['x86_64-nvidia_sn5600-r0', 'x86_64-nvidia_sn5640-r0', 'x86_64-arista_7060x6_64pe', 'x86_64-arista_7060x6_64pe_b']"
       - "'bmc' in topo_type"
 
 high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_full_counters:

--- a/tests/high_frequency_telemetry/counter_profiles.py
+++ b/tests/high_frequency_telemetry/counter_profiles.py
@@ -52,6 +52,77 @@ _BUFFER_POOL_COUNTERS_SN5640 = (
     # "WATERMARK_CELLS",
 )
 
+# ── Arista 7060X6 counters ──────────────────────────────────────────────
+# Applies to both x86_64-arista_7060x6_64pe and x86_64-arista_7060x6_64pe_b.
+
+_PORT_COUNTERS_7060X6 = (
+    "IF_IN_OCTETS",
+    "IF_IN_UCAST_PKTS",
+    "IF_IN_DISCARDS",
+    "IF_IN_ERRORS",
+    "IF_OUT_OCTETS",
+    "IF_OUT_DISCARDS",
+    "IF_OUT_ERRORS",
+    "IF_OUT_UCAST_PKTS",
+    "PFC_0_RX_PKTS",
+    "PFC_1_RX_PKTS",
+    "PFC_2_RX_PKTS",
+    "PFC_3_RX_PKTS",
+    "PFC_4_RX_PKTS",
+    "PFC_5_RX_PKTS",
+    "PFC_6_RX_PKTS",
+    "PFC_7_RX_PKTS",
+    "PFC_0_TX_PKTS",
+    "PFC_1_TX_PKTS",
+    "PFC_2_TX_PKTS",
+    "PFC_3_TX_PKTS",
+    "PFC_4_TX_PKTS",
+    "PFC_5_TX_PKTS",
+    "PFC_6_TX_PKTS",
+    "PFC_7_TX_PKTS",
+    "PFC_0_XOFF_TOTAL_DURATION",
+    "PFC_1_XOFF_TOTAL_DURATION",
+    "PFC_2_XOFF_TOTAL_DURATION",
+    "PFC_3_XOFF_TOTAL_DURATION",
+    "PFC_4_XOFF_TOTAL_DURATION",
+    "PFC_5_XOFF_TOTAL_DURATION",
+    "PFC_6_XOFF_TOTAL_DURATION",
+    "PFC_7_XOFF_TOTAL_DURATION",
+    "PFC_0_XOFF_MAX_DURATION",
+    "PFC_1_XOFF_MAX_DURATION",
+    "PFC_2_XOFF_MAX_DURATION",
+    "PFC_3_XOFF_MAX_DURATION",
+    "PFC_4_XOFF_MAX_DURATION",
+    "PFC_5_XOFF_MAX_DURATION",
+    "PFC_6_XOFF_MAX_DURATION",
+    "PFC_7_XOFF_MAX_DURATION",
+)
+
+_QUEUE_COUNTERS_7060X6 = (
+    "DROPPED_PACKETS",
+    "CURR_OCCUPANCY_BYTES",
+    "WATERMARK_BYTES",
+    "PACKETS",
+    "BYTES",
+    "WRED_ECN_MARKED_PACKETS",
+)
+
+_INGRESS_PRIORITY_GROUP_COUNTERS_7060X6 = (
+    "CURR_OCCUPANCY_BYTES",
+    "XOFF_ROOM_CURR_OCCUPANCY_BYTES",
+    "XOFF_ROOM_WATERMARK_BYTES",
+    "PACKETS",
+    "BYTES",
+    "DROPPED_PACKETS",
+    "SHARED_WATERMARK_BYTES",
+)
+
+_BUFFER_POOL_COUNTERS_7060X6 = (
+    "CURR_OCCUPANCY_BYTES",
+    "WATERMARK_BYTES",
+    "XOFF_ROOM_WATERMARK_BYTES",
+)
+
 SUPPORTED_STATS: Mapping[str, Mapping[CounterObjectType, Sequence[str]]] = {
     "x86_64-nvidia_sn5640-r0": {
         CounterObjectType.PORT: _PORT_COUNTERS_SN5640,
@@ -60,8 +131,16 @@ SUPPORTED_STATS: Mapping[str, Mapping[CounterObjectType, Sequence[str]]] = {
         CounterObjectType.BUFFER_POOL: _BUFFER_POOL_COUNTERS_SN5640,
     },
     "x86_64-arista_7060x6_64pe_b": {
-        CounterObjectType.PORT: (),
-        CounterObjectType.QUEUE: (),
+        CounterObjectType.PORT: _PORT_COUNTERS_7060X6,
+        CounterObjectType.QUEUE: _QUEUE_COUNTERS_7060X6,
+        CounterObjectType.INGRESS_PRIORITY_GROUP: _INGRESS_PRIORITY_GROUP_COUNTERS_7060X6,
+        CounterObjectType.BUFFER_POOL: _BUFFER_POOL_COUNTERS_7060X6,
+    },
+    "x86_64-arista_7060x6_64pe": {
+        CounterObjectType.PORT: _PORT_COUNTERS_7060X6,
+        CounterObjectType.QUEUE: _QUEUE_COUNTERS_7060X6,
+        CounterObjectType.INGRESS_PRIORITY_GROUP: _INGRESS_PRIORITY_GROUP_COUNTERS_7060X6,
+        CounterObjectType.BUFFER_POOL: _BUFFER_POOL_COUNTERS_7060X6,
     },
     _DEFAULT_PLATFORM: {
         CounterObjectType.PORT: (),


### PR DESCRIPTION
### Description of PR

Summary: Enable HFT tests on Arista 7060X6 platforms and add per-platform counter profiles.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Arista 7060X6 platforms now support HFT. The existing test infrastructure skips all HFT tests on 7060X6 because:
1. `x86_64-arista_7060x6_64pe` was not in the platform allowlist in `tests_mark_conditions.yaml`
2. Counter profiles for 7060X6 in `counter_profiles.py` were empty tuples

#### How did you do it?
1. **`tests_mark_conditions.yaml`**: Added `x86_64-arista_7060x6_64pe` to the HFT platform allowlist (alongside existing `x86_64-arista_7060x6_64pe_b`)
2. **`counter_profiles.py`**: Added full counter definitions for both 7060X6 variants:
   - **PORT** (40 counters): basic stats + PFC 0-7 RX/TX/XOFF_TOTAL_DURATION/XOFF_MAX_DURATION
   - **QUEUE** (6 counters): packets, bytes, drops, occupancy, watermark, ECN marked
   - **INGRESS_PRIORITY_GROUP** (7 counters): occupancy, xoff room, watermark, packets, bytes, drops, shared watermark
   - **BUFFER_POOL** (3 counters): occupancy, watermark, xoff room watermark

#### How did you verify/test it?
- Python syntax validation passed
- YAML syntax validation passed

#### Any platform specific information?
- `x86_64-arista_7060x6_64pe`
- `x86_64-arista_7060x6_64pe_b`

#### Supported testbed topology if it's a new test case?
any

### Documentation
N/A