### PR TITLE
Adding WD timeout entries for arm64-c8220tg_48a_o-r0

### DIFF
--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -211,6 +211,12 @@ x86_64-8102_28fh_dpu_o-r0:
     greater_timeout: 6553
     too_big_timeout: 6554
 
+arm64-c8220tg_48a_o-r0:
+  default:
+    valid_timeout: 10
+    greater_timeout: 6553
+    too_big_timeout: 6554
+
 # Nexthop watchdog
 x86_64-nexthop_.*:
   default:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Adding WD timeout entries for Cisco platform: arm64-c8220tg_48a_o-r0

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ x]  202603

### Approach
#### What is the motivation for this PR?
Watchdog timeout entriy is needed for the new platform to test sonic-mgmt watchdog tests

#### How did you do it?
Added the Watchdog timeout entries

#### How did you verify/test it?
Verified by running sonic-mgmt tests on this platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
