### PR TITLE
[cherry-pick 202511] test_qos_sai update for Cisco G200 (#20844)

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -701,6 +701,6 @@ def skip_traffic_test(request):
 
 @pytest.fixture(scope='function')
 def iptables_drop_ipv6_tx(ptfhost):
-    ptfhost.shell("ip6tables -P OUTPUT DROP")
+    ptfhost.shell("ip6tables -P OUTPUT DROP || true")
     yield
-    ptfhost.shell("ip6tables -P OUTPUT ACCEPT")
+    ptfhost.shell("ip6tables -P OUTPUT ACCEPT || true")

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3889,6 +3889,13 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping:
       - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in (constants['QOS_SAI_TOPO'] + ['t2_single_node_max', 't2_single_node_min']) and asic_type not in ['mellanox']"
 
+qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr:
+  skip:
+    reason: "Skip DWRR test on Cisco G200 platform."
+    conditions_logical_operator: or
+    conditions:
+      - "asic_type in ['cisco-8000'] and platform.startswith('x86_64-8122_')"
+
 qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange:
   skip:
     reason: "Skip DWRR weight change test on Mellanox platform. / Unsupported testbed type."
@@ -3897,6 +3904,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange:
       - "asic_type in ['mellanox']"
       - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in (constants['QOS_SAI_TOPO'] + ['t2_single_node_max', 't2_single_node_min']) and asic_type not in ['mellanox']"
+      - "asic_type in ['cisco-8000'] and platform.startswith('x86_64-8122_')"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiFullMeshTrafficSanity:
   skip:

--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -58,9 +58,9 @@ class QosParamCisco(object):
         # 0: Max queue depth in bytes
         # 1: Flow control configuration on this device, either 'separate' or 'shared'.
         # 2: Number of packets margin for the quantized queue watermark tests.
-        asic_params = {"gb": (6144000, 3072, 384, 1350, 2, 3),
-                       "gr": (24576000, 18000, 384, 1350, 2, 3),
-                       "gr2": (None, 1, 512, 64, 1, 3)}
+        asic_params = {"gb": (6144000, 3072, 384, 1350, 2, 3, 0),
+                       "gr": (24576000, 18000, 384, 1350, 2, 3, 0),
+                       "gr2": (None, 2, 512, 64, 3, 4, -40)}
         self.supports_autogen = dutAsic in asic_params and topo == "topo-any"
         if self.supports_autogen:
             # Asic dependent parameters
@@ -69,7 +69,8 @@ class QosParamCisco(object):
              self.buffer_size,
              self.preferred_packet_size,
              self.lossless_pause_tuning_pkts,
-             self.lossless_drop_tuning_pkts) = asic_params[dutAsic]
+             self.lossless_drop_tuning_pkts,
+             self.lossy_drop_tuning_pkts) = asic_params[dutAsic]
 
             self.flow_config = self.get_expected_flow_config()
 
@@ -88,11 +89,14 @@ class QosParamCisco(object):
 
             # Calculate real lossless/lossy thresholds while accounting for maxes
             if max_queue_depth is None:
+                egress_pool_reserved_buffer = 12582912  # 12MB reserve of the pool
                 dynamic_th = int(self.bufferConfig["BUFFER_PROFILE"]["egress_lossy_profile"]["dynamic_th"])
                 alpha = 2 ** dynamic_th
