### PR TITLE
[tests/common]: Respect ansible_port in paramiko SSH connections

### DIFF
--- a/ansible/devutil/ssh_utils.py
+++ b/ansible/devutil/ssh_utils.py
@@ -16,19 +16,23 @@ class SSHClient(paramiko.client.SSHClient):
     The 'connect' interface is overwrite to support multi passowrds.
     """
 
-    def connect(self, hostname, username=None, passwords=None, port=22):
+    def connect(self, hostname, username=None, passwords=None, port=22, sock=None):
         """
         @summary: Overwrite 'connect' of SSHClient in paramiko to support multi passwords
         @param hostname: The hostname or IP of target host
         @param username: The username for SSH login
         @param passwords: Passwords for SSH login, a list of string
+        @param sock: Optional proxy socket (paramiko.ProxyCommand) for jump host support
         """
         self.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         for i in range(0, len(passwords)):
             password = passwords[i]
             try:
-                super(SSHClient, self).connect(hostname=hostname,
-                                               port=port, username=username, password=password)
+                connect_kwargs = dict(hostname=hostname, port=port,
+                                      username=username, password=password)
+                if sock is not None:
+                    connect_kwargs['sock'] = sock
+                super(SSHClient, self).connect(**connect_kwargs)
             except paramiko.ssh_exception.AuthenticationException as e:
                 if i == len(passwords) - 1:
                     raise e

--- a/ansible/roles/test/files/ptftests/device_connection.py
+++ b/ansible/roles/test/files/ptftests/device_connection.py
@@ -22,13 +22,14 @@ class DeviceConnection:
     ssh key and that fails, it will attempt username/password combination
     '''
 
-    def __init__(self, hostname, username, password=None, alt_password=None):
+    def __init__(self, hostname, username, password=None, alt_password=None, sock=None):
         '''
         Class constructor
 
         @param hostname: hostname of device to connect to
         @param username: username for device connection
         @param password: password for device connection
+        @param sock: optional proxy socket (paramiko.ProxyCommand) for jump host support
         '''
         self.hostname = hostname
         self.username = username
@@ -36,6 +37,7 @@ class DeviceConnection:
         if alt_password:
             self.passwords += alt_password
         self.password_index = 0
+        self.sock = sock
 
     @retry(
         stop_max_attempt_number=4,
@@ -62,8 +64,13 @@ class DeviceConnection:
         stdOut = stdErr = []
         retValue = 1
         try:
-            client.connect(self.hostname, username=self.username,
-                           password=self.passwords[self.password_index], allow_agent=False)
+            connect_kwargs = dict(
+                hostname=self.hostname, username=self.username,
+                password=self.passwords[self.password_index], allow_agent=False
+            )
+            if self.sock is not None:
+                connect_kwargs['sock'] = self.sock
+            client.connect(**connect_kwargs)
             si, so, se = client.exec_command(cmd, timeout=timeout)
             stdOut = so.readlines()
             stdErr = se.readlines()
@@ -107,8 +114,13 @@ class DeviceConnection:
         client = paramiko.SSHClient()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         try:
-            client.connect(self.hostname, username=self.username,
-                           password=self.passwords[self.password_index], allow_agent=False)
+            connect_kwargs = dict(
+                hostname=self.hostname, username=self.username,
+                password=self.passwords[self.password_index], allow_agent=False
+            )
+            if self.sock is not None:
+                connect_kwargs['sock'] = self.sock
+            client.connect(**connect_kwargs)
             ftp_client = client.open_sftp()
             ftp_client.get(remote_path, local_path)
             ftp_client.close()

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -16,6 +16,7 @@ from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_assert as pt_assert
 from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
 from tests.common.utilities import wait_until
+from tests.common.utilities import create_proxy_from_ssh_args
 from jinja2 import Template
 from netaddr import valid_ipv4, valid_ipv6
 from tests.common.mellanox_data import is_mellanox_device, get_platform_data
@@ -870,6 +871,8 @@ def duthosts_ipv6_mgmt_only(duthosts, backup_and_restore_ansible_hosts, backup_a
         # "RuntimeError: dictionary changed size during iteration" error
         ssh_client = paramiko.SSHClient()
         ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        hostvars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]
+        ssh_common_args = hostvars.get("ansible_ssh_common_args", "")
         has_ipv6_config = False
         for key in list(mgmt_interface):
             ip_addr = key.split("|")[1]
@@ -883,8 +886,15 @@ def duthosts_ipv6_mgmt_only(duthosts, backup_and_restore_ansible_hosts, backup_a
                         # Add a temporary debug log to see if the DUT is reachable via IPv6 mgmt-ip. Will remove later
                         duthost_interface = duthost.shell("sudo ifconfig eth0")['stdout']
                         logging.debug(f"Checking host[{duthost.hostname}] ifconfig eth0:[{duthost_interface}]")
-                        ssh_client.connect(ip_addr_without_mask,
-                                           username="WRONG_USER", password="WRONG_PWD", timeout=15)
+                        connect_kwargs = dict(
+                            hostname=ip_addr_without_mask,
+                            username="WRONG_USER", password="WRONG_PWD", timeout=15
+                        )
+                        proxy_sock = create_proxy_from_ssh_args(
+                            ssh_common_args, ip_addr_without_mask, 22)
+                        if proxy_sock is not None:
+                            connect_kwargs['sock'] = proxy_sock
+                        ssh_client.connect(**connect_kwargs)
                     except AuthenticationException:
                         logger.info(f"Host[{duthost.hostname}] IPv6[{ip_addr_without_mask}] mgmt-ip is available")
                         ipv6_address[duthost.hostname].append(ip_addr_without_mask)

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -690,11 +690,13 @@ def creds_on_dut(duthost):
         creds["ansible_altpasswords"].append(hostvars["ansible_altpassword"])
 
     passwords = creds["ansible_altpasswords"] + [creds["sonicadmin_password"]]
+    port = hostvars.get("ansible_port", 22)
     creds['sonicadmin_password'] = get_dut_current_passwd(
         duthost.mgmt_ip,
         duthost.mgmt_ipv6,
         creds['sonicadmin_user'],
-        passwords
+        passwords,
+        port=port
     )
 
     for k, v in list(console_login_creds.items()):

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -13,7 +13,7 @@ from tests.common.errors import RunAnsibleModuleFail
 from collections import defaultdict
 from tests.common.connections.console_host import ConsoleHost, CONSOLE_LINECARD
 from tests.common.connections.linecard_console_conn import UnsupportedPlatformError
-from tests.common.utilities import get_dut_current_passwd, update_console_creds
+from tests.common.utilities import get_dut_current_passwd, update_console_creds, create_proxy_from_ssh_args
 from tests.common.connections.base_console_conn import (
     CONSOLE_SSH_CISCO_CONFIG,
     CONSOLE_SSH_DIGI_CONFIG,
@@ -738,12 +738,15 @@ def creds_on_dut(duthost):
 
     passwords = creds["ansible_altpasswords"] + [creds["sonicadmin_password"]]
     port = hostvars.get("ansible_port", 22)
+    ssh_common_args = hostvars.get("ansible_ssh_common_args", "")
+    proxy_sock = create_proxy_from_ssh_args(ssh_common_args, duthost.mgmt_ip, port)
     creds['sonicadmin_password'] = get_dut_current_passwd(
         duthost.mgmt_ip,
         duthost.mgmt_ipv6,
         creds['sonicadmin_user'],
         passwords,
-        port=port
+        port=port,
+        sock=proxy_sock
     )
 
     for k, v in list(console_login_creds.items()):

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -737,11 +737,13 @@ def creds_on_dut(duthost):
         creds["ansible_altpasswords"].append(hostvars["ansible_altpassword"])
 
     passwords = creds["ansible_altpasswords"] + [creds["sonicadmin_password"]]
+    port = hostvars.get("ansible_port", 22)
     creds['sonicadmin_password'] = get_dut_current_passwd(
         duthost.mgmt_ip,
         duthost.mgmt_ipv6,
         creds['sonicadmin_user'],
-        passwords
+        passwords,
+        port=port
     )
 
     for k, v in list(console_login_creds.items()):

--- a/tests/common/plugins/dut_monitor/pytest_dut_monitor.py
+++ b/tests/common/plugins/dut_monitor/pytest_dut_monitor.py
@@ -9,6 +9,7 @@ import yaml
 from collections import OrderedDict
 from datetime import datetime
 from .errors import HDDThresholdExceeded, RAMThresholdExceeded, CPUThresholdExceeded
+from tests.common.utilities import create_proxy_from_ssh_args
 
 
 logger = logging.getLogger(__name__)
@@ -32,8 +33,13 @@ class DUTMonitorPlugin(object):
     def dut_ssh(self, duthosts, rand_one_dut_hostname, creds):
         """Establish SSH connection with DUT"""
         duthost = duthosts[rand_one_dut_hostname]
+        hostvars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]
+        ssh_common_args = hostvars.get("ansible_ssh_common_args", "")
+        port = hostvars.get("ansible_port", 22)
+        proxy_sock = create_proxy_from_ssh_args(ssh_common_args, duthost.hostname, port)
         ssh = DUTMonitorClient(host=duthost.hostname, user=creds["sonicadmin_user"],
-                               password=creds["sonicadmin_password"])
+                               password=creds["sonicadmin_password"],
+                               sock=proxy_sock)
         yield ssh
 
     @pytest.fixture(autouse=True, scope="function")
@@ -232,11 +238,12 @@ class DUTMonitorClient(object):
         - start/stop hardware resources monitoring on DUT
         - automatically restart monitoring script on the DUT in case of lose network connectivity (device reboot, etc.)
     """
