### PR TITLE
fix duplicate route test case handling

### DIFF
--- a/tests/route/test_duplicate_route.py
+++ b/tests/route/test_duplicate_route.py
@@ -106,6 +106,7 @@ def verify_expected_loganalyzer_logs(
         ".*ERR.* object key SAI_OBJECT_TYPE_ROUTE_ENTRY:.* already exists.*",  # TODO move to expectRegex
         ".*ERR.* addRoutePost: Failed to create route.*",  # TODO move to expectRegex
         ".*ERR.* ipv4_route_bulk_updates API returned.*Key already exists in table.*",
+        ".*ERR.* Create route entry.*Failed.*",
         ".*ERR syncd#SDK:.*mlnx_route_pre_create: Route entry already exists in the Route DB.*",
         ".*ERR syncd#SDK:.*mlnx_route_bulk_set_impl: Failed to prepare route data for bulk operation. index:.*",
         ".*ERR syncd#SDK:.*mlnx_route_bulk_set_impl: No valid route entries for bulk operation in chunk starting at.*"


### PR DESCRIPTION


Description of PR:

This change ensures the duplicate route test correctly handles platforms that return SAI_STATUS_ITEM_ALREADY_EXISTS instead of raising a generic failure, improving test robustness and cross-platform compatibility and below are the testcases are impacted. 
Fixes https://github.com/sonic-net/sonic-mgmt/issues/27789

route/test_duplicate_route.py	test_duplicate_routes[6-Vlan-str-marvell-tl10-01-None]
route/test_duplicate_route.py	test_duplicate_routes[6-Loopback-str-marvell-tl10-01-None]
route/test_duplicate_route.py	test_duplicate_routes[4-Vlan-str-marvell-tl10-01-None]
route/test_duplicate_route.py	test_duplicate_routes[4-Loopback-str-marvell-tl10-01-None]

### Description of PR


Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

Tested branch
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

**Test result**

route/test_duplicate_route.py	test_duplicate_routes[6-Vlan-str-marvell-tl10-01-None]
route/test_duplicate_route.py	test_duplicate_routes[6-Loopback-str-marvell-tl10-01-None]
route/test_duplicate_route.py	test_duplicate_routes[4-Vlan-str-marvell-tl10-01-None]
route/test_duplicate_route.py	test_duplicate_routes[4-Loopback-str-marvell-tl10-01-None]
passed on Marvell Teralynx testbed


### Approach
duplicate route test correctly handles platforms that return SAI_STATUS_ITEM_ALREADY_EXISTS nstead of raising a generic failure

#### How did you do it?
added the SAI error string to the test case’s exception list

#### How did you verify/test it?
Ran the route/test_duplicate_route.py test module.

#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA
