### PR TITLE
Add BGP link-local (unnumbered) peering tests with conditional skip for FRR/bgpcfgd feature gaps

### DIFF
--- a/tests/bgp/test_bgp_link_local.py
+++ b/tests/bgp/test_bgp_link_local.py
@@ -5,11 +5,11 @@ This test validates that SONiC can establish BGP sessions using interface-based
 (unnumbered) peering, which uses IPv6 link-local addresses for session setup.
 
 Test plan:
-1. Select one PortChannel interface with an existing BGP neighbor
+1. Select one interface (PortChannel or Ethernet) with an existing BGP neighbor
 2. Record the neighbor's ASN and current BGP session details
 3. Remove the existing global-IP BGP sessions on both DUT and neighbor
 4. Configure unnumbered BGP peering on DUT (neighbor <interface> interface remote-as)
-5. Configure link-local BGP neighbor on EOS/cEOS peer using DUT's fe80 address
+5. Configure interface-based BGP neighbor on EOS/cEOS peer
 6. Verify the BGP session establishes successfully
 7. Verify routes are exchanged
 8. Clean up by restoring the original configuration via config reload
@@ -35,32 +35,34 @@ WAIT_TIMEOUT = 120
 POLL_INTERVAL = 10
 
 
-def get_neighbor_portchannel_intf(neigh_host, neigh_ipv4):
-    """Find the neighbor's Port-Channel interface that has the given IP address.
+def find_neigh_eos_intf(neigh_host, neigh_ipv4):
+    """Find the neighbor's interface (Port-Channel or Ethernet) that has the given IP.
 
     Args:
         neigh_host: Neighbor host object (EosHost)
         neigh_ipv4: IPv4 address to search for
 
     Returns:
-        Port-Channel interface name or None
+        Interface name (e.g. 'Port-Channel1', 'Ethernet1') or None
     """
     try:
         result = neigh_host.eos_command(commands=["show ip interface brief | json"])
         intf_data = result['stdout'][0] if isinstance(result['stdout'], list) else result['stdout']
         if isinstance(intf_data, dict):
             for intf_name, intf_info in intf_data.get('interfaces', {}).items():
-                if 'Port-Channel' in intf_name:
-                    ip_info = intf_info.get('interfaceAddress', {})
-                    if isinstance(ip_info, dict):
-                        addr = ip_info.get('ipAddr', {}).get('address', '')
+                # Skip loopback, management, vlan interfaces
+                if not (intf_name.startswith('Ethernet') or intf_name.startswith('Port-Channel')):
+                    continue
+                ip_info = intf_info.get('interfaceAddress', {})
+                if isinstance(ip_info, dict):
+                    addr = ip_info.get('ipAddr', {}).get('address', '')
+                    if addr == neigh_ipv4:
+                        return intf_name
+                elif isinstance(ip_info, list):
+                    for entry in ip_info:
+                        addr = entry.get('primaryIp', {}).get('address', '')
                         if addr == neigh_ipv4:
                             return intf_name
-                    elif isinstance(ip_info, list):
-                        for entry in ip_info:
-                            addr = entry.get('primaryIp', {}).get('address', '')
-                            if addr == neigh_ipv4:
-                                return intf_name
     except Exception as e:
         logger.warning("Could not query neighbor interfaces: {}".format(e))
     return None
@@ -70,7 +72,7 @@ def get_neighbor_portchannel_intf(neigh_host, neigh_ipv4):
 def setup_info(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):
     """Gather setup information for the link-local BGP test."""
     # This test uses eos_command/eos_config on the neighbor host, so it
-    # requires EOS/cEOS neighbors.  Skip gracefully for other neighbor types.
+    # requires EOS/cEOS neighbors.
     common_props = tbinfo.get('topo', {}).get('properties', {}).get(
         'configuration_properties', {}).get('common', {})
     neighbor_type = common_props.get('neighbor_type', 'eos')
@@ -82,7 +84,6 @@ def setup_info(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):
 
     dut_asn = common_props.get('dut_asn')
     if not dut_asn:
-        # Fallback: get ASN from running config
         config_facts_tmp = duthost.config_facts(
             host=duthost.hostname, source="running")['ansible_facts']
         device_metadata = config_facts_tmp.get('DEVICE_METADATA', {}).get('localhost', {})
@@ -93,40 +94,48 @@ def setup_info(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {})
     portchannels = config_facts.get('PORTCHANNEL', {})
-    dev_nbrs = config_facts.get('DEVICE_NEIGHBOR', {})
     portchannel_members = config_facts.get('PORTCHANNEL_MEMBER', {})
+    dev_nbrs = config_facts.get('DEVICE_NEIGHBOR', {})
+    intf_table = config_facts.get('INTERFACE', {})
+    pc_intf_table = config_facts.get('PORTCHANNEL_INTERFACE', {})
 
-    # Build map: neighbor name -> PortChannel
-    pc_to_neighbor = {}
+    # Build map: interface -> neighbor name
+    # For PortChannels: look up member interfaces in DEVICE_NEIGHBOR
+    intf_to_neighbor = {}
     for pc_name in portchannels:
         if pc_name not in portchannel_members:
             continue
         for member_intf in portchannel_members[pc_name]:
             if member_intf in dev_nbrs:
-                pc_to_neighbor[pc_name] = dev_nbrs[member_intf]['name']
+                intf_to_neighbor[pc_name] = dev_nbrs[member_intf]['name']
                 break
 
-    # Find a PortChannel with an established IPv4 BGP neighbor
+    # For direct Ethernet interfaces with BGP: check INTERFACE table
+    for intf_key in intf_table:
+        # intf_key could be "EthernetX" or "EthernetX|ip/mask"
+        intf_name = intf_key.split('|')[0] if '|' in intf_key else intf_key
+        if intf_name.startswith('Ethernet') and intf_name in dev_nbrs:
+            if intf_name not in intf_to_neighbor:
+                intf_to_neighbor[intf_name] = dev_nbrs[intf_name]['name']
+
+    # Find an interface with an established IPv4 BGP neighbor
     bgp_facts = duthost.bgp_facts()['ansible_facts']
     selected = None
     for neigh_ip, neigh_info in bgp_neighbors.items():
         if ':' in neigh_ip:
-            continue  # Skip IPv6 entries, find IPv4 first
-        # Only select neighbors with established BGP sessions
+            continue  # Skip IPv6, find IPv4 first
         bgp_state = bgp_facts.get('bgp_neighbors', {}).get(
             neigh_ip, {}).get('state', '')
         neigh_name = neigh_info.get('name', '')
         logger.info("Candidate neighbor %s (%s): BGP state=%s, in nbrhosts=%s",
                     neigh_ip, neigh_name, bgp_state, neigh_name in nbrhosts)
         if bgp_state != 'established':
-            logger.info("Skipping %s: BGP state is '%s', not 'established'", neigh_ip, bgp_state)
             continue
-        neigh_name = neigh_info.get('name', '')
         neigh_asn = neigh_info.get('asn', '')
-        for pc_name, pc_neigh_name in pc_to_neighbor.items():
-            if pc_neigh_name == neigh_name and neigh_name in nbrhosts:
+        for intf_name, mapped_neigh in intf_to_neighbor.items():
+            if mapped_neigh == neigh_name and neigh_name in nbrhosts:
                 selected = {
-                    'pc': pc_name,
+                    'intf': intf_name,
                     'neigh_name': neigh_name,
                     'neigh_ipv4': neigh_ip,
                     'neigh_asn': neigh_asn,
@@ -136,7 +145,9 @@ def setup_info(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):
             break
 
     if not selected:
-        pytest.skip("No PortChannel BGP neighbor with established session found")
+        pytest.skip("No BGP neighbor with established session found on any interface")
+
+    dut_intf = selected['intf']
 
     # Find IPv6 address for the same neighbor
     neigh_ipv6 = None
@@ -145,18 +156,21 @@ def setup_info(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):
             neigh_ipv6 = neigh_ip
             break
 
-    # Get DUT's addresses on this PortChannel
+    # Get DUT's addresses on this interface
     dut_ipv4 = None
     dut_ipv6 = None
-    for addr_key in config_facts.get('PORTCHANNEL_INTERFACE', {}).get(selected['pc'], {}):
+    # Check both PORTCHANNEL_INTERFACE and INTERFACE tables
+    addr_table = pc_intf_table.get(dut_intf, {}) if dut_intf.startswith('PortChannel') \
+        else intf_table.get(dut_intf, {})
+    for addr_key in addr_table:
         addr = addr_key.split('/')[0] if '/' in addr_key else addr_key
         if ':' in addr:
             dut_ipv6 = addr
         else:
             dut_ipv4 = addr
 
-    # Get DUT's link-local on this PortChannel
-    result = duthost.shell("ip -6 addr show dev {} scope link".format(selected['pc']))
+    # Get DUT's link-local on this interface
+    result = duthost.shell("ip -6 addr show dev {} scope link".format(dut_intf))
     dut_link_local = None
     for line in result['stdout'].split('\n'):
         if 'inet6 fe80' in line.strip():
@@ -164,26 +178,32 @@ def setup_info(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):
             break
 
     pytest_assert(dut_link_local,
-                  "No link-local address on {}".format(selected['pc']))
+                  "No link-local address on {}".format(dut_intf))
 
-    # Find the EOS neighbor's Port-Channel interface
+    # Find the EOS neighbor's interface
     neigh_host = nbrhosts[selected['neigh_name']]['host']
-    neigh_pc_intf = get_neighbor_portchannel_intf(neigh_host, selected['neigh_ipv4'])
-    if not neigh_pc_intf:
-        # Fallback: try common naming
-        pc_num = ''.join(c for c in selected['pc'] if c.isdigit())
-        for candidate in ["Port-Channel{}".format(pc_num),
+    neigh_intf = find_neigh_eos_intf(neigh_host, selected['neigh_ipv4'])
+    if not neigh_intf:
+        # Fallback: try common naming patterns
+        if dut_intf.startswith('PortChannel'):
+            pc_num = ''.join(c for c in dut_intf if c.isdigit())
+            candidates = ["Port-Channel{}".format(pc_num),
                           "Port-Channel1",
-                          "Port-Channel{}".format(int(pc_num) % 100 if pc_num else 1)]:
+                          "Port-Channel{}".format(int(pc_num) % 100 if pc_num else 1)]
+        else:
+            # For Ethernet, try Ethernet1 (cEOS typically uses Ethernet1 for the first port)
+            candidates = ["Ethernet1"]
+        for candidate in candidates:
             try:
                 neigh_host.eos_command(commands=["show interfaces {}".format(candidate)])
-                neigh_pc_intf = candidate
+                neigh_intf = candidate
                 break
             except Exception:
                 continue
 
-    pytest_assert(neigh_pc_intf,
-                  "Could not determine neighbor's Port-Channel interface")
+    pytest_assert(neigh_intf,
+                  "Could not determine neighbor's interface for {}".format(
+                      selected['neigh_name']))
 
     info = {
         'duthost': duthost,
@@ -191,28 +211,26 @@ def setup_info(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):
         'dut_ipv4': dut_ipv4,
         'dut_ipv6': dut_ipv6,
         'dut_link_local': dut_link_local,
-        'portchannel': selected['pc'],
+        'dut_intf': dut_intf,
         'neigh_name': selected['neigh_name'],
         'neigh_host': neigh_host,
         'neigh_asn': selected['neigh_asn'],
         'neigh_ipv4': selected['neigh_ipv4'],
         'neigh_ipv6': neigh_ipv6,
-        'neigh_pc_intf': neigh_pc_intf,
+        'neigh_intf': neigh_intf,
     }
 
     logger.info("Setup: DUT %s (%s) <-> %s (%s) via %s/%s",
                 dut_ipv4, dut_link_local, selected['neigh_name'],
-                selected['neigh_ipv4'], selected['pc'], neigh_pc_intf)
+                selected['neigh_ipv4'], dut_intf, neigh_intf)
 
     return info
 
 
-def bgp_unnumbered_established(duthost, portchannel):
-    """Check if the unnumbered BGP session via a PortChannel is established.
+def bgp_unnumbered_established(duthost, dut_intf):
+    """Check if the unnumbered BGP session via an interface is established.
 
     FRR shows unnumbered neighbors by interface name in 'show bgp summary'.
-    The Ansible bgp_facts module may not parse unnumbered peers, so we
-    use vtysh JSON output directly.
     """
     result = duthost.shell(
         "vtysh -c 'show bgp summary json'", module_ignore_errors=True)
@@ -225,7 +243,7 @@ def bgp_unnumbered_established(duthost, portchannel):
             for peer_key, peer_data in peers.items():
                 if peer_data.get('state') != 'Established':
                     continue
-                if (portchannel.lower() in peer_key.lower()):
+                if dut_intf.lower() in peer_key.lower():
                     logger.info(
                         "Unnumbered peer found: %s (AF=%s, pfxRcd=%s)",
                         peer_key, af, peer_data.get('pfxRcd', 0))
@@ -237,33 +255,21 @@ def bgp_unnumbered_established(duthost, portchannel):
 
 @pytest.fixture(scope='function')
 def configure_unnumbered_bgp(setup_info):
-    """Configure unnumbered BGP peering and restore original config afterward.
-
-    Setup:
-        1. Verify existing BGP session is up
-        2. Remove existing global-IP BGP sessions on both DUT and neighbor
-        3. Configure unnumbered BGP on DUT
-        4. Configure link-local neighbor on EOS peer
-    Teardown:
-        1. Remove link-local neighbor from EOS and restore original neighbors
-        2. Config reload on DUT
-        3. Wait for original BGP sessions to re-establish
-    """
+    """Configure unnumbered BGP peering and restore original config afterward."""
     duthost = setup_info['duthost']
     neigh_host = setup_info['neigh_host']
-    portchannel = setup_info['portchannel']
+    dut_intf = setup_info['dut_intf']
     dut_asn = setup_info['dut_asn']
     neigh_asn = setup_info['neigh_asn']
     neigh_ipv4 = setup_info['neigh_ipv4']
     neigh_ipv6 = setup_info['neigh_ipv6']
     dut_ipv4 = setup_info['dut_ipv4']
     dut_ipv6 = setup_info['dut_ipv6']
-    neigh_pc_intf = setup_info['neigh_pc_intf']
+    neigh_intf = setup_info['neigh_intf']
 
     # --- Setup ---
 
