### PR TITLE
Fix test_counterpoll_watermark on multi-asic

### DIFF
--- a/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
+++ b/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
@@ -202,8 +202,8 @@ def test_counterpoll_queue_watermark_pg_drop(duthosts, localhost, enum_rand_one_
     with allure.step("enable and verify all {} counterpolls on {} ..."
                      .format(RELEVANT_COUNTERPOLLS, duthost.hostname)):
         for asic in duthost.asics:
-            ConterpollHelper.enable_counterpoll(duthost, RELEVANT_COUNTERPOLLS)
-            verify_counterpoll_status(duthost, RELEVANT_COUNTERPOLLS, ENABLE)
+            ConterpollHelper.enable_counterpoll(asic, RELEVANT_COUNTERPOLLS)
+            verify_counterpoll_status(asic, RELEVANT_COUNTERPOLLS, ENABLE)
     # count FLEXCOUNTER_DB countrpolls and put in results dict key per countrpoll
     with allure.step("check all counterpolls {} results on {} ...".format(RELEVANT_COUNTERPOLLS, duthost.hostname)):
         for counterpoll in RELEVANT_COUNTERPOLLS:


### PR DESCRIPTION
Currently the test repeatedly re-enables counterpoll on the global duthost instead of on each asic instance. 
This fix is needed for multi-asic systems.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #23995 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fix  `tests/platform_tests/counterpoll/test_counterpoll_watermark.py` on multi-asic

#### How did you do it?
Currently the test loops for each asic but incorrectly passes the global duthost instead of the asic duthost to the counterpoll helper.
I fixed this to pass the correct host.

#### How did you verify/test it?
I reran `tests/platform_tests/counterpoll/test_counterpoll_watermark.py` on my multi-asic system and the test ran without error.
