### PR TITLE
Fix LLDP neighbor check flakiness after swss restart by waiting for neighbor re-learn

### DIFF
--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -129,6 +129,13 @@ def test_lldp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost,
                 )
 
 
+def _neighbor_has_lldp_entry(localhost, hostip, snmp_community, neighbor_interface):
+    """Return True if the neighbor's LLDP table contains the expected interface."""
+    nei_lldp_facts = localhost.lldp_facts(
+        host=hostip, version='v2c', community=snmp_community)['ansible_facts']
+    return neighbor_interface in nei_lldp_facts.get('ansible_lldp_facts', {})
+
+
 def check_lldp_neighbor(duthost, localhost, eos, sonic, collect_techsupport_all_duts,
                         enum_rand_one_frontend_asic_index, tbinfo, request):
     """ verify LLDP information on neighbors """
@@ -166,13 +173,22 @@ def check_lldp_neighbor(duthost, localhost, eos, sonic, collect_techsupport_all_
             hostip = nei_meta[v['chassis']['name']]['mgmt_addr']
 
         if request.config.getoption("--neighbor_type") == 'eos':
-            nei_lldp_facts = localhost.lldp_facts(host=hostip, version='v2c', community=eos['snmp_rocommunity'])[
-                'ansible_facts']
             neighbor_interface = v['port']['ifname']
+            snmp_community = eos['snmp_rocommunity']
         else:
-            nei_lldp_facts = localhost.lldp_facts(host=hostip, version='v2c', community=sonic['snmp_rocommunity'])[
-                'ansible_facts']
             neighbor_interface = v['port']['local']
+            snmp_community = sonic['snmp_rocommunity']
+
+        # After swss restart, the DUT's LLDP entry on the neighbor may have aged out
+        # during the restart window. Wait until the neighbor re-learns DUT's LLDP info.
+        assert wait_until(30, 5, 0, _neighbor_has_lldp_entry,
+                          localhost, hostip, snmp_community, neighbor_interface), \
+            "Neighbor {} did not learn LLDP on interface '{}' within 30s".format(
+                hostip, neighbor_interface)
+
+        nei_lldp_facts = localhost.lldp_facts(
+            host=hostip, version='v2c', community=snmp_community)['ansible_facts']
+
         # Verify the published DUT system name field is correct
         assert nei_lldp_facts['ansible_lldp_facts'][neighbor_interface]['neighbor_sys_name'] == duthost.hostname, (
             "LLDP neighbor system name mismatch for interface '{}'. "


### PR DESCRIPTION
### Description of PR

After swss restart on single/multi-ASIC devices, the DUT's LLDP entry on the neighbor may have aged out during the restart window. The check_lldp_neighbor test then fails because it immediately queries the neighbor's LLDP table via SNMP before the neighbor has re-learned the DUT's LLDP information.

This fix adds a wait_until(30, 5, 0) retry loop that polls the neighbor's LLDP table until the expected interface entry reappears, before proceeding with the LLDP fact assertions. A small helper _neighbor_has_lldp_entry is extracted to support the polling.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

The LLDP neighbor verification test (check_lldp_neighbor) is flaky after swss restart. During the restart window, the DUT stops sending LLDP PDUs, causing the neighbor's LLDP entry for the DUT to age out (default LLDP hold time is ~120s, but rapid restarts can exceed this). When the test immediately queries the neighbor via SNMP, the entry may not yet be re-learned, lead to a KeyError or assertion failure.

#### How did you do it?

- Extracted a helper function _neighbor_has_lldp_entry() that queries the neighbor's LLDP table via SNMP and checks if the expected interface is present.
- Refactored the eos/sonic branching to set neighbor_interface and snmp_community variables up front, removing duplicated lldp_facts calls.
- Added a wait_until call that polls every 5 seconds for up to 30 seconds, asserting the neighbor has re-learned the DUT's LLDP entry before proceeding with the existing LLDP fact assertions.

#### How did you verify/test it?

Ran `tests/lldp/test_lldp.py` on both single-ASIC and multi-ASIC DUTs. Confirmed that the test now waits for the neighbor to re-learn LLDP info and passes reliably instead of failing intermittently.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
