### PR TITLE
Fix valueError for test_qos_dscp_mapping.py

### DIFF
--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -285,7 +285,8 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
         ptf_dst_port_ids = get_stream_ptf_ports(links)
         pytest_assert(ptf_dst_port_ids, f"ptf_dst_port_ids is {ptf_dst_port_ids}")
 
-        ptf_dst_port_ids.remove(ptf_src_port_id)
+        if ptf_src_port_id in ptf_dst_port_ids:
+            ptf_dst_port_ids.remove(ptf_src_port_id)
 
         return {
             'ptf_src_port_id': ptf_src_port_id,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fix valueError for test_qos_dscp_mapping.py
When ptf_src_port_id not in ptf_dst_port_ids, ptf_dst_port_ids.remove(ptf_src_port_id) will raise valueError

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
fix valueError for test_qos_dscp_mapping.py

#### How did you do it?
Only when ptf_src_port_id in ptf_dst_port_ids, we can remove it

#### How did you verify/test it?
run test_qos_dscp_mapping.py 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
