### PR TITLE
[th6] Add sonic-mgmt configuration for packet trimming GCU tests

### DIFF
--- a/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/BALANCED/buffers_defaults_t0.j2
+++ b/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/BALANCED/buffers_defaults_t0.j2
@@ -1,0 +1,53 @@
+{%- set default_cable = '300m' %}
+
+{%- include 'buffer_ports.j2' %}
+
+{%- set ports2cable = {
+        'torrouter_server'       : '300m',
+        'leafrouter_torrouter'   : '300m',
+        'spinerouter_leafrouter' : '2000m',
+        'upperspinerouter_spinerouter' : '50m',
+        'upperspinerouter_lowerspinerouter' : '50m',
+        'regionalhub_upperspinerouter': '120000m',
+        'aznghub_upperspinerouter'    : '120000m',
+        'regionalhub_spinerouter': '120000m',
+        'aznghub_spinerouter'    : '120000m'
+        }
+-%}
+
+{%- macro generate_qos_bypass_port_list(PORT_QOS_BYPASS) %}
+    {# Generate list of ports #}
+    {%- for port_idx in range(256, 261, 4) %}
+        {%- if PORT_QOS_BYPASS.append("Ethernet%d" % (port_idx)) %}{%- endif %}
+    {%- endfor %}
+{%- endmacro %}
+
+{%- macro generate_buffer_pool_and_profiles() %}
+    "BUFFER_POOL": {
+        "ingress_lossless_pool": {
+            "size": "25766440000",
+            "type": "both",
+            "mode": "dynamic",
+            "xoff": "5301600256"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool":"ingress_lossless_pool",
+            "size":"0",
+            "xon_offset": "0",
+            "dynamic_th":"0"
+        },
+        "egress_lossless_profile": {
+            "pool":"ingress_lossless_pool",
+            "size":"0",
+            "dynamic_th":"-1"
+        },
+        "egress_lossy_profile": {
+            "pool":"ingress_lossless_pool",
+            "size":"0",
+            "dynamic_th":"-6"
+        }
+    },
+{%- endmacro %}
+

--- a/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/buffers_defaults_t0.j2
+++ b/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/buffers_defaults_t0.j2
@@ -1,0 +1,53 @@
+{%- set default_cable = '300m' %}
+
+{%- include 'buffer_ports.j2' %}
+
+{%- set ports2cable = {
+        'torrouter_server'       : '300m',
+        'leafrouter_torrouter'   : '300m',
+        'spinerouter_leafrouter' : '2000m',
+        'upperspinerouter_spinerouter' : '50m',
+        'upperspinerouter_lowerspinerouter' : '50m',
+        'regionalhub_upperspinerouter': '120000m',
+        'aznghub_upperspinerouter'    : '120000m',
+        'regionalhub_spinerouter': '120000m',
+        'aznghub_spinerouter'    : '120000m'
+        }
+-%}
+
+{%- macro generate_qos_bypass_port_list(PORT_QOS_BYPASS) %}
+    {# Generate list of ports #}
+    {%- for port_idx in range(256, 261, 4) %}
+        {%- if PORT_QOS_BYPASS.append("Ethernet%d" % (port_idx)) %}{%- endif %}
+    {%- endfor %}
+{%- endmacro %}
+
+{%- macro generate_buffer_pool_and_profiles() %}
+    "BUFFER_POOL": {
+        "ingress_lossless_pool": {
+            "size": "25766440000",
+            "type": "both",
+            "mode": "dynamic",
+            "xoff": "5301600256"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool":"ingress_lossless_pool",
+            "size":"0",
+            "xon_offset": "0",
+            "dynamic_th":"0"
+        },
+        "egress_lossless_profile": {
+            "pool":"ingress_lossless_pool",
+            "size":"0",
+            "dynamic_th":"-1"
+        },
+        "egress_lossy_profile": {
+            "pool":"ingress_lossless_pool",
+            "size":"0",
+            "dynamic_th":"-6"
+        }
+    },
+{%- endmacro %}
+


### PR DESCRIPTION
### Description of PR

This PR sets trim size to 392 and trim queue index to 7 in Generic Config Updater (GCU) tests for Broadcom ASICs.

Additionally PR introduces token matching for TH6 asics for use by `duthost.get_asic_name()`.

This was tested on a TH6-C device, however TH6-P uses same MMU architecture and these values remain the same.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

Log output to show ASIC retrieval working on nexthop th6 hwsku
```
01/04/2026 00:20:42 sonic.get_asic_name                      L1917 INFO   | asic: th6
01/04/2026 00:20:42 __init__.memory_utilization              L0143 INFO   | Hostname: sonic, Hwsku: NH-4220, Platform: x86_64-nexthop_4220-r0
```

Asymmetric
```                                                 
generic_config_updater/test_packet_trimming_config_asymmetric.py::test_packet_trimming_config_asym PASSED [100%]

------------------ generated xml file: /tmp/test-logs/tr.xml -------------------
======================= 1 passed, 77 warnings in 51.32s ========================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_packet_trimming_config_asym>
INFO:root:Can not get Allure report URL. Please check logs
run_group_tests: END: Wed Apr  1 00:21:15 UTC 2026
```


Symmetric
```
generic_config_updater/test_packet_trimming_config_symmetric.py::test_packet_trimming_config_sym PASSED [100%]

------------------ generated xml file: /tmp/test-logs/tr.xml -------------------
======================= 1 passed, 77 warnings in 54.74s ========================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
