### PR TITLE
Fixing dns test failure due to pmon crash in test_rendered_golden_config_override

### DIFF
--- a/tests/golden_config_infra/test_config_reload_with_rendered_golden_config.py
+++ b/tests/golden_config_infra/test_config_reload_with_rendered_golden_config.py
@@ -63,7 +63,7 @@ def setup_env(duthosts, rand_one_dut_hostname, tbinfo):
         duthost.file(path=GOLDEN_CONFIG, state='absent')
 
     # Restore config before test
-    config_reload(duthost)
+    config_reload(duthost, safe_reload=True)
 
 
 def config_compare(golden_config, running_config):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fixing dns test failure due to pmon crash in test_rendered_golden_config_override

pmon crashed during teardown of test_rendered_golden_config_override this caused failure in pretest of test_static_dns

Fix: Adding safe reload and wait to check if critical processes are up after teardown of test_rendered_golden_config_override this will ensure other tests are passing
Summary:
Fixes # #23869 
https://github.com/aristanetworks/sonic-qual.msft/issues/1163

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
This PR is to fix flaky failures in static dns test that were caused by pmon crash in test_rendered_golden_config_override.
pmon crashed in test_rendered_golden_config_override testcase . the teardown does a config_reload , but the process is not up. The next test's sanity fails as the process is not up and running. The fix ensures pmon is up and running after the teardown in test_rendered_golden_config_override

#### How did you do it?
I added a safe_reload=True in teardown of test_rendered_golden_config_override

#### How did you verify/test it?
I verified by running test_rendered_golden_config_override and test_static_dns together multiple times

#### Any platform specific information?
No. Applies to all platforms in dualtor testbeds.

#### Supported testbed topology if it's a new test case?
N/A - Bug fix for existing test.

### Documentation
No documentation needed. Internal test fix only.
