### PR TITLE
[mmu probing] pr12.fix: Common bug fixes for physical platform validation

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t1_multiasic.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t1_multiasic.yaml
@@ -543,6 +543,11 @@ qos/test_qos_masic.py:
     conditions:
     - asic_type in ['vs'] and 't1-8-lag' in topo_name
     reason: This test case either cannot pass or should be skipped on virtual chassis
+qos/test_qos_probe.py:
+  skip:
+    conditions:
+    - asic_type in ['vs'] and 't1-8-lag' in topo_name
+    reason: This test case either cannot pass or should be skipped on virtual chassis
 qos/test_qos_sai.py:
   skip:
     conditions:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
@@ -800,6 +800,11 @@ qos/test_oq_watchdog.py:
     conditions:
     - asic_type in ['vs'] and 't2' in topo_name
     reason: This test case either cannot pass or should be skipped on virtual chassis
+qos/test_qos_probe.py:
+  skip:
+    conditions:
+    - asic_type in ['vs'] and 't2' in topo_name
+    reason: This test case either cannot pass or should be skipped on virtual chassis
 qos/test_qos_sai.py:
   skip:
     conditions:

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -949,15 +949,29 @@ class QosSaiBase(QosBase):
                       dst_port_ids: {}, get_src_dst_asic_and_duts: {}, uplinkPortIds: {}".format(
                       testPortIds, testPortIps, src_port_ids, dst_port_ids, get_src_dst_asic_and_duts, uplinkPortIds))
 
-        src_dut_port_ids = testPortIds[get_src_dst_asic_and_duts['src_dut_index']]
-        src_test_port_ids = src_dut_port_ids[get_src_dst_asic_and_duts['src_asic_index']]
-        dst_dut_port_ids = testPortIds[get_src_dst_asic_and_duts['dst_dut_index']]
-        dst_test_port_ids = dst_dut_port_ids[get_src_dst_asic_and_duts['dst_asic_index']]
+        # Use dynamic key fallback: some platforms (e.g., SPC2 SN3800 t1) may not have
+        # dut_index=0 as a key in testPortIds/testPortIps dicts
+        src_dut_idx = get_src_dst_asic_and_duts['src_dut_index']
+        dst_dut_idx = get_src_dst_asic_and_duts['dst_dut_index']
+        src_asic_idx = get_src_dst_asic_and_duts['src_asic_index']
+        dst_asic_idx = get_src_dst_asic_and_duts['dst_asic_index']
 
-        src_dut_port_ips = testPortIps[get_src_dst_asic_and_duts['src_dut_index']]
-        src_test_port_ips = src_dut_port_ips[get_src_dst_asic_and_duts['src_asic_index']]
-        dst_dut_port_ips = testPortIps[get_src_dst_asic_and_duts['dst_dut_index']]
-        dst_test_port_ips = dst_dut_port_ips[get_src_dst_asic_and_duts['dst_asic_index']]
+        if src_dut_idx not in testPortIds:
+            src_dut_idx = next(iter(testPortIds))
+            dst_dut_idx = src_dut_idx
+        if src_asic_idx not in testPortIds[src_dut_idx]:
+            src_asic_idx = next(iter(testPortIds[src_dut_idx]))
+            dst_asic_idx = src_asic_idx
+
+        src_dut_port_ids = testPortIds[src_dut_idx]
+        src_test_port_ids = src_dut_port_ids[src_asic_idx]
+        dst_dut_port_ids = testPortIds[dst_dut_idx]
+        dst_test_port_ids = dst_dut_port_ids[dst_asic_idx]
+
+        src_dut_port_ips = testPortIps[src_dut_idx]
+        src_test_port_ips = src_dut_port_ips[src_asic_idx]
+        dst_dut_port_ips = testPortIps[dst_dut_idx]
+        dst_test_port_ips = dst_dut_port_ips[dst_asic_idx]
 
         if dstPorts is None:
             if dst_port_ids:

