### PR TITLE
[HA][smartswitch] enable running HA tests with any DPU pair

### DIFF
--- a/tests/ha/conftest.py
+++ b/tests/ha/conftest.py
@@ -507,27 +507,47 @@ def ha_owner(dpuhosts):
     yield owner
 
 
-def setup_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi_server, ha_owner):
+def setup_dash_ha_from_json_util(duthosts, dpuhosts, localhost, ptfhost, setup_gnmi_server, ha_owner):
     current_dir = os.path.dirname(os.path.abspath(__file__))
     base_dir = os.path.join(current_dir, "..", "common", "ha")
     ha_set_file = os.path.join(base_dir, "dash_ha_set_config_table.json")
+    primary_vdpu_key = f"vdpu0_{dpuhosts[0].dpu_index}:haset0_0"
+    standby_vdpu_key = f"vdpu1_{dpuhosts[1].dpu_index}:haset0_0"
 
+    ha_scope_per_dut_modified = []
     for index, (name, data) in enumerate(ha_scope_per_dut):
+        if name == "vdpu0_0:haset0_0":
+            name = primary_vdpu_key
+        elif name == "vdpu1_0:haset0_0":
+            name = standby_vdpu_key
+        ha_scope_per_dut_modified.append((name, data))
+
+    for index, (name, data) in enumerate(ha_scope_per_dut_modified):
         # Update the 'owner' key in the dictionary
-        ha_scope_per_dut[index][1]['owner'] = ha_owner
+        ha_scope_per_dut_modified[index][1]['owner'] = ha_owner
 
     logger.info("HA: setup from json for Primary and Standby")
 
     # Workaround for the neigh resolve issue
     # To be removed after fixes are merged: PR 147, 148 in sonic-dash-ha
     for i in range(len(duthosts)):
-        logger.info(f"Sending ping to DPU0 for {duthosts[i].hostname}")
+        logger.info(f"Sending ping to DPU{dpuhosts[i].dpu_index} for {duthosts[i].hostname}")
         ip_part = 200 + i
-        ping_result = duthosts[i].shell(f"ping -c 3 20.0.{ip_part}.1", module_ignore_errors=True)["stdout"]
+        ip_last = dpuhosts[i].dpu_index + 1
+        ping_result = duthosts[i].shell(f"ping -c 3 20.0.{ip_part}.{ip_last}", module_ignore_errors=True)["stdout"]
         logger.info(f"{duthosts[i].hostname} ping_result [{ping_result}]")
 
     with open(ha_set_file) as f:
         ha_set_data = json.load(f)["DASH_HA_SET_CONFIG_TABLE"]
+
+    # Update the entry for "haset0_0"
+    ha_set_entry = ha_set_data.get("haset0_0", {})
+
+    ha_set_entry["vdpu_ids"] = [f"vdpu0_{dpuhosts[0].dpu_index}", f"vdpu1_{dpuhosts[1].dpu_index}"]
+    ha_set_entry["preferred_vdpu_id"] = f"vdpu0_{dpuhosts[0].dpu_index}"
+
+    # Save the modified data back into the dictionary
+    ha_set_data["haset0_0"] = ha_set_entry
 
     # -------------------------------------------------
     # Step 1: Program HA SET on BOTH DUTs
@@ -546,7 +566,7 @@ def setup_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi_server
     # Step 2: Initial HA SCOPE per DUT
     # -------------------------------------------------
 
-    for duthost, (key, fields) in zip(duthosts, ha_scope_per_dut):
+    for duthost, (key, fields) in zip(duthosts, ha_scope_per_dut_modified):
         vdpu_id, ha_set_id = key.split(":", 1)
         ha_scope_messages = ha_scope_config(
             vdpu_id=vdpu_id,
@@ -561,17 +581,28 @@ def setup_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi_server
         )
 
 
-def remove_setup_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi_server, ha_owner):
+def remove_setup_dash_ha_from_json_util(duthosts, dpuhosts, localhost, ptfhost, setup_gnmi_server, ha_owner):
     current_dir = os.path.dirname(os.path.abspath(__file__))
     base_dir = os.path.join(current_dir, "..", "common", "ha")
     ha_set_file = os.path.join(base_dir, "dash_ha_set_config_table.json")
 
-    for index, (name, data) in enumerate(ha_scope_per_dut):
-        # Update the 'owner' key in the dictionary
-        ha_scope_per_dut[index][1]['owner'] = ha_owner
+    primary_vdpu_key = f"vdpu0_{dpuhosts[0].dpu_index}:haset0_0"
+    standby_vdpu_key = f"vdpu1_{dpuhosts[1].dpu_index}:haset0_0"
 
