### PR TITLE
Fix race condition in test_kernel_asic_mac_mismatch

### DIFF
--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -29,7 +29,7 @@ def setup(rand_selected_dut):
     rand_selected_dut.shell_cmds(cmds)
     yield
     cmds[0] = "docker exec swss supervisorctl start arp_update"
-    # rand_selected_dut.shell_cmds(cmds)
+    rand_selected_dut.shell_cmds(cmds)
 
 
 @pytest.fixture
@@ -122,6 +122,7 @@ def ip_version_string(version):
 
 @pytest.mark.parametrize("ip_version", [4, 6], ids=ip_version_string)
 def test_kernel_asic_mac_mismatch(
+    setup,
     setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally,
     toggle_all_simulator_ports_to_rand_selected_tor,  # noqa: F811
     rand_selected_dut, ip_version, setup_vlan_arp_responder,  # noqa: F811
@@ -159,7 +160,9 @@ def test_kernel_asic_mac_mismatch(
     asic_db_mac = rand_selected_dut.shell(
         f"sonic-db-cli APPL_DB hget 'NEIGH_TABLE:{vlan_name}:{target_ip}' 'neigh'"
     )['stdout']
-    pt_assert(neighbor_info[4].lower() != asic_db_mac.lower())
+    pt_assert(neighbor_info[4].lower() != asic_db_mac.lower(),
+              f"APPL_DB MAC was not corrupted: expected 00:00:00:00:00:00 but got {asic_db_mac}. "
+              "Ensure arp_update is stopped before modifying APPL_DB.")
     logger.info("APPL_DB and kernel are out of sync (expected)")
 
     rand_selected_dut.shell("docker exec swss supervisorctl start arp_update")

--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -21,7 +21,7 @@ pytestmark = [
 
 
 @pytest.fixture
-def setup(rand_selected_dut):
+def pause_arp_update(rand_selected_dut):
     cmds = [
         "docker exec swss supervisorctl stop arp_update",
         "ip neigh flush all"
@@ -122,7 +122,7 @@ def ip_version_string(version):
 
 @pytest.mark.parametrize("ip_version", [4, 6], ids=ip_version_string)
 def test_kernel_asic_mac_mismatch(
-    setup,
+    pause_arp_update,
     setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally,
     toggle_all_simulator_ports_to_rand_selected_tor,  # noqa: F811
     rand_selected_dut, ip_version, setup_vlan_arp_responder,  # noqa: F811

--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -26,10 +26,10 @@ def pause_arp_update(rand_selected_dut):
         "docker exec swss supervisorctl stop arp_update",
         "ip neigh flush all"
     ]
-    rand_selected_dut.shell_cmds(cmds)
+    rand_selected_dut.shell_cmds(cmds=cmds)
     yield
     cmds[0] = "docker exec swss supervisorctl start arp_update"
-    rand_selected_dut.shell_cmds(cmds)
+    rand_selected_dut.shell_cmds(cmds=cmds)
 
 
 @pytest.fixture


### PR DESCRIPTION
### Description of PR

Summary:

Fix flaky `test_kernel_asic_mac_mismatch` nightly failure caused by `arp_update` overwriting corrupted APPL_DB entries before the test can verify them.

ADO #37501765

#### Root Cause

`test_kernel_asic_mac_mismatch` corrupts the APPL_DB neighbor MAC to `00:00:00:00:00:00` and immediately reads it back to verify the corruption persists. However, the test never stops `arp_update` first — a `setup` fixture exists in the file that does this, but it was never wired into the test's parameters (bug since PR #14662 introduced the test). `arp_update`/neighsyncd overwrites the corrupted IPv4 MAC back to the real value within ~766ms between the `hset` and `hget` calls, causing the assertion to fail.

#### Fix

1. **Add `pause_arp_update` fixture** (renamed from `setup`) to the test parameters so `arp_update` is stopped during the APPL_DB corruption window.
2. **Uncomment teardown** in the fixture so `arp_update` is properly restarted after the test.
3. **Add descriptive error message** to the `pt_assert` that was producing the unhelpful `Failed: None`.
4. **Rename `setup` → `pause_arp_update`** for clarity on what the fixture does.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
`test_kernel_asic_mac_mismatch[*-ipv4]` is failing in nightly on Mellanox-SN2700 T0 testbeds. The triage bot misclassifies it as `test_setup_failure` with `Failed: None`.

#### How did you do it?
Changes to `tests/arp/test_arp_update.py`:
- Renamed `setup` fixture to `pause_arp_update` for clarity
- Added `pause_arp_update` fixture to the test function parameters (stops `arp_update` + flushes neighbors)
- Uncommented `rand_selected_dut.shell_cmds(cmds)` in fixture teardown (restarts `arp_update`)
- Added message string to `pt_assert` call

#### How did you verify/test it?
Root cause confirmed from nightly device logs: the IPv4 APPL_DB entry was overwritten within ~766ms between `hset` and `hget`, while IPv6 with less aggressive NDP refresh was unaffected.

#### Any platform specific information?
Observed on Mellanox-SN2700 (T0), but the race condition affects any platform where ARP refresh is fast enough to overwrite APPL_DB before the SSH round-trip completes.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
