### PR TITLE
[snappi_tests/bgp]: Xfail bgp scalability tests for #23857

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4842,6 +4842,42 @@ snappi_tests:
     conditions:
       - "asic_type in ['vs']"
 
+snappi_tests/bgp/test_bgp_convergence_performance.py:
+  xfail:
+    reason: "IxNetwork Error in L2/L3 Traffic Apply - https://github.com/sonic-net/sonic-mgmt/issues/23857"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23857"
+
+snappi_tests/bgp/test_bgp_local_link_failover.py:
+  xfail:
+    reason: "IxNetwork Error in L2/L3 Traffic Apply - https://github.com/sonic-net/sonic-mgmt/issues/23857"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23857"
+
+snappi_tests/bgp/test_bgp_remote_link_failover.py:
+  xfail:
+    reason: "IxNetwork Error in L2/L3 Traffic Apply - https://github.com/sonic-net/sonic-mgmt/issues/23857"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23857"
+
+snappi_tests/bgp/test_bgp_rib_in_capacity.py:
+  xfail:
+    reason: "IxNetwork Error in L2/L3 Traffic Apply - https://github.com/sonic-net/sonic-mgmt/issues/23857"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23857"
+
+snappi_tests/bgp/test_bgp_rib_in_convergence.py:
+  xfail:
+    reason: "IxNetwork Error in L2/L3 Traffic Apply - https://github.com/sonic-net/sonic-mgmt/issues/23857"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23857"
+
+snappi_tests/bgp/test_bgp_scalability.py:
+  xfail:
+    reason: "IxNetwork Error in L2/L3 Traffic Apply - https://github.com/sonic-net/sonic-mgmt/issues/23857"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23857"
+
 snappi_tests/dash:
   skip:
     reason: "Skipping dash on 2025 releases"


### PR DESCRIPTION
### Description of PR
Summary:
Mark impacted Snappi BGP test files as xfail under the conditional mark plugin while issue #23857 is open.  

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Multiple Snappi BGP tests are currently failing due to IxNetwork Error in L2/L3 Traffic Apply, which blocks stable execution while the root cause is being tracked in issue #23857.

#### How did you do it?
Added file-level conditional xfail entries in tests_mark_conditions.yaml for:
- snappi_tests/bgp/test_bgp_scalability.py
- snappi_tests/bgp/test_bgp_convergence_performance.py
- snappi_tests/bgp/test_bgp_rib_in_capacity.py
- snappi_tests/bgp/test_bgp_local_link_failover.py
- snappi_tests/bgp/test_bgp_remote_link_failover.py
- snappi_tests/bgp/test_bgp_rib_in_convergence.py

All entries use the same condition:
- https://github.com/sonic-net/sonic-mgmt/issues/23857

This makes the xfail auto-expire once the issue is closed.

#### How did you verify/test it?
- Verified all requested file-level xfail entries are present in tests_mark_conditions.yaml.
- Confirmed the change is limited to the conditional mark file.
- Full test execution was not run in this change.

#### Any platform specific information?
Applies to Snappi BGP test runs on supported physical TGEN environments.

#### Supported testbed topology if it's a new test case?
Not a new test case. Existing Snappi BGP tests.

### Documentation
No documentation update required.