### PR TITLE
Fix VRF test cleanup to restore full config after vrf bind

### DIFF
--- a/tests/dhcp_relay/test_dhcpv4_relay.py
+++ b/tests/dhcp_relay/test_dhcpv4_relay.py
@@ -18,6 +18,54 @@ from tests.common.dhcp_relay_utils import (
         sonic_dhcp_relay_unconfig
 )
 from tests.common.dhcp_relay_utils import enable_sonic_dhcpv4_relay_agent  # noqa: F401
+import json
+
+
+def _save_interface_ip_entries(duthost, table, interface):
+    """Save all CONFIG_DB entries for an interface, including the base entry.
+
+    Uses redis-cli to capture exact key-value pairs so they can be
+    restored after VRF operations strip them.
+    """
+    # Save the base entry (e.g. VLAN_INTERFACE|Vlan1000) and all IP entries
+    # Use two queries: one for the base entry, one for IP sub-entries
+    base_raw = duthost.shell(
+        'redis-cli -n 4 --json HGETALL "{}|{}"'.format(table, interface),
+        verbose=False)['stdout'].strip()
+    base_fields = json.loads(base_raw) if base_raw else {}
+
+    ip_keys_raw = duthost.shell(
+        'redis-cli -n 4 --json keys "{}|{}|*"'.format(table, interface),
+        verbose=False)['stdout'].strip()
+    ip_keys = json.loads(ip_keys_raw) if ip_keys_raw else []
+
+    saved = {}
+    # Always save the base entry
+    saved["{}|{}".format(table, interface)] = base_fields
+    for key in ip_keys:
+        raw = duthost.shell(
+            'redis-cli -n 4 --json HGETALL "{}"'.format(key),
+            verbose=False)['stdout'].strip()
+        fields = json.loads(raw) if raw else {}
+        saved[key] = fields
+    return saved
+
+
+def _restore_interface_ip_entries(duthost, saved_entries):
+    """Restore CONFIG_DB IP entries using sonic-db-cli.
+
+    Writes back the exact field-value pairs that were saved, preserving
+    attributes like the secondary flag. SONiC's intfmgrd automatically
+    applies CONFIG_DB changes to the kernel.
+    """
+    for key, fields in saved_entries.items():
+        if not fields or fields == {"NULL": "NULL"}:
+            duthost.shell('sonic-db-cli CONFIG_DB HSET "{}" "NULL" "NULL"'.format(key))
+        else:
+            for field, value in fields.items():
+                duthost.shell(
+                    'sonic-db-cli CONFIG_DB HSET "{}" "{}" "{}"'.format(key, field, value))
+
 
 pytestmark = [
     pytest.mark.topology('t0', 'm0'),
@@ -344,6 +392,12 @@ def test_dhcp_relay_with_non_default_vrf(
         portchannels = dhcp_relay['portchannels_with_ips']
         vlan_ip = "{}/{}".format(dhcp_relay['downlink_vlan_iface']['addr'], dhcp_relay['downlink_vlan_iface']['mask'])
 
+    # Save all interface IP entries before VRF operations strip them
+    saved_vlan_ips = _save_interface_ip_entries(duthost, "VLAN_INTERFACE", vlan_iface)
+    saved_pc_ips = {}
+    for pc in portchannels:
+        saved_pc_ips.update(_save_interface_ip_entries(duthost, "PORTCHANNEL_INTERFACE", pc))
+
     # Step 1: Remove IPs from interfaces
     for pc, params in portchannels.items():
         duthost.shell(f"sudo config interface ip remove {pc} {params['ip']}")
@@ -433,10 +487,17 @@ def test_dhcp_relay_with_non_default_vrf(
         duthost.shell(f"sudo config route del prefix vrf {CLIENT_VRF_NAME} 0.0.0.0/0 nexthop"
                       f" vrf {CLIENT_VRF_NAME} {first_params['nexthop']}")
         duthost.shell(f"sudo config vrf del {CLIENT_VRF_NAME}")
-        for pc, params in portchannels.items():
-            duthost.shell(f"sudo config interface ip add {pc} {params['ip']}")
 
-        duthost.shell(f"sudo config interface ip add {vlan_iface} {vlan_ip}")
+        # Restore all interface CONFIG_DB entries (base entry, IPs, and attributes).
+        # "config interface vrf bind" strips ALL IPs (secondary IPv4, IPv6, etc.),
+        # not just the primary. A simple "config interface ip add" only restores
+        # the primary IPv4, permanently losing secondary IPs and IPv6 addresses.
+        # Instead, we save and restore the exact CONFIG_DB entries via redis-cli,
+        # preserving all attributes (e.g. the secondary flag). intfmgrd then
+        # automatically applies the restored entries to the kernel.
+        _restore_interface_ip_entries(duthost, saved_vlan_ips)
+        _restore_interface_ip_entries(duthost, saved_pc_ips)
+        duthost.shell("sudo config save -y")
 
 
 def test_dhcp_relay_with_different_non_default_vrf(
@@ -481,6 +542,12 @@ def test_dhcp_relay_with_different_non_default_vrf(
         vlan_iface = str(dhcp_relay['downlink_vlan_iface']['name'])
         portchannels = dhcp_relay['portchannels_with_ips']
         vlan_ip = "{}/{}".format(dhcp_relay['downlink_vlan_iface']['addr'], dhcp_relay['downlink_vlan_iface']['mask'])
+
+    # Save all interface IP entries before VRF operations strip them
+    saved_vlan_ips = _save_interface_ip_entries(duthost, "VLAN_INTERFACE", vlan_iface)
+    saved_pc_ips = {}
+    for pc in portchannels:
+        saved_pc_ips.update(_save_interface_ip_entries(duthost, "PORTCHANNEL_INTERFACE", pc))
 
     # Step 1: Remove IPs from interfaces
     for pc, params in portchannels.items():
@@ -559,10 +626,17 @@ def test_dhcp_relay_with_different_non_default_vrf(
 
         duthost.shell(f"sudo config vrf del {CLIENT_VRF_NAME}")
         duthost.shell(f"sudo config vrf del {SERVER_VRF_NAME}")
-        for pc, params in portchannels.items():
-            duthost.shell(f"sudo config interface ip add {pc} {params['ip']}")
 
-        duthost.shell(f"sudo config interface ip add {vlan_iface} {vlan_ip}")
+        # Restore all interface CONFIG_DB entries (base entry, IPs, and attributes).
+        # "config interface vrf bind" strips ALL IPs (secondary IPv4, IPv6, etc.),
+        # not just the primary. A simple "config interface ip add" only restores
+        # the primary IPv4, permanently losing secondary IPs and IPv6 addresses.
+        # Instead, we save and restore the exact CONFIG_DB entries via redis-cli,
+        # preserving all attributes (e.g. the secondary flag). intfmgrd then
+        # automatically applies the restored entries to the kernel.
+        _restore_interface_ip_entries(duthost, saved_vlan_ips)
+        _restore_interface_ip_entries(duthost, saved_pc_ips)
+        duthost.shell("sudo config save -y")
 
 
 @pytest.mark.parametrize("max_hop_count", [CONFIG_HOP_COUNT, MAX_HOP_COUNT])


### PR DESCRIPTION
config interface vrf bind strips ALL IPs (secondary IPv4, IPv6, etc.) from the interface, but the original VRF test cleanup only re-added the primary IPv4 for VLAN and portchannel interfaces via config interface ip add. This permanently lost secondary IPs, IPv6 addresses, and base interface entries (e.g. PORTCHANNEL_INTERFACE|PortChannel101), corrupting
subsequent parametrize variants when config save -y persisted the loss.

Save exact CONFIG_DB entries (including base entries and attributes like the secondary flag) for both VLAN and portchannel interfaces via redis-cli before VRF operations, and restore them in cleanup. intfmgrd automatically applies the restored entries to the kernel, avoiding the need for config_reload.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

test_dhcp_relay_with_non_default_vrf and test_dhcp_relay_with_different_non_default_vrf are parametrized with ["vrf_selection", "source_intf", "server_id_override"]. The vrf_selection variant binds VLAN and portchannel interfaces to a VRF using config interface vrf bind, which strips all IPs. The cleanup only manually re-added the primary IPv4 for each
interface, but secondary IPv4 (e.g. 192.169.0.1/22 on Vlan1000 in t0-116), IPv6 addresses, and base interface table entries (e.g. PORTCHANNEL_INTERFACE|PortChannel101) were never restored. Between variants, config save -y persisted this loss, causing subsequent variants to fail.

#### How did you do it?

 - Added helper functions _save_interface_ip_entries and _restore_interface_ip_entries using redis-cli --json for reading and sonic-db-cli for writing
 - Before VRF operations, save all CONFIG_DB entries (base entry + IP entries with attributes) for affected VLAN and portchannel interfaces
 - In the finally cleanup block, after VRF deletion, restore all saved entries to CONFIG_DB. intfmgrd automatically applies changes to the kernel. Then config save -y to persist.
 - An alternative approach using config_reload to restore the full config was considered, but had two issues: (1) config_reload adds 60-120 seconds per call, totaling ~8 minutes for 4 VRF variants; (2) ports cycling during reload triggers SAI_API_PORT: Fec Alignment lock status failed syslog messages on Broadcom platforms, causing loganalyzer teardown 
errors. The redis-cli save/restore approach avoids both issues by writing directly to CONFIG_DB without restarting services or cycling ports.

#### How did you verify/test it?

 - Ran test_dhcp_relay_with_non_default_vrf (all 3 variants) on Broadcom 7260 testbed (t0-116 topology) with multi-IP VLAN configuration — all passed with 0 errors
 - Verified secondary IPs, IPv6, base VLAN and portchannel interface entries are properly restored after VRF test cleanup
 - No loganalyzer teardown errors

#### Any platform specific information?

Affects any platform with multi-IP VLAN interfaces (e.g. t0-116 topology where Vlan1000 has both primary and secondary IPv4).

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
