### PR TITLE
[packet_trimming] Xfail symmetric SRv6 trimming on isolated topo for 202412

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3862,6 +3862,12 @@ packet_trimming/test_packet_trimming_symmetric.py::TestPacketTrimmingSymmetric::
     conditions:
       - "asic_gen in ['th5']"
 
+packet_trimming/test_packet_trimming_symmetric.py::TestPacketTrimmingSymmetric::test_trimming_with_srv6:
+  xfail:
+    reason: "vlan decap is disabled in 202412 image"
+    conditions:
+      - "'isolated' in topo_name and release in ['202412']"
+
 #######################################
 #####           pc               #####
 #######################################


### PR DESCRIPTION
### Description of PR
Summary:
- Add a conditional xfail for `packet_trimming/test_packet_trimming_symmetric.py::TestPacketTrimmingSymmetric::test_trimming_with_srv6`.
- Xfail applies only when `'isolated' in topo_name` and `release in ['202412']`.
Fixes # (issue): N/A

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The SRv6 trimming case is expected to fail on isolated topologies for 202412 release images, so it should be marked xfail to preserve test signal while tracking known behavior.

#### How did you do it?
Added a testcase-level conditional mark entry in:
`tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`

Condition:
`'isolated' in topo_name and release in ['202412']`

#### How did you verify/test it?
Validated YAML syntax by parsing the updated file with `yaml.safe_load`.

#### Any platform specific information?
No platform-specific code path changes. Scope is limited to isolated topologies on 202412 release.

#### Supported testbed topology if it's a new test case?
N/A (not a new test case)

### Documentation
N/A