### PR TITLE
[bgp]: Consolidate PLACEHOLDER_PREFIX and fix missing setup_teardown in aggregate-address tests

### DIFF
--- a/tests/bgp/test_bgp_aggregate_address_bbr_dynamics.py
+++ b/tests/bgp/test_bgp_aggregate_address_bbr_dynamics.py
@@ -23,6 +23,7 @@ from bgp_bbr_helpers import config_bbr_by_gcu, get_bbr_default_state
 from bgp_aggregate_helpers import (
     BGP_AGGREGATE_ADDRESS,
     BGP_SETTLE_WAIT,
+    PLACEHOLDER_PREFIX,
     ROUTE_PROPAGATION_WAIT,
     AggregateCfg,
     announce_contributing_routes,
@@ -48,7 +49,6 @@ AGGR_V4_1 = "10.100.0.0/16"
 EXTRA_AGGR_V4_1 = "10.200.0.0/16"
 CONTRIBUTING_V4 = ["10.100.1.0/24", "10.100.2.0/24", "10.100.3.0/24"]
 CONTRIBUTING_V4_SECOND = ["10.200.1.0/24", "10.200.2.0/24"]
-PLACEHOLDER_PREFIX = "192.0.2.0/32"
 EXABGP_BASE_PORT = 5000
 EXABGP_BASE_PORT_V6 = 6000
 

--- a/tests/bgp/test_bgp_aggregate_address_config_crud.py
+++ b/tests/bgp/test_bgp_aggregate_address_config_crud.py
@@ -15,6 +15,7 @@ from natsort import natsorted
 
 from bgp_aggregate_helpers import (
     BGP_AGGREGATE_ADDRESS,
+    PLACEHOLDER_PREFIX,
     AggregateCfg,
     dump_db,
     gcu_add_aggregate,
@@ -47,7 +48,6 @@ EXTRA_AGGR_V6_1 = "2001:db8:200::/48"
 CONTRIBUTING_EXTRA_V4_1 = ["10.200.1.0/24"]
 CONTRIBUTING_EXTRA_V4_2 = ["10.150.1.0/24"]
 CONTRIBUTING_EXTRA_V6_1 = ["2001:db8:200:1::/64"]
-PLACEHOLDER_PREFIX = "192.0.2.0/32"
 EXABGP_BASE_PORT = 5000
 EXABGP_BASE_PORT_V6 = 6000
 

--- a/tests/bgp/test_bgp_aggregate_address_functional_params.py
+++ b/tests/bgp/test_bgp_aggregate_address_functional_params.py
@@ -26,6 +26,7 @@ from bgp_bbr_helpers import config_bbr_by_gcu, get_bbr_default_state, is_bbr_ena
 
 from bgp_aggregate_helpers import (
     BGP_AGGREGATE_ADDRESS,
+    PLACEHOLDER_PREFIX,
     AggregateCfg,
     announce_contributing_routes,
     dump_db,
@@ -53,7 +54,6 @@ AGGR_V4 = "10.100.0.0/16"
 AGGR_V6 = "2001:db8:100::/48"
 CONTRIBUTING_V4 = ["10.100.1.0/24", "10.100.2.0/24", "10.100.3.0/24"]
 CONTRIBUTING_V6 = ["2001:db8:100:1::/64", "2001:db8:100:2::/64", "2001:db8:100:3::/64"]
-PLACEHOLDER_PREFIX = "192.0.2.0/32"
 EXABGP_BASE_PORT = 5000
 EXABGP_BASE_PORT_V6 = 6000
 

--- a/tests/bgp/test_bgp_aggregate_address_link_failover.py
+++ b/tests/bgp/test_bgp_aggregate_address_link_failover.py
@@ -57,7 +57,12 @@ INTF_STATE_WAIT_TIMEOUT = 90
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_teardown(duthost):
-    """Create checkpoint before tests, rollback after."""
+    """Checkpoint before tests, rollback after.
+
+    Link-failover tests shut down and restore DUT interfaces, which can leave
+    stale BGP aggregate state if a test fails mid-way.  The checkpoint/rollback
+    ensures CONFIG_DB is restored to a clean state regardless of test outcome.
+    """
     create_checkpoint(duthost)
     default_aggregates = dump_db(duthost, "CONFIG_DB", BGP_AGGREGATE_ADDRESS)
     if not default_aggregates:

--- a/tests/bgp/test_bgp_aggregate_address_link_failover.py
+++ b/tests/bgp/test_bgp_aggregate_address_link_failover.py
@@ -17,11 +17,16 @@ from natsort import natsorted
 
 # Shared helpers from the aggregate-address helper module
 from bgp_aggregate_helpers import (
+    BGP_AGGREGATE_ADDRESS,
+    PLACEHOLDER_PREFIX,
     AggregateCfg,
+    dump_db,
     gcu_add_aggregate,
+    gcu_add_placeholder_aggregate,
     gcu_remove_aggregate,
 )
 
+from tests.common.gcu_utils import create_checkpoint, rollback_or_reload, delete_checkpoint
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.bgp_routing import inject_routes, verify_route_on_neighbors
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
@@ -48,6 +53,20 @@ EXABGP_BASE_PORT_V6 = 6000
 BGP_SESSION_WAIT_TIMEOUT = 300
 BGP_SESSION_POLL_INTERVAL = 10
 INTF_STATE_WAIT_TIMEOUT = 90
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_teardown(duthost):
+    """Create checkpoint before tests, rollback after."""
+    create_checkpoint(duthost)
+    default_aggregates = dump_db(duthost, "CONFIG_DB", BGP_AGGREGATE_ADDRESS)
+    if not default_aggregates:
+        gcu_add_placeholder_aggregate(duthost, PLACEHOLDER_PREFIX)
+    yield
+    try:
+        rollback_or_reload(duthost, fail_on_rollback_error=False)
+    finally:
+        delete_checkpoint(duthost)
 
 
 # ===========================================================================

--- a/tests/bgp/test_bgp_aggregate_address_resilience.py
+++ b/tests/bgp/test_bgp_aggregate_address_resilience.py
@@ -23,6 +23,7 @@ import pytest
 
 from bgp_aggregate_helpers import (
     BGP_AGGREGATE_ADDRESS,
+    PLACEHOLDER_PREFIX,
     AggregateCfg,
     dump_db,
     gcu_add_aggregate,
@@ -50,7 +51,6 @@ pytestmark = [
 # ---- Constants ----
 AGGR_V4 = "172.16.51.0/24"
 AGGR_V6 = "2000:172:16:50::/64"
-PLACEHOLDER_PREFIX = "192.0.2.0/32"
 BGP_SESSION_WAIT_TIMEOUT = 300
 BGP_SESSION_POLL_INTERVAL = 10
 

--- a/tests/bgp/test_bgp_aggregate_address_route_withdrawal.py
+++ b/tests/bgp/test_bgp_aggregate_address_route_withdrawal.py
@@ -17,6 +17,7 @@ from natsort import natsorted
 # Shared helpers from the aggregate-address helpers module
 from bgp_aggregate_helpers import (
     BGP_AGGREGATE_ADDRESS,
+    PLACEHOLDER_PREFIX,
     AggregateCfg,
     dump_db,
     gcu_add_aggregate,
@@ -37,7 +38,6 @@ pytestmark = [
 # ---- Test data ----
 AGGR_V4 = "10.100.0.0/16"
 CONTRIBUTING_V4 = ["10.100.1.0/24", "10.100.2.0/24", "10.100.3.0/24"]
-PLACEHOLDER_PREFIX = "192.0.2.0/32"
 EXABGP_BASE_PORT = 5000
 EXABGP_BASE_PORT_V6 = 6000
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- Consolidate duplicated `PLACEHOLDER_PREFIX` definitions across 6 BGP aggregate-address test files into a single import from `bgp_aggregate_helpers.py`.
- Add missing `setup_teardown` fixture (checkpoint/rollback and placeholder aggregate insertion) to `test_bgp_aggregate_address_link_failover.py`, which previously lacked it.

ADO: 37540734

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202603

### Approach
#### What is the motivation for this PR?
`PLACEHOLDER_PREFIX` was duplicated in every `test_bgp_aggregate_address_*.py` file. One file (`link_failover`) used a different value (`/24` vs `/32`), and also lacked the `setup_teardown` fixture that all other aggregate-address test modules use to create a checkpoint and ensure the `BGP_AGGREGATE_ADDRESS` table exists for GCU operations.

#### How did you do it?
 Removed local `PLACEHOLDER_PREFIX = "192.0.2.0/32"` definitions from 5 test files and added `PLACEHOLDER_PREFIX` to their existing `from bgp_aggregate_helpers import (...)` block.
- For `test_bgp_aggregate_address_link_failover.py`: removed the local `/24` definition, added the import, added the missing `setup_teardown` fixture (matching the pattern in all sibling test modules), and added the necessary imports (`BGP_AGGREGATE_ADDRESS`, `dump_db`, `gcu_add_placeholder_aggregate`, `create_checkpoint`, `rollback_or_reload`, `delete_checkpoint`).


#### How did you verify/test it?
Verified imports resolve correctly and no other references to the removed local definitions remain.

#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
M1
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
