### PR TITLE
[test/lldp] Ignore transient BRCM FEC counter errors in LLDP flap tests

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -31,6 +31,16 @@ def ignore_expected_loganalyzer_exceptions(duthosts, loganalyzer):
                 [
                     # Interface flaps in test_lldp_entry_table_after_flap can cause routeCheck to fail momentarily
                     r".*ERR.* 'routeCheck' status failed.*",
+                    # During interface flap, FlexCounter may poll FEC counters while the port PHY
+                    # is still link-training. Broadcom SAI returns "Operation disabled" (0xfffffff4)
+                    # which cascades through the counter read path. These are transient and resolve
+                    # once the link is up. Three patterns cover the full error cascade:
+                    #   1. SAI-level: FEC symbol error counter read returns "Operation disabled"
+                    #   2. SAI-level: parent function reports "port info data get failed"
+                    #   3. syncd-level: collectData fails to get port counter stats with error -2
+                    r".*ERR syncd#syncd.*_brcm_sai_read_fec_stat_err_counters.*Operation disabled.*",
+                    r".*ERR syncd#syncd.*_brcm_sai_read_fec_stat_err_counters.*port info data get failed.*",
+                    r".*ERR syncd#syncd.*collectData.*Failed to get stats of Port Counter.*: -2.*",
                 ]
             )
 


### PR DESCRIPTION
### Description of PR

Summary:
The lldp flap tests fail intermittently during loganalyzer teardown due to transient Broadcom SAI FEC counter read errors that appear in syslog during interface flap.

When FlexCounter polls FEC counters while a port's PHY is still link-training after shutdown/startup, 
the Broadcom SAI returns "Operation disabled" (0xfffffff4). This error cascades through three log lines:
1. `_brcm_sai_read_fec_stat_err_counters_acc`: SAI reports "Operation disabled"
2. `_brcm_sai_read_fec_stat_err_counters`: parent function reports "port info data get failed"
3. `collectData`: syncd reports "Failed to get stats of Port Counter" with error -2

These are harmless transient messages that resolve on the next poll cycle once the link is up. All actual test assertions pass the failures are only in loganalyzer teardown catching these unexpected ERR-level syslog entries.

This PR adds three narrowly-scoped regex patterns to the `ignore_expected_loganalyzer_exceptions` fixture to suppress only these specific FEC counter cascade errors during flap tests.

### Type of change

- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
12% failure rate on LLDP flap tests caused by loganalyzer catching benign Broadcom SAI FEC counter read errors that occur transiently during port link-up. The test logic itself passes every time, only the syslog monitoring reports false positives.

#### How did you do it?
Added three regex patterns to the existing `ignore_expected_loganalyzer_exceptions` fixture in `tests/lldp/test_lldp_syncd.py`. Each regex is narrowly scoped to match only the specific Broadcom FEC counter error cascade (function name + specific error string), ensuring real syncd errors are not suppressed.

#### How did you verify/test it?
- Confirmed all 45 historical failures match the same three syslog patterns being suppressed.
- Verified regex patterns do not match other syncd error types (different error codes, 
  different SAI functions, different daemons).

#### Any platform specific information?
The FEC counter errors are specific to Broadcom ASIC platforms. The regex patterns include 
`_brcm_sai_` prefix so they will not match on other vendor platforms.

#### Supported testbed topology if it's a new test case?
N/A 

### Documentation
N/A 