### PR TITLE
[Dualtor] --prober_type and --neighbor_mode arg addition for dualtor tests

### DIFF
--- a/tests/common/dualtor/mux_cable_config.py
+++ b/tests/common/dualtor/mux_cable_config.py
@@ -1,0 +1,180 @@
+"""
+Utilities and fixtures for applying prober_type / neighbor_mode to the
+MUX_CABLE stanza in the running golden config on dualtor testbeds.
+
+Note: dualtor topologies are single-ASIC only, so multi-ASIC handling is
+not needed here.
+"""
+
+import copy
+import json
+import logging
+import pytest
+
+from tests.common.config_reload import config_reload
+
+logger = logging.getLogger(__name__)
+
+GOLDEN_CONFIG_PATH = "/etc/sonic/running_golden_config.json"
+GOLDEN_CONFIG_BACKUP_PATH = "/etc/sonic/running_golden_config.json.mux_combo_bak"
+
+VALID_PROBER_TYPES = ("hardware", "software")
+VALID_NEIGHBOR_MODES = ("host-route", "prefix-route")
+
+MUX_COMBO_ALL = [
+    {"prober_type": pt, "neighbor_mode": nm}
+    for pt in VALID_PROBER_TYPES
+    for nm in VALID_NEIGHBOR_MODES
+]
+
+
+def _read_golden_config(duthost, path=GOLDEN_CONFIG_PATH):
+    """Read and parse a JSON golden config file from the DUT."""
+    result = duthost.shell("cat {}".format(path), module_ignore_errors=True)
+    if result["rc"] != 0:
+        logger.warning("Could not read %s on %s: %s", path, duthost.hostname, result.get("stderr", ""))
+        return None
+    try:
+        return json.loads(result["stdout"])
+    except (json.JSONDecodeError, ValueError) as exc:
+        logger.warning("Failed to parse %s on %s: %s", path, duthost.hostname, exc)
+        return None
+
+
+def _write_golden_config(duthost, config_data, path=GOLDEN_CONFIG_PATH):
+    """Write a JSON golden config file to the DUT."""
+    duthost.copy(content=json.dumps(config_data, indent=4), dest=path)
+
+
+def inject_mux_cable_fields(config_data, prober_type=None, neighbor_mode=None):
+    """
+    Inject ``prober_type`` and/or ``neighbor_mode`` into every entry under
+    the ``MUX_CABLE`` table of *config_data* (mutates in-place).
+
+    Either parameter can be None — only non-None values are written.
+    Returns True if any modification was made.
+    """
+    mux_cable = config_data.get("MUX_CABLE")
+    if not mux_cable:
+        return False
+
+    modified = False
+    for intf_name, intf_cfg in mux_cable.items():
+        if prober_type is not None:
+            intf_cfg["prober_type"] = prober_type
+            modified = True
+        if neighbor_mode is not None:
+            intf_cfg["neighbor_mode"] = neighbor_mode
+            modified = True
+    return modified
+
+
+def apply_mux_combo_to_dut(duthost, prober_type=None, neighbor_mode=None):
+    """
+    Apply prober_type and/or neighbor_mode to the running golden config on a
+    single DUT (single-ASIC only).
+
+    Steps:
+      1. Backup current golden config.
+      2. Modify MUX_CABLE entries with whichever fields were provided.
+      3. Write modified config back.
+      4. ``config reload`` from running_golden_config.
+      5. ``config save -y``.
+    """
+    logger.info(
+        "Applying MUX_CABLE combo prober_type=%s neighbor_mode=%s on %s",
+        prober_type, neighbor_mode, duthost.hostname,
+    )
+
+    main_cfg = _read_golden_config(duthost)
+    if main_cfg is None:
+        logger.info(
+            "running_golden_config.json not found on %s — generating from live CONFIG_DB",
+            duthost.hostname,
+        )
+        duthost.shell("sonic-cfggen -d --print-data > {}".format(GOLDEN_CONFIG_PATH))
+        main_cfg = _read_golden_config(duthost)
+        if main_cfg is None:
+            logger.error("Failed to generate running_golden_config.json on %s, skipping MUX combo", duthost.hostname)
+            return
+
+    # backup
+    _write_golden_config(duthost, main_cfg, GOLDEN_CONFIG_BACKUP_PATH)
+
+    # modify
+    main_cfg_mod = copy.deepcopy(main_cfg)
+    inject_mux_cable_fields(main_cfg_mod, prober_type, neighbor_mode)
+    _write_golden_config(duthost, main_cfg_mod, GOLDEN_CONFIG_PATH)
+
+    # reload + save
+    config_reload(duthost, config_source="running_golden_config", safe_reload=True)
+    duthost.shell("config save -y")
+    logger.info("MUX_CABLE combo applied and saved on %s", duthost.hostname)
+
+
+def revert_mux_combo_on_dut(duthost):
+    """
+    Restore the original running golden config from backup and reload.
+    """
+    logger.info("Reverting MUX_CABLE combo on %s", duthost.hostname)
+
+    # check backup exists
+    result = duthost.shell("test -f {}".format(GOLDEN_CONFIG_BACKUP_PATH), module_ignore_errors=True)
+    if result["rc"] != 0:
+        logger.warning("No MUX combo backup found on %s, skipping revert", duthost.hostname)
+        return
+
+    # restore original config
+    duthost.shell("cp {} {}".format(GOLDEN_CONFIG_BACKUP_PATH, GOLDEN_CONFIG_PATH))
+    duthost.shell("rm -f {}".format(GOLDEN_CONFIG_BACKUP_PATH))
+
+    # reload + save to restore original state
+    config_reload(duthost, config_source="running_golden_config", safe_reload=True)
+    duthost.shell("config save -y")
+    logger.info("MUX_CABLE combo reverted on %s", duthost.hostname)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def apply_mux_cable_combo(request, duthosts, tbinfo):
+    """
+    Session-scoped autouse fixture for dualtor_io suites.
+
+    When at least one of ``--prober_type`` or ``--neighbor_mode`` is provided,
+    this fixture will:
+
+    * **Setup**: Modify the running golden config on every DUT with the
+      requested field(s), then config reload + config save.
+    * **Teardown**: Restore the original golden config and reload + save.
+
+    If neither option is provided, this fixture is a no-op.
+    """
+    prober_type = request.config.getoption("--prober_type", default=None)
+    neighbor_mode = request.config.getoption("--neighbor_mode", default=None)
+
+    # Only activate for dualtor topologies
+    topo_name = tbinfo.get("topo", {}).get("name", "")
+    if "dualtor" not in topo_name:
+        logger.info("Topology '%s' is not dualtor — MUX combo fixture is a no-op", topo_name)
+        yield
+        return
+
+    # No-op if neither parameter is given
+    if prober_type is None and neighbor_mode is None:
+        logger.info("MUX combo fixture inactive — no --prober_type or --neighbor_mode given")
+        yield
+        return
+
+    logger.info(
+        "===== MUX CABLE COMBO: prober_type=%s, neighbor_mode=%s =====",
+        prober_type, neighbor_mode,
+    )
+
+    # --- Setup: apply combo to all DUTs ---
+    for duthost in duthosts:
+        apply_mux_combo_to_dut(duthost, prober_type, neighbor_mode)
+
+    yield
+
+    # --- Teardown: revert on all DUTs ---
+    for duthost in duthosts:
+        revert_mux_combo_on_dut(duthost)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -393,6 +393,18 @@ def pytest_addoption(parser):
     parser.addoption("--bgp_pc_config", action="store_true", default=False,
                      help="Use existing config from config_db for BGP RIB tests (skip duthost_bgp_config)")
 
