### PR TITLE
Dpu uptime and graceful reboot enhancements

### DIFF
--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -34,12 +34,6 @@ REBOOT_CAUSE_INT = 10
 PING_TIMEOUT = 30
 PING_TIME_INT = 10
 
-# Syslog error patterns to check after reboot (exclude known/expected messages)
-DPU_SYSLOG_ERROR_IGNORE_PATTERNS = [
-    r".*ERR.*transceiver.*",
-    r".*ERR.*syncd.*SAI_STATUS_ITEM_NOT_FOUND.*",
-]
-
 
 @pytest.fixture(scope='function')
 def num_dpu_modules(platform_api_conn):   # noqa F811
@@ -578,6 +572,8 @@ def get_dpu_uptime(dpuhosts, dpu_id):
         boot_time_str = result["stdout"].strip()
         return datetime.strptime(boot_time_str, "%Y-%m-%d %H:%M:%S")
     except Exception as e:
+        # Any of these cases (SSH error, command failure, parse error)
+        # indicate the DPU did not come back up properly.
         logging.warning("Failed to get uptime for DPU%d: %s", dpu_id, e)
         return None
 
@@ -615,11 +611,11 @@ def verify_dpu_rebooted(dpuhosts, dpu_name, pre_boot_time):
     dpu_id = int(re.search(r'\d+', dpu_name).group())
     post_boot_time = get_dpu_uptime(dpuhosts, dpu_id)
     if post_boot_time is None:
-        logging.warning("Cannot verify reboot for %s: post-reboot uptime unavailable", dpu_name)
-        return True
+        logging.error("Cannot get post-reboot uptime for %s: DPU likely did not come back up", dpu_name)
+        return False
     if pre_boot_time is None:
