### PR TITLE
platform_tests/test_intf_fec.py - Add platform check for "n/a" FEC_ERR_SYMBOL

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4087,6 +4087,12 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_info:
     conditions:
     - "https://github.com/sonic-net/sonic-buildimage/issues/23426 and ('sn4700' in platform or 'sn4280' in platform)"
 
+platform_tests/test_intf_fec.py::test_verify_fec_stats_counters:
+  skip:
+    reason: "Broadcom TH does not support FEC_SYMBOL_ERR at 50G"
+    conditions:
+      - "'Arista-7060CX-32S-D48C8'in hwsku"
+
 platform_tests/test_reboot.py:
   skip:
     reason: "Found regression issues on multi-asic topology, temperarily skip this test case until the issues are addressed."

--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -169,9 +169,6 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
         fec_symbol_err = intf.get('fec_symbol_err', '').replace(',', '').lower()
         # Check if fec_corr, fec_uncorr, and fec_symbol_err are valid integers
         try:
-            # Broadcom TH does not support FEC_SYMBOL_ERR at 50G - skip the check for the intf
-            if duthost.facts.get("hwsku", "unknown") == "Arista-7060CX-32S-D48C8" and fec_symbol_err == "n/a":
-                continue
             fec_corr_int = int(fec_corr)
             fec_uncorr_int = int(fec_uncorr)
             fec_symbol_err_int = int(fec_symbol_err)

--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -169,6 +169,9 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
         fec_symbol_err = intf.get('fec_symbol_err', '').replace(',', '').lower()
         # Check if fec_corr, fec_uncorr, and fec_symbol_err are valid integers
         try:
+            # Broadcom TH does not support FEC_SYMBOL_ERR at 50G - skip the check for the intf
+            if duthost.facts.get("hwsku", "unknown") == "Arista-7060CX-32S-D48C8" and fec_symbol_err == "n/a":
+                continue
             fec_corr_int = int(fec_corr)
             fec_uncorr_int = int(fec_uncorr)
             fec_symbol_err_int = int(fec_symbol_err)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Broadcom TH SAI does not support FEC_ERR_SYMBOL on 50G links. This test is reliant on that counter to work.

Skipping the test logic for intfs that has 50G link speed on the up.t0-56 topo.
Fixes #25762 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [] 202511
- [x] 202605

### Approach
#### What is the motivation for this PR?
The test is failing on Arista-7060CX-32S-D48C8.

#### How did you do it?
Skip the test logic for affected intfs as it is a ASIC/SAI support issue.

#### How did you verify/test it?
`platform_tests/test_intf_fec.py` no longer fails on Arista-7060CX-32S-D48C8.

#### Any platform specific information?
Broadcom Legacy (Tomahawk only).

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
