### PR TITLE
Fix dscp test dualtor

### DIFF
--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -78,14 +78,16 @@ def route_config(nbrhosts, tbinfo):
 
 
 @pytest.fixture(scope='function')
-def dscp_config(dscp_mode, duthost, loganalyzer):
+def dscp_config(dscp_mode, rand_selected_dut, loganalyzer):
     """
     Test setup and teardown
 
     Args:
-        request: pytest request
-        duthost (AnsibleHost): The DUT host
+        dscp_mode: DSCP decap mode (uniform/pipe)
+        rand_selected_dut: The randomly selected DUT (same as used by the test)
+        loganalyzer: Log analyzer fixture
     """
+    duthost = rand_selected_dut
     asic_type = duthost.facts['asic_type']
 
     # global DSCP_TO_TC_MAP update is not supported on Broadcom platforms
@@ -219,6 +221,7 @@ def send_and_verify_traffic(ptfadapter,
     except AssertionError as detail:
         if "Did not receive expected packet on any of ports" in str(detail):
             logger.error("Expected packet(s) was not received on any of the ports -> {}".format(ptf_dst_port_ids))
+        return None
 
 
 def find_queue_count_and_value(duthost, queue_val_list, dut_egress_port_list):
@@ -421,6 +424,13 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
                 # Sending large number of packets can cause socket buffer to be full and leads connection timeout.
                 logger.error("{}: Try reducing DEFAULT_PKT_COUNT value".format(str(e)))
                 failed_once = True
+
+            if dst_ptf_port_id_list is None:
+                logger.error("Traffic verification failed - no packets received")
+                for i in range(step):
+                    output_table.append([rotating_dscp + i, "N/A", 0, "FAILURE - NO PACKETS RECEIVED", "N/A"])
+                failed_once = True
+                continue
 
             if asic_type == 'vs':
                 logger.info("Skipping queue verification for VS platform")

--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -254,6 +254,7 @@ def send_and_verify_traffic(ptfadapter,
     except AssertionError as detail:
         if "Did not receive expected packet on any of ports" in str(detail):
             logger.error("Expected packet(s) was not received on any of the ports -> {}".format(ptf_dst_port_ids))
+        return None
 
 
 def find_queue_count_and_value(duthost, queue_val_list, dut_egress_port_list):
@@ -457,6 +458,13 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
                 # Sending large number of packets can cause socket buffer to be full and leads connection timeout.
                 logger.error("{}: Try reducing DEFAULT_PKT_COUNT value".format(str(e)))
                 failed_once = True
+
+            if dst_ptf_port_id_list is None:
+                logger.error("Traffic verification failed - no packets received")
+                for i in range(step):
+                    output_table.append([rotating_dscp + i, "N/A", 0, "FAILURE - NO PACKETS RECEIVED", "N/A"])
+                failed_once = True
+                continue
 
             if asic_type == 'vs':
                 logger.info("Skipping queue verification for VS platform")


### PR DESCRIPTION
### Description of PR

Summary:
Fix `test_qos_dscp_mapping.py` test failure on dualtor topologies where the `dscp_config` fixture was using the wrong DUT (`duthost` instead of `rand_selected_dut`).


### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?

The `dscp_config` fixture was using `duthost` (first DUT) but the test uses `rand_selected_dut` (randomly selected DUT). On dualtor topologies, this mismatch causes the fixture to configure DSCP settings on the wrong DUT.

#### How did you do it?

1. Changed `dscp_config` fixture parameter from `duthost` to `rand_selected_dut`
2. Added explicit `return None` in `send_and_verify_traffic()` for clarity
3. Added None handling in `_run_test()` to prevent `TypeError: 'NoneType' object is not subscriptable`
4. Removed extra `loganalyzer` argument from `_setup_test_params()` call

#### How did you verify/test it?

Ran `test_dscp_to_queue_mapping` on dualtor topology (tornado) with Cisco-8101-32FH-O-C01 DUTs. 
Test executed without Python errors and properly handled traffic verification failures.

#### Any platform specific information?

None - applies to all platforms supporting dualtor topologies.

#### Supported testbed topology if it's a new test case?

N/A - bug fix for existing test.

### Documentation
