### PR TITLE
Add wait_for_bgp to avoid memory utilization check failure

### DIFF
--- a/tests/override_config_table/test_override_config_table.py
+++ b/tests/override_config_table/test_override_config_table.py
@@ -4,7 +4,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import skip_release
 from tests.common.utilities import update_pfcwd_default_state
 from tests.common.config_reload import config_reload
-from tests.common.utilities import backup_config, restore_config, get_running_config,\
+from tests.common.utilities import backup_config, restore_config, get_running_config, \
     reload_minigraph_with_golden_config, file_exists_on_dut, compare_dicts_ignore_list_order, \
     NON_USER_CONFIG_TABLES
 from tests.common import mellanox_data
@@ -63,7 +63,7 @@ def setup_env(duthosts, golden_config_exists_on_dut, tbinfo, enum_rand_one_per_h
         backup_config(duthost, GOLDEN_CONFIG, GOLDEN_CONFIG_BACKUP)
 
     # Reload test env with minigraph
-    config_reload(duthost, config_source="minigraph", safe_reload=True)
+    config_reload(duthost, config_source="minigraph", safe_reload=True, wait_for_bgp=True)
     running_config = get_running_config(duthost)
 
     yield running_config
@@ -81,7 +81,7 @@ def setup_env(duthosts, golden_config_exists_on_dut, tbinfo, enum_rand_one_per_h
         duthost.file(path=GOLDEN_CONFIG, state='absent')
 
     # Restore config before test
-    config_reload(duthost)
+    config_reload(duthost, safe_reload=True, wait_for_bgp=True)
 
 
 def load_minigraph_with_golden_empty_input(duthost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: The setup_env fixture config_reload calls did not wait for BGP convergence, causing memory_utilization to capture a low baseline (~48MB) before BGP sessions were established. After BGP converged, normal steady-state memory (~178MB) was flagged as exceeding the increase threshold.
Fixes # (issue)
Fixes initermittent memory utilization check failure in test_load_minigraph_with_golden_config

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
test_load_minigraph_with_golden_config intermittently fails with memory_utilization ALARM in teardown:
[ALARM]: top:bgpd memory usage increased by 130.1 MB, exceeds increase threshold 128.0 MB (previous: 48.5 MB, current: 178.6 MB)
[ALARM]: frr_bgp:used memory usage increased by 133.0%, exceeds increase threshold 50% (previous: 44.0 MB, current: 177.0 MB)

The root cause is that setup_env fixture calls config_reload without wait_for_bgp=True. The memory_utilization fixture captures a baseline before BGP has converged (~48MB), and after BGP converges during the test body the memory rises to its normal steady-state (~178MB), triggering a false positive alarm.
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?
No. Applies to all platforms running BGP.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
