### PR TITLE
[BMC] Skip more tests unsupported on BMC topology

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2630,6 +2630,12 @@ generic_config_updater/test_dynamic_acl.py::test_gcu_acl_forward_rule_replacemen
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/21571 and 't0-isolated-d256u256s2' in topo_name"
 
+generic_config_updater/test_ecn_config_update.py:
+  skip:
+    reason: "ECN config updates rely on SWSS/orchagent; BMC SONiC image has no SWSS container"
+    conditions:
+      - "'bmc' in topo_type"
+
 generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates:
   skip:
     reason: "WRED dynamic config updates not implemented in SAI for PAC/GR2 ASICs"
@@ -2645,6 +2651,12 @@ generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[None-r
     reason: "Xfail due to GH issue: https://github.com/sonic-net/sonic-mgmt/issues/23597"
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/23597 and platform in ['x86_64-nvidia_sn5640-r0']"
+
+generic_config_updater/test_eth_interface.py:
+  skip:
+    reason: "Ethernet interface config update tests require the PORT table; BMC SONiC image has no PORT table (no front-panel data ports)"
+    conditions:
+      - "'bmc' in topo_type"
 
 generic_config_updater/test_eth_interface.py::test_port_speed_change_oper_status:
   skip:
@@ -4140,6 +4152,30 @@ platform_tests/test_reboot.py:
     conditions:
       - "(is_multi_asic==True) and (asic_type in ['vs']) and https://github.com/sonic-net/sonic-buildimage/issues/26743"
 
+platform_tests/test_reboot.py::test_fast_reboot:
+  skip:
+    reason: "fast-reboot is not supported on BMC SONiC image"
+    conditions:
+      - "'bmc' in topo_type"
+
+platform_tests/test_reboot.py::test_soft_reboot:
+  skip:
+    reason: "soft-reboot is not supported on BMC SONiC image"
+    conditions:
+      - "'bmc' in topo_type"
+
+platform_tests/test_reboot.py::test_warm_reboot:
+  skip:
+    reason: "warm-reboot is not supported on BMC SONiC image"
+    conditions:
+      - "'bmc' in topo_type"
+
+platform_tests/test_reboot.py::test_watchdog_reboot:
+  skip:
+    reason: "watchdog reboot is not supported on BMC SONiC image"
+    conditions:
+      - "'bmc' in topo_type"
+
 platform_tests/test_reload_config.py::test_reload_configuration:
   xfail:
     reason: "Test case has issue on the t0-isolated-d256u256s2 topo or smartswitch platform"
@@ -4667,9 +4703,11 @@ reboot/test_reboot_blocking_mode.py:
 #######################################
 reset_factory/test_reset_factory.py:
   skip:
-    reason: "This case has a known issue which leaves the DUT in a bad state. Skipping until the issue is addressed."
+    reason: "This case has a known issue which leaves the DUT in a bad state. Skipping until the issue is addressed. Also skipped on BMC due to a system clock image issue."
+    conditions_logical_operator: or
     conditions:
       - https://github.com/sonic-net/sonic-mgmt/issues/11103
+      - "'bmc' in topo_type"
 
 #######################################
 #####         restapi             #####
@@ -4925,6 +4963,12 @@ show_techsupport/test_auto_techsupport.py::TestAutoTechSupport::test_max_limit[c
     conditions:
       - https://github.com/sonic-net/sonic-buildimage/issues/15051
 
+show_techsupport/test_auto_techsupport.py::TestAutoTechSupport::test_rate_limit_interval:
+  skip:
+    reason: "auto techsupport relies on the eventd service which is not available on BMC SONiC image"
+    conditions:
+      - "'bmc' in topo_type"
+
 show_techsupport/test_auto_techsupport.py::TestAutoTechSupport::test_sai_sdk_dump:
   skip:
     reason: "Test supported only on Nvidia(Mellanox) devices / auto techsupport on multi asic platforms doesnt work"
@@ -4932,6 +4976,12 @@ show_techsupport/test_auto_techsupport.py::TestAutoTechSupport::test_sai_sdk_dum
     conditions:
       - "asic_type not in ['mellanox']"
       - "is_multi_asic==True"
+
+show_techsupport/test_auto_techsupport.py::TestAutoTechSupport::test_sanity:
+  skip:
+    reason: "auto techsupport relies on the eventd service which is not available on BMC SONiC image"
+    conditions:
+      - "'bmc' in topo_type"
 
 show_techsupport/test_techsupport.py::test_techsupport:
   xfail:
@@ -5312,6 +5362,12 @@ system_health/test_system_health.py::test_service_checker_with_process_exit:
     conditions:
       - "branch in ['internal-202012']"
       - "build_version.split('.')[1].isdigit() and int(build_version.split('.')[1]) <= 44"
+
+system_health/test_watchdog.py::test_orchagent_watchdog:
+  skip:
+    reason: "orchagent watchdog test requires SWSS/orchagent; BMC SONiC image has no orchagent"
+    conditions:
+      - "'bmc' in topo_type"
 
 #######################################
 #####           tacacs          #####


### PR DESCRIPTION
### Description of PR

BMC testbeds run with `--topology any,bmc`. Tests marked with `any` topology are automatically collected, but some of them depend on BMC SONiC image subsystems that are intentionally absent (SWSS/orchagent, PORT table, reboot support, eventd) or are impacted by known BMC image issues. These tests need to be skipped when running on BMC.

Adds / merges skip entries in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`, each gated on `''bmc'' in topo_type`:

| Test | Skip reason |
|------|-------------|
| `generic_config_updater/test_ecn_config_update.py` | No SWSS container on BMC |
| `generic_config_updater/test_eth_interface.py` | No PORT table (no front-panel data ports) on BMC |
| `platform_tests/test_reboot.py::test_soft_reboot` | soft-reboot not supported on BMC image |
| `platform_tests/test_reboot.py::test_fast_reboot` | fast-reboot not supported on BMC image |
| `platform_tests/test_reboot.py::test_warm_reboot` | warm-reboot not supported on BMC image |
| `platform_tests/test_reboot.py::test_watchdog_reboot` | watchdog reboot not supported on BMC image |
| `reset_factory/test_reset_factory.py` | System clock image issue on BMC (merged into existing entry with OR logic) |
| `system_health/test_watchdog.py::test_orchagent_watchdog` | No orchagent on BMC |
| `show_techsupport/test_auto_techsupport.py::TestAutoTechSupport::test_sanity` | No eventd service on BMC |
| `show_techsupport/test_auto_techsupport.py::TestAutoTechSupport::test_rate_limit_interval` | No eventd service on BMC |

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

A full sonic-mgmt baseline test run against a BMC testbed (~550 cases) surfaced `any`-topology tests that error/fail purely because their required subsystems are not present on the BMC SONiC image, or because of BMC-specific image issues. Skipping them correctly reflects that BMC does not ship those features.

#### How did you do it?

Added conditional-mark skip entries gated on `''bmc'' in topo_type`. For `reset_factory/test_reset_factory.py` an existing skip entry already exists (issue #11103); the BMC condition was merged in using `conditions_logical_operator: or` so both conditions remain in effect.

#### How did you verify/test it?

- Validated YAML syntax with `python3 -c "import yaml; yaml.safe_load(open(...))"`.
- Ran `.hooks/pre_commit_hooks/check_conditional_mark_sort.py` to confirm alphabetical order.
- Each entry was driven by a concrete failure in the baseline test run, with the root cause confirmed as a BMC image feature gap or image issue (not a test bug).

#### Any platform specific information?

Only affects testbeds whose topology type contains `bmc`; all other platforms are unaffected.

#### Supported testbed topology if it''s a new test case?

N/A — no new test cases.

### Documentation
N/A.