### PR TITLE
Fix console port clear polluting SSH session when menu_type is empty

### DIFF
--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -709,10 +709,10 @@ def duthost_clear_console_port(
         console_username: Username for the console account (overridden for Digi console)
         console_password: Password for the console account
     """
-    if menu_type == "console_ssh_":
+    if menu_type == "console_ssh":
         raise Exception("Device does not have a defined Console_menu_type.")
 
-    if menu_type == "console_conserver_":
+    if menu_type == "console_conserver":
         logger.info("Skip clearing conserver console port")
         return
 


### PR DESCRIPTION
The PR #22254 introduced a logic: when console_menu_type is empty or n/a, no tailing "_" in console_menu_type anymore.
duthost_clear_console_port needs to support this logic

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:Fix console port clear polluting SSH session when menu_type is empty. The PR #22254 introduced a logic: when console_menu_type is empty or n/a, no tailing "_" in console_menu_type anymore. The function duthost_clear_console_port needs to support this logic
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
