### PR TITLE
[multi-asic] fix static route commands in test_dip_sip for multi-asic

### DIFF
--- a/tests/ipfwd/test_dip_sip.py
+++ b/tests/ipfwd/test_dip_sip.py
@@ -40,21 +40,15 @@ def check_route(duthost, static_route, nexthop_ip, asic_id, ip_ver=4, expected_s
 
 
 def add_static_route(duthost, static_route, nexthop_ip, asic_id):
-    cli_cmd = "config route add prefix {} nexthop {}".format(static_route, nexthop_ip)
-    if duthost.is_multi_asic:
-        namespace = duthost.get_namespace_from_asic_id(asic_id)
-        cmd_prefix = "sudo ip netns exec {} ".format(namespace)
-        cli_cmd = cmd_prefix + cli_cmd
+    cli_ns_option = duthost.asic_instance(asic_id).cli_ns_option
+    cli_cmd = "config route {} add prefix {} nexthop {}".format(cli_ns_option, static_route, nexthop_ip)
     result = duthost.shell(cli_cmd)
     return result
 
 
 def delete_static_route(duthost, static_route, nexthop_ip, asic_id):
-    cli_cmd = "config route del prefix {} nexthop {}".format(static_route, nexthop_ip)
-    if duthost.is_multi_asic:
-        namespace = duthost.get_namespace_from_asic_id(asic_id)
-        cmd_prefix = "sudo ip netns exec {} ".format(namespace)
-        cli_cmd = cmd_prefix + cli_cmd
+    cli_ns_option = duthost.asic_instance(asic_id).cli_ns_option
+    cli_cmd = "config route {} del prefix {} nexthop {}".format(cli_ns_option, static_route, nexthop_ip)
     result = duthost.shell(cli_cmd)
     return result
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix `test_dip_sip.py` static route commands failing on multi-ASIC platforms due to the config route CLI now requiring `-n/--namespace.`
Fixes #23621 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The `config route` CLI now requires `-n/--namespace` on multi-ASIC platforms after sonic-utilities [#4269](https://github.com/sonic-net/sonic-utilities/pull/4269). 
The previous approach of wrapping commands with `sudo ip netns exec <namespace>` no longer works since the `config route` Click group enforces the `-n` option directly.
#### How did you do it?
- run config route from the host namespace using `-n <namespace>` instead of entering the ASIC namespace via `ip netns exec`
- use the existing `SonicAsic.cli_ns_option` property to build the namespace argument
#### How did you verify/test it?
Run `ipfwd/test_dip_sip.py` on single-asic and multi-asic platforms
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
