### PR TITLE
moved test_reboot_cause to test_reload_dpu.py

### DIFF
--- a/tests/smartswitch/platform_tests/test_platform_dpu.py
+++ b/tests/smartswitch/platform_tests/test_platform_dpu.py
@@ -57,31 +57,6 @@ def test_midplane_ip(duthosts, enum_rand_one_per_hwsku_hostname, platform_api_co
     pytest_assert(ping_status == 1, "Ping to one or more DPUs has failed")
 
 
-def test_reboot_cause(duthosts, dpuhosts,
-                      enum_rand_one_per_hwsku_hostname,
-                      platform_api_conn, num_dpu_modules):    # noqa: F811
-    """
-    @summary: Verify `Reboot Cause` using parallel execution.
-    """
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-
-    ip_address_list, dpu_on_list, dpu_off_list = pre_test_check(
-                                                 duthost,
-                                                 platform_api_conn,
-                                                 num_dpu_modules)
-
-    logging.info("Shutting DOWN the DPUs in parallel")
-    dpus_shutdown_and_check(duthost, dpu_on_list, num_dpu_modules)
-
-    logging.info("Starting UP the DPUs in parallel")
-    dpus_startup_and_check(duthost, dpu_on_list, num_dpu_modules)
-    post_test_dpus_check(duthost, dpuhosts,
-                         dpu_on_list, ip_address_list,
-                         num_dpu_modules,
-                         re.compile(r"reboot|Non-Hardware",
-                                    re.IGNORECASE))
-
-
 def test_pcie_link(duthosts, dpuhosts,
                    enum_rand_one_per_hwsku_hostname,
                    platform_api_conn, num_dpu_modules):   # noqa: F811

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -41,8 +41,8 @@ def invocation_type(request):
 
 @pytest.fixture(autouse=True)
 def ensure_dpus_up_after_test(duthosts, dpuhosts,
-                               enum_rand_one_per_hwsku_hostname,
-                               num_dpu_modules):  # noqa: F811
+                              enum_rand_one_per_hwsku_hostname,
+                              num_dpu_modules):  # noqa: F811
     """
     Teardown fixture: after each test case, ensure all DPUs are back online.
     If any DPU is found offline at the end of a test, it will be started up
@@ -416,6 +416,7 @@ def test_cold_reboot_switch(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname
     logging.info("Executing post switch reboot dpu check")
     post_test_dpus_check(duthost, dpuhosts, dpu_on_list, ip_address_list, num_dpu_modules,
                          re.compile(r"reboot|Non-Hardware", re.IGNORECASE))
+
 
 def test_reboot_cause(duthosts, dpuhosts,
                       enum_rand_one_per_hwsku_hostname,

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -14,8 +14,8 @@ from tests.common.helpers.dut_utils import is_mellanox_devices
 from tests.smartswitch.common.device_utils_dpu import check_dpu_link_and_status,\
     pre_test_check, post_test_switch_check, post_test_dpus_check,\
     dpus_shutdown_and_check, dpus_startup_and_check, check_dpus_module_status,\
-    num_dpu_modules, check_dpus_are_not_pingable, check_dpus_reboot_cause,\
-    get_dpuhost_for_dpu  # noqa: F401
+    check_dpu_module_status, num_dpu_modules, check_dpus_are_not_pingable,\
+    check_dpus_reboot_cause, get_dpuhost_for_dpu  # noqa: F401
 from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service  # noqa: F401,F403
 from tests.smartswitch.common.reboot import perform_reboot
 from tests.common.fixtures.grpc_fixtures import gnmi_tls  # noqa: F401
@@ -37,6 +37,31 @@ EXTRA_DPU_ONLINE_TIMEOUT_FOR_WATCHDOG = 40
 def invocation_type(request):
     """Parametrize reboot tests to run with both gNOI and CLI reboot paths."""
     return request.param
+
+
+@pytest.fixture(autouse=True)
+def ensure_dpus_up_after_test(duthosts, dpuhosts,
+                               enum_rand_one_per_hwsku_hostname,
+                               num_dpu_modules):  # noqa: F811
+    """
+    Teardown fixture: after each test case, ensure all DPUs are back online.
+    If any DPU is found offline at the end of a test, it will be started up
+    before the next test begins.
+    """
+    yield
+
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dpu_names = ["DPU{}".format(i) for i in range(num_dpu_modules)]
+    offline_dpus = [
+        dpu for dpu in dpu_names
+        if not check_dpu_module_status(duthost, "on", dpu)
+    ]
+    if offline_dpus:
+        logging.info("DPUs found offline after test: %s. Bringing them back UP...", offline_dpus)
+        dpus_startup_and_check(duthost, offline_dpus, num_dpu_modules)
+        logging.info("All DPUs are back online after recovery.")
+    else:
+        logging.info("All DPUs are online after test. No recovery needed.")
 
 
 def test_dpu_status_post_switch_reboot(duthosts, dpuhosts,
@@ -391,3 +416,29 @@ def test_cold_reboot_switch(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname
     logging.info("Executing post switch reboot dpu check")
     post_test_dpus_check(duthost, dpuhosts, dpu_on_list, ip_address_list, num_dpu_modules,
                          re.compile(r"reboot|Non-Hardware", re.IGNORECASE))
+
+def test_reboot_cause(duthosts, dpuhosts,
+                      enum_rand_one_per_hwsku_hostname,
+                      platform_api_conn, num_dpu_modules):    # noqa: F811
+    """
+    @summary: Verify `Reboot Cause` using parallel execution.
+              DPUs are shutdown and started up, then reboot-cause is verified.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+    ip_address_list, dpu_on_list, dpu_off_list = pre_test_check(
+        duthost,
+        platform_api_conn,
+        num_dpu_modules)
+
+    logging.info("Shutting DOWN the DPUs in parallel")
+    dpus_shutdown_and_check(duthost, dpu_on_list, num_dpu_modules)
+
+    logging.info("Starting UP the DPUs in parallel")
+    dpus_startup_and_check(duthost, dpu_on_list, num_dpu_modules)
+
+    post_test_dpus_check(duthost, dpuhosts,
+                         dpu_on_list, ip_address_list,
+                         num_dpu_modules,
+                         re.compile(r"reboot|Non-Hardware",
+                                    re.IGNORECASE))

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -40,7 +40,7 @@ def invocation_type(request):
 
 
 @pytest.fixture(autouse=True)
