### PR TITLE
Cisco-console: Increase the timeout for console_link_wiring test for cisco platform.

### DIFF
--- a/tests/console/test_console_link_wiring.py
+++ b/tests/console/test_console_link_wiring.py
@@ -34,6 +34,8 @@ def test_console_link_wiring(setup_c0, creds, target_line):
 
     packet_size = 64
     delay_factor = 3.2
+    if duthost.facts['platform'] in ["arm64-c8220tg_48a_o"]:
+        delay_factor *= 25.0
 
     # Estimate a reasonable data transfer time based on configured baud rate
     timeout_sec = (packet_size * 10) * delay_factor / int(baud_rate)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The console link wiring tests calculate the time required for the message to come reach the fanout-console using message length and baudrate. But in addition, we need time to process the packet in socat in the remote device as well. Considering these, we are increasing the time in this PR.

Summary:
Fixing the flaky-test-fail issue with loopback tests.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
The console link wiring test has flaky-fails.

#### How did you do it?
Added lot more time to allow for the processing of socat, picocom and ssh programs during the console transmission.

#### How did you verify/test it?
To be verified.
#### Any platform specific information?
Specific to Cisco-C8220TG.