### PR TITLE
Detect host unreachable globally via pytest_exception_interact hook

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -591,6 +591,54 @@ def pytest_sessionfinish(session, exitstatus):
         session.exitstatus = HOST_FIXTURE_FAILED_RC
 
 
+@pytest.hookimpl(trylast=True)
+def pytest_exception_interact(node, call, report):
+    """Detect host unreachable errors in any fixture/test and flag for testbed removal.
+
+    When a DUT or PTF host is unreachable, the exception may occur in any
+    fixture (not just duthosts or add_mgmt_test_mark). Without this hook,
+    such failures produce exit code 1, which ElasticTest does not treat as
+    a reason to remove the testbed. This hook catches the 'unreachable'
+    pattern globally and sets duthosts_fixture_failed so
+    pytest_sessionfinish sets exit code 15 (HOST_FIXTURE_FAILED_RC).
+    """
+    if call.excinfo is None:
+        return
+
+    exc = call.excinfo.value
+    exc_str = str(exc).lower()
+
+    # Only catch actual host unreachable - not auth failures, timeouts, etc.
+    if "unreachable" not in exc_str:
+        return
+
+    # Already flagged by another handler (e.g. add_mgmt_test_mark)
+    if node.config.cache.get("duthosts_fixture_failed", None):
+        return
+
+    # Extract which host(s) are unreachable from the dark attribute
+    unreachable_hosts = []
+    if hasattr(exc, "dark") and exc.dark:
+        unreachable_hosts = list(exc.dark.keys())
+
+    if unreachable_hosts:
+        logger.error(
+            "Host(s) unreachable detected in %s phase of %s: %s",
+            call.when,
+            getattr(node, "name", "unknown"),
+            ", ".join(unreachable_hosts),
+        )
+    else:
+        logger.error(
+            "Host unreachable detected in %s phase of %s: %s",
+            call.when,
+            getattr(node, "name", "unknown"),
+            repr(exc),
+        )
+
+    node.config.cache.set("duthosts_fixture_failed", True)
+
+
 @pytest.fixture(name="duthosts", scope="session")
 def fixture_duthosts(enhance_inventory, ansible_adhoc, tbinfo, request, ipv6_only_mgmt_enabled):
     """


### PR DESCRIPTION
### Description of PR

Summary:
Add a `pytest_exception_interact` hook to globally detect "host unreachable" errors in **any** fixture or test, and flag the testbed for removal from the ElasticTest test plan.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

PR #23260 changed sanity check defaults to skip pre-test and enable post-test sanity check. PR #23549 fixed `add_mgmt_test_mark` and `do_checks()` crash scenarios. However, there are still **module-scoped autouse fixtures** that resolve **before** `sanity_check` and access the DUT via SSH:

- `get_reboot_cause`: calls `duthost.get_up_time()` in setup
- `restore_golden_config_db`: calls `file_exists_on_dut()` + `duthost.shell()` in setup
- `yang_validation_check`: runs YANG validation on all DUTs in setup

If any of these fixtures encounters a DUT unreachable error:
1. `sanity_check` fixture never resolves → no post-check
2. Exit code is 1 (generic failure, **not** in ElasticTest kick-out list `[10, 11, 12, 15]`)
3. Testbed stays in the test plan and keeps getting assigned test cases that all fail

**Evidence**: Testplan `69d070a0eb4653619e057aff`, testbed `testbed-bjw2-can-t0-7260-8` — all 9 tests of `generic_config_updater/test_cacl.py` got ERROR with "Host unreachable in the inventory". The test.log confirmed "Prepare sanity check" was **never logged** — post-check never ran.

#### How did you do it?

Added a `pytest_exception_interact` hook (with `trylast=True`) in `tests/conftest.py` that:

1. **Checks the error message** — only triggers on exceptions containing "unreachable" (not auth failures, timeouts, etc.)
2. **Skips if already flagged** — avoids duplicate handling when `add_mgmt_test_mark` already caught the error
3. **Extracts unreachable hostname(s)** — reads the `dark` attribute of `AnsibleConnectionFailure` (dict with hostname keys) and logs the specific hosts
4. **Sets `duthosts_fixture_failed` cache flag** — `pytest_sessionfinish` then sets exit code 15 (`HOST_FIXTURE_FAILED_RC`) so ElasticTest kicks the testbed

This is a **global safety net** — it catches host unreachable in any fixture, including future ones that haven't been written yet.

#### How did you verify/test it?

1. Analyzed real failure logs from ElasticTest (testplan `69d070a0eb4653619e057aff`)
2. Confirmed the `AnsibleConnectionFailure` raised by pytest-ansible includes `dark=callback.unreachable` with hostnames as dict keys
3. Verified `pytest_exception_interact` hook fires for unhandled exceptions in fixture setup, call, and teardown phases
4. Confirmed `trylast=True` ensures this hook runs after the parallel_fixture plugin's existing `pytest_exception_interact` hook

#### Any platform specific information?

N/A — applies to all platforms.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A