### PR TITLE
Enhancement: detect duplicate entries in conditional mark YAML files

### DIFF
--- a/.hooks/pre_commit_hooks/check_conditional_mark_sort.py
+++ b/.hooks/pre_commit_hooks/check_conditional_mark_sort.py
@@ -14,6 +14,24 @@ def main():
                 for line in file_contents:
                     if re.match('^[a-zA-Z]', line):
                         conditions.append(line.strip().rstrip(":"))
+
+                seen = set()
+                duplicates = set()
+                for cond in conditions:
+                    if cond in seen:
+                        duplicates.add(cond)
+                    else:
+                        seen.add(cond)
+
+                if duplicates:
+                    print("Duplicate entries found in conditional mark YAML file")
+                    print("===========================================================================")
+                    print("File: {}".format(stage_file))
+                    print("===========================================================================")
+                    print("Duplicate entries: {}".format(sorted(duplicates)))
+                    print("===========================================================================")
+                    return 1
+
                 sorted_conditions = conditions[:]
                 sorted_conditions.sort()
                 for i in range(len(conditions)):


### PR DESCRIPTION
Add duplicate entry detection to the conditional mark pre-commit hook.

Currently, duplicated entries silently overwrite earlier ones. This change fails the check when duplicates are present to avoid configuration mistakes.

Fixes #22086