### PR TITLE
Improve VOQ and BGP tests: config_reload override, vtysh option and stability fixes

### DIFF
--- a/ansible/library/extract_log.py
+++ b/ansible/library/extract_log.py
@@ -169,7 +169,7 @@ def convert_date(fct, s):
     locale.setlocale(locale.LC_ALL, loc)
 
     if dt is None:
-        dt = 0
+        dt = datetime.datetime.min
         logger.warning(f"Failed to convert date from string, skipping unparseable line: {s}")
     return dt
 

--- a/tests/bgp/test_traffic_shift_lc.py
+++ b/tests/bgp/test_traffic_shift_lc.py
@@ -16,7 +16,8 @@ from tests.bgp.route_checker import assert_only_loopback_routes_announced_to_nei
 from tests.bgp.traffic_checker import get_traffic_shift_state, check_tsa_persistence_support, \
     verify_traffic_shift_per_asic
 from tests.bgp.constants import TS_NORMAL, TS_MAINTENANCE, TS_NO_NEIGHBORS
-from tests.conftest import get_hosts_per_hwsku
+from tests.conftest import get_hosts_per_hwsku, backup_golden_config, restore_golden_config, \
+    update_golden_config_tsa_enabled
 
 pytestmark = [
     pytest.mark.topology('t2')
@@ -360,9 +361,15 @@ def test_load_minigraph_with_traffic_shift_away(request, duthosts, nbrhosts, tra
     # Initially make sure both supervisor and line cards are in BGP operational normal state
     initial_tsa_check_before_and_after_test(duthosts)
 
+    # Backup and update golden_config_db.json to enable TSA
+    backup_path = "/tmp/golden_config_db_backup.json"
+    for duthost in frontend_nodes_per_hwsku:
+        backup_golden_config(duthost, backup_path)
+        update_golden_config_tsa_enabled(duthost, tsa_enabled=True)
+
     for duthost in frontend_nodes_per_hwsku:
         # Ensure that the DUT is not in maintenance already before start of the test
-        pytest_assert(wait_until(30, 5, 0, lambda: TS_NORMAL == get_traffic_shift_state(duthost, 'TSC no-stats')),
+        pytest_assert(wait_until(60, 5, 0, lambda: TS_NORMAL == get_traffic_shift_state(duthost, 'TSC no-stats')),
                       "DUT is not in normal state")
         if not check_tsa_persistence_support(duthost):
             pytest.skip("TSA persistence not supported in the image")
@@ -381,7 +388,7 @@ def test_load_minigraph_with_traffic_shift_away(request, duthosts, nbrhosts, tra
 
         for duthost in frontend_nodes_per_hwsku:
             # Verify DUT is in maintenance state.
-            pytest_assert(wait_until(30, 5, 0,
+            pytest_assert(wait_until(60, 5, 0,
                                      lambda: TS_MAINTENANCE == get_traffic_shift_state(duthost, 'TSC no-stats')),
                           "DUT is not in maintenance state")
             assert_only_loopback_routes_announced_to_neighs(
@@ -402,9 +409,13 @@ def test_load_minigraph_with_traffic_shift_away(request, duthosts, nbrhosts, tra
 
         # Verify DUT is in normal state.
         for duthost in frontend_nodes_per_hwsku:
-            pytest_assert(wait_until(30, 5, 0,
+            pytest_assert(wait_until(60, 5, 0,
                                      lambda: TS_NORMAL == get_traffic_shift_state(duthost, 'TSC no-stats')),
                           "DUT is not in normal state")
+
+        # Restore the original golden_config_db.json
+        for duthost in frontend_nodes_per_hwsku:
+            restore_golden_config(duthost, backup_path)
 
         # Wait until all routes are announced to neighbors
         verify_route_on_neighbors(frontend_nodes_per_hwsku, dut_nbrhosts, orig_v4_routes, orig_v6_routes)

--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -380,8 +380,17 @@ def check_neighbors(duthost, tbinfo):
 
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
+    # Check if this topo includes confed peer
+    confed_peer_topo = False
+    for v in bgp_facts['bgp_neighbors'].values():
+        if v.get('confed_peer', False):
+            confed_peer_topo = True
+            break
+
     for value in list(bgp_facts['bgp_neighbors'].values()):
         # Verify locat ASNs in bgp sessions
+        if confed_peer_topo and (not value.get("confed_peer", False)):
+            continue
         if (value['local AS'] != mg_facts['minigraph_bgp_asn']):
             raise RebootHealthError("Local ASNs not found in BGP session.\
                 Minigraph: {}. Found {}".format(value['local AS'], mg_facts['minigraph_bgp_asn']))

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -643,7 +643,9 @@ bgp/test_bgpmon.py::test_bgpmon:
 
 bgp/test_bgpmon_v6.py::test_bgpmon_no_ipv6_resolve_via_default:
   skip:
-    reason: "Not applicable for passive bgpmon_v6"
+    reason: "Not applicable for passive bgpmon_v6 and UT2 does not use bgpmon_v6"
+    conditions:
+      - "platform in ['x86_64-arista_7280dr3am_36']"
 
 bgp/test_startup_tsa_tsb_service.py::test_tsa_tsb_service_with_supervisor_abnormal_reboot:
   skip:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3861,6 +3861,34 @@ def setup_connection(request, setup_gnmi_server):
         channel.close()
 
 
+def backup_golden_config(duthost, backup_path="/tmp/golden_config_db_backup.json"):
+    duthost.shell("cp {} {}".format(GOLDEN_CONFIG_DB_PATH, backup_path))
+
+
+def restore_golden_config(duthost, backup_path="/tmp/golden_config_db_backup.json"):
+    duthost.shell("cp {} {}".format(backup_path, GOLDEN_CONFIG_DB_PATH))
+
+
+def update_golden_config_tsa_enabled(duthost, tsa_enabled=True):
+    """
+    @summary: Update golden_config_db.json on the DUT to set tsa_enabled in BGP_DEVICE_GLOBAL.
+    Handles both multi-asic and single-asic cases.
+    """
+    golden_config_db = json.loads(duthost.shell("cat {}".format(GOLDEN_CONFIG_DB_PATH))['stdout'])
+    tsa_enabled_str = "true" if tsa_enabled else "false"
+
+    if duthost.sonichost.is_multi_asic:
+        for asic in duthost.asics:
+            golden_config_db.setdefault(asic.namespace, {}) \
+                            .setdefault("BGP_DEVICE_GLOBAL", {}) \
+                            .setdefault("STATE", {})["tsa_enabled"] = tsa_enabled_str
+    else:
+        golden_config_db.setdefault("BGP_DEVICE_GLOBAL", {}) \
+                        .setdefault("STATE", {})["tsa_enabled"] = tsa_enabled_str
+
+    duthost.copy(content=json.dumps(golden_config_db, indent=4), dest=GOLDEN_CONFIG_DB_PATH)
+
+
 @pytest.fixture(scope="module", autouse=True)
 def restore_golden_config_db(duthost):
     if file_exists_on_dut(duthost, GOLDEN_CONFIG_DB_PATH_ORI):

--- a/tests/nat/conftest.py
+++ b/tests/nat/conftest.py
@@ -191,7 +191,7 @@ def apply_global_nat_config(duthost, config_nat_feature_enabled):
     nat_global_config(duthost)
     yield
     # reload config on teardown
-    config_reload(duthost, config_source='minigraph', safe_reload=True, check_intf_up_ports=True)
+    config_reload(duthost, config_source='minigraph', safe_reload=True, check_intf_up_ports=True, override_config=True)
 
 
 @pytest.fixture()
@@ -207,7 +207,7 @@ def reload_dut_config(request, duthost, setup_test_env):
     dut_iface = setup_data[interface_type]["vrf_conf"]["red"]["dut_iface"]
     gw_ip = setup_data[interface_type]["vrf_conf"]["red"]["gw"]
     mask = setup_data[interface_type]["vrf_conf"]["red"]["mask"]
-    config_reload(duthost, config_source='minigraph', safe_reload=True, check_intf_up_ports=True)
+    config_reload(duthost, config_source='minigraph', safe_reload=True, check_intf_up_ports=True, override_config=True)
     pch_ip = setup_info["pch_ips"][dut_iface]
     duthost.shell("sudo config interface ip remove {} {}/31".format(dut_iface, pch_ip))
     duthost.shell("sudo config interface ip add {} {}/{}".format(dut_iface, gw_ip, mask))

--- a/tests/pfcwd/test_pfc_config.py
+++ b/tests/pfcwd/test_pfc_config.py
@@ -329,7 +329,7 @@ class TestDefaultPfcConfig(object):
         # We can safely ignore them as they are not critical to the test.
         safe_reload_ignored_dockers = ['dhcp_server', 'dhcp_relay']
         config_reload(duthost, config_source='minigraph', safe_reload=True,
-                      safe_reload_ignored_dockers=safe_reload_ignored_dockers, override_config=True)
+                      safe_reload_ignored_dockers=safe_reload_ignored_dockers)
         # sleep 20 seconds to make sure configuration is loaded
         time.sleep(20)
         res = duthost.command('pfcwd show config')

--- a/tests/pfcwd/test_pfc_config.py
+++ b/tests/pfcwd/test_pfc_config.py
@@ -329,7 +329,7 @@ class TestDefaultPfcConfig(object):
         # We can safely ignore them as they are not critical to the test.
         safe_reload_ignored_dockers = ['dhcp_server', 'dhcp_relay']
         config_reload(duthost, config_source='minigraph', safe_reload=True,
-                      safe_reload_ignored_dockers=safe_reload_ignored_dockers)
+                      safe_reload_ignored_dockers=safe_reload_ignored_dockers, override_config=True)
         # sleep 20 seconds to make sure configuration is loaded
         time.sleep(20)
         res = duthost.command('pfcwd show config')

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -92,7 +92,7 @@ def setup(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, config_sflow_feature
     # -------- Testing ----------
     yield
     # -------- Teardown ----------
-    config_reload(duthost, config_source='minigraph', wait=120)
+    config_reload(duthost, config_source='minigraph', wait=120, override_config=True)
 
 # ----------------------------------------------------------------------------------
 

--- a/tests/voq/test_voq_chassis_app_db_consistency.py
+++ b/tests/voq/test_voq_chassis_app_db_consistency.py
@@ -247,7 +247,8 @@ def test_voq_chassis_app_db_consistency(duthosts, enum_rand_one_per_hwsku_fronte
         # Recover all states
         if test_case == "config_reload_with_config_save":
             logger.info("Restore config from minigraph.")
-            config_reload(duthost, config_source='minigraph', safe_reload=True, check_intf_up_ports=True)
+            config_reload(duthost, config_source='minigraph', safe_reload=True,
+                          check_intf_up_ports=True, override_config=True)
             wait_critical_processes(duthost)
             pytest_assert(wait_until(300, 20, 0, check_interface_status_of_up_ports, duthost),
                           "Not all ports that are admin up on are operationally up")

--- a/tests/voq/test_voq_intfs.py
+++ b/tests/voq/test_voq_intfs.py
@@ -113,7 +113,8 @@ def test_cycle_voq_intf(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
     finally:
         # restore interface from minigraph
         logger.info("Restore config from minigraph.")
-        config_reload(duthost, config_source='minigraph', safe_reload=True, check_intf_up_ports=True)
+        config_reload(duthost, config_source='minigraph', safe_reload=True,
+                      check_intf_up_ports=True, override_config=True)
         pytest_assert(wait_until(300, 10, 0, check_bgp_neighbors, duthosts),
                       "All BGP's are not established after config reload from original minigraph")
         duthost.shell_cmds(cmds=["config save -y"])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This pull request implements test improvements and stability fixes by updating configuration reload behavior, disabling vtysh in BGP update tests (bgp confed), and refining various test conditions.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
This PR is to improve test infra to support BGP confederation on LT2/FT2/UT2.
#### How did you do it?
By making changes to the test files
#### How did you verify/test it?
By running in msft lab
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
