### PR TITLE
Add UDS transport support to gNMI/gNOI test fixtures

### DIFF
--- a/docs/testplan/gnmi-uds-transport-design.md
+++ b/docs/testplan/gnmi-uds-transport-design.md
@@ -32,29 +32,28 @@ This enables:
 
 ## Architecture
 
-```
-┌─────────────────────────────────────────────────────────┐
-│ sonic-mgmt container                                    │
-│                                                         │
-│  Test Cases ──► gnmi_tls fixture (transport param)      │
-│                     │                                   │
-│            ┌────────┴────────┐                          │
-│            ▼                 ▼                           │
-│     transport='tls'    transport='uds'                  │
-│            │                 │                           │
-│     PtfGrpc/PtfGnoi    DutGrpc/DutGnoi                 │
-│     (ptfhost.shell)    (duthost.shell)                  │
-│            │                 │                           │
-└────────────┼─────────────────┼──────────────────────────┘
-             │                 │
-             ▼                 ▼
-┌──────────────────┐  ┌──────────────────────────────────┐
-│ PTF container     │  │ DUT host                         │
-│                   │  │                                  │
-│  grpcurl ─────────┼──┼──► gNMI server :50052 (TCP+TLS) │
-│                   │  │                                  │
-│                   │  │  grpcurl ──► gnmi.sock (UDS)     │
-└───────────────────┘  └──────────────────────────────────┘
+```mermaid
+flowchart TD
+    subgraph mgmt["sonic-mgmt container"]
+        tests["Test Cases"] --> fixture["gnmi_tls fixture\n(transport param)"]
+        fixture --> tls_path["transport='tls'\nPtfGrpc / PtfGnoi\n(ptfhost.shell)"]
+        fixture --> uds_path["transport='uds'\nDutGrpc / DutGnoi\n(duthost.shell)"]
+    end
+
+    subgraph ptf["PTF container"]
+        ptf_grpcurl["grpcurl"]
+    end
+
+    subgraph dut["DUT host"]
+        gnmi_tcp["gNMI server :50052\n(TCP+TLS)"]
+        gnmi_uds["gnmi.sock\n(UDS, plaintext)"]
+        dut_grpcurl["grpcurl"]
+    end
+
+    tls_path --> ptf_grpcurl
+    ptf_grpcurl -->|"TCP+TLS"| gnmi_tcp
+    uds_path --> dut_grpcurl
+    dut_grpcurl -->|"unix://"| gnmi_uds
 ```
 
 ## Components

--- a/docs/testplan/gnmi-uds-transport-design.md
+++ b/docs/testplan/gnmi-uds-transport-design.md
@@ -1,0 +1,296 @@
+# gNMI UDS Transport Support for Test Fixtures
+
+## Purpose
+
+Add Unix Domain Socket (UDS) transport support to the `gnmi_tls` test fixture, enabling
+gNMI/gNOI tests to run locally on the DUT via grpcurl over `/var/run/gnmi/gnmi.sock`
+instead of requiring TCP+TLS from the PTF container.
+
+## High Level Design
+
+| Rev   | Date       | Author      | Change Description |
+|-------|------------|-------------|--------------------|
+| Draft | 2026-04-13 | Dawei Huang | Initial version    |
+
+## Motivation
+
+The existing `gnmi_tls` fixture requires:
+- TLS certificate generation and distribution (DUT + PTF)
+- CONFIG_DB reconfiguration for TLS mode
+- gNMI server restart
+- Network connectivity from PTF to DUT management IP
+
+UDS transport eliminates all of this overhead. The gNMI server already listens on
+`/var/run/gnmi/gnmi.sock` without TLS, relying on filesystem permissions (0660) for
+access control. A DUT-local client connecting over UDS exercises the same gRPC services
+without the TLS setup cost.
+
+This enables:
+- Faster test execution (no cert generation, no server restart)
+- Testing gNMI/gNOI services independently of TLS infrastructure
+- Dual-transport testing: same test runs over both TCP+TLS and UDS
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ sonic-mgmt container                                    │
+│                                                         │
+│  Test Cases ──► gnmi_tls fixture (transport param)      │
+│                     │                                   │
+│            ┌────────┴────────┐                          │
+│            ▼                 ▼                           │
+│     transport='tls'    transport='uds'                  │
+│            │                 │                           │
+│     PtfGrpc/PtfGnoi    DutGrpc/DutGnoi                 │
+│     (ptfhost.shell)    (duthost.shell)                  │
+│            │                 │                           │
+└────────────┼─────────────────┼──────────────────────────┘
+             │                 │
+             ▼                 ▼
+┌──────────────────┐  ┌──────────────────────────────────┐
+│ PTF container     │  │ DUT host                         │
+│                   │  │                                  │
+│  grpcurl ─────────┼──┼──► gNMI server :50052 (TCP+TLS) │
+│                   │  │                                  │
+│                   │  │  grpcurl ──► gnmi.sock (UDS)     │
+└───────────────────┘  └──────────────────────────────────┘
+```
+
+## Components
+
+### 1. grpcurl Installation Fixture
+
+**File**: `tests/common/fixtures/grpc_fixtures.py` (or a new helper module)
+
+A session-scoped fixture that ensures grpcurl is available on the DUT host.
+
+**Behavior**:
+1. Check if grpcurl exists: `duthost.shell("which grpcurl")`
+2. If present, return early (idempotent)
+3. Detect DUT architecture: `duthost.shell("dpkg --print-architecture")` → amd64, arm64, armhf
+4. Download the matching grpcurl static binary from GitHub releases to the sonic-mgmt
+   container (which has internet access)
+5. Copy to DUT via `duthost.copy()` → `/usr/local/bin/grpcurl`
+6. Verify: `duthost.shell("grpcurl --version")`
+
+**Architecture mapping** (grpcurl release naming, e.g. v1.9.1):
+- `amd64` → `grpcurl_1.9.1_linux_amd64.tar.gz`
+- `arm64` → `grpcurl_1.9.1_linux_arm64.tar.gz`
+- `armhf` → `grpcurl_1.9.1_linux_armv6.tar.gz`
+
+The version is defined as a constant (e.g. `GRPCURL_VERSION = "1.9.1"`) in the
+fixture module, making it easy to bump.
+
+**Teardown**: None. grpcurl is left installed — it's idempotent and harmless.
+
+**Error handling**: If download or copy fails, the fixture calls `pytest.skip()`
+with a descriptive reason. This allows other tests in the session to proceed while
+UDS-transport tests are cleanly skipped.
+
+### 2. DutGrpc Client
+
+**File**: `tests/common/dut_grpc.py`
+
+A lightweight grpcurl-based gRPC client that runs on the DUT host via `duthost.shell()`.
+
+```python
+class DutGrpc:
+    """DUT-local gRPC client using grpcurl over Unix domain socket."""
+
+    def __init__(self, duthost, socket_path="/var/run/gnmi/gnmi.sock"):
+        self.duthost = duthost
+        self.target = f"unix:///{socket_path}"
+
+    def call_unary(self, service, method, request=None, timeout=10):
+        """Make a unary gRPC call. Returns parsed JSON dict."""
+
+    def call_server_streaming(self, service, method, request=None, timeout=30):
+        """Make a server-streaming gRPC call. Returns list of parsed JSON dicts."""
+
+    def list_services(self):
+        """List available gRPC services via reflection. Returns list of strings."""
+
+    def describe(self, symbol):
+        """Describe a gRPC service or method. Returns string description."""
+```
+
+**Key differences from PtfGrpc**:
+- Always plaintext (`-plaintext` flag)
+- Always UDS target (`unix:///path`)
+- Uses `duthost.shell()` instead of `ptfhost.shell()`
+- No TLS certificate configuration
+- No SmartSwitch routing headers
+- No GNMIEnvironment auto-configuration
+
+**Command construction example**:
+```
+grpcurl -plaintext -format json unix:///var/run/gnmi/gnmi.sock gnoi.system.System/Time
+```
+
+**~60 lines estimated**. Intentionally thin — shares no base class with PtfGrpc for now.
+
+### 3. DutGnoi Wrapper
+
+**File**: `tests/common/dut_gnoi.py`
+
+gNOI-specific wrapper around DutGrpc, mirroring PtfGnoi's interface.
+
+```python
+class DutGnoi:
+    """DUT-local gNOI client wrapping DutGrpc."""
+
+    def __init__(self, grpc_client):
+        self.grpc = grpc_client
+
+    def system_time(self):
+        """Get system time. Returns dict with 'time' key (nanoseconds)."""
+
+    def file_stat(self, path):
+        """Get file stats. Returns dict with 'stats' key."""
+```
+
+Same pattern as PtfGnoi: translates gNOI-specific method names into
+`call_unary("gnoi.system.System", "Time")` calls.
+
+### 4. gnmi_tls Fixture Modification
+
+**File**: `tests/common/fixtures/grpc_fixtures.py`
+
+The existing `gnmi_tls` fixture gains transport selection via `request.param`.
+
+```python
+@pytest.fixture(scope="module")
+def gnmi_tls(request, duthost, ptfhost):
+    transport = getattr(request, 'param', 'tls')
+
+    if transport == 'uds':
+        yield from _gnmi_uds_flow(duthost)
+    else:
+        yield from _gnmi_tls_flow(duthost, ptfhost)
+```
+
+**UDS flow** (`_gnmi_uds_flow`):
+1. Install grpcurl on DUT if needed (calls the installation helper inline —
+   not a separate fixture, to avoid complicating fixture dependency chains)
+2. Validate UDS socket exists: `duthost.shell("test -S /var/run/gnmi/gnmi.sock")`
+3. Create `DutGrpc` → `DutGnoi`
+4. Yield `GnmiFixture(host='localhost', port=0, tls=False, cert_paths=None,
+   grpc=dut_grpc, gnoi=dut_gnoi, gnmic=None)`
+5. No teardown needed (no CONFIG_DB changes, no certs)
+
+**TLS flow** (`_gnmi_tls_flow`): Existing behavior, unchanged.
+
+### 5. GnmiFixture Dataclass Update
+
+```python
+@dataclass
+class GnmiFixture:
+    host: str
+    port: int
+    tls: bool
+    cert_paths: Optional[CertPaths]
+    grpc: Union[PtfGrpc, DutGrpc]    # was: PtfGrpc
+    gnoi: Union[PtfGnoi, DutGnoi]    # was: PtfGnoi
+    gnmic: Optional[PtfGnmic]        # None for UDS transport
+    transport: str = 'tls'           # new field: 'tls' or 'uds'
+```
+
+The `transport` field lets tests that need transport-specific behavior branch on it.
+The `gnmic` field is `None` for UDS since gnmic isn't installed on the DUT.
+
+### 6. Test Opt-In Pattern
+
+Tests opt into dual-transport testing via indirect parametrize:
+
+```python
+# Runs once with TLS, once with UDS:
+@pytest.mark.parametrize("gnmi_tls", ["tls", "uds"], indirect=True)
+def test_system_time(gnmi_tls):
+    result = gnmi_tls.gnoi.system_time()
+    assert isinstance(result["time"], int)
+
+# Runs with TLS only (backward compatible, no change needed):
+def test_cert_validation(gnmi_tls):
+    assert gnmi_tls.tls is True
+    assert gnmi_tls.cert_paths is not None
+```
+
+Tests that use `gnmic` should either:
+- Skip UDS: `if gnmi_tls.gnmic is None: pytest.skip("gnmic not available on UDS")`
+- Or not parametrize with UDS
+
+## Directory Structure
+
+```
+tests/common/
+├── dut_grpc.py              # NEW: DUT-local grpcurl client
+├── dut_gnoi.py              # NEW: DUT-local gNOI wrapper
+├── ptf_grpc.py              # Existing: PTF grpcurl client (unchanged)
+├── ptf_gnoi.py              # Existing: PTF gNOI wrapper (unchanged)
+├── ptf_gnmic.py             # Existing: PTF gnmic wrapper (unchanged)
+└── fixtures/
+    └── grpc_fixtures.py     # Modified: transport param + grpcurl install
+```
+
+## Constraints and Edge Cases
+
+### Multi-Architecture DUTs
+The grpcurl download must match the DUT's architecture (amd64, arm64, armhf).
+Architecture is detected at runtime via `dpkg --print-architecture`. The fixture
+maps this to the correct grpcurl release artifact.
+
+### No Internet on DUT
+The DUT has no internet access. grpcurl is downloaded to the sonic-mgmt container
+(which typically has internet) and then copied to the DUT via `duthost.copy()`.
+If the sonic-mgmt container also lacks internet, the test should fail gracefully
+with a message explaining the dependency.
+
+### UDS Socket Availability
+The UDS socket at `/var/run/gnmi/gnmi.sock` is created by the telemetry process
+when started with `--unix_socket` (default: `/var/run/gnmi/gnmi.sock`). If the
+socket doesn't exist, the fixture raises with a clear error.
+
+### UDS Authentication
+The UDS server skips all authentication (no TLS, no JWT, no PAM, no client certs).
+Security relies on filesystem permissions (0660, root:root). Tests running over UDS
+exercise gRPC service logic but NOT authentication paths.
+
+### gnmic Not Available
+`GnmiFixture.gnmic` is `None` for UDS transport. Tests using gnmic must handle this
+(skip or don't parametrize with UDS).
+
+### Module-Scoped Fixture with Parametrize
+When a test uses `@pytest.mark.parametrize("gnmi_tls", ["tls", "uds"], indirect=True)`,
+pytest creates separate module-scoped fixture instances for each transport. This means
+the TLS setup/teardown cycle runs independently of the UDS path.
+
+## Future Work
+
+### DutGrpc / PtfGrpc Unification
+Both classes wrap grpcurl with similar command construction and JSON parsing logic.
+If DutGrpc grows beyond its current thin scope, extract a `GrpcurlClient` base class:
+
+```python
+class GrpcurlClient:
+    """Base: grpcurl command building + JSON parsing."""
+    def __init__(self, host, target, plaintext=False): ...
+    def call_unary(self, service, method, request=None): ...
+
+class PtfGrpc(GrpcurlClient):
+    """PTF-specific: TLS config, SmartSwitch headers, GNMIEnvironment."""
+
+class DutGrpc(GrpcurlClient):
+    """DUT-specific: always plaintext UDS."""
+```
+
+Only worth doing if DutGrpc's feature surface grows to overlap significantly with PtfGrpc.
+
+### gnmic on DUT
+If tests need gnmic over UDS, gnmic could be installed on the DUT host alongside
+grpcurl using the same download-and-copy mechanism. Not in scope for this design.
+
+### Testbed Setup Integration
+The grpcurl installation could move from a session-scoped fixture to an Ansible
+role in the testbed provisioning playbooks (`add-topo`), eliminating the per-session
+download. This is a follow-up optimization once the approach is validated.

--- a/tests/common/dut_gnoi.py
+++ b/tests/common/dut_gnoi.py
@@ -1,0 +1,94 @@
+# tests/common/dut_gnoi.py
+"""
+DUT-local gNOI client wrapper providing high-level gNOI operations.
+
+This module mirrors PtfGnoi's interface but wraps DutGrpc instead of PtfGrpc,
+operating over a local Unix domain socket on the DUT host.
+"""
+import logging
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+
+class DutGnoi:
+    """
+    DUT-local gNOI client wrapper.
+
+    Provides Pythonic interfaces for gNOI operations, delegating to DutGrpc
+    for low-level gRPC transport over UDS.
+
+    Usage:
+        grpc = DutGrpc(duthost)
+        gnoi = DutGnoi(grpc)
+        result = gnoi.system_time()
+    """
+
+    def __init__(self, grpc_client):
+        """
+        Args:
+            grpc_client: DutGrpc instance for low-level gRPC operations.
+        """
+        self.grpc_client = grpc_client
+
+    def system_time(self) -> Dict:
+        """
+        Get the current system time from the device.
+
+        Returns:
+            Dict with 'time' key (nanoseconds since epoch, as int).
+        """
+        response = self.grpc_client.call_unary("gnoi.system.System", "Time")
+
+        if "time" in response:
+            try:
+                response["time"] = int(response["time"])
+            except (ValueError, TypeError) as e:
+                logger.warning("Failed to convert time to int: %s", e)
+
+        return response
+
+    def file_stat(self, remote_file: str) -> Dict:
+        """
+        Get file statistics from the device.
+
+        Args:
+            remote_file: Path to the file on the device.
+
+        Returns:
+            Dict with 'stats' key containing file metadata.
+        """
+        request = {"path": remote_file}
+        response = self.grpc_client.call_unary("gnoi.file.File", "Stat", request)
+
+        if "stats" in response and isinstance(response["stats"], list):
+            for stat in response["stats"]:
+                for field in ("last_modified", "permissions", "size", "umask"):
+                    if field in stat:
+                        try:
+                            stat[field] = int(stat[field])
+                        except (ValueError, TypeError):
+                            pass
+
+        return response
+
+    def kill_process(self, name: str, restart: bool = False, signal: str = "SIGNAL_TERM") -> Dict:
+        """
+        Kill (and optionally restart) a process via gNOI System.KillProcess.
+
+        Args:
+            name: Process/service name to kill.
+            restart: Whether to restart after killing.
+            signal: Signal type (use SIGNAL_TERM, SIGNAL_KILL, etc.).
+
+        Returns:
+            Dict response (typically empty on success).
+        """
+        request = {"name": name, "restart": restart, "signal": signal}
+        return self.grpc_client.call_unary("gnoi.system.System", "KillProcess", request)
+
+    def __str__(self):
+        return f"DutGnoi(grpc_client={self.grpc_client})"
+
+    def __repr__(self):
+        return self.__str__()

--- a/tests/common/dut_gnoi.py
+++ b/tests/common/dut_gnoi.py
@@ -31,14 +31,17 @@ class DutGnoi:
         """
         self.grpc_client = grpc_client
 
-    def system_time(self) -> Dict:
+    def system_time(self, metadata=None) -> Dict:
         """
         Get the current system time from the device.
+
+        Args:
+            metadata: Optional gRPC metadata (dict or list of (key, value) tuples).
 
         Returns:
             Dict with 'time' key (nanoseconds since epoch, as int).
         """
-        response = self.grpc_client.call_unary("gnoi.system.System", "Time")
+        response = self.grpc_client.call_unary("gnoi.system.System", "Time", metadata=metadata)
 
         if "time" in response:
             try:
@@ -48,18 +51,19 @@ class DutGnoi:
 
         return response
 
-    def file_stat(self, remote_file: str) -> Dict:
+    def file_stat(self, remote_file: str, metadata=None) -> Dict:
         """
         Get file statistics from the device.
 
         Args:
             remote_file: Path to the file on the device.
+            metadata: Optional gRPC metadata (dict or list of (key, value) tuples).
 
         Returns:
             Dict with 'stats' key containing file metadata.
         """
         request = {"path": remote_file}
-        response = self.grpc_client.call_unary("gnoi.file.File", "Stat", request)
+        response = self.grpc_client.call_unary("gnoi.file.File", "Stat", request, metadata=metadata)
 
         if "stats" in response and isinstance(response["stats"], list):
             for stat in response["stats"]:
@@ -72,7 +76,8 @@ class DutGnoi:
 
         return response
 
-    def kill_process(self, name: str, restart: bool = False, signal: str = "SIGNAL_TERM") -> Dict:
+    def kill_process(self, name: str, restart: bool = False, signal: str = "SIGNAL_TERM",
+                     metadata=None) -> Dict:
         """
         Kill (and optionally restart) a process via gNOI System.KillProcess.
 
@@ -80,12 +85,13 @@ class DutGnoi:
             name: Process/service name to kill.
             restart: Whether to restart after killing.
             signal: Signal type (use SIGNAL_TERM, SIGNAL_KILL, etc.).
+            metadata: Optional gRPC metadata (dict or list of (key, value) tuples).
 
         Returns:
             Dict response (typically empty on success).
         """
         request = {"name": name, "restart": restart, "signal": signal}
-        return self.grpc_client.call_unary("gnoi.system.System", "KillProcess", request)
+        return self.grpc_client.call_unary("gnoi.system.System", "KillProcess", request, metadata=metadata)
 
     def __str__(self):
         return f"DutGnoi(grpc_client={self.grpc_client})"

--- a/tests/common/dut_grpc.py
+++ b/tests/common/dut_grpc.py
@@ -63,9 +63,14 @@ class DutGrpc:
         """Configure connection timeout in seconds."""
         self.timeout = int(timeout_seconds)
 
-    def _build_cmd(self, extra_args=None, service_method=None):
+    def _build_cmd(self, extra_args=None, service_method=None, metadata=None):
         """
         Build a grpcurl shell command string.
+
+        Args:
+            extra_args: Additional command arguments.
+            service_method: gRPC service/method target.
+            metadata: Optional gRPC metadata as dict or list of (key, value) tuples.
 
         Returns a string suitable for duthost.shell().
         """
@@ -73,6 +78,10 @@ class DutGrpc:
             "grpcurl", "-plaintext", "-format", "json",
             "-connect-timeout", str(self.timeout),
         ]
+        if metadata:
+            items = metadata.items() if isinstance(metadata, dict) else metadata
+            for name, value in items:
+                parts.extend(["-H", shlex.quote(f"{name}: {value}")])
         if extra_args:
             parts.extend(extra_args)
         parts.append(shlex.quote(self.target))
@@ -141,7 +150,7 @@ class DutGrpc:
         result = self._execute(cmd)
         return {"symbol": symbol, "description": result["stdout"].strip()}
 
-    def call_unary(self, service, method, request=None):
+    def call_unary(self, service, method, request=None, metadata=None):
         """
         Make a unary gRPC call.
 
@@ -149,6 +158,7 @@ class DutGrpc:
             service: Service name (e.g. "gnoi.system.System")
             method: Method name (e.g. "Time")
             request: Optional request dict.
+            metadata: Optional gRPC metadata as dict or list of (key, value) tuples.
 
         Returns:
             Parsed JSON response dict.
@@ -156,7 +166,7 @@ class DutGrpc:
         service_method = f"{service}/{method}"
         request_json = json.dumps(request) if request else "{}"
         extra_args = ["-d", shlex.quote(request_json)]
-        cmd = self._build_cmd(extra_args=extra_args, service_method=service_method)
+        cmd = self._build_cmd(extra_args=extra_args, service_method=service_method, metadata=metadata)
         result = self._execute(cmd)
 
         try:
@@ -164,7 +174,7 @@ class DutGrpc:
         except json.JSONDecodeError as e:
             raise DutGrpcCallError(f"Invalid JSON from {service_method}: {e}")
 
-    def call_server_streaming(self, service, method, request=None):
+    def call_server_streaming(self, service, method, request=None, metadata=None):
         """
         Make a server-streaming gRPC call.
 
@@ -172,6 +182,7 @@ class DutGrpc:
             service: Service name
             method: Method name
             request: Optional request dict.
+            metadata: Optional gRPC metadata as dict or list of (key, value) tuples.
 
         Returns:
             List of parsed JSON response dicts.
@@ -179,7 +190,7 @@ class DutGrpc:
         service_method = f"{service}/{method}"
         request_json = json.dumps(request) if request else "{}"
         extra_args = ["-d", shlex.quote(request_json)]
-        cmd = self._build_cmd(extra_args=extra_args, service_method=service_method)
+        cmd = self._build_cmd(extra_args=extra_args, service_method=service_method, metadata=metadata)
         result = self._execute(cmd)
 
         responses = []

--- a/tests/common/dut_grpc.py
+++ b/tests/common/dut_grpc.py
@@ -1,0 +1,219 @@
+"""
+DUT-local gRPC client using grpcurl over Unix domain socket.
+
+This module provides a grpcurl-based gRPC client that runs on the DUT host
+via duthost.shell(), connecting over a Unix domain socket for local testing
+without TLS overhead.
+
+Unlike PtfGrpc (which runs on the PTF container over TCP), DutGrpc always
+uses plaintext UDS and has no TLS certificate configuration.
+"""
+import json
+import shlex
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class DutGrpcError(Exception):
+    """Base exception for DutGrpc operations."""
+    pass
+
+
+class DutGrpcConnectionError(DutGrpcError):
+    """Connection-related gRPC errors (socket not found, connection refused)."""
+    pass
+
+
+class DutGrpcCallError(DutGrpcError):
+    """gRPC method call errors (unknown service, invalid response)."""
+    pass
+
+
+class DutGrpcTimeoutError(DutGrpcError):
+    """gRPC timeout errors."""
+    pass
+
+
+class DutGrpc:
+    """
+    DUT-local gRPC client using grpcurl over Unix domain socket.
+
+    Executes grpcurl commands on the DUT host via duthost.shell() to interact
+    with gRPC services over a local UDS. Always uses plaintext (no TLS).
+
+    Usage:
+        client = DutGrpc(duthost)
+        services = client.list_services()
+        result = client.call_unary("gnoi.system.System", "Time")
+    """
+
+    def __init__(self, duthost, socket_path="/var/run/gnmi/gnmi.sock"):
+        """
+        Args:
+            duthost: DUT host instance (must support .shell())
+            socket_path: Path to the gNMI Unix domain socket
+        """
+        self.duthost = duthost
+        self.socket_path = socket_path
+        self.target = f"unix:///{socket_path}"
+        self.timeout = 10
+
+    def configure_timeout(self, timeout_seconds):
+        """Configure connection timeout in seconds."""
+        self.timeout = int(timeout_seconds)
+
+    def _build_cmd(self, extra_args=None, service_method=None):
+        """
+        Build a grpcurl shell command string.
+
+        Returns a string suitable for duthost.shell().
+        """
+        parts = [
+            "grpcurl", "-plaintext", "-format", "json",
+            "-connect-timeout", str(self.timeout),
+        ]
+        if extra_args:
+            parts.extend(extra_args)
+        parts.append(self.target)
+        if service_method:
+            parts.append(service_method)
+        return " ".join(parts)
+
+    def _execute(self, cmd):
+        """Execute a grpcurl command and return the result dict, or raise on error."""
+        logger.debug("DutGrpc executing: %s", cmd)
+        result = self.duthost.shell(cmd, module_ignore_errors=True)
+
+        if result["rc"] != 0:
+            stderr = (result.get("stderr") or "").strip()
+            stdout = (result.get("stdout") or "").strip()
+            err_text = stderr or stdout
+
+            if any(kw in err_text.lower() for kw in (
+                "connection refused", "no such file", "dial",
+                "connect:", "connection failed",
+            )):
+                raise DutGrpcConnectionError(f"Connection failed to {self.target}: {err_text}")
+
+            if any(kw in err_text.lower() for kw in (
+                "timeout", "deadline exceeded",
+            )):
+                raise DutGrpcTimeoutError(f"Timed out after {self.timeout}s: {err_text}")
+
+            if any(kw in err_text.lower() for kw in (
+                "unknown service", "unknown method", "not found", "unimplemented",
+            )):
+                raise DutGrpcCallError(f"Service/method error: {err_text}")
+
+            raise DutGrpcError(f"grpcurl failed (rc={result['rc']}): {err_text}")
+
+        return result
+
+    def list_services(self):
+        """
+        List available gRPC services via reflection.
+
+        Returns:
+            List of service name strings (grpc.reflection.* filtered out).
+        """
+        cmd = self._build_cmd(service_method="list")
+        result = self._execute(cmd)
+
+        services = []
+        for line in result["stdout"].strip().split("\n"):
+            line = line.strip()
+            if line and not line.startswith("grpc."):
+                services.append(line)
+        return services
+
+    def describe(self, symbol):
+        """
+        Describe a gRPC service or method via reflection.
+
+        Args:
+            symbol: Fully qualified service or method name.
+
+        Returns:
+            Dict with 'symbol' and 'description' keys.
+        """
+        parts = [
+            "grpcurl", "-plaintext",
+            "-connect-timeout", str(self.timeout),
+            self.target, "describe", symbol,
+        ]
+        cmd = " ".join(parts)
+        result = self._execute(cmd)
+        return {"symbol": symbol, "description": result["stdout"].strip()}
+
+    def call_unary(self, service, method, request=None):
+        """
+        Make a unary gRPC call.
+
+        Args:
+            service: Service name (e.g. "gnoi.system.System")
+            method: Method name (e.g. "Time")
+            request: Optional request dict.
+
+        Returns:
+            Parsed JSON response dict.
+        """
+        service_method = f"{service}/{method}"
+        request_json = json.dumps(request) if request else "{}"
+        extra_args = ["-d", shlex.quote(request_json)]
+        cmd = self._build_cmd(extra_args=extra_args, service_method=service_method)
+        result = self._execute(cmd)
+
+        try:
+            return json.loads(result["stdout"].strip())
+        except json.JSONDecodeError as e:
+            raise DutGrpcCallError(f"Invalid JSON from {service_method}: {e}")
+
+    def call_server_streaming(self, service, method, request=None):
+        """
+        Make a server-streaming gRPC call.
+
+        Args:
+            service: Service name
+            method: Method name
+            request: Optional request dict.
+
+        Returns:
+            List of parsed JSON response dicts.
+        """
+        service_method = f"{service}/{method}"
+        request_json = json.dumps(request) if request else "{}"
+        extra_args = ["-d", shlex.quote(request_json)]
+        cmd = self._build_cmd(extra_args=extra_args, service_method=service_method)
+        result = self._execute(cmd)
+
+        responses = []
+        stdout = result["stdout"].strip()
+
+        # Try as single JSON first (grpcurl may wrap in one object)
+        try:
+            responses.append(json.loads(stdout))
+            return responses
+        except json.JSONDecodeError:
+            pass
+
+        # Fall back to line-by-line for streaming output
+        for line in stdout.split("\n"):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                responses.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+        if not responses:
+            raise DutGrpcCallError(f"No valid responses from streaming call {service_method}")
+
+        return responses
+
+    def __str__(self):
+        return f"DutGrpc(target={self.target})"
+
+    def __repr__(self):
+        return self.__str__()

--- a/tests/common/dut_grpc.py
+++ b/tests/common/dut_grpc.py
@@ -75,9 +75,9 @@ class DutGrpc:
         ]
         if extra_args:
             parts.extend(extra_args)
-        parts.append(self.target)
+        parts.append(shlex.quote(self.target))
         if service_method:
-            parts.append(service_method)
+            parts.append(shlex.quote(service_method))
         return " ".join(parts)
 
     def _execute(self, cmd):
@@ -137,12 +137,7 @@ class DutGrpc:
         Returns:
             Dict with 'symbol' and 'description' keys.
         """
-        parts = [
-            "grpcurl", "-plaintext",
-            "-connect-timeout", str(self.timeout),
-            self.target, "describe", symbol,
-        ]
-        cmd = " ".join(parts)
+        cmd = self._build_cmd(service_method=f"describe {symbol}")
         result = self._execute(cmd)
         return {"symbol": symbol, "description": result["stdout"].strip()}
 

--- a/tests/common/fixtures/grpc_fixtures.py
+++ b/tests/common/fixtures/grpc_fixtures.py
@@ -15,6 +15,9 @@ Deprecated fixtures (kept for backward compatibility):
 """
 import os
 import shutil
+import subprocess
+import tarfile
+import tempfile
 import time
 import pytest
 import logging
@@ -27,8 +30,88 @@ from tests.common.helpers.gnmi_utils import GNMIEnvironment
 from tests.common.ptf_grpc import PtfGrpc
 from tests.common.ptf_gnoi import PtfGnoi
 from tests.common.ptf_gnmic import PtfGnmic
+from tests.common.dut_grpc import DutGrpc
+from tests.common.dut_gnoi import DutGnoi
 
 logger = logging.getLogger(__name__)
+
+GRPCURL_VERSION = "1.9.1"
+
+# Architecture mapping: dpkg --print-architecture → grpcurl release suffix
+_GRPCURL_ARCH_MAP = {
+    "amd64": "linux_amd64",
+    "arm64": "linux_arm64",
+    "armhf": "linux_armv6",
+}
+
+
+def _ensure_grpcurl_on_dut(duthost):
+    """
+    Ensure grpcurl is available on the DUT host.
+
+    Downloads the correct architecture binary from GitHub releases to the
+    local machine (sonic-mgmt container), then copies it to the DUT.
+    Idempotent: skips download if grpcurl is already installed on the DUT.
+
+    Args:
+        duthost: DUT host instance.
+
+    Raises:
+        pytest.skip: If grpcurl cannot be provisioned.
+    """
+    # Check if already installed
+    check = duthost.shell("which grpcurl", module_ignore_errors=True)
+    if check["rc"] == 0:
+        logger.info("grpcurl already installed on DUT at %s", check["stdout"].strip())
+        return
+
+    # Detect DUT architecture
+    arch_result = duthost.shell("dpkg --print-architecture")
+    dut_arch = arch_result["stdout"].strip()
+    grpcurl_arch = _GRPCURL_ARCH_MAP.get(dut_arch)
+    if not grpcurl_arch:
+        pytest.skip(f"Unsupported DUT architecture for grpcurl: {dut_arch}")
+
+    tarball = f"grpcurl_{GRPCURL_VERSION}_{grpcurl_arch}.tar.gz"
+    url = f"https://github.com/fullstorydev/grpcurl/releases/download/v{GRPCURL_VERSION}/{tarball}"
+
+    logger.info("Downloading grpcurl %s for %s from %s", GRPCURL_VERSION, dut_arch, url)
+
+    # Download to local temp dir (sonic-mgmt container has internet)
+    local_tmp = tempfile.mkdtemp(prefix="grpcurl_")
+    local_tarball = os.path.join(local_tmp, tarball)
+    local_binary = os.path.join(local_tmp, "grpcurl")
+
+    try:
+        subprocess.check_call(["curl", "-fsSL", "-o", local_tarball, url], timeout=120)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        shutil.rmtree(local_tmp, ignore_errors=True)
+        pytest.skip(f"Failed to download grpcurl: {e}")
+
+    # Extract binary from tarball
+    try:
+        with tarfile.open(local_tarball, "r:gz") as tar:
+            member = tar.getmember("grpcurl")
+            tar.extract(member, path=local_tmp)
+    except (tarfile.TarError, KeyError) as e:
+        shutil.rmtree(local_tmp, ignore_errors=True)
+        pytest.skip(f"Failed to extract grpcurl from tarball: {e}")
+
+    # Copy to DUT
+    try:
+        duthost.copy(src=local_binary, dest="/usr/local/bin/grpcurl", mode="0755")
+    except Exception as e:
+        shutil.rmtree(local_tmp, ignore_errors=True)
+        pytest.skip(f"Failed to copy grpcurl to DUT: {e}")
+
+    shutil.rmtree(local_tmp, ignore_errors=True)
+
+    # Verify
+    verify = duthost.shell("grpcurl --version", module_ignore_errors=True)
+    if verify["rc"] != 0:
+        pytest.skip("grpcurl installed but --version check failed")
+
+    logger.info("grpcurl %s installed on DUT", GRPCURL_VERSION)
 
 
 @dataclass
@@ -46,17 +129,27 @@ class GnmiFixture:
     port: int
     tls: bool
     cert_paths: Optional[CertPaths]
-    grpc: PtfGrpc       # correctly configured client
-    gnoi: PtfGnoi       # convenience wrapper
-    gnmic: PtfGnmic     # gnmic CLI wrapper
+    grpc: object        # PtfGrpc (TLS/plaintext) or DutGrpc (UDS)
+    gnoi: object        # PtfGnoi or DutGnoi
+    gnmic: Optional[PtfGnmic]   # None for UDS transport
+    transport: str = 'tls'      # 'tls' or 'uds'
 
 
 @pytest.fixture(scope="module")
-def gnmi_tls(duthost, ptfhost):
+def gnmi_tls(request, duthost, ptfhost):
     """
-    Set up TLS-secured gNMI/gNOI environment and yield a coupled GnmiFixture.
+    Set up gNMI/gNOI environment and yield a coupled GnmiFixture.
 
-    This fixture:
+    Supports two transports:
+    - 'tls' (default): TCP+TLS from PTF container (existing behavior)
+    - 'uds': Unix domain socket from DUT host (no TLS, no server restart)
+
+    Opt-in to UDS via indirect parametrize:
+        @pytest.mark.parametrize("gnmi_tls", ["tls", "uds"], indirect=True)
+
+    Without parametrize, defaults to TLS (backward compatible).
+
+    TLS flow:
     1. Creates a configuration checkpoint for rollback
     2. Generates TLS certificates (backdated for clock skew)
     3. Distributes certificates to DUT and PTF
@@ -73,6 +166,13 @@ def gnmi_tls(duthost, ptfhost):
             assert isinstance(result["time"], int)
             assert gnmi_tls.port == 50052
     """
+    transport = getattr(request, 'param', 'tls')
+
+    if transport == 'uds':
+        yield from _gnmi_uds_flow(duthost)
+        return
+
+    # --- existing TLS flow below (unchanged) ---
     checkpoint_name = "gnoi_tls_setup"
     cert_dir = "/tmp/gnoi_certs"
 
@@ -129,6 +229,7 @@ def gnmi_tls(duthost, ptfhost):
             grpc=client,
             gnoi=gnoi_client,
             gnmic=gnmic_client,
+            transport='tls',
         )
 
         logger.info("Constructed PtfGnmic client: %s", gnmic_client)
@@ -180,10 +281,44 @@ def gnmi_plaintext(duthost, ptfhost):
         grpc=client,
         gnoi=gnoi_client,
         gnmic=gnmic_client,
+        transport='plaintext',
     )
 
     logger.info(f"Created plaintext GnmiFixture: {target}")
     yield fixture
+
+
+def _gnmi_uds_flow(duthost):
+    """
+    UDS transport flow — no TLS, no server restart, no CONFIG_DB changes.
+
+    Ensures grpcurl is on the DUT, validates the UDS socket exists,
+    and yields a GnmiFixture with DutGrpc/DutGnoi clients.
+    """
+    _ensure_grpcurl_on_dut(duthost)
+
+    # Validate UDS socket exists
+    socket_check = duthost.shell("test -S /var/run/gnmi/gnmi.sock", module_ignore_errors=True)
+    if socket_check["rc"] != 0:
+        pytest.skip("UDS socket /var/run/gnmi/gnmi.sock does not exist")
+
+    grpc_client = DutGrpc(duthost)
+    gnoi_client = DutGnoi(grpc_client)
+
+    fixture = GnmiFixture(
+        host="localhost",
+        port=0,
+        tls=False,
+        cert_paths=None,
+        grpc=grpc_client,
+        gnoi=gnoi_client,
+        gnmic=None,
+        transport="uds",
+    )
+
+    logger.info("UDS transport ready: %s", grpc_client)
+    yield fixture
+    # No teardown needed for UDS
 
 
 # ---------------------------------------------------------------------------

--- a/tests/common/fixtures/grpc_fixtures.py
+++ b/tests/common/fixtures/grpc_fixtures.py
@@ -35,11 +35,11 @@ from tests.common.dut_gnoi import DutGnoi
 
 logger = logging.getLogger(__name__)
 
-GRPCURL_VERSION = "1.9.1"
+GRPCURL_VERSION = "1.9.3"
 
 # Architecture mapping: dpkg --print-architecture → grpcurl release suffix
 _GRPCURL_ARCH_MAP = {
-    "amd64": "linux_amd64",
+    "amd64": "linux_x86_64",
     "arm64": "linux_arm64",
     "armhf": "linux_armv6",
 }

--- a/tests/common/fixtures/grpc_fixtures.py
+++ b/tests/common/fixtures/grpc_fixtures.py
@@ -66,7 +66,9 @@ def _ensure_grpcurl_on_dut(duthost):
         return
 
     # Detect DUT architecture
-    arch_result = duthost.shell("dpkg --print-architecture")
+    arch_result = duthost.shell("dpkg --print-architecture", module_ignore_errors=True)
+    if arch_result["rc"] != 0:
+        pytest.skip("Cannot detect DUT architecture via dpkg")
     dut_arch = arch_result["stdout"].strip()
     grpcurl_arch = _GRPCURL_ARCH_MAP.get(dut_arch)
     if not grpcurl_arch:
@@ -92,6 +94,11 @@ def _ensure_grpcurl_on_dut(duthost):
     try:
         with tarfile.open(local_tarball, "r:gz") as tar:
             member = tar.getmember("grpcurl")
+            # Validate extraction path to prevent path traversal
+            extracted = os.path.realpath(os.path.join(local_tmp, member.name))
+            if not extracted.startswith(os.path.realpath(local_tmp)):
+                shutil.rmtree(local_tmp, ignore_errors=True)
+                pytest.skip("Tarball member has unexpected path")
             tar.extract(member, path=local_tmp)
     except (tarfile.TarError, KeyError) as e:
         shutil.rmtree(local_tmp, ignore_errors=True)

--- a/tests/gnmi/test_gnoi_system.py
+++ b/tests/gnmi/test_gnoi_system.py
@@ -1,8 +1,8 @@
 """
-Simple integration tests for gNOI System service.
+Integration tests for gNOI System service.
 
-All tests automatically run with TLS server configuration by default.
-Users don't need to worry about TLS configuration.
+Tests run with TLS by default. Opt-in to dual transport (TLS + UDS)
+via the parametrize decorator on individual tests.
 """
 import pytest
 import logging
@@ -16,9 +16,11 @@ pytestmark = [
 ]
 
 
+@pytest.mark.parametrize("gnmi_tls", ["tls", "uds"], indirect=True)
 def test_system_time(gnmi_tls):  # noqa: F811
-    """Test System.Time RPC with TLS enabled by default."""
+    """Test System.Time RPC works over both TLS and UDS transports."""
     result = gnmi_tls.gnoi.system_time()
     assert "time" in result
     assert isinstance(result["time"], int)
-    logger.info(f"System time: {result['time']} nanoseconds since epoch")
+    assert result["time"] > 0
+    logger.info("System time via %s: %d ns", gnmi_tls.transport, result["time"])


### PR DESCRIPTION
### Description of PR

Add Unix Domain Socket (UDS) transport support to the `gnmi_tls` test fixture, enabling gNMI/gNOI tests to run locally on the DUT via grpcurl over `/var/run/gnmi/gnmi.sock` instead of requiring TCP+TLS from the PTF container.

The gNMI server already listens on the UDS without TLS, relying on filesystem permissions (0660) for access control. By connecting a DUT-local grpcurl client over this socket, we can exercise the same gRPC services without TLS certificate generation, CONFIG_DB reconfiguration, or server restart.

**New files:**
- `tests/common/dut_grpc.py` — Lightweight grpcurl wrapper that runs on the DUT host via `duthost.shell()`, connecting over UDS with plaintext
- `tests/common/dut_gnoi.py` — gNOI wrapper around DutGrpc, mirroring PtfGnoi interface (system_time, file_stat, kill_process)

**Modified files:**
- `tests/common/fixtures/grpc_fixtures.py` — `gnmi_tls` fixture gains transport dispatch (`tls` default, `uds` opt-in via indirect parametrize). Includes `_ensure_grpcurl_on_dut()` helper that auto-provisions grpcurl binary on the DUT.
- `tests/gnmi/test_gnoi_system.py` — `test_system_time` now runs over both TLS and UDS transports

**Design doc:** `docs/testplan/gnmi-uds-transport-design.md`

### Type of change

- [x] Testbed and Framework(new/improvement)

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

The existing `gnmi_tls` fixture requires TLS cert generation, CONFIG_DB changes, and server restart — all of which add latency and complexity. UDS transport bypasses all of this, enabling faster gNMI/gNOI testing with a simpler setup path.

#### How did you do it?

1. Created `DutGrpc` — a grpcurl-based gRPC client that runs on the DUT host via `duthost.shell()` over `unix:///var/run/gnmi/gnmi.sock`
2. Created `DutGnoi` — gNOI wrapper matching PtfGnoi interface
3. Updated `gnmi_tls` fixture to accept `request.param` for transport selection. When `uds` is requested, it provisions grpcurl on the DUT (download from GitHub releases, copy to DUT), validates the UDS socket, and yields a `GnmiFixture` with DutGrpc/DutGnoi clients. Default behavior (TLS) is unchanged.
4. Tests opt in via: `@pytest.mark.parametrize("gnmi_tls", ["tls", "uds"], indirect=True)`

#### How did you verify/test it?

- Temporary integration tests run against KVM testbed (vlab-01) at each step
- Syntax validation on all changed files
- Backward compatibility: existing tests using `gnmi_tls` without parametrize default to TLS

#### Any platform specific information?

grpcurl binary is auto-detected for the DUT architecture (`amd64`, `arm64`, `armhf`).

#### Supported testbed topology if it's a new test case?

`any` — UDS socket is available on all SONiC devices running the gnmi container.

### Documentation

Design doc included in this PR: `docs/testplan/gnmi-uds-transport-design.md`
