### PR TITLE
Add 'sfp' to the list of modules supported by test_sfp.py

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -310,7 +310,7 @@ class TestSfpApi(PlatformApiTestBase):
     def is_xcvr_optical(self, xcvr_info_dict):
         """Returns True if transceiver is optical, False if copper (DAC)"""
         # For QSFP-DD specification compliance will return type as passive or active
-        if xcvr_info_dict["type_abbrv_name"] in ["QSFP-DD", "OSFP-8X", "QSFP+C", "BP"]:
+        if xcvr_info_dict["type_abbrv_name"] in ["QSFP-DD", "OSFP-8X", "QSFP+C", "BP", "SFP"]:
             if xcvr_info_dict["specification_compliance"] == "Passive Copper Cable" or \
                     xcvr_info_dict["specification_compliance"] == "passive_copper_media_interface":
                 return False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Cisco-console server comes with SFP(10G), which is not yet added in test_sfp.py. This PR we add "sfp" to the list of modules supported by this script.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
Adding support for SFP in test_sfp.py.

#### How did you do it?
Added the "SFP" to the current list of modules.

#### How did you verify/test it?
Ran it in cisco console platform testbed:
```
===================================================================================================== PASSES =====================================================================================================
____________________________________________________________________________________ TestSfpApi.test_get_presence[sirc0-dut1] ____________________________________________________________________________________
_____________________________________________________________________________________ TestSfpApi.test_get_model[sirc0-dut1] ______________________________________________________________________________________
_____________________________________________________________________________________ TestSfpApi.test_get_serial[sirc0-dut1] _____________________________________________________________________________________
___________________________________________________________________________________ TestSfpApi.test_is_replaceable[sirc0-dut1] ___________________________________________________________________________________
________________________________________________________________________________ TestSfpApi.test_get_transceiver_info[sirc0-dut1] ________________________________________________________________________________
___________________________________________________________________________ TestSfpApi.test_get_transceiver_dom_real_value[sirc0-dut1] ___________________________________________________________________________
___________________________________________________________________________ TestSfpApi.test_get_transceiver_threshold_info[sirc0-dut1] ___________________________________________________________________________
__________________________________________________________________________________ TestSfpApi.test_get_reset_status[sirc0-dut1] __________________________________________________________________________________
_____________________________________________________________________________________ TestSfpApi.test_get_rx_los[sirc0-dut1] _____________________________________________________________________________________
____________________________________________________________________________________ TestSfpApi.test_get_tx_fault[sirc0-dut1] ____________________________________________________________________________________
__________________________________________________________________________________ TestSfpApi.test_get_temperature[sirc0-dut1] ___________________________________________________________________________________
____________________________________________________________________________________ TestSfpApi.test_get_voltage[sirc0-dut1] _____________________________________________________________________________________
____________________________________________________________________________________ TestSfpApi.test_get_tx_bias[sirc0-dut1] _____________________________________________________________________________________
____________________________________________________________________________________ TestSfpApi.test_get_rx_power[sirc0-dut1] ____________________________________________________________________________________
____________________________________________________________________________________ TestSfpApi.test_get_tx_power[sirc0-dut1] ____________________________________________________________________________________
_______________________________________________________________________________________ TestSfpApi.test_reset[sirc0-dut1] ________________________________________________________________________________________
_____________________________________________________________________________________ TestSfpApi.test_tx_disable[sirc0-dut1] _____________________________________________________________________________________
_________________________________________________________________________________ TestSfpApi.test_tx_disable_channel[sirc0-dut1] _________________________________________________________________________________
_______________________________________________________________________________________ TestSfpApi.test_lpmode[sirc0-dut1] _______________________________________________________________________________________
___________________________________________________________________________________ TestSfpApi.test_power_override[sirc0-dut1] ___________________________________________________________________________________
_______________________________________________________________________________ TestSfpApi.test_get_error_description[sirc0-dut1] ________________________________________________________________________________
______________________________________________________________________________________ TestSfpApi.test_thermals[sirc0-dut1] ______________________________________________________________________________________
--------------------------------------------------------- generated xml file: /run_logs/sir-c0/39632/2026-04-15-17-51-18/platform_tests/api/test_sfp.xml ---------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
============================================================================================ short test summary info =============================================================================================
PASSED platform_tests/api/test_sfp.py::TestSfpApi::test_get_presence[sirc0-dut1]
PASSED platform_tests/api/test_sfp.py::TestSfpApi::test_get_model[sirc0-dut1]
PASSED platform_tests/api/test_sfp.py::TestSfpApi::test_get_serial[sirc0-dut1]
PASSED platform_tests/api/test_sfp.py::TestSfpApi::test_is_replaceable[sirc0-dut1]
PASSED platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_info[sirc0-dut1]
PASSED platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_dom_real_value[sirc0-dut1]
PASSED platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_threshold_info[sirc0-dut1]
PASSED platform_tests/api/test_sfp.py::TestSfpApi::test_get_reset_status[sirc0-dut1]
PASSED platform_tests/api/test_sfp.py::TestSfpApi::test_get_rx_los[sirc0-dut1]
PASSED platform_tests/api/test_sfp.py::TestSfpApi::test_get_tx_fault[sirc0-dut1]
PASSED platform_tests/api/test_sfp.py::TestSfpApi::test_get_temperature[sirc0-dut1]
PASSED platform_tests/api/test_sfp.py::TestSfpApi::test_get_voltage[sirc0-dut1]
PASSED platform_tests/api/test_sfp.py::TestSfpApi::test_get_tx_bias[sirc0-dut1]
PASSED platform_tests/api/test_sfp.py::TestSfpApi::test_get_rx_power[sirc0-dut1]
PASSED platform_tests/api/test_sfp.py::TestSfpApi::test_get_tx_power[sirc0-dut1]
PASSED platform_tests/api/test_sfp.py::TestSfpApi::test_reset[sirc0-dut1]
PASSED platform_tests/api/test_sfp.py::TestSfpApi::test_tx_disable[sirc0-dut1]
PASSED platform_tests/api/test_sfp.py::TestSfpApi::test_tx_disable_channel[sirc0-dut1]
PASSED platform_tests/api/test_sfp.py::TestSfpApi::test_lpmode[sirc0-dut1]
PASSED platform_tests/api/test_sfp.py::TestSfpApi::test_power_override[sirc0-dut1]
PASSED platform_tests/api/test_sfp.py::TestSfpApi::test_get_error_description[sirc0-dut1]
PASSED platform_tests/api/test_sfp.py::TestSfpApi::test_thermals[sirc0-dut1]
FAILED platform_tests/api/test_sfp.py::TestSfpApi::test_get_name[sirc0-dut1] - Failed: Transceiver name 'QSFP_1' for PORT1 NOT found in platform.json, Transceiver name 'QSFP_2' for PORT2 NOT found in platform.json
============================================================================== 1 failed, 22 passed, 1 warning in 804.79s (0:13:24) ===============================================================================
sonic@arctos_cicd_all_202603:/data/tests$ 
```

#### Any platform specific information?
The list is not platform specific, but this is required to support the cisco console server.