### PR TITLE
Skip cold/warm/fast reboot in test_generic_hash on VS/KVM (#23637)

### DIFF
--- a/tests/hash/generic_hash_helper.py
+++ b/tests/hash/generic_hash_helper.py
@@ -31,6 +31,15 @@ VPP_SUPPORTED_HASH_ALGORITHM = ['CRC']
 MARVELL_TERALYNX_HASH_ALGORITHM = ['CRC', 'XOR']
 DEFAULT_SUPPORTED_HASH_ALGORITHM = ['CRC', 'CRC_CCITT', 'RANDOM', 'XOR']
 VPP_SUPPORTED_REBOOT_TYPES = ['cold', 'reload']
+# On VS/KVM, cold/warm/fast reboots take 5-8 minutes each. Combined with hash
+# configuration and two PTF traffic runs, test_reboot easily exceeds the 20-minute
+# per-module timeout enforced by Elastictest (see #23637). Restrict VS to 'reload'
+# only: config reload exercises the CONFIG_DB save/restore path that hash
+# persistence depends on, without the slow VM reboot overhead. SAI warm-restart
+# semantics are not covered, which is acceptable on VS because the virtual switch
+# does not model hardware warm-boot anyway. On real hardware all reboot types
+# (cold/warm/fast/reload) still run as before.
+VS_SUPPORTED_REBOOT_TYPES = ['reload']
 DEFAULT_SUPPORTED_REBOOT_TYPES = ['cold', 'warm', 'fast', 'reload']
 
 MELLANOX_ECMP_HASH_FIELDS = [
@@ -690,6 +699,8 @@ def get_reboot_type_from_option(request, reboot_option):
     asic_type = get_asic_type(request)
     if asic_type == 'vpp':
         supported_reboot_types = VPP_SUPPORTED_REBOOT_TYPES
+    elif asic_type == 'vs':
+        supported_reboot_types = VS_SUPPORTED_REBOOT_TYPES
     else:
         supported_reboot_types = DEFAULT_SUPPORTED_REBOOT_TYPES
 
@@ -700,7 +711,10 @@ def get_reboot_type_from_option(request, reboot_option):
     elif reboot_option in supported_reboot_types:
         return [reboot_option]
     else:
-        return [reboot_option]
+        # Explicitly requested reboot type is not supported on this asic
+        # (e.g. cold/warm/fast on VS). Fall back to the supported set so the
+        # asic-specific restriction cannot be bypassed via the --reboot option.
+        return supported_reboot_types[:]
 
 
 def get_encap_type_from_option(encap_type_option):

--- a/tests/hash/test_generic_hash.py
+++ b/tests/hash/test_generic_hash.py
@@ -694,6 +694,14 @@ def test_reboot(rand_selected_dut, tbinfo, ptfhost, localhost, fine_params, mg_f
     """
     ecmp_algorithm, ecmp_test_hash_field, ipver, inner_ipver, encap_type = fine_params.split('-')
     skip_unsupported_field_for_ecmp_test(ecmp_test_hash_field, encap_type)
+    # On VS/KVM, cold/warm/fast reboots take 5-8 minutes each, which combined
+    # with hash configuration and two PTF traffic runs easily exceeds the
+    # 20-minute per-module timeout enforced by Elastictest (see #23637).
+    # Config reload is sufficient to verify hash persistence on KVM since it
+    # tests the same CONFIG_DB save/restore path without the slow VM reboot.
+    if rand_selected_dut.facts['asic_type'] == 'vs' and reboot_type in ('cold', 'warm', 'fast'):
+        pytest.skip("Skipping {} reboot on VS/KVM to avoid module timeout; "
+                    "config reload covers hash persistence validation.".format(reboot_type))
     with allure.step('Randomly select an ecmp hash field to test '
                      'and configure all supported fields to the global ecmp and lag hash'):
         config_all_hash_fields(rand_selected_dut, global_hash_capabilities)

--- a/tests/hash/test_generic_hash.py
+++ b/tests/hash/test_generic_hash.py
@@ -697,9 +697,12 @@ def test_reboot(rand_selected_dut, tbinfo, ptfhost, localhost, fine_params, mg_f
     # On VS/KVM, cold/warm/fast reboots take 5-8 minutes each, which combined
     # with hash configuration and two PTF traffic runs easily exceeds the
     # 20-minute per-module timeout enforced by Elastictest (see #23637).
-    # Config reload is sufficient to verify hash persistence on KVM since it
-    # tests the same CONFIG_DB save/restore path without the slow VM reboot.
-    if rand_selected_dut.facts['asic_type'] == 'vs' and reboot_type in ('cold', 'warm', 'fast'):
+    # On VS/KVM, only run 'reload' here. Config reload exercises the CONFIG_DB
+    # save/restore path that hash persistence depends on, but it does not exercise
+    # SAI warm-restart semantics. That's acceptable on VS because the virtual
+    # switch does not model hardware warm-boot anyway; on real hardware all
+    # reboot types (cold/warm/fast/reload) still run as before.
+    if rand_selected_dut.facts['asic_type'] == 'vs' and reboot_type != 'reload':
         pytest.skip("Skipping {} reboot on VS/KVM to avoid module timeout; "
                     "config reload covers hash persistence validation.".format(reboot_type))
     with allure.step('Randomly select an ecmp hash field to test '

--- a/tests/hash/test_generic_hash.py
+++ b/tests/hash/test_generic_hash.py
@@ -694,14 +694,18 @@ def test_reboot(rand_selected_dut, tbinfo, ptfhost, localhost, fine_params, mg_f
     """
     ecmp_algorithm, ecmp_test_hash_field, ipver, inner_ipver, encap_type = fine_params.split('-')
     skip_unsupported_field_for_ecmp_test(ecmp_test_hash_field, encap_type)
-    # On VS/KVM, cold/warm/fast reboots take 5-8 minutes each, which combined
-    # with hash configuration and two PTF traffic runs easily exceeds the
-    # 20-minute per-module timeout enforced by Elastictest (see #23637).
-    # On VS/KVM, only run 'reload' here. Config reload exercises the CONFIG_DB
-    # save/restore path that hash persistence depends on, but it does not exercise
-    # SAI warm-restart semantics. That's acceptable on VS because the virtual
-    # switch does not model hardware warm-boot anyway; on real hardware all
-    # reboot types (cold/warm/fast/reload) still run as before.
+    # Defensive fallback for VS/KVM. The primary guard is at the parametrization
+    # level in get_reboot_type_from_option(), which restricts VS to 'reload' so
+    # cold/warm/fast are never collected (see VS_SUPPORTED_REBOOT_TYPES and #23637).
+    # This inline check stays as a belt-and-suspenders safety net in case a
+    # cold/warm/fast parametrization ever reaches this test on VS (e.g. a future
+    # refactor of the reboot-type selection): on VS/KVM those reboots take 5-8
+    # minutes each and, combined with hash configuration and two PTF traffic runs,
+    # easily exceed the 20-minute per-module timeout enforced by Elastictest.
+    # Config reload exercises the CONFIG_DB save/restore path that hash persistence
+    # depends on, but not SAI warm-restart semantics; that's acceptable on VS
+    # because the virtual switch does not model hardware warm-boot anyway. On real
+    # hardware all reboot types (cold/warm/fast/reload) still run as before.
     if rand_selected_dut.facts['asic_type'] == 'vs' and reboot_type != 'reload':
         pytest.skip("Skipping {} reboot on VS/KVM to avoid module timeout; "
                     "config reload covers hash persistence validation.".format(reboot_type))


### PR DESCRIPTION
### Description of PR

Summary:
Skip cold/warm/fast reboot in `test_generic_hash.py::test_reboot` on VS/KVM to avoid 20-minute module timeout. Config reload is retained for hash persistence testing.

Mitigates #23637 — the underlying KVM perf/timeout issue stays open and is tracked under the broader `kvm-perf` concern; this PR only stops the bleeding for `test_generic_hash`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

On VS/KVM Elastictest workers, `test_generic_hash.py` intermittently hits the 20-minute per-module timeout. The `test_reboot` function performs a full device reboot (cold/warm/fast, randomly chosen) which takes 5–8 minutes on KVM. Combined with hash configuration, two PTF traffic runs, and route convergence waits, the total runtime exceeds the module timeout—especially on loaded workers with slow disk I/O.

#### How did you do it?

On VS (`asic_type == 'vs'`), skip every reboot type except `reload`. Config reload exercises the same CONFIG_DB save/restore path that hash persistence depends on, without the slow VM reboot overhead. SAI warm-restart semantics aren't covered — that's acceptable on VS because the virtual switch doesn't model hardware warm-boot anyway. On real hardware all reboot types (cold/warm/fast/reload) still run as before.

#### How did you verify/test it?

- `flake8 --max-line-length=120` passes clean
- On VS/KVM: `test_reboot[reload]` still runs; cold/warm/fast are skipped
- On hardware: all reboot types continue to run as before (no change)

#### Any platform specific information?

VS/KVM only — hardware platforms are unaffected.

#### Supported testbed topology if it's a new test case?

N/A — bug fix.

### Documentation

N/A

---
*This PR was generated with the assistance of an AI agent on behalf of @yxieca.*
