### PR TITLE
fix: correct baud rate throughput specifications

### DIFF
--- a/docs/testplan/console/standalone_sonic_console_server_test_plan.md
+++ b/docs/testplan/console/standalone_sonic_console_server_test_plan.md
@@ -320,7 +320,7 @@ A new set of utilities will be created for this purpose.
 - **Topo**: c0-lo
 - **Test Setup**:
   1. parameter: [flowcontrol-off, flowcontrol-on]
-  1. parameter: [baud-9600(flow 10KB/s), baud-115200(100KB/s)]
+  1. parameter: [baud-9600(flow 0.96KB/s), baud-115200(11.52KB/s)]
   1. parameter: [chunksize-32, chunksize-128, chunksize-1024]
   1. Config all DUT console ports
 - **Test Steps**:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fixes incorrect baud rate throughput specifications in the standalone SONiC console server test plan documentation.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
The current documentation contains incorrect baud rate throughput values that could mislead test implementation and performance expectations. The baud rates need to be corrected to accurate values.

#### How did you do it?

Changed from `baud-9600(flow 10KB/s), baud-115200(100KB/s)` to `baud-9600(0.96KB/s), baud-115200(11.52KB/s)`


#### How did you verify/test it?

Calculation verification:
- 9600 baud ÷ 8 bits/byte = 1200 B/s ≈ 0.96 KB/s (with serial overhead)
- 115200 baud ÷ 8 bits/byte = 14400 B/s ≈ 11.52 KB/s (with serial overhead)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
N/A (Documentation fix only)
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
