### PR TITLE
Fix ValueError in is_xcvr_optical when specification_compliance is not a dict literal

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -309,13 +309,22 @@ class TestSfpApi(PlatformApiTestBase):
     #
     def is_xcvr_optical(self, xcvr_info_dict):
         """Returns True if transceiver is optical, False if copper (DAC)"""
-        # For QSFP-DD specification compliance will return type as passive or active
+        spec_compliance = xcvr_info_dict["specification_compliance"]
+        # For QSFP-DD/OSFP/CMIS-based transceivers, specification_compliance is a plain string.
+        # Some transceivers may report type_abbrv_name as "Unknown" while still being CMIS-based,
+        # so first try to parse as a dict; if that fails, treat as a plain string.
         if xcvr_info_dict["type_abbrv_name"] in ["QSFP-DD", "OSFP-8X", "QSFP+C", "BP", "SFP"]:
-            if xcvr_info_dict["specification_compliance"] == "Passive Copper Cable" or \
-                    xcvr_info_dict["specification_compliance"] == "passive_copper_media_interface":
+            if spec_compliance in ["Passive Copper Cable", "passive_copper_media_interface"]:
                 return False
         else:
-            spec_compliance_dict = ast.literal_eval(xcvr_info_dict["specification_compliance"])
+            try:
+                spec_compliance_dict = ast.literal_eval(spec_compliance)
+            except (ValueError, SyntaxError):
+                # specification_compliance is a plain string (e.g. for CMIS-based transceivers
+                # with type_abbrv_name reported as "Unknown"), handle like QSFP-DD
+                if spec_compliance in ["Passive Copper Cable", "passive_copper_media_interface"]:
+                    return False
+                return True
             if xcvr_info_dict["type_abbrv_name"] == "SFP":
                 compliance_code = spec_compliance_dict.get("SFP+CableTechnology")
                 if compliance_code == "Passive Cable":


### PR DESCRIPTION
### Description of PR

Summary:
Fix `ValueError: malformed node or string` in `TestSfpApi.is_xcvr_optical()` when a transceiver's `specification_compliance` field is a plain string instead of a Python dict literal.

The root cause is that some CMIS-based transceivers (e.g. `CAB-D-D-400G-2M` copper cable) report `type_abbrv_name` as `"Unknown"` instead of `"QSFP-DD"`. This causes `is_xcvr_optical()` to fall into the `else` branch (line 318) and call `ast.literal_eval("passive_copper_media_interface")`, which fails because it is a bare identifier, not a valid Python literal.

This affects 12 test cases that call `is_xcvr_optical()`: `test_get_temperature`, `test_get_voltage`, `test_get_tx_bias`, `test_get_rx_power`, `test_get_tx_power`, `test_tx_disable`, etc.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

Nightly test `platform_tests/api/test_sfp.py` fails on testbed `8101.t1.202511.O8C48.2` (Cisco 8101) with:

```
ValueError: malformed node or string on line 1: <ast.Name object at xxx>
```

Traceback:
```
File "tests/platform_tests/api/test_sfp.py", line 318, in is_xcvr_optical
    spec_compliance_dict = ast.literal_eval(xcvr_info_dict["specification_compliance"])
```

The failing transceiver data:
```
{
    'type': 'QSFP-DD Double Density 8X Pluggable Transceiver',
    'type_abbrv_name': 'Unknown',
    'hardware_rev': '0.0',
    'serial': 'ZZ2409130660',
    'manufacturer': 'A\x00\x00\x00\x00\x00Networks',
    'model': 'CAB-D-D-400G-2M',
    'connector': 'No separable connector',
    'encoding': 'N/A',
    'ext_identifier': 'Power Class 1 (0.25W Max)',
    'ext_rateselect_compliance': 'N/A',
    'cable_length': 2.0,
    'nominal_bit_rate': 'N/A',
    'vendor_date': '2024-09-11',
    'vendor_oui': 'a8-b0-ae',
    'specification_compliance': 'passive_copper_media_interface',
    'media_interface_technology': 'Copper cable unequalized',
    'vendor_rev': '00',
    'cmis_rev': '3.0',
    'vdm_supported': False,
    'application_advertisement': '{1: {host_electrical_interface_id: 400G CR8, ...}}'
}
```

Because `type_abbrv_name` is `"Unknown"` (not in `["QSFP-DD", "OSFP-8X", "QSFP+C", "BP"]`), the code falls to the `else` branch which assumes `specification_compliance` is a dict string parseable by `ast.literal_eval()`.

#### How did you do it?

Wrapped `ast.literal_eval()` in a `try/except (ValueError, SyntaxError)` block. When parsing fails, the raw `specification_compliance` string is checked against known copper cable identifiers (`"Passive Copper Cable"`, `"passive_copper_media_interface"`), matching the existing QSFP-DD handling logic.

#### How did you verify/test it?

Verified the fix logic against the actual transceiver data from the failing nightly test (testplan `8101.t1.202511.O8C48.2_NightlyTest_20260413.1`).

With the fix:
- Transceiver with `type_abbrv_name='Unknown'` and `specification_compliance='passive_copper_media_interface'` is correctly identified as copper (DAC) and optical-only tests are skipped.
- Transceiver with valid dict-format `specification_compliance` continues to be parsed normally.

#### Any platform specific information?

Observed on Cisco 8101 platform with `CAB-D-D-400G-2M` copper DAC cables that report `type_abbrv_name` as `"Unknown"`.

#### Supported testbed topology if it's a new test case?
N/A - this is a bug fix for an existing test.

### Documentation
N/A
