### PR TITLE
[duthost]: Convert wait(critical_services_fully_started) to duthost method

### DIFF
--- a/tests/bgp/test_bgp_operation_in_ro.py
+++ b/tests/bgp/test_bgp_operation_in_ro.py
@@ -90,7 +90,9 @@ def post_reboot_healthcheck(duthost, localhost, duthosts, wait_time):
     else:
         localhost.wait_for(host=duthost.mgmt_ip, port=22, state="started", delay=10, timeout=timeout)
     wait(wait_time, msg="Wait {} seconds for system to be stable.".format(wait_time))
-    if not wait_until(300, 20, 0, duthost.critical_services_fully_started):
+    try:
+        duthost.wait_critical_services_fully_started()
+    except TimeoutError:
         logger.error("Not all critical services fully started!")
         return False
     # If supervisor node is rebooted in chassis, linecards also will reboot.

--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -343,14 +343,12 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
         reboot(duthost, localhost, reboot_type=reboot_type, wait_warmboot_finalizer=True,
                warmboot_finalizer_timeout=360)
 
-    pytest_assert(wait_until(360, 10, 120, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started(timeout=360, poll_interval=10, wait=120)
 
     # Restore interfaces/neighbors before verifying BGP recovery
     failure_injection.restore()
 
-    pytest_assert(wait_until(120, 10, 30, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started(timeout=120, poll_interval=10, wait=30)
 
     timeout = 120
     if test_type == "swss_docker":

--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -793,12 +793,7 @@ def do_and_wait_reboot(duthost, localhost, reboot_type):
     with allure.step("Do {}".format(reboot_type)):
         reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True, check_intf_up_ports=True,
                wait_for_bgp=True, wait_warmboot_finalizer=True)
-        pytest_assert(
-            wait_until(300, 20, 0, duthost.critical_services_fully_started),
-            (
-                "Not all critical services started within the allotted time after reboot or config reload. "
-            )
-        )
+        duthost.wait_critical_services_fully_started()
 
         pytest_assert(
             wait_until(1200, 20, 0, check_interface_status_of_up_ports, duthost),

--- a/tests/bgp/test_startup_tsa_tsb_service.py
+++ b/tests/bgp/test_startup_tsa_tsb_service.py
@@ -1177,8 +1177,7 @@ def test_user_init_tsb_while_service_run_on_dut(request, duthosts, localhost, nb
                           "startup_tsa_tsb service is not in inactive state after user init TSB")
 
             # Make sure DUT continues to be in good state after TSB
-            assert wait_until(300, 20, 2, lc.critical_services_fully_started), \
-                "Not all critical services are fully started on {}".format(lc.hostname)
+            lc.wait_critical_services_fully_started(wait=2)
             crit_process_check_res = wait_until(600, 20, 0, _all_critical_processes_healthy, lc)
             int_status_check_res = wait_until(1200, 20, 0, check_interface_status_of_up_ports, lc)
             with lock:
@@ -1448,8 +1447,7 @@ def test_tsa_tsb_timer_efficiency(request, duthosts, localhost, nbrhosts, traffi
                           "startup_tsa_tsb service started much later than the expected time after dut reboot")
 
             logging.info("Wait until all critical services are fully started")
-            pytest_assert(wait_until(300, 20, 2, lc.critical_services_fully_started)), \
-                "Not all critical services are fully started on {}".format(lc.hostname)
+            lc.wait_critical_services_fully_started(wait=2)
 
             logging.info("Wait until all critical processes are fully started")
             crit_process_check_res = wait_until(600, 20, 0, _all_critical_processes_healthy, lc)

--- a/tests/bmp/test_docker_restart.py
+++ b/tests/bmp/test_docker_restart.py
@@ -1,8 +1,6 @@
 import pytest
 import logging
 
-from tests.common.utilities import wait_until
-from tests.common.helpers.assertions import pytest_assert
 
 logger = logging.getLogger(__name__)
 
@@ -22,5 +20,4 @@ def test_restart_bmp_docker(duthosts,
     logger.info(duthost.shell(cmd="docker ps", module_ignore_errors=True)['stdout'])
 
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()

--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -306,8 +306,7 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
         pytest_assert(wait_until(200, 10, 0, sonic_host.is_critical_processes_running_per_asic_or_host, "database"),
                       "Database not start.")
         sonic_host.critical_services_tracking_list()
-        pytest_assert(wait_until(wait + 300, 20, 0, sonic_host.critical_services_fully_started),
-                      "All critical services should be fully started!")
+        sonic_host.wait_critical_services_fully_started(timeout=wait + 300)
         wait_critical_processes(sonic_host)
         # After config load_minigraph, update-containers fires ~5s after the DNS config
         # change but slow-starting containers (e.g., restapi, 75-128s startup) may not

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -16,7 +16,7 @@ from ansible.plugins.loader import connection_loader
 from tests.common.devices.base import AnsibleHostBase
 from tests.common.devices.constants import ACL_COUNTERS_UPDATE_INTERVAL_IN_SEC
 from tests.common.helpers.dut_utils import is_supervisor_node, is_macsec_capable_node
-from tests.common.utilities import get_host_visible_vars
+from tests.common.utilities import get_host_visible_vars, wait_until
 from tests.common.cache import cached
 from tests.common.helpers.constants import DEFAULT_ASIC_ID, DEFAULT_NAMESPACE
 from tests.common.helpers.platform_api.chassis import is_inband_port
@@ -410,6 +410,10 @@ class SonicHost(AnsibleHostBase):
         result = self.critical_services_status()
         logging.debug("Status of critical services: %s" % str(result))
         return all(result.values())
+
+    def wait_critical_services_fully_started(self, timeout=300, poll_interval=20, wait=0):
+        if not wait_until(timeout, poll_interval, wait, self.critical_services_fully_started):
+            raise TimeoutError(f"{self.hostname}: Not all critical services are fully started")
 
     def get_monit_services_status(self):
         """

--- a/tests/common/helpers/upgrade_helpers.py
+++ b/tests/common/helpers/upgrade_helpers.py
@@ -134,8 +134,7 @@ def check_services(duthost, tbinfo):
     """
     dut_min_uptime = 900 if 't2' in tbinfo['topo']['name'] else 300
     logging.info("Wait until all critical services are fully started")
-    pytest_assert(wait_until(dut_min_uptime, 30, 30, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started(timeout=dut_min_uptime, poll_interval=30, wait=30)
 
     critical_services = [re.sub(r'(\d+)$', r'@\1', service) for service in duthost.critical_services]
     for service in critical_services:

--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -304,7 +304,9 @@ def check_services(duthost):
     Perform a health check of services
     """
     logging.info("Wait until all critical services are fully started")
-    if not wait_until(330, 30, 0, duthost.critical_services_fully_started):
+    try:
+        duthost.wait_critical_services_fully_started(timeout=330, poll_interval=30)
+    except TimeoutError:
         raise RebootHealthError("dut.critical_services_fully_started is False")
 
     critical_services = [re.sub(r'(\d+)$', r'@\1', service) for service in duthost.critical_services]

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -446,8 +446,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
         pytest_assert(wait_until(20, 5, 0, duthost.is_service_running, "redis", "database"), "Redis DB not start")
 
         duthost.critical_services_tracking_list()
-        pytest_assert(wait_until(wait + 400, 20, 0, duthost.critical_services_fully_started),
-                      "{}: All critical services should be fully started!".format(hostname))
+        duthost.wait_critical_services_fully_started(timeout=(wait + 400))
         wait_critical_processes(duthost)
 
         if check_intf_up_ports:

--- a/tests/config_setup/test_config_setup_boot.py
+++ b/tests/config_setup/test_config_setup_boot.py
@@ -46,7 +46,6 @@ from pathlib import Path
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
@@ -145,10 +144,7 @@ def real_dut(duthosts, rand_one_dut_hostname):
                   module_ignore_errors=True)
     duthost.shell("rm -f {}".format(REAL_CONFIG_DB_BAK), module_ignore_errors=True)
     duthost.shell("config reload -y -f", module_ignore_errors=True)
-    pytest_assert(
-        wait_until(300, 20, 0, duthost.critical_services_fully_started),
-        "Critical services did not start after config restore"
-    )
+    duthost.wait_critical_services_fully_started()
 
 
 # ---------------------------------------------------------------------------
@@ -502,10 +498,7 @@ class TestRealConfigSetupMinigraphFallback:
         )
 
         # Wait for services and verify mgmt IP survived
-        pytest_assert(
-            wait_until(120, 10, 0, duthost.critical_services_fully_started),
-            "Critical services did not start after config-setup boot"
-        )
+        duthost.wait_critical_services_fully_started(timeout=120, poll_interval=10)
 
         mgmt_ip_after = get_mgmt_ip(duthost)
         logger.info("Management IP after test: %s", mgmt_ip_after)

--- a/tests/configlet/util/base_test.py
+++ b/tests/configlet/util/base_test.py
@@ -133,8 +133,7 @@ def restore_orig_minigraph(duthost, skip_load=False):
 def load_minigraph(duthost):
     log_info("Loading minigraph")
     config_reload(duthost, config_source="minigraph", wait=RELOAD_WAIT_TIME, start_bgp=True)
-    assert wait_until(300, 20, 0, duthost.critical_services_fully_started), \
-        "All critical services should fully started!"
+    duthost.wait_critical_services_fully_started()
     assert wait_until(300, 20, 0, chk_for_pfc_wd, duthost), \
         "PFC_WD is missing in CONFIG-DB"
 

--- a/tests/configlet/util/mock_for_switch.py
+++ b/tests/configlet/util/mock_for_switch.py
@@ -94,6 +94,10 @@ class DutHost:
 
         return True
 
+    def wait_critical_services_fully_started(self, timeout=300, poll_interval=20, wait=0):
+        if not wait_until(timeout, poll_interval, wait, self.critical_services_fully_started):
+            raise TimeoutError(f"{self.hostname}: Not all critical services are fully started")
+
     def get_bgp_neighbor_info(self, neighbor_ip):
         """
         @summary: return bgp neighbor info

--- a/tests/container_upgrade/container_upgrade_helper.py
+++ b/tests/container_upgrade/container_upgrade_helper.py
@@ -3,7 +3,7 @@ import logging
 import json
 import time
 
-from tests.common.utilities import wait_until, file_exists_on_dut
+from tests.common.utilities import file_exists_on_dut
 from tests.common.helpers.assertions import pytest_assert as py_assert
 from tests.common.system_utils.docker import load_docker_registry_info
 from tests.common.system_utils.docker import download_image
@@ -121,8 +121,7 @@ def os_upgrade(duthost, localhost, tbinfo, image_url):
     reboot(duthost, localhost)
     logger.info("Waiting for critical services to startup")
     fetch_docker_conf(duthost)
-    py_assert(wait_until(300, 20, 20, duthost.critical_services_fully_started),
-              "All critical services should be fully started!")
+    duthost.wait_critical_services_fully_started(wait=20)
 
 
 def validate_is_v1_enabled(duthost, sidecar_container_name):

--- a/tests/dns/static_dns/test_static_dns.py
+++ b/tests/dns/static_dns/test_static_dns.py
@@ -91,8 +91,7 @@ def test_static_dns_basic(request, duthost, localhost, backup_and_restore_config
             config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
         else:
             reboot(duthost, localhost, reboot_type)
-            pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                          "All critical services should be fully started!")
+            duthost.wait_critical_services_fully_started()
             pytest_assert(wait_until(300, 20, 0, check_interface_status_of_up_ports, duthost),
                           "Not all ports that are admin up on are operationally up")
 

--- a/tests/dualtor/test_switchover_failure.py
+++ b/tests/dualtor/test_switchover_failure.py
@@ -147,7 +147,10 @@ def common_setup_teardown(
     if not hasattr(request.node, "rep_call") or request.node.rep_call.failed:
         logger.warning("Test failed, restarting swss")
         rand_selected_dut.restart_service("swss")
-        wait_until(60, 5, 0, rand_selected_dut.critical_services_fully_started)
+        try:
+            rand_selected_dut.wait_critical_services_fully_started(timeout=60, poll_interval=5)
+        except TimeoutError:
+            logger.warning("Critical services did not fully start after swss restart")
         wait_until(60, 5, 0, rand_selected_dut.critical_processes_running, "swss")
         wait_until(60, 5, 0, rand_selected_dut.critical_processes_running, "mux")
 

--- a/tests/generic_config_updater/add_cluster/test_add_cluster.py
+++ b/tests/generic_config_updater/add_cluster/test_add_cluster.py
@@ -1751,8 +1751,7 @@ def setup_add_cluster(tbinfo,
     with allure.step("Reload the system with config reload"):
         duthost.shell("config save -y")
         config_reload(duthost, config_source='config_db', safe_reload=True)
-        pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                      "All critical services should be fully started!")
+        duthost.wait_critical_services_fully_started()
         pytest_assert(wait_until(1200, 20, 0, check_interface_status_of_up_ports, duthost),
                       "Not all ports that are admin up on are operationally up")
 

--- a/tests/generic_config_updater/add_cluster/test_port_speed_change.py
+++ b/tests/generic_config_updater/add_cluster/test_port_speed_change.py
@@ -687,8 +687,7 @@ def setup_port_speed_change(duthosts,
     with allure.step("Reload the system with config reload so as to simulate that we start with speed B"):
         duthost.shell("config save -y")
         config_reload(duthost, config_source='config_db', safe_reload=True)
-        pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                      "All critical services should be fully started!")
+        duthost.wait_critical_services_fully_started()
 
     with allure.step("Verify no config failures after reload by applying an empty patch."):
         tmpfile = generate_tmpfile(duthost)

--- a/tests/generic_config_updater/test_multiasic_addcluster.py
+++ b/tests/generic_config_updater/test_multiasic_addcluster.py
@@ -1327,7 +1327,9 @@ def test_addcluster_workflow(duthosts, enum_downstream_dut_hostname, loganalyzer
     # Step 1.1: Reload minigraph
     logger.info("Reloading minigraph using 'config load_minigraph -y'")
     duthost.shell("sudo config load_minigraph -y", module_ignore_errors=False)
-    if not wait_until(300, 20, 0, duthost.critical_services_fully_started):
+    try:
+        duthost.wait_critical_services_fully_started()
+    except TimeoutError:
         logger.error("Not all critical services fully started!")
         pytest.fail("Critical services not fully started after minigraph reload")
 
@@ -1361,7 +1363,9 @@ def test_addcluster_workflow(duthosts, enum_downstream_dut_hostname, loganalyzer
     # Step 4: Reload minigraph
     logger.info("Reloading minigraph using 'config load_minigraph -y'")
     duthost.shell("sudo config load_minigraph -y", module_ignore_errors=False)
-    if not wait_until(300, 20, 0, duthost.critical_services_fully_started):
+    try:
+        duthost.wait_critical_services_fully_started()
+    except TimeoutError:
         logger.error("Not all critical services fully started!")
         pytest.fail("Critical services not fully started after minigraph reload")
 

--- a/tests/gnmi/test_gnoi_killprocess.py
+++ b/tests/gnmi/test_gnoi_killprocess.py
@@ -72,7 +72,7 @@ def test_gnoi_killprocess_then_restart(
 
     wait_critical_processes(duthost)
     pytest_assert(
-        duthost.critical_services_fully_started,
+        duthost.critical_services_fully_started(),
         "System unhealthy after gNOI API request",
     )
 
@@ -112,7 +112,7 @@ def test_gnoi_killprocess_restart(
 
     wait_critical_processes(duthost)
     pytest_assert(
-        duthost.critical_services_fully_started,
+        duthost.critical_services_fully_started(),
         "System unhealthy after gNOI API request",
     )
 
@@ -131,6 +131,6 @@ def test_invalid_signal(duthosts, rand_one_dut_hostname, gnmi_tls):  # noqa: F81
 
     wait_critical_processes(duthost)
     pytest_assert(
-        duthost.critical_services_fully_started,
+        duthost.critical_services_fully_started(),
         "System unhealthy after gNOI API request",
     )

--- a/tests/hash/test_generic_hash.py
+++ b/tests/hash/test_generic_hash.py
@@ -742,8 +742,7 @@ def test_reboot(rand_selected_dut, tbinfo, ptfhost, localhost, fine_params, mg_f
         else:
             reboot(rand_selected_dut, localhost, reboot_type=reboot_type)
         # Wait for the dut to recover
-        pytest_assert(wait_until(300, 20, 0, rand_selected_dut.critical_services_fully_started),
-                      "Not all critical services are fully started.")
+        rand_selected_dut.wait_critical_services_fully_started()
     with allure.step('Check the generic hash config after the reboot'):
         check_global_hash_config(rand_selected_dut, global_hash_capabilities['ecmp'], global_hash_capabilities['lag'])
         if ptf_params.get('vxlan_port') and ptf_params['vxlan_port'] != DEFAULT_VXLAN_PORT:

--- a/tests/iface_loopback_action/test_iface_loopback_action.py
+++ b/tests/iface_loopback_action/test_iface_loopback_action.py
@@ -113,8 +113,7 @@ def test_loopback_action_reload(request, duthost, localhost, ptfadapter, ports_c
             config_reload(duthost, safe_reload=True)
         else:
             reboot(duthost, localhost, reboot_type)
-            pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                          "All critical services should be fully started!")
+            duthost.wait_critical_services_fully_started()
         pytest_assert(wait_until(60, 20, 0, check_interface_status_of_up_ports, duthost),
                       "Not all ports that are admin up on are operationally up")
         # Wait for the rif counter to initialize

--- a/tests/ixia/pfc/test_pfc_pause_lossless.py
+++ b/tests/ixia/pfc/test_pfc_pause_lossless.py
@@ -3,9 +3,8 @@ import pytest
 
 from .files.helper import run_pfc_test
 from tests.common.cisco_data import is_cisco_device
-from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.helpers.assertions import pytest_require
 from tests.common.reboot import reboot
-from tests.common.utilities import wait_until
 from tests.ixia.files.helper import skip_warm_reboot
 
 logger = logging.getLogger(__name__)
@@ -238,8 +237,7 @@ def test_pfc_pause_single_lossless_prio_reboot(ixia_api,
     logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
     reboot(duthost, localhost, reboot_type=reboot_type)
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfc_test(api=ixia_api,
                  testbed_config=testbed_config,
@@ -306,8 +304,7 @@ def test_pfc_pause_multi_lossless_prio_reboot(ixia_api,
     logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
     reboot(duthost, localhost, reboot_type=reboot_type)
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfc_test(api=ixia_api,
                  testbed_config=testbed_config,

--- a/tests/ixia/pfc/test_pfc_pause_lossy.py
+++ b/tests/ixia/pfc/test_pfc_pause_lossy.py
@@ -2,14 +2,13 @@ import logging
 import pytest
 
 from .files.helper import run_pfc_test
-from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.helpers.assertions import pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts         # noqa: F401
 from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port,\
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config                     # noqa: F401
 from tests.common.ixia.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
     lossy_prio_list                                                                             # noqa: F401
 from tests.common.reboot import reboot
-from tests.common.utilities import wait_until
 from tests.ixia.files.helper import skip_warm_reboot
 
 logger = logging.getLogger(__name__)
@@ -164,8 +163,7 @@ def test_pfc_pause_single_lossy_prio_reboot(ixia_api, ixia_testbed_config, conn_
     logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
     reboot(duthost, localhost, reboot_type=reboot_type)
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfc_test(api=ixia_api,
                  testbed_config=testbed_config,
@@ -225,8 +223,7 @@ def test_pfc_pause_multi_lossy_prio_reboot(ixia_api, ixia_testbed_config, conn_g
     logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
     reboot(duthost, localhost, reboot_type=reboot_type)
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfc_test(api=ixia_api,
                  testbed_config=testbed_config,

--- a/tests/ixia/pfcwd/test_pfcwd_basic.py
+++ b/tests/ixia/pfcwd/test_pfcwd_basic.py
@@ -1,13 +1,12 @@
 import pytest
 import logging
 
-from tests.common.helpers.assertions import pytest_require, pytest_assert
+from tests.common.helpers.assertions import pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa: F401
 from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port,\
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config                 # noqa: F401
 from tests.common.ixia.qos_fixtures import prio_dscp_map, lossless_prio_list                # noqa: F401
 from tests.common.reboot import reboot
-from tests.common.utilities import wait_until
 from tests.ixia.files.helper import skip_warm_reboot
 from .files.pfcwd_basic_helper import run_pfcwd_basic_test
 from .files.helper import skip_pfcwd_test
@@ -152,8 +151,7 @@ def test_pfcwd_basic_single_lossless_prio_reboot(ixia_api, ixia_testbed_config, 
     logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
     reboot(duthost, localhost, reboot_type=reboot_type)
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfcwd_basic_test(api=ixia_api,
                          testbed_config=testbed_config,
@@ -208,8 +206,7 @@ def test_pfcwd_basic_multi_lossless_prio_reboot(ixia_api, ixia_testbed_config, c
     logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
     reboot(duthost, localhost, reboot_type=reboot_type)
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfcwd_basic_test(api=ixia_api,
                          testbed_config=testbed_config,
@@ -267,8 +264,7 @@ def test_pfcwd_basic_single_lossless_prio_service_restart(ixia_api, ixia_testbed
         duthost.command("systemctl reset-failed {}".format(service))
     duthost.command("systemctl restart {}".format(restart_service))
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfcwd_basic_test(api=ixia_api,
                          testbed_config=testbed_config,
@@ -324,8 +320,7 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(ixia_api, ixia_testbed_
         duthost.command("systemctl reset-failed {}".format(service))
     duthost.command("systemctl restart {}".format(restart_service))
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfcwd_basic_test(api=ixia_api,
                          testbed_config=testbed_config,

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -42,9 +42,7 @@ def restart_swss_container(duthosts, enum_rand_one_per_hwsku_frontend_hostname, 
     duthost.shell("sudo systemctl restart {}".format(asic.get_service_name("swss")))
 
     # make sure all critical services are up
-    assert wait_until(600, 5, 30, duthost.critical_services_fully_started), (
-        "Not all critical services are fully started after restarting orchagent. "
-    )
+    duthost.wait_critical_services_fully_started(timeout=600, poll_interval=5, wait=30)
 
     # wait for ports to be up and lldp neighbor information has been received by dut
     assert wait_until(300, 20, 60,
@@ -686,8 +684,7 @@ def test_lldp_interfaces_config_reload(duthosts, enum_rand_one_per_hwsku_fronten
 
         logger.info("Step 3: Waiting for system to stabilize after config reload")
         # Wait for LLDP to converge
-        assert wait_until(300, 10, 0, duthost.critical_services_fully_started), \
-            "Not all critical services are fully started after config reload"
+        duthost.wait_critical_services_fully_started(poll_interval=10)
 
         # Wait for all LLDP neighbors to be re-discovered using pre-reload count as baseline
         pytest_assert(

--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -392,8 +392,7 @@ def test_lldp_entry_table_after_syncd_orchagent(
             duthost.shell("sudo systemctl restart {}".format(asic.get_service_name("swss")))
     else:
         duthost.shell("sudo systemctl restart swss")
-    assert wait_until(600, 5, 120, duthost.critical_services_fully_started), \
-        "Not all critical services are fully started"
+    duthost.wait_critical_services_fully_started(timeout=600, poll_interval=5, wait=120)
     time.sleep(60)
     # Wait until all interfaces are up and lldp entries are populated
     for interface in lldp_entry_keys:

--- a/tests/mclag/test_mclag_l3.py
+++ b/tests/mclag/test_mclag_l3.py
@@ -247,8 +247,7 @@ class TestActiveDeviceStatusChange():
         duthost1.shell("config save -y")
         pytest_assert(wait_until(120, 5, 0, check_partner_lag_member, ptfhost, check_portchannels, "UP"),
                       "Expected partner Lag members isnt up")
-        pytest_assert(wait_until(300, 20, 0, duthost1.critical_services_fully_started),
-                      "All critical services should fully started!{}".format(duthost1.critical_services))
+        duthost1.wait_critical_services_fully_started()
 
     def test_active_down(self, duthost1, duthost2, ptfadapter, ptfhost, collect, get_routes, mclag_intf_num,
                          update_and_clean_ptf_agent, pre_active_setup):
@@ -298,8 +297,7 @@ class TestStandByDeviceStatusChange():
         duthost2.shell("config save -y")
         pytest_assert(wait_until(120, 5, 0, check_partner_lag_member, ptfhost, check_portchannels, "UP"),
                       "Expected partner Lag members isnt up")
-        pytest_assert(wait_until(300, 20, 0, duthost2.critical_services_fully_started),
-                      "All critical services should fully started!{}".format(duthost2.critical_services))
+        duthost2.wait_critical_services_fully_started()
 
     def test_standby_down(self, duthost1, duthost2, ptfadapter, ptfhost, collect, get_routes, mclag_intf_num,
                           update_and_clean_ptf_agent, pre_standby_setup):

--- a/tests/mvrf/test_mgmtvrf.py
+++ b/tests/mvrf/test_mgmtvrf.py
@@ -318,8 +318,7 @@ class TestReboot():
         duthost = duthosts[rand_one_dut_hostname]
         duthost.command("sudo config save -y")  # This will override config_db.json with mgmt vrf config
         reboot(duthost, localhost, reboot_type="warm")
-        pytest_assert(wait_until(120, 20, 0, duthost.critical_services_fully_started),
-                      "Not all critical services are fully started")
+        duthost.wait_critical_services_fully_started(timeout=120)
 
         # Change default critical services to check services that starts with bootOn timer
         # In some images, we have gnmi container only
@@ -335,8 +334,7 @@ class TestReboot():
             critical_services.append('telemetry')
         duthost.reset_critical_services_tracking_list(critical_services)
 
-        pytest_assert(wait_until(180, 20, 0, duthost.critical_services_fully_started),
-                      "Not all services which start with bootOn timer are fully started")
+        duthost.wait_critical_services_fully_started(timeout=180)
         self.basic_check_after_reboot(duthost, localhost, ptfhost, creds)
 
     @pytest.mark.disable_loganalyzer
@@ -344,8 +342,7 @@ class TestReboot():
         duthost = duthosts[rand_one_dut_hostname]
         duthost.command("sudo config save -y")  # This will override config_db.json with mgmt vrf config
         reboot(duthost, localhost)
-        pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                      "Not all critical services are fully started")
+        duthost.wait_critical_services_fully_started()
         self.basic_check_after_reboot(duthost, localhost, ptfhost, creds)
 
     @pytest.mark.disable_loganalyzer
@@ -353,6 +350,5 @@ class TestReboot():
         duthost = duthosts[rand_one_dut_hostname]
         duthost.command("sudo config save -y")  # This will override config_db.json with mgmt vrf config
         reboot(duthost, localhost, reboot_type="fast")
-        pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                      "Not all critical services are fully started")
+        duthost.wait_critical_services_fully_started()
         self.basic_check_after_reboot(duthost, localhost, ptfhost, creds)

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -581,8 +581,7 @@ def test_po_update_with_higher_lagids(
     wait_critical_processes(suphost)
 
     # Ensure all critical services have started on the supervisor node
-    pytest_assert(wait_until(330, 20, 0, suphost.critical_services_fully_started),
-                  "All critical services should fully started! {}".format(suphost.hostname))
+    suphost.wait_critical_services_fully_started(timeout=330)
 
     # For each linecard (frontend node), wait for startup and critical processes to start
     for linecard in duthosts.frontend_nodes:
@@ -594,8 +593,7 @@ def test_po_update_with_higher_lagids(
         wait_critical_processes(linecard)
 
         # Ensure all critical services have started on the linecard
-        pytest_assert(wait_until(330, 20, 0, linecard.critical_services_fully_started),
-                      "All critical services should fully started! {}".format(linecard.hostname))
+        linecard.wait_critical_services_fully_started(timeout=330)
 
     # Perform a sanity check on the LAG set
     lag_set_sanity(duthosts)

--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -20,7 +20,6 @@ from tests.common import constants
 from tests.common.helpers.pfcwd_helper import EXPECT_PFC_WD_DETECT_RE, EXPECT_PFC_WD_RESTORE_RE, pfcwd_show_status
 from tests.common.helpers.pfcwd_helper import send_background_traffic
 from tests.common.helpers.pfcwd_helper import has_neighbor_device
-from tests.common.utilities import wait_until
 from tests.common import config_reload
 
 TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "templates")
@@ -561,8 +560,7 @@ class TestPfcwdWb(SetupPfcwdFunc):
             if 'warm-reboot' in test_action:
                 reboot(self.dut, localhost, reboot_type="warm", wait_warmboot_finalizer=True)
 
-                assert wait_until(300, 20, 20, self.dut.critical_services_fully_started), \
-                    "All critical services should fully started!"
+                self.dut.wait_critical_services_fully_started(wait=20)
 
                 continue
 
@@ -631,8 +629,10 @@ class TestPfcwdWb(SetupPfcwdFunc):
                     except Exception as e:
                         pfcwd_show_status(self.dut, "pfcwd wr: run_test exception")
                         pytest.fail(str(e))
-            wait_until(300, 20, 20, self.dut.critical_services_fully_started), \
-                "All critical services should fully started!"
+            try:
+                self.dut.wait_critical_services_fully_started(wait=20)
+            except TimeoutError:
+                logging.warning("Not all critical services fully started after warm reboot")
 
     @pytest.fixture(params=['no_storm', 'storm', 'async_storm'])
     def testcase_action(self, request):

--- a/tests/platform_tests/cli/test_show_chassis_module.py
+++ b/tests/platform_tests/cli/test_show_chassis_module.py
@@ -189,13 +189,7 @@ def test_show_chassis_module_status_after_docker_restart(duthosts, tbinfo):
 
     logging.info(f"Wait until all critical processes are fully started on the supervisor node - {sup_hostname}")
     wait_critical_processes(suphost)
-    pytest_assert(
-        wait_until(330, 20, 0, suphost.critical_services_fully_started),
-        (
-            "All critical services should be fully started on the supervisor node - {}. "
-            "One or more critical services failed to start within the expected timeframe."
-        ).format(sup_hostname)
-    )
+    suphost.wait_critical_services_fully_started(timeout=330)
 
     for linecard in duthosts.frontend_nodes:
         lc_hostname = linecard.hostname

--- a/tests/platform_tests/fwutil/fwutil_common.py
+++ b/tests/platform_tests/fwutil/fwutil_common.py
@@ -7,7 +7,6 @@ import allure
 
 from copy import deepcopy
 
-from tests.common.utilities import wait_until
 from tests.common.reboot import SONIC_SSH_REGEX
 from tests.common.helpers.firmware_helper import show_firmware
 
@@ -113,7 +112,10 @@ def complete_install(duthost, localhost, boot_type, res, pdu_ctrl, component, au
                 host=hn, port=22, state='started', search_regex=SONIC_SSH_REGEX, delay=10, timeout=post_reboot_timeout)
 
         logger.info("Waiting on critical systems to come online...")
-        wait_until(300, 30, 0, duthost.critical_services_fully_started)
+        try:
+            duthost.wait_critical_services_fully_started(poll_interval=30)
+        except TimeoutError:
+            logger.warning("Not all critical services started within timeout")
         time.sleep(60)
 
         # Reboot back into original image if neccesary
@@ -126,7 +128,10 @@ def complete_install(duthost, localhost, boot_type, res, pdu_ctrl, component, au
             time.sleep(100)
             logger.info("Waiting on switch to come up....")
             localhost.wait_for(host=hn, port=22, state='started', delay=10, timeout=150)
-            wait_until(300, 30, 0, duthost.critical_services_fully_started)
+            try:
+                duthost.wait_critical_services_fully_started(poll_interval=30)
+            except TimeoutError:
+                logger.warning("Not all critical services started within timeout after rollback")
             time.sleep(60)
 
 

--- a/tests/platform_tests/test_cpu_memory_usage.py
+++ b/tests/platform_tests/test_cpu_memory_usage.py
@@ -6,8 +6,6 @@ from tests.platform_tests.counterpoll.cpu_memory_helper import counterpoll_type 
 from tests.common.constants import CounterpollConstants
 from tests.common.helpers.counterpoll_helper import ConterpollHelper
 from tests.common.mellanox_data import is_mellanox_device
-from tests.common.utilities import wait_until
-from tests.common.helpers.assertions import pytest_assert
 
 
 pytestmark = [
@@ -62,8 +60,7 @@ def test_cpu_memory_usage(rand_selected_dut, setup_thresholds):
     """Check DUT memory usage and process cpu usage are within threshold."""
     duthost = rand_selected_dut
     # Wait until all critical services is fully started
-    pytest_assert(wait_until(360, 20, 0, duthost.critical_services_fully_started),
-                  "All critical services must be fully started!{}".format(duthost.critical_services))
+    duthost.wait_critical_services_fully_started(timeout=360)
     MonitResult = namedtuple('MonitResult', ['processes', 'memory'])
     monit_results = duthost.monit_process(iterations=24)['monit_results']
 

--- a/tests/read_mac/test_read_mac_metadata.py
+++ b/tests/read_mac/test_read_mac_metadata.py
@@ -1,9 +1,7 @@
 import pytest
 import logging
 
-from tests.common.utilities import wait_until
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
-from tests.common.helpers.assertions import pytest_assert
 from tests.common.reboot import reboot
 from tests.common import config_reload
 
@@ -92,8 +90,7 @@ class ReadMACMetadata():
                 self.deploy_image_to_duthost(duthost, counter)
                 reboot(duthost, localhost, wait=120)
                 logger.info("Wait until system is stable")
-                pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                              "Not all critical services are fully started")
+                duthost.wait_critical_services_fully_started()
 
             if current_minigraph:
                 logger.info("Execute cli 'config load_minigraph -y' to apply new minigraph")

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -692,8 +692,7 @@ class TestReboot():
         verify_show_sflow(duthost, status='up', polling_int=80)
         duthost.command('sudo config save -y')
         reboot(duthost, localhost)
-        assert wait_until(
-            300, 20, 0, duthost.critical_services_fully_started), "Not all critical services are fully started"
+        duthost.wait_critical_services_fully_started()
         force_active_tor(duthost, "all")
         assert wait_until(60, 5, 0, verify_sflow_config_apply, duthost)
         verify_show_sflow(duthost, status='up', collector=[
@@ -723,8 +722,7 @@ class TestReboot():
             active_collectors="[]")
         duthost.command('sudo config save -y')
         reboot(duthost, localhost)
-        assert wait_until(
-            300, 20, 0, duthost.critical_services_fully_started), "Not all critical services are fully started"
+        duthost.wait_critical_services_fully_started()
         force_active_tor(duthost, "all")
         verify_show_sflow(duthost, status='down')
         for intf in var['sflow_ports']:
@@ -746,8 +744,7 @@ class TestReboot():
                           'collector0', 'collector1'])
         duthost.command('sudo config save -y')
         reboot(duthost, localhost, reboot_type='fast')
-        assert wait_until(
-            300, 20, 0, duthost.critical_services_fully_started), "Not all critical services are fully started"
+        duthost.wait_critical_services_fully_started()
         verify_show_sflow(duthost, status='up', collector=[
                           'collector0', 'collector1'])
         for intf in var['sflow_ports']:
@@ -770,8 +767,7 @@ class TestReboot():
                           'collector0', 'collector1'])
         duthost.command('sudo config save -y')
         reboot(duthost, localhost, reboot_type='warm')
-        assert wait_until(
-            300, 20, 0, duthost.critical_services_fully_started), "Not all critical services are fully started"
+        duthost.wait_critical_services_fully_started()
         verify_show_sflow(duthost, status='up', collector=[
                           'collector0', 'collector1'])
         for intf in var['sflow_ports']:

--- a/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
@@ -1,8 +1,7 @@
 import logging
 from tabulate import tabulate
 from statistics import mean
-from tests.common.utilities import (wait, wait_until)
-from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait
 logger = logging.getLogger(__name__)
 
 TGEN_AS_NUM = 65200
@@ -987,6 +986,5 @@ def cleanup_config(duthost):
         "/etc/sonic/config_db_backup.json", "/etc/sonic/config_db.json"))
     duthost.shell("sudo config reload -y \n")
     logger.info("Wait until all critical services are fully started")
-    pytest_assert(wait_until(360, 10, 1, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started(timeout=360, poll_interval=10, wait=1)
     logger.info('Convergence Test Completed')

--- a/tests/snappi_tests/bgp/files/bgp_test_gap_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_test_gap_helper.py
@@ -1,6 +1,5 @@
 from tabulate import tabulate
-from tests.common.utilities import (wait, wait_until)
-from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait
 import logging
 logger = logging.getLogger(__name__)
 
@@ -713,6 +712,5 @@ def cleanup_config(duthost):
     duthost.command("sudo cp {} {}".format("/etc/sonic/config_db_backup.json", "/etc/sonic/config_db.json"))
     duthost.shell("sudo config reload -y \n")
     logger.info("Wait until all critical services are fully started")
-    pytest_assert(wait_until(360, 10, 1, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started(timeout=360, poll_interval=10, wait=1)
     logger.info('Convergence Test Completed')

--- a/tests/snappi_tests/files/helper.py
+++ b/tests/snappi_tests/files/helper.py
@@ -196,7 +196,10 @@ def reboot_duts(request, localhost):
         node.shell("sudo config save -y")
         reboot(node, localhost, reboot_type=reboot_type, safe_reboot=True)
         logger.info("Wait until the system is stable")
-        wait_until(180, 20, 0, node.critical_services_fully_started)
+        try:
+            node.wait_critical_services_fully_started(timeout=180)
+        except TimeoutError:
+            logger.warning("Not all critical services started on {} within timeout".format(node.hostname))
         wait_until(180, 20, 0, check_interface_status_of_up_ports, node)
         wait_until(300, 10, 0, node.check_bgp_session_state_all_asics, up_bgp_neighbors, "established")
         if node.facts.get('asic_type') == "cisco-8000":
@@ -463,7 +466,10 @@ def reboot_duts_and_disable_wd(tgen_port_info, localhost, request):
         node.shell("sudo config save -y")
         reboot(node, localhost, reboot_type=reboot_type, safe_reboot=True)
         logger.info("Wait until the system is stable")
-        wait_until(180, 20, 0, node.critical_services_fully_started)
+        try:
+            node.wait_critical_services_fully_started(timeout=180)
+        except TimeoutError:
+            logger.warning("Not all critical services started on {} within timeout".format(node.hostname))
         wait_until(180, 20, 0, check_interface_status_of_up_ports, node)
         wait_until(300, 10, 0, node.check_bgp_session_state_all_asics, up_bgp_neighbors, "established")
 

--- a/tests/snappi_tests/pfc/warm_reboot/test_pfc_pause_lossless_warm_reboot.py
+++ b/tests/snappi_tests/pfc/warm_reboot/test_pfc_pause_lossless_warm_reboot.py
@@ -1,11 +1,10 @@
 import logging
 import pytest
 
-from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.helpers.assertions import pytest_require
 from tests.snappi_tests.files.helper import skip_warm_reboot
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.snappi_tests.pfc.files.helper import run_pfc_test
-from tests.common.utilities import wait_until
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
     fanout_graph_facts  # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
@@ -93,8 +92,7 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,  # noqa: F811
                  snappi_extra_params=snappi_extra_params)
     logger.info("Wait until the system is stable")
     wait_critical_processes(duthost)
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
 
 @pytest.mark.disable_loganalyzer
@@ -167,5 +165,4 @@ def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,  # noqa: F811
                  snappi_extra_params=snappi_extra_params)
     logger.info("Wait until the system is stable")
     wait_critical_processes(duthost)
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()

--- a/tests/snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py
@@ -292,8 +292,7 @@ def test_pfcwd_basic_single_lossless_prio_service_restart(snappi_api,           
             duthost.command("sudo systemctl reset-failed {}".format(proc))
             duthost.command("sudo systemctl restart {}".format(proc))
             logger.info("Wait until the system is stable")
-            pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, duthost.critical_services_fully_started),
-                          "Not all critical services are fully started")
+            duthost.wait_critical_services_fully_started(timeout=WAIT_TIME, poll_interval=INTERVAL)
             pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, check_interface_status_of_up_ports, duthost),
                           "Not all interfaces are up.")
             pytest_assert(wait_until(
@@ -305,8 +304,7 @@ def test_pfcwd_basic_single_lossless_prio_service_restart(snappi_api,           
             duthost.command("systemctl reset-failed {}".format(restart_service))
             duthost.command("systemctl restart {}".format(restart_service))
             logger.info("Wait until the system is stable")
-            pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, duthost.critical_services_fully_started),
-                          "Not all critical services are fully started")
+            duthost.wait_critical_services_fully_started(timeout=WAIT_TIME, poll_interval=INTERVAL)
 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
@@ -380,8 +378,7 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(snappi_api,            
             duthost.command("sudo systemctl reset-failed {}".format(proc))
             duthost.command("sudo systemctl restart {}".format(proc))
             logger.info("Wait until the system is stable")
-            pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, duthost.critical_services_fully_started),
-                          "Not all critical services are fully started")
+            duthost.wait_critical_services_fully_started(timeout=WAIT_TIME, poll_interval=INTERVAL)
             pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, check_interface_status_of_up_ports, duthost),
                           "Not all interfaces are up.")
             pytest_assert(wait_until(
@@ -393,8 +390,7 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(snappi_api,            
             duthost.command("systemctl reset-failed {}".format(restart_service))
             duthost.command("systemctl restart {}".format(restart_service))
             logger.info("Wait until the system is stable")
-            pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, duthost.critical_services_fully_started),
-                          "Not all critical services are fully started")
+            duthost.wait_critical_services_fully_started(timeout=WAIT_TIME, poll_interval=INTERVAL)
 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports

--- a/tests/snappi_tests/reboot/files/reboot_helper.py
+++ b/tests/snappi_tests/reboot/files/reboot_helper.py
@@ -1,5 +1,5 @@
 from tabulate import tabulate
-from tests.common.utilities import (wait, wait_until)
+from tests.common.utilities import wait
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.reboot import reboot
 from threading import Thread
@@ -559,9 +559,7 @@ def get_convergence_for_reboot_test(duthost,
     bgp_up_time = bgp_up_start_timer - bgp_down_start_timer
     loopback_up_time = loopback_up_start_timer - loopback_down_start_timer
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(360, 10, 1,
-                             duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started(timeout=360, poll_interval=10, wait=1)
     request = snappi_api.metrics_request()
     request.convergence.flow_names = []  # flow_names
     convergence_metrics = snappi_api.get_metrics(request).convergence_metrics

--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -12,7 +12,6 @@ from tests.common.helpers.assertions import pytest_require
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.helpers.thermal_control_test_helper import disable_thermal_policy     # noqa F401
 from .device_mocker import device_mocker_factory        # noqa F401
-from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.duthost_utils import is_support_mock_asic, is_support_fan, is_support_psu    # noqa F401
 
 pytestmark = [
@@ -598,5 +597,4 @@ class ProcessExitContext:
         self.dut.command('docker exec -t {} bash -c "supervisorctl start {}"'.format(
             self.container_name, self.process_name))
         # check with delay in which the dockers can be restarted
-        pytest_assert(wait_until(300, 20, 8, self.dut.critical_services_fully_started),
-                      "Not all critical services are fully started")
+        self.dut.wait_critical_services_fully_started(wait=8)

--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -111,7 +111,9 @@ def post_reboot_healthcheck(duthost, localhost, duthosts, wait_time):
     else:
         localhost.wait_for(host=duthost.mgmt_ip, port=22, state="started", delay=10, timeout=timeout)
     wait(wait_time, msg="Wait {} seconds for system to be stable.".format(wait_time))
-    if not wait_until(300, 20, 0, duthost.critical_services_fully_started):
+    try:
+        duthost.wait_critical_services_fully_started()
+    except TimeoutError:
         logger.error("Not all critical services fully started!")
         return False
     # If supervisor node is rebooted in chassis, linecards also will reboot.

--- a/tests/voq/test_voq_chassis_app_db_consistency.py
+++ b/tests/voq/test_voq_chassis_app_db_consistency.py
@@ -238,8 +238,7 @@ def test_voq_chassis_app_db_consistency(duthosts, enum_rand_one_per_hwsku_fronte
                 pytest_assert(check_db_consistency(duthosts, duthost, post_change_db_dump),
                               "DB_Consistency Failed During Reboot")
             localhost.wait_for(host=duthost.mgmt_ip, port=22, state="started", delay=10, timeout=300)
-            pytest_assert(wait_until(330, 20, 0, duthost.critical_services_fully_started),
-                          "All critical services should fully started!")
+            duthost.wait_critical_services_fully_started(timeout=330)
             pytest_assert(wait_until(600, 30, 0, check_db_consistency, duthosts, duthost, init_dump),
                           "DB_Consistency Failed After Reboot")
 

--- a/tests/voq/test_voq_disrupts.py
+++ b/tests/voq/test_voq_disrupts.py
@@ -181,8 +181,7 @@ def test_reboot_supervisor(duthosts, localhost, all_cfg_facts, nbrhosts, nbr_mac
     logger.info("-" * 80)
 
     reboot(duthosts.supervisor_nodes[0], localhost, wait=240)
-    assert wait_until(300, 20, 2, duthosts.supervisor_nodes[0].critical_services_fully_started),\
-        "Not all critical services are fully started"
+    duthosts.supervisor_nodes[0].wait_critical_services_fully_started(wait=2)
 
     poll_bgp_restored(duthosts)
 
@@ -228,8 +227,7 @@ def test_reboot_system(duthosts, localhost, all_cfg_facts, nbrhosts, nbr_macs, t
     parallel_run(reboot_node, [localhost], {}, duthosts.nodes, timeout=1000)
 
     for node in duthosts.nodes:
-        assert wait_until(300, 20, 2, node.critical_services_fully_started),\
-            "Not all critical services are fully started"
+        node.wait_critical_services_fully_started(wait=2)
 
     poll_bgp_restored(duthosts)
 

--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -1207,9 +1207,7 @@ class TestVrfWarmReboot:
         assert len(tbd_comp_list) == 0, "Some components didn't finish reconcile: {} ...".format(tbd_comp_list)
 
         # basic check after warm reboot
-        assert wait_until(
-            300, 20, 0, duthost.critical_services_fully_started
-        ), "All critical services should fully started!{}".format(duthost.critical_services)
+        duthost.wait_critical_services_fully_started()
 
         up_ports = [p for p, v in list(cfg_facts["PORT"].items()) if v.get("admin_status", None) == "up"]
         assert wait_until(300, 20, 0, check_interface_status, duthost, up_ports), "All interfaces should be up!"
@@ -1250,9 +1248,7 @@ class TestVrfWarmReboot:
         assert len(tbd_comp_list) == 0, "Some components didn't finish reconcile: {} ...".format(tbd_comp_list)
 
         # basic check after warm reboot
-        assert wait_until(
-            300, 20, 0, duthost.critical_services_fully_started
-        ), "Not all critical services are fully started"
+        duthost.wait_critical_services_fully_started()
 
         up_ports = [p for p, v in list(cfg_facts["PORT"].items()) if v.get("admin_status", None) == "up"]
         assert wait_until(300, 20, 0, check_interface_status, duthost, up_ports), "Not all interfaces are up"

--- a/tests/zmq/test_gnmi_zmq.py
+++ b/tests/zmq/test_gnmi_zmq.py
@@ -57,8 +57,7 @@ def enable_zmq(duthost):
     logger.debug("set subtype subtype: {}".format(result))
     save_reload_config(duthost)
 
-    pytest_assert(wait_until(360, 10, 120, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started(timeout=360, poll_interval=10, wait=120)
 
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {})


### PR DESCRIPTION

Clean up some very pervasive magic numbers throughout the test suite, when waiting for critical processes to start.
Some call sites have overridden values to keep the functionality the same. These should be reviewed and either removed or justified in a future change.

duthost.wait_critical_services_fully_started() method raises a TimeoutError if the wait fails.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
