### PR TITLE
Update sku-sensors-data.yml for 7280R4-32QF-32DF-F

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -7277,224 +7277,158 @@ sensors_checks:
       - raa228228-i2c-25-45/vout2/in4_crit_alarm
       - raa228228-i2c-25-45/vout2/in4_lcrit_alarm
       temp:
-      - amax31732-i2c-19-1c/temp1/temp1_crit_alarm
-      - amax31732-i2c-19-1c/temp1/temp1_lcrit_alarm
-      - amax31732-i2c-19-1c/temp1/temp1_max_alarm
-      - amax31732-i2c-19-1c/temp1/temp1_min_alarm
-      - amax31732-i2c-19-1c/temp2/temp2_crit_alarm
-      - amax31732-i2c-19-1c/temp2/temp2_fault
-      - amax31732-i2c-19-1c/temp2/temp2_lcrit_alarm
-      - amax31732-i2c-19-1c/temp2/temp2_max_alarm
-      - amax31732-i2c-19-1c/temp2/temp2_min_alarm
-      - amax31732-i2c-19-1c/temp3/temp3_crit_alarm
-      - amax31732-i2c-19-1c/temp3/temp3_fault
-      - amax31732-i2c-19-1c/temp3/temp3_lcrit_alarm
-      - amax31732-i2c-19-1c/temp3/temp3_max_alarm
-      - amax31732-i2c-19-1c/temp3/temp3_min_alarm
-      - amax31732-i2c-19-1c/temp4/temp4_crit_alarm
-      - amax31732-i2c-19-1c/temp4/temp4_fault
-      - amax31732-i2c-19-1c/temp4/temp4_lcrit_alarm
-      - amax31732-i2c-19-1c/temp4/temp4_max_alarm
-      - amax31732-i2c-19-1c/temp4/temp4_min_alarm
-      - amax31732-i2c-19-1c/temp5/temp5_crit_alarm
-      - amax31732-i2c-19-1c/temp5/temp5_fault
-      - amax31732-i2c-19-1c/temp5/temp5_lcrit_alarm
-      - amax31732-i2c-19-1c/temp5/temp5_max_alarm
-      - amax31732-i2c-19-1c/temp5/temp5_min_alarm
-      - dps800-i2c-22-58/temp1/temp1_crit_alarm
-      - dps800-i2c-22-58/temp1/temp1_lcrit_alarm
-      - dps800-i2c-22-58/temp1/temp1_max_alarm
-      - dps800-i2c-22-58/temp1/temp1_min_alarm
-      - dps800-i2c-22-58/temp2/temp2_crit_alarm
-      - dps800-i2c-22-58/temp2/temp2_lcrit_alarm
-      - dps800-i2c-22-58/temp2/temp2_max_alarm
-      - dps800-i2c-22-58/temp2/temp2_min_alarm
-      - dps800-i2c-22-58/temp3/temp3_crit_alarm
-      - dps800-i2c-22-58/temp3/temp3_lcrit_alarm
-      - dps800-i2c-22-58/temp3/temp3_max_alarm
-      - dps800-i2c-22-58/temp3/temp3_min_alarm
-      - dps800-i2c-23-58/temp1/temp1_crit_alarm
-      - dps800-i2c-23-58/temp1/temp1_lcrit_alarm
-      - dps800-i2c-23-58/temp1/temp1_max_alarm
-      - dps800-i2c-23-58/temp1/temp1_min_alarm
-      - dps800-i2c-23-58/temp2/temp2_crit_alarm
-      - dps800-i2c-23-58/temp2/temp2_lcrit_alarm
-      - dps800-i2c-23-58/temp2/temp2_max_alarm
-      - dps800-i2c-23-58/temp2/temp2_min_alarm
-      - dps800-i2c-23-58/temp3/temp3_crit_alarm
-      - dps800-i2c-23-58/temp3/temp3_lcrit_alarm
-      - dps800-i2c-23-58/temp3/temp3_max_alarm
-      - dps800-i2c-23-58/temp3/temp3_min_alarm
-      - isl68223-i2c-25-47/temp1/temp1_crit_alarm
-      - isl68223-i2c-25-47/temp1/temp1_lcrit_alarm
-      - isl68223-i2c-25-47/temp1/temp1_max_alarm
-      - isl68223-i2c-25-47/temp2/temp2_crit_alarm
-      - isl68223-i2c-25-47/temp2/temp2_lcrit_alarm
-      - isl68223-i2c-25-47/temp2/temp2_max_alarm
-      - isl68223-i2c-25-47/temp3/temp3_crit_alarm
-      - isl68223-i2c-25-47/temp3/temp3_lcrit_alarm
-      - isl68223-i2c-25-47/temp3/temp3_max_alarm
-      - isl68223-i2c-25-47/temp4/temp4_crit_alarm
-      - isl68223-i2c-25-47/temp4/temp4_lcrit_alarm
-      - isl68223-i2c-25-47/temp4/temp4_max_alarm
-      - isl68223-i2c-25-47/temp5/temp5_crit_alarm
-      - isl68223-i2c-25-47/temp5/temp5_lcrit_alarm
-      - isl68223-i2c-25-47/temp5/temp5_max_alarm
-      - isl68226-i2c-24-4c/temp1/temp1_crit_alarm
-      - isl68226-i2c-24-4c/temp1/temp1_lcrit_alarm
-      - isl68226-i2c-24-4c/temp1/temp1_max_alarm
-      - isl68226-i2c-24-4c/temp2/temp2_crit_alarm
-      - isl68226-i2c-24-4c/temp2/temp2_lcrit_alarm
-      - isl68226-i2c-24-4c/temp2/temp2_max_alarm
-      - isl68226-i2c-24-4c/temp3/temp3_crit_alarm
-      - isl68226-i2c-24-4c/temp3/temp3_lcrit_alarm
-      - isl68226-i2c-24-4c/temp3/temp3_max_alarm
-      - isl68226-i2c-24-4c/temp4/temp4_crit_alarm
-      - isl68226-i2c-24-4c/temp4/temp4_lcrit_alarm
-      - isl68226-i2c-24-4c/temp4/temp4_max_alarm
-      - isl68226-i2c-24-4c/temp5/temp5_crit_alarm
-      - isl68226-i2c-24-4c/temp5/temp5_lcrit_alarm
-      - isl68226-i2c-24-4c/temp5/temp5_max_alarm
-      - isl68226-i2c-24-4c/temp6/temp6_crit_alarm
-      - isl68226-i2c-24-4c/temp6/temp6_lcrit_alarm
-      - isl68226-i2c-24-4c/temp6/temp6_max_alarm
-      - isl68226-i2c-24-4c/temp7/temp7_crit_alarm
-      - isl68226-i2c-24-4c/temp7/temp7_lcrit_alarm
-      - isl68226-i2c-24-4c/temp7/temp7_max_alarm
-      - isl68226-i2c-24-4f/temp1/temp1_crit_alarm
-      - isl68226-i2c-24-4f/temp1/temp1_lcrit_alarm
-      - isl68226-i2c-24-4f/temp1/temp1_max_alarm
-      - isl68226-i2c-24-4f/temp2/temp2_crit_alarm
-      - isl68226-i2c-24-4f/temp2/temp2_lcrit_alarm
-      - isl68226-i2c-24-4f/temp2/temp2_max_alarm
-      - isl68226-i2c-24-4f/temp3/temp3_crit_alarm
-      - isl68226-i2c-24-4f/temp3/temp3_lcrit_alarm
-      - isl68226-i2c-24-4f/temp3/temp3_max_alarm
-      - isl68226-i2c-24-4f/temp4/temp4_crit_alarm
-      - isl68226-i2c-24-4f/temp4/temp4_lcrit_alarm
-      - isl68226-i2c-24-4f/temp4/temp4_max_alarm
-      - isl68226-i2c-24-4f/temp5/temp5_crit_alarm
-      - isl68226-i2c-24-4f/temp5/temp5_lcrit_alarm
-      - isl68226-i2c-24-4f/temp5/temp5_max_alarm
-      - isl68226-i2c-24-4f/temp6/temp6_crit_alarm
-      - isl68226-i2c-24-4f/temp6/temp6_lcrit_alarm
-      - isl68226-i2c-24-4f/temp6/temp6_max_alarm
-      - isl68226-i2c-24-4f/temp7/temp7_crit_alarm
-      - isl68226-i2c-24-4f/temp7/temp7_lcrit_alarm
-      - isl68226-i2c-24-4f/temp7/temp7_max_alarm
-      - isl68226-i2c-25-4c/temp1/temp1_crit_alarm
-      - isl68226-i2c-25-4c/temp1/temp1_lcrit_alarm
-      - isl68226-i2c-25-4c/temp1/temp1_max_alarm
-      - isl68226-i2c-25-4c/temp2/temp2_crit_alarm
-      - isl68226-i2c-25-4c/temp2/temp2_lcrit_alarm
-      - isl68226-i2c-25-4c/temp2/temp2_max_alarm
-      - isl68226-i2c-25-4c/temp3/temp3_crit_alarm
-      - isl68226-i2c-25-4c/temp3/temp3_lcrit_alarm
-      - isl68226-i2c-25-4c/temp3/temp3_max_alarm
-      - isl68226-i2c-25-4c/temp4/temp4_crit_alarm
-      - isl68226-i2c-25-4c/temp4/temp4_lcrit_alarm
-      - isl68226-i2c-25-4c/temp4/temp4_max_alarm
-      - isl68226-i2c-25-4c/temp5/temp5_crit_alarm
-      - isl68226-i2c-25-4c/temp5/temp5_lcrit_alarm
-      - isl68226-i2c-25-4c/temp5/temp5_max_alarm
-      - isl68226-i2c-25-4c/temp6/temp6_crit_alarm
-      - isl68226-i2c-25-4c/temp6/temp6_lcrit_alarm
-      - isl68226-i2c-25-4c/temp6/temp6_max_alarm
-      - isl68226-i2c-25-4c/temp7/temp7_crit_alarm
-      - isl68226-i2c-25-4c/temp7/temp7_lcrit_alarm
-      - isl68226-i2c-25-4c/temp7/temp7_max_alarm
+      - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_crit_alarm
+      - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_lcrit_alarm
+      - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_max_alarm
+      - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_min_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_crit_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_fault
+      - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_lcrit_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_max_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_min_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_crit_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_fault
+      - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_lcrit_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_max_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_min_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_crit_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_fault
+      - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_lcrit_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_max_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_min_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_crit_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_fault
+      - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_lcrit_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_max_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_min_alarm
+      - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_crit_alarm
+      - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_max_alarm
+      - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_min_alarm
+      - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_min_alarm
+      - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_crit_alarm
+      - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_max_alarm
+      - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_min_alarm
+      - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_crit_alarm
+      - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_lcrit_alarm
+      - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_max_alarm
+      - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_min_alarm
+      - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_min_alarm
+      - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_crit_alarm
+      - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_lcrit_alarm
+      - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_max_alarm
+      - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_min_alarm
+      - isl68223-i2c-25-47/POS0V8_PBVDD/temp1_crit_alarm
+      - isl68223-i2c-25-47/POS0V8_PBVDD/temp1_lcrit_alarm
+      - isl68223-i2c-25-47/POS0V8_PBVDD/temp1_max_alarm
+      - isl68226-i2c-24-4c/POS1V2_HBM_D0/temp1_crit_alarm
+      - isl68226-i2c-24-4c/POS1V2_HBM_D0/temp1_lcrit_alarm
+      - isl68226-i2c-24-4c/POS1V2_HBM_D0/temp1_max_alarm
+      - isl68226-i2c-24-4c/POS0V9_D0/temp2_crit_alarm
+      - isl68226-i2c-24-4c/POS0V9_D0/temp2_lcrit_alarm
+      - isl68226-i2c-24-4c/POS0V9_D0/temp2_max_alarm
+      - isl68226-i2c-24-4c/POS0V75_D0/temp3_crit_alarm
+      - isl68226-i2c-24-4c/POS0V75_D0/temp3_lcrit_alarm
+      - isl68226-i2c-24-4c/POS0V75_D0/temp3_max_alarm
+      - isl68226-i2c-24-4f/POS1V2_VAA_PHY/temp1_crit_alarm
+      - isl68226-i2c-24-4f/POS1V2_VAA_PHY/temp1_lcrit_alarm
+      - isl68226-i2c-24-4f/POS1V2_VAA_PHY/temp1_max_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY1/temp2_crit_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY1/temp2_lcrit_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY1/temp2_max_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY2/temp3_crit_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY2/temp3_lcrit_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY2/temp3_max_alarm
+      - isl68226-i2c-25-4c/POS1V2_HBM_D1/temp1_crit_alarm
+      - isl68226-i2c-25-4c/POS1V2_HBM_D1/temp1_lcrit_alarm
+      - isl68226-i2c-25-4c/POS1V2_HBM_D1/temp1_max_alarm
+      - isl68226-i2c-25-4c/POS0V9_D1/temp2_crit_alarm
+      - isl68226-i2c-25-4c/POS0V9_D1/temp2_lcrit_alarm
+      - isl68226-i2c-25-4c/POS0V9_D1/temp2_max_alarm
+      - isl68226-i2c-25-4c/POS0V75_D1/temp3_crit_alarm
+      - isl68226-i2c-25-4c/POS0V75_D1/temp3_lcrit_alarm
+      - isl68226-i2c-25-4c/POS0V75_D1/temp3_max_alarm
       - nvme-pci-0500/Composite/temp1_alarm
