### PR TITLE
Fix minigraph reload related tests for smartswitch

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -151,7 +151,8 @@ def config_reload_minigraph_with_rendered_golden_config_override(
         check_intf_up_ports=False, traffic_shift_away=False,
         golden_config_path=DEFAULT_GOLDEN_CONFIG_PATH,
         local_golden_config_template=GOLDEN_CONFIG_TEMPLATE,
-        dut_golden_config_template=None, remote_src=False, is_dut=True):
+        dut_golden_config_template=None, remote_src=False, is_dut=True,
+        safe_reload_ignored_dockers=[]):
     """
     This function facilitates new feature table testing without minigraph parser modification. It
     reloads the minigraph using a j2 file to render Golden Config, which overrides the ConfigDB.
@@ -180,7 +181,8 @@ def config_reload_minigraph_with_rendered_golden_config_override(
 
     config_reload(sonic_host, 'minigraph', wait, start_bgp, start_dynamic_buffer, safe_reload,
                   wait_before_force_reload, wait_for_bgp, check_intf_up_ports, traffic_shift_away,
-                  override_config=True, golden_config_path=golden_config_path, is_dut=is_dut)
+                  override_config=True, golden_config_path=golden_config_path, is_dut=is_dut,
+                  safe_reload_ignored_dockers=safe_reload_ignored_dockers)
 
 
 def pfcwd_feature_enabled(duthost):
@@ -196,7 +198,7 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
                   safe_reload=False, wait_before_force_reload=0, wait_for_bgp=False, wait_for_ibgp=True,
                   check_intf_up_ports=False, traffic_shift_away=False, override_config=False,
                   golden_config_path=DEFAULT_GOLDEN_CONFIG_PATH, is_dut=True, exec_tsb=False,
-                  yang_validate=True):
+                  yang_validate=True, safe_reload_ignored_dockers=[]):
     """
     reload SONiC configuration
     :param sonic_host: SONiC host object
@@ -306,9 +308,17 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
         pytest_assert(wait_until(200, 10, 0, sonic_host.is_critical_processes_running_per_asic_or_host, "database"),
                       "Database not start.")
         sonic_host.critical_services_tracking_list()
-        pytest_assert(wait_until(wait + 300, 20, 0, sonic_host.critical_services_fully_started),
-                      "All critical services should be fully started!")
-        wait_critical_processes(sonic_host)
+        if safe_reload_ignored_dockers:
+            original_critical_services = sonic_host.critical_services
+            sonic_host.sonichost.critical_services = \
+                [docker for docker in original_critical_services if docker not in safe_reload_ignored_dockers]
+        try:
+            pytest_assert(wait_until(wait + 300, 20, 0, sonic_host.critical_services_fully_started),
+                          "All critical services should be fully started!")
+            wait_critical_processes(sonic_host)
+        finally:
+            if safe_reload_ignored_dockers:
+                sonic_host.sonichost.critical_services = original_critical_services
         # After config load_minigraph, update-containers fires ~5s after the DNS config
         # change but slow-starting containers (e.g., restapi, 75-128s startup) may not
         # be running yet. Re-run update-containers now that all critical services are up

--- a/tests/golden_config_infra/test_config_reload_with_rendered_golden_config.py
+++ b/tests/golden_config_infra/test_config_reload_with_rendered_golden_config.py
@@ -84,10 +84,11 @@ def config_compare(golden_config, running_config):
             )
 
 
