### PR TITLE
xfail dhcp_relay test cases with sonic-relay-agent on mellanox platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1052,6 +1052,10 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_after_link_flap[sonic-relay-agent
     reason: "Test skipped: sonic dhcpv4 is not supported in the DUT image version < 202511"
     conditions:
       - "release < '202511'"
+  xfail:
+    reason: "xfail due to GitHub issue https://github.com/sonic-net/sonic-mgmt/issues/23601"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23601 and asic_type in ['mellanox']"
 
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_counter:
   skip:
@@ -1060,11 +1064,21 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_counter:
     conditions:
       - "release in ['201811', '201911', '202012']"
 
+dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default:
+  xfail:
+    reason: "xfail due to GitHub issue https://github.com/sonic-net/sonic-mgmt/issues/23601"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23601 and 'dualtor' in topo_name and asic_type in ['mellanox']"
+
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default[sonic-relay-agent]:
   skip:
     reason: "Test skipped: sonic dhcpv4 is not supported in the DUT image version < 202511"
     conditions:
       - "release < '202511'"
+  xfail:
+    reason: "xfail due to GitHub issue https://github.com/sonic-net/sonic-mgmt/issues/23601"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23601 and asic_type in ['mellanox']"
 
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_monitor_checksum_validation:
   skip:
@@ -1072,9 +1086,17 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_monitor_checksum_validation:
     conditions:
       - "https://github.com/sonic-net/sonic-buildimage/issues/24660"
   xfail:
-    reason: "xfail due to GitHub issue https://github.com/sonic-net/sonic-buildimage/issues/24402"
+    reason: "xfail due to GitHub issues https://github.com/sonic-net/sonic-buildimage/issues/24402 and https://github.com/sonic-net/sonic-mgmt/issues/23601"
+    conditions_logical_operator: or
     conditions:
       - "https://github.com/sonic-net/sonic-buildimage/issues/24402 and asic_type in ['mellanox', 'nvidia']"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23601 and 'dualtor' in topo_name and asic_type in ['mellanox']"
+
+dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_monitor_checksum_validation[sonic-relay-agent]:
+  xfail:
+    reason: "xfail due to GitHub issue https://github.com/sonic-net/sonic-mgmt/issues/23601"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23601 and asic_type in ['mellanox']"
 
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_random_sport:
   skip:
@@ -1083,6 +1105,16 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_random_sport:
     conditions:
       - "'dualtor' in topo_name and release in ['201811', '201911']"
       - "platform in ['x86_64-8111_32eh_o-r0']"
+  xfail:
+    reason: "xfail due to GitHub issue https://github.com/sonic-net/sonic-mgmt/issues/23601"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23601 and 'dualtor' in topo_name and asic_type in ['mellanox']"
+
+dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_random_sport[sonic-relay-agent]:
+  xfail:
+    reason: "xfail due to GitHub issue https://github.com/sonic-net/sonic-mgmt/issues/23601"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23601 and asic_type in ['mellanox']"
 
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_start_with_uplinks_down:
   skip:
@@ -1097,6 +1129,10 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_start_with_uplinks_down[sonic-rel
     reason: "Test skipped: sonic dhcpv4 is not supported in the DUT image version < 202511"
     conditions:
       - "release < '202511'"
+  xfail:
+    reason: "xfail due to GitHub issue https://github.com/sonic-net/sonic-mgmt/issues/23601"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23601 and asic_type in ['mellanox']"
 
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_unicast_mac:
   skip:
@@ -1105,12 +1141,20 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_unicast_mac:
     conditions:
       - "'dualtor' in topo_name and release in ['201811', '201911']"
       - "platform in ['x86_64-8111_32eh_o-r0']"
+  xfail:
+    reason: "xfail due to GitHub issue https://github.com/sonic-net/sonic-mgmt/issues/23601"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23601 and 'dualtor' in topo_name and asic_type in ['mellanox']"
 
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_unicast_mac[sonic-relay-agent]:
   skip:
     reason: "Test skipped: sonic dhcpv4 is not supported in the DUT image version < 202511"
     conditions:
       - "release < '202511'"
+  xfail:
+    reason: "xfail due to GitHub issue https://github.com/sonic-net/sonic-mgmt/issues/23601"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23601 and asic_type in ['mellanox']"
 
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_with_source_port_ip_in_relay_enabled:
   skip:
@@ -1118,12 +1162,20 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_with_source_port_ip_in_relay_enab
     conditions_logical_operator: or
     conditions:
       - "'dualtor' in topo_name and release in ['201811', '201911']"
+  xfail:
+    reason: "xfail due to GitHub issue https://github.com/sonic-net/sonic-mgmt/issues/23601"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23601 and 'dualtor' in topo_name and asic_type in ['mellanox']"
 
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_with_source_port_ip_in_relay_enabled[sonic-relay-agent]:
   skip:
     reason: "Test skipped: sonic dhcpv4 is not supported in the DUT image version < 202511"
     conditions:
       - "release < '202511'"
+  xfail:
+    reason: "xfail due to GitHub issue https://github.com/sonic-net/sonic-mgmt/issues/23601"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23601 and asic_type in ['mellanox']"
 
 dhcp_relay/test_dhcp_relay.py::test_interface_binding:
   skip:


### PR DESCRIPTION
### Description of PR

Summary: xfail dhcp_relay test cases with sonic-relay-agent on mellanox platform
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

