### PR TITLE
Cisco-console-server: Use Ethernet1 instead of Ethernet0 for cisco console server.

### DIFF
--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -243,8 +243,12 @@ def test_telemetry_output_ipv6_only(request, duthosts_ipv6_mgmt_only, localhost,
                       module_ignore_errors=False)
             time.sleep(GNMI_SERVER_START_WAIT_TIME)
             dut_ip = get_mgmt_ipv6(dut)
-            cmd = "~/gnmi_get -xpath_target COUNTERS_DB -xpath COUNTERS/Ethernet0 -target_addr \
-                [%s]:%s -logtostderr -insecure" % (dut_ip, env.gnmi_port)
+            port = "Ethernet0"
+            if dut.facts['platform'] in ['arm64-c8220tg_48a_o-r0']:
+                port = "Ethernet1"
+            cmd = f"~/gnmi_get -xpath_target COUNTERS_DB -xpath COUNTERS/{port} -target_addr \
+                [{dut_ip}]:{env.gnmi_port} -logtostderr -insecure"
+
             show_gnmi_out = dut.shell(cmd)['stdout']
             result = str(show_gnmi_out)
             dut.shell('sonic-db-cli CONFIG_DB hdel "%s|gnmi" user_auth' % (env.gnmi_config_table),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Cisco Console server has RJ45 for Ethernet0. The tests that assume SFP in Ethernet0 will fail when run on this platform. This PR addresses the failure of ip/test_mgmt_ipv6_only.py which uses Ethernet0 for the tests.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
Failure of ip/test_mgmt_ipv6_only.py in Cisco-C8220TG-48A-O since it uses Ethernet0 which is RJ45.

#### How did you do it?
I changed the port to Ethernet1 for thsi test.

#### How did you verify/test it?
Ran it on my testbeds:
```
================================================================================================ warnings summary ================================================================================================
../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================================== PASSES =====================================================================================================
____________________________________________________________________________________________ test_bgp_facts_ipv6_only ____________________________________________________________________________________________
__________________________________________________________________________________________ test_show_features_ipv6_only __________________________________________________________________________________________
______________________________________________________________________________________________ test_snmp_ipv6_only _______________________________________________________________________________________________
_____________________________________________________________________________________________ test_ro_user_ipv6_only _____________________________________________________________________________________________
_____________________________________________________________________________________________ test_rw_user_ipv6_only _____________________________________________________________________________________________
________________________________________________________________________________________ test_telemetry_output_ipv6_only _________________________________________________________________________________________
----------------------------------------------------------- generated xml file: /run_logs/sir-c0/39427/2026-04-13-21-35-22/ip/test_mgmt_ipv6_only.xml ------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
============================================================================================ short test summary info =============================================================================================
PASSED ip/test_mgmt_ipv6_only.py::test_bgp_facts_ipv6_only
PASSED ip/test_mgmt_ipv6_only.py::test_show_features_ipv6_only
PASSED ip/test_mgmt_ipv6_only.py::test_snmp_ipv6_only
PASSED ip/test_mgmt_ipv6_only.py::test_ro_user_ipv6_only
PASSED ip/test_mgmt_ipv6_only.py::test_rw_user_ipv6_only
PASSED ip/test_mgmt_ipv6_only.py::test_telemetry_output_ipv6_only
SKIPPED [1] ip/test_mgmt_ipv6_only.py:152: No IPv6 image url found for DUTs
SKIPPED [2] ip/test_mgmt_ipv6_only.py:159: DUT has no default route, skiped
SKIPPED [1] ip/test_mgmt_ipv6_only.py: Failed/Errored: To be included
============================================================================== 6 passed, 4 skipped, 1 warning in 1417.50s (0:23:37) ==============================================================================
sonic@arctos_cicd_all_202603:/data/tests$ 
```
#### Any platform specific information?
Specific to Cisco-C8220TG-48A-O.