### PR TITLE
Fix ansible hang issue by waiting for docker service before critical service checks

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -441,6 +441,8 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
         # function will return sooner.
 
         # Update critical service list after rebooting in case critical services changed after rebooting
+        pytest_assert(wait_until(300, 10, 0, duthost.is_host_service_running, "docker"),
+                      "Docker service failed to start on {}".format(hostname))
         pytest_assert(wait_until(200, 10, 0, duthost.is_critical_processes_running_per_asic_or_host, "database"),
                       "Database not start.")
         pytest_assert(wait_until(20, 5, 0, duthost.is_service_running, "redis", "database"), "Redis DB not start")

--- a/tests/platform_tests/fwutil/fwutil_common.py
+++ b/tests/platform_tests/fwutil/fwutil_common.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 
 from tests.common.utilities import wait_until
 from tests.common.reboot import SONIC_SSH_REGEX
+from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.firmware_helper import show_firmware
 
 logger = logging.getLogger(__name__)
@@ -112,6 +113,9 @@ def complete_install(duthost, localhost, boot_type, res, pdu_ctrl, component, au
             localhost.wait_for(
                 host=hn, port=22, state='started', search_regex=SONIC_SSH_REGEX, delay=10, timeout=post_reboot_timeout)
 
+        logger.info("Waiting for docker service to start")
+        pytest_assert(wait_until(300, 10, 0, duthost.is_host_service_running, "docker"),
+                      "Docker service failed to start")
         logger.info("Waiting on critical systems to come online...")
         wait_until(300, 30, 0, duthost.critical_services_fully_started)
         time.sleep(60)


### PR DESCRIPTION
Summary: Fix ansible hang issue by waiting for docker service before critical service checks
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
There might be an issue that we have docker client connecting to docker socket even before the docker service has started.

#### How did you do it?
Waiting until the docker daemon has actually started before querying docker ps actually

#### How did you verify/test it?
Regression pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
