### PR TITLE
[202511][http] Add support for IPv6 mgmt ip in test_http_copy

### DIFF
--- a/tests/http/start_http_server_ipv6.py
+++ b/tests/http/start_http_server_ipv6.py
@@ -7,8 +7,10 @@ PORT = 8080
 
 Handler = http.server.SimpleHTTPRequestHandler
 
+
 class IPv6TCPServer(socketserver.TCPServer):
     address_family = socket.AF_INET6
+
 
 httpd = IPv6TCPServer(("::", PORT, 0, 0), Handler)
 

--- a/tests/http/start_http_server_ipv6.py
+++ b/tests/http/start_http_server_ipv6.py
@@ -1,0 +1,16 @@
+import http.server
+import socket
+import socketserver
+
+PORT = 8080
+
+
+Handler = http.server.SimpleHTTPRequestHandler
+
+class IPv6TCPServer(socketserver.TCPServer):
+    address_family = socket.AF_INET6
+
+httpd = IPv6TCPServer(("::", PORT, 0, 0), Handler)
+
+print("serving at port", PORT)
+httpd.serve_forever()

--- a/tests/http/test_http_copy.py
+++ b/tests/http/test_http_copy.py
@@ -3,6 +3,7 @@ import pytest
 import time
 import tempfile
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.devices.multi_asic import MultiAsicSonicHost
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
@@ -15,19 +16,25 @@ SONIC_SSH_REGEX = "OpenSSH_[\\w\\.]+ Debian"
 HTTP_PORT = "8080"
 TEST_FILE_NAME = ""
 
-local_start_server_filename = "http/start_http_server.py"
-ptf_start_server_filename = "/tmp/start_http_server.py"
-local_stop_server_filename = "http/stop_http_server.py"
-ptf_stop_server_filename = "/tmp/stop_http_server.py"
+LOCAL_START_SERVER_FILENAME = "http/start_http_server.py"
+LOCAL_START_SERVER_FILENAME_IPV6 = "http/start_http_server_ipv6.py"
+PTF_START_SERVER_FILENAME = "/tmp/start_http_server.py"
+LOCAL_STOP_SERVER_FILENAME = "http/stop_http_server.py"
+PTF_STOP_SERVER_FILENAME = "/tmp/stop_http_server.py"
+
+
+def mgmt_ip_is_v6(duthost: MultiAsicSonicHost) -> bool:
+    return duthost.get_mgmt_ip()['version'] == 'v6'
 
 
 @pytest.fixture(autouse=True)
-def setup_teardown(ptfhost):
+def setup_teardown(ptfhost, duthost):
     global TEST_FILE_NAME
 
     # Copies http server files to ptf
-    ptfhost.copy(src=local_start_server_filename, dest=ptf_start_server_filename)
-    ptfhost.copy(src=local_stop_server_filename, dest=ptf_stop_server_filename)
+    local_start_server_filename = LOCAL_START_SERVER_FILENAME_IPV6 if mgmt_ip_is_v6(duthost) else LOCAL_START_SERVER_FILENAME
+    ptfhost.copy(src=local_start_server_filename, dest=PTF_START_SERVER_FILENAME)
+    ptfhost.copy(src=LOCAL_STOP_SERVER_FILENAME, dest=PTF_STOP_SERVER_FILENAME)
 
     with tempfile.NamedTemporaryFile(prefix="http_copy_test_file", suffix=".bin") as test_file:
         TEST_FILE_NAME = os.path.basename(test_file.name)
@@ -37,7 +44,7 @@ def setup_teardown(ptfhost):
         yield
 
         # Delete files off ptf and ensure that files were removed
-        files_to_remove = [ptf_start_server_filename, ptf_stop_server_filename]
+        files_to_remove = [PTF_START_SERVER_FILENAME, PTF_STOP_SERVER_FILENAME]
 
         for file in files_to_remove:
             ptfhost.file(path=file, state="absent")
@@ -47,16 +54,24 @@ def test_http_copy(duthosts, rand_one_dut_hostname, ptfhost):
     """Test that HTTP (copy) can be used to download objects to the DUT"""
 
     duthost = duthosts[rand_one_dut_hostname]
-    ptf_ip = ptfhost.mgmt_ip
+
+    if mgmt_ip_is_v6(duthost):
+        ptf_ip = ptfhost.mgmt_ipv6
+        curl_check_server_cmd = f"curl -6 [{ptf_ip}]:8080"
+        curl_copy_cmd = f"curl -O -6 [{ptf_ip}]:{HTTP_PORT}/{TEST_FILE_NAME}"
+    else:
+        ptf_ip = ptfhost.mgmt_ip
+        curl_check_server_cmd = f"curl {ptf_ip}:8080"
+        curl_copy_cmd = f"curl -O {ptf_ip}:{HTTP_PORT}/{TEST_FILE_NAME}"
 
     # Starts the http server on the ptf
