### PR TITLE
[PR Test] Dedup control-plane tests between t0 and t1-lag checkers

### DIFF
--- a/.azure-pipelines/impacted_area_testing/constant.py
+++ b/.azure-pipelines/impacted_area_testing/constant.py
@@ -26,5 +26,18 @@ PR_CHECKER_TOPOLOGY_NAME = {
     "t2": ["t2", "kvmtest-t2_"]
 }
 
+# Dedup rules: for each (keep_in, remove_from) pair, control-plane tests
+# that appear in both checkers will be removed from 'remove_from'.
+# Data-plane tests (detected automatically via traffic-pattern scanning)
+# are always kept in both.
+# Rules are evaluated against the *original* checker contents
+# (order-independent).
+#
+# To extend: add more pairs to cover additional topology overlaps,
+# e.g. ("t1_checker", "t2_checker") once t2 tests are stable.
+CONTROL_PLANE_DEDUP_RULES = [
+    ("t0_checker", "t1_checker"),
+]
+
 MAX_INSTANCE_NUMBER = 40
 MAX_GET_TOKEN_RETRY_TIMES = 3

--- a/.azure-pipelines/impacted_area_testing/get_test_scripts.py
+++ b/.azure-pipelines/impacted_area_testing/get_test_scripts.py
@@ -12,8 +12,9 @@ import re
 import logging
 import json
 import argparse
+import functools
 from natsort import natsorted
-from constant import PR_TOPOLOGY_TYPE, EXCLUDE_TEST_SCRIPTS
+from constant import PR_TOPOLOGY_TYPE, EXCLUDE_TEST_SCRIPTS, CONTROL_PLANE_DEDUP_RULES
 
 
 def topo_name_to_topo_checker(topo_name):
@@ -106,8 +107,310 @@ def collect_scripts_by_topology_type(features: str, location: str) -> dict:
     return {k: v for k, v in test_scripts_per_topology_checker.items() if v}
 
 
