### PR TITLE
[test] Add missing Arista-7060X6 HwSKU queue mappings for packet trimming tests

### DIFF
--- a/tests/generic_config_updater/test_packet_trimming_config_asymmetric.py
+++ b/tests/generic_config_updater/test_packet_trimming_config_asymmetric.py
@@ -52,6 +52,8 @@ def setup_env(duthost):
         th5_queue = {
             'Arista-7060X6-64PE-B-C448O16': 4,
             'Arista-7060X6-64PE-B-C512S2': 4,
+            'Arista-7060X6-64PE-B-O128': 4,
+            'Arista-7060X6-16PE-384C-B-O128S2': 4,
         }
 
         # TH5 trim queue defaults to 9 unless otherwise configured

--- a/tests/generic_config_updater/test_packet_trimming_config_symmetric.py
+++ b/tests/generic_config_updater/test_packet_trimming_config_symmetric.py
@@ -49,6 +49,8 @@ def setup_env(duthost):
         th5_queue = {
             'Arista-7060X6-64PE-B-C448O16': 4,
             'Arista-7060X6-64PE-B-C512S2': 4,
+            'Arista-7060X6-64PE-B-O128': 4,
+            'Arista-7060X6-16PE-384C-B-O128S2': 4,
         }
 
         # TH5 trim queue defaults to 9 unless otherwise configured


### PR DESCRIPTION
### Description of PR

Summary:
Add missing Arista-7060X6 HwSKU queue mappings (`Arista-7060X6-64PE-B-O128` and `Arista-7060X6-16PE-384C-B-O128S2`) to the `th5_queue` dictionary in both symmetric and asymmetric packet trimming config tests.

Without these entries, the `.get()` fallback returns queue index 9, which is out of the valid range (0-7), causing `orchagent ERR` on these platforms.

Related: ADO PBI 37430984

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`test_packet_trimming_config_asym` fails on Arista-7060X6-64PE-B-O128 and Arista-7060X6-16PE-384C-B-O128S2 because the `th5_queue` dictionary is missing entries for these HwSKUs. The `.get(hwsku, 9)` default returns 9, which exceeds the valid queue index range (0-7), triggering an orchagent error.

#### How did you do it?
Added the two missing HwSKU entries to the `th5_queue` dictionary with queue index 4 (consistent with the other Arista-7060X6 variants) in both:
- `tests/generic_config_updater/test_packet_trimming_config_asymmetric.py`
- `tests/generic_config_updater/test_packet_trimming_config_symmetric.py`

#### How did you verify/test it?
Verified that the queue index 4 is within valid range (0-7) and matches the other 7060X6 HwSKU variants already in the dictionary.

#### Any platform specific information?
Affects Arista-7060X6-64PE-B-O128 and Arista-7060X6-16PE-384C-B-O128S2 platforms.

#### Supported testbed topology if it's a new test case?
N/A (bug fix for existing tests)

### Documentation
N/A