-    logger.info("HA: remove SCOPE from json for Primary and Standby")
-    for duthost, (key, fields) in zip(duthosts, ha_scope_per_dut):
+    ha_scope_per_dut_modified = []
+    for index, (name, data) in enumerate(ha_scope_per_dut):
+        if name == "vdpu0_0:haset0_0":
+            name = primary_vdpu_key
+        elif name == "vdpu1_0:haset0_0":
+            name = standby_vdpu_key
+    ha_scope_per_dut_modified.append((name, data))
+
+    for index, (name, data) in enumerate(ha_scope_per_dut_modified):
+        # Update the 'owner' key in the dictionary
+        ha_scope_per_dut_modified[index][1]['owner'] = ha_owner
+
+    logger.info("HA: remove SCOPE for Primary and Standby")
+    for duthost, (key, fields) in zip(duthosts, ha_scope_per_dut_modified):
         vdpu_id, ha_set_id = key.split(":", 1)
         ha_scope_messages = ha_scope_config(
             vdpu_id=vdpu_id,
@@ -586,7 +617,7 @@ def remove_setup_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi
             set_db=False
         )
 
-    logger.info("HA: remove SET from json for Primary and Standby")
+    logger.info("HA: remove SET for Primary and Standby")
     with open(ha_set_file) as f:
         ha_set_data = json.load(f)["DASH_HA_SET_CONFIG_TABLE"]
 
@@ -603,38 +634,49 @@ def remove_setup_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi
 
 
 @pytest.fixture(scope="module")
-def setup_dash_ha_from_json(duthosts, localhost, ptfhost, setup_gnmi_server, ha_owner):
-    setup_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi_server, ha_owner)
+def setup_dash_ha_from_json(duthosts, dpuhosts, localhost, ptfhost, setup_gnmi_server, ha_owner):
+    setup_dash_ha_from_json_util(duthosts, dpuhosts, localhost, ptfhost, setup_gnmi_server, ha_owner)
     yield
-    remove_setup_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi_server, ha_owner)
+    remove_setup_dash_ha_from_json_util(duthosts, dpuhosts, localhost, ptfhost, setup_gnmi_server, ha_owner)
 
 
 @pytest.fixture(scope="function")
-def setup_dash_ha_from_json_func_scope(duthosts, localhost, ptfhost, setup_gnmi_server, ha_owner):
-    setup_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi_server, ha_owner)
+def setup_dash_ha_from_json_func_scope(duthosts, dpuhosts, localhost, ptfhost, setup_gnmi_server, ha_owner):
+    setup_dash_ha_from_json_util(duthosts, dpuhosts, localhost, ptfhost, setup_gnmi_server, ha_owner)
     yield
-    remove_setup_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi_server, ha_owner)
+    remove_setup_dash_ha_from_json_util(duthosts, dpuhosts, localhost, ptfhost, setup_gnmi_server, ha_owner)
 
 
-def activate_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi_server, ha_owner):
+def activate_dash_ha_from_json_util(duthosts, dpuhosts, localhost, ptfhost, setup_gnmi_server, ha_owner):
 
+    primary_vdpu_key = f"vdpu0_{dpuhosts[0].dpu_index}:haset0_0"
+    standby_vdpu_key = f"vdpu1_{dpuhosts[1].dpu_index}:haset0_0"
+
+    activate_scope_per_dut_modified = []
     for index, (name, data) in enumerate(activate_scope_per_dut):
-        # Update the 'owner' key in the dictionary
-        activate_scope_per_dut[index][1]['owner'] = ha_owner
+        if name == "vdpu0_0:haset0_0":
+            name = primary_vdpu_key
+        elif name == "vdpu1_0:haset0_0":
+            name = standby_vdpu_key
+        activate_scope_per_dut_modified.append((name, data))
+
+    for index, (name, data) in enumerate(activate_scope_per_dut_modified):
+        activate_scope_per_dut_modified[index][1]['owner'] = ha_owner
 
     # -------------------------------------------------
     # Step 4: Activate Role (using pending_operation_ids)
     # -------------------------------------------------
     logger.info("HA: activate Primary and Standby")
-    for duthost, (key, fields) in zip(duthosts, activate_scope_per_dut):
+    for duthost, (key, fields) in zip(duthosts, activate_scope_per_dut_modified):
         is_active = verify_ha_state(duthost, scope_key=key, expected_state="active", timeout=10, interval=5)
         if not is_active:
             break
 
     if is_active:
         logger.info("HA: Primary and Standby already active")
+        return
     else:
