### PR TITLE
Add sleep time before memory utilization check for tests/srv6/test_srv6_dataplane.py

### DIFF
--- a/tests/srv6/srv6_utils.py
+++ b/tests/srv6/srv6_utils.py
@@ -69,6 +69,8 @@ def validate_techsupport_generation(duthost, feature_list=[]):
     finally:
         logger.info(f'Delete {tech_support_file_path}')
         duthost.shell(f'sudo rm -rf {tech_support_file_path}')
+        logger.info('Sleeping for 5 seconds for memory usage recovery')
+        time.sleep(5)
 
 
 #

--- a/tests/srv6/test_srv6_dataplane.py
+++ b/tests/srv6/test_srv6_dataplane.py
@@ -27,7 +27,8 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.asic("mellanox", "broadcom", "vpp"),
-    pytest.mark.topology("t0", "t1")
+    pytest.mark.topology("t0", "t1"),
+    pytest.mark.disable_memory_utilization
 ]
 
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
There are several reasons:
1.The fixture memory_utilization is a functional scope fixture, and the configuration fixture in test_srv6_dataplane.py are module and class scope. So the memory check would be executed right after the scale srv6 configurations, the memory check result before test is not stable. 
2.There are bgp reload during test.
3.There are techsupport operation during test, it would lead the memory check post test not stable.


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The memory utilization check always failed at tests/srv6/test_srv6_dataplane.py
#### How did you do it?
Disable the memory utilization check for tests/srv6/test_srv6_dataplane.py
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
