### PR TITLE
console servers: Skip warm and fast reboots for C0.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1427,7 +1427,6 @@ platform_tests/test_reboot.py::test_fast_reboot:
       - "'isolated' in topo_name"
       - "is_smartswitch==True"
       - "'f2' in topo_name"
-      - "asic_type in ['vpp']"
   xfail:
     reason: "case failed and waiting for fix"
     conditions:
@@ -1455,7 +1454,6 @@ platform_tests/test_reboot.py::test_warm_reboot:
       - "hwsku in ['Arista-7050CX3-32S-C28S4']"
       - "'isolated' in topo_name"
       - "'f2' in topo_name"
-      - "asic_type in ['vpp']"
   xfail:
     reason: "case failed and waiting for fix"
     conditions:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1419,7 +1419,7 @@ platform_tests/test_reboot.py::test_continuous_reboot:
 
 platform_tests/test_reboot.py::test_fast_reboot:
   skip:
-    reason: "Skip test_fast_reboot for M*/t1/t2 / Fast reboot is broken on dualtor topology. Its not supported in vpp platform. Skipping for now. / Skip for smartswitch topology."
+    reason: "Skip test_fast_reboot for M*/t1/t2/c* / Fast reboot is broken on dualtor topology. Its not supported in vpp platform. Skipping for now. / Skip for smartswitch topology."
     conditions_logical_operator: or
     conditions:
       - "topo_type in ['m0', 'mx', 'm1', 't1', 't2', 'lt2', 'ft2']"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1419,7 +1419,7 @@ platform_tests/test_reboot.py::test_continuous_reboot:
 
 platform_tests/test_reboot.py::test_fast_reboot:
   skip:
-    reason: "Skip test_fast_reboot for M*/t1/t2/c* / Fast reboot is broken on dualtor topology. Its not supported in vpp platform. Skipping for now. / Skip for smartswitch topology."
+    reason: "Skip test_fast_reboot for M*/t1/t2/c* / Fast reboot is broken on dualtor topology. Skipping for now. / Skip for smartswitch topology."
     conditions_logical_operator: or
     conditions:
       - "topo_type in ['m0', 'mx', 'm1', 't1', 't2', 'lt2', 'ft2', 'c0']"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1419,7 +1419,7 @@ platform_tests/test_reboot.py::test_continuous_reboot:
 
 platform_tests/test_reboot.py::test_fast_reboot:
   skip:
-    reason: "Skip test_fast_reboot for M*/t1/t2 / Fast reboot is broken on dualtor topology. Skipping for now. / Skip for smartswitch topology."
+    reason: "Skip test_fast_reboot for M*/t1/t2 / Fast reboot is broken on dualtor topology. Its not supported in vpp platform. Skipping for now. / Skip for smartswitch topology."
     conditions_logical_operator: or
     conditions:
       - "topo_type in ['m0', 'mx', 'm1', 't1', 't2', 'lt2', 'ft2']"
@@ -1427,6 +1427,7 @@ platform_tests/test_reboot.py::test_fast_reboot:
       - "'isolated' in topo_name"
       - "is_smartswitch==True"
       - "'f2' in topo_name"
+      - "asic_type in ['vpp']"
   xfail:
     reason: "case failed and waiting for fix"
     conditions:
@@ -1446,7 +1447,7 @@ platform_tests/test_reboot.py::test_soft_reboot:
 
 platform_tests/test_reboot.py::test_warm_reboot:
   skip:
-    reason: "Skip test_warm_reboot for M*/t1/t2/lt2/ft2. Warm reboot is broken on dualtor topology. Skipping for now."
+    reason: "Skip test_warm_reboot for M*/t1/t2/lt2/ft2. Warm reboot is broken on dualtor topology. Its not supported in vpp platform. Skipping for now."
     conditions_logical_operator: or
     conditions:
       - "topo_type in ['m0', 'mx', 'm1', 't1', 't2', 'lt2', 'ft2']"
@@ -1454,6 +1455,7 @@ platform_tests/test_reboot.py::test_warm_reboot:
       - "hwsku in ['Arista-7050CX3-32S-C28S4']"
       - "'isolated' in topo_name"
       - "'f2' in topo_name"
+      - "asic_type in ['vpp']"
   xfail:
     reason: "case failed and waiting for fix"
     conditions:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1422,7 +1422,7 @@ platform_tests/test_reboot.py::test_fast_reboot:
     reason: "Skip test_fast_reboot for M*/t1/t2/c* / Fast reboot is broken on dualtor topology. Its not supported in vpp platform. Skipping for now. / Skip for smartswitch topology."
     conditions_logical_operator: or
     conditions:
