### PR TITLE
Add loganalyzer ignore rules for SAI RX signal detect and RX SNR errors

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -479,6 +479,10 @@ r, ".*ERR swss#orchagent:.*SAI_API_QUEUE, status: SAI_STATUS_INVALID_PARAMETER.*
 # SAI cannot read LT registers while the port serdes is mid-transition
 r, ".* ERR swss\d*#orchagent:.*getPortLinkTrainingFailure: Failed to get LT failure status for .*"
 
+# Ignore RX signal detect and RX SNR feature unavailable errors on broadcom platforms
+r, ".* ERR syncd\d*#syncd:.*SAI_API_PORT:brcm_sai_get_port_attribute_cmn:\d+ RX signal detect status get \d+ attrib \d+ failed with error Feature unavailable \(0xfffffff0\).*"
+r, ".* ERR syncd\d*#syncd:.*SAI_API_PORT:brcm_sai_get_port_attribute_cmn:\d+ bcm_port_phy_control_get rx snr failed with error Feature unavailable \(0xfffffff0\).*"
+
 # https://github.com/sonic-net/sonic-mgmt/issues/19347
 r, ".* ERR auditd.*: queue to plugins is full - dropping event"
 r, ".* ERR auditd.*: message repeated .*: \[ queue to plugins is full - dropping event\]"


### PR DESCRIPTION
 
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
 On certain Broadcom platforms, querying PHY-level port attributes returns
  "Feature unavailable (0xfffffff0)" when the PHY does not support these read-only diagnostic
  counters.
  These issues are coming due to sai api incorrectly passing port
  compatibility check for these attributes for unsupported ports.
  Until fixed, we must ignore these logs to prevent mgmt regressions.

  Following errors are seen:
  1. SAI_PORT_ATTR_RX_SIGNAL_DETECT (attrib 149): `ERR syncd#syncd: [none] SAI_API_PORT:brcm_sai_get_port_attribute_cmn:10440 RX signal detect status get <port> attrib 149 failed with error Feature unavailable (0xfffffff0).`
  2. SAI_PORT_ATTR_RX_SNR: `ERR syncd#syncd: [none] SAI_API_PORT:brcm_sai_get_port_attribute_cmn:11226 bcm_port_phy_control_get rx snr failed with error Feature unavailable (0xfffffff0).`


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
mgmt regression failures

#### How did you do it?
Added ignore logs for sai err logs.

#### How did you verify/test it?
python regex match and manual test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