+def dedup_control_plane_tests(scripts_per_checker, location):
+    """
+    Remove control-plane tests from checkers based on CONTROL_PLANE_DEDUP_RULES.
+
+    For each (keep_in, remove_from) rule, control-plane tests that appear in both
+    checkers are removed from 'remove_from'. Data-plane tests (PTF/Scapy traffic)
+    are always kept in both because forwarding behavior differs across topologies.
+
+    Rules are evaluated against a snapshot of the original checker contents so that
+    rule ordering does not affect the result.
+    """
+    valid_checkers = set(PR_TOPOLOGY_TYPE)
+    validated_rules = []
+    for keep_in, remove_from in CONTROL_PLANE_DEDUP_RULES:
+        if keep_in not in valid_checkers:
+            logging.warning("Dedup rule references unknown checker '%s', skipping", keep_in)
+            continue
+        if remove_from not in valid_checkers:
+            logging.warning("Dedup rule references unknown checker '%s', skipping", remove_from)
+            continue
+        if keep_in == remove_from:
+            logging.warning("Dedup rule has identical keep_in and remove_from '%s', skipping", keep_in)
+            continue
+        validated_rules.append((keep_in, remove_from))
+
+    # Snapshot original checker contents so rules are order-independent
+    original_contents = {k: set(v) for k, v in scripts_per_checker.items()}
+
+    for keep_in, remove_from in validated_rules:
+        keep_scripts = original_contents.get(keep_in, set())
+        if not keep_scripts or remove_from not in scripts_per_checker:
+            continue
+
+        overlap = [s for s in scripts_per_checker[remove_from] if s in keep_scripts]
+        if not overlap:
+            continue
+
+        data_plane_scripts = _detect_data_plane_tests(
+            overlap, location
+        )
+
+        original_count = len(scripts_per_checker[remove_from])
+        scripts_per_checker[remove_from] = [
+            s for s in scripts_per_checker[remove_from]
+            if s not in keep_scripts or s in data_plane_scripts
+        ]
+        deduped_count = original_count - len(scripts_per_checker[remove_from])
+        if deduped_count > 0:
+            dropped = [
+                s for s in overlap if s not in data_plane_scripts
+            ]
+            logging.info(
+                "Deduped %d control-plane tests from %s "
+                "(already in %s)",
+                deduped_count, remove_from, keep_in
+            )
+            logging.debug(
+                "Dedup %s: dropping %s", remove_from, dropped
+            )
+
+    # Remove empty checkers to avoid spawning empty PR jobs
+    return {k: v for k, v in scripts_per_checker.items() if v}
+
+
+# Patterns that indicate a test sends traffic through the data plane.
+_TRAFFIC_PATTERN = re.compile(r"|".join([
+    r"\bptfadapter\b",          # Packet send/receive adapter fixture
+    r"\bptf_runner\b",          # Runs a PTF test script
+    r"\bptf\.testutils\b",      # PTF send/verify utilities
+    r"from\s+ptf\s+import",     # Direct PTF framework import
+    r"import\s+ptf\b",          # Direct PTF framework import
+    r"\bsend_packet\b",         # Sends a crafted packet
+    r"\brun_ptf_script\b",      # Runs a PTF script
+    r"\bsnappi\b",              # Snappi traffic generator
+    r"\btgen_utils\b",          # Traffic generator utilities
+    r"\bcraft_packet\b",        # Packet crafting helper
+    r"\bpktgen\b",              # Kernel packet generator
+    r"from\s+scapy\b",          # Scapy packet library import
+    r"import\s+scapy\b",        # Scapy packet library import
+    r"\bixnetwork\w*\b",           # Ixia IxNetwork traffic generator
+    r"\btcpreplay\b",           # TCP replay traffic tool
+]))
+
+
+def _read_file_safe(filepath):
+    """Read file content, returning None on any error."""
+    try:
+        with open(filepath, "r", encoding="utf-8", errors="ignore") as f:
+            return f.read()
+    except (IOError, OSError, UnicodeDecodeError):
+        logging.warning("Could not read %s, treating as data-plane test (safe default)", filepath)
+        return None
+
+
+def _resolve_local_imports(filepath, content, location=""):
+    """Find Python modules imported from the same package or tests.*.
+
+    Args:
+        filepath: absolute path to the Python file being scanned
+        content: file content as a string
+        location: base directory of the test tree (repo root / tests dir);
+                  used to resolve absolute ``tests.X.Y`` imports
+    """
+    resolved = []
+    directory = os.path.dirname(filepath)
+    for line in content.split("\n"):
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        # from .module import ... (single-dot relative)
+        match = re.match(r"from\s+\.(\w+)\s+import", line)
+        if match:
+            mod = os.path.join(directory, match.group(1) + ".py")
+            if os.path.isfile(mod):
+                resolved.append(mod)
+            pkg_init = os.path.join(
+                directory, match.group(1), "__init__.py"
+            )
+            if os.path.isfile(pkg_init):
+                resolved.append(pkg_init)
+
+        # from ..module import ... (parent-relative imports)
+        match = re.match(r"from\s+\.\.(\w+)\s+import", line)
+        if match:
+            parent = os.path.dirname(directory)
+            if parent:
+                mod = os.path.join(
+                    parent, match.group(1) + ".py"
+                )
+                if os.path.isfile(mod):
+                    resolved.append(mod)
+                pkg_init = os.path.join(
+                    parent, match.group(1), "__init__.py"
+                )
+                if os.path.isfile(pkg_init):
+                    resolved.append(pkg_init)
+
+        # §3: from . import name  OR  from .. import name
+        # (bare relative imports without a module name after dots)
+        match = re.match(r"from\s+(\.+)\s+import\s+(\w+)", line)
+        if match:
+            dots = match.group(1)
+            name = match.group(2)
+            base = directory
+            for _ in range(len(dots) - 1):
+                base = os.path.dirname(base)
+            mod = os.path.join(base, name + ".py")
+            if os.path.isfile(mod):
+                resolved.append(mod)
+            pkg_init = os.path.join(base, name, "__init__.py")
+            if os.path.isfile(pkg_init):
+                resolved.append(pkg_init)
+
+        # from tests.feature.module import ... OR import tests.feature
+        # Handles both:
+        #   import tests.common.helpers → tests/common/helpers.py
+        #   from tests.common import helpers → tests/common.py AND
+        #       tests/common/helpers.py
+        match = re.match(
+            r"from\s+(tests\.\S+?)\s+import\s+(\w+)", line
+        )
+        if match:
+            pkg_path = match.group(1).replace(".", os.sep)
+            imp_name = match.group(2)
+            if location:
+                tests_root = os.path.dirname(location)
+                base = os.path.join(tests_root, pkg_path)
+            else:
+                base = pkg_path
+            # Try package file: tests/common.py
+            mod = base + ".py"
+            if os.path.isfile(mod):
+                resolved.append(mod)
+            # Try package __init__: tests/common/__init__.py
+            pkg_init = os.path.join(base, "__init__.py")
+            if os.path.isfile(pkg_init):
+                resolved.append(pkg_init)
+            # Try imported name: tests/common/helpers.py
+            sub_mod = os.path.join(base, imp_name + ".py")
+            if os.path.isfile(sub_mod):
+                resolved.append(sub_mod)
+            # Try imported name as package
+            sub_init = os.path.join(
+                base, imp_name, "__init__.py"
+            )
+            if os.path.isfile(sub_init):
+                resolved.append(sub_init)
+        else:
+            # import tests.common.helpers (no 'from')
+            match = re.match(
+                r"import\s+(tests\.\S+)", line
+            )
+            if match:
+                rel_mod = match.group(1).replace(
+                    ".", os.sep
+                ) + ".py"
+                if location:
+                    tests_root = os.path.dirname(location)
+                    mod = os.path.join(tests_root, rel_mod)
+                else:
+                    mod = rel_mod
+                if os.path.isfile(mod):
+                    resolved.append(mod)
+                pkg_dir = mod[:-3]
+                pkg_init = os.path.join(
+                    pkg_dir, "__init__.py"
+                )
+                if os.path.isfile(pkg_init):
+                    resolved.append(pkg_init)
+
+    return resolved
+
+
+def _collect_conftest_files(filepath, location):
+    """Collect conftest.py files from the test directory up to location.
+
+    pytest discovers fixtures by walking up the directory tree; a test
+    file implicitly imports fixtures from every conftest.py above it.
+    """
+    conftests = []
+    directory = os.path.dirname(os.path.abspath(filepath))
+    location_abs = os.path.abspath(location) if location else ""
+    while location_abs and directory.startswith(location_abs):
+        conftest = os.path.join(directory, "conftest.py")
+        if os.path.isfile(conftest) and conftest != os.path.abspath(filepath):
+            conftests.append(conftest)
+        if directory == location_abs:
+            break
+        parent = os.path.dirname(directory)
+        if parent == directory:
+            break
+        directory = parent
+    return conftests
+
+
+@functools.lru_cache(maxsize=None)
+def _has_traffic_pattern(filepath, location="", depth=0):
+    """Check if a file or its imports (up to 2 levels) contain traffic
+    patterns.
+
+    Returns True (data-plane) if the file is unreadable — safe default
+    to avoid accidentally deduping tests we can't inspect.
+
+    At depth 0 (the test file itself), also scans conftest.py files in
+    the directory chain up to *location*, since pytest fixtures defined
+    there are implicitly available to the test.
+    """
+    if depth > 2:
+        return False
+    content = _read_file_safe(filepath)
+    if content is None:
+        return True  # Unreadable → assume data-plane (keep in both)
+    if _TRAFFIC_PATTERN.search(content):
+        return True
+
+    # §1: At depth 0, scan conftest.py chain for traffic patterns
+    if depth == 0 and location:
+        for conftest in _collect_conftest_files(filepath, location):
+            if _has_traffic_pattern(conftest, location, depth + 1):
+                return True
+
+    for imported in _resolve_local_imports(filepath, content, location):
+        if _has_traffic_pattern(imported, location, depth + 1):
+            return True
+    return False
+
+
+def _detect_data_plane_tests(script_names, location):
+    """
+    Detect which scripts are data-plane tests by scanning for traffic
+    patterns.
+
+    Checks the test file itself, its conftest.py chain, and modules it
+    imports (up to 2 levels deep) for patterns like ptfadapter,
+    ptf_runner, send_packet, snappi, scapy, etc.
+
+    Args:
+        script_names: list of script paths relative to location
+        location: base directory of test scripts
+
+    Returns:
+        set of script names that are data-plane tests
+    """
+    _has_traffic_pattern.cache_clear()
+    data_plane = set()
+    for script_name in script_names:
+        filepath = os.path.join(location, script_name)
+        if _has_traffic_pattern(filepath, location):
+            data_plane.add(script_name)
+            logging.debug(
+                "Data-plane test detected: %s", script_name
+            )
+    if data_plane:
+        logging.info(
+            "Detected %d data-plane tests in overlap "
+            "(kept on both checkers)", len(data_plane)
+        )
+    return data_plane
+
+
 def main(features, location):
     scripts_list = collect_scripts_by_topology_type(features, location)
