### PR TITLE
Add PORT_PHY_ATTR_TYPE and PORT_PHY_ATTR

### DIFF
--- a/tests/common/constants.py
+++ b/tests/common/constants.py
@@ -37,6 +37,8 @@ class CounterpollConstants:
     QUEUE = 'queue'
     PORT_STAT_TYPE = 'PORT_STAT'
     PORT = 'port'
+    PORT_PHY_ATTR_TYPE = 'PHY'
+    PORT_PHY_ATTR = 'phy'
     PORT_BUFFER_DROP_TYPE = 'PORT_BUFFER_DROP'
     PORT_BUFFER_DROP = 'port-buffer-drop'
     RIF_STAT_TYPE = 'RIF_STAT'
@@ -52,6 +54,7 @@ class CounterpollConstants:
     COUNTERPOLL_MAPPING = {PG_DROP_STAT_TYPE: PG_DROP,
                            QUEUE_STAT_TYPE: QUEUE,
                            PORT_STAT_TYPE: PORT,
+                           PORT_PHY_ATTR_TYPE: PORT_PHY_ATTR,
                            PORT_BUFFER_DROP_TYPE: PORT_BUFFER_DROP,
                            RIF_STAT_TYPE: RIF,
                            BUFFER_POOL_WATERMARK_STAT_TYPE: WATERMARK,


### PR DESCRIPTION
PORT PHY attribute collection is enabled by default
see details in https://github.com/sonic-net/sonic-buildimage/pull/25327 and back port PR https://github.com/sonic-net/sonic-buildimage/pull/26178
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md
Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Summary:
Add `PORT_PHY_ATTR_TYPE` and `PORT_PHY_ATTR` constants to `CounterpollConstants` in `tests/common/constants.py`, and register the new PHY counter type in `COUNTERPOLL_MAPPING`. This aligns the test framework with the PORT PHY attribute collection feature introduced in [sonic-buildimage#25327](https://github.com/sonic-net/sonic-buildimage/pull/25327) (back port: [sonic-buildimage#26178](https://github.com/sonic-net/sonic-buildimage/pull/26178)).
### Type of change
<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement
### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
### Approach
#### What is the motivation for this PR?
PORT PHY attribute collection is enabled by default starting from [sonic-buildimage#25327](https://github.com/sonic-net/sonic-buildimage/pull/25327). The test framework's `CounterpollConstants` needs the corresponding `PORT_PHY_ATTR_TYPE` (`PHY`) and `PORT_PHY_ATTR` (`phy`) entries so that counterpoll-related tests can recognize and validate the new PHY counter type.
#### How did you do it?
Added two new constants (`PORT_PHY_ATTR_TYPE = 'PHY'` and `PORT_PHY_ATTR = 'phy'`) to `CounterpollConstants` and added the mapping `PORT_PHY_ATTR_TYPE: PORT_PHY_ATTR` to `COUNTERPOLL_MAPPING` in `tests/common/constants.py`.
#### How did you verify/test it?
Verified that existing counterpoll tests pass with the new constants and that the PHY counter type is correctly recognized in the mapping.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A (not a new test case)
### Documentation
N/A
