### PR TITLE
Wait for monit container_checker after gNMI cert config recovery

### DIFF
--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -86,6 +86,21 @@ def check_gnmi_status(duthost):
     return "RUNNING" in output['stdout']
 
 
+def _check_monit_container_checker(duthost):
+    """Check if monit container_checker service is healthy.
+
+    After gNMI cert config recovery, monit needs time to re-evaluate
+    container status. This function checks if container_checker has
+    returned to a healthy state (OK or Status ok).
+    """
+    monit_services = duthost.get_monit_services_status()
+    if not monit_services:
+        return False
+    container_checker = monit_services.get("container_checker", {})
+    status = container_checker.get("service_status", "")
+    return status in ("OK", "Status ok")
+
+
 def recover_cert_config(duthost):
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     # Kill the GNMI process
@@ -119,6 +134,13 @@ def recover_cert_config(duthost):
     if not check_container_state(duthost, "telemetry", should_be_running=True):
         logger.info("Telemetry container is not running after cert config recovery, restarting it")
         duthost.shell("sudo systemctl restart telemetry", module_ignore_errors=True)
+
+    # Wait for monit container_checker to report healthy status.
+    # After restarting processes/containers, monit needs time to re-evaluate
+    # service status. Without this wait, post-test sanity check may see stale
+    # "Status failed" from container_checker and fail the test on teardown.
+    if not wait_until(120, 10, 30, _check_monit_container_checker, duthost):
+        logger.warning("Monit container_checker did not recover to healthy status after cert config recovery")
 
 
 def check_ntp_sync_status(duthost):


### PR DESCRIPTION

### Description of PR

After gNMI cert config tests, `recover_cert_config()` restarts processes inside the gnmi container and optionally restarts the telemetry container. However, monit's `container_checker` program needs time to re-evaluate and report healthy status. Without waiting, post-test sanity check sees stale **Status failed** from `container_checker` and marks the test as error on teardown.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Persistent post-test sanity failures on gNMI tests observed across **7 out of 8 recent Cisco-8101 dualtor builds** (Mar 31 - Apr 13). After `apply_cert_config()` stops all supervisord programs in the gnmi container, `recover_cert_config()` restarts them but returns immediately. Monit `container_checker` (configured with `if status != 0 for 5 times within 5 cycles then alert`) reports `Status failed` after ~5 min of telemetry being down, causing post-test sanity check to fail.

Affected tests include:
- `test_gnmi_configdb_subscribe_authenticate` (7 builds, 19 hits)
- `test_gnmi_appldb_01` (6 builds, 18 hits)
- `test_gnmi_authorize_failed_with_revoked_cert` (6 builds, 17 hits)
- `test_gnmi_counterdb_streaming_sample_02` (4 builds, 12 hits)
- `test_gnmi_latency_01` (6 builds, 12 hits)

#### How did you do it?
Added `_check_monit_container_checker()` helper that queries `monit status` for the `container_checker` service. Called `wait_until(120, 10, 30, ...)` at the end of `recover_cert_config()` to wait up to 120s (with 30s initial delay) for `container_checker` to report OK.

#### How did you verify/test it?
Manually verified on DUT bjw2-can-8101c1-3:
1. Stopped telemetry container — after ~5 min, `container_checker` reached **Status failed** (5 consecutive failures)
2. Restarted telemetry — within ~1 min, `container_checker` recovered to **OK**
3. `wait_until(120, 10, 30)` provides sufficient margin for recovery

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
