### PR TITLE
Disable memory utilization check in test tests/bgp/test_bgp_gr_helper.py

### DIFF
--- a/tests/bgp/test_bgp_gr_helper.py
+++ b/tests/bgp/test_bgp_gr_helper.py
@@ -12,7 +12,8 @@ from tests.common.utilities import is_ipv6_only_topology
 
 pytestmark = [
     pytest.mark.topology('any'),
-    pytest.mark.device_type('vs')
+    pytest.mark.device_type('vs'),
+    pytest.mark.disable_memory_utilization
 ]
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Due to the preparation done in fixture setup_bgp_graceful_restart 
The frr_bgp before test memory usage is always much lower than the after test memory usage
It's reasonable due to the operations done on VMs in fixture setup_bgp_graceful_restart would make the frr_bgp memory usage fluctuated
So remove the memory utilization check for this test

Change-Id: I35199d1d1b9a3f83ccebf4ad82dcfe0fc0ae1051

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Memory utilization check failure on tests/bgp/test_bgp_gr_helper.py
#### How did you do it?
Remove the memory utilization check during the test
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
