### PR TITLE
[bgp] Increase wait_until timeout for BGP session down from 180s to 240s

### DIFF
--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -312,9 +312,10 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
     # Inject the failure — cleanup is guaranteed by the fixture teardown
     failure_injection.inject(failure_type)
 
-    # default keepalive is 60 seconds, timeout 180 seconds. Hence wait for 180 seconds before timeout.
+    # default keepalive is 60 seconds, hold time 180 seconds. Use 240 seconds to provide a safety margin
+    # and avoid a race condition where BGP takes the full hold time (~180s) to go down.
     pytest_assert(
-        wait_until(180, 10, 0, verify_bgp_session_down, duthost, neighbor),
+        wait_until(240, 10, 0, verify_bgp_session_down, duthost, neighbor),
         "neighbor {} state is still established".format(neighbor)
     )
 


### PR DESCRIPTION
### Description of PR
Increase the `wait_until` timeout for `verify_bgp_session_down` in `test_bgp_session_interface_down[neighbor-reboot]` from **180s → 240s**.

Fixes #(none — intermittent test flakiness, no upstream issue filed)
37406634

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework (new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The BGP default hold time is **180 seconds**. Using the same value for the `wait_until` timeout creates a race condition: if BGP takes close to the full hold time to go down, the test times out and fails even though no real bug exists.

Observed flakiness on Arista 7060CX-32S t1 testbeds (nightly, build 20251110.18):
- **FAIL run**: 15 polls × 10s = 150s of polling; all returned False → "still False after 180s" (10s deadline overshoot)
- **PASS run** (same testbed, same build, hours later): BGP went down at ~168s → `wait_until` returned True early

The BGP session took ~168–190s to go down after the neighbor interface was shut. With a 180s timeout the margin is only ~12s, making the test timing-sensitive.

#### How did you do it?
Increased `wait_until(180, ...)` → `wait_until(240, ...)` for `verify_bgp_session_down` in the neighbor-reboot test path. This gives 60s of headroom above the BGP hold time while keeping the test strict about eventual convergence.

#### How did you verify/test it?
Log comparison from two nightly runs on the same testbed:
- FAIL: `verify_bgp_session_down is still False after 180 seconds`
- PASS: `exit early with True (BGP down at 168.6s)`

#### Any platform specific information?
Observed on Arista 7060CX-32S t1 topology. The fix applies generally to all platforms since it is a timeout margin increase.

#### Supported testbed topology if it's a new test case?
N/A — not a new test case.

### Documentation
No documentation changes required.