-        for duthost, (key, fields) in zip(duthosts, activate_scope_per_dut):
+        for duthost, (key, fields) in zip(duthosts, activate_scope_per_dut_modified):
             vdpu_id, ha_set_id = key.split(":", 1)
             ha_scope_messages = ha_scope_config(
                 vdpu_id=vdpu_id,
@@ -647,7 +689,7 @@ def activate_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi_ser
                 ptfhost=ptfhost,
                 messages=ha_scope_messages,
             )
-        for idx, (duthost, (key, fields)) in enumerate(zip(duthosts, activate_scope_per_dut)):
+        for idx, (duthost, (key, fields)) in enumerate(zip(duthosts, activate_scope_per_dut_modified)):
             # Wait up to 300s — after a process-crash test the HA state machine
             # may need significant time to re-enter the activate_role flow.
             pending_id = wait_for_pending_operation_id(
@@ -681,7 +723,7 @@ def activate_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi_ser
                 expected_state = "active"
             else:
                 # Expect standby state on vDPU1
-                if key == "vdpu1_0:haset0_0":
+                if key == standby_vdpu_key:
                     expected_state = "standby"
                 else:
                     expected_state = "active"
@@ -696,23 +738,21 @@ def activate_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi_ser
         logger.info("HA: activate completed for Primary and Standby")
 
 
-def deactivate_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi_server, ha_owner):
+def deactivate_dash_ha_from_json_util(duthosts, dpuhosts, localhost, ptfhost, setup_gnmi_server):
 
-    for index, (name, data) in enumerate(activate_scope_per_dut):
-        # Update the 'owner' key in the dictionary
-        activate_scope_per_dut[index][1]['owner'] = ha_owner
+    primary_vdpu_key = f"vdpu0_{dpuhosts[0].dpu_index}:haset0_0"
+    standby_vdpu_key = f"vdpu1_{dpuhosts[1].dpu_index}:haset0_0"
 
-    logger.info("HA: de-activate Primary and Standby")
-    # First set Primary and Standby to dead
-    for index, duthost in enumerate(duthosts):
-        set_dead_dash_ha_scope(localhost, duthost, ptfhost, f"vdpu{index}_0:haset0_0")
+    logger.info("HA: de-activate Primary and Standby - set dead")
+    set_dead_dash_ha_scope(localhost, duthosts[0], ptfhost, primary_vdpu_key)
+    set_dead_dash_ha_scope(localhost, duthosts[1], ptfhost, standby_vdpu_key)
 
 
 @pytest.fixture(scope="function")
-def activate_dash_ha_from_json(duthosts, localhost, ptfhost, setup_gnmi_server, ha_owner):
-    activate_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi_server, ha_owner)
+def activate_dash_ha_from_json(duthosts, dpuhosts, localhost, ptfhost, setup_gnmi_server, ha_owner):
+    activate_dash_ha_from_json_util(duthosts, dpuhosts, localhost, ptfhost, setup_gnmi_server, ha_owner)
     yield
-    deactivate_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi_server, ha_owner)
+    deactivate_dash_ha_from_json_util(duthosts, dpuhosts, localhost, ptfhost, setup_gnmi_server)
 
 
 @pytest.fixture(scope="function")

--- a/tests/ha/conftest.py
+++ b/tests/ha/conftest.py
@@ -224,6 +224,16 @@ def config_facts(duthost):
     return duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
 
 
+@pytest.fixture(scope="module")
+def primary_vdpu_key(dpuhosts):
+    return f"vdpu0_{dpuhosts[0].dpu_index}:haset0_0"
+
+
+@pytest.fixture(scope="module")
+def standby_vdpu_key(dpuhosts):
+    return f"vdpu1_{dpuhosts[1].dpu_index}:haset0_0"
+
+
 def get_intf_from_ip(local_ip, config_facts):
     for intf, config in list(config_facts["INTERFACE"].items()):
         for ip in config:
