### PR TITLE
docs: add test cherry-pick guard design document

### DIFF
--- a/docs/tests/design-doc-test-cherry-pick-guard.md
+++ b/docs/tests/design-doc-test-cherry-pick-guard.md
@@ -1,6 +1,6 @@
 # Design Doc: Test Cherry-pick Guard for sonic-net/sonic-mgmt
 
-**Author:** (your alias)  
+**Author:** xwjiang-ms  
 **Status:** Draft  
 **Reviewers:** Nightly Guard Team, Platform Owners  
 
@@ -83,7 +83,7 @@ contributor adds a brand-new test to `master` and it gets approved for a release
 │  Job 1: detect-and-tag                                               │
 │  ├─ Fetch PR file diff via GitHub API                                │
 │  ├─ Match against test file patterns                                 │
-│  ├─ Output: has_new_tests, new_test_files, target_branch             │
+│  ├─ Output: has_new_tests (bool), new_test_files (list), target_branch│
 │  └─ If new tests found → add label "contains-new-tests"              │
 │                                                                      │
 │  Job 2: enforce-policy  (skipped if master or no new tests)          │

--- a/docs/tests/design-doc-test-cherry-pick-guard.md
+++ b/docs/tests/design-doc-test-cherry-pick-guard.md
@@ -89,8 +89,10 @@ contributor adds a brand-new test to `master` and it gets approved for a release
 │  Job 2: enforce-policy  (skipped if master or no new tests)          │
 │  ├─ Check for "cherry-pick-bypass-approved" label                     │
 │  ├─ Verify label adder is in @sonic-net/platform-owners (GitHub API) │
-│  ├─ Check for [cherry-pick-bypass-reason] comment                     │
+│  ├─ Check for [cherry-pick-bypass-reason] comment from authorized    │
+│  │   team member                                                      │
 │  ├─ FAIL with guidance comment  (any condition unmet)                │
+│  ├─ PASS → create/update check run on PR HEAD via Checks API        │
 │  └─ PASS → send email + post audit comment  (all conditions met)     │
 └──────────────────────────────────────────────────────────────────────┘
                                │
@@ -112,11 +114,28 @@ The workflow responds to two GitHub event types:
 
 | Event | Types | Why |
 |-------|-------|-----|
-| `pull_request_target` | `opened`, `synchronize`, `reopened`, `labeled`, `unlabeled` | Covers PR creation, force-pushes, and label changes |
+| `pull_request_target` | `opened`, `synchronize`, `reopened`, `labeled`, `unlabeled` | Covers PR creation, force-pushes, and label changes. Creates a check run on the PR HEAD SHA automatically. |
 | `issue_comment` | `created` | Re-evaluates policy when an explanation comment is added |
 
 `pull_request_target` is used (instead of `pull_request`) because cherry-pick PRs are
 created from a fork (`mssonicbld/sonic-mgmt`), which requires elevated token permissions.
