### PR TITLE
[memory_utilization]: Fix false memory alarm caused by monit stale cache

### DIFF
--- a/tests/common/plugins/memory_utilization/__init__.py
+++ b/tests/common/plugins/memory_utilization/__init__.py
@@ -52,6 +52,10 @@ def pytest_runtest_setup(item):
         if duthost.topo_type == 't2':
             continue
 
+        # Trigger monit to refresh its cache so subsequent collection reads fresh data
+        logger.info("Triggering monit refresh on {} before collecting memory data".format(duthost.hostname))
+        memory_monitors[duthost.hostname].execute_command("sudo monit validate")
+
         # Initial memory check for all registered commands
         for name, cmd, memory_params, memory_check in memory_monitors[duthost.hostname].commands:
             try:
@@ -90,6 +94,10 @@ def pytest_runtest_teardown(item, nextitem):
     for duthost in duthosts:
         if duthost.topo_type == 't2':
             continue
+
+        # Trigger monit to refresh its cache so subsequent collection reads fresh data
+        logger.info("Triggering monit refresh on {} before collecting memory data".format(duthost.hostname))
+        memory_monitors[duthost.hostname].execute_command("sudo monit validate")
 
         # memory check for all registered commands
         for name, cmd, memory_params, memory_check in memory_monitors[duthost.hostname].commands:

--- a/tests/common/plugins/memory_utilization/memory_utilization.py
+++ b/tests/common/plugins/memory_utilization/memory_utilization.py
@@ -432,7 +432,8 @@ class MemoryMonitor:
                     'name': name,
                     'cmd': command,
                     'memory_params': memory_params,
-                    'memory_check_fn': memory_check_fn
+                    'memory_check_fn': memory_check_fn,
+                    'order': item.get('order', 0)
                 }
 
         with open(MEMORY_UTILIZATION_DEPENDENCE_JSON_FILE, 'r') as file:
@@ -447,7 +448,8 @@ class MemoryMonitor:
                     'name': name,
                     'cmd': command,
                     'memory_params': memory_params,
-                    'memory_check_fn': memory_check_fn
+                    'memory_check_fn': memory_check_fn,
+                    'order': item.get('order', parameter_dict.get(name, {}).get('order', 0))
                 }
 
             if hwsku:
@@ -479,10 +481,11 @@ class MemoryMonitor:
                                         'name': name,
                                         'cmd': command,
                                         'memory_params': memory_params,
-                                        'memory_check_fn': memory_check_fn
+                                        'memory_check_fn': memory_check_fn,
+                                        'order': item.get('order', 0)
                                     }
 
-        for param in parameter_dict.values():
+        for param in sorted(parameter_dict.values(), key=lambda x: x.get('order', 0)):
             # Normalize thresholds in memory_params to ensure consistent behavior
             for mem_item, thresholds in param['memory_params'].items():
                 param['memory_params'][mem_item] = self._normalize_thresholds(thresholds)

