### PR TITLE
Only shutdown ebgp on certain duthosts in everflow setup

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -254,52 +254,60 @@ def check_ebgp_routes(num_v4_routes, num_v6_routes, duthost):
     return rtn_val
 
 
+def duthost_shutdown_ebgp(duthost):
+    orch_cpu_threshold = 10
+
+    orch_cpu_timeout = 60
+    # Get the original number of eBGP v4 and v6 routes on the DUT.
+    sumv4, sumv6 = duthost.get_ip_route_summary()
+    v4_routes_count = sumv4.get('ebgp', {'routes': 0})['routes']
+    v6_routes_count = sumv6.get('ebgp', {'routes': 0})['routes']
+    if v4_routes_count > 10000 or v6_routes_count > 10000:
+        orch_cpu_timeout = 120
+
+    # Shutdown all eBGP neighbors
+    duthost.command("sudo config bgp shutdown all")
+
+    # Verify that the total eBGP routes are 0.
+    pt_assert(wait_until(60, 2, 5, check_ebgp_routes, 0, 0, duthost),
+              "eBGP routes are not 0 after shutting down all neighbors on {}".format(duthost))
+    pt_assert(wait_until(orch_cpu_timeout, 2, 0, check_orch_cpu_utilization, duthost, orch_cpu_threshold),
+              "Orch CPU utilization {} > orch cpu threshold {} after shutdown all eBGP"
+              .format(duthost.shell("show processes cpu | grep orchagent | awk '{print $9}'")["stdout"],
+                      orch_cpu_threshold))
+
+    return v4_routes_count, v6_routes_count
+
+
+def duthost_startup_ebgp(duthost, v4_routes_count, v6_routes_count):
+    orch_cpu_threshold = 10
+    orch_cpu_timeout = 60
+    if v4_routes_count > 10000 or v6_routes_count > 10000:
+        orch_cpu_timeout = 120
+
+    duthost.command("sudo config bgp startup all")
+
+    pt_assert(wait_until(120, 10, 10, check_ebgp_routes, v4_routes_count, v6_routes_count, duthost),
+              "eBGP v4 routes are {}, and v6 route are {}, and not what they were originally after enabling "
+              "all neighbors on {}".format(v4_routes_count, v6_routes_count, duthost))
+    pt_assert(wait_until(orch_cpu_timeout, 2, 0, check_orch_cpu_utilization, duthost, orch_cpu_threshold),
+              "Orch CPU utilization {} > orch cpu threshold {} after startup all eBGP"
+              .format(duthost.shell("show processes cpu | grep orchagent | awk '{print $9}'")["stdout"],
+                      orch_cpu_threshold))
+
+
 @pytest.fixture(scope="module")
 def shutdown_ebgp(duthosts, rand_one_dut_hostname):
     # To store the original number of eBGP v4 and v6 routes.
     v4ebgps = {}
     v6ebgps = {}
-    orch_cpu_threshold = 10
-    # increase timeout for check_orch_cpu_utilization to 120sec for chassis
-    # especially uplink cards need >60sec for orchagent cpu usage to come down to 10%
-    duthost = duthosts[rand_one_dut_hostname]
-    orch_cpu_timeout = 60
     for duthost in duthosts.frontend_nodes:
-        # Get the original number of eBGP v4 and v6 routes on the DUT.
-        sumv4, sumv6 = duthost.get_ip_route_summary()
-        v4ebgps[duthost.hostname] = sumv4.get('ebgp', {'routes': 0})['routes']
-        v6ebgps[duthost.hostname] = sumv6.get('ebgp', {'routes': 0})['routes']
-        v4_routes_count = v4ebgps[duthost.hostname]
-        v6_routes_count = v6ebgps[duthost.hostname]
-        if v4_routes_count > 10000 or v6_routes_count > 10000:
-            orch_cpu_timeout = 120
-        # Shutdown all eBGP neighbors
-        duthost.command("sudo config bgp shutdown all")
-        # Verify that the total eBGP routes are 0.
-        pt_assert(wait_until(60, 2, 5, check_ebgp_routes, 0, 0, duthost),
-                  "eBGP routes are not 0 after shutting down all neighbors on {}".format(duthost))
-        pt_assert(wait_until(orch_cpu_timeout, 2, 0, check_orch_cpu_utilization, duthost, orch_cpu_threshold),
-                  "Orch CPU utilization {} > orch cpu threshold {} after shutdown all eBGP"
-                  .format(duthost.shell("show processes cpu | grep orchagent | awk '{print $9}'")["stdout"],
-                          orch_cpu_threshold))
+        v4ebgps[duthost.hostname], v6ebgps[duthost.hostname] = duthost_shutdown_ebgp(duthost)
 
     yield
 
     for duthost in duthosts.frontend_nodes:
