### PR TITLE
Add multi-VRF topology conversion in conftest.py to support direct pytest invocation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import logging
 import random
 import re
 import sys
+import shutil
 
 import pytest
 import yaml
@@ -388,6 +389,79 @@ def pytest_configure(config):
             config.pluginmanager.register(MacsecPluginT2())
         else:
             config.pluginmanager.register(MacsecPluginT0())
+    converge_topo_if_needed(config)
+
+
+def _load_testbed_config(tbfile, tbname):
+    """Load testbed configuration from file"""
+    with open(tbfile, 'r') as f:
+        testbed_data = yaml.safe_load(f)
+
+    for tb in testbed_data:
+        if tb.get('conf-name') == tbname:
+            return tb
+
+    logger.warning(f"Testbed '{tbname}' not found in '{tbfile}'")
+    return
+
+
+def converge_topo_if_needed(config):
+    tbname = config.getoption("testbed")
+    tbfile = config.getoption("testbed_file")
+    if tbname is None or tbfile is None:
+        return
+    try:
+        tb_config = _load_testbed_config(tbfile, tbname)
+        use_converged_peers = tb_config.get('use_converged_peers', False)
+        if not use_converged_peers:
+            logger.info(f"use_converged_peers=False for testbed '{tbname}', skipping converge")
+            return
+        logger.info(f"use_converged_peers=True for testbed '{tbname}', starting converge...")
+
+        topo_name = tb_config.get('topo', '').strip()
+        if not topo_name:
+            logger.warning(f"No valid topo name found in testbed '{tbname}', skipping converge")
+            return
+
+        tests_dir = os.path.dirname(os.path.abspath(__file__))
+        ansible_dir = os.path.join(os.path.dirname(tests_dir), "ansible")
+        vars_dir = os.path.join(ansible_dir, "vars")
+        topo_file = os.path.join(vars_dir, f"topo_{topo_name}.yml")
+        backup_file = f"{topo_file}.bak"
+
+        if not os.path.exists(topo_file):
+            logger.warning(f"Topo file not found: {topo_file}")
+            return
+
+        original_stat = os.stat(topo_file)
+        original_mode = original_stat.st_mode
+        original_uid = original_stat.st_uid
+        original_gid = original_stat.st_gid
+
+        if os.path.exists(backup_file):
+            logger.info("Backup file exists, recovering original topo file")
+            shutil.copy(backup_file, topo_file)
+        else:
+            logger.info(f"Creating backup: {backup_file}")
+            shutil.copy(topo_file, backup_file)
+
+        converger_path = os.path.join(ansible_dir, "ceos_topo_converger.py")
+        spec = importlib.util.spec_from_file_location("ceos_topo_converger", converger_path)
+        ceos_module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(ceos_module)
+
+        ceos_module.converge_testbed(backup_file, topo_file)
+        logger.info(f"✓ Topology '{topo_name}' converged successfully")
+
+        os.chmod(topo_file, original_mode)
+        os.chown(topo_file, original_uid, original_gid)
+        logger.info(f"File permissions restored to {original_uid}:{original_gid}")
+
+        config.cache.set("converged_topo_file", topo_file)
+        config.cache.set("converged_topo_backup", backup_file)
+    except Exception as e:
+        logger.error(f"Error during topo converge: {e}")
+        raise
 
 
 @pytest.fixture(scope="session")
@@ -587,6 +661,18 @@ def pytest_sessionfinish(session, exitstatus):
         session.config.cache.set("duthosts_fixture_failed", None)
         session.config.cache.set("ptfhost_exception", None)
         session.exitstatus = HOST_FIXTURE_FAILED_RC