-    def __init__(self, host, user, password):
+    def __init__(self, host, user, password, sock=None):
         self.running = False
         self.user = user
         self.password = password
         self.host = host
+        self.sock = sock
         self.init()
         self.run_channel = None
         self._thread = threading.Thread(name="Connection tracker", target=self._track_connection)
@@ -279,7 +286,11 @@ class DUTMonitorClient(object):
         logger.debug("Trying to establish connection ...")
         self.ssh = paramiko.SSHClient()
         self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        self.ssh.connect(self.host, username=self.user, password=self.password, timeout=5)
+        connect_kwargs = dict(hostname=self.host, username=self.user,
+                              password=self.password, timeout=5)
+        if self.sock is not None:
+            connect_kwargs['sock'] = self.sock
+        self.ssh.connect(**connect_kwargs)
 
     def close(self):
         """

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1345,7 +1345,7 @@ def capture_and_check_packet_on_dut(
         duthost.file(path=pcap_save_path, state="absent")
 
 
-def _paramiko_ssh(ip_address, username, passwords):
+def _paramiko_ssh(ip_address, username, passwords, port=22):
     """
     Connect to the device via ssh using paramiko
     Args:
@@ -1353,6 +1353,7 @@ def _paramiko_ssh(ip_address, username, passwords):
         username (str): The username of device
         passwords (str or list): Potential passwords of device
             this argument can be either a string or a list of string
