### PR TITLE
[tests/common]: re-run update-containers after safe_reload to fix restapi DNS race

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -309,6 +309,14 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
         pytest_assert(wait_until(wait + 300, 20, 0, sonic_host.critical_services_fully_started),
                       "All critical services should be fully started!")
         wait_critical_processes(sonic_host)
+        # After config load_minigraph, update-containers fires ~5s after the DNS config
+        # change but slow-starting containers (e.g., restapi, 75-128s startup) may not
+        # be running yet. Re-run update-containers now that all critical services are up
+        # to ensure every container gets the correct DNS nameservers.
+        if config_source == 'minigraph':
+            logger.info('Re-running update-containers to sync DNS to all running containers')
+            sonic_host.shell('/etc/resolvconf/update-libc.d/update-containers',
+                             module_ignore_errors=True)
         # PFCWD feature does not enable on some topology, for example M0
         if config_source == 'minigraph' and pfcwd_feature_enabled(sonic_host):
             # Supervisor node doesn't have PFC_WD


### PR DESCRIPTION
### Description of PR
Summary:
Fix intermittent `test_dns_resolv_conf` failures where `restapi` retains stale DNS nameservers after `config load_minigraph`.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

When `config load_minigraph` runs, `hostcfgd` triggers `resolv-config.service`, which calls `/etc/resolvconf/update-libc.d/update-containers` approximately 5–19 seconds later. This script iterates over currently-running containers (`docker ps`) and copies the updated `/etc/resolv.conf` into each one.

However, slow-starting containers like `restapi` take 75–128 seconds to fully start. At the time `update-containers` fires, `restapi` is not yet in `docker ps` and is silently skipped — leaving it with stale DNS nameservers from a previous config load.

`safe_reload=True` in `config_reload_minigraph_with_rendered_golden_config_override()` correctly waits for all critical services (including `restapi`) to be fully up via `wait_critical_processes()`. But by then, `update-containers` has already fired and the window to fix `restapi`'s DNS has been missed.

#### How did you do it?

After `wait_critical_processes()` returns (all containers including `restapi` are now running), re-run `update-containers` unconditionally when `config_source == 'minigraph'`. This ensures every container — including those that started late — receives the correct DNS nameservers from the current host `/etc/resolv.conf`.

```python
# After wait_critical_processes(), re-run update-containers for minigraph reloads
if config_source == 'minigraph':
    logger.info('Re-running update-containers to sync DNS to all running containers')
    sonic_host.shell('/etc/resolvconf/update-libc.d/update-containers',
                     module_ignore_errors=True)
```

#### How did you verify/test it?

- Root cause confirmed by capturing `journalctl` boot timestamps on physical testbed `bjw2-can-7260-7`:
  - `06:52:28` — `featured` starts `restapi.service`
  - `06:52:47–06:53:01` — `update-containers` runs for gnmi, lldp, pmon, snmp, telemetry — `restapi` absent
- Race condition reproduced manually: injected stale DNS into `restapi` via `docker exec`, then confirmed `update-containers` corrects it when run after `restapi` is up
- Elastictest job triggered on `testbed-bjw2-can-t0-7260-7` with this fix branch (plan ID: `69dc53cfb23d2427498917b1`)

repeat run the case 10 times, passed
https://elastictest.org/scheduler/testplan/69dc8290bdb4b72fe45cbfe2

#### Any platform specific information?

Affects all platforms running SONiC where `restapi` is enabled and `test_dns_resolv_conf` is executed after `config load_minigraph`. Observed on Arista 7260 (bjw2 lab).

#### Supported testbed topology if it's a new test case?

N/A — this is a fix in the test framework's `config_reload.py`, not a new test case.

### Documentation

No documentation changes required.
