### PR TITLE
[test_logrotate] logrotate debug message if failing

### DIFF
--- a/tests/syslog/test_logrotate.py
+++ b/tests/syslog/test_logrotate.py
@@ -144,12 +144,19 @@ def run_logrotate(duthost, force=False):
     """
     if force:
         logger.debug('Make sure there is no big /var/log/syslog exist by forcing execute logrotate')
-        cmd = 'sudo /usr/sbin/logrotate -f /etc/logrotate.conf > /dev/null 2>&1'
+        cmd = 'sudo /usr/sbin/logrotate -f /etc/logrotate.conf'
     else:
-        cmd = 'sudo /usr/sbin/logrotate /etc/logrotate.conf > /dev/null 2>&1'
+        cmd = 'sudo /usr/sbin/logrotate /etc/logrotate.conf'
     logger.info('Run logrotate command: {}'.format(cmd))
-    duthost.shell(cmd)
-
+    result = duthost.shell(cmd, module_ignore_errors=True)
+    if result.get('rc', 1) != 0:
+        logger.warning(
+            'Logrotate returned non-zero rc={} (stdout: {}, stderr: {})'.format(
+                result.get('rc'),
+                result.get('stdout', ''),
+                result.get('stderr', '')
+            )
+        )
 
 def multiply_with_unit(logrotate_threshold, num):
     """

--- a/tests/syslog/test_logrotate.py
+++ b/tests/syslog/test_logrotate.py
@@ -158,6 +158,7 @@ def run_logrotate(duthost, force=False):
             )
         )
 
+
 def multiply_with_unit(logrotate_threshold, num):
     """
     Multiply logrotate_threshold with number, and return the value


### PR DESCRIPTION
**Description of PR**
under the logrotate testcase, the logrotate cli cmd fails without printing any info
  sudo /usr/sbin/logrotate -f logrotate.conf > /dev/null 2>&1 returned rc=1 
  duthost.shell(cmd)

we should base on the stderr to find out the root-cause and take action
ex: file system has char corrupted or config file is not well defined

**example:**
we change the logic to dump stdout and stderr. ex:
xxxxxx test_logrotate.run_logrotate             L0132 WARNING| Logrotate returned non-zero rc=1 (stdout: , stderr: logrotate_script: xxxxxx )

Summary:
Fixes # (issue)
let stdout and stderr msg to be printed

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement

### Back port request
- [X] 202405
- [X] 202411
- [X] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
testcase failing
#### How did you do it?
we should base on the stderr to find out the root-cause and take action

#### How did you verify/test it?
Yes
#### Any platform specific information?
reproduce rate < 5%;  ex: file system has char corrupted or config file is not well defined

#### Supported testbed topology if it's a new test case?
Generic issue
### Documentation
