### PR TITLE
[bgp/agg]: Add test case 2.6 — BBR disable with non-summary-only verifies contributing routes remain visible

### DIFF
--- a/tests/bgp/test_bgp_aggregate_address_bbr_dynamics.py
+++ b/tests/bgp/test_bgp_aggregate_address_bbr_dynamics.py
@@ -12,7 +12,7 @@ Test cases:
   2.3  BBR toggle does NOT affect non-BBR-required aggregate
   2.4  Mixed BBR-required and non-BBR-required aggregates
   2.5  Rapid BBR state toggling
-  2.6  BBR disable with summary-only — contributing routes un-suppressed
+  2.6  BBR disable with non-summary-only — contributing routes remain visible
 """
 
 import logging
@@ -340,56 +340,42 @@ class TestGroup2BBRStateInteraction:
         finally:
             withdraw_contributing_routes(setup, CONTRIBUTING_V4, "ipv4")
 
-    def test_2_6_bbr_disable_summary_only_unsuppresses_contributing(
+    def test_2_6_bbr_disable_non_summary_only_contributing_routes_remain(
         self, duthosts, rand_one_dut_hostname, nbrhosts, m1_topo_setup
     ):
-        """Test Case 2.6: BBR disable with summary-only — contributing routes un-suppressed.
+        """Test Case 2.6: BBR disable with non-summary-only — contributing routes remain visible.
 
         Steps:
-        1. Enable BBR, add aggregate with bbr-required=true, summary-only=true
-        2. On M2: verify only aggregate received, contributing suppressed
+        1. Enable BBR, add aggregate with bbr-required=true, summary-only=false
+        2. On M2: verify aggregate and contributing routes both received
         3. Disable BBR
-        4. On M2: verify aggregate withdrawn AND contributing routes become visible (no longer suppressed)
+        4. On M2: verify aggregate withdrawn but contributing routes still visible
         """
         duthost = duthosts[rand_one_dut_hostname]
         self._skip_if_no_bbr(duthost)
         setup = m1_topo_setup
         upstream = setup['upstream_neighbors']
-        cfg = AggregateCfg(prefix=AGGR_V4_1, bbr_required=True, summary_only=True, as_set=False)
+        cfg = AggregateCfg(prefix=AGGR_V4_1, bbr_required=True, summary_only=False, as_set=False)
 
         config_bbr_by_gcu(duthost, "enabled")
         announce_contributing_routes(setup, CONTRIBUTING_V4, "ipv4")
         try:
             gcu_add_aggregate(duthost, cfg)
 
-            # BBR enabled + summary-only: aggregate received, contributing suppressed
+            # BBR enabled + non-summary-only: aggregate and contributing routes both received
             verify_bgp_aggregate_consistence(duthost, True, cfg)
             verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=True)
-            verify_contributing_routes_on_m2(nbrhosts, upstream, CONTRIBUTING_V4, expected_present=False)
+            verify_contributing_routes_on_m2(nbrhosts, upstream, CONTRIBUTING_V4, expected_present=True)
 
             # Disable BBR
             config_bbr_by_gcu(duthost, "disabled")
             time.sleep(ROUTE_PROPAGATION_WAIT)
 
-            # BBR disabled: aggregate withdrawn, contributing routes un-suppressed
+            # BBR disabled: aggregate withdrawn, contributing routes still visible
             verify_bgp_aggregate_consistence(duthost, False, cfg)
             logger.info("DUT state consistency verified: aggregate %s is inactive", AGGR_V4_1)
 
-            # Dump DUT BGP RIB for diagnostics
-            dut_bgp_rib = duthost.shell(
-                "vtysh -c 'show bgp ipv4 unicast {}'".format(AGGR_V4_1),
-                module_ignore_errors=True
-            )["stdout"]
-            logger.info("DUT BGP RIB for %s after BBR disable:\n%s", AGGR_V4_1, dut_bgp_rib)
-
-            dut_bgp_rib_longer = duthost.shell(
-                "vtysh -c 'show bgp ipv4 unicast {} longer-prefixes'".format(AGGR_V4_1),
-                module_ignore_errors=True
-            )["stdout"]
-            logger.info("DUT BGP RIB for %s after BBR disable (longer prefixes):\n%s", AGGR_V4_1, dut_bgp_rib_longer)
-
             verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=False)
-
             verify_contributing_routes_on_m2(nbrhosts, upstream, CONTRIBUTING_V4, expected_present=True)
 
             gcu_remove_aggregate(duthost, cfg.prefix)

--- a/tests/bgp/test_bgp_aggregate_address_bbr_dynamics.py
+++ b/tests/bgp/test_bgp_aggregate_address_bbr_dynamics.py
@@ -12,8 +12,10 @@ Test cases:
   2.3  BBR toggle does NOT affect non-BBR-required aggregate
   2.4  Mixed BBR-required and non-BBR-required aggregates
   2.5  Rapid BBR state toggling
