### PR TITLE
Add timestamp in the log file name for parallel add/remove-topo

### DIFF
--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -418,6 +418,7 @@ function wait_parallel_processes() {
   local operation_type=$1
   local -n pids_ref=$2
   local server_count=$3
+  local log_timestamp=$4
 
   # Wait for all parallel processes to complete
   if [[ "$parallel_execution" == "true" ]]; then
@@ -436,10 +437,11 @@ function wait_parallel_processes() {
       else
         echo "${operation_type}_topo output for server $i:"
       fi
-      if [ -f "/tmp/${operation_type}_topo_$i.log" ]; then
-        cat "/tmp/${operation_type}_topo_$i.log"
+      local log_file="/tmp/${operation_type}_topo_${i}_${log_timestamp}.log"
+      if [ -f "$log_file" ]; then
+        cat "$log_file"
       else
-        echo "Warning: Log file /tmp/${operation_type}_topo_$i.log not found"
+        echo "Warning: Log file $log_file not found"
       fi
     done
   fi
@@ -476,6 +478,9 @@ function add_topo
   # Array to store process IDs for parallel execution
   declare -a pids
 
+  # Timestamp for log files to avoid overwriting logs across retries
+  log_timestamp=$(date +%Y%m%d_%H%M%S)
+
   for i in $(seq 0 $(($server_count-1)))
   do
     if [ -n "$servers" ]; then
@@ -495,7 +500,7 @@ function add_topo
 
     if [[ "$parallel_execution" == "true" ]]; then
       # Parallel execution: run in background and capture PID
-      eval "$ansible_cmd" > "/tmp/add_topo_$i.log" 2>&1 &
+      eval "$ansible_cmd" > "/tmp/add_topo_${i}_${log_timestamp}.log" 2>&1 &
       pids[$i]=$!
     else
       # Serial execution: run synchronously
@@ -504,7 +509,7 @@ function add_topo
   done
 
   # Wait for all parallel processes to complete
-  wait_parallel_processes "add" pids "$server_count"
+  wait_parallel_processes "add" pids "$server_count" "$log_timestamp"
 
   # Execute fanout connection and cleanup steps
   for i in $(seq 0 $(($server_count-1)))
@@ -573,6 +578,9 @@ function remove_topo
   # Array to store process IDs for parallel execution
   declare -a pids
 
+  # Timestamp for log files to avoid overwriting logs across retries
+  log_timestamp=$(date +%Y%m%d_%H%M%S)
+
   for i in $(seq 0 $(($server_count-1)))
   do
     if [ -n "$servers" ]; then
@@ -591,7 +599,7 @@ function remove_topo
 
     if [[ "$parallel_execution" == "true" ]]; then
       # Parallel execution: run in background and capture PID
-      eval "$ansible_cmd" > "/tmp/remove_topo_$i.log" 2>&1 &
+      eval "$ansible_cmd" > "/tmp/remove_topo_${i}_${log_timestamp}.log" 2>&1 &
       pids[$i]=$!
     else
       # Serial execution: run synchronously
@@ -600,7 +608,7 @@ function remove_topo
   done
 
   # Wait for all parallel processes to complete
-  wait_parallel_processes "remove" pids "$server_count"
+  wait_parallel_processes "remove" pids "$server_count" "$log_timestamp"
 
   echo Done
 }


### PR DESCRIPTION
Summary: Add timestamp in the log file name for parallel add/remove-topo
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Deploy multi-server testbed, add/remove-topo save log in /tmp/add_topo_$i.log and /tmp/remove_topo_$i.log.
If deploy failure, it will retry. But the new log will overwrite the old log, causing hard to debug the failure in first run.


#### How did you do it?
Add timestamp in the log file.


Before fix
```
- add_topo_0.log
- add_topo_1.log
```

After fix
```
- add_topo_0_20260420_200812.log
- add_topo_1_20260420_200812.log
```


#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