-      - raa228228-i2c-24-45/temp1/temp1_crit_alarm
-      - raa228228-i2c-24-45/temp1/temp1_lcrit_alarm
-      - raa228228-i2c-24-45/temp1/temp1_max_alarm
-      - raa228228-i2c-24-45/temp2/temp2_crit_alarm
-      - raa228228-i2c-24-45/temp2/temp2_lcrit_alarm
-      - raa228228-i2c-24-45/temp2/temp2_max_alarm
-      - raa228228-i2c-24-45/temp3/temp3_crit_alarm
-      - raa228228-i2c-24-45/temp3/temp3_lcrit_alarm
-      - raa228228-i2c-24-45/temp3/temp3_max_alarm
-      - raa228228-i2c-25-45/temp1/temp1_crit_alarm
-      - raa228228-i2c-25-45/temp1/temp1_lcrit_alarm
-      - raa228228-i2c-25-45/temp1/temp1_max_alarm
-      - raa228228-i2c-25-45/temp2/temp2_crit_alarm
-      - raa228228-i2c-25-45/temp2/temp2_lcrit_alarm
-      - raa228228-i2c-25-45/temp2/temp2_max_alarm
-      - raa228228-i2c-25-45/temp3/temp3_crit_alarm
-      - raa228228-i2c-25-45/temp3/temp3_lcrit_alarm
-      - raa228228-i2c-25-45/temp3/temp3_max_alarm
+      - raa228228-i2c-24-45/POS0V75_VDDC_D0/temp1_crit_alarm
+      - raa228228-i2c-24-45/POS0V75_VDDC_D0/temp1_lcrit_alarm
+      - raa228228-i2c-24-45/POS0V75_VDDC_D0/temp1_max_alarm
+      - raa228228-i2c-24-45/POS3V3_OPTICS_A/temp2_crit_alarm
+      - raa228228-i2c-24-45/POS3V3_OPTICS_A/temp2_lcrit_alarm
+      - raa228228-i2c-24-45/POS3V3_OPTICS_A/temp2_max_alarm
+      - raa228228-i2c-25-45/POS0V75_VDDC_D1/temp1_crit_alarm
+      - raa228228-i2c-25-45/POS0V75_VDDC_D1/temp1_lcrit_alarm
+      - raa228228-i2c-25-45/POS0V75_VDDC_D1/temp1_max_alarm
+      - raa228228-i2c-25-45/POS3V3_OPTICS_B/temp2_crit_alarm
+      - raa228228-i2c-25-45/POS3V3_OPTICS_B/temp2_lcrit_alarm
+      - raa228228-i2c-25-45/POS3V3_OPTICS_B/temp2_max_alarm
 
     compares:
       fan: [ ]
       power: [ ]
       temp:
