### PR TITLE
[BGP] Fix rollback failure in test_bgp_dual_asn by cleaning up test peer ranges before teardown

### DIFF
--- a/tests/bgp/test_bgp_dual_asn.py
+++ b/tests/bgp/test_bgp_dual_asn.py
@@ -284,6 +284,14 @@ class BgpDualAsn:
             ptfhost.exabgp(name="bgps%d" % i, state="absent")
         logger.info("exabgp stopped")
 
+        # Delete test-specific BGP_PEER_RANGE entries so rollback can
+        # restore BGPVac without listen-range overlap
+        for name in [BGPSLB, BGPSLB_2, BGPSLB_V6, BGPSLB_V6_2]:
+            duthost.shell(
+                'sonic-db-cli CONFIG_DB del "BGP_PEER_RANGE|{}"'.format(name),
+                module_ignore_errors=True
+            )
+
         for port in self.ptf_ports:
             ptfhost.shell("ip addr flush dev {} scope global".format(port))
         duthost.command("sonic-clear arp")

--- a/tests/bgp/test_bgp_dual_asn.py
+++ b/tests/bgp/test_bgp_dual_asn.py
@@ -286,9 +286,13 @@ class BgpDualAsn:
 
         # Delete test-specific BGP_PEER_RANGE entries so rollback can
         # restore BGPVac without listen-range overlap
-        for name in [BGPSLB, BGPSLB_2, BGPSLB_V6, BGPSLB_V6_2]:
+        test_peer_ranges = [BGPSLB, BGPSLB_2, BGPSLB_V6, BGPSLB_V6_2]
+        del_keys = " ".join('"BGP_PEER_RANGE|{}"'.format(n) for n in test_peer_ranges)
+        ns_list = duthost.get_frontend_asic_namespace_list() or [None]
+        for ns in ns_list:
+            ns_flag = "-n {} ".format(ns) if ns else ""
             duthost.shell(
-                'sonic-db-cli CONFIG_DB del "BGP_PEER_RANGE|{}"'.format(name),
+                "sonic-db-cli {}CONFIG_DB del {}".format(ns_flag, del_keys),
                 module_ignore_errors=True
             )
 


### PR DESCRIPTION
### Description of PR

Summary:
Fix `test_bgp_dual_asn_v4` teardown failure where `rollback_or_reload()` fails to restore the production `BGPVac` peer-range because test-created `BGP_PEER_RANGE` entries (with overlapping subnets) are still present in CONFIG_DB.

The test splits the VLAN subnet (`192.168.0.0/21`) into two `/22` halves for its peer ranges. At teardown, `rollback_or_reload()` tries to restore `BGPVac` (`192.168.0.0/21`), but FRR rejects it with `% Listen range overlaps with existing listen range` because the test's `/22` ranges (specifically `BGPSLBPassive2`) are still active.

This is a race condition, bgpcfgd processes CONFIG_DB notifications asynchronously, and rollback may attempt to add `BGPVac` before the test ranges are removed, causing flaky loganalyzer errors.

Fixes # 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ x ] 202511

### Approach
#### What is the motivation for this PR?

`test_bgp_dual_asn_v4` adds two BGP peer-range groups (`BGPSLBPassive` with `192.168.0.0/22` and `BGPSLBPassive2` with `192.168.4.0/22`). The test only deletes the first group as part of its test logic, leaving `BGPSLBPassive2` in CONFIG_DB. When the `setup_env` fixture runs `rollback_or_reload()` to restore the original checkpoint (which contains `BGPVac` with `192.168.0.0/21`), FRR rejects the restore because `/21` overlaps with the still-active `/22`.

This produces `ERR bgp#bgpcfgd: % Listen range overlaps with existing listen range` in syslog, which loganalyzer catches as a test error.

#### How did you do it?

Added explicit deletion of all test-specific `BGP_PEER_RANGE` entries (`BGPSLBPassive`, `BGPSLBPassive2`, `BGPSLBPassiveV6`, `BGPSLBPassiveV62`) in `dual_asn_teardown()`, before the `setup_env` fixture teardown runs rollback. The deletions use `module_ignore_errors=True` since Redis `DEL` on non-existent keys is a safe no-op, handling all failure paths (deletion of non-existent peer ranges).

#### How did you verify/test it?

- Ran `test_bgp_dual_asn_v4` on `vms91-t0-7060x6-moby-512-3` (Broadcom 7060x6, SONiC 202511)
- Verified no `bgpcfgd` overlap errors in syslog during teardown
- Verified `BGPVac` is correctly restored after rollback via `show runningconfiguration bgp`

#### Any platform specific information?

Reproduced on Broadcom 7060x6 multi-ASIC but seems platform independent on T0

#### Supported testbed topology if it's a new test case?

N/A existing test, t0 topology.

### Documentation

N/A