### PR TITLE
[hft] Ignore expected SAI_TAM errors in log_analyzer during HFT tests

### DIFF
--- a/tests/high_frequency_telemetry/conftest.py
+++ b/tests/high_frequency_telemetry/conftest.py
@@ -6,6 +6,36 @@ from datetime import datetime, timezone
 logger = logging.getLogger(__name__)
 
 
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exceptions(duthosts, enum_rand_one_per_hwsku_hostname, loganalyzer):
+    """
+    Ignore expected SAI_TAM errors during HFT test execution.
+
+    When HFT is enabled, SONiC initially sends a buffer size of 65535 for IPFIX templates,
+    but SAI requires a larger buffer (e.g., 119352). SAI returns SAI_STATUS_BUFFER_OVERFLOW
+    with the required size, and SONiC retries with the correct size. This is normal behavior,
+    not a functional issue. The error logs can be safely ignored.
+
+    Args:
+        duthosts: list of DUTs.
+        enum_rand_one_per_hwsku_hostname: Hostname of a random chosen dut
+        loganalyzer: Loganalyzer utility fixture
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    if loganalyzer:
+        ignoreRegex = [
+            # SAI prints ERR when IPFIX template buffer is too small on first probe;
+            # SONiC retries with the correct size and succeeds - not a functional issue
+            ".*ERR syncd#SDK.*SAI_TAM.*mlnx_generate_ipfix_templates.*Buffer size is too small"
+            " to hold IPFIX template.*",
+            ".*ERR syncd#SDK.*SAI_TAM.*mlnx_tam_tel_type_get_ipfix_templates.*Failed to generate"
+            " IPFIX templates.*",
+            ".*ERR syncd#SDK.*SAI_TAM.*mlnx_tam_tel_type_attrib_get.*Failed to get attribute.*",
+            ".*ERR syncd#SDK.*SAI_UTILS.*get_dispatch_attribs_handler.*Failed Get.*IPFIX_TEMPLATES.*",
+        ]
+        loganalyzer[duthost.hostname].ignore_regex.extend(ignoreRegex)
+
+
 @pytest.fixture(scope="function")
 def ensure_swss_ready(duthosts, enum_rand_one_per_hwsku_hostname):
     """Ensure swss container is running and stable for at least 10 seconds.


### PR DESCRIPTION
Summary: [hft] Ignore expected SAI_TAM errors in log_analyzer during HFT tests
Fixes #

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Run test case `tests/high_frequency_telemetry/test_high_frequency_telemetry.py`, it might generate some message as below:
```
2026 Mar 25 02:35:54.311968 router ERR syncd#SDK: [SAI_TAM.ERR] client_pid=21, ./src/mlnx_sai_tam.c[5754]- mlnx_generate_ipfix_templates: Buffer size is too small to hold IPFIX template [size:65535, required:119352].
2026 Mar 25 02:35:54.311968 router ERR syncd#SDK: [SAI_TAM.ERR] client_pid=21, ./src/mlnx_sai_tam.c[5208]- mlnx_tam_tel_type_get_ipfix_templates: Failed to generate IPFIX templates.
2026 Mar 25 02:35:54.311968 router ERR syncd#SDK: [SAI_TAM.ERR] client_pid=21, ./src/mlnx_sai_tam.c[5116]- mlnx_tam_tel_type_attrib_get: Failed to get attribute.
2026 Mar 25 02:35:54.311968 router ERR syncd#SDK: [SAI_UTILS.ERR] client_pid=21, ./src/mlnx_sai_utils.c[2235]- get_dispatch_attribs_handler: Failed Get #0, IPFIX_TEMPLATES, key:TAM_TEL_TYPE [OID:0x140000004B] [ID:0]
```

Design team have confirmed these errors are printed from SAI as part of the normal flow in SONiC, where we request an estimated buffer size and get in response the required size to use. Later, we use the correct required size and work fine. So, this error can be ignored.


#### How did you do it?
Add autouse fixture to ignore this error message


#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
