### PR TITLE
Add topo_name and topo_type to test_ecmp_group_member_flap

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -888,7 +888,9 @@ def test_ecmp_group_member_flap(
             "single_fib_for_duts": single_fib_for_duts,
             "switch_type": switch_type,
             "asic_type": asic_type,
-            "skip_src_ports": filtered_ports
+            "skip_src_ports": filtered_ports,
+            "topo_name": updated_tbinfo['topo']['name'],
+            "topo_type": updated_tbinfo['topo']['type'],
         },
         log_file=log_file,
         qlen=PTF_QLEN,
@@ -944,7 +946,9 @@ def test_ecmp_group_member_flap(
             "single_fib_for_duts": single_fib_for_duts,
             "switch_type": switch_type,
             "asic_type": asic_type,
-            "skip_src_ports": filtered_ports
+            "skip_src_ports": filtered_ports,
+            "topo_name": updated_tbinfo['topo']['name'],
+            "topo_type": updated_tbinfo['topo']['type'],
         },
         log_file=member_down_log_file,
         qlen=PTF_QLEN,
@@ -994,7 +998,9 @@ def test_ecmp_group_member_flap(
             "single_fib_for_duts": single_fib_for_duts,
             "switch_type": switch_type,
             "asic_type": asic_type,
-            "skip_src_ports": filtered_ports
+            "skip_src_ports": filtered_ports,
+            "topo_name": updated_tbinfo['topo']['name'],
+            "topo_type": updated_tbinfo['topo']['type'],
         },
         log_file=member_up_log_file,
         qlen=PTF_QLEN,


### PR DESCRIPTION
### Description of PR

Summary:
Add topo_name and topo_type params to the ptf_runner calls in test_ecmp_group_member_flap so that topology-specific logic in fib_test.FibTest is correctly activated (e.g., FT2 ingress port handling, relaxed ip-proto balancing range on T2 topologies).

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
PR #18459 added topo_name and topo_type support to fib_test.FibTest on the PTF side, enabling topology-aware behavior (FT2 ingress port selection, relaxed ip-proto balancing range on T2). However, test_ecmp_group_member_flap never passed these params to the PTF runner, so the PTF test always fell back to empty defaults, missing the topology-specific code paths.

#### How did you do it?
Added topo_name and topo_type to the params dict in all three ptf_runner invocations within test_ecmp_group_member_flap (initial verification, post member-down, post member-up), following the same pattern already used in test_fib.

#### How did you verify/test it?
Verified the diff is consistent with the pattern used in test_fib and other FIB tests that already pass topo_name/topo_type.
The change is also verified on a local testbed.
```
<?xml version="1.0" encoding="utf-8"?><testsuites name="pytest tests"><testsuite name="pytest" errors="0" failures="0" skipped="0" tests="1" time="3611.581" timestamp="2026-04-21T22:02:13.091289+00:00" hostname="sonic-mgmt-bingwang"><properties><property name="topology" value="ft2-64" /><property name="testbed" value="vms13-ft2-7060x6-4" /><property name="timestamp" value="2026-04-21 22:03:13.211616" /><property name="host" value="str4-7060x6-512-4" /><property name="asic" value="broadcom" /><property name="platform" value="x86_64-arista_7060x6_64pe_b" /><property name="hwsku" value="Arista-7060X6-64PE-P64" /><property name="os_version" value="20251110.21" /></properties><testcase classname="tests.fib.test_fib" name="test_ecmp_group_member_flap[True-False-1514]" time="3564.582"><properties><property name="start" value="2026-04-21 22:03:00.079738" /><property name="end" value="2026-04-21 23:02:24.663725" /></properties></testcase></testsuite></testsuites>
```
#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A (improvement to existing test)

### Documentation
N/A