### PR TITLE
Fix test test_default_cfg_after_load_mg for testbed with golden config

### DIFF
--- a/tests/pfcwd/test_pfc_config.py
+++ b/tests/pfcwd/test_pfc_config.py
@@ -325,7 +325,7 @@ class TestDefaultPfcConfig(object):
             None
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-        config_reload(duthost, config_source='minigraph', safe_reload=True)
+        config_reload(duthost, config_source='minigraph', safe_reload=True, override_config=True)
         # sleep 20 seconds to make sure configuration is loaded
         time.sleep(20)
         res = duthost.command('pfcwd show config')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The test checks if pfcwd gets started after load_minigraph.
When loading minigraph, we need override the config with golden_config_db.json if there is one, for example, the smartswitch testbed.
Otherwise it may cause failure due to the config after minigraph load is not the one required for the testbed. For example on the smartswitch testbed the dhcp features are disabled if not override. And the critical service check fails due to this.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Fix test test_default_cfg_after_load_mg for testbed with golden config
#### How did you do it?
Set override_config=True in the config_reload()
#### How did you verify/test it?
Run the test on different Nvidia platforms.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
