### PR TITLE
Fix test issue introduced by PR#23535

### DIFF
--- a/tests/route/utils.py
+++ b/tests/route/utils.py
@@ -25,7 +25,9 @@ def generate_intf_neigh(asichost, num_neigh, ip_version, mg_facts=None, is_backe
         interfaces = asichost.show_interface(command="status")["ansible_facts"]["int_status"]
         for intf, values in list(interfaces.items()):
             if values["admin_state"] == "up" and values["oper_state"] == "up" and values["type"] != "DPU-NPU Data Port"\
-                  and (mg_facts is None or intf in mg_facts['minigraph_ports']):
+                  and (mg_facts is None or
+                       intf in mg_facts['minigraph_ports'] or
+                       intf in mg_facts['minigraph_portchannels']):
                 up_interfaces.append(intf)
         if not up_interfaces:
             raise Exception("DUT does not have up interfaces")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The new condition added in https://github.com/sonic-net/sonic-mgmt/pull/23535 filters out the portchannel interfaces. But on most t0 topology, only portchannel interfaces have neighbors.

So the test fails with exception:
```
Exception: DUT does not have interfaces available for test
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Fix test issue introduced by PR#23535
#### How did you do it?
Add portchannel into the condition.
#### How did you verify/test it?
Run the test route/test_route_perf.py on topo t0-56-o8v48, passed.
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
