### PR TITLE
[Mellanox] Update the test_check_sfp_eeprom due to design change 

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -12,6 +12,8 @@ import time
 from collections import defaultdict
 from natsort import natsorted
 from .transceiver_utils import all_transceivers_detected
+import ast
+from tests.common.mellanox_data import is_mellanox_device
 
 
 def parse_intf_status(lines):
@@ -335,3 +337,44 @@ def get_lport_to_first_subport_mapping(duthost, logical_intfs=None):
     first_subport_dict = {k: pport_to_lport_mapping[v][0] for k, v in physical_port_indices.items()}
     logging.debug("First subports mapping: {}".format(first_subport_dict))
     return first_subport_dict
+
+
+def get_ports_with_flat_memory(dut, conn_graph_facts):
+    """
+    This method is to get ports with flat memory
+    """
+    port_indexes_with_flat_memory = []
+    if is_mellanox_device(dut):
+        port_indexes_with_flat_memory = get_port_indexes_with_flat_memory(dut)
+
+    physical_intfs = conn_graph_facts["device_conn"][dut.hostname]
+    physical_port_index_map = get_physical_port_indices(dut, physical_intfs)
+    ports_with_flat_memory = []
+    for port, index in physical_port_index_map.items():
+        if index in port_indexes_with_flat_memory:
+            ports_with_flat_memory.append(port)
+    logging.info(f"Ports with flat memory: {ports_with_flat_memory}")
+    return ports_with_flat_memory
+
+
+def get_port_indexes_with_flat_memory(dut):
+    """
+    This method is to get port indexes with flat memory
+    """
+    cmd = """
+cat << EOF > get_port_indexes_with_flat_memory.py
+import sonic_platform.platform as P
+num_sfps = P.Platform().get_chassis().get_num_sfps()
+port_indexes_with_flat_memory = []
+for i in range(1, num_sfps + 1):
+    is_flat_memory = P.Platform().get_chassis().get_sfp(i).get_xcvr_api().is_flat_memory()
+    if is_flat_memory:
+        port_indexes_with_flat_memory.append(i)
+print(port_indexes_with_flat_memory)
+EOF
+"""
+    dut.shell(cmd)
+    port_indexes_with_flat_memory = dut.shell("python3 get_port_indexes_with_flat_memory.py")["stdout"]
+    port_indexes_with_flat_memory = ast.literal_eval(port_indexes_with_flat_memory)
+    logging.info(f"Port indexes with flat memory: {port_indexes_with_flat_memory}")
+    return port_indexes_with_flat_memory

--- a/tests/common/platform/transceiver_utils.py
+++ b/tests/common/platform/transceiver_utils.py
@@ -207,19 +207,6 @@ def get_sfp_eeprom_map_per_port(eeprom_infos):
     return sfp_eeprom_map_per_port
 
 
