### PR TITLE
Fix DHCP relay PTF test sniffer race condition (#23636)

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -13,6 +13,7 @@ from ptf import config
 from ptf.base_tests import BaseTest
 from ptf.mask import Mask
 import scapy.all as scapy2
+import threading
 from threading import Thread
 
 logger = logging.getLogger(__name__)
@@ -902,9 +903,30 @@ class DHCPTest(DataplaneBaseTest):
                 if self.option82 in pkt_options:
                     self.verified_option82 = True
 
-    def Sniffer(self, iface):
+    def Sniffer(self, iface, ready_event=None):
+        if ready_event:
+            ready_event.set()
         scapy2.sniff(iface=iface, filter="udp and (port 67 or 68)",
                      prn=self.pkt_callback, store=0, timeout=5)
+
+    def start_sniffers_and_wait(self):
+        """Start sniffer threads on all server ports and wait for them to be ready.
+
+        This avoids a race condition where packets could be sent before the
+        sniffer BPF socket is bound, causing missed packets and flaky failures.
+        """
+        events = []
+        threads = []
+        for interface_index in self.server_port_indices:
+            ready = threading.Event()
+            events.append(ready)
+            t1 = Thread(target=self.Sniffer, args=(
+                "eth"+str(interface_index), ready))
+            t1.start()
+            threads.append(t1)
+        for e in events:
+            e.wait(timeout=2)
+        return threads
 
     # Verify that the DHCP relay actually received and relayed the DHCPDISCOVER message to all of
     # its known DHCP servers. We also verify that the relay inserted Option 82 information in the
@@ -1247,10 +1269,7 @@ class DHCPTest(DataplaneBaseTest):
         else:
             # Start sniffer process for each server port to capture DHCP packet
             # and then verify option 82
-            for interface_index in self.server_port_indices:
-                t1 = Thread(target=self.Sniffer, args=(
-                    "eth"+str(interface_index),))
-                t1.start()
+            self.start_sniffers_and_wait()
 
             self.client_send_discover(
                 self.dest_mac_address, self.client_udp_src_port)
@@ -1321,10 +1340,7 @@ class DHCPInvalidChecksumTest(DHCPTest):
     def runTest(self):
         # Start sniffer process for each server port to capture DHCP packet
         # and then verify option 82
-        for interface_index in self.server_port_indices:
-            t1 = Thread(target=self.Sniffer, args=(
-                "eth"+str(interface_index),))
-            t1.start()
+        self.start_sniffers_and_wait()
 
         self.client_send_discover(
             self.dest_mac_address, self.client_udp_src_port)


### PR DESCRIPTION
### Description of PR

Summary:
Fix a race condition in the DHCPv4 relay PTF test where sniffer threads may not have their BPF socket bound before packets are sent, causing intermittent test failures.

Fixes #23636

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

The `DHCPTest` class starts scapy sniffer threads on server ports but immediately sends DHCP packets without waiting for the sniffers to be ready. On loaded workers, the BPF filter socket may not be bound before the packet arrives, causing the sniffer to miss packets. This leads to `verify_relayed_discover()` and similar assertions failing intermittently.

This flaky test triggers `stop_on_failure`, killing the entire t0 test plan (~2000+ tests) and blocking PRs that have nothing to do with DHCP relay. Observed across multiple unrelated PRs (sonic-buildimage#25506, #26545).

#### How did you do it?

- Add `threading.Event` synchronization to the `Sniffer()` method so it signals readiness before `scapy.sniff()` begins capturing
- Extract the sniffer startup pattern into a reusable `start_sniffers_and_wait()` method
- Apply the fix to all three affected test classes: `DHCPTest`, `DHCPPacketsServerToClientTest`, `DHCPInvalidChecksumTest`

#### How did you verify/test it?

- flake8 passes with max-line-length=120
- Tested on local KVM testbed

#### Any platform specific information?

N/A — affects all platforms running DHCP relay tests on loaded workers.

#### Supported testbed topology if it's a new test case?

N/A — bug fix.

### Documentation

N/A

---
*This PR was generated with the assistance of an AI agent on behalf of @yxieca.*