### PR TITLE
[snappi] Fix yaml.RepresenterError caused by AnsibleUnsafeText in snappi_fixtures

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -11,6 +11,8 @@ import subprocess
 import csv
 import json
 import os
+import yaml
+from ansible.utils.unsafe_proxy import AnsibleUnsafeText
 from copy import copy
 from tests.common.utilities import wait_until
 from tests.common.errors import RunAnsibleModuleFail
@@ -29,6 +31,7 @@ from tests.common.macsec.macsec_config_helper import set_macsec_profile, enable_
 from tests.common.snappi_tests.uhd.uhd_helpers import (NetworkConfigSettings, create_front_panel_ports,
                                                        create_connections, create_connections_pl, create_uhdIp_list,
                                                        create_arp_bypass, create_arp_bypass_pl, create_profiles)
+yaml.SafeDumper.add_representer(AnsibleUnsafeText, yaml.SafeDumper.represent_str)
 logger = logging.getLogger(__name__)
 _next_system_id = 1
 

--- a/tests/snappi_tests/test_snappi.py
+++ b/tests/snappi_tests/test_snappi.py
@@ -5,7 +5,7 @@ from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
     fanout_graph_facts                  # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
-    snappi_api, snappi_testbed_config   # noqa: F401
+    snappi_api, snappi_testbed_config, is_pfc_enabled  # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp
 from tests.common.snappi_tests.port import select_ports
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map  # noqa: F401


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [snappi] Fix yaml.RepresenterError caused by AnsibleUnsafeText in snappi_fixtures

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
When running `test_snappi.py`, the test fails with:

    yaml.representer.RepresenterError: ('cannot represent an object', '10.0.0.1')

**Root cause:** Newer versions of Ansible wrap string values returned from
facts/modules in `AnsibleUnsafeText`, which is a subclass of `str`.
`yaml.SafeDumper` has no registered representer for this type. When snappi
internally calls `yaml.safe_dump()` to serialize the `Config` object inside
`set_config()`, it encounters `AnsibleUnsafeText` values (e.g. IP addresses
from minigraph facts) and raises `RepresenterError`.

Note: calling `str()` on `AnsibleUnsafeText` does **not** fix the issue,
because the `str` subclass constructor returns the same subclass, not a plain
`str`.
#### How did you do it?
Register a YAML representer for `AnsibleUnsafeText` at module load time so
that `SafeDumper` handles it as a regular string.

#### How did you verify/test it?
Run `test_snappi.py` with a newer Ansible version (>=2.12) in ubuntu 24 where Ansible returns facts as `AnsibleUnsafeText`. 

#### Any platform specific information?
latest sonic-mgmt which relay on ubuntu 24

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
