### PR TITLE
[dhcp_relay] Rebind source-interface Loopback to client VRF in test_d…

### DIFF
--- a/tests/dhcp_relay/test_dhcpv4_relay.py
+++ b/tests/dhcp_relay/test_dhcpv4_relay.py
@@ -422,7 +422,46 @@ def test_dhcp_relay_with_non_default_vrf(
     duthost.shell(f"sudo config route add prefix vrf {CLIENT_VRF_NAME} 0.0.0.0/0 nexthop"
                   f" vrf {CLIENT_VRF_NAME} {first_params['nexthop']}")
 
+    # Pre-initialize Loopback rebind locals so the finally block's existence
+    # check still works even if Step 6 itself raises before assigning them.
+    loopback_for_src = dut_dhcp_relay_data[0]['loopback_iface']
+    loopback_ip_key_prefix = "LOOPBACK_INTERFACE|{}|".format(loopback_for_src)
+    saved_loopback_ips = {}
+
+    # Move the try: to cover Step 6 as well so that any partial failure during
+    # the Loopback IP-strip / vrf bind / restore sequence still triggers the
+    # cleanup in the finally block.
     try:
+        # Step 6: For the "source_intf" testcase only, rebind the
+        # source-interface Loopback into CLIENT_VRF_NAME.
+        #
+        # SONiC orchagent installs the IP2ME (trap-to-CPU) route per-VRF
+        # (intfsorch.cpp::addIp2MeRoute is called with
+        # vr_id = port.m_vr_id). The "source_intf" testcase passes
+        # --source-interface Loopback0 to the relay, so dhcp4relay sets
+        # giaddr to the Loopback IP and the server unicasts the OFFER back
+        # to that IP. If Loopback0 stays in the default VRF while the
+        # ingress interface is in CLIENT_VRF_NAME, platforms whose silicon
+        # enforces strict per-VRF IP2ME (for example, Broadcom Helix4) have
+        # no matching trap entry in CLIENT_VRF_NAME and silently drop the
+        # OFFER. Rebinding the Loopback into CLIENT_VRF_NAME co-locates the
+        # trap route with the ingress VRF so the test passes uniformly
+        # across platforms. The other testcases (vrf_selection,
+        # server_id_override) do not use --source-interface, so no rebind
+        # is required.
+        if testcase == "source_intf":
+            saved_loopback_ips = _save_interface_ip_entries(
+                duthost, "LOOPBACK_INTERFACE", loopback_for_src)
+            for key in list(saved_loopback_ips.keys()):
+                if key.startswith(loopback_ip_key_prefix):
+                    ip_with_mask = key.split("|", 2)[2]
+                    duthost.shell(
+                        f"sudo config interface ip remove {loopback_for_src} {ip_with_mask}",
+                        module_ignore_errors=True)
+            duthost.shell(
+                f"sudo config interface vrf bind {loopback_for_src} {CLIENT_VRF_NAME}")
+            _restore_interface_ip_entries(duthost, saved_loopback_ips)
+
         for dhcp_relay in dut_dhcp_relay_data:
             dhcp_servers = ",".join(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
             duthost.shell(f'config dhcpv4_relay del {vlan_iface}')
@@ -483,6 +522,22 @@ def test_dhcp_relay_with_non_default_vrf(
 
     finally:
         duthost.shell(f"config dhcpv4_relay del {vlan_iface}", module_ignore_errors=True)
+
+        # Unbind the source-interface Loopback from CLIENT_VRF_NAME before
+        # deleting the VRF so it has no remaining member interfaces.
+        # Only needed when we rebound it (source_intf testcase).
+        if saved_loopback_ips:
+            loopback_ip_key_prefix = "LOOPBACK_INTERFACE|{}|".format(loopback_for_src)
+            for key in list(saved_loopback_ips.keys()):
+                if key.startswith(loopback_ip_key_prefix):
+                    ip_with_mask = key.split("|", 2)[2]
+                    duthost.shell(
+                        f"sudo config interface ip remove {loopback_for_src} {ip_with_mask}",
+                        module_ignore_errors=True)
+            duthost.shell(
+                f"sudo config interface vrf unbind {loopback_for_src}",
+                module_ignore_errors=True)
+
         # VRF config cleanup
         duthost.shell(f"sudo config route del prefix vrf {CLIENT_VRF_NAME} 0.0.0.0/0 nexthop"
                       f" vrf {CLIENT_VRF_NAME} {first_params['nexthop']}")
@@ -495,6 +550,7 @@ def test_dhcp_relay_with_non_default_vrf(
         # Instead, we save and restore the exact CONFIG_DB entries via redis-cli,
         # preserving all attributes (e.g. the secondary flag). intfmgrd then
         # automatically applies the restored entries to the kernel.
+        _restore_interface_ip_entries(duthost, saved_loopback_ips)
         _restore_interface_ip_entries(duthost, saved_vlan_ips)
         _restore_interface_ip_entries(duthost, saved_pc_ips)
         duthost.shell("sudo config save -y")


### PR DESCRIPTION
…hcp_relay_with_non_default_vrf

test_dhcp_relay_with_non_default_vrf[source_intf] fails on platforms whose silicon enforces strict per-VRF IP2ME (CPU-trap) routing (e.g. Broadcom Helix4 / Arista CCS-720DT-48S), while passing on platforms whose silicon implicitly punts IP2ME globally (e.g. Broadcom Tomahawk2 / Arista DCS-7260CX3-64).

Root cause:

The test places the Vlan and uplink PortChannels in Vrf01 but leaves Loopback0 (used as --source-interface, so giaddr = Loopback0 IP) in the default VRF. The server OFFER is unicast back to the Loopback IP and ingresses on Vrf01. SONiC orchagent installs the IP2ME trap-to-CPU route per-VRF - intfsorch.cpp::addIp2MeRoute() is called with vr_id = port.m_vr_id - so the trap entry for the Loopback IP lives only in the default VRF. Silicon that strictly honours that scope has no matching trap in Vrf01 and drops the OFFER; silicon that treats IP2ME as global punts regardless of VRF, masking the mismatch.

Fix:

Rebind the source-interface Loopback into CLIENT_VRF_NAME for the duration of the test so the IP2ME trap route is co-located with the ingress VRF. The test then passes uniformly across platforms.

Uses the existing _save_interface_ip_entries / _restore_interface_ip_entries helpers so all Loopback IP attributes (IPv4, IPv6, secondary flag, etc.) are preserved across the rebind and restored on teardown.

Verified on bjw2-can-720dt-3 (Helix4, previously failing):
  3 passed in 770.06s
  - test_dhcp_relay_with_non_default_vrf[vrf_selection-sonic-relay-agent]
  - test_dhcp_relay_with_non_default_vrf[source_intf-sonic-relay-agent]  (previously FAIL)
  - test_dhcp_relay_with_non_default_vrf[server_id_override-sonic-relay-agent]

Note: the underlying cross-VRF IP2ME platform behaviour divergence is tracked separately; this commit only aligns the test's VRF layout with what all current SONiC platforms support.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

 Summary: Fix `test_dhcp_relay_with_non_default_vrf[source_intf]` so it passes uniformly across Broadcom platforms. Previously this parameterization FAILed on strict-per-VRF IP2ME silicon (Helix4 / CCS-720DT-48S) and PASSed on permissive-IP2ME silicon (Tomahawk2 / DCS-7260CX3-64) because the test left `Loopback0` in the default VRF while the data plane 
was in `Vrf01`, so the OFFER unicast to `giaddr = Loopback0 IP` had no matching IP2ME trap route in the ingress VRF on strict platforms.
 
 The change rebinds the source-interface Loopback into `CLIENT_VRF_NAME` for the duration of the test, co-locating the IP2ME trap route with the ingress VRF. Uses the existing `_save_interface_ip_entries` / `_restore_interface_ip_entries` helpers so all Loopback IP attributes (IPv4, IPv6, secondary flag, etc.) are preserved across the rebind and fully 
restored on teardown.
 
 Fixes # N/A — the underlying cross-VRF IP2ME platform behaviour divergence is tracked in a separate issue (linked below); this PR only unblocks the regression on strict-per-VRF platforms.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

 `test_dhcp_relay_with_non_default_vrf[source_intf]` was consistently failing on T0/M0 testbeds built on Arista CCS-720DT-48S (Broadcom Helix4) while passing on DCS-7260CX3-64 (Broadcom Tomahawk2), running the same SONiC image. Per-Ethernet + `any`-interface tcpdump on the Helix4 DUT showed that the server OFFER never reaches the DUT host kernel — it is 
dropped by the silicon. tcpdump taps at L2 ingress (pre-VRF-routing), so the drop is not a kernel / VRF-socket issue.
 
 The test places the Vlan and all uplink PortChannels in `Vrf01`, leaves `Loopback0` in the default VRF, and configures dhcrelay with `--source-interface Loopback0 --link-selection enable`. That makes the relay set `giaddr = Loopback0 IP` and causes the server to unicast the OFFER back to the Loopback IP, ingressing on `Vrf01`.
 
 SONiC orchagent installs the IP2ME (trap-to-CPU) route per-VRF:
 
 ```cpp
 // sonic-swss/orchagent/intfsorch.cpp
 addIp2MeRoute(port.m_vr_id, *ip_prefix);
 ...
 unicast_route_entry.vr_id = vrf_id;   // scoped to the interface's own VRF
```

So the trap entry for the Loopback IP exists only in default VRF. Helix4 honours that scope strictly (no trap match in Vrf01 → silicon drops or forwards the OFFER out Vrf01's default route, never punting to CPU). Tomahawk2 punts IP2ME globally regardless of vr_id, which masks the mismatch. Test pass/fail was therefore a silent function of platform, not of
SONiC correctness.

#### How did you do it?

Added a step right after the existing VRF setup (Step 5) that rebinds the --source-interface Loopback into CLIENT_VRF_NAME, and the inverse unbind in the finally block before config vrf del:

 1. _save_interface_ip_entries(duthost, "LOOPBACK_INTERFACE", loopback_for_src) — capture every CONFIG_DB attribute on the Loopback.
 2. config interface ip remove each saved IP (config interface vrf bind strips IPs).
 3. config interface vrf bind Loopback0 Vrf01.
 4. config interface ip add each saved IP back.
 5. In finally, symmetric remove-IP + config interface vrf unbind first (so the VRF has no members for config vrf del), then call _restore_interface_ip_entries(duthost, saved_loopback_ips) alongside the existing Vlan/PortChannel restores to put every original attribute back exactly.

Matches the save/restore pattern already used for Vlan and PortChannel interfaces in the same test, so v6 addresses and secondary flags survive the rebind.

#### How did you verify/test it?

Ran the full parameterised test on bjw2-can-720dt-3 (CCS-720DT-48S / Helix4 / M0 topology), which was failing before the change:

 Image:  SONiC.20251110.19  (master, build commit d45b800adc)
 Kernel: 6.12.41+deb13-sonic-amd64
 
 ================= 3 passed, 409 warnings in 770.06s (0:12:50) ==================
 PASSED  test_dhcp_relay_with_non_default_vrf[vrf_selection-sonic-relay-agent]
 PASSED  test_dhcp_relay_with_non_default_vrf[source_intf-sonic-relay-agent]   <-- previously FAIL
 PASSED  test_dhcp_relay_with_non_default_vrf[server_id_override-sonic-relay-agent]

No DUT left in a dirty state after teardown — show ip interface, show vrf, and redis-cli -n 4 KEYS "LOOPBACK_INTERFACE*" on the DUT matched pre-test state. BGP sessions on Loopback0 came back up automatically once Loopback0 was restored to default VRF in the finally block.

#### Any platform specific information?

This change is safe and desirable on every platform. It removes the silent platform dependency: the test now exercises the same VRF layout on every ASIC family and no longer relies on permissive cross-VRF IP2ME punt behaviour that isn't guaranteed by SAI.

The underlying platform behavioural divergence (strict-per-VRF IP2ME on Helix4 vs. permissive on Tomahawk2) is a separate platform/SAI question being tracked in its own issue and is not blocked by / does not block this PR.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
