### PR TITLE
Fix PgMinThreshold test flakiness

### DIFF
--- a/tests/common/helpers/ptf_tests_helper.py
+++ b/tests/common/helpers/ptf_tests_helper.py
@@ -115,9 +115,20 @@ def detect_portchannel_egress_member(duthost, tbinfo, ptf_adapter, portchannel_n
         tuple: (member_interface, ptf_port) or (None, None)
     """
     import ptf.testutils as testutils
+    from scapy.all import Ether, IP
 
     logger.info("Detecting egress member for {}".format(portchannel_name))
 
+    # Populate ARP entry for the packet destination so the ASIC neighbor table
+    # is up to date before sending detection traffic.
+    try:
+        dst_ip = Ether(bytes(test_packet))[IP].dst
+        logger.info("Pinging {} from DUT to populate ASIC neighbor entry".format(dst_ip))
+        duthost.shell("ping -c 4 -W 1 -q {}".format(dst_ip), module_ignore_errors=True)
+        ptf_adapter.dataplane.flush()
+    except Exception as e:
+        logger.warning("Could not ping dst_ip for ARP population: {}".format(e))
+        
     # Get PortChannel members
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     portchannels = mg_facts.get('minigraph_portchannels', {})
@@ -137,7 +148,7 @@ def detect_portchannel_egress_member(duthost, tbinfo, ptf_adapter, portchannel_n
         return None, None
 
     # Try each member port
-    num_test_packets = 100
+    num_test_packets = 100000
     timeout = 10.0
 
     for member_name, member_ptf_port in member_ptf_ports:
@@ -167,6 +178,8 @@ def detect_portchannel_egress_member(duthost, tbinfo, ptf_adapter, portchannel_n
             ptf_adapter.dataplane.flush()
             return member_name, member_ptf_port
 
+    import time 
+    time.sleep(30)
     # No working member found
     ptf_adapter.dataplane.flush()
     return None, None

--- a/tests/qos/files/qos_params.th5.yaml
+++ b/tests/qos/files/qos_params.th5.yaml
@@ -4,19 +4,15 @@ qos_params:
             cell_size: 254
             hdrm_pool_wm_multiplier: 1
             pg_min_threshold:
-                pg0_dscp: 8
-                pg1_dscp: 3
-                pg0: 0
-                pg1: 3
-                packet_size: 1500
+                pg0_dscp: 3
+                pg1_dscp: 4
+                pg0: 3
+                pg1: 4
+                packet_size: 64
                 cell_size: 254
-                shared_pool_size: 166000000
-                pg1_min_size: 10000000
-                pg0_pkts_to_fill: 2000000
-                pg1_pkts_to_fill: 2000000
-                pg0_pkts_to_drop: 0
-                pg1_pkts_to_drop: 0
-                pkts_num_margin: 1000
+                pg1_min_size: 76200
+                pg_pkts_to_fill: 100000
+                pkt_count_tolerance: 100
             200000_5m:
                 hdrm_pool_size:
                     dscps:

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -25,6 +25,7 @@ import pytest
 import time
 import json
 import re
+import ipaddress
 from tabulate import tabulate
 
 from tests.common.fixtures.conn_graph_facts import fanout_graph_facts, conn_graph_facts, get_graph_facts    # noqa: F401
@@ -44,7 +45,9 @@ from tests.common.utilities import wait_until
 from .qos_sai_base import QosSaiBase
 from tests.common.helpers.ptf_tests_helper import (downstream_links, upstream_links, select_random_link,  # noqa: F401
                                                    get_stream_ptf_ports, apply_dscp_cfg_setup, apply_dscp_cfg_teardown,
-                                                   fetch_test_logs_ptf)
+                                                   fetch_test_logs_ptf,
+                                                   select_test_interface_and_ptf_port, get_interface_ip_address,
+                                                   detect_portchannel_egress_member)  # noqa: F401
 from tests.common.utilities import get_ipv4_loopback_ip
 from tests.common.helpers.base_helper import read_logs
 
@@ -1973,7 +1976,7 @@ class TestQosSai(QosSaiBase):
 
     def testQosSaiPgMinThreshold(
         self, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        get_src_dst_asic_and_duts
+        get_src_dst_asic_and_duts, tbinfo, ptfadapter
     ):
         """
             Test QoS SAI PG MIN threshold behavior
@@ -1989,29 +1992,71 @@ class TestQosSai(QosSaiBase):
                     and test ports
                 dutQosConfig (Fixture, dict): Map containing DUT host QoS configuration
                 get_src_dst_asic_and_duts: Fixture for getting source/destination ASIC and DUTs
+                tbinfo: Testbed info fixture
+                ptfadapter: PTF adapter fixture
             Returns:
                 None
             Raises:
                 RunAnsibleModuleFail if ptf test fails
         """
+        import ptf.testutils as testutils
+
         qosConfig = dutQosConfig["param"]
 
         if "pg_min_threshold" not in qosConfig:
             pytest.skip("PG MIN threshold test parameters not configured for this platform")
 
-        src_dut_index = get_src_dst_asic_and_duts['src_dut_index']
-        src_asic_index = get_src_dst_asic_and_duts['src_asic_index']
-        dst_dut_index = get_src_dst_asic_and_duts['dst_dut_index']
-        dst_asic_index = get_src_dst_asic_and_duts['dst_asic_index']
+        # Get source DUT
+        src_dut = get_src_dst_asic_and_duts['src_dut']
 
-        src_testPortIps = dutConfig["testPortIps"][src_dut_index][src_asic_index]
-        dst_testPortIps = dutConfig["testPortIps"][dst_dut_index][dst_asic_index]
-        src_testPortIds = list(src_testPortIps.keys())
-        dst_testPortIds = list(dst_testPortIps.keys())
+        # Select test interface and PTF port using the helper function
+        test_interface, ptf_port_index = select_test_interface_and_ptf_port(src_dut, tbinfo)
+        pytest_assert(test_interface and ptf_port_index is not None,
+                      "Could not find test interface with PTF port mapping")
 
-        # Use first available source and destination ports
-        src_port_id = src_testPortIds[0]
-        dst_port_id = dst_testPortIds[0]
+        # Get IP address for the selected interface
+        mg_facts = src_dut.get_extended_minigraph_facts(tbinfo)
+        interface_ip = get_interface_ip_address(test_interface, mg_facts)
+        pytest_assert(interface_ip,
+                      "Could not find IP address for interface {}".format(test_interface))
+
+        # Calculate source and destination IPs from interface network
+        interface_network = ipaddress.ip_interface(interface_ip)
+        src_ip = str(interface_network.ip - 1)
+        dst_ip = str(interface_network.ip + 1)
+
+        logger.info("Selected test interface: {} (PTF port: {}), IP: {}".format(
+            test_interface, ptf_port_index, interface_ip))
+        logger.info("Source IP: {}, Destination IP: {}".format(src_ip, dst_ip))
+
+        # Create test packet for PortChannel detection
+        router_mac = src_dut.facts["router_mac"]
+        test_packet = testutils.simple_tcp_packet(
+            eth_dst=router_mac,
+            ip_src=src_ip,
+            ip_dst=dst_ip,
+            ip_dscp=0,
+        )
+
+        # If PortChannel, detect actual egress member
+        portchannels = mg_facts.get('minigraph_portchannels', {})
+        if test_interface in portchannels:
+            logger.info("{} is a PortChannel, detecting egress member".format(test_interface))
+
+            # Detect actual egress member
+            detected_interface, detected_ptf_port = detect_portchannel_egress_member(
+                src_dut, tbinfo, ptfadapter, test_interface, test_packet
+            )
+            if detected_interface and detected_ptf_port is not None:
+                logger.info("Detected egress member: {} (PTF port {})".format(
+                    detected_interface, detected_ptf_port))
+                test_interface = detected_interface
+                ptf_port_index = detected_ptf_port
+            else:
+                pytest.fail("Could not detect egress member for PortChannel {}".format(test_interface))
+
+        logger.info("Final test interface: {} (PTF port: {})".format(
+            test_interface, ptf_port_index))
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -2021,16 +2066,15 @@ class TestQosSai(QosSaiBase):
             "pg1_dscp": qosConfig["pg_min_threshold"]["pg1_dscp"],
             "pg0": qosConfig["pg_min_threshold"]["pg0"],
             "pg1": qosConfig["pg_min_threshold"]["pg1"],
-            "src_port_id": src_port_id,
-            "src_port_ip": src_testPortIps[src_port_id]['peer_addr'],
-            "dst_port_id": dst_port_id,
-            "dst_port_ip": dst_testPortIps[dst_port_id]['peer_addr'],
-            "shared_pool_size": qosConfig["pg_min_threshold"]["shared_pool_size"],
+            "src_port_id": ptf_port_index,
+            "src_port_ip": src_ip,
+            "dst_port_id": ptf_port_index,
+            "dst_port_ip": dst_ip,
+            "router_mac": router_mac,
             "pg1_min_size": qosConfig["pg_min_threshold"]["pg1_min_size"],
-            "pg0_pkts_to_fill": qosConfig["pg_min_threshold"]["pg0_pkts_to_fill"],
-            "pg0_pkts_to_drop": qosConfig["pg_min_threshold"]["pg0_pkts_to_drop"],
-            "pg1_pkts_to_fill": qosConfig["pg_min_threshold"]["pg1_pkts_to_fill"],
-            "pg1_pkts_to_drop": qosConfig["pg_min_threshold"]["pg1_pkts_to_drop"],
+            "pg_pkts_to_fill": qosConfig["pg_min_threshold"]["pg_pkts_to_fill"],
+            "pkt_count_tolerance": qosConfig["pg_min_threshold"]["pkt_count_tolerance"],
+            "test_interface": test_interface,
         })
 
         if "packet_size" in qosConfig["pg_min_threshold"]:
@@ -2039,11 +2083,6 @@ class TestQosSai(QosSaiBase):
         if "cell_size" in qosConfig["pg_min_threshold"]:
             testParams["cell_size"] = qosConfig["pg_min_threshold"]["cell_size"]
 
-        if "pkts_num_margin" in qosConfig["pg_min_threshold"]:
-            testParams["pkts_num_margin"] = qosConfig["pg_min_threshold"]["pkts_num_margin"]
-
-        # Note: Not passing log_file to avoid pcap generation for this high-volume test
-        # With 2M packets, pcap files become too large and cause OOM during compression
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.PgMinThresholdTest",
             testParams=testParams,

--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -145,7 +145,7 @@ class ThriftInterface(BaseTest):
         if self.dst_client != self.src_client:
             self.dst_transport.close()
 
-    def exec_cmd_on_dut(self, hostname, username, password, cmd):
+    def exec_cmd_on_dut(self, hostname, username, password, cmd, timeout=20):
         client = paramiko.SSHClient()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
@@ -157,7 +157,7 @@ class ThriftInterface(BaseTest):
         try:
             client.connect(hostname, username=username,
                            password=password, allow_agent=False)
-            si, so, se = client.exec_command(cmd, timeout=20)
+            si, so, se = client.exec_command(cmd, timeout=timeout)
             stdOut = so.readlines()
             stdErr = se.readlines()
             retValue = 0

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -7944,15 +7944,15 @@ class PgMinThresholdTest(sai_base_test.ThriftInterfaceDataPlane):
                 raise ValueError("Failed to apply PG1 profile: {}".format(stderr))
 
             # Step 5: Restart swss
-            cmd = 'sudo systemctl restart swss'
+            cmd = 'sudo systemctl restart swss &'
             stdout, stderr, ret = run_cmd_on_dut(self, cmd, timeout=100)
 
             if ret != 0:
                 print("Warning: Failed to restart swss: {}".format(stderr), file=sys.stderr)
-            else:
-                # Wait for orchagent to be ready after swss restart
-                if not wait_until(420, 10, 5, check_orchagent_ready, self):
-                    print("Warning: orchagent_restart_check did not succeed within timeout", file=sys.stderr)
+
+            if not wait_until(420, 10, 5, check_orchagent_ready, self):
+                print("Warning: orchagent_restart_check did not succeed within timeout", file=sys.stderr)
+                
             sai_base_test.ThriftInterfaceDataPlane.tearDown(self)
             sai_base_test.ThriftInterfaceDataPlane.setUp(self)
             time.sleep(1)

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -177,6 +177,134 @@ def flat_test_port_ids(hierarchy):
             yield from flat_test_port_ids(value)
 
 
+def wait_until(timeout, interval, delay, condition, *args, **kwargs):
+    """Wait until condition is True or timeout. Returns True if condition met, False otherwise."""
+    import traceback
+
+    print("Wait until {} is True, timeout is {} seconds, checking interval is {}, delay is {} seconds".format(
+        condition.__name__, timeout, interval, delay), file=sys.stderr)
+
+    if delay > 0:
+        print("Delay for {} seconds first".format(delay), file=sys.stderr)
+        time.sleep(delay)
+
+    start_time = time.time()
+    elapsed_time = 0
+
+    while elapsed_time < timeout:
+        print("Time elapsed: {:.1f} seconds".format(elapsed_time), file=sys.stderr)
+
+        try:
+            check_result = condition(*args, **kwargs)
+        except Exception as e:
+            exc_info = sys.exc_info()
+            details = traceback.format_exception(*exc_info)
+            print("Exception caught while checking {}: {}, error: {}".format(
+                condition.__name__, "".join(details), e), file=sys.stderr)
+            check_result = False
+
+        if check_result:
+            print("{} is True, exit early with True".format(condition.__name__), file=sys.stderr)
+            return True
+        else:
+            print("{} is False, wait {} seconds and check again".format(
+                condition.__name__, interval), file=sys.stderr)
+            time.sleep(interval)
+            elapsed_time = time.time() - start_time
+
+    if elapsed_time >= timeout:
+        print("{} is still False after {} seconds, exit with False".format(
+            condition.__name__, timeout), file=sys.stderr)
+        return False
+
+
+def check_orchagent_ready(test_case):
+    """Check if orchagent restart check succeeds"""
+    try:
+        stdout, stderr, ret = test_case.exec_cmd_on_dut(
+            test_case.src_server_ip,
+            test_case.test_params['dut_username'],
+            test_case.test_params['dut_password'],
+            "docker exec swss /usr/bin/orchagent_restart_check -n -s -w 2000",
+            timeout=100
+        )
+        if ret == 0 and stdout:
+            result = ''.join(stdout) if isinstance(stdout, list) else str(stdout)
+            return "RESTARTCHECK succeeded" in result
+        return False
+    except Exception as e:
+        print(f"orchagent_restart_check failed: {e}", file=sys.stderr)
+        return False
+
+
+def check_pg_packets_received(test_case, pg, pg_counters_base, recv_counters_base, pkts_to_send):
+    """Check if PG received packets >= sent packets
+
+    Args:
+        test_case: The test case instance
+        pg: Priority group number to check
+        pg_counters_base: Baseline PG counters
+        recv_counters_base: Baseline receive counters
+        pkts_to_send: Number of packets sent
+
+    Returns:
+        True if received packets >= sent packets, False otherwise
+    """
+    pg_counters = sai_thrift_read_pg_counters(
+        test_case.src_client, port_list['src'][test_case.src_port_id])
+    recv_counters, _ = sai_thrift_read_port_counters(
+        test_case.src_client, test_case.asic_type, port_list['src'][test_case.src_port_id])
+
+    pkts_received = pg_counters[pg] - pg_counters_base[pg]
+
+    # For Broadcom DNX, include ingress drops in received count
+    if test_case.platform_asic and test_case.platform_asic == "broadcom-dnx":
+        ingress_drops = ([recv_counters[cntr] - recv_counters_base[cntr]
+                         for cntr in test_case.ingress_counters])[0]
+        pkts_received += ingress_drops
+
+    print("PG{} check: received={}, sent={}".format(pg, pkts_received, pkts_to_send), file=sys.stderr)
+    return pkts_received >= pkts_to_send
+
+
+def read_pg_port_counters(test_case, src_port_id, dst_port_id):
+    """Read all PG and port counters, return dict with pg_counters, recv_counters, xmit_counters, and drop totals."""
+    # Read all PG counters
+    pg_counters = sai_thrift_read_pg_counters(
+        test_case.src_client, port_list['src'][src_port_id])
+
+    # Read port counters
+    recv_counters, _ = sai_thrift_read_port_counters(
+        test_case.src_client, test_case.asic_type, port_list['src'][src_port_id])
+    xmit_counters, _ = sai_thrift_read_port_counters(
+        test_case.dst_client, test_case.asic_type, port_list['dst'][dst_port_id])
+
+    # Calculate drops
+    ingress_drops = ([recv_counters[cntr] for cntr in test_case.ingress_counters])[0]
+    egress_drops = ([xmit_counters[cntr] for cntr in test_case.egress_counters])[0]
+    total_drops = ingress_drops + egress_drops
+
+    return {
+        'pg_counters': pg_counters,
+        'recv_counters': recv_counters,
+        'xmit_counters': xmit_counters,
+        'ingress_drops': ingress_drops,
+        'egress_drops': egress_drops,
+        'total_drops': total_drops
+    }
+
+
+def run_cmd_on_dut(test_case, cmd, timeout=30):
+    """Execute command on DUT."""
+    return test_case.exec_cmd_on_dut(
+        test_case.src_server_ip,
+        test_case.test_params['dut_username'],
+        test_case.test_params['dut_password'],
+        cmd,
+        timeout=timeout
+    )
+
+
 class CounterCollector:
     '''Collect, compare and display counters for test'''
 
@@ -7638,17 +7766,7 @@ class TrafficSanityTest(sai_base_test.ThriftInterfaceDataPlane):
 
 
 class PgMinThresholdTest(sai_base_test.ThriftInterfaceDataPlane):
-    """
-    Test to validate PG MIN threshold behavior.
-
-    Creates 2 buffer profiles for 2 different PGs:
-    - PG0: No PG MIN (uses shared pool only)
-    - PG1: Has PG MIN threshold configured
-
-    Validates:
-    - Traffic to PG0 exhausts shared pool, excess packets are dropped
-    - Traffic to PG1 gets PG MIN bandwidth guaranteed, packets exceeding (Shared - PG MIN) are dropped
-    """
+    """Test PG MIN threshold behavior: PG0 (no MIN) vs PG1 (with MIN)."""
 
     def setUp(self):
         sai_base_test.ThriftInterfaceDataPlane.setUp(self)
@@ -7660,14 +7778,17 @@ class PgMinThresholdTest(sai_base_test.ThriftInterfaceDataPlane):
         self.router_mac = self.test_params['router_mac']
         self.sonic_version = self.test_params['sonic_version']
         self.asic_type = self.test_params['sonic_asic_type']
+        self.platform_asic = self.test_params['platform_asic']
+
+        # Get counter names to query
+        self.ingress_counters, self.egress_counters = get_counter_names(
+            self.sonic_version)
 
         # PG configuration
         self.pg0_dscp = self.test_params['pg0_dscp']  # DSCP for PG0 (no PG MIN)
         self.pg1_dscp = self.test_params['pg1_dscp']  # DSCP for PG1 (with PG MIN)
         self.pg0 = self.test_params['pg0']  # PG number without MIN
         self.pg1 = self.test_params['pg1']  # PG number with MIN
-        self.pg0_cntr_idx = self.pg0 + 2
-        self.pg1_cntr_idx = self.pg1 + 2
 
         # Port configuration
         self.src_port_id = int(self.test_params['src_port_id'])
@@ -7676,24 +7797,48 @@ class PgMinThresholdTest(sai_base_test.ThriftInterfaceDataPlane):
         self.dst_port_ip = self.test_params['dst_port_ip']
 
         # Buffer configuration
-        self.shared_pool_size = int(self.test_params['shared_pool_size'])
-        self.pg1_min_size = int(self.test_params['pg1_min_size'])
-        self.packet_size = int(self.test_params.get('packet_size', 1500))
+        self.packet_size = int(self.test_params.get('packet_size', 64))
         self.cell_size = int(self.test_params.get('cell_size', 254))
+        self.pg1_min_size = int(self.test_params['pg1_min_size'])  # PG1 MIN threshold in bytes
+
+        # Calculate how many packets can be accommodated in PG1 MIN threshold
+        import math
+        # Step 1: Calculate cells per packet (ceil of packet_size / cell_size)
+        self.cells_per_packet = int(math.ceil(float(self.packet_size) / float(self.cell_size)))
+
+        # Step 2: Calculate total cells in PG1 threshold (floor of threshold / cell_size)
+        self.cells_in_pg1_threshold = int(math.floor(float(self.pg1_min_size) / float(self.cell_size)))
+
+        # Step 3: Calculate packets that can fit (floor of cells_in_threshold / cells_per_packet)
+        self.pg1_capacity_pkts = int(math.floor(float(self.cells_in_pg1_threshold) / float(self.cells_per_packet)))
 
         # Calculate packet counts
-        # For PG0: should fill shared pool completely
-        self.pg0_pkts_to_fill = int(self.test_params['pg0_pkts_to_fill'])
-        self.pg0_pkts_to_drop = int(self.test_params['pg0_pkts_to_drop'])
+        self.pg_pkts_to_fill = int(self.test_params['pg_pkts_to_fill'])
 
-        # For PG1: should fill PG MIN + remaining shared
-        self.pg1_pkts_to_fill = int(self.test_params['pg1_pkts_to_fill'])
-        self.pg1_pkts_to_drop = int(self.test_params['pg1_pkts_to_drop'])
+        # Packet count tolerance for drop comparison (accounts for timing variations and background traffic)
+        self.pkt_count_tolerance = int(self.test_params.get('pkt_count_tolerance', 5))
 
-        self.margin = int(self.test_params.get('pkts_num_margin', 5))
+        # Validate that PG1 capacity is greater than tolerance
+        assert self.pg1_capacity_pkts >= self.pkt_count_tolerance, \
+            "PG1 capacity ({}) must be greater than or equal to tolerance ({}) for meaningful test validation".format(
+                self.pg1_capacity_pkts, self.pkt_count_tolerance)
+
+        # Get test interface name from test_params
+        self.test_interface = self.test_params.get('test_interface')
+        if not self.test_interface:
+            raise ValueError("test_interface not provided in test_params")
 
         self.dst_port_mac = self.dataplane.get_mac(0, self.dst_port_id)
-        self.src_port_mac = self.dataplane.get_mac(0, self.src_port_id)
+
+        # Find PG0 profile and key
+        self.pg0_profile_name, self.pg0_key = self._find_pg_profile(self.pg0)
+        if not self.pg0_profile_name:
+            raise ValueError("Could not find profile for PG{} on {}".format(self.pg0, self.test_interface))
+
+        # Create PG1 key by replacing last part of PG0 key
+        self.pg1_key = "{}|{}".format(self.pg0_key.rsplit('|', 1)[0], self.pg1)
+
+        self._create_and_apply_pg1_buffer_profile()
 
         # Correct destination port if in LAG
         real_dst_port_id = get_rx_port(
@@ -7706,165 +7851,316 @@ class PgMinThresholdTest(sai_base_test.ThriftInterfaceDataPlane):
                 self.dst_port_id, real_dst_port_id), file=sys.stderr)
             self.dst_port_id = real_dst_port_id
 
+    def _find_pg_profile(self, pg_number):
+        """Find buffer profile and key for given PG. Returns (profile_name, pg_key) or (None, None)."""
+        # Get all BUFFER_PG keys for the interface
+        cmd = 'sonic-db-cli CONFIG_DB keys "BUFFER_PG|{}|*"'.format(self.test_interface)
+        stdout, stderr, ret = run_cmd_on_dut(self, cmd)
+
+        if ret != 0 or not stdout:
+            print("Warning: Failed to get BUFFER_PG keys: {}".format(stderr), file=sys.stderr)
+            return None, None
+
+        pg_keys = stdout if isinstance(stdout, list) else [stdout]
+
+        # Find the key that contains our PG number
+        for pg_key in pg_keys:
+            pg_key = pg_key.strip()
+            if not pg_key:
+                continue
+
+            # Extract PG range from key (e.g., "3-4" or "0")
+            pg_range = pg_key.split('|')[-1]
+
+            # Check if our PG is in this range
+            if '-' in pg_range:
+                start, end = map(int, pg_range.split('-'))
+                if start <= pg_number <= end:
+                    # Found the right key, get the profile
+                    cmd = 'sonic-db-cli CONFIG_DB HGET "{}" "profile"'.format(pg_key)
+                    stdout, stderr, ret = run_cmd_on_dut(self, cmd)
+
+                    if ret == 0 and stdout:
+                        profile = stdout[0].strip() if isinstance(stdout, list) else stdout.strip()
+                        return profile, pg_key
+            else:
+                # Single PG
+                if int(pg_range) == pg_number:
+                    cmd = 'sonic-db-cli CONFIG_DB HGET "{}" "profile"'.format(pg_key)
+                    stdout, stderr, ret = run_cmd_on_dut(self, cmd)
+
+                    if ret == 0 and stdout:
+                        profile = stdout[0].strip() if isinstance(stdout, list) else stdout.strip()
+                        return profile, pg_key
+
+        return None, None
+
+    def _create_and_apply_pg1_buffer_profile(self):
+        """Update PG0 profile size to 0, create PG1 profile with pg1_min_size, restart swss."""
+        try:
+
+            # Step 1: Get PG0 profile configuration
+            cmd = 'sonic-db-cli CONFIG_DB HGETALL "BUFFER_PROFILE|{}"'.format(self.pg0_profile_name)
+            stdout, stderr, ret = run_cmd_on_dut(self, cmd)
+
+            if ret != 0 or not stdout:
+                raise ValueError("Failed to get PG0 profile config: {}".format(stderr))
+
+            # Parse profile config
+            import ast
+            stdout_str = '\n'.join(stdout) if isinstance(stdout, list) else stdout
+            profile_config = ast.literal_eval(stdout_str.strip())
+
+            # Step 2: Update PG0 profile size to 0
+            cmd = 'sonic-db-cli CONFIG_DB HSET "BUFFER_PROFILE|{}" "size" "0"'.format(self.pg0_profile_name)
+            stdout, stderr, ret = run_cmd_on_dut(self, cmd)
+
+            if ret != 0:
+                print("Warning: Failed to update PG0 profile size: {}".format(stderr), file=sys.stderr)
+
+            # Step 3: Create new profile for PG1 with pg1_min_size
+            self.pg1_profile_name = "{}_pg_min_set".format(self.pg0_profile_name)
+
+            # Copy all fields from PG0 profile and update size
+            profile_config['size'] = str(self.pg1_min_size)
+
+            # Build HMSET command
+            hmset_args = []
+            for key, value in profile_config.items():
+                hmset_args.append('"{}" "{}"'.format(key, value))
+
+            cmd = 'sonic-db-cli CONFIG_DB -- HMSET "BUFFER_PROFILE|{}" {}'.format(
+                self.pg1_profile_name, ' '.join(hmset_args))
+            stdout, stderr, ret = run_cmd_on_dut(self, cmd)
+
+            if ret != 0:
+                raise ValueError("Failed to create PG1 profile: {}".format(stderr))
+
+            # Step 4: Apply PG1 profile to PG1
+            cmd = 'sonic-db-cli CONFIG_DB HSET "{}" "profile" "{}"'.format(self.pg1_key, self.pg1_profile_name)
+            stdout, stderr, ret = run_cmd_on_dut(self, cmd)
+
+            if ret != 0:
+                raise ValueError("Failed to apply PG1 profile: {}".format(stderr))
+
+            # Step 5: Restart swss
+            cmd = 'sudo systemctl restart swss'
+            stdout, stderr, ret = run_cmd_on_dut(self, cmd, timeout=100)
+
+            if ret != 0:
+                print("Warning: Failed to restart swss: {}".format(stderr), file=sys.stderr)
+            else:
+                # Wait for orchagent to be ready after swss restart
+                if not wait_until(420, 10, 5, check_orchagent_ready, self):
+                    print("Warning: orchagent_restart_check did not succeed within timeout", file=sys.stderr)
+            sai_base_test.ThriftInterfaceDataPlane.tearDown(self)
+            sai_base_test.ThriftInterfaceDataPlane.setUp(self)
+            time.sleep(1)
+
+        except Exception as e:
+            print("Error in _create_and_apply_pg1_buffer_profile: {}".format(str(e)), file=sys.stderr)
+            raise
+
     def tearDown(self):
-        sai_base_test.ThriftInterfaceDataPlane.tearDown(self)
+        """Cleanup: config reload to restore original configuration."""
+        try:
+            cmd = "sudo config reload -y -f &>/dev/null"
+            stdout, stderr, ret = run_cmd_on_dut(self, cmd, timeout=100)
 
-    def wait_for_counter_update(self, timeout=10, interval=0.5):
-        """
-        Wait for PG counters to stabilize after packet transmission.
-        Polls counters until they stop changing or timeout is reached.
+            if ret != 0:
+                print("Warning: Config reload failed: {}".format(stderr), file=sys.stderr)
+            else:
+                # Wait for orchagent to be ready after config reload
+                if not wait_until(420, 10, 5, check_orchagent_ready, self):
+                    print("Warning: orchagent_restart_check did not succeed within timeout", file=sys.stderr)
+                time.sleep(30)
 
-        Args:
-            timeout: Maximum time to wait in seconds
-            interval: Polling interval in seconds
-
-        Returns:
-            True if counters stabilized, False if timeout
-        """
-        start_time = time.time()
-        prev_counters = None
-        stable_count = 0
-        required_stable_reads = 3  # Require 3 consecutive stable reads
-
-        while (time.time() - start_time) < timeout:
-            curr_counters = sai_thrift_read_pg_counters(
-                self.src_client, port_list['src'][self.src_port_id])
-
-            if prev_counters is not None:
-                # Check if counters are stable (no change)
-                if curr_counters == prev_counters:
-                    stable_count += 1
-                    if stable_count >= required_stable_reads:
-                        print("Counters stabilized after {:.2f}s".format(
-                            time.time() - start_time), file=sys.stderr)
-                        return True
-                else:
-                    stable_count = 0
-
-            prev_counters = curr_counters
-            time.sleep(interval)
-
-        print("Warning: Counter stabilization timeout after {:.2f}s".format(
-            time.time() - start_time), file=sys.stderr)
-        return False
+        except Exception as e:
+            print("Error during tearDown: {}".format(str(e)), file=sys.stderr)
+        finally:
+            sai_base_test.ThriftInterfaceDataPlane.tearDown(self)
 
     def runTest(self):
-        print("\n=== Starting PG MIN Threshold Test (Simplified) ===", file=sys.stderr)
-        print("PG0 (lossy): DSCP={}, PG={}".format(self.pg0_dscp, self.pg0), file=sys.stderr)
-        print("PG1 (lossless): DSCP={}, PG={}".format(self.pg1_dscp, self.pg1), file=sys.stderr)
+        print("\n=== Starting PG MIN Threshold Test ===", file=sys.stderr)
+        print("PG0: DSCP={}, PG={}".format(self.pg0_dscp, self.pg0), file=sys.stderr)
+        print("PG1: DSCP={}, PG={}".format(self.pg1_dscp, self.pg1), file=sys.stderr)
+        print("PG1 MIN size: {} bytes, capacity: {} packets".format(
+            self.pg1_min_size, self.pg1_capacity_pkts), file=sys.stderr)
+        print("Total packets to send: {}".format(self.pg_pkts_to_fill), file=sys.stderr)
         sys.stderr.flush()
-
-        # Get baseline counters
-        pg_drop_counters_base = sai_thrift_read_pg_drop_counters(
-            self.src_client, port_list['src'][self.src_port_id])
-        pg_counters_base = sai_thrift_read_pg_counters(
-            self.src_client, port_list['src'][self.src_port_id])
 
         # Disable TX on destination port to accumulate packets
         self.sai_thrift_port_tx_disable(self.dst_client, self.asic_type, [self.dst_port_id])
 
         try:
-            # ===== Test: Send traffic to both PGs simultaneously =====
-            print("\n--- Sending traffic to both PGs to fill buffers ---", file=sys.stderr)
-
-            # Construct packets for both PGs
-            pkt_pg0 = construct_ip_pkt(
-                self.packet_size,
-                self.router_mac if self.router_mac != '' else self.dst_port_mac,
-                self.src_port_mac,
-                self.src_port_ip,
-                self.dst_port_ip,
-                self.pg0_dscp,
-                None,
-                ecn=1,
-                ttl=64
+            # Construct both PG0 and PG1 packets
+            print("\n--- Creating packets for PG0 and PG1 ---", file=sys.stderr)
+            pkt_pg0 = simple_tcp_packet(
+                pktlen=self.packet_size,
+                eth_dst=self.router_mac if self.router_mac != '' else self.dst_port_mac,
+                ip_src=self.src_port_ip,
+                ip_dst=self.dst_port_ip,
+                ip_tos=self.pg0_dscp << 2,
+                ip_ttl=64,
+                ip_ecn=1
             )
 
-            pkt_pg1 = construct_ip_pkt(
-                self.packet_size,
-                self.router_mac if self.router_mac != '' else self.dst_port_mac,
-                self.src_port_mac,
-                self.src_port_ip,
-                self.dst_port_ip,
-                self.pg1_dscp,
-                None,
-                ecn=1,
-                ttl=64
+            pkt_pg1 = simple_tcp_packet(
+                pktlen=self.packet_size,
+                eth_dst=self.router_mac if self.router_mac != '' else self.dst_port_mac,
+                ip_src=self.src_port_ip,
+                ip_dst=self.dst_port_ip,
+                ip_tos=self.pg1_dscp << 2,
+                ip_ttl=64,
+                ip_ecn=1
             )
+            print("PG0 packet: DSCP={}, TOS={}".format(self.pg0_dscp, self.pg0_dscp << 2), file=sys.stderr)
+            print("PG1 packet: DSCP={}, TOS={}".format(self.pg1_dscp, self.pg1_dscp << 2), file=sys.stderr)
 
-            # Send packets to PG0 (lossy)
-            print("Sending {} packets to PG0 (lossy)".format(self.pg0_pkts_to_fill), file=sys.stderr)
-            send_packet(self, self.src_port_id, pkt_pg0, self.pg0_pkts_to_fill)
-            self.wait_for_counter_update(timeout=10, interval=0.5)
+            # ===== PHASE 1: Send traffic to PG0 =====
+            print("\n--- PHASE 1: Sending traffic to PG0 ---", file=sys.stderr)
 
-            # Send packets to PG1 (lossless)
-            print("Sending {} packets to PG1 (lossless)".format(self.pg1_pkts_to_fill), file=sys.stderr)
-            send_packet(self, self.src_port_id, pkt_pg1, self.pg1_pkts_to_fill)
-            self.wait_for_counter_update(timeout=10, interval=0.5)
+            # Record baseline counters for PG0 using helper function
+            counters_base_pg0 = read_pg_port_counters(self, self.src_port_id, self.dst_port_id)
+            pg_counters_base_pg0 = counters_base_pg0['pg_counters']
+            recv_counters_base_pg0 = counters_base_pg0['recv_counters']
 
-            # Read drop counters and packet counters
-            pg_drop_counters = sai_thrift_read_pg_drop_counters(
-                self.src_client, port_list['src'][self.src_port_id])
-            pg_counters = sai_thrift_read_pg_counters(
-                self.src_client, port_list['src'][self.src_port_id])
+            print("Baseline PG0 counter: {}".format(counters_base_pg0['pg_counters'][self.pg0]), file=sys.stderr)
+            print("Baseline ingress drops: {}".format(counters_base_pg0['ingress_drops']), file=sys.stderr)
+            print("Baseline egress drops: {}".format(counters_base_pg0['egress_drops']), file=sys.stderr)
 
-            pg0_drops = pg_drop_counters[self.pg0] - pg_drop_counters_base[self.pg0]
-            pg1_drops = pg_drop_counters[self.pg1] - pg_drop_counters_base[self.pg1]
-            pg0_pkts = pg_counters[self.pg0] - pg_counters_base[self.pg0]
-            pg1_pkts = pg_counters[self.pg1] - pg_counters_base[self.pg1]
+            # Send packets to PG0
+            print("Sending {} packets to PG0".format(self.pg_pkts_to_fill), file=sys.stderr)
+            send_packet(self, self.src_port_id, pkt_pg0, self.pg_pkts_to_fill)
 
-            print("\n=== Results ===", file=sys.stderr)
-            print("PG0 (lossy) packets: {}, drops: {}".format(pg0_pkts, pg0_drops), file=sys.stderr)
-            print("PG1 (lossless) packets: {}, drops: {}".format(pg1_pkts, pg1_drops), file=sys.stderr)
+            print("Completed sending {} packets to PG0".format(self.pg_pkts_to_fill), file=sys.stderr)
 
-            # Validation: Multiple assertions to ensure test correctness
-            print("\n--- Validation ---", file=sys.stderr)
+            # Wait until received packets >= sent packets
+            if not wait_until(10, 2, 2, check_pg_packets_received, self, self.pg0,
+                              pg_counters_base_pg0, recv_counters_base_pg0, self.pg_pkts_to_fill):
+                print("Warning: PG0 did not receive all packets within timeout", file=sys.stderr)
 
-            # Assert 1: Packets were actually received on both PGs (sanity check)
-            assert pg0_pkts > 0, \
-                "No packets received on PG0 (lossy), expected {}".format(self.pg0_pkts_to_fill)
-            assert pg1_pkts > 0, \
-                "No packets received on PG1 (lossless), expected {}".format(self.pg1_pkts_to_fill)
-            print("Assert 1 PASSED: Packets received on both PGs (PG0={}, PG1={})".format(
-                pg0_pkts, pg1_pkts), file=sys.stderr)
+            # Read counters after PG0 traffic
+            print("Reading PG0 counters...", file=sys.stderr)
+            counters_after_pg0 = read_pg_port_counters(self, self.src_port_id, self.dst_port_id)
 
-            # Assert 2: PG0 (lossy) should have some drops (may be small if buffer is large)
-            # Relaxed: just check that lossy has any drops at all
-            assert pg0_drops > 0, \
-                "PG0 (lossy) should have at least some drops, but got {}".format(pg0_drops)
-            print("Assert 2 PASSED: PG0 (lossy) has drops ({})".format(pg0_drops), file=sys.stderr)
+            # Calculate results for PG0
+            pg0_pkts_received = counters_after_pg0['pg_counters'][self.pg0] - counters_base_pg0['pg_counters'][self.pg0]
+            pg0_ingress_drops = counters_after_pg0['ingress_drops'] - counters_base_pg0['ingress_drops']
+            pg0_egress_drops = counters_after_pg0['egress_drops'] - counters_base_pg0['egress_drops']
+            pg0_total_drops = pg0_ingress_drops + pg0_egress_drops
 
-            # Assert 3: PG1 (lossless) should have minimal or no drops
-            # Relaxed: allow some drops but should be much less than lossy
-            print("PG1 (lossless) drops: {} (margin: {})".format(pg1_drops, self.margin), file=sys.stderr)
-            if pg1_drops <= self.margin:
-                print("Assert 3 PASSED: PG1 (lossless) has minimal drops ({})".format(pg1_drops), file=sys.stderr)
-            else:
-                print("Assert 3 WARNING: PG1 (lossless) has more drops than expected ({} > {})".format(
-                    pg1_drops, self.margin), file=sys.stderr)
+            # For Broadcom DNX, include ingress drops in received count
+            if self.platform_asic and self.platform_asic == "broadcom-dnx":
+                pg0_pkts_received += pg0_ingress_drops
 
-            # Assert 4: Lossy should drop more than or equal to lossless (main validation)
-            assert pg0_drops >= pg1_drops, \
-                "PG0 (lossy) should drop at least as many packets as PG1 (lossless), but got PG0={}, PG1={}".format(
-                    pg0_drops, pg1_drops)
-            print("Assert 4 PASSED: PG0 drops ({}) >= PG1 drops ({})".format(pg0_drops, pg1_drops), file=sys.stderr)
+            print("\n=== PG0 Test Results ===", file=sys.stderr)
+            print("PG0 - sent: {}, received: {}, ingress drops: {}, egress drops: {}, total drops: {}".format(
+                self.pg_pkts_to_fill, pg0_pkts_received, pg0_ingress_drops, pg0_egress_drops, pg0_total_drops),
+                file=sys.stderr)
 
-            # Assert 5: If both have drops, lossy should drop more
-            if pg1_drops > 0:
-                drop_ratio = float(pg0_drops) / float(pg1_drops)
-                print("Drop ratio (PG0/PG1): {:.2f}".format(drop_ratio), file=sys.stderr)
-                # Relaxed: just check lossy drops more, not a specific ratio
-                assert pg0_drops > pg1_drops, \
-                    "When both PGs drop, PG0 (lossy) should drop more than PG1 (lossless), " \
-                    "but got PG0={}, PG1={}".format(pg0_drops, pg1_drops)
-                print("Assert 5 PASSED: PG0 drops more than PG1 (ratio: {:.2f})".format(drop_ratio), file=sys.stderr)
-            else:
-                print("Assert 5 PASSED: PG1 has no drops, PG0 has {} drops".format(pg0_drops), file=sys.stderr)
+            # Validation for PG0
+            print("\n--- Validating PG0 ---", file=sys.stderr)
+            assert pg0_pkts_received >= self.pg_pkts_to_fill, \
+                "PG0: Received packets ({}) should be >= sent packets ({})".format(
+                    pg0_pkts_received, self.pg_pkts_to_fill)
+            print("✓ PG0 Validation 1 PASSED: Received ({}) >= Sent ({})".format(
+                pg0_pkts_received, self.pg_pkts_to_fill), file=sys.stderr)
 
-            print("\nALL ASSERTIONS PASSED: Lossy traffic behavior validated", file=sys.stderr)
+            assert pg0_total_drops > 0, \
+                "PG0: Total drops ({}) should be > 0 (buffer should be exhausted)".format(pg0_total_drops)
+            print("✓ PG0 Validation 2 PASSED: Total drops ({}) > 0".format(pg0_total_drops), file=sys.stderr)
+
+            # ===== Enable TX to drain traffic =====
+            print("\n--- Draining PG0 traffic ---", file=sys.stderr)
+            self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, [self.dst_port_id])
+            print("TX enabled, waiting for traffic to drain...", file=sys.stderr)
+            time.sleep(60)
+            print("Traffic drained", file=sys.stderr)
+
+            # Disable TX again for PG1 test
+            print("Disabling TX for PG1 test...", file=sys.stderr)
+            self.sai_thrift_port_tx_disable(self.dst_client, self.asic_type, [self.dst_port_id])
+            print("TX disabled", file=sys.stderr)
+
+            # ===== PHASE 2: Send traffic to PG1 =====
+            print("\n--- PHASE 2: Sending traffic to PG1 ---", file=sys.stderr)
+
+            # Record baseline counters for PG1
+            counters_base_pg1 = read_pg_port_counters(self, self.src_port_id, self.dst_port_id)
+            pg_counters_base_pg1 = counters_base_pg1['pg_counters']
+            recv_counters_base_pg1 = counters_base_pg1['recv_counters']
+
+            print("Baseline PG1 counter: {}".format(counters_base_pg1['pg_counters'][self.pg1]), file=sys.stderr)
+            print("Baseline ingress drops: {}".format(counters_base_pg1['ingress_drops']), file=sys.stderr)
+            print("Baseline egress drops: {}".format(counters_base_pg1['egress_drops']), file=sys.stderr)
+
+            # Send packets to PG1
+            print("Sending {} packets to PG1".format(self.pg_pkts_to_fill), file=sys.stderr)
+            send_packet(self, self.src_port_id, pkt_pg1, self.pg_pkts_to_fill)
+
+            print("Completed sending {} packets to PG1".format(self.pg_pkts_to_fill), file=sys.stderr)
+
+            # Wait until received packets >= sent packets
+            if not wait_until(10, 2, 2, check_pg_packets_received, self, self.pg1,
+                              pg_counters_base_pg1, recv_counters_base_pg1, self.pg_pkts_to_fill):
+                print("Warning: PG1 did not receive all packets within timeout", file=sys.stderr)
+
+            # Read counters after PG1 traffic
+            print("Reading PG1 counters...", file=sys.stderr)
+            counters_after_pg1 = read_pg_port_counters(self, self.src_port_id, self.dst_port_id)
+
+            # Calculate results for PG1
+            pg1_pkts_received = counters_after_pg1['pg_counters'][self.pg1] - counters_base_pg1['pg_counters'][self.pg1]
+            pg1_ingress_drops = counters_after_pg1['ingress_drops'] - counters_base_pg1['ingress_drops']
+            pg1_egress_drops = counters_after_pg1['egress_drops'] - counters_base_pg1['egress_drops']
+            pg1_total_drops = pg1_ingress_drops + pg1_egress_drops
+
+            # For Broadcom DNX, include ingress drops in received count
+            if self.platform_asic and self.platform_asic == "broadcom-dnx":
+                pg1_pkts_received += pg1_ingress_drops
+
+            print("\n=== PG1 Test Results ===", file=sys.stderr)
+            print("PG1 - sent: {}, received: {}, ingress drops: {}, egress drops: {}, total drops: {}".format(
+                self.pg_pkts_to_fill, pg1_pkts_received, pg1_ingress_drops, pg1_egress_drops, pg1_total_drops),
+                file=sys.stderr)
+
+            # Validation for PG1
+            print("\n--- Validating PG1 ---", file=sys.stderr)
+            assert pg1_pkts_received >= self.pg_pkts_to_fill, \
+                "PG1: Received packets ({}) should be >= sent packets ({})".format(
+                    pg1_pkts_received, self.pg_pkts_to_fill)
+            print("✓ PG1 Validation 1 PASSED: Received ({}) >= Sent ({})".format(
+                pg1_pkts_received, self.pg_pkts_to_fill), file=sys.stderr)
+
+            # ===== PHASE 3: Compare PG0 and PG1 drops =====
+            print("\n--- PHASE 3: Comparing PG0 and PG1 drops ---", file=sys.stderr)
+            print("PG0 total drops: {}".format(pg0_total_drops), file=sys.stderr)
+            print("PG1 total drops: {}".format(pg1_total_drops), file=sys.stderr)
+            print("PG1 MIN capacity: {} packets".format(self.pg1_capacity_pkts), file=sys.stderr)
+            print("Tolerance: {} packets".format(self.pkt_count_tolerance), file=sys.stderr)
+
+            # Final validation: pg0_drops - pg1_drops >= tolerance
+            drop_difference = pg0_total_drops - pg1_total_drops
+
+            print("Drop difference (PG0 - PG1): {}".format(drop_difference), file=sys.stderr)
+
+            # Use margin for comparison because after draining PG0 traffic, PG1 traffic may not
+            # immediately utilize the full shared space even though all PG0 traffic has been drained.
+            # While waiting longer could help, it doesn't guarantee complete shared pool utilization.
+            assert drop_difference >= self.pkt_count_tolerance, \
+                "Drop difference ({}) should be >= tolerance ({}). " \
+                "This indicates PG1 MIN threshold is not protecting enough packets.".format(
+                    drop_difference, self.pkt_count_tolerance)
+            print("✓ Final Validation PASSED: Drop difference ({}) >= tolerance ({})".format(
+                drop_difference, self.pkt_count_tolerance), file=sys.stderr)
+
+            print("\n=== ALL VALIDATIONS PASSED ===", file=sys.stderr)
             print("=== PG MIN Threshold Test PASSED ===\n", file=sys.stderr)
             sys.stderr.flush()
 
         finally:
             # Re-enable TX on destination port
+            print("\n--- Enabling TX on destination port ---", file=sys.stderr)
             self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, [self.dst_port_id])
+            print("TX enabled", file=sys.stderr)


### PR DESCRIPTION
### Description of PR

Fix flaky PgMinThreshold test by correcting drop count comparison logic and packet handling sequence.

The PgMinThreshold test validates buffer behavior between two priority groups:
- PG0: No minimum threshold (uses shared pool only)
- PG1: Has minimum threshold configured

The test was failing intermittently due to incorrect drop counter logic and simultaneous packet transmission causing race conditions.

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request
- [ ] 202505

### Approach

#### What is the motivation for this PR?
The PgMinThreshold test was flaky, causing CI failures. The test needs to reliably validate that:
1. PG without minimum threshold drops more packets when shared pool is exhausted
2. PG with minimum threshold gets guaranteed bandwidth allocation

#### How did you do it?
1. Fixed packet sequence: Send packets sequentially instead of simultaneously
2. Corrected drop logic: Enable queue to free up queued packets so shared pool can be fully utilized
3. Added PG min configuration: Ensure PG minimum size is properly updated
4. Fixed assertions: Compare that PG without threshold has significantly more drops

#### How did you verify/test it?
Validated the changes on TH5 platform where the test now executes reliably with consistent results as expected.