-        logging.warning("Cannot verify reboot for %s: pre-reboot uptime was not recorded", dpu_name)
-        return True
+        logging.error("Cannot verify reboot for %s: pre-reboot uptime was not recorded", dpu_name)
+        return False
     rebooted = post_boot_time > pre_boot_time
     if rebooted:
         logging.info("%s confirmed rebooted: boot time changed from %s to %s",
@@ -644,109 +640,6 @@ def verify_all_dpus_rebooted(dpuhosts, dpu_on_list, pre_boot_times):
             failed.append(dpu_name)
     pytest_assert(not failed,
                   "DPUs {} did not reboot as expected (boot time unchanged)".format(failed))
-
-
-def check_dpu_syslog_errors(dpuhosts, dpu_id, since_boot_time=None):
-    """
-    Check DPU syslog for unexpected ERROR/CRIT messages after reboot.
-    Ignores patterns listed in DPU_SYSLOG_ERROR_IGNORE_PATTERNS.
-    Args:
-        dpuhosts: DPU host handles
-        dpu_id: Integer DPU index
-        since_boot_time: datetime; only scan logs after this time
-    Returns:
-        list of unexpected error lines (empty means no errors)
-    """
-    dpuhost = get_dpuhost_for_dpu(dpuhosts, dpu_id)
-    if dpuhost is None:
-        logging.warning("DPU%d not in dpuhosts; skipping syslog error check", dpu_id)
-        return []
-    if since_boot_time:
-        since_str = since_boot_time.strftime("%Y-%m-%d %H:%M:%S")
-        cmd = 'sudo journalctl -p err --since "{}" --no-pager -q 2>/dev/null'.format(since_str)
-    else:
-        cmd = "sudo journalctl -p err -b --no-pager -q 2>/dev/null"
-    try:
-        result = dpuhost.command(cmd, module_ignore_errors=True)
-        lines = result.get("stdout_lines", [])
-    except Exception as e:
-        logging.warning("Failed to read syslog on DPU%d: %s", dpu_id, e)
-        return []
-    ignore_patterns = [re.compile(p, re.IGNORECASE) for p in DPU_SYSLOG_ERROR_IGNORE_PATTERNS]
-    unexpected_errors = []
-    for line in lines:
-        if any(pat.match(line) for pat in ignore_patterns):
-            logging.debug("DPU%d: Ignoring expected syslog error: %s", dpu_id, line)
-            continue
-        unexpected_errors.append(line)
-    if unexpected_errors:
-        logging.error("DPU%d: Found %d unexpected syslog error(s) after reboot:",
-                      dpu_id, len(unexpected_errors))
-        for err in unexpected_errors:
-            logging.error("  %s", err)
-    else:
-        logging.info("DPU%d: No unexpected syslog errors found after reboot", dpu_id)
-    return unexpected_errors
-
-
-def check_all_dpus_no_syslog_errors(dpuhosts, dpu_on_list, pre_boot_times=None):
-    """
-    Check all online DPUs for unexpected syslog errors post-reboot.
-    Args:
-        dpuhosts: DPU host handles
-        dpu_on_list: List of DPU names online
-        pre_boot_times: Optional dict mapping dpu_name -> pre-reboot boot datetime
-    """
-    all_errors = {}
-    for dpu_name in dpu_on_list:
-        dpu_id = int(re.search(r'\d+', dpu_name).group())
-        since_time = pre_boot_times.get(dpu_name) if pre_boot_times else None
-        errors = check_dpu_syslog_errors(dpuhosts, dpu_id, since_boot_time=since_time)
-        if errors:
-            all_errors[dpu_name] = errors
-    pytest_assert(not all_errors,
-                  "Unexpected syslog errors found on DPUs after reboot: {}".format(
-                      {k: v[:5] for k, v in all_errors.items()}))
-
-
-def check_npu_syslog_errors(duthost, since_boot_time=None):
-    """
-    Check NPU syslog for unexpected ERROR/CRIT messages after reboot.
-    Args:
-        duthost: DUT host handle
-        since_boot_time: datetime; only scan logs after this time
-    Returns:
-        list of unexpected error lines (empty means no errors)
-    """
-    if since_boot_time:
-        since_str = since_boot_time.strftime("%Y-%m-%d %H:%M:%S")
-        cmd = 'sudo journalctl -p err --since "{}" --no-pager -q 2>/dev/null'.format(since_str)
-    else:
-        cmd = "sudo journalctl -p err -b --no-pager -q 2>/dev/null"
-    try:
-        result = duthost.command(cmd, module_ignore_errors=True)
-        lines = result.get("stdout_lines", [])
-    except Exception as e:
-        logging.warning("Failed to read syslog on NPU: %s", e)
-        return []
-    npu_ignore_patterns = [
-        re.compile(r".*kernel.*EXT4-fs error.*", re.IGNORECASE),
-        re.compile(r".*ERR.*syncd.*SAI_STATUS_ITEM_NOT_FOUND.*", re.IGNORECASE),
-    ]
-    unexpected_errors = []
-    for line in lines:
-        if any(pat.match(line) for pat in npu_ignore_patterns):
-            logging.debug("NPU: Ignoring expected syslog error: %s", line)
-            continue
-        unexpected_errors.append(line)
-    if unexpected_errors:
-        logging.warning("NPU: Found %d unexpected syslog error(s) after reboot",
-                        len(unexpected_errors))
-        for err in unexpected_errors[:10]:
-            logging.warning("  %s", err)
-    return unexpected_errors
-
-
 def post_test_dpu_check(duthost, dpuhosts, dpu_name, reboot_cause, extra_dpu_online_timeout=0, pre_boot_times=None):
     """
     Runs all required checks for a given DPU
@@ -793,12 +686,6 @@ def post_test_dpu_check(duthost, dpuhosts, dpu_name, reboot_cause, extra_dpu_onl
             f"DPU {dpu_name} did not reboot: boot time is unchanged"
         )
 
-        # Check DPU syslog for unexpected errors since last reboot
-        logging.info(f"Checking syslog for unexpected errors on {dpu_name}")
-        errors = check_dpu_syslog_errors(dpuhosts, dpu_id,
-                                         since_boot_time=pre_boot_times[dpu_name])
-        pytest_assert(not errors,
-                      f"Unexpected syslog errors on {dpu_name} after reboot: {errors[:5]}")
 
 
 def post_test_dpus_check(duthost, dpuhosts, dpu_on_list, ip_address_list,

--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -34,6 +34,14 @@ REBOOT_CAUSE_INT = 10
 PING_TIMEOUT = 30
 PING_TIME_INT = 10
 
+# Syslog error patterns to ignore on DPUs after reboot (known/expected messages).
+# These will be used as loganalyzer ignore patterns for DPUs once
+# loganalyzer gains --dpu-pattern support.
+DPU_SYSLOG_ERROR_IGNORE_PATTERNS = [
+    r".*ERR.*transceiver.*",
+    r".*ERR.*syncd.*SAI_STATUS_ITEM_NOT_FOUND.*",
+]
+
 
 @pytest.fixture(scope='function')
 def num_dpu_modules(platform_api_conn):   # noqa F811

--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -4,6 +4,7 @@ Helper script for DPU  operations
 import logging
 import pytest
 import re
+from datetime import datetime
 from tests.common.platform.device_utils import (  # noqa: F401,F403
     platform_api_conn, start_platform_api_service, get_configured_dpu_names
 )
@@ -32,6 +33,12 @@ REBOOT_CAUSE_TIMEOUT = 30
 REBOOT_CAUSE_INT = 10
 PING_TIMEOUT = 30
 PING_TIME_INT = 10
+
+# Syslog error patterns to check after reboot (exclude known/expected messages)
+DPU_SYSLOG_ERROR_IGNORE_PATTERNS = [
+    r".*ERR.*transceiver.*",
+    r".*ERR.*syncd.*SAI_STATUS_ITEM_NOT_FOUND.*",
+]
 
 
 @pytest.fixture(scope='function')
@@ -553,7 +560,195 @@ def post_test_switch_check(duthost, localhost,
     return
 
 
-def post_test_dpu_check(duthost, dpuhosts, dpu_name, reboot_cause, extra_dpu_online_timeout=0):
+
+def get_dpu_uptime(dpuhosts, dpu_id):
+    """
+    Retrieve the boot time of a DPU as a datetime object using 'uptime -s'.
+    Args:
+        dpuhosts: DPU host handles
+        dpu_id: Integer DPU index
+    Returns:
+        datetime of last boot, or None if unreachable
+    """
+    dpuhost = get_dpuhost_for_dpu(dpuhosts, dpu_id)
+    if dpuhost is None:
+        logging.warning("DPU%d not in dpuhosts; cannot retrieve uptime", dpu_id)
+        return None
+    try:
+        result = dpuhost.command("uptime -s")
+        boot_time_str = result["stdout"].strip()
+        return datetime.strptime(boot_time_str, "%Y-%m-%d %H:%M:%S")
+    except Exception as e:
+        logging.warning("Failed to get uptime for DPU%d: %s", dpu_id, e)
+        return None
+
+
+def get_all_dpu_uptimes(dpuhosts, dpu_on_list):
+    """
+    Collect boot times for all online DPUs before a reboot operation.
+    Args:
+        dpuhosts: DPU host handles
+        dpu_on_list: List of DPU names currently online (e.g. ['DPU0', 'DPU1'])
+    Returns:
+        dict mapping dpu_name -> datetime (last boot time), or None if unavailable
+    """
+    uptimes = {}
+    for dpu_name in dpu_on_list:
+        dpu_id = int(re.search(r'\d+', dpu_name).group())
+        uptimes[dpu_name] = get_dpu_uptime(dpuhosts, dpu_id)
+        if uptimes[dpu_name]:
+            logging.info("DPU %s last boot time before test: %s", dpu_name, uptimes[dpu_name])
+        else:
+            logging.warning("Could not record pre-test boot time for %s", dpu_name)
+    return uptimes
+
+
+def verify_dpu_rebooted(dpuhosts, dpu_name, pre_boot_time):
+    """
+    Verify that a DPU rebooted by comparing current boot time to pre-reboot boot time.
+    Args:
+        dpuhosts: DPU host handles
+        dpu_name: Name of the DPU (e.g. 'DPU0')
+        pre_boot_time: datetime of boot time before reboot
+    Returns:
+        True if rebooted (boot time changed), False otherwise
+    """
+    dpu_id = int(re.search(r'\d+', dpu_name).group())
+    post_boot_time = get_dpu_uptime(dpuhosts, dpu_id)
+    if post_boot_time is None:
+        logging.warning("Cannot verify reboot for %s: post-reboot uptime unavailable", dpu_name)
+        return True
+    if pre_boot_time is None:
+        logging.warning("Cannot verify reboot for %s: pre-reboot uptime was not recorded", dpu_name)
+        return True
+    rebooted = post_boot_time > pre_boot_time
+    if rebooted:
+        logging.info("%s confirmed rebooted: boot time changed from %s to %s",
+                     dpu_name, pre_boot_time, post_boot_time)
+    else:
+        logging.error("%s did NOT reboot: boot time unchanged (%s)", dpu_name, pre_boot_time)
+    return rebooted
+
+
+def verify_all_dpus_rebooted(dpuhosts, dpu_on_list, pre_boot_times):
+    """
+    Verify all online DPUs rebooted by comparing boot times.
+    Args:
+        dpuhosts: DPU host handles
+        dpu_on_list: List of DPU names that were online before reboot
+        pre_boot_times: dict mapping dpu_name -> pre-reboot boot datetime
+    """
+    failed = []
+    for dpu_name in dpu_on_list:
+        pre_time = pre_boot_times.get(dpu_name)
+        if not verify_dpu_rebooted(dpuhosts, dpu_name, pre_time):
+            failed.append(dpu_name)
+    pytest_assert(not failed,
+                  "DPUs {} did not reboot as expected (boot time unchanged)".format(failed))
+
+
+def check_dpu_syslog_errors(dpuhosts, dpu_id, since_boot_time=None):
+    """
+    Check DPU syslog for unexpected ERROR/CRIT messages after reboot.
+    Ignores patterns listed in DPU_SYSLOG_ERROR_IGNORE_PATTERNS.
+    Args:
+        dpuhosts: DPU host handles
+        dpu_id: Integer DPU index
+        since_boot_time: datetime; only scan logs after this time
+    Returns:
+        list of unexpected error lines (empty means no errors)
+    """
+    dpuhost = get_dpuhost_for_dpu(dpuhosts, dpu_id)
+    if dpuhost is None:
+        logging.warning("DPU%d not in dpuhosts; skipping syslog error check", dpu_id)
+        return []
+    if since_boot_time:
+        since_str = since_boot_time.strftime("%Y-%m-%d %H:%M:%S")
+        cmd = 'sudo journalctl -p err --since "{}" --no-pager -q 2>/dev/null'.format(since_str)
+    else:
+        cmd = "sudo journalctl -p err -b --no-pager -q 2>/dev/null"
+    try:
+        result = dpuhost.command(cmd, module_ignore_errors=True)
+        lines = result.get("stdout_lines", [])
+    except Exception as e:
+        logging.warning("Failed to read syslog on DPU%d: %s", dpu_id, e)
+        return []
+    ignore_patterns = [re.compile(p, re.IGNORECASE) for p in DPU_SYSLOG_ERROR_IGNORE_PATTERNS]
+    unexpected_errors = []
+    for line in lines:
+        if any(pat.match(line) for pat in ignore_patterns):
+            logging.debug("DPU%d: Ignoring expected syslog error: %s", dpu_id, line)
+            continue
+        unexpected_errors.append(line)
+    if unexpected_errors:
+        logging.error("DPU%d: Found %d unexpected syslog error(s) after reboot:",
+                      dpu_id, len(unexpected_errors))
+        for err in unexpected_errors:
+            logging.error("  %s", err)
+    else:
+        logging.info("DPU%d: No unexpected syslog errors found after reboot", dpu_id)
+    return unexpected_errors
+
+
+def check_all_dpus_no_syslog_errors(dpuhosts, dpu_on_list, pre_boot_times=None):
+    """
+    Check all online DPUs for unexpected syslog errors post-reboot.
+    Args:
+        dpuhosts: DPU host handles
+        dpu_on_list: List of DPU names online
+        pre_boot_times: Optional dict mapping dpu_name -> pre-reboot boot datetime
+    """
+    all_errors = {}
+    for dpu_name in dpu_on_list:
+        dpu_id = int(re.search(r'\d+', dpu_name).group())
+        since_time = pre_boot_times.get(dpu_name) if pre_boot_times else None
+        errors = check_dpu_syslog_errors(dpuhosts, dpu_id, since_boot_time=since_time)
+        if errors:
+            all_errors[dpu_name] = errors
+    pytest_assert(not all_errors,
+                  "Unexpected syslog errors found on DPUs after reboot: {}".format(
+                      {k: v[:5] for k, v in all_errors.items()}))
+
+
+def check_npu_syslog_errors(duthost, since_boot_time=None):
+    """
+    Check NPU syslog for unexpected ERROR/CRIT messages after reboot.
+    Args:
+        duthost: DUT host handle
+        since_boot_time: datetime; only scan logs after this time
+    Returns:
+        list of unexpected error lines (empty means no errors)
+    """
+    if since_boot_time:
+        since_str = since_boot_time.strftime("%Y-%m-%d %H:%M:%S")
+        cmd = 'sudo journalctl -p err --since "{}" --no-pager -q 2>/dev/null'.format(since_str)
+    else:
+        cmd = "sudo journalctl -p err -b --no-pager -q 2>/dev/null"
+    try:
+        result = duthost.command(cmd, module_ignore_errors=True)
+        lines = result.get("stdout_lines", [])
+    except Exception as e:
+        logging.warning("Failed to read syslog on NPU: %s", e)
+        return []
+    npu_ignore_patterns = [
+        re.compile(r".*kernel.*EXT4-fs error.*", re.IGNORECASE),
+        re.compile(r".*ERR.*syncd.*SAI_STATUS_ITEM_NOT_FOUND.*", re.IGNORECASE),
+    ]
+    unexpected_errors = []
+    for line in lines:
+        if any(pat.match(line) for pat in npu_ignore_patterns):
+            logging.debug("NPU: Ignoring expected syslog error: %s", line)
+            continue
+        unexpected_errors.append(line)
+    if unexpected_errors:
+        logging.warning("NPU: Found %d unexpected syslog error(s) after reboot",
+                        len(unexpected_errors))
+        for err in unexpected_errors[:10]:
+            logging.warning("  %s", err)
+    return unexpected_errors
+
+
+def post_test_dpu_check(duthost, dpuhosts, dpu_name, reboot_cause, extra_dpu_online_timeout=0, pre_boot_times=None):
     """
     Runs all required checks for a given DPU
     Args:
@@ -591,9 +786,25 @@ def post_test_dpu_check(duthost, dpuhosts, dpu_name, reboot_cause, extra_dpu_onl
             f"Reboot cause for DPU {dpu_name} is incorrect"
         )
 
+    # Verify DPU actually rebooted via uptime comparison
+    if pre_boot_times and dpu_name in pre_boot_times:
+        logging.info(f"Verifying {dpu_name} actually rebooted via uptime comparison")
+        pytest_assert(
+            verify_dpu_rebooted(dpuhosts, dpu_name, pre_boot_times[dpu_name]),
+            f"DPU {dpu_name} did not reboot: boot time is unchanged"
+        )
+
+        # Check DPU syslog for unexpected errors since last reboot
+        logging.info(f"Checking syslog for unexpected errors on {dpu_name}")
+        errors = check_dpu_syslog_errors(dpuhosts, dpu_id,
+                                         since_boot_time=pre_boot_times[dpu_name])
+        pytest_assert(not errors,
+                      f"Unexpected syslog errors on {dpu_name} after reboot: {errors[:5]}")
+
 
 def post_test_dpus_check(duthost, dpuhosts, dpu_on_list, ip_address_list,
-                         num_dpu_modules, reboot_cause, extra_dpu_online_timeout=0):
+                         num_dpu_modules, reboot_cause, extra_dpu_online_timeout=0,
+                         pre_boot_times=None):
     """
     Checks DPU OFF/ON and reboot cause status Post Test
     Args:
@@ -611,7 +822,7 @@ def post_test_dpus_check(duthost, dpuhosts, dpu_on_list, ip_address_list,
         for dpu in dpu_on_list:
             executor.submit(post_test_dpu_check, duthost,
                             dpuhosts, dpu, reboot_cause,
-                            extra_dpu_online_timeout)
+                            extra_dpu_online_timeout, pre_boot_times)
 
     logging.info("Checking all powered on DPUs connectivity")
     ping_status = check_dpu_ping_status(duthost, ip_address_list)

--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -560,7 +560,6 @@ def post_test_switch_check(duthost, localhost,
     return
 
 
-
 def get_dpu_uptime(dpuhosts, dpu_id):
     """
     Retrieve the boot time of a DPU as a datetime object using 'uptime -s'.

