### PR TITLE
[SmartSwitch] Update the auto techsupport test for DPU

### DIFF
--- a/tests/show_techsupport/test_auto_techsupport.py
+++ b/tests/show_techsupport/test_auto_techsupport.py
@@ -1188,7 +1188,8 @@ def validate_expected_stub_files(duthost, validation_folder, expected_stub_files
     :param not_expected_stub_files_list: not expected files list
     :param expected_max_folder_size: expected maximum folder size
     """
-    validation_files_list = duthost.shell('sudo ls {}'.format(validation_folder))['stdout_lines']
+    validation_files_list = duthost.shell(f'sudo ls -p {validation_folder} | grep -v /',
+                                          module_ignore_errors=True)['stdout_lines']
 
     # Check that all expected stub files exist
     validate_files_in_folder(validation_files_list, expected_stub_files_list)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The PR https://github.com/sonic-net/sonic-buildimage/pull/25496 added a directory /var/log/flows in DPU which affects the test case test_max_limit in the auto techsupport test.
It mistakenly counts the "flows" folder as one of the techsupport files.
Update the ls command to show only the files, excluding the "flows" folder.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Update the auto techsupport test for DPU
#### How did you do it?
Update the ls command to show only the files, excluding the "flows" folder.
#### How did you verify/test it?
Run the test on SN4280 and other non-smartswitch Nvidia platforms.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
