### PR TITLE
cisco-vpp: Skip two tests in test_thermal for arm64-c8220tg_48a_o

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -862,8 +862,9 @@ platform_tests/api/test_thermal.py::TestThermalApi::test_get_model:
     reason: "test_get_model is not supported in cisco and mellanox platform"
     conditions_logical_operator: or
     conditions:
-       - "asic_type in ['mellanox', 'cisco-8000', 'vs', 'vpp']"
+       - "asic_type in ['mellanox', 'cisco-8000', 'vs']"
        - "is_multi_asic==True and release in ['201911']"
+       - "platform.startswith('arm64-c8220tg_48a_o')"
 
 platform_tests/api/test_thermal.py::TestThermalApi::test_get_presence:
   skip:
@@ -880,8 +881,9 @@ platform_tests/api/test_thermal.py::TestThermalApi::test_get_serial:
     reason: "test_get_serial is not supported in cisco and mellanox platform"
     conditions_logical_operator: or
     conditions:
-       - "asic_type in ['mellanox', 'cisco-8000', 'vs', 'vpp']"
+       - "asic_type in ['mellanox', 'cisco-8000', 'vs']"
        - "is_multi_asic==True and release in ['201911']"
+       - "platform.startswith('arm64-c8220tg_48a_o')"
 
 platform_tests/api/test_thermal.py::TestThermalApi::test_get_status:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -862,7 +862,7 @@ platform_tests/api/test_thermal.py::TestThermalApi::test_get_model:
     reason: "test_get_model is not supported in cisco and mellanox platform"
     conditions_logical_operator: or
     conditions:
-       - "asic_type in ['mellanox', 'cisco-8000', 'vs']"
+       - "asic_type in ['mellanox', 'cisco-8000', 'vs', 'vpp']"
        - "is_multi_asic==True and release in ['201911']"
 
 platform_tests/api/test_thermal.py::TestThermalApi::test_get_presence:
@@ -880,7 +880,7 @@ platform_tests/api/test_thermal.py::TestThermalApi::test_get_serial:
     reason: "test_get_serial is not supported in cisco and mellanox platform"
     conditions_logical_operator: or
     conditions:
-       - "asic_type in ['mellanox', 'cisco-8000', 'vs']"
+       - "asic_type in ['mellanox', 'cisco-8000', 'vs', 'vpp']"
        - "is_multi_asic==True and release in ['201911']"
 
 platform_tests/api/test_thermal.py::TestThermalApi::test_get_status:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The test_get_model and test_get_serial are not supported in vpp platform, and they fail. This PR is to skip them.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
The two tests are failing in cisco console platform.

#### How did you do it?
Added `arm64-c8220tg_48a_o` to the skip list in the platform skip file.

#### How did you verify/test it?
Ran it on cisco console sever testbed:
```
====================================================================================================== PASSES =======================================================================================================
______________________________________________________________________________________ TestThermalApi.test_get_name[c0lo-dut] _______________________________________________________________________________________
____________________________________________________________________________________ TestThermalApi.test_get_presence[c0lo-dut] _____________________________________________________________________________________
_____________________________________________________________________________________ TestThermalApi.test_get_status[c0lo-dut] ______________________________________________________________________________________
_______________________________________________________________________________ TestThermalApi.test_get_position_in_parent[c0lo-dut] ________________________________________________________________________________
___________________________________________________________________________________ TestThermalApi.test_is_replaceable[c0lo-dut] ____________________________________________________________________________________
___________________________________________________________________________________ TestThermalApi.test_get_temperature[c0lo-dut] ___________________________________________________________________________________
________________________________________________________________________________ TestThermalApi.test_get_minimum_recorded[c0lo-dut] _________________________________________________________________________________
________________________________________________________________________________ TestThermalApi.test_get_maximum_recorded[c0lo-dut] _________________________________________________________________________________
__________________________________________________________________________________ TestThermalApi.test_get_low_threshold[c0lo-dut] __________________________________________________________________________________
_________________________________________________________________________________ TestThermalApi.test_get_high_threshold[c0lo-dut] __________________________________________________________________________________
_____________________________________________________________________________ TestThermalApi.test_get_low_critical_threshold[c0lo-dut] ______________________________________________________________________________
_____________________________________________________________________________ TestThermalApi.test_get_high_critical_threshold[c0lo-dut] _____________________________________________________________________________
__________________________________________________________________________________ TestThermalApi.test_set_low_threshold[c0lo-dut] __________________________________________________________________________________
_________________________________________________________________________________ TestThermalApi.test_set_high_threshold[c0lo-dut] __________________________________________________________________________________
------------------------------------------------------ generated xml file: /run_logs/c0lo/skip-thermal/2026-04-17-18-18-30/platform_tests/api/test_thermal.xml ------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
============================================================================================== short test summary info ==============================================================================================
PASSED platform_tests/api/test_thermal.py::TestThermalApi::test_get_name[c0lo-dut]
PASSED platform_tests/api/test_thermal.py::TestThermalApi::test_get_presence[c0lo-dut]
PASSED platform_tests/api/test_thermal.py::TestThermalApi::test_get_status[c0lo-dut]
PASSED platform_tests/api/test_thermal.py::TestThermalApi::test_get_position_in_parent[c0lo-dut]
PASSED platform_tests/api/test_thermal.py::TestThermalApi::test_is_replaceable[c0lo-dut]
PASSED platform_tests/api/test_thermal.py::TestThermalApi::test_get_temperature[c0lo-dut]
PASSED platform_tests/api/test_thermal.py::TestThermalApi::test_get_minimum_recorded[c0lo-dut]
PASSED platform_tests/api/test_thermal.py::TestThermalApi::test_get_maximum_recorded[c0lo-dut]
PASSED platform_tests/api/test_thermal.py::TestThermalApi::test_get_low_threshold[c0lo-dut]
PASSED platform_tests/api/test_thermal.py::TestThermalApi::test_get_high_threshold[c0lo-dut]
PASSED platform_tests/api/test_thermal.py::TestThermalApi::test_get_low_critical_threshold[c0lo-dut]
PASSED platform_tests/api/test_thermal.py::TestThermalApi::test_get_high_critical_threshold[c0lo-dut]
PASSED platform_tests/api/test_thermal.py::TestThermalApi::test_set_low_threshold[c0lo-dut]
PASSED platform_tests/api/test_thermal.py::TestThermalApi::test_set_high_threshold[c0lo-dut]
SKIPPED [1] platform_tests/api/test_thermal.py: test_get_model is not supported in cisco and mellanox platform
SKIPPED [1] platform_tests/api/test_thermal.py: test_get_serial is not supported in cisco and mellanox platform
=============================================================================== 14 passed, 2 skipped, 1 warning in 444.58s (0:07:24) ================================================================================
sonic@arctos_cicd_all_202603:/data/tests$ 
```
#### Any platform specific information?
Specific to vpp.