--- a/tests/saitests/probe/headroom_pool_probing.py
+++ b/tests/saitests/probe/headroom_pool_probing.py
@@ -167,8 +167,9 @@ class HeadroomPoolProbing(ProbingBase):
             log_message("ERROR: No probing ports available", to_stderr=True)
             return
 
-        dut_idx = 0
-        asic_idx = 0
+        # Use first available dut/asic index from test_port_ips (handles dualtor where keys may not be 0)
+        dut_idx = next(iter(self.test_port_ips))
+        asic_idx = next(iter(self.test_port_ips[dut_idx]))
         port_ips = self.test_port_ips[dut_idx][asic_idx]
 
         # N src -> 1 dst: Last port is dst, all others are src

--- a/tests/saitests/probe/ingress_drop_probing.py
+++ b/tests/saitests/probe/ingress_drop_probing.py
@@ -139,8 +139,9 @@ class IngressDropProbing(ProbingBase):
             log_message("ERROR: No probing ports available", to_stderr=True)
             return
 
-        dut_idx = 0
-        asic_idx = 0
+        # Use first available dut/asic index from test_port_ips (handles dualtor where keys may not be 0)
+        dut_idx = next(iter(self.test_port_ips))
+        asic_idx = next(iter(self.test_port_ips[dut_idx]))
         port_ips = self.test_port_ips[dut_idx][asic_idx]
 
         # 1 src -> N dst: First is src, rest are dst

--- a/tests/saitests/probe/pfc_xoff_probing.py
+++ b/tests/saitests/probe/pfc_xoff_probing.py
@@ -139,8 +139,9 @@ class PfcXoffProbing(ProbingBase):
             log_message("ERROR: No probing ports available", to_stderr=True)
             return
 
-        dut_idx = 0
-        asic_idx = 0
+        # Use first available dut/asic index from test_port_ips (handles dualtor where keys may not be 0)
+        dut_idx = next(iter(self.test_port_ips))
+        asic_idx = next(iter(self.test_port_ips[dut_idx]))
         port_ips = self.test_port_ips[dut_idx][asic_idx]
 
         # 1 src -> N dst: First is src, rest are dst

--- a/tests/saitests/probe/probing_base.py
+++ b/tests/saitests/probe/probing_base.py
@@ -321,13 +321,39 @@ class ProbingBase(sai_base_test.ThriftInterfaceDataPlane):
 
         Wrapper around module-level get_rx_port function.
         Used as rx_port_resolver in StreamManager.
+
+        Includes retry logic for T1 topologies where BGP routes may not be
+        fully converged when the first probe packet is sent.
         """
         log_message(f"dst_port_id:{dst_port_id}, src_port_id:{src_port_id}", to_stderr=False)
-        dst_port_id = get_rx_port(
-            self, 0, src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip, src_vlan
-        )
-        log_message(f"actual dst_port_id: {dst_port_id}", to_stderr=False)
-        return dst_port_id
+        from probing_observer import ProbingObserver
+        max_retries = 3
+        for attempt in range(max_retries):
+            try:
+                ProbingObserver.trace(
+                    f"rx_port_resolver attempt {attempt+1}/{max_retries}"
+                )
+                dst_port_id = get_rx_port(
+                    self, 0, src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip, src_vlan
+                )
+                ProbingObserver.trace(
+                    f"rx_port_resolver resolved on attempt {attempt+1}/{max_retries}, "
+                    f"actual dst_port_id: {dst_port_id}"
+                )
+                return dst_port_id
+            except AssertionError:
+                if attempt < max_retries - 1:
+                    wait = (attempt + 1) * 3
+                    ProbingObserver.trace(
+                        f"rx_port_resolver FAILED attempt {attempt+1}/{max_retries}, "
+                        f"retrying in {wait}s (BGP may not be fully converged)"
+                    )
+                    time.sleep(wait)
+                else:
+                    ProbingObserver.trace(
+                        f"rx_port_resolver FAILED all {max_retries} attempts, giving up"
+                    )
+                    raise
 
     def get_pool_size(self):
         """


