### PR TITLE
Fix macsec pretest failures on multi-asic linecard when macsec is disabled

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -117,7 +117,12 @@ class SonicHost(AnsibleHostBase):
             self.DEFAULT_ASIC_SERVICES.remove("syncd")
             self.DEFAULT_ASIC_SERVICES.remove("teamd")
 
-        if (router_type == 'UpperSpineRouter') or (router_subtype in ['UpstreamLC', 'DownstreamLC']):
+        is_macsec_device = (router_type == 'UpperSpineRouter') or (router_subtype in ['UpstreamLC', 'DownstreamLC'])
+        # Append macsec only when enabled to avoid pretest failures on multi-ASIC devices
+        # where per-ASIC containers (macsec0, macsec1) do not exist when macsec is disabled.
+        # e.g. in test_feature_status, test_disable_rsyslog_rate_limit
+        macsec_enabled = self._facts.get('features', {}).get('macsec', {}).get('state', 'disabled') == 'enabled'
+        if macsec_enabled and is_macsec_device:
             self.DEFAULT_ASIC_SERVICES.append("macsec")
         # Append gbsyncd only for non-VS to avoid pretest check for gbsyncd
         # e.g. in test_feature_status, test_disable_rsyslog_rate_limit


### PR DESCRIPTION
On multi-asic devices, macsec was unconditionally appended to DEFAULT_ASIC_SERVICES regardless of feature state. When macsec is disabled, the _init_multi_asic_services_props filter in multi_asic.py removes it from DEFAULT_ASIC_SERVICES. If modify_syslog_rate_limit("macsec") is called in this state, get_docker_name() returns "macsec" instead of the per-ASIC "macsecN" names, causing the container name resolution to fail.

Fix: mirror the gbsyncd pattern — only append macsec to DEFAULT_ASIC_SERVICES when the feature is enabled.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Append macsec to DEFAULT_ASIC_SERVICES only when the feature is enabled - mirror the gbsyncd pattern.

Summary:
Fixes #21344 

### Type of change
- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
test_pretest.py is failing on a multi asic sonic host while running macsec tests

#### How did you do it?
Append macsec to DEFAULT_ASIC_SERVICES only when the feature is enabled

#### How did you verify/test it?
Ran the test on a local setup

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
