### PR TITLE
Add smart switch full upgrade test all DPUs then reboot NPU

### DIFF
--- a/tests/common/fixtures/grpc_fixtures.py
+++ b/tests/common/fixtures/grpc_fixtures.py
@@ -502,3 +502,17 @@ def _delete_gnoi_certs(cert_dir):
     # Remove the entire certificate directory
     if os.path.exists(cert_dir):
         shutil.rmtree(cert_dir, ignore_errors=True)
+
+
+def reprovision_gnoi_tls(duthost, ptfhost, cert_dir="/tmp/gnoi_certs"):
+    """Re-run cert + CONFIG_DB + gNMI restart steps after a DUT reboot.
+
+    Use this between phases of an upgrade test where the NPU rebooted into a
+    new image and its gNMI server is no longer using the test-provisioned certs.
+    """
+    logger.info("Re-provisioning gNOI TLS after DUT reboot")
+    _create_gnoi_certs(duthost, ptfhost, cert_dir)
+    _configure_gnoi_tls_server(duthost)
+    _restart_gnoi_server(duthost)
+    _verify_gnoi_tls_connectivity(duthost, ptfhost)
+    logger.info("gNOI TLS re-provisioning complete")

--- a/tests/common/helpers/upgrade_helpers.py
+++ b/tests/common/helpers/upgrade_helpers.py
@@ -49,6 +49,7 @@ class GnoiUpgradeConfig:
     metadata: Optional[GrpcMetadata] = None
     ss_reboot_ready_timeout: int = 1200
     ss_reboot_message: str = "Rebooting DPU for maintenance"
+    skip_reboot: bool = False  # If True, only stage the image, do NOT reboot (reboot happens later via NPU)
 
 
 def pytest_runtest_setup(item):
@@ -432,13 +433,29 @@ def _wait_gnoi_time_ready(ptf_gnoi, metadata, cfg: GnoiUpgradeConfig, timeout=No
 
 
 def _upgrade_one_dpu_via_gnoi(duthost, tbinfo, ptf_gnoi, cfg: GnoiUpgradeConfig) -> Dict:
+    """
+    Upgrade a single DPU via gNOI.
+
+    Steps:
+      1. Verify the DPU is reachable (gNOI System.Time)
+      2. Transfer the image to the DPU (File.TransferToRemote)
+      3. Stage the image as the next boot image (System.SetPackage)
+      4. Reboot the DPU (System.Reboot)  -- skipped if cfg.skip_reboot=True
+      5. Wait for DPU to come back up (gNOI System.Time)  -- skipped if cfg.skip_reboot=True
+
+    When cfg.skip_reboot=True, only steps 1-3 are performed.
+    This is used when you want to stage the image on the DPU but trigger the
+    actual reboot later (e.g. via an NPU reboot that also reboots all DPUs).
+    """
     if cfg.metadata is None:
         raise ValueError("cfg.metadata must be provided for SmartSwitch DPU upgrade")
 
     md = cfg.metadata
 
+    # Step 1: Verify DPU is reachable before we start
     ptf_gnoi.system_time(metadata=md)
 
+    # Step 2: Download the image onto the DPU
     transfer_resp = ptf_gnoi.file_transfer_to_remote(
         url=cfg.to_image,
         local_path=cfg.dut_image_path,
@@ -446,6 +463,7 @@ def _upgrade_one_dpu_via_gnoi(duthost, tbinfo, ptf_gnoi, cfg: GnoiUpgradeConfig)
         metadata=md,
     )
 
+    # Step 3: Mark the downloaded image as the next boot image
     setpkg_resp = ptf_gnoi.system_set_package(
         local_path=cfg.dut_image_path,
         version=cfg.to_version,
@@ -453,6 +471,12 @@ def _upgrade_one_dpu_via_gnoi(duthost, tbinfo, ptf_gnoi, cfg: GnoiUpgradeConfig)
         metadata=md,
     )
 
+    # Steps 4 & 5 are skipped when skip_reboot=True (caller will trigger reboot separately)
+    if cfg.skip_reboot:
+        logger.info("skip_reboot=True: image staged on DPU, skipping reboot")
+        return {"transfer_resp": transfer_resp, "setpkg_resp": setpkg_resp, "reboot_resp": None}
+
+    # Step 4: Reboot the DPU
     method = str(cfg.upgrade_type).upper()
     try:
         reboot_resp = ptf_gnoi.system_reboot(
@@ -462,14 +486,15 @@ def _upgrade_one_dpu_via_gnoi(duthost, tbinfo, ptf_gnoi, cfg: GnoiUpgradeConfig)
             metadata=md,
         )
     except Exception as e:
-        logger.info("Reboot raised (often expected): %s", e)
+        logger.info("Reboot raised (often expected after DPU disconnect): %s", e)
         reboot_resp = None
 
     if cfg.allow_fail:
         return {"transfer_resp": transfer_resp, "setpkg_resp": setpkg_resp, "reboot_resp": reboot_resp}
 
+    # Step 5: Wait for DPU to come back up
     ok = _wait_gnoi_time_ready(ptf_gnoi, md, cfg)
-    pytest_assert(ok, f"gNOI Time not reachable within {cfg.ss_reboot_ready_timeout}s after reboot")
+    pytest_assert(ok, f"gNOI Time not reachable within {cfg.ss_reboot_ready_timeout}s after DPU reboot")
 
     return {"transfer_resp": transfer_resp, "setpkg_resp": setpkg_resp, "reboot_resp": reboot_resp}
 

--- a/tests/common/ptf_gnoi.py
+++ b/tests/common/ptf_gnoi.py
@@ -250,6 +250,7 @@ class PtfGnoi:
             "remote_download": remote_download,
         }
 
