### PR TITLE
[tacacs] Fix race condition in change_and_wait_aaa_config_update

### DIFF
--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -93,6 +93,10 @@ def change_and_wait_aaa_config_update(duthost, command, last_timestamp=None, tim
         return reload
 
     exist = wait_until(timeout, 1, 0, log_exist, duthost)
+    if exist:
+        # audisp-tacplus logs "re-initializing configuration" when re-init STARTS, not FINISHES.
+        # Wait for it to complete reconnection to auditd before proceeding.
+        time.sleep(3)
     pytest_assert(exist, "Not found aaa config update log: {}".format(command))
 
 


### PR DESCRIPTION
### Description of PR
Fix an intermittent failure in `tacacs/test_accounting.py` caused by a race condition in `change_and_wait_aaa_config_update`.

Fixes ADO #37409631 (https://msazure.visualstudio.com/One/_workitems/edit/37409631)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

`tacacs/test_accounting.py` intermittently fails with `check_local_log_exist()` exhausting all 6 retries (~40 min total) before finding zero accounting entries in syslog.

Root cause: `get_auditd_config_reload_timestamp()` greps journalctl for `"audisp-tacplus re-initializing configuration"` — this line appears when audisp-tacplus **starts** re-initialization, not when it **finishes**. `wait_until()` returns as soon as the new timestamp is detected, but audisp-tacplus is still mid-reconnect to auditd for another ~1.4 seconds.

The test immediately truncates syslog and runs the accounting test command during this gap. Events generated during re-init are never captured by audisp-tacplus.

Timeline evidence (from elastictest plan 69d07000eb4653619e057afa):
```
13:41:59  audisp-tacplus[693]: "re-initializing configuration" (START)
13:41:59  wait_until detects new timestamp → returns immediately  ← TOO EARLY
13:42:00  cleanup_tacacs_log truncates /var/log/syslog
13:42:00  test SSH command runs                                    ← audisp-tacplus STILL re-initializing!
13:42:01.432  hostcfgd: "AAA Update: key=accounting, data=..." (FINISH)
```

#### How did you do it?

Add `time.sleep(3)` after `wait_until()` returns in `change_and_wait_aaa_config_update` to allow audisp-tacplus to complete reconnection to auditd before the test proceeds. The `time` module is already imported.

#### How did you verify/test it?

Analyzed elastictest log from plan `69d07000eb4653619e057afa` — identified the 1.4-second gap between audisp-tacplus re-init start and hostcfgd AAA config write finish. A 3-second sleep covers this gap with margin.

The issue is more pronounced after many prior audisp-tacplus reloads (from preceding tests in the same run), which slow down the re-init cycle and widen the race window. Reruns pass because the testbed is in a fresh state.

#### Any platform specific information?

Affects all platforms running TACACS accounting tests.

#### Supported testbed topology if it's a new test case?

N/A — bug fix only.

**Affected test cases:**
- `test_accounting_local_only`
- `test_accounting_tacacs_and_local`
- `test_accounting_tacacs_and_local_all_tacacs_server_down`

### Documentation
N/A