### PR TITLE
[bgp] Replace pidof with pgrep -x to avoid syslog false-positive ERR

### DIFF
--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -905,10 +905,10 @@ def operate_orchagent(duthost, action=ACTION_STOP):
     """
     if action == ACTION_STOP:
         logging.info('Suspend orchagent process to simulate a delay')
-        cmd = 'sudo kill -SIGSTOP $(pidof orchagent)'
+        cmd = 'sudo kill -SIGSTOP $(pgrep -x orchagent)'
     else:
         logging.info('Recover orchagent process')
-        cmd = 'sudo kill -SIGCONT $(pidof orchagent)'
+        cmd = 'sudo kill -SIGCONT $(pgrep -x orchagent)'
     duthost.shell(cmd)
 
 

--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -330,7 +330,7 @@ def is_orchagent_stopped(duthost):
     Compatible for multi-asic
     """
     out_list = []
-    pids = duthost.shell("pidof orchagent")['stdout'].split()
+    pids = duthost.shell("pgrep -x orchagent")['stdout'].split()
     for pid in pids:
         cmd = 'cat /proc/{}/status | grep State'.format(pid)
         out = duthost.shell(cmd)['stdout']


### PR DESCRIPTION
### Description of PR

Summary: Replace `pidof orchagent` with `pgrep -x orchagent` in BGP suppress-fib helpers to eliminate a syslog false-positive ERR.

Fixes # (issue)
37409594

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

`pidof` scans all `/proc/<pid>/stat` entries. When a short-lived process exits mid-scan, Linux removes its `/proc/<pid>/stat` before `pidof` reads it. `pidof` logs the error **directly to syslog** via `syslog()` syscall (not stderr):

```
ERR pidof[1549411]: can't read from 1549407/stat
```

This is a benign Linux race condition, but SONiC's `LogAnalyzer` catches it as an unexpected `ERR`-level syslog message and marks the test run as `errors=1` even when the test itself passes. `2>/dev/null` does not help because the error goes to syslog, not stderr.

#### How did you do it?

Replace `pidof orchagent` with `pgrep -x orchagent` in:
- `operate_orchagent()` in `tests/bgp/bgp_helpers.py` (SIGSTOP and SIGCONT commands)
- `is_orchagent_stopped()` in `tests/bgp/test_bgp_suppress_fib.py`

`pgrep` silently skips vanished processes and does not write to syslog. The `-x` flag enforces exact name matching (equivalent to `pidof` behaviour). Output format differs (newline vs space) but `.split()` handles both.

#### How did you verify/test it?

Run `tests/bgp/test_bgp_suppress_fib.py` on a testbed — the base run should no longer show `errors=1` from the `pidof` race condition.

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