-    # Wait for the selected BGP session to be established (it was established
-    # at module setup time, but may have temporarily dropped)
+    # Wait for the selected BGP session to be established
     logger.info("Waiting for BGP session to %s to be established", neigh_ipv4)
     pytest_assert(
         wait_until(60, 5, 0, lambda: duthost.bgp_facts()['ansible_facts']
@@ -297,7 +303,7 @@ def configure_unnumbered_bgp(setup_info):
         neigh_host.eos_config(lines=remove_lines,
                               parents="router bgp {}".format(neigh_asn))
 
-    # Wait for old neighbor to be removed from DUT BGP before proceeding
+    # Wait for old neighbor to be removed
     def old_neighbor_removed():
         facts = duthost.bgp_facts()['ansible_facts']
         return neigh_ipv4 not in facts.get('bgp_neighbors', {})
@@ -305,16 +311,16 @@ def configure_unnumbered_bgp(setup_info):
     wait_until(30, 3, 0, old_neighbor_removed)
 
     # Configure unnumbered BGP on DUT
-    logger.info("Configure unnumbered BGP on DUT via %s", portchannel)
+    logger.info("Configure unnumbered BGP on DUT via %s", dut_intf)
     vtysh_add = [
         'config',
         'router bgp {}'.format(dut_asn),
-        'neighbor {} interface remote-as {}'.format(portchannel, neigh_asn),
+        'neighbor {} interface remote-as {}'.format(dut_intf, neigh_asn),
         'address-family ipv4 unicast',
-        'neighbor {} activate'.format(portchannel),
+        'neighbor {} activate'.format(dut_intf),
         'exit-address-family',
         'address-family ipv6 unicast',
-        'neighbor {} activate'.format(portchannel),
+        'neighbor {} activate'.format(dut_intf),
         'exit-address-family',
     ]
     cmd = 'vtysh ' + ' '.join(['-c "{}"'.format(c) for c in vtysh_add])
@@ -324,17 +330,14 @@ def configure_unnumbered_bgp(setup_info):
                       result.get('stderr', '')))
 
     # Configure BGP peering on EOS using interface-based (unnumbered) config.
-    # EOS does not support raw fe80:: addresses as BGP neighbors.
-    # Instead, EOS uses: neighbor interface <intf> peer-group <pg>
-    # with the peer-group configured for the remote AS.
     eos_peer_group = "LINK_LOCAL_PG"
     logger.info("Configure interface-based BGP peering on EOS via %s (peer-group %s)",
-                neigh_pc_intf, eos_peer_group)
+                neigh_intf, eos_peer_group)
     neigh_host.eos_config(
         lines=[
             "neighbor {} peer group".format(eos_peer_group),
             "neighbor {} remote-as {}".format(eos_peer_group, dut_asn),
-            "neighbor interface {} peer-group {}".format(neigh_pc_intf, eos_peer_group),
+            "neighbor interface {} peer-group {}".format(neigh_intf, eos_peer_group),
         ],
         parents="router bgp {}".format(neigh_asn))
 
@@ -365,26 +368,23 @@ def configure_unnumbered_bgp(setup_info):
     # --- Teardown ---
     logger.info("Teardown: Restoring original configuration")
 
-    # Remove interface-based peering from EOS and restore originals.
-    # Order matters: remove interface neighbor first, then deactivate
-    # from address-families, then remove the peer-group itself.
     eos_peer_group = "LINK_LOCAL_PG"
     try:
-        # Step 1: remove interface neighbor (must precede peer-group removal)
+        # Remove interface neighbor
         neigh_host.eos_config(
-            lines=["no neighbor interface {}".format(neigh_pc_intf)],
+            lines=["no neighbor interface {}".format(neigh_intf)],
             parents="router bgp {}".format(neigh_asn))
-        # Step 2: deactivate from address-families
+        # Deactivate from address-families
         for af in ["ipv4", "ipv6"]:
             neigh_host.eos_config(
                 lines=["no neighbor {} activate".format(eos_peer_group)],
                 parents=["router bgp {}".format(neigh_asn),
                          "address-family {}".format(af)])
-        # Step 3: remove the peer-group
+        # Remove peer-group
         neigh_host.eos_config(
             lines=["no neighbor {} peer group".format(eos_peer_group)],
             parents="router bgp {}".format(neigh_asn))
-        # Step 4: restore original numbered neighbors
+        # Restore original numbered neighbors
         restore_lines = []
         if dut_ipv4:
             restore_lines.append(
@@ -397,8 +397,6 @@ def configure_unnumbered_bgp(setup_info):
                                   parents="router bgp {}".format(neigh_asn))
     except Exception as e:
         logger.error("EOS cleanup failed: %s", e)
-        # Still proceed to config_reload below, but fail the teardown afterward
-        # so the error is visible rather than silently swallowed.
         eos_cleanup_failed = True
     else:
         eos_cleanup_failed = False
@@ -428,27 +426,27 @@ def test_bgp_link_local_ipv6(setup_info, configure_unnumbered_bgp):
     Test BGP peering over IPv6 link-local addresses (unnumbered).
 
     Validates that:
-    1. Unnumbered BGP session can be established via a PortChannel interface
+    1. Unnumbered BGP session can be established via an interface
     2. Routes are exchanged over the link-local session
     3. The session uses IPv6 link-local addressing
     """
     duthost = setup_info['duthost']
-    portchannel = setup_info['portchannel']
+    dut_intf = setup_info['dut_intf']
     initial_prefixes = configure_unnumbered_bgp['initial_prefixes']
 
     # Wait for BGP session to establish
     logger.info("Waiting for unnumbered BGP session to establish (timeout=%ds)",
                 WAIT_TIMEOUT)
     established = wait_until(WAIT_TIMEOUT, POLL_INTERVAL, 0,
-                             bgp_unnumbered_established, duthost, portchannel)
+                             bgp_unnumbered_established, duthost, dut_intf)
 
     if not established:
-        # Debug output before skipping
+        # Debug output
         summary = duthost.shell("vtysh -c 'show bgp summary'",
                                 module_ignore_errors=True)
         logger.error("BGP summary:\n%s", summary.get('stdout', ''))
         detail = duthost.shell(
-            "vtysh -c 'show bgp neighbors {}'".format(portchannel),
+            "vtysh -c 'show bgp neighbors {}'".format(dut_intf),
             module_ignore_errors=True)
         logger.error("Neighbor detail:\n%s", detail.get('stdout', ''))
         try:
@@ -462,22 +460,15 @@ def test_bgp_link_local_ipv6(setup_info, configure_unnumbered_bgp):
             logger.error("Could not get EOS BGP summary: %s", e)
 
         pytest.fail(
-            "Unnumbered BGP session via {} did not establish within {}s. "
-            "This could indicate a neighbor compatibility issue — the peer "
-            "may not support BGP peering over IPv6 link-local addresses."
-            .format(portchannel, WAIT_TIMEOUT))
+            "Unnumbered BGP session via {} did not establish within {}s."
+            .format(dut_intf, WAIT_TIMEOUT))
 
     logger.info("Unnumbered BGP session established!")
 
     # Verify routes are received
     logger.info("Verify routes are received via unnumbered session")
 
-    def routes_received_via_unnumbered(duthost, portchannel):
-        """Check if any routes are received via the unnumbered BGP peer.
-
-        Only matches peers identified by the specific PortChannel interface
-        name, not any arbitrary fe80 peer.
-        """
+    def routes_received(duthost, dut_intf):
         result = duthost.shell("vtysh -c 'show bgp summary json'",
                                module_ignore_errors=True)
         if result['rc'] != 0:
@@ -487,7 +478,7 @@ def test_bgp_link_local_ipv6(setup_info, configure_unnumbered_bgp):
             for af in ['ipv4Unicast', 'ipv6Unicast']:
                 for peer, data in bgp_summary.get(af, {}).get(
                         'peers', {}).items():
-                    if (portchannel.lower() in peer.lower()
+                    if (dut_intf.lower() in peer.lower()
                             and data.get('pfxRcd', 0) > 0):
                         return True
         except (json.JSONDecodeError, KeyError):
@@ -495,12 +486,10 @@ def test_bgp_link_local_ipv6(setup_info, configure_unnumbered_bgp):
         return False
 
     pytest_assert(
-        wait_until(30, 5, 0, routes_received_via_unnumbered,
-                   duthost, portchannel),
-        "No routes received via unnumbered BGP session on "
-        "{}".format(portchannel))
+        wait_until(30, 5, 0, routes_received, duthost, dut_intf),
+        "No routes received via unnumbered BGP session on {}".format(dut_intf))
 
-    # Get the actual route count for logging
+    # Log actual route count
     result = duthost.shell("vtysh -c 'show bgp summary json'",
                            module_ignore_errors=True)
     route_count = 0
@@ -510,24 +499,24 @@ def test_bgp_link_local_ipv6(setup_info, configure_unnumbered_bgp):
             for af in ['ipv4Unicast', 'ipv6Unicast']:
                 for peer, data in bgp_summary.get(af, {}).get(
                         'peers', {}).items():
-                    if portchannel.lower() in peer.lower():
+                    if dut_intf.lower() in peer.lower():
                         pfx = data.get('pfxRcd', 0)
                         if pfx > 0:
                             route_count = pfx
-                            logger.info("Peer %s (AF=%s): received %d "
-                                        "prefixes", peer, af, pfx)
+                            logger.info("Peer %s (AF=%s): received %d prefixes",
+                                        peer, af, pfx)
                             break
                 if route_count > 0:
                     break
         except (json.JSONDecodeError, KeyError) as e:
             logger.warning("Could not parse BGP summary JSON: %s", e)
-    logger.info("Received %d routes via unnumbered BGP (was %d via "
-                "global IP)", route_count, initial_prefixes)
+    logger.info("Received %d routes via unnumbered BGP (was %d via global IP)",
+                route_count, initial_prefixes)
 
-    # Verify session details using JSON output for robustness across FRR versions
+    # Verify session details
     logger.info("Verify session details")
     detail_json = duthost.shell(
-        "vtysh -c 'show bgp neighbors {} json'".format(portchannel),
+        "vtysh -c 'show bgp neighbors {} json'".format(dut_intf),
         module_ignore_errors=True)
     if detail_json['rc'] == 0:
         try:
@@ -538,22 +527,22 @@ def test_bgp_link_local_ipv6(setup_info, configure_unnumbered_bgp):
                 if state == 'Established':
                     session_established = True
                     logger.info("Session detail confirmed: %s is Established via %s",
-                                nbr_key, portchannel)
+                                nbr_key, dut_intf)
                     break
             pytest_assert(session_established,
-                          "BGP neighbor detail does not show Established state for {}".format(portchannel))
+                          "BGP neighbor detail does not show Established state "
+                          "for {}".format(dut_intf))
         except (json.JSONDecodeError, KeyError) as e:
-            logger.warning("Failed to parse neighbor JSON, falling back to text check: %s", e)
+            logger.warning("Failed to parse neighbor JSON: %s", e)
             detail = duthost.shell(
-                "vtysh -c 'show bgp neighbors {}'".format(portchannel),
+                "vtysh -c 'show bgp neighbors {}'".format(dut_intf),
                 module_ignore_errors=True)
             pytest_assert('Established' in detail.get('stdout', ''),
                           "BGP neighbor detail does not show Established state")
     else:
-        # JSON form not available, fall back to text
         detail = duthost.shell(
-            "vtysh -c 'show bgp neighbors {}'".format(portchannel),
+            "vtysh -c 'show bgp neighbors {}'".format(dut_intf),
             module_ignore_errors=True)
         pytest_assert('Established' in detail.get('stdout', ''),
                       "BGP neighbor detail does not show Established state")
-        logger.info("Session detail confirmed: Established via %s", portchannel)
+        logger.info("Session detail confirmed: Established via %s", dut_intf)

--- a/tests/bgp/test_bgp_link_local.py
+++ b/tests/bgp/test_bgp_link_local.py
@@ -283,9 +283,15 @@ def configure_unnumbered_bgp(setup_info):
     logger.info("Initial prefix count from %s: %d", neigh_ipv4,
                 initial_prefixes)
 
-    # Remove existing BGP sessions on DUT — must remove from both CONFIG_DB
-    # and FRR. If we only remove from FRR (vtysh), bgpcfgd will re-add the
-    # neighbor from CONFIG_DB, causing the test to fail.
+    # Stop bgpcfgd to prevent it from re-adding the numbered neighbor.
+    # bgpcfgd monitors CONFIG_DB and reconciles FRR config — even after
+    # removing the neighbor from both CONFIG_DB and FRR, bgpcfgd can
+    # re-add it from its internal peer cache or startup state.
+    logger.info("Stopping bgpcfgd to prevent neighbor reconciliation")
+    duthost.shell("docker exec bgp supervisorctl stop bgpcfgd",
+                  module_ignore_errors=True)
+
+    # Remove existing BGP neighbor from CONFIG_DB and FRR
     logger.info("Remove existing BGP neighbor %s from CONFIG_DB and FRR", neigh_ipv4)
     duthost.shell(
         'sonic-db-cli CONFIG_DB DEL "BGP_NEIGHBOR|{}"'.format(neigh_ipv4),
@@ -409,6 +415,11 @@ def configure_unnumbered_bgp(setup_info):
         eos_cleanup_failed = True
     else:
         eos_cleanup_failed = False
+
+    # Restart bgpcfgd before config reload (was stopped during setup)
+    logger.info("Restarting bgpcfgd before config reload")
+    duthost.shell("docker exec bgp supervisorctl start bgpcfgd",
+                  module_ignore_errors=True)
 
     # Config reload on DUT to restore everything
     config_reload(duthost, wait=120)

--- a/tests/bgp/test_bgp_link_local.py
+++ b/tests/bgp/test_bgp_link_local.py
@@ -4,21 +4,24 @@ Tests for BGP peering over IPv6 link-local addresses (unnumbered BGP).
 This test validates that SONiC can establish BGP sessions using interface-based
 (unnumbered) peering, which uses IPv6 link-local addresses for session setup.
 
-Test plan:
-1. Select one interface (PortChannel or Ethernet) with an existing BGP neighbor
-2. Record the neighbor's ASN and current BGP session details
-3. Remove the existing global-IP BGP sessions on both DUT and neighbor
-4. Configure unnumbered BGP peering on DUT (neighbor <interface> interface remote-as)
-5. Configure interface-based BGP neighbor on EOS/cEOS peer
-6. Verify the BGP session establishes successfully
-7. Verify routes are exchanged
-8. Clean up by restoring the original configuration via config reload
+Two scenarios are tested via parametrization:
+1. Unnumbered BGP over a PortChannel (LAG) interface
+2. Unnumbered BGP over a plain Ethernet interface (LAG broken)
 
-Addresses issue: https://github.com/sonic-net/sonic-mgmt/issues/18431
+Known issues blocking unnumbered BGP:
+- FRR 10.5.1 bug: https://github.com/sonic-net/sonic-buildimage/issues/26959
+- bgpcfgd bug: https://github.com/sonic-net/sonic-buildimage/issues/26960
+Tests are skipped via conditional_mark (tests_mark_conditions.yaml) while
+these issues are open. When both are resolved, remove the conditional marks
+and the bgpcfgd stop/start workaround in the fixture.
+
+Addresses: https://github.com/sonic-net/sonic-mgmt/issues/18431
+           https://github.com/sonic-net/sonic-mgmt/issues/24134
 """
 
 import json
 import logging