-      - - amax31732-i2c-19-1c/temp1/temp1_input
-        - amax31732-i2c-19-1c/temp1/temp1_crit
-      - - amax31732-i2c-19-1c/temp2/temp2_input
-        - amax31732-i2c-19-1c/temp2/temp2_crit
-      - - amax31732-i2c-19-1c/temp3/temp3_input
-        - amax31732-i2c-19-1c/temp3/temp3_crit
-      - - amax31732-i2c-19-1c/temp4/temp4_input
-        - amax31732-i2c-19-1c/temp4/temp4_crit
-      - - amax31732-i2c-19-1c/temp5/temp5_input
-        - amax31732-i2c-19-1c/temp5/temp5_crit
-      - - dps800-i2c-22-58/temp1/temp1_input
-        - dps800-i2c-22-58/temp1/temp1_crit
-      - - dps800-i2c-22-58/temp2/temp2_input
-        - dps800-i2c-22-58/temp2/temp2_crit
-      - - dps800-i2c-22-58/temp3/temp3_input
-        - dps800-i2c-22-58/temp3/temp3_crit
-      - - dps800-i2c-23-58/temp1/temp1_input
-        - dps800-i2c-23-58/temp1/temp1_crit
-      - - dps800-i2c-23-58/temp2/temp2_input
-        - dps800-i2c-23-58/temp2/temp2_crit
-      - - dps800-i2c-23-58/temp3/temp3_input
-        - dps800-i2c-23-58/temp3/temp3_crit
-      - - isl68223-i2c-25-47/temp1/temp1_input
-        - isl68223-i2c-25-47/temp1/temp1_crit
-      - - isl68223-i2c-25-47/temp3/temp3_input
-        - isl68223-i2c-25-47/temp3/temp3_crit
-      - - isl68226-i2c-24-4c/temp1/temp1_input
-        - isl68226-i2c-24-4c/temp1/temp1_crit
-      - - isl68226-i2c-24-4c/temp2/temp2_input
-        - isl68226-i2c-24-4c/temp2/temp2_crit
-      - - isl68226-i2c-24-4c/temp3/temp3_input
-        - isl68226-i2c-24-4c/temp3/temp3_crit
-      - - isl68226-i2c-24-4c/temp4/temp4_input
-        - isl68226-i2c-24-4c/temp4/temp4_crit
-      - - isl68226-i2c-24-4f/temp1/temp1_input
-        - isl68226-i2c-24-4f/temp1/temp1_crit
-      - - isl68226-i2c-24-4f/temp2/temp2_input
-        - isl68226-i2c-24-4f/temp2/temp2_crit
-      - - isl68226-i2c-24-4f/temp3/temp3_input
-        - isl68226-i2c-24-4f/temp3/temp3_crit
-      - - isl68226-i2c-24-4f/temp4/temp4_input
-        - isl68226-i2c-24-4f/temp4/temp4_crit
-      - - isl68226-i2c-25-4c/temp1/temp1_input
-        - isl68226-i2c-25-4c/temp1/temp1_crit
-      - - isl68226-i2c-25-4c/temp2/temp2_input
-        - isl68226-i2c-25-4c/temp2/temp2_crit
-      - - isl68226-i2c-25-4c/temp3/temp3_input
-        - isl68226-i2c-25-4c/temp3/temp3_crit
-      - - isl68226-i2c-25-4c/temp4/temp4_input
-        - isl68226-i2c-25-4c/temp4/temp4_crit
+      - - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_input
+        - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_crit
+      - - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_input
+        - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_crit
+      - - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_input
+        - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_crit
+      - - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_input
+        - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_crit
+      - - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_input
+        - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_crit
+      - - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_input
+        - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_crit
+      - - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_input
+        - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_crit
+      - - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_input
+        - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_crit
+      - - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_input
+        - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_crit
+      - - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_input
+        - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_crit
+      - - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_input
+        - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_crit
+      - - isl68223-i2c-25-47/POS0V8_PBVDD/temp1_input
+        - isl68223-i2c-25-47/POS0V8_PBVDD/temp1_crit
+      - - isl68226-i2c-24-4c/POS1V2_HBM_D0/temp1_input
+        - isl68226-i2c-24-4c/POS1V2_HBM_D0/temp1_crit
+      - - isl68226-i2c-24-4c/POS0V9_D0/temp2_input
+        - isl68226-i2c-24-4c/POS0V9_D0/temp2_crit
+      - - isl68226-i2c-24-4c/POS0V75_D0/temp3_input
+        - isl68226-i2c-24-4c/POS0V75_D0/temp3_crit
+      - - isl68226-i2c-24-4f/POS1V2_VAA_PHY/temp1_input
+        - isl68226-i2c-24-4f/POS1V2_VAA_PHY/temp1_crit
+      - - isl68226-i2c-24-4f/POS0V75_VDD_PHY1/temp2_input
+        - isl68226-i2c-24-4f/POS0V75_VDD_PHY1/temp2_crit
+      - - isl68226-i2c-24-4f/POS0V75_VDD_PHY2/temp3_input
+        - isl68226-i2c-24-4f/POS0V75_VDD_PHY2/temp3_crit
+      - - isl68226-i2c-25-4c/POS1V2_HBM_D1/temp1_input
+        - isl68226-i2c-25-4c/POS1V2_HBM_D1/temp1_crit
+      - - isl68226-i2c-25-4c/POS0V9_D1/temp2_input
+        - isl68226-i2c-25-4c/POS0V9_D1/temp2_crit
+      - - isl68226-i2c-25-4c/POS0V75_D1/temp3_input
+        - isl68226-i2c-25-4c/POS0V75_D1/temp3_crit
       - - nvme-pci-0500/Composite/temp1_input
         - nvme-pci-0500/Composite/temp1_crit
