### PR TITLE
[cacl] Skip SNMP probes in test_cacl_function on BMC topology

### DIFF
--- a/tests/cacl/test_cacl_function.py
+++ b/tests/cacl/test_cacl_function.py
@@ -20,12 +20,24 @@ SONIC_SSH_PORT = 22
 SONIC_SSH_REGEX = 'OpenSSH_[\\w\\.]+ Debian'
 
 
-def test_cacl_function(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds):
+def _is_bmc_topology(tbinfo):
+    """Return True if the current testbed is a BMC topology (no snmp container)."""
+    if not tbinfo:
+        return False
+    topo = tbinfo.get('topo', {}) or {}
+    return 'bmc' in (topo.get('type') or '') or 'bmc' in (topo.get('name') or '')
+
+
+def test_cacl_function(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds, tbinfo):
     """Test control plane ACL functionality on a SONiC device"""
 
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     data_acl = get_data_acl(duthost)
     dut_mgmt_ip = duthost.mgmt_ip
+    # SNMP container is not supported on BMC topology, skip SNMP probes there.
+    skip_snmp = _is_bmc_topology(tbinfo)
+    if skip_snmp:
+        logging.info("BMC topology detected; skipping SNMP probes in test_cacl_function.")
 
     # Start an NTP client
     if NTPLIB_INSTALLED:
