### PR TITLE
Skip the platform check in the secure boot test

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -248,7 +248,7 @@ def get_sonic_image_size(module):
                     break
 
 
-def install_new_sonic_image(module, new_image_url, save_as=None, required_space=1600):
+def install_new_sonic_image(module, new_image_url, save_as=None, required_space=1600, skip_platform_check=False):
     log("install new sonic image")
     if not save_as:
         log("Clean-up previous downloads first")
@@ -276,9 +276,12 @@ def install_new_sonic_image(module, new_image_url, save_as=None, required_space=
         return
 
     skip_package_migrate_param = ""
+    skip_platform_check_param = ""
     _, output, _ = exec_command(module, cmd="sonic_installer install --help", ignore_error=True)
     if "skip-package-migration" in output:
         skip_package_migrate_param = "--skip-package-migration"
+    if skip_platform_check and "skip-platform-check" in output:
+        skip_platform_check_param = "--skip-platform-check"
 
     if save_as.startswith("/tmp/tmpfs"):
         log("Create a tmpfs partition to download image to install")
@@ -294,7 +297,8 @@ def install_new_sonic_image(module, new_image_url, save_as=None, required_space=
         log("Running sonic_installer to install image at {}".format(save_as))
         rc, out, err = exec_command(
             module,
-            cmd="sonic_installer install {} {} -y".format(save_as, skip_package_migrate_param),
+            cmd="sonic_installer install {} {} {} -y".format(
+                save_as, skip_package_migrate_param, skip_platform_check_param),
             msg="installing new image", ignore_error=True
         )
         log("Done running sonic_installer to install image")
@@ -313,8 +317,8 @@ def install_new_sonic_image(module, new_image_url, save_as=None, required_space=
         log("Running sonic_installer to install image at {}".format(save_as))
         rc, out, err = exec_command(
             module,
-            cmd="sonic_installer install {} {} -y".format(
-                save_as, skip_package_migrate_param),
+            cmd="sonic_installer install {} {} {} -y".format(
+                save_as, skip_package_migrate_param, skip_platform_check_param),
             msg="installing new image", ignore_error=True
         )
         log("Always remove the downloaded temp image inside /host/ before proceeding")
@@ -466,6 +470,7 @@ def main():
             new_image_url=dict(required=False, type='str', default=None),
             save_as=dict(required=False, type='str', default=None),
             required_space=dict(required=False, type='int', default=1600),
+            skip_platform_check=dict(required=False, type='bool', default=False),
         ),
         supports_check_mode=False)
 
@@ -473,7 +478,7 @@ def main():
     new_image_url = module.params['new_image_url']
     save_as = module.params['save_as']
     required_space = module.params['required_space']
-
+    skip_platform_check = module.params['skip_platform_check']
     try:
         if new_image_url or save_as:
             results["current_stage"] = "start"
@@ -488,7 +493,8 @@ def main():
             setup_swap_if_necessary(module)
             results["current_stage"] = "install"
 
-            install_new_sonic_image(module, new_image_url, save_as, required_space)
+            install_new_sonic_image(
+                module, new_image_url, save_as, required_space, skip_platform_check)
             results["current_stage"] = "complete"
         else:
             reduce_installed_sonic_images(module)

--- a/tests/common/helpers/upgrade_helpers.py
+++ b/tests/common/helpers/upgrade_helpers.py
@@ -88,7 +88,7 @@ def check_sonic_version(duthost, target_version):
         "Upgrade sonic failed: target={} current={}".format(target_version, current_version)
 
 
-def install_sonic(duthost, image_url, tbinfo):
+def install_sonic(duthost, image_url, tbinfo, skip_platform_check=False):
     new_route_added = False
     if urlparse(image_url).scheme in ('http', 'https',):
         mg_gwaddr = duthost.get_extended_minigraph_facts(tbinfo).get("minigraph_mgmt_interface", {}).get("gwaddr")
@@ -103,7 +103,8 @@ def install_sonic(duthost, image_url, tbinfo):
             logger.info("Add default mgmt-gateway-route to the device via {}".format(mg_gwaddr))
             duthost.shell("ip route replace default via {}".format(mg_gwaddr), module_ignore_errors=True)
             new_route_added = True
-        res = duthost.reduce_and_add_sonic_images(new_image_url=image_url)
+        res = duthost.reduce_and_add_sonic_images(
+            new_image_url=image_url, skip_platform_check=skip_platform_check)
     else:
         out = duthost.command("df -BM --output=avail /host", module_ignore_errors=True)["stdout"]
         avail = int(out.split('\n')[1][:-1])
@@ -118,7 +119,8 @@ def install_sonic(duthost, image_url, tbinfo):
             duthost.shell("mount -t tmpfs -o size=1300M tmpfs /tmp/tmpfs", module_ignore_errors=True)
         logger.info("Image exists locally. Copying the image {} into the device path {}".format(image_url, save_as))
         duthost.copy(src=image_url, dest=save_as)
-        res = duthost.reduce_and_add_sonic_images(save_as=save_as)
+        res = duthost.reduce_and_add_sonic_images(
+            save_as=save_as, skip_platform_check=skip_platform_check)
 
     # if the new default mgmt-gateway route was added, remove it. This is done so that
     # default route src address matches Loopback0 address

--- a/tests/platform_tests/test_secure_upgrade.py
+++ b/tests/platform_tests/test_secure_upgrade.py
@@ -69,7 +69,7 @@ def test_non_secure_boot_upgrade_failure(duthost, non_secure_image_path, tbinfo)
     result = "image install failure"  # because we expect fail
     try:
         # in case of success result will take the target image name
-        result = install_sonic(duthost, non_secure_image_path, tbinfo)
+        result = install_sonic(duthost, non_secure_image_path, tbinfo, skip_platform_check=True)
     except RunAnsibleModuleFail as err:
         err_msg = str(err.results._check_key("msg"))
         logger.info("Expected fail, err msg is : {}".format(err_msg))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
We use a static image with bad signature for the test test_secure_upgrade.py.
For new platforms like SN6600_LD, the platform check fails due to the old image doesn't support the platform.
But to only validate the signature, we can skip the platform check in the secure boot test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Skip the platform check in the secure boot test to avoid always updating the test image for new platforms.
#### How did you do it?
Add a karg skip_platform_check=False in the install image methods and the ansible module. Set it as True only in the secure boot test. Since the default value is False, it doesn't affect any other tests.
#### How did you verify/test it?
Run the test test_secure_upgrade.py on SN6600_LD testbed.
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