-      - - raa228228-i2c-24-45/temp1/temp1_input
-        - raa228228-i2c-24-45/temp1/temp1_crit
-      - - raa228228-i2c-24-45/temp2/temp2_input
-        - raa228228-i2c-24-45/temp2/temp2_crit
-      - - raa228228-i2c-24-45/temp3/temp3_input
-        - raa228228-i2c-24-45/temp3/temp3_crit
-      - - raa228228-i2c-25-45/temp1/temp1_input
-        - raa228228-i2c-25-45/temp1/temp1_crit
-      - - raa228228-i2c-25-45/temp2/temp2_input
-        - raa228228-i2c-25-45/temp2/temp2_crit
-      - - raa228228-i2c-25-45/temp3/temp3_input
-        - raa228228-i2c-25-45/temp3/temp3_crit
-      - - tmp75-i2c-16-48/temp1/temp1_input
-        - tmp75-i2c-16-48/temp1/temp1_max
-      - - tmp75-i2c-19-48/temp1/temp1_input
-        - tmp75-i2c-19-48/temp1/temp1_max
+      - - raa228228-i2c-24-45/POS0V75_VDDC_D0/temp1_input
+        - raa228228-i2c-24-45/POS0V75_VDDC_D0/temp1_crit
+      - - raa228228-i2c-24-45/POS3V3_OPTICS_A/temp2_input
+        - raa228228-i2c-24-45/POS3V3_OPTICS_A/temp2_crit
+      - - raa228228-i2c-25-45/POS0V75_VDDC_D1/temp1_input
+        - raa228228-i2c-25-45/POS0V75_VDDC_D1/temp1_crit
+      - - raa228228-i2c-25-45/POS3V3_OPTICS_B/temp2_input
+        - raa228228-i2c-25-45/POS3V3_OPTICS_B/temp2_crit
+      - - tmp75-i2c-16-48/Outlet/temp1_input
+        - tmp75-i2c-16-48/Outlet/temp1_max
+      - - tmp75-i2c-19-48/Management Card/temp1_input
+        - tmp75-i2c-19-48/Management Card/temp1_max
 
     non_zero:
       fan:
@@ -7703,224 +7637,158 @@ sensors_checks:
       - raa228228-i2c-25-45/vout2/in4_crit_alarm
       - raa228228-i2c-25-45/vout2/in4_lcrit_alarm
       temp:
