### PR TITLE
chore: skip test_monitoring_critical_processes for vs

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4193,6 +4193,12 @@ process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical
     conditions:
     - "https://github.com/sonic-net/sonic-buildimage/issues/10336"
 
+  skip:
+    reason: "Testcase ignored due to issue: https://github.com/sonic-net/sonic-buildimage/issues/10336, skipping on vs due to teardown would still runs and can't recover if we mark xfail"
+    conditions:
+    - "https://github.com/sonic-net/sonic-buildimage/issues/10336"
+    - "asic_type in ['vs']"
+
 process_monitoring/test_critical_process_monitoring.py::test_orchagent_heartbeat:
   skip:
     reason: This test is intended for Orchagent freeze scenario during warm-reboot. It is not required for T1 devices, and not supported on 202412 release.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Currently, by xfail test_ciritcal_process_monitoring, the test fixtures are still running.

Due to https://github.com/sonic-net/sonic-mgmt/pull/21889/changes, we introduce critical monitoring for database. 

When the test marked as xfail, teardown still runs and led to the ERROR in the subsequent test.

Fixes # (issue) 37580365

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