+        port (int): The SSH port to connect to (default: 22)
     Returns:
         AuthResult: the ssh session of device
     """
@@ -1367,8 +1368,9 @@ def _paramiko_ssh(ip_address, username, passwords):
         try:
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-            ssh.connect(ip_address, username=username, password=password,
-                        allow_agent=False, look_for_keys=False, timeout=10)
+            ssh.connect(ip_address, port=port, username=username,
+                        password=password, allow_agent=False,
+                        look_for_keys=False, timeout=10)
             return ssh, password
         except AuthenticationException:
             continue
@@ -1379,18 +1381,19 @@ def _paramiko_ssh(ip_address, username, passwords):
     raise AuthenticationException
 
 
-def paramiko_ssh(ip_address, username, passwords):
-    ssh, pwd = _paramiko_ssh(ip_address, username, passwords)
+def paramiko_ssh(ip_address, username, passwords, port=22):
+    ssh, pwd = _paramiko_ssh(ip_address, username, passwords, port=port)
     return ssh
 
 
-def get_dut_current_passwd(ipv4_address, ipv6_address, username, passwords):
+def get_dut_current_passwd(ipv4_address, ipv6_address, username, passwords,
+                           port=22):
     try:
-        _, passwd = _paramiko_ssh(ipv4_address, username, passwords)
+        _, passwd = _paramiko_ssh(ipv4_address, username, passwords, port=port)
     except AuthenticationException:
         raise
     except Exception:
-        _, passwd = _paramiko_ssh(ipv6_address, username, passwords)
+        _, passwd = _paramiko_ssh(ipv6_address, username, passwords, port=port)
     return passwd
 
 

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1392,7 +1392,7 @@ def capture_and_check_packet_on_dut(
         duthost.file(path=pcap_save_path, state="absent")
 
 
-def _paramiko_ssh(ip_address, username, passwords):
+def _paramiko_ssh(ip_address, username, passwords, port=22):
     """
     Connect to the device via ssh using paramiko
     Args:
