### PR TITLE
[copp]: Re-install ptf_nn_agent in syncd after reboot if missing

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -207,6 +207,30 @@ def configure_syncd(dut, nn_target_port, nn_target_interface, nn_target_namespac
     dut.command("docker exec {} supervisorctl update".format(syncd_docker_name))
 
 
+def is_ptf_nn_agent_running(dut, nn_target_namespace):
+    """
+    Check if ptf_nn_agent is already running inside the syncd container.
+
+    On platforms where Docker state is stored in RAM (e.g., Arista 7060CX with
+    docker_inram=on), the syncd container is recreated on every cold reboot, losing
+    ptf_nn_agent. This helper is used to detect that case before attempting reinstall.
+
+    Args:
+        dut (SonicHost): The target device.
+        nn_target_namespace (str): The namespace for the syncd instance.
+
+    Returns:
+        bool: True if ptf_nn_agent is running, False otherwise.
+    """
+    asichost = dut.asic_instance_from_namespace(nn_target_namespace)
+    syncd_docker_name = asichost.get_docker_name("syncd")
+    result = dut.command(
+        "docker exec {} supervisorctl status ptf_nn_agent".format(syncd_docker_name),
+        module_ignore_errors=True
+    )
+    return result["rc"] == 0 and "RUNNING" in result["stdout"]
+
+
 def restore_syncd(dut, nn_target_namespace):
     asichost = dut.asic_instance_from_namespace(nn_target_namespace)
     syncd_docker_name = asichost.get_docker_name("syncd")

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -310,6 +310,18 @@ class TestCOPP(object):
         reboot(duthost, localhost, reboot_type=reboot_type, reboot_helper=None, reboot_kwargs=None)
 
         time.sleep(180)
+
+        # On platforms where Docker state lives in RAM (e.g., Arista 7060CX with docker_inram=on),
+        # the syncd container is recreated on every cold reboot, losing ptf_nn_agent.
+        # Re-install ptf_nn_agent only if it is not already running after the reboot.
+        if not copp_utils.is_ptf_nn_agent_running(duthost, copp_testbed.nn_target_namespace):
+            logger.info("ptf_nn_agent not running after reboot, re-configuring syncd")
+            copp_utils.configure_syncd(duthost, copp_testbed.nn_target_port,
+                                       copp_testbed.nn_target_interface,
+                                       copp_testbed.nn_target_namespace,
+                                       copp_testbed.nn_target_vlanid,
+                                       copp_testbed.swap_syncd, copp_testbed.creds)
+
         logger.info("Verify always_enable of {} == {} in config_db".format(self.trap_id, "true"))
         copp_utils.verify_always_enable_value(duthost, self.trap_id, "true")
 

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -283,7 +283,7 @@ class TestCOPP(object):
             "uninstalling {} trap fail".format(self.trap_id))
 
     @pytest.mark.disable_loganalyzer
-    def test_trap_config_save_after_reboot(self, duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname,
+    def test_trap_config_save_after_reboot(self, duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname, creds,
                                            ptfhost, check_image_version, copp_testbed, dut_type,
                                            backup_restore_config_db, request):   # noqa: F811
         """
@@ -320,7 +320,7 @@ class TestCOPP(object):
                                        copp_testbed.nn_target_interface,
                                        copp_testbed.nn_target_namespace,
                                        copp_testbed.nn_target_vlanid,
-                                       copp_testbed.swap_syncd, copp_testbed.creds)
+                                       copp_testbed.swap_syncd, creds)
 
         logger.info("Verify always_enable of {} == {} in config_db".format(self.trap_id, "true"))
         copp_utils.verify_always_enable_value(duthost, self.trap_id, "true")


### PR DESCRIPTION
### Description of PR
Summary: Fix `test_trap_config_save_after_reboot` failure on platforms where Docker state is stored in RAM (e.g., Arista 7060CX-32S with `docker_inram=on`).

Fixes # (issue)
ADO: https://msazure.visualstudio.com/One/_workitems/edit/37598227

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
On Arista 7060CX-32S (Aboot `norcal6`), the kernel parameter `docker_inram=on` causes `/var/lib/docker` to be loaded into a compressed RAM filesystem at boot. All Docker containers including `syncd` are wiped on every cold reboot.

`test_trap_config_save_after_reboot` installs `ptf_nn_agent` into the syncd container during fixture setup via `configure_syncd()`. After cold reboot, the syncd container is recreated from scratch without `ptf_nn_agent`, causing PTF's `nn_recv()` to block indefinitely and the test to fail.

On platforms with persistent Docker storage (e.g., Arista 7260CX3 with Aboot `norcal7`), the syncd container survives the cold reboot with `ptf_nn_agent` intact — test passes.

#### How did you do it?
1. Added `is_ptf_nn_agent_running()` helper to `copp_utils.py` — checks if `ptf_nn_agent` is running in the syncd container via `supervisorctl status`.
2. In `test_trap_config_save_after_reboot`, after the reboot and `time.sleep(180)`, conditionally call `configure_syncd()` only if `ptf_nn_agent` is not already running. This is a no-op on platforms where Docker persists across reboot.

#### How did you verify/test it?
- Reproduced failure on Arista 7060CX-32S (`crow` platform, `docker_inram=on docker_inram_algo=zstd`)
- Confirmed the fix restores `ptf_nn_agent` after cold reboot on the affected platform
- Confirmed no impact on Arista 7260CX3 (`rook` platform, persistent Docker) — `is_ptf_nn_agent_running()` returns True and `configure_syncd()` is skipped

#### Any platform specific information?
Affects Arista platforms with Aboot `norcal6` (e.g., 7060CX-32S) that set `docker_inram=on`. Platforms with Aboot `norcal7` (e.g., 7260CX3) are unaffected.

#### Supported testbed topology if it is a new test case?
N/A (existing test case, `t0` topology)

### Documentation
N/A
### Verify
| Testbed | Topo | Plan ID | Link |
|---------|------|---------|------|
| testbed-bjw3-can-t0-7060-4 | t0 | 69f0af421f6d9ccadfb46607 | [View](https://elastictest.org/scheduler/testplan/69f0af421f6d9ccadfb46607) |
| testbed-bjw3-can-t0-7060-5 | t0 | 69f0af4e0aae266263d658cd | [View](https://elastictest.org/scheduler/testplan/69f0af4e0aae266263d658cd) |
| testbed-bjw3-can-t0-7060-6 | t0 | 69f0af520aae266263d658cf | [View](https://elastictest.org/scheduler/testplan/69f0af520aae266263d658cf) |
| testbed-bjw2-can-t0-7260-10 | t0 | 6a067b9cb836de58495e2a99 | [View](https://elastictest.org/scheduler/testplan/6a067b9cb836de58495e2a99) |
| testbed-bjw2-can-t1-7260-11 | t1 | 6a067ba4b836de58495e2a9b | [View](https://elastictest.org/scheduler/testplan/6a067ba4b836de58495e2a9b) |

- **Test:** copp/test_copp.py
- **Branch:** dev/xuliping/20260515_internal-202511_copp-reboot-ptfnn
- **Image:** internal-202511 (sonic-aboot-broadcom.swi)