--- a/tests/common/plugins/memory_utilization/memory_utilization_common.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_common.json
@@ -2,7 +2,7 @@
   "COMMON": [
     {
       "name": "monit",
-      "cmd": "sudo monit validate",
+      "cmd": "sudo monit status",
       "memory_params": {
         "memory_usage": {
           "memory_increase_threshold": {

--- a/tests/common/plugins/memory_utilization/memory_utilization_common.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_common.json
@@ -2,6 +2,7 @@
   "COMMON": [
     {
       "name": "monit",
+      "order": 100,
       "cmd": "sudo monit status",
       "memory_params": {
         "memory_usage": {

--- a/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "monit",
-      "cmd": "sudo monit validate",
+      "cmd": "sudo monit status",
       "memory_params": {
         "memory_usage": {
           "memory_increase_threshold": {
@@ -214,7 +214,7 @@
   "Arista-7050QX": [
     {
       "name": "monit",
-      "cmd": "sudo monit validate",
+      "cmd": "sudo monit status",
       "memory_params": {
         "memory_usage": {
           "memory_increase_threshold": {
@@ -233,7 +233,7 @@
   "Mellanox-SN4600C": [
     {
       "name": "monit",
-      "cmd": "sudo monit validate",
+      "cmd": "sudo monit status",
       "memory_params": {
         "memory_usage": {
           "memory_increase_threshold": {
@@ -327,7 +327,7 @@
   "Arista-7060CX": [
     {
       "name": "monit",
-      "cmd": "sudo monit validate",
+      "cmd": "sudo monit status",
       "memory_params": {
         "memory_usage": {
           "memory_increase_threshold": {
@@ -385,7 +385,7 @@
   "Cisco-C8220TG": [
     {
       "name": "monit",
-      "cmd": "sudo monit validate",
+      "cmd": "sudo monit status",
       "memory_params": {
         "memory_usage": {
           "memory_increase_threshold": {

--- a/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
@@ -48,6 +48,7 @@
     },
     {
       "name": "monit",
+      "order": 100,
       "cmd": "sudo monit status",
       "memory_params": {
         "memory_usage": {


### PR DESCRIPTION
### Description of PR
Summary:
Fix false memory alarm in `memory_utilization` plugin caused by monit stale cache. When the monit daemon fires its 60s collection cycle mid-test, the fixture teardown reads a stale peak value instead of the pre-test baseline, producing a false delta alarm.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

The `memory_utilization` fixture was generating false memory alarms. In one case (`test_cacl.py`), the monit daemon collected memory mid-test at a usage peak (51%), and the fixture read that stale value at teardown — producing a false +10.3% delta alarm.

**Root cause:** The fixture reads `sudo monit status` cache data. If the daemon's 60-second collection cycle fires mid-test, teardown reads the mid-test peak rather than the pre-test baseline.

#### How did you do it?

1. **Add unconditional pre-trigger validate (`__init__.py`)** — Before executing configured commands in both setup and teardown, explicitly call `sudo monit validate` to anchor the daemon's collection cycle to the fixture's collection time.

2. **Replace all `monit validate` with `monit status` in JSON configs** — Since we now have a dedicated pre-trigger, the collection step uses `monit status` to read the cache after the daemon has had time to collect.

3. **Add `"order": 100` to monit entries in JSON configs + sort by `order` in `memory_utilization.py`** — `memory_utilization_common.json` contains only the monit command and is always loaded first into `parameter_dict`, so monit would always run first regardless of position in `memory_utilization_dependence.json`. To fix execution order without removing it from the common config, a numeric `order` field is added to monit entries (default `0` for all others, `100` for monit). The final collection loop uses `sorted(parameter_dict.values(), key=lambda x: x.get('order', 0))`, ensuring monit status always runs **last**.

**New COMMON execution order:**
| Step | Command | Duration |
|------|---------|----------|
| Pre-trigger | `sudo monit validate` | ~0.5s |
| 1 | `top -b -n 1` | ~1s |
| 2 | `free -m` | ~0.1s |
| 3 | `docker stats --no-stream` | ~3s |
| 4 | `vtysh -c "show memory bgp"` | ~0.5s |
| 5 | `vtysh -c "show memory zebra"` | ~0.5s |
| **6** | **`sudo monit status`** | ~0.1s ← reads fresh data |

After this fix: `monit status` runs ~6s after the pre-trigger, well past the daemon's ~2s collection window.

#### How did you verify/test it?

Triggered `generic_config_updater` feature jobs on 6 × 7260 testbeds with branch `dev/xuliping/20260422_fix_monit_stale_cache_internal-202511` and image `internal-202511`. No false memory alarms observed.

**Timing evidence — `test_pfcwd_status.py` (plan [69e9f8d60aae266263d651a6](https://elastictest.org/scheduler/testplan/69e9f8d60aae266263d651a6)):**

Monit `status` is confirmed to run **last** (after top/free/docker/frr_bgp/frr_zebra) in every setup and teardown, with a consistent 5–6 second gap from the pre-trigger `validate`:

| Test Case | Phase | `monit validate` | `monit status` | Gap |
|-----------|-------|-----------------|---------------|-----|
| test_stop_pfcwd[None-single] | Setup | 11:58:38 | 11:58:44 | **+6s** ✅ |
| test_stop_pfcwd[None-single] | Teardown | 11:58:54 | 11:59:00 | **+6s** ✅ |
| test_stop_pfcwd[None-all] | Setup | 11:59:27 | 11:59:33 | **+6s** ✅ |
| test_stop_pfcwd[None-all] | Teardown | 12:00:34 | 12:00:40 | **+6s** ✅ |
| test_start_pfcwd[None-single] | Setup | 12:01:56 | 12:02:02 | **+6s** ✅ |
| test_start_pfcwd[None-single] | Teardown | 12:02:15 | 12:02:20 | **+5s** ✅ |
| test_start_pfcwd[None-all] | Setup | 12:03:37 | 12:03:43 | **+6s** ✅ |
| test_start_pfcwd[None-all] | Teardown | 12:04:46 | 12:04:52 | **+6s** ✅ |

**Before fix** (from [test_bgp_speaker.py log](https://elastictest.org/scheduler/testplan/69e972486d4fb688a4e17a3a?testcase=generic_config_updater%2Ftest_bgp_speaker.py&type=log)): validate `03:32:28` → status `03:32:29` = **only 1 second** (stale data, false alarm triggered).

**Elastictest Jobs (latest round):**
| Testbed | Plan ID |
|---------|---------|
| testbed-bjw2-can-t1-7260-12 | [69e9f8d60aae266263d651a6](https://elastictest.org/scheduler/testplan/69e9f8d60aae266263d651a6) |
| testbed-bjw2-can-t1-7260-11 | [69e9f8dd31dfe8467068356f](https://elastictest.org/scheduler/testplan/69e9f8dd31dfe8467068356f) |
| testbed-bjw2-can-t0-7260-7 | [69e9f8e11f6d9ccadfb45f3a](https://elastictest.org/scheduler/testplan/69e9f8e11f6d9ccadfb45f3a) |
| testbed-bjw2-can-t0-7260-9 | [69e9f8e8275c1d63b55180f6](https://elastictest.org/scheduler/testplan/69e9f8e8275c1d63b55180f6) |
| tbtk5-t0-7260-01 | [69e9f8ed1f6d9ccadfb45f3c](https://elastictest.org/scheduler/testplan/69e9f8ed1f6d9ccadfb45f3c) |
| testbed-bjw-can-t1-7260-8 | [69e9f8f26d4fb688a4e17b41](https://elastictest.org/scheduler/testplan/69e9f8f26d4fb688a4e17b41) |

Branch: `dev/xuliping/20260422_fix_monit_stale_cache_internal-202511` | Image: `internal-202511`

#### Any platform specific information?

No platform-specific changes. The fix applies to all platforms using the `memory_utilization` plugin.

#### Supported testbed topology if it's a new test case?

N/A — this is a bug fix to the existing `memory_utilization` fixture, not a new test case.

### Documentation
N/A