### PR TITLE
platform: disable memory_utilization check in test_reboot

### DIFF
--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -26,6 +26,7 @@ from tests.common.platform.reboot_utils import reboot_and_check as _reboot_and_c
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
+    pytest.mark.disable_memory_utilization,
     pytest.mark.topology('any')
 ]
 


### PR DESCRIPTION
Reboots cause legitimate large memory swings. The `memory_utilization` plugin's 20% increase threshold generates false-positive `[ALARM]` failures in reboot tests (e.g., `free:used memory usage increased by 1070.0%, exceeds increase threshold 20%`). Adding `pytest.mark.disable_memory_utilization` suppresses these false alarms.

### Description of PR

Summary:

Add `pytest.mark.disable_memory_utilization` to `test_reboot.py` to skip the memory utilization plugin's before/after memory comparison for all reboot test cases.

During a reboot, the DUT's memory state changes dramatically and legitimately — services restart, caches are rebuilt, and memory allocation patterns shift significantly. Comparing memory usage before and after a reboot is not meaningful and will always trigger false-positive alarms from the `memory_utilization` plugin.

Observed false positive:
```
[ALARM]: free:used memory usage increased by 1070.0%, exceeds increase threshold 20% (previous: 2767.0 MB, current: 3837.0 MB)
```

The `memory_utilization` plugin already supports the `disable_memory_utilization` marker (used by `test_acl.py`, `test_pfc_config.py`, and `test_container_checker.py`) for exactly this purpose.

### Type of change

- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?
Reboot tests were generating false-positive memory utilization alarms. A 1070% memory increase is expected during/after a reboot (services restart, caches rebuild) and should not be flagged as a test failure.

#### How did you do it?
Added `pytest.mark.disable_memory_utilization` to the `pytestmark` list in `tests/platform_tests/test_reboot.py`. This is a one-line change that disables the memory utilization plugin's before/after comparison for all test cases in this file.

#### How did you verify/test it?
Observed failure in elastictest: `[ALARM]: free:used memory usage increased by 1070.0%, exceeds increase threshold 20%% (previous: 2767.0 MB, current: 3837.0 MB)`. The root cause is confirmed — this is the memory_utilization plugin firing on a reboot-induced memory change, which is expected behavior.

#### Any platform specific information?
None — applies to all platforms.

#### Supported testbed topology if it's a new test case?
N/A (bug fix).

### Documentation

N/A