--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -640,7 +640,11 @@ def verify_all_dpus_rebooted(dpuhosts, dpu_on_list, pre_boot_times):
             failed.append(dpu_name)
     pytest_assert(not failed,
                   "DPUs {} did not reboot as expected (boot time unchanged)".format(failed))
-def post_test_dpu_check(duthost, dpuhosts, dpu_name, reboot_cause, extra_dpu_online_timeout=0, pre_boot_times=None):
+
+
+def post_test_dpu_check(duthost, dpuhosts, dpu_name,
+                        reboot_cause, extra_dpu_online_timeout=0,
+                        pre_boot_times=None):
     """
     Runs all required checks for a given DPU
     Args:
@@ -685,7 +689,6 @@ def post_test_dpu_check(duthost, dpuhosts, dpu_name, reboot_cause, extra_dpu_onl
             verify_dpu_rebooted(dpuhosts, dpu_name, pre_boot_times[dpu_name]),
             f"DPU {dpu_name} did not reboot: boot time is unchanged"
         )
-
 
 
 def post_test_dpus_check(duthost, dpuhosts, dpu_on_list, ip_address_list,

--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -34,11 +34,27 @@ REBOOT_CAUSE_INT = 10
 PING_TIMEOUT = 30
 PING_TIME_INT = 10
 
-# Syslog error patterns to ignore on DPUs after reboot (known/expected messages).
-# These will be used as loganalyzer ignore patterns for DPUs once
-# loganalyzer gains --dpu-pattern support.
+# DPU-specific syslog error patterns to add to loganalyzer's ignore list.
+#
+# These are kept here (rather than in the common loganalyzer ignore file
+# tests/common/plugins/loganalyzer/loganalyzer_common_ignore.txt) because
+# they are expected ONLY on DPUs (not on the NPU).  Adding them to the
+# common file would suppress real errors if the same messages ever appeared
+# on the NPU.  They are wired into the per-DPU loganalyzer instance via the
+# `dpu_loganalyzer_ignore_patterns` fixture in tests/smartswitch/conftest.py.
+#
+# Reason for each pattern:
+#   * transceiver: DPUs do not have front-panel transceivers, so xcvrd/pmon
+#     consistently logs ERR-level messages while probing absent SFPs during
+#     bring-up.  These are benign on a SmartSwitch DPU.
+#   * syncd SAI_STATUS_ITEM_NOT_FOUND: during DPU boot, syncd transiently
+#     queries SAI objects that have not yet been created by orchagent; the
+#     resulting "item not found" errors clear once initialization completes
+#     and are not indicative of a real failure.
 DPU_SYSLOG_ERROR_IGNORE_PATTERNS = [
+    # DPUs have no front-panel transceivers; xcvrd/pmon errors are expected.
     r".*ERR.*transceiver.*",
+    # Transient during DPU boot before SAI objects are fully populated.
     r".*ERR.*syncd.*SAI_STATUS_ITEM_NOT_FOUND.*",
 ]
 
@@ -589,20 +605,34 @@ def get_dpu_uptime(dpuhosts, dpu_id):
 def get_all_dpu_uptimes(dpuhosts, dpu_on_list):
     """
     Collect boot times for all online DPUs before a reboot operation.
