### PR TITLE
(202511) fib/test_fib.py: User IPv6 addresses in outer header for IPinIPHashTest

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -25,6 +25,7 @@ from ptf.testutils import simple_tcpv6_packet
 from ptf.testutils import send_packet
 from ptf.testutils import verify_packet_any_port
 from ptf.testutils import simple_ipv4ip_packet
+from ptf.testutils import simple_ipv6ip_packet
 from ptf.testutils import simple_vxlan_packet
 from ptf.testutils import simple_vxlanv6_packet
 from ptf.testutils import simple_nvgre_packet
@@ -105,6 +106,7 @@ class HashTest(BaseTest):
         self.ipver = self.test_params.get('ipver', 'ipv4')
         self.is_active_active_dualtor = self.test_params.get("is_active_active_dualtor", False)
         self.topo_name = self.test_params.get('topo_name', '')
+        self.is_v6_topo = self.test_params.get('is_v6_topo', False)
 
         self.topo_type = self.test_params.get('topo_type', '')
         # set the base mac here to make it persistent across calls of check_ip_route
@@ -656,14 +658,19 @@ class IPinIPHashTest(HashTest):
         """
         @summary: return list of packets sending logs
         """
+        outer_ip_ver = "IPv6" if self.is_v6_topo else "IP"
+        next_header_key = "nh" if self.is_v6_topo else "proto"
+        outer_proto = ipinip_pkt[outer_ip_ver].nh if self.is_v6_topo else ipinip_pkt[outer_ip_ver].proto
         logs = []
