### PR TITLE
Fix packet trimming regression related to trim drop counter

### DIFF
--- a/tests/packet_trimming/base_packet_trimming.py
+++ b/tests/packet_trimming/base_packet_trimming.py
@@ -16,7 +16,7 @@ from tests.packet_trimming.packet_trimming_helper import (
     verify_queue_and_port_trim_counter_consistency, get_queue_trim_counters_json, compare_counters,
     has_non_zero_trim_counters, configure_port_mirror_session, remove_port_mirror_session,
     verify_queue_and_port_trim_sent_counter_consistency, verify_queue_and_port_trim_drop_counter_consistency,
-    compute_buffer_threshold, fill_egress_buffer)
+    compute_buffer_threshold, fill_egress_buffer, check_trim_drop_counter_zero, is_trim_drop_counter_stable)
 
 logger = logging.getLogger(__name__)
 
@@ -450,11 +450,24 @@ class BasePacketTrimming:
                                                                             supported=queue_level_trim_supported)
 
             finally:
+                errors = []
                 # Enable the trimmed queue with original scheduler
                 for port in trim_counter_params['egress_ports']:
                     for dut_member in port['dut_members']:
                         original_scheduler = original_schedulers.get(dut_member)
                         enable_egress_data_plane(duthost, dut_member, trim_queue, original_scheduler)
+                        if is_mellanox_device(duthost):
+                            # Known limitation: TRIM_DRP_PKTS is a calculated counter (TRIM_PKTS - TRIM_TX_PKTS)
+                            # rather than a real hardware counter. After restoring the blocked trim queue,
+                            # queued packets drain out and TRIM_DRP_PKTS gradually decreases to 0.
+                            # Wait for it to stabilize before reading baseline counters for the next step.
+                            if not wait_until(30, 2, 0, check_trim_drop_counter_zero, duthost, dut_member):
+                                errors.append(f"TRIM_DRP_PKTS on port {dut_member} did not stabilize to 0")
+                        elif not is_trim_drop_counter_stable(duthost, dut_member):
+                            errors.append(f"TRIM_DRP_PKTS on unblocked port {dut_member} is still increasing")
+
+                # assert after loop to ensure all ports get unblocked
+                pytest_assert(not errors, "\n".join(errors))
 
     def test_trimming_counters_with_feature_toggle(self, duthost, ptfadapter, test_params, trim_counter_params):
         """

--- a/tests/packet_trimming/packet_trimming_helper.py
+++ b/tests/packet_trimming/packet_trimming_helper.py
@@ -2966,6 +2966,45 @@ def compare_counters(counter1, counter2, keys_to_compare):
     logger.info("All specified counters match")
 
 
+def check_trim_drop_counter_zero(duthost, port):
+    """
+    Check if TRIM_DRP_PKTS counter on the specified port is 0.
+
+    Args:
+        duthost: DUT host object
+        port (str): port name, e.g. "Ethernet96"
+
+    Returns:
+        bool: True if TRIM_DRP_PKTS is 0, False otherwise
+    """
+    trim_drop = get_port_trim_counters_json(duthost, port)['TRIM_DRP_PKTS']
+    logger.info(f"TRIM_DRP_PKTS on port {port}: {trim_drop}")
+    return trim_drop == 0
+
+
+def is_trim_drop_counter_stable(duthost, port):
+    """
+    Check if TRIM_DRP_PKTS counter remains constant on the specified port
+
+    Args:
+        duthost: DUT host object
+        port (str): port name, e.g. "Ethernet96"
+
+    Returns:
+        bool: True if TRIM_DRP_PKTS counter stops increasing, otherwise False
+    """
+    start_time = time.time()
+    while time.time() - start_time < 30:
+        prev_trim_drop = get_port_trim_counters_json(duthost, port)['TRIM_DRP_PKTS']
+        # Ensure there is enough time to poll for an updated value from the ASIC
+        time.sleep(2 * (TRIMMING_COUNTER_INTERVAL / 1000))
+        curr_trim_drop = get_port_trim_counters_json(duthost, port)['TRIM_DRP_PKTS']
+        if prev_trim_drop == curr_trim_drop:
+            return True
+
+    return False
+
+
 def has_non_zero_trim_counters(duthost, port):
     """
     Checks if port level trim counters are non-zero.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #25992

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
There was a regression cause by https://github.com/sonic-net/sonic-mgmt/pull/22807. That PR assumes that the trim drop counter will decrease after removing the shaper applied to the congested queue. While this may be true for Mellanox, it is not the case on Broadcom (and likely other platforms) that the trim drop counter would ever decrease. The only time it should decrease is when the counter is explicitly cleared.

#### How did you do it?
Put the logic that checks for the counter to decrease in a Mellanox only block. Added an else case to check that the trim drop counter is no longer increasing.

#### How did you verify/test it?
Verified that packet trimming tests were passing with the change.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
