### PR TITLE
[TH6-128] test_bgpmon_v6: Add support for lt2 dut

### DIFF
--- a/tests/bgp/test_bgpmon_v6.py
+++ b/tests/bgp/test_bgpmon_v6.py
@@ -14,7 +14,7 @@ from tests.common.utilities import wait_tcp_connection
 from bgp_helpers import BGPMON_TEMPLATE_FILE, BGPMON_CONFIG_FILE, BGP_MONITOR_NAME, BGP_MONITOR_PORT
 
 pytestmark = [
-    pytest.mark.topology('t2'),
+    pytest.mark.topology('t2', 'lt2'),
 ]
 
 BGP_PORT = 179
@@ -25,46 +25,82 @@ ZERO_V6_ADDR = r'::/0'
 logger = logging.getLogger(__name__)
 
 
-# This API gets the ptf indices list and the local interfaces list for uplink LC
+# This API appends ptf_port_indices and local_dut_ports for the received neighbor list
+def append_uplink_ptf_ports(recv_neigh_list, duthost, tbinfo, ptf_port_indices, local_dut_ports):
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    for port, neighbor in mg_facts["minigraph_neighbors"].items():
+        if neighbor['name'] in recv_neigh_list and port in mg_facts["minigraph_ptf_indices"]:
+            if 'PortChannel' in port:
+                for member in mg_facts['minigraph_portchannels'][port]['members']:
+                    ptf_port_indices.append(mg_facts['minigraph_ptf_indices'][member])
+                    local_dut_ports.append(member)
+            else:
+                ptf_port_indices.append(mg_facts['minigraph_ptf_indices'][port])
+                local_dut_ports.append(port)
+
+
 def get_all_uplink_ptf_recv_ports(duthosts, tbinfo):
     """
-    This function returns ptf indices and local ports from dut which has connectivity to T3 (RNG/AZH) layer.
+    This function returns ptf_port indices and local dut ports for T2/LT2 duthosts
+    T2: PTF/local ports facing T3 neighbors (RegionalHub / AZNGHub).
+    LT2: PTF/local ports facing UT2 upstream neighbors (UpperSpineRouter).
     """
     ptf_port_indices = []
     local_dut_ports = []
-    recv_neigh_list = []
+    topo_type = tbinfo.get('topo', {}).get('type', '')
 
     for duthost in duthosts:
         if duthost.is_supervisor_node():
             continue
 
-        # First get all T3 neighbors, which are of type RegionalHub, AZNGHub
         config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
         device_neighbor_metadata = config_facts['DEVICE_NEIGHBOR_METADATA']
-        for k, v in device_neighbor_metadata.items():
-            # if this duthost has peer of type RH/AZNG, then it is uplink LC
-            if v['type'] == "RegionalHub" or v['type'] == "AZNGHub":
-                recv_neigh_list.append(k)
+        recv_neigh_list = []
 
-        mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-        for port, neighbor in mg_facts["minigraph_neighbors"].items():
-            if neighbor['name'] in recv_neigh_list and port in mg_facts["minigraph_ptf_indices"]:
-                if 'PortChannel' in port:
-                    for member in mg_facts['minigraph_portchannels'][port]['members']:
-                        ptf_port_indices.append(mg_facts['minigraph_ptf_indices'][member])
-                        local_dut_ports.append(member)
-                else:
-                    ptf_port_indices.append(mg_facts['minigraph_ptf_indices'][port])
-                    local_dut_ports.append(port)
+        if topo_type == 'lt2':
+            for k, v in device_neighbor_metadata.items():
+                if v['type'] == 'UpperSpineRouter':
+                    recv_neigh_list.append(k)
+        else:
+            # T2: upstream T3 (RH/AZNG)
+            for k, v in device_neighbor_metadata.items():
+                if v['type'] == "RegionalHub" or v['type'] == "AZNGHub":
+                    recv_neigh_list.append(k)
+
+        append_uplink_ptf_ports(recv_neigh_list, duthost, tbinfo, ptf_port_indices, local_dut_ports)
 
     return ptf_port_indices, local_dut_ports
 
 
-def get_uplink_route_mac(duthosts, port):
+def get_uplink_route_mac(duthosts, tbinfo, port):
     """
-    This function returns the router mac of dut/asic which has connectivity to T3 (RNG/AZH) layer,
-    based on the input local dut interface.
+    T2: router MAC for uplink LC (same logic as original — first DUT with T3 peer type).
+    LT2: router MAC for the DUT ASIC that owns ``port`` on a UT2-facing link.
     """
