### PR TITLE
[upgrade_path] Fix warmboot teardown to restore original DUT image

### DIFF
--- a/tests/upgrade_path/test_warmboot_data_consistency.py
+++ b/tests/upgrade_path/test_warmboot_data_consistency.py
@@ -80,6 +80,55 @@ def test_warmboot_data_consistency(localhost, duthosts, rand_one_dut_hostname, t
     duthost = duthosts[rand_one_dut_hostname]
     from_image, to_image = _resolve_test_params(request)
 
+    # Capture original image version before any changes so teardown can restore the DUT.
+    # The test installs multiple images and leaves the DUT on 'to_image' when finished.
+    # Pass --restore_to_image=<url> so the restore_image fixture can reinstall the original image.
+    original_sonic_version = get_current_sonic_version(duthost)
+    restore_to_image_url = request.config.getoption("restore_to_image", default=None)
+    if not restore_to_image_url:
+        logger.warning(
+            "No --restore_to_image provided. After this test the DUT will remain on '%s' "
+            "instead of the original '%s'. Pass --restore_to_image=<url> to restore properly.",
+            to_image, original_sonic_version
+        )
+
+    def _restore_dut_to_original_image():
+        """
+        Fallback teardown: restore the DUT to its original image if --restore_to_image was not
+        provided (in which case the module-scoped restore_image fixture does nothing).
+
+        Since reduce_and_add_sonic_images removes the original image when installing the base
+        image, restoration via set_next_boot is only possible if the original image is still
+        present in the installer list. If it has been removed, a clear error is raised so
+        operators know the testbed requires manual attention.
+        """
+        if restore_to_image_url:
+            # The restore_image module-scoped fixture will handle this via install_sonic.
+            return
+        current_version = get_current_sonic_version(duthost)
+        if current_version == original_sonic_version:
+            logger.info("DUT is already on original image %s, no restore needed.", original_sonic_version)
+            return
+        installed_images = duthost.shell("sudo sonic-installer list")["stdout"]
+        if original_sonic_version in installed_images:
+            logger.info(
+                "Restoring DUT from '%s' to original image '%s' via set_next_boot + cold reboot.",
+                current_version, original_sonic_version
+            )
+            duthost.shell("sudo sonic-installer set_next_boot {}".format(original_sonic_version))
+            reboot(duthost, localhost, reboot_type="cold", safe_reboot=True)
+        else:
+            raise AssertionError(
+                "DUT is on '{}' after test but cannot restore to original '{}': image is no longer "
+                "installed (reduce_and_add_sonic_images removed it). "
+                "Pass --restore_to_image=<original_image_url> in the test plan to enable "
+                "proper testbed restoration via the restore_image fixture.".format(
+                    current_version, original_sonic_version
+                )
+            )
+
+    request.addfinalizer(_restore_dut_to_original_image)
+
     # Install base image, erase config and boot into base image so there is a clean slate for the upgrade test
     cleanup_prev_images(duthost)
     boot_into_base_image(duthost, localhost, from_image, tbinfo)


### PR DESCRIPTION
### Description of PR
<!--
Summary of the change, motivation, context, and any dependencies.
-->
Summary:

`test_warmboot_data_consistency` installs multiple images (base and target) during its test sequence and leaves the DUT on the target image when it finishes. The `restore_image` fixture is supposed to restore the DUT to its original image after the test, but it only does so when `--restore_to_image=<url>` is passed to pytest. The current elastictest test plan does not pass this option, so the DUT is permanently left on the wrong image after the test runs.

This causes cascading failures in subsequent test cases that assume the DUT is on the original image. For example, the target image (202505) may have a different YANG schema than the original (202511), causing `config apply-patch` to fail with YANG validation errors in golden_config tests running on the same testbed.

**Root cause:** `reduce_and_add_sonic_images` (called inside `boot_into_base_image` → `install_sonic`) removes all images except the newly installed one. So the original image is irreversibly lost after phase 1 of the test unless its download URL was passed via `--restore_to_image`.

**Fix:** Add a `request.addfinalizer` at the start of the test that:
1. Captures the original image version before any image changes occur.
2. Logs a clear warning at test start if `--restore_to_image` is not configured.
3. In teardown (runs after the test body, before the module-scoped `restore_image` fixture):
   - Skips if `--restore_to_image` is set (the `restore_image` fixture handles it via `install_sonic`).
   - Restores the DUT via `set_next_boot` + cold reboot if the original image is still present.
   - Raises a clear `AssertionError` if the original image was removed, guiding operators to pass `--restore_to_image=<url>` in the test plan.

Fixes # (issue)
37433901

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework (new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

After `test_warmboot_data_consistency` runs, the DUT is left on the target image (e.g., 202505) instead of the original image (e.g., 202511). This contaminates the testbed for all subsequent test cases running on the same DUT, causing unrelated failures due to YANG schema differences or missing config items that only exist in the original image version.

#### How did you do it?

Added a `request.addfinalizer` inside the test function that captures the original image version before any changes, and restores it in teardown if `--restore_to_image` was not passed. The finalizer uses `sonic-installer set_next_boot` (when the original image is still in the installer list) or raises a clear error with remediation guidance (when it has been removed by `reduce_and_add_sonic_images`).

#### How did you verify/test it?

Analyzed production logs from elastictest plan `69d1de40eb4653619e057c34` where the failure was confirmed:
- `test_warmboot_data_consistency` installed 202411 (removing 202511) then 202505, left the DUT on 202505
- Subsequent `test_rendered_golden_config_override` on the same DUT failed because 202505 YANG lacks `zebra_nexthop`, causing `config apply-patch` to fail with rc=2

#### Any platform specific information?

N/A — applies to all platforms running `test_warmboot_data_consistency`.

#### Supported testbed topology if it's a new test case?

N/A — this is a bug fix for an existing test.

### Documentation