+    ##########################################
+    #   Dualtor MUX_CABLE combo options      #
+    ##########################################
+    parser.addoption("--prober_type", action="store", default=None, type=str,
+                     choices=["hardware", "software"],
+                     help="MUX_CABLE prober_type value (hardware|software). "
+                          "Only applies to dualtor/dualtor_io suites.")
+    parser.addoption("--neighbor_mode", action="store", default=None, type=str,
+                     choices=["host-route", "prefix-route"],
+                     help="MUX_CABLE neighbor_mode value (host-route|prefix-route). "
+                          "Only applies to dualtor/dualtor_io suites.")
+
 
 def pytest_configure(config):
     if config.getoption("enable_macsec"):

--- a/tests/dualtor_io/conftest.py
+++ b/tests/dualtor_io/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 
 from tests.common.dualtor.data_plane_utils import save_pcap                 # noqa: F401
+from tests.common.dualtor.mux_cable_config import apply_mux_cable_combo     # noqa: F401
 
 
 def pytest_configure(config):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

New knobs neighbor_mode and prober_type were added for the MUX_CABLE config in config_db. Support to test these knobs is needed as some vendors might not be supporting certain type of prober_type or neighbor_mode for there asic .

These Knobs are specific to dualtor testbeds only.
Prober_type - If software/Hardaware-offloaded icmp prober is needed to detect the tor should be active/standby state
Neighbor_mode - if neighbor nexthop should be treated as host route or prefix(lpm) route entry 

Choices -
prober_type - hardware/software
neighbor_mode - host-route/prefix-route  

Added cli-args support  to set and test different combinations for theses knobs. 


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

### Approach
#### What is the motivation for this PR?

New knobs neighbor_mode and prober_type were added for the MUX_CABLE config in config_db. Needed a test cli args to set different values for these knobs so that tests run can be done specific to vendor and testbed .

Nieghbor_mode was added on how mux neighbor addition is handled in orchagent . Whether it should be added as a host route or prefix route .

Prober_type : This knob enables ICMP probing in dualtor setups to be offloaded to ASIC rather than a software thread doing it .
 
Support to test these knobs is needed as some vendors might not be supporting certain type of prober_type or neighbor_mode for there asic .

#### How did you do it?

Added New CLI arg to run_test which modifies running_golden_config before run and restores it after run . to test that specific combination

#### How did you verify/test it?
Tested in local t0 testbeds and its setting the expected configuration in running_golden_config

#### Any platform specific information?
if no value given default value of prober_type will be of hardaware and neighbor mode will be prefix-route.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