-def golden_config_override_with_general_template(duthost):
+def golden_config_override_with_general_template(duthost, safe_reload_ignored_dockers):
     # This is to copy and parse the default template: tests/common/templates/golden_config_db.j2
     config_reload_minigraph_with_rendered_golden_config_override(
-        duthost, safe_reload=True, check_intf_up_ports=True
+        duthost, safe_reload=True, check_intf_up_ports=True,
+        safe_reload_ignored_dockers=safe_reload_ignored_dockers
     )
     overrided_config = get_running_config(duthost)
     golden_config = json.loads(
@@ -97,14 +98,15 @@ def golden_config_override_with_general_template(duthost):
     config_compare(golden_config, overrided_config)
 
 
-def golden_config_override_with_specific_template(duthost):
+def golden_config_override_with_specific_template(duthost, safe_reload_ignored_dockers):
     # This is to copy and parse the template: tests/golden_config_infra/templates/sample_golden_config_db.j2
     base_dir = os.path.dirname(os.path.realpath(__file__))
     template_dir = os.path.join(base_dir, 'templates')
     golden_config_j2 = os.path.join(template_dir, 'sample_golden_config_db.j2')
     config_reload_minigraph_with_rendered_golden_config_override(
         duthost, safe_reload=True, check_intf_up_ports=True,
-        local_golden_config_template=golden_config_j2
+        local_golden_config_template=golden_config_j2,
+        safe_reload_ignored_dockers=safe_reload_ignored_dockers
     )
     overrided_config = get_running_config(duthost)
     golden_config = json.loads(
@@ -120,5 +122,11 @@ def test_rendered_golden_config_override(duthosts, rand_one_dut_hostname, setup_
         pytest.skip("Skip this test on multi-asic platforms, \
                     since golden config format here is not compatible with multi-asics")
 
-    golden_config_override_with_general_template(duthost)
-    golden_config_override_with_specific_template(duthost)
+    safe_reload_ignored_dockers = []
+    if duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_smartswitch"):
+        # These are the critical services that are not included in the golden config template
+        # nor the default config. After the minigraph load they will be disabled.
+        safe_reload_ignored_dockers = ["dhcp_relay", "dhcp_server"]
+
+    golden_config_override_with_general_template(duthost, safe_reload_ignored_dockers)
+    golden_config_override_with_specific_template(duthost, safe_reload_ignored_dockers)

--- a/tests/pfcwd/test_pfc_config.py
+++ b/tests/pfcwd/test_pfc_config.py
@@ -325,7 +325,11 @@ class TestDefaultPfcConfig(object):
             None
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-        config_reload(duthost, config_source='minigraph', safe_reload=True)
+        # For smartswitch, dhcp_server and dhcp_relay are disabled after the reload.
+        # We can safely ignore them as they are not critical to the test.
+        safe_reload_ignored_dockers = ['dhcp_server', 'dhcp_relay']
+        config_reload(duthost, config_source='minigraph', safe_reload=True,
+                      safe_reload_ignored_dockers=safe_reload_ignored_dockers)
         # sleep 20 seconds to make sure configuration is loaded
         time.sleep(20)
         res = duthost.command('pfcwd show config')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
On smartsiwtch, when the test loads minigraph with the golden config specified in the test(which is actually empty), the dhcp_server and dhcp_relay will be disabled as they are not in the golden config nor in the default config.
Exclude them from the critical services to pass the check in config_reload method.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Fix 2 tests for smartswitch:
1. test test_config_reload_with_rendered_golden_config.py
2. tests/pfcwd/test_pfc_config.py
#### How did you do it?
1. Introduce a new arg **safe_reload_ignored_dockers** in the common config_reload method, the dockers in this list will be ignore in the critical services check when safe_reload. The way to ignore them is by updating the critical_services attribute of the sonichost, and recover it after the check.
2. Add the dhcp_server,dhcp_relay dockers to the ignore list in test test_config_reload_with_rendered_golden_config.py when it's running on smartswitch.
3. Add the dhcp_server,dhcp_relay dockers to the ignore list in test test_pfc_config.py statically as it's not relevant to the test purpose.
#### How did you verify/test it?
Run the test test_config_reload_with_rendered_golden_config.py and test_pfc_config.py on SN4280 smartswitch testbed.
#### Any platform specific information?
The change is for smartswitch but it can be also utilized for similar situations. 
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