@@ -34,14 +46,15 @@ def test_cacl_function(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cr
         logging.warning("Will not check NTP connection. ntplib is not installed.")
 
     # Ensure we can gather basic SNMP facts from the device. Should fail on timeout
-    get_snmp_facts(duthost,
-                   localhost,
-                   host=dut_mgmt_ip,
-                   version="v2c",
-                   community=creds['snmp_rocommunity'],
-                   wait=True,
-                   timeout=30,
-                   interval=5)
+    if not skip_snmp:
+        get_snmp_facts(duthost,
+                       localhost,
+                       host=dut_mgmt_ip,
+                       version="v2c",
+                       community=creds['snmp_rocommunity'],
+                       wait=True,
+                       timeout=30,
+                       interval=5)
 
     # Ensure we can send an NTP request
     if NTPLIB_INSTALLED:
@@ -83,14 +96,17 @@ def test_cacl_function(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cr
 
         pytest_assert(res.is_failed, "SSH did not timeout when expected. {}".format(res.get('msg', '')))
 
-        snmp_timeout = SNMP_DEFAULT_TIMEOUT
-        if duthost.facts['switch_type'] == "chassis-packet":
-            snmp_timeout = 5
-        # Ensure we CANNOT gather basic SNMP facts from the device
-        res = get_snmp_facts(duthost, localhost, host=dut_mgmt_ip, version='v2c', community=creds['snmp_rocommunity'],
-                             module_ignore_errors=True, snmp_timeout=snmp_timeout)
+        if not skip_snmp:
+            snmp_timeout = SNMP_DEFAULT_TIMEOUT
+            if duthost.facts['switch_type'] == "chassis-packet":
+                snmp_timeout = 5
+            # Ensure we CANNOT gather basic SNMP facts from the device
+            res = get_snmp_facts(duthost, localhost, host=dut_mgmt_ip, version='v2c',
+                                 community=creds['snmp_rocommunity'],
+                                 module_ignore_errors=True, snmp_timeout=snmp_timeout)
 
-        pytest_assert('ansible_facts' not in res and "No SNMP response received before timeout" in res.get('msg', ''))
+            pytest_assert('ansible_facts' not in res
+                          and "No SNMP response received before timeout" in res.get('msg', ''))
 
         # Ensure we cannot send an NTP request to the DUT
         if NTPLIB_INSTALLED:
@@ -118,14 +134,15 @@ def test_cacl_function(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cr
         duthost.file(path="/tmp/config_service_acls.sh", state="absent")
 
         # Ensure we can gather basic SNMP facts from the device once again. Should fail on timeout
-        get_snmp_facts(duthost,
-                       localhost,
-                       host=dut_mgmt_ip,
-                       version="v2c",
-                       community=creds['snmp_rocommunity'],
-                       wait=True,
-                       timeout=120,
-                       interval=20)
+        if not skip_snmp:
+            get_snmp_facts(duthost,
+                           localhost,
+                           host=dut_mgmt_ip,
+                           version="v2c",
+                           community=creds['snmp_rocommunity'],
+                           wait=True,
+                           timeout=120,
+                           interval=20)
     finally:
         if data_acl:
             recover_acl_rule(duthost, data_acl)

--- a/tests/cacl/test_cacl_function.py
+++ b/tests/cacl/test_cacl_function.py
@@ -20,24 +20,16 @@ SONIC_SSH_PORT = 22
 SONIC_SSH_REGEX = 'OpenSSH_[\\w\\.]+ Debian'
 
 
-def _is_bmc_topology(tbinfo):
-    """Return True if the current testbed is a BMC topology (no snmp container)."""
-    if not tbinfo:
-        return False
-    topo = tbinfo.get('topo', {}) or {}
-    return 'bmc' in (topo.get('type') or '') or 'bmc' in (topo.get('name') or '')
-
-
-def test_cacl_function(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds, tbinfo):
+def test_cacl_function(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds):
     """Test control plane ACL functionality on a SONiC device"""
 
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     data_acl = get_data_acl(duthost)
     dut_mgmt_ip = duthost.mgmt_ip
-    # SNMP container is not supported on BMC topology, skip SNMP probes there.
-    skip_snmp = _is_bmc_topology(tbinfo)
+    # SNMP container is not supported on BMC devices, skip SNMP probes there.
+    skip_snmp = duthost.is_bmc()
     if skip_snmp:
-        logging.info("BMC topology detected; skipping SNMP probes in test_cacl_function.")
+        logging.info("BMC device detected; skipping SNMP probes in test_cacl_function.")
 
     # Start an NTP client
     if NTPLIB_INSTALLED:


### PR DESCRIPTION
### Description of PR

Summary:
`cacl/test_cacl_function.py::test_cacl_function` fails on BMC topologies because BMC devices do not ship the `snmp` container. The very first baseline call in the test, `get_snmp_facts(..., wait=True, timeout=30)`, always times out with:

```
Failed: Timeout waiting for SNMP facts
```

NTP and SSH are available on BMC, so we still want to exercise the CACL apply/reset flow plus the NTP and SSH probes there. This PR wraps only the three SNMP probes (and the during-ACL `pytest_assert` that consumes the SNMP result) in a BMC-topology guard, preserving NTP and SSH CACL coverage on BMC.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`test_cacl_function` asserts that SNMP, NTP, and SSH all work both before and after a control-plane ACL swap. BMC topologies don't run the `snmp` container at all, so the first SNMP probe always fails before any CACL logic can be validated. That blocks the rest of the useful coverage (NTP and SSH) on BMC.

#### How did you do it?
- Use the existing `SonicHost.is_bmc()` method (`duthost._facts['router_type'] == 'NetworkBmc'`) to detect BMC devices.
- Wrapped the three `get_snmp_facts(...)` calls with `if not skip_snmp:`.
- Wrapped the during-ACL block (`snmp_timeout`, `get_snmp_facts`, and the paired `pytest_assert`) as a single unit so the assert is only reached when SNMP was actually probed.
- No behavior change on non-BMC devices.

#### How did you verify/test it?
- Ran `tests/cacl/test_cacl_function.py::test_cacl_function` locally on a Komodo BMC testbed (hwsku `NH-B27`, topology `bmc-dual-mgmt`, host `host1-komodo-bmc`) on 2026-04-22.
  - Result: **1 passed, 0 failed, 0 errors, 0 skipped** in 339s.
  - Log confirms the new guard took effect: `INFO root:test_cacl_function.py:32 BMC device detected; skipping SNMP probes in test_cacl_function.`
  - CACL apply/reset (`NTP_ACL`, `SNMP_ACL`, `SSH_ONLY`) rules were still exercised; SSH probes ran normally.
- No behavioral change on non-BMC devices by inspection: `skip_snmp` is `False` when `duthost.is_bmc()` is `False`, so the `get_snmp_facts` and `pytest_assert` calls execute exactly as before.

#### Any platform specific information?
Only activates on BMC devices (where `duthost.is_bmc()` is True, i.e. `router_type == NetworkBmc`). All other devices behave exactly as before.

#### Supported testbed topology if it's a new test case?
N/A ΓÇö bug fix to an existing test.

### Documentation
N/A


