### PR TITLE
[golden_config]: Add buffer and QoS config generation on top of port map for FT2/LT2 topologies

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -840,11 +840,44 @@
         shell: config load_minigraph -y
         when: "'lt2' in topo or 'ft2' in topo"
 
+      - name: Extract port speeds and hwsku from lab CSV files for PORT override
+        delegate_to: localhost
+        shell: |
+          python3 -c "
+          import csv, json
+          lab = '{{ lab_name }}'
+          hostname = '{{ inventory_hostname }}'
+          links_csv = '{{ links_csv | default('') }}' or 'files/sonic_' + lab + '_links.csv'
+          devices_csv = '{{ devices_csv | default('') }}' or 'files/sonic_' + lab + '_devices.csv'
+          port_speeds = {}
+          with open(links_csv) as f:
+              reader = csv.DictReader(f)
+              for row in reader:
+                  if row.get('StartDevice') == hostname:
+                      port_speeds[row['StartPort']] = row['BandWidth']
+                  elif row.get('EndDevice') == hostname:
+                      port_speeds[row['EndPort']] = row['BandWidth']
+          hwsku = ''
+          try:
+              with open(devices_csv) as f:
+                  reader = csv.DictReader(f)
+                  for row in reader:
+                      if row.get('Hostname') == hostname:
+                          hwsku = row.get('HwSku', '')
+                          break
+          except FileNotFoundError:
+              pass
+          print(json.dumps({'port_speeds': port_speeds, 'hwsku': hwsku}))
+          "
+        register: lab_csv_result
+        when: port_override_from_links | default(false) | bool
+
       - name: Generate golden_config_db.json
         generate_golden_config_db:
           topo_name: "{{ topo }}"
           port_index_map: "{{ port_index_map | default({}) }}"
-          hwsku: "{{ hwsku }}"
+          port_speeds: "{{ (lab_csv_result.stdout | from_json).port_speeds if (port_override_from_links | default(false) | bool) and lab_csv_result is defined and lab_csv_result.rc == 0 else omit }}"
+          hwsku: "{{ (lab_csv_result.stdout | from_json).hwsku if (port_override_from_links | default(false) | bool) and lab_csv_result is defined and lab_csv_result.rc == 0 and (lab_csv_result.stdout | from_json).hwsku else hwsku }}"
           vm_configuration: "{{ configuration if topo == 't1-filterleaf-lag' else omit }}"
           is_lit_mode: "{{ is_lit_mode | default(true) }}"
           npu_index: "{{ dut_index | default(0) | int }}"

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -884,6 +884,9 @@
           duts_list: "{{ testbed_facts['duts'] | default([]) }}"
           dut_loopbacks: "{{ topology.DUT.loopback | default({}) }}"
           console_ports: "{{ device_serial_link[inventory_hostname] | default(omit) if 'c0' in topo else omit }}"
+          cable_length: "{{ breakout_default_cable_length | default('40m') }}"
+          buffer_gen: "{{ buffer_gen | default(false) | bool }}"
+          neighbor_data: "{{ neighbor_data | default(omit) }}"
         become: true
 
       - name: Copy macsec profile json to dut

