### PR TITLE
[202305] stress_arp improvements: pacing and tolerance

### DIFF
--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -46,6 +46,8 @@ def add_arp(ptf_intf_ipv4_addr, intf1_index, ptfadapter):
                                           hw_snd=arp_src_mac,
                                           hw_tgt='ff:ff:ff:ff:ff:ff'
                                           )
+        # Add a short delay to avoid packet loss
+        time.sleep(0.01)
         testutils.send_packet(ptfadapter, intf1_index, pkt)
     logger.info("Sending {} arp entries".format(ip_num))
 
@@ -86,7 +88,7 @@ def test_ipv4_arp(duthost, garp_enabled, ip_and_intf_info, intfs_for_test,
         loop_times -= 1
         add_arp(ptf_intf_ipv4_hosts, intf1_index, ptfadapter)
 
-        pytest_assert(wait_until(20, 1, 0, lambda: get_fdb_dynamic_mac_count(duthost) >= arp_avaliable),
+        pytest_assert(wait_until(40, 1, 0, lambda: abs(arp_avaliable - get_fdb_dynamic_mac_count(duthost)) < 250),
                       "ARP Table Add failed")
 
         try:
@@ -136,7 +138,8 @@ def add_nd(ptfadapter, ip_and_intf_info, ptf_intf_index, nd_avaliable):
         nd_entry_mac = IntToMac(MacToInt(ARP_SRC_MAC) + entry)
         fake_src_addr = generate_global_addr(nd_entry_mac)
         ns_pkt = ipv6_packets_for_test(ip_and_intf_info, nd_entry_mac, fake_src_addr)
-
+        # Add a short delay to avoid packet loss
+        time.sleep(0.01)
         testutils.send_packet(ptfadapter, ptf_intf_index, ns_pkt)
 
 
@@ -160,7 +163,7 @@ def test_ipv6_nd(duthost, ptfhost, config_facts, tbinfo, ip_and_intf_info,
         loop_times -= 1
         add_nd(ptfadapter, ip_and_intf_info, ptf_intf_index, nd_avaliable)
 
-        pytest_assert(wait_until(20, 1, 0, lambda: get_fdb_dynamic_mac_count(duthost) >= nd_avaliable),
+        pytest_assert(wait_until(40, 1, 0, lambda: abs(nd_avaliable - get_fdb_dynamic_mac_count(duthost)) < 250),
                       "Neighbor Table Add failed")
 
         try:


### PR DESCRIPTION
### Description of PR

Summary:
fix `test_ipv4_arp` failure on Dell S6100 (Force10-S6100) platform.

The test fails because:
1. Sending 12000 ARP packets without pacing causes packet loss on slower platforms
2. The 20-second `wait_until` timeout is insufficient for the DUT to process all entries
3. Hash collisions in the FDB table mean the exact count may never match

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [x] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`test_ipv4_arp` in `arp/test_stress_arp.py` consistently fails on Dell S6100 (202305) with "ARP Table Add failed". The root cause is packet loss due to no send pacing, and an overly strict exact-match assertion on FDB count.

#### How did you do it?
- Add 10ms delay (`time.sleep(0.01)`) between packets in `add_arp()` and `add_nd()` to avoid packet loss
- Increase `wait_until` timeout from 20s to 40s to give the DUT more time to process entries
- Change assertion from `>= arp_available` to `abs(arp_available - count) < 250` to tolerate hash collisions in the FDB table

#### How did you verify/test it?
Verified on `tbtk5-t0-s6100-2` (Dell S6100, SONiC.20230531.46):
- Before fix: 1 failed, 1 passed (test_ipv4_arp failed with "ARP Table Add failed")
- After fix: **2 passed** in 9:02

#### Any platform specific information?
Tested on Dell S6100 (Force10-S6100), but the fix is platform-agnostic and benefits any slower platform.

#### Supported testbed topology if it's a new test case?
N/A (existing test, t0 topology)

### Documentation
N/A