### PR TITLE
Fix QoS DSCP test DUT mismatch in dualtor

### DIFF
--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -78,14 +78,15 @@ def route_config(nbrhosts, tbinfo):
 
 
 @pytest.fixture(scope='function')
-def dscp_config(dscp_mode, duthost, loganalyzer):
+def dscp_config(dscp_mode, rand_selected_dut, loganalyzer):
     """
     Test setup and teardown
 
     Args:
         request: pytest request
-        duthost (AnsibleHost): The DUT host
+        rand_selected_dut (AnsibleHost): The randomly selected DUT host
     """
+    duthost = rand_selected_dut
     asic_type = duthost.facts['asic_type']
 
     # global DSCP_TO_TC_MAP update is not supported on Broadcom platforms


### PR DESCRIPTION


The fixture now uses 'rand_selected_dut' instead of 'duthost' to ensure DSCP configuration is applied to the same DUT that will be tested. This guarantees both setup and validation occur on the same device.

Verified on dualtor-120 testbed with loop testing (10 runs) showing consistent pass rate after fix. Before fix, approximately 50% failure rate due to random DUT selection mismatch.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The dscp_config fixture was using 'duthost' parameter while the test_dscp_to_queue_mapping test uses 'rand_selected_dut'. In dualtor setups where two DUTs exist, this causes the fixture to configure one DUT (duthost) while the test randomly selects and validates a different DUT (rand_selected_dut), leading to intermittent test failures with error Failed: Wrong DSCP mode configured.

Summary:
Fixes #24080 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fixes intermittent test failures in `test_qos_dscp_mapping` on dualtor topologies. 
The test fails approximately 50% of the time with the error "Failed: Wrong DSCP mode configured" 
due to a DUT fixture mismatch between test setup and validation.

#### How did you do it?
Changed the `dscp_config` fixture parameter from `duthost` to `rand_selected_dut`
 to ensure both configuration setup and validation occur on the same DUT in dualtor environments.

  The fixture now:
  1. Accepts `rand_selected_dut` as a parameter (same as the test function)
  2. Assigns it to a local `duthost` variable for backward compatibility
  3. Ensures configuration is applied to the same DUT that will be validated

#### How did you verify/test it?
- Verified on dualtor-120 testbed (dt120) with loop testing (10 consecutive runs)
- Before fix: ~50% failure rate (random selection caused DUT mismatch)
- After fix: 100% pass rate (both setup and validation use same DUT)


#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
No

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A