### PR TITLE
Fix intf startup in fdb tests

### DIFF
--- a/tests/fdb/test_fdb_mac_learning.py
+++ b/tests/fdb/test_fdb_mac_learning.py
@@ -258,7 +258,8 @@ class TestFdbMacLearning:
             target_ports_to_ptf_mapping[2][0],
             target_ports_to_ptf_mapping[3][0]
         ]
-        duthost.shell("sudo config interface startup {}-{}".format(target_ports[0], target_ports[2][8:]))
+        duthost.shell("sudo config interface startup "
+                      f"{target_ports[0]},{target_ports[1]},{target_ports[2]}")
         self.wait_for_interfaces_ready(duthost, tbinfo, target_ports)
         self.dynamic_fdb_oper(duthost, tbinfo, ptfhost, target_ports_to_ptf_mapping[1:])
         for i in range(1, len(target_ports_to_ptf_mapping)):


### PR DESCRIPTION
Target ports for startup command may not be fully sequential (gaps may exist), which causes CLI syntax issues in the test.

Don't assume no gaps in the sequence, and use a more explicit CLI command.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #23737

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Improve robustness of test libraries, remove assumptions re. DUT state or config, and improve overall passrates.

#### How did you do it?
I changed the test library in question to use and explicit CLI command for interface configuration, instead of relying on the "-" CLI operator which assumes contiguous interface names.

#### How did you verify/test it?
I verified in a manual test run of fdb/test_fdb_mac_learning.py that the issue described by #23737 is no longer present with this fix.

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
#### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
