### PR TITLE
[C0] Fix console testcase failure in PR check

### DIFF
--- a/tests/console/test_console_availability.py
+++ b/tests/console/test_console_availability.py
@@ -11,7 +11,7 @@ pytestmark = [
 
 
 @pytest.mark.parametrize("target_line", ["1", "2", "3", "4"])
-def test_console_availability(duthost, creds, target_line, cleanup_modules):
+def test_console_availability(duthost, creds, target_line):
     """
     Test console are well functional.
     Verify console access is available after connecting from DUT

--- a/tests/console/test_console_udevrule.py
+++ b/tests/console/test_console_udevrule.py
@@ -3,7 +3,7 @@ import pytest
 from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('c0', 'c0-lo')
 ]
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. `tests/console/test_console_udevrule.py` should only run on C0 or C0-lo topo.
2. `tests/console/test_console_availability.py` doesn't rely on fixture `cleanup_module` which require the topo be c0 or c0-lo.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
1. `tests/console/test_console_udevrule.py` should only run on C0 or C0-lo topo.
2. `tests/console/test_console_availability.py` doesn't rely on fixture `cleanup_module` which require the topo be c0 or c0-lo.

#### How did you do it?
Update pytest mark and remove unnecessary fixture call.

#### How did you verify/test it?
Verified by PR test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