-        # Startup all the eBGP neighbors
-        duthost.command("sudo config bgp startup all")
-
-    for duthost in duthosts.frontend_nodes:
-        # Verify that total eBGP routes are what they were before shutdown of all eBGP neighbors
-        orig_v4_ebgp = v4ebgps[duthost.hostname]
-        orig_v6_ebgp = v6ebgps[duthost.hostname]
-        pt_assert(wait_until(120, 10, 10, check_ebgp_routes, orig_v4_ebgp, orig_v6_ebgp, duthost),
-                  "eBGP v4 routes are {}, and v6 route are {}, and not what they were originally after enabling "
-                  "all neighbors on {}".format(orig_v4_ebgp, orig_v6_ebgp, duthost))
-        pt_assert(wait_until(orch_cpu_timeout, 2, 0, check_orch_cpu_utilization, duthost, orch_cpu_threshold),
-                  "Orch CPU utilization {} > orch cpu threshold {} after startup all eBGP"
-                  .format(duthost.shell("show processes cpu | grep orchagent | awk '{print $9}'")["stdout"],
-                          orch_cpu_threshold))
+        duthost_startup_ebgp(duthost, v4ebgps[duthost.hostname], v6ebgps[duthost.hostname])
 
 
 @pytest.fixture(scope="module")

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -523,6 +523,7 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario):
         duthost_startup_ebgp(dut_host, v4ebgps[dut_host.hostname], v6ebgps[dut_host.hostname])
         dut_host.command("rm -rf {}".format(DUT_RUN_DIR))
 
+
 @pytest.fixture(scope="module", autouse=True)
 def skip_ipv6_everflow_tests(setup_info, erspan_ip_ver):
     """

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -513,9 +513,9 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario):
     v4ebgps = {}
     v6ebgps = {}
     for dut_host in ebgp_shutdown_duthosts:
-        v4_routes_count, v6_routes_count = duthost_shutdown_ebgp(duthost)
-        v4ebgps[duthost.hostname] = v4_routes_count
-        v6ebgps[duthost.hostname] = v6_routes_count
+        v4_routes_count, v6_routes_count = duthost_shutdown_ebgp(dut_host)
+        v4ebgps[dut_host.hostname] = v4_routes_count
+        v6ebgps[dut_host.hostname] = v6_routes_count
 
     yield setup_information
 

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -27,7 +27,7 @@ from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEI
 from tests.common.macsec.macsec_helper import MACSEC_INFO
 from tests.common.dualtor.dual_tor_common import mux_config              # noqa: F401
 from tests.common.helpers.sonic_db import AsicDbCli
-from tests.common.fixtures.duthost_utils import shutdown_ebgp          # noqa: F401
+from tests.common.fixtures.duthost_utils import duthost_shutdown_ebgp, duthost_startup_ebgp
 import json
 
 logger = logging.getLogger(__name__)
@@ -473,8 +473,7 @@ def assert_no_tx_queue_drops_on_mirror_port(duthost, mirror_port):
 
 
 @pytest.fixture(scope="module")
-def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario,
-               shutdown_ebgp):  # noqa: F811
+def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario):
     """
     Gather all required test information.
 
@@ -499,20 +498,30 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario,
 
     setup_information = gen_setup_information(duthost, downstream_duthost, upstream_duthost, tbinfo, topo_scenario)
 
+    # Disable BGP so that we don't keep on bouncing back mirror packets
+    # If we send TTL=1 packet we don't need this but in multi-asic TTL > 1
+
+    ebgp_shutdown_duthosts = []
     if 't2' in topo and 'lt2' not in topo and 'ft2' not in topo:
         for dut_host in duthosts.frontend_nodes:
+            ebgp_shutdown_duthosts.append(dut_host)
             dut_host.command("mkdir -p {}".format(DUT_RUN_DIR))
     else:
+        ebgp_shutdown_duthosts.append(duthost)
         duthost.command("mkdir -p {}".format(DUT_RUN_DIR))
+
+    v4ebgps = {}
+    v6ebgps = {}
+    for dut_host in ebgp_shutdown_duthosts:
+        v4_routes_count, v6_routes_count = duthost_shutdown_ebgp(duthost)
+        v4ebgps[duthost.hostname] = v4_routes_count
+        v6ebgps[duthost.hostname] = v6_routes_count
 
     yield setup_information
 
-    if 't2' in topo and 'lt2' not in topo and 'ft2' not in topo:
-        for dut_host in duthosts.frontend_nodes:
-            dut_host.command("rm -rf {}".format(DUT_RUN_DIR))
-    else:
-        duthost.command("rm -rf {}".format(DUT_RUN_DIR))
-
+    for dut_host in ebgp_shutdown_duthosts:
+        duthost_startup_ebgp(dut_host, v4ebgps[dut_host.hostname], v6ebgps[dut_host.hostname])
+        dut_host.command("rm -rf {}".format(DUT_RUN_DIR))
 
 @pytest.fixture(scope="module", autouse=True)
 def skip_ipv6_everflow_tests(setup_info, erspan_ip_ver):


### PR DESCRIPTION
### Description of PR

https://github.com/sonic-net/sonic-mgmt/pull/22949 switched to using `shutdown_ebgp` which shuts down ebgp on too many duthosts for certain topologies.
https://github.com/sonic-net/sonic-mgmt/issues/23825

This change goes back to the old behavior and tries to reuse the code in `shutdown_ebgp`.

Summary:
Fixes #23825 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Go back to the old ebgp shutdown behavior in everflow before https://github.com/sonic-net/sonic-mgmt/pull/22949 but refactor some of the code in `shutdown_ebgp` to make it re-usable

#### How did you do it?
Factor out the common code out of `shutdown_ebgp` into `duthost_shutdown_ebgp` and `duthost_startup_ebgp` that everflow's `setup_info` can reuse

#### How did you verify/test it?
Ran `test_everflow_ipv6.py` on a single-asic and multi-asic fixed box system and both passed.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