-      - amax31732-i2c-19-1c/temp1/temp1_crit_alarm
-      - amax31732-i2c-19-1c/temp1/temp1_lcrit_alarm
-      - amax31732-i2c-19-1c/temp1/temp1_max_alarm
-      - amax31732-i2c-19-1c/temp1/temp1_min_alarm
-      - amax31732-i2c-19-1c/temp2/temp2_crit_alarm
-      - amax31732-i2c-19-1c/temp2/temp2_fault
-      - amax31732-i2c-19-1c/temp2/temp2_lcrit_alarm
-      - amax31732-i2c-19-1c/temp2/temp2_max_alarm
-      - amax31732-i2c-19-1c/temp2/temp2_min_alarm
-      - amax31732-i2c-19-1c/temp3/temp3_crit_alarm
-      - amax31732-i2c-19-1c/temp3/temp3_fault
-      - amax31732-i2c-19-1c/temp3/temp3_lcrit_alarm
-      - amax31732-i2c-19-1c/temp3/temp3_max_alarm
-      - amax31732-i2c-19-1c/temp3/temp3_min_alarm
-      - amax31732-i2c-19-1c/temp4/temp4_crit_alarm
-      - amax31732-i2c-19-1c/temp4/temp4_fault
-      - amax31732-i2c-19-1c/temp4/temp4_lcrit_alarm
-      - amax31732-i2c-19-1c/temp4/temp4_max_alarm
-      - amax31732-i2c-19-1c/temp4/temp4_min_alarm
-      - amax31732-i2c-19-1c/temp5/temp5_crit_alarm
-      - amax31732-i2c-19-1c/temp5/temp5_fault
-      - amax31732-i2c-19-1c/temp5/temp5_lcrit_alarm
-      - amax31732-i2c-19-1c/temp5/temp5_max_alarm
-      - amax31732-i2c-19-1c/temp5/temp5_min_alarm
-      - dps800-i2c-22-58/temp1/temp1_crit_alarm
-      - dps800-i2c-22-58/temp1/temp1_lcrit_alarm
-      - dps800-i2c-22-58/temp1/temp1_max_alarm
-      - dps800-i2c-22-58/temp1/temp1_min_alarm
-      - dps800-i2c-22-58/temp2/temp2_crit_alarm
-      - dps800-i2c-22-58/temp2/temp2_lcrit_alarm
-      - dps800-i2c-22-58/temp2/temp2_max_alarm
-      - dps800-i2c-22-58/temp2/temp2_min_alarm
-      - dps800-i2c-22-58/temp3/temp3_crit_alarm
-      - dps800-i2c-22-58/temp3/temp3_lcrit_alarm
-      - dps800-i2c-22-58/temp3/temp3_max_alarm
-      - dps800-i2c-22-58/temp3/temp3_min_alarm
-      - dps800-i2c-23-58/temp1/temp1_crit_alarm
-      - dps800-i2c-23-58/temp1/temp1_lcrit_alarm
-      - dps800-i2c-23-58/temp1/temp1_max_alarm
-      - dps800-i2c-23-58/temp1/temp1_min_alarm
-      - dps800-i2c-23-58/temp2/temp2_crit_alarm
-      - dps800-i2c-23-58/temp2/temp2_lcrit_alarm
-      - dps800-i2c-23-58/temp2/temp2_max_alarm
-      - dps800-i2c-23-58/temp2/temp2_min_alarm
-      - dps800-i2c-23-58/temp3/temp3_crit_alarm
-      - dps800-i2c-23-58/temp3/temp3_lcrit_alarm
-      - dps800-i2c-23-58/temp3/temp3_max_alarm
-      - dps800-i2c-23-58/temp3/temp3_min_alarm
-      - isl68223-i2c-25-47/temp1/temp1_crit_alarm
-      - isl68223-i2c-25-47/temp1/temp1_lcrit_alarm
-      - isl68223-i2c-25-47/temp1/temp1_max_alarm
-      - isl68223-i2c-25-47/temp2/temp2_crit_alarm
-      - isl68223-i2c-25-47/temp2/temp2_lcrit_alarm
-      - isl68223-i2c-25-47/temp2/temp2_max_alarm
-      - isl68223-i2c-25-47/temp3/temp3_crit_alarm
-      - isl68223-i2c-25-47/temp3/temp3_lcrit_alarm
-      - isl68223-i2c-25-47/temp3/temp3_max_alarm
-      - isl68223-i2c-25-47/temp4/temp4_crit_alarm
-      - isl68223-i2c-25-47/temp4/temp4_lcrit_alarm
-      - isl68223-i2c-25-47/temp4/temp4_max_alarm
-      - isl68223-i2c-25-47/temp5/temp5_crit_alarm
-      - isl68223-i2c-25-47/temp5/temp5_lcrit_alarm
-      - isl68223-i2c-25-47/temp5/temp5_max_alarm
-      - isl68226-i2c-24-4c/temp1/temp1_crit_alarm
-      - isl68226-i2c-24-4c/temp1/temp1_lcrit_alarm
-      - isl68226-i2c-24-4c/temp1/temp1_max_alarm
-      - isl68226-i2c-24-4c/temp2/temp2_crit_alarm
-      - isl68226-i2c-24-4c/temp2/temp2_lcrit_alarm
-      - isl68226-i2c-24-4c/temp2/temp2_max_alarm
-      - isl68226-i2c-24-4c/temp3/temp3_crit_alarm
-      - isl68226-i2c-24-4c/temp3/temp3_lcrit_alarm
-      - isl68226-i2c-24-4c/temp3/temp3_max_alarm
-      - isl68226-i2c-24-4c/temp4/temp4_crit_alarm
-      - isl68226-i2c-24-4c/temp4/temp4_lcrit_alarm
-      - isl68226-i2c-24-4c/temp4/temp4_max_alarm
-      - isl68226-i2c-24-4c/temp5/temp5_crit_alarm
-      - isl68226-i2c-24-4c/temp5/temp5_lcrit_alarm
-      - isl68226-i2c-24-4c/temp5/temp5_max_alarm
-      - isl68226-i2c-24-4c/temp6/temp6_crit_alarm
-      - isl68226-i2c-24-4c/temp6/temp6_lcrit_alarm
-      - isl68226-i2c-24-4c/temp6/temp6_max_alarm
-      - isl68226-i2c-24-4c/temp7/temp7_crit_alarm
-      - isl68226-i2c-24-4c/temp7/temp7_lcrit_alarm
-      - isl68226-i2c-24-4c/temp7/temp7_max_alarm
-      - isl68226-i2c-24-4f/temp1/temp1_crit_alarm
-      - isl68226-i2c-24-4f/temp1/temp1_lcrit_alarm
-      - isl68226-i2c-24-4f/temp1/temp1_max_alarm
-      - isl68226-i2c-24-4f/temp2/temp2_crit_alarm
-      - isl68226-i2c-24-4f/temp2/temp2_lcrit_alarm
-      - isl68226-i2c-24-4f/temp2/temp2_max_alarm
-      - isl68226-i2c-24-4f/temp3/temp3_crit_alarm
-      - isl68226-i2c-24-4f/temp3/temp3_lcrit_alarm
-      - isl68226-i2c-24-4f/temp3/temp3_max_alarm
-      - isl68226-i2c-24-4f/temp4/temp4_crit_alarm
-      - isl68226-i2c-24-4f/temp4/temp4_lcrit_alarm
-      - isl68226-i2c-24-4f/temp4/temp4_max_alarm
-      - isl68226-i2c-24-4f/temp5/temp5_crit_alarm
-      - isl68226-i2c-24-4f/temp5/temp5_lcrit_alarm
-      - isl68226-i2c-24-4f/temp5/temp5_max_alarm
-      - isl68226-i2c-24-4f/temp6/temp6_crit_alarm
-      - isl68226-i2c-24-4f/temp6/temp6_lcrit_alarm
-      - isl68226-i2c-24-4f/temp6/temp6_max_alarm
-      - isl68226-i2c-24-4f/temp7/temp7_crit_alarm
-      - isl68226-i2c-24-4f/temp7/temp7_lcrit_alarm
-      - isl68226-i2c-24-4f/temp7/temp7_max_alarm
-      - isl68226-i2c-25-4c/temp1/temp1_crit_alarm
-      - isl68226-i2c-25-4c/temp1/temp1_lcrit_alarm
-      - isl68226-i2c-25-4c/temp1/temp1_max_alarm
-      - isl68226-i2c-25-4c/temp2/temp2_crit_alarm
-      - isl68226-i2c-25-4c/temp2/temp2_lcrit_alarm
-      - isl68226-i2c-25-4c/temp2/temp2_max_alarm
-      - isl68226-i2c-25-4c/temp3/temp3_crit_alarm
-      - isl68226-i2c-25-4c/temp3/temp3_lcrit_alarm
-      - isl68226-i2c-25-4c/temp3/temp3_max_alarm
-      - isl68226-i2c-25-4c/temp4/temp4_crit_alarm
-      - isl68226-i2c-25-4c/temp4/temp4_lcrit_alarm
-      - isl68226-i2c-25-4c/temp4/temp4_max_alarm
-      - isl68226-i2c-25-4c/temp5/temp5_crit_alarm
-      - isl68226-i2c-25-4c/temp5/temp5_lcrit_alarm
-      - isl68226-i2c-25-4c/temp5/temp5_max_alarm
-      - isl68226-i2c-25-4c/temp6/temp6_crit_alarm
-      - isl68226-i2c-25-4c/temp6/temp6_lcrit_alarm
-      - isl68226-i2c-25-4c/temp6/temp6_max_alarm
-      - isl68226-i2c-25-4c/temp7/temp7_crit_alarm
-      - isl68226-i2c-25-4c/temp7/temp7_lcrit_alarm
-      - isl68226-i2c-25-4c/temp7/temp7_max_alarm
+      - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_crit_alarm
+      - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_lcrit_alarm
+      - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_max_alarm
+      - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_min_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_crit_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_fault
+      - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_lcrit_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_max_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_min_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_crit_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_fault
+      - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_lcrit_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_max_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_min_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_crit_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_fault
+      - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_lcrit_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_max_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_min_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_crit_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_fault
+      - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_lcrit_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_max_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_min_alarm
+      - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_crit_alarm
+      - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_max_alarm
+      - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_min_alarm
+      - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_min_alarm
+      - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_crit_alarm
+      - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_max_alarm
+      - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_min_alarm
+      - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_crit_alarm
+      - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_lcrit_alarm
+      - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_max_alarm
+      - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_min_alarm
+      - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_min_alarm
+      - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_crit_alarm
+      - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_lcrit_alarm
+      - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_max_alarm
+      - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_min_alarm
+      - isl68223-i2c-25-47/POS0V8_PBVDD/temp1_crit_alarm
+      - isl68223-i2c-25-47/POS0V8_PBVDD/temp1_lcrit_alarm
+      - isl68223-i2c-25-47/POS0V8_PBVDD/temp1_max_alarm
+      - isl68226-i2c-24-4c/POS1V2_HBM_D0/temp1_crit_alarm
+      - isl68226-i2c-24-4c/POS1V2_HBM_D0/temp1_lcrit_alarm
+      - isl68226-i2c-24-4c/POS1V2_HBM_D0/temp1_max_alarm
+      - isl68226-i2c-24-4c/POS0V9_D0/temp2_crit_alarm
+      - isl68226-i2c-24-4c/POS0V9_D0/temp2_lcrit_alarm
+      - isl68226-i2c-24-4c/POS0V9_D0/temp2_max_alarm
+      - isl68226-i2c-24-4c/POS0V75_D0/temp3_crit_alarm
+      - isl68226-i2c-24-4c/POS0V75_D0/temp3_lcrit_alarm
+      - isl68226-i2c-24-4c/POS0V75_D0/temp3_max_alarm
+      - isl68226-i2c-24-4f/POS1V2_VAA_PHY/temp1_crit_alarm
+      - isl68226-i2c-24-4f/POS1V2_VAA_PHY/temp1_lcrit_alarm
+      - isl68226-i2c-24-4f/POS1V2_VAA_PHY/temp1_max_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY1/temp2_crit_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY1/temp2_lcrit_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY1/temp2_max_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY2/temp3_crit_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY2/temp3_lcrit_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY2/temp3_max_alarm
+      - isl68226-i2c-25-4c/POS1V2_HBM_D1/temp1_crit_alarm
+      - isl68226-i2c-25-4c/POS1V2_HBM_D1/temp1_lcrit_alarm
+      - isl68226-i2c-25-4c/POS1V2_HBM_D1/temp1_max_alarm
+      - isl68226-i2c-25-4c/POS0V9_D1/temp2_crit_alarm
+      - isl68226-i2c-25-4c/POS0V9_D1/temp2_lcrit_alarm
+      - isl68226-i2c-25-4c/POS0V9_D1/temp2_max_alarm
+      - isl68226-i2c-25-4c/POS0V75_D1/temp3_crit_alarm
+      - isl68226-i2c-25-4c/POS0V75_D1/temp3_lcrit_alarm
+      - isl68226-i2c-25-4c/POS0V75_D1/temp3_max_alarm
       - nvme-pci-0500/Composite/temp1_alarm