+    topo_type = tbinfo.get('topo', {}).get('type', '')
+
+    if topo_type == 'lt2':
+        for duthost in duthosts:
+            if duthost.is_supervisor_node():
+                continue
+            config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+            recv_neigh_list = [
+                k for k, v in config_facts['DEVICE_NEIGHBOR_METADATA'].items()
+                if v['type'] == 'UpperSpineRouter'
+            ]
+            mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+            for p, neighbor in mg_facts["minigraph_neighbors"].items():
+                if neighbor['name'] not in recv_neigh_list or p not in mg_facts["minigraph_ptf_indices"]:
+                    continue
+                if p == port:
+                    return duthost.get_port_asic_instance(port).get_router_mac() \
+                        if duthost.is_multi_asic else duthost.facts["router_mac"]
+                if 'PortChannel' in p and port in mg_facts['minigraph_portchannels'][p]['members']:
+                    return duthost.get_port_asic_instance(port).get_router_mac() \
+                        if duthost.is_multi_asic else duthost.facts["router_mac"]
+        pytest_assert(False, "Could not resolve router MAC for uplink port {}".format(port))
+
+    # T2 DUT
     for duthost in duthosts:
         if duthost.is_supervisor_node():
             continue
@@ -72,10 +108,7 @@ def get_uplink_route_mac(duthosts, port):
         config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
         device_neighbor_metadata = config_facts['DEVICE_NEIGHBOR_METADATA']
         for k, v in device_neighbor_metadata.items():
-            # if this duthost has peer of type RH/AZNG, then it is uplink LC
-            # return the router mac for that duthost/asic
             if v['type'] == "RegionalHub" or v['type'] == "AZNGHub":
-                # Get the router_mac based on which asic the port belongs to in this dut
                 return duthost.get_port_asic_instance(port).get_router_mac() \
                                     if duthost.is_multi_asic else duthost.facts["router_mac"]
 
