### PR TITLE
Delete SRv6 SIDs before locators in teardown

### DIFF
--- a/tests/packet_trimming/conftest.py
+++ b/tests/packet_trimming/conftest.py
@@ -283,14 +283,14 @@ def setup_srv6(duthost, request, rand_selected_dut, upstream_links, peer_links, 
     rand_selected_dut.command(f'sonic-db-cli CONFIG_DB DEL "STATIC_ROUTE|default|{SRV6_ROUTE_PREFIX}"')
     logger.info(f"Removed static route {SRV6_ROUTE_PREFIX}")
 
-    for locator_param in SRV6_MY_LOCATOR_LIST:
-        locator_name = locator_param[0]
-        del_srv6_locator(rand_selected_dut, locator_name)
-
     for sid_param in SRV6_MY_SID_LIST:
         locator_name = sid_param[0]
         ip_addr = sid_param[1]
         del_srv6_sid(rand_selected_dut, locator_name, ip_addr)
+
+    for locator_param in SRV6_MY_LOCATOR_LIST:
+        locator_name = locator_param[0]
+        del_srv6_locator(rand_selected_dut, locator_name)
 
 
 @pytest.fixture(scope="function")

--- a/tests/srv6/conftest.py
+++ b/tests/srv6/conftest.py
@@ -119,14 +119,14 @@ def config_setup(request, rand_selected_dut, srv6_crm_total_sids, upstream_links
         verify_srv6_counterpoll_status(rand_selected_dut, 'disable')
 
     with allure.step('Delete SRv6 Locators and SIDs'):
-        for locator_param in MyLocators.my_locator_list:
-            locator_name = locator_param[0]
-            del_srv6_locator(rand_selected_dut, locator_name)
-
         for sid_param in MySIDs.MY_SID_LIST:
             locator_name = sid_param[0]
             ip_addr = sid_param[1]
             del_srv6_sid(rand_selected_dut, locator_name, ip_addr)
+
+        for locator_param in MyLocators.my_locator_list:
+            locator_name = locator_param[0]
+            del_srv6_locator(rand_selected_dut, locator_name)
 
     with allure.step('Verify the CRM usage of SRv6 SID after the test'):
         used_mysid_num = 0


### PR DESCRIPTION
Summary: Delete SRv6 SIDs before locators in teardown
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
In the SRv6 and packet trimming cases, fixture will create SRv6 locators and SIDs in the setup stage and remove them in the teardown stage.

In the current code, the order is incorrect in the teardown stage (delete locators first, SIDs second), triggers a staticd crash issue: https://github.com/sonic-net/sonic-buildimage/issues/22690.
The issue had been fixed by FRR in https://github.com/FRRouting/frr/pull/20660. Fix is present in frr-10.4.3 / frr-10.5.2 / frr-10.6.0 tags but not in 10.4.1
```
create_srv6_locator
create_srv6_sid

yield

del_srv6_locator
del_srv6_sid
```


#### How did you do it?
Reverse the fixture teardown order in `tests/srv6/conftest.py` and `tests/packet_trimming/conftest.py` so SRv6 SIDs are removed before their parent locators.

#### How did you verify/test it?
Regression pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
