### PR TITLE
Skip test instead of failing when IPv6 mgmt IP is unavailable

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -834,10 +834,10 @@ def duthosts_ipv6_mgmt_only(duthosts, backup_and_restore_config_db_on_duts):
                     finally:
                         ssh_client.close()
 
-        pt_assert(len(ipv6_address[duthost.hostname]) > 0,
-                  f"{duthost.hostname} doesn't have IPv6 Management IP address")
-        pt_assert(has_available_ipv6_addr,
-                  f"{duthost.hostname} doesn't have available IPv6 Management IP address")
+        if not ipv6_address[duthost.hostname]:
+            pytest.skip(f"{duthost.hostname} doesn't have IPv6 Management IP address")
+        if not has_available_ipv6_addr:
+            pytest.skip(f"{duthost.hostname} doesn't have available IPv6 Management IP address")
 
     # Remove IPv4 mgmt-ip
     for duthost in duthosts.nodes:


### PR DESCRIPTION
Summary: Skip test instead of failing when IPv6 mgmt IP is unavailable
Fixes # 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
If DUT doesn't have IPv6 Management IP address or doesn't have available IPv6 Management IP address, the case should be skipped instead of fail

#### How did you do it?
Update code to skip the case when no doesn't have IPv6 Management IP address or doesn't have available IPv6 Management IP address.

#### How did you verify/test it?
Regression pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
