### PR TITLE
Handle T2 single asic fixed system interfaces in test_inface_namingmo…

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -769,12 +769,18 @@ class TestShowQueue():
                         hostname = fields[1]
                         if hostname != duthost.hostname:
                             continue
+
                     # The interface name is always the last but one field in the BUFFER_QUEUE entry key
+<<<<<<< HEAD
                     # Note that on multi-asic T2, filter interfaces by asic namespace since
                     # queue counters are queried per-asic. On single-asic T2 or
                     # non-T2 topologies, include all local interfaces.
                     if (duthost.is_multi_asic and tbinfo['topo']['type'] == 't2' and
                             fields[-3] != asic.namespace):
+=======
+                    # Skip interfaces that don't belong to this ASIC namespace on multi-ASIC devices
+                    if duthost.is_multi_asic and fields[-3] != asic.namespace:
+>>>>>>> 83ccbc568 (NOS-5853: Handle T2 single asic fixed system interfaces in test_inface_namingmode.py (#1390))
                         continue
                     interfaces.add(fields[-2])
                 except IndexError:

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -771,16 +771,8 @@ class TestShowQueue():
                             continue
 
                     # The interface name is always the last but one field in the BUFFER_QUEUE entry key
-<<<<<<< HEAD
-                    # Note that on multi-asic T2, filter interfaces by asic namespace since
-                    # queue counters are queried per-asic. On single-asic T2 or
-                    # non-T2 topologies, include all local interfaces.
-                    if (duthost.is_multi_asic and tbinfo['topo']['type'] == 't2' and
-                            fields[-3] != asic.namespace):
-=======
                     # Skip interfaces that don't belong to this ASIC namespace on multi-ASIC devices
                     if duthost.is_multi_asic and fields[-3] != asic.namespace:
->>>>>>> 83ccbc568 (NOS-5853: Handle T2 single asic fixed system interfaces in test_inface_namingmode.py (#1390))
                         continue
                     interfaces.add(fields[-2])
                 except IndexError:


### PR DESCRIPTION

This is regression from upstream PR: https://github.com/sonic-net/sonic-mgmt/pull/20410
T2 chassis and T2 multi asic cases are handled but missed out single asic case.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
test_show_queue_counters in test_iface_namingmode.py is failing due to lack of interfaces. Interfaces are not added for T2 single asic fixed systems

#### How did you do it?
updated the check to handle T2 FS also.

#### How did you verify/test it?
Tested on ut2, t1 boxes

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