+import time
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
@@ -36,7 +39,7 @@ POLL_INTERVAL = 10
 
 
 def find_neigh_eos_intf(neigh_host, neigh_ipv4):
-    """Find the neighbor's interface (Port-Channel or Ethernet) that has the given IP.
+    """Find the neighbor's interface that has the given IP.
 
     Args:
         neigh_host: Neighbor host object (EosHost)
@@ -46,12 +49,14 @@ def find_neigh_eos_intf(neigh_host, neigh_ipv4):
         Interface name (e.g. 'Port-Channel1', 'Ethernet1') or None
     """
     try:
-        result = neigh_host.eos_command(commands=["show ip interface brief | json"])
-        intf_data = result['stdout'][0] if isinstance(result['stdout'], list) else result['stdout']
+        result = neigh_host.eos_command(
+            commands=["show ip interface brief | json"])
+        intf_data = result['stdout'][0] if isinstance(
+            result['stdout'], list) else result['stdout']
         if isinstance(intf_data, dict):
             for intf_name, intf_info in intf_data.get('interfaces', {}).items():
-                # Skip loopback, management, vlan interfaces
-                if not (intf_name.startswith('Ethernet') or intf_name.startswith('Port-Channel')):
+                if not (intf_name.startswith('Ethernet')
+                        or intf_name.startswith('Port-Channel')):
                     continue
                 ip_info = intf_info.get('interfaceAddress', {})
                 if isinstance(ip_info, dict):
@@ -60,19 +65,22 @@ def find_neigh_eos_intf(neigh_host, neigh_ipv4):
                         return intf_name
                 elif isinstance(ip_info, list):
                     for entry in ip_info:
-                        addr = entry.get('primaryIp', {}).get('address', '')
+                        addr = entry.get('primaryIp', {}).get(
+                            'address', '')
                         if addr == neigh_ipv4:
                             return intf_name
     except Exception as e:
-        logger.warning("Could not query neighbor interfaces: {}".format(e))
+        logger.warning("Could not query neighbor interfaces: %s", e)
     return None
 
 
 @pytest.fixture(scope='module')
 def setup_info(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):
-    """Gather setup information for the link-local BGP test."""
-    # This test uses eos_command/eos_config on the neighbor host, so it
-    # requires EOS/cEOS neighbors.
+    """Gather setup information for the link-local BGP test.
+
+    Finds a PortChannel-based BGP neighbor and collects all the info needed
+    to test unnumbered BGP on both the PortChannel and its member Ethernet.
+    """
     common_props = tbinfo.get('topo', {}).get('properties', {}).get(
         'configuration_properties', {}).get('common', {})
     neighbor_type = common_props.get('neighbor_type', 'eos')
@@ -86,56 +94,52 @@ def setup_info(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):
     if not dut_asn:
         config_facts_tmp = duthost.config_facts(
             host=duthost.hostname, source="running")['ansible_facts']
-        device_metadata = config_facts_tmp.get('DEVICE_METADATA', {}).get('localhost', {})
+        device_metadata = config_facts_tmp.get(
+            'DEVICE_METADATA', {}).get('localhost', {})
         dut_asn = device_metadata.get('bgp_asn')
         if not dut_asn:
-            pytest.skip("dut_asn not found in testbed configuration_properties or DEVICE_METADATA")
+            pytest.skip("dut_asn not found in configuration")
 
-    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    config_facts = duthost.config_facts(
+        host=duthost.hostname, source="running")['ansible_facts']
     bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {})
     portchannels = config_facts.get('PORTCHANNEL', {})
     portchannel_members = config_facts.get('PORTCHANNEL_MEMBER', {})
     dev_nbrs = config_facts.get('DEVICE_NEIGHBOR', {})
-    intf_table = config_facts.get('INTERFACE', {})
     pc_intf_table = config_facts.get('PORTCHANNEL_INTERFACE', {})
 
-    # Build map: interface -> neighbor name
-    # For PortChannels: look up member interfaces in DEVICE_NEIGHBOR
-    intf_to_neighbor = {}
+    # Build map: PortChannel -> (neighbor_name, member_ethernet)
+    pc_to_info = {}
     for pc_name in portchannels:
         if pc_name not in portchannel_members:
             continue
-        for member_intf in portchannel_members[pc_name]:
+        members = list(portchannel_members[pc_name].keys())
+        for member_intf in members:
             if member_intf in dev_nbrs:
-                intf_to_neighbor[pc_name] = dev_nbrs[member_intf]['name']
+                pc_to_info[pc_name] = {
+                    'neigh_name': dev_nbrs[member_intf]['name'],
+                    'members': members,
+                }
                 break
 
-    # For direct Ethernet interfaces with BGP: check INTERFACE table
-    for intf_key in intf_table:
-        # intf_key could be "EthernetX" or "EthernetX|ip/mask"
-        intf_name = intf_key.split('|')[0] if '|' in intf_key else intf_key
-        if intf_name.startswith('Ethernet') and intf_name in dev_nbrs:
-            if intf_name not in intf_to_neighbor:
-                intf_to_neighbor[intf_name] = dev_nbrs[intf_name]['name']
-
-    # Find an interface with an established IPv4 BGP neighbor
+    # Find a PortChannel with an established IPv4 BGP neighbor
     bgp_facts = duthost.bgp_facts()['ansible_facts']
     selected = None
     for neigh_ip, neigh_info in bgp_neighbors.items():
         if ':' in neigh_ip:
-            continue  # Skip IPv6, find IPv4 first
+            continue
         bgp_state = bgp_facts.get('bgp_neighbors', {}).get(
             neigh_ip, {}).get('state', '')
         neigh_name = neigh_info.get('name', '')
-        logger.info("Candidate neighbor %s (%s): BGP state=%s, in nbrhosts=%s",
-                    neigh_ip, neigh_name, bgp_state, neigh_name in nbrhosts)
         if bgp_state != 'established':
             continue
         neigh_asn = neigh_info.get('asn', '')
-        for intf_name, mapped_neigh in intf_to_neighbor.items():
-            if mapped_neigh == neigh_name and neigh_name in nbrhosts:
+        for pc_name, pc_info in pc_to_info.items():
+            if (pc_info['neigh_name'] == neigh_name
+                    and neigh_name in nbrhosts):
                 selected = {
-                    'intf': intf_name,
+                    'pc_intf': pc_name,
+                    'member_ethernet': pc_info['members'][0],
                     'neigh_name': neigh_name,
                     'neigh_ipv4': neigh_ip,
                     'neigh_asn': neigh_asn,
@@ -145,23 +149,22 @@ def setup_info(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):
             break
 
     if not selected:
-        pytest.skip("No BGP neighbor with established session found on any interface")
+        pytest.skip("No PortChannel BGP neighbor found")
 
-    dut_intf = selected['intf']
+    pc_intf = selected['pc_intf']
 
-    # Find IPv6 address for the same neighbor
+    # Get IPv6 neighbor address
     neigh_ipv6 = None
     for neigh_ip, neigh_info in bgp_neighbors.items():
-        if neigh_info.get('name', '') == selected['neigh_name'] and ':' in neigh_ip:
+        if (neigh_info.get('name', '') == selected['neigh_name']
+                and ':' in neigh_ip):
             neigh_ipv6 = neigh_ip
             break
 
-    # Get DUT's addresses on this interface
+    # Get DUT's addresses on the PortChannel
     dut_ipv4 = None
     dut_ipv6 = None
-    # Check both PORTCHANNEL_INTERFACE and INTERFACE tables
-    addr_table = pc_intf_table.get(dut_intf, {}) if dut_intf.startswith('PortChannel') \
-        else intf_table.get(dut_intf, {})
+    addr_table = pc_intf_table.get(pc_intf, {})
     for addr_key in addr_table:
         addr = addr_key.split('/')[0] if '/' in addr_key else addr_key
         if ':' in addr:
@@ -169,49 +172,57 @@ def setup_info(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):
         else:
             dut_ipv4 = addr
 
-    # Get DUT's link-local on this interface
-    result = duthost.shell("ip -6 addr show dev {} scope link".format(dut_intf))
+    # Get DUT's link-local on the PortChannel
+    result = duthost.shell(
+        "ip -6 addr show dev {} scope link".format(pc_intf))
     dut_link_local = None
     for line in result['stdout'].split('\n'):
         if 'inet6 fe80' in line.strip():
             dut_link_local = line.strip().split()[1].split('/')[0]
             break
-
     pytest_assert(dut_link_local,
-                  "No link-local address on {}".format(dut_intf))
+                  "No link-local address on {}".format(pc_intf))
 
-    # Find the EOS neighbor's interface
+    # Find EOS neighbor's interface
     neigh_host = nbrhosts[selected['neigh_name']]['host']
     neigh_intf = find_neigh_eos_intf(neigh_host, selected['neigh_ipv4'])
     if not neigh_intf:
-        # Fallback: try common naming patterns
-        if dut_intf.startswith('PortChannel'):
-            pc_num = ''.join(c for c in dut_intf if c.isdigit())
-            candidates = ["Port-Channel{}".format(pc_num),
+        pc_num = ''.join(c for c in pc_intf if c.isdigit())
+        for candidate in ["Port-Channel{}".format(pc_num),
                           "Port-Channel1",
-                          "Port-Channel{}".format(int(pc_num) % 100 if pc_num else 1)]
-        else:
-            # For Ethernet, try Ethernet1 (cEOS typically uses Ethernet1 for the first port)
-            candidates = ["Ethernet1"]
-        for candidate in candidates:
+                          "Port-Channel{}".format(
+                              int(pc_num) % 100 if pc_num else 1)]:
             try:
-                neigh_host.eos_command(commands=["show interfaces {}".format(candidate)])
+                neigh_host.eos_command(
+                    commands=["show interfaces {}".format(candidate)])
                 neigh_intf = candidate
                 break
             except Exception:
                 continue
-
     pytest_assert(neigh_intf,
-                  "Could not determine neighbor's interface for {}".format(
-                      selected['neigh_name']))
+                  "Could not determine neighbor's interface")
+
+    # Get DUT IP prefixes with masks for later re-assignment
+    dut_ipv4_prefix = None
+    dut_ipv6_prefix = None
+    for addr_key in addr_table:
+        if '/' not in addr_key:
+            continue
+        if ':' in addr_key:
+            dut_ipv6_prefix = addr_key
+        else:
+            dut_ipv4_prefix = addr_key
 
     info = {
         'duthost': duthost,
         'dut_asn': dut_asn,
         'dut_ipv4': dut_ipv4,
         'dut_ipv6': dut_ipv6,
+        'dut_ipv4_prefix': dut_ipv4_prefix,
+        'dut_ipv6_prefix': dut_ipv6_prefix,
         'dut_link_local': dut_link_local,
-        'dut_intf': dut_intf,
+        'pc_intf': pc_intf,
+        'member_ethernet': selected['member_ethernet'],
         'neigh_name': selected['neigh_name'],
         'neigh_host': neigh_host,
         'neigh_asn': selected['neigh_asn'],
@@ -220,18 +231,17 @@ def setup_info(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):
         'neigh_intf': neigh_intf,
     }
 
-    logger.info("Setup: DUT %s (%s) <-> %s (%s) via %s/%s",
-                dut_ipv4, dut_link_local, selected['neigh_name'],
-                selected['neigh_ipv4'], dut_intf, neigh_intf)
+    logger.info(
+        "Setup: DUT %s (%s) <-> %s (%s) via %s (member %s) / %s",
+        dut_ipv4, dut_link_local, selected['neigh_name'],
+        selected['neigh_ipv4'], pc_intf,
+        selected['member_ethernet'], neigh_intf)
 
     return info
 
 
-def bgp_unnumbered_established(duthost, dut_intf):
-    """Check if the unnumbered BGP session via an interface is established.
-
-    FRR shows unnumbered neighbors by interface name in 'show bgp summary'.
-    """
+def bgp_unnumbered_established(duthost, intf_name):
+    """Check if unnumbered BGP session via an interface is established."""
     result = duthost.shell(
         "vtysh -c 'show bgp summary json'", module_ignore_errors=True)
     if result['rc'] != 0:
@@ -243,7 +253,7 @@ def bgp_unnumbered_established(duthost, dut_intf):
             for peer_key, peer_data in peers.items():
                 if peer_data.get('state') != 'Established':
                     continue
-                if dut_intf.lower() in peer_key.lower():
+                if intf_name.lower() in peer_key.lower():
                     logger.info(
                         "Unnumbered peer found: %s (AF=%s, pfxRcd=%s)",
                         peer_key, af, peer_data.get('pfxRcd', 0))
@@ -253,84 +263,47 @@ def bgp_unnumbered_established(duthost, dut_intf):
     return False
 
 
-@pytest.fixture(scope='function')
-def configure_unnumbered_bgp(setup_info):
-    """Configure unnumbered BGP peering and restore original config afterward."""
-    duthost = setup_info['duthost']
-    neigh_host = setup_info['neigh_host']
-    dut_intf = setup_info['dut_intf']
-    dut_asn = setup_info['dut_asn']
-    neigh_asn = setup_info['neigh_asn']
-    neigh_ipv4 = setup_info['neigh_ipv4']
-    neigh_ipv6 = setup_info['neigh_ipv6']
-    dut_ipv4 = setup_info['dut_ipv4']
-    dut_ipv6 = setup_info['dut_ipv6']
-    neigh_intf = setup_info['neigh_intf']
+def debug_bgp_state(duthost, intf_name, setup_info):
+    """Dump debug info when BGP session fails to establish."""
+    summary = duthost.shell(
+        "vtysh -c 'show bgp summary'", module_ignore_errors=True)
+    logger.error("BGP summary:\n%s", summary.get('stdout', ''))
 
-    # --- Setup ---
-
-    # Wait for the selected BGP session to be established
-    logger.info("Waiting for BGP session to %s to be established", neigh_ipv4)
-    pytest_assert(
-        wait_until(60, 5, 0, lambda: duthost.bgp_facts()['ansible_facts']
-                   .get('bgp_neighbors', {}).get(neigh_ipv4, {})
-                   .get('state', '') == 'established'),
-        "IPv4 BGP session to {} not established".format(neigh_ipv4))
-
-    bgp_facts = duthost.bgp_facts()['ansible_facts']
-    initial_prefixes = int(
-        bgp_facts['bgp_neighbors'][neigh_ipv4].get('accepted prefixes', 0))
-    logger.info("Initial prefix count from %s: %d", neigh_ipv4,
-                initial_prefixes)
-
-    # Stop bgpcfgd to prevent it from re-adding the numbered neighbor.
-    # bgpcfgd monitors CONFIG_DB and reconciles FRR config — even after
-    # removing the neighbor from both CONFIG_DB and FRR, bgpcfgd can
-    # re-add it from its internal peer cache or startup state.
-    logger.info("Stopping bgpcfgd to prevent neighbor reconciliation")
-    duthost.shell("docker exec bgp supervisorctl stop bgpcfgd",
-                  module_ignore_errors=True)
-
-    # Remove existing BGP neighbor from CONFIG_DB and FRR
-    logger.info("Remove existing BGP neighbor %s from CONFIG_DB and FRR", neigh_ipv4)
-    duthost.shell(
-        'sonic-db-cli CONFIG_DB DEL "BGP_NEIGHBOR|{}"'.format(neigh_ipv4),
+    detail = duthost.shell(
+        "vtysh -c 'show bgp neighbors {}'".format(intf_name),
         module_ignore_errors=True)
-    if neigh_ipv6:
-        duthost.shell(
-            'sonic-db-cli CONFIG_DB DEL "BGP_NEIGHBOR|{}"'.format(neigh_ipv6),
-            module_ignore_errors=True)
-    vtysh_remove = ['config', 'router bgp {}'.format(dut_asn),
-                    'no neighbor {}'.format(neigh_ipv4)]
-    if neigh_ipv6:
-        vtysh_remove.append('no neighbor {}'.format(neigh_ipv6))
-    cmd = 'vtysh ' + ' '.join(['-c "{}"'.format(c) for c in vtysh_remove])
-    duthost.shell(cmd, module_ignore_errors=True)
+    logger.error("Neighbor %s detail:\n%s",
+                 intf_name, detail.get('stdout', ''))
 
-    # Remove existing BGP session on EOS neighbor
-    logger.info("Remove DUT neighbors on EOS peer")
-    remove_lines = []
-    if dut_ipv4:
-        remove_lines.append("no neighbor {}".format(dut_ipv4))
-    if dut_ipv6:
-        remove_lines.append("no neighbor {}".format(dut_ipv6))
-    if remove_lines:
-        neigh_host.eos_config(lines=remove_lines,
-                              parents="router bgp {}".format(neigh_asn))
+    frr_run = duthost.shell(
+        "vtysh -c 'show running-config bgpd'",
+        module_ignore_errors=True)
+    logger.error("FRR running config:\n%s", frr_run.get('stdout', ''))
 
-    # Wait for old neighbor to be removed
-    def old_neighbor_removed():
-        facts = duthost.bgp_facts()['ansible_facts']
-        return neigh_ipv4 not in facts.get('bgp_neighbors', {})
+    try:
+        neigh_host = setup_info['neigh_host']
+        eos_bgp = neigh_host.eos_command(
+            commands=["show ip bgp summary"])
+        eos_out = eos_bgp['stdout'][0] if isinstance(
+            eos_bgp['stdout'], list) else eos_bgp['stdout']
+        logger.error("EOS BGP summary:\n%s", eos_out)
 
-    wait_until(30, 3, 0, old_neighbor_removed)
+        eos_run = neigh_host.eos_command(
+            commands=["show running-config section bgp"])
+        eos_run_out = eos_run['stdout'][0] if isinstance(
+            eos_run['stdout'], list) else eos_run['stdout']
+        logger.error("EOS BGP running config:\n%s", eos_run_out)
+    except Exception as e:
+        logger.error("Could not get EOS BGP info: %s", e)
 
-    # Configure unnumbered BGP on DUT
-    logger.info("Configure unnumbered BGP on DUT via %s", dut_intf)
-    vtysh_add = [
+
+def configure_unnumbered_dut(duthost, dut_asn, dut_intf, neigh_asn):
+    """Configure unnumbered BGP neighbor on DUT via vtysh."""
+    vtysh_cmds = [
         'config',
         'router bgp {}'.format(dut_asn),
-        'neighbor {} interface remote-as {}'.format(dut_intf, neigh_asn),
+        'neighbor {} interface v6only remote-as {}'.format(
+            dut_intf, neigh_asn),
         'address-family ipv4 unicast',
         'neighbor {} activate'.format(dut_intf),
         'exit-address-family',
@@ -338,68 +311,108 @@ def configure_unnumbered_bgp(setup_info):
         'neighbor {} activate'.format(dut_intf),
         'exit-address-family',
     ]
-    cmd = 'vtysh ' + ' '.join(['-c "{}"'.format(c) for c in vtysh_add])
+    cmd = 'vtysh ' + ' '.join(
+        ['-c "{}"'.format(c) for c in vtysh_cmds])
     result = duthost.shell(cmd)
     pytest_assert(result['rc'] == 0,
-                  "Failed to configure unnumbered BGP: {}".format(
-                      result.get('stderr', '')))
+                  "Failed to configure unnumbered BGP on {}: {}".format(
+                      dut_intf, result.get('stderr', '')))
 
-    # Configure BGP peering on EOS using interface-based (unnumbered) config.
+    # Log FRR running config for debugging
+    frr_cfg = duthost.shell(
+        "vtysh -c 'show running-config bgpd'",
+        module_ignore_errors=True)
+    logger.info("FRR running config after unnumbered setup on %s:\n%s",
+                dut_intf, frr_cfg.get('stdout', ''))
+
+
+def configure_unnumbered_eos(neigh_host, neigh_asn, dut_asn, neigh_intf):
+    """Configure interface-based BGP neighbor on EOS peer."""
     eos_peer_group = "LINK_LOCAL_PG"
-    logger.info("Configure interface-based BGP peering on EOS via %s (peer-group %s)",
-                neigh_intf, eos_peer_group)
     neigh_host.eos_config(
         lines=[
             "neighbor {} peer group".format(eos_peer_group),
             "neighbor {} remote-as {}".format(eos_peer_group, dut_asn),
-            "neighbor interface {} peer-group {}".format(neigh_intf, eos_peer_group),
+            "neighbor interface {} peer-group {}".format(
+                neigh_intf, eos_peer_group),
         ],
         parents="router bgp {}".format(neigh_asn))
 
-    # Enable address families for the peer-group
     for af in ["ipv4", "ipv6"]:
         neigh_host.eos_config(
-            lines=[
-                "neighbor {} activate".format(eos_peer_group),
-            ],
+            lines=["neighbor {} activate".format(eos_peer_group)],
             parents=["router bgp {}".format(neigh_asn),
                      "address-family {}".format(af)])
 
-    # Verify EOS accepted the config
+    # Verify config was accepted
     eos_bgp_cfg = neigh_host.eos_command(
         commands=["show running-config section bgp"])
     eos_cfg_text = eos_bgp_cfg['stdout'][0] if isinstance(
         eos_bgp_cfg['stdout'], list) else eos_bgp_cfg['stdout']
     logger.info("EOS BGP config after setup:\n%s", eos_cfg_text)
-    if eos_peer_group not in eos_cfg_text:
-        pytest.fail("EOS did not accept the interface-based BGP config. "
-                    "Running config:\n{}".format(eos_cfg_text))
+    pytest_assert(eos_peer_group in eos_cfg_text,
+                  "EOS did not accept interface-based BGP config")
+    return eos_peer_group
 
-    yield {
-        'initial_prefixes': initial_prefixes,
-        'eos_peer_group': eos_peer_group,
-    }
 
-    # --- Teardown ---
-    logger.info("Teardown: Restoring original configuration")
+def remove_numbered_bgp(duthost, neigh_host, dut_asn, neigh_asn,
+                        neigh_ipv4, neigh_ipv6, dut_ipv4, dut_ipv6):
+    """Remove existing numbered BGP sessions on both DUT and EOS."""
+    # Remove from CONFIG_DB
+    duthost.shell(
+        'sonic-db-cli CONFIG_DB DEL "BGP_NEIGHBOR|{}"'.format(neigh_ipv4),
+        module_ignore_errors=True)
+    if neigh_ipv6:
+        duthost.shell(
+            'sonic-db-cli CONFIG_DB DEL "BGP_NEIGHBOR|{}"'.format(
+                neigh_ipv6),
+            module_ignore_errors=True)
 
+    # Remove from FRR
+    vtysh_rm = ['config', 'router bgp {}'.format(dut_asn),
+                'no neighbor {}'.format(neigh_ipv4)]
+    if neigh_ipv6:
+        vtysh_rm.append('no neighbor {}'.format(neigh_ipv6))
+    cmd = 'vtysh ' + ' '.join(
+        ['-c "{}"'.format(c) for c in vtysh_rm])
+    duthost.shell(cmd, module_ignore_errors=True)
+
+    # Remove on EOS
+    remove_lines = []
+    if dut_ipv4:
+        remove_lines.append("no neighbor {}".format(dut_ipv4))
+    if dut_ipv6:
+        remove_lines.append("no neighbor {}".format(dut_ipv6))
+    if remove_lines:
+        neigh_host.eos_config(
+            lines=remove_lines,
+            parents="router bgp {}".format(neigh_asn))
+
+    # Wait for removal
+    def old_neighbor_gone():
+        facts = duthost.bgp_facts()['ansible_facts']
+        return neigh_ipv4 not in facts.get('bgp_neighbors', {})
+    wait_until(30, 3, 0, old_neighbor_gone)
+
+
+def cleanup_eos_unnumbered(neigh_host, neigh_asn, dut_asn,
+                           neigh_intf, dut_ipv4, dut_ipv6):
+    """Remove unnumbered config from EOS and restore numbered neighbors."""
     eos_peer_group = "LINK_LOCAL_PG"
     try:
-        # Remove interface neighbor
         neigh_host.eos_config(
             lines=["no neighbor interface {}".format(neigh_intf)],
             parents="router bgp {}".format(neigh_asn))
-        # Deactivate from address-families
         for af in ["ipv4", "ipv6"]:
             neigh_host.eos_config(
-                lines=["no neighbor {} activate".format(eos_peer_group)],
+                lines=[
+                    "no neighbor {} activate".format(eos_peer_group)],
                 parents=["router bgp {}".format(neigh_asn),
                          "address-family {}".format(af)])
-        # Remove peer-group
         neigh_host.eos_config(
-            lines=["no neighbor {} peer group".format(eos_peer_group)],
+            lines=[
+                "no neighbor {} peer group".format(eos_peer_group)],
             parents="router bgp {}".format(neigh_asn))
-        # Restore original numbered neighbors
         restore_lines = []
         if dut_ipv4:
             restore_lines.append(
@@ -408,97 +421,111 @@ def configure_unnumbered_bgp(setup_info):
             restore_lines.append(
                 "neighbor {} remote-as {}".format(dut_ipv6, dut_asn))
         if restore_lines:
-            neigh_host.eos_config(lines=restore_lines,
-                                  parents="router bgp {}".format(neigh_asn))
+            neigh_host.eos_config(
+                lines=restore_lines,
+                parents="router bgp {}".format(neigh_asn))
     except Exception as e:
         logger.error("EOS cleanup failed: %s", e)
-        eos_cleanup_failed = True
-    else:
-        eos_cleanup_failed = False
-
-    # Restart bgpcfgd before config reload (was stopped during setup)
-    logger.info("Restarting bgpcfgd before config reload")
-    duthost.shell("docker exec bgp supervisorctl start bgpcfgd",
-                  module_ignore_errors=True)
-
-    # Config reload on DUT to restore everything
-    config_reload(duthost, wait=120)
-
-    # Wait for all original BGP sessions to re-establish
-    original_neighbors = [neigh_ipv4]
-    if neigh_ipv6:
-        original_neighbors.append(neigh_ipv6)
-    if not wait_until(WAIT_TIMEOUT, POLL_INTERVAL, 0,
-                      duthost.check_bgp_session_state, original_neighbors):
-        pytest_assert(False,
-                      "BGP sessions did not re-establish after config reload")
-    else:
-        logger.info("Original configuration restored, all sessions up")
-
-    if eos_cleanup_failed:
-        pytest.fail("EOS cleanup failed during teardown - neighbor may still "
-                    "have stale link-local configuration")
 
 
-@pytest.mark.disable_loganalyzer
-def test_bgp_link_local_ipv6(setup_info, configure_unnumbered_bgp):
+def break_lag_to_ethernet(duthost, neigh_host, setup_info):
+    """Break PortChannel and move IPs to the member Ethernet interface.
+
+    Returns the EOS Ethernet interface name to use for peering.
     """
-    Test BGP peering over IPv6 link-local addresses (unnumbered).
+    pc_intf = setup_info['pc_intf']
+    eth_intf = setup_info['member_ethernet']
+    dut_ipv4_prefix = setup_info['dut_ipv4_prefix']
+    dut_ipv6_prefix = setup_info['dut_ipv6_prefix']
+    neigh_intf = setup_info['neigh_intf']
 
-    Validates that:
-    1. Unnumbered BGP session can be established via an interface
-    2. Routes are exchanged over the link-local session
-    3. The session uses IPv6 link-local addressing
-    """
-    duthost = setup_info['duthost']
-    dut_intf = setup_info['dut_intf']
-    initial_prefixes = configure_unnumbered_bgp['initial_prefixes']
+    logger.info("Breaking %s: removing %s, moving IPs to %s",
+                pc_intf, eth_intf, eth_intf)
+    duthost.shell(
+        "sudo config portchannel member del {} {}".format(
+            pc_intf, eth_intf))
+    if dut_ipv4_prefix:
+        duthost.shell(
+            "sudo config interface ip remove {} {}".format(
+                pc_intf, dut_ipv4_prefix),
+            module_ignore_errors=True)
+        duthost.shell(
+            "sudo config interface ip add {} {}".format(
+                eth_intf, dut_ipv4_prefix))
+    if dut_ipv6_prefix:
+        duthost.shell(
+            "sudo config interface ip remove {} {}".format(
+                pc_intf, dut_ipv6_prefix),
+            module_ignore_errors=True)
+        duthost.shell(
+            "sudo config interface ip add {} {}".format(
+                eth_intf, dut_ipv6_prefix))
 