+
+> **Important:** The `issue_comment` trigger does **not** automatically create a check run
+> on the PR HEAD SHA. To satisfy the required status check after posting a bypass comment,
+> the workflow must explicitly create or update a check run via the
+> [Checks API](https://docs.github.com/en/rest/checks/runs#create-a-check-run):
+>
+> ```
+> POST /repos/{owner}/{repo}/check-runs
+> {
+>   "name": "Cherry-pick policy check",
+>   "head_sha": "<PR HEAD SHA>",
+>   "status": "completed",
+>   "conclusion": "success" | "failure"
+> }
+> ```
+>
+> This requires the `checks: write` permission (see Section 6).
 
 ### 3.3 Test File Detection
 
@@ -130,6 +149,13 @@ A file is classified as a **new test file** if:
 | `tests/**/conftest.py` | pytest fixtures | `tests/bgp/conftest.py` |
 | `spytest/tests/**/*.py` | SpyTest | `spytest/tests/routing/test_ospf.py` |
 | `sdn_tests/**/*_test.go` | Bazel / Ondatra | `sdn_tests/pins_ondatra/bgp_test.go` |
+
+**Known limitations (v1):**
+- `spytest/tests/**/*.py` may match non-test utility files. This is accepted as
+  over-matching is safer than under-matching; false positives can use the bypass flow.
+- Cherry-picks may surface files as `"renamed"` rather than `"added"` depending on diff
+  similarity. A future iteration can also match `"renamed"` files whose new path matches
+  test patterns and whose previous path does not exist on the target branch.
 
 ### 3.4 Policy Enforcement State Machine
 
@@ -156,15 +182,17 @@ A file is classified as a **new test file** if:
    Yes                ❌ FAIL
     │               Post: unauthorized bypass comment
     │
-  ┌─┴──────────────────────┐
-  │                        │
-[cherry-pick-bypass-reason]  No explanation
-comment present?            comment
-  │                        │
- Yes                     ❌ FAIL
-  │                   Post: explanation required comment
+  ┌─┴──────────────────────────────┐
+  │                                │
+[cherry-pick-bypass-reason]     No explanation comment
+comment by authorized              from authorized member
+team member?
+  │                                │
+ Yes                             ❌ FAIL
+  │                          Post: explanation required comment
   │
 ✅ PASS
+Create/update check run on PR HEAD (Checks API)
 Send email notification (once)
 Post audit comment on PR
 ```
@@ -174,13 +202,26 @@ Post audit comment on PR
 Authorization is verified at **check runtime** using the GitHub API:
 
 ```
-GET /orgs/{AUTH_ORG}/teams/{AUTH_TEAM}/memberships/{label_adder_login}
+GET /orgs/{AUTH_ORG}/teams/{AUTH_TEAM}/memberships/{login}
 → 200 + { "state": "active" }  ← authorized
 → 404 or state != "active"     ← not authorized
 ```
 
 Default values: `AUTH_ORG=sonic-net`, `AUTH_TEAM=platform-owners`.  
 Both are configurable via GitHub repository variables without changing the workflow file.
+
+> **Note:** The team membership API (`GET /orgs/{org}/teams/{team}/memberships/{user}`)
+> requires the **`read:org`** OAuth scope. The default `GITHUB_TOKEN` does not have this
+> scope. The workflow must use either:
+> - A **Personal Access Token (PAT)** with `read:org` scope, stored as a repository secret, or
+> - A **GitHub App** installation token with Organization → Members → Read permission.
+>
+> See Section 6 for the full token requirements.
+
+**Label adder identification:** The workflow identifies who added the bypass label by
+querying the PR timeline API (`GET /repos/{owner}/{repo}/issues/{number}/timeline`) and
+finding the most recent `labeled` event for the `cherry-pick-bypass-approved` label. This
+approach works regardless of which event triggered the current workflow run.
 
 ### 3.6 Explanation Comment Format
 
@@ -197,12 +238,35 @@ Owner:   <Alias — you own any fallout from this cherry-pick>
 The workflow detects the most recent such comment, extracts the author and body,
 and includes both in the notification email and the audit comment.
 
+> **Authorization requirement:** The explanation comment must be authored by a member of
+> the authorized team (`@{AUTH_ORG}/{AUTH_TEAM}`). If the marker comment is posted by
+> a non-authorized user, the check fails with a message requesting an authorized member
+> to post the explanation. This prevents an unauthorized user from satisfying the
+> explanation requirement after someone else adds the bypass label.
+
 ### 3.7 Email Notification
 
-Implemented via `dawidd6/action-send-mail@v3` (SMTP/STARTTLS).  
+Sent via SMTP (STARTTLS) using an inline workflow step.
 Sent **once per PR** — a hidden HTML comment `<!-- cherry-pick-bypass-notification-sent -->`
 is embedded in the audit comment and checked before each send to prevent duplicates on
 workflow re-runs.
+
+> **Concurrency control:** To prevent a race condition where two concurrent workflow runs
+> both see "marker not present" and both send the email, the workflow uses a
+> [`concurrency` group](https://docs.github.com/en/actions/using-jobs/using-concurrency)
+> keyed on the PR number:
+>
+> ```yaml
+> concurrency:
+>   group: cherry-pick-guard-${{ github.event.pull_request.number || github.event.issue.number }}
+>   cancel-in-progress: false
+> ```
+
+> **Input sanitization:** The explanation text and file list are embedded in both the
+> PR comment (Markdown) and the notification email (HTML). All user-provided text must be
+> escaped before embedding:
+> - **Markdown comments:** Wrap in a code fence or escape special characters.
+> - **HTML email:** Apply HTML entity encoding to prevent injection.
 
 **Email content:**
 
@@ -218,8 +282,15 @@ Every bypass creates a permanent record directly on the PR:
 
 1. **`contains-new-tests` label** — visible in PR list views
 2. **`cherry-pick-bypass-approved` label** — records that an exception was granted
-3. **Explanation comment** — authored by the approver, timestamped by GitHub
+3. **Explanation comment** — authored by an authorized team member, timestamped by GitHub
 4. **Audit comment by bot** — confirms notification was sent, non-editable by the approver
+
+> **Comment edit/delete:** If the explanation comment is edited or deleted after the check
+> passes, the check is not automatically re-evaluated (GitHub does not fire events on
+> comment edits for `issue_comment: created`). This is accepted as a low-risk gap:
+> the audit comment posted by the bot preserves a snapshot of the explanation at
+> approval time. A future iteration may subscribe to `issue_comment: edited, deleted`
+> events if needed.
 
 ---
 
@@ -255,20 +326,37 @@ sonic-net/sonic-mgmt/
 │   ├── workflows/
 │   │   └── test-cherry-pick-guard.yml     # Main workflow (Jobs 1 & 2)
 │   └── scripts/
-│       ├── check_new_tests.py            # Standalone test-file detector (also used locally)
-│       └── send_bypass_notification.py   # SMTP email sender (standalone callable)
+│       └── check_new_tests.py             # Standalone test-file detector (also used locally)
 └── docs/
-    └── test-cherry-pick-policy.md         # End-user policy + setup guide
+    └── test-cherry-pick-policy.md          # End-user policy + setup guide
 ```
+
+> **Note:** Email sending is handled inline in the workflow via an SMTP step rather than a
+> separate script, to avoid duplicating logic and keep secrets management in one place.
 
 ---
 
 ## 6. Configuration Reference
 
+### Token Permissions
+
+The workflow requires the following permissions. Because `read:org` is not available to
+the default `GITHUB_TOKEN`, a **PAT or GitHub App token** must be provided as a secret
+(e.g. `CHERRY_PICK_GUARD_TOKEN`):
+
+| Permission | Scope | Why |
+|------------|-------|-----|
+| `pull-requests: write` | `GITHUB_TOKEN` | Post comments, add labels |
+| `issues: write` | `GITHUB_TOKEN` | Post comments on issue_comment trigger |
+| `contents: read` | `GITHUB_TOKEN` | Read PR file list |
+| `checks: write` | `GITHUB_TOKEN` | Create/update check runs on PR HEAD (required for `issue_comment` trigger) |
+| `read:org` | PAT or App token | Query team membership for bypass authorization |
+
 ### GitHub Secrets (Settings → Secrets → Actions)
 
 | Secret | Required | Example | Description |
 |--------|----------|---------|-------------|
+| `CHERRY_PICK_GUARD_TOKEN` | ✅ | `ghp_...` | PAT with `read:org` scope (or GitHub App token) |
 | `SMTP_SERVER` | ✅ | `smtp.office365.com` | SMTP relay hostname |
 | `SMTP_PORT` | ✅ | `587` | Port (587 = STARTTLS) |
 | `SMTP_USERNAME` | ✅ | `noreply@contoso.com` | SMTP login / sender |
@@ -296,10 +384,13 @@ On Settings → Branches, for pattern `20????`:
 | Risk | Mitigation |
 |------|-----------|
 | Unauthorized user adds bypass label | Workflow verifies label adder's org-team membership via GitHub API at runtime; fails even if label is present |
+| Unauthorized user posts explanation comment | Workflow verifies explanation comment author is also in the authorized team; both label and comment must come from authorized members |
 | Bypass label added before explanation | Two-step requirement: label + comment both needed; failing one fails the check |
-| Duplicate email spam on re-runs | Idempotent guard: checks for `<!-- cherry-pick-bypass-notification-sent -->` marker before sending |
+| Duplicate email spam on re-runs | Idempotent guard: checks for `<!-- cherry-pick-bypass-notification-sent -->` marker before sending; `concurrency` group prevents race conditions between parallel runs |
 | `pull_request_target` privilege escalation | Workflow only reads PR metadata via API; no checkout of untrusted code |
-| Token scope | Only `pull-requests: write` and `issues: write` permissions granted; no repo-write or secrets access |
+| Token scope | `GITHUB_TOKEN` has minimal permissions; `read:org` is isolated to a separate PAT/App token secret |
+| HTML/Markdown injection via explanation text | All user-provided text is HTML-entity-encoded before embedding in email and escaped in Markdown comments |
+| Comment edit/delete after approval | Bot-authored audit comment preserves a snapshot of the explanation at approval time; future iteration may re-evaluate on `issue_comment: edited` |
 
 ---
 
@@ -308,7 +399,7 @@ On Settings → Branches, for pattern `20????`:
 | Phase | Action | Verification |
 |-------|--------|-------------|
 | **Phase 1** | Commit workflow files to `master` | Workflow appears in Actions tab; no PRs blocked yet (no branch protection rule) |
-| **Phase 2** | Set GitHub Secrets with your own email as `GUARD_NOTIFICATION_EMAIL` | Open a test PR to a release branch adding a `test_*.py` file; verify block + email to yourself |
+| **Phase 2** | Set GitHub Secrets (SMTP + `CHERRY_PICK_GUARD_TOKEN`) with your own email as `GUARD_NOTIFICATION_EMAIL` | Open a test PR to a release branch adding a `test_*.py` file; verify block + email to yourself |
 | **Phase 3** | Verify bypass flow end-to-end | Have a `platform-owners` member add bypass label + explanation; verify pass + email |
 | **Phase 4** | Add branch protection rule for `20????` | Existing open cherry-pick PRs without new tests are unaffected |
 | **Phase 5** | Update `GUARD_NOTIFICATION_EMAIL` to guard team DL + platform owners alias | Done |
@@ -324,6 +415,7 @@ On Settings → Branches, for pattern `20????`:
 | 3 | Should `spytest/` new tests be treated differently (different ownership team)? | SpyTest owners | Open |
 | 4 | Do we need a weekly digest of all bypasses, or is per-bypass email sufficient? | Guard team | Open |
 | 5 | Should the policy also apply to non-release feature branches (e.g. `feature/*`)? | Platform team | Open |
+| 6 | PAT vs GitHub App: which approach for `read:org` scope is preferred? | Platform team | Open |
 
 ---
 

--- a/docs/tests/design-doc-test-cherry-pick-guard.md
+++ b/docs/tests/design-doc-test-cherry-pick-guard.md
@@ -1,0 +1,357 @@
+# Design Doc: Test Cherry-pick Guard for sonic-net/sonic-mgmt
+
+**Author:** (your alias)  
+**Status:** Draft  
+**Reviewers:** Nightly Guard Team, Platform Owners  
+
+---
+
+## 1. Background & Motivation
+
+The `sonic-net/sonic-mgmt` repository hosts the SONiC test framework used across all
+SONiC platform releases. It maintains a `master` branch for active development and a set
+of versioned **release branches** (e.g. `202205`, `202411`, `202505`) that correspond to
+stable SONiC images shipped to partners and customers.
+
+### Existing Cherry-pick Mechanism
+
+A GitHub Actions workflow (`pr_cherrypick_prestep.yml`) already automates backporting:
+
+1. A PR is merged to `master`.
+2. A reviewer adds the label **`Approved for 202XXX branch`**.
+3. The workflow automatically creates a cherry-pick PR targeting that release branch.
+4. The cherry-pick PR receives an **`automerge`** label and merges without additional review.
+
+### Problem
+
+This automated pipeline has **no guardrail against backporting new test files**. When a
+contributor adds a brand-new test to `master` and it gets approved for a release branch:
+
+- The new test was written against `master`-era APIs, fixtures, and topology assumptions.
+  It may fail or be incompatible on an older release branch.
+- Nightly run failures on release branches erode confidence in those branches and increase
+  on-call burden for the nightly guard team.
+- There is currently **no audit trail** or awareness notification when this happens.
+- The policy violation is discovered only after nightly failures, not at merge time.
+
+### Goals
+
+| Goal | Description |
+|------|-------------|
+| **Block** | Prevent new test files from being merged to non-master branches without review |
+| **Tag** | Automatically label PRs that introduce new test files for visibility |
+| **Bypass** | Allow authorized team members to override the block with justification |
+| **Notify** | Alert the nightly guard team and platform owners whenever a bypass is granted |
+| **Audit** | Preserve a permanent record of every bypass and its explanation on the PR |
+
+### Non-Goals
+
+- Blocking modifications to *existing* test files (only *newly added* files are in scope)
+- Enforcing code quality or test correctness
+- Replacing the existing cherry-pick automation (this is additive)
+- Blocking new tests merged to `master` (always allowed)
+
+---
+
+## 2. Terminology
+
+| Term | Meaning |
+|------|---------|
+| **Release branch** | Any branch matching `20????` (e.g. `202411`) — a stable release snapshot |
+| **New test file** | A file with `status: added` (not modified) matching test path patterns |
+| **Bypass** | An authorized exception allowing a new test to merge to a release branch |
+| **Policy check** | The GitHub Actions required status check enforcing this policy |
+| **Guard team** | The team responsible for nightly test health across release branches |
+
+---
+
+## 3. Design
+
+### 3.1 System Overview
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                        GitHub Pull Request                           │
+│  (direct PR to release branch  OR  auto-created cherry-pick PR)      │
+└──────────────────────────────┬───────────────────────────────────────┘
+                               │  opened / synchronize / labeled /
+                               │  unlabeled / issue_comment:created
+                               ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│              GitHub Actions: test-cherry-pick-guard.yml               │
+│                                                                      │
+│  Job 1: detect-and-tag                                               │
+│  ├─ Fetch PR file diff via GitHub API                                │
+│  ├─ Match against test file patterns                                 │
+│  ├─ Output: has_new_tests, new_test_files, target_branch             │
+│  └─ If new tests found → add label "contains-new-tests"              │
+│                                                                      │
+│  Job 2: enforce-policy  (skipped if master or no new tests)          │
+│  ├─ Check for "cherry-pick-bypass-approved" label                     │
+│  ├─ Verify label adder is in @sonic-net/platform-owners (GitHub API) │
+│  ├─ Check for [cherry-pick-bypass-reason] comment                     │
+│  ├─ FAIL with guidance comment  (any condition unmet)                │
+│  └─ PASS → send email + post audit comment  (all conditions met)     │
+└──────────────────────────────────────────────────────────────────────┘
+                               │
+              (bypass approved + all conditions met)
+                               │
+                               ▼
+              ┌────────────────────────────┐
+              │  SMTP Email Notification   │
+              │  To: Guard team + Owners   │
+              │  Subject: [AWARENESS]...   │
+              │  Body: PR, bypasser,       │
+              │        explanation, files  │
+              └────────────────────────────┘
+```
+
+### 3.2 Trigger Events
+
+The workflow responds to two GitHub event types:
+
+| Event | Types | Why |
+|-------|-------|-----|
+| `pull_request_target` | `opened`, `synchronize`, `reopened`, `labeled`, `unlabeled` | Covers PR creation, force-pushes, and label changes |
+| `issue_comment` | `created` | Re-evaluates policy when an explanation comment is added |
+
+`pull_request_target` is used (instead of `pull_request`) because cherry-pick PRs are
+created from a fork (`mssonicbld/sonic-mgmt`), which requires elevated token permissions.
+
+### 3.3 Test File Detection
+
+A file is classified as a **new test file** if:
+- Its `status` in the PR diff is `"added"` (not `"modified"` or `"renamed"`)
+- Its path matches one of the following patterns:
+
+| Pattern | Framework | Example |
+|---------|-----------|---------|
+| `tests/**/test_*.py` | pytest (primary) | `tests/bgp/test_bgp_fact.py` |
+| `tests/**/conftest.py` | pytest fixtures | `tests/bgp/conftest.py` |
+| `spytest/tests/**/*.py` | SpyTest | `spytest/tests/routing/test_ospf.py` |
+| `sdn_tests/**/*_test.go` | Bazel / Ondatra | `sdn_tests/pins_ondatra/bgp_test.go` |
+
+### 3.4 Policy Enforcement State Machine
+
+```
+                    ┌───────────────────────────────┐
+                    │  PR targets non-master branch  │
+                    │  AND has new test files        │
+                    └──────────────┬────────────────┘
+                                   │
+              ┌────────────────────┴──────────────────────┐
+              │                                           │
+    "cherry-pick-bypass-approved"              No bypass label present
+         label present?
+              │                                           │
+             Yes                                    ❌ FAIL
+              │                              Post: policy violation comment
+              │                              (once, idempotent)
+    ┌─────────┴──────────┐
+    │                    │
+  Label adder        Label adder NOT in
+  in authorized      authorized team
+  org team?
+    │                    │
+   Yes                ❌ FAIL
+    │               Post: unauthorized bypass comment
+    │
+  ┌─┴──────────────────────┐
+  │                        │
+[cherry-pick-bypass-reason]  No explanation
+comment present?            comment
+  │                        │
+ Yes                     ❌ FAIL
+  │                   Post: explanation required comment
+  │
+✅ PASS
+Send email notification (once)
+Post audit comment on PR
+```
+
+### 3.5 Bypass Authorization
+
+Authorization is verified at **check runtime** using the GitHub API:
+
+```
+GET /orgs/{AUTH_ORG}/teams/{AUTH_TEAM}/memberships/{label_adder_login}
+→ 200 + { "state": "active" }  ← authorized
+→ 404 or state != "active"     ← not authorized
+```
+
+Default values: `AUTH_ORG=sonic-net`, `AUTH_TEAM=platform-owners`.  
+Both are configurable via GitHub repository variables without changing the workflow file.
+
+### 3.6 Explanation Comment Format
+
+The explanation must be posted as a PR comment containing the marker
+`[cherry-pick-bypass-reason]` (case-insensitive). Enforced format:
+
+```
+[cherry-pick-bypass-reason]
+Reason:  <Why this test is needed on the release branch>
+Impact:  <What breaks without this backport>
+Owner:   <Alias — you own any fallout from this cherry-pick>
+```
+
+The workflow detects the most recent such comment, extracts the author and body,
+and includes both in the notification email and the audit comment.
+
+### 3.7 Email Notification
+
+Implemented via `dawidd6/action-send-mail@v3` (SMTP/STARTTLS).  
+Sent **once per PR** — a hidden HTML comment `<!-- cherry-pick-bypass-notification-sent -->`
+is embedded in the audit comment and checked before each send to prevent duplicates on
+workflow re-runs.
+
+**Email content:**
+
+| Field | Value |
+|-------|-------|
+| Subject | `[sonic-mgmt][AWARENESS] Cherry-pick Bypass — New Tests → <branch>` |
+| To | `GUARD_NOTIFICATION_EMAIL` (comma-separated, set as secret) |
+| Body | PR link, author, target branch, bypass approver, new file list, explanation text |
+
+### 3.8 Audit Trail
+
+Every bypass creates a permanent record directly on the PR:
+
+1. **`contains-new-tests` label** — visible in PR list views
+2. **`cherry-pick-bypass-approved` label** — records that an exception was granted
+3. **Explanation comment** — authored by the approver, timestamped by GitHub
+4. **Audit comment by bot** — confirms notification was sent, non-editable by the approver
+
+---
+
+## 4. Integration with Existing Cherry-pick System
+
+```
+  master PR merged
+       │
+       │  reviewer adds "Approved for 202411 branch"
+       ▼
+  pr_cherrypick_prestep.yml
+       │  creates cherry-pick PR targeting 202411
+       │  adds "automerge" label to new PR
+       ▼
+  NEW: test-cherry-pick-guard.yml runs on new cherry-pick PR
+       │
+       ├─ No new tests → ✅ automerge proceeds normally
+       │
+       └─ Has new tests → ❌ required check fails
+                          automerge is BLOCKED
+                          Platform owner must review and bypass
+```
+
+The guard is **additive and non-breaking** for PRs without new tests.
+
+---
+
+## 5. File Structure
+
+```
+sonic-net/sonic-mgmt/
+├── .github/
+│   ├── workflows/
+│   │   └── test-cherry-pick-guard.yml     # Main workflow (Jobs 1 & 2)
+│   └── scripts/
+│       ├── check_new_tests.py            # Standalone test-file detector (also used locally)
+│       └── send_bypass_notification.py   # SMTP email sender (standalone callable)
+└── docs/
+    └── test-cherry-pick-policy.md         # End-user policy + setup guide
+```
+
+---
+
+## 6. Configuration Reference
+
+### GitHub Secrets (Settings → Secrets → Actions)
+
+| Secret | Required | Example | Description |
+|--------|----------|---------|-------------|
+| `SMTP_SERVER` | ✅ | `smtp.office365.com` | SMTP relay hostname |
+| `SMTP_PORT` | ✅ | `587` | Port (587 = STARTTLS) |
+| `SMTP_USERNAME` | ✅ | `noreply@contoso.com` | SMTP login / sender |
+| `SMTP_PASSWORD` | ✅ | `••••` | SMTP password or app password |
+| `SMTP_FROM_EMAIL` | ✅ | `noreply@contoso.com` | From address |
+| `GUARD_NOTIFICATION_EMAIL` | ✅ | `guard@contoso.com` | Comma-separated recipients |
+
+### GitHub Variables (Settings → Variables → Actions)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AUTH_ORG` | `sonic-net` | Org owning the authorized team |
+| `AUTH_TEAM` | `platform-owners` | Team slug for bypass authorizers |
+
+### Branch Protection Rule
+
+On Settings → Branches, for pattern `20????`:
+- ✅ Require status checks: **`Cherry-pick policy check`**
+- ✅ Do not allow bypassing the above settings
+
+---
+
+## 7. Security Considerations
+
+| Risk | Mitigation |
+|------|-----------|
+| Unauthorized user adds bypass label | Workflow verifies label adder's org-team membership via GitHub API at runtime; fails even if label is present |
+| Bypass label added before explanation | Two-step requirement: label + comment both needed; failing one fails the check |
+| Duplicate email spam on re-runs | Idempotent guard: checks for `<!-- cherry-pick-bypass-notification-sent -->` marker before sending |
+| `pull_request_target` privilege escalation | Workflow only reads PR metadata via API; no checkout of untrusted code |
+| Token scope | Only `pull-requests: write` and `issues: write` permissions granted; no repo-write or secrets access |
+
+---
+
+## 8. Rollout Plan
+
+| Phase | Action | Verification |
+|-------|--------|-------------|
+| **Phase 1** | Commit workflow files to `master` | Workflow appears in Actions tab; no PRs blocked yet (no branch protection rule) |
+| **Phase 2** | Set GitHub Secrets with your own email as `GUARD_NOTIFICATION_EMAIL` | Open a test PR to a release branch adding a `test_*.py` file; verify block + email to yourself |
+| **Phase 3** | Verify bypass flow end-to-end | Have a `platform-owners` member add bypass label + explanation; verify pass + email |
+| **Phase 4** | Add branch protection rule for `20????` | Existing open cherry-pick PRs without new tests are unaffected |
+| **Phase 5** | Update `GUARD_NOTIFICATION_EMAIL` to guard team DL + platform owners alias | Done |
+
+---
+
+## 9. Open Questions
+
+| # | Question | Owner | Status |
+|---|----------|-------|--------|
+| 1 | Which GitHub team slug is the authoritative "platform owners" for sonic-mgmt? | Platform team | Open |
+| 2 | Should `conftest.py` modifications (not additions) also be blocked? | Guard team | Open |
+| 3 | Should `spytest/` new tests be treated differently (different ownership team)? | SpyTest owners | Open |
+| 4 | Do we need a weekly digest of all bypasses, or is per-bypass email sufficient? | Guard team | Open |
+| 5 | Should the policy also apply to non-release feature branches (e.g. `feature/*`)? | Platform team | Open |
+
+---
+
+## 10. Alternatives Considered
+
+### A. Block at the labeling step (before cherry-pick PR is created)
+Intercept `Approved for 202XXX branch` label on master PRs and refuse to create the
+cherry-pick PR if it adds new tests.
+
+**Rejected:** The existing cherry-pick workflow is not easily intercepted (it runs
+`pull_request_target: labeled`) and cannot "block" a label being added. A required
+status check on the cherry-pick PR itself is cleaner and more standard.
+
+### B. Maintain an allowlist of approved files in a config YAML
+Allow specific test files to be pre-approved for release branches.
+
+**Rejected:** Adds maintenance overhead and doesn't enforce a real review — the bypass
+explanation comment on the PR provides better traceability.
+
+### C. Use a GitHub App instead of a GitHub Actions workflow
+A GitHub App could react to label events in real time and have richer API access.
+
+**Rejected:** Requires provisioning and maintaining a separate service. GitHub Actions
+is already the established pattern in this repo and requires no new infrastructure.
+
+### D. Use GitHub Environments with required reviewers
+Mark the `release-branch` environment as requiring approval before deploy.
+
+**Rejected:** Environments are designed for deployment workflows, not PR merge gates.
+The label + comment pattern is more familiar to contributors already using the
+`Approved for 20XXXX branch` label system.

--- a/docs/tests/design-doc-test-cherry-pick-guard.md
+++ b/docs/tests/design-doc-test-cherry-pick-guard.md
@@ -141,19 +141,14 @@ created from a fork (`mssonicbld/sonic-mgmt`), which requires elevated token per
 
 A file is classified as a **new test file** if:
 - Its `status` in the PR diff is `"added"` (not `"modified"` or `"renamed"`)
-- Its path matches one of the following patterns:
+- Its path matches the following pattern:
 
 | Pattern | Framework | Example |
 |---------|-----------|---------|
-| `tests/**/test_*.py` | pytest (primary) | `tests/bgp/test_bgp_fact.py` |
-| `tests/**/conftest.py` | pytest fixtures | `tests/bgp/conftest.py` |
-| `spytest/tests/**/*.py` | SpyTest | `spytest/tests/routing/test_ospf.py` |
-| `sdn_tests/**/*_test.go` | Bazel / Ondatra | `sdn_tests/pins_ondatra/bgp_test.go` |
+| `tests/**/test_*.py` | pytest | `tests/bgp/test_bgp_fact.py` |
 
-**Known limitations (v1):**
-- `spytest/tests/**/*.py` may match non-test utility files. This is accepted as
-  over-matching is safer than under-matching; false positives can use the bypass flow.
-- Cherry-picks may surface files as `"renamed"` rather than `"added"` depending on diff
+**Known limitation (v1):**
+Cherry-picks may surface files as `"renamed"` rather than `"added"` depending on diff
   similarity. A future iteration can also match `"renamed"` files whose new path matches
   test patterns and whose previous path does not exist on the target branch.
 
@@ -411,11 +406,9 @@ On Settings → Branches, for pattern `20????`:
 | # | Question | Owner | Status |
 |---|----------|-------|--------|
 | 1 | Which GitHub team slug is the authoritative "platform owners" for sonic-mgmt? | Platform team | Open |
-| 2 | Should `conftest.py` modifications (not additions) also be blocked? | Guard team | Open |
-| 3 | Should `spytest/` new tests be treated differently (different ownership team)? | SpyTest owners | Open |
-| 4 | Do we need a weekly digest of all bypasses, or is per-bypass email sufficient? | Guard team | Open |
-| 5 | Should the policy also apply to non-release feature branches (e.g. `feature/*`)? | Platform team | Open |
-| 6 | PAT vs GitHub App: which approach for `read:org` scope is preferred? | Platform team | Open |
+| 2 | Do we need a weekly digest of all bypasses, or is per-bypass email sufficient? | Guard team | Open |
+| 3 | Should the policy also apply to non-release feature branches (e.g. `feature/*`)? | Platform team | Open |
+| 4 | PAT vs GitHub App: which approach for `read:org` scope is preferred? | Platform team | Open |
 
 ---
 

--- a/docs/tests/design-doc-test-cherry-pick-guard.md
+++ b/docs/tests/design-doc-test-cherry-pick-guard.md
@@ -40,9 +40,9 @@ contributor adds a brand-new test to `master` and it gets approved for a release
 |------|-------------|
 | **Block** | Prevent new test files from being merged to non-master branches without review |
 | **Tag** | Automatically label PRs that introduce new test files for visibility |
-| **Bypass** | Allow authorized team members to override the block with justification |
+| **Bypass** | Allow authorized team members to override the block by adding a label |
 | **Notify** | Alert the nightly guard team and platform owners whenever a bypass is granted |
-| **Audit** | Preserve a permanent record of every bypass and its explanation on the PR |
+| **Audit** | Preserve a permanent record of every bypass on the PR |
 
 ### Non-Goals
 
@@ -75,7 +75,7 @@ contributor adds a brand-new test to `master` and it gets approved for a release
 │  (direct PR to release branch  OR  auto-created cherry-pick PR)      │
 └──────────────────────────────┬───────────────────────────────────────┘
                                │  opened / synchronize / labeled /
-                               │  unlabeled / issue_comment:created
+                               │  unlabeled
                                ▼
 ┌──────────────────────────────────────────────────────────────────────┐
 │              GitHub Actions: test-cherry-pick-guard.yml               │
@@ -89,8 +89,6 @@ contributor adds a brand-new test to `master` and it gets approved for a release
 │  Job 2: enforce-policy  (skipped if master or no new tests)          │
 │  ├─ Check for "cherry-pick-bypass-approved" label                     │
 │  ├─ Verify label adder is in @sonic-net/platform-owners (GitHub API) │
-│  ├─ Check for [cherry-pick-bypass-reason] comment from authorized    │
-│  │   team member                                                      │
 │  ├─ FAIL with guidance comment  (any condition unmet)                │
 │  ├─ PASS → create/update check run on PR HEAD via Checks API        │
 │  └─ PASS → send email + post audit comment  (all conditions met)     │
@@ -110,32 +108,14 @@ contributor adds a brand-new test to `master` and it gets approved for a release
 
 ### 3.2 Trigger Events
 
-The workflow responds to two GitHub event types:
+The workflow responds to the following GitHub event:
 
 | Event | Types | Why |
 |-------|-------|-----|
 | `pull_request_target` | `opened`, `synchronize`, `reopened`, `labeled`, `unlabeled` | Covers PR creation, force-pushes, and label changes. Creates a check run on the PR HEAD SHA automatically. |
-| `issue_comment` | `created` | Re-evaluates policy when an explanation comment is added |
 
 `pull_request_target` is used (instead of `pull_request`) because cherry-pick PRs are
 created from a fork (`mssonicbld/sonic-mgmt`), which requires elevated token permissions.
-
-> **Important:** The `issue_comment` trigger does **not** automatically create a check run
-> on the PR HEAD SHA. To satisfy the required status check after posting a bypass comment,
-> the workflow must explicitly create or update a check run via the
-> [Checks API](https://docs.github.com/en/rest/checks/runs#create-a-check-run):
->
-> ```
-> POST /repos/{owner}/{repo}/check-runs
-> {
->   "name": "Cherry-pick policy check",
->   "head_sha": "<PR HEAD SHA>",
->   "status": "completed",
->   "conclusion": "success" | "failure"
-> }
-> ```
->
-> This requires the `checks: write` permission (see Section 6).
 
 ### 3.3 Test File Detection
 
@@ -177,17 +157,7 @@ Cherry-picks may surface files as `"renamed"` rather than `"added"` depending on
    Yes                ❌ FAIL
     │               Post: unauthorized bypass comment
     │
-  ┌─┴──────────────────────────────┐
-  │                                │
-[cherry-pick-bypass-reason]     No explanation comment
-comment by authorized              from authorized member
-team member?
-  │                                │
- Yes                             ❌ FAIL
-  │                          Post: explanation required comment
-  │
 ✅ PASS
-Create/update check run on PR HEAD (Checks API)
 Send email notification (once)
 Post audit comment on PR
 ```
@@ -218,28 +188,7 @@ querying the PR timeline API (`GET /repos/{owner}/{repo}/issues/{number}/timelin
 finding the most recent `labeled` event for the `cherry-pick-bypass-approved` label. This
 approach works regardless of which event triggered the current workflow run.
 
-### 3.6 Explanation Comment Format
-
-The explanation must be posted as a PR comment containing the marker
-`[cherry-pick-bypass-reason]` (case-insensitive). Enforced format:
-
-```
-[cherry-pick-bypass-reason]
-Reason:  <Why this test is needed on the release branch>
-Impact:  <What breaks without this backport>
-Owner:   <Alias — you own any fallout from this cherry-pick>
-```
-
-The workflow detects the most recent such comment, extracts the author and body,
-and includes both in the notification email and the audit comment.
-
-> **Authorization requirement:** The explanation comment must be authored by a member of
-> the authorized team (`@{AUTH_ORG}/{AUTH_TEAM}`). If the marker comment is posted by
-> a non-authorized user, the check fails with a message requesting an authorized member
-> to post the explanation. This prevents an unauthorized user from satisfying the
-> explanation requirement after someone else adds the bypass label.
-
-### 3.7 Email Notification
+### 3.6 Email Notification
 
 Sent via SMTP (STARTTLS) using an inline workflow step.
 Sent **once per PR** — a hidden HTML comment `<!-- cherry-pick-bypass-notification-sent -->`
@@ -257,35 +206,25 @@ workflow re-runs.
 >   cancel-in-progress: false
 > ```
 
-> **Input sanitization:** The explanation text and file list are embedded in both the
-> PR comment (Markdown) and the notification email (HTML). All user-provided text must be
-> escaped before embedding:
-> - **Markdown comments:** Wrap in a code fence or escape special characters.
-> - **HTML email:** Apply HTML entity encoding to prevent injection.
-
 **Email content:**
 
 | Field | Value |
 |-------|-------|
 | Subject | `[sonic-mgmt][AWARENESS] Cherry-pick Bypass — New Tests → <branch>` |
 | To | `GUARD_NOTIFICATION_EMAIL` (comma-separated, set as secret) |
-| Body | PR link, author, target branch, bypass approver, new file list, explanation text |
+| Body | PR link, author, target branch, bypass approver, new file list |
 
-### 3.8 Audit Trail
+### 3.7 Audit Trail
 
 Every bypass creates a permanent record directly on the PR:
 
 1. **`contains-new-tests` label** — visible in PR list views
 2. **`cherry-pick-bypass-approved` label** — records that an exception was granted
-3. **Explanation comment** — authored by an authorized team member, timestamped by GitHub
-4. **Audit comment by bot** — confirms notification was sent, non-editable by the approver
+3. **Audit comment by bot** — confirms notification was sent, records the approver
 
-> **Comment edit/delete:** If the explanation comment is edited or deleted after the check
-> passes, the check is not automatically re-evaluated (GitHub does not fire events on
-> comment edits for `issue_comment: created`). This is accepted as a low-risk gap:
-> the audit comment posted by the bot preserves a snapshot of the explanation at
-> approval time. A future iteration may subscribe to `issue_comment: edited, deleted`
-> events if needed.
+> **Future enhancement (v2):** An optional explanation comment requirement
+> (`[cherry-pick-bypass-reason]`) can be added if the team wants written justification
+> for each bypass. Keeping v1 label-only to validate the core workflow first.
 
 ---
 
@@ -342,9 +281,7 @@ the default `GITHUB_TOKEN`, a **PAT or GitHub App token** must be provided as a 
 | Permission | Scope | Why |
 |------------|-------|-----|
 | `pull-requests: write` | `GITHUB_TOKEN` | Post comments, add labels |
-| `issues: write` | `GITHUB_TOKEN` | Post comments on issue_comment trigger |
 | `contents: read` | `GITHUB_TOKEN` | Read PR file list |
-| `checks: write` | `GITHUB_TOKEN` | Create/update check runs on PR HEAD (required for `issue_comment` trigger) |
 | `read:org` | PAT or App token | Query team membership for bypass authorization |
 
 ### GitHub Secrets (Settings → Secrets → Actions)
@@ -379,13 +316,9 @@ On Settings → Branches, for pattern `20????`:
 | Risk | Mitigation |
 |------|-----------|
 | Unauthorized user adds bypass label | Workflow verifies label adder's org-team membership via GitHub API at runtime; fails even if label is present |
-| Unauthorized user posts explanation comment | Workflow verifies explanation comment author is also in the authorized team; both label and comment must come from authorized members |
-| Bypass label added before explanation | Two-step requirement: label + comment both needed; failing one fails the check |
 | Duplicate email spam on re-runs | Idempotent guard: checks for `<!-- cherry-pick-bypass-notification-sent -->` marker before sending; `concurrency` group prevents race conditions between parallel runs |
 | `pull_request_target` privilege escalation | Workflow only reads PR metadata via API; no checkout of untrusted code |
 | Token scope | `GITHUB_TOKEN` has minimal permissions; `read:org` is isolated to a separate PAT/App token secret |
-| HTML/Markdown injection via explanation text | All user-provided text is HTML-entity-encoded before embedding in email and escaped in Markdown comments |
-| Comment edit/delete after approval | Bot-authored audit comment preserves a snapshot of the explanation at approval time; future iteration may re-evaluate on `issue_comment: edited` |
 
 ---
 
@@ -395,7 +328,7 @@ On Settings → Branches, for pattern `20????`:
 |-------|--------|-------------|
 | **Phase 1** | Commit workflow files to `master` | Workflow appears in Actions tab; no PRs blocked yet (no branch protection rule) |
 | **Phase 2** | Set GitHub Secrets (SMTP + `CHERRY_PICK_GUARD_TOKEN`) with your own email as `GUARD_NOTIFICATION_EMAIL` | Open a test PR to a release branch adding a `test_*.py` file; verify block + email to yourself |
-| **Phase 3** | Verify bypass flow end-to-end | Have a `platform-owners` member add bypass label + explanation; verify pass + email |
+| **Phase 3** | Verify bypass flow end-to-end | Have a `platform-owners` member add bypass label; verify pass + email |
 | **Phase 4** | Add branch protection rule for `20????` | Existing open cherry-pick PRs without new tests are unaffected |
 | **Phase 5** | Update `GUARD_NOTIFICATION_EMAIL` to guard team DL + platform owners alias | Done |
 
@@ -426,7 +359,7 @@ status check on the cherry-pick PR itself is cleaner and more standard.
 Allow specific test files to be pre-approved for release branches.
 
 **Rejected:** Adds maintenance overhead and doesn't enforce a real review — the bypass
-explanation comment on the PR provides better traceability.
+label on the PR provides sufficient traceability for v1.
 
 ### C. Use a GitHub App instead of a GitHub Actions workflow
 A GitHub App could react to label events in real time and have richer API access.
@@ -440,3 +373,12 @@ Mark the `release-branch` environment as requiring approval before deploy.
 **Rejected:** Environments are designed for deployment workflows, not PR merge gates.
 The label + comment pattern is more familiar to contributors already using the
 `Approved for 20XXXX branch` label system.
+
+### E. Require an explanation comment in addition to the bypass label
+Require a `[cherry-pick-bypass-reason]` comment from an authorized team member before
+the check passes.
+
+**Deferred to v2:** Adds complexity (comment authorization, edit/delete handling,
+`issue_comment` trigger + Checks API). Label-only bypass is simpler and sufficient
+to validate the core blocking flow. Can be added later if the team wants written
+justification for each bypass.

--- a/docs/tests/design-doc-test-cherry-pick-guard.md
+++ b/docs/tests/design-doc-test-cherry-pick-guard.md
@@ -79,19 +79,21 @@ contributor adds a brand-new test to `master` and it gets approved for a release
                                ▼
 ┌──────────────────────────────────────────────────────────────────────┐
 │              GitHub Actions: test-cherry-pick-guard.yml               │
+│              name: "Test Cherry-pick Guard"                          │
 │                                                                      │
 │  Job 1: detect-and-tag                                               │
 │  ├─ Fetch PR file diff via GitHub API                                │
 │  ├─ Match against test file patterns                                 │
 │  ├─ Output: has_new_tests (bool), new_test_files (list), target_branch│
-│  └─ If new tests found → add label "contains-new-tests"              │
+│  ├─ If new tests found → add label "contains-new-tests"              │
+│  └─ If no new tests found → remove "contains-new-tests" label       │
 │                                                                      │
 │  Job 2: enforce-policy  (skipped if master or no new tests)          │
+│  │  name: "Cherry-pick policy check"   ← branch protection matches  │
 │  ├─ Check for "cherry-pick-bypass-approved" label                     │
 │  ├─ Verify label adder is in @sonic-net/platform-owners (GitHub API) │
 │  ├─ FAIL with guidance comment  (any condition unmet)                │
-│  ├─ PASS → create/update check run on PR HEAD via Checks API        │
-│  └─ PASS → send email + post audit comment  (all conditions met)     │
+│  └─ PASS → send email (best-effort) + post audit comment             │
 └──────────────────────────────────────────────────────────────────────┘
                                │
               (bypass approved + all conditions met)
@@ -99,12 +101,19 @@ contributor adds a brand-new test to `master` and it gets approved for a release
                                ▼
               ┌────────────────────────────┐
               │  SMTP Email Notification   │
+              │  (best-effort, non-gating) │
               │  To: Guard team + Owners   │
-              │  Subject: [AWARENESS]...   │
-              │  Body: PR, bypasser,       │
-              │        explanation, files  │
+              │  Subject: [ACTION REQ'D]   │
+              │  Body: PR, bypasser, files │
               └────────────────────────────┘
 ```
+
+**Canonical names for branch protection:**
+
+| YAML key | Value | Purpose |
+|----------|-------|---------|
+| Workflow `name:` | `Test Cherry-pick Guard` | Appears in Actions tab |
+| Job 2 `jobs.enforce-policy.name:` | `Cherry-pick policy check` | **This is the string branch protection matches** |
 
 ### 3.2 Trigger Events
 
@@ -117,20 +126,33 @@ The workflow responds to the following GitHub event:
 `pull_request_target` is used (instead of `pull_request`) because cherry-pick PRs are
 created from a fork (`mssonicbld/sonic-mgmt`), which requires elevated token permissions.
 
+> **Note:** If sonic-mgmt enables GitHub Merge Queues in the future, the workflow will
+> need an additional `merge_group` trigger to prevent merges from bypassing the check.
+
 ### 3.3 Test File Detection
 
 A file is classified as a **new test file** if:
 - Its `status` in the PR diff is `"added"` (not `"modified"` or `"renamed"`)
-- Its path matches the following pattern:
+- Its path matches any of the following patterns:
 
 | Pattern | Framework | Example |
 |---------|-----------|---------|
-| `tests/**/test_*.py` | pytest | `tests/bgp/test_bgp_fact.py` |
+| `tests/**/test_*.py` | pytest (default) | `tests/bgp/test_bgp_fact.py` |
+| `tests/**/*_test.py` | pytest (alternate) | `tests/bgp/bgp_fact_test.py` |
 
-**Known limitation (v1):**
+> **Note:** Both patterns are included because pytest's default discovery matches both
+> `test_*.py` and `*_test.py`. Check `tests/pytest.ini` / `tests/conftest.py` for any
+> non-default discovery configuration.
+
+**Known limitation (v1) — renames:**
 Cherry-picks may surface files as `"renamed"` rather than `"added"` depending on diff
-  similarity. A future iteration can also match `"renamed"` files whose new path matches
-  test patterns and whose previous path does not exist on the target branch.
+similarity. Specifically:
+- Cherry-picks created via `git cherry-pick` typically surface new files as `"added"`.
+- Cherry-picks of a prior rename (or created via `git format-patch`) can surface as
+  `"renamed"`, which v1 does not match.
+
+A future iteration can also match `"renamed"` files whose new path matches test patterns
+and whose previous path does not exist on the target branch.
 
 ### 3.4 Policy Enforcement State Machine
 
@@ -146,8 +168,8 @@ Cherry-picks may surface files as `"renamed"` rather than `"added"` depending on
          label present?
               │                                           │
              Yes                                    ❌ FAIL
-              │                              Post: policy violation comment
-              │                              (once, idempotent)
+              │                    Post: policy violation comment (once)
+              │                    Marker: <!-- cherry-pick-guard-violation -->
     ┌─────────┴──────────┐
     │                    │
   Label adder        Label adder NOT in
@@ -158,9 +180,27 @@ Cherry-picks may surface files as `"renamed"` rather than `"added"` depending on
     │               Post: unauthorized bypass comment
     │
 ✅ PASS
-Send email notification (once)
+Send email notification (best-effort, once)
 Post audit comment on PR
 ```
+
+**Idempotent comments:** Both the policy violation comment and the bypass audit comment
+use hidden HTML markers to ensure they are posted at most once per PR:
+- Violation comment: `<!-- cherry-pick-guard-violation -->`
+- Audit/notification comment: `<!-- cherry-pick-bypass-notification-sent -->`
+
+Before posting, the workflow searches existing PR comments for the marker. If found,
+the comment is not re-posted.
+
+**Label cleanup on force-push:** On each `synchronize` event, Job 1 re-evaluates the
+file diff. If `has_new_tests == false` (e.g., the contributor force-pushed to remove the
+new test files), the workflow removes the `contains-new-tests` label and Job 2 is
+skipped, allowing the PR to proceed without a bypass.
+
+**Behavior on `unlabeled` of `cherry-pick-bypass-approved`:** If someone removes the
+bypass label after a successful pass, the next workflow run reverts to FAIL, restoring
+the merge block. This acts as a useful kill switch — reviewers can revoke a bypass at
+any time by removing the label.
 
 ### 3.5 Bypass Authorization
 
@@ -172,21 +212,36 @@ GET /orgs/{AUTH_ORG}/teams/{AUTH_TEAM}/memberships/{login}
 → 404 or state != "active"     ← not authorized
 ```
 
-Default values: `AUTH_ORG=sonic-net`, `AUTH_TEAM=platform-owners`.  
+Default values: `AUTH_ORG=sonic-net`, `AUTH_TEAM=sonic-mgmt-platform-owners`.
 Both are configurable via GitHub repository variables without changing the workflow file.
+
+> **Note:** The team membership API checks **direct membership only**. If
+> `sonic-mgmt-platform-owners` adds child teams in the future, members of those child
+> teams will NOT be authorized. This is intentional for v1 to keep the authorization
+> model simple and auditable. If child team support is needed later, switch to the
+> broader org permission check.
 
 > **Note:** The team membership API (`GET /orgs/{org}/teams/{team}/memberships/{user}`)
 > requires the **`read:org`** OAuth scope. The default `GITHUB_TOKEN` does not have this
-> scope. The workflow must use either:
-> - A **Personal Access Token (PAT)** with `read:org` scope, stored as a repository secret, or
-> - A **GitHub App** installation token with Organization → Members → Read permission.
+> scope. The workflow uses a **GitHub App** installation token with Organization → Members
+> → Read permission (see Section 6).
 >
-> See Section 6 for the full token requirements.
+> **Decision (formerly Open Question #4):** GitHub App is chosen over PAT because:
+> - PATs are tied to individual accounts and break when the user leaves the org
+> - App tokens scope cleanly to the repository with auditable permissions
+> - App tokens auto-rotate and don't require manual secret rotation
 
 **Label adder identification:** The workflow identifies who added the bypass label by
 querying the PR timeline API (`GET /repos/{owner}/{repo}/issues/{number}/timeline`) and
 finding the most recent `labeled` event for the `cherry-pick-bypass-approved` label. This
 approach works regardless of which event triggered the current workflow run.
+
+> **Timeline API caveat:** The timeline endpoint has multi-second eventual-consistency
+> lag. When the workflow is triggered by a `labeled` event, it should prefer
+> `github.event.sender.login` (available immediately) over the timeline lookup. The
+> timeline lookup is used as a fallback for non-`labeled` triggers (e.g., `synchronize`)
+> where the sender is not the label adder. If the timeline lookup returns no matching
+> event, the workflow retries once after a 5-second delay before failing.
 
 ### 3.6 Email Notification
 
@@ -194,6 +249,11 @@ Sent via SMTP (STARTTLS) using an inline workflow step.
 Sent **once per PR** — a hidden HTML comment `<!-- cherry-pick-bypass-notification-sent -->`
 is embedded in the audit comment and checked before each send to prevent duplicates on
 workflow re-runs.
+
+**Email is best-effort and non-gating.** If the SMTP send fails, the workflow logs the
+error but does **not** fail the check. This prevents SMTP outages from blocking all
+new-test cherry-picks across release branches. A missed email is an audit gap (the PR
+comment audit trail still exists), not a merge gate.
 
 > **Concurrency control:** To prevent a race condition where two concurrent workflow runs
 > both see "marker not present" and both send the email, the workflow uses a
@@ -210,7 +270,7 @@ workflow re-runs.
 
 | Field | Value |
 |-------|-------|
-| Subject | `[sonic-mgmt][AWARENESS] Cherry-pick Bypass — New Tests → <branch>` |
+| Subject | `[sonic-mgmt][ACTION REQ'D] Cherry-pick Bypass — New Tests → <branch>` |
 | To | `GUARD_NOTIFICATION_EMAIL` (comma-separated, set as secret) |
 | Body | PR link, author, target branch, bypass approver, new file list |
 
@@ -220,7 +280,8 @@ Every bypass creates a permanent record directly on the PR:
 
 1. **`contains-new-tests` label** — visible in PR list views
 2. **`cherry-pick-bypass-approved` label** — records that an exception was granted
-3. **Audit comment by bot** — confirms notification was sent, records the approver
+3. **Audit comment by GitHub App bot** — posted by the GitHub App installation
+   (appears as `<app-name>[bot]`), confirms notification was sent, records the approver
 
 > **Future enhancement (v2):** An optional explanation comment requirement
 > (`[cherry-pick-bypass-reason]`) can be added if the team wants written justification
@@ -262,7 +323,8 @@ sonic-net/sonic-mgmt/
 │   └── scripts/
 │       └── check_new_tests.py             # Standalone test-file detector (also used locally)
 └── docs/
-    └── test-cherry-pick-policy.md          # End-user policy + setup guide
+    └── tests/
+        └── design-doc-test-cherry-pick-guard.md   # This design document
 ```
 
 > **Note:** Email sending is handled inline in the workflow via an SMTP step rather than a
@@ -274,21 +336,32 @@ sonic-net/sonic-mgmt/
 
 ### Token Permissions
 
-The workflow requires the following permissions. Because `read:org` is not available to
-the default `GITHUB_TOKEN`, a **PAT or GitHub App token** must be provided as a secret
-(e.g. `CHERRY_PICK_GUARD_TOKEN`):
+The workflow uses a **GitHub App** installation token for operations requiring elevated
+permissions. The default `GITHUB_TOKEN` is used for standard operations:
 
-| Permission | Scope | Why |
-|------------|-------|-----|
-| `pull-requests: write` | `GITHUB_TOKEN` | Post comments, add labels |
+| Permission | Token source | Why |
+|------------|-------------|-----|
+| `pull-requests: write` | `GITHUB_TOKEN` | Post comments, add/remove labels |
 | `contents: read` | `GITHUB_TOKEN` | Read PR file list |
-| `read:org` | PAT or App token | Query team membership for bypass authorization |
+| `read:org` | GitHub App token | Query team membership for bypass authorization |
+
+### GitHub App Setup
+
+Create a GitHub App with the following permissions and install it on the `sonic-net` org:
+
+| Permission | Access | Why |
+|------------|--------|-----|
+| Organization → Members | Read | Query team membership for bypass authorization |
+| Repository → Pull requests | Write | Post audit comments (optional — can use `GITHUB_TOKEN` instead) |
+
+Store the App ID and private key as repository secrets (see below).
 
 ### GitHub Secrets (Settings → Secrets → Actions)
 
 | Secret | Required | Example | Description |
 |--------|----------|---------|-------------|
-| `CHERRY_PICK_GUARD_TOKEN` | ✅ | `ghp_...` | PAT with `read:org` scope (or GitHub App token) |
+| `CHERRY_PICK_GUARD_APP_ID` | ✅ | `123456` | GitHub App ID |
+| `CHERRY_PICK_GUARD_APP_PRIVATE_KEY` | ✅ | `-----BEGIN RSA...` | GitHub App private key (PEM) |
 | `SMTP_SERVER` | ✅ | `smtp.office365.com` | SMTP relay hostname |
 | `SMTP_PORT` | ✅ | `587` | Port (587 = STARTTLS) |
 | `SMTP_USERNAME` | ✅ | `noreply@contoso.com` | SMTP login / sender |
@@ -301,12 +374,12 @@ the default `GITHUB_TOKEN`, a **PAT or GitHub App token** must be provided as a 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `AUTH_ORG` | `sonic-net` | Org owning the authorized team |
-| `AUTH_TEAM` | `platform-owners` | Team slug for bypass authorizers |
+| `AUTH_TEAM` | `sonic-mgmt-platform-owners` | Team slug for bypass authorizers |
 
 ### Branch Protection Rule
 
 On Settings → Branches, for pattern `20????`:
-- ✅ Require status checks: **`Cherry-pick policy check`**
+- ✅ Require status checks: **`Cherry-pick policy check`** (must match Job 2's `name:` exactly)
 - ✅ Do not allow bypassing the above settings
 
 ---
@@ -318,7 +391,8 @@ On Settings → Branches, for pattern `20????`:
 | Unauthorized user adds bypass label | Workflow verifies label adder's org-team membership via GitHub API at runtime; fails even if label is present |
 | Duplicate email spam on re-runs | Idempotent guard: checks for `<!-- cherry-pick-bypass-notification-sent -->` marker before sending; `concurrency` group prevents race conditions between parallel runs |
 | `pull_request_target` privilege escalation | Workflow only reads PR metadata via API; no checkout of untrusted code |
-| Token scope | `GITHUB_TOKEN` has minimal permissions; `read:org` is isolated to a separate PAT/App token secret |
+| Token scope | `GITHUB_TOKEN` has minimal permissions; `read:org` is isolated to a GitHub App token with scoped permissions |
+| SMTP outage | Email is best-effort; SMTP failure does not fail the check (see Section 3.6). The PR audit comment still provides a permanent record |
 
 ---
 
@@ -327,9 +401,9 @@ On Settings → Branches, for pattern `20????`:
 | Phase | Action | Verification |
 |-------|--------|-------------|
 | **Phase 1** | Commit workflow files to `master` | Workflow appears in Actions tab; no PRs blocked yet (no branch protection rule) |
-| **Phase 2** | Set GitHub Secrets (SMTP + `CHERRY_PICK_GUARD_TOKEN`) with your own email as `GUARD_NOTIFICATION_EMAIL` | Open a test PR to a release branch adding a `test_*.py` file; verify block + email to yourself |
-| **Phase 3** | Verify bypass flow end-to-end | Have a `platform-owners` member add bypass label; verify pass + email |
-| **Phase 4** | Add branch protection rule for `20????` | Existing open cherry-pick PRs without new tests are unaffected |
+| **Phase 2** | Set GitHub Secrets (SMTP + GitHub App keys) with your own email as `GUARD_NOTIFICATION_EMAIL` | Open a test PR to a release branch adding a `test_*.py` file; verify block + email to yourself |
+| **Phase 3** | Add branch protection rule for `20????` requiring `Cherry-pick policy check` | Confirm the check status shows as failing (required) on the test PR before any bypass label is added |
+| **Phase 4** | Verify bypass flow end-to-end | Have a `sonic-mgmt-platform-owners` member add bypass label on the test PR; verify pass + email |
 | **Phase 5** | Update `GUARD_NOTIFICATION_EMAIL` to guard team DL + platform owners alias | Done |
 
 ---
@@ -338,10 +412,10 @@ On Settings → Branches, for pattern `20????`:
 
 | # | Question | Owner | Status |
 |---|----------|-------|--------|
-| 1 | Which GitHub team slug is the authoritative "platform owners" for sonic-mgmt? | Platform team | Open |
+| 1 | ~~Which GitHub team slug?~~ Using `sonic-mgmt-platform-owners` as a concrete placeholder. Team to be created or re-pointed before Phase 4. | Platform team | **Resolved** |
 | 2 | Do we need a weekly digest of all bypasses, or is per-bypass email sufficient? | Guard team | Open |
 | 3 | Should the policy also apply to non-release feature branches (e.g. `feature/*`)? | Platform team | Open |
-| 4 | PAT vs GitHub App: which approach for `read:org` scope is preferred? | Platform team | Open |
+| 4 | ~~PAT vs GitHub App?~~ Resolved: GitHub App (see Section 3.5). | Platform team | **Resolved** |
 
 ---
 
@@ -382,3 +456,20 @@ the check passes.
 `issue_comment` trigger + Checks API). Label-only bypass is simpler and sufficient
 to validate the core blocking flow. Can be added later if the team wants written
 justification for each bypass.
+
+---
+
+## 11. Observability
+
+To track bypass frequency and detect potential policy abuse, the following observability
+mechanisms are recommended:
+
+- **Label-based query:** Use GitHub's search to list all PRs with the
+  `cherry-pick-bypass-approved` label: `is:pr label:cherry-pick-bypass-approved`
+- **Monthly audit:** Run a periodic query (e.g., Kusto or GitHub API script) against
+  the audit comments (`<!-- cherry-pick-bypass-notification-sent -->`) to count bypasses
+  per month, per branch, and per approver
+- **Dashboard (future):** If bypass volume warrants it, build a lightweight dashboard
+  showing bypass trends over time, top bypassed branches, and top approvers
+
+This data will inform whether v2's explanation comment requirement is needed.

--- a/docs/tests/design-doc-test-cherry-pick-guard.md
+++ b/docs/tests/design-doc-test-cherry-pick-guard.md
@@ -1,7 +1,7 @@
 # Design Doc: Test Cherry-pick Guard for sonic-net/sonic-mgmt
 
 **Author:** xwjiang-ms  
-**Status:** Draft  
+**Status:** Reviewed  
 **Reviewers:** Nightly Guard Team, Platform Owners  
 
 ---


### PR DESCRIPTION
### Description of PR

Summary:
Add design document for the **Test Cherry-pick Guard** — a GitHub Actions workflow that prevents new test files from being cherry-picked to release branches without proper review and approval.

This document covers:
- **Background & Motivation**: Why unguarded cherry-picks of new tests cause nightly failures on release branches
- **System Overview**: Two-job workflow (detect-and-tag + enforce-policy)
- **Policy Enforcement**: State machine for bypass authorization (label + team membership + explanation comment)
- **Email Notification**: Automatic awareness emails to the guard team and platform owners
- **Audit Trail**: Permanent record of every bypass on the PR itself
- **Integration**: How it fits with the existing `pr_cherrypick_prestep.yml` automation
- **Configuration Reference**: Required secrets, variables, and branch protection setup
- **Security Considerations**: Mitigations for privilege escalation, spam, and unauthorized bypass
- **Rollout Plan**: Phased deployment approach
- **Open Questions**: Items needing team input before finalization

File added: `docs/tests/design-doc-test-cherry-pick-guard.md`

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Production incidents where new tests cherry-picked to release branches silently fail on nightly runs, causing on-call burden and eroding confidence in release branches. This design doc proposes an automated guardrail.

#### How did you do it?
Added a design document under `docs/tests/` describing a two-job GitHub Actions workflow that detects new test files in PRs targeting release branches and blocks merge unless an authorized team member approves a bypass with justification.

#### How did you verify/test it?
Documentation-only change — no code to test.

#### Any platform specific information?
N/A — this is a repo-level CI/CD policy, not platform-specific.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
Yes — this PR **is** the documentation. It adds the design doc for team review before implementation.