### PR TITLE
[BGP] Fix flaky flap detection in test_bgp_dual_asn_v4 using FRR connection counters

### DIFF
--- a/tests/bgp/test_bgp_dual_asn.py
+++ b/tests/bgp/test_bgp_dual_asn.py
@@ -6,7 +6,6 @@ import random
 import re
 
 from tests.common import constants
-from datetime import datetime, timedelta
 from tests.common.utilities import skip_release
 from tests.common.utilities import wait_tcp_connection
 from tests.common.utilities import wait_until

--- a/tests/bgp/test_bgp_dual_asn.py
+++ b/tests/bgp/test_bgp_dual_asn.py
@@ -457,21 +457,17 @@ def verify_bgp_session(duthost, bgp_neighbor):
     )
 
 
-def get_bgp_uptime(duthost, bgp_neighbor):
-    # it's a work around for show ip bgp neighbors <ipaddress>, it can not show
-    # neighbors which are not configured
+def get_bgp_connection_count(duthost, bgp_neighbor):
+    """Get the established/dropped connection counts for a dynamic BGP neighbor."""
     output = duthost.shell(
-        "show ip bgp neighbors | grep -A 10 {} | grep 'Established'".format(
+        "show ip bgp neighbors | sed -n '/{}/,/^BGP neighbor/p' | grep 'Connections established'".format(
             bgp_neighbor
         )
     )
-    if not output["stdout"]:
-        pytest_assert(True, "Bgp neighbor {} is not up".format(bgp_neighbor))
-    time_string = re.search(r"up for (\d{2}:\d{2}:\d{2})", output["stdout"]).group(1)
-    t = datetime.strptime(time_string, "%H:%M:%S").time()
-    return int(
-        timedelta(hours=t.hour, minutes=t.minute, seconds=t.second).total_seconds()
-    )
+    pytest_assert(output["stdout"], "Could not find connection info for {}".format(bgp_neighbor))
+    match = re.search(r"Connections established (\d+);\s*dropped (\d+)", output["stdout"])
+    pytest_assert(match, "Could not parse connection counters for {}".format(bgp_neighbor))
+    return int(match.group(1)), int(match.group(2))
 
 
 def check_bgp_routes_exist(duthost, prefix):
@@ -525,8 +521,7 @@ def test_bgp_dual_asn_v4(
             30, 5, 10, verify_bgp_session, duthost, dualAsn.peer_addrs[0]
         ):
             pytest.fail("bgp peer %s should up" % dualAsn.peer_addrs[0])
-        current_bgp_uptime = get_bgp_uptime(duthost, dualAsn.peer_addrs[0])
-        current_time = time.time()
+        initial_established, initial_dropped = get_bgp_connection_count(duthost, dualAsn.peer_addrs[0])
         # announce route from valid bgp peer
         announce_route(ptfhost, NEIGHBOR_PORT_LIST[0], PREFIX, dualAsn.peer_addrs[0])
         # bgp peer which is not in peer range group should not up
@@ -589,10 +584,16 @@ def test_bgp_dual_asn_v4(
         check_bgp_routes_exist(duthost, PREFIX_2)
 
         # check original bgp neighbor no flapping
-        latest_time = time.time()
-        latest_bgp_uptime = get_bgp_uptime(duthost, dualAsn.peer_addrs[0])
-        if latest_time - current_time > latest_bgp_uptime - current_bgp_uptime:
-            pytest.fail("bgp %s flapped during testing" % dualAsn.peer_addrs[0])
+        # Verify the original BGP peer did not flap by comparing FRR connection counters.
+        # Uses established/dropped counts instead of uptime to avoid false positives
+        # from wall-clock vs BGP-uptime measurement drift over SSH.
+        final_established, final_dropped = get_bgp_connection_count(duthost, dualAsn.peer_addrs[0])
+        if final_established != initial_established or final_dropped != initial_dropped:
+            pytest.fail(
+                "bgp %s flapped during testing (established: %d->%d, dropped: %d->%d)"
+                % (dualAsn.peer_addrs[0], initial_established, final_established,
+                   initial_dropped, final_dropped)
+            )
 
         # remove first peer range group configuration, check it's neighbor's bgp state
         bgp_peer_range_delete_config(

--- a/tests/bgp/test_bgp_dual_asn.py
+++ b/tests/bgp/test_bgp_dual_asn.py
@@ -4,6 +4,7 @@ import logging
 import ipaddress
 import random
 import re
+import json
 
 from tests.common import constants
 from tests.common.utilities import skip_release
@@ -459,14 +460,28 @@ def verify_bgp_session(duthost, bgp_neighbor):
 def get_bgp_connection_count(duthost, bgp_neighbor):
     """Get the established/dropped connection counts for a dynamic BGP neighbor."""
     output = duthost.shell(
-        "show ip bgp neighbors | sed -n '/{}/,/^BGP neighbor/p' | grep 'Connections established'".format(
-            bgp_neighbor
-        )
+        'vtysh -c "show bgp neighbors {} json"'.format(bgp_neighbor),
+        module_ignore_errors=True,
     )
-    pytest_assert(output["stdout"], "Could not find connection info for {}".format(bgp_neighbor))
-    match = re.search(r"Connections established (\d+);\s*dropped (\d+)", output["stdout"])
-    pytest_assert(match, "Could not parse connection counters for {}".format(bgp_neighbor))
-    return int(match.group(1)), int(match.group(2))
+    pytest_assert(
+        output["rc"] == 0 and output["stdout"],
+        "Could not find connection info for {} (rc={})".format(
+            bgp_neighbor, output["rc"]
+        ),
+    )
+    bgp_info = json.loads(output["stdout"])
+    pytest_assert(
+        bgp_neighbor in bgp_info,
+        "Neighbor {} not found in vtysh JSON output".format(bgp_neighbor),
+    )
+    neighbor_info = bgp_info[bgp_neighbor]
+    established = neighbor_info.get("connectionsEstablished", 0)
+    dropped = neighbor_info.get("connectionsDropped", 0)
+    pytest_assert(
+        established > 0,
+        "connectionsEstablished is 0 for {} — session was never established".format(bgp_neighbor),
+    )
+    return established, dropped
 
 
 def check_bgp_routes_exist(duthost, prefix):
@@ -586,6 +601,9 @@ def test_bgp_dual_asn_v4(
         # Verify the original BGP peer did not flap by comparing FRR connection counters.
         # Uses established/dropped counts instead of uptime to avoid false positives
         # from wall-clock vs BGP-uptime measurement drift over SSH.
+        # Note: Any change in either counter (established or dropped) is treated as unexpected,
+        # including reconnections (e.g. graceful restart). This is intentional, during
+        # this test window, the original peer should maintain a single stable session without any flap.
         final_established, final_dropped = get_bgp_connection_count(duthost, dualAsn.peer_addrs[0])
         if final_established != initial_established or final_dropped != initial_dropped:
             pytest.fail(


### PR DESCRIPTION
### Description of PR

Fix flaky BGP flap detection in `test_bgp_dual_asn_v4` by replacing timing-based uptime comparison with FRR connection counters.

The existing flap check compared Python wall-clock elapsed time against BGP session uptime parsed from `show ip bgp neighbors`. This was unreliable due to:
1. BGP uptime is reported in whole seconds (integer truncation)
2. Asymmetric SSH round-trip delays between the baseline and check samples
3. Even sub-second discrepancies triggered false-positive flap failures

Summary:
Fixes false-positive `bgp X.X.X.X flapped during testing` failures in `test_bgp_dual_asn_v4`

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ x ] 202511

### Approach
#### What is the motivation for this PR?

`test_bgp_dual_asn_v4` was failing intermittently with `Failed: bgp 192.168.x.x flapped during testing` even when the BGP session never actually flapped. In the observed failure, the wall-clock delta was 88.13s while the BGP uptime delta was 88s — a 0.13s rounding error caused the test to incorrectly declare a flap.

#### How did you do it?

1. **Replaced `get_bgp_uptime()` with `get_bgp_connection_count()`** — Instead of comparing timestamps, the new function parses `Connections established N; dropped N` from FRR's `show ip bgp neighbors` output. If either counter changes between the baseline and final check, a flap genuinely occurred. This is deterministic with zero timing sensitivity.

2. **Used `sed` to extract the neighbor block** — Since dynamic (listen-range) peers can't be queried with `show ip bgp neighbors <ip>`, we use `sed -n '/<ip>/,/^BGP neighbor/p'` to extract the full block for the target neighbor, then grep for the connection counters.

#### How did you verify/test it?

- Ran `test_bgp_dual_asn_v4` on a t0 testbed, Broadcom, SONiC 202511 — test passes.
- Manually verified `Connections established` / `dropped` counters on DUT during test execution using `watch -n 2 'vtysh -c "show ip bgp neighbors" | grep -B 1 "Connections established"'`.

#### Any platform specific information?

None. The `Connections established N; dropped N` output format is standard across all FRR versions used in SONiC.

#### Supported testbed topology if it's a new test case?

N/A existing test, topology unchanged (t0).

### Documentation

N/A bug fix to existing test, no new features or test cases.