### PR TITLE
[snappi] Update IP in t2-ixia topo to 10.0.x.x subnet

### DIFF
--- a/ansible/vars/topo_t2-ixia-2lc-4.yml
+++ b/ansible/vars/topo_t2-ixia-2lc-4.yml
@@ -58,14 +58,14 @@ configuration:
       asn: 65200
       peers:
         65100:
-          - 10.1.1.0
+          - 10.0.1.0
           - FC00:1::1
     interfaces:
       Loopback0:
         ipv4: 100.1.0.1/32
         ipv6: 2064:100::1/128
       Ethernet1:
-        ipv4: 10.1.1.1/31
+        ipv4: 10.0.1.1/31
         ipv6: FC00:1::2/126
         dut_index: 0
     bp_interface:
@@ -80,14 +80,14 @@ configuration:
       asn: 65200
       peers:
         65100:
-          - 10.1.2.0
+          - 10.0.2.0
           - FC00:2::1
     interfaces:
       Loopback0:
         ipv4: 100.1.0.3/32
         ipv6: 2064:100::3/128
       Ethernet1:
-        ipv4: 10.1.2.1/31
+        ipv4: 10.0.2.1/31
         ipv6: FC00:2::2/126
         dut_index: 0
     bp_interface:
@@ -102,14 +102,14 @@ configuration:
       asn: 65200
       peers:
         65100:
-          - 10.1.3.0
+          - 10.0.3.0
           - FC00:3::1
     interfaces:
       Loopback0:
         ipv4: 100.1.0.4/32
         ipv6: 2064:100::4/128
       Ethernet1:
-        ipv4: 10.1.3.1/31
+        ipv4: 10.0.3.1/31
         ipv6: FC00:3::2/126
         dut_index: 1
     bp_interface:
@@ -124,14 +124,14 @@ configuration:
       asn: 65200
       peers:
         65100:
-          - 10.1.4.0
+          - 10.0.4.0
           - FC00:4::1
     interfaces:
       Loopback0:
         ipv4: 100.1.0.6/32
         ipv6: 2064:100::6/128
       Ethernet1:
-        ipv4: 10.1.4.1/31
+        ipv4: 10.0.4.1/31
         ipv6: FC00:4::2/126
         dut_index: 1
     bp_interface:

--- a/ansible/vars/topo_t2-ixia-3lc-4.yml
+++ b/ansible/vars/topo_t2-ixia-3lc-4.yml
@@ -64,14 +64,14 @@ configuration:
       asn: 65200
       peers:
         65100:
-          - 10.1.1.0
+          - 10.0.1.0
           - FC00:1::1
     interfaces:
       Loopback0:
         ipv4: 100.1.0.1/32
         ipv6: 2064:100::1/128
       Ethernet1:
-        ipv4: 10.1.1.1/31
+        ipv4: 10.0.1.1/31
         ipv6: FC00:1::2/126
         dut_index: 0
     bp_interface:
@@ -86,14 +86,14 @@ configuration:
       asn: 65200
       peers:
         65100:
-          - 10.1.2.0
+          - 10.0.2.0
           - FC00:2::1
     interfaces:
       Loopback0:
         ipv4: 100.1.0.3/32
         ipv6: 2064:100::3/128
       Ethernet1:
-        ipv4: 10.1.2.1/31
+        ipv4: 10.0.2.1/31
         ipv6: FC00:2::2/126
         dut_index: 0
     bp_interface:
@@ -108,14 +108,14 @@ configuration:
       asn: 65200
       peers:
         65100:
-          - 10.1.3.0
+          - 10.0.3.0
           - FC00:3::1
     interfaces:
       Loopback0:
         ipv4: 100.1.0.4/32
         ipv6: 2064:100::4/128
       Ethernet1:
-        ipv4: 10.1.3.1/31
+        ipv4: 10.0.3.1/31
         ipv6: FC00:3::2/126
         dut_index: 1
     bp_interface:
@@ -130,14 +130,14 @@ configuration:
       asn: 65200
       peers:
         65100:
-          - 10.1.4.0
+          - 10.0.4.0
           - FC00:4::1
     interfaces:
       Loopback0:
         ipv4: 100.1.0.6/32
         ipv6: 2064:100::6/128
       Ethernet1:
-        ipv4: 10.1.4.1/31
+        ipv4: 10.0.4.1/31
         ipv6: FC00:4::2/126
         dut_index: 1
     bp_interface:


### PR DESCRIPTION
### Description of PR

Update the interface IP used in the `topo_t2-ixia-2lc-4.yml` and `topo_t2-ixia-3lc-4.yml` topology var files from the `10.1.x.0/31` range to `10.0.x.0/31` to avoid conflicts with existing networks in the lab.

Only IPv4 addressing is changed; IPv6 addressing and all other topology attributes are untouched.

#### Summary: Fixes # (issue)

### Type of change

- [x] Test case(cleanup, fix, enhancement, new test case)
- [ ] Testbed
- [ ] Test infrastructure enhancement
- [ ] Tools
- [ ] Others

### Approach

#### What is the motivation for this PR?

The previously used `10.1.x.0/31` subnets conflicted our new networks in the lab. Re-IP to the `10.0.x.0/31` range to resolve the conflicts.

#### How did you do it?

Updated BGP peer IPs and `Ethernet1` IPv4 addresses in:
- `ansible/vars/topo_t2-ixia-2lc-4.yml`
- `ansible/vars/topo_t2-ixia-3lc-4.yml`

#### How did you verify/test it?


