### PR TITLE
[dhcp_server] Fix dhcp_server conftest: use correct supervisor process name

### DIFF
--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -34,7 +34,7 @@ def dhcp_server_setup_teardown(duthost):
                    is_supervisor_subprocess_running,
                    duthost,
                    DHCP_RELAY_CONTAINER_NAME,
-                   "dhcp-relay:dhcprelayd"),
+                   "dhcprelayd"),
         'dhcprelayd in container dhcp_relay is not running'
     )
 


### PR DESCRIPTION
The supervisor config in dhcp_relay container defines dhcprelayd as a standalone program, not under a dhcp-relay group. Change the conftest check from dhcp-relay:dhcprelayd to dhcprelayd to match the actual supervisor configuration.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

dhcp_server/test_dhcp_server.py tests using the sonic-relay-agent parametrization were hitting ERRORs in the module fixture because supervisorctl status dhcp-relay:dhcprelayd returns "no such process". The [group:dhcp-relay] section is not present in the baked docker-dhcp-relay.supervisord.conf — the process is registered as a standalone 
[program:dhcprelayd].


#### How did you do it?

Changed "dhcp-relay:dhcprelayd" to "dhcprelayd" in tests/dhcp_server/conftest.py.

#### How did you verify/test it?

Confirmed on a running Arista 7260 DUT (.19 image):

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
