### PR TITLE
Add gnoi_based invocation support to test_warm_reboot

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -74,7 +74,15 @@ reboot_ctrl_dict = {
         "wait": 90,
         "warmboot_finalizer_timeout": 180,
         "cause": "warm-reboot",
-        "test_reboot_cause_only": False
+        "test_reboot_cause_only": False,
+        "gnoi_api": {
+            "service": "gnoi.system.System",
+            "method": "Reboot",
+            "params": {
+                "method": 4,  # WARM Reboot
+                "message": "gNOI reboot test"
+            }
+        }
     },
     REBOOT_TYPE_WATCHDOG: {
         "command": "watchdogutil arm -s 5",

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -223,7 +223,7 @@ def test_fast_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_warm_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
-                     localhost, conn_graph_facts, xcvr_skip_list):      # noqa: F811
+                     localhost, conn_graph_facts, xcvr_skip_list, invocation_type, gnmi_tls):      # noqa: F811
     """
     @summary: This test case is to perform warm reboot and check platform status
     """
@@ -242,7 +242,8 @@ def test_warm_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
                 "ISSU is not supported on this DUT, skip this test case")
 
     reboot_and_check(localhost, duthost, conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {}),
-                     xcvr_skip_list, reboot_type=REBOOT_TYPE_WARM, duthosts=duthosts)
+                     xcvr_skip_list, reboot_type=REBOOT_TYPE_WARM, duthosts=duthosts,
+                     invocation_type=invocation_type, ptf_gnoi=gnmi_tls.gnoi)
 
 
 def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname,


### PR DESCRIPTION
Extend test_warm_reboot to support both gnoi_based and cli_based invocation types, mirroring the existing test_cold_reboot pattern.

Add gnoi_api entry for REBOOT_TYPE_WARM in reboot_ctrl_dict with method=4 (WARM) to enable gNOI-based warm reboot end-to-end.

To test:
root@sonic-mgmt:/data/sonic-mgmt/tests# ./run_tests.sh -n vms-kvm-t0 -d vlab-01 -f vtestbed.yaml -i ../ansible/veos_vtb  -u -m individual -c platform_tests/test_reboot.py::test_warm_reboot -e "--skip_sanity" -l info

INFO     tests.common.reboot:reboot.py:245 perform_reboot called with invocation_type: cli_based
INFO     tests.common.reboot:reboot.py:202 waiting for ssh to drop on vlab-01
INFO     tests.common.reboot:reboot.py:270 rebooting vlab-01 with command "warm-reboot"

tests/platform_tests/test_reboot.py::test_warm_reboot[gnoi_based-vlab-01]
  /data/sonic-mgmt/tests/conftest.py:1437: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    record_testsuite_property("timestamp", datetime.utcnow())

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
- generated xml file: /data/sonic-mgmt/tests/logs/platform_tests/test_reboot.py::test_warm_reboot.xml - -------------------- live log sessionfinish --------------------
INFO     root:__init__.py:67 Can not get Allure report URL. Please check logs
========= 2 passed, 164 warnings in 694.94s (0:11:34) ==========

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Testing warm reboot via gNOI.

#### How did you do it? 
Added invocation_type and gnmi_tls fixtures to
 test_warm_reboot (mirroring test_cold_reboot), and added a
 gnoi_api entry for REBOOT_TYPE_WARM in reboot_ctrl_dict with
 method=4 (gNOI WARM enum value).




#### How did you verify/test it?
root@sonic-mgmt:/data/sonic-mgmt/tests# ./run_tests.sh -n vms-kvm-t0 -d vlab-01 -f vtestbed.yaml -i ../ansible/veos_vtb  -u -m individual -c platform_tests/test_reboot.py::test_warm_reboot -e "--skip_sanity" -l info

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
