### PR TITLE
[202511][sflow] Parse Agent ID strings into ipaddress objects

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/sflow_test.py
+++ b/ansible/roles/test/files/ptftests/py3/sflow_test.py
@@ -22,6 +22,7 @@
             --socket-recv-size 16384
 """
 
+import ipaddress
 import ptf
 import json
 from ptf.base_tests import BaseTest
@@ -210,10 +211,11 @@ class SflowTest(BaseTest):
             counter_sample[intf] = 0
         self.assertTrue(data['total_counter_count'] > 0,
                         "No counter packets are received in collector %s" % collector)
+        agent_id = ipaddress.ip_address(self.agent_id)
         for i in range(1, data['total_counter_count']+1):
-            rcvd_agent_id = port_sample[collector]['CounterSample'][i]['agent_id']
+            rcvd_agent_id = ipaddress.ip_address(port_sample[collector]['CounterSample'][i]['agent_id'])
             self.assertTrue(
-                rcvd_agent_id == self.agent_id,
+                rcvd_agent_id == agent_id,
                 "Agent id in Sampled packet is not expected . Expected :  %s , received : %s"
                 % (self.agent_id, rcvd_agent_id))
             elements = port_sample[collector]['CounterSample'][i]['elements']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: In the sFlow ptftests, parse the Agent IDs into ipaddress objects for more accurate comparison between expected and actual values.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

In the sFlow ptftests, the Agent IDs, which are IP addresses, are compared as strings. This causes problems in `--mgmtIpv6Only` setups, since this comparison doesn't recognize normalized and fully-expanded IPv6 addresses as the same.

#### How did you do it?

This change transforms the strings into `IPv6Address`/`IPv4Address` object from the `ipaddress` library, so that the comparison will be accurate.

#### How did you verify/test it?

I confirmed in a Pikez M0 cluster with `--mgmtIpv6Only` that this change fixes the test.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
