### PR TITLE
Fix KeyError in counterpoll restore by adding missing counter types to COUNTERPOLL_MAPPING

### DIFF
--- a/tests/common/constants.py
+++ b/tests/common/constants.py
@@ -49,6 +49,16 @@ class CounterpollConstants:
     ACL_TYPE = "ACL"
     WRED_ECN_QUEUE_STAT_TYPE = 'WRED_ECN_QUEUE_STAT'
     WRED_QUEUE = 'wredqueue'
+    WRED_ECN_PORT_STAT_TYPE = 'WRED_ECN_PORT_STAT'
+    WRED_PORT = 'wredport'
+    PHY_TYPE = 'PHY'
+    PHY = 'phy'
+    FLOW_CNT_ROUTE_STAT_TYPE = 'FLOW_CNT_ROUTE_STAT'
+    FLOW_CNT_ROUTE = 'flowcnt-route'
+    SRV6_STAT_TYPE = 'SRV6_STAT'
+    SRV6 = 'srv6'
+    SWITCH_STAT_TYPE = 'SWITCH_STAT'
+    SWITCH = 'switch'
     COUNTERPOLL_MAPPING = {PG_DROP_STAT_TYPE: PG_DROP,
                            QUEUE_STAT_TYPE: QUEUE,
                            PORT_STAT_TYPE: PORT,
@@ -58,7 +68,12 @@ class CounterpollConstants:
                            QUEUE_WATERMARK_STAT_TYPE: WATERMARK,
                            PG_WATERMARK_STAT_TYPE: WATERMARK,
                            ACL_TYPE: ACL,
-                           WRED_ECN_QUEUE_STAT_TYPE: WRED_QUEUE}
+                           WRED_ECN_QUEUE_STAT_TYPE: WRED_QUEUE,
+                           WRED_ECN_PORT_STAT_TYPE: WRED_PORT,
+                           PHY_TYPE: PHY,
+                           FLOW_CNT_ROUTE_STAT_TYPE: FLOW_CNT_ROUTE,
+                           SRV6_STAT_TYPE: SRV6,
+                           SWITCH_STAT_TYPE: SWITCH}
     PORT_BUFFER_DROP_INTERVAL = '10000'
     COUNTERPOLL_INTERVAL = {PORT_BUFFER_DROP: 10000}
     SX_SDK = 'sx_sdk'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md
-->
### Description of PR

Summary:
On SONiC images (202511.17+), `counterpoll show` reports additional counter types (`PHY`, `WRED_ECN_PORT`, `FLOW_CNT_ROUTE`, `SRV6`, `SWITCH`) introduced by [sonic-net/sonic-utilities#4106](https://github.com/sonic-net/sonic-utilities/pull/4106) (cherry-picked to 202511 as [#4291](https://github.com/sonic-net/sonic-utilities/pull/4291)). These types were not present in `CounterpollConstants.COUNTERPOLL_MAPPING`, causing a `KeyError: 'PHY'` during teardown of `test_cpu_memory_usage_counterpoll` when `restore_counterpoll_status()` attempts to look up each type. This issue primarily affects Mellanox platforms.

This PR adds the missing counter type constants and their corresponding entries in `COUNTERPOLL_MAPPING`.

- **Related ADO**: [37209542](https://msazure.visualstudio.com/One/_workitems/edit/37209542)
- **Failed test**: `platform_tests/test_cpu_memory_usage.py`
- **Verification**: [ElasticTest test plan](https://elastictest.org/scheduler/testplan/69decd28a2ac2651eecd1de7?leftSideViewMode=detail&testcase=platform_tests%2ftest_cpu_memory_usage.py&type=console) - re-ran the failed test and it passed after this fix.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
SONiC 202511.17 introduced new counterpoll types (PHY, WRED_ECN_PORT, FLOW_CNT_ROUTE, SRV6, SWITCH) via  [sonic-net/sonic-utilities#4106](https://github.com/sonic-net/sonic-utilities/pull/4106) (cherry-picked to 202511 as [#4291](https://github.com/sonic-net/sonic-utilities/pull/4291)), but sonic-mgmt's `COUNTERPOLL_MAPPING` was not updated accordingly. This causes `KeyError` during test teardown on Mellanox platforms running 202511.17+.

#### How did you do it?
Added the missing counter type constants and their corresponding mapping entries to `CounterpollConstants` in `tests/common/constants.py`.

#### How did you verify/test it?
Re-ran `platform_tests/test_cpu_memory_usage.py` on affected Mellanox testbeds. The test passed with no teardown errors. See [verification test plan](https://elastictest.org/scheduler/testplan/69decd28a2ac2651eecd1de7?leftSideViewMode=detail&testcase=platform_tests%2ftest_cpu_memory_usage.py&type=console).

#### Any platform specific information?
This issue primarily affects Mellanox platforms on SONiC 202511.17+, where the new counterpoll types are present.

#### Supported testbed topology if it's a new test case?
N/A (bug fix for existing test)

### Documentation
N/A