+  2.6  BBR disable with summary-only — contributing routes un-suppressed
 """
 
+import logging
 import time
 
 import pytest
@@ -32,12 +34,15 @@ from bgp_aggregate_helpers import (
     gcu_remove_aggregate,
     verify_bgp_aggregate_cleanup,
     verify_bgp_aggregate_consistence,
+    verify_contributing_routes_on_m2,
     verify_route_on_m2,
     withdraw_contributing_routes,
 )
 from natsort import natsorted
 from tests.common.gcu_utils import create_checkpoint, rollback_or_reload, delete_checkpoint
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
+
+logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology("m1"),
@@ -334,3 +339,61 @@ class TestGroup2BBRStateInteraction:
             verify_bgp_aggregate_cleanup(duthost, cfg.prefix)
         finally:
             withdraw_contributing_routes(setup, CONTRIBUTING_V4, "ipv4")
+
+    def test_2_6_bbr_disable_summary_only_unsuppresses_contributing(
+        self, duthosts, rand_one_dut_hostname, nbrhosts, m1_topo_setup
+    ):
+        """Test Case 2.6: BBR disable with summary-only — contributing routes un-suppressed.
+
+        Steps:
+        1. Enable BBR, add aggregate with bbr-required=true, summary-only=true
+        2. On M2: verify only aggregate received, contributing suppressed
+        3. Disable BBR
+        4. On M2: verify aggregate withdrawn AND contributing routes become visible (no longer suppressed)
+        """
+        duthost = duthosts[rand_one_dut_hostname]
+        self._skip_if_no_bbr(duthost)
+        setup = m1_topo_setup
+        upstream = setup['upstream_neighbors']
+        cfg = AggregateCfg(prefix=AGGR_V4_1, bbr_required=True, summary_only=True, as_set=False)
+
+        config_bbr_by_gcu(duthost, "enabled")
+        announce_contributing_routes(setup, CONTRIBUTING_V4, "ipv4")
+        try:
+            gcu_add_aggregate(duthost, cfg)
+
+            # BBR enabled + summary-only: aggregate received, contributing suppressed
+            verify_bgp_aggregate_consistence(duthost, True, cfg)
+            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=True)
+            verify_contributing_routes_on_m2(nbrhosts, upstream, CONTRIBUTING_V4, expected_present=False)
+
+            # Disable BBR
+            config_bbr_by_gcu(duthost, "disabled")
+            time.sleep(ROUTE_PROPAGATION_WAIT)
+
+            # BBR disabled: aggregate withdrawn, contributing routes un-suppressed
+            verify_bgp_aggregate_consistence(duthost, False, cfg)
+            logger.info("DUT state consistency verified: aggregate %s is inactive", AGGR_V4_1)
+
+            # Dump DUT BGP RIB for diagnostics
+            dut_bgp_rib = duthost.shell(
+                "vtysh -c 'show bgp ipv4 unicast {}'".format(AGGR_V4_1),
+                module_ignore_errors=True
+            )["stdout"]
+            logger.info("DUT BGP RIB for %s after BBR disable:\n%s", AGGR_V4_1, dut_bgp_rib)
+
+            dut_bgp_rib_longer = duthost.shell(
+                "vtysh -c 'show bgp ipv4 unicast {} longer-prefixes'".format(AGGR_V4_1),
+                module_ignore_errors=True
+            )["stdout"]
+            logger.info("DUT BGP RIB for %s after BBR disable (longer prefixes):\n%s", AGGR_V4_1, dut_bgp_rib_longer)
+
+            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=False)
+
+            verify_contributing_routes_on_m2(nbrhosts, upstream, CONTRIBUTING_V4, expected_present=True)
+
+            gcu_remove_aggregate(duthost, cfg.prefix)
+            verify_bgp_aggregate_cleanup(duthost, cfg.prefix)
+        finally:
+            withdraw_contributing_routes(setup, CONTRIBUTING_V4, "ipv4")
+            config_bbr_by_gcu(duthost, "enabled")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Summary:
Add test case 2.6 (`test_2_6_bbr_disable_non_summary_only_contributing_routes_remain`) to Test Group 2 (BGP Aggregate Address — BBR Feature State Interaction). This test validates that when BBR is disabled on an aggregate configured with `bbr-required=true` and `summary-only=false`, the aggregate route is withdrawn from upstream M2 neighbors while the contributing (more-specific) routes remain visible — confirming no unintended route loss.

ADO:37510027
### Type of change

- [x] New Test case
    - [x] Skipped for non-supported platforms

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Tests 2.1–2.5 verify aggregate activation/deactivation and rapid toggling, but none confirm that contributing routes are unaffected when a non-summary-only aggregate is deactivated by BBR disable. This is important because a buggy implementation could inadvertently withdraw or suppress contributing routes when the aggregate becomes inactive, causing traffic loss.

#### How did you do it?
Added `test_2_6_bbr_disable_non_summary_only_contributing_routes_remain` to `TestGroup2BBRStateInteraction` in test_bgp_aggregate_address_bbr_dynamics.py. The test:
1. Enables BBR and configures an aggregate with `bbr-required=true, summary-only=false`
2. Announces contributing routes from M0 (downstream) via ExaBGP
3. Verifies both the aggregate and contributing routes are received on M2
4. Disables BBR via GCU
5. Verifies the aggregate is withdrawn **and** contributing routes remain visible on M2
6. Cleans up aggregate config and withdraws contributing routes

#### How did you verify/test it?
Validated on an M1 topology testbed against a SONiC DUT with BBR support.

#### Any platform specific information?
Test is skipped on platforms that do not support BGP BBR (`_skip_if_no_bbr`).

#### Supported testbed topology if it's a new test case?
`m1` (marked via `@pytest.mark.topology("m1")`)

### Documentation
