### PR TITLE
Skip test on ports which admin status is down in test_sfputil.py

### DIFF
--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -394,12 +394,16 @@ def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_h
         pytest.skip("Skip test as error status isn't supported")
     parsed_presence = parse_output(sfp_error_status["stdout_lines"][2:])
     physical_port_index_map = get_physical_port_indices(duthost, conn_graph_facts["device_conn"][duthost.hostname])
+    admin_up_port_set = set(duthost.get_admin_up_ports())
+
     for intf in dev_conn:
         if intf not in xcvr_skip_list[duthost.hostname]:
             expected_state = 'OK'
             intf_index = physical_port_index_map[intf]
             if cmd_sfp_error_status == "sudo sfputil show error-status --fetch-from-hardware"\
                     and is_mellanox_device(duthost) and is_sw_control_enabled(duthost, intf_index):
+                if intf not in admin_up_port_set:
+                    continue
                 expected_state = get_port_expected_error_state_for_mellanox_device_on_sw_control_enabled(
                     intf, passive_cable_ports[duthost.hostname], cmis_cable_ports_and_ver[duthost.hostname])
             elif "Not supported" in sfp_error_status['stdout']:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Deploy topology ptp-256 on all **optical** cables injected platform sn5640, the Ethernet256 to Ethernet511 would be admin and oper down.
When software control function enabled on optical cables, the output of command 'sfputil show error-status --fetch-from-hardware' on admin down ports would not be 'OK' 
Usually, it would be '**DataPathDeactivated**' or '**DataPathInitialized**'. 
Based on the facts, update the test to skip validation on the admin down ports

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The output of "sfputil show error-status --fetch-from-hardware" on software control enabled admin down and oper down optical ports could not be 'OK'.
#### How did you do it?
Skip the check on the software control enabled admin down and oper down optical ports 
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
