### PR TITLE
[tests/qos]: Skip test_dscp_to_queue_mapping[pipe] on Broadcom TH (Tomahawk 1) -- hardware limitation

### DIFF
--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -504,6 +504,13 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
         duthost = rand_selected_dut
         inner_dst_ip_list = route_config
 
+        # Broadcom TH (Tomahawk 1) does not support IPIP pipe mode:
+        # hardware always uses outer DSCP for egress queue selection, inner DSCP is ignored.
+        # Ref: ADO #37561457
+        if dscp_mode == 'pipe' and duthost.facts.get('hwsku', '').startswith('Arista-7060CX'):
+            pytest.skip('Broadcom TH (Tomahawk 1) does not support IPIP pipe mode -- '
+                        'hardware always uses outer DSCP for egress queue selection')
+
         with allure.step("Prepare test parameter"):
             test_params = self._setup_test_params(duthost, tbinfo, downstream_links, upstream_links)
 


### PR DESCRIPTION
Skip the IPIP pipe-mode DSCP-to-queue test on Arista-7060CX (Broadcom TH / Tomahawk 1) platforms, which have a silicon-level limitation that prevents the test from passing — the hardware always uses the outer DSCP for egress queue selection regardless of configured pipe mode.

### Description of PR

Summary:
Fixes nightly test failure on 7060CX platform: `test_dscp_to_queue_mapping[pipe]` always fails because Broadcom TH (BCM56960) ignores the inner DSCP during IPIP tunnel decapsulation.

The fix adds a `pytest.skip()` guard at the start of `test_dscp_to_queue_mapping` when `dscp_mode == "pipe"` and the DUT hwsku starts with `"Arista-7060CX"`. The pattern is consistent with existing platform-specific skips in `pfc_storm.py`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach

#### What is the motivation for this PR?
The `test_dscp_to_queue_mapping[pipe]` test case has been failing on all Broadcom TH (Tomahawk 1, BCM56960) platforms (e.g., Arista-7060CX-32S) with 0% pass rate. Investigation confirmed this is a silicon limitation: the TH ASIC always uses the outer header DSCP for queue selection when decapsulating IPIP packets, regardless of the configured pipe vs. uniform mode. This is not a regression — it is a fundamental hardware limitation. ADO #37561457 tracks the investigation.

#### How did you do it?
Added a 7-line skip guard in `TestQoSSaiDSCPQueueMapping_IPIP_Base.test_dscp_to_queue_mapping()` that skips the test when `dscp_mode == "pipe"` and `duthost.facts['hwsku'].startswith("Arista-7060CX")`. This is consistent with how other TH-specific skips are implemented in the qos suite (e.g., `pfc_storm.py`).

#### How did you verify/test it?
- Confirmed test always fails on TH platforms (Arista-7060CX) in nightly runs (0/N pass).
- Skip guard uses `hwsku.startswith("Arista-7060CX")` which covers all 7060 SKUs (7060CX-32S, 7060CX2-32S, etc.).
- Uniform mode tests are unaffected.

#### Any platform specific information?
Affects all Arista-7060CX variants (Broadcom TH / BCM56960 ASIC). Does not affect TH2 (7060CX2) or other platforms.

#### Supported testbed topology if it's a new test case?
N/A (this is a skip for an existing test case)

### Documentation

N/A