### PR TITLE
Skip packet trimming tests when testbed lacks required TGEN ports

### DIFF
--- a/tests/snappi_tests/packet_trimming/files/packet_trimming_helper.py
+++ b/tests/snappi_tests/packet_trimming/files/packet_trimming_helper.py
@@ -1,6 +1,7 @@
 import inspect
 import time
 import logging
+import pytest
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id
@@ -74,6 +75,22 @@ def run_packet_trimming_test(
 
     if snappi_test_params is None:
         snappi_test_params = SnappiTestParams()
+
+    # Skip test if testbed does not have enough TGEN ports
+    num_required = (
+        snappi_test_params.num_tx_links
+        + snappi_test_params.num_rx_links
+    )
+    num_available = len(port_config_list)
+    if num_available < num_required:
+        pytest.skip(
+            "Test requires {} ports ({} TX + {} RX) but testbed has only {} ports".format(
+                num_required,
+                snappi_test_params.num_tx_links,
+                snappi_test_params.num_rx_links,
+                num_available,
+            )
+        )
 
     caller_name = inspect.stack()[1].function
     snappi_test_params.packet_capture_file = f'packet_trimming_{caller_name}'  # will be saved as .pcapng


### PR DESCRIPTION
### Description of PR

Summary:
Tests like `test_ten_to_one_symmetric_dscp_trimming` and `test_twelve_to_one_symmetric_dscp_trimming` require 10-12 TX TGEN ports, but most tgen testbeds only have 2-4 ports. This causes these tests to fail with a `pytest_assert` error in `setup_base_traffic_config()` instead of being gracefully skipped, resulting in a 0% pass rate (64 errors / 0 passed over 30 days).

This PR adds a `pytest.skip()` guard at the beginning of `run_packet_trimming_test()` in the packet trimming helper that checks the number of available TGEN ports against the required `num_tx_links + num_rx_links`. If the testbed does not have enough ports, the test is cleanly skipped with a descriptive message instead of failing.

Fixes: ADO PBI 37501693

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Packet trimming tests that require many TX ports (8, 10, 12) always fail on standard tgen testbeds that have only 2-4 TGEN ports. The failure message from `pytest_assert` ("Cannot find enough TX ports") counts as a test error, polluting nightly test results with known-infrastructure failures.

#### How did you do it?
Added a skip guard at the start of `run_packet_trimming_test()` in `packet_trimming_helper.py`:
- Added `import pytest`
- After the `snappi_test_params` initialization, check `len(port_config_list)` against `num_tx_links + num_rx_links`
- If insufficient ports, call `pytest.skip()` with a descriptive message

This ensures all packet trimming tests (symmetric and asymmetric) that go through this helper will be properly skipped when the testbed lacks enough ports.

#### How did you verify/test it?
- Code review of `setup_base_traffic_config()` confirms `port_config_list` represents available TGEN ports
- The skip check uses the same port count comparison that `setup_base_traffic_config()` would later assert on (line 109-110 in `traffic_generation.py`)
- Pre-commit checks (trailing whitespace, line length, blank lines) passed

#### Any platform specific information?
N/A - This affects all platforms using tgen topology with limited TGEN ports.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A