### PR TITLE
Add **kwargs to BaseConsoleConn.find_prompt() on 202505 branch

### DIFF
--- a/tests/common/connections/base_console_conn.py
+++ b/tests/common/connections/base_console_conn.py
@@ -76,8 +76,8 @@ class BaseConsoleConn(CiscoBaseConnection):
         # not supported
         pass
 
-    def find_prompt(self, delay_factor=1):
-        return super(BaseConsoleConn, self).find_prompt(delay_factor)
+    def find_prompt(self, delay_factor=1, **kwargs):
+        return super(BaseConsoleConn, self).find_prompt(delay_factor, **kwargs)
 
     def clear_buffer(self):
         # todo


### PR DESCRIPTION
### Description of PR

Summary:
Add `**kwargs` to `BaseConsoleConn.find_prompt()` method signature on the 202505 branch.

The `find_prompt()` method in `BaseConsoleConn` (`tests/common/connections/base_console_conn.py`) was missing `**kwargs`, causing `test_console_reversessh` / `test_console_reversessh_connectivity` failures when callers pass keyword arguments that the parent class `CiscoBaseConnection.find_prompt()` accepts.

This fix aligns the 202505 branch with the master branch, which already has this fix.

Ref: ADO PBI 37501756

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`test_console_reversessh` and `test_console_reversessh_connectivity` are failing on the 202505 branch because `BaseConsoleConn.find_prompt()` lacks `**kwargs` in its method signature. When netmiko or test code calls `find_prompt()` with keyword arguments, a `TypeError` is raised.

#### How did you do it?
Added `**kwargs` to the `find_prompt(self, delay_factor=1)` method signature and forwarded it to the parent `super().find_prompt()` call, matching the fix already present on master.

#### How did you verify/test it?
- Verified the master branch already has this fix and tests pass there
- Confirmed the 202505 branch was missing `**kwargs`
- The change is minimal (2 lines) and matches the proven master branch code

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A