+        self.grpc_client.configure_max_time(3600)   # image download can take a long time
         response = self.grpc_client.call_unary("gnoi.file.File", "TransferToRemote", request, metadata=metadata)
         logger.info("TransferToRemote completed: %s -> %s", url, local_path)
         return response

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -352,6 +352,18 @@ def pytest_addoption(parser):
         default=4,
         help="Max parallel workers for SmartSwitch gNOI upgrade tests (default: 4)",
     )
+    parser.addoption(
+        "--ss_npu_target_image",
+        action="store",
+        default="",
+        help="SmartSwitch NPU image URL used in the full upgrade test (DPUs staged first, then NPU rebooted)",
+    )
+    parser.addoption(
+        "--ss_npu_target_version",
+        action="store",
+        default="",
+        help="SmartSwitch NPU version string used in the full upgrade test (e.g. SONiC-OS-internal-202511.xxx)",
+    )
     ##################################
     #   Container Upgrade options    #
     ##################################

--- a/tests/upgrade_path/test_upgrade_gnoi.py
+++ b/tests/upgrade_path/test_upgrade_gnoi.py
@@ -55,6 +55,10 @@ def test_upgrade_via_gnoi(
     )
 
     def upgrade_path_preboot_setup():
+        # Save TLS config to disk before the reboot so it persists through it.
+        # setup_upgrade_test reboots the DUT which restores CONFIG_DB from disk,
+        # and without this save the gnmi_tls fixture's config would be wiped.
+        duthost.shell("sudo config save -y")
         setup_upgrade_test(duthost, localhost, from_image, to_image, tbinfo,
                            upgrade_type)
 

--- a/tests/upgrade_path/test_upgrade_smart_switch_gnoi.py
+++ b/tests/upgrade_path/test_upgrade_smart_switch_gnoi.py
@@ -2,13 +2,16 @@ import logging
 import pytest
 
 from tests.common.fixtures.grpc_fixtures import (  # noqa: F401
-    ptf_grpc, ptf_gnoi, setup_gnoi_tls_server
+    gnmi_tls, ptf_grpc, ptf_gnoi, setup_gnoi_tls_server
 )
 from tests.common.helpers.upgrade_helpers import (
     GnoiUpgradeConfig,
+    perform_gnoi_upgrade,
     perform_gnoi_upgrade_smartswitch_dpu,
     perform_gnoi_upgrade_smartswitch_dpus_parallel,
 )
+from tests.common.utilities import wait_until
+from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.device_utils import get_configured_dpu_names
 
 logger = logging.getLogger(__name__)
@@ -177,3 +180,146 @@ def test_upgrade_multiple_dpus_via_gnoi_parallel(
         cfgs=cfgs,
         max_workers=workers,
     )
