### PR TITLE
HA privatelink support when running snappi_tests

### DIFF
--- a/tests/common/snappi_tests/ixload/snappi_fixtures.py
+++ b/tests/common/snappi_tests/ixload/snappi_fixtures.py
@@ -83,8 +83,6 @@ def setup_config_snappi_l47(request, duthosts, tbinfo, ha_test_case=None):
         l47_version = tbinfo['l47_version']
         service_type = tbinfo['service_type']
         chassis_ip = tbinfo['chassis_ip']
-        chassis_user_login = tbinfo['chassis_user_login']
-        chassis_user_passwd = tbinfo['chassis_user_passwd']
         clean_l47trafficgen_staticarps = tbinfo['clean_l47trafficgen_staticarps']
         gw_ip = tbinfo['l47_gateway']
         eni_per_dpu = int(tbinfo.get('eni_per_dpu', 0))
@@ -106,8 +104,6 @@ def setup_config_snappi_l47(request, duthosts, tbinfo, ha_test_case=None):
 
         connection_dict = {
             'chassis_ip': chassis_ip,
-            'chassis_user_login': chassis_user_login,
-            'chassis_user_passwd': chassis_user_passwd,
             'gw_ip': gw_ip,
             'port': '8080',
             'ixos_version': ixos_version,
@@ -116,14 +112,15 @@ def setup_config_snappi_l47(request, duthosts, tbinfo, ha_test_case=None):
 
         logger.info("Cleaning old static ARP files from the l47traifficgen server")
         if clean_l47trafficgen_staticarps:
-            delete_staticarp_files(chassis_ip, chassis_user_login, chassis_user_passwd, ixos_version)
+            delete_staticarp_files(chassis_ip, tbinfo, ixos_version)
 
         nw_config = NetworkConfigSettings()
         if ha_test_case != "cps":
             nw_config.ENI_COUNT = 32  # Set to 32 ENIs for HA test cases to test 1 Active/Standby DPU
         if ha_test_case == "cps" and eni_per_dpu > 0:
             nw_config.ENI_COUNT = eni_per_dpu
-        api, config, initial_cps_value = l47_trafficgen_main(ports_list, connection_dict, nw_config, service_type,
+        api, config, initial_cps_value = l47_trafficgen_main(ports_list, tbinfo, connection_dict, nw_config,
+                                                             service_type,
                                                              test_type_dict['all'], test_filename,
                                                              test_type_dict['initial_cps_obj'])
 

--- a/tests/common/snappi_tests/ixload/snappi_fixtures.py
+++ b/tests/common/snappi_tests/ixload/snappi_fixtures.py
@@ -3,7 +3,8 @@ This module contains the snappi fixture in the snappi_tests directory.
 """
 from tests.common.snappi_tests.ixload.snappi_helper import (l47_trafficgen_main, duthost_ha_config,
                                                             npu_startup, dpu_startup, set_static_routes, set_ha_roles,
-                                                            set_ha_admin_up, set_ha_activate_role, duthost_port_config)
+                                                            set_ha_admin_up, set_ha_activate_role, duthost_port_config,
+                                                            delete_staticarp_files)
 from tests.common.snappi_tests.uhd.uhd_helpers import NetworkConfigSettings  # noqa: F403, F401
 import pytest
 import threading
@@ -78,15 +79,24 @@ def setup_config_snappi_l47(request, duthosts, tbinfo, ha_test_case=None):
     if l47_trafficgen_enabled:
         logger.info(f"Configuring L47 parameters for test case: {ha_test_case}")
 
+        ixos_version = tbinfo['ixos_version']
         l47_version = tbinfo['l47_version']
         service_type = tbinfo['service_type']
         chassis_ip = tbinfo['chassis_ip']
+        chassis_user_login = tbinfo['chassis_user_login']
+        chassis_user_passwd = tbinfo['chassis_user_passwd']
+        clean_l47trafficgen_staticarps = tbinfo['clean_l47trafficgen_staticarps']
         gw_ip = tbinfo['l47_gateway']
+        eni_per_dpu = int(tbinfo.get('eni_per_dpu', 0))
 
         ports_list = tbinfo['ports_list']
         ports_list = {k: [tuple(x) for x in v] for k, v in ports_list.items()}
 
-        test_filename = "dash_cps"
+        if service_type == "vnet2vnet":
+            test_filename = "dash_vnet2vnet"
+        else:
+            test_filename = "dash_pl"
+
         initial_cps_obj = (len(ports_list['Traffic1@Network1']) * 4000000) // 2
 
         test_type_dict = {
@@ -96,16 +106,26 @@ def setup_config_snappi_l47(request, duthosts, tbinfo, ha_test_case=None):
 
         connection_dict = {
             'chassis_ip': chassis_ip,
+            'chassis_user_login': chassis_user_login,
+            'chassis_user_passwd': chassis_user_passwd,
             'gw_ip': gw_ip,
             'port': '8080',
+            'ixos_version': ixos_version,
             'version': l47_version,
         }
+
+        logger.info("Cleaning old static ARP files from the l47traifficgen server")
+        if clean_l47trafficgen_staticarps:
+            delete_staticarp_files(chassis_ip, chassis_user_login, chassis_user_passwd, ixos_version)
 
         nw_config = NetworkConfigSettings()
         if ha_test_case != "cps":
             nw_config.ENI_COUNT = 32  # Set to 32 ENIs for HA test cases to test 1 Active/Standby DPU
+        if ha_test_case == "cps" and eni_per_dpu > 0:
+            nw_config.ENI_COUNT = eni_per_dpu
         api, config, initial_cps_value = l47_trafficgen_main(ports_list, connection_dict, nw_config, service_type,
-                                                             test_type_dict['all'], test_type_dict['initial_cps_obj'])
+                                                             test_type_dict['all'], test_filename,
+                                                             test_type_dict['initial_cps_obj'])
 
         if l47_trafficgen_save:
             snappi_l47_params['save'] = True
@@ -247,7 +267,7 @@ def setup_config_npu_dpu(request, duthosts, localhost, tbinfo, ha_test_case=None
             duthost1 = duthosts[0]
 
             # Configure SmartSwitch
-            # duthost_port_config(duthost)
+            duthost_port_config(duthost1)
 
             static_ipsmacs_dict1 = duthost_ha_config(duthost1, nw_config)
 
@@ -281,6 +301,7 @@ def config_snappi_l47(request, duthosts, tbinfo):
     """
     Fixture configures L47 parameters
     """
+    logger.info("Entering L47 configuration setup")
     return setup_config_snappi_l47(request, duthosts, tbinfo)
 
 

--- a/tests/common/snappi_tests/ixload/snappi_fixtures.py
+++ b/tests/common/snappi_tests/ixload/snappi_fixtures.py
@@ -85,7 +85,7 @@ def setup_config_snappi_l47(request, duthosts, tbinfo, ha_test_case=None):
         chassis_ip = tbinfo['chassis_ip']
         clean_l47trafficgen_staticarps = tbinfo['clean_l47trafficgen_staticarps']
         gw_ip = tbinfo['l47_gateway']
-        eni_per_dpu = int(tbinfo.get('eni_per_dpu', 0))
+        eni_per_dpu = int(tbinfo.get('eni_per_dpu', 32))
 
         ports_list = tbinfo['ports_list']
         ports_list = {k: [tuple(x) for x in v] for k, v in ports_list.items()}

--- a/tests/common/snappi_tests/ixload/snappi_helper.py
+++ b/tests/common/snappi_tests/ixload/snappi_helper.py
@@ -1366,9 +1366,6 @@ def patch_dut_config(api, nw_config):
         print(f"An error occurred: {e}")
         return None
 
-    # Here patch ranges
-    # TODO fix the multiplier
-
     count = 0
     NETWORK_RANGE_ID = 0
     VLAN_ID = 1

--- a/tests/common/snappi_tests/ixload/snappi_helper.py
+++ b/tests/common/snappi_tests/ixload/snappi_helper.py
@@ -609,7 +609,6 @@ def duthost_port_config(duthost):
     duthost.shell("sudo cp /etc/sonic/0HA_BACKUP/config_db.json  /etc/sonic/config_db.json")
 
     # logger.info(f"{duthost.hostname} Reloading config_db.json")
-    # duthost.shell("sudo config reload -y \n")
 
     logger.info(f"{duthost.hostname} Saving config_db.json")
     duthost.shell("sudo config save -y")
@@ -1472,28 +1471,6 @@ def patch_communityList2(api, nw_config):
             return None
 
     return
-
-
-"""
-def test_saveAs(api, test_filename):
-
-    saveAs_operation = 'ixload/test/operations/saveAs'
-    #url = "{}/{}".format(base_url, saveAs_operation)
-    paramDict = {
-        'fullPath': "C:\\automation\\{}.rxf".format(test_filename),
-        'overWrite': True
-    }
-
-    #response = requests.post(url, data=json.dumps(paramDict), headers=headers)
-    try:
-        # Code that may raise an exception
-        res = api.ixload_configure("post", saveAs_operation, paramDict)
-    except Exception as e:
-        # Handle any exception
-        logger.info(f"An error occurred: {e}")
-
-    return
-"""
 
 
 def delete_staticarp_files(chassis_ip, chassis_user_login, chassis_user_passwd, ixos_version):

--- a/tests/common/snappi_tests/ixload/snappi_helper.py
+++ b/tests/common/snappi_tests/ixload/snappi_helper.py
@@ -346,11 +346,11 @@ def _set_routes_on_dut(duthosts, duthost, tbinfo, local_files, local_dir, dpu_in
             if duthost == duthosts[1]:
                 target_ip = f'169.254.200.{dpu_index + 1}'
             else:
-                target_ip = f'18.{dpu_index}.202.1'
+                target_ip = f'20.0.200.{dpu_index+1}'
         else:
-            target_ip = f'18.{dpu_index}.202.1'
+            target_ip = f'20.0.200.{dpu_index+1}'
     else:
-        target_ip = f'18.{dpu_index}.202.1'
+        target_ip = f'20.0.200.{dpu_index+1}'
     target_username = tbinfo.get('dpu_target_username', 'admin')
     target_password = tbinfo.get('dpu_target_passwd', 'YourPaSsWoRd')
 
@@ -400,9 +400,9 @@ def _set_routes_on_dut(duthosts, duthost, tbinfo, local_files, local_dir, dpu_in
                     'sudo config route del prefix 0.0.0.0/0 via 169.254.200.254', delay_factor=2)
                 logger.info(f"{duthost.hostname} Execute on DPU Target: {output}")
                 time.sleep(1)
-                logger.info(f'sudo config route add prefix 0.0.0.0/0 nexthop 18.{dpu_index}.202.0')
+                logger.info(f'sudo config route add prefix 0.0.0.0/0 nexthop 20.0.200.{dpu_index+1}')
                 output = net_connect_jump.send_command_timing(
-                    f'sudo config route add prefix 0.0.0.0/0 nexthop 18.{dpu_index}.202.0', delay_factor=2)
+                    f'sudo config route add prefix 0.0.0.0/0 nexthop 20.0.200.{dpu_index+1}', delay_factor=2)
                 logger.info(f"{duthost.hostname} Execute on DPU Target: {output}")
                 output = net_connect_jump.send_command_timing('show ip route', delay_factor=2)
                 logger.info(f"{duthost.hostname} Execute on DPU Target: {output}")
@@ -448,10 +448,10 @@ def _set_routes_on_dut(duthosts, duthost, tbinfo, local_files, local_dir, dpu_in
                     logger.info(f'Restarting hamgrd on {duthost.hostname}: docker restart dash-hadpu0')
                     duthost.shell("docker restart dash-hadpu0")
                     logger.info(f'Removing interface from {duthost.hostname}: '
-                                f'sudo config interface ip rem Ethernet0 18.{dpu_index}.202.1/31')
+                                f'sudo config interface ip rem Ethernet0 20.0.200.{dpu_index+1}/31')
                     time.sleep(2)
                     output = net_connect_jump.send_command_timing(
-                        f'sudo config interface ip rem Ethernet0 18.{dpu_index}.202.1/31', delay_factor=2)
+                        f'sudo config interface ip rem Ethernet0 20.0.200.{dpu_index+1}/31', delay_factor=2)
                     logger.info(
                         f'Deleting route on {duthost.hostname}: sudo ip route del 0.0.0.0/0 via 169.254.200.254')
                     time.sleep(2)
@@ -459,10 +459,10 @@ def _set_routes_on_dut(duthosts, duthost, tbinfo, local_files, local_dir, dpu_in
                         'sudo ip route del 0.0.0.0/0 via 169.254.200.254', delay_factor=2)
                     logger.info(
                         f'Adding route on {duthost.hostname}: '
-                        f'sudo config route add prefix 0.0.0.0/0 nexthop 20.{dpu_index}.202.0')
+                        f'sudo config route add prefix 0.0.0.0/0 nexthop 20.0.201.{dpu_index+1}')
                     time.sleep(2)
                     output = net_connect_jump.send_command_timing(
-                        f'sudo config route add prefix 0.0.0.0/0 nexthop 20.{dpu_index}.202.0', delay_factor=2)
+                        f'sudo config route add prefix 0.0.0.0/0 nexthop 20.0.201.{dpu_index+1}', delay_factor=2)
                     active_ethpass_ip = tbinfo['active_ethpass_ip']
                     active_mac = tbinfo['active_mac']
                     logger.info(
@@ -473,9 +473,9 @@ def _set_routes_on_dut(duthosts, duthost, tbinfo, local_files, local_dir, dpu_in
                         f'ping -c 3 {active_ethpass_ip}')  # noqa:  E231
                     output_ping = duthost.command(f"ping -c 3 {active_ethpass_ip}", module_ignore_errors=True)
                     logger.info(f'Correcting route on {duthost.hostname}: '
-                                f'sudo config route del prefix 221.0.0.{dpu_index+1}/32 nexthop 20.{dpu_index}.202.1')
+                                f'sudo config route del prefix 221.0.0.{dpu_index+1}/32 nexthop 20.0.201.{dpu_index+1}')
                     output = duthost.command(f'sudo config route del prefix 221.0.0.{dpu_index+1}/32 '
-                                             f'nexthop 20.{dpu_index}.202.1', module_ignore_errors=True)
+                                             f'nexthop 20.0.201.{dpu_index+1}', module_ignore_errors=True)
                     logger.info(f'Adding correct route on {duthost.hostname}: '
                                 f'sudo config route add prefix 221.0.0.{dpu_index+1}/32 nexthop 220.0.4.1')
                     output = duthost.command(f'sudo config route add prefix 221.0.0.{dpu_index+1}/32 '
@@ -491,10 +491,10 @@ def _set_routes_on_dut(duthosts, duthost, tbinfo, local_files, local_dir, dpu_in
                     output = net_connect_jump.send_command_timing(
                         'sudo ip route del 0.0.0.0/0 via 169.254.200.254', delay_factor=2)
                     logger.info(f'Adding route on {duthost.hostname}: '
-                                f'sudo config route add prefix 0.0.0.0/0 nexthop 18.{dpu_index}.202.0')
+                                f'sudo config route add prefix 0.0.0.0/0 nexthop 20.0.200.{dpu_index+1}')
                     time.sleep(2)
                     output = net_connect_jump.send_command_timing(
-                        f'sudo config route add prefix 0.0.0.0/0 nexthop 18.{dpu_index}.202.0', delay_factor=2)
+                        f'sudo config route add prefix 0.0.0.0/0 nexthop 20.0.200.{dpu_index+1}', delay_factor=2)
 
                     standby_ethpass_ip = tbinfo['standby_ethpass_ip']
                     standby_mac = tbinfo['standby_mac']
@@ -575,7 +575,7 @@ def load_dpu_configs_on_dut(
                                                 ha_test_case)
     remote_dir = f"{remote_dir}/dpu{dpu_index}"
     _ensure_remote_dir_on_dut(duthost, remote_dir)
-    _telemetry_run_on_dut(duthost)
+    # _telemetry_run_on_dut(duthost)
     _copy_files_to_dut(duthost, local_files, remote_dir)
 
     delay = initial_delay_sec
@@ -590,7 +590,7 @@ def load_dpu_configs_on_dut(
                 logger.info(f"RPC unavailable for {rb}; retrying after telemetry restart")  # noqa: E702
                 duthost.shell("docker ps --format '{{.Names}}' | grep -w gnmi || true", module_ignore_errors=True)
                 time.sleep(120)
-                _telemetry_run_on_dut(duthost)
+                # _telemetry_run_on_dut(duthost)
                 time.sleep(retry_delay_sec)
                 _docker_run_config_on_dut(duthost, remote_dir, dpu_index, rb)
 
@@ -884,6 +884,7 @@ def npu_startup(duthosts, duthost, localhost):
             logger.info(f"DPU boot successful on {duthost.hostname}")
             break
 
+    '''
     if duthost == duthosts[1]:  # standby device
         logger.info(f"Removing unwanted IPs from standby device: {duthost.hostname}")
         remove_dpu_ip_addresses_from_npu(
@@ -891,6 +892,7 @@ def npu_startup(duthosts, duthost, localhost):
             ip_prefixes_to_remove=["18"],  # Removes 18.X.202.0/31 addresses
             additional_filters=["220.0.1.1/", "220.0.2.1/", "220.0.3.1/", "220.0.4.1/"]
         )
+    '''
 
     return True
 
@@ -904,12 +906,12 @@ def dpu_startup(duthosts, duthost, tbinfo, static_ipmacs_dict, ha_test_case):
 
     # Determine which IPs to ping based on duthost
     if len(duthosts) > 1 and duthost == duthosts[1]:
-        # For duthosts[1], ping 20.0.202.1, 20.1.202.1, ..., 20.7.202.1
+        # For duthosts[1], ping 20.0.201.1...20.0.201.8
         ip_list_to_ping = [f"169.254.200.{i+1}" for i in range(8)]
         logger.info(f"Using standby side midplane IPs for {duthost.hostname}: {ip_list_to_ping}")
     elif len(duthosts) > 1 and duthost == duthosts[0]:
-        # For duthosts[0], ping 18.0.202.1, ..., 18.7.202.1
-        ip_list_to_ping = [f"18.{i}.202.1" for i in range(8)]
+        # For duthosts[0], ping 20.0.200.1, ..., 20.0.200.8
+        ip_list_to_ping = [f"20.0.200.{i+1}" for i in range(8)]
         logger.info(f"Using active side IPs for {duthost.hostname}: {ip_list_to_ping}")
     else:
         # Fallback to original logic for single DUT setup

--- a/tests/common/snappi_tests/ixload/snappi_helper.py
+++ b/tests/common/snappi_tests/ixload/snappi_helper.py
@@ -6,7 +6,6 @@ from netmiko import ConnectHandler
 from scp import SCPClient
 from pathlib import Path
 import paramiko
-import io
 import snappi
 import stat
 import time
@@ -1560,12 +1559,20 @@ def set_chassis_connect(chassis_ip, tbinfo):
 
     chassis_user_login = tbinfo.get('chassis_user_login')
     chassis_user_passwd = tbinfo.get('chassis_user_passwd')
-    # setting up ssh connection
-    ssh_client = paramiko.SSHClient()
-    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())  # lgtm[py/accepts-unknown-host-key]
 
-    ssh_client.connect(hostname=f'{chassis_ip}', username=f'{chassis_user_login}',
-                       password=f'{chassis_user_passwd}')
+    # setting up ssh connection
+    try:
+        logger.info("Setting up an SSH client to connect to chassis")
+        ssh_client = paramiko.SSHClient()
+        logger.info("Loading host keys for SSH client")
+        ssh_client.load_system_host_keys()
+        logger.info(f"Connecting to {chassis_ip}...")
+        ssh_client.connect(hostname=f'{chassis_ip}', username=f'{chassis_user_login}',
+                           password=f'{chassis_user_passwd}')
+    except Exception as e:
+        logger.error(f"Failed to connect to {chassis_ip}, make sure credentials are correct and network is "
+                     f"reachable and chassis is part of known_hosts: {e}")
+        return None
 
     return ssh_client
 
@@ -1600,8 +1607,9 @@ def set_trafficgen_staticarps(staticarp_ranges, chassis_ip, tbinfo,
                     f"RemoteIPv4={ip_addr}, RemoteIPv4Incr=0.0.0.2, "
                     f"Count={count}, VlanID={vlan_id}\n")
 
-        with io.open(filename, 'w+') as f:
-            f.writelines(lines)  # lgtm[py/clear-text-storage-sensitive-data]
+        fd = os.open(filename, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, 'w') as f:
+            f.writelines(lines)
 
         with SCPClient(ssh_client.get_transport()) as scp_client:
             try:

--- a/tests/common/snappi_tests/ixload/snappi_helper.py
+++ b/tests/common/snappi_tests/ixload/snappi_helper.py
@@ -352,8 +352,8 @@ def _set_routes_on_dut(duthosts, duthost, tbinfo, local_files, local_dir, dpu_in
             target_ip = f'18.{dpu_index}.202.1'
     else:
         target_ip = f'18.{dpu_index}.202.1'
-    target_username = 'admin'
-    target_password = 'YourPaSsWoRd'
+    target_username = tbinfo.get('dpu_target_username', 'admin')
+    target_password = tbinfo.get('dpu_target_passwd', 'YourPaSsWoRd')
 
     # Connect to jump host
     net_connect_jump = ConnectHandler(**jump_host)
@@ -1312,9 +1312,6 @@ def set_timelineCustom(api, initial_cps_value):
     except Exception as e:
         # Handle any exception
         logger.info(f"An error occurred: {e}")
-    except Exception as e:
-        # Handle any exception
-        logger.info(f"An error occurred: {e}")
 
     return
 
@@ -1473,7 +1470,7 @@ def patch_communityList2(api, nw_config):
     return
 
 
-def delete_staticarp_files(chassis_ip, chassis_user_login, chassis_user_passwd, ixos_version):
+def delete_staticarp_files(chassis_ip, tbinfo, ixos_version):
     def delete_files(ssh_client, remote_path, logger=None):
         """
         Delete a remote file using SFTP. If it doesn't exist, do nothing.
@@ -1503,22 +1500,20 @@ def delete_staticarp_files(chassis_ip, chassis_user_login, chassis_user_passwd, 
             if sftp:
                 sftp.close()
 
-    # setting up ssh connection
-    ssh_client = paramiko.SSHClient()
-    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-
     # Connect to remote host
     logger.info(f"Connecting to {chassis_ip}...")
-    ssh_client.connect(hostname=f'{chassis_ip}', username=f'{chassis_user_login}', password=f'{chassis_user_passwd}')
+    ssh_client = set_chassis_connect(chassis_ip, tbinfo)
 
     card = 1  # Update this to use card number as an index
     # client
-    delete_files(ssh_client,
-                 f'/home/ixia_apps/ixos/{ixos_version}/nfs/rw/ports/{card}/1/ixtcp.arp', logger)
+    client_path = os.path.join(f'/home/ixia_apps/ixos/{ixos_version}/nfs/rw/ports/{card}/1/ixtcp.arp')
+    delete_files(ssh_client, client_path, logger)
 
     # server
-    delete_files(ssh_client,
-                 f'/home/ixia_apps/ixos/{ixos_version}/nfs/rw/ports/{card}/2/ixtcp.arp', logger)
+    server_path = os.path.join(f'/home/ixia_apps/ixos/{ixos_version}/nfs/rw/ports/{card}/2/ixtcp.arp')
+    delete_files(ssh_client, server_path, logger)
+
+    close_chassis_connect(ssh_client)
 
     return
 
@@ -1561,7 +1556,26 @@ def set_test_preferences(api):
     return
 
 
-def set_trafficgen_staticarps(api, staticarp_ranges, chassis_ip, chassis_user_login, chassis_user_passwd,
+def set_chassis_connect(chassis_ip, tbinfo):
+
+    chassis_user_login = tbinfo.get('chassis_user_login')
+    chassis_user_passwd = tbinfo.get('chassis_user_passwd')
+    # setting up ssh connection
+    ssh_client = paramiko.SSHClient()
+    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+    ssh_client.connect(hostname=f'{chassis_ip}', username=f'{chassis_user_login}',
+                       password=f'{chassis_user_passwd}')
+
+    return ssh_client
+
+
+def close_chassis_connect(ssh_client):
+    # Close the SSH connection
+    ssh_client.close()
+
+
+def set_trafficgen_staticarps(staticarp_ranges, chassis_ip, tbinfo,
                               ixos_version, nw_config):
     def build_arp_payload(ssh_client, staticarp_ranges, ENI_TOTAL, filename, is_server, remote_path):
         lines = []
@@ -1601,43 +1615,37 @@ def set_trafficgen_staticarps(api, staticarp_ranges, chassis_ip, chassis_user_lo
     ENI_TOTAL = nw_config.ENI_COUNT
     card = 1  # Make this an index
 
-    ssh_client = paramiko.SSHClient()
-    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-
     # Connect to remote host
     logger.info(f"Connecting to {chassis_ip}...")
-    ssh_client.connect(hostname=f'{chassis_ip}', username=f'{chassis_user_login}', password=f'{chassis_user_passwd}')
+    ssh_client = set_chassis_connect(chassis_ip, tbinfo)
 
     # Create client files
+    client_path = os.path.join(f'/home/ixia_apps/ixos/{ixos_version}/nfs/rw/ports/{card}/1/ixtcp.arp')
     build_arp_payload(
-        ssh_client, staticarp_ranges, ENI_TOTAL, f"ixtcp_{card}.arp", False,
-        f'/home/ixia_apps/ixos/{ixos_version}/nfs/rw/ports/{card}/1/ixtcp.arp'
+        ssh_client, staticarp_ranges, ENI_TOTAL, f"ixtcp_{card}.arp", False, client_path
     )
 
     # Create server files
+    server_path = os.path.join(f'/home/ixia_apps/ixos/{ixos_version}/nfs/rw/ports/{card}/2/ixtcp.arp')
     build_arp_payload(
-        ssh_client, staticarp_ranges, ENI_TOTAL, f"ixtcp_{card}_1.arp", True,
-        f'/home/ixia_apps/ixos/{ixos_version}/nfs/rw/ports/{card}/2/ixtcp.arp'
+        ssh_client, staticarp_ranges, ENI_TOTAL, f"ixtcp_{card}_1.arp", True, server_path
     )
 
-    # Close the SSH connection
-    ssh_client.close()
+    close_chassis_connect(ssh_client)
 
     logger.info("ARP files created successfully!")
 
     return
 
 
-def l47_trafficgen_main(ports_list, connection_dict, nw_config, service_type,
+def l47_trafficgen_main(ports_list, tbinfo, connection_dict, nw_config, service_type,
                         test_type, test_filename, initial_cps_value):
 
     # Start Here ######
     main_start_time = time.time()
     gw_ip = connection_dict['gw_ip']
     port = connection_dict['port']
-    chassis_ip = connection_dict['chassis_ip']
-    chassis_user_login = connection_dict['chassis_user_login']
-    chassis_user_passwd = connection_dict['chassis_user_passwd']
+    chassis_ip = tbinfo.get('chassis_ip')
     ixl_version = connection_dict['version']
     ixos_version = connection_dict['ixos_version']
 
@@ -1651,8 +1659,7 @@ def l47_trafficgen_main(ports_list, connection_dict, nw_config, service_type,
     ip_list = create_ip_list(nw_config, service_type)
     if service_type == 'privatelink':
         staticarp_ranges = create_staticarp_ranges(nw_config, ip_list)
-        set_trafficgen_staticarps(api, staticarp_ranges, chassis_ip, chassis_user_login, chassis_user_passwd,
-                                  ixos_version, nw_config)
+        set_trafficgen_staticarps(staticarp_ranges, chassis_ip, tbinfo, ixos_version, nw_config)
 
     logger.info("Setting devices")
     time_device_time = time.time()

--- a/tests/common/snappi_tests/ixload/snappi_helper.py
+++ b/tests/common/snappi_tests/ixload/snappi_helper.py
@@ -3,8 +3,12 @@ from tests.common.helpers.assertions import pytest_assert  # noqa F401
 from tests.common.snappi_tests.uhd.uhd_helpers import NetworkConfigSettings  # noqa: F403, F401
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from netmiko import ConnectHandler
+from scp import SCPClient
 from pathlib import Path
+import paramiko
+import io
 import snappi
+import stat
 import time
 import os
 import glob
@@ -14,6 +18,42 @@ import json
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def patch_dutnetwork_range(api, base_url, session_id, test_id, dut_id, network_range_id, first_ip, username, password):
+    """
+    Sends a PATCH request to update the first IP in the network range.
+
+    Args:
+        base_url (str): The base URL of the API (e.g., "https://10.3.8.23:8443").
+        session_id (int): The session ID (e.g., 0).
+        test_id (str): The test ID (e.g., "activeTest").
+        dut_id (int): The DUT ID (e.g., 0).
+        network_range_id (int): The network range ID (e.g., 0).
+        first_ip (str): The new first IP to set (e.g., "1.2.3.4").
+        username (str): The username for authentication.
+        password (str): The password for authentication.
+
+    Returns:
+        Response: The response object from the PATCH request.
+    """
+    url = (f"{base_url}/api/v1/sessions/{session_id}/ixload/test/{test_id}/dutList/{dut_id}/dutConfig/networkRangeList/"
+           f"{network_range_id}")
+    payload = {
+        "firstIp": first_ip
+    }
+
+    try:
+        res = api.ixload_configure("patch", url, payload)  # noqa: F841
+        if res.status_code == 204:
+            logger.info("PATCH request successful: 204 No Content")
+        else:
+            logger.info(f"PATCH request failed: {res.status_code} {res.reason}")
+            logger.info(res.text)
+        return res
+    except res.RequestException as e:
+        logger.info(f"An error occurred: {e}")
+        return None
 
 
 def set_static_routes(duthost, static_ipmacs_dict):
@@ -564,8 +604,6 @@ def load_dpu_configs_on_dut(
 def duthost_port_config(duthost):
 
     # copy HA config
-    # duthost.command("sudo cp {} {}".format(
-    #    "/etc/sonic/0HA_BACKUP/config_db.json", "/etc/sonic/config_db.json"))
     logger.info(f"{duthost.hostname} Loading custom HA config_db.json")
     duthost.shell("sudo sonic-cfggen -j /etc/sonic/0HA_BACKUP/config_db.json --write-to-db")
     duthost.shell("sudo cp /etc/sonic/0HA_BACKUP/config_db.json  /etc/sonic/config_db.json")
@@ -582,14 +620,6 @@ def duthost_port_config(duthost):
 def duthost_ha_config(duthost, nw_config):
 
     # Smartswitch configure
-    """
-    logger.info('Cleaning up config')
-    logger.info("Wait until all critical services are fully started")
-    pytest_assert(wait_until(360, 10, 1,
-                             duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
-
-    """
 
     static_ipsmacs_dict = {}
 
@@ -870,21 +900,6 @@ def npu_startup(duthosts, duthost, localhost):
 def dpu_startup(duthosts, duthost, tbinfo, static_ipmacs_dict, ha_test_case):
 
     logger.info(f"Pinging each DPU on {duthost.hostname}")
-    """
-    dpuIFKeys = [k for k in static_ipmacs_dict['static_ips'] if k.startswith("221.0")]
-    passing_dpus = []
-
-    for x, ipKey in enumerate(dpuIFKeys):
-        logger.info(f"On {duthost.hostname} pinging DPU{x}: {static_ipmacs_dict['static_ips'][ipKey]}")
-        output_ping = duthost.command(f"ping -c 3 {static_ipmacs_dict['static_ips'][ipKey]}", module_ignore_errors=True)
-        if output_ping.get("rc", 1) == 0 and "0% packet loss" in output_ping.get("stdout", ""):
-            logger.info(f"Ping success on {duthost.hostname}")
-            passing_dpus.append(x)
-            pass
-        else:
-            logger.info(f"Ping failure on {duthost.hostname}")
-            pass
-    """
     remote_dir = "/tmp/dpu_configs"
     initial_delay_sec = 20
     retry_delay_sec = 10
@@ -918,19 +933,6 @@ def dpu_startup(duthosts, duthost, tbinfo, static_ipmacs_dict, ha_test_case):
             pass
 
     errors = {}
-
-    """
-    if ha_test_case != "cps":
-        max_workers = 2
-        required_dpus = [0, 2]
-        if all(dpu in passing_dpus for dpu in required_dpus):
-            passing_dpus = required_dpus
-        else:
-            passing_dpus = []
-            return passing_dpus
-    else:
-        max_workers = min(8, max(1, len(passing_dpus)))
-    """
 
     # max_workers = min(8, max(1, len(passing_dpus)))
     max_workers = min(8, max(1, len(passing_dpus)))
@@ -1005,23 +1007,48 @@ def assignPorts(api, ports_list):
     return
 
 
-def build_node_ips(count, vpc, nw_config, nodetype="client"):
-    if nodetype in "client":
-        ip = nw_config.ipp(int(nw_config.IP_R_START) + (nw_config.IP_STEP_NSG * count)
-                           + int(nw_config.IP_STEP_ENI) * (vpc - 1))
-    if nodetype in "server":
-        ip = nw_config.ipp(int(nw_config.IP_L_START) + int(nw_config.IP_STEP_ENI) * (vpc - 1))
+def build_node_ips(count, vpc, nw_config, service_type='vnet2vnet', nodetype="client"):
+
+    if service_type == 'vnet2vnet':
+        if nodetype in "client":
+            ip = nw_config.ipp(int(nw_config.IP_R_START) + (nw_config.IP_STEP_NSG * count)
+                               + int(nw_config.IP_STEP_ENI) * (vpc - 1))
+        if nodetype in "server":
+            ip = nw_config.ipp(int(nw_config.IP_L_START) + int(nw_config.IP_STEP_ENI) * (vpc - 1))
+    else:
+        # service_type == 'privatelink'
+        if nodetype in "dut_client":
+            ip = nw_config.ipp(int(nw_config.IP_R_START) + (nw_config.IP_STEP_NSG * count) +
+                               int(nw_config.IP_STEP_ENI) * (vpc - 1))
+        if nodetype in "client":
+            ip = nw_config.ipp(int(nw_config.IP_L_START) + int(nw_config.IP_STEP_ENI) * (vpc - 1))
+        if nodetype in "server":
+            ip = nw_config.ipp((int(nw_config.IPv6_R_START) + (int(nw_config.IPv6_Range_Increment) * (vpc - 1))))
 
     return str(ip)
 
 
-def build_node_macs(count, vpc, nw_config, nodetype="client"):
+def build_node_macs(count, vpc, nw_config, service_type='vnet2vnet', nodetype="client"):
 
-    if nodetype in "client":
-        m = nw_config.maca(int(nw_config.MAC_R_START) + int(nw_config.maca(nw_config.ENI_MAC_STEP)) * (vpc - 1)
-                           + (int(nw_config.maca(nw_config.ACL_TABLE_MAC_STEP)) * count))
-    if nodetype in "server":
-        m = nw_config.maca(int(nw_config.MAC_L_START) + int(nw_config.maca(nw_config.ENI_MAC_STEP)) * (vpc - 1))
+    if service_type == 'vnet2vnet':
+        if nodetype in "client":
+            m = nw_config.maca(int(nw_config.MAC_R_START) + int(nw_config.maca(nw_config.ENI_MAC_STEP)) * (vpc - 1)
+                               + (int(nw_config.maca(nw_config.ACL_TABLE_MAC_STEP)) * count))
+        if nodetype in "server":
+            m = nw_config.maca(int(nw_config.MAC_L_START) + int(nw_config.maca(nw_config.ENI_MAC_STEP)) * (vpc - 1))
+    else:
+        # service_type == private_link
+        if nodetype in "staticarp_client":
+            m = nw_config.maca(int(nw_config.MAC_R_START) + int(nw_config.maca('00:00:00:00:00:80')) * (vpc - 1)
+                               + (int(nw_config.maca(nw_config.ENI_MAC_STEP)) * count))
+        if nodetype in "dut_client":
+            m = nw_config.maca(int(nw_config.MAC_R_START) + int(nw_config.maca(nw_config.ENI_MAC_STEP)) * (vpc - 1) +
+                               (int(nw_config.maca(nw_config.ACL_TABLE_MAC_STEP)) * count))
+        if nodetype in "client":
+            m = nw_config.maca(int(nw_config.MAC_L_START) + int(nw_config.maca(nw_config.ENI_MAC_STEP)) * (vpc - 1))
+        if nodetype in "server":
+            m = nw_config.maca(int(nw_config.MAC_R_START) + int(nw_config.maca(nw_config.ENI_MAC_STEP)) * (vpc - 1) +
+                               (int(nw_config.maca(nw_config.ACL_TABLE_MAC_STEP)) * count))
 
     return str(m).replace('-', ':')
 
@@ -1041,24 +1068,73 @@ def build_node_vlan(index, nw_config, nodetype="client"):
     return vlan
 
 
-def create_ip_list(nw_config):
+def create_staticarp_ranges(nw_config, ip_list):
+
+    staticarp_ranges = {'client': [], 'server': []}
+
+    # client side
+    count = 0
+    NETWORK_RANGE_ID = 0
+    VLAN_ID = 1
+    CLIENT_BASE_IP = int(nw_config.ipp("1.4.0.1"))
+    INCREMENT_ENI = int(nw_config.ipp("0.64.0.0"))
+    INCREMENT_NSG = int(nw_config.ipp("0.2.0.0"))
+
+    for eni in range(0, nw_config.ENI_COUNT):
+        for eni_j in range(0, 10):
+            FIRST_IP = str(nw_config.ipp(CLIENT_BASE_IP + eni * INCREMENT_ENI + eni_j * INCREMENT_NSG))
+            mac_client = build_node_macs(eni, eni_j+1, nw_config, 'privatelink', nodetype="staticarp_client")
+            payload = {
+                "firstIp": FIRST_IP,
+                "mac": mac_client,
+                "vlanId": VLAN_ID + 1000,
+            }
+
+            staticarp_ranges['client'].append(payload)
+            count += 1
+            NETWORK_RANGE_ID += 1
+            # logger.info(f"Creating staticarp range for eni {eni} eni_j {eni_j} mac {mac_client} firstIp {FIRST_IP}")
+        VLAN_ID += 1
+
+    # server side
+    for eni in ip_list:
+        payload = {
+            "firstIp": eni['ip_client'],
+            "mac": eni['mac_client'],
+            "vlanId": eni['vlan_server'],
+        }
+        staticarp_ranges['server'].append(payload)
+
+    return staticarp_ranges
+
+
+def create_ip_list(nw_config, service_type):
 
     ip_list = []
 
+    ENI_START = nw_config.ENI_START
     ENI_COUNT = nw_config.ENI_COUNT
     logger.info("Creating an ENI_COUNT = {} for l47 trafficgen".format(ENI_COUNT))
 
-    for eni in range(nw_config.ENI_START, ENI_COUNT + 1):
+    for eni in range(ENI_START, ENI_COUNT + 1):
         ip_dict_temp = {}
-        ip_client = build_node_ips(0, eni, nw_config, nodetype="client")
-        mac_client = build_node_macs(0, eni, nw_config, nodetype="client")
+
+        if service_type == 'privatelink':
+            dut_ip_client = build_node_ips(0, eni, nw_config, service_type, nodetype="dut_client")
+            dut_vlan_client = build_node_vlan(eni - 1, nw_config, nodetype="dut_client")
+
+        ip_client = build_node_ips(0, eni, nw_config, service_type, nodetype="client")
+        mac_client = build_node_macs(0, eni, nw_config, service_type, nodetype="client")
         vlan_client = build_node_vlan(eni - 1, nw_config, nodetype="client")
 
-        ip_server = build_node_ips(0, eni, nw_config, nodetype="server")
-        mac_server = build_node_macs(0, eni, nw_config, nodetype="server")
+        ip_server = build_node_ips(0, eni, nw_config, service_type, nodetype="server")
+        mac_server = build_node_macs(0, eni, nw_config, service_type, nodetype="server")
         vlan_server = build_node_vlan(eni - 1, nw_config, nodetype="server")
 
         ip_dict_temp['eni'] = eni
+        if service_type == 'privatelink':
+            ip_dict_temp['dut_ip_client'] = dut_ip_client
+            ip_dict_temp['dut_vlan_client'] = dut_vlan_client
         ip_dict_temp['ip_client'] = ip_client
         ip_dict_temp['mac_client'] = mac_client
         ip_dict_temp['vlan_client'] = vlan_client
@@ -1118,7 +1194,7 @@ def get_objectIDs(api, url):
     return objectIDs
 
 
-def set_rangeList(api):
+def set_rangeList(api, service_type):
     """
     Adjust both rangeList, macRange, and vlanRange as needed
     """
@@ -1143,8 +1219,9 @@ def set_rangeList(api):
     for i, cid in enumerate(client_objectIDs):
         try:
             # Code that may raise an exception
-            res1 = api.ixload_configure("patch", "{}/{}".format(clientList_url, cid), dict1)  # noqa: F841
-            res2 = api.ixload_configure("patch", "{}/{}".format(clientList_url, cid), dict2)  # noqa: F841
+            if service_type != 'privatelink':
+                res1 = api.ixload_configure("patch", "{}/{}".format(clientList_url, cid), dict1)  # noqa: F841
+                res2 = api.ixload_configure("patch", "{}/{}".format(clientList_url, cid), dict2)  # noqa: F841
             res3 = api.ixload_configure("patch", "{}/{}/vlanRange".format(clientList_url, cid), vlan_dict)  # noqa: F841
         except Exception as e:
             # Handle any exception
@@ -1161,11 +1238,16 @@ def set_rangeList(api):
     return
 
 
-def set_trafficMapProfile(api):
+def set_trafficMapProfile(api, service_type):
 
     # Make Traffic Map Settings
     portMapPolicy_json = {'portMapPolicy': 'customMesh'}
-    destination_url = "ixload/test/activeTest/communityList/0/activityList/0/destinations/0"
+
+    if service_type == 'vnet2vnet':
+        destination_url = "ixload/test/activeTest/communityList/0/activityList/0/destinations/0"
+    else:
+        destination_url = "ixload/test/activeTest/communityList/0/activityList/0/destinations/1"
+
     try:
         # Code that may raise an exception
         res = api.ixload_configure("patch", destination_url, portMapPolicy_json)
@@ -1175,7 +1257,12 @@ def set_trafficMapProfile(api):
 
     # meshType
     meshType_json = {'meshType': 'vlanRangePairs'}
-    submapsIpv4_url = "ixload/test/activeTest/communityList/0/activityList/0/destinations/0/customPortMap/submapsIPv4/0"
+    if service_type == 'vnet2vnet':
+        submapsIpv4_url = ("ixload/test/activeTest/communityList/0/activityList/0/destinations/0/"
+                           "customPortMap/submapsIPv4/0")
+    else:
+        submapsIpv4_url = ("ixload/test/activeTest/communityList/0/activityList/0/destinations/1/customPortMap/"
+                           "submapsIPv4/0")
     try:
         # Code that may raise an exception
         res = api.ixload_configure("patch", submapsIpv4_url, meshType_json)  # noqa: F841
@@ -1222,9 +1309,239 @@ def set_timelineCustom(api, initial_cps_value):
     try:
         # Code that may raise an exception
         res = api.ixload_configure("patch", timelineObjectives_url, timeline_json)  # noqa: F841
+        res = api.ixload_configure("patch", activityList_url, activityList_json)  # noqa: F841
     except Exception as e:
         # Handle any exception
         logger.info(f"An error occurred: {e}")
+    except Exception as e:
+        # Handle any exception
+        logger.info(f"An error occurred: {e}")
+
+    return
+
+
+def create_dut_config(api):
+
+    param = {
+        "type": "VirtualDut"
+    }
+
+    url = 'ixload/test/activeTest/dutList'
+    try:
+        # Code that may raise an exception
+        res = api.ixload_configure("post", url, param)  # noqa: F841
+    except Exception as e:
+        # Handle any exception
+        print(f"An error occurred: {e}")
+
+    return
+
+
+def add_dut_ranges(api, nw_config):
+
+    data = {}
+
+    # Here Create Ranges
+    url_networkRangeList = 'ixload/test/activeTest/dutList/0/dutConfig/networkRangeList'
+    for i in range((nw_config.ENI_COUNT * 10) - 1):
+        try:
+            # Code that may raise an exception
+            res = api.ixload_configure("post", url_networkRangeList, data)  # noqa: F841
+        except Exception as e:
+            # Handle any exception
+            print(f"An error occurred: {e}")
+            return None
+
+    return
+
+
+def patch_dut_config(api, nw_config):
+
+    param_comment = {
+        "comment": "DASH Private Link"
+    }
+
+    url_attributes = 'ixload/test/activeTest/dutList/0'
+
+    try:
+        # Code that may raise an exception
+        res = api.ixload_configure("patch", url_attributes, param_comment)  # noqa: F841
+    except Exception as e:
+        # Handle any exception
+        print(f"An error occurred: {e}")
+        return None
+
+    # Here patch ranges
+    # TODO fix the multiplier
+
+    count = 0
+    NETWORK_RANGE_ID = 0
+    VLAN_ID = 1
+    BASE_IP = int(nw_config.ipp("1.4.0.1"))
+    INCREMENT_ENI = int(nw_config.ipp("0.64.0.0"))
+    INCREMENT_NSG = int(nw_config.ipp("0.2.0.0"))
+
+    for i in range(0, nw_config.ENI_COUNT):
+        for j in range(0, 10):
+            FIRST_IP = str(nw_config.ipp(BASE_IP + i * INCREMENT_ENI + j * INCREMENT_NSG))
+            payload = {
+                "firstIp": FIRST_IP,
+                "ipCount": nw_config.ENI_COUNT * 2,
+                "ipIncrStep": "0.0.0.2",
+                "networkMask": "255.192.0.0",
+                "vlanCount": 1,
+                'vlanEnable': True,
+                "vlanId": VLAN_ID,
+                "vlanUniqueCount": 1
+            }
+            url_networkRangeList_index = f'ixload/test/activeTest/dutList/0/dutConfig/networkRangeList/{count}'
+
+            try:
+                # Code that may raise an exception
+                res = api.ixload_configure("patch", url_networkRangeList_index, payload)  # noqa: F841
+            except Exception as e:
+                # Handle any exception
+                print(f"An error occurred: {e}")
+                return None
+
+            count += 1
+            NETWORK_RANGE_ID += 1
+        VLAN_ID += 1
+
+    return
+
+
+def patch_destination_actionList(api):
+
+    param_comment = {
+        "destination": "DUT1:80"
+    }
+
+    url_actionList2 = '/ixload/test/activeTest/communityList/0/activityList/0/agent/actionList/2'
+
+    try:
+        # Code that may raise an exception
+        res = api.ixload_configure("patch", url_actionList2, param_comment)  # noqa: F841
+    except Exception as e:
+        # Handle any exception
+        print(f"An error occurred: {e}")
+        return None
+
+    return
+
+
+def patch_communityList2(api, nw_config):
+
+    url = "ixload/test/activeTest/communityList/1/network/stack/childrenList/5/childrenList/6/rangeList"
+    objectIDs = get_objectIDs(api, url)
+
+    """
+    param_ipv6 = {
+        'ipType': 'IPv6',
+        'prefix': 128,
+    }
+    """
+
+    param_doubleIncrement = {
+        'doubleIncrement': True,
+    }
+
+    # secondCount is based on # VNET mapping per ENI 64K requirement.  Adjust scale to set.
+    scale = 0.01
+    first_count = nw_config.ACL_TABLE_COUNT * 2
+    second_count = int((64000 * scale)/first_count)
+    param_doubleIncrement2 = {
+        'firstIncrementBy': '::002:0',
+        'firstCount': first_count,
+        'gatewayAddress': '::0',
+        'gatewayIncrement': '::0',
+        'secondCount': second_count,
+        'secondIncrementBy': '::2'
+    }
+
+    for id in objectIDs:
+        url = f"ixload/test/activeTest/communityList/1/network/stack/childrenList/5/childrenList/6/rangeList/{id}"
+        try:
+            # Code that may raise an exception
+            # res1 = api.ixload_configure("patch", url, param_ipv6)  # noqa: F841
+            res2 = api.ixload_configure("patch", url, param_doubleIncrement)  # noqa: F841
+            res3 = api.ixload_configure("patch", url, param_doubleIncrement2)  # noqa: F841
+        except Exception as e:
+            # Handle any exception
+            print(f"An error occurred: {e}")
+            return None
+
+    return
+
+
+"""
+def test_saveAs(api, test_filename):
+
+    saveAs_operation = 'ixload/test/operations/saveAs'
+    #url = "{}/{}".format(base_url, saveAs_operation)
+    paramDict = {
+        'fullPath': "C:\\automation\\{}.rxf".format(test_filename),
+        'overWrite': True
+    }
+
+    #response = requests.post(url, data=json.dumps(paramDict), headers=headers)
+    try:
+        # Code that may raise an exception
+        res = api.ixload_configure("post", saveAs_operation, paramDict)
+    except Exception as e:
+        # Handle any exception
+        logger.info(f"An error occurred: {e}")
+
+    return
+"""
+
+
+def delete_staticarp_files(chassis_ip, chassis_user_login, chassis_user_passwd, ixos_version):
+    def delete_files(ssh_client, remote_path, logger=None):
+        """
+        Delete a remote file using SFTP. If it doesn't exist, do nothing.
+        """
+        sftp = None
+        try:
+            sftp = ssh_client.open_sftp()
+            try:
+                attrs = sftp.stat(remote_path)
+                if stat.S_ISDIR(attrs.st_mode):
+                    msg = f"Refusing to delete directory: {remote_path}"
+
+                    logger.warning(msg)
+                    return
+            except FileNotFoundError:
+                msg = f"File not found (nothing to delete): {remote_path}"
+                logger.info(msg)
+                return
+
+            sftp.remove(remote_path)
+            msg = f"Deleted: {remote_path}"
+            logger.info(msg)
+        except Exception as e:
+            msg = f"Failed to delete {remote_path}: {e}"
+            logger.exception(msg)
+        finally:
+            if sftp:
+                sftp.close()
+
+    # setting up ssh connection
+    ssh_client = paramiko.SSHClient()
+    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+    # Connect to remote host
+    logger.info(f"Connecting to {chassis_ip}...")
+    ssh_client.connect(hostname=f'{chassis_ip}', username=f'{chassis_user_login}', password=f'{chassis_user_passwd}')
+
+    card = 1  # Update this to use card number as an index
+    # client
+    delete_files(ssh_client,
+                 f'/home/ixia_apps/ixos/{ixos_version}/nfs/rw/ports/{card}/1/ixtcp.arp', logger)
+
+    # server
+    delete_files(ssh_client,
+                 f'/home/ixia_apps/ixos/{ixos_version}/nfs/rw/ports/{card}/2/ixtcp.arp', logger)
 
     return
 
@@ -1248,14 +1565,104 @@ def set_userIPMappings(api):
     return
 
 
-def l47_trafficgen_main(ports_list, connection_dict, nw_config, test_type, test_filename, initial_cps_value):
+def set_test_preferences(api):
+
+    url = "ixload/preferences"
+
+    param_allowRouteConflicts = {
+        'allowRouteConflicts': True
+    }
+
+    try:
+        # Code that may raise an exception
+        res = api.ixload_configure("patch", url, param_allowRouteConflicts)  # noqa: F841
+    except Exception as e:
+        # Handle any exception
+        logger.info(f"An error occurred: {e}")
+        return None
+
+    return
+
+
+def set_trafficgen_staticarps(api, staticarp_ranges, chassis_ip, chassis_user_login, chassis_user_passwd,
+                              ixos_version, nw_config):
+    def build_arp_payload(ssh_client, staticarp_ranges, ENI_TOTAL, filename, is_server, remote_path):
+        lines = []
+        if is_server:
+            count = 1
+            for i in range(ENI_TOTAL):
+                mac_addr = staticarp_ranges['server'][i]['mac']
+                ip_addr = staticarp_ranges['server'][i]['firstIp']
+                vlan_id = staticarp_ranges['server'][i]['vlanId']
+                lines.append(
+                    f"RemoteMAC={mac_addr}, RemoteMACIncr=00:00:00:00:00:02, "  # noqa: E231
+                    f"RemoteIPv4={ip_addr}, RemoteIPv4Incr=0.0.0.2, "
+                    f"Count={count}, VlanID={vlan_id}\n")
+        else:
+            count = ENI_TOTAL * 2
+            for i in range(ENI_TOTAL*10):
+                mac_addr = staticarp_ranges['client'][i]['mac']
+                ip_addr = staticarp_ranges['client'][i]['firstIp']
+                vlan_id = staticarp_ranges['client'][i]['vlanId']
+                lines.append(
+                    f"RemoteMAC={mac_addr}, RemoteMACIncr=00:00:00:00:00:02, "  # noqa: E231
+                    f"RemoteIPv4={ip_addr}, RemoteIPv4Incr=0.0.0.2, "
+                    f"Count={count}, VlanID={vlan_id}\n")
+
+        with io.open(filename, 'w+') as f:
+            f.writelines(lines)
+
+        with SCPClient(ssh_client.get_transport()) as scp_client:
+            try:
+                scp_client.put(filename, remote_path)
+            except Exception as e:
+                logger.error(f"SCP failed arp payload upload to trafficgen server: {e}")
+
+        os.remove(filename)
+        return
+
+    ENI_TOTAL = nw_config.ENI_COUNT
+    card = 1  # Make this an index
+
+    ssh_client = paramiko.SSHClient()
+    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+    # Connect to remote host
+    logger.info(f"Connecting to {chassis_ip}...")
+    ssh_client.connect(hostname=f'{chassis_ip}', username=f'{chassis_user_login}', password=f'{chassis_user_passwd}')
+
+    # Create client files
+    build_arp_payload(
+        ssh_client, staticarp_ranges, ENI_TOTAL, f"ixtcp_{card}.arp", False,
+        f'/home/ixia_apps/ixos/{ixos_version}/nfs/rw/ports/{card}/1/ixtcp.arp'
+    )
+
+    # Create server files
+    build_arp_payload(
+        ssh_client, staticarp_ranges, ENI_TOTAL, f"ixtcp_{card}_1.arp", True,
+        f'/home/ixia_apps/ixos/{ixos_version}/nfs/rw/ports/{card}/2/ixtcp.arp'
+    )
+
+    # Close the SSH connection
+    ssh_client.close()
+
+    logger.info("ARP files created successfully!")
+
+    return
+
+
+def l47_trafficgen_main(ports_list, connection_dict, nw_config, service_type,
+                        test_type, test_filename, initial_cps_value):
 
     # Start Here ######
     main_start_time = time.time()
     gw_ip = connection_dict['gw_ip']
     port = connection_dict['port']
     chassis_ip = connection_dict['chassis_ip']
+    chassis_user_login = connection_dict['chassis_user_login']
+    chassis_user_passwd = connection_dict['chassis_user_passwd']
     ixl_version = connection_dict['version']
+    ixos_version = connection_dict['ixos_version']
 
     api = snappi.api(location="{}:{}".format(gw_ip, port), ext="ixload", verify=False, version=ixl_version)
     config = api.config()
@@ -1264,7 +1671,11 @@ def l47_trafficgen_main(ports_list, connection_dict, nw_config, test_type, test_
     port_2 = config.ports.port(name="p2", location="{}/1/2".format(chassis_ip))[-1]  # noqa: F841
 
     # client/server IP ranges created here
-    ip_list = create_ip_list(nw_config)
+    ip_list = create_ip_list(nw_config, service_type)
+    if service_type == 'privatelink':
+        staticarp_ranges = create_staticarp_ranges(nw_config, ip_list)
+        set_trafficgen_staticarps(api, staticarp_ranges, chassis_ip, chassis_user_login, chassis_user_passwd,
+                                  ixos_version, nw_config)
 
     logger.info("Setting devices")
     time_device_time = time.time()
@@ -1319,12 +1730,20 @@ def l47_trafficgen_main(ports_list, connection_dict, nw_config, test_type, test_
             eth2.step = "00:00:00:00:00:02"
 
             # ip section
-            ip2 = eth2.ipv4_addresses.ipv4()[-1]
-            ip2.name = "{}.ipv4".format(eth2.name)
-            ip2.address = eni_info['ip_server']
-            ip2.prefix = 10
-            ip2.gateway = "0.0.0.0"
-            ip2.count = 1
+            if service_type == 'privatelink':
+                ip2 = eth2.ipv6_addresses.ipv6()[-1]
+                ip2.name = "{}.ipv6".format(eth2.name)
+                ip2.address = eni_info['ip_server']
+                ip2.prefix = 128
+                ip2.gateway = "::0"
+                # ip2.count = 1
+            else:
+                ip2 = eth2.ipv4_addresses.ipv4()[-1]
+                ip2.name = "{}.ipv4".format(eth2.name)
+                ip2.address = eni_info['ip_server']
+                ip2.prefix = 10
+                ip2.gateway = "0.0.0.0"
+                ip2.count = 1
 
             # vlan section
             vlan2 = eth2.vlans.vlan()[-1]
@@ -1495,6 +1914,19 @@ def l47_trafficgen_main(ports_list, connection_dict, nw_config, test_type, test_
     set_userIPMappings(api)
     logger.info("userIpMapping completed")
 
+    # Create DUTLIST
+    if service_type == 'privatelink':
+        logger.info("Configuring DUT list settings")
+        create_dut_config(api)
+        add_dut_ranges(api, nw_config)
+        patch_dut_config(api, nw_config)
+
+        # Patch Traffic between Network1 and DUT
+        patch_destination_actionList(api)
+
+        # Patch Network 2 IPv6
+        patch_communityList2(api, nw_config)
+
     logger.info("Configuring custom port settings")
     time_assignPort_time = time.time()
     assignPorts(api, ports_list)
@@ -1510,14 +1942,14 @@ def l47_trafficgen_main(ports_list, connection_dict, nw_config, test_type, test_
     # Here adjust Double Increment and vlanRange unique number
     logger.info("Configuring rangeList settings for client and server")
     test_rangeList_time = time.time()
-    set_rangeList(api)
+    set_rangeList(api, service_type)
     test_rangeList_finish_time = time.time()
     logger.info("rangeList settings completed {}".format(test_rangeList_finish_time-test_rangeList_time))
 
     # Adjust Traffic Profile
     logger.info("Custom trafficmaps")
     test_trafficmaps_time = time.time()
-    set_trafficMapProfile(api)
+    set_trafficMapProfile(api, service_type)
     test_trafficmaps_finish = time.time()
     logger.info("Finished traffic maps configuration {}".format(test_trafficmaps_finish - test_trafficmaps_time))
 
@@ -1533,6 +1965,10 @@ def l47_trafficgen_main(ports_list, connection_dict, nw_config, test_type, test_
     set_timelineCustom(api, initial_cps_value)
     test_timeline_finish = time.time()
     logger.info("Finished timeline configurations {}".format(test_timeline_finish - test_timeline_time))
+
+    # allow route conflicts
+    logger.info("Setting test preferences to allow route conflicts to enabled")
+    set_test_preferences(api)
 
     # save file
     # logger.info("Saving Test File")

--- a/tests/common/snappi_tests/ixload/snappi_helper.py
+++ b/tests/common/snappi_tests/ixload/snappi_helper.py
@@ -1562,7 +1562,7 @@ def set_chassis_connect(chassis_ip, tbinfo):
     chassis_user_passwd = tbinfo.get('chassis_user_passwd')
     # setting up ssh connection
     ssh_client = paramiko.SSHClient()
-    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())  # lgtm[py/accepts-unknown-host-key]
 
     ssh_client.connect(hostname=f'{chassis_ip}', username=f'{chassis_user_login}',
                        password=f'{chassis_user_passwd}')
@@ -1601,7 +1601,7 @@ def set_trafficgen_staticarps(staticarp_ranges, chassis_ip, tbinfo,
                     f"Count={count}, VlanID={vlan_id}\n")
 
         with io.open(filename, 'w+') as f:
-            f.writelines(lines)
+            f.writelines(lines)  # lgtm[py/clear-text-storage-sensitive-data]
 
         with SCPClient(ssh_client.get_transport()) as scp_client:
             try:

--- a/tests/common/snappi_tests/ixload/snappi_helper.py
+++ b/tests/common/snappi_tests/ixload/snappi_helper.py
@@ -43,7 +43,7 @@ def patch_dutnetwork_range(api, base_url, session_id, test_id, dut_id, network_r
     }
 
     try:
-        res = api.ixload_configure("patch", url, payload)  # noqa: F841
+        res = api.ixload_configure("patch", url, payload)
         if res.status_code == 204:
             logger.info("PATCH request successful: 204 No Content")
         else:
@@ -235,8 +235,8 @@ def set_ha_admin_up(duthosts, duthost, tbinfo):
             logger.info(f"Active side cmd1 output: {output_cmd1['stdout']}")
 
             time.sleep(2)
-            output = duthost.shell(f'sudo arp -s {standby_ethpass_ip} {standby_mac}')
-            output_ping = duthost.command(f"ping -c 3 {standby_ethpass_ip}", module_ignore_errors=True)  # noqa: F841
+            duthost.shell(f'sudo arp -s {standby_ethpass_ip} {standby_mac}')
+            duthost.command(f"ping -c 3 {standby_ethpass_ip}", module_ignore_errors=True)
         except Exception as e:
             logger.error(f"{duthost.hostname} Error setting HA admin up active side: {str(e)}")
     else:
@@ -251,8 +251,8 @@ def set_ha_admin_up(duthosts, duthost, tbinfo):
             logger.info(f"Standby side cmd1 output: {output_cmd1['stdout']}")
 
             time.sleep(2)
-            output = duthost.shell(f'sudo arp -s {active_ethpass_ip} {active_mac}')  # noqa: F841
-            output_ping = duthost.command(f"ping -c 3 {active_ethpass_ip}", module_ignore_errors=True)  # noqa: F841
+            duthost.shell(f'sudo arp -s {active_ethpass_ip} {active_mac}')
+            duthost.command(f"ping -c 3 {active_ethpass_ip}", module_ignore_errors=True)
         except Exception as e:
             logger.error(f"{duthost.hostname} Error setting HA admin up standby side: {str(e)}")
 
@@ -471,7 +471,7 @@ def _set_routes_on_dut(duthosts, duthost, tbinfo, local_files, local_dir, dpu_in
                     logger.info(
                         f'Pinging standby side loopback intf from {duthost.hostname}: '
                         f'ping -c 3 {active_ethpass_ip}')  # noqa:  E231
-                    output_ping = duthost.command(f"ping -c 3 {active_ethpass_ip}", module_ignore_errors=True)
+                    duthost.command(f"ping -c 3 {active_ethpass_ip}", module_ignore_errors=True)
                     logger.info(f'Correcting route on {duthost.hostname}: '
                                 f'sudo config route del prefix 221.0.0.{dpu_index+1}/32 nexthop 20.0.201.{dpu_index+1}')
                     output = duthost.command(f'sudo config route del prefix 221.0.0.{dpu_index+1}/32 '
@@ -503,8 +503,7 @@ def _set_routes_on_dut(duthosts, duthost, tbinfo, local_files, local_dir, dpu_in
                     output = duthost.shell(f'sudo arp -s {standby_ethpass_ip} {standby_mac}')
                     logger.info(
                         f'Pinging active side loopback intf from {duthost.hostname}: sudo ping -c 3 {standby_ethpass_ip}')  # noqa:  E231
-                    output_ping = duthost.command(f"ping -c 3 {standby_ethpass_ip}",  # noqa: F841
-                                                  module_ignore_errors=True)
+                    duthost.command(f"ping -c 3 {standby_ethpass_ip}", module_ignore_errors=True)
     except Exception as e:
         logger.error(f"{duthost.hostname} Error during DPU configuration: {str(e)}")
         raise
@@ -998,10 +997,8 @@ def assignPorts(api, ports_list):
             chassisId, cardId, portId = portTuple
             paramDict = {"chassisId": chassisId, "cardId": cardId, "portId": portId}
             try:
-                # Code that may raise an exception
-                res = api.ixload_configure("post", portListUrl, paramDict)  # noqa: F841
+                api.ixload_configure("post", portListUrl, paramDict)
             except Exception as e:
-                # Handle any exception
                 logger.info(f"An error occurred: {e}")
 
     return
@@ -1036,19 +1033,19 @@ def checkPorts(api, ports_list):
 def build_node_ips(count, vpc, nw_config, service_type='vnet2vnet', nodetype="client"):
 
     if service_type == 'vnet2vnet':
-        if nodetype in "client":
+        if nodetype == "client":
             ip = nw_config.ipp(int(nw_config.IP_R_START) + (nw_config.IP_STEP_NSG * count)
                                + int(nw_config.IP_STEP_ENI) * (vpc - 1))
-        if nodetype in "server":
+        if nodetype == "server":
             ip = nw_config.ipp(int(nw_config.IP_L_START) + int(nw_config.IP_STEP_ENI) * (vpc - 1))
     else:
         # service_type == 'privatelink'
-        if nodetype in "dut_client":
+        if nodetype == "dut_client":
             ip = nw_config.ipp(int(nw_config.IP_R_START) + (nw_config.IP_STEP_NSG * count) +
                                int(nw_config.IP_STEP_ENI) * (vpc - 1))
-        if nodetype in "client":
+        if nodetype == "client":
             ip = nw_config.ipp(int(nw_config.IP_L_START) + int(nw_config.IP_STEP_ENI) * (vpc - 1))
-        if nodetype in "server":
+        if nodetype == "server":
             ip = nw_config.ipp((int(nw_config.IPv6_R_START) + (int(nw_config.IPv6_Range_Increment) * (vpc - 1))))
 
     return str(ip)
@@ -1057,22 +1054,22 @@ def build_node_ips(count, vpc, nw_config, service_type='vnet2vnet', nodetype="cl
 def build_node_macs(count, vpc, nw_config, service_type='vnet2vnet', nodetype="client"):
 
     if service_type == 'vnet2vnet':
-        if nodetype in "client":
+        if nodetype == "client":
             m = nw_config.maca(int(nw_config.MAC_R_START) + int(nw_config.maca(nw_config.ENI_MAC_STEP)) * (vpc - 1)
                                + (int(nw_config.maca(nw_config.ACL_TABLE_MAC_STEP)) * count))
-        if nodetype in "server":
+        if nodetype == "server":
             m = nw_config.maca(int(nw_config.MAC_L_START) + int(nw_config.maca(nw_config.ENI_MAC_STEP)) * (vpc - 1))
     else:
         # service_type == private_link
-        if nodetype in "staticarp_client":
+        if nodetype == "staticarp_client":
             m = nw_config.maca(int(nw_config.MAC_R_START) + int(nw_config.maca('00:00:00:00:00:80')) * (vpc - 1)
                                + (int(nw_config.maca(nw_config.ENI_MAC_STEP)) * count))
-        if nodetype in "dut_client":
+        if nodetype == "dut_client":
             m = nw_config.maca(int(nw_config.MAC_R_START) + int(nw_config.maca(nw_config.ENI_MAC_STEP)) * (vpc - 1) +
                                (int(nw_config.maca(nw_config.ACL_TABLE_MAC_STEP)) * count))
-        if nodetype in "client":
+        if nodetype == "client":
             m = nw_config.maca(int(nw_config.MAC_L_START) + int(nw_config.maca(nw_config.ENI_MAC_STEP)) * (vpc - 1))
-        if nodetype in "server":
+        if nodetype == "server":
             m = nw_config.maca(int(nw_config.MAC_R_START) + int(nw_config.maca(nw_config.ENI_MAC_STEP)) * (vpc - 1) +
                                (int(nw_config.maca(nw_config.ACL_TABLE_MAC_STEP)) * count))
 
@@ -1184,10 +1181,8 @@ def edit_l1_settings(api):
     for i in range(2):
         portl1_url = "ixload/test/activeTest/communityList/{}/network/portL1Settings".format(i)
         try:
-            # Code that may raise an exception
-            res = api.ixload_configure("patch", portl1_url, params)  # noqa: F841
+            api.ixload_configure("patch", portl1_url, params)
         except Exception as e:
-            # Handle any exception
             logger.info(f"An error occurred: {e}")
 
     return
@@ -1244,21 +1239,17 @@ def set_rangeList(api, service_type):
 
     for i, cid in enumerate(client_objectIDs):
         try:
-            # Code that may raise an exception
             if service_type != 'privatelink':
-                res1 = api.ixload_configure("patch", "{}/{}".format(clientList_url, cid), dict1)  # noqa: F841
-                res2 = api.ixload_configure("patch", "{}/{}".format(clientList_url, cid), dict2)  # noqa: F841
-            res3 = api.ixload_configure("patch", "{}/{}/vlanRange".format(clientList_url, cid), vlan_dict)  # noqa: F841
+                api.ixload_configure("patch", "{}/{}".format(clientList_url, cid), dict1)
+                api.ixload_configure("patch", "{}/{}".format(clientList_url, cid), dict2)
+            api.ixload_configure("patch", "{}/{}/vlanRange".format(clientList_url, cid), vlan_dict)
         except Exception as e:
-            # Handle any exception
             logger.info(f"An error occurred: {e}")
 
     for i, sid in enumerate(server_objectIDs):
         try:
-            # Code that may raise an exception
-            res1 = api.ixload_configure("patch", "{}/{}/vlanRange".format(serverList_url, sid), vlan_dict)  # noqa: F841
+            api.ixload_configure("patch", "{}/{}/vlanRange".format(serverList_url, sid), vlan_dict)
         except Exception as e:
-            # Handle any exception
             logger.info(f"An error occurred: {e}")
 
     return
@@ -1275,10 +1266,8 @@ def set_trafficMapProfile(api, service_type):
         destination_url = "ixload/test/activeTest/communityList/0/activityList/0/destinations/1"
 
     try:
-        # Code that may raise an exception
-        res = api.ixload_configure("patch", destination_url, portMapPolicy_json)
+        api.ixload_configure("patch", destination_url, portMapPolicy_json)
     except Exception as e:
-        # Handle any exception
         logger.info(f"An error occurred: {e}")
 
     # meshType
@@ -1290,10 +1279,8 @@ def set_trafficMapProfile(api, service_type):
         submapsIpv4_url = ("ixload/test/activeTest/communityList/0/activityList/0/destinations/1/customPortMap/"
                            "submapsIPv4/0")
     try:
-        # Code that may raise an exception
-        res = api.ixload_configure("patch", submapsIpv4_url, meshType_json)  # noqa: F841
+        api.ixload_configure("patch", submapsIpv4_url, meshType_json)
     except Exception as e:
-        # Handle any exception
         logger.info(f"An error occurred: {e}")
 
     return
@@ -1307,10 +1294,8 @@ def set_tcpCustom(api):
     param_json = {'maxPersistentRequests': 1}
     # response = requests.patch(url, json=param_json)
     try:
-        # Code that may raise an exception
-        res = api.ixload_configure("patch", tcp_agent_url, param_json)  # noqa: F841
+        api.ixload_configure("patch", tcp_agent_url, param_json)
     except Exception as e:
-        # Handle any exception
         logger.info(f"An error occurred: {e}")
 
     return
@@ -1318,10 +1303,10 @@ def set_tcpCustom(api):
 
 def set_timelineCustom(api, initial_cps_value):
 
-    activityList_url = "ixload/test/activeTest/communityList/0/activityList/0"  # noqa: F841
+    activityList_url = "ixload/test/activeTest/communityList/0/activityList/0"
     timelineObjectives_url = "ixload/test/activeTest/communityList/0/activityList/0/timeline"
 
-    activityList_json = {  # noqa: F841
+    activityList_json = {
         'constraintType': 'ConnectionRateConstraint',
         'constraintValue': initial_cps_value,
         'enableConstraint': False,
@@ -1333,11 +1318,9 @@ def set_timelineCustom(api, initial_cps_value):
     }
 
     try:
-        # Code that may raise an exception
-        res = api.ixload_configure("patch", timelineObjectives_url, timeline_json)  # noqa: F841
-        res = api.ixload_configure("patch", activityList_url, activityList_json)  # noqa: F841
+        api.ixload_configure("patch", timelineObjectives_url, timeline_json)
+        api.ixload_configure("patch", activityList_url, activityList_json)
     except Exception as e:
-        # Handle any exception
         logger.info(f"An error occurred: {e}")
 
     return
@@ -1351,11 +1334,9 @@ def create_dut_config(api):
 
     url = 'ixload/test/activeTest/dutList'
     try:
-        # Code that may raise an exception
-        res = api.ixload_configure("post", url, param)  # noqa: F841
+        api.ixload_configure("post", url, param)
     except Exception as e:
-        # Handle any exception
-        print(f"An error occurred: {e}")
+        logger.info(f"An error occurred: {e}")
 
     return
 
@@ -1368,11 +1349,9 @@ def add_dut_ranges(api, nw_config):
     url_networkRangeList = 'ixload/test/activeTest/dutList/0/dutConfig/networkRangeList'
     for i in range((nw_config.ENI_COUNT * 10) - 1):
         try:
-            # Code that may raise an exception
-            res = api.ixload_configure("post", url_networkRangeList, data)  # noqa: F841
+            api.ixload_configure("post", url_networkRangeList, data)
         except Exception as e:
-            # Handle any exception
-            print(f"An error occurred: {e}")
+            logger.info(f"An error occurred: {e}")
             return None
 
     return
@@ -1387,11 +1366,9 @@ def patch_dut_config(api, nw_config, eni_per_dpu):
     url_attributes = 'ixload/test/activeTest/dutList/0'
 
     try:
-        # Code that may raise an exception
-        res = api.ixload_configure("patch", url_attributes, param_comment)  # noqa: F841
+        api.ixload_configure("patch", url_attributes, param_comment)
     except Exception as e:
-        # Handle any exception
-        print(f"An error occurred: {e}")
+        logger.info(f"An error occurred: {e}")
         return None
 
     count = 0
@@ -1422,11 +1399,9 @@ def patch_dut_config(api, nw_config, eni_per_dpu):
             url_networkRangeList_index = f'ixload/test/activeTest/dutList/0/dutConfig/networkRangeList/{count}'
 
             try:
-                # Code that may raise an exception
-                res = api.ixload_configure("patch", url_networkRangeList_index, payload)  # noqa: F841
+                api.ixload_configure("patch", url_networkRangeList_index, payload)
             except Exception as e:
-                # Handle any exception
-                print(f"An error occurred: {e}")
+                logger.info(f"An error occurred: {e}")
                 return None
 
             count += 1
@@ -1445,11 +1420,9 @@ def patch_destination_actionList(api):
     url_actionList2 = '/ixload/test/activeTest/communityList/0/activityList/0/agent/actionList/2'
 
     try:
-        # Code that may raise an exception
-        res = api.ixload_configure("patch", url_actionList2, param_comment)  # noqa: F841
+        api.ixload_configure("patch", url_actionList2, param_comment)
     except Exception as e:
-        # Handle any exception
-        print(f"An error occurred: {e}")
+        logger.info(f"An error occurred: {e}")
         return None
 
     return
@@ -1459,13 +1432,6 @@ def patch_communityList2(api, nw_config):
 
     url = "ixload/test/activeTest/communityList/1/network/stack/childrenList/5/childrenList/6/rangeList"
     objectIDs = get_objectIDs(api, url)
-
-    """
-    param_ipv6 = {
-        'ipType': 'IPv6',
-        'prefix': 128,
-    }
-    """
 
     param_doubleIncrement = {
         'doubleIncrement': True,
@@ -1487,13 +1453,10 @@ def patch_communityList2(api, nw_config):
     for id in objectIDs:
         url = f"ixload/test/activeTest/communityList/1/network/stack/childrenList/5/childrenList/6/rangeList/{id}"
         try:
-            # Code that may raise an exception
-            # res1 = api.ixload_configure("patch", url, param_ipv6)  # noqa: F841
-            res2 = api.ixload_configure("patch", url, param_doubleIncrement)  # noqa: F841
-            res3 = api.ixload_configure("patch", url, param_doubleIncrement2)  # noqa: F841
+            api.ixload_configure("patch", url, param_doubleIncrement)
+            api.ixload_configure("patch", url, param_doubleIncrement2)
         except Exception as e:
-            # Handle any exception
-            print(f"An error occurred: {e}")
+            logger.info(f"An error occurred: {e}")
             return None
 
     return
@@ -1556,10 +1519,8 @@ def set_userIPMappings(api):
     }
 
     try:
-        # Code that may raise an exception
-        res = api.ixload_configure("patch", url, param_userIpMapping)  # noqa: F841
+        api.ixload_configure("patch", url, param_userIpMapping)
     except Exception as e:
-        # Handle any exception
         logger.info(f"An error occurred: {e}")
         return None
 
@@ -1575,10 +1536,8 @@ def set_test_preferences(api):
     }
 
     try:
-        # Code that may raise an exception
-        res = api.ixload_configure("patch", url, param_allowRouteConflicts)  # noqa: F841
+        api.ixload_configure("patch", url, param_allowRouteConflicts)
     except Exception as e:
-        # Handle any exception
         logger.info(f"An error occurred: {e}")
         return None
 
@@ -1691,8 +1650,8 @@ def l47_trafficgen_main(ports_list, tbinfo, connection_dict, nw_config, service_
     api = snappi.api(location="{}:{}".format(gw_ip, port), ext="ixload", verify=False, version=ixl_version)
     config = api.config()
 
-    port_1 = config.ports.port(name="p1", location="{}/1/1".format(chassis_ip))[-1]  # noqa: F841
-    port_2 = config.ports.port(name="p2", location="{}/1/2".format(chassis_ip))[-1]  # noqa: F841
+    config.ports.port(name="p1", location="{}/1/1".format(chassis_ip))
+    config.ports.port(name="p2", location="{}/1/2".format(chassis_ip))
 
     # client/server IP ranges created here
     ip_list = create_ip_list(nw_config, service_type)
@@ -1926,7 +1885,7 @@ def l47_trafficgen_main(ports_list, tbinfo, connection_dict, nw_config, service_
     # Set config
     logger.info("Configuring custom settings")
     time_custom_time = time.time()
-    response = api.set_config(config)  # noqa: F841
+    api.set_config(config)
     port = connection_dict['port']
 
     time_custom_finish = time.time()
@@ -1994,11 +1953,6 @@ def l47_trafficgen_main(ports_list, tbinfo, connection_dict, nw_config, service_
     logger.info("Setting test preferences to allow route conflicts to enabled")
     set_test_preferences(api)
 
-    # save file
-    # logger.info("Saving Test File")
-    test_save_time = time.time()  # noqa: F841
-    test_save_finish_time = time.time()  # noqa: F841
-    # logger.info("Finished saving: {}".format(test_save_finish_time - test_save_time))
     main_finish_time = time.time()
     logger.info("Ixload configuration app finished in {}".format(main_finish_time - main_start_time))
 
@@ -2016,10 +1970,8 @@ def saveAs(api, test_filename):
 
     # response = requests.post(url, data=json.dumps(paramDict), headers=headers)
     try:
-        # Code that may raise an exception
-        res = api.ixload_configure("post", saveAs_operation, paramDict)  # noqa: F841
+        api.ixload_configure("post", saveAs_operation, paramDict)
     except Exception as e:
-        # Handle any exception
         logger.info(f"An error occurred: {e}")
 
     return

--- a/tests/common/snappi_tests/ixload/snappi_helper.py
+++ b/tests/common/snappi_tests/ixload/snappi_helper.py
@@ -1007,6 +1007,32 @@ def assignPorts(api, ports_list):
     return
 
 
+def checkPorts(api, ports_list):
+
+    # Expected port tuples
+    expected_ports = [port for ports in ports_list.values() for port in ports]
+    logger.info(f"Expected ports: {expected_ports}")
+
+    # Check both client and server
+    for objectID, url in [(0, "ixload/test/activeTest/communityList/0/network/portList"),
+                          (1, "ixload/test/activeTest/communityList/1/network/portList")]:
+        port_ids = get_objectIDs(api, url)
+        logger.info(f"Community {objectID} portListIDs: {port_ids}")
+
+        for port_id in port_ids:
+            payload = {}
+            port_details = api.ixload_configure("get", f"{url}/{port_id}", payload)
+            port_tuple = (port_details.chassisId,
+                          port_details.cardId,
+                          port_details.portId)
+
+            if port_tuple not in expected_ports:
+                logger.info(f"Removing port {port_tuple} (objectID: {port_id})")
+                api.ixload_configure("delete", f"{url}/{port_id}", {})
+
+    return
+
+
 def build_node_ips(count, vpc, nw_config, service_type='vnet2vnet', nodetype="client"):
 
     if service_type == 'vnet2vnet':
@@ -1921,6 +1947,7 @@ def l47_trafficgen_main(ports_list, tbinfo, connection_dict, nw_config, service_
     logger.info("Configuring custom port settings")
     time_assignPort_time = time.time()
     assignPorts(api, ports_list)
+    checkPorts(api, ports_list)
     time_assignPort_finish = time.time()
     logger.info("Custom port settings completed: {}".format(time_assignPort_finish - time_assignPort_time))
 

--- a/tests/common/snappi_tests/ixload/snappi_helper.py
+++ b/tests/common/snappi_tests/ixload/snappi_helper.py
@@ -1684,7 +1684,7 @@ def l47_trafficgen_main(ports_list, tbinfo, connection_dict, nw_config, service_
     gw_ip = connection_dict['gw_ip']
     port = connection_dict['port']
     chassis_ip = tbinfo.get('chassis_ip')
-    eni_per_dpu = int(tbinfo.get('eni_per_dpu', 0))
+    eni_per_dpu = int(tbinfo.get('eni_per_dpu', 32))
     ixl_version = connection_dict['version']
     ixos_version = connection_dict['ixos_version']
 

--- a/tests/common/snappi_tests/ixload/snappi_helper.py
+++ b/tests/common/snappi_tests/ixload/snappi_helper.py
@@ -1378,7 +1378,7 @@ def add_dut_ranges(api, nw_config):
     return
 
 
-def patch_dut_config(api, nw_config):
+def patch_dut_config(api, nw_config, eni_per_dpu):
 
     param_comment = {
         "comment": "DASH Private Link"
@@ -1401,12 +1401,17 @@ def patch_dut_config(api, nw_config):
     INCREMENT_ENI = int(nw_config.ipp("0.64.0.0"))
     INCREMENT_NSG = int(nw_config.ipp("0.2.0.0"))
 
+    if eni_per_dpu == 64:
+        ipCount = 64
+    else:
+        ipCount = nw_config.ENI_COUNT * 2
+
     for i in range(0, nw_config.ENI_COUNT):
         for j in range(0, 10):
             FIRST_IP = str(nw_config.ipp(BASE_IP + i * INCREMENT_ENI + j * INCREMENT_NSG))
             payload = {
                 "firstIp": FIRST_IP,
-                "ipCount": nw_config.ENI_COUNT * 2,
+                "ipCount": ipCount,
                 "ipIncrStep": "0.0.0.2",
                 "networkMask": "255.192.0.0",
                 "vlanCount": 1,
@@ -1679,6 +1684,7 @@ def l47_trafficgen_main(ports_list, tbinfo, connection_dict, nw_config, service_
     gw_ip = connection_dict['gw_ip']
     port = connection_dict['port']
     chassis_ip = tbinfo.get('chassis_ip')
+    eni_per_dpu = int(tbinfo.get('eni_per_dpu', 0))
     ixl_version = connection_dict['version']
     ixos_version = connection_dict['ixos_version']
 
@@ -1936,7 +1942,7 @@ def l47_trafficgen_main(ports_list, tbinfo, connection_dict, nw_config, service_
         logger.info("Configuring DUT list settings")
         create_dut_config(api)
         add_dut_ranges(api, nw_config)
-        patch_dut_config(api, nw_config)
+        patch_dut_config(api, nw_config, eni_per_dpu)
 
         # Patch Traffic between Network1 and DUT
         patch_destination_actionList(api)

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -25,8 +25,9 @@ from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValue
     prefix_length, dut_ipv6_start, snappi_ipv6_start, v6_prefix_length, dut_ip_for_non_macsec_port
 from tests.common.macsec.macsec_config_helper import set_macsec_profile, enable_macsec_port, disable_macsec_port, \
     delete_macsec_profile
-from tests.common.snappi_tests.uhd.uhd_helpers import NetworkConfigSettings, create_front_panel_ports, \
-    create_connections, create_uhdIp_list, create_arp_bypass, create_profiles
+from tests.common.snappi_tests.uhd.uhd_helpers import (NetworkConfigSettings, create_front_panel_ports,
+                                                       create_connections, create_connections_pl, create_uhdIp_list,
+                                                       create_arp_bypass, create_arp_bypass_pl, create_profiles)
 logger = logging.getLogger(__name__)
 _next_system_id = 1
 
@@ -1771,10 +1772,14 @@ def setup_config_uhd_connect(request, tbinfo, ha_test_case=None):
         ethpass_ports = [row for row in csv_data if row['EthernetPass'] == 'True']
         has_switchover = any(dpu.get('SwitchOverPort') == 'True' for dpu in dpu_ports)
 
+        service_type = tbinfo['service_type']
         uhdConnect_ip = tbinfo['uhd_ip']
         num_cps_cards = tbinfo['num_cps_cards']
         num_tcpbg_cards = tbinfo['num_tcpbg_cards']
         num_udpbg_cards = tbinfo['num_udpbg_cards']
+        vxlan_port = tbinfo.get('vxlan_port', 0)
+        vxlan_src_port = tbinfo.get('vxlan_src_port', 0)
+        vxlan_endpoint_vni = tbinfo.get('vxlan_endpoint_vni', 1000)
         num_dpu_ports = len(dpu_ports)
 
         cards_dict = {
@@ -1788,7 +1793,8 @@ def setup_config_uhd_connect(request, tbinfo, ha_test_case=None):
             'switchover_port': has_switchover
         }
 
-        uhdSettings = NetworkConfigSettings()  # noqa: F405
+        # uhdSettings = NetworkConfigSettings(vxlan_endpoint_vni)  # noqa: F405
+        uhdSettings = NetworkConfigSettings(vxlan_endpoint_vni)  # noqa: F405
         uhdSettings.set_mac_addresses(tbinfo['l47_tg_clientmac'], tbinfo['l47_tg_servermac'], tbinfo['dut_mac'])
         total_cards = num_cps_cards + num_tcpbg_cards + num_udpbg_cards
         subnet_mask = uhdSettings.subnet_mask
@@ -1796,9 +1802,19 @@ def setup_config_uhd_connect(request, tbinfo, ha_test_case=None):
         logger.info(f"Configuring UHD connect for {uhdSettings.ENI_COUNT} ENIs")
         ip_list = create_uhdIp_list(subnet_mask, uhdSettings, cards_dict)  # noqa: F405
         fp_ports_list = create_front_panel_ports(int(total_cards * 2), uhdSettings, cards_dict)  # noqa: F405
-        arp_bypass_list = create_arp_bypass(fp_ports_list, ip_list, uhdSettings, cards_dict, subnet_mask)  # noqa: F405
-        connections_list = create_connections(fp_ports_list, ip_list, subnet_mask, uhdSettings,  # noqa: F405
-                                              cards_dict, arp_bypass_list)
+
+        if service_type == 'vnet2vnet':
+            file_name = "tempUhdConfig_vnet2vnet.json"
+            arp_bypass_list = create_arp_bypass(fp_ports_list, ip_list, uhdSettings, cards_dict,
+                                                subnet_mask)
+            connections_list = create_connections(fp_ports_list, ip_list, subnet_mask, uhdSettings,  # noqa: F405
+                                                  cards_dict, arp_bypass_list, vxlan_port, vxlan_src_port)
+        else:
+            # privatelink
+            file_name = "tempUhdConfig_pl.json"
+            arp_bypass_list = create_arp_bypass_pl(fp_ports_list, ip_list, uhdSettings, cards_dict, subnet_mask)
+            connections_list = create_connections_pl(fp_ports_list, ip_list, subnet_mask, uhdSettings, cards_dict,
+                                                     arp_bypass_list, vxlan_port, vxlan_src_port)
 
         config = {
             "profiles": create_profiles(uhdSettings),  # noqa: F405
@@ -1810,7 +1826,6 @@ def setup_config_uhd_connect(request, tbinfo, ha_test_case=None):
             'Content-Type': 'application/json'
         }
 
-        file_name = "tempUhdConfig.json"
         file_location = os.getcwd()
         uhd_post_url = uhdSettings.uhd_post_url
         url = "https://{}/{}".format(uhdConnect_ip, uhd_post_url)  # noqa: F841
@@ -1819,7 +1834,10 @@ def setup_config_uhd_connect(request, tbinfo, ha_test_case=None):
         logger.info(f"Pushing created UHD configuration file {file_name} to UHD Connect")
         uhdConf_cmd = ('curl -k -X POST -H \"Content-Type: application/json\" -d @\"{}/{}\"   '
                        '{}').format(file_location, file_name, url)
-        subprocess.run(uhdConf_cmd, shell=True, capture_output=True, text=True)
+        try:
+            res = subprocess.run(uhdConf_cmd, shell=True, capture_output=True, text=True)  # noqa: F841
+        except Exception as e:
+            logger.error(f"UHD config upload failed: {e}")
 
         if not save_uhd_config:
             logger.info("Removing UHD config file")

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1793,7 +1793,6 @@ def setup_config_uhd_connect(request, tbinfo, ha_test_case=None):
             'switchover_port': has_switchover
         }
 
-        # uhdSettings = NetworkConfigSettings(vxlan_endpoint_vni)  # noqa: F405
         uhdSettings = NetworkConfigSettings(vxlan_endpoint_vni)  # noqa: F405
         uhdSettings.set_mac_addresses(tbinfo['l47_tg_clientmac'], tbinfo['l47_tg_servermac'], tbinfo['dut_mac'])
         total_cards = num_cps_cards + num_tcpbg_cards + num_udpbg_cards

--- a/tests/common/snappi_tests/uhd/uhd_helpers.py
+++ b/tests/common/snappi_tests/uhd/uhd_helpers.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 
 class NetworkConfigSettings:
-    def __init__(self):
+    def __init__(self, vxlan_endpoint_vni=1000):
         self.ipp = ipaddress.ip_address
         self.maca = macaddress.MAC
 
@@ -15,8 +15,10 @@ class NetworkConfigSettings:
         self.ENI_COUNT = 256
         self.ENI_MAC_STEP = '00:00:00:18:00:00'
         self.ENI_STEP = 1
-        self.ENI_L2R_STEP = 1000
+        self.ENI_L2R_STEP = vxlan_endpoint_vni
+        self.ENI_PER_PORT = 64
 
+        self.VTEP_IP = self.ipp("221.0.0.1")
         self.PAL = self.ipp("221.1.0.1")
         self.PAR = self.ipp("221.2.0.1")
         self.STATIC = self.ipp("221.0.0.1")
@@ -26,6 +28,7 @@ class NetworkConfigSettings:
         self.ACL_TABLE_MAC_STEP = '00:00:00:02:00:00'
         self.ACL_POLICY_MAC_STEP = '00:00:00:00:00:32'
 
+        self.ENI_VNI_NVGRE_START = 1000
         self.ACL_RULES_NSG = 1000
         self.ACL_TABLE_COUNT = 5
 
@@ -41,6 +44,8 @@ class NetworkConfigSettings:
 
         self.IP_L_START = self.ipp('1.1.0.1')
         self.IP_R_START = self.ipp('1.4.0.1')
+        self.IPv6_R_START = self.ipp('2603:100:3E8::104:1')
+        self.IPv6_Range_Increment = self.ipp('0:0:1::40:0')
 
         self.MAC_L_START = self.maca('00:1A:C5:00:00:01')
         self.MAC_R_START = self.maca('00:1B:6E:00:00:01')
@@ -56,6 +61,19 @@ class NetworkConfigSettings:
         self.l47_tg_servermac = ''
         self.first_staticArpMac = ''
         self.dut_mac = ''
+
+        # PrivateLink
+        self.NVGRE_COUNT = 32
+        self.NVGRE_SUBMASK = 48
+        self.NVGRE_VSID = 100
+        self.NVGRE_IP = self.ipp('2603:100:3e8::0:0')
+        self.NVGRE_IP_STEP = self.ipp(ipaddress.ip_address('0:0:1::0:0'))
+        self.PAL_PL = self.ipp("221.2.0.0")
+        self.PAR_PL = self.ipp("221.1.0.0")
+
+    def dec2hex(self, dec):
+        hex_str = hex(dec)[2:]
+        return hex_str
 
     def set_mac_addresses(self, clientmac, servermac, dutmac):
 
@@ -319,6 +337,233 @@ def create_front_panel_ports(count, config, cards_dict):
     return fp_list
 
 
+def create_arp_bypass_pl(fp_ports_list, ip_list, config, cards_dict, subnet_mask):
+
+    connections_list = []
+    ethpass_ports = cards_dict['ethpass_ports']
+    num_cps_cards = cards_dict['num_cps_cards']
+    first_cps_card, first_tcpbg_card = set_first_stateful_cards(cards_dict)
+
+    vrange_count = config.ENI_COUNT//num_cps_cards
+    vlan_start = (config.ENI_L2R_STEP + 1) - vrange_count  # noqa: F841
+
+    # eth_bypass set here
+    connections_list.append(_get_eth_bypass_dict(config, ethpass_ports))
+
+    return connections_list
+
+
+def create_connections_pl(fp_ports_list, ip_list, subnet_mask, config, cards_dict, arp_bypass_list,
+                          vxlan_port, vxlan_src_port):
+
+    connections_list = arp_bypass_list
+
+    num_cps_cards = cards_dict['num_cps_cards']
+
+    first_cps_card, first_tcpbg_card = set_first_stateful_cards(cards_dict)
+    """
+    if cards_dict['num_cps_cards'] > 0:
+        first_cps_card = 1
+        first_tcpbg_card = cards_dict['num_cps_cards'] + 1
+    """
+
+    # TODO loopback IP need updated for multiple DPUs for example: 'dst_ip': {'choice': 'ipv4', 'ipv4': '221.0.0.1'}
+    # ip6 = int(config.NVGRE_IP)  # noqa: F841
+    ip6_step = int(config.NVGRE_IP_STEP)
+    nvgre_count = config.NVGRE_COUNT
+    nvgre_eni = config.ENI_START
+    vtep_ip = config.VTEP_IP
+    vtep_ip_tmp = 0
+    underlay_ip = config.PAL_PL
+    underlay_ip_tmp = 0
+    vlan_endpoint_ip = config.PAR_PL
+    vlanEP_ip_tmp = 0
+    # ip_start = config.IP_L_START  # noqa: F841
+    # ip_tmp = 0
+    client_vlan_start = config.ENI_L2R_STEP + 1
+    client_vlan_tmp = 0
+    # vxlan_vni_start = config.ENI_L2R_STEP * 2
+    vxlan_vni_start = config.ENI_L2R_STEP
+    vxlan_vni_tmp = 0
+    nvgre_ip = "2603:100:%s:0::0" % (config.dec2hex(config.ENI_VNI_NVGRE_START))
+    nvgre_ip_tmp = 0
+
+    for port in range(num_cps_cards):
+
+        server_dict_temp = {
+            'name': 'l47 Server {}'.format(port+1),
+            'functions': [],
+            'endpoints': []
+        }
+
+        client_dict_temp = {
+            'name': 'l47 Client {}'.format(port+1),
+            'functions': [],
+            'endpoints': []
+        }
+
+        # client_vlan = build_node_vlan(eni, config, nodetype="client")
+        # server_vlan = build_node_vlan(eni, config, nodetype="server")
+
+        # client_card, test_role = find_card_slot(first_cps_card, first_tcpbg_card, server_vlan)
+        # client_cps_port = find_port(num_cps_cards, first_cps_card, first_tcpbg_card, server_vlan, test_role)
+        # server_card, test_role = find_card_slot(first_cps_card, first_tcpbg_card, server_vlan)
+
+        # TODO needed when there are multiple DPU Ports
+        # dpu_port = 1 if server_vlan <= 128 else 2
+
+        # Server side
+        """
+        if server_vlan == 256:
+            overlay_ip_addr = 0
+        else:
+            overlay_ip_addr = eni+1
+        """
+        # overlay_ip_addr = eni
+
+        # if server_vlan <= 128:
+        #    lb_ip = 1
+        # else:
+        #    lb_ip = 2
+
+        # client_role, server_role = find_testrole(test_role, server_vlan)
+
+        # TODO VNIs need to be +1000 for production
+        production = True  # turn ON for now
+        if production is True:
+            vni_index = 1000
+        else:
+            vni_index = 0  # noqa: F841
+
+        nvgre_ip_tmp = str(ipaddress.ip_address(nvgre_ip) + (ip6_step * (port * nvgre_count)))
+        vtep_ip_tmp = vtep_ip + (1 * port)
+        underlay_ip_tmp = underlay_ip + (config.NVGRE_COUNT * port)
+        server_conn_tmp = {
+            "choice": "connect_vlan_nvgre",
+            "connect_vlan_nvgre": {
+                "vlan_endpoint_settings": {
+                    "outgoing_nvgre_header": {
+                        "src_mac": {"choice": "mac", "mac": "{}".format(config.l47_tg_servermac)},
+                        "dst_mac": {"choice": "mac", "mac": "{}".format(config.dut_mac)},
+                        "src_ip": {"choice": "ipv4_range", "ipv4_range": {'start': "{}".format(underlay_ip_tmp),
+                                                                          'count': nvgre_count, 'step': '0.0.0.1'}},
+                        "dst_ip": {"choice": "ipv4", "ipv4": "{}".format(vtep_ip_tmp)},
+                    }
+                },
+                "nvgre_endpoint_settings": {
+                    "vsid": {"choice": "vsid", "vsid": config.NVGRE_VSID},
+                    "protocols": {"accept": ["tcp"]}, "routing_method": "ip_routing",  # noqa: E128
+                    "ip_routing": {"destination_ips": {"choice": "ipv6_range",
+                    "ipv6_range": {'start': "{}".format(ipaddress.ip_address(nvgre_ip_tmp)),  # noqa: E128
+                                   'subnet_bits': config.NVGRE_SUBMASK, 'count': nvgre_count,
+                                   'step': "{}".format(str(ipaddress.ip_address(ip6_step)))}}}
+                }
+            }
+        }
+        server_dict_temp['functions'].append(server_conn_tmp)
+        nvgre_eni_temp = nvgre_eni + (nvgre_count * port)
+        server_dict_temp['endpoints'].append(
+            {"choice": "front_panel", "front_panel": {
+                "port_name": "l47_port_{}s".format(port + 1),  # noqa: E122
+                "vlan": {"choice": "vlan_range", "vlan_range": {"start": nvgre_eni_temp, "count": 32, "step": 1}}},
+             "tags": ["vlan"]},
+        )
+        server_dict_temp['endpoints'].append(
+            {"choice": "front_panel", "front_panel": {"port_name": "l47_dpuPort_{}".format(1)},
+             "tags": ["nvgre"]}
+        )
+
+        # Client Side
+        # TODO vni_index
+        client_start = config.IP_L_START
+        ip_tmp = client_start + (int(ipaddress.ip_address('8.0.0.0')) * port)
+        vlanEP_ip_tmp = vlan_endpoint_ip + (nvgre_count * port)
+        vxlan_vni_tmp = vxlan_vni_start + (nvgre_count * port)
+
+        client_conn_tmp = {
+            "choice": "connect_vlan_vxlan",
+            "connect_vlan_vxlan": {
+                "vlan_endpoint_settings": {
+                    "outgoing_vxlan_header": {
+                        "src_mac": {"choice": "mac", "mac": f"{config.l47_tg_clientmac}"},
+                        "dst_mac": {"choice": "mac", "mac": f"{config.dut_mac}"},
+                        "src_ip": {
+                            "choice": "ipv4_range",
+                            "ipv4_range": {
+                                "start": f"{vlanEP_ip_tmp}",
+                                "count": nvgre_count,
+                                "step": "0.0.0.1",
+                            },
+                        },
+                        "dst_ip": {"choice": "ipv4", "ipv4": f"{vtep_ip_tmp}"},
+                    }
+                },
+                "vxlan_endpoint_settings": {
+                    "vni": {
+                        "choice": "vni_range",
+                        "vni_range": {
+                            "start": vxlan_vni_tmp,
+                            "count": nvgre_count,
+                            "step": 1,
+                        },
+                    },
+                    "protocols": {"accept": ["tcp"]},
+                    "routing_method": "ip_routing",
+                    "ip_routing": {
+                        "destination_ips": {
+                            "choice": "ipv4_range",
+                            "ipv4_range": {
+                                "start": f"{ip_tmp}",
+                                "count": config.NVGRE_COUNT,
+                                "step": "0.64.0.0",
+                            },
+                        }
+                    },
+                },
+            },
+        }
+
+        if not (vxlan_port == 0 and vxlan_src_port == 0):
+            vxlan_settings = client_conn_tmp["connect_vlan_vxlan"]["vxlan_endpoint_settings"]
+            vxlan_settings["udp_src_port"] = vxlan_port
+            vxlan_settings["udp_dst_port"] = vxlan_src_port
+
+        client_vlan_tmp = client_vlan_start + (nvgre_count * port)
+        client_dict_temp['functions'].append(client_conn_tmp)
+        client_dict_temp['endpoints'].append(
+            {"choice": "front_panel", "front_panel": {
+                "port_name": "l47_port_{}c".format(port+1),
+                "vlan": {"choice": "vlan_range", "vlan_range": {'start': client_vlan_tmp, 'count': nvgre_count,
+                                                                'step': 1}}}, "tags": ["vlan"]},
+        )
+
+        client_dict_temp['endpoints'].append(
+            {"choice": "front_panel", "front_panel": {"port_name": "l47_dpuPort_{}".format(1)},
+             "tags": ["vxlan"]}
+        )
+
+        # Add server and client settings to connections_list
+        connections_list.append(server_dict_temp)
+        connections_list.append(client_dict_temp)
+
+    return connections_list
+
+
+def _get_eth_bypass_dict(config, ethpass_ports):
+    eth_bypass_dict = {
+        'name': "Eth Bypass",
+        'functions': [{"choice": "connect_ethernet", "connect_ethernet": {}}],
+        'endpoints': []
+    }
+    for port in ethpass_ports:
+        eth_bypass_dict['endpoints'].append(
+            {'choice': 'front_panel', 'front_panel': {'port_name': 'l47_port_11{}'.format(port['FrontPanel']),
+                                                      'vlan': {'choice': 'non_vlan'}}}
+        )
+
+    return eth_bypass_dict
+
+
 def create_arp_bypass(fp_ports_list, ip_list, config, cards_dict, subnet_mask):
 
     connections_list = []
@@ -334,6 +579,8 @@ def create_arp_bypass(fp_ports_list, ip_list, config, cards_dict, subnet_mask):
         else:
             first_tcpbg_card = 0
     """
+
+    """
     eth_bypass_dict = {
         'name': "Eth Bypass",
         'functions': [{"choice": "connect_ethernet", "connect_ethernet": {}}],
@@ -347,6 +594,9 @@ def create_arp_bypass(fp_ports_list, ip_list, config, cards_dict, subnet_mask):
                     {'port_name': 'l47_port_11{}'.format(port['FrontPanel']), 'vlan': {'choice': 'non_vlan'}}}
             )
         connections_list.append(eth_bypass_dict)
+    """
+    # eth_bypass set here
+    connections_list.append(_get_eth_bypass_dict(config, ethpass_ports))
 
     for eni, ip in enumerate(ip_list):
 
@@ -383,7 +633,8 @@ def create_arp_bypass(fp_ports_list, ip_list, config, cards_dict, subnet_mask):
     return connections_list
 
 
-def create_connections(fp_ports_list, ip_list, subnet_mask, config, cards_dict, arp_bypass_list):
+def create_connections(fp_ports_list, ip_list, subnet_mask, config, cards_dict, arp_bypass_list,
+                       vxlan_port=0, vxlan_src_port=0):
 
     connections_list = arp_bypass_list
 
@@ -459,6 +710,12 @@ def create_connections(fp_ports_list, ip_list, subnet_mask, config, cards_dict, 
                     "ip_routing": {"destination_ips": {"choice": "ipv4",
                     "ipv4": "{}".format(ip_list[eni]['ip_server'])}}}  # noqa: E128
         }}
+
+        if not (vxlan_port == 0 and vxlan_src_port == 0):
+            server_vxlan_settings = server_conn_tmp["connect_vlan_vxlan"]["vxlan_endpoint_settings"]
+            server_vxlan_settings["udp_src_port"] = vxlan_port
+            server_vxlan_settings["udp_dst_port"] = vxlan_src_port
+
         server_dict_temp['functions'].append(server_conn_tmp)
         server_dict_temp['endpoints'].append(
             {"choice": "front_panel", "front_panel": {
@@ -489,6 +746,11 @@ def create_connections(fp_ports_list, ip_list, subnet_mask, config, cards_dict, 
                                             "count": 1, "subnet_bits": subnet_mask
                                         }}}}
         }}
+
+        if not (vxlan_port == 0 and vxlan_src_port == 0):
+            client_vxlan_settings = client_conn_tmp["connect_vlan_vxlan"]["vxlan_endpoint_settings"]
+            client_vxlan_settings["udp_src_port"] = vxlan_port
+            client_vxlan_settings["udp_dst_port"] = vxlan_src_port
 
         client_dict_temp['functions'].append(client_conn_tmp)
         client_dict_temp['endpoints'].append(

--- a/tests/common/snappi_tests/uhd/uhd_helpers.py
+++ b/tests/common/snappi_tests/uhd/uhd_helpers.py
@@ -355,15 +355,8 @@ def create_connections_pl(fp_ports_list, ip_list, subnet_mask, config, cards_dic
                           vxlan_port, vxlan_src_port):
 
     connections_list = arp_bypass_list
-
     num_cps_cards = cards_dict['num_cps_cards']
-
     first_cps_card, first_tcpbg_card = set_first_stateful_cards(cards_dict)
-    """
-    if cards_dict['num_cps_cards'] > 0:
-        first_cps_card = 1
-        first_tcpbg_card = cards_dict['num_cps_cards'] + 1
-    """
 
     # ip6 = int(config.NVGRE_IP)  # noqa: F841
     ip6_step = int(config.NVGRE_IP_STEP)

--- a/tests/common/snappi_tests/uhd/uhd_helpers.py
+++ b/tests/common/snappi_tests/uhd/uhd_helpers.py
@@ -624,11 +624,6 @@ def create_connections(fp_ports_list, ip_list, subnet_mask, config, cards_dict, 
     connections_list = arp_bypass_list
 
     first_cps_card, first_tcpbg_card = set_first_stateful_cards(cards_dict)
-    """
-    if cards_dict['num_cps_cards'] > 0:
-        first_cps_card = 1
-        first_tcpbg_card = cards_dict['num_cps_cards'] + 1
-    """
 
     for eni, ip in enumerate(ip_list):
 

--- a/tests/common/snappi_tests/uhd/uhd_helpers.py
+++ b/tests/common/snappi_tests/uhd/uhd_helpers.py
@@ -297,8 +297,6 @@ def create_front_panel_ports(count, config, cards_dict):
             data_index += 1
 
     # l47 Front Panel DPU
-    # TODO add num_dpuPorts then build this part
-
     dpu_ports_length = len(cards_dict['dpu_ports'])
     dpu_port = 0
     switchover_port = 0
@@ -367,7 +365,6 @@ def create_connections_pl(fp_ports_list, ip_list, subnet_mask, config, cards_dic
         first_tcpbg_card = cards_dict['num_cps_cards'] + 1
     """
 
-    # TODO loopback IP need updated for multiple DPUs for example: 'dst_ip': {'choice': 'ipv4', 'ipv4': '221.0.0.1'}
     # ip6 = int(config.NVGRE_IP)  # noqa: F841
     ip6_step = int(config.NVGRE_IP_STEP)
     nvgre_count = config.NVGRE_COUNT
@@ -409,9 +406,6 @@ def create_connections_pl(fp_ports_list, ip_list, subnet_mask, config, cards_dic
         # client_cps_port = find_port(num_cps_cards, first_cps_card, first_tcpbg_card, server_vlan, test_role)
         # server_card, test_role = find_card_slot(first_cps_card, first_tcpbg_card, server_vlan)
 
-        # TODO needed when there are multiple DPU Ports
-        # dpu_port = 1 if server_vlan <= 128 else 2
-
         # Server side
         """
         if server_vlan == 256:
@@ -428,7 +422,6 @@ def create_connections_pl(fp_ports_list, ip_list, subnet_mask, config, cards_dic
 
         # client_role, server_role = find_testrole(test_role, server_vlan)
 
-        # TODO VNIs need to be +1000 for production
         production = True  # turn ON for now
         if production is True:
             vni_index = 1000
@@ -474,7 +467,6 @@ def create_connections_pl(fp_ports_list, ip_list, subnet_mask, config, cards_dic
         )
 
         # Client Side
-        # TODO vni_index
         client_start = config.IP_L_START
         ip_tmp = client_start + (int(ipaddress.ip_address('8.0.0.0')) * port)
         vlanEP_ip_tmp = vlan_endpoint_ip + (nvgre_count * port)
@@ -645,7 +637,6 @@ def create_connections(fp_ports_list, ip_list, subnet_mask, config, cards_dict, 
         first_tcpbg_card = cards_dict['num_cps_cards'] + 1
     """
 
-    # TODO loopback IP need updated for multiple DPUs for example: 'dst_ip': {'choice': 'ipv4', 'ipv4': '221.0.0.1'}
     for eni, ip in enumerate(ip_list):
 
         server_dict_temp = {
@@ -667,7 +658,6 @@ def create_connections(fp_ports_list, ip_list, subnet_mask, config, cards_dict, 
         # client_cps_port = find_port(num_cps_cards, first_cps_card, first_tcpbg_card, server_vlan, test_role)
         server_card, test_role = find_card_slot(config, cards_dict, first_cps_card, first_tcpbg_card, server_vlan)
 
-        # TODO needed when there are multiple DPU Ports
         # dpu_port = 1 if server_vlan <= 128 else 2
         # dpu_port = 1
 
@@ -689,7 +679,6 @@ def create_connections(fp_ports_list, ip_list, subnet_mask, config, cards_dict, 
 
         client_role, server_role = find_testrole(test_role, server_vlan)
 
-        # TODO VNIs need to be +1000 for production
         production = True  # turn ON for now
         if production is True:
             vni_index = 1000
@@ -728,7 +717,6 @@ def create_connections(fp_ports_list, ip_list, subnet_mask, config, cards_dict, 
         )
 
         # Client Side
-        # TODO vni_index
         client_conn_tmp = {"choice": "connect_vlan_vxlan", "connect_vlan_vxlan": {
             "vlan_endpoint_settings": {
                 "outgoing_vxlan_header": {

--- a/tests/common/snappi_tests/uhd/uhd_helpers.py
+++ b/tests/common/snappi_tests/uhd/uhd_helpers.py
@@ -90,9 +90,9 @@ class NetworkConfigSettings:
 
 
 def build_node_ips(count, vpc, config, nodetype="client"):
-    if nodetype in "client":
+    if nodetype == "client":
         ip = config.ipp(int(config.IP_R_START) + (config.IP_STEP_NSG * count) + int(config.IP_STEP_ENI) * (vpc - 1))
-    if nodetype in "server":
+    if nodetype == "server":
         ip = config.ipp(int(config.IP_L_START) + int(config.IP_STEP_ENI) * (vpc - 1))
 
     return str(ip)
@@ -339,11 +339,8 @@ def create_arp_bypass_pl(fp_ports_list, ip_list, config, cards_dict, subnet_mask
 
     connections_list = []
     ethpass_ports = cards_dict['ethpass_ports']
-    num_cps_cards = cards_dict['num_cps_cards']
-    first_cps_card, first_tcpbg_card = set_first_stateful_cards(cards_dict)
-
-    vrange_count = config.ENI_COUNT//num_cps_cards
-    vlan_start = (config.ENI_L2R_STEP + 1) - vrange_count  # noqa: F841
+    # num_cps_cards = cards_dict['num_cps_cards']
+    # first_cps_card, first_tcpbg_card = set_first_stateful_cards(cards_dict)
 
     # eth_bypass set here
     connections_list.append(_get_eth_bypass_dict(config, ethpass_ports))
@@ -358,7 +355,6 @@ def create_connections_pl(fp_ports_list, ip_list, subnet_mask, config, cards_dic
     num_cps_cards = cards_dict['num_cps_cards']
     first_cps_card, first_tcpbg_card = set_first_stateful_cards(cards_dict)
 
-    # ip6 = int(config.NVGRE_IP)  # noqa: F841
     ip6_step = int(config.NVGRE_IP_STEP)
     nvgre_count = config.NVGRE_COUNT
     nvgre_eni = config.ENI_START
@@ -368,8 +364,6 @@ def create_connections_pl(fp_ports_list, ip_list, subnet_mask, config, cards_dic
     underlay_ip_tmp = 0
     vlan_endpoint_ip = config.PAR_PL
     vlanEP_ip_tmp = 0
-    # ip_start = config.IP_L_START  # noqa: F841
-    # ip_tmp = 0
     client_vlan_start = config.ENI_L2R_STEP + 1
     client_vlan_tmp = 0
     # vxlan_vni_start = config.ENI_L2R_STEP * 2
@@ -413,13 +407,7 @@ def create_connections_pl(fp_ports_list, ip_list, subnet_mask, config, cards_dic
         # else:
         #    lb_ip = 2
 
-        # client_role, server_role = find_testrole(test_role, server_vlan)
-
-        production = True  # turn ON for now
-        if production is True:
-            vni_index = 1000
-        else:
-            vni_index = 0  # noqa: F841
+        # vni_index = 1000
 
         nvgre_ip_tmp = str(ipaddress.ip_address(nvgre_ip) + (ip6_step * (port * nvgre_count)))
         vtep_ip_tmp = vtep_ip + (1 * port)
@@ -595,7 +583,7 @@ def create_arp_bypass(fp_ports_list, ip_list, config, cards_dict, subnet_mask):
         server_vlan = build_node_vlan(eni, config, nodetype="server")
 
         client_card, test_role = find_card_slot(config, cards_dict, first_cps_card, first_tcpbg_card, server_vlan)
-        client_port = find_port(num_cps_cards, first_cps_card, first_tcpbg_card, server_vlan, test_role)  # noqa: F841
+        find_port(num_cps_cards, first_cps_card, first_tcpbg_card, server_vlan, test_role)
         # server_card, test_role = find_card_slot(first_cps_card, first_tcpbg_card, server_vlan)
 
         if cards_dict['num_tcpbg_cards'] > 0:
@@ -667,11 +655,7 @@ def create_connections(fp_ports_list, ip_list, subnet_mask, config, cards_dict, 
 
         client_role, server_role = find_testrole(test_role, server_vlan)
 
-        production = True  # turn ON for now
-        if production is True:
-            vni_index = 1000
-        else:
-            vni_index = 0
+        vni_index = 1000
 
         server_conn_tmp = {"choice": "connect_vlan_vxlan", "connect_vlan_vxlan": {
             "vlan_endpoint_settings": {

--- a/tests/snappi_tests/dash/ha/ha_helper.py
+++ b/tests/snappi_tests/dash/ha/ha_helper.py
@@ -39,7 +39,7 @@ def run_ha_test(duthosts, localhost, tbinfo, ha_test_case, config_npu_dpu, confi
 
         # Traffic Starts
         if ha_test_case == 'cps':
-            api = run_cps_search(api, file_name, initial_cps_value, passing_dpus)
+            api = run_cps_search(api, config_snappi_l47, file_name, initial_cps_value, passing_dpus)
             logger.info("Test Ending")
         elif ha_test_case == 'planned_switchover':
             api = run_planned_switchover(duthosts, tbinfo, file_name, api, initial_cps_value)
@@ -500,14 +500,16 @@ def analyze_tcp_retries_resets(stats_client_result, stats_server_result):
     return retries_resets
 
 
-def run_cps_search(api, file_name, initial_cps_value, passing_dpus):
+def run_cps_search(api, config_snappi_l47, file_name, initial_cps_value, passing_dpus):
 
     error_threshold = 0.01  # noqa: F841
-    MAX_CPS = 30000000
+    MAX_CPS_PER_CARD = 4500000
+    MAX_CPS = len(config_snappi_l47['ports_list']['Traffic1@Network1']) * MAX_CPS_PER_CARD
     MIN_CPS = 0
     threshold = 1000000
     test_iteration = 1
     test_value = initial_cps_value
+    num_test_cards = len(config_snappi_l47['ports_list']['Traffic1@Network1'])
     activityList_url = "ixload/test/activeTest/communityList/0"
     constraint_url = "ixload/test/activeTest/communityList/0/activityList/0"
     releaseConfig_url = "ixload/test/operations/abortAndReleaseConfigWaitFinish"
@@ -618,20 +620,26 @@ def run_cps_search(api, file_name, initial_cps_value, passing_dpus):
             logger.info('Test Iteration Pass')
             test_result = "Pass"
             MIN_CPS = test_value
-            test_value = (MAX_CPS + MIN_CPS) / 2
+            test_value = int(MAX_CPS + MIN_CPS / 2)
+            if test_value > int(num_test_cards * MAX_CPS_PER_CARD):
+                # limit the max CPS setting to 4.5M cps per card
+                test_value = int(num_test_cards * MAX_CPS_PER_CARD)
         else:
             logger.info('Test Iteration Fail')
             test_result = "Fail"
             MAX_CPS = test_value
-            test_value = (MAX_CPS + MIN_CPS) / 2
+            test_value = int((MAX_CPS + MIN_CPS) / 2)
 
         if len(passing_dpus) == 0:
             passing_dpus = 0
 
-        columns = ['#Run', 'CPS Objective', 'Max CPS', f'{err_maxname}', 'Number of DPUs (Indexes)', 'Test Result']
+        columns = ['#Run', 'CPS Test Objective', 'Max CPS', f'{err_maxname}', 'Number of DPUs (Indexes)', 'Test Result']
         testRuns.append([test_iteration, cps_objective_value, cps_max, err_maxvalue, passing_dpus, test_result])
         table = tabulate(testRuns, headers=columns, tablefmt='psql')
         logger.info(table)
+
+        max_cps_testruns = max(run[2] for run in testRuns)
+        logger.info(f"The max CPS from all test runs is {max_cps_testruns}")
 
         logger.info("Iteration Ended...")
         logger.info('MIN_CPS = %d' % MIN_CPS)

--- a/tests/snappi_tests/dash/ha/ha_helper.py
+++ b/tests/snappi_tests/dash/ha/ha_helper.py
@@ -515,6 +515,7 @@ def run_cps_search(api, config_snappi_l47, file_name, initial_cps_value, passing
     releaseConfig_url = "ixload/test/operations/abortAndReleaseConfigWaitFinish"
     testRuns = []
 
+    # Find MAX CPS, track errors
     while ((MAX_CPS - MIN_CPS) > threshold):
 
         collector = ContinuousMetricsCollector(collection_interval=1)
@@ -660,6 +661,10 @@ def run_cps_search(api, config_snappi_l47, file_name, initial_cps_value, passing
         logger.info("Changing app state to stop")
         cs.app.state = 'stop'  # cs.app.state.START
         api.set_control_state(cs)
+
+    logger.info("Test Iteration Complete:")
+    logger.info(table)
+    logger.info(f"Final max CPS from all test runs is {max_cps_testruns}")
 
     return api
 

--- a/tests/snappi_tests/dash/sample_testbed.yaml
+++ b/tests/snappi_tests/dash/sample_testbed.yaml
@@ -1,30 +1,43 @@
----
-
 - conf-name: vms-snappi-sonic
   group-name: vms6-1
   topo: ptf32
   ptf_image_name: docker-ptf-snappi
-  ptf: snappi_sonic_l47
+  ptf: snappi_sonic_ixl
   ptf_ip: 10.1.1.3
-  service_type: vnet2vnet
+  service_type: privatelink
+  #service_type: vnet2vnet
+  #vxlan_port: 64200
+  #vxlan_src_port: 65330
   l47_gateway: 10.1.1.3
   l47_tg_servermac: 140776176680961
   l47_tg_clientmac: 140776176680962
   dut_mac: 40501075136016
-  l47_version: 11.00.0.292
+  ixos_version: 26.0.2600.14
+  l47_version: 26.0.0.94
   chassis_ip: 10.1.1.4
+  eni_per_dpu: 32
+  chassis_user_login: root
+  chassis_user_passwd: somePassWordForTesting
+  dpu_target_username: admin
+  dpu_target_passwd: YourPaSsWoRd
+  clean_l47trafficgen_staticarps: True
   uhd_ip: 10.1.1.5
+  vxlan_endpoint_vni: 1000
   dpu_active_ip: 172.35.1.1
   dpu_standby_ip: 172.35.1.2
-  dpu_active_mac: b0:8d:57:cd:36:ef
-  dpu_standby_mac: ec:19:2e:f1:ca:af
+  dpu_active_mac: bb:dd:55:cc:33:ee
+  dpu_standby_mac: ee:99:22:ff:cc:ff
   dpu_active_if: Ethernet224
   dpu_standby_if: Ethernet240
   num_cps_cards: 8
-  num_tcpbg_cards: 4
-  num_udpbg_cards: 1
+  num_tcpbg_cards: 0
+  num_udpbg_cards: 0
   num_dpus: 1
-  dpu_ports_list: 5, 6
+  dpu_ports_list: [5, 6]
+  active_ethpass_ip: 220.0.4.1
+  active_mac: 44:dd:ee:33:44:00
+  standby_ethpass_ip: 220.0.4.2
+  standby_mac: 22:55:44:22:55:11
   ports_list:
     Traffic1@Network1:
       - [ 1, 1, 1 ]

--- a/tests/snappi_tests/dash/test_cps.py
+++ b/tests/snappi_tests/dash/test_cps.py
@@ -3,6 +3,8 @@ from tests.snappi_tests.dash.ha.ha_helper import is_smartswitch, run_ha_test
 from tests.common.snappi_tests.snappi_fixtures import config_uhd_connect  # noqa F401
 from tests.common.snappi_tests.ixload.snappi_fixtures import config_snappi_l47  # noqa F401
 from tests.common.snappi_tests.ixload.snappi_fixtures import config_npu_dpu  # noqa F401
+from tests.common.snappi_tests.ixload.snappi_fixtures import setup_config_snappi_l47, setup_config_npu_dpu  # noqa F401
+from tests.common.snappi_tests.snappi_fixtures import setup_config_uhd_connect  # noqa F401
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import pytest
@@ -31,7 +33,7 @@ def test_cps_baby_hero(
                        request,
 ): # noqa F811
 
-    fixture_names = ["config_snappi_l47", "config_npu_dpu", "config_uhd_connect"]
+    fixture_names = ["config_snappi_l47", "config_npu_dpu", "config_uhd_connect"]  # noqa: F841
 
     results = {}
     errors = {}
@@ -40,14 +42,38 @@ def test_cps_baby_hero(
     if sw1 is False:
         pytest.skip("Skipping test since is not a smartswitch")
 
-    def _resolve_fixture(name):
-        # Resolve the fixture value on-demand
-        return request.getfixturevalue(name)
+    def _run_config_snappi_l47():
+        try:
+            return setup_config_snappi_l47(request, duthost, tbinfo, ha_test_case)
+        except Exception as e:
+            raise e
 
+    def _run_config_npu_dpu():
+        try:
+            return setup_config_npu_dpu(request, duthost, localhost, tbinfo, ha_test_case)
+        except Exception as e:
+            raise e
+
+    def _run_config_uhd_connect():
+        try:
+            return setup_config_uhd_connect(request, tbinfo, ha_test_case)
+        except Exception as e:
+            raise e
+
+    # Run the setup functions in parallel
     with ThreadPoolExecutor(max_workers=3) as ex:
-        fm = {ex.submit(_resolve_fixture, name): name for name in fixture_names}
-        for fut in as_completed(fm):
-            name = fm[fut]
+        future_snappi = ex.submit(_run_config_snappi_l47)
+        future_npu = ex.submit(_run_config_npu_dpu)
+        future_uhd = ex.submit(_run_config_uhd_connect)
+
+        futures = {
+            future_snappi: "config_snappi_l47",
+            future_npu: "config_npu_dpu",
+            future_uhd: "config_uhd_connect"
+        }
+
+        for fut in as_completed(futures):
+            name = futures[fut]
             try:
                 results[name] = fut.result()
             except Exception as e:


### PR DESCRIPTION
HA privatelink support for testcases.

testbed-cli:
python3 -m pytest --inventory ../ansible/snappi-sonic --host-pattern all --testbed vms-snappi-sonic --testbed_file ../ansible/testbed_HA.yaml --show-capture=stdout --log-cli-level info -ra --allow_recover --skip_sanity --disable_loganalyzer --uhd_config ../ansible/files/sonic_lab_links_uhd.csv --save_uhd_config --npu_dpu_startup --l47_trafficgen --save_l47_trafficgen snappi_tests/dash/test_cps.py

Sample ouput from a CPS test:
----------+
|   #Run |   CPS Test Objective |   Max CPS |   Client Retries | Number of DPUs (Indexes)   | Test Result   |
|--------+----------------------+-----------+------------------+----------------------------+---------------|
|      1 |              2000000 |   2000350 |            33 | {'dpu1': [], 'dpu2': []}   | Pass          |
|      2 |              4500000 |   2970000 |           3839 | {'dpu1': [], 'dpu2': []}   | Fail          |
|      3 |              3250000 |   2680000 |           2874 | {'dpu1': [], 'dpu2': []}   | Fail          |
|      4 |              2625000 |   2605300 |           4201 | {'dpu1': [], 'dpu2': []}   | Fail          |
+--------+----------------------+-----------+------------------+----------------------------+---------------+
INFO     tests.snappi_tests.dash.ha.ha_helper:ha_helper.py:642 The max CPS from all test runs is 2970000


### Description of PR
Add support for service_type = privatelink.

Summary:
Fixes # (issue)

### Type of change


- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Add support for service_type = privatelink

#### How did you do it?
Created in local sonic-mgmt container.

#### How did you verify/test it?
Using a local sonic-mgmt container

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
t1-smartswitch

### Documentation

