### PR TITLE
vpp: enable test_bgp_session on non kvm platforms

### DIFF
--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -296,7 +296,9 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
 
     # Skip the test on Virtual Switch due to fanout switch dependency and warm reboot
     asic_type = duthost.facts['asic_type']
-    if (asic_type == "vs" or asic_type == "vpp") and (failure_type == "interface" or test_type == "reboot"):
+    platform = duthost.facts['platform']
+    if ((asic_type == "vs" or asic_type == "vpp") and platform == "x86_64-kvm_x86_64-r0") \
+            and (failure_type == "interface" or test_type == "reboot"):
         pytest.skip("BGP session test is not supported on Virtual Switch")
 
     # Skip the test if BGP or SWSS autorestart is disabled

--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -297,8 +297,8 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
     # Skip the test on Virtual Switch due to fanout switch dependency and warm reboot
     asic_type = duthost.facts['asic_type']
     platform = duthost.facts['platform']
-    if ((asic_type == "vs" or asic_type == "vpp") and platform == "x86_64-kvm_x86_64-r0") \
-            and (failure_type == "interface" or test_type == "reboot"):
+    is_virtual_platform = (asic_type in ("vs", "vpp")) and platform == "x86_64-kvm_x86_64-r0"
+    if is_virtual_platform and (failure_type == "interface" or test_type == "reboot"):
         pytest.skip("BGP session test is not supported on Virtual Switch")
 
     # Skip the test if BGP or SWSS autorestart is disabled

--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -6,6 +6,7 @@ from tests.common.platform.device_utils import fanout_switch_port_lookup
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
+from tests.common.helpers.dut_utils import is_virtual_platform
 from tests.common.reboot import reboot
 
 logger = logging.getLogger(__name__)
@@ -295,10 +296,7 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
         pytest.skip("Warm Reboot is not supported on isolated topology or smartswitch")
 
     # Skip the test on Virtual Switch due to fanout switch dependency and warm reboot
-    asic_type = duthost.facts['asic_type']
-    platform = duthost.facts['platform']
-    is_virtual_platform = (asic_type in ("vs", "vpp")) and platform == "x86_64-kvm_x86_64-r0"
-    if is_virtual_platform and (failure_type == "interface" or test_type == "reboot"):
+    if is_virtual_platform(duthost) and (failure_type == "interface" or test_type == "reboot"):
         pytest.skip("BGP session test is not supported on Virtual Switch")
 
     # Skip the test if BGP or SWSS autorestart is disabled


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
enable test_bgp_session on non kvm platforms

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Currently, we skip interface and reboot if asic-type is vpp. This condition is too limiting because we have hardware platform with vpp dataplane.
#### How did you do it?
Add platform == x86_64-kvm_x86_64-r0
#### How did you verify/test it?
Run sonic-mgmt
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
