### PR TITLE
[test] Fix ValueError in test_ecn_config_utility when ecnconfig output has empty lines

### DIFF
--- a/tests/qos/test_ecn_config.py
+++ b/tests/qos/test_ecn_config.py
@@ -272,7 +272,7 @@ def test_ecn_config_utility(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     if result['stdout_lines']:
         ecn_list = {}
         for iter, line in enumerate(result['stdout_lines']):
-            if iter < 2 or '---' in line:
+            if iter < 2 or '---' in line or not line.strip():
                 continue
             else:
                 key, value = line.split(maxsplit=1)


### PR DESCRIPTION
### Description of PR

Summary:
Fix `ValueError: not enough values to unpack` crash in `test_ecn_config_utility` when `ecnconfig -l` command output contains empty lines.

When parsing the output of `ecnconfig -l`, the code splits each line with `line.split(maxsplit=1)` and unpacks into two variables. If the output contains empty or whitespace-only lines, the split produces fewer than 2 values, causing a `ValueError`. This adds an empty-line guard to skip such lines.

Fixes PBI#37432210


```
ecnconfig -l

"stdout_lines": [
    "Profile: WRED_LOSSLESS_Q3",
    "-----------------------  -------",
    "ecn                      ecn_all",
    "green_drop_probability   5",
    "green_max_threshold      262144",
    "green_min_threshold      131072",
    "red_drop_probability     5",
    "red_max_threshold        262144",
    "red_min_threshold        131072",
    "wred_green_enable        true",
    "wred_red_enable          true",
    "wred_yellow_enable       true",
    "yellow_drop_probability  5",
    "yellow_max_threshold     262144",
    "yellow_min_threshold     131072",
    "-----------------------  -------",
    "",
    "Profile: WRED_LOSSLESS_Q4",
    "-----------------------  -------",
    "ecn                      ecn_all",
    "green_drop_probability   5",
    "green_max_threshold      262144",
    "green_min_threshold      131072",
    "red_drop_probability     5",
    "red_max_threshold        262144",
    "red_min_threshold        131072",
    "wred_green_enable        true",
    "wred_red_enable          true",
    "wred_yellow_enable       true",
    "yellow_drop_probability  5",
    "yellow_max_threshold     262144",
    "yellow_min_threshold     131072",
    "-----------------------  -------"
  ],
```

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

`test_ecn_config_utility` in `tests/qos/test_ecn_config.py` crashes with:
```
ValueError: not enough values to unpack (expected 2, got 1)
```
when `ecnconfig -l` output contains empty or whitespace-only lines. The parser at line ~278 does:
```python
field, value = line.split(maxsplit=1)
```
which fails on empty lines.

#### How did you do it?

Added `or not line.strip()` to the existing skip condition so empty/whitespace-only lines are filtered out before the split:

**Before:**
```python
if iter < 2 or '---' in line:
    continue
```

**After:**
```python
if iter < 2 or '---' in line or not line.strip():
    continue
```

#### How did you verify/test it?

- Code inspection confirms the guard handles empty strings, whitespace-only strings, and newline-only strings
- The change is a single-line addition that does not alter behavior for non-empty lines

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
