### PR TITLE
Skip test_qos_probe.py on multi-asic KVM and T2 KVM testbeds

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4346,7 +4346,7 @@ qos/test_qos_probe.py:
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/22599"
       # Multi-asic KVM: testPortIds empty for VS platform
       - "'t1-8-lag' in topo_name and https://github.com/sonic-net/sonic-mgmt/issues/24068"
-      # T2 KVM: SonicAsic.command() rejects module_ignore_errors
+      # T2: SonicAsic.command() rejects module_ignore_errors in updateFeatureState
       - "topo_type in ['t2'] and https://github.com/sonic-net/sonic-mgmt/issues/24069"
       # Cisco-8000 GB series (8102/8101 GB SKUs)
       - "hwsku in ['Cisco-8102-C64', 'Cisco-8101-O8C48', 'Cisco-8102-28FH-DPU-O'] and https://github.com/sonic-net/sonic-mgmt/issues/22601"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4344,6 +4344,10 @@ qos/test_qos_probe.py:
     conditions:
       # Virtual Switch support
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/22599"
+      # Multi-asic KVM: testPortIds empty for VS platform
+      - "'t1-8-lag' in topo_name and https://github.com/sonic-net/sonic-mgmt/issues/24068"
+      # T2 KVM: SonicAsic.command() rejects module_ignore_errors
+      - "topo_type in ['t2'] and https://github.com/sonic-net/sonic-mgmt/issues/24069"
       # Cisco-8000 GB series (8102/8101 GB SKUs)
       - "hwsku in ['Cisco-8102-C64', 'Cisco-8101-O8C48', 'Cisco-8102-28FH-DPU-O'] and https://github.com/sonic-net/sonic-mgmt/issues/22601"
       # Cisco-8000 GR/GR2 series (8101 GR/GR2 SKUs)


### PR DESCRIPTION
### Description of PR

Summary:
Add conditional_mark skip conditions for `test_qos_probe.py` on multi-asic KVM and T2 KVM testbeds where the test currently crashes due to known bugs.

Related to #24068 and #24069 (does not close them — the skips are gated on the issues being open).

### Type of change

- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

`test_qos_probe.py` (introduced in PR #22547) fails on:
1. **Multi-asic KVM** (`vms-kvm-four-asic-t1-lag`): `KeyError: 0` at `qos_sai_base.py:952` because `testPortIds` dict is empty — VS `dutConfig.json` is single-asic only (#24068)
2. **T2 KVM** (`vms-kvm-t2`): `TypeError: SonicAsic.command() got an unexpected keyword argument module_ignore_errors` at `qos_sai_base.py:1654` — `updateFeatureState()` passes a `SonicAsic` object which does not support `module_ignore_errors` kwarg (#24069)

The existing skip condition `asic_type in ["vs"]` (tracking #22599) covers single-asic VS, but these are additional distinct bugs on multi-asic and T2 topologies that need separate tracking.

#### How did you do it?

Added two new conditional_mark skip conditions in `tests_mark_conditions.yaml`:
- `is_multi_asic and asic_type in ["vs"]` gated on #24068
- `topo_type in ["t2"] and asic_type in ["vs"]` gated on #24069

When the tracking issues are closed (bugs fixed), the skips will automatically deactivate.

#### How did you verify/test it?

Verified the YAML syntax and condition expressions match existing patterns in the file. The conditions follow the same `<platform_check> and <issue_url>` pattern used by all other entries in the `test_qos_probe.py` skip block.

#### Any platform specific information?

Affects VS (Virtual Switch) platform only, on multi-asic and T2 KVM topologies.

#### Supported testbed topology if it's a new test case?

N/A — this is a skip condition, not a new test case.

### Documentation

N/A