### PR TITLE
xfail route flow counter for v6 topo on mellanox platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4747,6 +4747,10 @@ route/test_route_flow_counter.py:
     conditions:
       - "platform in ['x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
       - "asic_type in ['vs']"
+  xfail:
+    reason: "xfail for IPv6-only topologies, didn't use IPv6 when should"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/19926 and '-v6-' in topo_name and asic_type in ['mellanox']"
 
 route/test_route_perf.py:
   skip:


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Summary:
Revert the previous change that removed `xfail` for `test_route_flow_counter.py`, and restore `xfail` for v6 topology on Mellanox platforms to avoid expected known failures.
Fixes #N/A
### Type of change
<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement
### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
### Approach
#### What is the motivation for this PR?
The test case is still expected to fail on v6 topology with Mellanox platforms due to the known issue https://github.com/sonic-net/sonic-mgmt/issues/19926
#### How did you do it?
Reverted the commit that removed the `xfail` condition, restoring the original conditional mark behavior.
#### How did you verify/test it?
Verified the latest commit content/message and confirmed the `xfail` condition is restored for the target scenario.
#### Any platform specific information?
Yes. This change is specific to Mellanox platforms on v6 topology.
#### Supported testbed topology if it's a new test case?
N/A (not a new test case).
### Documentation
N/A. No documentation or Wiki update is required for this test-case behavior correction.