### PR TITLE
chore: get_dut_version add dpu smart switch support

### DIFF
--- a/.azure-pipelines/get_dut_version.py
+++ b/.azure-pipelines/get_dut_version.py
@@ -51,14 +51,25 @@ def get_duts_version(sonichosts, output=None):
     """
     Collect version information from DUTs via `show version`.
 
+    For SmartSwitch testbeds, if a DPU host is unreachable, enables NAT on its
+    NPU host and retries the command.
+
     Returns:
         dict: Parsed version info per DUT, structured with general fields and Docker images.
     """
     try:
         ret = {}
-        duts_version = sonichosts.command("show version")
+        duts_version = sonichosts.command("show version", module_ignore_errors=True)
 
         for dut, version in duts_version.items():
+            # If a DPU host is unreachable, try enabling NAT and retry
+            if version.get("unreachable") or (version.get("failed") and not version.get("stdout_lines")):
+                if "dpu" in dut.lower():
+                    version = _retry_dpu_with_nat(sonichosts, dut)
+                if version is None:
+                    logger.warning("Skipping unreachable or failed host: %s", dut)
+                    continue
+
             dut_info = {}
             dut_version = version.get("stdout_lines", [])
             in_docker_section = False
@@ -130,6 +141,34 @@ def validate_args(args):
         level=_log_level_map[args.log_level],
         format="%(asctime)s %(filename)s#%(lineno)d %(levelname)s - %(message)s"
     )
+
+
+def _retry_dpu_with_nat(sonichosts, dpu_hostname):
+    """Enable NAT for a single DPU host and retry 'show version'.
+
+    Returns the retried command result dict on success, or None.
+    """
+    try:
+        from devutil.devices.dpu_utils import enable_nat_for_dpuhosts
+    except ImportError:
+        logger.warning("dpu_utils not available, skipping NAT enablement for %s", dpu_hostname)
+        return None
+
+    npu_hosts = [h for h in sonichosts if "dpu" not in h.hostname.lower()]
+    try:
+        logger.info("Enabling NAT for DPU host: %s", dpu_hostname)
+        enable_nat_for_dpuhosts(npu_hosts, sonichosts.inventories, [dpu_hostname])
+
+        # Retry the command on the now-reachable DPU
+        retry_result = sonichosts.command("show version", module_ignore_errors=True)
+        version = retry_result.get(dpu_hostname)
+        if version and not version.get("unreachable") and version.get("stdout_lines"):
+            return version
+        logger.warning("DPU host %s still unreachable after enabling NAT", dpu_hostname)
+    except Exception as e:
+        logger.warning("Failed to enable NAT for %s: %s", dpu_hostname, repr(e))
+
+    return None
 
 
 def main(args):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: For special testbed such as smartswitch, we will try to get DPU information. If there is SSH issue, the current get_dut_version will ignore it. 

The script will still return the correct version of OS number, ASIC type and DUT for main host.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Enhance get_dut_version script to skip if DUT is unreachable in a testbed and check DPU components

#### How did you do it?

#### How did you verify/test it?
Verified locally that we're able to obtain device information for smartswitch with DPU components.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
