### PR TITLE
[kubesonic]: Fix teardown not disabling ctrmgrd after failed k8s join

### DIFF
--- a/tests/kubesonic/test_k8s_join_disjoin.py
+++ b/tests/kubesonic/test_k8s_join_disjoin.py
@@ -375,10 +375,10 @@ def setup_and_teardown(duthost, vmhost, creds):
 
     yield
 
-    # Ensure the DUT is disjoined so ctrmgrd restores locally-managed container
-    # states (restapi, swss, syncd, etc.) that were disabled during k8s join
-    # preparation. Without this, a failed join leaves containers permanently
-    # disabled for all subsequent tests on the device.
+    # Disable ctrmgrd k8s retry loop after a failed join. Without this,
+    # ctrmgrd retries indefinitely in the background and emits ERR log lines
+    # into subsequent tests' LogAnalyzer windows, causing false failures
+    # (e.g., test_snmp_queues sees match:2, expected:0 in teardown).
     # This is idempotent: calling 'disable on' when already disjoined is a no-op.
     duthost.shell("sudo config kube server disable on", module_ignore_errors=True)
     time.sleep(5)

--- a/tests/kubesonic/test_k8s_join_disjoin.py
+++ b/tests/kubesonic/test_k8s_join_disjoin.py
@@ -375,6 +375,14 @@ def setup_and_teardown(duthost, vmhost, creds):
 
     yield
 
+    # Ensure the DUT is disjoined so ctrmgrd restores locally-managed container
+    # states (restapi, swss, syncd, etc.) that were disabled during k8s join
+    # preparation. Without this, a failed join leaves containers permanently
+    # disabled for all subsequent tests on the device.
+    # This is idempotent: calling 'disable on' when already disjoined is a no-op.
+    duthost.shell("sudo config kube server disable on", module_ignore_errors=True)
+    time.sleep(5)
+
     # Clean up the k8s table in configdb
     clean_configdb_k8s_table(duthost)
 


### PR DESCRIPTION
### Description of PR

**Summary:** Fix `test_kubesonic_join_and_disjoin` teardown not calling `config kube server disable on` after a failed k8s join. This leaves `ctrmgrd` continuously retrying the failed join and emitting `ERR` log lines into the next test's LogAnalyzer window → unrelated tests (e.g., `test_snmp_queues`) fail with `LogAnalyzer: unexpected matches found`.

Fixes ADO PBI: https://msazure.visualstudio.com/One/_workitems/edit/37659260

---

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework (new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

---

### Approach

#### What is the motivation for this PR?

When `test_kubesonic_join_and_disjoin` fails to join the DUT to the k8s cluster, the teardown did not call `config kube server disable on`. This leaves `ctrmgrd` in an active k8s-join state, causing downstream syslog pollution:

After the failed join, `ctrmgrd` continues processing k8s join artifacts and emitting `ERR` log lines into `/var/log/syslog`. These lines fall inside the **next test's** LogAnalyzer window, causing a false failure:

```
LogAnalyzer: Found 2 unexpected matches (expected 0)
ERR ctrmgrd.py: Refer file /tmp/tmpeel28qb6kube_hints_ for troubleshooting
ERR ctrmgrd.py: [WARNING SystemVerification]: Docker 28.2.2 not validated ...
```

**Root cause chain:**
original elastic job link: https://elastictest.org/scheduler/testplan/69e79fb88e43924279229609?leftSideViewMode=detail&prop=start_time&order=ascending&testcase=snmp%2Ftest_snmp_queue.py&type=console

| Step | What happens |
|---|---|
| `test_kubesonic_join_and_disjoin` fails (4×) | ctrmgrd left in active k8s-join retry loop |
| Teardown exits without `disable on` | ctrmgrd keeps retrying and emitting `ERR` lines |
| Next test (`test_snmp_queues`) starts | LogAnalyzer window opens |
| ctrmgrd ERR lines appear at 00:08:08 | Match:2 inside LogAnalyzer window (00:07:28–00:09:30) |
| LogAnalyzer reports unexpected matches | ❌ `test_snmp_queues` teardown FAIL |

#### How did you fix it?

Add `sudo config kube server disable on` + `time.sleep(5)` in teardown **before** `clean_configdb_k8s_table`:

```python
duthost.shell("sudo config kube server disable on", module_ignore_errors=True)
time.sleep(5)
```

- `disable on` signals ctrmgrd to abort any pending k8s operations and stop retrying.
- `time.sleep(5)` allows ctrmgrd to fully settle before the next test starts — preventing syslog `ERR` lines from bleeding into downstream LogAnalyzer windows.
- `module_ignore_errors=True` makes this idempotent: calling `disable on` when already disjoined is a no-op and will not fail.

#### How did you verify/test it?

**Verify elastic jobs** (branch: `dev/xuliping/20260426_fix_kubesonic_teardown_internal-202511`, image: `internal-202511`, cases: `kubesonic/test_k8s_join_disjoin.py` + `snmp/test_snmp_queue.py`):

| Testbed | Plan ID |
|---------|---------|
| testbed-bjw2-can-t0-4600c-5 | [69ee0a80275c1d63b55184e6](https://elastictest.org/scheduler/testplan/69ee0a80275c1d63b55184e6) |
| testbed-bjw-can-4600c-1 | [69ee0a892ecee1601aca17c9](https://elastictest.org/scheduler/testplan/69ee0a892ecee1601aca17c9) |
| vms20-rdma-t1-sn2700 | [69ee0a911f6d9ccadfb46335](https://elastictest.org/scheduler/testplan/69ee0a911f6d9ccadfb46335) |
| ptp-robot-sn2700-1 | [69ee0a9d678eea40b1d99cff](https://elastictest.org/scheduler/testplan/69ee0a9d678eea40b1d99cff) |
| vms20-rdma-t0-msn2700 | [69ee0aa82ecee1601aca17cb](https://elastictest.org/scheduler/testplan/69ee0aa82ecee1601aca17cb) |
| tbtk5-t0-2700-4 | [69ee0ab00aae266263d65616](https://elastictest.org/scheduler/testplan/69ee0ab00aae266263d65616) |
| tbtk5-t0-2700-3 | [69ee0aba0aae266263d65618](https://elastictest.org/scheduler/testplan/69ee0aba0aae266263d65618) |
| vms21-t0-2700 | [69ee0ac4275c1d63b55184e8](https://elastictest.org/scheduler/testplan/69ee0ac4275c1d63b55184e8) |

#### Platform-specific information

Tested on Mellanox 4600c. The fix applies to **any platform** where `ctrmgrd` manages container ownership via the `FEATURE` table in ConfigDB.

### Documentation

N/A