### PR TITLE
Override config in restore_test_env of GCU test_cacl.py

### DIFF
--- a/tests/generic_config_updater/test_cacl.py
+++ b/tests/generic_config_updater/test_cacl.py
@@ -49,7 +49,8 @@ def get_iptable_rules(duthost, ip_netns_namespace_prefix):
 @pytest.fixture(scope="module", autouse=True)
 def restore_test_env(duthosts, rand_one_dut_front_end_hostname):
     duthost = duthosts[rand_one_dut_front_end_hostname]
-    config_reload(duthost, config_source="minigraph", safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+    config_reload(duthost, config_source="minigraph", safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True,
+                  override_config=True)
     yield
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The fixture restore_test_env is to restore the config to the default, but it is actually not fully working on the testbed with golden_config because of missing override_config=True in the args.
This causes failure now on smartswitch testbed because if the default config is not overridden by the golden config, dhcp_server and dhcp_relay will be disabled after the reload and the critical service check will fail.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Bug fix in GCU test_cacl.py
#### How did you do it?
Override config in restore_test_env of GCU test_cacl.py
#### How did you verify/test it?
Run the test on SN4280 smartswitch testbed.
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
