### PR TITLE
Update GCU NTP test for Chrony binddevice changes

### DIFF
--- a/tests/generic_config_updater/test_ntp.py
+++ b/tests/generic_config_updater/test_ntp.py
@@ -80,7 +80,7 @@ def server_exist_in_conf(duthost, server_pattern):
     """
     content = duthost.command("cat {}".format(NTP_CONF))
     for line in content['stdout_lines']:
-        if re.search(server_pattern, line):
+        if re.search(server_pattern, line, re.MULTILINE):
             return True
     return False
 
@@ -332,7 +332,8 @@ def ntp_server_set_intf(duthost, ntp_service, src_intf):
 
         if ntp_daemon == NtpDaemon.CHRONY:
             pytest_assert(
-                server_exist_in_conf(duthost, f"bindacqdevice {src_intf}"),
+                server_exist_in_conf(duthost, f"^bindacqdevice {src_intf}")
+                or server_exist_in_conf(duthost, "^bindacqaddress "),
                 f"Failed to set source interface to {src_intf}"
             )
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

sonic-net/sonic-buildimage#26160 will update chrony.conf.j2 to use `bindacqaddress` instead of `bindacqdevice`, to fix an issue where binding to Loopback0 will cause NTP to never get synchronized.

#### How did you do it?

Update the GCU NTP test to modify the check it does to look for either `bindacqdevice` or `bindacqaddress`, depending on what image version is being tested.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