+    scripts_list = dedup_control_plane_tests(scripts_list, location)
     print(json.dumps(scripts_list))
 
 

--- a/.azure-pipelines/impacted_area_testing/test_get_test_scripts.py
+++ b/.azure-pipelines/impacted_area_testing/test_get_test_scripts.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Unit tests for get_test_scripts.py dedup and data-plane detection."""
+
+import os
+import sys
+import tempfile
+import shutil
+
+# Ensure the module under test is importable
+sys.path.insert(0, os.path.dirname(__file__))
+
+import pytest  # noqa: E402
+from get_test_scripts import (  # noqa: E402
+    dedup_control_plane_tests,
+    _collect_conftest_files,
+    _detect_data_plane_tests,
+    _has_traffic_pattern,
+    _read_file_safe,
+    _resolve_local_imports,
+)
+
+
+@pytest.fixture
+def test_dir():
+    """Create a temp directory, cleaned up after test."""
+    d = tempfile.mkdtemp()
+    yield d
+    shutil.rmtree(d)
+    _has_traffic_pattern.cache_clear()
+
+
+def _write_file(directory, relpath, content=""):
+    """Helper to create a file under directory."""
+    full = os.path.join(directory, relpath)
+    os.makedirs(os.path.dirname(full), exist_ok=True)
+    with open(full, "w") as f:
+        f.write(content)
+    return full
+
+
+# ── dedup_control_plane_tests ──────────────────────────────
+
+class TestDedupControlPlaneTests:
+
+    def test_no_overlap_returns_unchanged(self, test_dir):
+        scripts = {
+            "t0_checker": ["a/test_a.py"],
+            "t1_checker": ["b/test_b.py"],
+        }
+        _write_file(test_dir, "a/test_a.py", "# control plane")
+        _write_file(test_dir, "b/test_b.py", "# control plane")
+        result = dedup_control_plane_tests(scripts, test_dir)
+        assert result["t0_checker"] == ["a/test_a.py"]
+        assert result["t1_checker"] == ["b/test_b.py"]
+
+    def test_control_plane_overlap_deduped(self, test_dir):
+        _write_file(test_dir, "a/test_a.py", "# pure config")
+        _write_file(test_dir, "b/test_b.py", "# t1 only")
+        scripts = {
+            "t0_checker": ["a/test_a.py"],
+            "t1_checker": ["a/test_a.py", "b/test_b.py"],
+        }
+        result = dedup_control_plane_tests(scripts, test_dir)
+        assert "a/test_a.py" in result["t0_checker"]
+        assert "a/test_a.py" not in result["t1_checker"]
+        assert "b/test_b.py" in result["t1_checker"]
+
+    def test_data_plane_overlap_kept(self, test_dir):
+        _write_file(test_dir, "a/test_a.py", "import ptfadapter\n")
+        scripts = {
+            "t0_checker": ["a/test_a.py"],
+            "t1_checker": ["a/test_a.py"],
+        }
+        result = dedup_control_plane_tests(scripts, test_dir)
+        assert "a/test_a.py" in result.get("t0_checker", [])
+        assert "a/test_a.py" in result.get("t1_checker", [])
+
+    def test_empty_checker_removed(self, test_dir):
+        _write_file(test_dir, "a/test_a.py", "# config test")
+        scripts = {
+            "t0_checker": ["a/test_a.py"],
+            "t1_checker": ["a/test_a.py"],
+        }
+        result = dedup_control_plane_tests(scripts, test_dir)
+        assert "t1_checker" not in result
+
+    def test_missing_keep_checker_skips_rule(self, test_dir):
+        _write_file(test_dir, "a/test_a.py", "# test")
+        scripts = {"t1_checker": ["a/test_a.py"]}
+        result = dedup_control_plane_tests(scripts, test_dir)
+        assert result["t1_checker"] == ["a/test_a.py"]
+
+    def test_rules_are_order_independent(
+        self, test_dir, monkeypatch
+    ):
+        """Conflicting rule orders produce identical results."""
+        _write_file(test_dir, "a/test_shared.py", "# config")
+        _write_file(test_dir, "b/test_t1.py", "# config")
+        _write_file(test_dir, "c/test_t2.py", "# config")
+
+        # (A,B) then (B,C) vs (B,C) then (A,B)
+        rules_fwd = [
+            ("t0_checker", "t1_checker"),
+            ("t1_checker", "t2_checker"),
+        ]
+        rules_rev = [
+            ("t1_checker", "t2_checker"),
+            ("t0_checker", "t1_checker"),
+        ]
+
+        def make_scripts():
+            return {
+                "t0_checker": ["a/test_shared.py"],
+                "t1_checker": [
+                    "a/test_shared.py", "b/test_t1.py"
+                ],
+                "t2_checker": ["b/test_t1.py", "c/test_t2.py"],
+            }
+
+        monkeypatch.setattr(
+            "get_test_scripts.CONTROL_PLANE_DEDUP_RULES",
+            rules_fwd,
+        )
+        r1 = dedup_control_plane_tests(make_scripts(), test_dir)
+
+        monkeypatch.setattr(
+            "get_test_scripts.CONTROL_PLANE_DEDUP_RULES",
+            rules_rev,
+        )
+        r2 = dedup_control_plane_tests(make_scripts(), test_dir)
+
+        assert r1 == r2
+
+
+# ── Data-plane detection ───────────────────────────────────
+
+class TestDataPlaneDetection:
+
+    @pytest.mark.parametrize("pattern", [
+        "import ptfadapter",
+        "from ptf import testutils",
+        "import ptf",
+        "ptf_runner(",
+        "ptf.testutils.send_packet",
+        "send_packet(port, pkt)",
+        "run_ptf_script('test.py')",
+        "import snappi",
+        "from tgen_utils import traffic",
+        "craft_packet()",
+        "pktgen.start()",
+        "from scapy.all import IP",
+        "import scapy.layers",
+        "from ixnetwork_restpy import Session",
+        "tcpreplay --intf1 eth0",
+    ])
+    def test_traffic_patterns_detected(self, test_dir, pattern):
+        fp = _write_file(test_dir, "test_dp.py", pattern)
+        assert _has_traffic_pattern(fp) is True
+
+    def test_word_boundary_avoids_false_positive(self, test_dir):
+        """'snappishly' should NOT trigger snappi pattern."""
+        fp = _write_file(
+            test_dir, "test_fp.py", "word = 'snappishly'\n"
+        )
+        assert _has_traffic_pattern(fp) is False
+
+    def test_control_plane_not_detected(self, test_dir):
+        fp = _write_file(
+            test_dir, "test_cp.py",
+            "import pytest\ndef test_config():\n    pass\n",
+        )
+        assert _has_traffic_pattern(fp) is False
+
+    def test_indirect_traffic_via_import(self, test_dir):
+        _write_file(test_dir, "helper.py", "import ptfadapter\n")
+        fp = _write_file(
+            test_dir, "test_ind.py",
+            "from .helper import something\n",
+        )
+        assert _has_traffic_pattern(fp) is True
+
+    def test_detect_data_plane_tests_returns_set(self, test_dir):
+        _write_file(test_dir, "test_dp.py", "import ptfadapter\n")
+        _write_file(test_dir, "test_cp.py", "import pytest\n")
+        result = _detect_data_plane_tests(
+            ["test_dp.py", "test_cp.py"], test_dir
+        )
+        assert result == {"test_dp.py"}
+
+
+# ── §1: Conftest fixture scanning ─────────────────────────
+
+class TestConftestScanning:
+
+    def test_conftest_traffic_detected(self, test_dir):
+        """Traffic pattern in conftest.py → test is data-plane."""
+        _write_file(
+            test_dir, "bgp/conftest.py",
+            "import ptfadapter\n",
+        )
+        fp = _write_file(
+            test_dir, "bgp/test_foo.py",
+            "def test_x(dataplane_setup):\n    pass\n",
+        )
+        assert _has_traffic_pattern(fp, test_dir) is True
+
+    def test_parent_conftest_traffic_detected(self, test_dir):
+        """conftest.py in parent dir is also scanned."""
+        _write_file(
+            test_dir, "conftest.py", "import ptfadapter\n"
+        )
+        fp = _write_file(
+            test_dir, "bgp/test_foo.py",
+            "def test_x(dp):\n    pass\n",
+        )
+        assert _has_traffic_pattern(fp, test_dir) is True
+
+    def test_no_conftest_stays_control_plane(self, test_dir):
+        fp = _write_file(
+            test_dir, "bgp/test_foo.py",
+            "def test_x():\n    pass\n",
+        )
+        assert _has_traffic_pattern(fp, test_dir) is False
+
+    def test_conftest_not_deduped_via_dedup(self, test_dir):
+        """Overlap with conftest traffic stays in both checkers."""
+        _write_file(
+            test_dir, "bgp/conftest.py",
+            "import ptfadapter\n",
+        )
+        _write_file(
+            test_dir, "bgp/test_foo.py",
+            "def test_x(dp):\n    pass\n",
+        )
+        scripts = {
+            "t0_checker": ["bgp/test_foo.py"],
+            "t1_checker": ["bgp/test_foo.py"],
+        }
+        result = dedup_control_plane_tests(scripts, test_dir)
+        assert "bgp/test_foo.py" in result.get("t0_checker", [])
+        assert "bgp/test_foo.py" in result.get("t1_checker", [])
+
+    def test_collect_conftest_files(self, test_dir):
+        _write_file(test_dir, "conftest.py", "")
+        _write_file(test_dir, "bgp/conftest.py", "")
+        fp = _write_file(test_dir, "bgp/test_x.py", "")
+        conftests = _collect_conftest_files(fp, test_dir)
+        assert len(conftests) == 2
+        assert any("bgp" in c for c in conftests)
+
+
+# ── Unreadable files (safe default) ───────────────────────
+
+class TestUnreadableFiles:
+
+    def test_read_file_safe_returns_none_on_missing(self):
+        assert _read_file_safe("/nonexistent/test.py") is None
+
+    def test_has_traffic_pattern_true_for_unreadable(self):
+        assert _has_traffic_pattern("/nonexistent/test.py") is True
+
+    def test_unreadable_file_not_deduped(self, test_dir):
+        scripts = {
+            "t0_checker": ["missing/test_gone.py"],
+            "t1_checker": ["missing/test_gone.py"],
+        }
+        result = dedup_control_plane_tests(scripts, test_dir)
+        assert "missing/test_gone.py" in result.get(
+            "t0_checker", []
+        )
+        assert "missing/test_gone.py" in result.get(
+            "t1_checker", []
+        )
+
+
+# ── Import resolution ─────────────────────────────────────
+
+class TestResolveImports:
+
+    def test_relative_import(self, test_dir):
+        _write_file(test_dir, "pkg/helper.py", "")
+        fp = _write_file(
+            test_dir, "pkg/test_x.py",
+            "from .helper import func\n",
+        )
+        resolved = _resolve_local_imports(
+            fp, "from .helper import func\n"
+        )
+        assert any("helper.py" in r for r in resolved)
+
+    def test_parent_relative_import(self, test_dir):
+        _write_file(test_dir, "common/utils.py", "")
+        fp = _write_file(
+            test_dir, "common/sub/test_x.py",
+            "from ..utils import func\n",
+        )
+        resolved = _resolve_local_imports(
+            fp, "from ..utils import func\n"
+        )
+        assert any("utils.py" in r for r in resolved)
+
+    def test_bare_relative_import(self, test_dir):
+        """§3: from . import module should be resolved."""
+        _write_file(test_dir, "pkg/helper.py", "")
+        fp = _write_file(
+            test_dir, "pkg/test_x.py",
+            "from . import helper\n",
+        )
+        resolved = _resolve_local_imports(
+            fp, "from . import helper\n"
+        )
+        assert any("helper.py" in r for r in resolved)
+
+    def test_bare_parent_relative_import(self, test_dir):
+        """§3: from .. import module should be resolved."""
+        _write_file(test_dir, "common/utils.py", "")
+        fp = _write_file(
+            test_dir, "common/sub/test_x.py",
+            "from .. import utils\n",
+        )
+        resolved = _resolve_local_imports(
+            fp, "from .. import utils\n"
+        )
+        assert any("utils.py" in r for r in resolved)
+
+    def test_absolute_tests_import_with_location(self, test_dir):
+        """§2: tests.X.Y resolved relative to location."""
+        loc = os.path.join(test_dir, "tests")
+        os.makedirs(os.path.join(loc, "common"), exist_ok=True)
+        _write_file(test_dir, "tests/common/helpers.py", "")
+        fp = _write_file(
+            test_dir, "tests/bgp/test_bgp.py",
+            "import tests.common.helpers\n",
+        )
+        resolved = _resolve_local_imports(
+            fp, "import tests.common.helpers\n", location=loc
+        )
+        assert any("helpers.py" in r for r in resolved)
+
+    def test_from_tests_pkg_import_mod(self, test_dir):
+        """from tests.common import helpers resolves helpers.py."""
+        loc = os.path.join(test_dir, "tests")
+        os.makedirs(os.path.join(loc, "common"), exist_ok=True)
+        _write_file(test_dir, "tests/common/helpers.py", "")
+        fp = _write_file(
+            test_dir, "tests/bgp/test_bgp.py",
+            "from tests.common import helpers\n",
+        )
+        resolved = _resolve_local_imports(
+            fp,
+            "from tests.common import helpers\n",
+            location=loc,
+        )
+        assert any("helpers.py" in r for r in resolved)
+
+    def test_package_init_resolved(self, test_dir):
+        os.makedirs(
+            os.path.join(test_dir, "pkg", "subpkg"),
+            exist_ok=True,
+        )
+        _write_file(test_dir, "pkg/subpkg/__init__.py", "")
+        fp = _write_file(
+            test_dir, "pkg/test_x.py",
+            "from .subpkg import thing\n",
+        )
+        resolved = _resolve_local_imports(
+            fp, "from .subpkg import thing\n"
+        )
+        assert any("__init__.py" in r for r in resolved)


### PR DESCRIPTION
### Description of PR

#### Summary
For impacted-area based PR testing, control-plane tests that appear in both `t0_checker` and `t1_checker` are redundant — they verify configuration, management and monitoring behavior that is topology-independent. This PR adds a dedup step that removes control-plane tests from `t1_checker` when they already exist in `t0_checker`, reducing redundant PR test runs.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
ADO #37050348 — one-testcase-per-testbed optimization for PR tests. When the same control-plane test (e.g. SSH, SNMP, NTP, LLDP config tests) runs on both t0 and t1-lag topologies, the results are identical. Removing the duplicate t1-lag run saves CI resources without losing coverage.

#### How did you do it?
Added `dedup_control_plane_tests()` to `get_test_scripts.py` which:

1. Finds tests that overlap between `t0_checker` and `t1_checker`
2. **Auto-detects** data-plane tests by scanning each test file and its imported modules (up to 2 levels deep) for traffic-sending patterns:
   - `ptfadapter`, `ptf_runner`, `ptf.testutils`, `send_packet`, `run_ptf_script`
   - `snappi`, `tgen_utils`, `craft_packet`, `pktgen`
3. Keeps data-plane tests on both topologies (forwarding behavior is topology-dependent)
4. Removes control-plane tests from `t1_checker` (already covered by `t0_checker`)
5. Prunes empty checker keys to avoid spawning empty CI jobs

**No hardcoded list is needed** — new data-plane tests are automatically recognized as long as they import or call any traffic-sending code within 2 levels of their import chain.

#### How did you verify/test it?
Local testing with broad feature combinations (ssh, snmp, acl, bgp, tacacs, gnmi, telemetry, syslog, ntp, lldp, crm, pfcwd, fib, everflow, copp, qos, route, database):
- Before dedup: t0_checker=115, t1_checker=108
- After dedup: t0_checker=115, t1_checker=28 (80 control-plane tests removed)
- All 28 remaining t1 tests are correctly identified as data-plane (acl, copp, everflow, fib, pfcwd, qos, route_flap, etc.)
- Verified data-plane detection catches both direct usage (`ptfadapter` in test file) and indirect usage (helper modules that import PTF)

#### Previous or related PRs
N/A — this is a new optimization for the impacted area testing pipeline.