### PR TITLE
[ansible] Add Juniper-QFX5241-64-OD hwsku to Broadcom testbed variables

### DIFF
--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -7,7 +7,7 @@ ansible_altpassword: YourPaSsWoRd
 
 sonic_version: "v2"
 
-broadcom_hwskus: [ 'ACS-S6000', 'ACS-S6000-Q24S32', 'ACS-N3132', 'Force10-S6000', 'Force10-S6000-Q24S32', 'Nexus-3132-GE-Q32', 'Nexus-3132-GX-Q32', 'Arista-7050-QX32', 'Arista-7050-QX-32S', 'Force10-S6100', 'Accton-AS7712-32X', 'Arista-7260CX3-D108C8',  'Arista-7260CX3-C64', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-C32-T1', 'Arista-7060CX-32S-D48C8', 'Celestica-DX010-C32', 'Celestica-E1031-T48S4', "Seastone-DX010", 'Arista-7260CX3-Q64' ]
+broadcom_hwskus: [ 'ACS-S6000', 'ACS-S6000-Q24S32', 'ACS-N3132', 'Force10-S6000', 'Force10-S6000-Q24S32', 'Nexus-3132-GE-Q32', 'Nexus-3132-GX-Q32', 'Arista-7050-QX32', 'Arista-7050-QX-32S', 'Force10-S6100', 'Accton-AS7712-32X', 'Arista-7260CX3-D108C8',  'Arista-7260CX3-C64', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-C32-T1', 'Arista-7060CX-32S-D48C8', 'Celestica-DX010-C32', 'Celestica-E1031-T48S4', "Seastone-DX010", 'Arista-7260CX3-Q64' , 'Juniper-QFX5241-64-OD']
 
 broadcom_td2_hwskus: ['Force10-S6000', 'Force10-S6000-Q24S32', 'Arista-7050-QX32', 'Arista-7050-QX-32S', 'Nexus-3164', 'Arista-7050QX32S-Q32']
 broadcom_td3_hwskus: ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7050CX3-32S-C28S4', 'Arista-7050CX3-32S-S128', 'Arista-7050CX3-32S-C6S104', 'Arista-7050CX3-32S-C28S16',
@@ -17,7 +17,7 @@ broadcom_th_hwskus: ['Force10-S6100', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32
 broadcom_th2_hwskus: ['Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Arista-7260CX3-C64', 'Arista-7260CX3-Q64']
 broadcom_th3_hwskus: ['DellEMC-Z9332f-M-O16C64',  'DellEMC-Z9332f-O32']
 broadcom_th4_hwskus: ['Arista-7060DX5-32', 'Arista-7060DX5-64S']
-broadcom_th5_hwskus: ['Arista-7060X6-64DE', 'Arista-7060X6-64DE-64x400G', 'Arista-7060X6-64DE-O128S2', 'Arista-7060X6-64DE-256x200G', 'Arista-7060X6-64PE', 'Arista-7060X6-64PE-64x400G', 'Arista-7060X6-64PE-O128S2', 'Arista-7060X6-64PE-256x200G', 'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8', 'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16', 'Arista-7060X6-16PE-384C-O128S2', 'NH-4010', 'Arista-7060X6-64PE-P32O64', 'Arista-7060X6-64PE-P64', 'Arista-7060X6-16PE-384C-B-O128S2', 'Arista-7060X6-16PE-384C-B-O128S2-LAB', 'Arista-7060X6-16PE-384C-B-O128S2-COPPER-LAB', 'Arista-7060X6-64PE-B-O128', 'Arista-7060X6-64PE-B-P32O64', 'Arista-7060X6-64PE-B-P32V128']
+broadcom_th5_hwskus: ['Arista-7060X6-64DE', 'Arista-7060X6-64DE-64x400G', 'Arista-7060X6-64DE-O128S2', 'Arista-7060X6-64DE-256x200G', 'Arista-7060X6-64PE', 'Arista-7060X6-64PE-64x400G', 'Arista-7060X6-64PE-O128S2', 'Arista-7060X6-64PE-256x200G', 'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8', 'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16', 'Arista-7060X6-16PE-384C-O128S2', 'NH-4010', 'Arista-7060X6-64PE-P32O64', 'Arista-7060X6-64PE-P64', 'Arista-7060X6-16PE-384C-B-O128S2', 'Arista-7060X6-16PE-384C-B-O128S2-LAB', 'Arista-7060X6-16PE-384C-B-O128S2-COPPER-LAB', 'Arista-7060X6-64PE-B-O128', 'Arista-7060X6-64PE-B-P32O64', 'Arista-7060X6-64PE-B-P32V128', 'Juniper-QFX5241-64-OD']
 broadcom_j2c+_hwskus: ['Nokia-IXR7250E-36x100G', 'Nokia-IXR7250E-36x400G', 'Arista-7280DR3A-36', 'Arista-7280DR3AK-36', 'Arista-7280DR3AK-36S', 'Arista-7280DR3AM-36', 'Arista-7800R3A-36DM2-C36', 'Arista-7800R3A-36DM2-D36', 'Arista-7800R3AK-36DM2-C36', 'Arista-7800R3AK-36DM2-D36', 'Nokia-IXR7250-X3B']
 
 broadcom_jr2_hwskus: ['Arista-7800R3-48CQ2-C48', 'Arista-7800R3-48CQM2-C48']


### PR DESCRIPTION
### Description of PR

Summary:
Registers the Juniper Broadcom (Tomahawk5) hwsku `Juniper-QFX5241-64-OD` in the testbed Broadcom hwsku lists so the platform is recognized by the test framework. Adds it to `broadcom_hwskus` and `broadcom_th5_hwskus` in `ansible/group_vars/sonic/variables`.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
The test framework did not recognize the Juniper-QFX5241-64-OD platform because its hwsku was missing from the Broadcom hwsku registries.

#### How did you do it?
Added `Juniper-QFX5241-64-OD` to the `broadcom_hwskus` and `broadcom_th5_hwskus` lists in `ansible/group_vars/sonic/variables`.

#### How did you verify/test it?
Configuration-only change; confirmed the hwsku now resolves in the Broadcom hwsku lists consumed by the testbed.

#### Any platform specific information?
Juniper QFX5241-64-OD (Broadcom Tomahawk5).

<!-- Title and description updated by @bhouse-nexthop (maintainer) for clarity and future reference. Original title: "Update variables". -->