-    # Wait for BGP session to establish
-    logger.info("Waiting for unnumbered BGP session to establish (timeout=%ds)",
-                WAIT_TIMEOUT)
-    established = wait_until(WAIT_TIMEOUT, POLL_INTERVAL, 0,
-                             bgp_unnumbered_established, duthost, dut_intf)
+    # Wait for link-local address on Ethernet
+    time.sleep(5)
+    ll_check = duthost.shell(
+        "ip -6 addr show {} scope link".format(eth_intf),
+        module_ignore_errors=True)
+    logger.info("Link-local on %s:\n%s",
+                eth_intf, ll_check.get('stdout', ''))
+
+    # EOS side: remove Port-Channel, use Ethernet1 directly
+    eos_eth_intf = "Ethernet1"
+    logger.info("Configuring EOS %s for direct Ethernet peering",
+                eos_eth_intf)
+    neigh_host.eos_config(
+        lines=["no interface {}".format(neigh_intf)],
+        module_ignore_errors=True)
+
+    return eos_eth_intf
+
+
+def restore_lag_on_eos(neigh_host, neigh_intf):
+    """Restore EOS Port-Channel after LAG breakout test."""
+    try:
+        if "Port-Channel" in neigh_intf:
+            neigh_host.eos_config(
+                lines=[
+                    "interface {}".format(neigh_intf),
+                    "channel-group 1 mode active",
+                ],
+                module_ignore_errors=True)
+    except Exception as e:
+        logger.warning("EOS LAG restore attempt: %s", e)
+
+
+def verify_bgp_established(duthost, intf_name, setup_info):
+    """Wait for unnumbered BGP to establish; dump debug on failure."""
+    logger.info(
+        "Waiting for unnumbered BGP on %s to establish (timeout=%ds)",
+        intf_name, WAIT_TIMEOUT)
+    established = wait_until(
+        WAIT_TIMEOUT, POLL_INTERVAL, 0,
+        bgp_unnumbered_established, duthost, intf_name)
 
     if not established:
