### PR TITLE
Enhance and harden test_console_stress.py

### DIFF
--- a/tests/dut_console/test_console_stress.py
+++ b/tests/dut_console/test_console_stress.py
@@ -1,3 +1,5 @@
+import hashlib
+
 import pytest
 from tests.common.helpers.assertions import pytest_assert
 
@@ -30,7 +32,7 @@ def test_console_stress_output(duthost_console):
     num_lines = 1000
     output = duthost_console.send_command(
         f"python3 -c \"for i in range({num_lines}): print(f'LINE_{{i:04d}}: ' + '0123456789' * 10)\"",
-        max_loops=300
+        read_timeout=300
     )
 
     # Parse output into lines
@@ -75,15 +77,16 @@ def test_console_stress_input(duthost_console):
     # Use 100,000 characters: 10,000 repetitions of '0123456789'
     large_string = '0123456789' * 10000  # 100,000 chars
 
-    # Send the large string via echo and capture the output
-    output = duthost_console.send_command(
-        f"echo '{large_string}'",
-        max_loops=300
+    expected_hash = hashlib.md5(large_string.encode()).hexdigest()
+    output = duthost_console.send_command_timing(
+        f"echo -n '{large_string}' | md5sum",
+        read_timeout=300,
+        last_read=2.0
     )
 
-    # Verify the output matches what we sent
-    pytest_assert(output.strip() == large_string,
-                  f"Echo output mismatch: expected {len(large_string)} chars, got {len(output.strip())} chars")
+    pytest_assert(expected_hash in output,
+                  f"Input integrity check failed: md5sum of echoed 100K chars "
+                  f"expected {expected_hash}, console returned: {output!r}")
 
     # Verify console is still responsive
     response = duthost_console.send_command("echo test_responsive")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR makes improvements and hardens `test_console_stress.py`

Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/23818

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

`test_console_stress.py` is a new test case recently introduced and has been failing consistently on Nexthop devices.

#### How did you do it?
Test was using `max_loops=300`, coupled with the default `loop_delay` of `0.025` only waits for 7.5 secs before timing out in `test_console_stress_output`. Changed it to `read_timeout=300` to increase timeout allowance and also `max_loops` is being deprecated according to Netniko docs.
<img width="1329" height="734" alt="Screenshot 2026-04-09 at 8 43 31 PM" src="https://github.com/user-attachments/assets/62205d97-b5fb-4ed2-9cda-92e8ec75c041" />

Replaced `send_command` with send_command_timing in `test_console_stress_input` because `send_command` internally calls `command_echo_read()` with a hardcoded 10-second timeout that cannot be overridden. The 100,000-character echo command takes longer than 10 seconds to echo back over console, causing a `ReadTimeout` before the actual output is ever read. `send_command_timing` skips echo matching entirely, avoiding this limitation. Since `send_command_timing` returns the raw channel output (command echo + output + prompt), the test now strips the command echo and prompt before verifying the payload.

#### How did you verify/test it?
previously when the test was failing:
```
dut_console/test_console_stress.py::test_console_stress_output
-------------------------------- live log call ---------------------------------
09/04/2026 09:57:30 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
  File "/opt/venv/lib/python3.12/site-packages/_pytest/python.py", line 1720, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/opt/venv/lib/python3.12/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/pluggy/_callers.py", line 167, in _multicall
    raise exception
  File "/opt/venv/lib/python3.12/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/_pytest/python.py", line 166, in pytest_pyfunc_call
    result = testfunction(**testargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/AzDevOps/sonic-mgmt/tests/dut_console/test_console_stress.py", line 31, in test_console_stress_output
    output = duthost_console.send_command(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/netmiko/base_connection.py", line 111, in wrapper_decorator
    return_val = func(self, *args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/netmiko/utilities.py", line 667, in wrapper_decorator
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/netmiko/base_connection.py", line 1841, in send_command
    raise ReadTimeout(msg)
netmiko.exceptions.ReadTimeout: 
Pattern not detected: 'admin:\\~\\$' in output.

Things you might try to fix this:
1. Explicitly set your pattern using the expect_string argument.
2. Increase the read_timeout to a larger value.

You can also look at the Netmiko session_log or debug log for more information.



FAILED                                                                   [ 50%]
dut_console/test_console_stress.py::test_console_stress_input
-------------------------------- live log call ---------------------------------
09/04/2026 09:57:41 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
  File "/opt/venv/lib/python3.12/site-packages/_pytest/python.py", line 1720, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/opt/venv/lib/python3.12/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/pluggy/_callers.py", line 167, in _multicall
    raise exception
  File "/opt/venv/lib/python3.12/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/_pytest/python.py", line 166, in pytest_pyfunc_call
    result = testfunction(**testargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/AzDevOps/sonic-mgmt/tests/dut_console/test_console_stress.py", line 79, in test_console_stress_input
    output = duthost_console.send_command(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/netmiko/base_connection.py", line 111, in wrapper_decorator
    return_val = func(self, *args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/netmiko/utilities.py", line 667, in wrapper_decorator
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/netmiko/base_connection.py", line 1791, in send_command
    new_data = self.command_echo_read(cmd=cmd, read_timeout=10)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/netmiko/base_connection.py", line 1494, in command_echo_read
    new_data = self.read_until_pattern(
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/netmiko/base_connection.py", line 755, in read_until_pattern
    raise ReadTimeout(msg)
netmiko.exceptions.ReadTimeout: 

Pattern not detected: "echo\\ '012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
...
```

On Nexthop devices, with the fix:

<img width="1160" height="322" alt="Screenshot 2026-04-09 at 8 57 18 PM" src="https://github.com/user-attachments/assets/0da798b1-8dc0-4a7d-b3c7-f9ad0a1d9927" />


```
09/04/2026 21:57:57 base_connection.read_channel             L0652 DEBUG  | read_channel: 
09/04/2026 21:57:57 base_connection.find_prompt              L1462 DEBUG  | [find_prompt()]: prompt is admin:~$
09/04/2026 21:57:57 base_connection.wrapper_decorator        L0128 DEBUG  | write_channel: b'python3 -c "for i in range(1000): print(f\'LINE_{i:04d}: \' + \'0123456789\' * 10)"\n'
...
09/04/2026 21:57:58 base_connection.read_channel             L0652 DEBUG  | read_channel: python3 -c "for i in range(1000): print(f'LINE_{i:04d}: ' + '0123456789' * 10)"
...
09/04/2026 21:57:58 base_connection.read_until_pattern       L0743 DEBUG  | Pattern found: (python3\ \-c\ "for\ i\ in\ range\(1000\):\ print\(f'LINE_\{i:04d\}:\ '\ \+\ '0123456789'\ \*\ 10\)") admin:~$ python3 -c "for i in range(1000): print(f'LINE_{i:04d}: ' + '0123456789' * 10)"
...
09/04/2026 21:57:58 base_connection.read_channel             L0652 DEBUG  | read_channel: LINE_0000: 0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
LINE_0001: 0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
LINE_0002: 0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
LINE_0003: 0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
LINE_0004: 0123456789012345678901234567890123456789012345678
...
9/04/2026 21:59:56 base_connection.read_channel             L0652 DEBUG  | read_channel: 1234567890123456789
LINE_0997: 0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
LINE_0998: 0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
LINE_0999: 0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
...
09/04/2026 21:59:56 base_connection.read_channel             L0652 DEBUG  | read_channel: echo test_responsive
test_responsive

09/04/2026 21:59:56 base_connection.read_until_pattern       L0743 DEBUG  | Pattern found: (echo\ test_responsive) echo test_responsive
09/04/2026 21:59:56 base_connection.read_channel             L0652 DEBUG  | read_channel: 
09/04/2026 21:59:56 base_connection.read_channel             L0652 DEBUG  | read_channel: 
09/04/2026 21:59:56 base_connection.read_channel             L0652 DEBUG  | read_channel: 
```

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
