### PR TITLE
fix(generate_golden_config_db): skip zebra_nexthop injection if YANG unsupported

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -639,7 +639,17 @@ class GenerateGoldenConfigDBModule(object):
 
         sonic_cfggen does not parse ZebraNexthop from minigraph, so we read
         the XML directly and set it via the golden_config_db override mechanism.
+
+        Only injects the value if the installed YANG model supports zebra_nexthop
+        (older KVM images may not have this leaf, causing YANG validation failures).
         """
+        # Check if the installed YANG schema supports zebra_nexthop before injecting.
+        # Older images may lack this leaf, causing load_minigraph --override_config to
+        # fail YANG validation. This mirrors the pattern used in update_zmq_config().
+        rc, yang_content, _ = self.module.run_command(
+            "sudo cat /usr/local/yang-models/sonic-device_metadata.yang")
+        if rc != 0 or "zebra_nexthop" not in yang_content:
+            return config
         zebra_nexthop = self._parse_zebra_nexthop_from_minigraph()
         if zebra_nexthop is None:
             return config


### PR DESCRIPTION
Fix `DEPLOY_MINIGRAPH_FAILED` on KVM virtual testbeds caused by PR #22763 unconditionally injecting `zebra_nexthop` into `golden_config_db.json`. On KVM images running branch 202311 (which lack the `zebra_nexthop` leaf in `sonic-device_metadata.yang`), YANG validation fails during `config load_minigraph --override_config`.

**Note: This is not a code bug per se.** The root cause is a mismatch between the sonic-mgmt branch and the SONiC image branch used on KVM testbeds — the correct fix is to ensure the same branch is used for both sonic-mgmt and the SONiC image. This PR adds a defensive YANG model check to avoid test infrastructure failures when such a branch mismatch occurs.

### Description of PR

Summary:
Fixes DEPLOY_MINIGRAPH_FAILED on KVM t0 virtual testbeds.

PR #22763 introduced `update_zebra_nexthop_config()` in `ansible/library/generate_golden_config_db.py`, which unconditionally injects `zebra_nexthop: disabled` into `DEVICE_METADATA.localhost` in `golden_config_db.json`. On KVM testbeds running image `internal-202311.129953908-e9f1b1fb21`, the installed `sonic-device_metadata.yang` does not contain the `zebra_nexthop` leaf (it was added in 202511+). This causes YANG validation to fail:

```
sonic_yang(3):All Keys are not parsed in DEVICE_METADATA: dict_keys(['zebra_nexthop'])
/etc/sonic/golden_config_db.json fails YANG validation!
```

leading to `DEPLOY_MINIGRAPH_FAILED` in the prepare phase of every KVM test run.

**Root cause**: The KVM testbed was running a 202311 SONiC image while using a newer (202511+) sonic-mgmt. The proper fix is to align the sonic-mgmt branch with the SONiC image branch. This PR is a defensive workaround to prevent test infrastructure failures caused by such branch mismatches.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach

#### What is the motivation for this PR?
KVM virtual testbeds run image branch 202311. `sonic-device_metadata.yang` on 202311 does not have the `zebra_nexthop` leaf, which was only added in 202511. After PR #22763 was merged, `generate_golden_config_db.py` injects `zebra_nexthop` unconditionally, breaking YANG validation on any image that predates the leaf.

The correct long-term fix is to ensure sonic-mgmt branch and SONiC image branch are always aligned. This PR adds a backward-compatibility guard to tolerate mismatches and prevent test infrastructure failures in the interim.

#### How did you do it?
Added a YANG model check at the start of `update_zebra_nexthop_config()`, identical to the pattern in `update_zmq_config()` (L596):

```python
rc, yang_content, _ = self.module.run_command(
    "sudo cat /usr/local/yang-models/sonic-device_metadata.yang")
if rc != 0 or "zebra_nexthop" not in yang_content:
    return config
```

If the installed YANG model does not contain `zebra_nexthop`, the function returns early without modifying the config. On newer images (202511+) where the leaf is present, behavior is unchanged.

#### How did you verify/test it?
- Analyzed 4.2MB prepare log from failing KVM testbed (elastictest plan `69d806b864259d7df8aa687c`)
- Confirmed YANG validation error: `All Keys are not parsed in DEVICE_METADATA: dict_keys(['zebra_nexthop'])`
- Confirmed KVM image version from log: `internal-202311.129953908-e9f1b1fb21`
- Code change follows the same guard pattern already used in `update_zmq_config()`

#### Any platform specific information?
Affects KVM virtual testbeds (`vms-kvm-t0`) running 202311 images. Physical hardware is unaffected (newer images or `yang_config_validation: disable`).

#### Supported testbed topology if it's a new test case?
N/A — this is an infrastructure fix in the testbed preparation code, not a new test case.

### Documentation

N/A
