### PR TITLE
[202511] Skip test_qos_dscp_mapping for topos t1-isolated-[d32|d128]

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4264,11 +4264,12 @@ qos/test_pfc_pause.py::test_pfc_pause_lossless:
 
 qos/test_qos_dscp_mapping.py:
   skip:
-    reason: "ECN marking in combination with tunnel decap not yet supported. Test is also skipped on KVM since it is run in nightly."
+    reason: "ECN marking in combination with tunnel decap not yet supported. Test is also skipped on KVM since it is run in nightly. / Test does not apply to topos with no T2 uplinks (t1-isolated-d32, t1-isolated-d128)"
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['cisco-8000'] and platform.startswith('x86_64-8122_')"
       - "asic_type in ['vs']"
+      - "topo_name in ['t1-isolated-d32', 't1-isolated-d128']"
 
 qos/test_qos_dscp_mapping.py::TestQoSSaiDSCPQueueMapping_IPIP_Base::test_dscp_to_queue_mapping[pipe:
   skip:


### PR DESCRIPTION
The test does not apply to topos without T2 uplinks such as those.

### Description of PR
The test doesn't apply when the topology doesn't have T2 uplinks.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type:

### Tested branches
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Test results

Results of running the tests in a `t1-isolated-d128` cluster with `202511` code:
```
===========================================================================================================================
short test summary info
============================================================================================================================
SKIPPED [1] qos/test_qos_dscp_mapping.py: ECN marking in combination
with tunnel decap not yet supported. Test is also skipped on KVM since
it is run in nightly. / Test does not apply to topos with no T2 uplinks
(t1-isolated-d32, t1-isolated-d128)
SKIPPED [1] qos/test_qos_dscp_mapping.py: Pipe decap mode not supported
due to either SAI or platform limitation / M* topo does not support qos
========================================================================================================================
2 skipped, 4 warnings in 8.05s
  ========================================================================================================================
```
This confirms the test is skipped. Without the changes in this PR, the test doesn't get skipped and fails.

### Approach
#### What is the motivation for this PR?

Previously, when a test setup had T2 uplinks, the test didn't execute anything since the test parameter inner_dst_ip_list would be empty. However, the PR https://github.com/sonic-net/sonic-mgmt/pull/20429 added a range expression with three arguments (L357), which causes the test to fail with a ValueError when the size of that list is zero.

#### How did you do it?

This change makes the test be explicitly skipped for those topos.

#### How did you verify/test it?

I ran the test with these changes in a
sonicmgmt.qspf-o128.t1-isolated-d128 cluster and confirmed it's
skipped:
```
===========================================================================================================================
short test summary info
============================================================================================================================
SKIPPED [1] qos/test_qos_dscp_mapping.py: ECN marking in combination
with tunnel decap not yet supported. Test is also skipped on KVM since
it is run in nightly. / Test does not apply to topos with no T2 uplinks
(t1-isolated-d32, t1-isolated-d128)
SKIPPED [1] qos/test_qos_dscp_mapping.py: Pipe decap mode not supported
due to either SAI or platform limitation / M* topo does not support qos
========================================================================================================================
2 skipped, 4 warnings in 8.05s
  ========================================================================================================================
```

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
