### PR TITLE
[Test Gap] Enforce apply-patch timeout in GCU shared test utility

### DIFF
--- a/tests/common/gu_utils.py
+++ b/tests/common/gu_utils.py
@@ -2,7 +2,6 @@ import json
 import logging
 import pytest
 import os
-import time
 import re
 from jsonpointer import JsonPointer
 from tests.common.helpers.assertions import pytest_assert
@@ -127,13 +126,30 @@ def apply_patch(duthost, json_data, dest_file):
     cmds = 'config apply-patch {}'.format(dest_file)
 
     logger.info("Commands: {}".format(cmds))
-    start_time = time.time()
-    output = duthost.shell(cmds, module_ignore_errors=True)
-    elapsed_time = time.time() - start_time
     gcu_timeout = get_gcu_timeout(duthost)
-    if elapsed_time > gcu_timeout:
-        logger.error("Command took too long: {} seconds".format(elapsed_time))
-        raise TimeoutError("Command execution timeout: {} seconds".format(elapsed_time))
+
+    # Run the command asynchronously so we can poll for completion and
+    # time out without blocking the test runner indefinitely.  This
+    # uses wait_until (the standard polling helper used across the repo)
+    # instead of an ad-hoc bash 'timeout' wrapper, giving us periodic
+    # logging and Python-level control over the thread.
+    pool, async_result = duthost.shell(cmds, module_ignore_errors=True,
+                                       module_async=True)
+    try:
+        completed = wait_until(gcu_timeout, 10, 0,
+                               lambda: async_result.ready())
+        if not completed:
+            logger.error("apply-patch did not complete within {} seconds, "
+                         "terminating".format(gcu_timeout))
+            raise TimeoutError(
+                "Command execution timeout: {} seconds".format(gcu_timeout))
+
+        # .get() returns the result on success or re-raises the
+        # original exception from the worker thread on failure.
+        output = async_result.get()
+    finally:
+        pool.terminate()
+        pool.join()
 
     return output
 
@@ -649,4 +665,9 @@ def get_bgp_speaker_runningconfig(duthost):
 
 
 def get_gcu_timeout(duthost):
+    """Return the GCU apply-patch timeout (in seconds) for this platform.
+
+    Platforms listed in GCUTIMEOUT_MAP get a custom value; everything
+    else defaults to 600 s.
+    """
     return GCUTIMEOUT_MAP.get(duthost.facts['platform'], 600)


### PR DESCRIPTION
### Description of PR
Summary:
Fixes the GCU test infrastructure gap where `apply_patch()` in `tests/common/gu_utils.py` does not enforce an effective timeout on the `config apply-patch` shell command, allowing GCU patch application to block test execution indefinitely.

`GCUTIMEOUT_MAP` and `get_gcu_timeout()` already exist in this file but the original implementation only measured elapsed time *after* the synchronous `duthost.shell()` call returned -- it could never pre-empt a hung command.

This change replaces the synchronous call with `module_async=True` + `wait_until()` polling so that a hung GCU is detected and terminated at the Python level, failing the test instead of blocking CI indefinitely.

Fixes #23846

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`apply_patch()` in `tests/common/gu_utils.py` is the shared utility called by ~35 test files across `tests/generic_config_updater/` and `tests/bgp/`. The original code ran the shell command synchronously and only checked elapsed time *after* the command returned -- a hung GCU would block the test runner indefinitely with no mechanism to pre-empt it.

#### How did you do it?
Used `module_async=True` to run the shell command in a Python `ThreadPool` (via `AnsibleHostBase._run()` in `tests/common/devices/base.py`), then polled for completion using `wait_until()` -- the standard polling helper used across the repo (`tests/common/utilities.py`). This gives us:

1. **Proactive timeout enforcement** -- if the command doesn't complete within `gcu_timeout` seconds (default 600s, platform-specific overrides in `GCUTIMEOUT_MAP`), we raise `TimeoutError` and terminate the thread pool
2. **Periodic debug logging** -- `wait_until` logs elapsed time at each 10-second poll interval at debug level
3. **Python-level thread control** -- `pool.terminate()` + `pool.join()` in a `finally` block ensures cleanup in all code paths (success, timeout, and exception)
4. **Return-value compatibility** -- `async_result.get()` returns the same Ansible result dict (`rc`, `stdout`, `stderr`) as synchronous `duthost.shell()`, so all callers (`expect_op_success`, `expect_op_failure`, direct `output['rc']` checks) are fully compatible

This follows a similar pattern to the existing `module_async=True` usage in `tests/platform_tests/test_reload_config.py`, improved by using `wait_until` instead of a manual `time.sleep` loop.

Also removed the now-unused `import time` and added a docstring to `get_gcu_timeout()`.

#### How did you verify/test it?
- Verified `async_result.get()` returns the identical Ansible result dict as sync `duthost.shell()` by tracing through `AnsibleHostBase._run()` in `tests/common/devices/base.py`
- Confirmed all ~35 caller files handle the return value identically (pass to `expect_op_success()` or check `output['rc']` directly)
- No lint errors introduced (only pre-existing unresolved imports for pytest/jsonpointer)

#### Any platform specific information?
No -- affects all platforms via shared test utility. Platform-specific timeouts are handled by `GCUTIMEOUT_MAP` (Nokia IXS7215: 1200s, Nvidia SN5640: 3600s, all others: 600s default).

#### Supported testbed topology if it's a new test case?
N/A -- framework change, not a new test case

### Documentation
N/A