### PR TITLE
[dhcp_server] Fix dhcp_server customize_options yang leafref error

### DIFF
--- a/tests/dhcp_server/dhcp_server_test_common.py
+++ b/tests/dhcp_server/dhcp_server_test_common.py
@@ -122,6 +122,20 @@ def apply_dhcp_server_config_cli(duthost, config_commands):
 
 def apply_dhcp_server_config_gcu(duthost, config_to_apply):
     logging.info("The dhcp_server_config: %s" % config_to_apply)
+    # Pre-write CUSTOMIZED_OPTIONS entries to CONFIG_DB before calling GCU.
+    # GCU does not respect yang leafref dependency order when applying changes,
+    # so it may write DHCP_SERVER_IPV4 (which references CUSTOMIZED_OPTIONS via
+    # the customized_options field) before the referenced entry exists, causing
+    # a transient yang validation error in syslog. By writing the options first,
+    # the leafref is satisfied when GCU writes DHCP_SERVER_IPV4.
+    for op in config_to_apply:
+        if op.get("op") == "add" and "/DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS/" in op.get("path", ""):
+            option_name = op["path"].split("/")[-1]
+            fields = " ".join('"{}" "{}"'.format(k, v) for k, v in op["value"].items())
+            duthost.shell(
+                'sonic-db-cli CONFIG_DB HSET "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS|{}" {}'.format(
+                    option_name, fields),
+                module_ignore_errors=True)
     tmpfile = duthost.shell('mktemp')['stdout']
     try:
         duthost.copy(content=json.dumps(config_to_apply, indent=4), dest=tmpfile)


### PR DESCRIPTION
Pre-write DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS entries to CONFIG_DB before calling config apply-patch (GCU). GCU does not respect yang leafref dependency order when applying changes to CONFIG_DB, so it may write DHCP_SERVER_IPV4 (which references CUSTOMIZED_OPTIONS via the customized_options leafref field) before the referenced entry exists. This causes a transient sonic_yang Data Loading Failed error in syslog, which loganalyzer catches as a test failure.

By writing the customized options entries directly via sonic-db-cli HSET before GCU runs, the leafref target already exists when GCU writes DHCP_SERVER_IPV4, avoiding the yang validation error.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

test_dhcp_server_port_based_customize_options fails with a loganalyzer ERROR due to a sonic_yang: Data Loading Failed syslog entry. The error occurs because config apply-patch (GCU) does not respect yang leafref dependency order when writing entries to CONFIG_DB. It writes DHCP_SERVER_IPV4|Vlan1000 (which has customized_options:
["test_customized_option_1"]) before writing DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS|test_customized_option_1, creating a transient state where the leafref points to a non-existing entry.

This fix pre-writes DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS entries directly to CONFIG_DB via sonic-db-cli HSET before calling config apply-patch. When GCU writes DHCP_SERVER_IPV4 with the customized_options reference, the target entry already exists, so the yang leafref validation passes.


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

test_dhcp_server_port_based_customize_options consistently errors on teardown because loganalyzer catches this syslog entry:

 ERR sonic_yang: Data Loading Failed:Leafref ".../DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS/.../name"
 of value "test_customized_option_1" points to a non-existing leaf.

The test itself passes (DHCP server correctly sends packets with custom options), but the loganalyzer teardown fails because GCU's internal write ordering triggers a transient yang validation error during config application.

#### How did you do it?

Added a pre-write step to apply_dhcp_server_config_gcu in dhcp_server_test_common.py. Before calling config apply-patch, the function scans the patch for DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS entry additions and writes them directly to CONFIG_DB using sonic-db-cli HSET. GCU then sees these entries already exist in the current state and the leafref from 
DHCP_SERVER_IPV4 is satisfied during yang validation.

#### How did you verify/test it?

Ran test_dhcp_server_port_based_customize_options on Arista 7260 (20251110.19 image):

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
