### PR TITLE
Accept Connection Collision Resolution in test_bgp_peer_shutdown

### DIFF
--- a/tests/bgp/test_bgp_peer_shutdown.py
+++ b/tests/bgp/test_bgp_peer_shutdown.py
@@ -152,9 +152,12 @@ def match_bgp_notification(packet, src_ip, dst_ip, action, bgp_session_down_time
 
     bgp_fields = packet[bgp.BGPNotification].fields
     if action == "cease":
-        # error_code 6: Cease, error_subcode 3: Peer De-configured. References: RFC 4271
+        # error_code 6: Cease. References: RFC 4271
+        # error_subcode 3: Peer De-configured — expected during admin shutdown
+        # error_subcode 7: Connection Collision Resolution — may occur transiently
+        #   if FRR attempts to reconnect while the old session is still clearing
         return (bgp_fields["error_code"] == 6 and
-                bgp_fields["error_subcode"] == 3 and
+                bgp_fields["error_subcode"] in (3, 7) and
                 (bgp_session_down_time is None or float(packet.time) < bgp_session_down_time))
     else:
         return False


### PR DESCRIPTION
### Description of PR

Summary: Accept Cease/Connection Collision Resolution (subcode 7) alongside Peer De-configured (subcode 3) in `test_bgp_peer_shutdown` to handle transient collision events after FRR 10.5.1 upgrade.

Fixes #23832

### Type of change

- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

After the FRR 10.5.1 upgrade (sonic-buildimage [#25839](https://github.com/sonic-net/sonic-buildimage/pull/25839)), `test_bgp_peer_shutdown` intermittently fails because FRR sends a Cease/Connection Collision Resolution (subcode 7) notification during peer shutdown. This happens when FRR attempts to reconnect while the old session is still in Clearing state, triggering the collision detection path in `bgp_collision_detect()`.

The FRR 10.5.1 `peerhash->connectionhash` refactor (commit `68a42dc6ec`) changed how incoming connections are matched during collision detection, making this race more likely to occur.

#### How did you do it?

Updated `match_bgp_notification()` in `tests/bgp/test_bgp_peer_shutdown.py` to accept both subcode 3 (Peer De-configured) and subcode 7 (Connection Collision Resolution) as valid Cease notifications. Both are legitimate BGP behaviors during session teardown per RFC 4271.

#### How did you verify/test it?

- Code review of FRR 10.5.1 collision detection path confirms subcode 7 is a valid transient event during shutdown
- flake8 passes with max-line-length=120

#### Any platform specific information?

Observed on VS/KVM (x86_64-kvm_x86_64-r0, HwSKU Force10-S6000) but applies to all platforms running FRR 10.5.1.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