-      - raa228228-i2c-24-45/temp1/temp1_crit_alarm
-      - raa228228-i2c-24-45/temp1/temp1_lcrit_alarm
-      - raa228228-i2c-24-45/temp1/temp1_max_alarm
-      - raa228228-i2c-24-45/temp2/temp2_crit_alarm
-      - raa228228-i2c-24-45/temp2/temp2_lcrit_alarm
-      - raa228228-i2c-24-45/temp2/temp2_max_alarm
-      - raa228228-i2c-24-45/temp3/temp3_crit_alarm
-      - raa228228-i2c-24-45/temp3/temp3_lcrit_alarm
-      - raa228228-i2c-24-45/temp3/temp3_max_alarm
-      - raa228228-i2c-25-45/temp1/temp1_crit_alarm
-      - raa228228-i2c-25-45/temp1/temp1_lcrit_alarm
-      - raa228228-i2c-25-45/temp1/temp1_max_alarm
-      - raa228228-i2c-25-45/temp2/temp2_crit_alarm
-      - raa228228-i2c-25-45/temp2/temp2_lcrit_alarm
-      - raa228228-i2c-25-45/temp2/temp2_max_alarm
-      - raa228228-i2c-25-45/temp3/temp3_crit_alarm
-      - raa228228-i2c-25-45/temp3/temp3_lcrit_alarm
-      - raa228228-i2c-25-45/temp3/temp3_max_alarm
+      - raa228228-i2c-24-45/POS0V75_VDDC_D0/temp1_crit_alarm
+      - raa228228-i2c-24-45/POS0V75_VDDC_D0/temp1_lcrit_alarm
+      - raa228228-i2c-24-45/POS0V75_VDDC_D0/temp1_max_alarm
+      - raa228228-i2c-24-45/POS3V3_OPTICS_A/temp2_crit_alarm
+      - raa228228-i2c-24-45/POS3V3_OPTICS_A/temp2_lcrit_alarm
+      - raa228228-i2c-24-45/POS3V3_OPTICS_A/temp2_max_alarm
+      - raa228228-i2c-25-45/POS0V75_VDDC_D1/temp1_crit_alarm
+      - raa228228-i2c-25-45/POS0V75_VDDC_D1/temp1_lcrit_alarm
+      - raa228228-i2c-25-45/POS0V75_VDDC_D1/temp1_max_alarm
+      - raa228228-i2c-25-45/POS3V3_OPTICS_B/temp2_crit_alarm
+      - raa228228-i2c-25-45/POS3V3_OPTICS_B/temp2_lcrit_alarm
+      - raa228228-i2c-25-45/POS3V3_OPTICS_B/temp2_max_alarm
 
     compares:
       fan: [ ]
       power: [ ]
       temp:
