### PR TITLE
Implement post-test CONFIG_DB state cleanup fixture

### DIFF
--- a/tests/gnmi/test_gnmi_configdb.py
+++ b/tests/gnmi/test_gnmi_configdb.py
@@ -24,7 +24,23 @@ pytestmark = [
 ]
 
 
+<<<<<<< HEAD:tests/gnmi/test_gnmi_configdb.py
 def get_first_interface(duthost):
+=======
+@pytest.fixture
+def restore_bgp_asn(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+    old_bgp_asn = duthost.shell(sonic_cli_cmd("hget"))['stdout']
+    try:
+        yield
+    finally:
+        ret = duthost.shell(sonic_cli_cmd("hset") + old_bgp_asn)
+        if ret['rc'] != 0:
+            pytest.fail("failed to restore original CONFIG_DB state")
+
+
+def get_first_interface(duthost, excluded_interfaces=[]):
+>>>>>>> 2907bdcbe (NOS-6928: implement post-test cleanup for VRF-aware tests (#1448)):tests/gnmi/vrf_aware_tests/test_gnmi_configdb.py
     cmds = "show interface status"
     output = duthost.shell(cmds)
     assert (not output['rc']), "No output"
@@ -76,7 +92,18 @@ def wait_bgp_neighbor(duthost):
                   "Not all BGP sessions are established on DUT")
 
 
+<<<<<<< HEAD:tests/gnmi/test_gnmi_configdb.py
 def test_gnmi_configdb_incremental_01(duthosts, rand_one_dut_hostname, ptfhost):
+=======
+def sonic_cli_cmd(op):
+    '''
+    Generate `sonic-db-cli` command to read/update/remove (hget/hset/hdel respectively) BGP ASN
+    '''
+    return f"sonic-db-cli CONFIG_DB {op} \"DEVICE_METADATA|localhost\" bgp_asn "
+
+
+def test_gnmi_configdb_incremental_01(duthosts, rand_one_dut_hostname, ptfhost, vrf_config):
+>>>>>>> 2907bdcbe (NOS-6928: implement post-test cleanup for VRF-aware tests (#1448)):tests/gnmi/vrf_aware_tests/test_gnmi_configdb.py
     '''
     Verify GNMI native write, incremental config for configDB
     Toggle interface admin status
@@ -182,7 +209,12 @@ def test_gnmi_configdb_streaming_sample_01(duthosts, rand_one_dut_hostname, ptfh
 
 
 @pytest.mark.parametrize('test_data', test_data_metadata)
+<<<<<<< HEAD:tests/gnmi/test_gnmi_configdb.py
 def test_gnmi_configdb_streaming_onchange_01(duthosts, rand_one_dut_hostname, ptfhost, test_data):
+=======
+def test_gnmi_configdb_streaming_onchange_01(
+        duthosts, rand_one_dut_hostname, ptfhost, test_data, vrf_config, restore_bgp_asn):
+>>>>>>> 2907bdcbe (NOS-6928: implement post-test cleanup for VRF-aware tests (#1448)):tests/gnmi/vrf_aware_tests/test_gnmi_configdb.py
     '''
     Verify GNMI subscribe API, streaming onchange mode
     Subscribe streaming onchange mode
@@ -196,10 +228,10 @@ def test_gnmi_configdb_streaming_onchange_01(duthosts, rand_one_dut_hostname, pt
             if not run_flag.value:
                 break
             time.sleep(0.5)
-            cmd = "sonic-db-cli CONFIG_DB hdel \"DEVICE_METADATA|localhost\" bgp_asn "
+            cmd = sonic_cli_cmd("hdel")
             duthost.shell(cmd, module_ignore_errors=True)
             time.sleep(0.5)
-            cmd = "sonic-db-cli CONFIG_DB hset \"DEVICE_METADATA|localhost\" bgp_asn " + str(i+1000)
+            cmd = sonic_cli_cmd("hset") + str(i+1000)
             duthost.shell(cmd, module_ignore_errors=True)
 
     client_task = multiprocessing.Process(target=worker, args=(duthost, run_flag,))
@@ -212,7 +244,11 @@ def test_gnmi_configdb_streaming_onchange_01(duthosts, rand_one_dut_hostname, pt
     assert msg.count("bgp_asn") >= exp_cnt, test_data["name"] + ": " + msg
 
 
+<<<<<<< HEAD:tests/gnmi/test_gnmi_configdb.py
 def test_gnmi_configdb_streaming_onchange_02(duthosts, rand_one_dut_hostname, ptfhost):
+=======
+def test_gnmi_configdb_streaming_onchange_02(duthosts, rand_one_dut_hostname, ptfhost, vrf_config, restore_bgp_asn):
+>>>>>>> 2907bdcbe (NOS-6928: implement post-test cleanup for VRF-aware tests (#1448)):tests/gnmi/vrf_aware_tests/test_gnmi_configdb.py
     '''
     Verify GNMI subscribe API, streaming onchange mode
     Subscribe table, and verify gnmi output has table key
@@ -226,7 +262,7 @@ def test_gnmi_configdb_streaming_onchange_02(duthosts, rand_one_dut_hostname, pt
             if not run_flag.value:
                 break
             time.sleep(0.5)
-            cmd = "sonic-db-cli CONFIG_DB hset \"DEVICE_METADATA|localhost\" bgp_asn " + str(i+1000)
+            cmd = sonic_cli_cmd("hset") + str(i+1000)
             duthost.shell(cmd, module_ignore_errors=True)
 
     client_task = multiprocessing.Process(target=worker, args=(duthost, run_flag,))

--- a/tests/gnmi/test_gnmi_configdb.py
+++ b/tests/gnmi/test_gnmi_configdb.py
@@ -24,9 +24,6 @@ pytestmark = [
 ]
 
 
-<<<<<<< HEAD:tests/gnmi/test_gnmi_configdb.py
-def get_first_interface(duthost):
-=======
 @pytest.fixture
 def restore_bgp_asn(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
@@ -40,7 +37,6 @@ def restore_bgp_asn(duthosts, rand_one_dut_hostname):
 
 
 def get_first_interface(duthost, excluded_interfaces=[]):
->>>>>>> 2907bdcbe (NOS-6928: implement post-test cleanup for VRF-aware tests (#1448)):tests/gnmi/vrf_aware_tests/test_gnmi_configdb.py
     cmds = "show interface status"
     output = duthost.shell(cmds)
     assert (not output['rc']), "No output"
@@ -92,9 +88,6 @@ def wait_bgp_neighbor(duthost):
                   "Not all BGP sessions are established on DUT")
 
 
-<<<<<<< HEAD:tests/gnmi/test_gnmi_configdb.py
-def test_gnmi_configdb_incremental_01(duthosts, rand_one_dut_hostname, ptfhost):
-=======
 def sonic_cli_cmd(op):
     '''
     Generate `sonic-db-cli` command to read/update/remove (hget/hset/hdel respectively) BGP ASN
@@ -103,7 +96,6 @@ def sonic_cli_cmd(op):
 
 
 def test_gnmi_configdb_incremental_01(duthosts, rand_one_dut_hostname, ptfhost, vrf_config):
->>>>>>> 2907bdcbe (NOS-6928: implement post-test cleanup for VRF-aware tests (#1448)):tests/gnmi/vrf_aware_tests/test_gnmi_configdb.py
     '''
     Verify GNMI native write, incremental config for configDB
     Toggle interface admin status
@@ -209,12 +201,8 @@ def test_gnmi_configdb_streaming_sample_01(duthosts, rand_one_dut_hostname, ptfh
 
 
 @pytest.mark.parametrize('test_data', test_data_metadata)
-<<<<<<< HEAD:tests/gnmi/test_gnmi_configdb.py
-def test_gnmi_configdb_streaming_onchange_01(duthosts, rand_one_dut_hostname, ptfhost, test_data):
-=======
 def test_gnmi_configdb_streaming_onchange_01(
         duthosts, rand_one_dut_hostname, ptfhost, test_data, vrf_config, restore_bgp_asn):
->>>>>>> 2907bdcbe (NOS-6928: implement post-test cleanup for VRF-aware tests (#1448)):tests/gnmi/vrf_aware_tests/test_gnmi_configdb.py
     '''
     Verify GNMI subscribe API, streaming onchange mode
     Subscribe streaming onchange mode
@@ -244,11 +232,7 @@ def test_gnmi_configdb_streaming_onchange_01(
     assert msg.count("bgp_asn") >= exp_cnt, test_data["name"] + ": " + msg
 
 
-<<<<<<< HEAD:tests/gnmi/test_gnmi_configdb.py
-def test_gnmi_configdb_streaming_onchange_02(duthosts, rand_one_dut_hostname, ptfhost):
-=======
 def test_gnmi_configdb_streaming_onchange_02(duthosts, rand_one_dut_hostname, ptfhost, vrf_config, restore_bgp_asn):
->>>>>>> 2907bdcbe (NOS-6928: implement post-test cleanup for VRF-aware tests (#1448)):tests/gnmi/vrf_aware_tests/test_gnmi_configdb.py
     '''
     Verify GNMI subscribe API, streaming onchange mode
     Subscribe table, and verify gnmi output has table key


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #24034 

This PR aims to restore CONFIG_DB's contents back to its original state, at the end of every test in `test_gnmi_configdb.py` that mutates it.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

To reset CONFIG_DB state properly and prevent cascading failures for subsequent/future tests.

#### How did you do it?

Added a cleanup fixture to restore the original state of CONFIG_DB prior to state changes made during testing

#### How did you verify/test it?

Ran gnmi/test_gnmi_configdb.py with the changes on a testbed to ensure tests still pass.
```
=============================== warnings summary ===============================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: Type google._upb._message.MessageMapContainer uses PyType_Spec with a metaclass that has custom tp_new. This is deprecated and will no longer be allowed in Python 3.14.

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: Type google._upb._message.ScalarMapContainer uses PyType_Spec with a metaclass that has custom tp_new. This is deprecated and will no longer be allowed in Python 3.14.

../../../opt/venv/lib/python3.12/site-packages/google/protobuf/internal/well_known_types.py:93
2026-04-15 23:40:44.232 Test gnmi/test_gnmi_configdb.py passed
2026-04-15 23:40:44.232
============================================================
2026-04-15 23:40:44.232 Test execution summary:
2026-04-15 23:40:44.232 Total tests: 1
2026-04-15 23:40:44.232 Passed: 1
2026-04-15 23:40:44.232 Failed: 0
2026-04-15 23:40:44.232
Detailed test results:
2026-04-15 23:40:44.251
+--------------------------------------------+----------------+--------+-------+
| Test                                       | Execution Time | Status | Error |
+--------------------------------------------+----------------+--------+-------+
| gnmi/test_gnmi_configdb.py                 |       00:24:37 | Passed |       |
+--------------------------------------------+----------------+--------+-------+
```

#### Any platform specific information?

no. this stuff is platform-agnostic

#### Supported testbed topology if it's a new test case?

n/a

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

#### reproducing issue

Without the changes in this PR, tests satisfying all 3 conditions will fail:
- test(s) which run after  test_gnmi_configdb_streaming_onchange_01 or test_gnmi_configdb_streaming_onchange_02
- said test(s) cause re-initialization of BGP sessions with DUT's neighbors
- uses wait_bgp_neighbor as part of the test

