### PR TITLE
Fix IPv6 received-routes lookup in bgp_update_timer while preserving multi-asic vtysh handling

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -338,6 +338,11 @@ def test_bgp_update_timer_single_route(
     try:
         n0.start_session()
         n1.start_session()
+        bgp_neighbor_cmd_tmpl = (
+            "show bgp ipv6 neighbors {} received-routes"
+            if is_v6_topo
+            else "show ip bgp neighbors {} received-routes"
+        )
 
         # ensure new sessions are ready
         if not wait_until(
@@ -357,17 +362,17 @@ def test_bgp_update_timer_single_route(
                 n0.announce_route(route)
                 time.sleep(constants.sleep_interval)
                 res = asichost.run_vtysh(
-                    " -c \'show ip bgp neighbors {} received-routes\'".format(n0.ip))
+                    " -c '{}'".format(bgp_neighbor_cmd_tmpl.format(n0.ip)))
                 check_routes_presence(res, route["prefix"])
                 res = asichost.run_vtysh(
-                    " -c \'show ip bgp neighbors {} received-routes\'".format(n1.ip))
+                    " -c '{}'".format(bgp_neighbor_cmd_tmpl.format(n1.ip)))
                 check_routes_presence(res, route["prefix"])
                 n0.withdraw_route(route)
                 res = asichost.run_vtysh(
-                    " -c \'show ip bgp neighbors {} received-routes\'".format(n0.ip))
+                    " -c '{}'".format(bgp_neighbor_cmd_tmpl.format(n0.ip)))
                 check_routes_presence(res, route["prefix"])
                 res = asichost.run_vtysh(
-                    " -c \'show ip bgp neighbors {} received-routes\'".format(n1.ip))
+                    " -c '{}'".format(bgp_neighbor_cmd_tmpl.format(n1.ip)))
                 check_routes_presence(res, route["prefix"])
                 time.sleep(constants.sleep_interval)
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:Fix IPv6 received-routes lookup in bgp_update_timer while preserving multi-asic vtysh handling
Fixes # (issue)
Fix `bgp_update_timer` to use the correct `received-routes` lookup for IPv6 topologies instead of always issuing the IPv4 `show ip bgp neighbors ... received-routes` command.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`test_bgp_update_timer_single_route` always used the IPv4 `received-routes` command when validating learned routes from BGP neighbors. This causes incorrect route lookup on IPv6 topologies and can lead to false failures. The fix also needs to preserve the existing multi-asic command execution flow through `asichost.run_vtysh()`.

#### How did you do it?
Introduced a topology-aware BGP neighbor command template:
- use `show bgp ipv6 neighbors {} received-routes` for IPv6 topologies
- keep using `show ip bgp neighbors {} received-routes` for IPv4 topologies
The selected command template is then reused consistently for both neighbors during route announce and withdraw verification, while keeping the existing `asichost.run_vtysh()` path unchanged.

#### How did you verify/test it?
trigger the test case

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