+
+
+@pytest.fixture(scope="module")
+def smartswitch_full_upgrade_lists(request, duthost):
+    """
+    Parameters for the full SmartSwitch upgrade test.
+    DPU image/version come from --target_image_list / --target_version.
+    NPU image/version come from --ss_npu_target_image / --ss_npu_target_version.
+    """
+    upgrade_type = request.config.getoption("upgrade_type")
+    dpu_to_image = request.config.getoption("target_image_list")
+    dpu_to_version = request.config.getoption("target_version")
+    npu_to_image = request.config.getoption("ss_npu_target_image")
+    npu_to_version = request.config.getoption("ss_npu_target_version")
+    ss_reboot_ready_timeout = 600
+
+    # Try to get DPU indices from CONFIG_DB first.
+    # If that returns empty (DPU table not populated), fall back to --ss_target_indices.
+    names = get_configured_dpu_names(duthost)
+    if names:
+        dpu_indices = list(range(len(names)))
+    else:
+        ss_target_indices = request.config.getoption("ss_target_indices")
+        if ss_target_indices:
+            dpu_indices = [int(x.strip()) for x in ss_target_indices.split(",") if x.strip()]
+        else:
+            pytest.fail(
+                "Could not determine DPU indices: CONFIG_DB DPU table is empty and "
+                "--ss_target_indices was not provided. Pass e.g. --ss_target_indices=0,1,2,3"
+            )
+
+    return (upgrade_type, dpu_to_image, dpu_to_version, npu_to_image, npu_to_version,
+            dpu_indices, ss_reboot_ready_timeout)
+
+
+@pytest.mark.device_type("smartswitch")
+def test_upgrade_smartswitch_all_dpus_then_npu(
+    localhost, duthosts, ptfhost, enum_rand_one_per_hwsku_hostname,
+    tbinfo, conn_graph_facts, xcvr_skip_list, request,
+    smartswitch_full_upgrade_lists, gnmi_tls  # noqa: F811
+):
+    """
+    Full SmartSwitch upgrade: stage all DPUs first, then upgrade the NPU.
+
+    Phase 1 - Stage image on all DPUs in parallel (no reboot):
+              Each DPU gets TransferToRemote + SetPackage with skip_reboot=True.
+
+    Phase 2 - Upgrade the NPU:
+              TransferToRemote + SetPackage + Reboot on the NPU.
+              The NPU reboot also reboots all DPUs automatically.
+
+    Phase 3 - Wait for all DPUs to come back up.
+
+    Required CLI args:
+      --target_image_list       DPU image URL
+      --target_version          DPU version string
+      --ss_npu_target_image     NPU image URL
+      --ss_npu_target_version   NPU version string
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+    (upgrade_type, dpu_to_image, dpu_to_version,
+     npu_to_image, npu_to_version,
+     dpu_indices, reboot_ready_timeout) = smartswitch_full_upgrade_lists
+
+    assert dpu_to_image, "--target_image_list is required (DPU image URL)"
+    assert npu_to_image, "--ss_npu_target_image is required (NPU image URL)"
+
+    dut_image_path = "/var/tmp/sonic_image.bin"
+
+    # ------------------------------------------------------------------
+    # Phase 1: Stage image on all DPUs in parallel (no reboot yet).
+    # skip_reboot=True means only TransferToRemote + SetPackage run.
+    # The DPUs will reboot in Phase 2 when the NPU reboots.
+    # ------------------------------------------------------------------
+    logger.info("Phase 1: Staging image on all %d DPUs (no reboot)", len(dpu_indices))
+
+    dpu_cfgs = [
+        GnoiUpgradeConfig(
+            to_image=dpu_to_image,
+            dut_image_path=dut_image_path,
+            upgrade_type=upgrade_type,
+            to_version=dpu_to_version,
+            metadata=_build_dpu_metadata(idx),
+            ss_reboot_ready_timeout=reboot_ready_timeout,
+            skip_reboot=True,
+        )
+        for idx in dpu_indices
+    ]
+    perform_gnoi_upgrade_smartswitch_dpus_parallel(
+        duthost=duthost,
+        tbinfo=tbinfo,
+        ptf_gnoi=gnmi_tls.gnoi,
+        cfgs=dpu_cfgs,
+        max_workers=len(dpu_indices),
+    )
+    logger.info("Phase 1 complete: image staged on all DPUs")
+
+    # ------------------------------------------------------------------
+    # Phase 2: Upgrade the NPU.
+    # NPU reboot automatically reboots all DPUs.
+    # perform_gnoi_upgrade waits for the NPU to come back before returning.
+    # ------------------------------------------------------------------
+    logger.info("Phase 2: Upgrading NPU (will also reboot all DPUs)")
+
+    # Save TLS config to disk before the NPU reboot so it persists through it.
+    # The NPU reboot restores CONFIG_DB from disk, wiping the gnmi_tls fixture's config.
+    duthost.shell("sudo config save -y")
+
+    npu_cfg = GnoiUpgradeConfig(
+        to_image=npu_to_image,
+        dut_image_path=dut_image_path,
+        upgrade_type=upgrade_type,
+        to_version=npu_to_version,
+        ss_reboot_ready_timeout=reboot_ready_timeout,
+    )
+    perform_gnoi_upgrade(
+        ptf_gnoi=gnmi_tls.gnoi,
+        duthost=duthost,
+        tbinfo=tbinfo,
+        cfg=npu_cfg,
+        localhost=localhost,
+        conn_graph_facts=conn_graph_facts,
+        xcvr_skip_list=xcvr_skip_list,
+        duthosts=duthosts,
+    )
+    logger.info("Phase 2 complete: NPU is back up")
+
+    # ------------------------------------------------------------------
+    # Phase 3: Wait for each DPU to come back up.
+    # Since the NPU reboot also reboots all DPUs, they should come up
+    # shortly after the NPU. We poll gNOI System.Time per DPU to confirm.
+    # ------------------------------------------------------------------
+    logger.info("Phase 3: Waiting for all DPUs to come back up")
+
+    for idx in dpu_indices:
+        logger.info("Waiting for DPU %d...", idx)
+        ok = wait_until(reboot_ready_timeout, 10, 0, gnmi_tls.gnoi.system_time,
+                        metadata=_build_dpu_metadata(idx))
+        pytest_assert(ok, "DPU {} did not come back up within {}s after NPU reboot".format(idx, reboot_ready_timeout))
+        logger.info("DPU %d is back up", idx)
+
+    logger.info("Phase 3 complete: all %d DPUs are back up", len(dpu_indices))

--- a/tests/upgrade_path/test_upgrade_smart_switch_gnoi.py
+++ b/tests/upgrade_path/test_upgrade_smart_switch_gnoi.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 
 from tests.common.fixtures.grpc_fixtures import (  # noqa: F401
-    gnmi_tls, ptf_grpc, ptf_gnoi, setup_gnoi_tls_server
+    gnmi_tls, ptf_grpc, ptf_gnoi, setup_gnoi_tls_server, reprovision_gnoi_tls
 )
 from tests.common.helpers.upgrade_helpers import (
     GnoiUpgradeConfig,
@@ -203,13 +203,12 @@ def smartswitch_full_upgrade_lists(request, duthost):
         dpu_indices = list(range(len(names)))
     else:
         ss_target_indices = request.config.getoption("ss_target_indices")
-        if ss_target_indices:
-            dpu_indices = [int(x.strip()) for x in ss_target_indices.split(",") if x.strip()]
-        else:
+        if not ss_target_indices:
             pytest.fail(
                 "Could not determine DPU indices: CONFIG_DB DPU table is empty and "
                 "--ss_target_indices was not provided. Pass e.g. --ss_target_indices=0,1,2,3"
             )
+        dpu_indices = [int(x.strip()) for x in ss_target_indices.split(",") if x.strip()]
 
     return (upgrade_type, dpu_to_image, dpu_to_version, npu_to_image, npu_to_version,
             dpu_indices, ss_reboot_ready_timeout)
@@ -285,10 +284,6 @@ def test_upgrade_smartswitch_all_dpus_then_npu(
     # ------------------------------------------------------------------
     logger.info("Phase 2: Upgrading NPU (will also reboot all DPUs)")
 
-    # Save TLS config to disk before the NPU reboot so it persists through it.
-    # The NPU reboot restores CONFIG_DB from disk, wiping the gnmi_tls fixture's config.
-    duthost.shell("sudo config save -y")
-
     npu_cfg = GnoiUpgradeConfig(
         to_image=npu_to_image,
         dut_image_path=dut_image_path,
@@ -307,6 +302,10 @@ def test_upgrade_smartswitch_all_dpus_then_npu(
         duthosts=duthosts,
     )
     logger.info("Phase 2 complete: NPU is back up")
+
+    # NPU rebooted into a new image — its gNMI is no longer using our certs.
+    # Re-provision before talking to the NPU/DPU gNOI in Phase 3.
+    reprovision_gnoi_tls(duthost, ptfhost)
 
     # ------------------------------------------------------------------
     # Phase 3: Wait for each DPU to come back up.


### PR DESCRIPTION
 Adds test_upgrade_smartswitch_all_dpus_then_npu which stages the new image
 on all DPUs (no reboot), then upgrades the NPU. Since the NPU reboot also
 reboots all DPUs, everything comes up on the new image in one cycle

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
 Adds test_upgrade_smartswitch_all_dpus_then_npu which stages the new image
 on all DPUs (no reboot), then upgrades the NPU. Since the NPU reboot also
 reboots all DPUs, everything comes up on the new image in one cycle

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Test case to upgrade both the NPU and DPU's.  


#### How did you do it?
  - Added skip_reboot=True to GnoiUpgradeConfig so DPUs can be staged without rebooting
  - Phase 1 calls the existing parallel DPU upgrade with skip_reboot=True
  - Phase 2 calls the existing perform_gnoi_upgrade for the NPU (reboot triggers all DPUs to reboot too)
  - Phase 3 polls gnoi.system_time per DPU to confirm everything came back up

#### How did you verify/test it?
v-cshekar@sonic-mgmt-v-cshekar:/var/src/sonic-mgmt-int/tests$   sudo ./run_tests.sh \
      -i ../ansible/str3,../ansible/veos \
      -n vms12-t1-smartswitch-4280-02 \
      -u -m individual \
      -c upgrade_path/test_upgrade_smart_switch_gnoi.py::test_upgrade_smartswitch_all_dpus_then_npu \
      -d str3-msn4280-02 \
      -e "--upgrade_type=cold \
          --base_image_list=http://10.64.247.148:8080/sonic-mellanox-20251110.18.bin \
          --target_image_list=http://10.64.247.148:8080/sonic-nvidia-bluefield.bin \
          --target_version=SONiC-OS-internal-202511.161794596-73a019c26a \
          --ss_npu_target_image=http://10.64.247.148:8080/sonic-mellanox-20251110.20.bin \
          --ss_npu_target_version=SONiC-OS-20251110.20 \
          --ss_target_indices=0,1" \
      -e "--skip_sanity" \
      -l info 2>&1 | tee /tmp/gnoi_run5.log

INFO     tests.common.fixtures.grpc_fixtures:grpc_fixtures.py:307 gNOI server restart completed
INFO     tests.common.fixtures.grpc_fixtures:grpc_fixtures.py:312 Verifying gNOI TLS connectivity
INFO     tests.common.fixtures.grpc_fixtures:grpc_fixtures.py:339 TLS connectivity verification completed successfully
INFO     tests.common.fixtures.grpc_fixtures:grpc_fixtures.py:363 gNOI TLS re-provisioning complete
INFO     tests.upgrade_path.test_upgrade_smart_switch_gnoi:test_upgrade_smart_switch_gnoi.py:315 Phase 3: Waiting for all DPUs to come back up
INFO     tests.upgrade_path.test_upgrade_smart_switch_gnoi:test_upgrade_smart_switch_gnoi.py:318 Waiting for DPU 0...
INFO     tests.upgrade_path.test_upgrade_smart_switch_gnoi:test_upgrade_smart_switch_gnoi.py:322 DPU 0 is back up
INFO     tests.upgrade_path.test_upgrade_smart_switch_gnoi:test_upgrade_smart_switch_gnoi.py:318 Waiting for DPU 1...
INFO     tests.upgrade_path.test_upgrade_smart_switch_gnoi:test_upgrade_smart_switch_gnoi.py:322 DPU 1 is back up
INFO     tests.upgrade_path.test_upgrade_smart_switch_gnoi:test_upgrade_smart_switch_gnoi.py:324 Phase 3 complete: all 2 DPUs are back up
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
