### PR TITLE
[snappi_tests]: portchannel mapping on Ixia tgen

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -345,15 +345,11 @@ def __portchannel_intf_config(config, port_config_list, duthost, snappi_ports):
         v4_entry = next((e for e in entries if __valid_ipv4_addr(e['addr'])), None)
         v6_entry = next((e for e in entries if not __valid_ipv4_addr(e['addr'])), None)
 
-        # Added fix to select member_port_id based on peer_port and peer_dut
         member_port_ids = [
-            int(sp['port_id'])
-            for sp in (snappi_ports)
+            i for i, sp in enumerate(snappi_ports)
             for m in members
-            if ((sp['peer_port'] == m) and (sp['peer_device'] == duthost.hostname))]
-
-        member_port_ids = [int(sp['port_id']) for sp in (snappi_ports) for m in members if
-                           ((sp['peer_port'] == m) and (sp['peer_device'] == duthost.hostname))]
+            if sp['peer_port'] == m and sp.get('peer_device') == duthost.hostname
+        ]
 
         if not member_port_ids:
             continue
@@ -364,15 +360,25 @@ def __portchannel_intf_config(config, port_config_list, duthost, snappi_ports):
         lag.protocol.lacp.actor_key = 1
 
         for phy in members:
-            # Added fix to select snappi_ports based on peer-device and peer-hostname.
             port_ids = [
-                int(sp['port_id'])
-                for sp in (snappi_ports)
-                if ((sp['peer_port'] == phy) and (sp['peer_device'] == duthost.hostname))]
+                i for i, sp in enumerate(snappi_ports)
+                if sp['peer_port'] == phy and sp.get('peer_device') == duthost.hostname
+            ]
 
             if len(port_ids) != 1:
                 continue
             port_id = port_ids[0]
+            if port_id >= len(config.ports):
+                pytest.fail(
+                    "PortChannel member mapping error on {}: member {} mapped to port_id {} "
+                    "but config.ports has {} entries".format(
+                        duthost.hostname,
+                        phy,
+                        port_id,
+                        len(config.ports),
+                    ),
+                    pytrace=False,
+                )
             mac = __gen_mac(port_id)
             lp = lag.ports.port(port_name=config.ports[port_id].name)[-1]
             lp.lacp.actor_port_number = 1
@@ -2160,7 +2166,13 @@ def tgen_port_info(request: pytest.FixtureRequest, snappi_port_selection, get_sn
         if not snappi_ports:
             pytest.skip(f"Unsupported combination for {flatten_skeleton_parameter}")
 
-        return snappi_dut_base_config(duthosts, snappi_ports, snappi_api, setup=True)
+        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(
+            duthosts, snappi_ports, snappi_api, setup=True)
+        try:
+            yield (testbed_config, port_config_list, snappi_ports)
+        finally:
+            logger.info('Snappi cleanup after test')
+            setup_dut_ports(False, duthosts, testbed_config, port_config_list, snappi_ports)
 
 
 def flatten_list(lst):

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -391,8 +391,7 @@ def __portchannel_intf_config(config, port_config_list, duthost, snappi_ports):
         for phy in members:
             # Added fix to select snappi_ports based on peer-device and peer-hostname.
             port_ids = [
-                int(sp['port_id'])
-                for sp in (snappi_ports)
+                i for i, sp in enumerate(snappi_ports)
                 if ((sp['peer_port'] == phy) and (sp['peer_device'] == duthost.hostname))]
 
             if len(port_ids) != 1:


### PR DESCRIPTION
### Description of PR

Summary:
Fix snappi fixture PortChannel member mapping

Fixes #[23913](https://github.com/sonic-net/sonic-mgmt/issues/23913)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

`__portchannel_intf_config` used `int(sp['port_id'])` (the Ixia physical port number) as the index into `config.ports`, which is only populated with the subset of TGEN-connected ports indexed from `0`. On testbeds where the PortChannel member's Ixia physical port number (e.g. `6`) is ≥ the number of configured TGEN ports (e.g. `3`), this causes an `IndexError: list index out of range` crash during fixture setup on this line because port_id was assigned with `6` (which should have been `2` using `enumerate`-based index mapping).

```
lp = lag.ports.port(port_name=config.ports[port_id].name)[-1]
```

#### How did you do it?

Replaced `int(sp['port_id'])` lookup with `enumerate`-based index mapping filtered by `peer_device`, consistent with how `config.ports` is constructed.

#### How did you verify/test it?

Reproduced the `IndexError` on testbed running `snappi_tests/qos/test_ipip_packet_reorder_with_snappi.py`, where DUT `Ethernet108` (PortChannel101 member) maps to Ixia port `6` but only 3 TGEN ports are configured. Confirmed the fix resolves the crash.

#### Any platform specific information?

Observed on Ixia tesbeds with IxNetwork TGEN. Affects any testbed where PortChannel member ports on TGEN (Ixia) have a higher fanout physical port number than the total count of TGEN-connected ports.

#### Supported testbed topology if it's a new test case?

N/A — this is a bug fix in the test framework fixture, not a new test case. Applicable to all `tgen` topology testbeds.

### Documentation

No documentation changes required.