### PR TITLE
Fix vxlan_pkt.show() printing packets to stdout in hash_test

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -872,7 +872,6 @@ class VxlanHashTest(HashTest):
                             sport,
                             dport,
                             src_port))
-        logs.append(vxlan_pkt.show(dump=True))
         return logs
 
     def set_packet_parameter(self, pkt, exp_pkt, hash_key, ip_proto, version='IP'):

--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -872,7 +872,7 @@ class VxlanHashTest(HashTest):
                             sport,
                             dport,
                             src_port))
-        logs.append(vxlan_pkt.show())
+        logs.append(vxlan_pkt.show(dump=True))
         return logs
 
     def set_packet_parameter(self, pkt, exp_pkt, hash_key, ip_proto, version='IP'):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Remove the `vxlan_pkt.show()` call from `VxlanHashTest.create_packets_logs`.
`scapy`'s `show()` prints the full packet content to stdout as a side effect and returns `None`,
flooding the Ansible output on every test iteration with noise like:
```
stdout =
Using packet manipulation module: ptf.packet_scapy
###[ Ethernet ]###
  dst       = a4:7a:72:55:45:d4
  src       = 00:06:07:08:09:0a
  type      = IPv4
###[ IP ]###
     version   = 4
     ihl       = None
...
```
Since there are lots of packets, printing logs takes hours for regression pipeline.
The packet content is not needed in the logs, so the call is simply removed.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
When `test_fib`/`test_vxlan_hash` fails, the entire VxLAN packet structure is printed to stdout on every test iteration, producing massive output that significantly slows down failure diagnosis.

#### How did you do it?
Remove the `vxlan_pkt.show()` line from `VxlanHashTest.create_packets_logs`.

#### How did you verify/test it?
Code inspection.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->