### PR TITLE
[dhcp_relay] clean up DHCPV4_RELAY entries in agent_mode and max_hop_c…

### DIFF
--- a/tests/dhcp_relay/test_dhcpv4_relay.py
+++ b/tests/dhcp_relay/test_dhcpv4_relay.py
@@ -344,6 +344,12 @@ def test_dhcp_relay_agent_mode(
     except LogAnalyzerError as err:
         logger.error("Unable to find expected log in syslog")
         raise err
+    finally:
+        # Restore the baseline DHCPV4_RELAY row shape that
+        # enable_sonic_dhcpv4_relay_agent set up (dhcpv4_servers only,
+        # no agent_relay_mode), by reusing the same helpers.
+        sonic_dhcp_relay_unconfig(duthost, dut_dhcp_relay_data)
+        sonic_dhcp_relay_config(duthost, dut_dhcp_relay_data)
 
 
 @pytest.mark.parametrize("testcase", ["vrf_selection", "source_intf", "server_id_override"])
@@ -694,3 +700,9 @@ def test_dhcp_max_hop_count(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
     except LogAnalyzerError as err:
         logger.error("Unable to find expected log in syslog")
         raise err
+    finally:
+        # Restore the baseline DHCPV4_RELAY row shape that
+        # enable_sonic_dhcpv4_relay_agent set up (dhcpv4_servers only,
+        # no agent_relay_mode / max_hop_count), by reusing the same helpers.
+        sonic_dhcp_relay_unconfig(duthost, dut_dhcp_relay_data)
+        sonic_dhcp_relay_config(duthost, dut_dhcp_relay_data)


### PR DESCRIPTION
…ount tests

test_dhcp_relay_agent_mode and test_dhcp_max_hop_count both mutate DHCPV4_RELAY|<Vlan> via 'config dhcpv4_relay add --agent-relay-mode ... [--max-hop-count ...]' but never delete the entry afterward. The modified entry persists in CONFIG_DB across the test session and is later flagged by the shared post-test config_db check in conftest.py when the next test (often an unrelated dhcp_relay/dhcpv6_relay case) runs its teardown -- producing a teardown ERROR that misattributes the failure to that downstream test.

Add a symmetric 'finally' that runs 'config dhcpv4_relay del <vlan>' for each Vlan the test touched, mirroring the unconditional 'del' the test already performs at the start of each iteration.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

test_dhcp_relay_agent_mode and test_dhcp_max_hop_count in tests/dhcp_relay/test_dhcpv4_relay.py both mutate DHCPV4_RELAY|<Vlan> via config dhcpv4_relay add --agent-relay-mode … [--max-hop-count …] but never delete the entry afterward. The modified entry persists in CONFIG_DB across the test session and is later flagged by the shared post-test 
config_db_check in tests/conftest.py when the next test (often an unrelated dhcp_relay/dhcpv6_relay case) runs its teardown — producing a teardown ERROR that misattributes the failure to that downstream test.

Add a symmetric finally block to each test that runs config dhcpv4_relay del <vlan> for every Vlan the test touched, mirroring the unconditional del the test already performs at the start of each iteration.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

On T0 720dt regression runs, an unrelated DHCPv6 case (TestDhcpv6RelayWithMultipleVlan::test_dhcp_relay_default[3]) has been intermittently reporting a teardown ERROR. Investigation showed:

 - The v6 test itself passes; the ERROR comes from tests/conftest.py line ~3869 (config_db_check).
 - The diagnostic dump shows a DHCPV4_RELAY|Vlan1000 entry in cur_only_config containing agent_relay_mode=append, max_hop_count=16, and 48 dhcpv4_servers — clearly seeded by the preceding test_dhcp_max_hop_count.
 - Both test_dhcp_max_hop_count and test_dhcp_relay_agent_mode add the entry inside try: but have no finally: cleanup. They rely on the next iteration's config dhcpv4_relay del to wipe state, which never runs after the last iteration.

The leakage causes the next test's teardown check to flag the divergence and (until the parallel YANG fix in sonic-buildimage#26886 lands) also fail YANG validation on the append/replace short-form values, producing a confusing teardown ERROR on a completely unrelated test.

#### How did you do it?

Added a 4-line finally: block at the end of both test_dhcp_relay_agent_mode and test_dhcp_max_hop_count:

 finally:
     # Restore baseline DHCPV4_RELAY state so leftover agent_relay_mode/max_hop_count doesn't trip
     # the post-test config_db YANG validation in shared conftest teardown.
     for dhcp_relay in dut_dhcp_relay_data:
         vlan = str(dhcp_relay['downlink_vlan_iface']['name'])
         duthost.shell(f'config dhcpv4_relay del {vlan}', module_ignore_errors=True)

This mirrors the unconditional config dhcpv4_relay del {vlan} already performed at the start of each loop iteration, so it preserves the existing test assumption that no Vlan-scoped DHCPV4_RELAY baseline must be retained.

module_ignore_errors=True keeps the cleanup robust if a particular Vlan was never reached (e.g., the test failed inside the first iteration before the matching add).

No production code, no test logic, and no parameter set changes — purely additive teardown hygiene.

#### How did you verify/test it?

Ran on 720dt testbed with the patch applied:

 dhcp_relay/test_dhcpv4_relay.py::test_dhcp_max_hop_count[2-sonic-relay-agent]                    PASSED [ 16%]
 dhcp_relay/test_dhcpv4_relay.py::test_dhcp_max_hop_count[16-sonic-relay-agent]                   PASSED [ 33%]
 dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_agent_mode[discard-sonic-relay-agent]           PASSED [ 50%]
 dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_agent_mode[replace-sonic-relay-agent]           PASSED [ 66%]
 dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_agent_mode[append-sonic-relay-agent]            PASSED [ 83%]
 dhcp_relay/test_dhcpv6_relay.py::TestDhcpv6RelayWithMultipleVlan::test_dhcp_relay_default[3]     PASSED [100%]
 ================= 6 passed, 533 warnings in 1380.75s (0:23:00) =================

Post-test verification on the DUT:

 admin@HOSTNAME:~$ sonic-db-cli CONFIG_DB keys 'DHCPV4_RELAY|*'
 admin@HOSTNAME:~$ sonic-db-cli CONFIG_DB keys 'DHCPV6_RELAY|*'
 admin@HOSTNAME:~$

No leftover entries. Critically, the v6 test_dhcp_relay_default[3] case — which previously reported a teardown ERROR when chained after test_dhcp_max_hop_count — now passes cleanly with no config_db_check error.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
