### PR TITLE
Reorder fixtures to guarantee post-test sanity check always runs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3948,9 +3948,26 @@ def setup_dualtor_mux_ports(active_active_ports, duthost, duthosts, tbinfo, requ
 
 
 def pytest_runtest_setup(item):
-    # Let's place `setup_dualtor_mux_ports` at the tail of fixture list
-    # to make it running as last as possible.
     fixtureinfo = item._fixtureinfo
+
+    # Ensure sanity_check resolves FIRST among module-scoped fixtures.
+    # Post-test sanity check runs in sanity_check's teardown (after yield).
+    # By resolving it first, pytest guarantees its teardown runs last,
+    # so post-check ALWAYS executes even if later fixtures crash.
+    if "sanity_check" in fixtureinfo.names_closure:
+        fixtureinfo.names_closure.remove("sanity_check")
+        for i, name in enumerate(fixtureinfo.names_closure):
+            fxdefs = fixtureinfo.name2fixturedefs.get(name, [])
+            if fxdefs and fxdefs[0].scope == "module":
+                fixtureinfo.names_closure.insert(
+                    i, "sanity_check"
+                )
+                break
+        else:
+            fixtureinfo.names_closure.append("sanity_check")
+
+    # Place setup_dualtor_mux_ports at the tail of fixture list
+    # to make it running as last as possible.
     for fixturedef in fixtureinfo.name2fixturedefs.values():
         fixturedef = fixturedef[0]
         if fixturedef.argname == "setup_dualtor_mux_ports":


### PR DESCRIPTION
### Description of PR

Summary:
Reorder `sanity_check` to resolve **first** among module-scoped fixtures, guaranteeing that post-test sanity check always runs even if later fixtures crash with DUT unreachable.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

After PR #23260 changed defaults to skip pre-test sanity check and enable post-test sanity check, there is a structural gap:

**The problem:** Several module-scoped autouse fixtures resolve **before** `sanity_check` and access the DUT via SSH:
- `get_reboot_cause` — calls `duthost.get_up_time()` (line 2800)
- `restore_golden_config_db` — calls `duthost.shell()` (line 3726)
- `yang_validation_check` — runs YANG validation on all DUTs (line 3981)

Actual fixture resolution order from test.log:
```
[28] teardown_barrier_module
[29] clear_neigh_entries
[30] core_dump_and_config_check     # depends on sanity_check ✅
[31] get_reboot_cause               # SSH before yield ⚠️
[32] reset_critical_services_list
[33] restore_golden_config_db       # SSH before yield ⚠️
[34] temporarily_disable_route_check
[35] yang_validation_check          # SSH before yield ⚠️
[36] sanity_check                   # POST-CHECK IS HERE — too late!
```

If any of [31]-[35] crashes with `AnsibleConnectionFailure: Host unreachable`, `sanity_check` never starts → post-check never runs → exit code 1 → ElasticTest does not kick the unhealthy testbed.

#### How did you do it?

Added fixture reordering logic in the existing `pytest_runtest_setup` hook to move `sanity_check` to the **front** of the module-scoped fixture group. This uses the same proven pattern as:
- `setup_dualtor_mux_ports` tail reordering (already in this function)
- `parallel_fixture` barrier reordering (`bisect_left`/`bisect_right`)

After the change, the resolution order becomes:
```
[28] teardown_barrier_module
[29] sanity_check                   # RESOLVES FIRST → yields → post-check guaranteed
[30] clear_neigh_entries
[31] core_dump_and_config_check
[32] get_reboot_cause               # even if this crashes...
[33] restore_golden_config_db       # or this...
...                                  # ...sanity_check teardown (post-check) STILL RUNS
```

**Pytest yield-fixture guarantee:** once `sanity_check` reaches `yield` (no SSH needed since pre-check is skipped by default), its teardown (post-check) **always** runs, even if later fixtures crash.

#### How did you verify/test it?

Verified on **testbed-bjw2-can-t1-7260-11** (Arista 7260, t1-64-lag):

**Test 1 — Normal operation (healthy DUT):**
- Ran `test_lldp.py::test_lldp` with `-s` (sanity check enabled)
- Log confirmed: `Prepare sanity check` → `No pre-test sanity check item, skip` → test passed → `Start post-test sanity check` → all checks passed ✅

**Test 2 — Simulated host unreachable:**
- Injected `AnsibleConnectionFailure("Host unreachable")` in `get_reboot_cause` fixture
- Log confirmed the complete flow:
  1. `Prepare sanity check` — sanity_check resolved FIRST ✅
  2. `SIMULATING HOST UNREACHABLE in get_reboot_cause` — fixture crashed after sanity_check yielded
  3. `Host(s) unreachable detected in setup phase of test_lldp: bjw2-can-7260-11` — caught by PR #23728 hook
  4. `Start post-test sanity check` — **POST-CHECK RAN** despite crash ✅
  5. Exit code = **15** (ElasticTest testbed removal code) ✅

**Companion PR:** #23728 adds `pytest_exception_interact` hook as a safety net — catches "host unreachable" globally and sets exit code 15. Together they provide two layers of defense.

#### Any platform specific information?

N/A — applies to all platforms.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A