### PR TITLE
Skip `ip_proto` variant in `test_fib.py` test on UT2 64p topos

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -414,6 +414,11 @@ def hash_keys(duthost, tbinfo):
         #  to ensure packets are evenly distributed to all 64 egress ports
         if 'ip-proto' in hash_keys:
             hash_keys.remove('ip-proto')
+    if tbinfo['topo']['name'] in ['t2_single_node_max_64p', 't2_single_node_max_64p_v2']:
+        # Remove ip-proto on topos that have 64 ports as there isn't enough entropy in
+        # the ip-proto field (8-bits) to get a good distribution across that many ports
+        if 'ip-proto' in hash_keys:
+            hash_keys.remove('ip-proto')
     # remove the ingress port from multi asic platform
     # In multi asic platform each asic has different hash seed,
     # the same packet coming in different asic


### PR DESCRIPTION
### Description of PR
On 64p UT2 topos we've seen that the `ip_proto` variant of `test_fib.py` can fail due to poor distributions seen across the 32-port ECMP.
This isn't surprising as `ip_proto` only has 8-bits so 256 unique values which isn't enough entropy to expect a good distribution across a 32-port ECMP
```
16:22:48.727  root      : INFO    : hash_key=**ip-proto**, hit count map: {57: 512, 12: 256, 3: 320, 63: 256, 0: 256, 59: 320, 54: 416, 58: 96, 15: 320, 56: 192, 53: 320, 4: 192, 5: 384, 9: 288, 52: 128, 49: 256, 55: 256, 7: 160, 50: 480, 8: 224, 51: 192, 13: 288, 10: 256, 2: 96, 11: 224, 14: 128, 1: 320, 62: 192, 60: 256, 48: 64, 61: 224, 6: 128}
16:22:48.727  root      : INFO    : type         port(s)            exp_cnt         act_cnt         diff(%)
16:22:48.727  root      : INFO    : ECMP         [0]                    250             256            2.4%
16:22:48.727  root      : INFO    : ECMP         [1]                    250             320      28.000000000000004%
16:22:48.727  root      : INFO    : ECMP         [2]                    250              96          -61.6%
16:22:48.727  root      : INFO    : ECMP         [3]                    250             320      28.000000000000004%
16:22:48.727  root      : INFO    : ECMP         [4]                    250             192      -23.200000000000003%
16:22:48.727  root      : INFO    : ECMP         [5]                    250             384           53.6%
16:22:48.727  root      : INFO    : ECMP         [6]                    250             128          -48.8%
16:22:48.727  root      : INFO    : ECMP         [7]                    250             160          -36.0%
16:22:48.727  root      : INFO    : ECMP         [8]                    250             224          -10.4%
16:22:48.727  root      : INFO    : ECMP         [9]                    250             288           15.2%
16:22:48.727  root      : INFO    : ECMP         [10]                   250             256            2.4%
16:22:48.727  root      : INFO    : ECMP         [11]                   250             224          -10.4%
16:22:48.727  root      : INFO    : ECMP         [12]                   250             256            2.4%
16:22:48.727  root      : INFO    : ECMP         [13]                   250             288           15.2%
16:22:48.727  root      : INFO    : ECMP         [14]                   250             128          -48.8%
16:22:48.727  root      : INFO    : ECMP         [15]                   250             320      28.000000000000004%
16:22:48.727  root      : INFO    : ECMP         [48]                   250              64          -74.4%
16:22:48.727  root      : INFO    : ECMP         [49]                   250             256            2.4%
16:22:48.727  root      : INFO    : ECMP         [50]                   250             480           **92.0%**
16:22:48.728  root      : INFO    : ECMP         [51]                   250             192      -23.200000000000003%
16:22:48.728  root      : INFO    : ECMP         [52]                   250             128          -48.8%
16:22:48.728  root      : INFO    : ECMP         [53]                   250             320      28.000000000000004%
16:22:48.728  root      : INFO    : ECMP         [54]                   250             416           66.4%
16:22:48.728  root      : INFO    : ECMP         [55]                   250             256            2.4%
16:22:48.728  root      : INFO    : ECMP         [56]                   250             192      -23.200000000000003%
16:22:48.728  root      : INFO    : ECMP         [57]                   250             512      **104.80000000000001%**
16:22:48.728  root      : INFO    : ECMP         [58]                   250              96          -61.6%
16:22:48.728  root      : INFO    : ECMP         [59]                   250             320      28.000000000000004%
16:22:48.728  root      : INFO    : ECMP         [60]                   250             256            2.4%
16:22:48.728  root      : INFO    : ECMP         [61]                   250             224          -10.4%
16:22:48.728  root      : INFO    : ECMP         [62]                   250             192      -23.200000000000003%
16:22:48.728  root      : INFO    : ECMP         [63]                   250             256            2.4%
```

This PR skips the `ip_proto` variant specifically on these UT2 64p topos

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The `ip_proto` variant doesn't have enough entropy to pass reliably on UT2 64p topos so skip it.

#### How did you do it?
Remove the `ip_proto` from the list of `hash_keys` for topos `t2_single_node_max_64p` and `t2_single_node_max_64p_v2`

#### How did you verify/test it?
Ran all testlets in `fib/test_fib.py` and saw they all passed on our UT2 64p topo

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
