### PR TITLE
Fix background_traffic mask to ignore IPv6 TC and FL fields

### DIFF
--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -169,6 +169,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                             exp_pkt.set_do_not_care_scapy(packet.Ether, 'dst')
                             exp_pkt.set_do_not_care_scapy(packet.Ether, 'src')
                             exp_pkt.set_do_not_care_packet(scapy.IPv6, "hlim")
+                            exp_pkt.set_do_not_care_packet(scapy.IPv6, "tc")
+                            exp_pkt.set_do_not_care_packet(scapy.IPv6, "fl")
                             testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=ptfadapter.ptf_port_set,
                                                              timeout=5)
                     count += 1


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Ignoring the IPv6 Traffic Class and Flow Label fields in the `background_traffic` fixture's packet mask.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # https://github.com/aristanetworks/sonic-qual.msft/issues/1197

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
`everflow/test_everflow_ipv6.py` is flaky, its failing at background traffic verification

#### How did you do it?
The `background_traffic` fixture's packet mask did not ignore the IPv6 Traffic Class and Flow Label fields, causing `verify_packet_any_port` to fail when the fanout switch remarks `DSCP`. The mirror packet verification in `everflow_test_utilities.py` already masks these fields ([here](https://github.com/sonic-net/sonic-mgmt/blob/8c864658c70cc6a651bfc32fd81f01a7cf936829/tests/everflow/everflow_test_utilities.py#L1551)). Apply the same masking to the `background_traffic` pre-flight check.

#### How did you verify/test it?
Ran the `everflow/test_everflow_ipv6.py` test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