-      - - amax31732-i2c-19-1c/temp1/temp1_input
-        - amax31732-i2c-19-1c/temp1/temp1_crit
-      - - amax31732-i2c-19-1c/temp2/temp2_input
-        - amax31732-i2c-19-1c/temp2/temp2_crit
-      - - amax31732-i2c-19-1c/temp3/temp3_input
-        - amax31732-i2c-19-1c/temp3/temp3_crit
-      - - amax31732-i2c-19-1c/temp4/temp4_input
-        - amax31732-i2c-19-1c/temp4/temp4_crit
-      - - amax31732-i2c-19-1c/temp5/temp5_input
-        - amax31732-i2c-19-1c/temp5/temp5_crit
-      - - dps800-i2c-22-58/temp1/temp1_input
-        - dps800-i2c-22-58/temp1/temp1_crit
-      - - dps800-i2c-22-58/temp2/temp2_input
-        - dps800-i2c-22-58/temp2/temp2_crit
-      - - dps800-i2c-22-58/temp3/temp3_input
-        - dps800-i2c-22-58/temp3/temp3_crit
-      - - dps800-i2c-23-58/temp1/temp1_input
-        - dps800-i2c-23-58/temp1/temp1_crit
-      - - dps800-i2c-23-58/temp2/temp2_input
-        - dps800-i2c-23-58/temp2/temp2_crit
-      - - dps800-i2c-23-58/temp3/temp3_input
-        - dps800-i2c-23-58/temp3/temp3_crit
-      - - isl68223-i2c-25-47/temp1/temp1_input
-        - isl68223-i2c-25-47/temp1/temp1_crit
-      - - isl68223-i2c-25-47/temp3/temp3_input
-        - isl68223-i2c-25-47/temp3/temp3_crit
-      - - isl68226-i2c-24-4c/temp1/temp1_input
-        - isl68226-i2c-24-4c/temp1/temp1_crit
-      - - isl68226-i2c-24-4c/temp2/temp2_input
-        - isl68226-i2c-24-4c/temp2/temp2_crit
-      - - isl68226-i2c-24-4c/temp3/temp3_input
-        - isl68226-i2c-24-4c/temp3/temp3_crit
-      - - isl68226-i2c-24-4c/temp4/temp4_input
-        - isl68226-i2c-24-4c/temp4/temp4_crit
-      - - isl68226-i2c-24-4f/temp1/temp1_input
-        - isl68226-i2c-24-4f/temp1/temp1_crit
-      - - isl68226-i2c-24-4f/temp2/temp2_input
-        - isl68226-i2c-24-4f/temp2/temp2_crit
-      - - isl68226-i2c-24-4f/temp3/temp3_input
-        - isl68226-i2c-24-4f/temp3/temp3_crit
-      - - isl68226-i2c-24-4f/temp4/temp4_input
-        - isl68226-i2c-24-4f/temp4/temp4_crit
-      - - isl68226-i2c-25-4c/temp1/temp1_input
-        - isl68226-i2c-25-4c/temp1/temp1_crit
-      - - isl68226-i2c-25-4c/temp2/temp2_input
-        - isl68226-i2c-25-4c/temp2/temp2_crit
-      - - isl68226-i2c-25-4c/temp3/temp3_input
-        - isl68226-i2c-25-4c/temp3/temp3_crit
-      - - isl68226-i2c-25-4c/temp4/temp4_input
-        - isl68226-i2c-25-4c/temp4/temp4_crit
+      - - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_input
+        - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_crit
+      - - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_input
+        - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_crit
+      - - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_input
+        - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_crit
+      - - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_input
+        - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_crit
+      - - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_input
+        - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_crit
+      - - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_input
+        - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_crit
+      - - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_input
+        - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_crit
+      - - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_input
+        - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_crit
+      - - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_input
+        - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_crit
+      - - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_input
+        - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_crit
+      - - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_input
+        - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_crit
+      - - isl68223-i2c-25-47/POS0V8_PBVDD/temp1_input
+        - isl68223-i2c-25-47/POS0V8_PBVDD/temp1_crit
+      - - isl68226-i2c-24-4c/POS1V2_HBM_D0/temp1_input
+        - isl68226-i2c-24-4c/POS1V2_HBM_D0/temp1_crit
+      - - isl68226-i2c-24-4c/POS0V9_D0/temp2_input
+        - isl68226-i2c-24-4c/POS0V9_D0/temp2_crit
+      - - isl68226-i2c-24-4c/POS0V75_D0/temp3_input
+        - isl68226-i2c-24-4c/POS0V75_D0/temp3_crit
+      - - isl68226-i2c-24-4f/POS1V2_VAA_PHY/temp1_input
+        - isl68226-i2c-24-4f/POS1V2_VAA_PHY/temp1_crit
+      - - isl68226-i2c-24-4f/POS0V75_VDD_PHY1/temp2_input
+        - isl68226-i2c-24-4f/POS0V75_VDD_PHY1/temp2_crit
+      - - isl68226-i2c-24-4f/POS0V75_VDD_PHY2/temp3_input
+        - isl68226-i2c-24-4f/POS0V75_VDD_PHY2/temp3_crit
+      - - isl68226-i2c-25-4c/POS1V2_HBM_D1/temp1_input
+        - isl68226-i2c-25-4c/POS1V2_HBM_D1/temp1_crit
+      - - isl68226-i2c-25-4c/POS0V9_D1/temp2_input
+        - isl68226-i2c-25-4c/POS0V9_D1/temp2_crit
+      - - isl68226-i2c-25-4c/POS0V75_D1/temp3_input
+        - isl68226-i2c-25-4c/POS0V75_D1/temp3_crit
       - - nvme-pci-0500/Composite/temp1_input
         - nvme-pci-0500/Composite/temp1_crit
