### PR TITLE
[dhcp_relay] Add missing relay_agent params to stress test DHCPTest call

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay_stress.py
+++ b/tests/dhcp_relay/test_dhcp_relay_stress.py
@@ -6,13 +6,15 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
 from tests.common.dhcp_relay_utils import check_dhcp_stress_status
 from tests.common.dhcp_relay_utils import restart_dhcp_service
+from tests.common.dhcp_relay_utils import enable_sonic_dhcpv4_relay_agent  # noqa F401
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until, capture_and_check_packet_on_dut
 from tests.ptf_runner import ptf_runner
 
 pytestmark = [
     pytest.mark.topology('t0', 'm0'),
-    pytest.mark.device_type('vs')
+    pytest.mark.device_type('vs'),
+    pytest.mark.parametrize("relay_agent", ["isc-relay-agent", "sonic-relay-agent"])
 ]
 
 BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
@@ -20,7 +22,8 @@ DEFAULT_DHCP_CLIENT_PORT = 68
 DEFAULT_DHCP_SERVER_PORT = 67
 
 
-def test_dhcp_relay_restart_with_stress(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
+def test_dhcp_relay_restart_with_stress(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist,
+                                        testing_config, relay_agent,
                                         request, setup_standby_ports_on_rand_unselected_tor,
                                         toggle_all_simulator_ports_to_rand_selected_tor_m):      # noqa F811
     """
@@ -57,7 +60,9 @@ def test_dhcp_relay_restart_with_stress(ptfhost, dut_dhcp_relay_data, validate_d
                             "testing_mode": testing_mode,
                             "duration": duration,
                             "pps": pps,
-                            "kvm_support": True},
+                            "kvm_support": True,
+                            "relay_agent": relay_agent,
+                            "downlink_vlan_iface_name": str(dut_dhcp_relay_data[0]["downlink_vlan_iface"]["name"])},
                    log_file="/tmp/dhcp_relay_stress_test.DHCPContinuousStressTest.log", is_python3=True,
                    async_mode=True)
 
@@ -98,12 +103,15 @@ def test_dhcp_relay_restart_with_stress(ptfhost, dut_dhcp_relay_data, validate_d
                             "switch_loopback_ip": dut_dhcp_relay_data[0]['switch_loopback_ip'],
                             "uplink_mac": str(dut_dhcp_relay_data[0]['uplink_mac']),
                             "testing_mode": testing_mode,
-                            "kvm_support": True},
+                            "kvm_support": True,
+                            "relay_agent": relay_agent,
+                            "downlink_vlan_iface_name": str(dut_dhcp_relay_data[0]["downlink_vlan_iface"]["name"])},
                    log_file="/tmp/dhcp_relay_test.stress.DHCPTest.log", is_python3=True)
 
 
 @pytest.mark.parametrize('dhcp_type', ['discover', 'offer', 'request', 'ack'])
-def test_dhcp_relay_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
+def test_dhcp_relay_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_dut_routes_exist,
+                           testing_config, relay_agent,
                            setup_standby_ports_on_rand_unselected_tor,
                            toggle_all_simulator_ports_to_rand_selected_tor_m,     # noqa F811
                            dhcp_type, clean_processes_after_stress_test):
@@ -139,7 +147,9 @@ def test_dhcp_relay_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_du
             "packets_send_duration": packets_send_duration,
             "client_packets_per_sec": client_packets_per_sec,
             "testing_mode": testing_mode,
-            "kvm_support": True
+            "kvm_support": True,
+            "relay_agent": relay_agent,
+            "downlink_vlan_iface_name": str(dhcp_relay["downlink_vlan_iface"]["name"])
         }
         count_file = '/tmp/dhcp_stress_test_{}'.format(dhcp_type)
 


### PR DESCRIPTION
PR #19198 added relay_agent and downlink_vlan_iface_name as required parameters in DHCPTest.setUp for sonic-relay-agent support, but test_dhcp_relay_stress.py was not updated. This causes KeyError: 'relay_agent' and TypeError: can only concatenate str (not "NoneType") to str failures when the stress test calls DHCPTest to verify relay functionality after
stress.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

test_dhcp_relay_restart_with_stress calls ptf_runner with dhcp_relay_test.DHCPTest after the stress phase to verify relay still works. DHCPTest.setUp now requires relay_agent (line 168) and uses downlink_vlan_iface_name (line 199) to build the circuit_id for option82 when relay_agent == "sonic-relay-agent". Both parameters were missing from the stress
test's ptf_runner call.

#### How did you do it?

Added "relay_agent": "sonic-relay-agent" and "downlink_vlan_iface_name" to the ptf_runner params for the DHCPTest call in test_dhcp_relay_restart_with_stress.

#### How did you verify/test it?

 - Before fix: KeyError: 'relay_agent' on every run (confirmed on 7260 hardware and in nightly results across 7260-1, 7260-2, 7260-7)
 - After fix: KeyError resolved, DHCPTest setUp completes successfully

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
