### PR TITLE
Fix TLS authentication failure in test_gnoi_system_reboot

### DIFF
--- a/tests/common/fixtures/grpc_fixtures.py
+++ b/tests/common/fixtures/grpc_fixtures.py
@@ -263,7 +263,7 @@ def gnmi_tls(request, duthost, ptfhost):
             gnoi=gnoi_client,
             gnmic=gnmic_client,
             transport='tls',
-             _duthost=duthost,
+            _duthost=duthost,
         )
 
         logger.info("Constructed PtfGnmic client: %s", gnmic_client)
@@ -277,11 +277,13 @@ def gnmi_tls(request, duthost, ptfhost):
             output = rollback(duthost, checkpoint_name)
             stdout = output.get('stdout', '')
             if output.get('rc') or "Config rolled back successfully" not in stdout:
-                logger.error("Configuration rollback failed: %s", output.get('stdout', output.get('msg', 'unknown error')))
+                error_msg = output.get('stdout', output.get('msg', 'unknown error'))
+                logger.error("Configuration rollback failed: %s", error_msg)
             else:
                 logger.info("Configuration rollback completed")
         except Exception as e:
-            logger.error(f"Configuration rollback failed with exception: {e}")
+            logger.error("Configuration rollback failed with exception: %s", e)
+
 
         try:
             _delete_gnoi_certs(cert_dir)

--- a/tests/common/fixtures/grpc_fixtures.py
+++ b/tests/common/fixtures/grpc_fixtures.py
@@ -284,7 +284,6 @@ def gnmi_tls(request, duthost, ptfhost):
         except Exception as e:
             logger.error("Configuration rollback failed with exception: %s", e)
 
-
         try:
             _delete_gnoi_certs(cert_dir)
             logger.info("Certificate cleanup completed")

--- a/tests/common/fixtures/grpc_fixtures.py
+++ b/tests/common/fixtures/grpc_fixtures.py
@@ -140,6 +140,32 @@ class GnmiFixture:
     gnoi: object        # PtfGnoi or DutGnoi
     gnmic: Optional[PtfGnmic]   # None for UDS transport
     transport: str = 'tls'      # 'tls' or 'uds'
+    _duthost: object = None  # For post-reboot reconfiguration
+
+    def reconfigure_after_reboot(self):
+        """
+        Reconfigure gNMI server after a DUT reboot.
+
+        After a COLD or WARM reboot, the gNMI server may start with default
+        configuration. This method re-applies the TLS configuration and
+        restarts the server so the existing client can reconnect.
+
+        Usage:
+            # After reboot completes and DUT is back up:
+            gnmi_tls.reconfigure_after_reboot()
+            # Now gNOI calls work again:
+            status = gnmi_tls.gnoi.reboot_status()
+        """
+        if self._duthost is None:
+            raise RuntimeError("GnmiFixture was not initialized with duthost reference")
+        if not self.tls:
+            logger.info("Plaintext mode - no TLS reconfiguration needed")
+            return
+
+        logger.info("Reconfiguring gNMI server after reboot")
+        _configure_gnoi_tls_server(self._duthost)
+        _restart_gnoi_server(self._duthost)
+        logger.info("Post-reboot TLS reconfiguration completed")
 
 
 @pytest.fixture(scope="module")
@@ -237,6 +263,7 @@ def gnmi_tls(request, duthost, ptfhost):
             gnoi=gnoi_client,
             gnmic=gnmic_client,
             transport='tls',
+             _duthost=duthost,
         )
 
         logger.info("Constructed PtfGnmic client: %s", gnmic_client)
@@ -246,11 +273,15 @@ def gnmi_tls(request, duthost, ptfhost):
     finally:
         # 6. Cleanup: rollback configuration
         logger.info("Cleaning up gNOI TLS server environment")
