### PR TITLE
Add module_ignore_errors to dhcpv4_relay del in test cleanup

### DIFF
--- a/tests/dhcp_relay/test_dhcpv4_relay.py
+++ b/tests/dhcp_relay/test_dhcpv4_relay.py
@@ -164,7 +164,7 @@ def test_dhcp_relay_option82_suboptions(ptfhost, dut_dhcp_relay_data, validate_d
         for dhcp_relay in dut_dhcp_relay_data:
             vlan = str(dhcp_relay['downlink_vlan_iface']['name'])
             dhcp_servers = ",".join(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
-            duthost.shell(f'config dhcpv4_relay del {vlan}')
+            duthost.shell(f'config dhcpv4_relay del {vlan}', module_ignore_errors=True)
             loopback_iface = dhcp_relay["loopback_iface"]    # noqa: F841
 
             # Add test-case specific options
@@ -256,7 +256,7 @@ def test_dhcp_relay_agent_mode(
 
             vlan = str(dhcp_relay['downlink_vlan_iface']['name'])
             dhcp_servers = ",".join(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
-            duthost.shell(f'config dhcpv4_relay del {vlan}')
+            duthost.shell(f'config dhcpv4_relay del {vlan}', module_ignore_errors=True)
 
             # Update CONFIG_DB
             duthost.shell(f'config dhcpv4_relay add --dhcpv4-servers {dhcp_servers}'
@@ -371,7 +371,7 @@ def test_dhcp_relay_with_non_default_vrf(
     try:
         for dhcp_relay in dut_dhcp_relay_data:
             dhcp_servers = ",".join(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
-            duthost.shell(f'config dhcpv4_relay del {vlan_iface}')
+            duthost.shell(f'config dhcpv4_relay del {vlan_iface}', module_ignore_errors=True)
             loopback_iface = dhcp_relay["loopback_iface"]    # noqa: F841
 
             # Add test-case specific options
@@ -511,7 +511,7 @@ def test_dhcp_relay_with_different_non_default_vrf(
         for dhcp_relay in dut_dhcp_relay_data:
             dhcp_servers = ",".join(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
             loopback_iface = dhcp_relay["loopback_iface"]    # noqa: F841
-            duthost.shell(f'config dhcpv4_relay del {vlan_iface}')
+            duthost.shell(f'config dhcpv4_relay del {vlan_iface}', module_ignore_errors=True)
 
             duthost.shell(f'config dhcpv4_relay add --dhcpv4-servers {dhcp_servers}'
                           f' --server-vrf {SERVER_VRF_NAME} --vrf-selection enable'
@@ -579,7 +579,7 @@ def test_dhcp_max_hop_count(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
 
             vlan = str(dhcp_relay['downlink_vlan_iface']['name'])
             dhcp_servers = ",".join(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
-            duthost.shell(f'config dhcpv4_relay del {vlan}')
+            duthost.shell(f'config dhcpv4_relay del {vlan}', module_ignore_errors=True)
 
             # Update CONFIG_DB
             duthost.shell(f'config dhcpv4_relay add --dhcpv4-servers {dhcp_servers}'


### PR DESCRIPTION
### Description of PR

Summary:
Add `module_ignore_errors=True` to all `config dhcpv4_relay del` calls inside try blocks in `test_dhcpv4_relay.py`.

When interfaces are bound to a VRF, the DHCP relay config for that interface is automatically cleared. The subsequent `config dhcpv4_relay del` command then fails with rc=2, causing the test to abort before it can reconfigure and run the actual test logic.

The `finally` blocks already use `module_ignore_errors=True` for cleanup, but the `del` calls inside `try` blocks (used before reconfiguring) were missing this parameter.

Fixes ADO PBI 37501737

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`test_dhcp_relay_with_non_default_vrf` fails because `config dhcpv4_relay del` returns rc=2 when VRF bind has already cleared the relay config. The test aborts instead of proceeding to reconfigure.

#### How did you do it?
Added `module_ignore_errors=True` to all 5 `config dhcpv4_relay del` calls inside try blocks in:
- `test_dhcp_relay_option82_suboptions`
- `test_dhcp_relay_agent_mode`
- `test_dhcp_relay_with_non_default_vrf`
- `test_dhcp_relay_with_different_non_default_vrf`
- `test_dhcp_max_hop_count`

The `finally` cleanup blocks already had this parameter; only the try-block reconfiguration calls were missing it.

#### How did you verify/test it?
Code review confirmed the fix is consistent with the existing `finally` block pattern. The `del` command is immediately followed by an `add` command that reconfigures the relay, so ignoring the error on `del` is safe.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A