--- a/ansible/library/buffer_config_helper.py
+++ b/ansible/library/buffer_config_helper.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""
+Generate buffer and QoS tables for golden_config_db.json.
+
+Produces all buffer-related config_db tables for a given PORT table so that
+a DUT can perform a full ``config reload`` without crashing due to missing
+buffer configuration.
+
+Tables generated:
+    BUFFER_POOL, BUFFER_PROFILE, BUFFER_PG, BUFFER_QUEUE,
+    QUEUE, PORT_QOS_MAP, CABLE_LENGTH, SCHEDULER, WRED_PROFILE
+"""
+
+import re
+
+PORT_NAME_RE = re.compile(r"^Ethernet(\d+)$")
+
+# Default pool sizes (from reference config_db_moby.json)
+DEFAULT_INGRESS_POOL_SIZE = "164075364"
+DEFAULT_EGRESS_POOL_SIZE = "164075364"
+
+# Default management port indices — these get reduced QoS (no PFC)
+DEFAULT_MGMT_PORT_INDICES = [512, 513]
+
+# Queue-to-scheduler mapping (queue_id -> scheduler name)
+QUEUE_SCHEDULER_MAP = {
+    0: "SCHEDULER_DEFAULT",
+    1: "SCHEDULER_Q1",
+    2: "SCHEDULER_DEFAULT",
+    3: "SCHEDULER_Q3",
+    4: "SCHEDULER_Q4",
+    5: "SCHEDULER_DEFAULT",
+    6: "SCHEDULER_Q6",
+    7: "SCHEDULER_DEFAULT",
+}
+
+# Lossless queues that also get a WRED profile
+QUEUE_WRED_MAP = {
+    3: "WRED_LOSSLESS_Q3",
+    4: "WRED_LOSSLESS_Q4",
+}
+
+
+# ---------------------------------------------------------------------------
+# Placeholder functions — the user will supply real formulas later
+# ---------------------------------------------------------------------------
+
+def compute_xoff(speed, cable_length):
+    """Compute xoff value for a lossless BUFFER_PROFILE entry.
+
+    Args:
+        speed: port speed as string (e.g. "400000")
+        cable_length: cable length as string (e.g. "40m")
+
+    Returns:
+        xoff value as a string
+    """
+    # TODO: replace with real formula
+    return "0"
+
+
+def compute_static_th(speed, cable_length):
+    """Compute static_th value for a lossless BUFFER_PROFILE entry.
+
+    Args:
+        speed: port speed as string (e.g. "400000")
+        cable_length: cable length as string (e.g. "40m")
+
+    Returns:
+        static_th value as a string
+    """
+    # TODO: replace with real formula
+    return "0"
+
+
+def compute_pool_xoff(port_speeds, cable_lengths):
+    """Compute xoff value for the ingress_lossless_pool.
+
+    Args:
+        port_speeds: list of speed strings for all ports
+        cable_lengths: list of cable length strings for all ports
+
+    Returns:
+        pool xoff value as a string
+    """
+    # TODO: replace with real formula
+    return "0"
+
+
+# ---------------------------------------------------------------------------
+# Table generators
+# ---------------------------------------------------------------------------
+
+def _parse_port_index(port_name):
+    """Extract the numeric index from an Ethernet port name."""
+    m = PORT_NAME_RE.match(port_name)
+    return int(m.group(1)) if m else None
+
+
+def _sort_port_names(port_names):
+    """Sort port names numerically by Ethernet index."""
+    def _key(name):
+        idx = _parse_port_index(name)
+        return (idx is None, idx if idx is not None else 0, name)
+    return sorted(port_names, key=_key)
+
+
+def _is_mgmt_port(port_name, mgmt_port_indices):
+    """Check if a port is a management port based on its index."""
+    idx = _parse_port_index(port_name)
+    if idx is None:
+        return False
+    return idx in mgmt_port_indices
+
+
+def generate_buffer_pool(ingress_pool_size=DEFAULT_INGRESS_POOL_SIZE,
+                         egress_pool_size=DEFAULT_EGRESS_POOL_SIZE,
+                         pool_xoff="0"):
+    """Generate the BUFFER_POOL table.
+
+    Pool sizes are kept as-is (passed in, not computed).
+    The xoff for ingress_lossless_pool comes from the placeholder function.
+    """
+    return {
+        "egress_lossless_pool": {
+            "mode": "static",
+            "size": egress_pool_size,
+            "type": "egress",
+        },
+        "ingress_lossless_pool": {
+            "mode": "dynamic",
+            "size": ingress_pool_size,
+            "type": "ingress",
+            "xoff": pool_xoff,
+        },
+    }
+
+
+def generate_buffer_profiles(speed_cable_pairs):
+    """Generate the BUFFER_PROFILE table.
+
+    Creates a pg_lossless profile for each unique (speed, cable_length) pair
+    and three static profiles that don't vary by speed.
+
+    Args:
+        speed_cable_pairs: set of (speed_str, cable_length_str) tuples
+
+    Returns:
+        dict of profile_name -> profile_fields
+    """
+    profiles = {
+        "egress_lossless_profile": {
+            "pool": "egress_lossless_pool",
+            "size": "0",
+            "static_th": "165364160",
+        },
+        "egress_lossy_profile": {
+            "dynamic_th": "0",
+            "pool": "egress_lossless_pool",
+            "size": "1778",
+        },
+        "ingress_lossy_profile": {
+            "pool": "ingress_lossless_pool",
+            "size": "0",
+            "static_th": "165364160",
+        },
+    }
+
+    for speed, cable in sorted(speed_cable_pairs):
+        name = "pg_lossless_{}_{}_profile".format(speed, cable)
+        profiles[name] = {
+            "dynamic_th": "0",
+            "pool": "ingress_lossless_pool",
+            "size": "18796",
+            "xoff": compute_xoff(speed, cable),
+            "xon": "0",
+            "xon_offset": "3556",
+        }
+
+    return profiles
+
+
+def generate_buffer_pg(port_names, speed_cable_map, mgmt_port_indices=None):
+    """Generate the BUFFER_PG table.
+
+    Each port gets:
+        PG 0       -> ingress_lossy_profile
+        PG 3-4     -> pg_lossless_{speed}_{cable}_profile  (data ports only)
+
+    Management ports only get PG 0 (no lossless PG).
+
+    Args:
+        port_names: list of port name strings
+        speed_cable_map: dict of port_name -> (speed_str, cable_length_str)
+        mgmt_port_indices: list of integer port indices for management ports
+
+    Returns:
+        dict of "port|pg" -> {"profile": profile_name}
+    """
+    if mgmt_port_indices is None:
+        mgmt_port_indices = list(DEFAULT_MGMT_PORT_INDICES)
+
+    buffer_pg = {}
+    for port in _sort_port_names(port_names):
+        buffer_pg["{}|0".format(port)] = {
+            "profile": "ingress_lossy_profile",
+        }
+        if not _is_mgmt_port(port, mgmt_port_indices):
+            speed, cable = speed_cable_map[port]
+            profile_name = "pg_lossless_{}_{}_profile".format(speed, cable)
+            buffer_pg["{}|3-4".format(port)] = {
+                "profile": profile_name,
+            }
+    return buffer_pg
+
+
+def generate_buffer_queue(port_names):
+    """Generate the BUFFER_QUEUE table.
+
+    Each port gets three queue range entries:
+        0-2  -> egress_lossy_profile
+        3-4  -> egress_lossless_profile
+        5-6  -> egress_lossy_profile
+
+    Args:
+        port_names: list of port name strings
+
+    Returns:
+        dict of "port|queue_range" -> {"profile": profile_name}
+    """
+    buffer_queue = {}
+    for port in _sort_port_names(port_names):
+        buffer_queue["{}|0-2".format(port)] = {
+            "profile": "egress_lossy_profile",
+        }
+        buffer_queue["{}|3-4".format(port)] = {
+            "profile": "egress_lossless_profile",
+        }
+        buffer_queue["{}|5-6".format(port)] = {
+            "profile": "egress_lossy_profile",
+        }
+    return buffer_queue
+
+
+def generate_queue_table(port_names):
+    """Generate the QUEUE table.
+
+    Each port gets 8 queue entries (0-7) with scheduler assignments.
+    Lossless queues (3, 4) also get WRED profiles.
+
+    Args:
+        port_names: list of port name strings
+
+    Returns:
+        dict of "port|queue_id" -> {scheduler, [wred_profile]}
+    """
+    queue_table = {}
+    for port in _sort_port_names(port_names):
+        for qid in range(8):
+            entry = {"scheduler": QUEUE_SCHEDULER_MAP[qid]}
+            if qid in QUEUE_WRED_MAP:
+                entry["wred_profile"] = QUEUE_WRED_MAP[qid]
+            queue_table["{}|{}".format(port, qid)] = entry
+    return queue_table
+
+
+def generate_port_qos_map(port_names, mgmt_port_indices=None):
+    """Generate the PORT_QOS_MAP table.
+
+    Normal data ports get the full 6-field QoS config (with PFC).
+    Management ports get a reduced 3-field config (no PFC).
+    A ``global`` entry is always included.
+
+    Args:
+        port_names: list of port name strings
+        mgmt_port_indices: list of integer port indices that are management
+            ports (default: [512, 513])
+
+    Returns:
+        dict of port_name_or_global -> qos_fields
+    """
+    if mgmt_port_indices is None:
+        mgmt_port_indices = list(DEFAULT_MGMT_PORT_INDICES)
+
+    qos_map = {}
+    for port in _sort_port_names(port_names):
+        if _is_mgmt_port(port, mgmt_port_indices):
+            qos_map[port] = {
+                "dscp_to_tc_map": "AZURE",
+                "tc_to_pg_map": "AZURE",
+                "tc_to_queue_map": "AZURE",
+            }
+        else:
+            qos_map[port] = {
+                "dscp_to_tc_map": "AZURE",
+                "pfc_enable": "3,4",
+                "pfc_to_queue_map": "AZURE",
+                "pfcwd_sw_enable": "3,4",
+                "tc_to_pg_map": "AZURE",
+                "tc_to_queue_map": "AZURE",
+            }
+
+    qos_map["global"] = {
+        "dscp_to_tc_map": "AZURE",
+    }
+    return qos_map
+
+
+def generate_cable_length(port_names, cable_length_default="40m",
+                         port_cable_lengths=None):
+    """Generate the CABLE_LENGTH table.
+
+    Uses per-port cable lengths when available, otherwise falls back to
+    the default for all ports.
+
+    Args:
+        port_names: list of port name strings
+        cable_length_default: fallback cable length string (e.g. "40m")
+        port_cable_lengths: optional dict of port_name -> cable_length.
+            Ports not in this dict get ``cable_length_default``.
+
+    Returns:
+        dict with single key "AZURE" mapping port names to lengths
+    """
+    azure = {}
+    for port in _sort_port_names(port_names):
+        if port_cable_lengths and port in port_cable_lengths:
+            azure[port] = port_cable_lengths[port]
+        else:
+            azure[port] = cable_length_default
+    return {"AZURE": azure}
+
+
+def generate_scheduler_and_wred():
+    """Generate constant SCHEDULER and WRED_PROFILE tables.
+
+    These tables have no per-port variation; values match the reference
+    config_db_moby.json.
+
+    Returns:
+        tuple of (scheduler_dict, wred_profile_dict)
+    """
+    scheduler = {
+        "SCHEDULER_DEFAULT": {"type": "DWRR", "weight": "10"},
+        "SCHEDULER_Q1": {"type": "DWRR", "weight": "10"},
+        "SCHEDULER_Q3": {"type": "DWRR", "weight": "20"},
+        "SCHEDULER_Q4": {"type": "DWRR", "weight": "10"},
+        "SCHEDULER_Q6": {"type": "DWRR", "weight": "70"},
+    }
+
+    wred_entry = {
+        "ecn": "ecn_all",
+        "green_drop_probability": "5",
+        "green_max_threshold": "262144",
+        "green_min_threshold": "131072",
+        "red_drop_probability": "5",
+        "red_max_threshold": "262144",
+        "red_min_threshold": "131072",
+        "wred_green_enable": "true",
+        "wred_red_enable": "true",
+        "wred_yellow_enable": "true",
+        "yellow_drop_probability": "5",
+        "yellow_max_threshold": "262144",
+        "yellow_min_threshold": "131072",
+    }
+
+    wred_profile = {
+        "WRED_LOSSLESS_Q3": dict(wred_entry),
+        "WRED_LOSSLESS_Q4": dict(wred_entry),
+    }
+
+    return scheduler, wred_profile
+
+
+def generate_all_buffer_tables(port_table,
+                               cable_length_default="40m",
+                               mgmt_port_indices=None,
+                               ingress_pool_size=DEFAULT_INGRESS_POOL_SIZE,
+                               egress_pool_size=DEFAULT_EGRESS_POOL_SIZE,
+                               port_cable_lengths=None):
+    """Generate all buffer and QoS tables for a golden config.
+
+    This is the main entry point. Given a PORT table (as produced by
+    ``generate_port_table_from_platform`` or minigraph), it produces all
+    8 buffer/QoS tables ready to be merged into the golden config JSON.
+
+    Args:
+        port_table: dict of port_name -> port_entry (must have "speed" field)
+        cable_length_default: default cable length string (e.g. "40m")
+        mgmt_port_indices: list of int port indices for management ports
+            (default: [512, 513])
+        ingress_pool_size: pool size string for ingress_lossless_pool
+        egress_pool_size: pool size string for egress_lossless_pool
+        port_cable_lengths: optional dict of port_name -> cable_length.
+            When provided, each port uses its own cable length for
+            profile selection. Ports not in this dict fall back to
+            ``cable_length_default``.
+
+    Returns:
+        dict with keys: BUFFER_POOL, BUFFER_PROFILE, BUFFER_PG,
+            BUFFER_QUEUE, QUEUE, PORT_QOS_MAP, CABLE_LENGTH,
+            SCHEDULER, WRED_PROFILE
+    """
+    if mgmt_port_indices is None:
+        mgmt_port_indices = list(DEFAULT_MGMT_PORT_INDICES)
+
+    port_names = list(port_table.keys())
+
+    # Build per-port (speed, cable_length) mapping
+    speed_cable_map = {}
+    port_speeds_list = []
+    cable_lengths_list = []
+    for port in port_names:
+        speed = port_table[port].get("speed", "0")
+        if port_cable_lengths and port in port_cable_lengths:
+            cable = port_cable_lengths[port]
+        else:
+            cable = cable_length_default
+        speed_cable_map[port] = (speed, cable)
+        port_speeds_list.append(speed)
+        cable_lengths_list.append(cable)
+
+    # Unique (speed, cable) pairs for profile generation
+    speed_cable_pairs = set(speed_cable_map.values())
+
+    # Pool xoff from placeholder
+    pool_xoff = compute_pool_xoff(port_speeds_list, cable_lengths_list)
+
+    # Generate all tables
+    scheduler, wred_profile = generate_scheduler_and_wred()
+
+    result = {
+        "BUFFER_POOL": generate_buffer_pool(
+            ingress_pool_size, egress_pool_size, pool_xoff),
+        "BUFFER_PROFILE": generate_buffer_profiles(speed_cable_pairs),
+        "BUFFER_PG": generate_buffer_pg(
+            port_names, speed_cable_map, mgmt_port_indices),
+        "BUFFER_QUEUE": generate_buffer_queue(port_names),
+        "QUEUE": generate_queue_table(port_names),
+        "PORT_QOS_MAP": generate_port_qos_map(port_names, mgmt_port_indices),
+        "CABLE_LENGTH": generate_cable_length(
+            port_names, cable_length_default, port_cable_lengths),
+        "SCHEDULER": scheduler,
+        "WRED_PROFILE": wred_profile,
+    }
+
+    return result

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -16,6 +16,9 @@ import ipaddress
 from ansible.module_utils.basic import AnsibleModule
 from sonic_py_common import device_info, multi_asic
 from ansible.module_utils.smartswitch_utils import smartswitch_hwsku_config, smartswitch_vlan_config
+from buffer_config_helper import generate_all_buffer_tables
+from get_ports2cable import (normalize_role, resolve_port_cable_lengths,
+                             resolve_ports2cable_dict)
 
 DOCUMENTATION = '''
 module: generate_golden_config_db.py
@@ -181,10 +184,15 @@ class GenerateGoldenConfigDBModule(object):
                                     hwsku=dict(required=False, type='str', default=None),
                                     vm_configuration=dict(required=False, type='dict', default={}),
                                     is_lit_mode=dict(required=False, type='bool', default=True),
+                                    bgp_confd_asn=dict(required=False, type='str', default=None),
+                                    bgp_confd_peers=dict(required=False, type='str', default=None),
                                     npu_index=dict(required=False, type='int', default=0),
                                     duts_list=dict(required=False, type='list', default=[]),
                                     dut_loopbacks=dict(required=False, type='dict', default={}),
-                                    console_ports=dict(required=False, type='dict', default=None)),
+                                    console_ports=dict(required=False, type='dict', default=None),
+                                    cable_length=dict(required=False, type='str', default='40m'),
+                                    buffer_gen=dict(required=False, type='bool', default=False),
+                                    neighbor_data=dict(required=False, type='dict', default=None)),
                                     supports_check_mode=True)
         self.topo_name = self.module.params['topo_name']
         self.port_index_map = self.module.params['port_index_map']
@@ -203,6 +211,9 @@ class GenerateGoldenConfigDBModule(object):
         self.duts_list = self.module.params['duts_list']
         self.dut_loopbacks = self.module.params['dut_loopbacks']
         self.console_ports = self.module.params['console_ports']
+        self.cable_length = self.module.params['cable_length']
+        self.buffer_gen = self.module.params['buffer_gen']
+        self.neighbor_data = self.module.params['neighbor_data']
 
     def generate_mgfx_golden_config_db(self):
         rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
@@ -942,6 +953,44 @@ class GenerateGoldenConfigDBModule(object):
         ori_config_db["DEVICE_METADATA"]["localhost"]["zebra_nexthop"] = zebra_nexthop
         return json.dumps(ori_config_db, indent=4)
 
+    def _resolve_cable_lengths(self, port_table, ori_config):
+        """Resolve per-port cable lengths from neighbor data and ports2cable.
+
+        Uses neighbor_data (passed from playbook) if available, otherwise
+        falls back to DEVICE_NEIGHBOR from the minigraph config. Resolves
+        the ports2cable mapping from the platform-specific defaults file
+        or hardcoded defaults.
+
+        Returns:
+            dict of port_name -> cable_length_string
+        """
+        device_metadata = ori_config.get("DEVICE_METADATA", {})
+        my_role_raw = device_metadata.get("localhost", {}).get("type", "")
+        my_role = normalize_role(my_role_raw)
+
+        ports2cable = resolve_ports2cable_dict(
+            self.platform, self.hwsku, device_metadata)
+
+        # Build per-port neighbor type mapping
+        neighbor_types = {}
+        if self.neighbor_data:
+            # neighbor_data passed directly from playbook: port -> neighbor_type
+            neighbor_types = self.neighbor_data
+        else:
+            # Fall back to minigraph DEVICE_NEIGHBOR + DEVICE_NEIGHBOR_METADATA
+            device_neighbor = ori_config.get("DEVICE_NEIGHBOR", {})
+            device_neighbor_meta = ori_config.get("DEVICE_NEIGHBOR_METADATA", {})
+            for port_name in port_table:
+                neighbor_entry = device_neighbor.get(port_name, {})
+                neighbor_name = neighbor_entry.get("name")
+                if neighbor_name and neighbor_name in device_neighbor_meta:
+                    neighbor_types[port_name] = device_neighbor_meta[
+                        neighbor_name].get("type", "")
+
+        return resolve_port_cable_lengths(
+            list(port_table.keys()), neighbor_types, ports2cable,
+            my_role, self.cable_length)
+
     def generate_lt2_ft2_golden_config_db(self):
         """
         Generate golden_config for FT2/LT2 topologies.
@@ -949,6 +998,9 @@ class GenerateGoldenConfigDBModule(object):
         Rebuilds the PORT table from platform.json to get correct lanes, aliases,
         and indices for the current breakout mode. Falls back to minigraph PORT
         with FEC added if platform.json is not available.
+
+        When buffer_gen is enabled, includes all buffer and QoS tables with
+        per-port cable lengths resolved from neighbor data.
         """
         SUPPORTED_TOPO = ["ft2-64", "lt2-p32o64", "lt2-o128"]
         if self.topo_name not in SUPPORTED_TOPO:
@@ -970,7 +1022,14 @@ class GenerateGoldenConfigDBModule(object):
 
         port_table = generate_port_table_from_platform(port_speeds, platform_json_path)
         if port_table:
-            return json.dumps({"PORT": port_table}, indent=4)
+            golden_config = {"PORT": port_table}
+            if self.buffer_gen:
+                port_cable_lengths = self._resolve_cable_lengths(
+                    port_table, ori_config)
+                golden_config.update(generate_all_buffer_tables(
+                    port_table, self.cable_length,
+                    port_cable_lengths=port_cable_lengths))
+            return json.dumps(golden_config, indent=4)
 
         # Fallback: use minigraph PORT with FEC added for high-speed ports
         SUPPORTED_PORT_SPEED = ["200000", "400000", "800000"]
@@ -978,7 +1037,14 @@ class GenerateGoldenConfigDBModule(object):
             if config["speed"] in SUPPORTED_PORT_SPEED and "fec" not in config:
                 config["fec"] = "rs"
 
-        return json.dumps({"PORT": minigraph_ports}, indent=4)
+        golden_config = {"PORT": minigraph_ports}
+        if self.buffer_gen:
+            port_cable_lengths = self._resolve_cable_lengths(
+                minigraph_ports, ori_config)
+            golden_config.update(generate_all_buffer_tables(
+                minigraph_ports, self.cable_length,
+                port_cable_lengths=port_cable_lengths))
+        return json.dumps(golden_config, indent=4)
 
     def generate_t0_f2_golden_config_db(self):
         """

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -9,6 +9,7 @@ import copy
 from jinja2 import Template
 import logging
 import json
