### PR TITLE
[dhcp_relay] Fix message-type parsing to handle scapy DHCP option pad/end markers

### DIFF
--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -193,9 +193,13 @@ def calculate_counters_per_pkts(pkts, is_v6=False):
                 elif scapy.DHCP6_RelayReply in pkt:
                     message_type_int = pkt[scapy.DHCP6_RelayReply].msgtype  # Relay-Reply
             else:
-                for opt, val in pkt[scapy.DHCP].options:
-                    if opt == "message-type":
-                        message_type_int = val
+                for message_type_value in pkt[scapy.DHCP].options:
+                    if message_type_value[0] == 'message-type':
+                        message_type_int = message_type_value[1]
+                        # Get the message type value and convert it to an integer
+                        break
+                else:
+                    continue
             message_type_str = (SUPPORTED_DHCPV6_TYPE if is_v6 else SUPPORTED_DHCPV4_TYPE)[message_type_int - 1] \
                 if message_type_int is not None and message_type_int > 0 else "Unknown"
             sport = pkt[scapy.UDP].sport if pkt.haslayer(scapy.UDP) else None


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

 scapy's `pkt[scapy.DHCP].options` list ends with bare-string markers like `"end"` and `"pad"` (not `(opt, val)` tuples). The previous loop:
 
 ```python
 for opt, val in pkt[scapy.DHCP].options:
```

unpacks each entry as a 2-tuple, which raises ValueError the moment iteration reaches one of these padding strings. The exception aborts the whole calculate_counters_per_pkts call, leaving DHCP RX/TX counters miscounted in dhcp_relay tests.

Switch to indexing (message_type_value[0] / [1]) with an explicit equality check on 'message-type', plus a for ... else: continue so packets with no message-type option (or only pad/end entries) are skipped cleanly instead of inheriting a stale value from the previous packet.

Fixes counter mismatches in test_dhcp_counter_stress and similar tests.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

scapy includes pad/end byte markers as plain strings at the tail of pkt[scapy.DHCP].options. The existing 2-tuple unpack for opt, val in ... raises ValueError on those strings, which propagates out of calculate_counters_per_pkts and aborts counter calculation entirely. Downstream dhcp_relay tests then fail with confusing "actual vs expected" counter
mismatches that are not actually relay bugs — they are a parsing bug in the test utility.

Additionally, when a packet has no message-type option at all, the loop would silently leave message_type_int set to whatever value the previous iteration left in scope, double-counting the previous packet's type.

#### How did you do it?

 - Replaced the 2-tuple unpack with index access (message_type_value[0] / message_type_value[1]) so pad/end string entries no longer trigger ValueError.
 - Added an explicit break once message-type is found, paired with a for ... else: continue so packets with no message-type option are skipped cleanly instead of inheriting the previous packet's message_type_int.

#### How did you verify/test it?

 On `bjw2-can-720dt-4` (newer scapy), reran the previously failing dhcp_relay counter-stress suite — counters now match expected values.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
