### PR TITLE
[HA] [smartswitch] fix the renaming of dash_ha_set_dpu_config_table

### DIFF
--- a/tests/ha/conftest.py
+++ b/tests/ha/conftest.py
@@ -564,7 +564,7 @@ def setup_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi_server
 def remove_setup_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi_server, ha_owner):
     current_dir = os.path.dirname(os.path.abspath(__file__))
     base_dir = os.path.join(current_dir, "..", "common", "ha")
-    ha_set_file = os.path.join(base_dir, "dash_ha_set_dpu_config_table.json")
+    ha_set_file = os.path.join(base_dir, "dash_ha_set_config_table.json")
 
     for index, (name, data) in enumerate(ha_scope_per_dut):
         # Update the 'owner' key in the dictionary

--- a/tests/ha/ha_utils.py
+++ b/tests/ha/ha_utils.py
@@ -314,7 +314,7 @@ def wait_for_pending_operation_id(
 def bfd_pin_primary(localhost, ptfhost, duthosts):
     current_dir = os.path.dirname(os.path.abspath(__file__))
     base_dir = os.path.join(current_dir, "..", "common", "ha")
-    ha_set_file = os.path.join(base_dir, "dash_ha_set_dpu_config_table.json")
+    ha_set_file = os.path.join(base_dir, "dash_ha_set_config_table.json")
     with open(ha_set_file) as f:
         ha_set_data = json.load(f)["DASH_HA_SET_CONFIG_TABLE"]
 
@@ -336,7 +336,7 @@ def bfd_pin_primary(localhost, ptfhost, duthosts):
 def bfd_unpin_primary(localhost, ptfhost, duthosts):
     current_dir = os.path.dirname(os.path.abspath(__file__))
     base_dir = os.path.join(current_dir, "..", "common", "ha")
-    ha_set_file = os.path.join(base_dir, "dash_ha_set_dpu_config_table.json")
+    ha_set_file = os.path.join(base_dir, "dash_ha_set_config_table.json")
     with open(ha_set_file) as f:
         ha_set_data = json.load(f)["DASH_HA_SET_CONFIG_TABLE"]
 
@@ -358,7 +358,7 @@ def bfd_unpin_primary(localhost, ptfhost, duthosts):
 def bfd_pin_both_sides(localhost, ptfhost, duthosts):
     current_dir = os.path.dirname(os.path.abspath(__file__))
     base_dir = os.path.join(current_dir, "..", "common", "ha")
-    ha_set_file = os.path.join(base_dir, "dash_ha_set_dpu_config_table.json")
+    ha_set_file = os.path.join(base_dir, "dash_ha_set_config_table.json")
     with open(ha_set_file) as f:
         ha_set_data = json.load(f)["DASH_HA_SET_CONFIG_TABLE"]
 
@@ -380,7 +380,7 @@ def bfd_pin_both_sides(localhost, ptfhost, duthosts):
 def bfd_unpin_both_sides(localhost, ptfhost, duthosts):
     current_dir = os.path.dirname(os.path.abspath(__file__))
     base_dir = os.path.join(current_dir, "..", "common", "ha")
-    ha_set_file = os.path.join(base_dir, "dash_ha_set_dpu_config_table.json")
+    ha_set_file = os.path.join(base_dir, "dash_ha_set_config_table.json")
     with open(ha_set_file) as f:
         ha_set_data = json.load(f)["DASH_HA_SET_CONFIG_TABLE"]
 


### PR DESCRIPTION
### Description of PR
Summary:
dash_ha_set_dpu_config_table.json has been renamed to dash_ha_set_config_table.json but some places in the code are still using the old name. 
This change fixes this issue.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Rename of the dash_ha_set_dpu_config_table.json is breaking the existing code where old name is still in use.

#### How did you do it?
Changed the name where needed.

#### How did you verify/test it?
Run the test that is using this.

#### Any platform specific information?
Smartswitch
#### Supported testbed topology if it's a new test case?
HA topology
### Documentation
N/A
