### PR TITLE
[202305] Fix clock skew in test_bgp_update_timer_session_down

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -487,7 +487,9 @@ def test_bgp_update_timer_session_down(
         bgp_pcap = BGP_DOWN_LOG_TMPL
         with log_bgp_updates(duthost, "any", bgp_pcap, n0.namespace):
             duthost.shell("config bgp shutdown neighbor {}".format(n0.name))
-            current_time = time.time()
+            # Use DUT clock for baseline since pcap timestamps are in DUT time
+            cmd_dut_time = duthost.shell("date +%s.%6N", module_ignore_errors=True)
+            current_time = float(cmd_dut_time["stdout"])
             time.sleep(constants.sleep_interval)
 
         if constants.log_dir:


### PR DESCRIPTION
### Description of PR

Summary:

Use DUT clock (`date +%s.%6N` via SSH) instead of test container's `time.time()` as baseline for withdraw interval measurement in `test_bgp_update_timer_session_down`.

**Root cause:** The pcap timestamps are captured on the DUT, but the baseline `current_time` used `time.time()` from the test container. When clocks are not synchronized (DUT was ~334s ahead), the withdraw interval appeared as 323-357s instead of actual <1s.

**Note:** `test_bgp_update_timer_single_route` is unaffected because it measures pcap-to-pcap intervals (both in DUT clock).

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202205
- [x] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

`test_bgp_update_timer_session_down` intermittently fails when the DUT clock and test container clock are out of sync. The withdraw interval is computed as `bgp_update.time - current_time`, where `bgp_update.time` is from the DUT's pcap but `current_time` is from the test container's `time.time()`. Any clock drift directly corrupts the measurement.

#### How did you do it?

Replaced `current_time = time.time()` with `duthost.shell("date +%s.%6N")` to read the DUT's system clock, matching the clock domain of the pcap timestamps.

#### How did you verify/test it?

Verified on tbtk5-t1-s6100-5 (S6100/202305) on internal-202305.

#### Any platform specific information?

N/A - affects all platforms where DUT and test container clocks may drift.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A