### PR TITLE
Increase config_reload_timeout for Nokia-7215 platform tests

### DIFF
--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -187,7 +187,7 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
 
     config_reload_timeout = 120
     if hwsku in ["Nokia-M0-7215", "Nokia-7215"]:
-        config_reload_timeout = 180
+        config_reload_timeout = 240
 
     if not config_force_option_supported(duthost):
         return


### PR DESCRIPTION

### Description of PR

Summary: 
This change increases `config_reload_timeout` from 180s to 240s in `platform_tests/test_reload_config.py` for Nokia-M0-7215 and Nokia-7215. The goal is to avoid false test failures caused by longer `config reload -y` completion time after recent platform specific changes.

`test_reload_configuration_checks` is failing on Nokia-7215 because `config reload -y` may not finish within the current 180 sec timeout. The command is triggered asynchronously and although the handler is returned the reload flow can still be in progress when the test reaches its timeout.

In 202511, cherry-pick of PR [#4390](https://github.com/sonic-net/sonic-utilities/pull/4390) ( PR [#4174](https://github.com/sonic-net/sonic-utilities/pull/4174) in master ) added extra logic in `_restart_services()` for `armhf-nokia_ixs7215_52x-r0`, including an explicit 15 sec sleep, swss & syncd stop/reset/restart operations and management interface recovery handling. This introduces additional delay on top of the existing config reload sequence which pushes its completion beyond the current 180 sec timeout.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach

- This is a test timeout adjustment only with scope limited to Nokia related HWSKUs. 
- No functional behavior is changed in config reload itself. 
- This only aligns the wait time in the test to match the longer reload execution path.
 
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?
