### PR TITLE
[critical_services] Exclude snmp from tracking list on BMC topology

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -100,6 +100,12 @@ class MultiAsicSonicHost(object):
         if is_dpu and 'snmp' in service_list:
             service_list.remove('snmp')
 
+        # BMC topology: snmp is not deployed on BMC image (SNMP runs on the host NOS,
+        # not on the management-plane BMC board), so exclude it from critical services.
+        is_bmc = 'bmc' in (self.topo_type or '')
+        if is_bmc and 'snmp' in service_list:
+            service_list.remove('snmp')
+
         # Update the asic service based on feature table state and asic flag
         filtered_asic_services = []
         for service in self.sonichost.DEFAULT_ASIC_SERVICES:


### PR DESCRIPTION
### Description of PR

Summary:
Exclude `snmp` from the critical-services tracking list when the DUT is running on a BMC topology.

On a SONiC BMC board (and BMC topologies in general) the BMC runs a management-plane SONiC image. SNMP is not deployed on BMC by design ΓÇö it runs on the host NOS, not on the BMC. As a result, the default `critical_services = [pmon, snmp, database, lldp]` tracking list is incorrect for BMC, and a wide range of tests fail during teardown/sanity with:

```
Failed: All critical services should be fully started!
```

with the final snapshot being `{'pmon': True, 'snmp': False, 'database': True, 'lldp': True}`.

This PR mirrors the existing DPU pattern (a few lines above, introduced for the same reason on DPU) and removes `snmp` from the tracking list when `'bmc' in topo_type`.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Unblock ~20 test failures on the SONiC BMC testbed whose only failure mode is the framework tracking a service (`snmp`) that is not deployed on SONiC BMC. Tests affected (all failed on teardown / critical process check with the same `snmp: False` footprint):

| Feature | File | Cases |
| --- | --- | ---: |
| dns | `dns/static_dns/test_static_dns.py` | 1 |
| dns | `dns/test_dns_resolv_conf.py` | 1 |
| generic_config_updater | `generic_config_updater/test_cacl.py` | 8 |
| platform_tests | `platform_tests/test_reboot.py` | 1 |
| syslog | `syslog/test_logrotate.py` | 1 |
| container_hardening | `container_hardening/test_container_hardening.py` | 1 |
| db_migrator | `db_migrator/test_migrate_dns.py` | 1 |
| golden_config_infra | `golden_config_infra/test_config_reload_with_rendered_golden_config.py` | 1 |
| override_config_table | `override_config_table/test_override_config_table.py` | 1 |
| scp | `scp/test_scp_copy.py` | 1 |
| tacacs | `tacacs/test_authorization.py` | 2 |

#### How did you do it?

In `MultiAsicSonicHost.critical_services_tracking_list()`, added a BMC guard right after the existing DPU guard:

```python
is_bmc = 'bmc' in (self.topo_type or '')
if is_bmc and 'snmp' in service_list:
    service_list.remove('snmp')
```

No behavioral change for non-BMC topologies.

#### How did you verify/test it?

Verified on a SONiC BMC DUT (`testbed-host1-komodo-bmc`, Komodo BMC board) by applying the patch locally in the sonic-mgmt container and re-running one of the affected tests, `syslog/test_logrotate.py::test_logrotate_small_size`.

- **Before the patch**: test failed with `Failed: All critical services should be fully started!`, snapshot = `{'pmon': True, 'snmp': False, 'database': True, 'lldp': True}`.
- **After the patch**: the `critical_services_fully_started` check now passes (framework-tracked services list becomes `{pmon, database, lldp}`, matching what is actually deployed on BMC); execution proceeds past that check.

#### Any platform specific information?

Only affects DUTs whose `topo_type` contains `bmc`.

#### Supported testbed topology if it's a new test case?