@@ -1400,6 +1400,7 @@ def _paramiko_ssh(ip_address, username, passwords):
         username (str): The username of device
         passwords (str or list): Potential passwords of device
             this argument can be either a string or a list of string
+        port (int): The SSH port to connect to (default: 22)
     Returns:
         AuthResult: the ssh session of device
     """
@@ -1414,8 +1415,9 @@ def _paramiko_ssh(ip_address, username, passwords):
         try:
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-            ssh.connect(ip_address, username=username, password=password,
-                        allow_agent=False, look_for_keys=False, timeout=10)
+            ssh.connect(ip_address, port=port, username=username,
+                        password=password, allow_agent=False,
+                        look_for_keys=False, timeout=10)
             return ssh, password
         except AuthenticationException:
             continue
@@ -1426,18 +1428,19 @@ def _paramiko_ssh(ip_address, username, passwords):
     raise AuthenticationException
 
 
-def paramiko_ssh(ip_address, username, passwords):
-    ssh, pwd = _paramiko_ssh(ip_address, username, passwords)
+def paramiko_ssh(ip_address, username, passwords, port=22):
+    ssh, pwd = _paramiko_ssh(ip_address, username, passwords, port=port)
     return ssh
 
 
-def get_dut_current_passwd(ipv4_address, ipv6_address, username, passwords):
+def get_dut_current_passwd(ipv4_address, ipv6_address, username, passwords,
+                           port=22):
     try:
-        _, passwd = _paramiko_ssh(ipv4_address, username, passwords)
+        _, passwd = _paramiko_ssh(ipv4_address, username, passwords, port=port)
     except AuthenticationException:
         raise
     except Exception:
-        _, passwd = _paramiko_ssh(ipv6_address, username, passwords)
+        _, passwd = _paramiko_ssh(ipv6_address, username, passwords, port=port)
     return passwd
 
 

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1392,7 +1392,90 @@ def capture_and_check_packet_on_dut(
         duthost.file(path=pcap_save_path, state="absent")
 
 
-def _paramiko_ssh(ip_address, username, passwords, port=22):
+def create_proxy_from_ssh_args(ssh_common_args, target_host, target_port):
+    """
+    Parse ansible_ssh_common_args and create a paramiko.ProxyCommand if
+    a ProxyCommand or ProxyJump option is present.
+
+    Args:
+        ssh_common_args (str): The value of ansible_ssh_common_args
+        target_host (str): The target hostname/IP for %h substitution
+        target_port (int): The target port for %p substitution
+
+    Returns:
+        paramiko.ProxyCommand or None
+    """
+    if not ssh_common_args:
+        return None
+
+    import shlex
+    tokens = shlex.split(ssh_common_args)
+
+    proxy_cmd = None
+    proxy_jump = None
+
+    i = 0
+    while i < len(tokens):
+        if tokens[i] == "-o" and i + 1 < len(tokens):
+            opt = tokens[i + 1]
+            if opt.startswith("ProxyCommand="):
+                proxy_cmd = opt.split("=", 1)[1]
+            elif opt.startswith("ProxyJump="):
+                proxy_jump = opt.split("=", 1)[1]
+            i += 2
+        elif tokens[i].startswith("-oProxyCommand="):
+            proxy_cmd = tokens[i].split("=", 1)[1]
+            i += 1
+        elif tokens[i].startswith("-oProxyJump="):
+            proxy_jump = tokens[i].split("=", 1)[1]
+            i += 1
+        else:
+            i += 1
+
+    cmd_str = None
+    if proxy_cmd:
+        cmd_str = proxy_cmd
+    elif proxy_jump:
+        # Convert ProxyJump to an equivalent ssh -W command
+        cmd_str = "ssh -W %h:%p {}".format(proxy_jump)
+
+    if cmd_str:
+        cmd_str = cmd_str.replace("%h", str(target_host)).replace("%p", str(target_port))
+        return paramiko.ProxyCommand(cmd_str)
+
+    return None
+
+
+def _fresh_proxy_sock(sock):
+    """Return a fresh paramiko.ProxyCommand instance for one connect attempt.
+
+    paramiko.ProxyCommand wraps a subprocess.Popen that dies after the first
+    ssh disconnect (including auth failure). The password-retry loop in
+    _paramiko_ssh() therefore needs a fresh subprocess per attempt, otherwise
+    the second attempt's ssh.connect(sock=<dead>) fails with BrokenPipeError
+    before it can even try the second password.
+
+    Uses the ProxyCommand.cmd argv list to spawn a new instance. Non-
+    ProxyCommand socket types (or None) pass through unchanged - the caller
+    is assumed to be handling reuse.
+
+    Args:
+        sock: A paramiko.ProxyCommand, another socket-like object, or None.
+
+    Returns:
+        A fresh paramiko.ProxyCommand when the input is one, else the
+        original object.
+    """
+    if sock is None:
+        return None
+    # Duck-type on paramiko.ProxyCommand: has an argv list on `.cmd`.
+    cmd = getattr(sock, "cmd", None)
+    if not isinstance(cmd, list) or not cmd:
+        return sock
+    return paramiko.ProxyCommand(" ".join(cmd))
+
+
+def _paramiko_ssh(ip_address, username, passwords, port=22, sock=None):
     """
     Connect to the device via ssh using paramiko
     Args:
