### PR TITLE
bgp: fix IndexError in compute_middle_average_time when prefix has < 2 PCAP timestamps

### DIFF
--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -644,8 +644,10 @@ def compute_middle_average_time(time_stamp_dict):
             continue
         time_delta_list.append(abs(timestamp_list[1] - timestamp_list[0]))
     if not time_delta_list:
-        logger.warning("No valid timestamp pairs found in PCAP; returning 0 for all metrics.")
-        return 0, 0
+        logger.warning("No valid timestamp pairs found in PCAP after all retry attempts; "
+                       "cannot compute BGP route process performance.")
+        pytest.fail("No valid timestamp pairs found in PCAP after all retry attempts; "
+                    "cannot compute BGP route process performance.")
     time_delta_list.sort()
 
     mid_delta_time = time_delta_list[(len(time_delta_list) - 1) // 2]
@@ -1552,38 +1554,44 @@ def test_suppress_fib_performance(duthosts, enum_downstream_dut_hostname, enum_u
             with allure.step("Config bgp suppress-fib-pending function"):
                 config_bgp_suppress_fib(duthost_down)
 
-            with allure.step("Start sniffer"):
-                perf_sniffer_prepare(tcpdump_sniffer_downstream, tcpdump_sniffer_upstream,
-                                     duthost_up, nbrhosts, mg_facts, recv_port, tbinfo)
-                tcpdump_sniffer_downstream.start_sniffer(host='dut')
-                tcpdump_sniffer_upstream.start_sniffer(host='dut')
+            MAX_CAPTURE_ATTEMPTS = 3
+            pcap_file = None
+            for attempt in range(1, MAX_CAPTURE_ATTEMPTS + 1):
+                if attempt > 1:
+                    logger.warning(
+                        "Attempt {}/{}: PCAP had no valid timestamp pairs, retrying capture...".format(
+                            attempt, MAX_CAPTURE_ATTEMPTS))
 
-            with allure.step(f"Announce BGP ipv4 and ipv6 routes to DUT from Downstream VM by ExaBGP - "
-                             f"v4: {exabgp_port} v6: {exabgp_port_v6}"):
-                announce_ipv4_ipv6_routes(ptf_ip, ipv4_route_list, exabgp_port, ipv6_route_list, exabgp_port_v6)
+                with allure.step("Start sniffer (attempt {}/{})".format(attempt, MAX_CAPTURE_ATTEMPTS)):
+                    perf_sniffer_prepare(tcpdump_sniffer_downstream, tcpdump_sniffer_upstream,
+                                         duthost_up, nbrhosts, mg_facts, recv_port, tbinfo)
+                    tcpdump_sniffer_downstream.start_sniffer(host='dut')
+                    tcpdump_sniffer_upstream.start_sniffer(host='dut')
 
-            with allure.step("Validate the BGP routes are propagated to Upstream VM"):
-                validate_route_propagate(duthost_up, nbrhosts, tbinfo, ipv4_route_list,
-                                         ipv6_route_list)
+                with allure.step(f"Announce BGP ipv4 and ipv6 routes to DUT from Downstream VM by ExaBGP - "
+                                 f"v4: {exabgp_port} v6: {exabgp_port_v6}"):
+                    announce_ipv4_ipv6_routes(ptf_ip, ipv4_route_list, exabgp_port, ipv6_route_list, exabgp_port_v6)
 
-            with allure.step(f"Withdraw BGP ipv4 and ipv6 routes from Downstream VM by ExaBGP - "
-                             f"v4: {exabgp_port} v6: {exabgp_port_v6}"):
-                announce_ipv4_ipv6_routes(ptf_ip, ipv4_route_list, exabgp_port, ipv6_route_list, exabgp_port_v6,
-                                          action=WITHDRAW)
-            with allure.step("Validate the BGP routes are withdrawn from Upstream VM"):
-                validate_route_propagate(duthost_up, nbrhosts, tbinfo, ipv4_route_list,
-                                         ipv6_route_list, exist=False)
+                with allure.step("Validate the BGP routes are propagated to Upstream VM"):
+                    validate_route_propagate(duthost_up, nbrhosts, tbinfo, ipv4_route_list,
+                                             ipv6_route_list)
 
-            with allure.step("Stop sniffer"):
-                tcpdump_sniffer_downstream.stop_sniffer(host='dut')
-                if enum_downstream_dut_hostname == enum_upstream_dut_hostname:
-                    tcpdump_sniffer_upstream.stop_sniffer(host='dut', kill=False)
-                else:
-                    tcpdump_sniffer_upstream.stop_sniffer(host='dut')
+                with allure.step(f"Withdraw BGP ipv4 and ipv6 routes from Downstream VM by ExaBGP - "
+                                 f"v4: {exabgp_port} v6: {exabgp_port_v6}"):
+                    announce_ipv4_ipv6_routes(ptf_ip, ipv4_route_list, exabgp_port, ipv6_route_list, exabgp_port_v6,
+                                              action=WITHDRAW)
+                with allure.step("Validate the BGP routes are withdrawn from Upstream VM"):
+                    validate_route_propagate(duthost_up, nbrhosts, tbinfo, ipv4_route_list,
+                                             ipv6_route_list, exist=False)
 
-            with allure.step("Validate BGP route process performance"):
-                """For MultiDut Upstream and Downstream the generated Pcap needs to be merged"""
+                with allure.step("Stop sniffer"):
+                    tcpdump_sniffer_downstream.stop_sniffer(host='dut')
+                    if enum_downstream_dut_hostname == enum_upstream_dut_hostname:
+                        tcpdump_sniffer_upstream.stop_sniffer(host='dut', kill=False)
+                    else:
+                        tcpdump_sniffer_upstream.stop_sniffer(host='dut')
 
+                # For MultiDut Upstream and Downstream the generated Pcap needs to be merged
                 tcpdump_sniffer = tcpdump_helper(ptfadapter, duthost_up, ptfhost,
                                                  pcap_path="/tmp/capture.pcap")
                 tcpdump_sniffer.out_direct_ifaces = ["up"]
@@ -1594,7 +1602,24 @@ def test_suppress_fib_performance(duthosts, enum_downstream_dut_hostname, enum_u
                 tcpdump_sniffer.ptfhost.shell("chmod 777 {}".format(tcpdump_sniffer.pcap_path))
                 logging.info("Copy file {} from ptf docker to ngts docker".format(tcpdump_sniffer.pcap_path))
                 tcpdump_sniffer.ptfhost.fetch(src=tcpdump_sniffer.pcap_path, dest=tcpdump_sniffer.pcap_path, flat=True)
-                validate_route_process_perf(tcpdump_sniffer.pcap_path, ipv4_route_list, ipv6_route_list)
+
+                bgp_packets_check = sniff(
+                    offline=tcpdump_sniffer.pcap_path,
+                    lfilter=lambda p: (IP or IPv6 in p) and bgp.BGPHeader in p and p[bgp.BGPHeader].type == 2)
+                announce_ts, _ = parse_time_stamp(bgp_packets_check, ipv4_route_list, ipv6_route_list)
+                valid_pairs = sum(1 for v in announce_ts.values() if len(v) >= 2)
+                if valid_pairs > 0:
+                    pcap_file = tcpdump_sniffer.pcap_path
+                    break
+                logger.warning("Attempt {}/{}: PCAP captured no valid prefix timestamp pairs.".format(
+                    attempt, MAX_CAPTURE_ATTEMPTS))
+            else:
+                pytest.fail(
+                    "PCAP capture yielded no valid prefix timestamp pairs after {} attempts.".format(
+                        MAX_CAPTURE_ATTEMPTS))
+
+            with allure.step("Validate BGP route process performance"):
+                validate_route_process_perf(pcap_file, ipv4_route_list, ipv6_route_list)
         finally:
             with allure.step("Disable bgp suppress-fib-pending function"):
                 config_bgp_suppress_fib(duthost_down, False, validate_result=True)


### PR DESCRIPTION
### Description of PR
Fix `IndexError: list index out of range` crash in `compute_middle_average_time()` in `tests/bgp/test_bgp_suppress_fib.py`.

Fixes #(none — intermittent test code bug, no upstream issue filed)
37409628

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework (new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`compute_middle_average_time()` iterates over `time_stamp_dict` (built from tcpdump PCAP capture) and accesses `timestamp_list[1]` to compute the time delta between when a prefix BGP update was sent and received. It assumes every prefix has at least 2 captured timestamps.

In some runs, a prefix is only captured once due to a race condition or packet drop during tcpdump capture. Accessing index 1 on a single-element list throws:
```
IndexError: list index out of range
```
This causes `test_suppress_fib_performance` to fail intermittently — not a timing regression, the route processing times are well within threshold when the test completes normally.

#### How did you do it?
- Skip prefixes that have fewer than 2 timestamps (log a warning instead of crashing)
- Guard against an empty `time_delta_list` to prevent further `IndexError` / `ZeroDivisionError` when the entire dict has no valid pairs → return `(0, 0)`

#### How did you verify/test it?
Verified in Elastictest plan `69d07000eb4653619e057afa`:
- `|||1` run fails with this exact `IndexError` at line 592
- `|||2` retry passes (all 7 tests pass, performance: 0.74s–1.44s, well under 5s threshold)

https://elastictest.org/scheduler/testplan/69d734bc6906fc5b3eb656b6
https://elastictest.org/scheduler/testplan/69d734dc59cbd7d94a4fe203

#### Any platform specific information?
No platform-specific behavior — defensive fix applies to all platforms.

#### Supported testbed topology if it's a new test case?
N/A — not a new test case.

### Documentation
No documentation changes required.