-        logs.append('Sent Ether(src={}, dst={})/IP(src={}, dst={}, proto={})/{}(src={}, '
+        logs.append('Sent Ether(src={}, dst={})/{}(src={}, dst={}, {}={})/{}(src={}, '
                     'dst={}, proto={})/TCP(sport={}, dport={} on port {})'
                     .format(ipinip_pkt.src,
                             ipinip_pkt.dst,
-                            ipinip_pkt['IP'].src,
-                            ipinip_pkt['IP'].dst,
-                            ipinip_pkt['IP'].proto,
+                            outer_ip_ver,
+                            ipinip_pkt[outer_ip_ver].src,
+                            ipinip_pkt[outer_ip_ver].dst,
+                            next_header_key,
+                            outer_proto,
                             version,
                             pkt[version].src,
                             pkt[version].dst,
@@ -674,13 +681,14 @@ class IPinIPHashTest(HashTest):
         return logs
 
     def set_packet_parameter(self, pkt, exp_pkt, hash_key, ip_proto, version='IP'):
+        outer_ip_ver = "IPv6" if self.is_v6_topo else "IP"
         if hash_key == 'ip-proto':
             if version == 'IP':
-                pkt['IP'].payload.proto = ip_proto
-                exp_pkt['IP'].payload.proto = ip_proto
+                pkt[outer_ip_ver].payload.proto = ip_proto
+                exp_pkt[outer_ip_ver].payload.proto = ip_proto
             else:
-                pkt['IP'].payload['IPv6'].nh = ip_proto
-                exp_pkt['IP'].payload['IPv6'].nh = ip_proto
+                pkt[outer_ip_ver].payload['IPv6'].nh = ip_proto
+                exp_pkt[outer_ip_ver].payload['IPv6'].nh = ip_proto
 
     def create_pkt(
             self, router_mac, src_mac, dst_mac, ip_src, ip_dst, sport, dport, version='IP',
@@ -699,7 +707,6 @@ class IPinIPHashTest(HashTest):
                                     tcp_sport=sport,
                                     tcp_dport=dport,
                                     ip_ttl=64)
-            func = simple_ipv4ip_packet
         else:
             pkt = simple_tcpv6_packet(pktlen=inner_pkt_len if vlan_id == 0 else inner_pkt_len + 4,
                                       dl_vlan_enable=False if vlan_id == 0 else True,
@@ -710,15 +717,24 @@ class IPinIPHashTest(HashTest):
                                       tcp_sport=sport,
                                       tcp_dport=dport,
                                       ipv6_hlim=64)
-            func = simple_ipv4ip_packet
-        ipinip_pkt = func(
-            eth_dst=router_mac,
-            eth_src=src_mac,
-            ip_src=outer_src_ip,
-            ip_dst=outer_dst_ip,
-            inner_frame=pkt[version])
-        exp_pkt = ipinip_pkt.copy()
-        exp_pkt['IP'].ttl -= 1
+        if self.is_v6_topo:
+            ipinip_pkt = simple_ipv6ip_packet(
+                eth_dst=router_mac,
+                eth_src=src_mac,
+                ipv6_src=outer_src_ipv6,
+                ipv6_dst=outer_dst_ipv6,
+                inner_frame=pkt['IPv6'])
+            exp_pkt = ipinip_pkt.copy()
+            exp_pkt['IPV6'].hlim -= 1
+        else:
+            ipinip_pkt = simple_ipv4ip_packet(
+                eth_dst=router_mac,
+                eth_src=src_mac,
+                ip_src=outer_src_ip,
+                ip_dst=outer_dst_ip,
+                inner_frame=pkt[version])
+            exp_pkt = ipinip_pkt.copy()
+            exp_pkt['IP'].ttl -= 1
         return ipinip_pkt, exp_pkt, pkt
 
     def apply_mask_to_exp_pkt(self, masked_exp_pkt, version='IP'):
@@ -751,6 +767,9 @@ class IPinIPHashTest(HashTest):
         # The outer_src_ip and outer_dst_ip are fixed
         outer_src_ip = '80.1.0.31'
         outer_dst_ip = '80.1.0.32'
+        if self.is_v6_topo:
+            outer_src_ip = '80::31'
+            outer_dst_ip = '80::32'
         src_port, exp_port_lists, next_hops = self.get_src_and_exp_ports(
             outer_dst_ip)
         if self.switch_type == "chassis-packet":

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -19,7 +19,7 @@ from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_port
 from tests.common.dualtor.dual_tor_utils import config_active_active_dualtor_active_standby                 # noqa: F401
 from tests.common.dualtor.dual_tor_utils import validate_active_active_dualtor_setup                        # noqa: F401
 from tests.common.dualtor.dual_tor_common import active_active_ports                                        # noqa: F401
-from tests.common.utilities import is_ipv4_address
+from tests.common.utilities import is_ipv4_address, is_ipv6_only_topology
 
 from tests.common.fixtures.fib_utils import (  # noqa: F401
     single_fib_for_duts,
@@ -582,7 +582,8 @@ def test_hash(add_default_route_to_dut, duthosts, tbinfo, setup_vlan,      # noq
             "switch_type": switch_type,
             "is_active_active_dualtor": is_active_active_dualtor,
             "topo_name": updated_tbinfo['topo']['name'],
-            "topo_type": updated_tbinfo['topo']['type']
+            "topo_type": updated_tbinfo['topo']['type'],
+            "is_v6_topo": is_ipv6_only_topology(updated_tbinfo),
         },
         log_file=log_file,
         qlen=PTF_QLEN,
@@ -633,7 +634,8 @@ def test_ipinip_hash(add_default_route_to_dut, duthost, duthosts,               
                        "ignore_ttl": ignore_ttl,
                        "single_fib_for_duts": single_fib_for_duts,
                        "ipver": ipver,
-                       "topo_name": tbinfo['topo']['name']
+                       "topo_name": tbinfo['topo']['name'],
+                       "is_v6_topo": is_ipv6_only_topology(tbinfo),
                        },
                log_file=log_file,
                qlen=PTF_QLEN,
@@ -679,7 +681,8 @@ def test_ipinip_hash_negative(add_default_route_to_dut, duthosts,           # no
                    "single_fib_for_duts": single_fib_for_duts,
                    "ipver": ipver,
                    "topo_name": tbinfo['topo']['name'],
-                   "topo_type": tbinfo['topo']['type']
+                   "topo_type": tbinfo['topo']['type'],
+                   "is_v6_topo": is_ipv6_only_topology(tbinfo),
                },
                log_file=log_file,
                qlen=PTF_QLEN,
@@ -737,7 +740,8 @@ def test_vxlan_hash(add_default_route_to_dut, duthost, duthosts,                
                        "single_fib_for_duts": single_fib_for_duts,
                        "ipver": vxlan_ipver,
                        "topo_name": tbinfo['topo']['name'],
-                       "topo_type": tbinfo['topo']['type']
+                       "topo_type": tbinfo['topo']['type'],
+                       "is_v6_topo": is_ipv6_only_topology(tbinfo),
                        },
                log_file=log_file,
                qlen=PTF_QLEN,
@@ -800,7 +804,8 @@ def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                
                        "single_fib_for_duts": single_fib_for_duts,
                        "ipver": nvgre_ipver,
                        "topo_name": tbinfo['topo']['name'],
-                       "topo_type": tbinfo['topo']['type']
+                       "topo_type": tbinfo['topo']['type'],
+                       "is_v6_topo": is_ipv6_only_topology(tbinfo),
                        },
                log_file=log_file,
                qlen=PTF_QLEN,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
When running on isolated-v6 testbeds, use IPv6 addressing in the outermost L3 header of IPinIP packets, as IPv4 addresses are not configured and are unresolvable on these testbeds.

Summary:
Fixes #21160 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
This removes an issue caused by a mismatch between test expectations and the testbed configuration, namely the assumption that IPv4 addresses can be used on testbeds that are isolated-v6.  This came up during imagequal testing of a different branch and will need to be addressed there as well.

#### How did you do it?
Evaluate whether or not the testbed is isolated-v6 and safe this in a class attribute.  If this attribute is true, pass IPv6 addresses to packet-creation and verification methods so that the L3 addresses in outer headers of IPinIP packets are IPv6.  IPv6-specific scapy methods are utilized where applicable.

#### How did you verify/test it?
Verified that the test case now uses IPv6 addressing in outer IPinIP headers, and that it no longer fails due to nexthop resolution issues.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