@@ -1401,6 +1484,13 @@ def _paramiko_ssh(ip_address, username, passwords, port=22):
         passwords (str or list): Potential passwords of device
             this argument can be either a string or a list of string
         port (int): The SSH port to connect to (default: 22)
+        sock (paramiko.ProxyCommand or None): Optional proxy socket for
+            connecting through a jump host (default: None). When a
+            ProxyCommand instance is supplied, a fresh subprocess is
+            spawned per password attempt via _fresh_proxy_sock() - the
+            underlying subprocess dies after the first ssh disconnect,
+            so reusing the same instance across retries yields a
+            BrokenPipeError.
     Returns:
         AuthResult: the ssh session of device
     """
@@ -1412,12 +1502,18 @@ def _paramiko_ssh(ip_address, username, passwords, port=22):
         raise Exception("The passwords argument must be either a string or a list of string.")
 
     for password in candidate_passwords:
+        current_sock = _fresh_proxy_sock(sock)
         try:
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-            ssh.connect(ip_address, port=port, username=username,
-                        password=password, allow_agent=False,
-                        look_for_keys=False, timeout=10)
+            connect_kwargs = dict(
+                hostname=ip_address, port=port, username=username,
+                password=password, allow_agent=False,
+                look_for_keys=False, timeout=10
+            )
+            if current_sock is not None:
+                connect_kwargs['sock'] = current_sock
+            ssh.connect(**connect_kwargs)
             return ssh, password
         except AuthenticationException:
             continue
@@ -1428,19 +1524,22 @@ def _paramiko_ssh(ip_address, username, passwords, port=22):
     raise AuthenticationException
 
 
-def paramiko_ssh(ip_address, username, passwords, port=22):
-    ssh, pwd = _paramiko_ssh(ip_address, username, passwords, port=port)
+def paramiko_ssh(ip_address, username, passwords, port=22, sock=None):
+    ssh, pwd = _paramiko_ssh(ip_address, username, passwords, port=port,
+                             sock=sock)
     return ssh
 
 
 def get_dut_current_passwd(ipv4_address, ipv6_address, username, passwords,
-                           port=22):
+                           port=22, sock=None):
     try:
-        _, passwd = _paramiko_ssh(ipv4_address, username, passwords, port=port)
+        _, passwd = _paramiko_ssh(ipv4_address, username, passwords, port=port,
+                                  sock=sock)
     except AuthenticationException:
         raise
     except Exception:
-        _, passwd = _paramiko_ssh(ipv6_address, username, passwords, port=port)
+        _, passwd = _paramiko_ssh(ipv6_address, username, passwords, port=port,
+                                  sock=sock)
     return passwd
 
 

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1392,7 +1392,61 @@ def capture_and_check_packet_on_dut(
         duthost.file(path=pcap_save_path, state="absent")
 
 
-def _paramiko_ssh(ip_address, username, passwords, port=22):
+def create_proxy_from_ssh_args(ssh_common_args, target_host, target_port):
+    """
+    Parse ansible_ssh_common_args and create a paramiko.ProxyCommand if
+    a ProxyCommand or ProxyJump option is present.
+
+    Args:
+        ssh_common_args (str): The value of ansible_ssh_common_args
+        target_host (str): The target hostname/IP for %h substitution
+        target_port (int): The target port for %p substitution
+
+    Returns:
+        paramiko.ProxyCommand or None
+    """
+    if not ssh_common_args:
+        return None
+
+    import shlex
+    tokens = shlex.split(ssh_common_args)
+
+    proxy_cmd = None
+    proxy_jump = None
+
+    i = 0
+    while i < len(tokens):
+        if tokens[i] == "-o" and i + 1 < len(tokens):
+            opt = tokens[i + 1]
+            if opt.startswith("ProxyCommand="):
+                proxy_cmd = opt.split("=", 1)[1]
+            elif opt.startswith("ProxyJump="):
+                proxy_jump = opt.split("=", 1)[1]
+            i += 2
+        elif tokens[i].startswith("-oProxyCommand="):
+            proxy_cmd = tokens[i].split("=", 1)[1]
+            i += 1
+        elif tokens[i].startswith("-oProxyJump="):
+            proxy_jump = tokens[i].split("=", 1)[1]
+            i += 1
+        else:
+            i += 1
+
+    cmd_str = None
+    if proxy_cmd:
+        cmd_str = proxy_cmd
+    elif proxy_jump:
+        # Convert ProxyJump to an equivalent ssh -W command
+        cmd_str = "ssh -W %h:%p {}".format(proxy_jump)
+
+    if cmd_str:
+        cmd_str = cmd_str.replace("%h", str(target_host)).replace("%p", str(target_port))
+        return paramiko.ProxyCommand(cmd_str)
+
+    return None
+
+
+def _paramiko_ssh(ip_address, username, passwords, port=22, sock=None):
     """
     Connect to the device via ssh using paramiko
     Args:
