### PR TITLE
DPUs: Include disk type 'MMC' for dpu ssdhealth check . Also fix for PR: 23641 

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -518,7 +518,7 @@ def test_show_platform_ssdhealth(duthosts, enum_supervisor_dut_hostname):
     if not any(disk_type in ssdhealth_output_lines[0] for disk_type in supported_disks):
         pytest.skip("Disk Type {} is not supported".format(disk))
     if disk in ["EMMC", "MMC"] and platform != AMD_ELBA_PLATFORM:
-        pytest.skip("{} disk health is only supported on platform {}".format(disk, AMD_ELBA_PLATFORM))
+        pytest.skip("'{}' disk health check is not supported on platform {}".format(disk, platform))
 
     ssdhealth_dict = util.parse_colon_speparated_lines(ssdhealth_output_lines)
     expected_fields = {"Disk Type", "Device Model", "Health", "Temperature"}

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -499,7 +499,7 @@ def test_show_platform_ssdhealth(duthosts, enum_supervisor_dut_hostname):
     """
     duthost = duthosts[enum_supervisor_dut_hostname]
     cmds_list = [CMD_SHOW_PLATFORM, "ssdhealth"]
-    supported_disks = ["SATA", "NVME", "EMMC"]
+    supported_disks = ["SATA", "NVME", "EMMC", "MMC"]
 
     platform_ssd_device_path_dict = {BF_3_PLATFORM: "/dev/nvme0"}
     unsupported_ssd_values_per_platform = {AMD_ELBA_PLATFORM: ["Temperature"]}
@@ -514,8 +514,12 @@ def test_show_platform_ssdhealth(duthosts, enum_supervisor_dut_hostname):
     logging.info("Verifying output of '{}' on ''{}'...".format(cmd, duthost.hostname))
 
     ssdhealth_output_lines = duthost.command(cmd)["stdout_lines"]
+    disk = ssdhealth_output_lines[0].split(':')[-1].strip()
     if not any(disk_type in ssdhealth_output_lines[0] for disk_type in supported_disks):
-        pytest.skip("Disk Type {} is not supported".format(ssdhealth_output_lines[0].split(':')[-1]))
+        pytest.skip("Disk Type {} is not supported".format(disk))
+    if disk in ["EMMC", "MMC"] and platform != AMD_ELBA_PLATFORM:
+        pytest.skip("{} disk health is only supported on platform {}".format(disk, AMD_ELBA_PLATFORM))
+
     ssdhealth_dict = util.parse_colon_speparated_lines(ssdhealth_output_lines)
     expected_fields = {"Disk Type", "Device Model", "Health", "Temperature"}
     actual_fields = set(ssdhealth_dict.keys())


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
-->
DPUs: Update disk type with 'MMC' for amd elba platform. Also fix for issue PR: 23641

Summary:
Fixes # (issue)
- AMD elba platform uses MMC in ssdhealth output.
- FIx for issue :  https://github.com/sonic-net/sonic-mgmt/issues/23641

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach

#### Supported testbed topology if it's a new test case?
- Testbed : Smartswitch with DPUs 