-                theoretical_drop_thr = int(self.egress_pool_size * alpha / (1. + alpha))
-                self.lossy_drop_bytes = (self.gr_get_hw_thr_buffs(theoretical_drop_thr // self.buffer_size) *
-                                         self.buffer_size)
+                profile_reserved_memory = int(self.bufferConfig["BUFFER_PROFILE"]["egress_lossy_profile"]["size"])
+                theoretical_drop_thr = int(profile_reserved_memory +
+                                           (self.egress_pool_size - egress_pool_reserved_buffer) * alpha / (1. + alpha))
+                self.lossy_drop_bytes = ((self.gr_get_hw_thr_buffs(theoretical_drop_thr // self.buffer_size, True)
+                                         + self.lossy_drop_tuning_pkts) * self.buffer_size)
                 self.log("Lossy queue drop theoretical {} adjusted to {}".format(theoretical_drop_thr,
                                                                                  self.lossy_drop_bytes))
                 pre_pad_pause = attempted_pause
@@ -312,18 +316,21 @@ class QosParamCisco(object):
             return mantissa, exp
         return None, None
 
-    def gr2_get_mantissa_exp(self, thr):
+    def gr2_get_mantissa_exp(self, thr, is_lossy=False):
         mantissa_len = 5
         exponent = max(thr.bit_length() - mantissa_len, 0)
         mantissa = thr >> exponent
+        if is_lossy:
+            # gr2 lossy egress drop threshold is 1 off due to queue occupancy is quantized
+            mantissa += 1
         return mantissa, exponent
 
-    def gr_get_hw_thr_buffs(self, thr):
+    def gr_get_hw_thr_buffs(self, thr, is_lossy=False):
         ''' thr must be in units of buffers '''
         if self.dutAsic == "gr":
             mantissa, exp = self.gr_get_mantissa_exp(thr)
         elif self.dutAsic == "gr2":
-            mantissa, exp = self.gr2_get_mantissa_exp(thr)
+            mantissa, exp = self.gr2_get_mantissa_exp(thr, is_lossy)
         else:
             assert False, "Invalid asic {} for gr_get_hw_thr_buffs".format(self.dutAsic)
         if mantissa is None or exp is None:
@@ -467,6 +474,8 @@ class QosParamCisco(object):
                       "pkts_num_hysteresis": self.hysteresis_bytes // self.buffer_size // packet_buffs,
                       "pkts_num_dismiss_pfc": 2,
                       "packet_size": packet_size}
+            if self.dutAsic == "gr2":
+                params["pkts_num_margin"] = 6
             self.write_params("xon_{}".format(param_i), params)
 
     def __define_pg_shared_watermark(self):
@@ -485,12 +494,18 @@ class QosParamCisco(object):
             lossless_params.update({"dscp": 3,
                                     "pg": 3,
                                     "pkts_num_trig_pfc": (self.lossless_drop_thr // self.buffer_size)})
+            if self.dutAsic == "gr2":
+                lossless_params["pkts_num_margin"] = 6
+                lossless_params["pkts_num_margin_lower_bound"] = 3
             self.write_params("wm_pg_shared_lossless", lossless_params)
         if self.should_autogen(["wm_pg_shared_lossy"]):
             lossy_params = common_params.copy()
             lossy_params.update({"dscp": self.dscp_queue0,
                                  "pg": 0,
                                  "pkts_num_trig_egr_drp": self.lossy_drop_bytes // self.buffer_size})
+            if self.dutAsic == "gr2":
+                lossy_params["pkts_num_margin"] = 14
+                lossy_params["pkts_num_margin_lower_bound"] = 6
             self.write_params("wm_pg_shared_lossy", lossy_params)
 
     def __define_buffer_pool_watermark(self):
@@ -507,6 +522,7 @@ class QosParamCisco(object):
                                "packet_size": packet_size}
             if self.dutAsic == "gr2":
                 lossless_params["pkts_num_margin"] = 8
+                lossless_params["extra_cap_margin"] = 20
             self.write_params("wm_buf_pool_lossless", lossless_params)
         if self.should_autogen(["wm_buf_pool_lossy"]):
             lossy_params = {"dscp": self.dscp_queue0,
@@ -519,6 +535,7 @@ class QosParamCisco(object):
                             "packet_size": packet_size}
             if self.dutAsic == "gr2":
                 lossy_params["pkts_num_margin"] = 8
+                lossy_params["extra_cap_margin"] = 25
             self.write_params("wm_buf_pool_lossy", lossy_params)
 
     def __define_q_shared_watermark(self):
@@ -539,6 +556,8 @@ class QosParamCisco(object):
                             "pkts_num_trig_egr_drp": self.lossy_drop_bytes // self.buffer_size,
                             "pkts_num_margin": self.q_wmk_margin,
                             "cell_size": self.buffer_size}
+            if self.dutAsic == "gr2":
+                lossy_params["pkts_num_margin"] = 9
             self.write_params("wm_q_shared_lossy", lossy_params)
 
     def __define_lossy_queue_voq(self):
@@ -581,6 +600,8 @@ class QosParamCisco(object):
                       "pkts_num_margin": 4,
                       "packet_size": self.preferred_packet_size,
                       "cell_size": self.buffer_size}
+            if self.dutAsic == "gr2":
+                params["pkts_num_margin"] = 8
             self.write_params("lossy_queue_1", params)
 
     def __define_lossless_voq(self):
@@ -625,9 +646,6 @@ class QosParamCisco(object):
         if self.should_autogen(["wm_q_wm_all_ports"]):
             lossy_lossless_action_thr = min(self.lossy_drop_bytes, self.pause_thr)
             pkts_num_leak_out = 0
-            if self.dutAsic == "gr2":
-                # Send a burst of leakout packets to optimize runtime. Expected leakout is around 950
-                pkts_num_leak_out = 800
             self.log("In __define_q_watermark_all_ports, using min lossy-drop/lossless-pause threshold of {}".format(
                 lossy_lossless_action_thr))
             params = {"ecn": 1,
@@ -636,6 +654,11 @@ class QosParamCisco(object):
                       "cell_size": self.buffer_size,
                       "pkts_num_leak_out": pkts_num_leak_out,
                       "packet_size": packet_size}
+            if self.dutAsic == "gr2":
+                # Send a burst of leakout packets to optimize runtime. Expected leakout is around 250
+                params["pkts_num_leak_out"] = 200
+                # Decrease pkt_count due to lossy drop threshold inaccuracy
+                params["pkt_count"] -= 8
             self.write_params("wm_q_wm_all_ports", params)
 
     def __define_pg_drop(self):

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2482,6 +2482,12 @@ class QosSaiBase(QosBase):
                 dut_asic.command("counterpoll watermark disable")
                 dut_asic.command("counterpoll queue disable")
 
+        yield
+
+        for dut_asic in get_src_dst_asic_and_duts['all_asics']:
+            dut_asic.command("counterpoll watermark enable")
+            dut_asic.command("counterpoll queue enable")
+
     @pytest.fixture
     def blockGrpcTraffic(self, tbinfo, lower_tor_host, nic_simulator_info):   # noqa F811
 
@@ -3202,6 +3208,53 @@ def set_queue_pir(interface, queue, rate):
         sai_profile_content = duthost.shell(get_sai_profile_cmd)['stdout']
         logging.info(f"sai_profile_content: {sai_profile_content}")
         return "SAI_KEY_DISABLE_PORT_ALPHA=1" not in sai_profile_content
+
+    def copy_clear_pg_wm_script_cisco_8000(self, dut, ports, asic=""):
+        dshell_script = '''
+from common import *
+from sai_utils import *
+def clear_pg_watermark(interface):
+  port_oid = get_port_oid(interface)
+  port_api = sai_api_query(SAI_API_PORT)
+  num_ipgs_attr = sai_attribute_t(SAI_PORT_ATTR_NUMBER_OF_INGRESS_PRIORITY_GROUPS, 0)
+  port_api.get_port_attribute(port_oid, 1, num_ipgs_attr)
+  ipg_list = sai_object_list_t([0] * num_ipgs_attr.value.u32)
+  attr = sai_attribute_t(SAI_PORT_ATTR_INGRESS_PRIORITY_GROUP_LIST, ipg_list)
+  port_api.get_port_attribute(port_oid, 1, attr)
+  ipg_pylist  = ipg_list.to_pylist()
+  ipg_attr_ids = ingressPriorityGroupStatVec(1)
+  ipg_attr_ids[0] = SAI_INGRESS_PRIORITY_GROUP_STAT_SHARED_WATERMARK_BYTES
+  for ipg_oid in ipg_pylist:
+    getIngressPriorityGroupCountersExt(ipg_oid, ipg_attr_ids, SAI_STATS_MODE_READ_AND_CLEAR)
+'''
+
+        for intf in ports:
+            dshell_script += f'\nclear_pg_watermark("{intf}")'
+
+        copy_dshell_script_cisco_8000(dut, asic, dshell_script, script_name="clear_pg_wm.py")
+
+    @pytest.fixture(scope="function", autouse=False)
+    def clear_pg_wm(self, get_src_dst_asic_and_duts, dutConfig):
+        src_port = dutConfig['dutInterfaces'][dutConfig["testPorts"]["src_port_id"]]
+        src_dut = get_src_dst_asic_and_duts['src_dut']
+        src_asic = get_src_dst_asic_and_duts['src_asic']
+        src_index = src_asic.asic_index
+
+        if src_dut.facts['asic_type'] != "cisco-8000" or dutConfig["dutAsic"] != "gr2":
+            yield
+            return
+
+        interfaces = self.get_port_channel_members(src_dut, src_port)
+
+        self.copy_clear_pg_wm_script_cisco_8000(
+            dut=src_dut,
+            ports=interfaces,
+            asic=src_index)
+
+        src_dut.shell('sudo show platform npu script -s clear_pg_wm.py')
+
+        yield
+        return
 
     @pytest.fixture(scope='class', autouse=True)
     def ecnLosslessProfile(

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1267,11 +1267,8 @@ class TestQosSai(QosSaiBase):
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
+        testParams.update(qosConfig[bufPool])
         testParams.update({
-            "dscp": qosConfig[bufPool]["dscp"],
-            "ecn": qosConfig[bufPool]["ecn"],
-            "pg": qosConfig[bufPool]["pg"],
-            "queue": qosConfig[bufPool]["queue"],
             "pkts_num_margin": qosConfig[bufPool].get("pkts_num_margin", 0),
             "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
             "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
@@ -1280,7 +1277,6 @@ class TestQosSai(QosSaiBase):
             "pkts_num_leak_out": dutQosConfig["param"][portSpeedCableLength]["pkts_num_leak_out"],
             "pkts_num_fill_min": fillMin,
             "pkts_num_fill_shared": triggerDrop - 1,
-            "cell_size": qosConfig[bufPool]["cell_size"],
             "buf_pool_roid": buf_pool_roid
         })
 
@@ -1288,12 +1284,6 @@ class TestQosSai(QosSaiBase):
             testParams["platform_asic"] = dutTestParams["basicParams"]["platform_asic"]
         else:
             testParams["platform_asic"] = None
-
-        if "packet_size" in list(qosConfig[bufPool].keys()):
-            testParams["packet_size"] = qosConfig[bufPool]["packet_size"]
-
-        if dutTestParams["basicParams"]["sonic_asic_type"] == 'cisco-8000' and dutConfig["dutAsic"] == "gr2":
-            testParams["extra_cap_margin"] = 20
 
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.BufferPoolWatermarkTest",
@@ -1753,7 +1743,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("pgProfile", ["wm_pg_shared_lossless", "wm_pg_shared_lossy"])
     def testQosSaiPgSharedWatermark(
         self, pgProfile, ptfhost, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dutQosConfig,
-        resetWatermark, skip_src_dst_different_asic, change_lag_lacp_timer, blockGrpcTraffic,
+        resetWatermark, skip_src_dst_different_asic, change_lag_lacp_timer, blockGrpcTraffic, clear_pg_wm,
         iptables_drop_ipv6_tx  # noqa: F811
     ):
         """
@@ -1814,19 +1804,15 @@ class TestQosSai(QosSaiBase):
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
+        testParams.update(qosConfig[pgProfile])
         testParams.update({
-            "dscp": qosConfig[pgProfile]["dscp"],
-            "ecn": qosConfig[pgProfile]["ecn"],
-            "pg": qosConfig[pgProfile]["pg"],
             "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
             "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
             "src_port_id": dutConfig["testPorts"]["src_port_id"],
             "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
             "src_port_vlan": dutConfig["testPorts"]["src_port_vlan"],
             "pkts_num_leak_out": dutQosConfig["param"][portSpeedCableLength]["pkts_num_leak_out"],
-            "pkts_num_fill_min": qosConfig[pgProfile]["pkts_num_fill_min"],
             "pkts_num_fill_shared": pktsNumFillShared,
-            "cell_size": qosConfig[pgProfile]["cell_size"],
             "hwsku": dutTestParams['hwsku'],
             "ip_type": dutConfig["ip_type"]
         })
@@ -1846,12 +1832,6 @@ class TestQosSai(QosSaiBase):
             else:
                 pytest.skip(
                     "PGSharedWatermark: pkts_num_egr_mem_short_long is missing in yaml file ")
-
-        if "packet_size" in list(qosConfig[pgProfile].keys()):
-            testParams["packet_size"] = qosConfig[pgProfile]["packet_size"]
-
-        if "pkts_num_margin" in list(qosConfig[pgProfile].keys()):
-            testParams["pkts_num_margin"] = qosConfig[pgProfile]["pkts_num_margin"]
 
         # For J2C+ we need the internal header size in calculating the shared watermarks
         if "internal_hdr_size" in list(qosConfig.keys()):

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -5461,6 +5461,7 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         hwsku = self.test_params['hwsku']
         internal_hdr_size = self.test_params.get('internal_hdr_size', 0)
         platform_asic = self.test_params['platform_asic']
+        margin_lower_bound = self.test_params.get('pkts_num_margin_lower_bound', 0)
         ip_type = self.test_params.get('ip_type', 'ipv4')
 
         if 'packet_size' in list(self.test_params.keys()):
@@ -5679,14 +5680,15 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                             ((pkts_num_leak_out + pkts_num_fill_min + expected_wm + margin)
                              * (packet_length + internal_hdr_size)))
                 else:
-                    msg = "lower bound: %d, actual value: %d, upper bound (+%d): %d" % (
-                        expected_wm * cell_size,
+                    msg = "lower bound (-%d): %d, actual value: %d, upper bound (+%d): %d" % (
+                        margin_lower_bound,
+                        (expected_wm - margin_lower_bound) * cell_size,
                         pg_shared_wm_res[pg],
                         margin,
                         (expected_wm + margin) * cell_size)
                     assert pg_shared_wm_res[pg] <= (
                             expected_wm + margin) * cell_size, msg
-                    assert expected_wm * cell_size <= pg_shared_wm_res[pg], msg
+                    assert (expected_wm - margin_lower_bound) * cell_size <= pg_shared_wm_res[pg], msg
 
                 pkts_num = pkts_inc
 
@@ -5718,7 +5720,7 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             else:
                 print("exceeded pkts num sent: %d, expected watermark: %d, actual value: %d" % (
                     pkts_num, ((expected_wm + cell_occupancy) * cell_size), pg_shared_wm_res[pg]), file=sys.stderr)
-                assert (expected_wm * cell_size <= pg_shared_wm_res[pg] <= (
+                assert ((expected_wm - margin_lower_bound) * cell_size <= pg_shared_wm_res[pg] <= (
                         expected_wm + margin + cell_occupancy) * cell_size)
         finally:
             self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])


### PR DESCRIPTION
### Description of PR

Summary:
Manual cherry-pick of #20844 to 202511 branch (auto cherry-pick had conflicts).

Fixed test_qos_sai failures for Cisco G200.

Original PR: https://github.com/sonic-net/sonic-mgmt/pull/20844
202505 PR: https://github.com/sonic-net/sonic-mgmt/pull/21162

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Cherry-pick of #20844 to 202511 branch. The auto cherry-pick failed due to a conflict in `tests_mark_conditions.yaml` where the 202511 branch has additional `t2_single_node_max/min` topology entries not present in the original PR's base.

#### How did you do it?
Manual cherry-pick with conflict resolution. The conflict was in the `testQosSaiDwrrWeightChange` skip conditions — kept both the 202511-specific topology filter update and the new Cisco G200 skip condition from the original PR.

#### How did you verify/test it?
Verified by original PR author on Cisco 8122: test_qos_sai.py 100% passed (16 passed, 40 skipped).

#### Any platform specific information?
Cisco 8122 (G200).

#### Supported testbed topology if it's a new test case?

### Documentation