### PR TITLE
[qos]: add rotate_syslog fixture to test_dscp_to_queue_mapping

### DIFF
--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -489,7 +489,8 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
     def test_dscp_to_queue_mapping(self, ptfadapter, rand_selected_dut, localhost, dscp_config, dscp_mode,
                                    toggle_all_simulator_ports_to_rand_selected_tor, completeness_level,  # noqa F811
                                    setup_standby_ports_on_rand_unselected_tor, route_config,
-                                   tbinfo, downstream_links, upstream_links, dut_qos_maps_module, loganalyzer):  # noqa F811
+                                   tbinfo, downstream_links, upstream_links, dut_qos_maps_module, loganalyzer,  # noqa F811
+                                   rotate_syslog):  # noqa F811
         """
             Test QoS SAI DSCP to queue mapping for IP-IP packets in DSCP "uniform" and "pipe" mode
         """


### PR DESCRIPTION
### Description of PR

**Summary:**
Add `rotate_syslog` fixture to `test_dscp_to_queue_mapping` to prevent syslog rotation from affecting loganalyzer marker detection.

**Problem:**
Syslog rotation (`logrotate -f /etc/logrotate.conf`) can run during the test and clear `/var/log/syslog`. When this happens between `loganalyzer` setup (which records the start marker) and teardown (which searches the log), the start marker is missing — causing `loganalyzer` to report a false failure.

**Fix:**
Add `rotate_syslog` fixture to `test_dscp_to_queue_mapping`. This fixture forces syslog rotation **before** the test starts, so loganalyzer always finds its start marker in the fresh syslog file.

### Type of change
- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach

#### What is the motivation for this PR?
Syslog rotation can clear `/var/log/syslog` during test execution, removing the loganalyzer start marker and causing false failures in `test_dscp_to_queue_mapping`.

Related ADO: https://msazure.visualstudio.com/One/_workitems/edit/37406599

#### How did you do it?
Added `rotate_syslog` fixture to `test_dscp_to_queue_mapping` function signature. The `rotate_syslog` fixture (already defined in `tests/conftest.py`) forces a log rotation before test body runs, ensuring loganalyzer's start marker is written to a fresh syslog.

#### How did you verify/test it?
Verified on `bjw3-can-7060-2` (Arista-7060CX-32S-C32, broadcom-legacy-th, 202511). The `loganalyzer` fixture now correctly finds its start marker and completes without false failures.

#### Any platform specific information?
Tested on `broadcom-legacy-th` (Arista 7060CX).

### Documentation
N/A