### PR TITLE
dhcp_relay: fix test_dhcp_relay_with_different_non_default_vrf on pla…

### DIFF
--- a/tests/dhcp_relay/test_dhcpv4_relay.py
+++ b/tests/dhcp_relay/test_dhcpv4_relay.py
@@ -523,10 +523,15 @@ def test_dhcp_relay_with_different_non_default_vrf(
         3. Bind VLAN interface to CLIENT_VRF_NAME and PortChannels to SERVER_VRF_NAME.
         4. Reassign IPs back to the interfaces.
         5. Add default routes in SERVER_VRF_NAME for DHCP server reachability.
-        6. Configure DHCP relay with vrf_selection and link_selection enabled.
-        7. Run the DHCP relay test from the PTF host.
-        8. Optionally validate DHCP relay logs using loganalyzer.
-        9. Cleanup: remove routes and VRF bindings, restore original config.
+        6. Rebind the source-interface Loopback into SERVER_VRF_NAME so the IP2ME
+           (CPU-trap) route for the Loopback IP lives in the same VRF that the
+           OFFER ingresses on (required on platforms that enforce strict per-VRF
+           IP2ME, e.g. Broadcom Helix4).
+        7. Configure DHCP relay with vrf_selection and link_selection enabled.
+        8. Run the DHCP relay test from the PTF host.
+        9. Optionally validate DHCP relay logs using loganalyzer.
+        10. Cleanup: remove routes and VRF bindings, restore original config
+            (including unbinding the Loopback from SERVER_VRF_NAME).
 
     Expected Results:
         - DHCP Discover, Offer, Request, and ACK messages are relayed successfully across different VRFs.
@@ -574,7 +579,40 @@ def test_dhcp_relay_with_different_non_default_vrf(
     duthost.shell(f"sudo config route add prefix vrf {SERVER_VRF_NAME} 0.0.0.0/0 nexthop"
                   f" vrf {SERVER_VRF_NAME} {first_params['nexthop']}")
 
+    # Pre-initialize Loopback rebind locals so the finally block's existence
+    # check still works even if Step 6 itself raises before assigning them.
+    loopback_for_src = dut_dhcp_relay_data[0]['loopback_iface']
+    loopback_ip_key_prefix = "LOOPBACK_INTERFACE|{}|".format(loopback_for_src)
+    saved_loopback_ips = {}
+
+    # Move the try: to cover Step 6 as well so that any partial failure during
+    # the Loopback IP-strip / vrf bind / restore sequence still triggers the
+    # cleanup in the finally block.
     try:
+        # Step 6: Rebind the source-interface Loopback into SERVER_VRF_NAME for
+        # the duration of the test. This test passes --source-interface
+        # Loopback0, so dhcp4relay sets giaddr to the Loopback IP and a real
+        # DHCP server unicasts the OFFER back to that IP (this is exactly what
+        # PTF mocks once source_interface=True / link_selection=True are passed
+        # below). The OFFER ingresses on the server-facing PortChannel uplinks,
+        # which are bound to SERVER_VRF_NAME. If Loopback0 stays in the default
+        # VRF, platforms whose silicon enforces strict per-VRF IP2ME handling
+        # (for example, Broadcom Helix4) have no matching trap entry in
+        # SERVER_VRF_NAME and silently drop the OFFER. Rebinding the Loopback
+        # into SERVER_VRF_NAME co-locates the trap route with the OFFER ingress
+        # VRF so the test passes uniformly across platforms.
+        saved_loopback_ips = _save_interface_ip_entries(
+            duthost, "LOOPBACK_INTERFACE", loopback_for_src)
+        for key in list(saved_loopback_ips.keys()):
+            if key.startswith(loopback_ip_key_prefix):
+                ip_with_mask = key.split("|", 2)[2]
+                duthost.shell(
+                    f"sudo config interface ip remove {loopback_for_src} {ip_with_mask}",
+                    module_ignore_errors=True)
+        duthost.shell(
+            f"sudo config interface vrf bind {loopback_for_src} {SERVER_VRF_NAME}")
+        _restore_interface_ip_entries(duthost, saved_loopback_ips)
+
         for dhcp_relay in dut_dhcp_relay_data:
             dhcp_servers = ",".join(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
             loopback_iface = dhcp_relay["loopback_iface"]    # noqa: F841
@@ -610,6 +648,16 @@ def test_dhcp_relay_with_different_non_default_vrf(
                                "client_vrf": CLIENT_VRF_NAME,
                                "link_selection_ip": str(dhcp_relay['downlink_vlan_iface']['link_selection_ip']),
                                "server_vrf": True,
+                               # Tell PTF to mock a real DHCP server that honors giaddr.
+                               # Without these flags, create_dhcp_offer_packet() falls into
+                               # the elif branch and unicasts the OFFER to relay_iface_ip
+                               # (Vlan IP, in CLIENT_VRF) instead of switch_loopback_ip
+                               # (Loopback IP). Since this test's data plane crosses VRFs,
+                               # targeting the Vlan IP from the SERVER_VRF ingress means
+                               # the OFFER never matches any IP2ME entry on platforms that
+                               # enforce strict per-VRF IP2ME (e.g. Broadcom Helix4).
+                               "source_interface": True,
+                               "link_selection": True,
                                "portchannels_ip_list": dhcp_relay['portchannels_ip_list'],
                                "downlink_vlan_iface_name": str(dhcp_relay['downlink_vlan_iface']['name'])},
                        log_file="/tmp/test_dhcp_relay_with_different_non_default_vrf.DHCPTest.log", is_python3=True)
@@ -620,6 +668,23 @@ def test_dhcp_relay_with_different_non_default_vrf(
 
     finally:
         duthost.shell(f"config dhcpv4_relay del {vlan_iface}", module_ignore_errors=True)
+
+        # Unbind the source-interface Loopback from SERVER_VRF_NAME before
+        # deleting the VRF so it has no remaining member interfaces. Restore
+        # the saved CONFIG_DB entries so all original Loopback IP attributes
+        # (IPv4, IPv6, secondary flag, etc.) come back.
+        if saved_loopback_ips:
+            for key in list(saved_loopback_ips.keys()):
+                if key.startswith(loopback_ip_key_prefix):
+                    ip_with_mask = key.split("|", 2)[2]
+                    duthost.shell(
+                        f"sudo config interface ip remove {loopback_for_src} {ip_with_mask}",
+                        module_ignore_errors=True)
+            duthost.shell(
+                f"sudo config interface vrf unbind {loopback_for_src}",
+                module_ignore_errors=True)
+            _restore_interface_ip_entries(duthost, saved_loopback_ips)
+
         # VRF config cleanup
         duthost.shell(f"sudo config route del prefix vrf {SERVER_VRF_NAME} 0.0.0.0/0 nexthop"
                       f" vrf {SERVER_VRF_NAME} {first_params['nexthop']}")


### PR DESCRIPTION
…tforms with strict per-VRF IP2ME

test_dhcp_relay_with_different_non_default_vrf fails on platforms whose silicon enforces strict per-VRF IP2ME / CPU-trap routing (e.g. Broadcom Helix4 / Arista CCS-720DT-48S), while passing on platforms whose silicon implicitly punts IP2ME globally (e.g. Broadcom Tomahawk2).

Two independent issues had to be fixed:

1) PTF mock server target IP (test bug)

   The test configures dhcp_relay with --source-interface Loopback0
   --link-selection enable. dhcp4relay therefore correctly emits the
   relayed DISCOVER with giaddr = Loopback0 IP, and a real DHCP server
   would unicast the OFFER back to that IP.

   But the PTF kwargs for this test never set source_interface /
   link_selection on the PTF side, so dhcp_relay_test.py::create_dhcp_offer_packet()
   falls through to the elif branch and unicasts the OFFER to
   relay_iface_ip (the Vlan1000 IP, in CLIENT_VRF_NAME), not to
   switch_loopback_ip. PTF was modelling a server that ignores giaddr.
   This passes on Tomahawk2 because IP2ME is global, masking the bug.
   On Helix4 the OFFER targets an IP that is owned by CLIENT_VRF only
   while ingressing on a SERVER_VRF uplink, so silicon drops it.

   Fix: pass source_interface=True, link_selection=True to the PTF
   ptf_runner kwargs so PTF unicasts the OFFER to the Loopback IP.

2) Cross-VRF IP2ME (platform behavior divergence, masked test-side)

   Even with PTF corrected, the OFFER ingresses on a SERVER_VRF
   PortChannel uplink while Loopback0 lives in the default VRF.
   sonic-swss/orchagent installs the IP2ME trap-to-CPU route per-VRF
   (intfsorch.cpp::addIp2MeRoute is called with vr_id = port.m_vr_id),
   so on Helix4 the trap entry for the Loopback IP is not visible from
   SERVER_VRF and the OFFER is dropped before the host kernel sees it.
   Tomahawk2 punts IP2ME globally, hiding the divergence.

   Fix: rebind Loopback0 into SERVER_VRF_NAME for the duration of the
   test, using the existing _save_interface_ip_entries /
   _restore_interface_ip_entries helpers so IPv6 and secondary-flag
   attributes are preserved across the rebind and restored on teardown.

Verified on bjw2-can-720dt-3 (Helix4, previously failing):

  test_dhcp_relay_with_different_non_default_vrf[sonic-relay-agent]
  ============== 1 passed in 359.67s (0:05:59) ==============
  Post-test DUT monit: clean (no stale ASIC routes).

Note: the underlying cross-VRF IP2ME platform behaviour divergence is tracked separately; this commit only aligns the test setup with what all current SONiC platforms support.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
 
 Summary:
 Fixes `test_dhcp_relay_with_different_non_default_vrf` which has been failing on Broadcom Helix4 platforms (Arista CCS-720DT-48S) since the test was added. The failure had two compounding root causes — a PTF mock-server bug that was masked on Tomahawk2 by silicon-level global IP2ME punt behavior, and a cross-VRF IP2ME divergence between SONiC platforms 
that is being tracked as a separate platform/SAI behavior issue.
 
 This PR is **not blocked by and does not depend on** #24043 (which fixes a sibling test, `test_dhcp_relay_with_non_default_vrf[source_intf]`, with the same Loopback-rebind idiom). The two PRs touch different functions in the same file and use the same proven pattern, but each is self-contained.
 
 Reviewer entry points:
 - `tests/dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_with_different_non_default_vrf` — the patched test
 - `ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py::create_dhcp_offer_packet` — the PTF branch logic that the new kwargs target
 - Related issue tracking the underlying SAI cross-VRF IP2ME divergence: see issue link in commit thread
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

 `test_dhcp_relay_with_different_non_default_vrf` has been silently failing on Helix4 (720dt) DUTs in the SONiC baseline regression while passing on Tomahawk2 (7260) DUTs against the same SONiC image. Triage showed the test combines 
(a) an inconsistent PTF mock — DUT is told to use `--source-interface Loopback0` but PTF mocks a server that unicasts OFFERs to the Vlan IP instead — with 
(b) a real per-VRF IP2ME silicon-behavior divergence that is masked on platforms with permissive global IP2ME punt. The combination produced platform-specific test fragility with no operator-visible signal.
 
#### How did you do it?

 1. **PTF kwarg fix.** Added `source_interface=True, link_selection=True` to the `ptf_runner` params for this test, so `create_dhcp_offer_packet()` takes the `(link_selection AND source_interface)` branch and unicasts the OFFER to `switch_loopback_ip` (giaddr-correct, real-server behavior).
 2. **Loopback VRF co-location.** Added a Step 6 that rebinds `Loopback0` into `SERVER_VRF_NAME` for the duration of the test, with a matching `finally` cleanup that unbinds it and restores all original IP attributes via the existing `_save_interface_ip_entries` / `_restore_interface_ip_entries` helpers (preserves IPv6, secondary flags, etc.). This co-locates the IP2ME (CPU-trap) route for `Loopback0`'s IP with the OFFER ingress VRF on platforms that enforce strict per-VRF IP2ME.
 
 No production code is changed. The fix is purely test-side.

#### How did you verify/test it?

 - Ran `tests/dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_with_different_non_default_vrf` on `testbed-bjw2-can-720dt-3` (Arista CCS-720DT-48S, Broadcom Helix4, m0 topology) — previously failing platform.
 - Pre-fix baseline (after a clean `config reload -y -f`): **FAIL** at `verify_offer_received` (`Expected packet was not received on device 0, port 0`).
 - Confirmed root cause via DUT-side packet captures (`-i Ethernet48..51`, `-i Vlan1000`, `-i any`, plus inside the `dhcp_relay` container) and PTF log (`/tmp/test_dhcp_relay_with_different_non_default_vrf.DHCPTest.log`):
   - DUT correctly relays DISCOVER with `giaddr=10.1.0.32` (Loopback0 IP) on uplinks (48 frames captured on Ethernet48).
   - PTF emits OFFER with `dst_ip=192.168.0.1` (Vlan IP, **not** the Loopback IP) — confirming the PTF mock bug.
   - **Zero** OFFER frames seen on any host-side interface — confirming silicon-level drop.
 - Post-fix run with this PR's patch: **1 passed in 359.67s** + post-run DUT `monit` summary clean (no stale ASIC routes, `routeCheck` OK).
 
#### Any platform specific information?

 - Confirmed-failing-without-fix platforms: Broadcom Helix4 (Arista CCS-720DT-48S). Likely affects other ASICs that strictly honor per-VRF IP2ME.
 - Implicitly-passing platforms (where the PTF mock bug was historically masked): Broadcom Tomahawk2 (Arista DCS-7260CX3-64).
 - The fix is platform-agnostic — it makes PTF behave like a real DHCP server and ensures the IP2ME route is in the OFFER ingress VRF, both of which are correct on every platform.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
