### PR TITLE
Fix test_nhop_group_interface_flap to restore fanout ports in cleanup

### DIFF
--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -974,5 +974,10 @@ def test_nhop_group_interface_flap(duthosts, enum_rand_one_per_hwsku_frontend_ho
 
     finally:
         asic.command(arp_evict_cmd % gather_facts['src_router_intf_name'])
+        for i in range(0, len(gather_facts['src_port'])):
+            fanout, fanout_port = fanout_switch_port_lookup(fanouthosts, duthost.hostname,
+                                                            gather_facts['src_port'][i])
+            logger.debug("No Shut fanout sw: %s, port: %s", fanout, fanout_port)
+            fanout.no_shutdown(fanout_port)
         nhop.delete_routes()
         arplist.clean_up()

--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -978,6 +978,7 @@ def test_nhop_group_interface_flap(duthosts, enum_rand_one_per_hwsku_frontend_ho
             fanout, fanout_port = fanout_switch_port_lookup(fanouthosts, duthost.hostname,
                                                             gather_facts['src_port'][i])
             logger.debug("No Shut fanout sw: %s, port: %s", fanout, fanout_port)
-            fanout.no_shutdown(fanout_port)
+            if is_vs_device(duthost) is False:
+                fanout.no_shutdown(fanout_port)
         nhop.delete_routes()
         arplist.clean_up()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #23753

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
 #### What is the motivation for this PR?
 `test_nhop_group_interface_flap` shuts down fanout switch ports during the test but only restores them inside the `try` block. If the test fails or hits an exception before reaching the `no_shutdown` calls, the fanout ports remain down, causing subsequent tests to fail due to missing links.

#### How did you do it?
Added `fanout.no_shutdown()` calls for all `src_port` entries in the `finally` block, ensuring fanout ports are unconditionally restored during cleanup regardless of test outcome.

#### How did you verify/test it?
Verified that fanout ports are correctly restored after both test pass and test failure scenarios.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A — this is a fix to an existing test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
