### PR TITLE
Add test_techsupport_ssd_dump to check ssd.dump

### DIFF
--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -439,6 +439,23 @@ def validate_dump_file_content(duthost, dump_folder_path, is_bmc_present):
     assert len(log), "Folder 'log' in dump archive is empty. Expected not empty folder"
     assert "interface.xcvrs.eeprom.raw" in dump, "EEPROM hexdump no exist in the dump"
 
+    # Check SSD dump for platforms with NVME device
+    if duthost.facts['asic_type'] in ["mellanox"]:
+        nvme_check = duthost.shell("ls /dev/nvme* 2>/dev/null", module_ignore_errors=True)
+        if nvme_check["rc"] == 0:
+            # Skip SSD dump check on images where generate_ssd_dump is not present
+            ssd_tool_check = duthost.shell(
+                "ls /usr/local/bin/generate_ssd_dump", module_ignore_errors=True)
+            if ssd_tool_check["rc"] != 0:
+                logger.warning("/usr/local/bin/generate_ssd_dump not found on DUT, "
+                               "skipping SSD dump validation (feature not present in this image)")
+            else:
+                assert "ssd.dump" in dump, \
+                    "SSD dump file (ssd.dump) not found in dump folder of techsupport archive"
+                ssd_dump_path = "{}/dump/ssd.dump".format(dump_folder_path)
+                ssd_size = int(duthost.command("stat -c '%s' {}".format(ssd_dump_path))["stdout"].strip())
+                assert ssd_size > 0, "SSD dump file exists but is empty"
+
 
 def add_asic_arg(format_str, cmds_list, asic_num):
     """


### PR DESCRIPTION

### Description of PR

Summary:
SSD dump should be included as part of tech support collection on platforms with NVME storage. This change adds automated validation to ensure `ssd.dump` is correctly generated and packaged into the techsupport archive.
Utilities change reference: https://github.com/sonic-net/sonic-utilities/pull/4508

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202605

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- master: pass
- 202605: pass

### Approach
#### What is the motivation for this PR?
SSD dump should be included as part of tech support collection. This change adds automated validation to ensure ssd.dump is correctly generated and packaged into the techsupport archive.
#### How did you do it?
1. Extended validate_dump_file_content() in tests/show_techsupport/test_techsupport.py (called by existing test_techsupport) with the following logic:
2. Only runs on Mellanox (asic_type == "mellanox") platforms that have an NVME device (/dev/nvme0 exists).
3. Skips validation with a warning if /usr/local/bin/generate_ssd_dump is not present on the image (backward compatible with older images that don't have this feature).
4. When the tool is present, asserts that ssd.dump exists under the dump/ folder of the extracted techsupport archive and that its file size is greater than 0.
#### How did you verify/test it?
Tested on mellanox SN4280 with one NVME mounted.
#### Any platform specific information?
Any platform that has nvme mounted.
#### Supported testbed topology if it's a new test case?
Any
### Documentation
NA