-        # Debug output
-        summary = duthost.shell("vtysh -c 'show bgp summary'",
-                                module_ignore_errors=True)
-        logger.error("BGP summary:\n%s", summary.get('stdout', ''))
-        detail = duthost.shell(
-            "vtysh -c 'show bgp neighbors {}'".format(dut_intf),
-            module_ignore_errors=True)
-        logger.error("Neighbor detail:\n%s", detail.get('stdout', ''))
-        try:
-            neigh_host = setup_info['neigh_host']
-            eos_bgp = neigh_host.eos_command(
-                commands=["show ip bgp summary"])
-            eos_out = eos_bgp['stdout'][0] if isinstance(
-                eos_bgp['stdout'], list) else eos_bgp['stdout']
-            logger.error("EOS BGP summary:\n%s", eos_out)
-        except Exception as e:
-            logger.error("Could not get EOS BGP summary: %s", e)
-
+        debug_bgp_state(duthost, intf_name, setup_info)
         pytest.fail(
-            "Unnumbered BGP session via {} did not establish within {}s."
-            .format(dut_intf, WAIT_TIMEOUT))
+            "Unnumbered BGP session via {} did not establish within {}s"
+            .format(intf_name, WAIT_TIMEOUT))
 
-    logger.info("Unnumbered BGP session established!")
+    logger.info("Unnumbered BGP session on %s established!", intf_name)
 
-    # Verify routes are received
-    logger.info("Verify routes are received via unnumbered session")
 
-    def routes_received(duthost, dut_intf):
-        result = duthost.shell("vtysh -c 'show bgp summary json'",
-                               module_ignore_errors=True)
+def verify_routes_received(duthost, intf_name):
+    """Verify routes are received over the unnumbered session."""
+    def routes_received():
+        result = duthost.shell(
+            "vtysh -c 'show bgp summary json'",
+            module_ignore_errors=True)
         if result['rc'] != 0:
             return False
         try:
             bgp_summary = json.loads(result['stdout'])
             for af in ['ipv4Unicast', 'ipv6Unicast']:
-                for peer, data in bgp_summary.get(af, {}).get(
-                        'peers', {}).items():
-                    if (dut_intf.lower() in peer.lower()
+                for peer, data in bgp_summary.get(
+                        af, {}).get('peers', {}).items():
+                    if (intf_name.lower() in peer.lower()
                             and data.get('pfxRcd', 0) > 0):
                         return True
         except (json.JSONDecodeError, KeyError):
@@ -506,63 +533,109 @@ def test_bgp_link_local_ipv6(setup_info, configure_unnumbered_bgp):
         return False
 
     pytest_assert(
-        wait_until(30, 5, 0, routes_received, duthost, dut_intf),
-        "No routes received via unnumbered BGP session on {}".format(dut_intf))
+        wait_until(30, 5, 0, routes_received),
+        "No routes received via unnumbered BGP on {}".format(intf_name))
+    logger.info("Routes received via unnumbered BGP on %s", intf_name)
 
-    # Log actual route count
-    result = duthost.shell("vtysh -c 'show bgp summary json'",
-                           module_ignore_errors=True)
-    route_count = 0
-    if result['rc'] == 0:
-        try:
-            bgp_summary = json.loads(result['stdout'])
-            for af in ['ipv4Unicast', 'ipv6Unicast']:
-                for peer, data in bgp_summary.get(af, {}).get(
-                        'peers', {}).items():
-                    if dut_intf.lower() in peer.lower():
-                        pfx = data.get('pfxRcd', 0)
-                        if pfx > 0:
-                            route_count = pfx
-                            logger.info("Peer %s (AF=%s): received %d prefixes",
-                                        peer, af, pfx)
-                            break
-                if route_count > 0:
-                    break
-        except (json.JSONDecodeError, KeyError) as e:
-            logger.warning("Could not parse BGP summary JSON: %s", e)
-    logger.info("Received %d routes via unnumbered BGP (was %d via global IP)",
-                route_count, initial_prefixes)
 
-    # Verify session details
-    logger.info("Verify session details")
-    detail_json = duthost.shell(
-        "vtysh -c 'show bgp neighbors {} json'".format(dut_intf),
-        module_ignore_errors=True)
-    if detail_json['rc'] == 0:
-        try:
-            nbr_data = json.loads(detail_json['stdout'])
-            session_established = False
-            for nbr_key, nbr_info in nbr_data.items():
-                state = nbr_info.get('bgpState', '')
-                if state == 'Established':
-                    session_established = True
-                    logger.info("Session detail confirmed: %s is Established via %s",
-                                nbr_key, dut_intf)
-                    break
-            pytest_assert(session_established,
-                          "BGP neighbor detail does not show Established state "
-                          "for {}".format(dut_intf))
-        except (json.JSONDecodeError, KeyError) as e:
-            logger.warning("Failed to parse neighbor JSON: %s", e)
-            detail = duthost.shell(
-                "vtysh -c 'show bgp neighbors {}'".format(dut_intf),
-                module_ignore_errors=True)
-            pytest_assert('Established' in detail.get('stdout', ''),
-                          "BGP neighbor detail does not show Established state")
+@pytest.fixture(scope='function',
+                params=['portchannel', 'ethernet'],
+                ids=['portchannel', 'ethernet'])
+def configure_unnumbered_bgp(request, setup_info):
+    """Configure unnumbered BGP on a DUT interface.
+
+    Parametrized with two scenarios:
+    - portchannel: test unnumbered BGP on the existing PortChannel
+    - ethernet: break the PortChannel, test on the member Ethernet
+
+    Both scenarios:
+    1. Wait for baseline numbered BGP to be established
+    2. Stop bgpcfgd (workaround for sonic-buildimage#26960)
+    3. Remove existing numbered BGP sessions
+    4. (ethernet only) Break LAG and move IPs to member Ethernet
+    5. Configure unnumbered BGP on DUT and EOS
+    6. Yield the test interface name
+    7. Teardown: restore EOS, restart bgpcfgd, config_reload
+    """
+    intf_type = request.param
+    duthost = setup_info['duthost']
+    neigh_host = setup_info['neigh_host']
+    dut_asn = setup_info['dut_asn']
+    neigh_asn = setup_info['neigh_asn']
+    neigh_ipv4 = setup_info['neigh_ipv4']
+    neigh_ipv6 = setup_info['neigh_ipv6']
+    dut_ipv4 = setup_info['dut_ipv4']
+    dut_ipv6 = setup_info['dut_ipv6']
+    neigh_intf = setup_info['neigh_intf']
+
+    # Wait for baseline BGP session
+    logger.info("Waiting for BGP session to %s to be established",
+                neigh_ipv4)
+    pytest_assert(
+        wait_until(60, 5, 0, lambda: duthost.bgp_facts()['ansible_facts']
+                   .get('bgp_neighbors', {}).get(neigh_ipv4, {})
+                   .get('state', '') == 'established'),
+        "IPv4 BGP session to {} not established".format(neigh_ipv4))
+
+    # Stop bgpcfgd to prevent neighbor reconciliation
+    # TODO: Remove this workaround when sonic-buildimage#26960 is fixed.
+    # bgpcfgd injects 'no capability link-local' which blocks unnumbered BGP.
+    # Stopping bgpcfgd isolates the FRR behavior so that when FRR is fixed
+    # (sonic-buildimage#26959), the test will pass and alert us.
+    logger.info("Stopping bgpcfgd")
+    duthost.shell("docker exec bgp supervisorctl stop bgpcfgd",
+                  module_ignore_errors=True)
+
+    # Remove numbered BGP
+    remove_numbered_bgp(duthost, neigh_host, dut_asn, neigh_asn,
+                        neigh_ipv4, neigh_ipv6, dut_ipv4, dut_ipv6)
+
+    # Determine DUT and EOS interfaces based on scenario
+    eos_intf = neigh_intf
+    if intf_type == 'portchannel':
+        dut_intf = setup_info['pc_intf']
     else:
-        detail = duthost.shell(
-            "vtysh -c 'show bgp neighbors {}'".format(dut_intf),
-            module_ignore_errors=True)
-        pytest_assert('Established' in detail.get('stdout', ''),
-                      "BGP neighbor detail does not show Established state")
-        logger.info("Session detail confirmed: Established via %s", dut_intf)
+        dut_intf = setup_info['member_ethernet']
+        eos_intf = break_lag_to_ethernet(
+            duthost, neigh_host, setup_info)
+
+    # Configure unnumbered BGP
+    configure_unnumbered_dut(duthost, dut_asn, dut_intf, neigh_asn)
+    configure_unnumbered_eos(neigh_host, neigh_asn, dut_asn, eos_intf)
+
+    yield {'dut_intf': dut_intf, 'intf_type': intf_type}
+
+    # Teardown
+    logger.info("Teardown [%s]: restoring BGP config", intf_type)
+    cleanup_eos_unnumbered(neigh_host, neigh_asn, dut_asn,
+                           eos_intf, dut_ipv4, dut_ipv6)
+    if intf_type == 'ethernet':
+        restore_lag_on_eos(neigh_host, neigh_intf)
+    duthost.shell("docker exec bgp supervisorctl start bgpcfgd",
+                  module_ignore_errors=True)
+    config_reload(duthost, wait=120)
+    original_neighbors = [neigh_ipv4]
+    if neigh_ipv6:
+        original_neighbors.append(neigh_ipv6)
+    if not wait_until(WAIT_TIMEOUT, POLL_INTERVAL, 0,
+                      duthost.check_bgp_session_state,
+                      original_neighbors):
+        logger.error("BGP sessions did not re-establish after restore")
+
+
+@pytest.mark.disable_loganalyzer
+def test_bgp_link_local(setup_info, configure_unnumbered_bgp):
+    """Test unnumbered BGP peering over PortChannel and Ethernet interfaces.
+
+    Parametrized via configure_unnumbered_bgp fixture:
+    - test_bgp_link_local[portchannel]: unnumbered BGP on LAG
+    - test_bgp_link_local[ethernet]: break LAG, unnumbered on plain Ethernet
+
+    Validates that SONiC can establish an unnumbered BGP session using
+    interface-based peering and receive routes over it.
+    """
+    duthost = setup_info['duthost']
+    dut_intf = configure_unnumbered_bgp['dut_intf']
+
+    verify_bgp_established(duthost, dut_intf, setup_info)
+    verify_routes_received(duthost, dut_intf)

--- a/tests/bgp/test_bgp_link_local.py
+++ b/tests/bgp/test_bgp_link_local.py
@@ -80,11 +80,6 @@ def setup_info(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):
 
     duthost = duthosts[rand_one_dut_hostname]
 
-    # BGP unnumbered over PortChannel does not work on VS platform
-    # (virtual switch + cEOS neighbors lack proper link-local peering support)
-    if duthost.facts.get('asic_type') == 'vs':
-        pytest.skip("BGP unnumbered over PortChannel not supported on VS/KVM")
-
     dut_asn = common_props.get('dut_asn')
     if not dut_asn:
         # Fallback: get ASN from running config

--- a/tests/bgp/test_bgp_link_local.py
+++ b/tests/bgp/test_bgp_link_local.py
@@ -8,20 +8,12 @@ Two scenarios are tested via parametrization:
 1. Unnumbered BGP over a PortChannel (LAG) interface
 2. Unnumbered BGP over a plain Ethernet interface (LAG broken)
 