-def ensure_dpus_up_after_test(duthosts, dpuhosts,
+def ensure_dpus_up_after_test(duthosts,
                               enum_rand_one_per_hwsku_hostname,
                               num_dpu_modules):  # noqa: F811
     """
@@ -52,16 +52,19 @@ def ensure_dpus_up_after_test(duthosts, dpuhosts,
 
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dpu_names = ["DPU{}".format(i) for i in range(num_dpu_modules)]
-    offline_dpus = [
-        dpu for dpu in dpu_names
-        if not check_dpu_module_status(duthost, "on", dpu)
-    ]
-    if offline_dpus:
-        logging.info("DPUs found offline after test: %s. Bringing them back UP...", offline_dpus)
-        dpus_startup_and_check(duthost, offline_dpus, num_dpu_modules)
-        logging.info("All DPUs are back online after recovery.")
-    else:
-        logging.info("All DPUs are online after test. No recovery needed.")
+    try:
+        offline_dpus = [
+            dpu for dpu in dpu_names
+            if not check_dpu_module_status(duthost, "on", dpu)
+        ]
+        if offline_dpus:
+            logging.info("DPUs found offline after test: %s. Bringing them back UP...", offline_dpus)
+            dpus_startup_and_check(duthost, offline_dpus, num_dpu_modules)
+            logging.info("All DPUs are back online after recovery.")
+        else:
+            logging.info("All DPUs are online after test. No recovery needed.")
+    except Exception as e:
+        logging.warning("DPU recovery in teardown failed (non-fatal): %s", e)
 
 
 def test_dpu_status_post_switch_reboot(duthosts, dpuhosts,


### PR DESCRIPTION
### Description of PR
Summary:

This PR improves the SmartSwitch DPU platform test suite with two focused changes:

Moved test_reboot_cause from test_platform_dpu.py to test_reload_dpu.py — this test verifies DPU reboot cause after a shutdown/startup cycle, which logically belongs alongside other reload/reboot tests rather than in the platform feature tests.

Added automatic DPU recovery between test cases — an autouse pytest fixture (ensure_dpus_up_after_test) is added to test_reload_dpu.py that runs teardown after every test. If any DPU is found offline at the end of a test, it is automatically brought back up before the next test begins, preventing test isolation failures.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ x] 202511

### Approach
#### What is the motivation for this PR?

- `test_reboot_cause` was misplaced in `test_platform_dpu.py` alongside static platform feature tests. Since it performs a DPU shutdown/startup cycle to verify reboot cause, it fits naturally with the other reboot/reload tests in test_reload_dpu.py.
- Reboot and reload tests (kernel panic, memory exhaustion, DPU reboot, etc.) can leave DPUs in an offline state if a test fails or completes unexpectedly. Without recovery, the next test's `pre_test_check` would fail immediately, causing a cascade of unrelated failures.

#### How did you do it?

- Removed `test_reboot_cause` from `test_platform_dpu.py` and added it to test_reload_dpu.py with an improved docstring.
- Added an `autouse=True` pytest fixture `ensure_dpus_up_after_test` in test_reload_dpu.py. After each test (`yield`), it:
- Checks the module status of all DPUs
- Calls `dpus_startup_and_check()` for any DPU found offline
- Logs whether recovery was performed or not

#### How did you verify/test it?

- Ran the modified tests on a SmartSwitch testbed to confirm:
- `test_reboot_cause` executes correctly in its new location
- After tests that leave DPUs offline (e.g., `test_dpu_status_post_dpu_kernel_panic`), the recovery fixture successfully brings DPUs back up before the subsequent test runs
- Verified no `flake8` / syntax errors in both modified files

#### Any platform specific information?

Applicable to SmartSwitch platforms only (`topology: smartswitch`). Tested on Nvidia/Mellanox and Cisco SmartSwitch platforms.

#### Supported testbed topology if it's a new test case?

`smartswitch`


### Documentation
N/A