### PR TITLE
Add counter margins for cisco-8000 for various test_qos_sai tests

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -2681,7 +2681,8 @@ class LosslessVoq(sai_base_test.ThriftInterfaceDataPlane):
                     diff = counter_details_after[i][0][cntr] - counter_details_before[i][0][cntr]
                     if 'cisco-8000' in asic_type:
                         # For cisco-8000, adding margin to avoid test failure caused by small amount of RX drops
-                        assert diff <= COUNTER_MARGIN, "Unexpected ingress drop {} on port {}".format(diff, src_details[i])
+                        assert diff <= COUNTER_MARGIN, \
+                            "Unexpected ingress drop {} on port {}".format(diff, src_details[i])
                     else:
                         assert diff == 0, "Unexpected ingress drop {} on port {}".format(diff, src_details[i])
 
@@ -2719,7 +2720,8 @@ class LosslessVoq(sai_base_test.ThriftInterfaceDataPlane):
                     diff = counter_details_3[i][0][cntr] - counter_details_before[i][0][cntr]
                     if 'cisco-8000' in asic_type:
                         # For cisco-8000, adding margin to avoid test failure caused by small amount of RX drops
-                        assert diff <= COUNTER_MARGIN, "Unexpected ingress drop {} on port {}".format(diff, src_details[i])
+                        assert diff <= COUNTER_MARGIN, \
+                            "Unexpected ingress drop {} on port {}".format(diff, src_details[i])
                     else:
                         assert diff == 0, "Unexpected ingress drop {} on port {}".format(diff, src_details[i])
 


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (issue)
Fixing RX-drop issues on various test_qos_sai tests. In these failures, there is mostly delta of only +1 packet.
Ok to add 2 packets COUNTER_MARGIN

### Type of change

- [X ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ X] 202511

### Approach
#### What is the motivation for this PR?
Passing sonic-mgmt test_qos_sai tests

#### How did you do it?
Add 2 packets COUNTER_MARGIN for tolerance

#### How did you verify/test it?
Ran the test_qos_sai tests with the fix in 202511 branch 

** LossyQueueTest **
============================================================================ PASSES ============================================================================
_________________________________________________________ TestQosSai.testQosSaiLossyQueue[single_asic] _________________________________________________________
---------------------------- generated xml file: /tmp/qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue_2026-03-27-21-46-48.xml ----------------------------
INFO:root:Can not get Allure report URL. Please check logs
-------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------
27/03/2026 21:54:22 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
=================================================================== short test summary info ====================================================================
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue[single_asic]
SKIPPED [1] qos/test_qos_sai.py:1294: Did not find any frontend node that is multi-asic - so can't run single_dut_multi_asic tests
SKIPPED [3] qos/test_qos_sai.py:1294: multi-dut is not supported on T1 topologies
===================================================== 1 passed, 4 skipped, 1 warning in 451.95s (0:07:31) ======================================================
sonic@sonic-ucs-m5-16:/data/tests$ 

** testQosSaiLosslessVoq **
testQosSaiLosslessVoq
================================================================== short test summary info ===================================================================
SKIPPED [4] qos/test_qos_sai.py:776: Did not find any frontend node that is multi-asic - so can't run single_dut_multi_asic tests
SKIPPED [12] qos/test_qos_sai.py:776: multi-dut is not supported on T1 topologies
Results (1435.23s (0:23:55)):
       4 passed
      16 skipped
DEBUG:tests.conftest:[log_custom_msg] item: <Function testQosSaiLosslessVoq[multi_dut_shortlink_to_longlink-lossless_voq_4]>
INFO:root:Can not get Allure report URL. Please check logs
sonic@sonic-ucs-m3-4:/data/tests


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
