### PR TITLE
Fix float division causing invalid cable length in test_exceeding_headroom

### DIFF
--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -2539,13 +2539,13 @@ def test_exceeding_headroom(duthosts, rand_one_dut_hostname,
 
         # Find the exact point from which the accumulative headroom starts to exceed the limit via using binary seach
         cable_length_upper = cable_length
-        cable_length_step /= 2
+        cable_length_step //= 2
         cable_length -= cable_length_step
         cable_length_lower = cable_length
         logging.info("Cable length {} can be applied but {} can't. Finding the exact maximum cable length"
                      .format(cable_length_lower, cable_length_upper))
         while True:
-            cable_length = (cable_length_upper + cable_length_lower) / 2
+            cable_length = (cable_length_upper + cable_length_lower) // 2
             duthost.shell(
                 'config interface cable-length {} {}m'.format(port_to_test, cable_length))
             expected_profile = make_expected_profile_name(


### PR DESCRIPTION
Summary: Fix float division causing invalid cable length in test_exceeding_headroom
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
In Python 3, the `/` operator returns a float, causing cable length values like "473.0m" to be sent to `config interface cable-length`. The YANG validation rejects this as an invalid cable length format.

#### How did you do it?
- Change `cable_length_step /= 2` to `cable_length_step //= 2`
- Change `(cable_length_upper + cable_length_lower) / 2` to `// 2`

This ensures cable length values remain integers throughout the binary
search, producing valid formats like "473m" instead of "473.0m".

#### How did you verify/test it?
Regression pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
