### PR TITLE
Improve autorestart postcheck: capture diagnostics before config_reload

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -555,14 +555,26 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
     critical_proceses, bgp_check = postcheck_critical_processes_status(
         duthost, feature_autorestart_states, up_bgp_neighbors
     )
+    if not critical_proceses:
+        processes_status = duthost.all_critical_process_status()
+        for cname, procs in list(processes_status.items()):
+            if procs["status"] is False or len(procs["exited_critical_process"]) > 0:
+                logger.info("Post-check: container '{}' has exited critical processes: {}"
+                            .format(cname, procs["exited_critical_process"]))
+    if not bgp_check:
+        bgp_neigh = duthost.get_bgp_neighbors()
+        down_sessions = {ip: info['state'] for ip, info in list(bgp_neigh.items()) if info['state'] != 'established'}
+        logger.info("Post-check: BGP sessions not established: {}".format(down_sessions))
     if not (critical_proceses and bgp_check):
-        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
-        # after config reload, the feature autorestart config is reset,
-        # so, before next test, enable again
-        enable_autorestart(duthost)
-
+        # Capture diagnostic state BEFORE config_reload, otherwise all sessions
+        # will appear established in the error message after recovery.
         failed_check = "[Critical Process] " if not critical_proceses else ""
         failed_check += "[BGP] " if not bgp_check else ""
+        bgp_failures = [
+            {x: v['state']}
+            for x, v in list(duthost.get_bgp_neighbors().items())
+            if v['state'] != 'established'
+        ]
         processes_status = duthost.all_critical_process_status()
         pstatus = [
             {
@@ -574,6 +586,11 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
                 "status"
             ] is False and len(v["exited_critical_process"]) > 0
         ]
+
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+        # after config reload, the feature autorestart config is reset,
+        # so, before next test, enable again
+        enable_autorestart(duthost)
 
         if (duthost.get_facts().get("modular_chassis") and
                 duthost.facts["asic_type"] == "cisco-8000" and
@@ -591,11 +608,7 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
                 ("{}check failed, testing feature {}, \nBGP:{}, \nNeighbors:{}"
                  "\nProcess status {}").format(
                     failed_check, container_name,
-                    [
-                        {x: v['state']}
-                        for x, v in list(duthost.get_bgp_neighbors().items())
-                        if v['state'] != 'established'
-                    ],
+                    bgp_failures,
                     up_bgp_neighbors, pstatus
                 )
             )

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -556,7 +556,7 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
         duthost, feature_autorestart_states, up_bgp_neighbors
     )
     if not (critical_proceses and bgp_check):
-        config_reload(duthost, safe_reload=True)
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
         # after config reload, the feature autorestart config is reset,
         # so, before next test, enable again
         enable_autorestart(duthost)


### PR DESCRIPTION
### Description of PR

Summary:
Improve the autorestart post-check failure handling to capture diagnostic state **before** `config_reload`, and add `check_intf_up_ports=True` and `wait_for_bgp=True` to ensure proper DUT recovery.

**Problem:** When the post-check fails (BGP sessions not established or critical processes down), the old code calls `config_reload` first, then captures `bgp_failures` and `pstatus` for the error message. By that point, BGP sessions have re-established and processes have recovered — so `pytest.fail` shows an empty failure list, making it impossible to diagnose what actually went wrong.

**Fix:** Now `bgp_failures`, `pstatus`, and `failed_check` are all captured **before** `config_reload`, so the `pytest.fail` message shows the actual unestablished BGP sessions and failed processes at the time of failure. Additional diagnostic logging is also added before the recovery to help triage nightly failures.

### Type of change

- [x] Test case improvement
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

After a container autorestart test fails the post-check (critical processes or BGP check), the test calls `config_reload` to recover the DUT. Two issues with the old code:

1. **Lost diagnostic info**: `config_reload` was called before capturing BGP and process status for the error message. After reload, all sessions are established and processes are running — so `pytest.fail` showed empty/healthy state instead of the actual failure.
2. **Incomplete recovery**: Without `wait_for_bgp=True` and `check_intf_up_ports=True`, the reload could complete before BGP sessions and interfaces were fully up, causing cascading failures in subsequent container tests.

This was observed in nightly runs on t1-64-lag topology (Arista-7260CX3-C64) where teamd container restart caused BGP sessions to not recover within 360s.

#### How did you do it?

1. **Added diagnostic logging** before the recovery block: logs which critical processes exited and which BGP sessions are not established
2. **Moved `config_reload` + `enable_autorestart`** after capturing `bgp_failures`, `pstatus`, and `failed_check` — so the error message reflects the actual failure state
3. **Pre-captured `bgp_failures`** list before reload to avoid re-querying BGP neighbors after recovery (which would show all established)
4. **Added `check_intf_up_ports=True, wait_for_bgp=True`** to `config_reload` for reliable DUT recovery

#### How did you verify/test it?

- Ran `autorestart/test_container_autorestart.py -k teamd` on STR lab testbed vms64-t1-7260-14 (Arista-7260CX3, t1-64-lag topology) with internal-202511 branch
- Verified the diagnostic logging captures correct failure state before recovery

#### Any platform specific information?
N/A - this change applies to all platforms.

#### Supported testbed topology if it's a new test case?
N/A - not a new test case.

### Documentation
N/A