### PR TITLE
[deleted] add portchannel using bond

### DIFF
--- a/ansible/library/ptf_portchannel.py
+++ b/ansible/library/ptf_portchannel.py
@@ -153,6 +153,29 @@ def disable_portchannel(module, teamd_config):
             module, cmd="supervisorctl stop portchannel-{}".format(conf["name"]), ignore_error=True)
 
 
+def create_bond(module, portchannel_config):
+    """Create bond interfaces with LACP mode and enslave member ports."""
+    for conf in portchannel_config:
+        name = conf["name"]
+        # Remove stale bond if it exists for idempotency
+        exec_command(module, "ip link del {}".format(name), ignore_error=True)
+        exec_command(module, "ip link add {} type bond mode 802.3ad".format(name))
+        for intf in conf["intfs"]:
+            exec_command(module, "ip link set dev {} down".format(intf))
+            exec_command(module, "ip link set dev {} master {}".format(intf, name))
+        exec_command(module, "ip link set dev {} up".format(name))
+
+
+def remove_bond(module, portchannel_config):
+    """Remove bond interfaces and restore member ports."""
+    for conf in portchannel_config:
+        name = conf["name"]
+        exec_command(module, "ip link set dev {} down".format(name), ignore_error=True)
+        exec_command(module, "ip link del {}".format(name), ignore_error=True)
+        for intf in conf["intfs"]:
+            exec_command(module, "ip link set dev {} up".format(intf), ignore_error=True)
+
+
 def setup_portchannel_conf():
     try:
         os.mkdir(portchannel_conf_path, 0o755)
@@ -165,23 +188,31 @@ def main():
         argument_spec=dict(
             cmd=dict(required=True, choices=['start', 'stop'], type='str'),
             portchannel_config=dict(required=True, type='dict'),
+            mode=dict(required=False, choices=['teamd', 'bond'], default='teamd', type='str'),
         ),
         supports_check_mode=False)
     cmd = module.params['cmd']
+    mode = module.params['mode']
     portchannel_config = module.params['portchannel_config']
-    teamd_config = parse_teamd_config(module, portchannel_config)
+    parsed_config = parse_teamd_config(module, portchannel_config)
 
     setup_portchannel_conf()
 
     try:
-        if cmd == 'start':
-            create_teamd_conf(module, teamd_config)
-            create_supervisor_conf(module, teamd_config)
-            enable_portchannel(module, teamd_config)
-        elif cmd == 'stop':
-            disable_portchannel(module, teamd_config)
-            remove_supervisor_conf(module, teamd_config)
-            remove_teamd_conf(module, teamd_config)
+        if mode == 'bond':
+            if cmd == 'start':
+                create_bond(module, parsed_config)
+            elif cmd == 'stop':
+                remove_bond(module, parsed_config)
+        else:
+            if cmd == 'start':
+                create_teamd_conf(module, parsed_config)
+                create_supervisor_conf(module, parsed_config)
+                enable_portchannel(module, parsed_config)
+            elif cmd == 'stop':
+                disable_portchannel(module, parsed_config)
+                remove_supervisor_conf(module, parsed_config)
+                remove_teamd_conf(module, parsed_config)
     except Exception:
         module.fail_json(msg=traceback.format_exc())
 

--- a/ansible/roles/vm_set/tasks/ptf_portchannel.yml
+++ b/ansible/roles/vm_set/tasks/ptf_portchannel.yml
@@ -14,10 +14,15 @@
   set_fact:
     portchannel_config: "{{ topology['DUT']['portchannel_config'] | default({})}}"
 
+- name: find portchannel mode
+  set_fact:
+    portchannel_mode: "{{ topology['DUT']['portchannel_mode'] | default('teamd') }}"
+
 - name: Start PTF portchannel
   ptf_portchannel:
     cmd: start
     portchannel_config: "{{ portchannel_config }}"
+    mode: "{{ portchannel_mode }}"
   delegate_to: "{{ ptf_host }}"
   when: ptf_portchannel_action == 'start'
 
@@ -25,6 +30,7 @@
   ptf_portchannel:
     cmd: stop
     portchannel_config: "{{ portchannel_config }}"
+    mode: "{{ portchannel_mode }}"
   delegate_to: "{{ ptf_host }}"
   ignore_unreachable: yes
   when: ptf_portchannel_action == 'stop'

--- a/ansible/vars/topo_t0-f2-d40u8.yml
+++ b/ansible/vars/topo_t0-f2-d40u8.yml
@@ -171,6 +171,44 @@ topology:
         - 23
       vm_offset: 7
   DUT:
+    portchannel_mode: bond
+    portchannel_config:
+      PortChannel1001:
+        intfs: [32, 33]
+      PortChannel1002:
+        intfs: [40, 41]
+      PortChannel1003:
+        intfs: [44, 45]
+      PortChannel1004:
+        intfs: [48, 49]
+      PortChannel1005:
+        intfs: [60, 61]
+      PortChannel1006:
+        intfs: [64, 65]
+      PortChannel1007:
+        intfs: [76, 77]
+      PortChannel1008:
+        intfs: [80, 81]
+      PortChannel1009:
+        intfs: [92, 93]
+      PortChannel1010:
+        intfs: [96, 97]
+      PortChannel1011:
+        intfs: [108, 109]
+      PortChannel1012:
+        intfs: [112, 113]
+      PortChannel1013:
+        intfs: [124, 125]
+      PortChannel1014:
+        intfs: [128, 129]
+      PortChannel1015:
+        intfs: [140, 141]
+      PortChannel1016:
+        intfs: [144, 145]
+      PortChannel1017:
+        intfs: [148, 149]
+      PortChannel1018:
+        intfs: [156, 157]
     vlan_configs:
       default_vlan_config: one_vlan_a
       one_vlan_a:


### PR DESCRIPTION
Cherry-picked from internal branch. Adds portchannel support using bond mode for PTF topology.

Changes:
- Updated ptf_portchannel.py to support bond-based portchannel creation
- Added portchannel tasks in ptf_portchannel.yml
- Added portchannel config to topo_t0-f2-d40u8.yml

Signed-off-by: Dashuai Zhang <dashuaizhang@microsoft.com>