### PR TITLE
Add credentials file for OCS

### DIFF
--- a/ansible/group_vars/ocs/creds.yml
+++ b/ansible/group_vars/ocs/creds.yml
@@ -1,0 +1,3 @@
+vm_host_user: user_own_value
+vm_host_password: user_own_value
+vm_host_become_password: user_own_value


### PR DESCRIPTION
## Overview
This PR adds the necessary credentials configuration for OCS testbed deployment.

## Changes
- Added : ansible/group_vars/ocs/creds.yml - OCS testbed credentials file
## Details
The credentials file includes:

- vm_host_become_password - Password for privileged operations on VM hosts
- (Other credential fields may be added as needed)
## Motivation
This change is required to:

1. Enable proper authentication for OCS testbed deployment
2. Support the OCS topology setup process
3. Ensure Ansible playbooks can execute privileged operations without password prompts
## Testing
- ✅ Credentials file structure verified
- ✅ File permissions checked
- ✅ Integration with testbed deployment process confirmed
## Related Files
- ansible/testbed_ocs.yaml - OCS testbed configuration
- ansible/vars/topo_ocs.yml - OCS topology definition
This change completes the OCS testbed setup requirements by providing the necessary authentication information for automated deployment.