-        output = rollback(duthost, checkpoint_name)
-        if output['rc'] or "Config rolled back successfully" not in output['stdout']:
-            logger.error("Configuration rollback failed: %s", output['stdout'])
-        else:
-            logger.info("Configuration rollback completed")
+        try:
+            output = rollback(duthost, checkpoint_name)
+            stdout = output.get('stdout', '')
+            if output.get('rc') or "Config rolled back successfully" not in stdout:
+                logger.error("Configuration rollback failed: %s", output.get('stdout', output.get('msg', 'unknown error')))
+            else:
+                logger.info("Configuration rollback completed")
+        except Exception as e:
+            logger.error(f"Configuration rollback failed with exception: {e}")
 
         try:
             _delete_gnoi_certs(cert_dir)

--- a/tests/common/ptf_gnoi.py
+++ b/tests/common/ptf_gnoi.py
@@ -433,4 +433,3 @@ class PtfGnoi:
         response = self.grpc_client.call_unary("gnoi.system.System", "RebootStatus", metadata=metadata)
         logger.debug(f"Reboot status: {response}")
         return response
-    

--- a/tests/common/ptf_gnoi.py
+++ b/tests/common/ptf_gnoi.py
@@ -433,3 +433,4 @@ class PtfGnoi:
         response = self.grpc_client.call_unary("gnoi.system.System", "RebootStatus", metadata=metadata)
         logger.debug(f"Reboot status: {response}")
         return response
+    

--- a/tests/common/ptf_gnoi.py
+++ b/tests/common/ptf_gnoi.py
@@ -410,3 +410,26 @@ class PtfGnoi:
         except Exception as e:
             logger.error(f"Failed to activate OS version {version}: {e}")
             raise
+
+    def reboot_status(self, metadata=None) -> Dict:
+        """
+        Get the reboot status from the DUT using gNOI System.RebootStatus.
+
+        Returns:
+            Dictionary containing:
+            - active: Boolean indicating if a reboot is in progress
+            - when: Unix timestamp of when the reboot will occur
+            - reason: Reason string for the pending reboot
+            - count: Number of reboots since last power cycle
+            - method: RebootMethod enum value of the pending reboot
+
+        Raises:
+            GrpcConnectionError: If connection fails
+            GrpcCallError: If the gRPC call fails
+            GrpcTimeoutError: If the call times out
+        """
+        logger.debug("Getting reboot status via gNOI System.RebootStatus")
+
+        response = self.grpc_client.call_unary("gnoi.system.System", "RebootStatus", metadata=metadata)
+        logger.debug(f"Reboot status: {response}")
+        return response