-def get_ports_with_flat_memory(dut):
-    ports_with_flat_memory = []
-    cmd_show_eeprom = "sudo sfputil show eeprom -d"
-
-    eeprom_infos = dut.command(cmd_show_eeprom, module_ignore_errors=True)['stdout']
-    sfp_eerpom_map_per_port = get_sfp_eeprom_map_per_port(eeprom_infos)
-    for port_name, sfp_eeprom in sfp_eerpom_map_per_port.items():
-        if "DOM values not supported for flat memory module" in " ".join(sfp_eeprom):
-            ports_with_flat_memory.append(port_name)
-    logging.info(f"Ports with flat memory: {ports_with_flat_memory}")
-    return ports_with_flat_memory
-
-
 def parse_one_sfp_eeprom_info(sfp_eeprom_info):
     """
     Parse the one sfp eeprom info, return top_key, sfp_eeprom_info_dict

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1478,6 +1478,14 @@ platform_tests/test_service_warm_restart.py:
 #######################################
 #####   test_xcvr_info_in_db.py   #####
 #######################################
+
+platform_tests/test_xcvr_info_in_db.py:
+  skip:
+    reason: 'Transceiver info tests require SFP hardware, not available on VS platform'
+    conditions_logical_operator: or
+    conditions:
+      - "asic_type in ['vs']"
+
 platform_tests/test_xcvr_info_in_db.py::test_xcvr_info_in_db:
   xfail:
     reason: "CLI Utility sfpshow not working correctly"

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -7,8 +7,8 @@ from tests.common.mellanox_data import is_mellanox_device
 from .args.counterpoll_cpu_usage_args import add_counterpoll_cpu_usage_args
 from tests.common.helpers.mellanox_thermal_control_test_helper import suspend_hw_tc_service, resume_hw_tc_service
 from tests.common.platform.device_utils import MGFX_HWSKU, MGFX_XCVR_INTF
-from tests.common.platform.transceiver_utils import get_ports_with_flat_memory, \
-    get_passive_cable_port_list, get_cmis_cable_ports_and_ver
+from tests.common.platform.transceiver_utils import get_passive_cable_port_list, get_cmis_cable_ports_and_ver
+from tests.common.platform.interface_utils import get_ports_with_flat_memory
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -229,10 +229,10 @@ def dpu_npu_port_list(duthosts):
 
 
 @pytest.fixture(scope="module")
-def port_list_with_flat_memory(duthosts):
+def port_list_with_flat_memory(duthosts, conn_graph_facts):
     ports_with_flat_memory = {}
     for dut in duthosts:
-        ports_with_flat_memory.update({dut.hostname: get_ports_with_flat_memory(dut)})
+        ports_with_flat_memory.update({dut.hostname: get_ports_with_flat_memory(dut, conn_graph_facts)})
     logging.info(f"port list with flat memory: {ports_with_flat_memory}")
     return ports_with_flat_memory
 

--- a/tests/platform_tests/mellanox/test_check_sfp_eeprom.py
+++ b/tests/platform_tests/mellanox/test_check_sfp_eeprom.py
@@ -2,11 +2,12 @@ import pytest
 import allure
 
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts  # noqa: F401
-from .util import check_sfp_eeprom_info, is_support_dom, get_pci_cr0_path, get_pciconf0_path
+from .util import check_sfp_eeprom_info
 from tests.common.platform.transceiver_utils import parse_sfp_eeprom_infos
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.platform_tests.conftest import check_pmon_uptime_minutes
+import logging
 
 pytestmark = [
     pytest.mark.asic('mellanox', 'nvidia-bluefield'),
@@ -19,16 +20,11 @@ SHOW_EEPOMR_CMDS = ["show interface transceiver eeprom -d",
 
 @pytest.fixture(scope="module", autouse=True)
 def sfp_test_intfs_to_dom_map(duthosts, rand_one_dut_hostname, conn_graph_facts, xcvr_skip_list,  # noqa: F811
-                              get_sw_control_ports):
+                              get_sw_control_ports, port_list_with_flat_memory):  # noqa: F811
     '''
     This fixture is to get map sfp test intfs to dom
     '''
     duthost = duthosts[rand_one_dut_hostname]
-
-    ports_map = duthost.config_facts(host=duthost.hostname, source="running")[
-        'ansible_facts']["PORT"]
-    port_name_to_index_map = dict(
-        [(port, value["index"]) for port, value in list(ports_map.items())])
 
     sfp_test_intf_list = list(
         conn_graph_facts["device_conn"][duthost.hostname].keys())
@@ -37,28 +33,13 @@ def sfp_test_intfs_to_dom_map(duthosts, rand_one_dut_hostname, conn_graph_facts,
         # Exclude get_sw_control_ports from sfp_test_intf_list
         sfp_test_intf_list = [port for port in sfp_test_intf_list if port not in get_sw_control_ports]
 
-    intf_with_dom_dict = {}
-
     sfp_test_intfs_to_dom_map_dict = {}
-    platform = duthost.facts['platform']
-    dpu_platform_list = ["arm64-nvda_bf-9009d3b600cvaa", "arm64-nvda_bf-9009d3b600svaa"]
-    pci_path = get_pciconf0_path(duthost) if platform in dpu_platform_list else get_pci_cr0_path(duthost)
 
     for intf in sfp_test_intf_list:
         if intf not in xcvr_skip_list[duthost.hostname]:
-            port_index = port_name_to_index_map[intf]
-            original_port_index = port_index
-            if port_index in intf_with_dom_dict:
-                inft_support_dom = intf_with_dom_dict[port_index]
-            else:
-                if platform in dpu_platform_list and port_index == '2':
-                    pci_path = "{}.1".format(pci_path)
-                    port_index = '1'
-                inft_support_dom = is_support_dom(
-                    duthost, port_index, pci_path)
-                intf_with_dom_dict[original_port_index] = inft_support_dom
+            inft_support_dom = False if intf in port_list_with_flat_memory[duthost.hostname] else True
             sfp_test_intfs_to_dom_map_dict[intf] = inft_support_dom
-
+    logging.info(f"sfp_test_intfs_to_dom_map_dict: {sfp_test_intfs_to_dom_map_dict}")
     return sfp_test_intfs_to_dom_map_dict
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
1. Update the function to get the port with flat memory, because the PR https://github.com/sonic-net/sonic-utilities/pull/3950 removed the string of 'DOM values not supported for flat memory module' from the output of "sudo sfputil show eeprom -d"
2. To avoid a circular import, move get_ports_with_flat_memory from platform/transceiver_utils.py to  platform/interface_utils.py.
3. Update test_check_sfp_eeprom_with_option_dom: For ports that do not have flat memory, it implies DOM support. Remove the old code for checking DOM support, as the previous method is no longer applicable.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Update tests/platform_tests/mellanox/test_check_sfp_eeprom.py due to design change

#### How did you do it?
Update the function to get the port with flat memory

#### How did you verify/test it?
Run the test on mellanox device

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
