### PR TITLE
[C0] Skip static-route test on C0 due to no VLAN

### DIFF
--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -34,7 +34,7 @@ from tests.common.helpers.dut_ports import get_vlan_interface_list, get_vlan_int
 COUNT = 10
 
 pytestmark = [
-    pytest.mark.topology('t0', 'm0', 'mx', 'c0'),
+    pytest.mark.topology('t0', 'm0', 'mx'),
     pytest.mark.device_type('vs')
 ]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
test_static_route is designed for VLAN scenario. (#3429)
Skip it on C0 because C0 topo doesn't have VLAN.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
test_static_route is designed for VLAN scenario. (#3429)
Skip it on C0 because C0 topo doesn't have VLAN.

#### How did you do it?
Removed C0 mark from this testcase.

#### How did you verify/test it?
Verified by PR test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
