### PR TITLE
Reapply TLS cert config after preboot reboot in NPU upgrade test

### DIFF
--- a/tests/common/fixtures/grpc_fixtures.py
+++ b/tests/common/fixtures/grpc_fixtures.py
@@ -193,10 +193,10 @@ def gnmi_tls(request, duthost, ptfhost):
         _create_gnoi_certs(duthost, ptfhost, cert_dir)
 
         # 3. Configure server for TLS mode
-        _configure_gnoi_tls_server(duthost)
+        configure_gnoi_tls_server(duthost)
 
         # 4. Restart gNOI server process
-        _restart_gnoi_server(duthost)
+        restart_gnoi_server(duthost)
 
         # 5. Verify TLS connectivity
         _verify_gnoi_tls_connectivity(duthost, ptfhost)
@@ -409,7 +409,7 @@ def _create_gnoi_certs(duthost, ptfhost, cert_dir):
     logger.info("Certificate generation and distribution completed")
 
 
-def _configure_gnoi_tls_server(duthost):
+def configure_gnoi_tls_server(duthost):
     """Configure CONFIG_DB for TLS mode."""
     logger.info("Configuring gNOI server for TLS mode")
 
@@ -435,7 +435,7 @@ def _configure_gnoi_tls_server(duthost):
     logger.info("TLS configuration completed")
 
 
-def _restart_gnoi_server(duthost):
+def restart_gnoi_server(duthost):
     """Restart gNOI server to pick up new TLS configuration."""
     logger.info("Restarting gNOI server process")
 

--- a/tests/upgrade_path/test_upgrade_gnoi.py
+++ b/tests/upgrade_path/test_upgrade_gnoi.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from tests.common.fixtures.grpc_fixtures import gnmi_tls  # noqa: F401
+from tests.common.fixtures.grpc_fixtures import gnmi_tls, configure_gnoi_tls_server, restart_gnoi_server  # noqa: F401
 from tests.upgrade_path.test_upgrade_path import setup_upgrade_test
 from tests.common.helpers.upgrade_helpers import perform_gnoi_upgrade, GnoiUpgradeConfig
 
@@ -57,6 +57,10 @@ def test_upgrade_via_gnoi(
     def upgrade_path_preboot_setup():
         setup_upgrade_test(duthost, localhost, from_image, to_image, tbinfo,
                            upgrade_type)
+        # Re-apply TLS cert config after the DUT reboot done by setup_upgrade_test.
+        # That reboot restores CONFIG_DB from disk, wiping the gnmi_tls fixture's setup.
+        configure_gnoi_tls_server(duthost)
+        restart_gnoi_server(duthost)
 
     perform_gnoi_upgrade(
         ptf_gnoi=gnmi_tls.gnoi,

--- a/tests/upgrade_path/test_upgrade_smart_switch_gnoi.py
+++ b/tests/upgrade_path/test_upgrade_smart_switch_gnoi.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 
 from tests.common.fixtures.grpc_fixtures import (  # noqa: F401
-    ptf_grpc, ptf_gnoi, setup_gnoi_tls_server
+    gnmi_tls, ptf_grpc, ptf_gnoi, setup_gnoi_tls_server
 )
 from tests.common.helpers.upgrade_helpers import (
     GnoiUpgradeConfig,


### PR DESCRIPTION
The gnmi_tls fixture configures gNOI TLS certs in CONFIG_DB (Redis only). When test_upgrade_via_gnoi runs boot_into_base_image as part of cold reboot setup, the DUT reboots and CONFIG_DB is restored from config_db.json on disk, which contains the original streamingtelemetryserver.cer (no IP SANs). This caused all subsequent gNOI calls to fail with an x509 IP SAN validation error.

Fix by making configure_gnoi_tls_server and restart_gnoi_server public and calling them in upgrade_path_preboot_setup after the DUT comes back up from the preboot reboot, restoring the TLS cert configuration before any gNOI calls are made.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The gnmi_tls fixture configures gNOI TLS certs in CONFIG_DB (Redis only). When test_upgrade_via_gnoi runs boot_into_base_image as part of cold reboot setup, the DUT reboots and CONFIG_DB is restored from config_db.json on disk, which contains the original streamingtelemetryserver.cer (no IP SANs). This caused all subsequent gNOI calls to fail with an x509 IP SAN validation error.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The motivation for this PR is that after a cold reboot during the NPU upgrade test, the
 DUT restores CONFIG_DB from disk — which contains a TLS cert without IP SANs —
 overwriting the in-memory gNOI TLS configuration set by gnmi_tls fixture, causing
 subsequent gNOI calls to fail with x509 IP SAN validation errors

#### How did you do it?
The fix makes configure_gnoi_tls_server and restart_gnoi_server public functions, then
calls them in upgrade_path_preboot_setup after the DUT comes back up from the preboot
reboot — ensuring the TLS cert configuration is restored before any gNOI calls are made.

#### How did you verify/test it?
v-cshekar@sonic-mgmt-v-cshekar:/var/src/sonic-mgmt-int/tests$ sudo ./run_tests.sh \
    -i ../ansible/str3,../ansible/veos \
    -n vms69-t1-smartswitch-4280-22 \
    -u -m individual \
    -c upgrade_path/test_upgrade_gnoi.py \
    -d str3-nvidia-4280-E04-U22 \
    -e "--upgrade_type=cold \
        --base_image_list=http://10.64.247.103:8080/sonic-mellanox-20251110.18.bin \
        --target_image_list=http://10.64.247.103:8080/sonic-mellanox-20251110.18.bin \
        --target_version=SONiC-OS-20251110.18" \
    -e "--skip_sanity" \
    -l info

 tests/upgrade_path/test_upgrade_gnoi.py::test_upgrade_via_gnoi ✓                                                                                                           100% ██████████----------------------------------------------------------------------------------- live log logreport ------------------------------------------------------------------------------------
INFO     root:__init__.py:345 [Parallel Fixture] Terminating parallel fixture manager
INFO     root:__init__.py:199 [Parallel Fixture] Current worker threads status:
No alive worker thread found.



#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
Applicable to smart switch

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
