### PR TITLE
Fix file ownership in topo converge and always restore on exit.

### DIFF
--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -202,7 +202,13 @@ function converge_topo_if_needed
             sudo cp "$topo_file" "$backup_file"
         fi
 
+        original_owner=$(stat -c '%u:%g' "$topo_file")
+        original_mode=$(stat -c '%a' "$topo_file")
+
         sudo python -m ceos_topo_converger "$backup_file" "$topo_file"
+
+        chown "$original_owner" "$topo_file"
+        chmod "$original_mode" "$topo_file"
     fi
 }
 

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -6,8 +6,8 @@ function restore_topo_if_needed
  {
      if [[ -n "$backup_file" && -f "$backup_file" ]]; then
          echo "Backup exists, restore backup file"
-         cp "$backup_file" "$topo_file"
-         rm -f "$backup_file"
+         rm -f "$topo_file"
+         mv "$backup_file" "$topo_file"
          echo "Original topo file restored"
      fi
  }

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -196,19 +196,14 @@ function converge_topo_if_needed
 
         if [[ -f "$backup_file" ]];then
             echo "Backup file exists, recover..."
-            sudo cp "$backup_file" "$topo_file"
+            cp "$backup_file" "$topo_file"
         elif [[ -f "$topo_file" ]]; then
             echo "Back up topo file"
-            sudo cp "$topo_file" "$backup_file"
+            cp "$topo_file" "$backup_file"
         fi
 
-        original_owner=$(stat -c '%u:%g' "$topo_file")
-        original_mode=$(stat -c '%a' "$topo_file")
+        python -m ceos_topo_converger "$backup_file" "$topo_file"
 
-        sudo python -m ceos_topo_converger "$backup_file" "$topo_file"
-
-        chown "$original_owner" "$topo_file"
-        chmod "$original_mode" "$topo_file"
     fi
 }
 
@@ -1320,6 +1315,6 @@ esac
 
 if [[ -f "$backup_file" ]];then
     echo "Backup exists, restore backup file"
-    sudo rm -f "$topo_file"
-    sudo mv "$backup_file" "$topo_file"
+    rm -f "$topo_file"
+    mv "$backup_file" "$topo_file"
 fi

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -2,6 +2,18 @@
 
 set -e
 
+function restore_topo_if_needed
+ {
+     if [[ -n "$backup_file" && -f "$backup_file" ]]; then
+         echo "Backup exists, restore backup file"
+         cp "$backup_file" "$topo_file"
+         rm -f "$backup_file"
+         echo "Original topo file restored"
+     fi
+ }
+
+ trap restore_topo_if_needed EXIT
+
 function usage
 {
   echo "testbed-cli. Interface to testbeds"
@@ -1312,9 +1324,3 @@ case "${subcmd}" in
   *)           usage
                ;;
 esac
-
-if [[ -f "$backup_file" ]];then
-    echo "Backup exists, restore backup file"
-    rm -f "$topo_file"
-    mv "$backup_file" "$topo_file"
-fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fix file permission issues in topology converge by removing unnecessary sudo commands. 
When converge runs with sudo, both the topology file and its backup end up with `root:root` ownership, preventing regular users from editing or committing these files.

Two small improvements to the topology converge flow in testbed-cli.sh:
 1. Remove unnecessary sudo from converge operations so topology and backup files retain the current user's ownership.
 2. Replace end-of-script restore with trap to guarantee the backup is always restored on exit, regardless of whether the script completes successfully or exits early.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Improvement 1 – Remove unnecessary sudo: Converge operations (cp, python -m ceos_topo_converger) were run with sudo, causing the topology file and its backup to be owned by root:root. Since these files live in the repo directory and belong to the current user, sudo is not needed.
Running without it keeps the original file ownership intact, so users can still edit and git commit the files normally.

Improvement 2 – Guarantee restore on exit: The restore block was placed at the end of the script. With set -e, any failure (e.g., ansible-playbook error) exits the script immediately, skipping the restore and leaving a modified topo file behind. Moving the restore logic into a `trap restore_topo_if_needed EXIT` handler ensures the backup is always restored on exit, whether the script succeeds or fails.

#### How did you do it?
1. Removed sudo from cp and python -m ceos_topo_converger calls inside converge_topo_if_needed.
 2. Introduced a restore_topo_if_needed function and registered it via trap restore_topo_if_needed EXIT at the top of the script, replacing the end-of-script restore block.

#### How did you verify/test it?
Ran add-topo on a multi-VRF testbed with use_converged_peers: True. Verified that:
- Topology and backup files retain the original user's ownership after converge
- Topo file is correctly restored on normal exit
- Topo file is correctly restored when the script exits due to a mid-way failure

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