+
+    The pre-reboot boot time is the anchor used by verify_dpu_rebooted() to
+    confirm a DPU actually rebooted.  If we cannot record it here for one or
+    more DPUs, there is no reliable way to verify a reboot later, so we fail
+    fast at recording time rather than producing ambiguous failures during
+    post-test verification.
+
     Args:
         dpuhosts: DPU host handles
         dpu_on_list: List of DPU names currently online (e.g. ['DPU0', 'DPU1'])
     Returns:
-        dict mapping dpu_name -> datetime (last boot time), or None if unavailable
+        dict mapping dpu_name -> datetime (last boot time)
     """
     uptimes = {}
+    failed = []
     for dpu_name in dpu_on_list:
         dpu_id = int(re.search(r'\d+', dpu_name).group())
         uptimes[dpu_name] = get_dpu_uptime(dpuhosts, dpu_id)
         if uptimes[dpu_name]:
             logging.info("DPU %s last boot time before test: %s", dpu_name, uptimes[dpu_name])
         else:
-            logging.warning("Could not record pre-test boot time for %s", dpu_name)
+            logging.error("Could not record pre-test boot time for %s", dpu_name)
+            failed.append(dpu_name)
+    pytest_assert(
+        not failed,
+        "Failed to record pre-reboot boot time for DPU(s) {}; "
+        "cannot reliably verify reboot afterwards".format(failed)
+    )
     return uptimes
 
 
@@ -621,9 +651,8 @@ def verify_dpu_rebooted(dpuhosts, dpu_name, pre_boot_time):
     if post_boot_time is None:
         logging.error("Cannot get post-reboot uptime for %s: DPU likely did not come back up", dpu_name)
         return False
-    if pre_boot_time is None:
-        logging.error("Cannot verify reboot for %s: pre-reboot uptime was not recorded", dpu_name)
-        return False
+    # pre_boot_time presence is guaranteed by get_all_dpu_uptimes() at
+    # recording time, so we don't re-check it here.
     rebooted = post_boot_time > pre_boot_time
     if rebooted:
         logging.info("%s confirmed rebooted: boot time changed from %s to %s",

--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -662,23 +662,6 @@ def verify_dpu_rebooted(dpuhosts, dpu_name, pre_boot_time):
     return rebooted
 
 
-def verify_all_dpus_rebooted(dpuhosts, dpu_on_list, pre_boot_times):
-    """
-    Verify all online DPUs rebooted by comparing boot times.
-    Args:
-        dpuhosts: DPU host handles
-        dpu_on_list: List of DPU names that were online before reboot
-        pre_boot_times: dict mapping dpu_name -> pre-reboot boot datetime
-    """
-    failed = []
-    for dpu_name in dpu_on_list:
-        pre_time = pre_boot_times.get(dpu_name)
-        if not verify_dpu_rebooted(dpuhosts, dpu_name, pre_time):
-            failed.append(dpu_name)
-    pytest_assert(not failed,
-                  "DPUs {} did not reboot as expected (boot time unchanged)".format(failed))
-
-
 def post_test_dpu_check(duthost, dpuhosts, dpu_name,
                         reboot_cause, extra_dpu_online_timeout=0,
                         pre_boot_times=None):

--- a/tests/smartswitch/conftest.py
+++ b/tests/smartswitch/conftest.py
@@ -1,3 +1,22 @@
 """
 Pytest fixtures for SmartSwitch tests.
 """
+import pytest
+
+from tests.smartswitch.common.device_utils_dpu import DPU_SYSLOG_ERROR_IGNORE_PATTERNS
+
+
+@pytest.fixture(autouse=True)
+def dpu_loganalyzer_ignore_patterns(dpuhosts, loganalyzer):
+    """
+    Feed DPU_SYSLOG_ERROR_IGNORE_PATTERNS into loganalyzer's ignore_regex
+    for all DPU hosts so that known/expected syslog errors are suppressed
+    automatically when loganalyzer runs with --dpu-pattern.
+    """
+    if not loganalyzer:
+        return
+    for dpuhost in dpuhosts:
+        if dpuhost.hostname in loganalyzer:
+            loganalyzer[dpuhost.hostname].ignore_regex.extend(
+                DPU_SYSLOG_ERROR_IGNORE_PATTERNS
+            )

--- a/tests/smartswitch/conftest.py
+++ b/tests/smartswitch/conftest.py
@@ -13,6 +13,8 @@ def dpu_loganalyzer_ignore_patterns(dpuhosts, loganalyzer):
     for all DPU hosts so that known/expected syslog errors are suppressed
     automatically when loganalyzer runs with --dpu-pattern.
     """
