### PR TITLE
[tests/iface_namingmode]: wait for LLDP neighbors to converge in test_show_lldp_table

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -312,7 +312,22 @@ class TestShowLLDP():
         dutHostGuest, mode, ifmode = setup_config_mode
         minigraph_neighbors = setup['minigraph_facts']['minigraph_neighbors']
 
-        lldp_table = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} show lldp table'.format(ifmode))['stdout']
+        lldp_table_result = {}
+
+        def _lldp_table_ready():
+            lldp_table_result['output'] = dutHostGuest.shell(
+                'SONIC_CLI_IFACE_MODE={} show lldp table'.format(ifmode))['stdout']
+            expected_intfs = lldp_interfaces['alias'] if mode == 'alias' else lldp_interfaces['interface']
+            return all(re.search(re.escape(intf), lldp_table_result['output']) for intf in expected_intfs)
+
+        pytest_assert(
+            wait_until(ESTABLISH_LLDP_NEIGHBOR_TIMEOUT, 10, 0, _lldp_table_ready),
+            "LLDP table did not converge with all expected interfaces within {} seconds".format(
+                ESTABLISH_LLDP_NEIGHBOR_TIMEOUT
+            )
+        )
+
+        lldp_table = lldp_table_result['output']
         logger.info('lldp_table:\n{}'.format(lldp_table))
 
         vrf_map = {}


### PR DESCRIPTION
### Description of PR
Fix intermittent test failures in `test_show_lldp_table` caused by reading the LLDP table before neighbors have fully converged.

Replace the immediate `dutHostGuest.shell(...)` call with a `wait_until` loop using the existing `ESTABLISH_LLDP_NEIGHBOR_TIMEOUT = 90` constant, polling every 10 seconds until all expected interfaces appear in the LLDP table.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [x] Test case improvement

### Approach
#### What is the motivation for this PR?
`test_show_lldp_table` reads the LLDP table immediately after setup, but LLDP neighbors may not have converged yet, causing intermittent assertion failures.

#### How did you do it?
- Added a `_lldp_table_ready()` closure that checks whether all expected interfaces appear in the LLDP table output
- Wrapped the shell call in `wait_until(ESTABLISH_LLDP_NEIGHBOR_TIMEOUT, 10, 0, _lldp_table_ready)` using the existing module-level constant
- Used a closure dict (`lldp_table_result`) to capture the last output for downstream assertions

#### How did you verify/test it?
Manually verified the logic matches the existing `ESTABLISH_LLDP_NEIGHBOR_TIMEOUT` usage pattern in the same file.

#### Supported testbed topology if it's a new test case?
`any` (existing topology marker unchanged)

### Documentation
No documentation changes required.