### PR TITLE
[topo] Support portless BMC topo in add/remove/renumber-topo

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -111,7 +111,7 @@
         state: started
         restart: no
         detach: True
-        network_mode: none
+        network_mode: "{{ mgmt_bridge if ptf_use_docker_network | default(false) else 'none' }}"
         capabilities:
           - net_admin
         privileged: yes
@@ -127,7 +127,7 @@
 
     - name: Create vlan ports for dut
       include_tasks: create_dut_port.yml
-      when: external_port is defined
+      when: "external_port is defined and 'bmc' not in topo"
       loop: "{{ duts_name.split(',') }}"
       loop_control:
         loop_var: dut_name
@@ -169,7 +169,8 @@
       pull: "{{ 'missing' if (ptf_modified | default(false) | bool) else 'always' }}"
       state: started
       restart: no
-      network_mode: none
+      network_mode: "{{ mgmt_bridge if ptf_use_docker_network | default(false) else 'none' }}"
+      networks: "{{ [{'name': mgmt_bridge, 'ipv4_address': ptf_ip | regex_replace('/.*', '')}] if ptf_use_docker_network | default(false) else omit }}"
       detach: True
       capabilities:
         - net_admin
@@ -209,16 +210,25 @@
 
   - name: Get dut ports
     include_tasks: get_dut_port.yml
+    when: "'bmc' not in topo"
     loop: "{{ duts_name.split(',') }}"
     loop_control:
       loop_var: dut_name
 
   - name: Create vlan ports for dut
     include_tasks: create_dut_port.yml
-    when: external_port is defined
+    when: "external_port is defined and 'bmc' not in topo"
     loop: "{{ duts_name.split(',') }}"
     loop_control:
       loop_var: dut_name
+
+  - name: Set default empty port lists for portless topo
+    set_fact:
+      duts_fp_ports: {}
+      duts_mgmt_port: []
+      duts_midplane_ports: {}
+      duts_inband_ports: {}
+    when: "'bmc' in topo"
 
   - debug: msg="{{ duts_fp_ports }}"
   - debug: msg="{{ duts_mgmt_port }}"
@@ -257,10 +267,10 @@
       dut_interfaces: "{{ dut_interfaces | default('') }}"
       multi_vrf: "{{ topo_is_multi_vrf }}"
       multi_vrf_data: "{{ convergence_data|default({}) }}"
-      topo_config: "{{ configuration }}"
+      topo_config: "{{ configuration | default({}) }}"
       is_vs_chassis: "{{ is_vs_chassis | default(false) }}"
     become: yes
-    when: not enable_async
+    when: not enable_async and "bmc" not in topo
 
   - name: Bind topology {{ topo }} to VMs. base vm = {{ VM_base }} (async mode)
     loop: "{{ VM_targets|flatten(levels=1) }}"
@@ -294,14 +304,14 @@
       dut_interfaces: "{{ dut_interfaces | default('') }}"
       multi_vrf: "{{ topo_is_multi_vrf }}"
       multi_vrf_data: "{{ convergence_data|default({}) }}"
-      topo_config: "{{ configuration }}"
+      topo_config: "{{ configuration | default({}) }}"
       is_vs_chassis: "{{ is_vs_chassis | default(false) }}"
     become: yes
     async: 3600
     poll: 0
     throttle: 50
     register: async_bind_vm
-    when: enable_async
+    when: enable_async and "bmc" not in topo
 
   - name: Wait for bind tasks to complete
     become: yes
@@ -345,7 +355,7 @@
 
   - name: Change MAC address for PTF interfaces
     include_tasks: ptf_change_mac.yml
-    when: topo != 'fullmesh'
+    when: topo != 'fullmesh' and not (ptf_use_docker_network | default(false))
 
   # ptf container may reuse the same ip address with a new random mac address
   # for ptf container's mgmt network interface, so we need to send gratuitous
@@ -394,6 +404,7 @@
     include_tasks: ptf_portchannel.yml
     vars:
       ptf_portchannel_action: start
+    when: "'bmc' not in topo"
 
   - name: Announce routes
     include_tasks: announce_routes.yml
@@ -401,6 +412,7 @@
       - topo != 'fullmesh'
       - not 'ptf' in topo
       - not 'cable' in topo
+      - not 'bmc' in topo
 
   - name: Start mux simulator
     include_tasks: control_mux_simulator.yml
