### PR TITLE
[npu-driven][ssw][ha] remove hard-coded owner 

### DIFF
--- a/tests/ha/conftest.py
+++ b/tests/ha/conftest.py
@@ -498,12 +498,12 @@ def setup_ha_config(duthosts, tbinfo):
 @pytest.fixture(scope="module")
 def ha_owner(dpuhosts):
     """
-    Fixture to parametrize HA owner type (dpu or npu) for the test.
+    Fixture to parametrize HA owner type (dpu or switch) for the test.
     """
     if 'pensando' in dpuhosts[0].facts['asic_type']:
         owner = "dpu"
     else:
-        owner = "npu"
+        owner = "switch"
     yield owner
 
 

--- a/tests/ha/ha_utils.py
+++ b/tests/ha/ha_utils.py
@@ -188,7 +188,7 @@ def verify_ha_state(
     return success
 
 
-def activate_primary_dash_ha(localhost, duthost, ptfhost, scope_key, expected_op_type):
+def activate_primary_dash_ha(localhost, duthost, ptfhost, scope_key, expected_op_type, owner="dpu"):
     """
     Activate Role using pending_operation_ids
     """
@@ -196,12 +196,12 @@ def activate_primary_dash_ha(localhost, duthost, ptfhost, scope_key, expected_op
                 "version": "1",
                 "disabled": False,
                 "desired_ha_state": "active",
-                "owner": "dpu",
+                "owner": owner,
             }
     return activate_dash_ha(localhost, duthost, ptfhost, scope_key, fields, expected_op_type)
 
 
-def activate_secondary_dash_ha(localhost, duthost, ptfhost, scope_key, expected_op_type):
+def activate_secondary_dash_ha(localhost, duthost, ptfhost, scope_key, expected_op_type, owner="dpu"):
     """
     Activate Role using pending_operation_ids
     """
@@ -209,7 +209,7 @@ def activate_secondary_dash_ha(localhost, duthost, ptfhost, scope_key, expected_
                 "version": "1",
                 "disabled": False,
                 "desired_ha_state": "unspecified",
-                "owner": "dpu",
+                "owner": owner,
             }
     return activate_dash_ha(localhost, duthost, ptfhost, scope_key, fields, expected_op_type)
 

--- a/tests/ha/test_ha_planned_shutdown.py
+++ b/tests/ha/test_ha_planned_shutdown.py
@@ -144,7 +144,8 @@ def test_ha_planned_shutdown(
     logging.info("Primary shutdown all {} packets received".format(send_count))
 
     # Re-activate primary
-    pytest_assert(activate_primary_dash_ha(localhost, duthosts[0], ptfhost, "vdpu0_0:haset0_0", "activate_role"),
+    pytest_assert(activate_primary_dash_ha(localhost, duthosts[0], ptfhost, "vdpu0_0:haset0_0", "activate_role",
+                                            owner=ha_owner),
                   "Failed to re-activate HA on primary")
 
     packet_sending_flag = queue.Queue(1)
@@ -188,5 +189,6 @@ def test_ha_planned_shutdown(
     logging.info("standby shutdown all {} packets received".format(send_count))
 
     # Re-activate standby
-    pytest_assert(activate_secondary_dash_ha(localhost, duthosts[1], ptfhost, "vdpu1_0:haset0_0", "activate_role"),
+    pytest_assert(activate_secondary_dash_ha(localhost, duthosts[1], ptfhost, "vdpu1_0:haset0_0", "activate_role",
+                                              owner=ha_owner),
                   "Failed to re-activate HA on standby")

--- a/tests/ha/test_ha_planned_shutdown.py
+++ b/tests/ha/test_ha_planned_shutdown.py
@@ -145,7 +145,7 @@ def test_ha_planned_shutdown(
 
     # Re-activate primary
     pytest_assert(activate_primary_dash_ha(localhost, duthosts[0], ptfhost, "vdpu0_0:haset0_0", "activate_role",
-                                            owner=ha_owner),
+                                           owner=ha_owner),
                   "Failed to re-activate HA on primary")
 
     packet_sending_flag = queue.Queue(1)
@@ -190,5 +190,5 @@ def test_ha_planned_shutdown(
 
     # Re-activate standby
     pytest_assert(activate_secondary_dash_ha(localhost, duthosts[1], ptfhost, "vdpu1_0:haset0_0", "activate_role",
-                                              owner=ha_owner),
+                                             owner=ha_owner),
                   "Failed to re-activate HA on standby")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to fix two items:
1. npu driven ha should have `switch` as owner instead of `npu` 
2. removing hard-coded ha owner 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
This is to make test cases work for npu-driven ha. 

#### How did you do it?
As the description suggests. 

#### How did you verify/test it?
Verified with steady state. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
