### PR TITLE
[Chassis] Fix route baseline capture in test_tsa_b_c_with_no_neighbors

### DIFF
--- a/tests/bgp/test_traffic_shift_lc.py
+++ b/tests/bgp/test_traffic_shift_lc.py
@@ -222,6 +222,8 @@ def test_tsa_b_c_with_no_neighbors(request, duthosts, nbrhosts, core_dump_and_co
             # Get all routes on neighbors before doing TSA
             orig_v4_routes[duthost] = parse_routes_on_neighbors(duthost, dut_nbrhosts[duthost], 4)
             orig_v6_routes[duthost] = parse_routes_on_neighbors(duthost, dut_nbrhosts[duthost], 6)
+
+        for duthost in frontend_nodes_per_hwsku:
             # Remove the Neighbors for the particular BGP instance
             bgp_neighbors[duthost] = remove_bgp_neighbors(duthost, asic_index)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #24126 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
`test_tsa_b_c_with_no_neighbors` intermittently fails on VoQ chassis when upstream and downstream linecards have different HWSKUs. The route baseline capture and BGP neighbor removal were in the same per-hwsku loop, so removing neighbors on the upstream linecard (processed first) bounced the iBGP session and caused the downstream linecard to lose routes
before its baseline was captured. The test then reported these as "additional routes" after restoration.

#### How did you do it?
- Split into two loops: snapshot all baselines first, then remove the neighbors
#### How did you verify/test it?

#### Any platform specific information?
Run `tests/bgp/traffic_shift_lc.py` on T2 Chassis
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
