### PR TITLE
[dhcp_relay] Skip test_dhcp_relay_on_dualtor_standby on non-dualtor t…

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1117,6 +1117,12 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_monitor_checksum_validation:
     conditions:
       - "https://github.com/sonic-net/sonic-buildimage/issues/24402 and asic_type in ['mellanox', 'nvidia']"
 
+dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_on_dualtor_standby:
+  skip:
+    reason: "Test requires dualtor topology (uses rand_unselected_dut which returns None on non-dualtor)"
+    conditions:
+      - "'dualtor' not in topo_name"
+
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_random_sport:
   skip:
     reason: "Skip test_dhcp_relay_random_sport on dualtor in 201811 and 201911 or platform x86_64-8111_32eh_o-r0"


### PR DESCRIPTION
…opologies

The test was added in #19198 and uses the rand_unselected_dut fixture, which returns None on non-dualtor testbeds. The test does not guard against this and calls restart_dhcpmon_in_debug(standby_duthost) unconditionally, leading to:

    AttributeError: 'NoneType' object has no attribute 'shell'

on every t0/m0 testbed that is not dualtor. Add a conditional_mark entry to skip the test when topo_name does not contain 'dualtor'.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

 Add a `conditional_mark` entry that skips `dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_on_dualtor_standby` when the testbed's `topo_name` does not contain `'dualtor'`.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

 `test_dhcp_relay_on_dualtor_standby` was added in #19198. It uses the `rand_unselected_dut` fixture, which returns `None` on non-dualtor testbeds. The test body does not guard against this and calls `restart_dhcpmon_in_debug(standby_duthost)` unconditionally, producing:
 
 ```
 File "tests/dhcp_relay/test_dhcp_relay.py", line 667, in test_dhcp_relay_on_dualtor_standby
     restart_dhcpmon_in_debug(standby_duthost)
 File "tests/dhcp_relay/test_dhcp_relay.py", line 170, in restart_dhcpmon_in_debug
     program_list = duthost.shell("ps aux | grep {}".format(program_name))
 AttributeError: 'NoneType' object has no attribute 'shell'
 ```
 
 This happens on every `t0`/`m0` testbed that is not dualtor (the module-level `pytestmark = pytest.mark.topology('t0', 'm0')` does not narrow it to dualtor only).

#### How did you do it?
 
 Added the following block in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` (placed alphabetically between `test_dhcp_relay_monitor_checksum_validation` and `test_dhcp_relay_random_sport`):
 
 ```yaml
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_on_dualtor_standby:
   skip:
     reason: "Test requires dualtor topology (uses rand_unselected_dut which returns None on non-dualtor)"
     conditions:
       - "'dualtor' not in topo_name"
 ```
 
 This pattern matches existing entries that gate dualtor-only tests, e.g. `dualtor_io/test_grpc_server_failure.py`.
 
 The skip applies to both `[isc-relay-agent]` and `[sonic-relay-agent]` parametrizations because the rule targets the test ID prefix.

#### How did you verify/test it?

 - Reproduced the failure today on `testbed-bjw2-can-720dt-4` (`t0-standalone-128`) — both `[isc-relay-agent]` and `[sonic-relay-agent]` instances fail with the `AttributeError` above.
 - Confirmed `'dualtor' not in topo_name` evaluates `True` for `t0-standalone-128` (and other non-dualtor t0/m0 topos), and `False` for dualtor / dualtor-aa / dualtor-mixed, so the test continues to run on intended topologies.
 - The pre-commit hook `check conditional mark sort` passes, confirming the entry is in the correct alphabetical position.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