@@ -416,6 +428,7 @@
 
   - name: Start tacacs+ daily daemon
     include_tasks: start_tacacs_daily_daemon.yml
+    when: not (ptf_use_docker_network | default(false))
 
   when: container_type == "PTF"
 

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -282,7 +282,7 @@
 
 - name: Setup external front port
   include_tasks: external_port.yml
-  when: external_port is defined
+  when: external_port is defined and "bmc" not in topo
 
 - name: Setup internal management network
   include_tasks: internal_mgmt_network.yml

--- a/ansible/roles/vm_set/tasks/remove_topo.yml
+++ b/ansible/roles/vm_set/tasks/remove_topo.yml
@@ -30,12 +30,22 @@
     include_tasks: ptf_portchannel.yml
     vars:
       ptf_portchannel_action: stop
+    when: "'bmc' not in topo"
 
   - name: Get duts ports
     include_tasks: get_dut_port.yml
+    when: "'bmc' not in topo"
     loop: "{{ duts_name.split(',') }}"
     loop_control:
       loop_var: dut_name
+
+  - name: Set default empty port lists for portless topo
+    set_fact:
+      duts_fp_ports: {}
+      duts_mgmt_port: []
+      duts_midplane_ports: {}
+      duts_inband_ports: {}
+    when: "'bmc' in topo"
 
   - name: Unbind topology {{ topo }} to VMs. base vm = {{ VM_base }}
     vm_topology:
@@ -56,7 +66,7 @@
       multi_vrf: "{{ topo_is_multi_vrf }}"
       multi_vrf_data: "{{ convergence_data|default({}) }}"
     become: yes
-    when: not enable_async
+    when: not enable_async and "bmc" not in topo
 
   - name: Unbind topology {{ topo }} to VMs. base vm = {{ VM_base }} (async mode)
     loop: "{{ VM_hosts | flatten(levels=1) }}"
@@ -85,7 +95,7 @@
     poll: 0
     throttle: 50
     register: async_unbind_vm
-    when: enable_async
+    when: enable_async and "bmc" not in topo
 
   - name: Wait for unbind tasks to complete
     become: yes
@@ -124,7 +134,7 @@
 
   - name: Remove duts ports
     include_tasks: remove_dut_port.yml
-    when: external_port is defined
+    when: "external_port is defined and 'bmc' not in topo"
     loop: "{{ duts_name.split(',') }}"
     loop_control:
       loop_var: dut_name

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -31,6 +31,7 @@
     include_tasks: ptf_portchannel.yml
     vars:
       ptf_portchannel_action: stop
+    when: "'bmc' not in topo"
 
   - name: Kill exabgp and ptf_nn_agent processes in PTF container
     ptf_control:
@@ -60,6 +61,7 @@
 
   - name: Get dut ports
     include_tasks: get_dut_port.yml
+    when: "'bmc' not in topo"
     loop: "{{ duts_name.split(',') }}"
     loop_control:
       loop_var: dut_name
@@ -80,6 +82,7 @@
       max_fp_num: "{{ max_fp_num }}"
       is_vs_chassis: "{{ is_vs_chassis | default(false) }}"
     become: yes
+    when: "'bmc' not in topo"
 
   - name: Stop ptf container ptf_{{ vm_set_name }}
     docker_container:
@@ -117,7 +120,8 @@
       pull: yes
       state: started
       restart: yes
-      network_mode: none
+      network_mode: "{{ mgmt_bridge if ptf_use_docker_network | default(false) else 'none' }}"
+      networks: "{{ [{'name': mgmt_bridge, 'ipv4_address': ptf_ip | regex_replace('/.*', '')}] if ptf_use_docker_network | default(false) else omit }}"
       detach: True
       capabilities:
         - net_admin
@@ -146,10 +150,18 @@
 
   - name: Create vlan ports for dut
     include_tasks: create_dut_port.yml
-    when: external_port is defined
+    when: "external_port is defined and 'bmc' not in topo"
     loop: "{{ duts_name.split(',') }}"
     loop_control:
       loop_var: dut_name
+
+  - name: Set default empty port lists for portless topo
+    set_fact:
+      duts_fp_ports: {}
+      duts_mgmt_port: []
+      duts_midplane_ports: {}
+      duts_inband_ports: {}
+    when: "'bmc' in topo"
 
   - debug: msg="{{ duts_fp_ports }}"
   - debug: msg="{{ duts_mgmt_port }}"