-      - - raa228228-i2c-24-45/temp1/temp1_input
-        - raa228228-i2c-24-45/temp1/temp1_crit
-      - - raa228228-i2c-24-45/temp2/temp2_input
-        - raa228228-i2c-24-45/temp2/temp2_crit
-      - - raa228228-i2c-24-45/temp3/temp3_input
-        - raa228228-i2c-24-45/temp3/temp3_crit
-      - - raa228228-i2c-25-45/temp1/temp1_input
-        - raa228228-i2c-25-45/temp1/temp1_crit
-      - - raa228228-i2c-25-45/temp2/temp2_input
-        - raa228228-i2c-25-45/temp2/temp2_crit
-      - - raa228228-i2c-25-45/temp3/temp3_input
-        - raa228228-i2c-25-45/temp3/temp3_crit
-      - - tmp75-i2c-16-48/temp1/temp1_input
-        - tmp75-i2c-16-48/temp1/temp1_max
-      - - tmp75-i2c-19-48/temp1/temp1_input
-        - tmp75-i2c-19-48/temp1/temp1_max
+      - - raa228228-i2c-24-45/POS0V75_VDDC_D0/temp1_input
+        - raa228228-i2c-24-45/POS0V75_VDDC_D0/temp1_crit
+      - - raa228228-i2c-24-45/POS3V3_OPTICS_A/temp2_input
+        - raa228228-i2c-24-45/POS3V3_OPTICS_A/temp2_crit
+      - - raa228228-i2c-25-45/POS0V75_VDDC_D1/temp1_input
+        - raa228228-i2c-25-45/POS0V75_VDDC_D1/temp1_crit
+      - - raa228228-i2c-25-45/POS3V3_OPTICS_B/temp2_input
+        - raa228228-i2c-25-45/POS3V3_OPTICS_B/temp2_crit
+      - - tmp75-i2c-16-48/Outlet/temp1_input
+        - tmp75-i2c-16-48/Outlet/temp1_max
+      - - tmp75-i2c-19-48/Management Card/temp1_input
+        - tmp75-i2c-19-48/Management Card/temp1_max
 
     non_zero:
       fan:


### PR DESCRIPTION
The static data in this file must match with the aliases and ignore statements in sensors.conf for the corresponding platform.

This is a Arista platform specific change.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The names of sensors here must match with the aliases using in sensors.conf

#### How did you do it?
Modified sku-sensors-data.yml to reflect the sensor aliases.

#### How did you verify/test it?
Passed platform_tests/test_sensors.py::test_sensors on this platform

#### Any platform specific information?
Applies to Arista 7280R4-32QF-32DF-F and 7280R4K-32QF-32DF-F models

#### Supported testbed topology if it's a new test case?
NA

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
NA