-Known issues blocking unnumbered BGP:
-- FRR 10.5.1 bug: https://github.com/sonic-net/sonic-buildimage/issues/26959
-- bgpcfgd bug: https://github.com/sonic-net/sonic-buildimage/issues/26960
-Tests are skipped via conditional_mark (tests_mark_conditions.yaml) while
-these issues are open. When both are resolved, remove the conditional marks
-and the bgpcfgd stop/start workaround in the fixture.
-
 Addresses: https://github.com/sonic-net/sonic-mgmt/issues/18431
            https://github.com/sonic-net/sonic-mgmt/issues/24134
 """
 
 import json
 import logging
-import time
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
@@ -241,7 +233,12 @@ def setup_info(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):
 
 
 def bgp_unnumbered_established(duthost, intf_name):
-    """Check if unnumbered BGP session via an interface is established."""
+    """Check if unnumbered BGP session via an interface is established.
+
+    Verifies that the session uses link-local (fe80::) addressing,
+    not IPv4 fallback. FRR may ignore 'v6only' and fall back to IPv4
+    on interfaces that have an IPv4 address — that's a false positive.
+    """
     result = duthost.shell(
         "vtysh -c 'show bgp summary json'", module_ignore_errors=True)
     if result['rc'] != 0:
@@ -255,9 +252,34 @@ def bgp_unnumbered_established(duthost, intf_name):
                     continue
                 if intf_name.lower() in peer_key.lower():
                     logger.info(
-                        "Unnumbered peer found: %s (AF=%s, pfxRcd=%s)",
+                        "Candidate peer: %s (AF=%s, pfxRcd=%s)",
                         peer_key, af, peer_data.get('pfxRcd', 0))
-                    return True
+                    # Verify it's using link-local, not IPv4 fallback
+                    neigh_detail = duthost.shell(
+                        "vtysh -c 'show bgp neighbors {} json'"
+                        .format(intf_name),
+                        module_ignore_errors=True)
+                    if neigh_detail['rc'] == 0:
+                        try:
+                            nd = json.loads(neigh_detail['stdout'])
+                            # FRR nests under interface or IP key
+                            for key, info in nd.items():
+                                remote = info.get(
+                                    'bgpNeighborAddr', '')
+                                if remote.startswith('fe80'):
+                                    logger.info(
+                                        "Confirmed link-local peer:"
+                                        " %s remote=%s",
+                                        peer_key, remote)
+                                    return True
+                                logger.warning(
+                                    "Peer %s uses %s (not "
+                                    "link-local) — IPv4 fallback",
+                                    peer_key, remote)
+                        except (json.JSONDecodeError, KeyError):
+                            pass
+                    # If we can't verify, don't accept it
+                    return False
     except (json.JSONDecodeError, KeyError) as e:
         logger.warning("Failed to parse BGP summary JSON: %s", e)
     return False
@@ -298,7 +320,7 @@ def debug_bgp_state(duthost, intf_name, setup_info):
 
 
 def configure_unnumbered_dut(duthost, dut_asn, dut_intf, neigh_asn):
-    """Configure unnumbered BGP neighbor on DUT via vtysh."""
+    """Configure unnumbered BGP neighbor on DUT via vtysh (FRR direct)."""
     vtysh_cmds = [
         'config',
         'router bgp {}'.format(dut_asn),
@@ -326,9 +348,52 @@ def configure_unnumbered_dut(duthost, dut_asn, dut_intf, neigh_asn):
                 dut_intf, frr_cfg.get('stdout', ''))
 
 
-def configure_unnumbered_eos(neigh_host, neigh_asn, dut_asn, neigh_intf):
+def configure_unnumbered_dut_configdb(
+        duthost, dut_asn, dut_intf, neigh_asn):
+    """Configure unnumbered BGP neighbor on DUT via CONFIG_DB (production path).
+
+    CONFIG_DB BGP_NEIGHBOR uses IP addresses as keys — there is no schema
+    for interface-based (unnumbered) neighbors. This function attempts the
+    configuration to validate the production path, but it is expected to
+    fail until bgpcfgd gains unnumbered BGP support (sonic-buildimage#26960).
+    """
+    # CONFIG_DB BGP_NEIGHBOR expects IP key; use interface name anyway
+    # to test if bgpcfgd can handle it (it currently cannot).
+    neighbor_entry = {
+        "asn": str(neigh_asn),
+        "name": dut_intf,
+        "admin_status": "up",
+    }
+    entry_json = json.dumps(neighbor_entry)
+    duthost.shell(
+        "sonic-db-cli CONFIG_DB HMSET 'BGP_NEIGHBOR|{}' {}".format(
+            dut_intf,
+            ' '.join('{} {}'.format(k, v)
+                     for k, v in neighbor_entry.items())),
+        module_ignore_errors=True)
+    logger.info(
+        "CONFIG_DB BGP_NEIGHBOR|%s set: %s (bgpcfgd may not process this)",
+        dut_intf, entry_json)
+
+    # Log FRR running config to see if bgpcfgd picked it up
+    import time
+    time.sleep(10)  # Give bgpcfgd time to process
+    frr_cfg = duthost.shell(
+        "vtysh -c 'show running-config bgpd'",
+        module_ignore_errors=True)
+    logger.info("FRR running config after CONFIG_DB setup on %s:\n%s",
+                dut_intf, frr_cfg.get('stdout', ''))
+
+
+def configure_unnumbered_eos(neigh_host, neigh_asn, dut_asn, neigh_intf,
+                             eos_vrf=None):
     """Configure interface-based BGP neighbor on EOS peer."""
     eos_peer_group = "LINK_LOCAL_PG"
+    # In converged mode, BGP config lives under a VRF context
+    if eos_vrf:
+        bgp_parent = "router bgp {} vrf {}".format(neigh_asn, eos_vrf)
+    else:
+        bgp_parent = "router bgp {}".format(neigh_asn)
     neigh_host.eos_config(
         lines=[
             "neighbor {} peer group".format(eos_peer_group),
@@ -336,12 +401,12 @@ def configure_unnumbered_eos(neigh_host, neigh_asn, dut_asn, neigh_intf):
             "neighbor interface {} peer-group {}".format(
                 neigh_intf, eos_peer_group),
         ],
-        parents="router bgp {}".format(neigh_asn))
+        parents=bgp_parent)
 
     for af in ["ipv4", "ipv6"]:
         neigh_host.eos_config(
             lines=["neighbor {} activate".format(eos_peer_group)],
-            parents=["router bgp {}".format(neigh_asn),
+            parents=[bgp_parent,
                      "address-family {}".format(af)])
 
     # Verify config was accepted
@@ -357,7 +422,11 @@ def configure_unnumbered_eos(neigh_host, neigh_asn, dut_asn, neigh_intf):
 
 def remove_numbered_bgp(duthost, neigh_host, dut_asn, neigh_asn,
                         neigh_ipv4, neigh_ipv6, dut_ipv4, dut_ipv6):
-    """Remove existing numbered BGP sessions on both DUT and EOS."""
+    """Remove existing numbered BGP sessions on both DUT and EOS.
+
+    Uses direct sonic-db-cli + vtysh instead of config commands to
+    avoid config reconciliation side effects.
+    """
     # Remove from CONFIG_DB
     duthost.shell(
         'sonic-db-cli CONFIG_DB DEL "BGP_NEIGHBOR|{}"'.format(neigh_ipv4),
@@ -393,6 +462,74 @@ def remove_numbered_bgp(duthost, neigh_host, dut_asn, neigh_asn,
         facts = duthost.bgp_facts()['ansible_facts']
         return neigh_ipv4 not in facts.get('bgp_neighbors', {})
     wait_until(30, 3, 0, old_neighbor_gone)
+
+
+def restore_eos_bgp_config(neigh_host, neigh_asn):
+    """Restore EOS BGP config by removing unnumbered and re-adding numbered.
+
+    Since 'configure replace startup-config' fails on cEOS (deprecated
+    'ipv6 nd ra suppress' in startup-config), we surgically remove
+    the unnumbered config and re-add numbered neighbors from the saved
+    backup captured before modifications.
+    """
+    # This is now handled by the full EOS restore in teardown.
+    # Kept as a no-op for interface compatibility.
+    pass
+
+
+def restore_eos_full_config(neigh_host, saved_config_path):
+    """Restore EOS to pre-test state using configure replace.
+
+    Uses a saved copy of the running-config (captured before test
+    modifications) to atomically restore the full EOS config.
+    Running-config avoids deprecated syntax issues in startup-config.
+    Waits for EOS BGP to re-establish after restore.
+    """
+    try:
+        neigh_host.eos_command(commands=[
+            "configure replace flash:{}".format(saved_config_path)
+        ])
+        logger.info("EOS config replaced from flash:%s",
+                    saved_config_path)
+    except Exception as e:
+        logger.error("EOS config restore failed: %s", e)
+        return
+
+    # Wait for EOS BGP sessions to re-establish
+    def eos_bgp_established():
+        try:
+            result = neigh_host.eos_command(
+                commands=["show ip bgp summary | json"])
+            bgp_data = result['stdout'][0] if isinstance(
+                result['stdout'], list) else result['stdout']
+            if isinstance(bgp_data, dict):
+                peers = bgp_data.get('vrfs', {}).get(
+                    'default', {}).get('peers', {})
+                return all(
+                    p.get('peerState') == 'Established'
+                    for p in peers.values())
+        except Exception:
+            pass
+        return False
+
+    if wait_until(120, 10, 0, eos_bgp_established):
+        logger.info("EOS BGP sessions re-established after restore")
+    else:
+        logger.warning("EOS BGP sessions did not re-establish "
+                       "within 120s after config restore")
+
+
+def save_eos_running_config(neigh_host, filename="pre-test-config"):
+    """Save EOS running-config to flash for later configure replace."""
+    try:
+        neigh_host.eos_command(commands=[
+            "copy running-config flash:{}".format(filename)
+        ])
+        logger.info("Saved EOS running-config to flash:%s", filename)
+        return filename
+    except Exception as e:
+        logger.error("Failed to save EOS running-config: %s", e)
+        return None
 
 
 def cleanup_eos_unnumbered(neigh_host, neigh_asn, dut_asn,
@@ -439,45 +576,146 @@ def break_lag_to_ethernet(duthost, neigh_host, setup_info):
     dut_ipv6_prefix = setup_info['dut_ipv6_prefix']
     neigh_intf = setup_info['neigh_intf']
 
-    logger.info("Breaking %s: removing %s, moving IPs to %s",
-                pc_intf, eth_intf, eth_intf)
+    logger.info("Breaking %s: removing %s for direct Ethernet peering",
+                pc_intf, eth_intf)
     duthost.shell(
         "sudo config portchannel member del {} {}".format(
             pc_intf, eth_intf))
+    # Remove IPs from PortChannel (no longer has a member)
     if dut_ipv4_prefix:
         duthost.shell(
             "sudo config interface ip remove {} {}".format(
                 pc_intf, dut_ipv4_prefix),
             module_ignore_errors=True)
-        duthost.shell(
-            "sudo config interface ip add {} {}".format(
-                eth_intf, dut_ipv4_prefix))
     if dut_ipv6_prefix:
         duthost.shell(
             "sudo config interface ip remove {} {}".format(
                 pc_intf, dut_ipv6_prefix),
             module_ignore_errors=True)
-        duthost.shell(
-            "sudo config interface ip add {} {}".format(
-                eth_intf, dut_ipv6_prefix))
+    # Do NOT add IPs to Ethernet — unnumbered BGP should use
+    # link-local only. Adding IPv4 would allow FRR to fall back
+    # to numbered peering, masking the v6only bug.
 
     # Wait for link-local address on Ethernet
-    time.sleep(5)
-    ll_check = duthost.shell(
-        "ip -6 addr show {} scope link".format(eth_intf),
-        module_ignore_errors=True)
-    logger.info("Link-local on %s:\n%s",
-                eth_intf, ll_check.get('stdout', ''))
+    def _has_link_local():
+        out = duthost.shell(
+            "ip -6 addr show {} scope link".format(eth_intf),
+            module_ignore_errors=True)['stdout']
+        return 'inet6 fe80' in out
 
-    # EOS side: remove Port-Channel, use Ethernet1 directly
-    eos_eth_intf = "Ethernet1"
+    pytest_assert(
+        wait_until(30, 2, 0, _has_link_local),
+        "No link-local on {} after LAG breakout".format(eth_intf))
+
+    # EOS side: derive member Ethernet from Port-Channel.
+    # Parse running-config to find which Ethernet has channel-group
+    # for this Port-Channel (works on all cEOS versions).
+    pc_num = neigh_intf.replace("Port-Channel", "")
+    eos_run = neigh_host.eos_command(
+        commands=["show running-config"])
+    eos_full_cfg = eos_run['stdout'][0] if isinstance(
+        eos_run['stdout'], list) else eos_run['stdout']
+    eos_eth_intf = None
+    current_intf = None
+    for line in eos_full_cfg.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("interface Ethernet"):
+            current_intf = stripped.split()[-1]
+        elif (current_intf and
+              "channel-group {}".format(pc_num) in stripped):
+            eos_eth_intf = current_intf
+            break
+        elif stripped.startswith("interface ") and current_intf:
+            current_intf = None
+    if not eos_eth_intf:
+        eos_eth_intf = "Ethernet1"
+        logger.warning("Could not derive EOS member, falling back to %s",
+                       eos_eth_intf)
+    logger.info("Derived EOS member interface: %s from %s",
+                eos_eth_intf, neigh_intf)
+
+    # Detect VRF assignment on Port-Channel before removing it
+    # (converged peers use VRFs like ARISTA01T1)
+    pc_vrf = None
+    pc_cfg_result = neigh_host.eos_command(
+        commands=["show running-config interfaces {}".format(neigh_intf)])
+    pc_cfg_out = pc_cfg_result['stdout'][0] if isinstance(
+        pc_cfg_result['stdout'], list) else pc_cfg_result['stdout']
+    for line in str(pc_cfg_out).splitlines():
+        stripped = line.strip()
+        if stripped.startswith("vrf "):
+            pc_vrf = stripped.split()[1]
+            break
+    if pc_vrf:
+        logger.info("Port-Channel %s is in VRF %s (converged mode)",
+                    neigh_intf, pc_vrf)
+
     logger.info("Configuring EOS %s for direct Ethernet peering",
                 eos_eth_intf)
     neigh_host.eos_config(
         lines=["no interface {}".format(neigh_intf)],
         module_ignore_errors=True)
+    # After removing Port-Channel, EOS Ethernet reverts to switchport
+    # mode (cEOS default). Must configure as routed port for L3 peering.
+    eos_intf_lines = [
+        "no switchport",
+        "ipv6 enable",
+    ]
+    if pc_vrf:
+        # Assign Ethernet to the same VRF as the original Port-Channel
+        # so EOS BGP (configured under this VRF) can peer over it.
+        eos_intf_lines.insert(0, "vrf {}".format(pc_vrf))
+    neigh_host.eos_config(
+        lines=eos_intf_lines,
+        parents="interface {}".format(eos_eth_intf),
+        module_ignore_errors=True)
 
-    return eos_eth_intf
+    # Verify EOS Ethernet has link-local address
+    eos_ll_result = neigh_host.eos_command(
+        commands=["show ipv6 interface {} brief".format(eos_eth_intf)])
+    eos_ll_out = eos_ll_result['stdout'][0] if isinstance(
+        eos_ll_result['stdout'], list) else eos_ll_result['stdout']
+    logger.info("EOS %s IPv6 status:\n%s", eos_eth_intf, eos_ll_out)
+
+    # Get EOS link-local for ping test
+    eos_ll_detail = neigh_host.eos_command(
+        commands=["show ipv6 interface {}".format(eos_eth_intf)])
+    eos_ll_detail_out = eos_ll_detail['stdout'][0] if isinstance(
+        eos_ll_detail['stdout'], list) else eos_ll_detail['stdout']
+    logger.info("EOS %s IPv6 detail:\n%s",
+                eos_eth_intf, eos_ll_detail_out)
+
+    # Also check DUT side link-local
+    dut_ll = duthost.shell(
+        "ip -6 addr show {} scope link".format(eth_intf),
+        module_ignore_errors=True)
+    logger.info("DUT %s link-local:\n%s",
+                eth_intf, dut_ll.get('stdout', ''))
+
+    # Try ping from DUT to EOS link-local (parse fe80 from EOS output)
+    eos_ll_addr = None
+    for line in str(eos_ll_detail_out).splitlines():
+        if 'fe80' in line.lower():
+            # Extract fe80::xxx address
+            for token in line.split():
+                if token.lower().startswith('fe80'):
+                    eos_ll_addr = token.split('/')[0]
+                    break
+            if eos_ll_addr:
+                break
+    if eos_ll_addr:
+        ping_result = duthost.shell(
+            "ping6 -c 3 -I {} {}".format(eth_intf, eos_ll_addr),
+            module_ignore_errors=True)
+        logger.info("Ping DUT %s -> EOS %s (%s): rc=%d\n%s",
+                    eth_intf, eos_eth_intf, eos_ll_addr,
+                    ping_result['rc'],
+                    ping_result.get('stdout', ''))
+    else:
+        logger.warning("No link-local found on EOS %s — cannot ping",
+                       eos_eth_intf)
+
+    return eos_eth_intf, pc_vrf
 
 
 def restore_lag_on_eos(neigh_host, neigh_intf):
@@ -539,25 +777,30 @@ def verify_routes_received(duthost, intf_name):
 
 
 @pytest.fixture(scope='function',
-                params=['portchannel', 'ethernet'],
-                ids=['portchannel', 'ethernet'])
+                params=['portchannel', 'ethernet',
+                        'portchannel-frrtest'],
+                ids=['portchannel', 'ethernet',
+                     'portchannel-frrtest'])
 def configure_unnumbered_bgp(request, setup_info):
     """Configure unnumbered BGP on a DUT interface.
 
-    Parametrized with two scenarios:
-    - portchannel: test unnumbered BGP on the existing PortChannel
-    - ethernet: break the PortChannel, test on the member Ethernet
+    Params:
+    - portchannel: unnumbered BGP on existing PortChannel (full stack)
+    - ethernet: break LAG, unnumbered BGP on member Ethernet (full stack)
+    - portchannel-frrtest: stops bgpcfgd to isolate FRR regression testing
 
-    Both scenarios:
+    Steps:
     1. Wait for baseline numbered BGP to be established
-    2. Stop bgpcfgd (workaround for sonic-buildimage#26960)
-    3. Remove existing numbered BGP sessions
-    4. (ethernet only) Break LAG and move IPs to member Ethernet
+    2. Remove existing numbered BGP sessions
+    3. Remove IPv4/IPv6 addresses from test interface
+    4. (ethernet only) Break LAG, configure EOS Ethernet as routed port
     5. Configure unnumbered BGP on DUT and EOS
     6. Yield the test interface name
-    7. Teardown: restore EOS, restart bgpcfgd, config_reload
+    7. Teardown: restore EOS via configure replace, config_reload DUT
     """
-    intf_type = request.param
+    param = request.param
+    stop_bgpcfgd = param.endswith('-frrtest')
+    intf_type = param.replace('-frrtest', '')
     duthost = setup_info['duthost']
     neigh_host = setup_info['neigh_host']
     dut_asn = setup_info['dut_asn']
@@ -577,42 +820,92 @@ def configure_unnumbered_bgp(request, setup_info):
                    .get('state', '') == 'established'),
         "IPv4 BGP session to {} not established".format(neigh_ipv4))
 
-    # Stop bgpcfgd to prevent neighbor reconciliation
-    # TODO: Remove this workaround when sonic-buildimage#26960 is fixed.
-    # bgpcfgd injects 'no capability link-local' which blocks unnumbered BGP.
-    # Stopping bgpcfgd isolates the FRR behavior so that when FRR is fixed
-    # (sonic-buildimage#26959), the test will pass and alert us.
-    logger.info("Stopping bgpcfgd")
-    duthost.shell("docker exec bgp supervisorctl stop bgpcfgd",
-                  module_ignore_errors=True)
+    # Save EOS running-config before any modifications
+    eos_config_backup = save_eos_running_config(neigh_host)
+
+    # Track whether post-yield teardown ran, so addfinalizer
+    # doesn't duplicate the cleanup.
+    teardown_done = []
+
+    # Register addfinalizer for full cleanup — runs even if fixture
+    # crashes before yield (e.g. EOS command error during setup).
+    # This ensures EOS config is restored and DUT is config_reloaded.
+    def _full_cleanup():
+        if teardown_done:
+            return
+        logger.info("addfinalizer: restoring EOS and DUT config")
+        if eos_config_backup:
+            restore_eos_full_config(neigh_host, eos_config_backup)
+        if stop_bgpcfgd:
+            duthost.shell("docker exec bgp supervisorctl start bgpcfgd",
+                          module_ignore_errors=True)
+        config_reload(duthost, wait=120)
+    request.addfinalizer(_full_cleanup)
+
+    # Optionally stop bgpcfgd to isolate FRR behavior for regression testing.
+    # When bgpcfgd is running, it may inject config that masks FRR issues.
+    if stop_bgpcfgd:
+        logger.info("Stopping bgpcfgd (FRR isolation mode)")
+        duthost.shell("docker exec bgp supervisorctl stop bgpcfgd",
+                      module_ignore_errors=True)
 
     # Remove numbered BGP
     remove_numbered_bgp(duthost, neigh_host, dut_asn, neigh_asn,
                         neigh_ipv4, neigh_ipv6, dut_ipv4, dut_ipv6)
 
+    # Remove IPv4/IPv6 addresses from test interface to prevent FRR
+    # from falling back to numbered peering (ignoring v6only keyword).
+    # This makes the test deterministic — only link-local can be used.
+    if intf_type == 'portchannel':
+        dut_test_intf = setup_info['pc_intf']
+        if setup_info.get('dut_ipv4_prefix'):
+            duthost.shell(
+                "sudo config interface ip remove {} {}".format(
+                    dut_test_intf, setup_info['dut_ipv4_prefix']),
+                module_ignore_errors=True)
+        if setup_info.get('dut_ipv6_prefix'):
+            duthost.shell(
+                "sudo config interface ip remove {} {}".format(
+                    dut_test_intf, setup_info['dut_ipv6_prefix']),
+                module_ignore_errors=True)
+        # Remove IPs on EOS side too
+        neigh_host.eos_config(
+            lines=[
+                "no ip address",
+                "no ipv6 address",
+            ],
+            parents="interface {}".format(neigh_intf),
+            module_ignore_errors=True)
+
     # Determine DUT and EOS interfaces based on scenario
     eos_intf = neigh_intf
+    eos_vrf = None
     if intf_type == 'portchannel':
         dut_intf = setup_info['pc_intf']
     else:
         dut_intf = setup_info['member_ethernet']
-        eos_intf = break_lag_to_ethernet(
+        eos_intf, eos_vrf = break_lag_to_ethernet(
             duthost, neigh_host, setup_info)
 
     # Configure unnumbered BGP
-    configure_unnumbered_dut(duthost, dut_asn, dut_intf, neigh_asn)
-    configure_unnumbered_eos(neigh_host, neigh_asn, dut_asn, eos_intf)
+    if stop_bgpcfgd:
+        # FRR isolation: configure directly via vtysh
+        configure_unnumbered_dut(duthost, dut_asn, dut_intf, neigh_asn)
+    else:
+        # Production path: configure via CONFIG_DB (bgpcfgd renders FRR)
+        configure_unnumbered_dut_configdb(
+            duthost, dut_asn, dut_intf, neigh_asn)
+    configure_unnumbered_eos(
+        neigh_host, neigh_asn, dut_asn, eos_intf, eos_vrf=eos_vrf)
 
     yield {'dut_intf': dut_intf, 'intf_type': intf_type}
 
-    # Teardown
-    logger.info("Teardown [%s]: restoring BGP config", intf_type)
-    cleanup_eos_unnumbered(neigh_host, neigh_asn, dut_asn,
-                           eos_intf, dut_ipv4, dut_ipv6)
-    if intf_type == 'ethernet':
-        restore_lag_on_eos(neigh_host, neigh_intf)
-    duthost.shell("docker exec bgp supervisorctl start bgpcfgd",
-                  module_ignore_errors=True)
+    # Teardown — restore full EOS config from saved backup.
+    # This handles both BGP config and interface/Port-Channel restoration,
+    # which is critical for the ethernet variant that breaks the LAG.
+    logger.info("Teardown [%s]: restoring full EOS config from backup",
+                intf_type)
+    restore_eos_full_config(neigh_host, eos_config_backup)
     config_reload(duthost, wait=120)
     original_neighbors = [neigh_ipv4]
     if neigh_ipv6:
@@ -621,18 +914,17 @@ def configure_unnumbered_bgp(request, setup_info):
                       duthost.check_bgp_session_state,
                       original_neighbors):
         logger.error("BGP sessions did not re-establish after restore")
+    teardown_done.append(True)
 
 
 @pytest.mark.disable_loganalyzer
 def test_bgp_link_local(setup_info, configure_unnumbered_bgp):
-    """Test unnumbered BGP peering over PortChannel and Ethernet interfaces.
+    """Test unnumbered BGP peering via link-local addresses.
 
-    Parametrized via configure_unnumbered_bgp fixture:
-    - test_bgp_link_local[portchannel]: unnumbered BGP on LAG
-    - test_bgp_link_local[ethernet]: break LAG, unnumbered on plain Ethernet
-
-    Validates that SONiC can establish an unnumbered BGP session using
-    interface-based peering and receive routes over it.
+    Parametrized variants:
+    - [portchannel]: unnumbered BGP on LAG interface (full stack)
+    - [ethernet]: break LAG, unnumbered BGP on plain Ethernet (full stack)
+    - [portchannel-frrtest]: bgpcfgd stopped, isolates FRR regressions
     """
     duthost = setup_info['duthost']
     dut_intf = configure_unnumbered_bgp['dut_intf']

--- a/tests/bgp/test_bgp_link_local.py
+++ b/tests/bgp/test_bgp_link_local.py
@@ -263,7 +263,6 @@ def configure_unnumbered_bgp(setup_info):
     neigh_ipv6 = setup_info['neigh_ipv6']
     dut_ipv4 = setup_info['dut_ipv4']
     dut_ipv6 = setup_info['dut_ipv6']
-    dut_link_local = setup_info['dut_link_local']
     neigh_pc_intf = setup_info['neigh_pc_intf']
 
     # --- Setup ---
@@ -329,30 +328,55 @@ def configure_unnumbered_bgp(setup_info):
                   "Failed to configure unnumbered BGP: {}".format(
                       result.get('stderr', '')))
 
-    # Configure link-local neighbor on EOS
-    # EOS does not support the Linux/FRR "fe80::addr%intf" notation.
-    # Use separate neighbor + update-source commands instead.
-    eos_neighbor = dut_link_local
-    logger.info("Configure link-local BGP neighbor on EOS (%s via %s)",
-                eos_neighbor, neigh_pc_intf)
+    # Configure BGP peering on EOS using interface-based (unnumbered) config.
+    # EOS does not support raw fe80:: addresses as BGP neighbors.
+    # Instead, EOS uses: neighbor interface <intf> peer-group <pg>
+    # with the peer-group configured for the remote AS.
+    eos_peer_group = "LINK_LOCAL_PG"
+    logger.info("Configure interface-based BGP peering on EOS via %s (peer-group %s)",
+                neigh_pc_intf, eos_peer_group)
     neigh_host.eos_config(
         lines=[
-            "neighbor {} remote-as {}".format(eos_neighbor, dut_asn),
-            "neighbor {} update-source {}".format(eos_neighbor, neigh_pc_intf),
+            "neighbor {} peer group".format(eos_peer_group),
+            "neighbor {} remote-as {}".format(eos_peer_group, dut_asn),
+            "neighbor interface {} peer-group {}".format(neigh_pc_intf, eos_peer_group),
         ],
         parents="router bgp {}".format(neigh_asn))
 
+    # Enable address families for the peer-group
+    for af in ["ipv4", "ipv6"]:
+        neigh_host.eos_config(
+            lines=[
+                "neighbor {} activate".format(eos_peer_group),
+            ],
+            parents=["router bgp {}".format(neigh_asn),
+                     "address-family {}".format(af)])
+
+    # Verify EOS accepted the config
+    eos_bgp_cfg = neigh_host.eos_command(
+        commands=["show running-config section bgp"])
+    eos_cfg_text = eos_bgp_cfg['stdout'][0] if isinstance(
+        eos_bgp_cfg['stdout'], list) else eos_bgp_cfg['stdout']
+    logger.info("EOS BGP config after setup:\n%s", eos_cfg_text)
+    if eos_peer_group not in eos_cfg_text:
+        pytest.fail("EOS did not accept the interface-based BGP config. "
+                    "Running config:\n{}".format(eos_cfg_text))
+
     yield {
         'initial_prefixes': initial_prefixes,
-        'eos_neighbor': eos_neighbor,
+        'eos_peer_group': eos_peer_group,
     }
 
     # --- Teardown ---
     logger.info("Teardown: Restoring original configuration")
 
-    # Remove link-local neighbor from EOS and restore originals
+    # Remove interface-based peering from EOS and restore originals
+    eos_peer_group = "LINK_LOCAL_PG"
     try:
-        cleanup_lines = ["no neighbor {}".format(eos_neighbor)]
+        cleanup_lines = [
+            "no neighbor interface {}".format(neigh_pc_intf),
+            "no neighbor {}".format(eos_peer_group),
+        ]
         if dut_ipv4:
             cleanup_lines.append(
                 "neighbor {} remote-as {}".format(dut_ipv4, dut_asn))

--- a/tests/bgp/test_bgp_link_local.py
+++ b/tests/bgp/test_bgp_link_local.py
@@ -365,21 +365,36 @@ def configure_unnumbered_bgp(setup_info):
     # --- Teardown ---
     logger.info("Teardown: Restoring original configuration")
 
-    # Remove interface-based peering from EOS and restore originals
+    # Remove interface-based peering from EOS and restore originals.
+    # Order matters: remove interface neighbor first, then deactivate
+    # from address-families, then remove the peer-group itself.
     eos_peer_group = "LINK_LOCAL_PG"
     try:
-        cleanup_lines = [
-            "no neighbor interface {}".format(neigh_pc_intf),
-            "no neighbor {}".format(eos_peer_group),
-        ]
+        # Step 1: remove interface neighbor (must precede peer-group removal)
+        neigh_host.eos_config(
+            lines=["no neighbor interface {}".format(neigh_pc_intf)],
+            parents="router bgp {}".format(neigh_asn))
+        # Step 2: deactivate from address-families
+        for af in ["ipv4", "ipv6"]:
+            neigh_host.eos_config(
+                lines=["no neighbor {} activate".format(eos_peer_group)],
+                parents=["router bgp {}".format(neigh_asn),
+                         "address-family {}".format(af)])
+        # Step 3: remove the peer-group
+        neigh_host.eos_config(
+            lines=["no neighbor {} peer group".format(eos_peer_group)],
+            parents="router bgp {}".format(neigh_asn))
+        # Step 4: restore original numbered neighbors
+        restore_lines = []
         if dut_ipv4:
-            cleanup_lines.append(
+            restore_lines.append(
                 "neighbor {} remote-as {}".format(dut_ipv4, dut_asn))
         if dut_ipv6:
-            cleanup_lines.append(
+            restore_lines.append(
                 "neighbor {} remote-as {}".format(dut_ipv6, dut_asn))
-        neigh_host.eos_config(lines=cleanup_lines,
-                              parents="router bgp {}".format(neigh_asn))
+        if restore_lines:
+            neigh_host.eos_config(lines=restore_lines,
+                                  parents="router bgp {}".format(neigh_asn))
     except Exception as e:
         logger.error("EOS cleanup failed: %s", e)
         # Still proceed to config_reload below, but fail the teardown afterward

--- a/tests/bgp/test_bgp_link_local.py
+++ b/tests/bgp/test_bgp_link_local.py
@@ -283,8 +283,17 @@ def configure_unnumbered_bgp(setup_info):
     logger.info("Initial prefix count from %s: %d", neigh_ipv4,
                 initial_prefixes)
 
-    # Remove existing BGP sessions on DUT
-    logger.info("Remove existing BGP neighbor %s on DUT", neigh_ipv4)
+    # Remove existing BGP sessions on DUT — must remove from both CONFIG_DB
+    # and FRR. If we only remove from FRR (vtysh), bgpcfgd will re-add the
+    # neighbor from CONFIG_DB, causing the test to fail.
+    logger.info("Remove existing BGP neighbor %s from CONFIG_DB and FRR", neigh_ipv4)
+    duthost.shell(
+        'sonic-db-cli CONFIG_DB DEL "BGP_NEIGHBOR|{}"'.format(neigh_ipv4),
+        module_ignore_errors=True)
+    if neigh_ipv6:
+        duthost.shell(
+            'sonic-db-cli CONFIG_DB DEL "BGP_NEIGHBOR|{}"'.format(neigh_ipv6),
+            module_ignore_errors=True)
     vtysh_remove = ['config', 'router bgp {}'.format(dut_asn),
                     'no neighbor {}'.format(neigh_ipv4)]
     if neigh_ipv6:

--- a/tests/bgp/test_bgp_link_local.py
+++ b/tests/bgp/test_bgp_link_local.py
@@ -277,6 +277,8 @@ def bgp_unnumbered_established(duthost, intf_name):
                                     "link-local) — IPv4 fallback",
                                     peer_key, remote)
                         except (json.JSONDecodeError, KeyError):
+                            # Can't parse neighbor detail; fall through
+                            # to return False below
                             pass
                     # If we can't verify, don't accept it
                     return False
@@ -509,6 +511,7 @@ def restore_eos_full_config(neigh_host, saved_config_path):
                     p.get('peerState') == 'Established'
                     for p in peers.values())
         except Exception:
+            # EOS command or parsing failed; treat as not established
             pass
         return False
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -434,6 +434,27 @@ bgp/test_bgp_gr_helper.py::test_bgp_gr_helper_routes_perserved:
     conditions:
       - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
 
+# BGP link-local (unnumbered) tests — skip while upstream issues are open.
+# Using 'skip' instead of 'xfail' because:
+#   - These tests take ~16 minutes total (setup, 120s wait timeout per test, teardown
+#     with config reload) only to confirm two known feature gaps.
+#   - xfail would still execute the full test and consume CI resources every run,
+#     which is wasteful when the outcome is predetermined by open image-level bugs.
+#   - skip preserves the test code for when the issues are resolved — once both
+#     issues below are closed, the conditional mark becomes inactive and the tests
+#     run normally with zero code changes needed.
+# Issues:
+#   - sonic-buildimage#26959: FRR 10.5.1 bgpd cannot resolve interface to link-local
+#     address for unnumbered BGP — session stays Idle with (unspec), FD=-1.
+#   - sonic-buildimage#26960: bgpcfgd reactively injects 'no capability link-local'
+#     for interface-based neighbors, overriding manual corrections.
+bgp/test_bgp_link_local.py::test_bgp_link_local:
+  skip:
+    reason: "FRR 10.5.1 cannot resolve interface to link-local for unnumbered BGP (sonic-buildimage#26959); bgpcfgd also blocks link-local capability (sonic-buildimage#26960)"
+    conditions:
+      - https://github.com/sonic-net/sonic-buildimage/issues/26959
+      - https://github.com/sonic-net/sonic-buildimage/issues/26960
+
 bgp/test_bgp_max_route.py::test_bgp_max_prefix_behavior:
   xfail:
     reason: "Test failed on multi-asic PR tests"
@@ -6112,23 +6133,3 @@ zmq/test_gnmi_zmq.py::test_gnmi_zmq:
       - "is_mgmt_ipv6_only==True"
       - "https://github.com/sonic-net/sonic-mgmt/issues/20395"
 
-# BGP link-local (unnumbered) tests — skip while upstream issues are open.
-# Using 'skip' instead of 'xfail' because:
-#   - These tests take ~16 minutes total (setup, 120s wait timeout per test, teardown
-#     with config reload) only to confirm two known feature gaps.
-#   - xfail would still execute the full test and consume CI resources every run,
-#     which is wasteful when the outcome is predetermined by open image-level bugs.
-#   - skip preserves the test code for when the issues are resolved — once both
-#     issues below are closed, the conditional mark becomes inactive and the tests
-#     run normally with zero code changes needed.
-# Issues:
-#   - sonic-buildimage#26959: FRR 10.5.1 bgpd cannot resolve interface to link-local
-#     address for unnumbered BGP — session stays Idle with (unspec), FD=-1.
-#   - sonic-buildimage#26960: bgpcfgd reactively injects 'no capability link-local'
-#     for interface-based neighbors, overriding manual corrections.
-bgp/test_bgp_link_local.py::test_bgp_link_local:
-  skip:
-    reason: "FRR 10.5.1 cannot resolve interface to link-local for unnumbered BGP (sonic-buildimage#26959); bgpcfgd also blocks link-local capability (sonic-buildimage#26960)"
-    conditions:
-      - https://github.com/sonic-net/sonic-buildimage/issues/26959
-      - https://github.com/sonic-net/sonic-buildimage/issues/26960

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -6111,3 +6111,24 @@ zmq/test_gnmi_zmq.py::test_gnmi_zmq:
     conditions:
       - "is_mgmt_ipv6_only==True"
       - "https://github.com/sonic-net/sonic-mgmt/issues/20395"
+
+# BGP link-local (unnumbered) tests — skip while upstream issues are open.
+# Using 'skip' instead of 'xfail' because:
+#   - These tests take ~16 minutes total (setup, 120s wait timeout per test, teardown
+#     with config reload) only to confirm two known feature gaps.
+#   - xfail would still execute the full test and consume CI resources every run,
+#     which is wasteful when the outcome is predetermined by open image-level bugs.
+#   - skip preserves the test code for when the issues are resolved — once both
+#     issues below are closed, the conditional mark becomes inactive and the tests
+#     run normally with zero code changes needed.
+# Issues:
+#   - sonic-buildimage#26959: FRR 10.5.1 bgpd cannot resolve interface to link-local
+#     address for unnumbered BGP — session stays Idle with (unspec), FD=-1.
+#   - sonic-buildimage#26960: bgpcfgd reactively injects 'no capability link-local'
+#     for interface-based neighbors, overriding manual corrections.
+bgp/test_bgp_link_local.py::test_bgp_link_local:
+  skip:
+    reason: "FRR 10.5.1 cannot resolve interface to link-local for unnumbered BGP (sonic-buildimage#26959); bgpcfgd also blocks link-local capability (sonic-buildimage#26960)"
+    conditions:
+      - https://github.com/sonic-net/sonic-buildimage/issues/26959
+      - https://github.com/sonic-net/sonic-buildimage/issues/26960

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -448,11 +448,16 @@ bgp/test_bgp_gr_helper.py::test_bgp_gr_helper_routes_perserved:
 #     address for unnumbered BGP — session stays Idle with (unspec), FD=-1.
 #   - sonic-buildimage#26960: bgpcfgd reactively injects 'no capability link-local'
 #     for interface-based neighbors, overriding manual corrections.
-bgp/test_bgp_link_local.py::test_bgp_link_local:
+bgp/test_bgp_link_local.py::test_bgp_link_local[ethernet]:
   skip:
-    reason: "FRR 10.5.1 cannot resolve interface to link-local for unnumbered BGP (sonic-buildimage#26959); bgpcfgd also blocks link-local capability (sonic-buildimage#26960)"
+    reason: "bgpcfgd lacks unnumbered BGP support via CONFIG_DB (sonic-buildimage#26960)"
     conditions:
-      - https://github.com/sonic-net/sonic-buildimage/issues/26959
+      - https://github.com/sonic-net/sonic-buildimage/issues/26960
+
+bgp/test_bgp_link_local.py::test_bgp_link_local[portchannel]:
+  skip:
+    reason: "bgpcfgd lacks unnumbered BGP support via CONFIG_DB (sonic-buildimage#26960)"
+    conditions:
       - https://github.com/sonic-net/sonic-buildimage/issues/26960
 
 bgp/test_bgp_max_route.py::test_bgp_max_prefix_behavior:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -6132,4 +6132,3 @@ zmq/test_gnmi_zmq.py::test_gnmi_zmq:
     conditions:
       - "is_mgmt_ipv6_only==True"
       - "https://github.com/sonic-net/sonic-mgmt/issues/20395"
-


### PR DESCRIPTION
### Description of PR

Summary:
Add `test_bgp_link_local` to validate BGP unnumbered (link-local) peering over both PortChannel and plain Ethernet interfaces, using EOS interface-based peering. Three parametrized variants test the production CONFIG_DB path (skipped) and FRR directly (runs in CI as regression guard).

Fixes #18431
Fixes #24134

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Issue #18431 requested a test for BGP peering over IPv6 link-local addresses (unnumbered BGP). During implementation, we discovered:

1. **FRR 10.5.1 works correctly** — unnumbered BGP establishes on both PortChannel and plain Ethernet when configured properly (sonic-net/sonic-buildimage#26959 closed — original failures were EOS test configuration issues)
2. **bgpcfgd/CONFIG_DB feature gap** (sonic-net/sonic-buildimage#26960): CONFIG_DB `BGP_NEIGHBOR` table uses IP addresses as keys — there is no schema for interface-based (unnumbered) BGP neighbors. bgpcfgd cannot configure unnumbered BGP via the production path.

#### How did you do it?

- **Three parametrized test variants** in a single `test_bgp_link_local` function:
  - `[portchannel]`: Tests production CONFIG_DB path on PortChannel — **skipped** (bgpcfgd can't configure it)
  - `[ethernet]`: Tests production CONFIG_DB path on Ethernet (breaks LAG first) — **skipped** (same reason)
  - `[portchannel-frrtest]`: Stops bgpcfgd, configures FRR directly via vtysh — **runs in CI** as FRR regression guard
- **EOS interface-based peering:** Uses `neighbor interface <intf> peer-group LINK_LOCAL_PG`
- **EOS Ethernet fix:** After LAG breakout, applies `no switchport` + `ipv6 enable` on the freed Ethernet (without these, EOS has no link-local address → BGP stays Idle)
- **VRF-aware LAG breakout:** Detects VRF on Port-Channel before removal, assigns freed Ethernet to same VRF (supports converged peer topologies)
- **Reliable teardown:** Saves EOS running-config before test, restores via `configure replace` + DUT `config_reload`
- **Conditional skip via `tests_mark_conditions.yaml`:** `[portchannel]` and `[ethernet]` skip while sonic-buildimage#26960 is open. When bgpcfgd adds unnumbered support, tests auto-enable with no code changes.

#### How did you verify/test it?

Locally verified on KVM T0 testbed (P520-1, non-converged 4 cEOS, FRR 10.5.1):

**v26 (2-variant, all vtysh):** 2/2 PASSED (717s), 4/4 BGP Established post-test — confirms FRR works on both PortChannel and Ethernet.

**v26b (3-variant, CONFIG_DB for vanilla):**
- `[portchannel]` FAILED (expected — CONFIG_DB can't express unnumbered neighbor)
- `[ethernet]` FAILED (expected — same reason)
- `[portchannel-frrtest]` PASSED (bgpcfgd stopped, FRR configured directly)
- 4/4 BGP Established post-test

flake8 clean (max-line-length=120), CodeQL clean.

#### Any platform specific information?

Requires EOS/cEOS neighbors. Topology: t0.

#### Supported testbed topology if it's a new test case?

t0

### Documentation
N/A
