### PR TITLE
Calculate PFC watchdog timers dynamically based on port count

### DIFF
--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -25,6 +25,11 @@ VENDOR_SPEC_ADDITIONAL_INFO_RE = {
     }
 
 EXPECT_PFC_WD_RESTORE_RE = ".*storm restored.*"
+PFCWD_DEFAULT_DETECT_TIME = 200
+PFCWD_DEFAULT_RESTORE_TIME = 200
+PFCWD_DEFAULT_POLL_INTERVAL = 200
+PFCWD_DEFAULT_PORT_NUM = 32
+PFCWD_MAX_POLL_INTERVAL = 1000
 
 logger = logging.getLogger(__name__)
 
@@ -330,6 +335,38 @@ def set_pfc_timers():
 def update_pfc_poll_interval(duthost, poll_interval):
     logger.info("Setting PFC watchdog poll interval to {}ms".format(poll_interval))
     duthost.command("pfcwd interval {}".format(poll_interval))
+
+
+def calculate_pfcwd_default_timers(duthost):
+    """
+    Calculate PFC watchdog default timers dynamically based on port count.
+
+    The logic from sonic-utilities pfcwd start_default:
+    https://github.com/sonic-net/sonic-utilities/blob/fb3d73db/pfcwd/main.py#L402
+
+    Args:
+        duthost: DUT host instance
+
+    Returns:
+        pfc_timers (dict): dynamically calculated PFC watchdog timers
+    """
+    config_facts = duthost.config_facts(host=duthost.hostname, source='running')['ansible_facts']
+    port_num = len(config_facts.get('PORT', {}))
+
+    multiply = max(1, (port_num - 1) // PFCWD_DEFAULT_PORT_NUM + 1)
+
+    poll_interval = min(PFCWD_DEFAULT_POLL_INTERVAL * multiply, PFCWD_MAX_POLL_INTERVAL)
+
+    pfc_timers = {
+        'pfc_wd_detect_time': PFCWD_DEFAULT_DETECT_TIME * multiply,
+        'pfc_wd_restore_time': PFCWD_DEFAULT_RESTORE_TIME * multiply,
+        'pfc_wd_restore_time_large': 3000,
+        'pfc_wd_poll_time': poll_interval
+    }
+
+    logger.info(f"Port count: {port_num}, multiply factor: {multiply}, calculated PFC timers: {pfc_timers}")
+
+    return pfc_timers
 
 
 def select_test_ports(test_ports):

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -7,6 +7,7 @@ from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts      
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.pfc_storm import PFCStorm
 from tests.common.helpers.pfcwd_helper import start_wd_on_ports, start_background_traffic     # noqa: F401
+from tests.common.helpers.pfcwd_helper import calculate_pfcwd_default_timers
 
 from tests.common.plugins.loganalyzer import DisableLogrotateCronContext
 from tests.common.helpers.pfcwd_helper import send_background_traffic
@@ -72,6 +73,9 @@ def pfcwd_timer_setup_restore(setup_pfc_test, enum_fanout_graph_facts, duthosts,
     test_ports = setup_info['test_ports']
     timers = setup_info['pfc_timers']
     eth0_ip = setup_info['eth0_ip']
+    dynamic_timers = calculate_pfcwd_default_timers(duthost)
+    logger.info(f"Updating timers: original={timers}, dynamic={dynamic_timers}")
+    timers.update(dynamic_timers)
     # In Python2, dict.keys() returns list object, but in Python3 returns an iterable but not indexable object.
     # So that convert to list explicitly.
     pfc_wd_test_port = list(test_ports.keys())[0]
@@ -81,7 +85,7 @@ def pfcwd_timer_setup_restore(setup_pfc_test, enum_fanout_graph_facts, duthosts,
     fanout = fanouthosts
     peer_params = populate_peer_info(asic_type, neighbors, fanout_info, pfc_wd_test_port)
     storm_handle = set_storm_params(dut, fanout_info, fanout, peer_params)
-    timers['pfc_wd_restore_time'] = 400
+    dut.command("pfcwd interval {}".format(timers['pfc_wd_poll_time']))
     start_wd_on_ports(dut, pfc_wd_test_port, timers['pfc_wd_restore_time'],
                       timers['pfc_wd_detect_time'])
     # enable routing from mgmt interface to localhost


### PR DESCRIPTION
Summary: Calculate PFC watchdog timers dynamically based on port count
Fixes # 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
On sonic-mgmt side, the `test_pfcwd_timer_accuracy` case used hardcoded timer values (detection=400ms, restoration=400ms, poll=400ms).
On the DUT side, the actual PFC watchdog timers is dynamic calculated based on the ports number by "pfcwd start_default" in sonic-utilities.
It cause pfcwd timer is mismatch between the test's expected values and the real device behavior.

The dynamic calculation method from the sonic-utilities pfcwd start_default logic:
https://github.com/sonic-net/sonic-utilities/blob/fb3d73db/pfcwd/main.py#L402
```
  multiply = max(1, (port_num - 1) // 32 + 1)
  detection_time = 200 * multiply
  restoration_time = 200 * multiply
  poll_interval = min(200 * multiply, 1000)
```

#### How did you do it?
Update test_pfcwd_timer_accuracy case to generate generate pfcwd timers threshold dynamically

#### How did you verify/test it?
Regression test pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
