### PR TITLE
Fix pfcwd interval helper

### DIFF
--- a/tests/generic_config_updater/test_pfcwd_interval.py
+++ b/tests/generic_config_updater/test_pfcwd_interval.py
@@ -1,3 +1,15 @@
+"""
+Test for PFC Watchdog (PFCWD) poll interval configuration updates via GCU.
+
+T2 Topology Support:
+    This test uses `rand_one_dut_front_end_hostname` to ensure compatibility
+    with T2 topologies. On T2, only linecards (not supervisor nodes) have
+    frontend ASICs with Ethernet interfaces and PFC_WD configuration. Using
+    `rand_one_dut_front_end_hostname` automatically selects either a
+    linecard on T2 or a regular DUT, ensuring the test always targets a
+    node with the required PFC_WD config.
+"""
+
 import logging
 import pytest
 import json
@@ -11,18 +23,6 @@ from tests.common.gu_utils import format_json_patch_for_multiasic
 from tests.common.gu_utils import create_checkpoint, delete_checkpoint
 from tests.common.gu_utils import rollback_or_reload
 from tests.common.gu_utils import is_valid_platform_and_version
-
-"""
-Test for PFC Watchdog (PFCWD) poll interval configuration updates via GCU.
-
-T2 Topology Support:
-    This test uses `rand_one_dut_front_end_hostname` to ensure compatibility
-    with T2 topologies. On T2, only linecards (not supervisor nodes) have
-    frontend ASICs with Ethernet interfaces and PFC_WD configuration. Using
-    `rand_one_dut_front_end_hostname` automatically selects either a
-    linecard on T2 or a regular DUT, ensuring the test always targets a
-    node with the required PFC_WD config.
-"""
 
 pytestmark = [
     pytest.mark.asic('cisco-8000', 'mellanox', 'marvell-teralynx'),
@@ -38,29 +38,32 @@ READ_FLEXCOUNTER_DB_INTERVAL = 20
 @pytest.fixture(scope="module")
 def ensure_dut_readiness(duthosts, rand_one_dut_front_end_hostname):
     """
-    Setup/teardown fixture for pfcwd interval config update tst
+    Setup/teardown fixture for pfcwd interval config update test.
 
     Args:
         duthosts: DUT hosts object
         rand_one_dut_front_end_hostname: frontend DUT hostname
             (linecard on T2, regular DUT otherwise)
+
+    Yields:
+        duthost: The selected DUT host object
     """
     duthost = duthosts[rand_one_dut_front_end_hostname]
     create_checkpoint(duthost)
 
-    yield
+    yield duthost
 
     try:
-        logger.info("Rolled back to original  checkpoint")
+        logger.info("Rolled back to original checkpoint")
         rollback_or_reload(duthost)
     finally:
         delete_checkpoint(duthost)
 
 
 @pytest.fixture(autouse=True, scope="module")
-def enable_default_pfcwd_configuration(duthosts,
-                                       rand_one_dut_front_end_hostname):
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+def enable_default_pfcwd_configuration(ensure_dut_readiness):
+    """Enable default PFCWD configuration on the DUT."""
+    duthost = ensure_dut_readiness
     res = duthost.shell(
         'redis-dump -d 4 --pretty -k \"DEVICE_METADATA|localhost\"')
     meta_data = json.loads(res["stdout"])
@@ -210,11 +213,10 @@ def get_new_interval(duthost, is_valid, ip_netns_namespace_prefix,
 @pytest.mark.parametrize("field_pre_status", ["existing", "nonexistent"])
 @pytest.mark.parametrize("is_valid_config_update", [True, False])
 def test_pfcwd_interval_config_updates(
-        duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness, oper,
-        field_pre_status, is_valid_config_update,
+        ensure_dut_readiness, oper, field_pre_status, is_valid_config_update,
         enum_rand_one_frontend_asic_index, ip_netns_namespace_prefix,
         cli_namespace_prefix, loganalyzer):
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+    duthost = ensure_dut_readiness
     asic_namespace = duthost.get_namespace_from_asic_id(
         enum_rand_one_frontend_asic_index)
 

--- a/tests/generic_config_updater/test_pfcwd_interval.py
+++ b/tests/generic_config_updater/test_pfcwd_interval.py
@@ -139,7 +139,7 @@ def get_detection_restoration_times(duthost, ip_netns_namespace_prefix, cli_name
 
             return int(detection_time), int(restoration_time)
 
-    pytest_assert(True, "Failed to read detection_time and/or restoration time")
+    pytest_assert(False, "Failed to read detection_time and/or restoration time")
 
 
 def get_new_interval(duthost, is_valid, ip_netns_namespace_prefix, cli_namespace_prefix):

--- a/tests/generic_config_updater/test_pfcwd_interval.py
+++ b/tests/generic_config_updater/test_pfcwd_interval.py
@@ -4,11 +4,25 @@ import json
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
-from tests.common.gu_utils import apply_patch, expect_op_success, expect_op_failure
+from tests.common.gu_utils import apply_patch
+from tests.common.gu_utils import expect_op_success, expect_op_failure
 from tests.common.gu_utils import generate_tmpfile, delete_tmpfile
 from tests.common.gu_utils import format_json_patch_for_multiasic
-from tests.common.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
+from tests.common.gu_utils import create_checkpoint, delete_checkpoint
+from tests.common.gu_utils import rollback_or_reload
 from tests.common.gu_utils import is_valid_platform_and_version
+
+"""
+Test for PFC Watchdog (PFCWD) poll interval configuration updates via GCU.
+
+T2 Topology Support:
+    This test uses `rand_one_dut_front_end_hostname` to ensure compatibility
+    with T2 topologies. On T2, only linecards (not supervisor nodes) have
+    frontend ASICs with Ethernet interfaces and PFC_WD configuration. Using
+    `rand_one_dut_front_end_hostname` automatically selects either a
+    linecard on T2 or a regular DUT, ensuring the test always targets a
+    node with the required PFC_WD config.
+"""
 
 pytestmark = [
     pytest.mark.asic('cisco-8000', 'mellanox', 'marvell-teralynx'),
@@ -22,13 +36,16 @@ READ_FLEXCOUNTER_DB_INTERVAL = 20
 
 
 @pytest.fixture(scope="module")
-def ensure_dut_readiness(duthost):
+def ensure_dut_readiness(duthosts, rand_one_dut_front_end_hostname):
     """
     Setup/teardown fixture for pfcwd interval config update tst
 
     Args:
-        duthost: DUT host object
+        duthosts: DUT hosts object
+        rand_one_dut_front_end_hostname: frontend DUT hostname
+            (linecard on T2, regular DUT otherwise)
     """
+    duthost = duthosts[rand_one_dut_front_end_hostname]
     create_checkpoint(duthost)
 
     yield
@@ -41,31 +58,42 @@ def ensure_dut_readiness(duthost):
 
 
 @pytest.fixture(autouse=True, scope="module")
-def enable_default_pfcwd_configuration(duthost):
-    res = duthost.shell('redis-dump -d 4 --pretty -k \"DEVICE_METADATA|localhost\"')
+def enable_default_pfcwd_configuration(duthosts,
+                                       rand_one_dut_front_end_hostname):
+    duthost = duthosts[rand_one_dut_front_end_hostname]
+    res = duthost.shell(
+        'redis-dump -d 4 --pretty -k \"DEVICE_METADATA|localhost\"')
     meta_data = json.loads(res["stdout"])
-    pfc_status = meta_data["DEVICE_METADATA|localhost"]["value"].get("default_pfcwd_status", "")
+    pfc_status = meta_data["DEVICE_METADATA|localhost"]["value"].get(
+        "default_pfcwd_status", "")
     if pfc_status == 'disable':
-        duthost.shell('redis-cli -n 4 hset \"DEVICE_METADATA|localhost\" default_pfcwd_status enable')
+        duthost.shell(
+            'redis-cli -n 4 hset \"DEVICE_METADATA|localhost\" '
+            'default_pfcwd_status enable')
         # apply cofig to all namespaces also for multi-asic platforms
         for asic_id in duthost.get_asic_ids():
             if asic_id:
                 duthost.asic_instance(asic_id).command(
-                    'redis-cli -n 4 hset \"DEVICE_METADATA|localhost\" default_pfcwd_status enable'
+                    'redis-cli -n 4 hset \"DEVICE_METADATA|localhost\" '
+                    'default_pfcwd_status enable'
                 )
     # Enable default pfcwd configuration
     start_pfcwd = duthost.shell('config pfcwd start_default')
-    pytest_assert(not start_pfcwd['rc'], "Failed to start default pfcwd config")
+    pytest_assert(not start_pfcwd['rc'],
+                  "Failed to start default pfcwd config")
     # apply cofig to all namespaces also for multi-asic platforms
     for asic_id in duthost.get_asic_ids():
         if asic_id:
-            start_pfcwd = duthost.asic_instance(asic_id).command('config pfcwd start_default')
-            pytest_assert(not start_pfcwd['rc'], "Failed to start default pfcwd config for asic")
+            start_pfcwd = duthost.asic_instance(asic_id).command(
+                'config pfcwd start_default')
+            pytest_assert(not start_pfcwd['rc'],
+                          "Failed to start default pfcwd config for asic")
 
 
 def ensure_application_of_updated_config(duthost, value, cli_namespace_prefix):
     """
-    Ensures application of the JSON patch config update by verifying field value presence in FLEX COUNTER DB
+    Ensures application of the JSON patch config update by verifying
+    field value presence in FLEX COUNTER DB
 
     Args:
         duthost: DUT host object
@@ -73,18 +101,22 @@ def ensure_application_of_updated_config(duthost, value, cli_namespace_prefix):
         cli_namespace_prefix: fixture for the formatted cli namespace
     """
     def _confirm_value_in_flex_counter_db():
-        cmd = 'sonic-db-cli {} PFC_WD_DB hget FLEX_COUNTER_GROUP_TABLE:PFC_WD POLL_INTERVAL'.format(
-            cli_namespace_prefix)
+        cmd = ('sonic-db-cli {} PFC_WD_DB hget '
+               'FLEX_COUNTER_GROUP_TABLE:PFC_WD POLL_INTERVAL').format(
+                   cli_namespace_prefix)
         poll_interval = duthost.shell(cmd)["stdout"]
         return value == poll_interval
 
     pytest_assert(
-        wait_until(READ_FLEXCOUNTER_DB_TIMEOUT, READ_FLEXCOUNTER_DB_INTERVAL, 0, _confirm_value_in_flex_counter_db),
-        "FLEX COUNTER DB does not properly reflect newly POLL_INTERVAL expected value: {}".format(value)
+        wait_until(READ_FLEXCOUNTER_DB_TIMEOUT, READ_FLEXCOUNTER_DB_INTERVAL,
+                   0, _confirm_value_in_flex_counter_db),
+        "FLEX COUNTER DB does not properly reflect newly POLL_INTERVAL "
+        "expected value: {}".format(value)
     )
 
 
-def prepare_pfcwd_interval_config(duthost, value, ip_netns_namespace_prefix, cli_namespace_prefix):
+def prepare_pfcwd_interval_config(duthost, value, ip_netns_namespace_prefix,
+                                  cli_namespace_prefix):
     """
     Prepares config db by setting pfcwd poll interval to specified value.
     If value is empty string, delete the current entry.
@@ -95,17 +127,20 @@ def prepare_pfcwd_interval_config(duthost, value, ip_netns_namespace_prefix, cli
         ip_netns_namespace_prefix: fixture for the formatted ip netns namespace
         cli_namespace_prefix: fixture for the formatted cli namespace
     """
-    logger.info("Setting configdb entry pfcwd poll interval to value: {}".format(value))
+    logger.info("Setting configdb entry pfcwd poll interval to value: "
+                "{}".format(value))
 
     if value:
         cmd = "{} pfcwd interval {}".format(ip_netns_namespace_prefix, value)
     else:
-        cmd = r"sonic-db-cli {} CONFIG_DB del \PFC_WD\GLOBAL\POLL_INTERVAL".format(cli_namespace_prefix)
+        cmd = r"sonic-db-cli {} CONFIG_DB del \PFC_WD\GLOBAL\POLL_INTERVAL"
+        cmd = cmd.format(cli_namespace_prefix)
 
     duthost.shell(cmd)
 
 
-def get_detection_restoration_times(duthost, ip_netns_namespace_prefix, cli_namespace_prefix):
+def get_detection_restoration_times(duthost, ip_netns_namespace_prefix,
+                                    cli_namespace_prefix):
     """
     Returns detection_time, restoration_time for an interface.
     Poll_interval must be greater than both in order to be valid
@@ -116,46 +151,55 @@ def get_detection_restoration_times(duthost, ip_netns_namespace_prefix, cli_name
         cli_namespace_prefix: fixture for the formatted cli namespace
     """
 
-    cmd = '{} config pfcwd start --action drop all 400 --restoration-time 400'.format(
-        ip_netns_namespace_prefix)
+    cmd = ('{} config pfcwd start --action drop all 400 '
+           '--restoration-time 400').format(ip_netns_namespace_prefix)
     duthost.shell(cmd, module_ignore_errors=True)
     pfcwd_config = duthost.shell(f"show pfcwd config {cli_namespace_prefix}")
     pytest_assert(not pfcwd_config['rc'], "Unable to read pfcwd config")
 
     for line in pfcwd_config['stdout_lines']:
         if line.startswith('Ethernet'):
-            interface = line.split()[0]     # Since line starts with Ethernet, we can safely use 0 index
-            cmd = "sonic-db-cli {} CONFIG_DB hget \"PFC_WD|{}\" \"detection_time\" ".format(
-                cli_namespace_prefix, interface)
+            # Since line starts with Ethernet, we can safely use 0 index
+            interface = line.split()[0]
+            cmd = ('sonic-db-cli {} CONFIG_DB hget \"PFC_WD|{}\" '
+                   '\"detection_time\" ').format(cli_namespace_prefix,
+                                                 interface)
             output = duthost.shell(cmd, module_ignore_errors=True)
             pytest_assert(not output['rc'], "Unable to read detection time")
             detection_time = output["stdout"]
 
-            cmd = "sonic-db-cli {} CONFIG_DB hget \"PFC_WD|{}\" \"restoration_time\" ".format(
-                cli_namespace_prefix, interface)
+            cmd = ('sonic-db-cli {} CONFIG_DB hget \"PFC_WD|{}\" '
+                   '\"restoration_time\" ').format(cli_namespace_prefix,
+                                                   interface)
             output = duthost.shell(cmd, module_ignore_errors=True)
             pytest_assert(not output['rc'], "Unable to read restoration time")
             restoration_time = output["stdout"]
 
             return int(detection_time), int(restoration_time)
 
-    pytest_assert(False, "Failed to read detection_time and/or restoration time")
+    # Fail explicitly if no Ethernet interfaces found with PFC_WD config.
+    pytest_assert(False, "Failed to read detection_time and/or restoration "
+                         "time")
 
 
-def get_new_interval(duthost, is_valid, ip_netns_namespace_prefix, cli_namespace_prefix):
+def get_new_interval(duthost, is_valid, ip_netns_namespace_prefix,
+                     cli_namespace_prefix):
     """
-    Returns new interval value for pfcwd poll interval, based on the operation being performed
+    Returns new interval value for pfcwd poll interval, based on the
+    operation being performed
 
     Args:
         duthost: DUT host object
-        is_valid: if is_valid is true, return a valid new interval. Config update should succeed.
+        is_valid: if is_valid is true, return a valid new interval.
+            Config update should succeed.
+            If is_valid is false, return an invalid new interval.
+            Config update should fail.
         ip_netns_namespace_prefix: fixture for the formatted ip netns namespace
         cli_namespace_prefix: fixture for the formatted cli namespace
-        If is_valid is false, return an invalid new interval. Config update should fail.
     """
 
-    detection_time, restoration_time = get_detection_restoration_times(duthost, ip_netns_namespace_prefix,
-                                                                       cli_namespace_prefix)
+    detection_time, restoration_time = get_detection_restoration_times(
+        duthost, ip_netns_namespace_prefix, cli_namespace_prefix)
     if is_valid:
         return max(detection_time, restoration_time) - 10
     else:
@@ -165,34 +209,46 @@ def get_new_interval(duthost, is_valid, ip_netns_namespace_prefix, cli_namespace
 @pytest.mark.parametrize("oper", ["add", "replace"])
 @pytest.mark.parametrize("field_pre_status", ["existing", "nonexistent"])
 @pytest.mark.parametrize("is_valid_config_update", [True, False])
-def test_pfcwd_interval_config_updates(duthost, ensure_dut_readiness, oper,
-                                       field_pre_status, is_valid_config_update,
-                                       enum_rand_one_frontend_asic_index,
-                                       ip_netns_namespace_prefix,
-                                       cli_namespace_prefix,
-                                       loganalyzer):
-    asic_namespace = duthost.get_namespace_from_asic_id(enum_rand_one_frontend_asic_index)
+def test_pfcwd_interval_config_updates(
+        duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness, oper,
+        field_pre_status, is_valid_config_update,
+        enum_rand_one_frontend_asic_index, ip_netns_namespace_prefix,
+        cli_namespace_prefix, loganalyzer):
+    duthost = duthosts[rand_one_dut_front_end_hostname]
+    asic_namespace = duthost.get_namespace_from_asic_id(
+        enum_rand_one_frontend_asic_index)
 
-    if not is_valid_config_update and loganalyzer and loganalyzer[duthost.hostname]:
+    if not is_valid_config_update and loganalyzer \
+            and loganalyzer[duthost.hostname]:
         ignore_regex_list = [
-            ".*ERR.*Data Loading Failed:detection_time must be greater than or equal to POLL_INTERVAL.*"
+            ".*ERR.*Data Loading Failed:detection_time must be greater than "
+            "or equal to POLL_INTERVAL.*"
         ]
         loganalyzer[duthost.hostname].ignore_regex.extend(ignore_regex_list)
 
-    new_interval = get_new_interval(duthost, is_valid_config_update, ip_netns_namespace_prefix,
+    new_interval = get_new_interval(duthost, is_valid_config_update,
+                                    ip_netns_namespace_prefix,
                                     cli_namespace_prefix)
 
-    operation_to_new_value_map = {"add": "{}".format(new_interval), "replace": "{}".format(new_interval)}
-    detection_time, restoration_time = get_detection_restoration_times(duthost, ip_netns_namespace_prefix,
-                                                                       cli_namespace_prefix)
+    operation_to_new_value_map = {
+        "add": "{}".format(new_interval),
+        "replace": "{}".format(new_interval)
+    }
+    detection_time, restoration_time = get_detection_restoration_times(
+        duthost, ip_netns_namespace_prefix, cli_namespace_prefix)
     pre_status = max(detection_time, restoration_time)
-    field_pre_status_to_value_map = {"existing": "{}".format(pre_status), "nonexistent": ""}
+    field_pre_status_to_value_map = {
+        "existing": "{}".format(pre_status),
+        "nonexistent": ""
+    }
 
-    prepare_pfcwd_interval_config(duthost, field_pre_status_to_value_map[field_pre_status],
-                                  ip_netns_namespace_prefix, cli_namespace_prefix)
+    prepare_pfcwd_interval_config(
+        duthost, field_pre_status_to_value_map[field_pre_status],
+        ip_netns_namespace_prefix, cli_namespace_prefix)
 
     tmpfile = generate_tmpfile(duthost)
-    logger.info("tmpfile {} created for json patch of pfcwd poll interval and operation: {}".format(tmpfile, oper))
+    logger.info("tmpfile {} created for json patch of pfcwd poll interval "
+                "and operation: {}".format(tmpfile, oper))
     value = operation_to_new_value_map[oper]
     logger.info("value to be added to json patch: {}".format(value))
 
@@ -202,15 +258,18 @@ def test_pfcwd_interval_config_updates(duthost, ensure_dut_readiness, oper,
             "path": "/PFC_WD/GLOBAL/POLL_INTERVAL",
             "value": "{}".format(value)
         }]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
-                                                 is_asic_specific=True, asic_namespaces=[asic_namespace])
+    json_patch = format_json_patch_for_multiasic(
+        duthost=duthost, json_data=json_patch,
+        is_asic_specific=True, asic_namespaces=[asic_namespace])
 
     try:
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
 
-        if is_valid_config_update and is_valid_platform_and_version(duthost, "PFC_WD", "PFCWD enable/disable", oper):
+        if is_valid_config_update and is_valid_platform_and_version(
+                duthost, "PFC_WD", "PFCWD enable/disable", oper):
             expect_op_success(duthost, output)
-            ensure_application_of_updated_config(duthost, value, cli_namespace_prefix)
+            ensure_application_of_updated_config(duthost, value,
+                                                 cli_namespace_prefix)
         else:
             expect_op_failure(output)
     finally:


### PR DESCRIPTION
### Description of PR

Summary:
Fix `test_pfcwd_interval_config_updates` failure on T2 topologies due to incorrect DUT selection.

Fixes: MIGSOFTWAR-37212

**Root Cause**: On T2 topologies, the testbed has both supervisor nodes and linecard nodes. The test was using `duthost` directly, which could target a supervisor node. Supervisors have no frontend ASICs with Ethernet interfaces or PFC_WD configuration, causing:

1. `enum_rand_one_frontend_asic_index` returns `None` (no frontend ASICs)
2. Namespace prefix fixtures resolve to empty strings (wrong namespace)
3. `show pfcwd config` returns no Ethernet interfaces
4. `get_detection_restoration_times()` loop finds no interfaces, falls through
5. Function returns `None` instead of `(detection_time, restoration_time)`
6. Caller fails with `TypeError: cannot unpack non-iterable NoneType object`

**Fix**: 
1. Use `rand_one_dut_front_end_hostname` instead of `duthost` to ensure the test targets a linecard (data-plane node) on T2, or the regular DUT on non-T2 topologies
2. Fix `pytest_assert(True, ...)` -> `pytest_assert(False, ...)` to properly fail when no interfaces are found (was a no-op before)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

`test_pfcwd_interval_config_updates` fails on T2 topologies (e.g., T2-TITAN) with `TypeError: cannot unpack non-iterable NoneType object` because the test targets a supervisor node that has no PFC_WD configuration.

#### How did you do it?

- Changed fixtures and test function to use `duthosts[rand_one_dut_front_end_hostname]` instead of `duthost`
- This fixture automatically selects a linecard on T2 topologies or the regular DUT on other topologies
- Fixed the fallback assertion in `get_detection_restoration_times()` to properly fail instead of silently returning None
- Applied flake8 formatting fixes throughout the file
- Added module-level documentation explaining the T2 topology handling
- Slight refactoring to make code more DRY (avoiding multiple assignments to _duthost_ )

#### How did you verify/test it?

- Verified fix logic against error trace in MIGSOFTWAR-37212
- Confirmed `rand_one_dut_front_end_hostname` behavior in conftest.py
- Verified flake8 compliance
- Tested on a T2 testbed 


#### Any platform specific information?

Affects T2 topologies where supervisor and linecard nodes are separate. The fix is backward-compatible with all other topologies.

#### Supported testbed topology if it's a new test case?

N/A - bug fix for existing test. Test remains marked `@pytest.mark.topology('any')`.

### Documentation

Added module-level docstring explaining T2 topology handling and inline comment for the assertion fix.