@@ -181,10 +193,11 @@
       netns_mgmt_ip_addr: "{{ netns_mgmt_ip if netns_mgmt_ip is defined else omit }}"
       is_vs_chassis: "{{ is_vs_chassis | default(false) }}"
     become: yes
+    when: "'bmc' not in topo"
 
   - name: Change MAC address for PTF interfaces
     include_tasks: ptf_change_mac.yml
-    when: topo != 'fullmesh'
+    when: topo != 'fullmesh' and not (ptf_use_docker_network | default(false))
 
   - name: Send arp ping packet to gw for flusing the ARP table
     command: docker exec -i ptf_{{ vm_set_name }} python -c "from scapy.all import *; arping('{{ mgmt_gw }}')"
@@ -198,12 +211,14 @@
     include_tasks: ptf_portchannel.yml
     vars:
       ptf_portchannel_action: start
+    when: "'bmc' not in topo"
 
   - name: Announce routes
     include_tasks: announce_routes.yml
     when:
       - topo != 'fullmesh'
       - not 'ptf' in topo
+      - not 'bmc' in topo
 
   - name: Start mux simulator
     include_tasks: control_mux_simulator.yml
@@ -219,5 +234,6 @@
 
   - name: Start tacacs+ daily daemon
     include_tasks: start_tacacs_daily_daemon.yml
+    when: not (ptf_use_docker_network | default(false))
 
   when: container_type == "PTF"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1234,11 +1234,13 @@ def vmhosts(enhance_inventory, ansible_adhoc, request, tbinfo):
     elif "servers" in tbinfo:
         for server in tbinfo["servers"].keys():
             vmhost = get_test_server_host(inv_files, server)
-            hosts.append(VMHost(ansible_adhoc, vmhost.name))
+            if vmhost:
+                hosts.append(VMHost(ansible_adhoc, vmhost.name))
     elif "server" in tbinfo:
         server = tbinfo["server"]
         vmhost = get_test_server_host(inv_files, server)
-        hosts.append(VMHost(ansible_adhoc, vmhost.name))
+        if vmhost:
+            hosts.append(VMHost(ansible_adhoc, vmhost.name))
     else:
         logger.info("No VM host exist for this topology: {}".format(tbinfo['topo']['name']))
     return hosts


### PR DESCRIPTION
### Description of PR
Support portless BMC (Baseboard Management Controller) topo in add/remove/renumber-topo playbooks.

BMC devices run SONiC but have no data-plane ports, no VMs, no VLAN trunking. The existing topo playbooks assume ports, VMs, and bridge binding exist, causing failures when deploying BMC testbeds.

This PR adds guards to skip port/VM-specific tasks for BMC topo and enables an optional Docker network mode (`ptf_use_docker_network`) for PTF container deployment on servers without a Linux management bridge.

### Summary
**Motivation:** Enable add-topo, remove-topo, and renumber-topo operations for BMC testbeds, which have no data-plane ports or VM neighbors.

**Implementation:**
- Guard dut port, vlan port, bind/unbind topology, ptf_change_mac, portchannel, announce_routes, and tacacs tasks for BMC topo
- Add `ptf_use_docker_network` host_var flag for Docker network PTF deployment (alternative to Linux bridge)
- Add default empty port lists (`duts_fp_ports`, `duts_mgmt_port`, `duts_midplane_ports`, `duts_inband_ports`) for portless topos
- Default `configuration` to `{}` for topos without VM config
- Skip external_port setup for BMC topo (prevents eno1 misconfiguration)
- Fix `vmhosts` fixture in conftest.py to handle testbeds without resolvable VM hosts

### Type of change
- Framework improvement

### Back port request
Not needed

### Approach
#### What is the motivation for this PR?
BMC devices are managed by SONiC but lack data-plane ports, VMs, BGP, syncd, and other switch-specific features. The topo playbooks fail with undefined variable errors when these features are assumed to exist.

#### How did you do it?
Added `when` guards to skip tasks that don't apply to BMC topo:
- `"bmc" not in topo` — for VM binding, portchannel, route announcement
- `device_vlan_map_list is defined` — for port-related tasks  
- `not (ptf_use_docker_network | default(false))` — for tasks that delegate to PTF host (unreachable when PTF is on a Docker network)

#### How did you verify/test it?
- Successfully ran add-topo, renumber-topo, and remove-topo on a BMC testbed
- Ran platform_tests/cli/test_show_platform.py — 2 passed, confirming test framework works with BMC
- Verified PTF container creation with Docker network mode
