### PR TITLE
Fix route propagation check failure in test_vnet_route tests cases

### DIFF
--- a/tests/vxlan/test_vnet_bgp_route_precedence.py
+++ b/tests/vxlan/test_vnet_bgp_route_precedence.py
@@ -40,9 +40,16 @@ def _check_route_check_pass(duthost):
 
 def _check_route_on_dut(duthost, route, prefix_type):
     """Check that a route is present on the DUT."""
-    cmd = f"show ip route {route}" if prefix_type == 'v4' else f"show ipv6 route {route}"
-    result = duthost.shell(cmd, module_ignore_errors=True)
-    return route in result.get('stdout', '')
+    # First check default VRF, then check VNET routes to avoid false negatives for VNET routes
+    ip_cmd = f"show ip route {route}" if prefix_type == 'v4' else f"show ipv6 route {route}"
+    result = duthost.shell(ip_cmd, module_ignore_errors=True)
+    if route in result.get('stdout', ''):
+        return True
+
+    # VNET routes live outside the default VRF, check VNET route table
+    vnet_cmd = f"show vnet routes all | grep -F '{route}'"
+    vnet_result = duthost.shell(vnet_cmd, module_ignore_errors=True)
+    return route in vnet_result.get('stdout', '')
 
 
 prefix_offset = 19


### PR DESCRIPTION
Fix route propagation check failure in test_vnet_route tests cases

The issue is introduced by #22593.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:Fix route propagation check failure in test_vnet_route
  The issue is introduced by #22593. The function _check_route_on_dut can't get the vnet route correctly.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
