### PR TITLE
[TH6-128] Reduce snmp-facts walk iterations to decrease tests run-time

### DIFF
--- a/tests/snmp/test_snmp_interfaces.py
+++ b/tests/snmp/test_snmp_interfaces.py
@@ -40,6 +40,20 @@ def disable_conterpoll(duthosts, enum_rand_one_per_hwsku_hostname):
                                                                     CounterpollConstants.RIF])
 
 
+@pytest.fixture(scope="module")
+def snmp_interfaces_module_facts(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_all_duts):
+    """
+    One SNMP walk per module except for test_snmp_interfaces_error_discard / verify_snmp_counter
+    (needs fresh facts after counter writes).
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    hostip = duthost.host.options['inventory_manager'].get_host(
+        duthost.hostname).vars['ansible_host']
+    return get_snmp_facts(
+        duthost, localhost, host=hostip, version="v2c",
+        community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
+
+
 def get_interfaces(duthost, tbinfo):
     """
     Method to get interfaces for testing
@@ -297,15 +311,10 @@ def verify_snmp_counter(duthost, localhost, creds_all_duts, hostip, mg_facts, ri
 
 
 @pytest.mark.bsl
-def test_snmp_interfaces(localhost, creds_all_duts, duthosts, enum_rand_one_per_hwsku_hostname):
+def test_snmp_interfaces(duthosts, enum_rand_one_per_hwsku_hostname, snmp_interfaces_module_facts):
     """compare the snmp facts between observed states and target state"""
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    hostip = duthost.host.options['inventory_manager'].get_host(
-        duthost.hostname).vars['ansible_host']
-
-    snmp_facts = get_snmp_facts(
-        duthost, localhost, host=hostip, version="v2c",
-        community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
+    snmp_facts = snmp_interfaces_module_facts
 
     snmp_ifnames = [v['name']
                     for k, v in list(snmp_facts['snmp_interfaces'].items())]
@@ -325,16 +334,11 @@ def test_snmp_interfaces(localhost, creds_all_duts, duthosts, enum_rand_one_per_
 
 
 @pytest.mark.bsl
-def test_snmp_mgmt_interface(localhost, creds_all_duts, duthosts, enum_rand_one_per_hwsku_hostname):
+def test_snmp_mgmt_interface(duthosts, enum_rand_one_per_hwsku_hostname, snmp_interfaces_module_facts):
     """compare the snmp facts between observed states and target state"""
 
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    hostip = duthost.host.options['inventory_manager'].get_host(
-        duthost.hostname).vars['ansible_host']
-
-    snmp_facts = get_snmp_facts(
-        duthost, localhost, host=hostip, version="v2c",
-        community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
+    snmp_facts = snmp_interfaces_module_facts
     config_facts = duthost.config_facts(
         host=duthost.hostname, source="persistent")['ansible_facts']
 
@@ -359,15 +363,11 @@ def test_snmp_mgmt_interface(localhost, creds_all_duts, duthosts, enum_rand_one_
             not result, "Unexpected comparsion of SNMP: {}".format(result))
 
 
-def test_snmp_interfaces_mibs(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_all_duts):
+def test_snmp_interfaces_mibs(duthosts, enum_rand_one_per_hwsku_hostname, snmp_interfaces_module_facts):
     """Verify correct behaviour of port MIBs ifIndex, ifMtu, ifSpeed,
        ifAdminStatus, ifOperStatus, ifAlias, ifHighSpeed, ifType """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    hostip = duthost.host.options['inventory_manager'].get_host(
-        duthost.hostname).vars['ansible_host']
-    snmp_facts = get_snmp_facts(
-        duthost, localhost, host=hostip, version="v2c",
-        community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
+    snmp_facts = snmp_interfaces_module_facts
 
     for asic in duthost.asics:
         config_facts = duthost.config_facts(

--- a/tests/snmp/test_snmp_psu.py
+++ b/tests/snmp/test_snmp_psu.py
@@ -13,16 +13,22 @@ pytestmark = [
 ]
 
 
-@pytest.mark.bsl
-def test_snmp_numpsu(duthosts, enum_supervisor_dut_hostname, localhost, creds_all_duts):
+@pytest.fixture(scope="module")
+def snmp_psu_module_facts(duthosts, enum_supervisor_dut_hostname, localhost, creds_all_duts):
+    """One SNMP walk per module shared by PSU count and PSU status tests."""
     duthost = duthosts[enum_supervisor_dut_hostname]
-
     hostip = duthost.host.options['inventory_manager'].get_host(
         duthost.hostname).vars['ansible_host']
-
-    snmp_facts = get_snmp_facts(
+    return get_snmp_facts(
         duthost, localhost, host=hostip, version="v2c",
         community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
+
+
+@pytest.mark.bsl
+def test_snmp_numpsu(duthosts, enum_supervisor_dut_hostname, snmp_psu_module_facts):
+    duthost = duthosts[enum_supervisor_dut_hostname]
+
+    snmp_facts = snmp_psu_module_facts
     res = duthost.shell("psuutil numpsus", module_ignore_errors=True)
 
     # For kvm testbed, we will get the expected return code 2 because of no chassis
@@ -43,13 +49,9 @@ def test_snmp_numpsu(duthosts, enum_supervisor_dut_hostname, localhost, creds_al
 
 
 @pytest.mark.bsl
-def test_snmp_psu_status(duthosts, enum_supervisor_dut_hostname, localhost, creds_all_duts):
+def test_snmp_psu_status(duthosts, enum_supervisor_dut_hostname, snmp_psu_module_facts):
     duthost = duthosts[enum_supervisor_dut_hostname]
-    hostip = duthost.host.options['inventory_manager'].get_host(
-        duthost.hostname).vars['ansible_host']
-    snmp_facts = get_snmp_facts(
-        duthost, localhost, host=hostip, version="v2c",
-        community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
+    snmp_facts = snmp_psu_module_facts
 
     psus_on = 0
     msg = "Unexpected operstatus results {} != {} for PSU {}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR tries to fix the issue #23739.

Fixes #23739

On DUTs like TH6-128 where there are more ports, fetching SNMP facts every time for each test increases the overall tests execution run time.

To reduce that, for certain SNMP tests like 'test_snmp_interfaces' and 'tests_snmp_psu', snmp facts is fetched only once per module and used the same facts for all the tests under that module.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

- To reduce the SNMP tests execution run time.

#### How did you do it?

- Fetch snmp facts only once per module and use the same facts for all the tests under that module.

#### How did you verify/test it?

- Ran the SNMP tests with change above and noted a significant reduction in the test execution time for the above test suites.
- For the other SNMP tests, fetching snmp facts is required to get the updated information. Those tests are not touched.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