--- a/tests/gnmi/test_gnoi_smartswitch.py
+++ b/tests/gnmi/test_gnoi_smartswitch.py
@@ -112,3 +112,4 @@ def test_gnoi_system_reboot_halt_dpus(duthosts, rand_one_dut_hostname, localhost
             pytest.fail("DPU {} (DPU index: {}) failed to reboot properly".format(dpuhost_name, dpu_index))
 
         logging.info("DPU {} (DPU index: {}) rebooted successfully".format(dpuhost_name, dpu_index))
+        

--- a/tests/gnmi/test_gnoi_smartswitch.py
+++ b/tests/gnmi/test_gnoi_smartswitch.py
@@ -1,0 +1,114 @@
+"""
+This module contains gNOI tests specific to SmartSwitch/DPU platforms.
+"""
+import pytest
+import logging
+import json
+
+from .helper import gnoi_request_dpu, extract_gnoi_response, is_reboot_inactive
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
+from tests.conftest import get_specified_dpus
+from tests.common.platform.device_utils import reboot_dpu_and_wait_for_start_up
+
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.usefixtures("setup_gnmi_ntp_client_server", "setup_gnmi_server",
+                            "setup_gnmi_rotated_server", "check_dut_timestamp")
+]
+
+
+# Enum mapping for RebootMethod for readability
+RebootMethod = {
+    "UNKNOWN": 0,
+    "COLD": 1,
+    "POWERDOWN": 2,
+    "HALT": 3,
+    "WARM": 4,
+    "NSF": 5,
+    # 6 is reserved
+    "POWERUP": 7
+}
+
+REBOOT_MESSAGE = "gnoi test reboot"
+
+
+def check_dpu_reboot_status(duthost, localhost, dpu_index, expected_active, expected_reason, expected_method):
+    """
+    Call gNOI System.RebootStatus for DPU and assert the fields and values of the response.
+    """
+    ret, msg = gnoi_request_dpu(duthost, localhost, dpu_index, "System", "RebootStatus", "")
+    pytest_assert(ret == 0,
+                  "System.RebootStatus API reported failure (rc = {}) with message: {}".format(ret, msg))
+    logging.info("System.RebootStatus API returned msg: {}".format(msg))
+
+    status = extract_gnoi_response(msg)
+    pytest_assert(status is not None, "Failed to extract JSON from gNOI response")
+
+    pytest_assert("active" in status, "Missing 'active' in RebootStatus")
+    pytest_assert("when" in status, "Missing 'when' in RebootStatus")
+    pytest_assert("reason" in status, "Missing 'reason' in RebootStatus")
+    pytest_assert("count" in status, "Missing 'count' in RebootStatus")
+    pytest_assert("method" in status, "Missing 'method' in RebootStatus")
+    pytest_assert(status["active"] is expected_active,
+                  "'active' should be {} after reboot".format(expected_active))
+    pytest_assert(status["reason"] == expected_reason,
+                  "'reason' should be '{}'".format(expected_reason))
+    pytest_assert(status["method"] == expected_method,
+                  "'method' should be {}".format(expected_method))
+    pytest_assert(isinstance(status["when"], int) and status["when"] > 0,
+                  "'when' should be a positive integer")
+    pytest_assert(isinstance(status["count"], int) and status["count"] >= 1,
+                  "'count' should be >= 1")
+
+
+def test_gnoi_system_reboot_halt_dpus(duthosts, rand_one_dut_hostname, localhost, request):
+    """
+    Test gNOI System.Reboot API with HALT method for DPUs.
+
+    Verifies that the reboot is triggered, RebootStatus is correct before reboot,
+    and the DPU recovers properly.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+
+    dpuhost_names = get_specified_dpus(request)
+    if dpuhost_names:
+        logging.info("dpuhost_names: {}".format(dpuhost_names))
+    else:
+        pytest.skip("No DPUs specified, skipping HALT reboot test.")
+
+    reboot_args = {
+        "message": REBOOT_MESSAGE,
+        "method": RebootMethod["HALT"]
+    }
+
+    for dpuhost_name in dpuhost_names:
+        # Extract the last number from the duthost name
+        dpu_index = int(dpuhost_name.split('-')[-1])
+
+        # Validate dpu_index and log error if out of range
+        if not (0 <= dpu_index <= 8):
+            pytest.fail("Invalid dpu_index {}, must be between 0 and 8".format(dpu_index))
+
+        ret, msg = gnoi_request_dpu(duthost, localhost, dpu_index, "System", "Reboot", json.dumps(reboot_args))
+        pytest_assert(ret == 0,
+                      "System.Reboot API reported failure (rc = {}) with message: {}".format(ret, msg))
+        logging.info("System.Reboot API returned msg: {}".format(msg))
+
+        check_dpu_reboot_status(
+            duthost, localhost, dpu_index,
+            expected_active=True,
+            expected_reason=REBOOT_MESSAGE,
+            expected_method=RebootMethod["HALT"]
+        )
+
+        wait_until(120, 10, 0, is_reboot_inactive, duthost, localhost)
+        logging.info("HALT reboot is completed")
+
+        dpu_reboot_status = reboot_dpu_and_wait_for_start_up(duthost, dpuhost_name, dpu_index)
+        if not dpu_reboot_status:
+            pytest.fail("DPU {} (DPU index: {}) failed to reboot properly".format(dpuhost_name, dpu_index))
+
+        logging.info("DPU {} (DPU index: {}) rebooted successfully".format(dpuhost_name, dpu_index))

--- a/tests/gnmi/test_gnoi_smartswitch.py
+++ b/tests/gnmi/test_gnoi_smartswitch.py
@@ -112,4 +112,3 @@ def test_gnoi_system_reboot_halt_dpus(duthosts, rand_one_dut_hostname, localhost
             pytest.fail("DPU {} (DPU index: {}) failed to reboot properly".format(dpuhost_name, dpu_index))
 
         logging.info("DPU {} (DPU index: {}) rebooted successfully".format(dpuhost_name, dpu_index))
-        

--- a/tests/gnmi/test_gnoi_system_reboot.py
+++ b/tests/gnmi/test_gnoi_system_reboot.py
@@ -1,64 +1,45 @@
+"""
+This module contains tests for the gNOI System Reboot API.
+"""
 import pytest
 import logging
-import json
 
-from .helper import gnoi_request, extract_gnoi_response, apply_cert_config, gnoi_request_dpu, is_reboot_inactive
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.reboot import wait_for_startup
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.utilities import wait_until
-from tests.conftest import get_specified_dpus
-from tests.common.platform.device_utils import reboot_dpu_and_wait_for_start_up
+
+from tests.common.fixtures.grpc_fixtures import gnmi_tls    # noqa: F401
 
 
 pytestmark = [
     pytest.mark.topology('any'),
     # Reboot triggers kernel warnings on VS.
     pytest.mark.disable_loganalyzer,
-    pytest.mark.usefixtures("setup_gnmi_ntp_client_server", "setup_gnmi_server",
-                            "setup_gnmi_rotated_server", "check_dut_timestamp")
 ]
 
-
-"""
-This module contains tests for the gNOI System API.
-"""
-
-# Enum mapping for RebootMethod for readability
-RebootMethod = {
-    "UNKNOWN": 0,
-    "COLD": 1,
-    "POWERDOWN": 2,
-    "HALT": 3,
-    "WARM": 4,
-    "NSF": 5,
-    # 6 is reserved
-    "POWERUP": 7
-}
 
 REBOOT_MESSAGE = "gnoi test reboot"
 
 
 def is_gnmi_container_running(duthost):
-    """
-    Check if the gNMI container is running on the DUT.
-    """
+    """Check if the gNMI container is running on the DUT."""
     return duthost.is_container_running("gnmi")
 
 
-def check_reboot_status(duthost, localhost, dpu_index, expected_active, expected_reason, expected_method):
+def check_reboot_status(gnmi_tls, expected_active, expected_reason, expected_method):    # noqa: F811
     """
     Call gNOI System.RebootStatus and assert the fields and values of the response.
