### PR TITLE
[fdb] Ignore expected cleanup ERR in testFdbMacLearning

### DIFF
--- a/tests/fdb/test_fdb_mac_learning.py
+++ b/tests/fdb/test_fdb_mac_learning.py
@@ -22,7 +22,8 @@ def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
 
     ignore_errors = [
         r".*ERR swss#orchagent: .*update: Failed to get port by bridge port ID.*",
-        r".* ERR swss#tunnel_packet_handler.py: All portchannels failed to come up within \d+ minutes, exiting.*"
+        r".* ERR swss#tunnel_packet_handler.py: All portchannels failed to come up within \d+ minutes, exiting.*",
+        r".*ERR swss#orchagent: .*meta_sai_validate_route_entry: object key SAI_OBJECT_TYPE_ROUTE_ENTRY:.* doesn't exist.*",  # noqa: E501
         ]
     if loganalyzer:
         for duthost in duthosts:


### PR DESCRIPTION

### Description of PR
In a dualtor topology, the `prepare_test` fixture shuts down all switch interfaces before the test runs. Orchagent processes the resulting link-down events asynchronously, triggering mux tunnel route cleanup (`192.168.0.x/32`) that spills a few seconds past the LogAnalyzer startmarker. For routes already removed by a prior cleanup pass, orchagent logs `ERR meta_sai_validate_route_entry: doesn't exist` — a harmless double-delete race condition entirely unrelated to FDB MAC learning. LogAnalyzer flags these as unexpected errors, causing a false teardown failure. The fix adds this pattern to the existing `ignore_errors` list in `ignore_expected_loganalyzer_exception`, consistent with two similar orchagent patterns already suppressed in the same fixture.

Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/24085

### Type of change


- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
`testFdbMacLearning` fails intermittently on teardown on `dualtor-120` topologies. All FDB MAC learning assertions inside the test body pass correctly — the failure is a false positive caused by the LogAnalyzer fixture catching orchagent syslog noise generated during test setup.

#### How did you do it?
Added one regex pattern to the `ignore_errors` list inside the existing
`ignore_expected_loganalyzer_exception` fixture in
`tests/fdb/test_fdb_mac_learning.py`:
`r".*ERR swss#orchagent: .*meta_sai_validate_route_entry: object key SAI_OBJECT_TYPE_ROUTE_ENTRY:.* doesn't exist.*",`
This suppresses the double-delete ERR that orchagent logs when it
attempts to remove a mux tunnel route already cleaned up by a prior
code path during bulk interface shutdown in dualtor topologies

#### How did you verify/test it?

- Confirmed all PTF runs returned rc=0 (fdb_mac_learning_test.FdbMacLearningTest ... ok)
- Confirmed all wait_until(fdb_table_has_dummy_mac_for_interface) assertions returned True
- Confirmed testARPCompleted in the same class passed with no regressions
- Confirmed post-test sanity check passed on both DUTs (orchagent_usage: 0.0%, all health checks failed: False)
- Confirmed the errors appear 40 seconds before the test body starts, proving they are setup artifacts not caused by test logic

#### Any platform specific information?
No. Applies to all platforms in dualtor testbeds.

#### Supported testbed topology if it's a new test case?
N/A — existing test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
