### PR TITLE
Add wait_for_bgp to config_reload in golden config test to avoid memory check failure

### DIFF
--- a/tests/golden_config_infra/test_config_reload_with_rendered_golden_config.py
+++ b/tests/golden_config_infra/test_config_reload_with_rendered_golden_config.py
@@ -49,7 +49,7 @@ def setup_env(duthosts, rand_one_dut_hostname, tbinfo):
         backup_config(duthost, GOLDEN_CONFIG, GOLDEN_CONFIG_BACKUP)
 
     # Reload test env with minigraph
-    config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
 
     yield
 
@@ -64,7 +64,7 @@ def setup_env(duthosts, rand_one_dut_hostname, tbinfo):
         duthost.file(path=GOLDEN_CONFIG, state='absent')
 
     # Restore config before test
-    config_reload(duthost)
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
 
 
 def config_compare(golden_config, running_config):


### PR DESCRIPTION
Summary: Add wait_for_bgp to config_reload in golden config test to avoid memory check failure
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
After config_reload, BGP sessions need time to fully converge. During this period, memory usage is transiently elevated. Without waiting for BGP to come up, the memory utilization plugin may capture this transient spike and report a false ALARM.

#### How did you do it?
Add `wait_for_bgp=True` (along with safe_reload and check_intf_up_ports) to both config_reload calls in the setup_env fixture of test_config_reload_with_rendered_golden_config.py.

#### How did you verify/test it?
Regression pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
