### PR TITLE
Add Arista-7060CX-32S-Q32 to broadcom hwsku lists for QoS tests

### DIFF
--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -7,13 +7,13 @@ ansible_altpassword: YourPaSsWoRd
 
 sonic_version: "v2"
 
-broadcom_hwskus: [ 'ACS-S6000', 'ACS-S6000-Q24S32', 'ACS-N3132', 'Force10-S6000', 'Force10-S6000-Q24S32', 'Nexus-3132-GE-Q32', 'Nexus-3132-GX-Q32', 'Arista-7050-QX32', 'Arista-7050-QX-32S', 'Force10-S6100', 'Accton-AS7712-32X', 'Arista-7260CX3-D108C8',  'Arista-7260CX3-C64', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-C32-T1', 'Arista-7060CX-32S-D48C8', 'Celestica-DX010-C32', 'Celestica-E1031-T48S4', "Seastone-DX010", 'Arista-7260CX3-Q64' ]
+broadcom_hwskus: [ 'ACS-S6000', 'ACS-S6000-Q24S32', 'ACS-N3132', 'Force10-S6000', 'Force10-S6000-Q24S32', 'Nexus-3132-GE-Q32', 'Nexus-3132-GX-Q32', 'Arista-7050-QX32', 'Arista-7050-QX-32S', 'Force10-S6100', 'Accton-AS7712-32X', 'Arista-7260CX3-D108C8',  'Arista-7260CX3-C64', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-C32-T1', 'Arista-7060CX-32S-D48C8', 'Arista-7060CX-32S-Q32', 'Celestica-DX010-C32', 'Celestica-E1031-T48S4', "Seastone-DX010", 'Arista-7260CX3-Q64' ]
 
 broadcom_td2_hwskus: ['Force10-S6000', 'Force10-S6000-Q24S32', 'Arista-7050-QX32', 'Arista-7050-QX-32S', 'Nexus-3164', 'Arista-7050QX32S-Q32']
 broadcom_td3_hwskus: ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7050CX3-32S-C28S4', 'Arista-7050CX3-32S-S128', 'Arista-7050CX3-32S-C6S104', 'Arista-7050CX3-32S-C28S16',
                       'Arista-7050CX3-32C-C32', 'Arista-7050CX3-32C-D48C8', 'Arista-7050CX3-32C-C28S4', 'Arista-7050CX3-32C-S128', 'Arista-7050CX3-32C-C6S104', 'Arista-7050CX3-32C-C28S16']
 broadcom_td4_hwskus: ['Nokia-IXR7220-D4-36D']
-broadcom_th_hwskus: ['Force10-S6100', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-C32-T1', 'Arista-7060CX-32S-D48C8', 'Celestica-DX010-C32', "Seastone-DX010" ]
+broadcom_th_hwskus: ['Force10-S6100', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-C32-T1', 'Arista-7060CX-32S-D48C8', 'Arista-7060CX-32S-Q32', 'Celestica-DX010-C32', "Seastone-DX010" ]
 broadcom_th2_hwskus: ['Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Arista-7260CX3-C64', 'Arista-7260CX3-Q44', 'Arista-7260CX3-Q64']
 broadcom_th3_hwskus: ['DellEMC-Z9332f-M-O16C64',  'DellEMC-Z9332f-O32']
 broadcom_th4_hwskus: ['Arista-7060DX5-32', 'Arista-7060DX5-64S']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add `Arista-7060CX-32S-Q32` to `broadcom_hwskus` and `broadcom_th_hwskus` in `ansible/group_vars/sonic/variables`. This HwSKU was missing from the lists, causing all QoS SAI tests to fail with `Cannot identify DUT ASIC type` during setup on this platform (90 failures in 60 days).

The 7060CX-32S-Q32 uses Broadcom Tomahawk 1 (TH/BCM56960), same ASIC as the existing `Arista-7060CX-32S-C32` and `Arista-7060CX-32S-D48C8` entries.

Fixes https://dev.azure.com/msazure/One/_workitems/edit/37507175

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fix `Cannot identify DUT ASIC type` assertion failure for Arista-7060CX-32S-Q32 in `tests/qos/qos_sai_base.py`. The test setup iterates `SUPPORTED_ASIC_LIST` and checks if the DUT HwSKU is in the corresponding `broadcom_*_hwskus` variable. Q32 was not listed, so `dutAsic` remained `None`.

#### How did you do it?
Added `Arista-7060CX-32S-Q32` to:
- `broadcom_hwskus` (generic broadcom list)
- `broadcom_th_hwskus` (Tomahawk 1 specific list)

Same pattern as existing 7060CX-32S-C32 and D48C8 entries.

#### How did you verify/test it?
Code review. Same well-established pattern as PR #22437 (Cisco-8101-32FH-O), PR #13230 (TH5), PR #10410 (SN4700-O8C48).

#### Any platform specific information?
Arista-7060CX-32S-Q32, Broadcom Tomahawk 1 (BCM56960), T0 topology.

#### Supported testbed topology if it's a new test case?
N/A (bug fix, not new test case)

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A