### PR TITLE
Fix intermittent LogAnalyzer failure in testFdbMacLearning by ignorin…

### DIFF
--- a/tests/fdb/test_fdb_mac_learning.py
+++ b/tests/fdb/test_fdb_mac_learning.py
@@ -22,7 +22,8 @@ def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
 
     ignore_errors = [
         r".*ERR swss#orchagent: .*update: Failed to get port by bridge port ID.*",
-        r".* ERR swss#tunnel_packet_handler.py: All portchannels failed to come up within \d+ minutes, exiting.*"
+        r".* ERR swss#tunnel_packet_handler.py: All portchannels failed to come up within \d+ minutes, exiting.*",
+        r".*meta_sai_validate_route_entry:.*doesn't exist.*",
         ]
     if loganalyzer:
         for duthost in duthosts:


### PR DESCRIPTION
### Description of PR

Summary:
Fixes #24085

This PR fixes an intermittent failure in `testFdbMacLearning` where LogAnalyzer flags expected ERR logs during teardown in a dualtor topology.

---

### Type of change

- [x] Bug fix

---

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

---

### Approach

#### What is the motivation for this PR?

`testFdbMacLearning` fails intermittently due to LogAnalyzer detecting ERR logs during teardown, even though all test assertions pass successfully.

This happens because of asynchronous mux tunnel route cleanup in dualtor topology, which can emit logs like:

`meta_sai_validate_route_entry: object ... doesn't exist`

These logs are expected and should not cause test failures.

---

#### How did you do it?

Added a scoped ignore pattern in `test_fdb_mac_learning.py`:
r".*meta_sai_validate_route_entry:.doesn't exist."


This suppresses expected errors generated during async cleanup without masking unrelated issues.

---

#### How did you verify/test it?

- Verified the regex matches the observed log pattern
- Ensured consistency with existing `ignore_expected_loganalyzer_exception` usage in other tests
- Local full test execution not feasible due to dependency on dualtor testbed

---

#### Any platform specific information?

No, this issue is not platform-specific. It is related to dualtor teardown timing and asynchronous cleanup.

---

#### Supported testbed topology if it's a new test case?

N/A

---

### Documentation

N/A
