### PR TITLE
[202511] Support IPv6 in create_grpc_channel

### DIFF
--- a/tests/gnmi/grpc_utils.py
+++ b/tests/gnmi/grpc_utils.py
@@ -39,7 +39,8 @@ def create_grpc_channel(duthost):
     ip = duthost.mgmt_ip
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     port = env.gnmi_port
-    target = f"{ip}:{port}"
+    mgmt_ipv6_only = duthost.get_mgmt_ip()['version'] == 'v6'
+    target = f"{ip}:{port}" if not mgmt_ipv6_only else f"[{ip}]:{port}"
 
     # Load the TLS certificates
     with open("gnmiCA.pem", "rb") as f:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
In the gnmi/ tests, when creating a channel in a mgmtIpv6Only setup, format the target server address string for IPv6 by putting the IP address inside square brackets (e.g., "[fd7a:629f:52a4:1b18::ac18:90f6]:50052").

This change is a PR for `sonic-net:202511` because it only applies to `202511`. In `master`, the file being modified has been removed.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

In `mgmtIpv6Only=True` setups, this test would fail since the server address string would be malformed since the mgmt IP address is IPv6.

#### How did you do it?

I changed the test such that it would properly format the string in IPv6 contexts.

#### How did you verify/test it?

I ran the failing test in a cluster sanitized with `mgmtIpv6Only=True` and in one with `mgmtIpv6Only=False`, with these changes. In both cases the test passes

#### Any platform specific information?

N/A.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