-    ptfhost.command(f"python {ptf_start_server_filename}", module_async=True)
+    ptfhost.command(f"python {PTF_START_SERVER_FILENAME}", module_async=True)
 
     # Validate HTTP Server has started
     started = False
     tries = 0
     while not started and tries < 10:
-        if os.system("curl {}:8080".format(ptf_ip)) == 0:
+        if os.system(curl_check_server_cmd) == 0:
             started = True
         tries += 1
         time.sleep(1)
@@ -76,7 +91,7 @@ def test_http_copy(duthosts, rand_one_dut_hostname, ptfhost):
     orig_checksum = output.split()[0]
 
     # Have DUT request file from http server
-    duthost.command("curl -O {}:{}/{}".format(ptf_ip, HTTP_PORT, TEST_FILE_NAME))
+    duthost.command(curl_copy_cmd)
 
     # Validate file was received
     file_stat = duthost.stat(path="./{}".format(TEST_FILE_NAME))
@@ -91,13 +106,13 @@ def test_http_copy(duthosts, rand_one_dut_hostname, ptfhost):
     pytest_assert(orig_checksum == new_checksum, "Original file differs from file sent to the DUT")
 
     # Stops http server
-    ptfhost.command(f"python {ptf_stop_server_filename}")
+    ptfhost.command(f"python {PTF_STOP_SERVER_FILENAME}")
 
     # Ensure that HTTP server was closed
     started = True
     tries = 0
     while started and tries < 10:
-        if os.system("curl {}:8080".format(ptf_ip)) != 0:
+        if os.system(curl_check_server_cmd) != 0:
             started = False
         tries += 1
         time.sleep(1)

--- a/tests/http/test_http_copy.py
+++ b/tests/http/test_http_copy.py
@@ -30,8 +30,10 @@ def mgmt_ip_is_v6(duthost: MultiAsicSonicHost) -> bool:
 
 
 @pytest.fixture(autouse=True)
-def setup_teardown(ptfhost, duthost):
+def setup_teardown(ptfhost, duthosts, rand_one_dut_hostname):
     global TEST_FILE_NAME
+
+    duthost = duthosts[rand_one_dut_hostname]
 
     # Copies http server files to ptf
     local_start_server_filename = LOCAL_START_SERVER_FILENAME_IPV6 if mgmt_ip_is_v6(duthost) else LOCAL_START_SERVER_FILENAME

--- a/tests/http/test_http_copy.py
+++ b/tests/http/test_http_copy.py
@@ -5,11 +5,13 @@ import tempfile
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.devices.multi_asic import MultiAsicSonicHost
 
+
 pytestmark = [
     pytest.mark.disable_loganalyzer,
     pytest.mark.topology("any", "t1-multi-asic"),
     pytest.mark.device_type("vs"),
 ]
+
 
 SONIC_SSH_PORT = 22
 SONIC_SSH_REGEX = "OpenSSH_[\\w\\.]+ Debian"

--- a/tests/http/test_http_copy.py
+++ b/tests/http/test_http_copy.py
@@ -36,7 +36,8 @@ def setup_teardown(ptfhost, duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
 
     # Copies http server files to ptf
-    local_start_server_filename = LOCAL_START_SERVER_FILENAME_IPV6 if mgmt_ip_is_v6(duthost) else LOCAL_START_SERVER_FILENAME
+    local_start_server_filename = (LOCAL_START_SERVER_FILENAME_IPV6 if mgmt_ip_is_v6(duthost)
+                                   else LOCAL_START_SERVER_FILENAME)
     ptfhost.copy(src=local_start_server_filename, dest=PTF_START_SERVER_FILENAME)
     ptfhost.copy(src=LOCAL_STOP_SERVER_FILENAME, dest=PTF_STOP_SERVER_FILENAME)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
When --mgmtIpv6Only is set, create a test HTTP server that uses IPv6.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

http/test_http_copy.py creates an HTTP server on the test server. By default, it creates an IPv4-only server, which the test dut can't talk to through an IPv6 mgmt IP, so the test fails when the option `--mgmtIpv6Only` is set.

#### How did you do it?

I updated the test such that it creates an Ipv6 server when the test is run with `--mgmtIpv6Only`.
I also made some style fixes, like putting constants in all caps.

#### How did you verify/test it?

To test it, I ran http/test_http_copy.py in two clusters, one with --mgtmIpv6Only and one without, using duts that consistently hit the bug. The test passes for both.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
