### PR TITLE
[copp] Pin ptf_nn_agent.py wget URLs to nnpy-compatible PTF commit (workaround)

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -20,6 +20,14 @@ _ADD_IP_SCRIPT = "scripts/add_ip.sh"
 _ADD_IP_BACKEND_SCRIPT = "scripts/add_ip_backend.sh"
 _UPDATE_COPP_SCRIPT = "copp/scripts/update_copp_config.py"
 
+_PTF_COMMIT = "9d41838d634c479fc24fac7a527ec5ee2d0ce8eb"
+_PTF_NN_AGENT_URL = (
+    "https://raw.githubusercontent.com/p4lang/ptf"
+    "/{}/ptf_nn/ptf_nn_agent.py".format(_PTF_COMMIT))
+_PTF_AFPACKET_URL = (
+    "https://raw.githubusercontent.com/p4lang/ptf"
+    "/{}/src/ptf/afpacket.py".format(_PTF_COMMIT))
+
 _BASE_COPP_CONFIG = "/tmp/base_copp_config.json"
 _APP_DB_COPP_CONFIG = ":/etc/swss/config.d/00-copp.config.json"
 _CONFIG_DB_COPP_CONFIG = "/etc/sonic/copp_cfg.json"
@@ -214,7 +222,7 @@ def _install_nano_bookworm(dut, creds, syncd_docker_name):
         http_proxy = creds.get('proxy_env', {}).get('http_proxy', '')
         https_proxy = creds.get('proxy_env', {}).get('https_proxy', '')
         # Change the permission of /tmp to 1777 to workaround issue sonic-net/sonic-buildimage#16034
-        cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
+        cmd = '''docker exec -e http_proxy={0} -e https_proxy={1} {2} bash -c " \
                 mkdir -p /var/tmp_build \
                 && rm -rf /var/lib/apt/lists/* \
                 && apt-get update \
@@ -223,13 +231,12 @@ def _install_nano_bookworm(dut, creds, syncd_docker_name):
                 && TMPDIR=/var/tmp_build pip3 install --no-cache-dir cffi==1.16.0 \
                 && TMPDIR=/var/tmp_build pip3 install --no-cache-dir nnpy \
                 && rm -rf /var/tmp_build \
-                && mkdir -p /opt && cd /opt && wget \
-                https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
-                && mkdir ptf && cd ptf && wget \
-                https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
+                && mkdir -p /opt && cd /opt && wget {3} \
+                && mkdir ptf && cd ptf && wget {4} && touch __init__.py \
                 && apt-get -y purge build-essential libssl-dev libffi-dev python3-dev \
                 python3-setuptools wget \
-                " '''.format(http_proxy, https_proxy, syncd_docker_name)
+                " '''.format(http_proxy, https_proxy, syncd_docker_name,
+                             _PTF_NN_AGENT_URL, _PTF_AFPACKET_URL)
         dut.command(cmd)
 
 
@@ -260,7 +267,7 @@ def _install_nano(dut, creds,  syncd_docker_name):
         check_cmd = "docker exec -i {} bash -c 'cat /etc/os-release'".format(syncd_docker_name)
         # Change the permission of /tmp to 1777 to workaround issue sonic-net/sonic-buildimage#16034
         if "bullseye" in dut.shell(check_cmd)['stdout'].lower():
-            cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
+            cmd = '''docker exec -e http_proxy={0} -e https_proxy={1} {2} bash -c " \
                     chmod 1777 /tmp \
                     && rm -rf /var/lib/apt/lists/* \
                     && apt-get update \
@@ -270,13 +277,12 @@ def _install_nano(dut, creds,  syncd_docker_name):
                     && tar xzf 1.0.0.tar.gz && cd nanomsg-1.0.0 \
                     && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0 \
                     && rm -f 1.0.0.tar.gz && pip3 install cffi && pip3 install --upgrade cffi && pip3 install nnpy \
-                    && mkdir -p /opt && cd /opt && wget \
-                    https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
-                    && mkdir ptf && cd ptf && wget \
-                    https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
-                    " '''.format(http_proxy, https_proxy, syncd_docker_name)
+                    && mkdir -p /opt && cd /opt && wget {3} \
+                    && mkdir ptf && cd ptf && wget {4} && touch __init__.py \
+                    " '''.format(http_proxy, https_proxy, syncd_docker_name,
+                                 _PTF_NN_AGENT_URL, _PTF_AFPACKET_URL)
         else:
