### PR TITLE
[qos] Skip test_dscp_to_queue_mapping[pipe] on Broadcom TH (Tomahawk 1) — hardware limitation

### DIFF
--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -504,6 +504,13 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
         duthost = rand_selected_dut
         inner_dst_ip_list = route_config
 
+        # Broadcom TH (Tomahawk 1) does not support IPIP pipe mode:
+        # hardware always uses outer DSCP for egress queue selection, inner DSCP is ignored.
+        # Ref: ADO #37561457
+        if dscp_mode == "pipe" and duthost.facts.get("hwsku", "").startswith("Arista-7060CX"):
+            pytest.skip("Broadcom TH (Tomahawk 1) does not support IPIP pipe mode "
+                        "-- hardware always uses outer DSCP for egress queue selection")
+
         with allure.step("Prepare test parameter"):
             test_params = self._setup_test_params(duthost, tbinfo, downstream_links, upstream_links)
 

--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -90,6 +90,10 @@ def dscp_config(dscp_mode, duthost, loganalyzer):
 
     # global DSCP_TO_TC_MAP update is not supported on Broadcom platforms
     if asic_type == 'broadcom':
+        hwsku = duthost.facts.get("hwsku", "")
+        if dscp_mode == "pipe" and hwsku.startswith("Arista-7060CX"):
+            pytest.skip("Broadcom TH (Tomahawk 1) does not support IPIP pipe mode"
+                        " -- hardware always uses outer DSCP for egress queue selection")
         apply_dscp_cfg_setup(duthost, dscp_mode, loganalyzer)
         yield
         apply_dscp_cfg_teardown(duthost, loganalyzer)
@@ -503,13 +507,6 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
         """
         duthost = rand_selected_dut
         inner_dst_ip_list = route_config
-
-        # Broadcom TH (Tomahawk 1) does not support IPIP pipe mode:
-        # hardware always uses outer DSCP for egress queue selection, inner DSCP is ignored.
-        # Ref: ADO #37561457
-        if dscp_mode == "pipe" and duthost.facts.get("hwsku", "").startswith("Arista-7060CX"):
-            pytest.skip("Broadcom TH (Tomahawk 1) does not support IPIP pipe mode "
-                        "-- hardware always uses outer DSCP for egress queue selection")
 
         with allure.step("Prepare test parameter"):
             test_params = self._setup_test_params(duthost, tbinfo, downstream_links, upstream_links)


### PR DESCRIPTION
Broadcom TH (Tomahawk 1 / BCM56960) does not support IPIP pipe mode: the hardware always selects
egress queue from the outer DSCP header, ignoring inner DSCP. This is a silicon-level limitation
that cannot be fixed in software. The test has been failing at 0/233 pass rate on Arista 7060CX
devices.

### Description of PR

**Root cause of previous fix attempt:** The `pytest.skip()` was placed in the test body, but the
`dscp_config` fixture calls `apply_dscp_cfg_setup()` (docker exec swss cp) **before** yielding.
So by the time the test body executes, setup already ran — the skip never fired.

**Correct fix:** Skip is now placed inside `dscp_config` fixture, in the `broadcom` branch,
**before** `apply_dscp_cfg_setup()` is called. This skips the entire test including setup/teardown.

Changes:
- `tests/qos/test_qos_dscp_mapping.py`: Move `pytest.skip()` from test body to `dscp_config` fixture, BEFORE `apply_dscp_cfg_setup` call, for Arista-7060CX (TH1) + pipe mode

ADO tracking: https://dev.azure.com/msazure/One/_workitems/edit/37561457

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Test case improvement
    - [x] Skipped for non-supported platforms

### Back port request

- [x] 202511

### Approach

#### What is the motivation for this PR?

Broadcom TH (Tomahawk 1 / BCM56960) silicon does not support IPIP pipe mode — the chip always
uses outer DSCP for egress queue selection, ignoring inner DSCP. The test `test_dscp_to_queue_mapping[pipe]`
has a 0% pass rate (0/233 runs from Aug 2023 to Apr 2024) on 7060CX devices (Arista-7060CX-32S-C32,
-D48C8, -Q32). This is a fundamental hardware limitation, not a software regression.

#### How did you do it?

Added `pytest.skip()` in the `dscp_config` fixture inside the `if asic_type == 'broadcom':` block,
**before** `apply_dscp_cfg_setup()` is called. This is the correct location because the fixture
runs before the test body — placing the skip in the test body didn't work since setup had already
executed when the test body ran.

The skip guard checks both `dscp_mode == "pipe"` and `hwsku.startswith("Arista-7060CX")` (TH1
detection, consistent with `tests/common/helpers/pfc_storm.py`).

#### How did you verify/test it?Elastictest verification jobs running `qos/test_qos_dscp_mapping.py` on 2 Arista-7060CX (TH1, legacy-th) T0 testbeds with branch `dev/xuliping/20260416_dscp_pipe_skip_internal-202511`:| Testbed | Topo | Job |
|---------|------|-----|
| testbed-bjw3-can-t0-7060-7 | T0 | https://elastictest.org/scheduler/testplan/69e486bb93b9d587312f2b53 |
| testbed-bjw3-can-t0-7060-8 | T0 | https://elastictest.org/scheduler/testplan/69e486be8e43924279229167 |#### Any platform specific information?

Applies specifically to Broadcom TH (Tomahawk 1 / BCM56960) platforms with hwsku prefix
`Arista-7060CX` (e.g., Arista-7060CX-32S-C32, Arista-7060CX-32S-D48C8, Arista-7060CX-32S-Q32).
Does not affect TH2 (7260CX3), TH4 (7060DX5), TH5 (7060X6), or other vendors.

### Documentation

N/A