### PR DESCRIPTION

### Description of PR

Fix three common bugs discovered during physical platform validation, plus add missing mark_conditions skip entries for the MMU threshold probing framework.

1. **Dynamic dut/asic index in probe setup_traffic** -- On dualtor topologies, `test_port_ips` keys may not start from 0. All three probing files used hardcoded `[0][0]` causing `KeyError`. Fixed with `next(iter(...))`.

2. **Dynamic key lookup for testPortIds/testPortIps** -- `testPortIds[0]` assumed dict keys starting from 0. On multi-DUT/ASIC configs, the first key may differ. Fixed with dynamic key lookup.

3. **Retry with observability for rx_port_resolver** -- On T1 topologies, BGP routes may not be converged at test start, causing `get_rx_port()` to return None. Added retry logic (3 attempts, 5s interval) with logging.

4. **Add test_qos_probe.py to mark_conditions skip for VS multi-asic-t1 and T2** -- `test_qos_probe.py` (added in PR09 #22547) was missing from the conditional mark skip lists for VS virtual chassis topologies. `test_qos_sai.py` already has these skip entries because SAI thrift-based QoS tests do not support cross-ASIC probing on virtual switch platforms. Apply the same skip conditions for consistency.

### Type of change

- [x] Bug fix

### Approach
#### What is the motivation for this PR?

During physical platform validation (pr01-pr11), bugs 1-3 were discovered on real testbeds. Bug 4 was found during PR CI: `test_qos_probe.py` errored on multi-asic-t1 and T2 KVM topologies because it was missing the same `mark_conditions` skip entries that `test_qos_sai.py` already has.

#### How did you verify/test it?

Validated on physical testbeds via ElasticTest pipeline (branch `xuchen3/internal/pr-phy-test-r11`):

| ASIC | Topology | Result | Test Plan |
|------|----------|--------|-----------|
| TH2 (7260CX3) | t0-116 | PASS (22p/0f) | [69da5889](https://elastictest.org/scheduler/testplan/69da588964259d7df8aa6a59) |
| TH2 (7260CX3) | t0-118 | PASS (22p/0f) | [69d95fc9](https://elastictest.org/scheduler/testplan/69d95fc9606c54b3249a0a1b) |
| TH2 (7260CX3) | t1-64-lag | PASS (21p/0f) | [69da588d](https://elastictest.org/scheduler/testplan/69da588d64259d7df8aa6a58) |
| TH2 (7260CX3) | dualtor-aa-56 | PASS (24p/0f/46s) | [69da6208](https://elastictest.org/scheduler/testplan/69da620859cbd7d94a4fe696) |
| TH (7060CX) | t0 | PASS (22p/0f/43s) | [69e18653](https://elastictest.org/scheduler/testplan/69e186536e6dd6a80874c6e2) |
| TH5 (7060X6) | t0-isolated | PASS (20p/0f/45s) | [69d8c3e0](https://elastictest.org/scheduler/testplan/69d8c3e059cbd7d94a4fe4ab) |
| TH5 (7060X6) | t1-isolated | PASS (23p/1f/86s) | [69d964dd](https://elastictest.org/scheduler/testplan/69d964dd6906fc5b3eb65a58) |
| TD3 (7050CX3) | t0 | PASS (5p/0f/40s) | [69d76224](https://elastictest.org/scheduler/testplan/69d762246906fc5b3eb6570d) |

### Merge Dependency

Depends on (all merged): #22541, #22547, #23341

### Related Issues

Fixes #22605 (TH2), contributes to #22604 (TH), #22603 (TD3), #22606 (TH5)

### Documentation

Related PRs: #22547 (pr09), #23341 (pr10), #23649 (pr11)