### PR TITLE
[qos]: add rotate_syslog fixture to test_dscp_to_queue_mapping

### DIFF
--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -496,7 +496,7 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
     def test_dscp_to_queue_mapping(self, ptfadapter, rand_selected_dut, localhost, dscp_config, dscp_mode,
                                    toggle_all_simulator_ports_to_rand_selected_tor, completeness_level,  # noqa F811
                                    setup_standby_ports_on_rand_unselected_tor, route_config,
-                                   tbinfo, downstream_links, upstream_links, dut_qos_maps_module, loganalyzer):  # noqa F811
+                                   tbinfo, downstream_links, upstream_links, dut_qos_maps_module, loganalyzer, rotate_syslog):  # noqa F811
         """
             Test QoS SAI DSCP to queue mapping for IP-IP packets in DSCP "uniform" and "pipe" mode
         """


### PR DESCRIPTION
### Description of PR
Summary:
`test_dscp_to_queue_mapping` in `TestQoSSaiDSCPQueueMapping_IPIP_Base` occasionally fails because syslog rotation occurs between loganalyzer's start marker and end marker, causing the start marker to be lost.

Adding the `rotate_syslog` fixture forces a syslog rotation **before** the test starts, so loganalyzer can reliably find its start marker within the current log file.

Fixes ADO#37406599

### Type of change
- [x] Bug fix

### Back port request
- [x] 202511

### Approach
#### What is the motivation for this PR?
When syslog rotates during the test, loganalyzer fails to find its start marker because the marker ended up in the rotated (old) log file. This causes spurious test failures unrelated to actual QoS behavior.

#### How did you do it?
Added `rotate_syslog` to the `test_dscp_to_queue_mapping` function signature. This fixture triggers a syslog rotation before the test runs, ensuring loganalyzer's start marker is always written to the current (fresh) log file.

#### How did you verify/test it?
Verified on internal-202511 branch with an Arista 7060CX-32S-C32 testbed. The `uniform` variant passes correctly. The `rotate_syslog` fixture is confirmed working — loganalyzer start/end markers were found as expected.

#### Any platform specific information?
None — fix applies to all platforms that run this test.

#### Supported testbed topology if it's a new test case?
Existing test — dual-tor topology.