### PR TITLE
[dhcp_relay] Fix enable_sonic_dhcpv4_relay_agent teardown order

### DIFF
--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -416,10 +416,16 @@ def enable_sonic_dhcpv4_relay_agent(duthost, request):
             sonic_dhcp_relay_config(duthost, dut_dhcp_relay_data, True)
         yield
     finally:
-        # Cleanup: disable the feature flag
+        # Cleanup: remove sonic relay config first, then clear the feature flag
+        # and restart. The order matters because sonic_dhcpv4_flag_config_and_unconfig
+        # restarts the dhcp_relay container, and the supervisor config is rendered
+        # from a Jinja2 template at startup. If sonic relay config is still present
+        # when has_sonic_dhcpv4_relay is cleared, the template may render without
+        # the [group:dhcp-relay] section (relay count == 0), leaving dhcprelayd as
+        # a standalone program instead of a group member.
         if request.getfixturevalue("relay_agent") == "sonic-relay-agent":
-            sonic_dhcpv4_flag_config_and_unconfig(duthost, False)
             sonic_dhcp_relay_unconfig(duthost, dut_dhcp_relay_data)
+            sonic_dhcpv4_flag_config_and_unconfig(duthost, False)
 
 
 def check_dhcpv4_socket_status(duthost, dut_dhcp_relay_data=None, process_and_socket_check=None):


### PR DESCRIPTION
Swap sonic_dhcp_relay_unconfig and sonic_dhcpv4_flag_config_and_unconfig in the fixture teardown so that the sonic relay config is removed before the has_sonic_dhcpv4_relay flag is cleared and dhcp_relay is restarted.

sonic_dhcpv4_flag_config_and_unconfig restarts the dhcp_relay container, and the supervisor config is rendered from a Jinja2 template at startup. With the old order, the restart happens while sonic relay config is still present but the flag is cleared, which can cause the template to render without the [group:dhcp-relay] section (relay count evaluates to 0), leaving dhcprelayd as a standalone program instead of a group member. This inconsistency causes subsequent tests to fail when checking supervisor process status with a hardcoded process name.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Fix the teardown order in enable_sonic_dhcpv4_relay_agent fixture to prevent the dhcp_relay container from entering an inconsistent supervisor state.

The fixture's teardown previously called sonic_dhcpv4_flag_config_and_unconfig(duthost, False) (which clears has_sonic_dhcpv4_relay, saves config, and restarts dhcp_relay) before sonic_dhcp_relay_unconfig (which runs config dhcpv4_relay del). This meant the container restarted with the flag cleared but sonic relay config still in CONFIG_DB.

The dhcp_relay container's supervisor config is rendered from a Jinja2 template (docker-dhcp-relay.supervisord.conf.j2) at startup. The template includes dhcp-relay.programs.j2 to create [group:dhcp-relay] programs=dhcprelayd,dhcp6relay when VLANs have DHCP relay configured. With the old teardown order, the restart could happen with a CONFIG_DB state
where the relay count evaluates to 0, causing the template to skip the group section. This leaves dhcprelayd as a standalone [program:dhcprelayd] instead of a group member dhcp-relay:dhcprelayd, which breaks any subsequent supervisor status checks using the group-prefixed name.

Fix: call sonic_dhcp_relay_unconfig first to remove the sonic relay config, then sonic_dhcpv4_flag_config_and_unconfig to clear the flag and restart. This way, when the container restarts, the original VLAN dhcp_servers (ISC relay config) are still present in CONFIG_DB, the relay count is > 0, and the [group:dhcp-relay] section is properly rendered.


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

The enable_sonic_dhcpv4_relay_agent fixture teardown left the dhcp_relay container in an inconsistent supervisor state where dhcprelayd appeared as a standalone program instead of under the dhcp-relay group. This caused dhcp_server tests (and any other tests checking dhcp-relay:dhcprelayd) to fail with "ERROR (no such process)" when the fixture ran
between test modules.

#### How did you do it?

Swapped the order of two calls in the finally block:

Before:

 sonic_dhcpv4_flag_config_and_unconfig(duthost, False)  # clears flag, saves, RESTARTS
 sonic_dhcp_relay_unconfig(duthost, dut_dhcp_relay_data)  # removes sonic relay config (too late)

After:

 sonic_dhcp_relay_unconfig(duthost, dut_dhcp_relay_data)  # removes sonic relay config first
 sonic_dhcpv4_flag_config_and_unconfig(duthost, False)    # then clears flag, saves, restarts

#### How did you verify/test it?

Identified the root cause by comparing supervisor configs across DUT states:

 - After config reload (clean state): [group:dhcp-relay] present, dhcp-relay:dhcprelayd RUNNING
 - After old fixture teardown: group missing, standalone dhcprelayd RUNNING
 - Traced through the Jinja2 template to confirm the group is only rendered when relay count > 0
 - Verified the fixture teardown order determines the CONFIG_DB state at restart time

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