@@ -1401,6 +1455,8 @@ def _paramiko_ssh(ip_address, username, passwords, port=22):
         passwords (str or list): Potential passwords of device
             this argument can be either a string or a list of string
         port (int): The SSH port to connect to (default: 22)
+        sock (paramiko.ProxyCommand or None): Optional proxy socket for
+            connecting through a jump host (default: None)
     Returns:
         AuthResult: the ssh session of device
     """
@@ -1415,9 +1471,14 @@ def _paramiko_ssh(ip_address, username, passwords, port=22):
         try:
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-            ssh.connect(ip_address, port=port, username=username,
-                        password=password, allow_agent=False,
-                        look_for_keys=False, timeout=10)
+            connect_kwargs = dict(
+                hostname=ip_address, port=port, username=username,
+                password=password, allow_agent=False,
+                look_for_keys=False, timeout=10
+            )
+            if sock is not None:
+                connect_kwargs['sock'] = sock
+            ssh.connect(**connect_kwargs)
             return ssh, password
         except AuthenticationException:
             continue
@@ -1428,19 +1489,22 @@ def _paramiko_ssh(ip_address, username, passwords, port=22):
     raise AuthenticationException
 
 
-def paramiko_ssh(ip_address, username, passwords, port=22):
-    ssh, pwd = _paramiko_ssh(ip_address, username, passwords, port=port)
+def paramiko_ssh(ip_address, username, passwords, port=22, sock=None):
+    ssh, pwd = _paramiko_ssh(ip_address, username, passwords, port=port,
+                             sock=sock)
     return ssh
 
 
 def get_dut_current_passwd(ipv4_address, ipv6_address, username, passwords,
-                           port=22):
+                           port=22, sock=None):
     try:
-        _, passwd = _paramiko_ssh(ipv4_address, username, passwords, port=port)
+        _, passwd = _paramiko_ssh(ipv4_address, username, passwords, port=port,
+                                  sock=sock)
     except AuthenticationException:
         raise
     except Exception:
-        _, passwd = _paramiko_ssh(ipv6_address, username, passwords, port=port)
+        _, passwd = _paramiko_ssh(ipv6_address, username, passwords, port=port,
+                                  sock=sock)
     return passwd
 
 


### PR DESCRIPTION
### Description of PR

Summary:
The `_paramiko_ssh()`, `paramiko_ssh()`, and `get_dut_current_passwd()` functions in `tests/common/utilities.py` hardcode SSH port 22. When devices are accessed through port-forwarding proxies or non-standard ports, the `ansible_port` inventory variable is ignored, causing connection timeouts.

This PR adds an optional `port` parameter (default: 22) to all three functions and extracts `ansible_port` from host variables in `creds_on_dut()` to pass it through the call chain.

Fully backward compatible — all existing callers that do not pass a port argument continue to use port 22.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

When running SONiC tests through SSH port-forwarding proxies (e.g., jump hosts), devices are reached on non-standard ports (like 10001 instead of 22). The `ansible_port` inventory variable correctly tells Ansible which port to use, but the `creds` fixture bypasses Ansible's SSH and calls paramiko directly with hardcoded port 22. This causes the `creds_on_dut()` function to time out on every test that uses the `creds` fixture.

#### How did you do it?

- Added an optional `port=22` parameter to `_paramiko_ssh()`, `paramiko_ssh()`, and `get_dut_current_passwd()` in `tests/common/utilities.py`
- In `creds_on_dut()` (`tests/common/helpers/dut_utils.py`), extract `ansible_port` from the DUT's host variables and pass it to `get_dut_current_passwd()`
- All new parameters default to 22, maintaining full backward compatibility

#### How did you verify/test it?

Verified end-to-end on a physical Cisco-8102-28FH-DPU-C28 testbed accessed through an SSH port-forwarding proxy:
- `test_bgp_facts` passed cleanly (`1 passed, 162 warnings`)
- The `creds` fixture successfully connected via paramiko on the forwarded port (10001 → 10.5.27.100:22)
- All post-test sanity checks passed (processes, interfaces, BGP, dbmemory, monit, secureboot, orchagent_usage)

#### Any platform specific information?

No — this is platform-agnostic. It only affects the test framework's SSH connection logic.

#### Supported testbed topology if it's a new test case?

N/A — this is a bug fix to existing framework code.

### Documentation

No documentation changes needed — this is a backward-compatible parameter addition.