### PR TITLE
Enhance container tests to support vendor-specific privileged containers

### DIFF
--- a/tests/container_hardening/conftest.py
+++ b/tests/container_hardening/conftest.py
@@ -1,0 +1,27 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--vendor-specific-privileged-containers",
+        action="store",
+        default="",
+        required=False,
+        help="Comma-separated list of additional containers allowed to run "
+             "in privileged mode (e.g. vendor-specific containers)"
+    )
+
+
+@pytest.fixture(scope="module")
+def vendor_specific_privileged_containers(request):
+    """
+    Return a list of vendor-specific container names that are allowed to run
+    in privileged mode beyond the base PRIVILEGED_CONTAINERS list.
+
+    Pass via command line:
+        pytest --vendor-specific-privileged-containers "container1,container2"
+    """
+    opt = request.config.getoption("--vendor-specific-privileged-containers", default="")
+    if opt:
+        return [c.strip() for c in opt.split(",")]
+    return []

--- a/tests/container_hardening/test_container_hardening.py
+++ b/tests/container_hardening/test_container_hardening.py
@@ -39,7 +39,7 @@ def get_base_container_name(container_name):
 
 
 def test_container_block_device_mounted(duthosts, enum_rand_one_per_hwsku_hostname, enum_rand_one_asic_index,
-                                        enum_dut_feature):
+                                        enum_dut_feature, vendor_specific_privileged_containers):
     """
     Test only containers allowed have access to block devices such as /dev/vda*, /dev/sda*, /dev/nvme0n1*
     """
@@ -49,7 +49,7 @@ def test_container_block_device_mounted(duthosts, enum_rand_one_per_hwsku_hostna
     disabled_containers = get_disabled_container_list(duthost)
 
     skip_condition = disabled_containers[:]
-    skip_condition.extend(CONTAINERS_WITH_BLOCKDEVICE_MOUNT)
+    skip_condition.extend(CONTAINERS_WITH_BLOCKDEVICE_MOUNT + vendor_specific_privileged_containers)
     # bgp0 -> bgp, bgp -> bgp, p4rt -> p4rt
     feature_name = get_base_container_name(container_name)
     pytest_require(feature_name not in skip_condition, "Skipping test for container {}".format(feature_name))
@@ -75,7 +75,8 @@ def test_container_block_device_mounted(duthosts, enum_rand_one_per_hwsku_hostna
     pytest_assert(not base_output, 'The base block device {} exists.'.format(base_device))
 
 
-def test_container_privileged(duthosts, enum_rand_one_per_hwsku_hostname):
+def test_container_privileged(duthosts, enum_rand_one_per_hwsku_hostname,
+                              vendor_specific_privileged_containers):
     """
     Test that no containers are running in privileged mode except those explicitly allowed.
 
@@ -83,6 +84,7 @@ def test_container_privileged(duthosts, enum_rand_one_per_hwsku_hostname):
     and fails if any container not in PRIVILEGED_CONTAINERS is running with --privileged.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    allowed_privileged = PRIVILEGED_CONTAINERS + vendor_specific_privileged_containers
 
     # Get all running containers
     running_containers = duthost.shell(
@@ -100,7 +102,7 @@ def test_container_privileged(duthosts, enum_rand_one_per_hwsku_hostname):
 
         if is_privileged:
             base_name = get_base_container_name(container_name)
-            if base_name not in PRIVILEGED_CONTAINERS:
+            if base_name not in allowed_privileged:
                 logger.error("Container '{}' is running in privileged mode but is not allowed".format(container_name))
                 unauthorized_privileged.append(container_name)
             else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md
Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Summary:
The container hardening tests (`test_container_block_device_mounted` and `test_container_privileged`) use a hardcoded allow-list of privileged containers. Some vendors run additional containers in privileged mode that are legitimate for their platform, causing false test failures. This PR adds a `--vendor-specific-privileged-containers` CLI option so vendors can dynamically extend the allow-list at runtime without modifying the test code.
Fixes # (issue)
### Type of change
<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement
### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
### Approach
#### What is the motivation for this PR?
Different vendors may run additional containers in privileged mode that are specific to their platform (e.g., vendor-specific hardware management containers). The existing `PRIVILEGED_CONTAINERS` and `CONTAINERS_WITH_BLOCKDEVICE_MOUNT` lists are hardcoded, so these vendor-specific containers cause `test_container_privileged` and `test_container_block_device_mounted` to fail even though the privileged mode is intentional and expected.
#### How did you do it?
1. **Added `tests/container_hardening/conftest.py`** with:
   - A `pytest_addoption` hook that registers a new `--vendor-specific-privileged-containers` CLI option accepting a comma-separated list of container names.
   - A module-scoped `vendor_specific_privileged_containers` fixture that parses the option into a Python list.
2. **Modified `tests/container_hardening/test_container_hardening.py`**:
   - `test_container_block_device_mounted`: Added the `vendor_specific_privileged_containers` fixture as a parameter and extended the skip condition list with vendor-specific containers.
   - `test_container_privileged`: Added the `vendor_specific_privileged_containers` fixture as a parameter and merged it with `PRIVILEGED_CONTAINERS` into a combined `allowed_privileged` list used for privilege checks.
#### How did you verify/test it?
- Verified the test logic by running the container hardening tests with and without the `--vendor-specific-privileged-containers` flag.
- Confirmed that passing vendor-specific container names correctly skips/allows them in both `test_container_block_device_mounted` and `test_container_privileged`.
- Confirmed that without the flag, existing behavior is unchanged (empty list, no extra containers allowed).
#### Any platform specific information?
This change is platform-agnostic. Vendors supply their specific container names via the CLI option at test invocation time.
#### Supported testbed topology if it's a new test case?
N/A — this is an improvement to existing test cases that run on topology `any`.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A — no new test cases or features; this is an enhancement to the existing container hardening