### PR TITLE
Remove stale xfail for cacl/test_cacl_application.py

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -692,10 +692,6 @@ cacl/test_cacl_application.py:
     reason: "skip test_cacl_application in PR test temporarily"
     conditions:
       - "asic_type in ['vs']"
-  xfail:
-    reason: "Wait PR https://github.com/sonic-net/sonic-host-services/pull/301 include in sonic-buildimage"
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/21175"
 
 cacl/test_cacl_application.py::test_cacl_acl_loader_commands_internal:
   skip:


### PR DESCRIPTION
### Description of PR

Summary:
Remove the stale xfail mark for `cacl/test_cacl_application.py` from `tests_mark_conditions.yaml`.

The xfail was added to wait for [sonic-net/sonic-host-services#301](https://github.com/sonic-net/sonic-host-services/pull/301) to be included in sonic-buildimage. That PR was merged on 2025-10-24 (~6 months ago) and has been included in builds for months. The xfail is no longer needed.

Fixes https://github.com/sonic-net/sonic-mgmt/issues/21175

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Issue [#21175](https://github.com/sonic-net/sonic-mgmt/issues/21175) was created to track removing the xfail for `cacl/test_cacl_application.py` after [sonic-net/sonic-host-services#301](https://github.com/sonic-net/sonic-host-services/pull/301) was merged into sonic-buildimage.

The PR was merged on 2025-10-24 and the xfail condition is now satisfied. Keeping the stale xfail suppresses real failures and pollutes nightly test reports.

#### How did you do it?
Removed the 4-line xfail block from `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`:
`yaml
  xfail:
    reason: "Wait PR https://github.com/sonic-net/sonic-host-services/pull/301 include in sonic-buildimage"
    conditions:
      - "https://github.com/sonic-net/sonic-mgmt/issues/21175"
`

The skip condition for VS (`asic_type in ['vs']`) is kept as-is since it serves a different purpose (PR testing).

#### How did you verify/test it?
- Verified [sonic-net/sonic-host-services#301](https://github.com/sonic-net/sonic-host-services/pull/301) was merged on 2025-10-24
- Checked Kusto test results: `cacl.test_cacl_application` tests are running on HW testbeds with reasonable pass rates
- Confirmed no CRLF corruption in the diff (exactly 4 lines removed)

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A