-            cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
+            cmd = '''docker exec -e http_proxy={0} -e https_proxy={1} {2} bash -c " \
                     chmod 1777 /tmp \
                     && rm -rf /var/lib/apt/lists/* \
                     && apt-get update \
@@ -287,11 +293,10 @@ def _install_nano(dut, creds,  syncd_docker_name):
                     && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0 \
                     && rm -f 1.0.0.tar.gz && pip2 install cffi==1.7.0 && pip2 install --upgrade \
                     cffi==1.7.0 && pip2 install nnpy \
-                    && mkdir -p /opt && cd /opt && wget \
-                    https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
-                    && mkdir ptf && cd ptf && wget \
-                    https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
-                    " '''.format(http_proxy, https_proxy, syncd_docker_name)
+                    && mkdir -p /opt && cd /opt && wget {3} \
+                    && mkdir ptf && cd ptf && wget {4} && touch __init__.py \
+                    " '''.format(http_proxy, https_proxy, syncd_docker_name,
+                                 _PTF_NN_AGENT_URL, _PTF_AFPACKET_URL)
         dut.command(cmd)
 
 


### PR DESCRIPTION
Pin the `wget` download URLs in `copp_utils.py` for `ptf_nn_agent.py` and `afpacket.py` to the last nnpy-compatible PTF commit (`9d41838d`), instead of tracking `master`. This is a workaround to prevent COPP tests from hanging on testbeds where only `nnpy` is installed.

### Description of PR

Summary:

On Apr 5 2026, p4lang/ptf PR #234 (commit `ebc00f94`) changed `ptf_nn_agent.py` to import `pynng` instead of `nnpy`. Current SONiC production PTF container images have `nnpy` installed but NOT `pynng`. When `copp_utils.py` downloads `ptf_nn_agent.py` from the unversioned `master` URL, it gets the new pynng-based version, which crashes immediately on startup. This causes port 10900 to never open, and COPP tests time out after 600 seconds.

This PR pins all three `wget` call sites in `copp_utils.py` to commit `9d41838d634c479fc24fac7a527ec5ee2d0ce8eb` (Apr 2 2026 — last nnpy-compatible state) for both `ptf_nn_agent.py` and `afpacket.py`.

The proper long-term fix is for the PTF container image build to install `pynng`. This PR is an explicit workaround to unblock COPP tests until that infrastructure update is available.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach

#### What is the motivation for this PR?
After p4lang/ptf commit `ebc00f94` (Apr 5 2026), `ptf_nn_agent.py` requires `pynng`. SONiC production PTF containers only have `nnpy`. The unversioned `master` URL causes a crash at startup, blocking all COPP tests.

#### How did you do it?
Changed 6 URL occurrences across 3 code paths in `copp_utils.py` (`_install_nano_bookworm`, `_install_nano` bullseye path, `_install_nano` buster/py2 path) from `master` to pinned commit hash `9d41838d634c479fc24fac7a527ec5ee2d0ce8eb` for both `ptf_nn_agent.py` and `afpacket.py`.

#### How did you verify/test it?
Verified on internal testbed (bjw13-5, DUT bjw-can-7260-11) with 202511 branch — COPP tests pass after pinning. PTF container on the testbed confirmed to have `nnpy` v0.10.0 installed, `pynng` absent.

passed on T0 and T1
https://elastictest.org/scheduler/testplan/69d824c02e61bab317c442d5
https://elastictest.org/scheduler/testplan/69d824d559cbd7d94a4fe3b4

#### Any platform specific information?
Affects all platforms that run COPP tests with `copp_utils.py` network namespace (NN) agent setup.

#### Supported testbed topology if it's a new test case?
N/A (bug fix, not a new test case)

### Documentation

N/A