@@ -97,16 +130,34 @@ def common_v6_setup_teardown(duthosts, tbinfo, enum_rand_one_per_hwsku_frontend_
     else:
         cfg_facts = duthost.config_facts(source='persistent', asic_index='all')[0]['ansible_facts']
 
-    if 'Loopback4096' in cfg_facts['LOOPBACK_INTERFACE']:
-        lbs4096 = list(cfg_facts['LOOPBACK_INTERFACE']['Loopback4096'].keys())
-        for lb4096 in lbs4096:
-            lb4096intf = ipaddress.ip_interface(lb4096)
-            if lb4096intf.ip.version == 6:
-                if "/" in lb4096:
-                    local_addr = lb4096.split("/")[0]
+    local_addr = None
+    topo_type = tbinfo.get('topo', {}).get('type', '')
+
+    if topo_type == 'lt2':
+        if 'Loopback0' in cfg_facts['LOOPBACK_INTERFACE']:
+            lbs = list(cfg_facts['LOOPBACK_INTERFACE']['Loopback0'].keys())
+            for lb in lbs:
+                lbintf = ipaddress.ip_interface(lb)
+                if lbintf.ip.version == 6:
+                    if "/" in lb:
+                        local_addr = lb.split("/")[0]
+                    else:
+                        local_addr = lb
                     break
-                else:
-                    local_addr = lb4096
+    else:
+        # T2 — IPv6 on Loopback4096 only
+        if 'Loopback4096' in cfg_facts['LOOPBACK_INTERFACE']:
+            lbs4096 = list(cfg_facts['LOOPBACK_INTERFACE']['Loopback4096'].keys())
+            for lb4096 in lbs4096:
+                lb4096intf = ipaddress.ip_interface(lb4096)
+                if lb4096intf.ip.version == 6:
+                    if "/" in lb4096:
+                        local_addr = lb4096.split("/")[0]
+                    else:
+                        local_addr = lb4096
+                    break
+
+    pytest_assert(local_addr, "Failed to get IPv6 loopback for BGP monitor (T2: Loopback4096; lt2: Loopback0)")
 
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
     # Assign peer addr to an interface on ptf
@@ -136,7 +187,7 @@ def bgpmon_peer_connected(asichost, bgpmon_peer):
         return False
 
 
-def test_bgpmon_v6(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname,
+def test_bgpmon_v6(duthosts, localhost, tbinfo, enum_rand_one_per_hwsku_frontend_hostname,
                    enum_rand_one_frontend_asic_index, common_v6_setup_teardown,
                    set_timeout_for_bgpmon, ptfadapter, ptfhost):
     """
@@ -146,7 +197,8 @@ def test_bgpmon_v6(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostnam
     asichost = duthost.asic_instance(enum_rand_one_frontend_asic_index)
 
     local_addr, peer_addr, peer_ports, local_ports, asn, router_id = common_v6_setup_teardown
-    pytest_assert(peer_ports is not None, "No upstream neighbors in the testbed")
+    pytest_assert(len(peer_ports) > 0,
+                  "No upstream PTF ports found for BGP monitor (check topology / neighbor types)")
 
     # Flush dataplane
     ptfadapter.dataplane.flush()
@@ -156,7 +208,7 @@ def test_bgpmon_v6(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostnam
 
     port_index = random.randint(0, len(peer_ports)-1)
     logger.info("Configured route to from PTF to LC on PTF port {}".format(peer_ports[port_index]))
-    router_mac = get_uplink_route_mac(duthosts, local_ports[port_index])
+    router_mac = get_uplink_route_mac(duthosts, tbinfo, local_ports[port_index])
     ptf_interface = "eth" + str(peer_ports[port_index])
     ptfhost.shell("ip -6 addr add {} dev {}".format(peer_addr + "/128", ptf_interface))
     ptfhost.shell("ip neigh add %s lladdr %s dev %s" % (local_addr, router_mac, ptf_interface))
@@ -184,7 +236,7 @@ def test_bgpmon_v6(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostnam
         ptfhost.shell("ip -6 addr del %s dev %s" % (peer_addr + "/128", ptf_interface))
 
 
-def test_bgpmon_no_ipv6_resolve_via_default(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname, ptfhost,
+def test_bgpmon_no_ipv6_resolve_via_default(duthosts, localhost, tbinfo, enum_rand_one_per_hwsku_frontend_hostname, ptfhost,
                                             enum_rand_one_frontend_asic_index, common_v6_setup_teardown, ptfadapter):
     """
     Verify no syn for BGP is sent when 'ipv6 nht resolve-via-default' is disabled.
@@ -193,7 +245,8 @@ def test_bgpmon_no_ipv6_resolve_via_default(duthosts, localhost, enum_rand_one_p
     asichost = duthost.asic_instance(enum_rand_one_frontend_asic_index)
 
     local_addr, peer_addr, peer_ports, local_ports, asn, router_id = common_v6_setup_teardown
-    pytest_assert(peer_ports is not None, "No upstream neighbors in the testbed")
+    pytest_assert(len(peer_ports) > 0,
+                  "No upstream PTF ports found for BGP monitor (check topology / neighbor types)")
 
     # Flush dataplane
     ptfadapter.dataplane.flush()
@@ -203,7 +256,7 @@ def test_bgpmon_no_ipv6_resolve_via_default(duthosts, localhost, enum_rand_one_p
 
     port_index = random.randint(0, len(peer_ports)-1)
     logger.info("Configured route to from PTF to LC on PTF port {}".format(peer_ports[port_index]))
-    router_mac = get_uplink_route_mac(duthosts, local_ports[port_index])
+    router_mac = get_uplink_route_mac(duthosts, tbinfo, local_ports[port_index])
     ptf_interface = "eth" + str(peer_ports[port_index])
     ptfhost.shell("ip -6 addr add {} dev {}".format(peer_addr + "/128", ptf_interface))
     ptfhost.shell("ip neigh add %s lladdr %s dev %s" % (local_addr, router_mac, ptf_interface))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR fixes the issue #23741 

- Currently 'test_bgpmon_v6' test doesn't work for LT2 topo DUTs.
- This PR tries to fix the above issue, add support for LT2 topo DUTs without modifying the existing T2 implementation.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

- '_test_bgpmon_v6_' - Add support for LT2 topo DUTs

#### How did you do it?

- Support added based on LT2 topo's neighbor type '_UpperSpineRouter_'
- Implement LT2 in such a way that it doesn't affect the existing implementation for T2 DUTs.

#### How did you verify/test it?

- Ran '_test_bgpmon_v6_' test on both LT2 and T2 DUTs and made sure test is passing without any issues.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
**T2 test result:**

<img width="1911" height="598" alt="image" src="https://github.com/user-attachments/assets/d886105a-2b07-4c53-8345-1900f1713c02" />


**LT2 test result:**

<img width="1913" height="592" alt="image" src="https://github.com/user-attachments/assets/762b5453-efa0-4fcc-9cab-bdcabf0bfacf" />
