### PR TITLE
Fix extract_log crash on unparseable syslog lines from logrotate race

### DIFF
--- a/ansible/library/extract_log.py
+++ b/ansible/library/extract_log.py
@@ -168,6 +168,9 @@ def convert_date(fct, s):
 
     locale.setlocale(locale.LC_ALL, loc)
 
+    if dt is None:
+        dt = 0
+        logger.warning(f"Failed to convert date from string, skipping unparseable line: {s}")
     return dt
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Print warning log so that lines with unparseable dates (e.g. split/truncated fragments caused by logrotate race conditions) are logged and skipped instead of crashing the entire LogAnalyzer teardown. When dt is None, set it to 0 to avoid exceptions during comparison.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Print warning log so that lines with unparseable dates

#### How did you do it?
print it

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
