### PR TITLE
[dhcp_relay] Fix test_dhcp_counter_stress: add missing relay_agent params and remo…

### DIFF
--- a/tests/dhcp_relay/test_dhcp_counter_stress.py
+++ b/tests/dhcp_relay/test_dhcp_counter_stress.py
@@ -9,19 +9,20 @@ from tests.common.dhcp_relay_utils import init_dhcpmon_counters, validate_dhcpmo
                                           validate_counters_and_pkts_consistency
 from tests.common.utilities import wait_until, capture_and_check_packet_on_dut
 from tests.common.dhcp_relay_utils import check_dhcp_stress_status
+from tests.common.dhcp_relay_utils import enable_sonic_dhcpv4_relay_agent  # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.ptf_runner import ptf_runner
 
 pytestmark = [
     pytest.mark.topology('t0', 'm0'),
-    pytest.mark.device_type('physical')
+    pytest.mark.device_type('physical'),
+    pytest.mark.parametrize("relay_agent", ["isc-relay-agent", "sonic-relay-agent"])
 ]
 
 BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
 DEFAULT_DHCP_CLIENT_PORT = 68
 DEFAULT_DHCP_SERVER_PORT = 67
 DUAL_TOR_MODE = 'dual'
-BUFFER_SIZE = 1024  # 1 MiB (tcpdump --buffer-size is in KiB)
 logger = logging.getLogger(__name__)
 PACKET_RATE_PER_SEC_MAP = {
     "Mellanox-SN2700": 20
@@ -42,7 +43,7 @@ def ignore_expected_loganalyzer_exceptions(rand_one_dut_hostname, loganalyzer):
 
 
 @pytest.mark.parametrize('dhcp_type', ['discover', 'offer', 'request', 'ack'])
-def test_dhcpmon_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_dut_routes_exist,
+def test_dhcpmon_relay_counters_stress(ptfhost, relay_agent, ptfadapter, dut_dhcp_relay_data, validate_dut_routes_exist,
                                        testing_config, setup_standby_ports_on_rand_unselected_tor,
                                        toggle_all_simulator_ports_to_rand_selected_tor_m,     # noqa F811
                                        dhcp_type, clean_processes_after_stress_test,
@@ -84,9 +85,11 @@ def test_dhcpmon_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
             "packets_send_duration": packets_send_duration,
             "client_packets_per_sec": client_packets_per_sec,
             "testing_mode": testing_mode,
-            "kvm_support": True
+            "kvm_support": True,
+            "relay_agent": relay_agent,
+            "downlink_vlan_iface_name": str(dhcp_relay["downlink_vlan_iface"]["name"])
         }
-        count_file = '/tmp/dhcp_stress_test_{}.json'.format(dhcp_type)
+        count_file = '/tmp/dhcp_stress_test_{}'.format(dhcp_type)
 
         def _check_count_file_exists():
             command = 'ls {} > /dev/null 2>&1 && echo exists || echo missing'.format(count_file)
@@ -125,7 +128,6 @@ def test_dhcpmon_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
             pkts_filter="udp dst port %s or udp dst port %s" % (DEFAULT_DHCP_SERVER_PORT,
                                                                 DEFAULT_DHCP_CLIENT_PORT),
             pkts_validator=_verify_packets,
-            tcpdump_buffer_size=BUFFER_SIZE
         ):
             ptf_runner(ptfhost, "ptftests", "dhcp_relay_stress_test.DHCPStress{}Test".format(dhcp_type.capitalize()),
                        platform_dir="ptftests", params=params,


### PR DESCRIPTION
…ve excessive buffer

PR #19198 added relay_agent and downlink_vlan_iface_name as required parameters in DHCPTest.setUp, but test_dhcp_counter_stress.py was not updated. Also removes the excessive BUFFER_SIZE (1GB kernel buffer) that caused memory spikes, using the default instead. Fixes count file extension mismatch (.json removed).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

test_dhcpmon_relay_counters_stress calls DHCPStress{Type}Test via ptf_runner, which extends DHCPTest. Since PR #19198, DHCPTest.setUp requires relay_agent and downlink_vlan_iface_name. Without these, the PTF test crashes silently in setUp, the count file is never created, and the test fails with "count file is missing".

Additionally, BUFFER_SIZE = 1024 * 1024 sets the tcpdump --buffer-size to 1,048,576 KiB (1 GB), causing a ~2GB memory spike on the DUT (from 45% to 76% usage). This is unnecessary since the test only captures on a single interface with a small amount of traffic. Removing it uses the default 102,400 KiB (100 MB), which is sufficient.

The count file extension was also mismatched — the test reads .json but the PTF stress test writes without .json.

#### How did you do it?

 - Added relay_agent and downlink_vlan_iface_name to the ptf_runner params
 - Removed BUFFER_SIZE = 1024 * 1024 definition and tcpdump_buffer_size=BUFFER_SIZE override, falling back to the default
 - Removed .json extension from count file path to match PTF output

#### How did you verify/test it?

 - Before fix: test fails with "count file is missing" (PTF setUp crash) and memory spikes to 76%
 - After fix: PTF test runs successfully, count file is created, memory stays at ~45%
 - Tested on Broadcom 7260 (t0-116 topology)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
