### PR TITLE
[snappi/fixtures]: Fix shared fanout port resolution and add tgen_port_info teardown

### DIFF
--- a/tests/common/fixtures/conn_graph_facts.py
+++ b/tests/common/fixtures/conn_graph_facts.py
@@ -20,12 +20,27 @@ def fanout_graph_facts(localhost, duthosts, rand_one_tgen_dut_hostname, conn_gra
         return facts
 
     selected_dut_hostnames = [dh.hostname for dh in duthosts]
-    for _, val in list(dev_conn[duthost.hostname].items()):
+    for dut_port, val in list(dev_conn[duthost.hostname].items()):
         fanout = val["peerdevice"]
         if fanout not in facts:
             # Query graph using selected DUT + fanout so linked ports are scoped to selected DUTs.
             scoped_graph_facts = get_graph_facts(duthost, localhost, selected_dut_hostnames + [fanout])
             facts[fanout] = {k: v[fanout] for k, v in list(scoped_graph_facts.items()) if fanout in v}
+
+        # When multiple DUTs share the same fanout port in the CSV, the last
+        # entry overwrites earlier ones in graph_utils links dict. Patch the
+        # fanout's device_conn using the DUT's own (always-correct) connection
+        # data so shared Ixia/SNAPPI ports resolve to the current DUT while
+        # preserving any optional attributes already present on the entry.
+        fanout_port = val["peerport"]
+        fanout_device_conn = facts[fanout].setdefault('device_conn', {})
+        fanout_port_conn = fanout_device_conn.setdefault(fanout_port, {})
+        fanout_port_conn.update({
+            "peerdevice": duthost.hostname,
+            "peerport": dut_port,
+            "speed": val.get("speed", ""),
+            "fec_disable": val.get("fec_disable", False),
+        })
     return facts
 
 

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -2160,7 +2160,15 @@ def tgen_port_info(request: pytest.FixtureRequest, snappi_port_selection, get_sn
         if not snappi_ports:
             pytest.skip(f"Unsupported combination for {flatten_skeleton_parameter}")
 
-        return snappi_dut_base_config(duthosts, snappi_ports, snappi_api, setup=True)
+        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(
+            duthosts, snappi_ports, snappi_api, setup=True)
+
+        # Fixture setup is complete; yield the prepared testbed data to the test.
+        yield (testbed_config, port_config_list, snappi_ports)
+
+        # Cleanup runs after the test finishes and fixture execution resumes.
+        logger.info('Snappi cleanup after test')
+        setup_dut_ports(False, duthosts, testbed_config, port_config_list, snappi_ports)
 
 
 def flatten_list(lst):


### PR DESCRIPTION
### Description of PR
Summary:
Fix shared fanout port resolution and add teardown to dynamic port selection `tgen_port_info` fixture in SNAPPI tests.

When multiple DUTs share the same Ixia/SNAPPI fanout port in lab CSV `ansible/files/*links.csv`, `graph_utils` link dict may keep only the last mapping, causing incorrect port resolution for the active DUT. Also, `tgen_port_info` used `return` in a fixture path that requires post-test cleanup, which can lead to teardown not running and StopIteration-related issues during iteration flows.

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
- Ensure SNAPPI/Ixia fanout port mapping is deterministic and DUT-correct in shared-port topologies.
- Ensure fixture lifecycle is correct so cleanup always runs after tests.

#### How did you do it?
- In `conn_graph_facts` fanout fixture flow, patched fanout `device_conn` using the selected DUT’s own connection data (`peerdevice`, `peerport`, `speed`, `fec_disable`) so shared fanout ports resolve to the current DUT even when CSV/link dict has overwrite behavior.
- In `snappi_fixtures` `tgen_port_info`, changed fixture behavior from `return` to `yield`.
- Added teardown after `yield` with `setup_dut_ports(False, ...)` to guarantee cleanup executes.

#### How did you verify/test it?
- Validation run details:

Before the change, the tests were skipped as fanout_graph_facts produced an empty fanout port dictionary item:
```
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio[multidut_port_info0-100.0-single_linecard_single_asic-True] 
SKIPPED (Need Minimum of 2 ports defined in ansible/files/*links.csv...) [  2%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio[multidut_port_info0-100.0-single_linecard_single_asic-False] SKIPPED [  5%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio[multidut_port_info1-100.0-single_linecard_single_asic-True] SKIPPED [  7%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio[multidut_port_info1-100.0-single_linecard_single_asic-False] SKIPPED [ 10%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info0-100.0-single_linecard_single_asic-True] SKIPPED [ 12%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info0-100.0-single_linecard_single_asic-False] SKIPPED [ 15%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info1-100.0-single_linecard_single_asic-True] SKIPPED [ 17%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info1-100.0-single_linecard_single_asic-False] SKIPPED [ 20%]
...
```


After the change, `fanout_graph_facts` returns the relevant Ixia/SNAPPI fanout ports, allowing the tests to pass.
```
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio[multidut_port_info0-100.0-single_linecard_single_asic-True] PASSED [  2%]                                             
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio[multidut_port_info0-100.0-single_linecard_single_asic-False] PASSED [  5%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio[multidut_port_info1-100.0-single_linecard_single_asic-True] PASSED [  7%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio[multidut_port_info1-100.0-single_linecard_single_asic-False] PASSED [ 10%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info0-100.0-single_linecard_single_asic-True] PASSED [ 12%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info0-100.0-single_linecard_single_asic-False] PASSED [ 15%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info1-100.0-single_linecard_single_asic-True] PASSED [ 17%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info1-100.0-single_linecard_single_asic-False] PASSED [ 20%]
...
```

#### Any platform specific information?
- No platform-specific dependency introduced.
- Change applies to SNAPPI/Ixia shared-fanout scenarios and fixture lifecycle behavior.

#### Supported testbed topology if it's a new test case?
- N/A (no new test case added).

### Documentation
- No documentation update required (behavioral fix in existing fixture and connection mapping logic).