### PR TITLE
config_reload() options for CACL cleanup_scale_rules() function

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -151,7 +151,7 @@ def clean_scale_rules(duthosts, enum_rand_one_per_hwsku_hostname, collect_ignore
     # delete the tmp file
     duthost.file(path=SCALE_ACL_FILE, state='absent')
     logger.info("Reload config to recover configuration.")
-    config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
 
 
 @pytest.fixture(scope="function")
@@ -260,7 +260,7 @@ def dummy_acl_rules(duthosts, enum_rand_one_per_hwsku_hostname):
     duthost.file(path=file_path, state='absent')
 
     logger.info("Reloading config to recover original ACL configuration...")
-    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
 
 
 def is_acl_rule_empty(duthost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->

Cherry-pick due to conflict: https://github.com/sonic-net/sonic-mgmt/pull/22718

### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Config reload options for CACL cleanup_scale_rules() function

Summary:
Fixes # (issue)

For a long time, it is observed that the test_cacl_scale_rules_ipv6 test case fails due to Increase in Memory threshold. And it also, reported an incorrect percentage in increase in System Memory.

Debugging the issue, it was found that cleanup_scale_rules() which was called as part of previous test case test_cacl_scale_rules_ipv4() teardown function, actually invokes config_reload() which does not complete the restart of syncd process fully. Hence, the VM RSS memory occupied by syncd is too low, which eventually becomes normal. So, the difference between "Before test" and "After test" "free -m" command "used" field increases more than 20% causing the test case to fail. Fixed it with adding to the config_reload() option of wait_for_bgp = True, which fixes the issue.

There was also a cosmetic issue of reporting Increased MB usage as Increased percentage usage. Fixed this issue also.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

This CICD defect is there nearly for more than 3 months and the defect was frequently reproducible.

#### How did you do it?

Made the above two code changes required for threshold output formatting and fixed cleanup issue causing false positive

#### How did you verify/test it?

Added the fix and rerun the test

#### Any platform specific information?

It is across platforms - t0, t1 and t2.

#### Supported testbed topology if it's a new test case?

Existing testcase

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
