### PR TITLE
Add skip condition for gnmi tests for ipv6 mgmt dut

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2852,6 +2852,13 @@ gnmi/test_gnmi_configdb.py::test_gnmi_configdb_incremental_02:
       - "is_mgmt_ipv6_only==True"
       - "https://github.com/sonic-net/sonic-mgmt/issues/20395"
 
+gnmi/test_gnmi_configdb.py::test_gnmi_configdb_set_authenticate:
+  skip:
+    reason: "dut ipv6 mgmt ip not supported"
+    conditions:
+      - "is_mgmt_ipv6_only==True"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20395"
+
 gnmi/test_gnmi_configdb.py::test_gnmi_configdb_streaming_onchange_01:
   skip:
     reason: "dut ipv6 mgmt ip not supported"
@@ -2913,6 +2920,13 @@ gnmi/test_gnmi_smartswitch.py:
     reason: 'SmartSwitch gNMI tests require SmartSwitch platform, not applicable to BMC'
     conditions:
       - "'bmc' in topo_type"
+
+gnmi/test_gnmi_stress.py::test_gnmi_latency_01:
+  skip:
+    reason: "dut ipv6 mgmt ip not supported"
+    conditions:
+      - "is_mgmt_ipv6_only==True"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20395"
 
 gnmi/test_gnoi_killprocess.py:
   skip:


### PR DESCRIPTION
### Description of PR
Summary:
Add skip conditions for two gNMI test cases (`test_gnmi_configdb_set_authenticate` and `test_gnmi_latency_01`) when the DUT management interface is IPv6-only, as these tests do not support IPv6 management IP.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement
### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
### Approach
#### What is the motivation for this PR?
The gNMI tests `test_gnmi_configdb_set_authenticate` and `test_gnmi_latency_01` fail when the DUT uses an IPv6-only management IP. Other gNMI tests in the same file already have skip conditions for this scenario, but these two test cases were missing the corresponding skip entries.
#### How did you do it?
Added skip conditions in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` for:
- `gnmi/test_gnmi_configdb.py::test_gnmi_configdb_set_authenticate`
- `gnmi/test_gnmi_stress.py::test_gnmi_latency_01`
Both entries skip when `is_mgmt_ipv6_only==True` with a reference to issue https://github.com/sonic-net/sonic-mgmt/issues/20395.
#### How did you verify/test it?
Verified that the affected test cases are correctly skipped on testbeds with IPv6-only management IP configuration.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A