### PR TITLE
Fix test_show_queue_counters for non-T2 multi-ASIC devices

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -771,8 +771,14 @@ class TestShowQueue():
                             continue
 
                     # The interface name is always the last but one field in the BUFFER_QUEUE entry key
-                    # Skip interfaces that don't belong to this ASIC namespace on multi-ASIC devices
-                    if duthost.is_multi_asic and fields[-3] != asic.namespace:
+                    # On multi-ASIC T2 (VOQ), BUFFER_QUEUE keys include the namespace field:
+                    #   BUFFER_QUEUE|<hostname>|<namespace>|Ethernet0|0-2
+                    # so fields[-3] is the namespace. Filter by it to match per-ASIC query scope.
+                    # On non-T2 multi-ASIC, SonicDbCli(asic) already queries per-ASIC CONFIG_DB,
+                    # keys are just BUFFER_QUEUE|Ethernet0|0-2, so fields[-3] is "BUFFER_QUEUE"
+                    # and must NOT be filtered.
+                    if (duthost.is_multi_asic and tbinfo["topo"]["type"] == "t2"
+                            and fields[-3] != asic.namespace):
                         continue
                     interfaces.add(fields[-2])
                 except IndexError:


### PR DESCRIPTION
### Description of PR

Summary:
Fix `test_show_queue_counters` assertion failure on non-T2 multi-ASIC devices (e.g., `vms-kvm-four-asic-t1-lag`).

PR #23881 removed the T2 topology guard that PR #23358 added to the multi-ASIC namespace filter, re-introducing the bug for non-T2 multi-ASIC topologies.

Fixes the regression from https://github.com/sonic-net/sonic-mgmt/pull/23881

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

`test_show_queue_counters[alias-vlab-08]` fails with `AssertionError: No interfaces were found` on multi-ASIC non-T2 topologies (e.g., `four-asic-t1-lag`).

**Root cause:** `SonicDbCli(asic, "CONFIG_DB")` already queries per-ASIC CONFIG_DB, so BUFFER_QUEUE keys have the format `BUFFER_QUEUE|Ethernet0|0-2` (3 fields). The filter `fields[-3] != asic.namespace` compares `"BUFFER_QUEUE"` (the table name) with `"asic0"` — always True — so every interface is filtered out.

The namespace field only exists in T2/VOQ key format: `BUFFER_QUEUE|<hostname>|<namespace>|Ethernet0|0-2`.

**Timeline:**
- PR #20410 (Jan 2026): Introduced the namespace filter for T2 multi-ASIC
- PR #23358 (Apr 2 2026): Fixed by adding `tbinfo['topo']['type'] == 't2'` guard
- PR #23881 (Apr 14 2026): Removed the guard to fix T2 single-ASIC, re-breaking non-T2 multi-ASIC

#### How did you do it?

Restored the T2 topology guard so the namespace filter only applies where the BUFFER_QUEUE key format actually contains a namespace field (T2/VOQ). Non-T2 multi-ASIC devices rely on `SonicDbCli(asic)` per-ASIC scoping instead.

#### How did you verify/test it?

Root cause confirmed by analyzing test log from ElasticTest plan `69df02bca2ac2651eecd1e4d` (four-asic-t1-lag topology).

#### Any platform specific information?

Affects all non-T2 multi-ASIC platforms running `test_iface_namingmode.py`.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A