### PR TITLE
T2:snappi:Change assert to require - for its possible that the link speeds can …

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -513,8 +513,8 @@ def snappi_testbed_config(conn_graph_facts, fanout_graph_facts,     # noqa: F811
         if port_speed is None:
             port_speed = int(snappi_ports[i]['speed'])
 
-        pytest_assert(port_speed == int(snappi_ports[i]['speed']),
-                      'Ports have different link speeds')
+        pytest_require(port_speed == int(snappi_ports[i]['speed']),
+                       'Ports have different link speeds')
 
     speed_gbps = int(port_speed/1000)
 
@@ -805,7 +805,7 @@ def snappi_dut_base_config(duthost_list,
 
     new_snappi_ports = [dict(list(sp.items()) + [('port_id', i)])
                         for i, sp in enumerate(snappi_ports) if sp['location'] in tgen_ports]
-    pytest_assert(len(set([sp['speed'] for sp in new_snappi_ports])) == 1, 'Ports have different link speeds')
+    pytest_require(len(set([sp['speed'] for sp in new_snappi_ports])) == 1, 'Ports have different link speeds')
     [config.ports.port(name='Port {}'.format(sp['port_id']), location=sp['location']) for sp in new_snappi_ports]
     speed_gbps = int(int(new_snappi_ports[0]['speed'])/1000)
 


### PR DESCRIPTION
…be different sometimes.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The testbed doesn't always contain same speeds - Depending on variables.py for snappi tests, there can be same or different speeeds for rx and tx ports. If a test requires same speeds, it should skip the case when it ends up with different port speeds.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405
- [ ] 202411
- [X] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
The snappi tests fails when it comes across different port speeds between tx and rx ports. In a mixed testbed, we will have both same-speeds and different-speeds. Due to this, we end up with these failures:
```
ERROR snappi_tests/test_multidut_snappi.py::test_snappi[multidut_port_info3] - Failed: Ports have different link speeds
ERROR snappi_tests/ecn/test_bp_fabric_ecn_marking_with_snappi.py::test_fabric_ecn_marking_lossless_prio[multidut_port_info3] - Failed: Ports have different link speeds
ERROR snappi_tests/ecn/test_ecn_marking_with_pfc_quanta_variance_with_snappi.py::test_ecn_marking_with_pfc_quanta_variance[multidut_port_info3-test_ecn_config1] - Failed: Ports have different link speeds
ERROR snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[multidut_port_info3-yy40-mixed-long|4] - Failed: Ports have different link speeds
ERROR snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_counter_check[multidut_port_info3-yy40-mixed-long|4] - Failed: Ports have different link speeds
ERROR snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio_reboot[multidut_port_info3-cold-yy40-mixed-long|4] - Failed: Ports have different link speeds
ERROR snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_multi_lossless_prio_reboot[multidut_port_info3-cold] - Failed: Ports have different link speeds
ERROR snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_multi_lossless_prio_reboot[multidut_port_info3-fast] - Failed: Ports have different link speeds
ERROR snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py::test_pfc_pause_multi_lossy_prio[multidut_port_info3] - Failed: Ports have different link speeds
ERROR snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio_reboot[multidut_port_info3-warm-yy40-mixed-long|6] - Failed: Ports have different link speeds
ERROR snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py::test_pfc_pause_multi_lossy_prio_reboot[multidut_port_info3-warm] - Failed: Ports have different link speeds
ERROR snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py::test_pfc_pause_multi_lossy_prio_reboot[multidut_port_info3-cold] - Failed: Ports have different link speeds
ERROR snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio[multidut_port_info3-True] - Failed: Ports have different link speeds
ERROR snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio[multidut_port_info3-False] - Failed: Ports have different link speeds
ERROR snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info3-True] - Failed: Ports have different link speeds
ERROR snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info3-False] - Failed: Ports have different link speeds
ERROR snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_reboot[multidut_port_info3-warm-yy40-mixed-long|3-True] - Failed: Ports have different link speeds
ERROR snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_reboot[multidut_port_info3-fast-yy40-mixed-long|3-True] - Failed: Ports have different link speeds
ERROR snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_reboot[multidut_port_info3-warm-True] - Failed: Ports have different link speeds
ERROR snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_reboot[multidut_port_info3-cold-True] - Failed: Ports have different link speeds
ERROR snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_reboot[multidut_port_info3-cold-False] - Failed: Ports have different link speeds
ERROR snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_reboot[multidut_port_info3-fast-False] - Failed: Ports have different link speeds
ERROR snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_service_restart[multidut_port_info3-True-swss] - Failed: Ports have different link speeds
ERROR snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_restart_service[multidut_port_info3-True-swss] - Failed: Ports have different link speeds
ERROR snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_restart_service[multidut_port_info3-False-swss] - Failed: Ports have different link speeds
FAILED snappi_tests/pfcwd/test_pfcwd_burst_storm_with_snappi.py::test_pfcwd_burst_storm_single_lossless_prio[multidut_port_info3] - Failed: Ports have different link speeds
FAILED snappi_tests/pfcwd/test_pfcwd_runtime_traffic_with_snappi.py::test_pfcwd_runtime_traffic[multidut_port_info3] - Failed: Ports have different link speeds
```

#### How did you do it?
Instead of assert, I changed the condition to require - which will skip the test.

#### How did you verify/test it?
Ran one of the failing cases above. It correctly skips now:
```
================================================================================================= warnings summary ==================================================================================================
../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-------------------------------------------------------------- generated xml file: /run_logs/ixia/debug/2026-04-12-22-45-57/tr_2026-04-12-22-45-57.xml --------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
============================================================================================== short test summary info ==============================================================================================
SKIPPED [1] common/helpers/assertions.py:22: Ports have different link speeds
===================================================================================== 1 skipped, 1 warning in 281.17s (0:04:41) =====================================================================================
```