### PR TITLE
Execute a complete config reload then check lldp table

### DIFF
--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -682,7 +682,7 @@ def test_lldp_interfaces_config_reload(duthosts, enum_rand_one_per_hwsku_fronten
                       "No LLDP neighbors found before config reload")
 
         logger.info("Step 2: Performing config reload")
-        config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
 
         logger.info("Step 3: Waiting for system to stabilize after config reload")
         # Wait for LLDP to converge


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The data plane port neighbors always would be the VMs on server. 
The mgmt port neighbors of eth0 would be devices in lab.
The LLDP packet update start time on VMs may be different from the devices in local lab.
During a config reload, right after the ports up, the LLDP receiving time of VMs at server and devices in lab may be different, it would lead to the lldp neighbor entry of eth0 several seconds later than the data port lldp neighbor entries.
It would lead to function verify_lldp_table failure under this scenario.

Do a BGP validation during the config reload, to avoid the issue above.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Avoid lldp neighbor entry check when lacking of eth0 entry
#### How did you do it?
Wait for bgp when doing config reload
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