+import os
 import re
 import ipaddress
 
@@ -52,10 +53,129 @@ def is_full_lossy_hwsku(hwsku):
     return hwsku in LOSSY_HWSKU
 
 
+def find_matching_breakout_mode(breakout_modes, num_ports, speed_mbps):
+    """Find matching breakout mode in platform.json's breakout_modes dict.
+
+    Returns (bmode_key, aliases_list) or (None, None) if no match found.
+    """
+    speed_g = speed_mbps // 1000
+    for bmode_key, bmode_aliases in breakout_modes.items():
+        bmode_clean = re.sub(r'\[.*\]', '', bmode_key)
+        m = re.match(r'(\d+)x(\d+)G', bmode_clean)
+        if not m or int(m.group(1)) != num_ports:
+            continue
+        default_speed_g = int(m.group(2))
+        if default_speed_g == speed_g:
+            return bmode_key, bmode_aliases
+        bracket_match = re.search(r'\[(.*?)\]', bmode_key)
+        if bracket_match:
+            supported = [int(s.strip().replace('G', '')) for s in bracket_match.group(1).split(',')]
+            if speed_g in supported:
+                return bmode_key, bmode_aliases
+    return None, None
+
+
+def generate_port_table_from_platform(port_speeds, platform_json_path):
+    """Generate a PORT table from port names/speeds + platform.json.
+
+    For each physical cage in platform.json, finds which ports from port_speeds
+    belong to it, determines the breakout mode, and generates PORT entries with
+    correct lanes, aliases, indices, speed, and FEC.
+
+    Args:
+        port_speeds: dict of {port_name: speed_str} from minigraph
+        platform_json_path: path to platform.json on the DUT
+
+    Returns:
+        dict of PORT table entries, or None on failure
+    """
+    if not os.path.isfile(platform_json_path):
+        return None
+
+    with open(platform_json_path) as f:
+        platform_data = json.load(f)
+
+    if 'interfaces' not in platform_data:
+        return None
+
+    plat_intfs = platform_data['interfaces']
+    port_table = {}
+
+    for cage_name in sorted(plat_intfs.keys(), key=lambda x: int(x.replace('Ethernet', ''))):
+        cage_info = plat_intfs[cage_name]
+        cage_base = int(cage_name.replace('Ethernet', ''))
+        lane_str = cage_info.get('lanes', '')
+        lane_list = [l.strip() for l in lane_str.split(',') if l.strip()]
+        total_lanes = len(lane_list)
+        if total_lanes == 0:
+            continue
+
+        index_str = cage_info.get('index', '')
+        index_list = [i.strip() for i in index_str.split(',') if i.strip()]
+        breakout_modes = cage_info.get('breakout_modes', {})
+
+        # Find which ports from port_speeds belong to this cage
+        ports_in_cage = {}
+        for pname, pspeed in port_speeds.items():
+            if not pname.startswith('Ethernet') or not pname[8:].isdigit():
+                continue
+            pnum = int(pname[8:])
+            if cage_base <= pnum < cage_base + total_lanes:
+                ports_in_cage[pname] = int(pspeed)
+
+        if not ports_in_cage:
+            continue
+
+        num_ports = len(ports_in_cage)
+        speed_mbps = list(ports_in_cage.values())[0]
+
+        # Find matching breakout mode for alias resolution
+        _, aliases = find_matching_breakout_mode(breakout_modes, num_ports, speed_mbps)
+
+        # Fallback alias generation
+        if aliases is None:
+            cage_idx = index_list[0] if index_list else str(cage_base // total_lanes + 1)
+            if num_ports == 1:
+                aliases = ['etp{}'.format(cage_idx)]
+            else:
+                aliases = ['etp{}{}'.format(cage_idx, chr(ord('a') + i)) for i in range(num_ports)]
+
+        # Generate PORT entries
+        lanes_per_port = total_lanes // num_ports
+        sorted_port_names = sorted(ports_in_cage.keys(), key=lambda x: int(x[8:]))
+
+        for sub_idx, port_name in enumerate(sorted_port_names):
+            start_lane = sub_idx * lanes_per_port
+            end_lane = start_lane + lanes_per_port
+            sub_lanes = ','.join(lane_list[start_lane:end_lane])
+
+            alias = aliases[sub_idx] if sub_idx < len(aliases) else port_name
+            index = index_list[start_lane] if start_lane < len(index_list) else '1'
+
+            port_entry = {
+                'alias': alias,
+                'lanes': sub_lanes,
+                'speed': str(speed_mbps),
+                'index': index,
+                'admin_status': 'up',
+                'mtu': '9100',
+                'tpid': '0x8100',
+                'pfc_asym': 'off'
+            }
+
+            if speed_mbps >= 200000:
+                port_entry['fec'] = 'rs'
+
+            port_table[port_name] = port_entry
+
+    return port_table
+
+
 class GenerateGoldenConfigDBModule(object):
     def __init__(self):
         self.module = AnsibleModule(argument_spec=dict(topo_name=dict(required=True, type='str'),
                                     port_index_map=dict(required=False, type='dict', default=None),
+                                    port_speeds=dict(required=False, type='dict', default=None),
                                     macsec_profile=dict(required=False, type='str', default=None),
                                     num_asics=dict(required=False, type='int', default=1),
                                     hwsku=dict(required=False, type='str', default=None),
@@ -68,10 +188,14 @@ class GenerateGoldenConfigDBModule(object):
                                     supports_check_mode=True)
         self.topo_name = self.module.params['topo_name']
         self.port_index_map = self.module.params['port_index_map']
+        self.port_speeds = self.module.params['port_speeds']
         self.macsec_profile = self.module.params['macsec_profile']
         self.num_asics = self.module.params['num_asics']
         self.hwsku = self.module.params['hwsku']
-        self.platform, _ = device_info.get_platform_and_hwsku()
+        self.platform, dut_hwsku = device_info.get_platform_and_hwsku()
+        # Use DUT's own hwsku as fallback when playbook doesn't provide one
+        if not self.hwsku and dut_hwsku:
+            self.hwsku = dut_hwsku
 
         self.vm_configuration = self.module.params['vm_configuration']
         self.is_lit_mode = self.module.params['is_lit_mode']
@@ -820,21 +944,41 @@ class GenerateGoldenConfigDBModule(object):
 
     def generate_lt2_ft2_golden_config_db(self):
         """
-        Generate golden_config for FT2 to enable FEC.
-        **Only PORT table is updated**.
+        Generate golden_config for FT2/LT2 topologies.
+
+        Rebuilds the PORT table from platform.json to get correct lanes, aliases,
+        and indices for the current breakout mode. Falls back to minigraph PORT
+        with FEC added if platform.json is not available.
         """
         SUPPORTED_TOPO = ["ft2-64", "lt2-p32o64", "lt2-o128"]
         if self.topo_name not in SUPPORTED_TOPO:
             return "{}"
-        SUPPORTED_PORT_SPEED = ["200000", "400000", "800000"]
+
         ori_config = json.loads(self.get_config_from_minigraph())
-        port_config = ori_config.get("PORT", {})
-        for name, config in port_config.items():
-            # Enable FEC for ports with supported speed
+        minigraph_ports = ori_config.get("PORT", {})
+
+        # Try to rebuild PORT from platform.json for correct lanes/aliases.
+        # Prefer links.csv port speeds (self.port_speeds) over minigraph ports,
+        # because links.csv reflects the desired breakout layout after an HWSKU
+        # change, while minigraph may still have the old port count/speeds.
+        platform_json_path = os.path.join(
+            '/usr/share/sonic/device', self.platform, 'platform.json')
+        if self.port_speeds:
+            port_speeds = {name: str(speed) for name, speed in self.port_speeds.items()}
+        else:
+            port_speeds = {name: cfg.get("speed", "0") for name, cfg in minigraph_ports.items()}
+
+        port_table = generate_port_table_from_platform(port_speeds, platform_json_path)
+        if port_table:
+            return json.dumps({"PORT": port_table}, indent=4)
+
+        # Fallback: use minigraph PORT with FEC added for high-speed ports
+        SUPPORTED_PORT_SPEED = ["200000", "400000", "800000"]
+        for name, config in minigraph_ports.items():
             if config["speed"] in SUPPORTED_PORT_SPEED and "fec" not in config:
                 config["fec"] = "rs"
 
-        return json.dumps({"PORT": port_config}, indent=4)
+        return json.dumps({"PORT": minigraph_ports}, indent=4)
 
     def generate_t0_f2_golden_config_db(self):
         """
@@ -951,6 +1095,27 @@ class GenerateGoldenConfigDBModule(object):
                     "has_per_asic_scope": "True",
                 }
             })
+
+        # Ensure DEVICE_METADATA always includes hwsku — config override-config-table
+        # replaces the entire table, so missing fields (like hwsku) get wiped on the DUT
+        config_dict = json.loads(config)
+        if "DEVICE_METADATA" not in config_dict:
+            config_dict["DEVICE_METADATA"] = {}
+        if "localhost" not in config_dict["DEVICE_METADATA"]:
+            config_dict["DEVICE_METADATA"]["localhost"] = {}
+        dm = config_dict["DEVICE_METADATA"]["localhost"]
+        if not dm.get("hwsku"):
+            hwsku = self.hwsku
+            if not hwsku:
+                rc, out, _ = self.module.run_command(
+                    "sonic-cfggen -d -v 'DEVICE_METADATA[\"localhost\"][\"hwsku\"]'")
+                if rc == 0 and out.strip():
+                    hwsku = out.strip()
+            if hwsku:
+                dm["hwsku"] = hwsku
+        if not dm.get("platform") and self.platform:
+            dm["platform"] = self.platform
+        config = json.dumps(config_dict, indent=4)
 
         with open(GOLDEN_CONFIG_DB_PATH, "w") as temp_file:
             temp_file.write(config)

--- a/ansible/library/get_ports2cable.py
+++ b/ansible/library/get_ports2cable.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""
+Determine the applicable ports2cable mapping for a SONiC device.
+
+Replicates the Jinja2 logic in buffers_config.j2:
+  1. Resolve the device role -> topology postfix (t0, t1, t2, etc.)
+  2. Locate the platform-specific buffers_defaults_<postfix>.j2
+  3. If that file defines ports2cable, parse and return it
+  4. Otherwise, return the hardcoded defaults from buffers_config.j2
+
+This module can be used standalone (CLI) or imported for per-port cable
+length resolution from neighbor data.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+HARDCODED_PORTS2CABLE = {
+    'internal':                              '5m',
+    'torrouter_server':                      '5m',
+    'leafrouter_torrouter':                  '40m',
+    'upperspinerouter_spinerouter':          '30m',
+    'upperspinerouter_lowerspinerouter':     '30m',
+    'spinerouter_leafrouter':                '300m',
+    'lowerspinerouter_leafrouter':           '500m',
+    'fabricspinerouter_lowerspinerouter':    '5m',
+    'regionalhub_upperspinerouter':          '80000m',
+    'regionalhub_spinerouter':              '80000m',
+    'aznghub_upperspinerouter':             '80000m',
+    'aznghub_spinerouter':                  '80000m',
+}
+
+# Map full SONiC role names to the simplified form used in ports2cable keys.
+# Matching is done case-insensitively against the lowercased role string.
+# Order matters — more specific patterns must come before general ones.
+_ROLE_NORMALIZE_PATTERNS = [
+    ('lowerspinerouter', 'lowerspinerouter'),
+    ('upperspinerouter', 'upperspinerouter'),
+    ('fabricspinerouter', 'fabricspinerouter'),
+    ('regionalhub', 'regionalhub'),
+    ('aznghub', 'aznghub'),
+    ('torrouter', 'torrouter'),
+    ('leafrouter', 'leafrouter'),
+    ('spinerouter', 'spinerouter'),
+    ('server', 'server'),
+]
+
+
+def normalize_role(role_type):
+    """Normalize a SONiC device role to the simplified ports2cable key form.
+
+    Examples:
+        BackEndToRRouter   -> torrouter
+        BackEndLeafRouter  -> leafrouter
+        SpineRouter        -> spinerouter
+        LowerSpineRouter   -> lowerspinerouter
+        FabricSpineRouter  -> fabricspinerouter
+        Server             -> server
+
+    Args:
+        role_type: device type string from DEVICE_METADATA or
+            DEVICE_NEIGHBOR_METADATA (e.g. "BackEndToRRouter")
+
+    Returns:
+        Normalized role string, or the lowercased input if no pattern matches.
+    """
+    if not role_type:
+        return ''
+    lowered = role_type.lower()
+    for pattern, normalized in _ROLE_NORMALIZE_PATTERNS:
+        if pattern in lowered:
+            return normalized
+    return lowered
+
+
+def resolve_ports2cable_key(my_role, neighbor_role):
+    """Build a ports2cable lookup key from two normalized roles.
+
+    Args:
+        my_role: normalized role of the local device (e.g. "leafrouter")
+        neighbor_role: normalized role of the neighbor (e.g. "torrouter")
+
+    Returns:
+        Key string like "leafrouter_torrouter"
+    """
+    return "{}_{}".format(my_role, neighbor_role)
+
+
+def resolve_port_cable_lengths(port_names, neighbor_data, ports2cable,
+                               my_role, cable_length_default="40m"):
+    """Resolve per-port cable lengths using neighbor role data.
+
+    For each port, looks up its neighbor's role in ``neighbor_data``,
+    builds a ports2cable key from (my_role, neighbor_role), and looks up
+    the cable length. Tries both key orderings since the ports2cable
+    mapping may use either direction (e.g. "leafrouter_torrouter" vs
+    "torrouter_leafrouter"). Falls back to ``cable_length_default`` when
+    the neighbor or mapping is unknown.
+
+    Args:
+        port_names: list of port name strings
+        neighbor_data: dict of port_name -> neighbor_type (role string,
+            e.g. "BackEndLeafRouter"). Ports without an entry get the
+            default cable length.
+        ports2cable: dict of role_pair_key -> cable_length (e.g.
+            {"leafrouter_torrouter": "40m"})
+        my_role: normalized role of the local device (e.g. "torrouter")
+        cable_length_default: fallback cable length string
+
+    Returns:
+        dict of port_name -> cable_length_string
+    """
+    result = {}
+    for port in port_names:
+        neighbor_type = neighbor_data.get(port)
+        if not neighbor_type:
+            result[port] = cable_length_default
+            continue
+        neighbor_normalized = normalize_role(neighbor_type)
+        key_fwd = resolve_ports2cable_key(my_role, neighbor_normalized)
+        key_rev = resolve_ports2cable_key(neighbor_normalized, my_role)
+        if key_fwd in ports2cable:
+            result[port] = ports2cable[key_fwd]
+        elif key_rev in ports2cable:
+            result[port] = ports2cable[key_rev]
+        else:
+            result[port] = cable_length_default
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Functions that read from the DUT filesystem / CLI (used by standalone mode
+# and by the Ansible module which runs on the DUT)
+# ---------------------------------------------------------------------------
+
+def get_device_metadata():
+    """Read DEVICE_METADATA from config DB via sonic-cfggen."""
+    try:
+        out = subprocess.check_output(
+            ['sonic-cfggen', '-d', '--var-json', 'DEVICE_METADATA'],
+            text=True, stderr=subprocess.DEVNULL
+        )
+        return json.loads(out)
+    except Exception as e:
+        print(f"Error reading DEVICE_METADATA: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def get_platform_and_hwsku():
+    """Return (platform, hwsku) from 'show platform summary'."""
+    try:
+        out = subprocess.check_output(
+            ['show', 'platform', 'summary'], text=True, stderr=subprocess.DEVNULL
+        )
+        platform = hwsku = None
+        for line in out.splitlines():
+            if line.startswith('Platform:'):
+                platform = line.split(':', 1)[1].strip()
+            elif line.startswith('HwSKU:'):
+                hwsku = line.split(':', 1)[1].strip()
+        return platform, hwsku
+    except Exception as e:
+        print(f"Error reading platform summary: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def resolve_topology_postfix(metadata):
+    """
+    Replicate the Jinja2 logic that maps device role/subrole
+    to a filename postfix (t0, t1, t2, lt2, ft2, def).
+    """
+    localhost = metadata.get('localhost', {})
+    switch_role = localhost.get('type', '').lower()
+    switch_subrole = localhost.get('subtype', '').lower()
+
+    if not switch_role:
+        return 'def'
+
+    if 'torrouter' in switch_role and 'mgmt' not in switch_role:
+        return 't0'
+    elif 'leafrouter' in switch_role and 'mgmt' not in switch_role:
+        return 't1'
+    elif 'lowerspinerouter' in switch_role and 'mgmt' not in switch_role:
+        return 'lt2'
+    elif 'spinerouter' in switch_role and 'mgmt' not in switch_role:
+        if switch_subrole == 'lowerspinerouter':
+            return 'lt2'
+        elif switch_role == 'fabricspinerouter':
+            return 'ft2'
+        else:
+            return 't2'
+    else:
+        return 'def'
+
+
+def parse_ports2cable_from_j2(filepath):
+    """
+    Parse a ports2cable dict definition from a Jinja2 defaults file.
+    Looks for: {%- set ports2cable = { ... } -%}
+    Returns the dict if found, None otherwise.
+    """
+    try:
+        with open(filepath, 'r') as f:
+            content = f.read()
+    except FileNotFoundError:
+        return None
+
+    if 'ports2cable' not in content:
+        return None
+
+    # Extract the dict block between set ports2cable = { ... }
+    pattern = r"set\s+ports2cable\s*=\s*\{([^}]+)\}"
+    match = re.search(pattern, content, re.DOTALL)
+    if not match:
+        return None
+
+    raw = match.group(1)
+    result = {}
+    for entry in re.finditer(r"'([^']+)'\s*:\s*'([^']+)'", raw):
+        result[entry.group(1)] = entry.group(2)
+
+    return result if result else None
+
+
+def find_platform_defaults_file(platform, hwsku, postfix):
+    """
+    Locate the platform-specific buffers_defaults_<postfix>.j2 file.
+    Search order matches SONiC template resolution.
+    """
+    base = '/usr/share/sonic/device'
+    candidates = [
+        os.path.join(base, platform, hwsku, f'buffers_defaults_{postfix}.j2'),
+    ]
+    for path in candidates:
+        if os.path.isfile(path):
+            return path
+    return None
+
+
+def resolve_ports2cable_dict(platform, hwsku, device_metadata):
+    """Resolve the ports2cable mapping for a device.
+
+    Tries platform-specific buffers_defaults file first, then falls back
+    to hardcoded defaults. This is the importable equivalent of
+    ``get_ports2cable()`` without subprocess calls — it only reads from
+    the DUT filesystem to check for the platform-specific J2 file.
+
+    Args:
+        platform: platform string (e.g. "x86_64-arista_7060x6_64pe")
+        hwsku: HwSKU string (e.g. "Arista-7060X6-64PE-O128S2")
+        device_metadata: DEVICE_METADATA dict from config DB
+
+    Returns:
+        ports2cable dict (role_pair_key -> cable_length)
+    """
+    postfix = resolve_topology_postfix(device_metadata)
+    if platform and hwsku:
+        defaults_file = find_platform_defaults_file(platform, hwsku, postfix)
+        if defaults_file:
+            platform_ports2cable = parse_ports2cable_from_j2(defaults_file)
+            if platform_ports2cable is not None:
+                return platform_ports2cable
+    return dict(HARDCODED_PORTS2CABLE)
+
+
+def get_ports2cable():
+    """Main logic: return the applicable ports2cable dict and its source."""
+    metadata = get_device_metadata()
+    platform, hwsku = get_platform_and_hwsku()
+    postfix = resolve_topology_postfix(metadata)
+
+    localhost = metadata.get('localhost', {})
+    switch_role = localhost.get('type', 'unknown')
+
+    print(f"Platform : {platform}")
+    print(f"HwSKU    : {hwsku}")
+    print(f"Role     : {switch_role}")
+    print(f"Topology : {postfix}")
+    print()
+
+    defaults_file = find_platform_defaults_file(platform, hwsku, postfix)
+
+    if defaults_file:
+        print(f"Defaults file: {defaults_file}")
+        platform_ports2cable = parse_ports2cable_from_j2(defaults_file)
+        if platform_ports2cable is not None:
+            print("Source   : platform-specific (from defaults file)\n")
+            return platform_ports2cable
+        else:
+            print("ports2cable not defined in defaults file.")
+
+    else:
+        print("No platform-specific defaults file found.")
+
+    print("Source   : hardcoded defaults (buffers_config.j2)\n")
+    return HARDCODED_PORTS2CABLE
+
+
+if __name__ == '__main__':
+    ports2cable = get_ports2cable()
+    print(json.dumps(ports2cable, indent=4))

--- a/ansible/scripts/generate_port_config.py
+++ b/ansible/scripts/generate_port_config.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""
+Generate a PORT table JSON from links.csv + platform.json.
+
+This script runs on the sonic-mgmt server and produces a config_db-compatible
+PORT table JSON file that can be applied directly to a DUT — no port_config.ini,
+hwsku.json, minigraph, or deploy-mg needed.
+
+Data sources:
+  - links.csv: provides port names and speeds (the "what")
+  - platform.json: provides lanes, aliases, indices, breakout_modes (the "how")
+  - devices.csv: provides hwsku for DEVICE_METADATA
+
+Output:
+  A JSON file with PORT and DEVICE_METADATA tables, suitable for:
+    scp output.json dut:/etc/sonic/port_config_override.json
+    ssh dut "sudo sonic-cfggen -j /etc/sonic/port_config_override.json --write-to-db"
+
+Usage:
+    python3 generate_port_config.py \\
+        --links-csv ansible/files/sonic_str4_links.csv \\
+        --devices-csv ansible/files/sonic_str4_devices.csv \\
+        --platform-json /path/to/sonic-buildimage/device/<platform>/platform.json \\
+        --hostname str4-7060x6-64pe-11 \\
+        --output /tmp/port_config_override.json
+
+    # Or auto-detect platform.json from sonic-buildimage repo:
+    python3 generate_port_config.py \\
+        --links-csv ansible/files/sonic_str4_links.csv \\
+        --devices-csv ansible/files/sonic_str4_devices.csv \\
+        --buildimage-root /home/user/sonic-buildimage \\
+        --hostname str4-7060x6-64pe-11 \\
+        --output /tmp/port_config_override.json
+
+    # Apply on DUT:
+    scp /tmp/port_config_override.json dut:/etc/sonic/
+    ssh dut "sudo sonic-cfggen -j /etc/sonic/port_config_override.json --write-to-db && sudo config save -y"
+"""
+
+import argparse
+import csv
+import glob
+import json
+import os
+import re
+import sys
+
+
+def read_links_csv(csv_path, hostname):
+    """Extract {port_name: speed} for a given hostname from links.csv."""
+    port_speeds = {}
+    with open(csv_path) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            if row['StartDevice'] == hostname:
+                port_speeds[row['StartPort']] = row['BandWidth']
+            elif row['EndDevice'] == hostname:
+                port_speeds[row['EndPort']] = row['BandWidth']
+    return port_speeds
+
+
+def read_devices_csv(csv_path, hostname):
+    """Extract device info for a given hostname from devices.csv."""
+    with open(csv_path) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            if row['Hostname'] == hostname:
+                return row
+    return None
+
+
+def find_platform_json(buildimage_root, hwsku):
+    """Auto-detect platform.json path from sonic-buildimage repo using hwsku."""
+    pattern = os.path.join(buildimage_root, 'device', '*', '*', 'platform.json')
+    for pj_path in glob.glob(pattern):
+        platform_dir = os.path.dirname(pj_path)
+        # Check if any hwsku dir under this platform matches (exact or base)
+        for entry in os.listdir(platform_dir):
+            entry_path = os.path.join(platform_dir, entry)
+            if os.path.isdir(entry_path) and (entry == hwsku or hwsku.startswith(entry)):
+                return pj_path
+    return None
+
+
+def find_matching_breakout_mode(breakout_modes, num_ports, speed_mbps):
+    """Find matching breakout mode in platform.json's breakout_modes dict."""
+    speed_g = speed_mbps // 1000
+    for bmode_key, bmode_aliases in breakout_modes.items():
+        bmode_clean = re.sub(r'\[.*\]', '', bmode_key)
+        m = re.match(r'(\d+)x(\d+)G', bmode_clean)
+        if not m or int(m.group(1)) != num_ports:
+            continue
+        default_speed_g = int(m.group(2))
+        if default_speed_g == speed_g:
+            return bmode_key, bmode_aliases
+        bracket_match = re.search(r'\[(.*?)\]', bmode_key)
+        if bracket_match:
+            supported = [int(s.strip().replace('G', '')) for s in bracket_match.group(1).split(',')]
+            if speed_g in supported:
+                return bmode_key, bmode_aliases
+    return None, None
+
+
+def generate_port_table(port_speeds, platform_json_path):
+    """
+    Generate a PORT table from port names/speeds + platform.json.
+
+    For each physical cage in platform.json, finds which ports from port_speeds
+    belong to it, determines the breakout mode, and generates PORT entries with
+    correct lanes, aliases, indices, speed, and FEC.
+    """
+    with open(platform_json_path) as f:
+        platform_data = json.load(f)
+
+    if 'interfaces' not in platform_data:
+        print("Error: platform.json has no 'interfaces' section", file=sys.stderr)
+        return None
+
+    plat_intfs = platform_data['interfaces']
+    port_table = {}
+
+    for cage_name in sorted(plat_intfs.keys(), key=lambda x: int(x.replace('Ethernet', ''))):
+        cage_info = plat_intfs[cage_name]
+        cage_base = int(cage_name.replace('Ethernet', ''))
+        lane_str = cage_info.get('lanes', '')
+        lane_list = [l.strip() for l in lane_str.split(',') if l.strip()]
+        total_lanes = len(lane_list)
+        if total_lanes == 0:
+            continue
+
+        index_str = cage_info.get('index', '')
+        index_list = [i.strip() for i in index_str.split(',') if i.strip()]
+        breakout_modes = cage_info.get('breakout_modes', {})
+
+        # Find which ports from port_speeds belong to this cage
+        ports_in_cage = {}
+        for pname, pspeed in port_speeds.items():
+            if not pname.startswith('Ethernet') or not pname[8:].isdigit():
+                continue
+            pnum = int(pname[8:])
+            if cage_base <= pnum < cage_base + total_lanes:
+                ports_in_cage[pname] = int(pspeed)
+
+        if not ports_in_cage:
+            continue
+
+        num_ports = len(ports_in_cage)
+        speed_mbps = list(ports_in_cage.values())[0]
+
+        # Find matching breakout mode for alias resolution
+        bmode_key, aliases = find_matching_breakout_mode(breakout_modes, num_ports, speed_mbps)
+
+        # Fallback alias generation
+        if aliases is None:
+            cage_idx = index_list[0] if index_list else str(cage_base // total_lanes + 1)
+            if num_ports == 1:
+                aliases = ['etp{}'.format(cage_idx)]
+            else:
+                aliases = ['etp{}{}'.format(cage_idx, chr(ord('a') + i)) for i in range(num_ports)]
+
+        # Generate PORT entries
+        lanes_per_port = total_lanes // num_ports
+        sorted_port_names = sorted(ports_in_cage.keys(), key=lambda x: int(x[8:]))
+
+        for sub_idx, port_name in enumerate(sorted_port_names):
+            start_lane = sub_idx * lanes_per_port
+            end_lane = start_lane + lanes_per_port
+            sub_lanes = ','.join(lane_list[start_lane:end_lane])
+
+            alias = aliases[sub_idx] if sub_idx < len(aliases) else port_name
+            index = index_list[start_lane] if start_lane < len(index_list) else '1'
+
+            port_entry = {
+                'alias': alias,
+                'lanes': sub_lanes,
+                'speed': str(speed_mbps),
+                'index': index,
+                'admin_status': 'up',
+                'mtu': '9100',
+                'tpid': '0x8100',
+                'pfc_asym': 'off'
+            }
+
+            if speed_mbps >= 200000:
+                port_entry['fec'] = 'rs'
+
+            port_table[port_name] = port_entry
+
+    return port_table
+
+
+def validate_port_config(port_speeds, platform_json_path, hwsku):
+    """
+    Validate that ports in links.csv match valid breakout modes in platform.json
+    and are consistent with the HwSKU pattern.
+
+    Known HwSKU patterns for 7060X6-64PE (64 cages, 8 lanes each):
+      Uniform:  O128 → all 64 cages 2x, C256 → 32 odd cages 8x, 256x200G → all 64 cages 4x
+      Split:    P32O64 → cages 1-32 1x + cages 33-64 2x
+      Copper:   C* → only odd-numbered cages used (even cages skipped)
+
+    Returns list of warning strings. Empty list = all good.
+    """
+    with open(platform_json_path) as f:
+        platform_data = json.load(f)
+
+    plat_intfs = platform_data.get('interfaces', {})
+    warnings = []
+
+    # Build per-cage port counts from links.csv
+    cage_ports = {}
+    cage_speeds = {}
+    orphan_ports = []
+
+    for pname, pspeed in port_speeds.items():
+        if not pname.startswith('Ethernet') or not pname[8:].isdigit():
+            continue
+        pnum = int(pname[8:])
+
+        # Find which cage this port belongs to
+        matched_cage = None
+        for cage_name, cage_info in plat_intfs.items():
+            cage_base = int(cage_name.replace('Ethernet', ''))
+            lane_str = cage_info.get('lanes', '')
+            total_lanes = len([l for l in lane_str.split(',') if l.strip()])
+            if total_lanes > 0 and cage_base <= pnum < cage_base + total_lanes:
+                matched_cage = cage_name
+                break
+
+        if matched_cage is None:
+            orphan_ports.append(pname)
+            continue
+
+        cage_ports.setdefault(matched_cage, []).append(pname)
+        cage_speeds.setdefault(matched_cage, set()).add(int(pspeed))
+
+    # Check 1: Orphan ports (not in any cage)
+    if orphan_ports:
+        warnings.append("Ports not in any platform.json cage: {}".format(
+            ', '.join(sorted(orphan_ports, key=lambda x: int(x[8:])))))
+
+    # Check 2: Mixed speeds within a cage
+    for cage, speeds in cage_speeds.items():
+        if len(speeds) > 1:
+            warnings.append("Cage {} has mixed speeds: {} (all ports in a cage must have the same speed)".format(
+                cage, ', '.join(str(s) for s in sorted(speeds))))
+
+    # Check 3: Breakout mode exists in platform.json
+    for cage_name, ports in cage_ports.items():
+        cage_info = plat_intfs[cage_name]
+        breakout_modes = cage_info.get('breakout_modes', {})
+        num_ports = len(ports)
+        speed_mbps = list(cage_speeds[cage_name])[0] if len(cage_speeds[cage_name]) == 1 else 0
+
+        if speed_mbps > 0:
+            bmode_key, _ = find_matching_breakout_mode(breakout_modes, num_ports, speed_mbps)
+            if bmode_key is None:
+                speed_g = speed_mbps // 1000
+                available = ', '.join(sorted(breakout_modes.keys()))
+                warnings.append("Cage {} ({}): no matching breakout mode for {}x{}G. Available: [{}]".format(
+                    cage_name,
+                    ', '.join(sorted(ports, key=lambda x: int(x[8:]))),
+                    num_ports, speed_g, available))
+
+    # Check 4: HwSKU-specific pattern validation
+    if hwsku and hwsku != 'Unknown':
+        total_non_mgmt = len([p for p in port_speeds if p.startswith('Ethernet') and
+                              p[8:].isdigit() and int(p[8:]) < 512])
+        total_cages = len(plat_intfs)
+        non_mgmt_cages = len([k for k in plat_intfs if int(k.replace('Ethernet', '')) < 512])
+        used_cages = len([c for c in cage_ports if int(c.replace('Ethernet', '')) < 512])
+
+        # Detect copper pattern (C* HwSKUs use only odd cages)
+        if re.search(r'-C\d+', hwsku):
+            even_cages_used = []
+            for cage in cage_ports:
+                cage_num = int(cage.replace('Ethernet', ''))
+                if cage_num < 512:
+                    cage_index = cage_num // 8
+                    if cage_index % 2 == 1:  # even-numbered cages (0-indexed odd = physical even)
+                        even_cages_used.append(cage)
+            if even_cages_used:
+                warnings.append("HwSKU '{}' is copper (C*) but links.csv uses even-numbered cages: {}. "
+                                "Copper HwSKUs typically use only odd-numbered cages.".format(
+                                    hwsku, ', '.join(sorted(even_cages_used, key=lambda x: int(x[8:])))))
+
+        # Detect split pattern (P* HwSKUs: first half 1x, second half broken out)
+        if re.search(r'-P\d+', hwsku):
+            first_half_breakouts = set()
+            second_half_breakouts = set()
+            for cage, ports in cage_ports.items():
+                cage_num = int(cage.replace('Ethernet', ''))
+                if cage_num < 512:
+                    cage_index = cage_num // 8
+                    if cage_index < non_mgmt_cages // 2:
+                        first_half_breakouts.add(len(ports))
+                    else:
+                        second_half_breakouts.add(len(ports))
+            if len(first_half_breakouts) > 1:
+                warnings.append("HwSKU '{}' is split (P*) but first half cages have inconsistent breakout: {}".format(
+                    hwsku, first_half_breakouts))
+            if len(second_half_breakouts) > 1:
+                warnings.append("HwSKU '{}' is split (P*) but second half cages have inconsistent breakout: {}".format(
+                    hwsku, second_half_breakouts))
+
+    return warnings
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generate PORT table JSON from links.csv + platform.json',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+    parser.add_argument('--links-csv', required=True,
+                        help='Path to sonic_<lab>_links.csv')
+    parser.add_argument('--devices-csv', required=True,
+                        help='Path to sonic_<lab>_devices.csv')
+    parser.add_argument('--hostname', required=True,
+                        help='DUT hostname (e.g., str4-7060x6-64pe-11)')
+    parser.add_argument('--platform-json', default=None,
+                        help='Path to platform.json (from DUT or sonic-buildimage)')
+    parser.add_argument('--buildimage-root', default=None,
+                        help='Path to sonic-buildimage repo root (auto-detects platform.json)')
+    parser.add_argument('--output', '-o', default=None,
+                        help='Output JSON file path (default: stdout)')
+    parser.add_argument('--full-config', action='store_true',
+                        help='Include DEVICE_METADATA in output')
+    args = parser.parse_args()
+
+    # Read port speeds from links.csv
+    port_speeds = read_links_csv(args.links_csv, args.hostname)
+    if not port_speeds:
+        print("Error: no ports found for hostname '{}' in {}".format(
+            args.hostname, args.links_csv), file=sys.stderr)
+        sys.exit(1)
+    print("Found {} ports for {} in links.csv".format(len(port_speeds), args.hostname),
+          file=sys.stderr)
+
+    # Read device info from devices.csv
+    device_info = read_devices_csv(args.devices_csv, args.hostname)
+    if not device_info:
+        print("Warning: hostname '{}' not found in {}".format(
+            args.hostname, args.devices_csv), file=sys.stderr)
+        device_info = {}
+
+    hwsku = device_info.get('HwSku', 'Unknown')
+
+    # Resolve platform.json path
+    platform_json = args.platform_json
+    if not platform_json and args.buildimage_root:
+        platform_json = find_platform_json(args.buildimage_root, hwsku)
+        if platform_json:
+            print("Auto-detected platform.json: {}".format(platform_json), file=sys.stderr)
+    if not platform_json:
+        print("Error: --platform-json or --buildimage-root required", file=sys.stderr)
+        sys.exit(1)
+    if not os.path.isfile(platform_json):
+        print("Error: platform.json not found at {}".format(platform_json), file=sys.stderr)
+        sys.exit(1)
+
+    # Generate PORT table
+    port_table = generate_port_table(port_speeds, platform_json)
+    if not port_table:
+        print("Error: failed to generate PORT table", file=sys.stderr)
+        sys.exit(1)
+
+    # Validate links.csv ports against platform.json and HwSKU pattern
+    validation_warnings = validate_port_config(port_speeds, platform_json, hwsku)
+    if validation_warnings:
+        print("\nValidation warnings:", file=sys.stderr)
+        for w in validation_warnings:
+            print("  WARNING: {}".format(w), file=sys.stderr)
+        print("", file=sys.stderr)
+
+    # Build output config
+    config = {"PORT": port_table}
+
+    if args.full_config and device_info:
+        config["DEVICE_METADATA"] = {
+            "localhost": {
+                "hwsku": hwsku,
+                "hostname": args.hostname,
+                "type": device_info.get('Type', 'LeafRouter'),
+                "synchronous_mode": "enable",
+                "yang_config_validation": "disable"
+            }
+        }
+
+    # Summary
+    print("Generated PORT table: {} entries".format(len(port_table)), file=sys.stderr)
+    speeds = {}
+    for p in port_table.values():
+        s = int(p['speed']) // 1000
+        speeds[s] = speeds.get(s, 0) + 1
+    for s in sorted(speeds.keys(), reverse=True):
+        print("  {}x {}G".format(speeds[s], s), file=sys.stderr)
+
+    # Output
+    output = json.dumps(config, indent=4, sort_keys=True)
+    if args.output:
+        with open(args.output, 'w') as f:
+            f.write(output + '\n')
+        print("Written to {}".format(args.output), file=sys.stderr)
+    else:
+        print(output)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/scripts/update_links_for_breakout.py
+++ b/ansible/scripts/update_links_for_breakout.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""
+Update sonic_<lab>_links.csv for a generic HwSku breakout change.
+
+This script remaps DUT port entries in links.csv from the current port layout
+to a new breakout layout. It maps groups of ports from the source breakout
+to the target breakout based on physical cage assignments.
+
+Supports uniform breakout (all cages same) and mixed breakout (different
+breakout per port range).
+
+Usage:
+    # Uniform breakout — all cages get the same mode
+    python3 update_links_for_breakout.py \\
+        --links-csv ansible/files/sonic_str4_links.csv \\
+        --hostname str4-7060x6-64pe-11 \\
+        --target-breakout 2x400G \\
+        [--lanes-per-cage 8] \\
+        [--mgmt-ports 512,513] \\
+        [--dry-run]
+
+    # Mixed breakout — different modes per port range
+    python3 update_links_for_breakout.py \\
+        --links-csv ansible/files/sonic_str4_links.csv \\
+        --hostname str4-7060x6-64pe-11 \\
+        --target-breakout "1x800G:0-255,2x400G:256-504" \\
+        [--dry-run]
+
+Examples:
+    # Uniform: all cages to 2x400G
+    python3 update_links_for_breakout.py \\
+        --links-csv ansible/files/sonic_str4_links.csv \\
+        --hostname str4-7060x6-64pe-11 \\
+        --target-breakout 2x400G
+
+    # Mixed: P32O64 — first 32 cages 1x800G, last 32 cages 2x400G
+    python3 update_links_for_breakout.py \\
+        --links-csv ansible/files/sonic_str4_links.csv \\
+        --hostname str4-7060x6-64pe-11 \\
+        --target-breakout "1x800G:0-255,2x400G:256-504"
+
+    # Mixed: first half 4x200G, second half 8x100G
+    python3 update_links_for_breakout.py \\
+        --links-csv ansible/files/sonic_str4_links.csv \\
+        --hostname str4-7060x6-64pe-11 \\
+        --target-breakout "4x200G:0-255,8x100G:256-504"
+
+    # Dry run to preview changes
+    python3 update_links_for_breakout.py \\
+        --links-csv ansible/files/sonic_str4_links.csv \\
+        --hostname str4-7060x6-64pe-11 \\
+        --target-breakout "1x800G:0-255,2x400G:256-504" \\
+        --dry-run
+"""
+
+import argparse
+import csv
+import io
+import re
+import sys
+
+
+def parse_breakout(breakout_str):
+    """Parse breakout string like '2x400G' into (num_ports, speed_mbps)."""
+    m = re.match(r'(\d+)x(\d+)G$', breakout_str)
+    if not m:
+        print(f"Error: Invalid breakout format '{breakout_str}'. Expected NxSPEEDG (e.g., 2x400G)")
+        sys.exit(1)
+    num_ports = int(m.group(1))
+    speed_mbps = int(m.group(2)) * 1000
+    return num_ports, speed_mbps
+
+
+def parse_breakout_spec(spec_str):
+    """Parse breakout specification into a list of (num_ports, speed_mbps, start, end) tuples.
+
+    Supports:
+      - Uniform:  "2x400G"  (applies to all non-mgmt ports)
+      - Mixed:    "1x800G:0-255,2x400G:256-504"  (per port range)
+    """
+    ranges = []
+
+    if ':' not in spec_str:
+        # Uniform mode — single breakout for all ports
+        num_ports, speed_mbps = parse_breakout(spec_str)
+        ranges.append((num_ports, speed_mbps, 0, 511))
+        return ranges
+
+    for part in spec_str.split(','):
+        part = part.strip()
+        if ':' not in part:
+            print(f"Error: Mixed breakout entry '{part}' must have format NxSPEEDG:START-END")
+            sys.exit(1)
+        brkout_str, range_str = part.split(':', 1)
+        num_ports, speed_mbps = parse_breakout(brkout_str.strip())
+        range_match = re.match(r'(\d+)-(\d+)', range_str.strip())
+        if not range_match:
+            print(f"Error: Invalid range '{range_str}'. Expected START-END (e.g., 0-255)")
+            sys.exit(1)
+        start = int(range_match.group(1))
+        end = int(range_match.group(2))
+        ranges.append((num_ports, speed_mbps, start, end))
+
+    return ranges
+
+
+def get_breakout_for_port(port_num, breakout_ranges, lanes_per_cage):
+    """Find which breakout spec applies to this port number.
+
+    Returns (num_ports, speed_mbps, lanes_per_port) or None if no range matches.
+    """
+    for num_ports, speed_mbps, start, end in breakout_ranges:
+        if start <= port_num <= end:
+            lanes_per_port = lanes_per_cage // num_ports
+            return num_ports, speed_mbps, lanes_per_port
+    return None
+
+
+def get_cage_base(port_num, lanes_per_cage):
+    """Get the base port number for the physical cage containing this port."""
+    return (port_num // lanes_per_cage) * lanes_per_cage
+
+
+def csv_split_line(line):
+    """Split a CSV line respecting quoted fields (e.g. '\"100,200\"' stays as one field)."""
+    reader = csv.reader(io.StringIO(line.rstrip('\n')))
+    for row in reader:
+        return row
+    return []
+
+
+def csv_join_line(parts):
+    """Join fields into a CSV line, quoting fields that contain commas."""
+    buf = io.StringIO()
+    writer = csv.writer(buf, lineterminator='')
+    writer.writerow(parts)
+    return buf.getvalue() + '\n'
+
+
+def parse_vlan_field(vlan_str):
+    """Parse VLAN field like '1681', '1681-1712', or '1681,1690-1700' into a set of VLAN IDs."""
+    vlans = set()
+    if not vlan_str or not vlan_str.strip():
+        return vlans
+    cleaned = vlan_str.strip().strip('"')
+    for part in cleaned.split(','):
+        part = part.strip().strip('"')
+        if '-' in part:
+            start, end = part.split('-', 1)
+            vlans.update(range(int(start.strip()), int(end.strip()) + 1))
+        else:
+            try:
+                vlans.add(int(part))
+            except ValueError:
+                pass
+    return vlans
+
+
+def format_vlan_range(vlans):
+    """Format a set of VLAN IDs into a compact range string.
+
+    Produces contiguous ranges separated by commas.
+    E.g., {1, 2, 3, 5, 6, 8} -> '1-3,5-6,8'
+    """
+    if not vlans:
+        return ''
+    sorted_vlans = sorted(vlans)
+    ranges = []
+    start = end = sorted_vlans[0]
+    for v in sorted_vlans[1:]:
+        if v == end + 1:
+            end = v
+        else:
+            ranges.append(str(start) if start == end else f'{start}-{end}')
+            start = end = v
+    ranges.append(str(start) if start == end else f'{start}-{end}')
+    return ','.join(ranges)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Update links.csv for generic HwSku breakout change',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog='Breakout spec can be uniform ("2x400G") or mixed ("1x800G:0-255,2x400G:256-504")')
+    parser.add_argument('--links-csv', required=True, help='Path to sonic_<lab>_links.csv')
+    parser.add_argument('--hostname', required=True, help='DUT hostname (e.g., str4-7060x6-64pe-11)')
+    parser.add_argument('--target-breakout', required=True,
+                        help='Target breakout: uniform "2x400G" or mixed "1x800G:0-255,2x400G:256-504"')
+    parser.add_argument('--lanes-per-cage', type=int, default=8, help='Lanes per physical cage (default: 8)')
+    parser.add_argument('--mgmt-ports', default='512,513',
+                        help='Comma-separated management port numbers (default: 512,513)')
+    parser.add_argument('--dry-run', action='store_true', help='Preview changes without writing')
+    args = parser.parse_args()
+
+    breakout_ranges = parse_breakout_spec(args.target_breakout)
+    mgmt_ports = set(int(p) for p in args.mgmt_ports.split(','))
+
+    print(f"Target breakout: {args.target_breakout}")
+    for num_ports, speed_mbps, start, end in breakout_ranges:
+        lanes_per_port = args.lanes_per_cage // num_ports
+        print(f"  Ethernet{start}-{end}: {num_ports}x{speed_mbps // 1000}G "
+              f"({num_ports} ports/cage, {lanes_per_port} lanes/port)")
+    print(f"  Management ports: {mgmt_ports}")
+    print()
+
+    with open(args.links_csv) as f:
+        lines = f.readlines()
+
+    # --- Pre-scan: collect existing VLANs and DUT fanout info ---
+    all_vlans_in_file = set()
+    old_dut_vlans = set()
+    dut_fanout_devices = set()
+
+    for line in lines:
+        parts = csv_split_line(line)
+        if len(parts) > 5 and parts[5].strip():
+            all_vlans_in_file.update(parse_vlan_field(parts[5]))
+        if f'{args.hostname},' in line and len(parts) > 2:
+            port_str = parts[1].strip()
+            if port_str.startswith('Ethernet'):
+                port_num = int(port_str.replace('Ethernet', ''))
+                vlan_mode = parts[6].strip() if len(parts) > 6 else ''
+                if port_num not in mgmt_ports and vlan_mode != 'Trunk':
+                    if len(parts) > 5:
+                        old_dut_vlans.update(parse_vlan_field(parts[5]))
+                    if parts[2].strip():
+                        dut_fanout_devices.add(parts[2].strip())
+
+    max_vlan = max(all_vlans_in_file) if all_vlans_in_file else 0
+    next_vlan = max_vlan + 1
+
+    # --- Main processing: remap existing DUT entries ---
+    new_lines = []
+    seen_target_ports = set()
+    cage_info = {}
+    new_dut_vlans = set()
+    dut_lines_original = 0
+    dut_lines_new = 0
+    skipped = 0
+    mgmt_kept = 0
+    last_dut_access_idx = -1
+
+    for line in lines:
+        # Keep non-DUT lines unchanged
+        if f'{args.hostname},' not in line:
+            new_lines.append(line)
+            continue
+
+        dut_lines_original += 1
+        parts = csv_split_line(line)
+        dut_port = parts[1]
+        port_num = int(dut_port.replace('Ethernet', ''))
+
+        # Keep management ports unchanged
+        if port_num in mgmt_ports:
+            new_lines.append(line)
+            dut_lines_new += 1
+            mgmt_kept += 1
+            continue
+
+        # Find which breakout applies to this port
+        brkout = get_breakout_for_port(port_num, breakout_ranges, args.lanes_per_cage)
+        if brkout is None:
+            skipped += 1
+            continue
+        num_ports, speed_mbps, lanes_per_port = brkout
+
+        # Map source port to target port within the same cage
+        cage_base = get_cage_base(port_num, args.lanes_per_cage)
+        target_port_num = cage_base + ((port_num - cage_base) // lanes_per_port) * lanes_per_port
+
+        # Track cage info for expansion
+        if cage_base not in cage_info:
+            all_targets = set(cage_base + i * lanes_per_port for i in range(num_ports))
+            cage_info[cage_base] = {
+                'template': parts[:],
+                'covered': set(),
+                'all_targets': all_targets,
+                'speed_mbps': speed_mbps,
+            }
+
+        # Skip if we already have a link for this target port
+        if target_port_num in seen_target_ports:
+            skipped += 1
+            continue
+
+        seen_target_ports.add(target_port_num)
+        cage_info[cage_base]['covered'].add(target_port_num)
+        target_port = f'Ethernet{target_port_num}'
+
+        # Update fanout port with the same delta as DUT port remapping
+        fanout_port_str = parts[3].strip()
+        if fanout_port_str.startswith('Ethernet'):
+            fanout_num = int(fanout_port_str.replace('Ethernet', ''))
+            parts[3] = f'Ethernet{fanout_num + (target_port_num - port_num)}'
+
+        # Update: DUT port name and speed (VlanID preserved from source)
+        parts[1] = target_port
+        parts[4] = str(speed_mbps)
+        if len(parts) > 5 and parts[5].strip():
+            new_dut_vlans.update(parse_vlan_field(parts[5]))
+
+        last_dut_access_idx = len(new_lines)
+        new_lines.append(csv_join_line(parts))
+        dut_lines_new += 1
+
+    # --- Generate expansion entries for target ports missing a source entry ---
+    expansion_entries = []
+    for cage_base in sorted(cage_info):
+        info = cage_info[cage_base]
+        missing = sorted(info['all_targets'] - info['covered'])
+        for port_num in missing:
+            entry = info['template'][:]
+            entry[1] = f'Ethernet{port_num}'
+            # Compute correct fanout port based on offset from template
+            tpl_dut = info['template'][1].strip()
+            tpl_fan = info['template'][3].strip()
+            if tpl_dut.startswith('Ethernet') and tpl_fan.startswith('Ethernet'):
+                tpl_dut_num = int(tpl_dut.replace('Ethernet', ''))
+                tpl_fan_num = int(tpl_fan.replace('Ethernet', ''))
+                entry[3] = f'Ethernet{tpl_fan_num + (port_num - tpl_dut_num)}'
+            entry[4] = str(info['speed_mbps'])
+            entry[5] = str(next_vlan)
+            if len(entry) > 6:
+                entry[6] = 'Access'
+            new_dut_vlans.add(next_vlan)
+            next_vlan += 1
+            expansion_entries.append(csv_join_line(entry))
+            dut_lines_new += 1
+
+    # --- Generate entries for cages with no source entries at all ---
+    # Enumerate all expected cages from breakout ranges and find ones not in cage_info
+    for num_ports, speed_mbps, start, end in breakout_ranges:
+        lanes_per_port = args.lanes_per_cage // num_ports
+        # Find a donor template from the nearest populated cage in this range
+        donor_base = None
+        for cb in sorted(cage_info):
+            if start <= cb <= end:
+                donor_base = cb
+                break
+        if donor_base is None:
+            continue
+        donor = cage_info[donor_base]
+
+        for cage_base in range(start, end + 1, args.lanes_per_cage):
+            if cage_base in cage_info:
+                continue
+            # Generate all target ports for this empty cage
+            for i in range(num_ports):
+                port_num = cage_base + i * lanes_per_port
+                if port_num > end:
+                    break
+                entry = donor['template'][:]
+                entry[0] = args.hostname
+                entry[1] = f'Ethernet{port_num}'
+                # Compute fanout port from donor template offset
+                tpl_dut = donor['template'][1].strip()
+                tpl_fan = donor['template'][3].strip()
+                if tpl_dut.startswith('Ethernet') and tpl_fan.startswith('Ethernet'):
+                    tpl_dut_num = int(tpl_dut.replace('Ethernet', ''))
+                    tpl_fan_num = int(tpl_fan.replace('Ethernet', ''))
+                    entry[3] = f'Ethernet{tpl_fan_num + (port_num - tpl_dut_num)}'
+                entry[4] = str(speed_mbps)
+                entry[5] = str(next_vlan)
+                if len(entry) > 6:
+                    entry[6] = 'Access'
+                new_dut_vlans.add(next_vlan)
+                next_vlan += 1
+                expansion_entries.append(csv_join_line(entry))
+                dut_lines_new += 1
+
+    if expansion_entries:
+        insert_pos = last_dut_access_idx + 1 if last_dut_access_idx >= 0 else len(new_lines)
+        for i, entry in enumerate(expansion_entries):
+            new_lines.insert(insert_pos + i, entry)
+
+    # --- Update trunk/root fanout VLAN range ---
+    trunk_updated = False
+    if dut_fanout_devices and new_dut_vlans:
+        for i, line in enumerate(new_lines):
+            parts = csv_split_line(line)
+            if len(parts) > 6 and parts[6].strip() == 'Trunk':
+                start_dev = parts[0].strip()
+                end_dev = parts[2].strip()
+                if start_dev in dut_fanout_devices or end_dev in dut_fanout_devices:
+                    trunk_vlans = parse_vlan_field(parts[5])
+                    trunk_vlans -= old_dut_vlans
+                    trunk_vlans |= new_dut_vlans
+                    # Trunk lines use min-max range to avoid commas in CSV
+                    vlan_min = min(trunk_vlans)
+                    vlan_max = max(trunk_vlans)
+                    parts[5] = f'{vlan_min}-{vlan_max}'
+                    new_lines[i] = csv_join_line(parts)
+                    trunk_updated = True
+
+    # Summary
+    total_non_mgmt = dut_lines_new - mgmt_kept
+    print(f"Results:")
+    print(f"  Original DUT entries: {dut_lines_original}")
+    print(f"  New DUT entries: {dut_lines_new} ({total_non_mgmt} ports + {mgmt_kept} mgmt)")
+    print(f"  Skipped duplicates: {skipped}")
+    if expansion_entries:
+        vlan_start = next_vlan - len(expansion_entries)
+        print(f"  Expansion: {len(expansion_entries)} new entries added "
+              f"(VLANs {vlan_start}-{next_vlan - 1})")
+    if trunk_updated:
+        print(f"  Trunk VLAN range updated for root fanout")
+    print()
+
+    # Show sample entries
+    dut_new = [l for l in new_lines if f'{args.hostname},' in l]
+    print("Sample entries (first 5):")
+    for l in dut_new[:5]:
+        print(f"  {l.rstrip()}")
+    print("Sample entries (last 3):")
+    for l in dut_new[-3:]:
+        print(f"  {l.rstrip()}")
+
+    if args.dry_run:
+        print("\n[DRY RUN] No changes written.")
+    else:
+        with open(args.links_csv, 'w') as f:
+            f.writelines(new_lines)
+        print(f"\nWritten to {args.links_csv}")
+
+
+if __name__ == '__main__':
+    main()
+

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -22,6 +22,7 @@ function usage
   echo "    $0 [options] set-l2 <testbed-name> <vault-password-file>"
   echo "    $0 [options] install-image <testbed-name> <inventory> <image-url>"
   echo "    $0 [options] collect-show-tech <testbed-name> <inventory> <vault-password-file>"
+  echo "    $0 [options] update-breakout <testbed-name> <links-csv> <target-breakout> [--dry-run]"
   echo
   echo "Options:"
   echo "    -t <tbfile>     : testbed CSV file name (default: 'testbed.yaml')"
@@ -85,6 +86,11 @@ function usage
   echo "To collect show techsupport result of a testbed: $0 collect-show-tech 'testbed-name' 'inventory' ~/.password"
   echo "    collect-show-tech supports specify output path for dumped files"
   echo "        -e output_path=<user-specified-path>"
+  echo "To update links.csv for a breakout/HWSKU change: $0 update-breakout 'testbed-name' 'links-csv' '2x400G'"
+  echo "    update-breakout supports additional options passed through to the script:"
+  echo "        --lanes-per-cage N    Lanes per physical cage (default: 8)"
+  echo "        --mgmt-ports M        Comma-separated management port numbers (default: 512,513)"
+  echo "        --dry-run             Preview changes without writing"
   echo
   echo "You should define your topology in testbed YAML file"
   echo
@@ -931,6 +937,39 @@ function config_y_cable
   echo Done
 }
 
+function update_breakout
+{
+  testbed_name=$1
+  links_csv=$2
+  target_breakout=$3
+  shift
+  shift
+  shift
+
+  if [ -z "$target_breakout" ]; then
+    echo "Error: update-breakout requires <testbed-name> <links-csv> <target-breakout>"
+    usage
+  fi
+
+  echo "Updating links.csv breakout for testbed '$testbed_name'"
+
+  read_file $testbed_name
+
+  # Use first DUT hostname from testbed
+  hostname=$(echo "$duts" | cut -d',' -f1)
+  echo "  DUT hostname: $hostname"
+  echo "  Links CSV: $links_csv"
+  echo "  Target breakout: $target_breakout"
+
+  python3 scripts/update_links_for_breakout.py \
+    --links-csv "$links_csv" \
+    --hostname "$hostname" \
+    --target-breakout "$target_breakout" \
+    "$@"
+
+  echo Done
+}
+
 function set_l2_mode
 {
   testbed_name=$1
@@ -1303,6 +1342,8 @@ case "${subcmd}" in
   collect-show-tech) collect_show_tech $@
                ;;
   config-vs-chassis) config_vs_chassis $@
+               ;;
+  update-breakout) update_breakout $@
                ;;
   add-vnut-topo)    add_vnut_topo "$@"
                ;;

--- a/docs/testbed/generic_hwsku_port_config.md
+++ b/docs/testbed/generic_hwsku_port_config.md
@@ -1,0 +1,346 @@
+# Generic HwSKU PORT Table Generation
+
+## Problem
+
+Each HwSKU variant (e.g., `Arista-7060X6-64PE-O128S2`, `-C256S2`, `-C224O8`) requires
+its own `port_config.ini` file in `sonic-buildimage`. Changing the breakout layout
+means creating a new HwSKU name, a new directory, a new `port_config.ini`, and a new
+`sonic-buildimage` PR. This doesn't scale.
+
+## Solution
+
+Generate the PORT table dynamically from two data sources:
+
+- **`links.csv`** — the lab topology file on the sonic-mgmt server. Provides port names
+  and speeds (the "what").
+- **`platform.json`** — the hardware description on the DUT (or in a `sonic-buildimage`
+  checkout). Provides physical lanes, aliases, indices, and valid breakout modes
+  (the "how").
+
+No `port_config.ini` or `hwsku.json` is needed. No HwSKU name parsing.
+
+## Architecture
+
+```
+ ┌────────────┐     ┌──────────────┐
+ │ links.csv  │     │ devices.csv  │
+ │ (mgmt srv) │     │ (mgmt srv)   │
+ │            │     │              │
+ │ port names │     │ hostname →   │
+ │ + speeds   │     │ hwsku        │
+ └─────┬──────┘     └──────┬───────┘
+       │                   │
+       │    ┌──────────────┘
+       │    │    ┌───────────────┐
+       │    │    │ platform.json │
+       │    │    │ (on DUT or    │
+       │    │    │  buildimage)  │
+       │    │    │               │
+       │    │    │ lanes, index, │
+       │    │    │ aliases,      │
+       │    │    │ breakout_modes│
+       ▼    ▼    └───────┬───────┘
+ ┌───────────────────────┴──────────────┐
+ │       generate_port_config.py        │
+ │                                      │
+ │  1. read_links_csv()  → port:speed   │
+ │  2. validate()        → warnings     │
+ │  3. generate_port_table()            │
+ │     for each cage in platform.json:  │
+ │       • find ports in cage range     │
+ │       • match breakout mode          │
+ │       • split lanes evenly           │
+ │       • assign alias from platform   │
+ │  4. output JSON                      │
+ └──────────────┬───────────────────────┘
+                │
+                ▼
+     PORT table JSON → scp to DUT → sonic-cfggen --write-to-db
+```
+
+## How It Works
+
+### Physical Switch Layout
+
+A switch like the Arista 7060X6-64PE has 64 physical cages (QSFP-DD), each with
+8 SerDes lanes. `platform.json` describes all cages and their valid breakout modes:
+
+```json
+{
+  "interfaces": {
+    "Ethernet0": {
+      "lanes": "17,18,19,20,21,22,23,24",
+      "index": "1,1,1,1,1,1,1,1",
+      "breakout_modes": {
+        "1x800G[400G]": ["etp1"],
+        "2x400G": ["etp1a", "etp1b"],
+        "4x200G": ["etp1a", "etp1b", "etp1c", "etp1d"],
+        "8x100G": ["etp1a", "etp1b", "etp1c", "etp1d", "etp1e", "etp1f", "etp1g", "etp1h"]
+      }
+    }
+  }
+}
+```
+
+### The Matching Algorithm
+
+For each cage in `platform.json`, the script:
+
+1. **Collects** which `links.csv` ports fall into this cage's address range
+2. **Matches** the port count + speed against `breakout_modes` to find the right mode
+3. **Splits** the cage's lanes evenly among the ports
+4. **Assigns** aliases from the matched breakout mode
+
+Example for cage `Ethernet0` with 8 lanes `[17,18,19,20,21,22,23,24]`:
+
+| links.csv ports in cage | Breakout matched | Lane assignment |
+|-------------------------|-----------------|-----------------|
+| 1 port × 800G | `1x800G` | Ethernet0 → lanes=17,18,19,20,21,22,23,24 |
+| 2 ports × 400G | `2x400G` | Ethernet0 → 17,18,19,20; Ethernet4 → 21,22,23,24 |
+| 4 ports × 200G | `4x200G` | Ethernet0 → 17,18; Ethernet2 → 19,20; ... |
+| 8 ports × 100G | `8x100G` | Ethernet0 → 17; Ethernet1 → 18; ... |
+
+### Mixed Breakout
+
+Each cage is processed independently, so mixed breakout is supported:
+
+```
+Cage 1: 1 port at 800G  → 1x800G (all 8 lanes)
+Cage 2: 2 ports at 400G → 2x400G (4 lanes each)
+Cage 3: 8 ports at 100G → 8x100G (1 lane each)
+```
+
+## Usage
+
+### Step 1: Generate PORT table JSON (on mgmt server)
+
+```bash
+python3 ansible/scripts/generate_port_config.py \
+    --links-csv ansible/files/sonic_str4_links.csv \
+    --devices-csv ansible/files/sonic_str4_devices.csv \
+    --hostname str4-7060x6-64pe-11 \
+    --platform-json ~/sonic-buildimage/device/arista/x86_64-arista_7060x6_64pe/platform.json \
+    --full-config \
+    -o /tmp/port_config_override.json
+```
+
+Or auto-detect `platform.json` from a `sonic-buildimage` checkout:
+
+```bash
+python3 ansible/scripts/generate_port_config.py \
+    --links-csv ansible/files/sonic_str4_links.csv \
+    --devices-csv ansible/files/sonic_str4_devices.csv \
+    --hostname str4-7060x6-64pe-11 \
+    --buildimage-root ~/sonic-buildimage \
+    -o /tmp/port_config_override.json
+```
+
+### Step 2: Apply to DUT (after load_minigraph)
+
+```bash
+# Copy override to DUT
+scp /tmp/port_config_override.json dut:/etc/sonic/
+
+# Apply (overwrites PORT table in config_db)
+ssh dut "sudo sonic-cfggen -j /etc/sonic/port_config_override.json --write-to-db && sudo config save -y"
+```
+
+### Changing Breakout (update links.csv)
+
+To remap `links.csv` for a new breakout layout:
+
+```bash
+python3 ansible/scripts/update_links_for_breakout.py \
+    --links-csv ansible/files/sonic_str4_links.csv \
+    --hostname str4-7060x6-64pe-11 \
+    --target-breakout 2x400G \
+    --dry-run
+
+# Remove --dry-run to apply
+```
+
+## Integration with Existing Flow
+
+All other config_db tables (DEVICE_NEIGHBOR, VLAN, BGP_NEIGHBOR, LOOPBACK, etc.)
+continue to come from minigraph via `config load_minigraph`. This script only
+overrides the PORT table:
+
+```
+config load_minigraph -y         ← all tables from minigraph
+generate_port_config.py          ← PORT override from links.csv + platform.json
+sonic-cfggen -j ... --write-to-db  ← overwrite just PORT
+```
+
+## Validation
+
+The script validates the `links.csv` ports against `platform.json`:
+
+- **Orphan ports** — ports not mapping to any physical cage
+- **Mixed speeds** — different speeds within the same cage
+- **Invalid breakout** — port count + speed not in `breakout_modes`
+- **HwSKU pattern checks** — copper (C*) and split (P*) pattern validation
+
+## End-to-End HWSKU Conversion (C256 → O128 Example)
+
+This walkthrough converts a DUT from `Arista-7060X6-64PE-C256S2` (4x200G, 256 ports)
+to `Arista-7060X6-64PE-O128S2` (2x400G, 128 ports).
+
+### Prerequisites
+
+- Testbed name (e.g., `str4-t1-lag`)
+- Links CSV path (e.g., `ansible/files/sonic_str4_links.csv`)
+- Devices CSV path (e.g., `ansible/files/sonic_str4_devices.csv`)
+- Inventory file (e.g., `str4-inventory`)
+- Vault password file (e.g., `~/.password`)
+
+### Step 1: Pre-checks — verify current state
+
+```bash
+# Check current HWSKU and port count on DUT
+ssh dut "show platform summary"
+ssh dut "show interfaces status | wc -l"
+ssh dut "show interfaces status | grep -c 'up'"
+ssh dut "show bgp summary"
+```
+
+Save the output for comparison after conversion.
+
+### Step 2: Update links.csv for new breakout
+
+Preview the changes first with `--dry-run`:
+
+```bash
+# From sonic-mgmt/ansible/ directory
+./testbed-cli.sh update-breakout str4-t1-lag \
+    files/sonic_str4_links.csv 2x400G --dry-run
+```
+
+Verify the output shows:
+- Correct number of new DUT entries (128 ports for O128)
+- VLANs preserved for existing ports, new VLANs assigned for new ports
+- Trunk VLAN range updated for root fanout
+
+Apply when satisfied:
+
+```bash
+./testbed-cli.sh update-breakout str4-t1-lag \
+    files/sonic_str4_links.csv 2x400G
+```
+
+### Step 3: Update devices.csv — change HwSKU
+
+Edit `ansible/files/sonic_str4_devices.csv` and change the DUT's HwSKU:
+
+```
+# Before:
+str4-7060x6-64pe-11,...,Arista-7060X6-64PE-C256S2,...
+# After:
+str4-7060x6-64pe-11,...,Arista-7060X6-64PE-O128S2,...
+```
+
+### Step 4: Redeploy leaf fanout
+
+The leaf fanout needs to be reconfigured for the new breakout and VLANs:
+
+```bash
+cd ansible
+ansible-playbook -i str4-inventory fanout.yml \
+    -l str4-fanout-01 \
+    --vault-password-file ~/.password
+```
+
+### Step 5: Update root fanout VLAN trunks
+
+The root fanout trunk ports need the updated VLAN range:
+
+```bash
+ansible-playbook -i str4-inventory fanout_connect.yml \
+    --vault-password-file ~/.password \
+    -e dut=str4-7060x6-64pe-11
+```
+
+### Step 6: Deploy minigraph with golden config
+
+This generates minigraph with the new port layout, builds the golden config
+(which replaces the PORT table using platform.json), and applies both:
+
+```bash
+./testbed-cli.sh deploy-mg str4-t1-lag str4-inventory ~/.password
+```
+
+What happens under the hood:
+1. Minigraph is generated with the new 128-port layout
+2. `generate_golden_config_db` rebuilds the PORT table from `platform.json`
+   with correct lanes, aliases, indices, speed, and FEC
+3. `config load_minigraph --override_config -y` applies minigraph + PORT override
+
+### Step 7: Verify port status
+
+Wait ~60 seconds for ports to come up, then verify:
+
+```bash
+# All ports should be operationally up
+ssh dut "show interfaces status"
+
+# Count should match expected (128 data ports + management)
+ssh dut "show interfaces status | grep -c 'up'"
+
+# Check for any ports that are admin up but oper down
+ssh dut "show interfaces status | grep 'up.*down'"
+
+# Verify port speeds are correct (all should be 400G)
+ssh dut "show interfaces status | awk '{print \$5}' | sort | uniq -c"
+
+# Verify PORT table in config_db has correct lanes and aliases
+ssh dut "sonic-cfggen -d --var-json PORT" | python3 -m json.tool | head -30
+```
+
+### Step 8: Verify BGP sessions
+
+```bash
+# All BGP neighbors should be in Established state
+ssh dut "show bgp summary"
+
+# Check for any non-established sessions
+ssh dut "show bgp summary | grep -v Established | grep -v 'Neighbor\|entries'"
+
+# Verify neighbor count matches expected topology
+ssh dut "show bgp summary | grep -c Established"
+```
+
+### Step 9: Verify LLDP neighbors
+
+```bash
+# LLDP confirms physical connectivity matches links.csv
+ssh dut "show lldp table"
+ssh dut "show lldp table | wc -l"
+```
+
+### Step 10: Run sanity tests
+
+```bash
+cd tests
+
+# Run pretest checks (interfaces, BGP, basic connectivity)
+pytest test_pretest.py \
+    --testbed=str4-t1-lag \
+    --inventory=../ansible/str4-inventory \
+    -v
+
+# Run link flap test to verify all links recover
+pytest platform_tests/test_link_flap.py \
+    --testbed=str4-t1-lag \
+    --inventory=../ansible/str4-inventory \
+    -v
+```
+
+### Troubleshooting
+
+| Symptom | Check | Fix |
+|---------|-------|-----|
+| Ports admin up but oper down | `show interfaces status` | Verify fanout is configured for new breakout; check cable/transceiver |
+| Wrong port count | `sonic-cfggen -d --var-json PORT \| python3 -c "import json,sys; print(len(json.load(sys.stdin)))"` | Re-run `deploy-mg`; verify links.csv has correct entries |
+| BGP sessions not established | `show bgp summary` | Wait longer (up to 180s); check `show ip interface` for correct IPs |
+| VLANs not trunked | Check root fanout: `show vlan` | Re-run `fanout_connect.yml` |
+| Wrong lanes/aliases in PORT | `sonic-cfggen -d --var-json PORT` | Verify `platform.json` exists on DUT at `/usr/share/sonic/device/<platform>/` |
+| Golden config not applied | `cat /etc/sonic/golden_config_db.json` | Check that topo is `ft2-64`, `lt2-p32o64`, or `lt2-o128` |


### PR DESCRIPTION
To be merged only after #23052 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->


Summary: Adds buffer/QoS table generation (BUFFER_POOL, BUFFER_PROFILE, BUFFER_PG, BUFFER_QUEUE, QUEUE, PORT_QOS_MAP, CABLE_LENGTH, SCHEDULER, WRED_PROFILE) to golden_config_db.json so FT2/LT2 DUTs can config reload without missing buffer config.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
FT2/LT2 topologies with breakout ports lack buffer configuration after golden_config overrides the PORT table, causing config reload failures.

#### How did you do it?
Added buffer_config_helper.py and get_ports2cable.py library modules. Extended generate_golden_config_db.py with cable_length, buffer_gen, and neighbor_data params to generate all buffer/QoS tables when buffer_gen is enabled.

#### How did you verify/test it?
Validation pending off of #23052 being able to retrieve neighbor data.

#### Any platform specific information?
Uses platform-specific ports2cable.ini for cable length mapping; falls back to a default cable length (40m) when unavailable.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
