### PR TITLE
fix pre/post tests errors in run_tests.sh

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -346,15 +346,15 @@ function pre_post_extra_params()
 function prepare_dut()
 {
     echo "=== Preparing DUT for subsequent tests ==="
-    echo Running: ${PYTEST_EXEC} ${SCRIPT_PATH} ${PYTEST_UTIL_OPTS} ${PRET_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} $(pre_post_extra_params) -m pretest
-    ${PYTEST_EXEC} ${SCRIPT_PATH} ${PYTEST_UTIL_OPTS} ${PRET_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} $(pre_post_extra_params) -m pretest
+    echo Running: ${PYTEST_EXEC} ${SCRIPT_PATH}/test_pretest.py ${PYTEST_UTIL_OPTS} ${PRET_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} $(pre_post_extra_params) -m pretest
+    ${PYTEST_EXEC} ${SCRIPT_PATH}/test_pretest.py ${PYTEST_UTIL_OPTS} ${PRET_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} $(pre_post_extra_params) -m pretest
 }
 
 function cleanup_dut()
 {
     echo "=== Cleaning up DUT after tests ==="
-    echo Running: ${PYTEST_EXEC} ${SCRIPT_PATH} ${PYTEST_UTIL_OPTS} ${POST_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} $(pre_post_extra_params) -m posttest
-    ${PYTEST_EXEC} ${SCRIPT_PATH} ${PYTEST_UTIL_OPTS} ${POST_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} $(pre_post_extra_params) -m posttest
+    echo Running: ${PYTEST_EXEC} ${SCRIPT_PATH}/test_posttest.py ${PYTEST_UTIL_OPTS} ${POST_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} $(pre_post_extra_params) -m posttest
+    ${PYTEST_EXEC} ${SCRIPT_PATH}/test_posttest.py ${PYTEST_UTIL_OPTS} ${POST_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} $(pre_post_extra_params) -m posttest
 }
 
 function run_group_tests()


### PR DESCRIPTION
### Description

when different testbed file location is provided, pretest may fail:
```
PASS:  ./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c bgp/test_bgp_fact.py -f vtestbed.yaml -i ../ansible/veos_vtb 
FAIL:   ./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c bgp/test_bgp_fact.py -f ../ansible/vtestbed.yaml -i ../ansible/veos_vtb
```

```
root@new-mgmt-int:/data/sonic-mgmt/tests# ./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c bgp/test_bgp_fact.py -f ../ansible/vtestbed.yaml -i ../ansible/veos_vtb                                                                     
pkill: pattern that searches for process name longer than 15 characters will result in zero matches             
Try `pkill -f' option to match against the complete command line.                                                                                                                                                                
=== Clearing pytest cache ===                                                                                   
=== Preparing DUT for subsequent tests ===                                                                      
Running: python3 -m pytest --inventory ../ansible/veos_vtb --host-pattern vlab-01 --dpu-pattern None --testbed vms-kvm-t0 --testbed_file ../ansible/vtestbed.yaml --log-cli-level warning --log-file-level debug --kube_master un
set --showlocals --assert plain --show-capture no -rav --allow_recover --ignore=ptftests --ignore=acstests --ignore=saitests --ignore=scripts --ignore=k8s --ignore=sai_qualify --junit-xml=logs/pretest.xml --log-file=logs/pret
est.log --topology util -m pretest                                                                                                                                                                                               
ERROR: usage: __main__.py [options] [file_or_dir] [file_or_dir] [...]                                           
__main__.py: error: unrecognized arguments: --dpu-pattern --testbed vms-kvm-t0 --testbed_file ../ansible/vtestbed.yaml --kube_master unset --allow_recover --topology util                                                       
  inifile: /data/sonic-mgmt/pyproject.toml                                                                      
  rootdir: /data/sonic-mgmt                                                                                     
                                                                                                                                                                                                                                 
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!                                                                  
!!!!!  Prepare DUT failed, skip testing  !!!!!                                                                  
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!          
root@new-mgmt-int:/data/sonic-mgmt/tests#                                                                  
```

### Root Cause

When `prepare_dut()` / `cleanup_dut()` invoke pytest without an explicit test file argument, pytest has no path pointing into `tests/`. As a result, `tests/conftest.py` is **never loaded during initial plugin discovery**, and causing pytest fails with `unrecognized arguments`

### Changes
- `prepare_dut()`: Pass `${SCRIPT_PATH}/test_pretest.py` so pytest discovers `tests/conftest.py`
- `cleanup_dut()`: Pass `${SCRIPT_PATH}/test_posttest.py` so pytest discovers `tests/conftest.py`

Signed-off-by: Dashuai Zhang <dashuaizhang@microsoft.com>