### PR TITLE
Add collectData PORT_PHY_ATTR failure to loganalyzer ignore list

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -482,8 +482,11 @@ r, ".*ERR swss#orchagent:.*SAI_API_QUEUE, status: SAI_STATUS_INVALID_PARAMETER.*
 r, ".* ERR swss\d*#orchagent:.*getPortLinkTrainingFailure: Failed to get LT failure status for .*"
 
 # Ignore RX signal detect and RX SNR feature unavailable errors on broadcom platforms
+# and the corresponding collectData failure from FlexCounter PORT_PHY_ATTR polling
+# https://github.com/sonic-net/sonic-mgmt/issues/24023
 r, ".* ERR syncd\d*#syncd:.*SAI_API_PORT:brcm_sai_get_port_attribute_cmn:\d+ RX signal detect status get \d+ attrib \d+ failed with error Feature unavailable \(0xfffffff0\).*"
 r, ".* ERR syncd\d*#syncd:.*SAI_API_PORT:brcm_sai_get_port_attribute_cmn:\d+ bcm_port_phy_control_get rx snr failed with error Feature unavailable \(0xfffffff0\).*"
+r, ".* ERR syncd\d*#syncd: :- collectData: Failed to get port attr for VID 0x[0-9a-fA-F]+, RID:0x[0-9a-fA-F]+: -2.*"
 
 # https://github.com/sonic-net/sonic-mgmt/issues/19347
 r, ".* ERR auditd.*: queue to plugins is full - dropping event"


### PR DESCRIPTION
#### Description of PR
address the issue https://github.com/sonic-net/sonic-mgmt/issues/24023
Add the `collectData: Failed to get port attr` syslog pattern to loganalyzer common ignore list.

On Broadcom platforms (Arista-7260CX3, 7060X6), the FlexCounter PORT_PHY_ATTR polling generates two ERR syslog entries every ~10 seconds when SAI returns "Feature unavailable" for attributes like `SAI_PORT_ATTR_RX_SIGNAL_DETECT`:

1. `ERR syncd#syncd: SAI_API_PORT:brcm_sai_get_port_attribute_cmn:10440 RX signal detect status get N attrib 149 failed with error Feature unavailable (0xfffffff0)` — **already ignored**
2. `ERR syncd#syncd: :- collectData: Failed to get port attr for VID 0x..., RID:0x...: -2` — **NOT ignored, causes teardown failures**

The second message causes loganalyzer teardown failures on **all** tests using loganalyzer on affected platforms. On 202511 image 20251110.20, this caused 8,700+ test failures.

The proper fix in syncd is tracked in [sonic-sairedis #1855](https://github.com/sonic-net/sonic-sairedis/pull/1855). This sonic-mgmt change provides immediate relief by ignoring the syslog until the syncd fix is deployed.

#### Type of change
- [x] Bug fix

#### Back port request
- [x] 202511

#### Approach
#### What is the motivation for this PR?
Unblock all Broadcom platform nightly tests that fail at loganalyzer teardown due to the `collectData` ERR syslog.

#### How did you do it?
Added one regex pattern to `loganalyzer_common_ignore.txt` alongside the existing RX signal detect and RX SNR patterns.

#### How did you verify/test it?
Verified the regex matches the actual syslog format from ElasticTest logs on Arista-7260CX3 testbeds.

#### Related PRs
- [sonic-sairedis #1855](https://github.com/sonic-net/sonic-sairedis/pull/1855) — Proper syncd fix (PORT_PHY_ATTR::collectData initAttrData check)
- [sonic-sairedis #1799](https://github.com/sonic-net/sonic-sairedis/pull/1799) — Partial fix (PORT_PHY_SERDES_ATTR only)
- [[[Arista issue #1232](https://github.com/aristanetworks/sonic-qual.msft/issues/1232)](https://github.com/sonic-net/sonic-mgmt/issues/24023)](https://github.com/sonic-net/sonic-mgmt/issues/24023)
