### PR TITLE
[dualtor_io] Add duplication tolerance to test_active_tor_downlink_down_downstream_active/standby

### DIFF
--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -215,15 +215,19 @@ def test_active_tor_downlink_down_upstream(
 def test_active_tor_downlink_down_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa: F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa: F811
-    shutdown_upper_tor_downlink_intfs                                   # noqa: F811
+    shutdown_upper_tor_downlink_intfs,                                  # noqa: F811
+    link_down_downstream_active_duplication_setting                     # noqa: F811
 ):
     """
     Send traffic from T1 to active ToR and shutdown the active ToR downlink on DUT.
     Verify switchover and disruption lasts < 1 second
     """
+    allowed_duplication, merge_duplications = link_down_downstream_active_duplication_setting
     send_t1_to_server_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=1, action=shutdown_upper_tor_downlink_intfs
+        allowed_disruption=1, action=shutdown_upper_tor_downlink_intfs,
+        allowed_duplication=allowed_duplication,
+        merge_duplications_into_disruptions=merge_duplications
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -235,15 +239,19 @@ def test_active_tor_downlink_down_downstream_active(
 def test_active_tor_downlink_down_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa: F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa: F811
-    shutdown_upper_tor_downlink_intfs                                   # noqa: F811
+    shutdown_upper_tor_downlink_intfs,                                  # noqa: F811
+    link_down_downstream_active_duplication_setting                     # noqa: F811
 ):
     """
     Send traffic from T1 to standby ToR and shutdown the active ToR downlink on DUT.
     Verify switchover and disruption lasts < 1 second
     """
+    allowed_duplication, merge_duplications = link_down_downstream_active_duplication_setting
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=1, action=shutdown_upper_tor_downlink_intfs
+        allowed_disruption=1, action=shutdown_upper_tor_downlink_intfs,
+        allowed_duplication=allowed_duplication,
+        merge_duplications_into_disruptions=merge_duplications
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,


### PR DESCRIPTION
## Summary

Add `link_down_downstream_active_duplication_setting` fixture to both `test_active_tor_downlink_down_downstream_active` and `test_active_tor_downlink_down_downstream_standby` to handle Cisco/Mellanox mux cable traffic duplication during switchover.

## Root Cause

On Cisco-8101C01-C32, shutting down the active ToR downlink causes 14-17 traffic duplications during mux failover, exceeding the default max of 2.

**Cross-vendor data (14d):**
- **Cisco-8101C01-C32**: 69% pass rate
- **Arista-7050CX3-32S-C32**: 96% pass rate
- **Arista-7260CX3-D108C8**: 100% pass rate

## Fix

The sibling test `test_active_link_down_downstream_active` (line 77) already uses `link_down_downstream_active_duplication_setting` which:
- Detects Cisco/Mellanox HWSKUs
- Sets `allowed_duplication = (1, len(mux_config))`
- Enables `merge_duplications_into_disruptions = True`

This PR applies the **same pattern** to both:
- `test_active_tor_downlink_down_downstream_active`
- `test_active_tor_downlink_down_downstream_standby`

## ADO Reference

Fixes: [ADO #37278672](https://msazure.visualstudio.com/One/_workitems/edit/37278672)