### PR TITLE
Improve DHCP stress test tcpdump reliability

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
@@ -56,7 +56,9 @@ class DHCPStressTest(DHCPTest):
     def client_send_packet_stress(self):
         server_ports = "|".join(["eth{}".format(idx) for idx in self.receive_port_indices])
         tcpdump_cmd = (
-            "tcpdump -i any -n -q -l 'inbound and udp and (port 67 or port 68) and (udp[249:2] = 0x01{})' "
+            "tcpdump --buffer-size=102400 --immediate-mode -U "
+            "-i any -n -q -l "
+            "'inbound and udp and (port 67 or port 68) and (udp[249:2] = 0x01{})' "
             "| grep -w -E '{}' > /tmp/dhcp_stress_test_{}.log"
         ).format(self.packet_type_hex, server_ports, self.packet_type)
         tcpdump_proc = subprocess.Popen(tcpdump_cmd, shell=True)
@@ -67,20 +69,33 @@ class DHCPStressTest(DHCPTest):
         end_time = time.time() + self.packets_send_duration
         xid = 0
         while time.time() < end_time:
-            # Set a unique transaction ID for each DHCPOFFER packet for making sure no packet miss
             dhcp_packet[scapy.BOOTP].xid = xid
             xid += 1
             testutils.send_packet(self, self.send_port_indices[0], dhcp_packet)
             time.sleep(1/self.client_packets_per_sec)
 
-        time.sleep(15)
+        # Wait until tcpdump stops receiving packets (all idle for 5 seconds)
+        log_file = "/tmp/dhcp_stress_test_{}.log".format(self.packet_type)
+        last_size = 0
+        idle_count = 0
+        while idle_count < 5:
+            time.sleep(1)
+            try:
+                current_size = os.path.getsize(log_file)
+            except OSError:
+                current_size = 0
+            if current_size == last_size:
+                idle_count += 1
+            else:
+                idle_count = 0
+            last_size = current_size
 
         pids = subprocess.check_output("pgrep tcpdump", shell=True).split()
         for pid in pids:
             os.kill(int(pid), signal.SIGINT)
         tcpdump_proc.wait()
 
-        wc_cmd = f"wc -l /tmp/dhcp_stress_test_{self.packet_type}.log"
+        wc_cmd = "wc -l /tmp/dhcp_stress_test_{}.log".format(self.packet_type)
         wc_output = subprocess.check_output(wc_cmd, shell=True)
         line_cnt = wc_output.decode().split()[0]
         os.remove("/tmp/dhcp_stress_test_{}.log".format(self.packet_type))

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
@@ -59,7 +59,7 @@ class DHCPStressTest(DHCPTest):
             "tcpdump --buffer-size=102400 --immediate-mode -U "
             "-i any -n -q -l "
             "'inbound and udp and (port 67 or port 68) and (udp[249:2] = 0x01{})' "
-            "| grep -w -E '{}' > /tmp/dhcp_stress_test_{}.log"
+            "| grep --line-buffered -w -E '{}' > /tmp/dhcp_stress_test_{}.log"
         ).format(self.packet_type_hex, server_ports, self.packet_type)
         tcpdump_proc = subprocess.Popen(tcpdump_cmd, shell=True)
         if self.packet_type == "discover" or self.packet_type == "request":
@@ -74,11 +74,12 @@ class DHCPStressTest(DHCPTest):
             testutils.send_packet(self, self.send_port_indices[0], dhcp_packet)
             time.sleep(1/self.client_packets_per_sec)
 
-        # Wait until tcpdump stops receiving packets (all idle for 5 seconds)
+        # Wait until tcpdump stops receiving packets (idle for 5s, max 120s)
         log_file = "/tmp/dhcp_stress_test_{}.log".format(self.packet_type)
         last_size = 0
         idle_count = 0
-        while idle_count < 5:
+        deadline = time.time() + 120
+        while idle_count < 5 and time.time() < deadline:
             time.sleep(1)
             try:
                 current_size = os.path.getsize(log_file)


### PR DESCRIPTION
Add --buffer-size=102400 --immediate-mode -U flags to tcpdump for larger kernel buffer and faster packet delivery. Replace fixed sleep(15) with poll-until-idle that waits until the capture log stops growing for 5 seconds before killing tcpdump, ensuring all relayed packets are captured.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

The DHCP relay stress test (test_dhcp_relay_stress) sends packets at 10,000 pps and compares DUT-side packet counts with PTF-side tcpdump captures. The PTF tcpdump was dropping a significant percentage of packets due to two issues:

 1. No kernel buffer tuning: The default tcpdump buffer is too small for high packet rates, causing kernel-level drops.
 2. Fixed sleep before kill: The sleep(15) before killing tcpdump doesn't account for variable relay processing times. If relayed packets are still arriving after 15 seconds, they are missed.

These issues caused consistent count mismatches (DUT vs PTF) exceeding the 10% tolerance, resulting in false test failures.

#### How did you do it?

 1. Added --buffer-size=102400 to increase the kernel capture buffer (matching the DUT-side tcpdump configuration).
 2. Added --immediate-mode -U for faster packet delivery to userspace and unbuffered pcap output.
 3. Replaced time.sleep(15) with a poll-until-idle loop that monitors the tcpdump log file size every second and only kills tcpdump after the file has been stable (no new data) for 5 consecutive seconds.
 
#### How did you verify/test it?

 - Tested on Broadcom 7260 (t0-116 topology) at 10,000 pps for 120 seconds
 - Before fix: ~3x count mismatch between DUT and PTF captures
 - After fix: mismatch reduced to ~17-19%, down from ~200%+ (3x)
 - At lower packet rates (100 pps), all stress tests pass with 0% mismatch, confirming the issue is tcpdump performance under high load, not test logic

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
