### PR TITLE
tests/gnmi: use --insecure instead of --noTLS for test environments

### DIFF
--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -123,6 +123,7 @@ class GNMIEnvironment(object):
                     if match:
                         self.gnmi_port = int(match.group(1))
                         # Check for --noTLS flag
+                        # --noTLS means no TLS; --insecure means TLS with self-signed cert (use_tls=True)
                         self.use_tls = '--noTLS' not in res['stdout']
                         logger.info(f"Detected from process: port={self.gnmi_port}, tls={self.use_tls}")
                         return
@@ -131,7 +132,7 @@ class GNMIEnvironment(object):
 
         # Final fallback: use standard defaults
         self.gnmi_port = 8080
-        self.use_tls = False
+        self.use_tls = True  # default to insecure TLS (GNMI|certs configured in tests)
         logger.info(f"Using default config: port={self.gnmi_port}, tls={self.use_tls}")
 
 
@@ -425,3 +426,40 @@ def gnmi_capabilities(duthost, localhost):
         return -1, output['stderr']
     else:
         return 0, output['stdout']
+
+
+def ensure_gnmi_insecure_mode(duthost, mode=GNMIEnvironment.GNMI_MODE):
+    """
+    Configure GNMI/TELEMETRY certs table in CONFIG_DB with empty cert fields.
+    This causes the startup script to use --insecure (TLS with self-signed cert)
+    instead of --noTLS (cleartext), improving security while maintaining test compatibility.
+
+    Args:
+        duthost: DUT host object
+        mode: GNMI_MODE uses GNMI|certs table; TELEMETRY_MODE uses TELEMETRY|certs
+    """
+    if mode == GNMIEnvironment.GNMI_MODE:
+        table = "GNMI|certs"
+    else:
+        table = "TELEMETRY|certs"
+
+    logger.info(f"Configuring {table} with empty cert fields to enable --insecure mode")
+    # Include ca_crt "" to avoid jq returning string "null" for missing key,
+    # which would cause telemetry startup script to pass --ca_crt null and block port binding.
+    duthost.shell(f'sonic-db-cli CONFIG_DB hset "{table}" server_crt "" server_key "" ca_crt ""',
+                  module_ignore_errors=True)
+
+
+def cleanup_gnmi_insecure_mode(duthost, mode=GNMIEnvironment.GNMI_MODE):
+    """Remove the empty cert config added by ensure_gnmi_insecure_mode."""
+    if mode == GNMIEnvironment.GNMI_MODE:
+        table = "GNMI|certs"
+    else:
+        table = "TELEMETRY|certs"
+
+    # Only remove if no real certs are configured
+    result = duthost.shell(f'sonic-db-cli CONFIG_DB hget "{table}" server_crt',
+                           module_ignore_errors=True)
+    if result['stdout'].strip() == "":
+        logger.info(f"Removing empty cert config from {table}")
+        duthost.shell(f'sonic-db-cli CONFIG_DB del "{table}"', module_ignore_errors=True)

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -506,7 +506,7 @@ def gnoi_request_dpu(duthost, localhost, dpu_index, module, rpc, request_json_da
     cmd += "-cert /etc/sonic/telemetry/gnmiclient.crt "
     cmd += "-key /etc/sonic/telemetry/gnmiclient.key "
     cmd += "-ca /etc/sonic/telemetry/gnmiCA.pem "
-    cmd += "-notls "
+    cmd += "-insecure "
     cmd += "-logtostderr -module {} -rpc {} ".format(module, rpc)
     cmd += f'-jsonin \'{request_json_data}\''
     output = duthost.shell(cmd, module_ignore_errors=True)

--- a/tests/zmq/conftest.py
+++ b/tests/zmq/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+import logging
+
+from tests.common.helpers.gnmi_utils import ensure_gnmi_insecure_mode, cleanup_gnmi_insecure_mode, GNMIEnvironment
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def setup_gnmi_insecure(duthosts, rand_one_dut_hostname):
+    """
+    Configure GNMI|certs with empty cert fields so telemetry starts with --insecure
+    (TLS with self-signed cert) instead of --noTLS (cleartext).
+
+    This mirrors the pattern of setup_gnoi_tls_server but uses the lightweight
+    --insecure mode rather than full certificate management.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    ensure_gnmi_insecure_mode(duthost, mode=GNMIEnvironment.GNMI_MODE)
+    yield
+    cleanup_gnmi_insecure_mode(duthost, mode=GNMIEnvironment.GNMI_MODE)

--- a/tests/zmq/test_gnmi_zmq.py
+++ b/tests/zmq/test_gnmi_zmq.py
@@ -81,7 +81,6 @@ def gnmi_set(duthost, ptfhost, delete_list, update_list, replace_list):
     port = 8080
     cmd = '/root/env-python3/bin/python /root/gnxi/gnmi_cli_py/py_gnmicli.py '
     cmd += '--timeout 30 --notls '
-    cmd += '--notls '
     cmd += '-t %s -p %u ' % (ip, port)
     cmd += '-xo sonic-db '
     cmd += '-m set-update '
@@ -121,7 +120,7 @@ def test_gnmi_zmq(duthosts,
                   enable_zmq):
     duthost = duthosts[rand_one_dut_hostname]
 
-    command = 'ps -auxww | grep "/usr/sbin/telemetry -logtostderr --noTLS --port 8080"'
+    command = 'ps -auxww | grep "/usr/sbin/telemetry.*--port 8080"'
     gnmi_process = duthost.shell(command, module_ignore_errors=True)["stdout"]
     logger.debug("gnmi_process: {}".format(gnmi_process))
 


### PR DESCRIPTION
When no certs are configured, telemetry defaults to --noTLS (cleartext gRPC). This change configures an empty GNMI|certs entry in CONFIG_DB before tests run, causing telemetry to use --insecure (TLS with self-signed cert) instead.

Changes:
- Add setup_gnmi_insecure fixture in tests/zmq/conftest.py to configure GNMI|certs before ZMQ tests
- Wire enable_zmq fixture to depend on setup_gnmi_insecure so config reload picks up --insecure mode
- Update test commands from -notls to -insecure
- Add ensure_gnmi_insecure_mode/cleanup_gnmi_insecure_mode helpers to gnmi_utils.py
- Update default use_tls fallback to True (insecure TLS is the expected test mode)