### PR TITLE
[voq] Fix test_voq_queue_counter broken awk command on multi-ASIC

### DIFF
--- a/tests/voq/test_voq_counter.py
+++ b/tests/voq/test_voq_counter.py
@@ -70,7 +70,7 @@ def test_voq_queue_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     else:
         cmd_bcmcmd_false = "'port enable sfi false'"
         cmd_bcmcmd_true = "'port enable sfi true'"
-        cmd = "show queue counters --voq --nonzero| grep -i 'Ethernet-IB' |grep -i 'VOQ0' |awk '{{print $7}}'"
+        cmd = "show queue counters --voq --nonzero| grep -i 'Ethernet-IB' |grep -i 'VOQ0' |awk '{print $7}'"
         try:
             bcm_changes = True
             for asic in duthost.asics:
@@ -84,7 +84,7 @@ def test_voq_queue_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
                 integers = [int(item.replace(',', '')) for item in out if item.replace(',', '').strip().isdigit()]
                 return any(num > 0 for num in integers)
 
-            pytest_assert(wait_until(300, 0, 0, queue_counter_assertion),
+            pytest_assert(wait_until(300, 5, 0, queue_counter_assertion),
                           "Credit-WD-Del/pkts is not increasing "
                           "Ref: https://github.com/sonic-net/sonic-buildimage/issues/21098")
         finally:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #23940
Fixes the multi-ASIC `else` branch in `tests/voq/test_voq_counter.py`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
PR #23047 added Q3D single-ASIC support to `test_voq_queue_counter` and inlined the grep arguments for the multi-asic branch, removing the `.format()` call. However, the double-brace awk escaping (`'{{print $7}}'`) was not converted to single braces. Without `.format()`, the double braces are passed literally to Ansible, which interprets `{{print $7}}` as a Jinja2 expression and fails on the `$` character. This causes the test to fail on all multi-ASIC platforms.

#### How did you do it?
- Change awk '{{print $7}}' to '{print $7}' to avoid Ansible Jinja2 templating error
- Change wait_until polling interval from 0 to 5 seconds

#### How did you verify/test it?
Tested changes on multi-asic T2 platforms.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
