### PR TITLE
Fix SNMP ifInErrors/ifOutErrors validation for multi-member PortChannels

### DIFF
--- a/tests/snmp/test_snmp_interfaces.py
+++ b/tests/snmp/test_snmp_interfaces.py
@@ -301,10 +301,10 @@ def verify_snmp_counter(duthost, localhost, creds_all_duts, hostip, mg_facts, ri
     if not check_counter_with_margin(int(rif_snmp_facts['ifOutDiscards']), expected_out_discards, 'ifOutDiscards'):
         return False
 
-    if not check_counter_with_margin(int(rif_snmp_facts['ifInErrors']), COUNTER_VALUE, 'ifInErrors'):
+    if not check_counter_with_margin(int(rif_snmp_facts['ifInErrors']), COUNTER_VALUE * num_port_intfs, 'ifInErrors'):
         return False
 
-    if not check_counter_with_margin(int(rif_snmp_facts['ifOutErrors']), COUNTER_VALUE, 'ifOutErrors'):
+    if not check_counter_with_margin(int(rif_snmp_facts['ifOutErrors']), COUNTER_VALUE * num_port_intfs, 'ifOutErrors'):
         return False
 
     return True


### PR DESCRIPTION
### Description of PR

Summary:
Fix regression in `verify_snmp_counter` where `ifInErrors` and `ifOutErrors` expected values were not multiplied by `num_port_intfs` for multi-member PortChannel interfaces.

PR #23272 refactored the counter validation to use `check_counter_with_margin` but regressed the `ifInErrors`/`ifOutErrors` expected values back to `COUNTER_VALUE` instead of `COUNTER_VALUE * num_port_intfs`, which was originally fixed by PR #22118.

PBI#36433389

failed reason:
```
>       pytest_assert(wait_until(60, 10, 0, verify_snmp_counter, duthost, localhost, creds_all_duts, hostip, mg_facts,
                                 rif_interface, rif_counters, port_counters, num_port_intfs),
                      "SNMP counter validate Failure")
E       Failed: SNMP counter validate Failure
```
test log:
`14/04/2026 00:26:02 test_snmp_interfaces.check_counter_with_ L0277 INFO   | ifInErrors value is 10000 but must not exceed 5100 (expected 5000 + margin 100)`

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

For PortChannel interfaces with multiple member ports (e.g., 2-member LAG), `COUNTER_VALUE` (5000) is set on **each** member port's `SAI_PORT_STAT_IF_IN_ERRORS` and `SAI_PORT_STAT_IF_OUT_ERRORS`. SNMP aggregates these across all member ports, so the reported `ifInErrors`/`ifOutErrors` equals `COUNTER_VALUE * num_port_intfs`.

PR #22118 correctly fixed this, but PR #23272 (which refactored to `check_counter_with_margin`) inadvertently regressed it back to comparing against just `COUNTER_VALUE`. This causes `test_snmp_interfaces_error_discard` to fail on any PortChannel with >1 member port.

Note: `ifInDiscards` and `ifOutDiscards` are already correctly using aggregated port counters — only `ifInErrors`/`ifOutErrors` had this regression.

#### How did you do it?

Changed the expected values in `verify_snmp_counter` from `COUNTER_VALUE` to `COUNTER_VALUE * num_port_intfs` for both `ifInErrors` and `ifOutErrors`, matching the pattern already used for port counter assertions and discards.

#### How did you verify/test it?

Ran `test_snmp_interfaces_error_discard` on testbed-bjw2-can-t0-7260-1 (t0-116 topology, internal-202511) with this fix:
- **Before fix**: FAILED with `SNMP counter validate Failure` (ifInErrors was 10000 but expected 5000, because PortChannel had 2 members)
- **After fix**: **1 passed** in 365.74s

#### Any platform specific information?
Affects any platform where PortChannels have multiple member ports. Verified on Broadcom 7260CX3 (Memory:4096M, 64 ports).

#### Supported testbed topology if it's a new test case?
N/A (existing test fix)

### Documentation
N/A