### PR TITLE
[DASH] Fixes for FNIC and metering tests

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -865,6 +865,12 @@ dash/test_dash_eni_counter.py:
     conditions:
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/16407"
 
+dash/test_dash_metering.py:
+  skip:
+    reason: "Metering w/ FNIC not supported on Nvidia yet"
+    conditions:
+      - "hwsku not in ['Mellanox-SN4280-O8C40', 'Mellanox-SN4280-O28']"
+
 dash/test_dash_privatelink.py:
   skip:
     conditions_logical_operator: or

--- a/tests/dash/conftest.py
+++ b/tests/dash/conftest.py
@@ -507,21 +507,18 @@ def single_endpoint(request):
 
 
 @pytest.fixture
-def dpu_setup(duthost, dpuhosts, dpu_index, skip_config):
+def dpu_setup(dpuhosts, dpu_index, skip_config):
     if skip_config:
 
         return
     dpuhost = dpuhosts[dpu_index]
-    # explicitly add mgmt IP route so the default route doesn't disrupt SSH access
-    dpuhost.shell(f'ip route replace {duthost.mgmt_ip}/32 via 169.254.200.254')
+
     intfs = dpuhost.shell("show ip int")["stdout"]
     dpu_cmds = list()
     if "Loopback0" not in intfs:
         dpu_cmds.append("config loopback add Loopback0")
         dpu_cmds.append(f"config int ip add Loopback0 {pl.APPLIANCE_VIP}/32")
 
-    if dpuhost.npu_data_port_ip:
-        dpu_cmds.append(f"ip route replace default via {dpuhost.npu_data_port_ip}")
     dpuhost.shell_cmds(cmds=dpu_cmds)
 
 

--- a/tests/dash/test_dash_metering.py
+++ b/tests/dash/test_dash_metering.py
@@ -3,6 +3,7 @@ import time
 
 import configs.privatelink_config as pl
 import ptf.testutils as testutils
+import ptf.packet as scapy
 import pytest
 from constants import LOCAL_PTF_INTF, REMOTE_PTF_RECV_INTF, REMOTE_PTF_SEND_INTF
 from gnmi_utils import apply_messages
@@ -62,7 +63,6 @@ def common_setup_teardown(
         **pl.ROUTING_TYPE_PL_CONFIG,
         **pl.ROUTING_TYPE_VNET_CONFIG,
         **pl.VNET_CONFIG,
-        **pl.VNET2_CONFIG,
         **pl.METER_POLICY_V4_CONFIG,
         **pl.ROUTE_GROUP1_CONFIG,
         **pl.ROUTE_GROUP2_CONFIG,
@@ -261,6 +261,7 @@ def test_fnic_dash_metering(localhost, duthost, ptfhost, ptfadapter, dash_pl_con
         vm_to_dpu_pkt, exp_dpu_to_pe_pkt, pe_to_dpu_pkt, exp_dpu_to_vm_pkt = rand_udp_port_packets(
             dash_pl_config, floating_nic=True, outbound_vni=pl.ENI_TRUSTED_VNI
         )
+        exp_dpu_to_vm_pkt.set_do_not_care_packet(scapy.IP, "dst")
         # Usually `testutils.send` automatically updates the packet payload to include the test name
         # and `testutils.verify_packet*` updates the expected packet payload to match. Since we are polling
         # the dataplane directly for the DPU to VM packet, we need to manually update the payload

--- a/tests/dash/test_fnic.py
+++ b/tests/dash/test_fnic.py
@@ -61,7 +61,6 @@ def common_setup_teardown(
         **pl.ROUTING_TYPE_PL_CONFIG,
         **pl.ROUTING_TYPE_VNET_CONFIG,
         **pl.VNET_CONFIG,
-        **pl.VNET2_CONFIG,
         **pl.ROUTE_GROUP1_CONFIG,
         **pl.METER_POLICY_V4_CONFIG,
         **tunnel_config,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Both test_fnic.py and test_dash_metering.py were failing

#### How did you do it?
- For both test cases, remove unused VNET2 configuration that was causing VNI collision with VNET1
- Remove default route setup on DPU (this should be part of the DPU default config)
- For metering tests, ignore the DPU to VM packet expected IP since it will be a tunnel endpoint IP (and is verified later by `verify_tunnel_packets`)

#### How did you verify/test it?
Run on Cisco smartswitch testbed and observed 100% passing for both test modules
Run `test_fnic.py` only on Nvidia and observed 100% passing (metering w/ FNIC is not supported yet and is skipped accordingly)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
