### PR TITLE
[dhcp_server] Fix dhcp_server conftest: handle dynamic supervisor process naming

### DIFF
--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -9,6 +9,50 @@ DHCP_SERVER_CONTAINER_NAME = "dhcp_server"
 DHCP_SERVER_FEATRUE_NAME = "dhcp_server"
 
 
+def is_dhcprelayd_running(duthost):
+    """
+    Check if dhcprelayd is running in the dhcp_relay container, handling
+    dynamic supervisor process naming.
+
+    The dhcp_relay container's supervisor config is dynamically generated from
+    a Jinja2 template (docker-dhcp-relay.supervisord.conf.j2) at container
+    startup based on CONFIG_DB state. The template conditionally includes
+    dhcp-relay.programs.j2, which creates a [group:dhcp-relay] section that
+    groups dhcprelayd and dhcp6relay together.
+
+    The group is created when there are VLANs with DHCP relay configured
+    (dhcp_servers or dhcpv6_servers in CONFIG_DB). On a normal production DUT,
+    this is almost always the case, and the process appears as
+    "dhcp-relay:dhcprelayd" (group:program format). In this state,
+    supervisorctl requires the group prefix; the bare name "dhcprelayd"
+    returns "ERROR (no such process)" (rc=4).
+
+    When the relay count is 0 (no VLANs with dhcp_servers or dhcpv6_servers),
+    the template skips the group section, and dhcprelayd becomes a standalone
+    [program:dhcprelayd]. In this state, the bare name works but the
+    group-prefixed name fails.
+
+    Note: the enable_sonic_dhcpv4_relay_agent fixture teardown does not cause
+    this condition — config dhcpv4_relay add/del does not modify VLAN.dhcp_servers,
+    so the original relay config remains intact after teardown. The no-group state
+    has been observed in practice but the exact trigger is unclear; it may result
+    from external CONFIG_DB modifications or edge cases during container restarts.
+
+    This function tries both naming conventions to handle either state.
+    """
+    # Try group format first (normal production state)
+    result = duthost.shell(
+        "docker exec {} supervisorctl status dhcp-relay:dhcprelayd".format(DHCP_RELAY_CONTAINER_NAME),
+        module_ignore_errors=True)
+    if "RUNNING" in result.get("stdout", ""):
+        return True
+    # Fall back to standalone format (after test fixture modifies CONFIG_DB)
+    result = duthost.shell(
+        "docker exec {} supervisorctl status dhcprelayd".format(DHCP_RELAY_CONTAINER_NAME),
+        module_ignore_errors=True)
+    return "RUNNING" in result.get("stdout", "")
+
+
 @pytest.fixture(scope="module", autouse=True)
 def dhcp_server_setup_teardown(duthost):
     features_state, _ = duthost.get_feature_status()
@@ -21,6 +65,7 @@ def dhcp_server_setup_teardown(duthost):
 
     def is_supervisor_subprocess_running(duthost, container_name, app_name):
         return "RUNNING" in duthost.shell(f"docker exec {container_name} supervisorctl status {app_name}")["stdout"]
+
     py_assert(
         wait_until(120, 1, 1,
                    is_supervisor_subprocess_running,
@@ -31,10 +76,8 @@ def dhcp_server_setup_teardown(duthost):
     )
     py_assert(
         wait_until(120, 1, 1,
-                   is_supervisor_subprocess_running,
-                   duthost,
-                   DHCP_RELAY_CONTAINER_NAME,
-                   "dhcprelayd"),
+                   is_dhcprelayd_running,
+                   duthost),
         'dhcprelayd in container dhcp_relay is not running'
     )
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
 
Follow-up to #23940. The previous fix changed the hardcoded supervisor process name from "dhcp-relay:dhcprelayd" to "dhcprelayd", but this only works when the [group:dhcp-relay] section is absent from the supervisor config. On a clean/normal DUT where the group exists, supervisorctl status dhcprelayd returns "ERROR (no such process)" (rc=4) because
supervisor requires the group-prefixed name dhcp-relay:dhcprelayd.

The dhcp_relay container's supervisor config is dynamically generated from a Jinja2 template (docker-dhcp-relay.supervisord.conf.j2) at container startup. The template conditionally includes dhcp-relay.programs.j2, which creates [group:dhcp-relay] programs=dhcprelayd,dhcp6relay. The group is rendered when VLANs have DHCP relay configured (dhcp_servers or 
dhcpv6_servers in CONFIG_DB) — which is the normal state on any production DUT.

In the no-group state, dhcprelayd is a standalone [program:dhcprelayd] and the bare name works but the group-prefixed name fails. We observed this state during testing but were unable to reproduce it through the normal test fixture flow — config dhcpv4_relay add/del does not modify VLAN.dhcp_servers, and the fixture teardown (
sonic_dhcpv4_flag_config_and_unconfig + sonic_dhcp_relay_unconfig) leaves the VLAN DHCP server config intact, so the group should always be created after restart. The no-group state may have been caused by external DUT modifications during debugging (e.g., manual CONFIG_DB edits, custom binary installs).

This PR adds is_dhcprelayd_running() as a defensive fix that tries both naming conventions — group format (dhcp-relay:dhcprelayd) first, then standalone (dhcprelayd) — to handle either state reliably. The original is_supervisor_subprocess_running() is left unchanged for other processes with stable naming like kea-dhcp4.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

The previous fix (#23940) broke dhcp_server tests on clean DUTs where the supervisor [group:dhcp-relay] exists. On a normal DUT with DHCP relay configured, the process name is dhcp-relay:dhcprelayd (group:program format), and supervisorctl status dhcprelayd fails with rc=4.

#### How did you do it?

Added is_dhcprelayd_running(duthost) function that:

 1. Tries supervisorctl status dhcp-relay:dhcprelayd (group format, normal production state)
 2. If not found, falls back to supervisorctl status dhcprelayd (standalone format)
 3. Returns True if either reports RUNNING

The function includes a detailed docstring explaining the Jinja2 template rendering flow and why the naming is dynamic.

#### How did you verify/test it?

Confirmed both naming states on Arista 7260 (20251110.19 image):

 Clean DUT (after config reload) — group exists:
 $ supervisorctl status dhcp-relay:dhcprelayd
 dhcp-relay:dhcprelayd            RUNNING   pid 180    ← group format works
 
 $ supervisorctl status dhcprelayd
 dhcprelayd: ERROR (no such process)                   ← bare name FAILS
 
 Modified DUT (after test fixture clears has_sonic_dhcpv4_relay + restart):
 $ supervisorctl status dhcp-relay:dhcprelayd
 dhcp-relay:dhcprelayd: ERROR (no such process)        ← group format FAILS
 
 $ supervisorctl status dhcprelayd
 dhcprelayd                       RUNNING   pid 163    ← bare name works

Full test run with this fix: 43 passed, 2 failed (pre-existing), 3 errors (sporadic teardown) — zero fixture setup errors.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
