### PR TITLE
Fix BGP pcap parsing in test_bgp_suppress_fib with scapy TCPSession

### DIFF
--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -10,6 +10,7 @@ import time
 from scapy.all import sniff, IP, IPv6
 from scapy.contrib import bgp
 from scapy.config import conf
+from scapy.sessions import TCPSession
 import ptf.testutils as testutils
 import ptf.packet as scapy
 from copy import deepcopy
@@ -657,7 +658,7 @@ def compute_middle_average_time(time_stamp_dict):
 
 def validate_route_process_perf(pcap_file, ipv4_route_list, ipv6_route_list):
     route_num = len(ipv4_route_list + ipv6_route_list)
-    bgp_packets = sniff(offline=pcap_file,
+    bgp_packets = sniff(offline=pcap_file, session=TCPSession,
                         lfilter=lambda p: (IP or IPv6 in p) and bgp.BGPHeader in p and p[bgp.BGPHeader].type == 2)
     announce_prefix_time_stamp, withdraw_prefix_time_stamp = parse_time_stamp(bgp_packets, ipv4_route_list,
                                                                               ipv6_route_list)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enable scapy TCP reassembly (`TCPSession`) when parsing BGP pcap captures in `test_bgp_suppress_fib.py`, fixing `AttributeError: prefix` crashes caused by BGP UPDATE messages that span multiple TCP segments.

This is a follow-up to [#21843](https://github.com/sonic-net/sonic-mgmt/pull/21843) which added `hasattr` guards for IPv4 routes as a workaround for the same underlying issue. That PR treated the symptom (malformed route objects) but not the root cause (lack of TCP reassembly).

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

`test_suppress_fib_performance` fails with `AttributeError: prefix` when parsing IPv6 BGP routes from pcap files. The root cause is that `scapy.sniff()` without `session=TCPSession` parses each TCP segment independently. When a large BGP UPDATE message (carrying many IPv6 routes) spans multiple TCP segments, scapy produces malformed/incomplete NLRI route objects that lack a `prefix` attribute.

[#21843](https://github.com/sonic-net/sonic-mgmt/pull/21843) partially addressed this by adding `hasattr(route, 'prefix')` guards for the IPv4 loops, but the IPv6 loops were left unprotected, and the root cause (missing TCP reassembly) was not fixed.

Scapy 2.7.0 added BGP TCP reassembly support ([secdev/scapy#4756](https://github.com/secdev/scapy/pull/4756)), but it must be explicitly enabled by passing `session=TCPSession` to `sniff()`.

#### How did you do it?

1. Added `from scapy.sessions import TCPSession` import.
2. Passed `session=TCPSession` to the `sniff()` call in `validate_route_process_perf()`, so scapy reassembles the TCP stream before parsing BGP messages.

#### How did you verify/test it?

Tested on T1 isolated Cisco-8101 DUT. The `test_suppress_fib_performance` test that previously failed with `AttributeError: prefix` now passes consistently.

#### Any platform specific information?

No platform specific changes. The fix applies to all platforms.

#### Supported testbed topology if it's a new test case?

N/A - existing test case fix.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
