### PR TITLE
T2:Snappi:parallelize config-reload in snappi-pfcwd/test_pfcwd_basic_with_snappi.py

### DIFF
--- a/tests/snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py
@@ -5,6 +5,7 @@ import time
 import re
 from collections import defaultdict
 from tests.common.helpers.assertions import pytest_require, pytest_assert                               # noqa: F401
+from tests.common.helpers.parallel import parallel_run
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts, \
     fanout_graph_facts_multidut     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
@@ -47,8 +48,9 @@ def save_restore_config(tgen_port_info):          # noqa: F811
     for duthost in list(set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']])):
         duthost.shell(f"sudo cp {dest}/config_db*json /etc/sonic/")
 
-    for duthost in list(set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']])):
-        config_reload(duthost)
+    def my_config_reload(node, results):
+        config_reload(node, safe_reload=True)
+    parallel_run(my_config_reload, [], {}, list(set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']])))
 
 
 @pytest.mark.parametrize("trigger_pfcwd", [True, False])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This simple PR parallelize the config_reload in pfcwd/test_pfcwd_basic_with_snappi.py in the cleanup code. There is no change in logic of the code, just saving time by parallel execution of config-reload for the duts.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
Saving time for config-reload in T2.

#### How did you do it?
Parallelize the config-reload code in the above function.

#### How did you verify/test it?
Ran it in our testbeds:
```
============================================================================================ short test summary info =============================================================================================
PASSED snappi_tests/pfcwd/test_pfcwd_a2a_with_snappi.py::test_multidut_pfcwd_all_to_all[multidut_port_info0-True]
PASSED snappi_tests/pfcwd/test_pfcwd_a2a_with_snappi.py::test_multidut_pfcwd_all_to_all[multidut_port_info0-False]
PASSED snappi_tests/pfcwd/test_pfcwd_a2a_with_snappi.py::test_multidut_pfcwd_all_to_all[multidut_port_info1-True]
PASSED snappi_tests/pfcwd/test_pfcwd_a2a_with_snappi.py::test_multidut_pfcwd_all_to_all[multidut_port_info1-False]
PASSED snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_drop_90_10[multidut_port_info0-verify_port_speed1-False]
PASSED snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_drop_90_10[multidut_port_info1-verify_port_speed1-False]
PASSED snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_drop_uni[multidut_port_info0-verify_port_speed1-False]
PASSED snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_drop_uni[multidut_port_info1-verify_port_speed1-False]
PASSED snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_drop_over_subs_40_09[multidut_port_info0-verify_port_speed_oversubscribe1-True]
PASSED snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_drop_over_subs_40_09[multidut_port_info1-verify_port_speed_oversubscribe1-True]
PASSED snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_disable_pause_cngtn[multidut_port_info0-verify_port_speed1-True]
PASSED snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_disable_pause_cngtn[multidut_port_info1-verify_port_speed1-True]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio[multidut_port_info0-True]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio[multidut_port_info0-False]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio[multidut_port_info1-True]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio[multidut_port_info1-False]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info0-True]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info0-False]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info1-True]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info1-False]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_reboot[multidut_port_info0-cold-c30-lc4|4-True]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_reboot[multidut_port_info0-cold-c30-lc4|4-False]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_reboot[multidut_port_info1-cold-c30-lc4|4-True]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_reboot[multidut_port_info1-cold-c30-lc4|4-False]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_reboot[multidut_port_info0-cold-True]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_reboot[multidut_port_info0-cold-False]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_reboot[multidut_port_info1-cold-True]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_reboot[multidut_port_info1-cold-False]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_service_restart[multidut_port_info0-True-swss]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_service_restart[multidut_port_info0-False-swss]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_service_restart[multidut_port_info1-True-swss]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_service_restart[multidut_port_info1-False-swss]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_restart_service[multidut_port_info0-True-swss]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_restart_service[multidut_port_info0-False-swss]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_restart_service[multidut_port_info1-True-swss]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_restart_service[multidut_port_info1-False-swss]
PASSED snappi_tests/pfcwd/test_pfcwd_burst_storm_with_snappi.py::test_pfcwd_burst_storm_single_lossless_prio[multidut_port_info0]
PASSED snappi_tests/pfcwd/test_pfcwd_burst_storm_with_snappi.py::test_pfcwd_burst_storm_single_lossless_prio[multidut_port_info1]
SKIPPED [2] snappi_tests/pfcwd/test_pfcwd_actions.py:94: Need Minimum of 2 ports of speed 100G defined in ansible/files/*links.csv file
SKIPPED [2] snappi_tests/pfcwd/test_pfcwd_actions.py:222: Need Minimum of 2 ports of speed 100G defined in ansible/files/*links.csv file
SKIPPED [4] snappi_tests/pfcwd/test_pfcwd_actions.py:350: Forward action is not supported in cisco-8000.
SKIPPED [2] snappi_tests/pfcwd/test_pfcwd_actions.py:524: Need Minimum of 3 ports of speed 100G defined in ansible/files/*links.csv file
SKIPPED [4] snappi_tests/pfcwd/test_pfcwd_actions.py:662: Forward action is not supported in cisco-8000.
SKIPPED [2] snappi_tests/pfcwd/test_pfcwd_actions.py:833: Need Minimum of 2 ports of speed 100G defined in ansible/files/*links.csv file
SKIPPED [4] snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py:144: Reboot type warm is not supported on cisco-8000 switches
SKIPPED [4] snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py:144: Reboot type fast is not supported on cisco-8000 switches
SKIPPED [4] snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py:192: Reboot type warm is not supported on cisco-8000 switches
SKIPPED [4] snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py:192: Reboot type fast is not supported on cisco-8000 switches
SKIPPED [1] snappi_tests/pfcwd/test_pfcwd_mixed_speed.py:27: got empty parameter set ['multidut_port_info'], function test_mixed_speed_pfcwd_enable at /data/tests/snappi_tests/pfcwd/test_pfcwd_mixed_speed.py:26
SKIPPED [1] snappi_tests/pfcwd/test_pfcwd_mixed_speed.py:163: got empty parameter set ['multidut_port_info'], function test_mixed_speed_pfcwd_disable at /data/tests/snappi_tests/pfcwd/test_pfcwd_mixed_speed.py:162
ERROR snappi_tests/pfcwd/test_pfcwd_a2a_with_snappi.py::test_multidut_pfcwd_all_to_all[multidut_port_info0-True] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost c30-lc2>', 'analyze_logs--<MultiAsicSonicHost c30-lc4>']" failed with exit code "1"
ERROR snappi_tests/pfcwd/test_pfcwd_a2a_with_snappi.py::test_multidut_pfcwd_all_to_all[multidut_port_info1-True] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost c30-lc2>', 'analyze_logs--<MultiAsicSonicHost c30-lc4>']" failed with exit code "1"
ERROR snappi_tests/pfcwd/test_pfcwd_a2a_with_snappi.py::test_multidut_pfcwd_all_to_all[multidut_port_info1-False] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost c30-lc2>', 'analyze_logs--<MultiAsicSonicHost c30-lc4>']" failed with exit code "1"
ERROR snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_drop_90_10[multidut_port_info0-verify_port_speed1-False] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost c30-lc4>', 'analyze_logs--<MultiAsicSonicHost c30-lc2>']" failed with exit code "1"
ERROR snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_drop_90_10[multidut_port_info1-verify_port_speed1-False] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost c30-lc2>', 'analyze_logs--<MultiAsicSonicHost c30-lc4>']" failed with exit code "1"
ERROR snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_drop_uni[multidut_port_info0-verify_port_speed1-False] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost c30-lc2>', 'analyze_logs--<MultiAsicSonicHost c30-lc4>']" failed with exit code "1"
ERROR snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_drop_uni[multidut_port_info1-verify_port_speed1-False] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost c30-lc2>', 'analyze_logs--<MultiAsicSonicHost c30-lc4>']" failed with exit code "1"
ERROR snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_drop_over_subs_40_09[multidut_port_info0-verify_port_speed_oversubscribe1-True] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost c30-lc2>', 'analyze_logs--<MultiAsicSonicHost c30-lc4>']" failed with exit code "1"
ERROR snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_drop_over_subs_40_09[multidut_port_info1-verify_port_speed_oversubscribe1-True] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost c30-lc4>', 'analyze_logs--<MultiAsicSonicHost c30-lc2>']" failed with exit code "1"
ERROR snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_disable_pause_cngtn[multidut_port_info0-verify_port_speed1-True] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost c30-lc2>', 'analyze_logs--<MultiAsicSonicHost c30-lc4>']" failed with exit code "1"
ERROR snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_disable_pause_cngtn[multidut_port_info1-verify_port_speed1-True] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost c30-lc4>', 'analyze_logs--<MultiAsicSonicHost c30-lc2>']" failed with exit code "1"
ERROR snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio[multidut_port_info0-True] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost c30-lc2>', 'analyze_logs--<MultiAsicSonicHost c30-lc4>']" failed with exit code "1"
ERROR snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio[multidut_port_info1-True] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost c30-lc2>', 'analyze_logs--<MultiAsicSonicHost c30-lc4>']" failed with exit code "1"
ERROR snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info0-True] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost c30-lc4>', 'analyze_logs--<MultiAsicSonicHost c30-lc2>']" failed with exit code "1"
ERROR snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info1-True] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost c30-lc4>', 'analyze_logs--<MultiAsicSonicHost c30-lc2>']" failed with exit code "1"
ERROR snappi_tests/pfcwd/test_pfcwd_burst_storm_with_snappi.py::test_pfcwd_burst_storm_single_lossless_prio[multidut_port_info0] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost c30-lc2>', 'analyze_logs--<MultiAsicSonicHost c30-lc4>']" failed with exit code "1"
ERROR snappi_tests/pfcwd/test_pfcwd_m2o_with_snappi.py::test_pfcwd_many_to_one[multidut_port_info0-True] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost c30-lc2>', 'analyze_logs--<MultiAsicSonicHost c30-lc4>']" failed with exit code "1"
ERROR snappi_tests/pfcwd/test_pfcwd_m2o_with_snappi.py::test_pfcwd_many_to_one[multidut_port_info0-False] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost c30-lc2>', 'analyze_logs--<MultiAsicSonicHost c30-lc4>']" failed with exit code "1"
ERROR snappi_tests/pfcwd/test_pfcwd_m2o_with_snappi.py::test_pfcwd_many_to_one[multidut_port_info1-False] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost c30-lc2>', 'analyze_logs--<MultiAsicSonicHost c30-lc4>']" failed with exit code "1"
ERROR snappi_tests/pfcwd/test_pfcwd_runtime_traffic_with_snappi.py::test_pfcwd_runtime_traffic[multidut_port_info0] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost c30-lc2>', 'analyze_logs--<MultiAsicSonicHost c30-lc4>']" failed with exit code "1"
FAILED snappi_tests/pfcwd/test_pfcwd_m2o_with_snappi.py::test_pfcwd_many_to_one[multidut_port_info0-True] - snappi_ixnetwork.exceptions.SnappiIxnException:   File "/home/sonic/.local/lib/python3.8/site-packages/snappi_ixnetwork/snappi_api.py", line 588, in get_metrics
FAILED snappi_tests/pfcwd/test_pfcwd_m2o_with_snappi.py::test_pfcwd_many_to_one[multidut_port_info0-False] - Failed: Test Flow 1 -> 0 Prio 4 should not have any dropped packet
FAILED snappi_tests/pfcwd/test_pfcwd_m2o_with_snappi.py::test_pfcwd_many_to_one[multidut_port_info1-True] - Failed: Background Flow 1 -> 0 Prio 1 should not have any dropped packet
FAILED snappi_tests/pfcwd/test_pfcwd_m2o_with_snappi.py::test_pfcwd_many_to_one[multidut_port_info1-False] - Failed: Test Flow 1 -> 0 Prio 3 should not have any dropped packet
FAILED snappi_tests/pfcwd/test_pfcwd_runtime_traffic_with_snappi.py::test_pfcwd_runtime_traffic[multidut_port_info0] - Failed: 100574712 packets of Data Flow Prio 1 are dropped
FAILED snappi_tests/pfcwd/test_pfcwd_runtime_traffic_with_snappi.py::test_pfcwd_runtime_traffic[multidut_port_info1] - Failed: 100574712 packets of Data Flow Prio 1 are dropped
================================================================ 6 failed, 38 passed, 34 skipped, 42 warnings, 20 errors in 37466.58s (10:24:26) =================================================================
sonic@snappi-sonic-mgmt-msft-t2-400g:/data/tests$ 
```