### PR TITLE
Fix incorrect skip condition for dualtor active-active topo in new gcu case

### DIFF
--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -1442,7 +1442,7 @@ def test_gcu_acl_dualtor_standby_drop_takes_priority_across_tables(rand_selected
 
     if not setup["is_dualtor"]:
         pytest.skip("Test only valid for active-standby dual ToR setups, skipping on non dual ToR device.")
-    if "dualtor-aa" in setup["topo"]:
+    if "dualtor-aa" in tbinfo["topo"]["name"]:
         pytest.skip("Test not valid for dualtor active-active setups, skipping on dualtor active-active device.")
 
     itfs, _ = rand_selected_interface


### PR DESCRIPTION
Summary: Fix incorrect skip condition for dualtor active-active topo in new gcu case
Fixes # (issue)


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
PR [21926](https://github.com/sonic-net/sonic-mgmt/pull/21926) add new case only for dualtor active-standby topo and want to skip on active-active topo,
but the skip condition never takes effect because `setup["topo"]` is derived from `tbinfo["topo"]["type"]`,
which is always "t0" for all dualtor topo (get_testbed_type() in tests/common/testbed.py remaps "dualtor" to "t0").
So "dualtor-aa" in "t0" is always False, and the test runs on dualtor active-active setups where it should be skipped.

#### How did you do it?
Change from `if "dualtor-aa" in setup["topo"]` to `if "dualtor-aa" in tbinfo["topo"]["name"]`

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
