### PR TITLE
[pfcwd] Disable memory utilization check for test_default_cfg_after_load_mg

### DIFF
--- a/tests/pfcwd/test_pfc_config.py
+++ b/tests/pfcwd/test_pfc_config.py
@@ -312,6 +312,7 @@ class TestPfcConfig(object):
 
 
 @pytest.mark.usefixtures('mg_cfg_setup')
+@pytest.mark.disable_memory_utilization
 class TestDefaultPfcConfig(object):
     def test_default_cfg_after_load_mg(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         """


### PR DESCRIPTION
### Description of PR
Summary: Disable memory utilization check for `TestDefaultPfcConfig` to avoid false-positive alarms when `config load_minigraph` restarts containers.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/37433902

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`test_default_cfg_after_load_mg` calls `config_reload(config_source='minigraph')`, which runs `config load_minigraph -y` on the DUT and restarts swss and dependent containers (swss, syncd, teamd, bgp, etc.).

The `memory_utilization` plugin captures a **before** snapshot and an **after** snapshot for each test. When containers restart mid-test:
- **Before** snapshot: captured while containers are down → artificially low RSS
- **After** snapshot: captured after containers fully recover → normal RSS
- The delta easily exceeds the 20% threshold → **false-positive memory alarm**

The `mg_cfg_setup` fixture teardown also calls `config_reload(config_source='minigraph')` for state restoration, compounding the issue.

#### How did you do it?
Added `@pytest.mark.disable_memory_utilization` to the `TestDefaultPfcConfig` class in `tests/pfcwd/test_pfc_config.py`.

This is the same pattern already used in `tests/acl/test_acl.py` and other tests that trigger container restarts.

#### How did you verify/test it?
Verified by analyzing a real failure log where `test_watchdog_reboot` produced a false-positive memory alarm following a `test_warm_reboot` failure that left containers down — the same root cause applies here.

#### Any platform specific information?
N/A — applies to all platforms where `config load_minigraph` restarts containers.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation