### PR TITLE
Fixes BGP scale test route announcement timeout issue

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -132,6 +132,7 @@ def wait_for_http(host_ip, http_port, timeout=10):
             started = True
         except socket.error:
             tries += 1
+            time.sleep(1)
 
     return started
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Fixes BGP scale test HTTP connection timeout issue

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
The BGP scale test on the T1 topology failed during route announcement after restarting all exabgpv6 services due to an HTTP connection timeout. A missing sleep call caused the wait_for_http method to effectively perform no waiting.

#### How did you do it?
Added the sleep(1) back to wait_for_http method.

#### How did you verify/test it?
Run BGP scale test on T1 topology and verify no more HTTP connection errors.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