@@ -595,7 +605,7 @@ def remove_setup_dash_ha_from_json_util(duthosts, dpuhosts, localhost, ptfhost, 
             name = primary_vdpu_key
         elif name == "vdpu1_0:haset0_0":
             name = standby_vdpu_key
-    ha_scope_per_dut_modified.append((name, data))
+        ha_scope_per_dut_modified.append((name, data))
 
     for index, (name, data) in enumerate(ha_scope_per_dut_modified):
         # Update the 'owner' key in the dictionary

--- a/tests/ha/test_ha_dpu_process_crash.py
+++ b/tests/ha/test_ha_dpu_process_crash.py
@@ -42,9 +42,6 @@ HA_CHECK_INTERVAL = 5
 TRAFFIC_SEND_INTERVAL = 0.1
 PL_VERIFY_TIMEOUT = 10
 
-ACTIVE_SCOPE_KEY = "vdpu0_0:haset0_0"
-STANDBY_SCOPE_KEY = "vdpu1_0:haset0_0"
-
 MAX_TRAFFIC_LOSS_PCT = 5.0
 
 DPU_CRITICAL_PROCESSES = [
@@ -145,6 +142,16 @@ def standby_dpuhost(dpuhosts):
     return dpuhosts[1]
 
 
+@pytest.fixture(scope="module")
+def primary_vdpu_key(dpuhosts):
+    return f"vdpu0_{dpuhosts[0].dpu_index}:haset0_0"
+
+
+@pytest.fixture(scope="module")
+def standby_vdpu_key(dpuhosts):
+    return f"vdpu1_{dpuhosts[1].dpu_index}:haset0_0"
+
+
 class TestDpuProcessCrash:
 
     def _run(
@@ -225,10 +232,10 @@ class TestDpuProcessCrash:
         self._run(
             process_name=process_name, container=container,
             crash_dpuhost=primary_dpuhost, crash_duthost=primary_dut,
-            crash_scope_key=ACTIVE_SCOPE_KEY,
+            crash_scope_key=primary_vdpu_key,
             expected_ha_state_after_crash="active",
             verify_duthost=standby_dut,
-            verify_scope_key=STANDBY_SCOPE_KEY,
+            verify_scope_key=standby_vdpu_key,
             expected_ha_state_verify="active",
             ptfadapter=ptfadapter, dash_pl_config=dash_pl_config,
             traffic_dut_index=0,
@@ -237,7 +244,7 @@ class TestDpuProcessCrash:
     @pytest.mark.parametrize("process_name,container", DPU_CRITICAL_PROCESSES)
     def test_crash_active_dpu_traffic_on_standby(
         self, process_name, container,
-        primary_dut, standby_dut, primary_dpuhost,
+        primary_dut, standby_dut, primary_dpuhost, primary_vdpu_key, standby_vdpu_key,
         setup_ha_config, setup_gnmi_server, setup_dash_ha_from_json_func_scope, setup_dash_pl_pipeline,
         ptfadapter, dash_pl_config,
         activate_dash_ha_from_json,
@@ -245,10 +252,10 @@ class TestDpuProcessCrash:
         self._run(
             process_name=process_name, container=container,
             crash_dpuhost=primary_dpuhost, crash_duthost=primary_dut,
-            crash_scope_key=ACTIVE_SCOPE_KEY,
+            crash_scope_key=primary_vdpu_key,
             expected_ha_state_after_crash="active",
             verify_duthost=standby_dut,
-            verify_scope_key=STANDBY_SCOPE_KEY,
+            verify_scope_key=standby_vdpu_key,
             expected_ha_state_verify="active",
             ptfadapter=ptfadapter, dash_pl_config=dash_pl_config,
             traffic_dut_index=1,
@@ -257,7 +264,7 @@ class TestDpuProcessCrash:
     @pytest.mark.parametrize("process_name,container", DPU_CRITICAL_PROCESSES)
     def test_crash_standby_dpu_traffic_on_active(
         self, process_name, container,
-        primary_dut, standby_dut, standby_dpuhost,
+        primary_dut, standby_dut, standby_dpuhost, primary_vdpu_key, standby_vdpu_key,
         setup_ha_config, setup_gnmi_server, setup_dash_ha_from_json_func_scope, setup_dash_pl_pipeline,
         ptfadapter, dash_pl_config,
         activate_dash_ha_from_json,
@@ -265,10 +272,10 @@ class TestDpuProcessCrash:
         self._run(
             process_name=process_name, container=container,
             crash_dpuhost=standby_dpuhost, crash_duthost=standby_dut,
-            crash_scope_key=STANDBY_SCOPE_KEY,
+            crash_scope_key=standby_vdpu_key,
             expected_ha_state_after_crash="active",
             verify_duthost=primary_dut,
-            verify_scope_key=ACTIVE_SCOPE_KEY,
+            verify_scope_key=primary_vdpu_key,
             expected_ha_state_verify="active",
             ptfadapter=ptfadapter, dash_pl_config=dash_pl_config,
             traffic_dut_index=0,
@@ -277,7 +284,7 @@ class TestDpuProcessCrash:
     @pytest.mark.parametrize("process_name,container", DPU_CRITICAL_PROCESSES)
     def test_crash_standby_dpu_traffic_on_standby(
         self, process_name, container,
-        primary_dut, standby_dut, standby_dpuhost,
+        primary_dut, standby_dut, standby_dpuhost, primary_vdpu_key, standby_vdpu_key,
         setup_ha_config, setup_gnmi_server, setup_dash_ha_from_json_func_scope, setup_dash_pl_pipeline,
         ptfadapter, dash_pl_config,
         activate_dash_ha_from_json,
@@ -285,10 +292,10 @@ class TestDpuProcessCrash:
         self._run(
             process_name=process_name, container=container,
             crash_dpuhost=standby_dpuhost, crash_duthost=standby_dut,
-            crash_scope_key=STANDBY_SCOPE_KEY,
+            crash_scope_key=standby_vdpu_key,
             expected_ha_state_after_crash="active",
             verify_duthost=primary_dut,
-            verify_scope_key=ACTIVE_SCOPE_KEY,
+            verify_scope_key=primary_vdpu_key,
             expected_ha_state_verify="active",
             ptfadapter=ptfadapter, dash_pl_config=dash_pl_config,
             traffic_dut_index=1,

--- a/tests/ha/test_ha_dpu_process_crash.py
+++ b/tests/ha/test_ha_dpu_process_crash.py
@@ -142,16 +142,6 @@ def standby_dpuhost(dpuhosts):
     return dpuhosts[1]
 
 
-@pytest.fixture(scope="module")
-def primary_vdpu_key(dpuhosts):
-    return f"vdpu0_{dpuhosts[0].dpu_index}:haset0_0"
-
-
-@pytest.fixture(scope="module")
-def standby_vdpu_key(dpuhosts):
-    return f"vdpu1_{dpuhosts[1].dpu_index}:haset0_0"
-
-
 class TestDpuProcessCrash:
 
     def _run(
@@ -228,6 +218,8 @@ class TestDpuProcessCrash:
         setup_ha_config, setup_gnmi_server, setup_dash_ha_from_json_func_scope, setup_dash_pl_pipeline,
         ptfadapter, dash_pl_config,
         activate_dash_ha_from_json,
+        primary_vdpu_key,
+        standby_vdpu_key
     ):
         self._run(
             process_name=process_name, container=container,

--- a/tests/ha/test_ha_link_failure.py
+++ b/tests/ha/test_ha_link_failure.py
@@ -28,10 +28,10 @@ TRAFFIC_LOSS_DURATION = 2.0  # Up to 2s of allowable loss during link failure.
 RATE_PPS = 20  # packets per second
 
 
-def restore_ha_state(localhost, ptfhost, duthost):
+def restore_ha_state(localhost, ptfhost, duthost, standby_vdpu_key="vdpu1_0:haset0_0"):
     try:
-        set_dead_dash_ha_scope(localhost, duthost, ptfhost, "vdpu1_0:haset0_0")
-        activate_secondary_dash_ha(localhost, duthost, ptfhost, "vdpu1_0:haset0_0", "activate_role")
+        set_dead_dash_ha_scope(localhost, duthost, ptfhost, standby_vdpu_key)
+        activate_secondary_dash_ha(localhost, duthost, ptfhost, standby_vdpu_key, "activate_role")
     except Exception as e:
         logger.error(f"HA state restoration on {duthost.hostname} exception: {e}")
 
@@ -232,7 +232,8 @@ def test_ha_link_failure(
     else:
         remove_acl_link_drop(duthosts[0], dash_pl_config[0][NPU_DATAPLANE_PORT])
     # take system out of split-brain
-    restore_ha_state(localhost, ptfhost, duthosts[1])
+    standby_vdpu_key = f"vdpu1_{dpuhosts[1].dpu_index}:haset0_0"
+    restore_ha_state(localhost, ptfhost, duthosts[1], standby_vdpu_key=standby_vdpu_key)
 
     traffic = "traffic to standby" if traffic_to_standby else "traffic to primary"
     link_fail = "Standby link fail" if standby_link_fail else "Primary link fail"

--- a/tests/ha/test_ha_npu_process_crash.py
+++ b/tests/ha/test_ha_npu_process_crash.py
@@ -46,8 +46,6 @@ HA_CHECK_INTERVAL = 5
 TRAFFIC_SEND_INTERVAL = 0.1
 PL_VERIFY_TIMEOUT = 10
 
-ACTIVE_SCOPE_KEY = "vdpu0_0:haset0_0"
-STANDBY_SCOPE_KEY = "vdpu1_0:haset0_0"
 
 # Processes whose containers must be fully restarted for recovery because
 # dependent-startup injects required runtime arguments (e.g. --slot-id).
@@ -202,6 +200,16 @@ def primary_dut(duthosts):
 @pytest.fixture(scope="module")
 def standby_dut(duthosts):
     return duthosts[1]
+
+
+@pytest.fixture(scope="module")
+def primary_vdpu_key(dpuhosts):
+    return f"vdpu0_{dpuhosts[0].dpu_index}:haset0_0"
+
+
+@pytest.fixture(scope="module")
+def standby_vdpu_key(dpuhosts):
+    return f"vdpu1_{dpuhosts[1].dpu_index}:haset0_0"
 
 
 class TestNpuProcessCrash:
@@ -465,10 +473,10 @@ class TestNpuProcessCrash:
         self._run(
             process_name=process_name, container=container,
             crash_duthost=primary_dut,
-            crash_scope_key=ACTIVE_SCOPE_KEY,
+            crash_scope_key=primary_vdpu_key,
             expected_ha_state_after_crash="active",
             verify_duthost=standby_dut,
-            verify_scope_key=STANDBY_SCOPE_KEY,
+            verify_scope_key=standby_vdpu_key,
             expected_ha_state_verify="active",
             ptfadapter=ptfadapter, dash_pl_config=dash_pl_config,
             traffic_dut_index=0, duthosts=duthosts,
@@ -478,7 +486,7 @@ class TestNpuProcessCrash:
     @pytest.mark.parametrize("process_name,container", NPU_CRITICAL_PROCESSES)
     def test_crash_active_npu_traffic_on_standby(
         self, process_name, container,
-        primary_dut, standby_dut, duthosts,
+        primary_dut, standby_dut, primary_vdpu_key, standby_vdpu_key, duthosts,
         setup_ha_config, setup_dash_ha_from_json,
         setup_gnmi_server, setup_dash_pl_pipeline_module_scope,
         ptfadapter, dash_pl_config,
@@ -488,10 +496,10 @@ class TestNpuProcessCrash:
         self._run(
             process_name=process_name, container=container,
             crash_duthost=primary_dut,
-            crash_scope_key=ACTIVE_SCOPE_KEY,
+            crash_scope_key=primary_vdpu_key,
             expected_ha_state_after_crash="active",
             verify_duthost=standby_dut,
-            verify_scope_key=STANDBY_SCOPE_KEY,
+            verify_scope_key=standby_vdpu_key,
             expected_ha_state_verify="active",
             ptfadapter=ptfadapter, dash_pl_config=dash_pl_config,
             traffic_dut_index=1, duthosts=duthosts,
@@ -501,7 +509,7 @@ class TestNpuProcessCrash:
     @pytest.mark.parametrize("process_name,container", NPU_CRITICAL_PROCESSES)
     def test_crash_standby_npu_traffic_on_active(
         self, process_name, container,
-        primary_dut, standby_dut, duthosts,
+        primary_dut, standby_dut, primary_vdpu_key, standby_vdpu_key, duthosts,
         setup_ha_config, setup_dash_ha_from_json,
         setup_gnmi_server, setup_dash_pl_pipeline_module_scope,
         ptfadapter, dash_pl_config,
@@ -511,10 +519,10 @@ class TestNpuProcessCrash:
         self._run(
             process_name=process_name, container=container,
             crash_duthost=standby_dut,
-            crash_scope_key=STANDBY_SCOPE_KEY,
+            crash_scope_key=standby_vdpu_key,
             expected_ha_state_after_crash="active",
             verify_duthost=primary_dut,
-            verify_scope_key=ACTIVE_SCOPE_KEY,
+            verify_scope_key=primary_vdpu_key,
             expected_ha_state_verify="active",
             ptfadapter=ptfadapter, dash_pl_config=dash_pl_config,
             traffic_dut_index=0, duthosts=duthosts,
@@ -524,7 +532,7 @@ class TestNpuProcessCrash:
     @pytest.mark.parametrize("process_name,container", NPU_CRITICAL_PROCESSES)
     def test_crash_standby_npu_traffic_on_standby(
         self, process_name, container,
-        primary_dut, standby_dut, duthosts,
+        primary_dut, standby_dut, primary_vdpu_key, standby_vdpu_key, duthosts,
         setup_ha_config, setup_dash_ha_from_json,
         setup_gnmi_server, setup_dash_pl_pipeline_module_scope,
         ptfadapter, dash_pl_config,
@@ -534,10 +542,10 @@ class TestNpuProcessCrash:
         self._run(
             process_name=process_name, container=container,
             crash_duthost=standby_dut,
-            crash_scope_key=STANDBY_SCOPE_KEY,
+            crash_scope_key=standby_vdpu_key,
             expected_ha_state_after_crash="active",
             verify_duthost=primary_dut,
-            verify_scope_key=ACTIVE_SCOPE_KEY,
+            verify_scope_key=primary_vdpu_key,
             expected_ha_state_verify="active",
             ptfadapter=ptfadapter, dash_pl_config=dash_pl_config,
             traffic_dut_index=1, duthosts=duthosts,

--- a/tests/ha/test_ha_npu_process_crash.py
+++ b/tests/ha/test_ha_npu_process_crash.py
@@ -202,16 +202,6 @@ def standby_dut(duthosts):
     return duthosts[1]
 
 
-@pytest.fixture(scope="module")
-def primary_vdpu_key(dpuhosts):
-    return f"vdpu0_{dpuhosts[0].dpu_index}:haset0_0"
-
-
-@pytest.fixture(scope="module")
-def standby_vdpu_key(dpuhosts):
-    return f"vdpu1_{dpuhosts[1].dpu_index}:haset0_0"
-
-
 class TestNpuProcessCrash:
 
     def _run(
@@ -469,6 +459,8 @@ class TestNpuProcessCrash:
         ptfadapter, dash_pl_config,
         localhost, ptfhost,
         activate_dash_ha_from_json,
+        primary_vdpu_key,
+        standby_vdpu_key
     ):
         self._run(
             process_name=process_name, container=container,

--- a/tests/ha/test_ha_planned_shutdown.py
+++ b/tests/ha/test_ha_planned_shutdown.py
@@ -89,6 +89,7 @@ def test_ha_planned_shutdown(
     ptfadapter,
     localhost,
     duthosts,
+    dpuhosts,
     ptfhost,
     activate_dash_ha_from_json,
     ha_owner,
@@ -98,6 +99,9 @@ def test_ha_planned_shutdown(
     rate_pps = 10  # packets per second
     initial_send_count = 10
     delay = 1.0 / rate_pps
+
+    primary_vdpu_key = f"vdpu0_{dpuhosts[0].dpu_index}:haset0_0"
+    standby_vdpu_key = f"vdpu1_{dpuhosts[1].dpu_index}:haset0_0"
 
     vm_to_dpu_pkt, exp_dpu_to_pe_pkt = outbound_pl_packets(dash_pl_config[0], encap_proto)
     rcv_outbound_pl_ports = dash_pl_config[0][REMOTE_PTF_RECV_INTF] + dash_pl_config[1][REMOTE_PTF_RECV_INTF]
@@ -109,7 +113,7 @@ def test_ha_planned_shutdown(
         while packet_sending_flag.empty() or (not packet_sending_flag.get()):
             time.sleep(0.2)
         logging.info("Set primary to dead")
-        set_dead_dash_ha_scope(localhost, duthosts[0], ptfhost, "vdpu0_0:haset0_0")
+        set_dead_dash_ha_scope(localhost, duthosts[0], ptfhost, primary_vdpu_key)
 
     t = threading.Thread(target=primary_ha_action, name="primary_ha_action_thread")
     t.start()
@@ -136,16 +140,15 @@ def test_ha_planned_shutdown(
     t.join()
     time.sleep(2)
 
-    pytest_assert(verify_ha_state(duthosts[0], "vdpu0_0:haset0_0", "dead"),
+    pytest_assert(verify_ha_state(duthosts[0], primary_vdpu_key, "dead"),
                   "Primary HA state is not dead")
-    pytest_assert(verify_ha_state(duthosts[1], "vdpu1_0:haset0_0", "standalone"),
-                  "Secondary HA state is not standalone")
+    pytest_assert(verify_ha_state(duthosts[1], standby_vdpu_key, "standalone"),
+                  "Standby HA state is not standalone")
 
     logging.info("Primary shutdown all {} packets received".format(send_count))
 
     # Re-activate primary
-    pytest_assert(activate_primary_dash_ha(localhost, duthosts[0], ptfhost, "vdpu0_0:haset0_0", "activate_role",
-                                           owner=ha_owner),
+    pytest_assert(activate_primary_dash_ha(localhost, duthosts[0], ptfhost, primary_vdpu_key, "activate_role"),
                   "Failed to re-activate HA on primary")
 
     packet_sending_flag = queue.Queue(1)
@@ -155,7 +158,7 @@ def test_ha_planned_shutdown(
         while packet_sending_flag.empty() or (not packet_sending_flag.get()):
             time.sleep(0.2)
         logging.info("Set standby to dead")
-        set_dead_dash_ha_scope(localhost, duthosts[1], ptfhost, "vdpu1_0:haset0_0")
+        set_dead_dash_ha_scope(localhost, duthosts[1], ptfhost, standby_vdpu_key)
 
     t = threading.Thread(target=standby_ha_action, name="standby_ha_action_thread")
     t.start()
@@ -181,14 +184,13 @@ def test_ha_planned_shutdown(
     t.join()
     time.sleep(2)
 
-    pytest_assert(verify_ha_state(duthosts[1], "vdpu1_0:haset0_0", "dead"),
-                  "Secondary HA state is not dead")
-    pytest_assert(verify_ha_state(duthosts[0], "vdpu0_0:haset0_0", "standalone"),
+    pytest_assert(verify_ha_state(duthosts[1], standby_vdpu_key, "dead"),
+                  "Standby HA state is not dead")
+    pytest_assert(verify_ha_state(duthosts[0], primary_vdpu_key, "standalone"),
                   "Primary HA state is not standalone")
 
     logging.info("standby shutdown all {} packets received".format(send_count))
 
     # Re-activate standby
-    pytest_assert(activate_secondary_dash_ha(localhost, duthosts[1], ptfhost, "vdpu1_0:haset0_0", "activate_role",
-                                             owner=ha_owner),
-                  "Failed to re-activate HA on standby")
+    pytest_assert(activate_secondary_dash_ha(localhost, duthosts[1], ptfhost, standby_vdpu_key, "activate_role",
+                                             owner=ha_owner), "Failed to re-activate HA on standby")

--- a/tests/ha/test_ha_planned_shutdown.py
+++ b/tests/ha/test_ha_planned_shutdown.py
@@ -93,15 +93,14 @@ def test_ha_planned_shutdown(
     ptfhost,
     activate_dash_ha_from_json,
     ha_owner,
-    dash_pl_config
+    dash_pl_config,
+    primary_vdpu_key,
+    standby_vdpu_key
 ):
     encap_proto = "vxlan"
     rate_pps = 10  # packets per second
     initial_send_count = 10
     delay = 1.0 / rate_pps
-
-    primary_vdpu_key = f"vdpu0_{dpuhosts[0].dpu_index}:haset0_0"
-    standby_vdpu_key = f"vdpu1_{dpuhosts[1].dpu_index}:haset0_0"
 
     vm_to_dpu_pkt, exp_dpu_to_pe_pkt = outbound_pl_packets(dash_pl_config[0], encap_proto)
     rcv_outbound_pl_ports = dash_pl_config[0][REMOTE_PTF_RECV_INTF] + dash_pl_config[1][REMOTE_PTF_RECV_INTF]

--- a/tests/ha/test_ha_reconfigure.py
+++ b/tests/ha/test_ha_reconfigure.py
@@ -17,15 +17,16 @@ The fixture parameters will configure HA and test will start by doing a deconfig
 """
 
 
-def test_ha_reconfigure(request, duthosts, localhost, ptfhost, setup_ha_config,
+def test_ha_reconfigure(request, duthosts, localhost, dpuhosts, ptfhost, setup_ha_config,
                         setup_dash_ha_from_json, activate_dash_ha_from_json, ha_owner):
 
     for i in range(NUM_RECONFIGS):
-        logger.info("Deconfigure HA")
-        deactivate_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi_server, ha_owner)
-        remove_setup_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi_server, ha_owner)
+        iter = i + 1
+        logger.info(f"HA: deconfigure iteration {iter}")
+        deactivate_dash_ha_from_json_util(duthosts, dpuhosts, localhost, ptfhost, setup_gnmi_server)
+        remove_setup_dash_ha_from_json_util(duthosts, dpuhosts, localhost, ptfhost, setup_gnmi_server, ha_owner)
 
         # Reconfigure HA to verify that configuration was removed properly
-        logger.info("Reconfigure HA")
-        setup_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi_server, ha_owner)
-        activate_dash_ha_from_json_util(duthosts, localhost, ptfhost, setup_gnmi_server, ha_owner)
+        logger.info(f"HA: reconfigure iteration {iter}")
+        setup_dash_ha_from_json_util(duthosts, dpuhosts, localhost, ptfhost, setup_gnmi_server, ha_owner)
+        activate_dash_ha_from_json_util(duthosts, dpuhosts, localhost, ptfhost, setup_gnmi_server, ha_owner)


### PR DESCRIPTION
### Description of PR
Summary:
Currently all the HA tests are run with DUT0-DPU0 as primary and DUT1-DPU0 as standby. 
This change will allow running any combination of primary and standby for all the HA tests.
For example you can have DUT0-DPU2 as primary and DUT1-DPU3 as standby.


### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The primary and standby DPUs are currently hardcoded to be DUT0-DPU0 and DU1-DPU0. We need to be able to test any pair of DPUs in the HA topology.

#### How did you do it?
Modified the infra and HA tests to allow for any DPU pair.

#### How did you verify/test it?
I run the following 2 tests:
1 passed, 689 warnings in 1071.61s (0:17:86)
tests.ha.test_ha_planned_shutdown" name="test_ha_planned_shutdown" time="1071.615"

1 passed, 689 warnings in 864.40s (0:14:24)
tests.ha.test_ha_reconfigure" name="test_ha_reconfigure" time="856.378"

#### Any platform specific information?
Smartswitch

#### Supported testbed topology if it's a new test case?
HA topology

### Documentation
N/A
