### PR TITLE
Fix enableECN QoS Fixture on Chassis

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -14,6 +14,7 @@ import collections
 
 from tests.common.fixtures.ptfhost_utils import ptf_portmap_file  # noqa: F401
 from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.helpers.counterpoll_helper import ConterpollHelper
 from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
 from tests.common.mellanox_data import is_mellanox_device as isMellanoxDevice
 from tests.common.cisco_data import is_cisco_device, copy_dshell_script_cisco_8000, run_dshell_command
@@ -3433,36 +3434,19 @@ def clear_pg_watermark(interface):
         By default WRED_ECN_QUEUE and WRED_ECN_PORT are disabled for polling.
         Enable flexcounter groups WRED_ECN_QUEUE and WRED_ECN_PORT using counterpoll CLI
         """
-        duthost = duthosts.frontend_nodes[0]
-        if duthost.sonichost.is_multi_asic:
-            for duthost in get_src_dst_asic_and_duts['all_duts']:
-                for asic in duthost.asics:
-                    namespace_arg = '-n asic{}'.format(asic.asic_index)
-                    try:
-                        duthost.command("sudo counterpoll wredqueue {} enable".format(namespace_arg))
-                        duthost.command("sudo counterpoll wredport {} enable".format(namespace_arg))
-                    except Exception:
-                        pass  # VS/KVM counterpoll may not support -n namespace
-                duthost.command("sudo config save -y")
-        else:
-            for dut_asic in get_src_dst_asic_and_duts["all_asics"]:
-                dut_asic.command("counterpoll wredqueue enable")
-                dut_asic.command("counterpoll wredport enable")
+        for duthost in get_src_dst_asic_and_duts['all_duts']:
+            for dut_asic in duthost.asics:
+                try:
+                    ConterpollHelper.enable_counterpoll(dut_asic, ['wredqueue', 'wredport'])
+                except Exception as e:  # VS/KVM counterpoll may not support -n namespace
+                    logging.error(f"Failed to enable counterpoll for {dut_asic.hostname} with error: {e}")
             duthost.command("sudo config save -y")
 
         yield
-        if duthost.sonichost.is_multi_asic:
-            for duthost in get_src_dst_asic_and_duts['all_duts']:
-                for asic in duthost.asics:
-                    namespace_arg = '-n asic{}'.format(asic.asic_index)
-                    try:
-                        duthost.command("sudo counterpoll wredqueue {} disable".format(namespace_arg))
-                        duthost.command("sudo counterpoll wredport {} disable".format(namespace_arg))
-                    except Exception:
-                        pass  # VS/KVM counterpoll may not support -n namespace
-                duthost.command("sudo config save -y")
-        else:
-            for dut_asic in get_src_dst_asic_and_duts["all_asics"]:
-                dut_asic.command("counterpoll wredqueue disable")
-                dut_asic.command("counterpoll wredport disable")
+        for duthost in get_src_dst_asic_and_duts['all_duts']:
+            for dut_asic in duthost.asics:
+                try:
+                    ConterpollHelper.disable_counterpoll(dut_asic, ['wredqueue', 'wredport'])
+                except Exception as e:  # VS/KVM counterpoll may not support -n namespace
+                    logging.error(f"Failed to disable counterpoll for {dut_asic.hostname} with error: {e}")
             duthost.command("sudo config save -y")


### PR DESCRIPTION
`tests/qos/test_qos_sai.py` are failing on a chassis that has both a multi asic and a single asic linecard.
This commit fixes the issue and provides a general code improvement.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #23998 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
`tests/qos/qos_sai_base.py` has a new `enableEcn` fixture which uses counterpoll CLI to enable wredqueue and wredport counters, followed by disabling them.
This fixture incorrectly assumes that if the first Linecard of a chassis is multi asic then they all are and it then incorrectly uses the counterpoll CLI to enable and disable these counters on each linecard.

This PR fixes the issue.

#### How did you do it?
Update the code to loop over all dut asics and using the counterpoll helper instead.

#### How did you verify/test it?
Reran `tests/qos/test_qos_sai.py` on single asic, multi asic, and on chassis to verify the qos tests pass instead of error.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