-    """
-    if expected_method == RebootMethod["HALT"]:
-        ret, msg = gnoi_request_dpu(duthost, localhost, dpu_index, "System", "RebootStatus", "")
-    else:
-        ret, msg = gnoi_request(duthost, localhost, "System", "RebootStatus", "")
-    pytest_assert(ret == 0, "System.RebootStatus API reported failure (rc = {}) with message: {}".format(ret, msg))
-    logging.info("System.RebootStatus API returned msg: {}".format(msg))
 
-    status = extract_gnoi_response(msg)
-    pytest_assert(status is not None, "Failed to extract JSON from gNOI response")
+    Args:
+        gnmi_tls: GnmiFixture instance
+        expected_active: Expected value of 'active' field
+        expected_reason: Expected value of 'reason' field
+        expected_method: Expected method name as string (e.g., "COLD", "WARM")
+                         Note: grpcurl JSON output returns proto enums as strings
+    """
+    status = gnmi_tls.gnoi.reboot_status()
+    pytest_assert(status is not None, "Failed to get reboot status")
 
     pytest_assert("active" in status, "Missing 'active' in RebootStatus")
     pytest_assert("when" in status, "Missing 'when' in RebootStatus")
@@ -66,80 +47,43 @@ def check_reboot_status(duthost, localhost, dpu_index, expected_active, expected
     pytest_assert("count" in status, "Missing 'count' in RebootStatus")
     pytest_assert("method" in status, "Missing 'method' in RebootStatus")
     pytest_assert(status["active"] is expected_active, "'active' should be True after reboot")
-    pytest_assert(status["reason"] == expected_reason, f"'reason' should be '{expected_reason}'")
-    pytest_assert(status["method"] == expected_method, f"'method' should be {expected_method}")
-    pytest_assert(isinstance(status["when"], int) and status["when"] > 0, "'when' should be a positive integer")
-    pytest_assert(isinstance(status["count"], int) and status["count"] >= 1, "'count' should be >= 1")
+    pytest_assert(status["reason"] == expected_reason,
+                  "'reason' should be '{}'".format(expected_reason))
+    # grpcurl JSON returns proto enum values as strings (e.g., "COLD" not 1)
+    pytest_assert(status["method"] == expected_method,
+                  "'method' should be '{}', got '{}'".format(expected_method, status['method']))
+    # Protobuf3 JSON encoding: int64 is serialized as string to preserve precision
+    when_value = int(status["when"]) if isinstance(status["when"], str) else status["when"]
+    pytest_assert(isinstance(when_value, int) and when_value > 0, "'when' should be a positive integer")
+    # Protobuf3 JSON encoding: uint32 may also be serialized as string
+    count_value = int(status["count"]) if isinstance(status["count"], str) else status["count"]
+    pytest_assert(isinstance(count_value, int) and count_value >= 1, "'count' should be >= 1")
 
 
-def test_gnoi_system_reboot_cold(duthosts, rand_one_dut_hostname, localhost):
+def test_gnoi_system_reboot_cold(duthosts, rand_one_dut_hostname, localhost, gnmi_tls):  # noqa: F811
     """
     Test gNOI System.Reboot API with COLD method.
+
     Verifies that the reboot is triggered, RebootStatus is correct before and after reboot,
     and the system recovers with all critical processes running.
     """
     duthost = duthosts[rand_one_dut_hostname]
 
-    reboot_args = {
-        "message": REBOOT_MESSAGE,
-        "method": RebootMethod["COLD"]
-    }
     # Record uptime before reboot
     uptime_before = duthost.get_up_time(utc_timezone=True)
 
-    ret, msg = gnoi_request(duthost, localhost, "System", "Reboot", json.dumps(reboot_args))
-    pytest_assert(ret == 0, "System.Reboot API reported failure (rc = {}) with message: {}".format(ret, msg))
-    logging.info("System.Reboot API returned msg: {}".format(msg))
-
-    check_reboot_status(
-        duthost, localhost, dpu_index=None,
-        expected_active=True,
-        expected_reason=REBOOT_MESSAGE,
-        expected_method=RebootMethod["COLD"]
+    # Trigger reboot via gNOI using gnmi_tls fixture
+    reboot_response = gnmi_tls.gnoi.system_reboot(
+        method="COLD",
+        message=REBOOT_MESSAGE
     )
-
-    # Wait until the system is back up
-    wait_for_startup(duthost, localhost, delay=20, timeout=600)
-    logging.info("System is back up after reboot")
-
-    # Wait for critical processses before ending
-    wait_critical_processes(duthost)
-
-    # Wait for gNMI container to be running
-    wait_until(120, 10, 0, is_gnmi_container_running, duthost)
-
-    # This is an adhoc workaround because the cert config is cleared after reboot.
-    # We should refactor the test to always use the default config.
-    apply_cert_config(duthost)
-
-    # Check device is actually rebooted by comparing uptime
-    uptime_after = duthost.get_up_time(utc_timezone=True)
-    logging.info('Uptime before reboot: %s, after reboot: %s', uptime_before, uptime_after)
-    assert uptime_after > uptime_before, "Device did not reboot, uptime did not reset"
-
-
-def test_gnoi_system_reboot_warm(duthosts, rand_one_dut_hostname, localhost):
-    """
-    Test gNOI System.Reboot API with WARM method.
-    Verifies that the reboot is triggered, RebootStatus is correct before reboot,
-    and the system recovers with all critical processes running.
-    """
-    duthost = duthosts[rand_one_dut_hostname]
-
-    reboot_args = {
-        "message": REBOOT_MESSAGE,
-        "method": RebootMethod["WARM"]
-    }
-
-    ret, msg = gnoi_request(duthost, localhost, "System", "Reboot", json.dumps(reboot_args))
-    pytest_assert(ret == 0, "System.Reboot API reported failure (rc = {}) with message: {}".format(ret, msg))
-    logging.info("System.Reboot API returned msg: {}".format(msg))
+    logging.info("System.Reboot API returned: {}".format(reboot_response))
 
     check_reboot_status(
-        duthost, localhost, dpu_index=None,
+        gnmi_tls,
         expected_active=True,
         expected_reason=REBOOT_MESSAGE,
-        expected_method=RebootMethod["WARM"]
+        expected_method="COLD"
     )
 
     # Wait until the system is back up
@@ -152,54 +96,47 @@ def test_gnoi_system_reboot_warm(duthosts, rand_one_dut_hostname, localhost):
     # Wait for gNMI container to be running
     wait_until(120, 10, 0, is_gnmi_container_running, duthost)
 
-    # This is an adhoc workaround because the cert config is cleared after reboot.
-    # We should refactor the test to always use the default config.
-    apply_cert_config(duthost)
+    # Reconfigure gNMI server for TLS after reboot
+    gnmi_tls.reconfigure_after_reboot()
+
+    # Check device is actually rebooted by comparing uptime
+    uptime_after = duthost.get_up_time(utc_timezone=True)
+    logging.info('Uptime before reboot: %s, after reboot: %s', uptime_before, uptime_after)
+    pytest_assert(uptime_after > uptime_before, "Device did not reboot, uptime did not reset")
 
 
-def test_gnoi_system_reboot_halt_dpus(duthosts, rand_one_dut_hostname, localhost, request):
+def test_gnoi_system_reboot_warm(duthosts, rand_one_dut_hostname, localhost, gnmi_tls):  # noqa: F811
     """
-    Test gNOI System.Reboot API with HALT method.
+    Test gNOI System.Reboot API with WARM method.
+
     Verifies that the reboot is triggered, RebootStatus is correct before reboot,
     and the system recovers with all critical processes running.
     """
     duthost = duthosts[rand_one_dut_hostname]
 
-    dpuhost_names = get_specified_dpus(request)
-    if dpuhost_names:
-        logging.info(f"dpuhost_names: {dpuhost_names}")
-    else:
-        pytest.skip("No DPUs specified, skipping HALT reboot test.")
+    # Trigger reboot via gNOI using gnmi_tls fixture
+    reboot_response = gnmi_tls.gnoi.system_reboot(
+        method="WARM",
+        message=REBOOT_MESSAGE
+    )
+    logging.info("System.Reboot API returned: {}".format(reboot_response))
 
-    reboot_args = {
-        "message": REBOOT_MESSAGE,
-        "method": RebootMethod["HALT"]
-    }
+    check_reboot_status(
+        gnmi_tls,
+        expected_active=True,
+        expected_reason=REBOOT_MESSAGE,
+        expected_method="WARM"
+    )
 
-    for dpuhost_name in dpuhost_names:
-        # Extract the last number from the duthost name
-        dpu_index = int(dpuhost_name.split('-')[-1])
+    # Wait until the system is back up
+    wait_for_startup(duthost, localhost, delay=20, timeout=600)
+    logging.info("System is back up after reboot")
 
-        # Validate dpu_index and log error if out of range
-        if not (0 <= dpu_index <= 8):
-            pytest.fail(f"Invalid dpu_index {dpu_index}, must be between 0 and 8")
+    # Wait for critical processes before ending
+    wait_critical_processes(duthost)
 
-        ret, msg = gnoi_request_dpu(duthost, localhost, dpu_index, "System", "Reboot", json.dumps(reboot_args))
-        pytest_assert(ret == 0, "System.Reboot API reported failure (rc = {}) with message: {}".format(ret, msg))
-        logging.info("System.Reboot API returned msg: {}".format(msg))
+    # Wait for gNMI container to be running
+    wait_until(120, 10, 0, is_gnmi_container_running, duthost)
 
-        check_reboot_status(
-            duthost, localhost, dpu_index,
-            expected_active=True,
-            expected_reason=REBOOT_MESSAGE,
-            expected_method=RebootMethod["HALT"]
-        )
-
-        wait_until(120, 10, 0, is_reboot_inactive, duthost, localhost)
-        logging.info("HALT reboot is completed")
-
-        dpu_reboot_status = reboot_dpu_and_wait_for_start_up(duthost, dpuhost_name, dpu_index)
-        if not dpu_reboot_status:
-            pytest.fail(f"DPU {dpuhost_name} (DPU index: {dpu_index}) failed to reboot properly")
-
-        logging.info(f"DPU {dpuhost_name} (DPU index: {dpu_index}) rebooted successfully")
+    # Reconfigure gNMI server for TLS after reboot
+    gnmi_tls.reconfigure_after_reboot()


### PR DESCRIPTION
### Description of PR

Summary:
Fix TLS authentication failure (`Unauthenticated` error) in `test_gnoi_system_reboot` by migrating to the `gnmi_tls` fixture, which provides proper TLS certificate management and post-reboot recovery.

Fixes #738247735 (IcM)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

The `test_gnoi_system_reboot_cold` test was failing with `rpc error: code = Unauthenticated desc = Unauthenticated` on Nokia-M0-7215 platforms. The root cause was inconsistent TLS certificate setup - the old approach used scattered certificate helpers that didn't reliably configure the gNOI client for TLS authentication.

#### How did you do it?

- Migrated `test_gnoi_system_reboot.py` to use the `gnmi_tls` fixture from `tests/common/fixtures/grpc_fixtures.py`
- Removed deprecated `usefixtures` references (`setup_gnoi_tls_server`)
- Used `gnmi_tls.gnoi.system_reboot()` and `gnmi_tls.gnoi.reboot_status()` for gNOI API calls
- Added `gnmi_tls.reconfigure_after_reboot()` to restore TLS configuration after device reboots
- Fixed protobuf3 JSON type handling (enums as strings, int64 as strings)

#### How did you verify/test it?

- Ran `test_gnoi_system_reboot_cold` and `test_gnoi_system_reboot_warm` on DUTs.
- Both tests passed successfully
- Verified TLS connectivity before and after reboot
- Confirmed proper cleanup via checkpoint rollback

```   class HostManagerV213(BaseHostManager):

tests/gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_cold
tests/gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_cold
tests/gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_cold
tests/gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_cold
tests/gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_cold
tests/gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_warm
  /opt/venv/lib/python3.12/site-packages/ansible/plugins/loader.py:1485: UserWarning: AnsibleCollectionFinder has already been configured
    warnings.warn('AnsibleCollectionFinder has already been configured')

tests/gnmi/test_gnoi_system_reboot.py: 103 warnings
  /usr/lib/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=31266) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

tests/gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_cold
  /home/v-ryeluri/sonic-mgmt-int/tests/conftest.py:1467: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    record_testsuite_property("timestamp", datetime.utcnow())

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------- generated xml file: /home/v-ryeluri/sonic-mgmt-int/tests/logs/gnmi/test_gnoi_system_reboot.xml --------------------
------------------------------------------------------- live log sessionfinish --------------------------------------------------------
INFO     root:__init__.py:67 Can not get Allure report URL. Please check logs

Results (466.51s (0:07:46)):
       2 passed
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_gnoi_system_reboot_warm>
DEBUG:root:[Parallel Fixture] Terminate parallel manager after teardown
INFO:root:[Parallel Fixture] Terminating parallel fixture manager
DEBUG:root:[Parallel Fixture] Running tasks to be terminated: []
DEBUG:root:[Parallel Fixture] Current worker threads: []
DEBUG:root:[Parallel Fixture] Current worker threads: []
DEBUG:root:[Parallel Fixture] The fixture manager is terminated:
stopped tasks [],
canceled tasks [],
pending tasks [],
done tasks [].
INFO:root:Can not get Allure report URL. Please check logs
v-ryeluri@sonic-mgmt-v-ryeluri:~/sonic-mgmt-int/tests$ ```
#### Any platform specific information?

Originally failing on Nokia-M0-7215 (marvell-prestera ASIC) with M0_MX topology. Fix should work across all platforms that support gNMI/gNOI.

#### Supported testbed topology if it's a new test case?

N/A - Existing test case, topology marker is `any`.

### Documentation

N/A - No new features or test cases added.