### PR TITLE
[upgrade_sonic][chassis]: reboot sup seperately

### DIFF
--- a/ansible/upgrade_sonic.yml
+++ b/ansible/upgrade_sonic.yml
@@ -52,6 +52,12 @@
     - set_fact:
         real_ansible_host: "{{ ansible_ssh_host }}"
 
+    - name: find supervisor dut of testbed
+      set_fact:
+        sup_dut: "{{ item | default(None) }}"
+      when: hostvars[item]['card_type'] is defined and hostvars[item]['card_type'] == 'supervisor'
+      loop: "{{ testbed_facts['duts'] }}"
+
     - block:
 
         - name: Set next boot device to ONIE
@@ -115,12 +121,14 @@
 
         # Reboot may need some time to update firmware firstly.
         # Increasing the async time to 300 seconds to avoid reboot being interrupted.
-        - name: Reboot switch
+        # Don't reboot supervisor yet as it could interrupt linecard initialization.
+        - name: Reboot devices
           become: true
           shell: reboot
           async: 300
           poll: 0
           ignore_errors: true
+          when: inventory_hostname != sup_dut
 
       when: upgrade_type == "sonic"
 
@@ -135,6 +143,31 @@
         delay: 180
         timeout: 600
       changed_when: false
+
+    # reboot supervisor and wait for it to come back
+    - block:
+      - name: Reboot supervisor
+        become: true
+        shell: reboot
+        async: 300
+        poll: 0
+        ignore_errors: true
+
+      - name: Wait for sup to come back (to SONiC)
+        local_action: wait_for
+        args:
+          host: "{{ real_ansible_host }}"
+          port: 22
+          state: started
+          search_regex: "OpenSSH"
+          delay: 180
+          timeout: 600
+        changed_when: false
+
+      - name: Wait for chassis initialization
+        pause: seconds=60
+
+      when: upgrade_type == "sonic" and inventory_hostname == sup_dut
 
     - name: Wait for SONiC initialization
       pause: seconds=60

--- a/ansible/upgrade_sonic.yml
+++ b/ansible/upgrade_sonic.yml
@@ -128,7 +128,7 @@
           async: 300
           poll: 0
           ignore_errors: true
-          when: inventory_hostname != sup_dut
+          when: sup_dut is not defined or inventory_hostname != sup_dut
 
       when: upgrade_type == "sonic"
 
@@ -167,7 +167,7 @@
       - name: Wait for chassis initialization
         pause: seconds=60
 
-      when: upgrade_type == "sonic" and inventory_hostname == sup_dut
+      when: upgrade_type == "sonic" and sup_dut is defined and inventory_hostname == sup_dut
 
     - name: Wait for SONiC initialization
       pause: seconds=60


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Existing implementation of upgrade sonic will upgrade then reboot all duts in parallel. For chassis systems this can put linecards in a bad state if the sup reboots before the LCs have finished doing their thing / the sup reboots while LCs are doing first boot initialisation.

For Chassis, update/reboot linecards first, then do the supervisor

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
