### PR TITLE
fix(copp): replace nnpy with pynng for ptf_nn_agent compatibility

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -207,7 +207,7 @@ def restore_syncd(dut, nn_target_namespace):
 
 
 def _install_nano_bookworm(dut, creds, syncd_docker_name):
-    output = dut.command("docker exec {} bash -c '[ -d /usr/include/nanomsg ] || \
+    output = dut.command("docker exec {} bash -c 'python3 -c \"import pynng\" 2>/dev/null || \
         echo copp'".format(syncd_docker_name))
 
     if output["stdout"] == "copp":
@@ -219,14 +219,13 @@ def _install_nano_bookworm(dut, creds, syncd_docker_name):
                 && rm -rf /var/lib/apt/lists/* \
                 && apt-get update \
                 && apt-get install -y python3-pip build-essential libssl-dev libffi-dev \
-                python3-dev python3-setuptools wget libnanomsg-dev python-is-python3 \
-                && TMPDIR=/var/tmp_build pip3 install --no-cache-dir cffi==1.16.0 \
-                && TMPDIR=/var/tmp_build pip3 install --no-cache-dir nnpy \
+                python3-dev python3-setuptools wget python-is-python3 \
+                && TMPDIR=/var/tmp_build pip3 install --no-cache-dir pynng \
                 && rm -rf /var/tmp_build \
                 && mkdir -p /opt && cd /opt && wget \
-                https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
+                https://raw.githubusercontent.com/p4lang/ptf/main/ptf_nn/ptf_nn_agent.py \
                 && mkdir ptf && cd ptf && wget \
-                https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
+                https://raw.githubusercontent.com/p4lang/ptf/main/src/ptf/afpacket.py && touch __init__.py \
                 && apt-get -y purge build-essential libssl-dev libffi-dev python3-dev \
                 python3-setuptools wget \
                 " '''.format(http_proxy, https_proxy, syncd_docker_name)
@@ -251,8 +250,8 @@ def _install_nano(dut, creds,  syncd_docker_name):
         output = dut.command("docker exec {} bash -c '[ -d /usr/local/include/nanomsg ] || \
             echo copp'".format(syncd_docker_name))
     else:
-        output = dut.command("docker exec {} bash -c '[ -d /usr/local/include/nanomsg ] && [ -d /opt/ptf ] || \
-            echo copp'".format(syncd_docker_name))
+        output = dut.command("docker exec {} bash -c '([ -d /usr/local/include/nanomsg ] || \
+            python3 -c \"import pynng\" 2>/dev/null) && [ -d /opt/ptf ] || echo copp'".format(syncd_docker_name))
 
     if output["stdout"] == "copp":
         http_proxy = creds.get('proxy_env', {}).get('http_proxy', '')
@@ -265,15 +264,12 @@ def _install_nano(dut, creds,  syncd_docker_name):
                     && rm -rf /var/lib/apt/lists/* \
                     && apt-get update \
                     && apt-get install -y python3-pip build-essential libssl-dev libffi-dev \
-                    python3-dev python-setuptools wget cmake python-is-python3 \
-                    && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
-                    && tar xzf 1.0.0.tar.gz && cd nanomsg-1.0.0 \
-                    && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0 \
-                    && rm -f 1.0.0.tar.gz && pip3 install cffi && pip3 install --upgrade cffi && pip3 install nnpy \
+                    python3-dev python-setuptools wget python-is-python3 \
+                    && pip3 install --no-cache-dir pynng \
                     && mkdir -p /opt && cd /opt && wget \
-                    https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
+                    https://raw.githubusercontent.com/p4lang/ptf/main/ptf_nn/ptf_nn_agent.py \
                     && mkdir ptf && cd ptf && wget \
-                    https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
+                    https://raw.githubusercontent.com/p4lang/ptf/main/src/ptf/afpacket.py && touch __init__.py \
                     " '''.format(http_proxy, https_proxy, syncd_docker_name)
         else:
             cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
@@ -287,10 +283,12 @@ def _install_nano(dut, creds,  syncd_docker_name):
                     && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0 \
                     && rm -f 1.0.0.tar.gz && pip2 install cffi==1.7.0 && pip2 install --upgrade \
                     cffi==1.7.0 && pip2 install nnpy \
-                    && mkdir -p /opt && cd /opt && wget \
-                    https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
-                    && mkdir ptf && cd ptf && wget \
-                    https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
+                    && PTF_SHA=9d41838d634c479fc24fac7a527ec5ee2d0ce8eb \
+                    && mkdir -p /opt && cd /opt \
+                    && wget https://raw.githubusercontent.com/p4lang/ptf/$PTF_SHA/ptf_nn/ptf_nn_agent.py \
+                    && mkdir ptf && cd ptf \
+                    && wget https://raw.githubusercontent.com/p4lang/ptf/$PTF_SHA/src/ptf/afpacket.py \
+                    && touch __init__.py \
                     " '''.format(http_proxy, https_proxy, syncd_docker_name)
         dut.command(cmd)
 


### PR DESCRIPTION
p4lang/ptf PR #234 (merged 2026-04-05) replaced nnpy with pynng in ptf_nn_agent.py, breaking test_copp.py::test_policer across all testbeds. This PR updates copp_utils.py accordingly.

### Description of PR

Summary:

This PR fixes a regression introduced by p4lang/ptf PR #234 (merged 2026-04-05),
which replaced nnpy with pynng in ptf_nn_agent.py. copp_utils.py was still installing
nnpy, causing ptf_nn_agent to immediately crash with ImportError: pynng not found.
The supervisor autorestart loop then kept port 10900 closed, causing PTF to get EOF
and test_policer to hang for 10 minutes before failing.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach

#### What is the motivation for this PR?
p4lang/ptf PR #234 (merged 2026-04-05, tagged breaking-change) replaced nnpy
with pynng in ptf_nn_agent.py. The new agent exits immediately if pynng is not
found. copp_utils.py was still installing nnpy, causing ptf_nn_agent to crash
in a supervisor restart loop. Port 10900 (used by PTF to communicate with the
agent) never opened, causing PTF to receive EOF and test_policer to hang for
10 minutes before timing out. This regression started affecting all testbeds on
2026-04-06 after the nightly picked up the new ptf_nn_agent.py.

#### How did you do it?
- _install_nano_bookworm: install pynng instead of nnpy, remove libnanomsg-dev
  and cffi==1.16.0, update wget URLs from master to main, update skip condition
  to check pynng import instead of nanomsg include directory
- _install_nano (bullseye): install pynng instead of nnpy, remove cmake and
  nanomsg-from-source build steps, update wget URLs from master to main
- _install_nano (bullseye): update skip condition to accept either nanomsg
  install (legacy) or pynng import (new) as satisfied
- _install_nano (buster/Python2): unchanged — retains nnpy with URLs pinned
  to last nnpy-compatible commit SHA 9d41838d634c479fc24fac7a527ec5ee2d0ce8eb

#### How did you verify/test it?
Root cause confirmed via Kusto: last passing test_policer[ARP] was 2026-04-05
00:46 UTC; all runs after 2026-04-05 19:06 UTC (p4lang/ptf merge) failed.
55+ module-level failures observed across bjw3, bjw2, and other testbeds.
Local build and pre-commit hooks (flake8, trailing-whitespace) pass.

#### Any platform specific information?
Bookworm and bullseye DUTs: migrate to pynng.
Buster DUTs (Python2): retain nnpy pinned to SHA (unchanged).

#### Supported testbed topology if it's a new test case?
N/A — this is a bug fix to the copp test setup helper.

### Documentation

N/A