### PR TITLE
Fix test_show_lldp_table: wait for LLDP convergence before assertion

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -14,7 +14,6 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 
-ESTABLISH_LLDP_NEIGHBOR_TIMEOUT = 90
 PORT_TOGGLE_TIMEOUT = 30
 
 def skip_test_for_multi_asic(duthosts,enum_rand_one_per_hwsku_frontend_hostname ):
@@ -219,10 +218,13 @@ class TestShowLLDP():
         dutHostGuest, mode, ifmode = setup_config_mode
         minigraph_neighbors = setup['minigraph_facts']['minigraph_neighbors']
 
+        lldp_table_result = {}
+
         def _lldp_table_ready():
-            table = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} show lldp table'.format(ifmode))['stdout']
+            lldp_table_result['output'] = dutHostGuest.shell(
+                'SONIC_CLI_IFACE_MODE={} show lldp table'.format(ifmode))['stdout']
             expected_intfs = lldp_interfaces['alias'] if mode == 'alias' else lldp_interfaces['interface']
-            return all(re.search(r'{}'.format(re.escape(intf)), table) for intf in expected_intfs)
+            return all(re.search(re.escape(intf), lldp_table_result['output']) for intf in expected_intfs)
 
         pytest_assert(
             wait_until(ESTABLISH_LLDP_NEIGHBOR_TIMEOUT, 10, 0, _lldp_table_ready),
@@ -231,7 +233,7 @@ class TestShowLLDP():
             )
         )
 
-        lldp_table = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} show lldp table'.format(ifmode))['stdout']
+        lldp_table = lldp_table_result['output']
         logger.info('lldp_table:\n{}'.format(lldp_table))
 
         if mode == 'alias':

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -14,6 +14,7 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 
+ESTABLISH_LLDP_NEIGHBOR_TIMEOUT = 90
 PORT_TOGGLE_TIMEOUT = 30
 
 def skip_test_for_multi_asic(duthosts,enum_rand_one_per_hwsku_frontend_hostname ):

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -218,6 +218,18 @@ class TestShowLLDP():
         dutHostGuest, mode, ifmode = setup_config_mode
         minigraph_neighbors = setup['minigraph_facts']['minigraph_neighbors']
 
+        def _lldp_table_ready():
+            table = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} show lldp table'.format(ifmode))['stdout']
+            expected_intfs = lldp_interfaces['alias'] if mode == 'alias' else lldp_interfaces['interface']
+            return all(re.search(r'{}'.format(re.escape(intf)), table) for intf in expected_intfs)
+
+        pytest_assert(
+            wait_until(ESTABLISH_LLDP_NEIGHBOR_TIMEOUT, 10, 0, _lldp_table_ready),
+            "LLDP table did not converge with all expected interfaces within {} seconds".format(
+                ESTABLISH_LLDP_NEIGHBOR_TIMEOUT
+            )
+        )
+
         lldp_table = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} show lldp table'.format(ifmode))['stdout']
         logger.info('lldp_table:\n{}'.format(lldp_table))
 


### PR DESCRIPTION
Fix `test_show_lldp_table` intermittent failure: the test called `show lldp table` exactly once with no retry, racing against `lldp-syncd`'s periodic force-repopulate window. This PR adds a `wait_until()` convergence loop to make the test robust.

### Description of PR

Summary:
Fixes intermittent failure in `iface_namingmode/test_iface_namingmode.py::TestShowLLDP::test_show_lldp_table`

`lldp-syncd` runs on a periodic cycle and performs a **force-repopulate** (deletes all `LLDP_ENTRY` table entries and re-adds them) whenever interface state changes. The old test code called `show lldp table` exactly once — if this call landed in the middle of a force-repopulate wave, the table contained only `eth0`, causing the assertion to fail.

**Root cause (confirmed from failure log, plan `69d724402e61bab317c440ff`):**
- `lldp-syncd` fired a force-repopulate for all 32 data ports at `06:18:47`
- The test's `show lldp table` call at `06:19:34` returned only `eth0` (`Total entries displayed: 1`)
- This is a **test robustness issue**, not a product code bug — the fix adds a proper convergence wait

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?
`test_show_lldp_table` failed intermittently because it read the LLDP table during `lldp-syncd`'s force-repopulate window. There is no way to prevent `lldp-syncd` from running its periodic cycle, so the test must be made resilient to it by waiting for the table to fully converge.

#### How did you do it?
Added a `_lldp_table_ready()` helper inside `test_show_lldp_table` that checks whether all expected interfaces are present in `show lldp table` output. Wrapped it with `wait_until(ESTABLISH_LLDP_NEIGHBOR_TIMEOUT=90, period=10, delay=0)` to poll every 10 seconds (matching the `lldp-syncd` update interval) for up to 90 seconds before proceeding to assertions.

Also added the `ESTABLISH_LLDP_NEIGHBOR_TIMEOUT = 90` module-level constant.

#### How did you verify/test it?
Root cause confirmed from the failure log: `lldp-syncd` syslog events show force-repopulate at `06:18:47`; the test's `show lldp table` at `06:19:34` returned only 1 entry (`Total entries displayed: 1`). The fix ensures the test waits for all entries to reappear before asserting.

#### Any platform specific information?
N/A — applies to any testbed running `iface_namingmode` tests.

#### Supported testbed topology if it's a new test case?
N/A (test case improvement, not a new test case)

### Documentation

N/A