-      - "topo_type in ['m0', 'mx', 'm1', 't1', 't2', 'lt2', 'ft2']"
+      - "topo_type in ['m0', 'mx', 'm1', 't1', 't2', 'lt2', 'ft2', 'c0']"
       - "'dualtor' in topo_name and https://github.com/sonic-net/sonic-buildimage/issues/16502"
       - "'isolated' in topo_name"
       - "is_smartswitch==True"
@@ -1447,10 +1447,10 @@ platform_tests/test_reboot.py::test_soft_reboot:
 
 platform_tests/test_reboot.py::test_warm_reboot:
   skip:
-    reason: "Skip test_warm_reboot for M*/t1/t2/lt2/ft2. Warm reboot is broken on dualtor topology. Its not supported in vpp platform. Skipping for now."
+    reason: "Skip test_warm_reboot for M*/t1/t2/lt2/ft2/c*. Warm reboot is broken on dualtor topology. Its not supported in vpp platform. Skipping for now."
     conditions_logical_operator: or
     conditions:
-      - "topo_type in ['m0', 'mx', 'm1', 't1', 't2', 'lt2', 'ft2']"
+      - "topo_type in ['m0', 'mx', 'm1', 't1', 't2', 'lt2', 'ft2', 'c0']"
       - "'dualtor' in topo_name and https://github.com/sonic-net/sonic-buildimage/issues/16502"
       - "hwsku in ['Arista-7050CX3-32S-C28S4']"
       - "'isolated' in topo_name"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1446,7 +1446,7 @@ platform_tests/test_reboot.py::test_soft_reboot:
 
 platform_tests/test_reboot.py::test_warm_reboot:
   skip:
-    reason: "Skip test_warm_reboot for M*/t1/t2/lt2/ft2/c*. Warm reboot is broken on dualtor topology. Its not supported in vpp platform. Skipping for now."
+    reason: "Skip test_warm_reboot for M*/t1/t2/lt2/ft2/c*. Warm reboot is broken on dualtor topology. Skipping for now."
     conditions_logical_operator: or
     conditions:
       - "topo_type in ['m0', 'mx', 'm1', 't1', 't2', 'lt2', 'ft2', 'c0']"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip warm and fast reboots since they are not supported in console platforms.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The fast and warm reboots are not supported on C0. So we will add a skip for them in the platform-skip file.

#### How did you do it?
Added c0 topo type check in the platform conditional mark file.

#### How did you verify/test it?
Ran it in our testbed, and verified that the skips are working.

```
====================================================================================================== PASSES =======================================================================================================
___________________________________________________________________________________________ test_cold_reboot[sirc0-dut1] ____________________________________________________________________________________________
_________________________________________________________________________________________ test_watchdog_reboot[sirc0-dut1] __________________________________________________________________________________________
---------------------------------------------------------- generated xml file: /run_logs/sir-c0/pr23595/2026-04-19-22-47-51/platform_tests/test_reboot.xml ----------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
============================================================================================== short test summary info ==============================================================================================
PASSED platform_tests/test_reboot.py::test_cold_reboot[sirc0-dut1]
PASSED platform_tests/test_reboot.py::test_watchdog_reboot[sirc0-dut1]
SKIPPED [1] platform_tests/test_reboot.py: Skip test_soft_reboot for M* and test is supported only on S6100 hwsku
SKIPPED [1] platform_tests/test_reboot.py: Skip test_fast_reboot for M*/t1/t2 / Fast reboot is broken on dualtor topology. Its not supported in vpp platform. Skipping for now. / Skip for smartswitch topology.
SKIPPED [1] platform_tests/test_reboot.py: Skip test_warm_reboot for M*/t1/t2/lt2/ft2. Warm reboot is broken on dualtor topology. Its not supported in vpp platform. Skipping for now.
ERROR platform_tests/test_reboot.py::test_continuous_reboot[sirc0-dut1] - AssertionError: Not all pmon daemons running.
FAILED platform_tests/test_reboot.py::test_continuous_reboot[sirc0-dut1] - AssertionError: Not all pmon daemons running.
====================================================================== 1 failed, 2 passed, 3 skipped, 1 warning, 1 error in 2549.52s (0:42:29) ======================================================================
sonic@arctos_cicd_all_202603:/data/tests$ 
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
