### PR TITLE
[sflow] Properly enable sflow tests on VS/KVM

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/sflow_test.py
+++ b/ansible/roles/test/files/ptftests/py3/sflow_test.py
@@ -279,7 +279,17 @@ class SflowTest(BaseTest):
                                                       ip_dst=ip_dst_addr,
                                                       ip_ttl=64)
                 no_of_packets = self.interfaces[intf]['sample_rate']
-                testutils.send(self, src_port, tcp_pkt, count=no_of_packets)
+                # VS TAP interfaces have a limited kernel receive queue depth.
+                # Sending large bursts causes drops before the TC ingress sampler sees them.
+                # Send in small batches with a brief pause to let the queue drain.
+                BATCH_SIZE = 32
+                remaining = no_of_packets
+                while remaining > 0:
+                    burst = min(BATCH_SIZE, remaining)
+                    testutils.send(self, src_port, tcp_pkt, count=burst)
+                    remaining -= burst
+                    if remaining > 0:
+                        time.sleep(0.001)
                 index += 1
             pktlen += 10  # send traffic with different packet sizes
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4797,6 +4797,10 @@ sflow/test_sflow.py::TestReboot::testWarmreboot:
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
       - "platform in ['x86_64-nvidia_sn5640-r0']"
+  xfail:
+    reason: "testWarmreboot sflow failure: VS SAI warm reboot bug (sonic-net/sonic-buildimage#26594)"
+    conditions:
+      - "https://github.com/sonic-net/sonic-buildimage/issues/26594 and asic_type in ['vs']"
 
 #######################################
 #####      show_techsupport       #####

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -345,7 +345,8 @@ def partial_ptf_runner(request, duthosts, rand_one_dut_hostname, ptfhost, tbinfo
                   'router_mac': var['router_mac'],
                   'dst_port': var['ptf_test_indices'][2],
                   'agent_id': var['lo_ip'],
-                  'sflow_ports_file': "/tmp/sflow_ports.json"}
+                  'sflow_ports_file': "/tmp/sflow_ports.json",
+                  'kvm_support': True}
         params.update(kwargs)
 
         # Make sure hsflowd daemon has processed collector config before


### PR DESCRIPTION
### Description of PR

Summary:
A previous attempt to enable sflow/test_sflow.py on VS (#21208) removed the global skip condition but omitted `kvm_support=True` on the `ptf_runner` call. As a result, `ptf_runner` silently skips the PTF test on KVM DUTs (`dut_type == "kvm"` and `kvm_support is False`), causing the test to report PASS without actually running any traffic.

Fixes #23873

### Type of change

- [x] Bug fix
- [x] Test case improvement

### Approach
#### What is the motivation for this PR?

With `kvm_support=True` missing, running sflow tests on a VS testbed appeared
to pass but the PTF traffic test was never executed. Three fixes are included:

1. **`kvm_support=True`** in the `ptf_runner` call in `partial_ptf_runner` so the PTF test actually executes on VS/KVM DUTs.
2. **PTF packet batching** — VS TAP interfaces have a limited kernel receive queue depth. Sending the full sampling burst (~512 packets) at once causes ~20% packet loss before the TC ingress sampler processes them, leading to under-sampling failures. Sending in 32-packet batches with a 1ms pause between batches allows the queue to drain.
3. **xfail `testWarmreboot` on VS** — VS SAI does not re-apply TC ingress filters after `vs_recreate_hostif_tap_interfaces()` creates new TAP interfaces during warm reboot, resulting in 0 sflow samples. Tracked in sonic-net/sonic-buildimage#26594. The xfail will clear automatically once that issue is resolved.

#### How did you do it?

- `tests/sflow/test_sflow.py`: Add `kvm_support=True` to `ptf_runner` call.
- `ansible/roles/test/files/ptftests/py3/sflow_test.py`: Send packets in 32-packet batches with 1ms between batches.
- `tests_mark_conditions.yaml`: Add `xfail` for `testWarmreboot` on VS, conditioned on sonic-net/sonic-buildimage#26594 being open.

#### How did you verify/test it?

Validated on a VS testbed.

#### Any platform specific information?

VS/KVM only.

NOTE: This is an AI-assisted PR, please review accordingly.

*— anders-bot (AI-assisted, on behalf of @anders-nexthop)*
