### PR TITLE
Skip test_src_mac_rewrite on dualtor topology

### DIFF
--- a/tests/acl/test_src_mac_rewrite.py
+++ b/tests/acl/test_src_mac_rewrite.py
@@ -57,6 +57,10 @@ def generate_mac_address(index):
 
 @pytest.fixture(name="setUp", scope="module")
 def fixture_setUp(rand_selected_dut, tbinfo, ptfadapter):
+    if 'dualtor' in tbinfo['topo']['name']:
+        pytest.skip("test_src_mac_rewrite does not support dualtor topology - "
+                    "VXLAN tunnel config does not propagate to APP_DB on dualtor")
+
     data = {}
 
     # Basic setup


### PR DESCRIPTION
The test creates VXLAN tunnel config via sonic-cfggen --write-to-db (CONFIG_DB) then verifies it in APP_DB (redis-cli -n 0). On dualtor topology, the VXLAN tunnel config does not propagate from CONFIG_DB to APP_DB, causing the test to always fail with:
  'VXLAN tunnel tunnel_v4 not found in APP_DB after config reload'

This test was originally designed for t0 topology only (pytestmark has topology('t0')), but gets scheduled on dualtor via the nightly test scheduler. Add explicit skip for dualtor topologies.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
