### PR TITLE
[202511][Cherry-pick of PR23217] Don't check TSA value in CHASSIS_DB if it doesn't exist

### DIFF
--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -986,7 +986,9 @@ def initial_tsa_check_before_and_after_test(duthosts):
                               "Supervisor {} tsa_enabled config is enabled".format(duthost.hostname))
 
     def run_tsb_on_linecard_and_verify(lc):
-        if verify_dut_configdb_tsa_value(lc) is not False or get_tsa_chassisdb_config(lc) != 'false' or \
+        is_chassis = not lc.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_chassis_config_absent")
+        if verify_dut_configdb_tsa_value(lc) is not False or \
+                (is_chassis and get_tsa_chassisdb_config(lc) != 'false') or \
                 get_traffic_shift_state(lc, cmd='TSC no-stats') != TS_NORMAL:
             lc.shell('TSB')
             lc.shell('sudo config save -y')


### PR DESCRIPTION
Manually Cherry-pick of https://github.com/sonic-net/sonic-mgmt/pull/23217 to 202511.
Didn't need tests_mark_conditions_voq.yaml change as it was already added in 202511 by https://github.com/sonic-net/sonic-mgmt/pull/23348