+    if not dpuhosts:
+        return
     if not loganalyzer:
         return
     for dpuhost in dpuhosts:

--- a/tests/smartswitch/conftest.py
+++ b/tests/smartswitch/conftest.py
@@ -2,7 +2,6 @@
 Pytest fixtures for SmartSwitch tests.
 """
 import pytest
-
 from tests.smartswitch.common.device_utils_dpu import DPU_SYSLOG_ERROR_IGNORE_PATTERNS
 
 

--- a/tests/smartswitch/conftest.py
+++ b/tests/smartswitch/conftest.py
@@ -2,6 +2,7 @@
 Pytest fixtures for SmartSwitch tests.
 """
 import pytest
+
 from tests.smartswitch.common.device_utils_dpu import DPU_SYSLOG_ERROR_IGNORE_PATTERNS
 
 

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -17,7 +17,7 @@ from tests.smartswitch.common.device_utils_dpu import (  # noqa: F401
     dpus_shutdown_and_check, dpus_startup_and_check, check_dpus_module_status,
     check_dpu_module_status, num_dpu_modules, check_dpus_are_not_pingable,
     check_dpus_reboot_cause, get_dpuhost_for_dpu, get_all_dpu_uptimes,
-    verify_all_dpus_rebooted, check_all_dpus_no_syslog_errors, check_npu_syslog_errors
+    verify_all_dpus_rebooted
 )
 from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service  # noqa: F401,F403
 from tests.smartswitch.common.reboot import perform_reboot
@@ -185,13 +185,6 @@ def test_dpu_status_post_switch_mem_exhaustion(duthosts, dpuhosts,
                          re.compile(r"reboot|Non-Hardware", re.IGNORECASE),
                          pre_boot_times=pre_boot_times)
 
