### PR TITLE
[restapi] Restore RESTAPI cert config after config_reload in cleanup_…

### DIFF
--- a/tests/restapi/test_restapi.py
+++ b/tests/restapi/test_restapi.py
@@ -100,12 +100,14 @@ def check_reset_status_after_reboot(reboot_type, pre_reboot_status, post_reboot_
 
 
 @pytest.fixture
-def cleanup_after_testing(rand_selected_dut):
+def cleanup_after_testing(duthosts, rand_one_dut_hostname):
     """
     Cleanup DUT by config reload after test running.
     """
     yield
-    config_reload(rand_selected_dut)
+    duthost = duthosts[rand_one_dut_hostname]
+    config_reload(duthost)
+    apply_cert_config(duthost)
 
 
 '''


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

This PR fixes a cleanup issue in the RESTAPI test suite. After a test finishes, `cleanup_after_testing` reloads the DUT configuration, but it does not restore the RESTAPI certificate configuration. As a result, subsequent RESTAPI test cases that rely on certificate-based authentication can fail unexpectedly, including `test_data_path_sad` in sequential runs.
Fixes:
RESTAPI test failures caused by missing certificate re-configuration after `config_reload` during cleanup.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`cleanup_after_testing` is expected to restore the DUT to a clean state after each RESTAPI test. However, `config_reload` clears the existing runtime configuration and the fixture did not re-apply the RESTAPI certificate setup afterward. This leaves the DUT in a state where later RESTAPI tests using cert-based authentication may fail.

#### How did you do it?
Updated `cleanup_after_testing` to:
1. Get the selected DUT from `duthosts` and `rand_one_dut_hostname`
2. Run `config_reload(duthost)`
3. Re-apply the RESTAPI certificate configuration with `apply_cert_config(duthost)`
This makes the cleanup flow consistent with other places in the same test file where certificate config is restored after reboot or config reload.

#### How did you verify/test it?

#### Any platform specific information?


#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
