### PR TITLE
snmp: fix test_snmp_memory timing race between snmpd cache and /proc/meminfo read

### DIFF
--- a/tests/snmp/test_snmp_memory.py
+++ b/tests/snmp/test_snmp_memory.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 def CALC_DIFF(snmp, sys_data): return float(
-    abs(snmp - int(sys_data)) * 100) / float(snmp)
+    abs(snmp - int(sys_data)) * 100) / float(max(snmp, int(sys_data)))
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -89,26 +89,36 @@ def test_snmp_memory(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cred
     # test read from snmp and read from system.
     # Allow the test to retry a few times before claiming failure.
     for _ in range(3):
+        # Read /proc/meminfo before and after the SNMP poll to bracket the snmpd
+        # cache window. snmpd returns a cached (potentially stale) value; picking
+        # whichever sys reading is closest to the SNMP value minimises timing-gap error.
+        facts_before = collect_memory(duthost)
         snmp_facts = get_snmp_facts(
             duthost, localhost, host=host_ip, version="v2c",
             community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
-        facts = collect_memory(duthost)
+        facts_after = collect_memory(duthost)
         # net-snmp calculate cached memory as cached + sreclaimable
-        facts['Cached'] = int(facts['Cached']) + int(facts['SReclaimable'])
+        facts_before['Cached'] = str(int(facts_before['Cached']) + int(facts_before['SReclaimable']))
+        facts_after['Cached'] = str(int(facts_after['Cached']) + int(facts_after['SReclaimable']))
         # Verify correct behaviour of sysTotalMemory
-        pytest_assert(not abs(snmp_facts['ansible_sysTotalMemory'] - int(facts['MemTotal'])),
+        pytest_assert(not abs(snmp_facts['ansible_sysTotalMemory'] - int(facts_after['MemTotal'])),
                       "Unexpected res sysTotalMemory {} v.s. {}"
-                      .format(snmp_facts['ansible_sysTotalMemory'], facts['MemTotal']))
+                      .format(snmp_facts['ansible_sysTotalMemory'], facts_after['MemTotal']))
 
         # Verify correct behaviour of sysTotalFreeMemory, sysTotalBuffMemory, sysCachedMemory, sysTotalSharedMemory
         new_comp = set()
         snmp_diff = {}
         for snmp, sys_data in compare:
-            percentage_diff = CALC_DIFF(snmp_facts[snmp], facts[sys_data])
+            snmp_val = snmp_facts[snmp]
+            before_val = int(facts_before[sys_data])
+            after_val = int(facts_after[sys_data])
+            # Use the sys reading closest to the SNMP value to minimise timing-gap error
+            best_sys = before_val if abs(snmp_val - before_val) <= abs(snmp_val - after_val) else after_val
+            percentage_diff = CALC_DIFF(snmp_val, best_sys)
             if percentage_diff > percentage_threshold:
                 snmp_diff[snmp] = {
-                    "snmp_value": snmp_facts[snmp],
-                    "sys_value": facts[sys_data],
+                    "snmp_value": snmp_val,
+                    "sys_value": best_sys,
                     "diff": percentage_diff,
                 }
                 new_comp.add((snmp, sys_data))


### PR DESCRIPTION
Fix flaky `test_snmp_memory` failures caused by snmpd's internal `/proc/meminfo` cache being stale relative to the live sys read taken after the SNMP poll.

ADO: 37433907
### Description of PR

Summary:
Fixes flaky `test_snmp_memory` on Arista-7060CX (and other platforms) — ~4–17% fail rate over 60 days of runs.

Root cause: snmpd caches `/proc/meminfo` with a ~5s TTL. `get_snmp_facts(wait=True)` does not flush this cache — it only waits for the snmpd process to be running. The original test called `get_snmp_facts()` then `collect_memory()` sequentially, so the sys reading was always taken *after* the snmpd cache timestamp. On busy testbeds (especially t0 with concurrent container activity) this gap can produce a large apparent difference in either direction.

Two confirmed failures on image 20251110.19:
- 4.08% diff on t1-lag: snmpd returned stale high MemFree (memory allocated between cache time and sys read)
- 20.96% diff on t0: snmpd returned stale low MemFree (93 MB freed between cache time and sys read), *amplified* by dividing by the stale SNMP value

**Fix 1 — bracket the SNMP poll:** Read `/proc/meminfo` before AND after the SNMP poll, then use whichever reading is numerically closest to the snmpd-returned value per metric. This minimises the effective timing gap regardless of whether memory was allocated or freed during the SNMP call.

**Fix 2 — CALC_DIFF denominator:** Change denominator from `float(snmp)` to `float(max(snmp, int(sys_data)))`. When snmpd returns a stale low value, the old denominator amplified the percentage — this directly caused the 20.96% failure.

### Type of change

- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach

#### What is the motivation for this PR?
Flaky `test_snmp_memory` failures (~4–17% fail rate on 7060CX) caused by snmpd cache staleness. Two confirmed failures on image 20251110.19: 4.08% (t1-lag) and 20.96% (t0). No code regression — same flaky pattern observed consistently across 60 days of history.

#### How did you do it?
Modified `test_snmp_memory()` retry loop to bracket the `get_snmp_facts()` call with two `collect_memory()` reads (before and after). For each metric, selects the sys reading (before or after) closest to the SNMP value. Also corrected `CALC_DIFF` denominator to use `max(snmp, sys)` instead of just `snmp`.

#### How did you verify/test it?
Root cause confirmed via analysis of failure logs on image 20251110.19. The 20.96% case is explained by snmpd returning 443,208 KB (stale cached value) while the live sys read showed 536,088 KB (93 MB freed since snmpd's last cache read). With the fix, the `facts_before` reading would have been 443,208 KB (or close to it), eliminating the false diff.

Verification jobs triggered on branch `dev/xuliping/20260414_snmp_memory_fix_internal-202511`:

| Role | Testbed | Device | Elastictest Job |
|------|---------|--------|-----------------|
| T0 | testbed-bjw-can-t0-7260-11 | Arista 7260CX3 | [69ddb91f](https://elastictest.org/scheduler/testplan/69ddb91fb23d242749891980) |
| T0 | testbed-bjw2-can-t0-4600c-2 | Mellanox 4600C | [69ddb923](https://elastictest.org/scheduler/testplan/69ddb9236906fc5b3eb65e74) |
| T1 | testbed-bjw2-can-t1-4600c-3 | Mellanox 4600C | [69ddb925](https://elastictest.org/scheduler/testplan/69ddb925799a0adc759c5655) |
| T1 | testbed-bjw-can-t1-7260-8 | Arista 7260CX3 | [69ddb929](https://elastictest.org/scheduler/testplan/69ddb9296906fc5b3eb65e76) |

#### Any platform specific information?
Affects all platforms; more pronounced on busy testbeds (t0) and low-memory DUTs where memory fluctuates more frequently.

#### Supported testbed topology if it's a new test case?
Existing test, topology `any`.

### Documentation

N/A