### PR TITLE
[BUG] Fix is_multi_vrf_peer KeyError for vsonic neighbors

### DIFF
--- a/tests/bgp/test_bgp_gr_helper.py
+++ b/tests/bgp/test_bgp_gr_helper.py
@@ -154,7 +154,7 @@ def test_bgp_gr_helper_routes_perserved(duthosts, rand_one_dut_hostname, nbrhost
         test_neighbor_name = dev_nbrs[test_interface]['name']
 
     nbrhost = nbrhosts[test_neighbor_name]
-    if nbrhost['is_multi_vrf_peer']:
+    if nbrhost.get('is_multi_vrf_peer', False):
         vrf = test_neighbor_name
         exabgp_ips = [nbrhost['multi_vrf_data']['ptf_bp_config'].get("ipv4"),
                       nbrhost['multi_vrf_data']['ptf_bp_config'].get("ipv6")]

--- a/tests/bgp/test_bgp_router_id.py
+++ b/tests/bgp/test_bgp_router_id.py
@@ -74,7 +74,7 @@ def verify_bgp(enum_asic_index, duthost, expected_bgp_router_id, neighbor_type, 
             "Local IP map: {}"
         ).format(neighbor_name, local_ip_map))
         localip = local_ip_map[neighbor_name]
-        vrf = neighbor_name if nbrhost["is_multi_vrf_peer"] else "default"
+        vrf = neighbor_name if nbrhost.get("is_multi_vrf_peer", False) else "default"
         verify_bgp_peer(neighbor_type, nbrhost, localip, expected_bgp_router_id, is_v6_topo, vrf=vrf)
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fix KeyError: 'is_multi_vrf_peer' in test_bgp_router_id when peers are vsonic VMs. And while at it, fix the same issue in test_bgp_gr_helper too. This key is set only for cEOS peers, and so the tests fail when peers are vSONIC VMs.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

The nbrhosts fixture only sets `is_multi_vrf_peer` for EOS neighbors, not sonic. When `test_bgp_router_id.py` runs with vsonic peers, `nbrhost["is_multi_vrf_peer"]` raises a `KeyError`.

#### How did you do it?
Use `.get("is_multi_vrf_peer", False)` which is the same pattern already used in tests/bgp/conftest.py (e.g., `node.get('is_multi_vrf_peer', False)`).

#### How did you verify/test it?
Run tests/bgp/test_bgp_router_id.py on a testbed with vsonic neighbors

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
