### PR TITLE
Add new fields in DASH_HA_GLOBAL_CONFIG

### DIFF
--- a/tests/ha/conftest.py
+++ b/tests/ha/conftest.py
@@ -608,7 +608,8 @@ def generate_ha_config_for_dut(switch_id: int, duthost, peer_duthost, tbinfo):
                 "dp_channel_src_port_min": "7001",
                 "dp_channel_src_port_max": "7010",
                 "dp_channel_probe_interval_ms": "500",
-                "vnet_name": "Vnet_55",
+                "dpu_vnet": "Vnet_55",
+                "dpu_vlan": "Vlan55",
                 "dp_channel_probe_fail_threshold": "5"
             }
         },


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Right now, HAmgrd expect dpu_vnet and dpu_vlan in DASH_HA_GLOBAL_CONFIG.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
