### PR TITLE
[bgp] Fix test_bgp_peer_shutdown to filter outgoing notification packets

### DIFF
--- a/tests/bgp/test_bgp_peer_shutdown.py
+++ b/tests/bgp/test_bgp_peer_shutdown.py
@@ -7,6 +7,7 @@ import time
 import pytest
 from scapy.all import sniff, IP, IPv6
 from scapy.contrib import bgp
+from scapy.layers.l2 import CookedLinux
 
 from tests.bgp.bgp_helpers import capture_bgp_packages_to_file, fetch_and_delete_pcap_file
 from tests.common.errors import RunAnsibleModuleFail
@@ -135,11 +136,20 @@ def is_neighbor_session_established(duthost, neighbor):
 
 
 def bgp_notification_packets(pcap_file, is_v6_topo):
-    """Get bgp notification packets from pcap file."""
+    """Get incoming bgp notification packets from pcap file.
+
+    When tcpdump captures on the 'any' interface with LINUX_SLL link type,
+    each packet has a CookedLinux header with a pkttype field indicating
+    direction. Filter out outgoing packets (pkttype == 4, 'sent-by-us')
+    so only incoming notifications are validated.
+    """
     ip_ver = IPv6 if is_v6_topo else IP
     packets = sniff(
         offline=pcap_file,
-        lfilter=lambda p: ip_ver in p and bgp.BGPHeader in p and p[bgp.BGPHeader].type == 3,
+        lfilter=lambda p: (ip_ver in p and
+                           bgp.BGPHeader in p and
+                           p[bgp.BGPHeader].type == 3 and
+                           not (CookedLinux in p and p[CookedLinux].pkttype == 4)),
     )
     return packets
 
@@ -152,12 +162,9 @@ def match_bgp_notification(packet, src_ip, dst_ip, action, bgp_session_down_time
 
     bgp_fields = packet[bgp.BGPNotification].fields
     if action == "cease":
-        # error_code 6: Cease. References: RFC 4271
-        # error_subcode 3: Peer De-configured — expected during admin shutdown
-        # error_subcode 7: Connection Collision Resolution — may occur transiently
-        #   if FRR attempts to reconnect while the old session is still clearing
+        # error_code 6: Cease, error_subcode 3: Peer De-configured. References: RFC 4271
         return (bgp_fields["error_code"] == 6 and
-                bgp_fields["error_subcode"] in (3, 7) and
+                bgp_fields["error_subcode"] == 3 and
                 (bgp_session_down_time is None or float(packet.time) < bgp_session_down_time))
     else:
         return False


### PR DESCRIPTION
### What this PR does

Fixes intermittent `test_bgp_peer_shutdown` failures caused by outgoing BGP NOTIFICATION packets being captured and incorrectly validated. Also restores the strict `subcode == 3` check since the direction filter properly addresses the root cause.

### Root Cause

`capture_bgp_packages_to_file()` uses `tcpdump -y LINUX_SLL -i any`, which captures **both incoming and outgoing** BGP packets. During peer shutdown, the DUT may send its own outgoing BGP NOTIFICATION (e.g., Cease/Connection Collision Resolution, subcode 7) in addition to receiving the expected incoming Cease/Peer De-configured (subcode 3) from the PTF peer. This can happen on any FRR version — e.g., during collision detection, hold timer expiry, or session clearing races —

The failure path:
1. `bgp_notification_packets()` returns all notifications (both directions) with no direction filter
2. The test loop calls `pytest.fail()` on any non-matching packet
3. `match_bgp_notification()` checks `src_ip == n0.ip (PTF)` — the outgoing packet has `src=DUT`, so IPs are reversed → returns `False`
4. `pytest.fail("BGP notification packet does not match expected values")`


### Changes

- **`bgp_notification_packets()`**: Added a `CookedLinux` pkttype filter to exclude outgoing packets (`pkttype == 4`, "sent-by-us"). When tcpdump captures with LINUX_SLL link type, each packet carries a CookedLinux header indicating direction. The filter uses `not (CookedLinux in p and p[CookedLinux].pkttype == 4)` — safe no-op if the header is absent.
- **`match_bgp_notification()`**: Restored strict `error_subcode == 3` check. With outgoing packets properly filtered, the test should only see incoming Cease/Peer De-configured (subcode 3) notifications from the PTF peer — which is the test's original intent.

### How to verify

1. Run `test_bgp_peer_shutdown` on any T0/T1 topology — should no longer fail intermittently on outgoing notifications
2. Backward-compatible: on captures without CookedLinux headers (non-`any` interface), the filter is a no-op and all packets pass through as before