### PR TITLE
Fix DSCP mapping test failures: loganalyzer, and memory monitor

### DIFF
--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -24,7 +24,8 @@ from tests.common.fixtures.duthost_utils import dut_qos_maps_module  # noqa F401
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1')
+    pytest.mark.topology('t0', 't1'),
+    pytest.mark.disable_memory_utilization
 ]
 
 DEFAULT_MAPPING_TYPE = "AZURE"
@@ -520,7 +521,7 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
         ):
             with allure.step("Do warm-reboot"):
                 reboot(duthost, localhost, reboot_type="warm", safe_reboot=True, check_intf_up_ports=True,
-                       wait_warmboot_finalizer=True)
+                       wait_warmboot_finalizer=True, ignore_loganalyzer=loganalyzer)
 
             with allure.step("Run test after warm-reboot"):
                 self._run_test(ptfadapter, duthost, tbinfo, test_params, inner_dst_ip_list, dut_qos_maps_module,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fixed test_qos_dscp_mapping which was failing due to two issues: loganalyzer false positives during warm-reboot, and a memory utilization alarm triggered by expected post-reboot memory spikes.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
`test_qos_dscp_mapping` was failing due to two issues: loganalyzer false positives during warm-reboot, and a memory utilization alarm triggered by expected post-reboot memory spikes.

#### How did you do it?
- Added `ignore_loganalyzer=loganalyzer` to the `reboot()` call so benign warm-reboot syslog messages are suppressed.
- Added `pytest.mark.disable_memory_utilization` since the warm-reboot causes an expected transient memory spike that exceeds the 10% threshold.

#### How did you verify/test it?
Ran `test_qos_dscp_mapping.py` on `t0` topology (Cisco-8000). Uniform mode passed, pipe mode correctly skipped due to platform limitation. No errors in teardown.

#### Any platform specific information?
Tested on Cisco-8000 series.

#### Supported testbed topology if it's a new test case?
N/A — existing test, no topology changes.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

#### Test Run
[test_run_qos.log](https://github.com/user-attachments/files/26905250/test_run_qos.log)