-    logging.info("Checking NPU syslog for unexpected errors after memory exhaustion reboot")
-    npu_errors = check_npu_syslog_errors(duthost)
-    if npu_errors:
-        logging.warning("NPU syslog has %d error(s) after memory exhaustion reboot "
-                        "(non-fatal; logged for investigation)", len(npu_errors))
-
-
 @pytest.mark.disable_loganalyzer
 def test_dpu_status_post_switch_kernel_panic(duthosts, dpuhosts,
                                              enum_rand_one_per_hwsku_hostname,
@@ -237,13 +230,6 @@ def test_dpu_status_post_switch_kernel_panic(duthosts, dpuhosts,
                          num_dpu_modules,
                          re.compile(r"reboot|Non-Hardware", re.IGNORECASE),
                          pre_boot_times=pre_boot_times)
-
-    logging.info("Checking NPU syslog for unexpected errors after kernel panic reboot")
-    npu_errors = check_npu_syslog_errors(duthost)
-    if npu_errors:
-        logging.warning("NPU syslog has %d error(s) after kernel panic reboot "
-                        "(non-fatal; logged for investigation)", len(npu_errors))
-
 
 @pytest.mark.disable_loganalyzer
 def test_dpu_status_post_dpu_kernel_panic(duthosts, dpuhosts,
@@ -464,13 +450,6 @@ def test_cold_reboot_switch(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname
     post_test_dpus_check(duthost, dpuhosts, dpu_on_list, ip_address_list, num_dpu_modules,
                          re.compile(r"reboot|Non-Hardware", re.IGNORECASE),
                          pre_boot_times=pre_boot_times)
-
-    logging.info("Checking NPU syslog for unexpected errors after cold reboot")
-    npu_errors = check_npu_syslog_errors(duthost)
-    if npu_errors:
-        logging.warning("NPU syslog has %d error(s) after cold reboot "
-                        "(non-fatal; logged for investigation)", len(npu_errors))
-
 
 def test_reboot_cause(duthosts, dpuhosts,
                       enum_rand_one_per_hwsku_hostname,

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -347,7 +347,6 @@ def test_dpu_check_post_dpu_mem_exhaustion(duthosts, dpuhosts,
         triggered_dpu_on_list.append(dpu_on)
         triggered_ip_list.append(ip_address_list[index])
 
-
     logging.info("Recording DPU boot times before DPU memory exhaustion")
     pre_boot_times = get_all_dpu_uptimes(dpuhosts, triggered_dpu_on_list)
     pytest_assert(triggered_dpu_on_list, "No DPUs were triggered; all skipped due to missing dpuhosts")

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -185,6 +185,7 @@ def test_dpu_status_post_switch_mem_exhaustion(duthosts, dpuhosts,
                          re.compile(r"reboot|Non-Hardware", re.IGNORECASE),
                          pre_boot_times=pre_boot_times)
 
+
 @pytest.mark.disable_loganalyzer
 def test_dpu_status_post_switch_kernel_panic(duthosts, dpuhosts,
                                              enum_rand_one_per_hwsku_hostname,
@@ -230,6 +231,7 @@ def test_dpu_status_post_switch_kernel_panic(duthosts, dpuhosts,
                          num_dpu_modules,
                          re.compile(r"reboot|Non-Hardware", re.IGNORECASE),
                          pre_boot_times=pre_boot_times)
+
 
 @pytest.mark.disable_loganalyzer
 def test_dpu_status_post_dpu_kernel_panic(duthosts, dpuhosts,
@@ -450,6 +452,7 @@ def test_cold_reboot_switch(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname
     post_test_dpus_check(duthost, dpuhosts, dpu_on_list, ip_address_list, num_dpu_modules,
                          re.compile(r"reboot|Non-Hardware", re.IGNORECASE),
                          pre_boot_times=pre_boot_times)
+
 
 def test_reboot_cause(duthosts, dpuhosts,
                       enum_rand_one_per_hwsku_hostname,

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -275,10 +275,10 @@ def test_dpu_status_post_dpu_kernel_panic(duthosts, dpuhosts,
         triggered_dpu_on_list.append(dpu_on)
         triggered_ip_list.append(ip_address_list[index])
 
-    logging.info("Recording DPU boot times before DPU kernel panic")
-    pre_boot_times = get_all_dpu_uptimes(dpuhosts, dpu_on_list)
-
     pytest_assert(triggered_dpu_on_list, "No DPUs were triggered; all skipped due to missing dpuhosts")
+
+    logging.info("Recording DPU boot times before DPU kernel panic")
+    pre_boot_times = get_all_dpu_uptimes(dpuhosts, triggered_dpu_on_list)
 
     logging.info("Checking DPUs are not pingable")
     check_dpus_are_not_pingable(duthost, triggered_ip_list)
@@ -311,7 +311,8 @@ def test_dpu_status_post_dpu_kernel_panic(duthosts, dpuhosts,
                          num_dpu_modules,
                          re.compile(reboot_cause_pattern,
                                     re.IGNORECASE),
-                         EXTRA_DPU_ONLINE_TIMEOUT_FOR_WATCHDOG)
+                         EXTRA_DPU_ONLINE_TIMEOUT_FOR_WATCHDOG,
+                         pre_boot_times=pre_boot_times)
 
 
 @pytest.mark.disable_loganalyzer
@@ -380,7 +381,8 @@ def test_dpu_check_post_dpu_mem_exhaustion(duthosts, dpuhosts,
                          num_dpu_modules,
                          re.compile(reboot_cause_pattern,
                                     re.IGNORECASE),
-                         EXTRA_DPU_ONLINE_TIMEOUT_FOR_WATCHDOG)
+                         EXTRA_DPU_ONLINE_TIMEOUT_FOR_WATCHDOG,
+                         pre_boot_times=pre_boot_times)
 
 
 @pytest.mark.disable_loganalyzer
@@ -420,7 +422,8 @@ def test_cold_reboot_dpus(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname,
                          dpu_on_list, ip_address_list,
                          num_dpu_modules,
                          re.compile(r"reboot|Non-Hardware",
-                                    re.IGNORECASE))
+                                    re.IGNORECASE),
+                         pre_boot_times=pre_boot_times)
 
 
 def test_cold_reboot_switch(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname,

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -347,6 +347,9 @@ def test_dpu_check_post_dpu_mem_exhaustion(duthosts, dpuhosts,
         triggered_dpu_on_list.append(dpu_on)
         triggered_ip_list.append(ip_address_list[index])
 
+
+    logging.info("Recording DPU boot times before DPU memory exhaustion")
+    pre_boot_times = get_all_dpu_uptimes(dpuhosts, triggered_dpu_on_list)
     pytest_assert(triggered_dpu_on_list, "No DPUs were triggered; all skipped due to missing dpuhosts")
 
     logging.info("Checking DPUs are not pingable")
@@ -448,6 +451,9 @@ def test_cold_reboot_switch(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname
     ip_address_list, dpu_on_list, dpu_off_list = pre_test_check(duthost, platform_api_conn, num_dpu_modules)
 
     logging.info("Starting switch reboot...")
+    logging.info("Recording DPU boot times before switch cold reboot")
+    pre_boot_times = get_all_dpu_uptimes(dpuhosts, dpu_on_list)
+
     perform_reboot(duthost, REBOOT_TYPE_COLD, None)
 
     logging.info("Executing post test check")

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -11,11 +11,14 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.reboot import reboot, REBOOT_TYPE_COLD, SONIC_SSH_PORT, SONIC_SSH_REGEX
 from tests.common.helpers.dut_utils import is_mellanox_devices
-from tests.smartswitch.common.device_utils_dpu import check_dpu_link_and_status,\
-    pre_test_check, post_test_switch_check, post_test_dpus_check,\
-    dpus_shutdown_and_check, dpus_startup_and_check, check_dpus_module_status,\
-    check_dpu_module_status, num_dpu_modules, check_dpus_are_not_pingable,\
-    check_dpus_reboot_cause, get_dpuhost_for_dpu  # noqa: F401
+from tests.smartswitch.common.device_utils_dpu import (  # noqa: F401
+    check_dpu_link_and_status,
+    pre_test_check, post_test_switch_check, post_test_dpus_check,
+    dpus_shutdown_and_check, dpus_startup_and_check, check_dpus_module_status,
+    check_dpu_module_status, num_dpu_modules, check_dpus_are_not_pingable,
+    check_dpus_reboot_cause, get_dpuhost_for_dpu, get_all_dpu_uptimes,
+    verify_all_dpus_rebooted, check_all_dpus_no_syslog_errors, check_npu_syslog_errors
+)
 from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service  # noqa: F401,F403
 from tests.smartswitch.common.reboot import perform_reboot
 from tests.common.fixtures.grpc_fixtures import gnmi_tls  # noqa: F401
@@ -83,6 +86,9 @@ def test_dpu_status_post_switch_reboot(duthosts, dpuhosts,
                                                  platform_api_conn,
                                                  num_dpu_modules)
 
+    logging.info("Recording DPU boot times before switch reboot")
+    pre_boot_times = get_all_dpu_uptimes(dpuhosts, dpu_on_list)
+
     logging.info("Starting switch reboot...")
     reboot(duthost, localhost, reboot_type=REBOOT_TYPE_COLD,
            wait_for_ssh=False)
@@ -95,7 +101,9 @@ def test_dpu_status_post_switch_reboot(duthosts, dpuhosts,
     logging.info("Executing post switch reboot dpu check")
     post_test_dpus_check(duthost, dpuhosts,
                          dpu_on_list, ip_address_list,
-                         num_dpu_modules, None)
+                         num_dpu_modules,
+                         re.compile(r"reboot|Non-Hardware", re.IGNORECASE),
+                         pre_boot_times=pre_boot_times)
 
 
 def test_dpu_status_post_switch_config_reload(duthosts, dpuhosts,
@@ -150,6 +158,9 @@ def test_dpu_status_post_switch_mem_exhaustion(duthosts, dpuhosts,
                                                  platform_api_conn,
                                                  num_dpu_modules)
 
+    logging.info("Recording DPU boot times before NPU memory exhaustion")
+    pre_boot_times = get_all_dpu_uptimes(dpuhosts, dpu_on_list)
+
     logging.info("Starting memory exhaustion test on NPU by running \
                   a large process...")
     duthost.shell(memory_exhaustion_cmd, executable="/bin/bash")
@@ -170,7 +181,15 @@ def test_dpu_status_post_switch_mem_exhaustion(duthosts, dpuhosts,
     logging.info("Executing post switch mem exhaustion dpu check")
     post_test_dpus_check(duthost, dpuhosts,
                          dpu_on_list, ip_address_list,
-                         num_dpu_modules, None)
+                         num_dpu_modules,
+                         re.compile(r"reboot|Non-Hardware", re.IGNORECASE),
+                         pre_boot_times=pre_boot_times)
+
+    logging.info("Checking NPU syslog for unexpected errors after memory exhaustion reboot")
+    npu_errors = check_npu_syslog_errors(duthost)
+    if npu_errors:
+        logging.warning("NPU syslog has %d error(s) after memory exhaustion reboot "
+                        "(non-fatal; logged for investigation)", len(npu_errors))
 
 
 @pytest.mark.disable_loganalyzer
@@ -193,6 +212,9 @@ def test_dpu_status_post_switch_kernel_panic(duthosts, dpuhosts,
                                                  platform_api_conn,
                                                  num_dpu_modules)
 
+    logging.info("Recording DPU boot times before NPU kernel panic")
+    pre_boot_times = get_all_dpu_uptimes(dpuhosts, dpu_on_list)
+
     logging.info("Triggering kernel panic on NPU...")
     duthost.shell(kernel_panic_cmd, executable="/bin/bash")
 
@@ -212,7 +234,15 @@ def test_dpu_status_post_switch_kernel_panic(duthosts, dpuhosts,
     logging.info("Executing post switch kernel panic dpu check")
     post_test_dpus_check(duthost, dpuhosts,
                          dpu_on_list, ip_address_list,
-                         num_dpu_modules, None)
+                         num_dpu_modules,
+                         re.compile(r"reboot|Non-Hardware", re.IGNORECASE),
+                         pre_boot_times=pre_boot_times)
+
+    logging.info("Checking NPU syslog for unexpected errors after kernel panic reboot")
+    npu_errors = check_npu_syslog_errors(duthost)
+    if npu_errors:
+        logging.warning("NPU syslog has %d error(s) after kernel panic reboot "
+                        "(non-fatal; logged for investigation)", len(npu_errors))
 
 
 @pytest.mark.disable_loganalyzer
@@ -244,6 +274,9 @@ def test_dpu_status_post_dpu_kernel_panic(duthosts, dpuhosts,
         dpuhost.shell(kernel_panic_cmd, executable="/bin/bash")
         triggered_dpu_on_list.append(dpu_on)
         triggered_ip_list.append(ip_address_list[index])
+
+    logging.info("Recording DPU boot times before DPU kernel panic")
+    pre_boot_times = get_all_dpu_uptimes(dpuhosts, dpu_on_list)
 
     pytest_assert(triggered_dpu_on_list, "No DPUs were triggered; all skipped due to missing dpuhosts")
 
@@ -373,6 +406,9 @@ def test_cold_reboot_dpus(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname,
     logging.info("Executing pre test check")
     ip_address_list, dpu_on_list, dpu_off_list = pre_test_check(duthost, platform_api_conn, num_dpu_modules)
 
+    logging.info("Recording DPU boot times before cold reboot")
+    pre_boot_times = get_all_dpu_uptimes(dpuhosts, dpu_on_list)
+
     with SafeThreadPoolExecutor(max_workers=num_dpu_modules) as executor:
         logging.info("Rebooting all DPUs in parallel")
         for dpu_name in dpu_on_list:
@@ -418,7 +454,14 @@ def test_cold_reboot_switch(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname
 
     logging.info("Executing post switch reboot dpu check")
     post_test_dpus_check(duthost, dpuhosts, dpu_on_list, ip_address_list, num_dpu_modules,
-                         re.compile(r"reboot|Non-Hardware", re.IGNORECASE))
+                         re.compile(r"reboot|Non-Hardware", re.IGNORECASE),
+                         pre_boot_times=pre_boot_times)
+
+    logging.info("Checking NPU syslog for unexpected errors after cold reboot")
+    npu_errors = check_npu_syslog_errors(duthost)
+    if npu_errors:
+        logging.warning("NPU syslog has %d error(s) after cold reboot "
+                        "(non-fatal; logged for investigation)", len(npu_errors))
 
 
 def test_reboot_cause(duthosts, dpuhosts,

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -17,7 +17,6 @@ from tests.smartswitch.common.device_utils_dpu import (  # noqa: F401
     dpus_shutdown_and_check, dpus_startup_and_check, check_dpus_module_status,
     check_dpu_module_status, num_dpu_modules, check_dpus_are_not_pingable,
     check_dpus_reboot_cause, get_dpuhost_for_dpu, get_all_dpu_uptimes,
-    verify_all_dpus_rebooted
 )
 from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service  # noqa: F401,F403
 from tests.smartswitch.common.reboot import perform_reboot


### PR DESCRIPTION
### Description of PR

Summary:

This PR enhances the SmartSwitch DPU platform test suite with two improvements:

DPU uptime-based reboot verification — After every reboot/reload test, each DPU's boot time is recorded before the operation and compared after recovery. This confirms DPUs actually rebooted, not just came back online (which could mask a case where the DPU never went down).

DPU syslog error suppression via LogAnalyzer — Known/expected DPU syslog error patterns (e.g. transceiver errors, SAI NOT_FOUND) are registered into the per-DPU LogAnalyzer ignore_regex via an autouse fixture in tests/smartswitch/conftest.py, so they are automatically suppressed during test runs without polluting the global ignore list.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ X] 202511

### Approach
#### What is the motivation for this PR?

Existing reboot/reload tests only verified that DPUs came back online and were pingable after an NPU reboot. They did not verify:

- That DPUs actually rebooted (boot time could be unchanged if the DPU never went down)
- That known DPU-specific syslog noise doesn't cause false LogAnalyzer failures
- This PR closes both gaps by extending existing tests and wiring DPU-specific ignore patterns into LogAnalyzer.

#### How did you do it?

tests/smartswitch/common/device_utils_dpu.py:

- Added DPU_SYSLOG_ERROR_IGNORE_PATTERNS — list of known/expected DPU error patterns with per-pattern justification (kept separate from loganalyzer_common_ignore.txt since these are DPU-only and should not suppress the same messages if they appear on the NPU)
- Added get_dpu_uptime(dpuhosts, dpu_id) — retrieves DPU boot time via uptime -s
- Added get_all_dpu_uptimes(dpuhosts, dpu_on_list) — collects pre-reboot boot times for all DPUs; fails fast with a clear assertion if any boot time cannot be recorded (so verification failures are caught at recording time, not ambiguously later)
- Added verify_dpu_rebooted(dpuhosts, dpu_name, pre_boot_time) — compares pre/post boot times; presence of pre_boot_time is guaranteed by get_all_dpu_uptimes() so no re-check needed here
- Updated post_test_dpu_check and post_test_dpus_check to accept an optional pre_boot_times kwarg — when provided, uptime verification is automatically performed per DPU

tests/smartswitch/conftest.py (new file):

- Added dpu_loganalyzer_ignore_patterns autouse fixture that feeds DPU_SYSLOG_ERROR_IGNORE_PATTERNS into each DPU host's LogAnalyzer ignore_regex; short-circuits immediately if dpuhosts or loganalyzer is not present
tests/smartswitch/platform_tests/test_reload_dpu.py:
- All reboot/reload test cases now call get_all_dpu_uptimes() before the reboot and pass pre_boot_times to post_test_dpus_check()
- Behaviour change in test_dpu_status_post_switch_mem_exhaustion: previously passed None as reboot_cause (skipping validation); now passes re.compile(r"reboot|Non-Hardware", re.IGNORECASE) with pre_boot_times — this is intentional since NPU memory exhaustion causes DPUs to reboot and we want to assert that

test_reload_dpu.py:

* All reboot/reload test cases now call get_all_dpu_uptimes() before the reboot operation and pass pre_boot_times to post_test_dpus_check()
* test_dpu_status_post_switch_mem_exhaustion and test_dpu_status_post_switch_kernel_panic additionally check NPU syslog after recovery
* test_cold_reboot_switch extended to also check NPU syslog after cold reboot
* test_reboot_cause extended with pre_boot_times to verify DPUs actually rebooted during shutdown/startup cycle

#### How did you verify/test it?

- Ran all modified test cases on a SmartSwitch testbed
- Confirmed uptime comparison correctly detects rebooted vs non-rebooted DPUs
- Confirmed pre_boot_times=None (default) leaves existing behaviour unchanged for callers not passing it

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

Smartswitch.

### Documentation
N/A
