### PR TITLE
[conditional_mark] Fix nodeid matching: also strip 'tests/' prefix

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -691,12 +691,15 @@ def pytest_collection_modifyitems(session, config, items):
         json.dumps(basic_facts, indent=2)))
     dynamic_update_skip_reason = session.config.option.dynamic_update_skip_reason
     basic_facts['constants'] = MARK_CONDITIONS_CONSTANTS
-    # Normalize nodeids: strip root directory prefix if present (pytest 9.0+ includes it)
+    # Normalize nodeids: strip root directory prefix and tests/ dir if present (pytest 9.0+ includes them)
     root_prefix = os.path.basename(str(session.config.rootpath)) + "/"
+    tests_prefix = "tests/"
     for item in items:
         nodeid = item.nodeid
         if nodeid.startswith(root_prefix):
             nodeid = nodeid[len(root_prefix):]
+        if nodeid.startswith(tests_prefix):
+            nodeid = nodeid[len(tests_prefix):]
         all_matches = find_all_matches(nodeid, conditions, session, dynamic_update_skip_reason, basic_facts)
 
         if all_matches:


### PR DESCRIPTION
### Description of PR

Summary: Fix `conditional_mark` plugin so skip/xfail marks from `tests_mark_conditions*.yaml` are actually applied when pytest is invoked with `rootdir = repo root` (the default, since `pyproject.toml` lives there).

Pytest 9.0+ nodeids are relative to `rootdir` and do NOT include the rootdir directory name itself. When `rootdir` is the repo root, nodeids look like `tests/cacl/test_cacl_application.py::test_cacl_application_dualtor[...]` with a `tests/` prefix, but YAML condition keys are stored without that prefix (e.g. `cacl/test_cacl_application.py::test_cacl_application_dualtor`). As a result, `nodeid.startswith(condition_entry)` always returns False and every skip/xfail condition in the YAML files is silently ignored.

This patch strips a leading `tests/` prefix from the normalized nodeid so entries like `tests/cacl/test_cacl_application.py::test_cacl_application_dualtor[...]` reduce to `cacl/test_cacl_application.py::test_cacl_application_dualtor[...]` and match the YAML keys.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

Several tests that should be skipped by conditions in `tests_mark_conditions*.yaml` were running and erroring in fixture setup on topologies they were never meant to run on. Investigation showed the conditional_mark plugin was never emitting `Found match` / `Adding mark` log lines, even for entries that clearly matched on paper.

The culprit was nodeid normalization: pytest nodeids under the current `rootdir = repo root` configuration include a `tests/` prefix that is not present in the YAML keys.

#### How did you do it?

Added a strip step for a leading `"tests/"` prefix in `pytest_collection_modifyitems`:

```python
tests_prefix = "tests/"
for item in items:
    nodeid = item.nodeid
    if nodeid.startswith(root_prefix):
        nodeid = nodeid[len(root_prefix):]
    if nodeid.startswith(tests_prefix):
        nodeid = nodeid[len(tests_prefix):]
    all_matches = find_all_matches(nodeid, ...)
```

#### How did you verify/test it?

Ran `cacl/test_cacl_application.py::test_cacl_application_dualtor` on a physical testbed (topology `bmc-dual-mgmt`, which is not in the allowed dualtor list) where the YAML has:

```yaml
cacl/test_cacl_application.py::test_cacl_application_dualtor:
  skip:
    reason: "test_cacl_application_dualtor is only supported on dualtor topology"
    conditions:
      - "topo_name not in ['dualtor', 'dualtor-56', 'dualtor-64', 'dualtor-64-breakout', 'dualtor-120']"
```

Before the patch:
- `errors=2 failures=0 skipped=0 tests=2` — both parametrizations ran and errored in fixture setup
- No `Found match` / `Adding mark` log line emitted.

After the patch:
- `errors=0 failures=0 skipped=2 tests=2` — both parametrizations skipped with the expected YAML reason
- Log shows `Found match "..."` and `Adding mark skip(reason=...)`.

#### Any platform specific information?

None — this is a framework-level fix affecting all platforms/topologies that rely on `tests_mark_conditions*.yaml`.

#### Supported testbed topology if it's a new test case?

N/A — bug fix to framework plugin.

### Documentation

N/A