+
+    topo_file = session.config.cache.get("converged_topo_file", None)
+    backup_file = session.config.cache.get("converged_topo_backup", None)
+    if topo_file and backup_file and os.path.exists(backup_file):
+        logger.info(f"Restoring original topo file from backup: {backup_file} -> {topo_file}")
+        try:
+            shutil.copy(backup_file, topo_file)
+            logger.info("Original topo file restored successfully")
+            session.config.cache.set("converged_topo_file", None)
+            session.config.cache.set("converged_topo_backup", None)
+        except Exception as e:
+            logger.error(f"Failed to restore topo file: {e}")
 
 
 @pytest.fixture(name="duthosts", scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -451,7 +451,7 @@ def converge_topo_if_needed(config):
         spec.loader.exec_module(ceos_module)
 
         ceos_module.converge_testbed(backup_file, topo_file)
-        logger.info(f"✓ Topology '{topo_name}' converged successfully")
+        logger.info(f"Topology '{topo_name}' converged successfully")
 
         os.chmod(topo_file, original_mode)
         os.chown(topo_file, original_uid, original_gid)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -412,6 +412,8 @@ def converge_topo_if_needed(config):
         return
     try:
         tb_config = _load_testbed_config(tbfile, tbname)
+        if not tb_config:
+            return
         use_converged_peers = tb_config.get('use_converged_peers', False)
         if not use_converged_peers:
             logger.info(f"use_converged_peers=False for testbed '{tbname}', skipping converge")

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -57,33 +57,7 @@ function get_dut_from_testbed_file() {
             IFS=$'+' read -r -a tb_lines <<< $content
             tb_line=${tb_lines[0]}
             DUT_NAME=$(python3 -c "from __future__ import print_function; tb=eval(\"$tb_line\"); print(\",\".join(tb[\"dut\"]))")
-
-            topo_name=$(python3 -c "from __future__ import print_function; tb=eval(\"$tb_line\"); print(tb.get('topo', ''))")
-            use_converged_peers=$(python3 -c "from __future__ import print_function; tb=eval(\"$tb_line\"); print(tb.get('use_converged_peers', ''))")
-            converge_topo_if_needed "$topo_name" "$use_converged_peers"
         fi
-    fi
-}
-
-function converge_topo_if_needed
-{
-    topo_name="$1"
-    use_converged_peers="$2"
-    ANSIBLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)/ansible"
-    VARS_DIR="$ANSIBLE_DIR/vars"
-    topo_file="$VARS_DIR/topo_${topo_name}.yml"
-    backup_file="${topo_file}".bak
-    if [[ "$use_converged_peers" == "True" ]]; then
-        echo "use_converged_peers is true, converging topo..."
-
-        if [[ -f "$backup_file" ]];then
-            echo "Backup file exists, recover..."
-            sudo cp "$backup_file" "$topo_file"
-        elif [[ -f "$topo_file" ]]; then
-            echo "Back up topo file"
-            sudo cp "$topo_file" "$backup_file"
-        fi
-        sudo PYTHONPATH="$ANSIBLE_DIR:$PYTHONPATH" python -m ceos_topo_converger "$backup_file" "$topo_file"
     fi
 }
 
@@ -583,12 +557,6 @@ fi
 
 if [[ x"${TEST_METHOD}" != x"debug" && x"${BYPASS_UTIL}" == x"False" ]]; then
     cleanup_dut
-fi
-
-if [[ -f "$backup_file" ]];then
-    echo "Backup exists, restore backup file"
-    sudo rm -f "$topo_file"
-    sudo mv "$backup_file" "$topo_file"
 fi
 
 exit ${RC}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add multi-VRF testbed topology conversion logic into conftest.py so that it is triggered automatically when tests are invoked directly via pytest  without relying on run_test.sh as the entry point.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
For multi-VRF testbeds, the original testbed topology config file (ansible/vars/topo_xxx.yml) needs to be converted at runtime before tests can execute correctly. Previously, this conversion was integrated into run_test.sh (the standard test entry point) and testbed-cli.sh (the deployment entry point).

However, we found that somebody may invoke tests directly via pytest, bypassing run_test.sh entirely. This caused the topology conversion to be skipped, leading to failures in multi-VRF related test cases.

#### How did you do it?

Added a converge_topo_if_needed() function called from pytest_configure in tests/conftest.py. The logic:
 1. Reads the testbed config file and checks if the target testbed has use_converged_peers: True.
 2. If so, creates a backup of the original topo file (topo_xxx.yml.bak) and invokes ceos_topo_converger.converge_testbed() to produce the converted topo file in-place.
 3. If a backup already exists (e.g., from a previous interrupted run), it first restores the original before re-converting, ensuring idempotency.
 4. In pytest_sessionfinish, the original topo file is always restored from the backup, keeping the testbed config clean after each run.
 5. If any error occurs during conversion, the backup is restored immediately to prevent leaving the testbed in an inconsistent state.

#### How did you verify/test it?

Verified by running multi-VRF test cases on a testbed with use_converged_peers: True, triggered via pytest directly. Confirmed that:
 - The topo file is correctly converted before tests run.
 - The original topo file is restored after the session finishes.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
