### PR TITLE
[BMC] Default console baud rate set to 115200 for BMC platforms

### DIFF
--- a/tests/dut_console/test_console_baud_rate.py
+++ b/tests/dut_console/test_console_baud_rate.py
@@ -22,9 +22,12 @@ def is_sonic_console(conn_graph_facts, dut_hostname):
 
 
 def get_expected_baud_rate(duthost):
-    DEFAULT_BAUDRATE = 9600
+    # BMC platforms configure the kernel console at 115200 baud, while the rest of the
+    # fleet historically defaults to 9600. Inventory-level `console_baudrate` hostvar
+    # still takes precedence over this platform-class default when present.
+    default_baudrate = 115200 if duthost.is_bmc() else 9600
     hostvars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]
-    return hostvars.get('console_baudrate', DEFAULT_BAUDRATE)
+    return hostvars.get('console_baudrate', default_baudrate)
 
 
 def test_console_baud_rate_config(duthost):


### PR DESCRIPTION
### Description of PR

Summary:
`dut_console/test_console_baud_rate.py::test_console_baud_rate_config` currently fails on BMC DUTs:

```
Failed: Device baud rate is 115200, expected 9600
```

BMC platforms (e.g. `NH-B27`, `AST2700-EVB-BMC`) configure the kernel console at 115200 baud in `/proc/cmdline`, while the rest of the fleet historically uses 9600. The test's `get_expected_baud_rate()` helper hardcodes a 9600 default that is wrong for the BMC device class, which in turn flips the module-level `pass_config_test` flag and cascades failures into the two downstream tests (`test_baud_rate_sonic_connect`, `test_baud_rate_boot_connect`) via their setup `pytest_assert`.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Make the baseline `dut_console` test suite pass on BMC topology without per-host inventory tweaks on every BMC lab.

#### How did you do it?
In `get_expected_baud_rate(duthost)`, select the default baud rate based on `SonicHost.is_bmc()` (i.e. `router_type == 'NetworkBmc'`): 115200 for BMC, 9600 otherwise. The inventory-level `console_baudrate` hostvar still takes precedence when set, so existing non-BMC per-host overrides are preserved.

#### How did you verify/test it?
- Reproduced the original failure on a Komodo BMC testbed (`host1-komodo-bmc`, hwsku `NH-B27`); baseline XML shows `Failed: Device baud rate is 115200, expected 9600`.
- With this patch, `get_expected_baud_rate()` returns 115200 on that DUT, matching `/proc/cmdline` and unblocking the downstream cases in the same module.
- Non-BMC behavior is unchanged: `is_bmc()` returns False and the default stays at 9600; any host with `console_baudrate` in its inventory vars continues to win.

#### Any platform specific information?
Behavior change is gated by `SonicHost.is_bmc()`, which is True only for DUTs whose facts report `router_type == 'NetworkBmc'`. No impact on router / fabric / linecard DUTs.

#### Supported testbed topology if it's a new test case?
N/A — existing test; the `pytest.mark.topology('any')` marker is unchanged.

### Documentation
N/A
