### PR TITLE
Enhance DASH-HA Private Link Steady State test

### DIFF
--- a/tests/ha/conftest.py
+++ b/tests/ha/conftest.py
@@ -675,7 +675,14 @@ def activate_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi_ser
                 messages=ha_scope_messages,
             )
             # Verify HA state using fields
-            expected_state = "active"
+            if ha_owner == "dpu":
+                expected_state = "active"
+            else:
+                # Expect standby state on vDPU1
+                if key == "vdpu1_0:haset0_0":
+                    expected_state = "standby"
+                else:
+                    expected_state = "active"
             assert verify_ha_state(
                 duthost,
                 scope_key=key,

--- a/tests/ha/test_ha_steady_state_pl.py
+++ b/tests/ha/test_ha_steady_state_pl.py
@@ -103,6 +103,7 @@ def test_privatelink_basic_transform(
     dash_pl_config,
     encap_proto
 ):
+    # traffic to active
     vm_to_dpu_pkt, exp_dpu_to_pe_pkt = outbound_pl_packets(dash_pl_config[0], encap_proto)
     pe_to_dpu_pkt, exp_dpu_to_vm_pkt = inbound_pl_packets(dash_pl_config[0])
 
@@ -112,4 +113,16 @@ def test_privatelink_basic_transform(
     flow_op = compare_flow_tables_pdsctl(dpuhosts[0], dpuhosts[1])
     pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
     testutils.send(ptfadapter, dash_pl_config[0][REMOTE_PTF_SEND_INTF], pe_to_dpu_pkt, 1)
+    testutils.verify_packet(ptfadapter, exp_dpu_to_vm_pkt, dash_pl_config[0][LOCAL_PTF_INTF])
+
+    # traffic to standby
+    vm_to_dpu_pkt, exp_dpu_to_pe_pkt = outbound_pl_packets(dash_pl_config[1], encap_proto)
+    pe_to_dpu_pkt, exp_dpu_to_vm_pkt = inbound_pl_packets(dash_pl_config[1])
+
+    ptfadapter.dataplane.flush()
+    testutils.send(ptfadapter, dash_pl_config[1][LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
+    testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, dash_pl_config[0][REMOTE_PTF_RECV_INTF])
+    flow_op = compare_flow_tables_pdsctl(dpuhosts[0], dpuhosts[1])
+    pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
+    testutils.send(ptfadapter, dash_pl_config[1][REMOTE_PTF_SEND_INTF], pe_to_dpu_pkt, 1)
     testutils.verify_packet(ptfadapter, exp_dpu_to_vm_pkt, dash_pl_config[0][LOCAL_PTF_INTF])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. Add a traffic test to standby switch
2. Distinguish the expected HA states for two DPUs when ha_owner is switch
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
