### PR TITLE
Fixed test_check_sfp_eeprom.py to work with XODIN cables.

### DIFF
--- a/tests/platform_tests/mellanox/util.py
+++ b/tests/platform_tests/mellanox/util.py
@@ -1,6 +1,9 @@
 import re
 import logging
 
+# Known vendor pn's that does not support Channel Monitor values.
+CHANNEL_MONITOR_DISABLED_VENDOR_PNS = {"980-9IAM2-00X001", "980-9IAM1-00X001", "NMA4OPT-XRJALMU0"}
+
 
 def check_sfp_eeprom_info(duthost, sfp_eeprom_info, is_support_dom, show_eeprom_cmd, is_flat_memory):
     """
@@ -43,6 +46,11 @@ def check_sfp_eeprom_info(duthost, sfp_eeprom_info, is_support_dom, show_eeprom_
         excluded_keys = excluded_keys | {"ChannelMonitorValues", "ChannelThresholdValues", "ModuleMonitorValues",
                                          "ModuleThresholdValues", "MonitorData", "ThresholdData"}
         expected_keys = expected_keys - excluded_keys
+
+    vendor_pn = (sfp_eeprom_info.get("Vendor PN", "") or "").strip().upper()
+    if vendor_pn in CHANNEL_MONITOR_DISABLED_VENDOR_PNS:
+        excluded_keys = excluded_keys | {"ChannelMonitorValues"}
+        expected_keys = expected_keys - {"ChannelMonitorValues"}
 
     for key in expected_keys:
         assert key in sfp_eeprom_info, "key {} doesn't exist in {}".format(
@@ -119,12 +127,13 @@ def check_sfp_eeprom_info(duthost, sfp_eeprom_info, is_support_dom, show_eeprom_
                 check_dom_monitor_key_and_data_format(expected_module_threshold_values_keys_and_value_pattern,
                                                       sfp_eeprom_info["ModuleThresholdValues"])
 
-            logging.info(
-                "Check if ChannelMonitorValues's value format is correct")
-            for k, v in list(sfp_eeprom_info["ChannelMonitorValues"].items()):
-                pattern = pattern_power if "Power" in k else pattern_bias
-                assert re.match(
-                    pattern, v), "Value of {}:{} format is not correct. pattern is {}".format(k, v, pattern)
+            if "ChannelMonitorValues" not in excluded_keys:
+                logging.info(
+                    "Check if ChannelMonitorValues's value format is correct")
+                for k, v in list(sfp_eeprom_info["ChannelMonitorValues"].items()):
+                    pattern = pattern_power if "Power" in k else pattern_bias
+                    assert re.match(
+                        pattern, v), "Value of {}:{} format is not correct. pattern is {}".format(k, v, pattern)
 
             logging.info(
                 "Check ModuleMonitorValues keys exist and the corresponding value format is correct")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->

### Description of PR

There is a bug in **EEPROM verification** in `sonic-mgmt/tests/platform_tests/mellanox/util.py` that affects ports connected with active cables that do not support showing Tx/Rx optical power.  
When running `test_check_sfp_eeprom.py`, ports using such cables cause the test to fail because the code attempts to read **ChannelMonitorValues** (Tx/Rx optical power) from the EEPROM output.

XODIN active copper cables are a special case:
- They are **non–flat memory** and support reading **temperature**.
- They **do not** support reading **Tx/Rx optical power**.

The existing logic treats all non–flat memory modules as if ChannelMonitorValues are available. For the affected XODIN cables this leads to a failed read and the test terminates with an error instead of passing or cleanly skipping the unsupported checks.

This PR adds special-case handling for a **known list of tested XODIN cables**: when the module’s **vendor part number** is one of  
`{"980-9IAM2-00X001", "980-9IAM1-00X001", "NMA4OPT-XRJALMU0"}`, the code **skips ChannelMonitorValues checks** while leaving the existing behavior unchanged for all other modules.

Summary:
Fixes: N/A — no external issue was filed because the affected XODIN cables are not used in Microsoft testbeds.

---

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix  
- [ ] Testbed and Framework(new/improvement)  
- [ ] New Test case  
    - [ ] Skipped for non-supported platforms  
- [x] Test case improvement  

---

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A — there is no corresponding Microsoft ADO issue because the affected XODIN cables are not used in Microsoft testbeds.

Failure type: Other — platform test false failure for XODIN active copper cables that do not support `ChannelMonitorValues`.

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- 202605: 202605_RC.55-aa693d196f_Internal — **PASS**. `test_check_sfp_eeprom.py` passed with the proposed change on a Mellanox testbed containing affected XODIN active copper cables. The test skipped unsupported `ChannelMonitorValues` checks for the listed XODIN vendor part numbers, while EEPROM validation continued successfully for the remaining optics and cables. Evidence: [Allure report](https://allure.nvidia.com/allure-docker-service/projects/sonic-slm-60-platform-tests-mellanox-test-check-sfp-eeprom-py/reports/52/index.html#suites/f679e7122dc1fb1b76fbc484eb0933ee/4b06d2d4a5de3b2c/)

### Approach

#### What is the motivation for this PR?

To **fix EEPROM verification for a known set of XODIN cables** and restore stability of `test_check_sfp_eeprom.py` on Mellanox platforms where some ports are connected using these cables.  
Without this fix, any DUT with such XODIN-connected ports fails the test due to unsupported ChannelMonitorValues access, even though the hardware is behaving correctly.

#### How did you do it?

- Updated `sonic-mgmt/tests/platform_tests/mellanox/util.py` to treat certain XODIN cables specially based on their **exact vendor part number**.  
- Introduced `CHANNEL_MONITOR_DISABLED_VENDOR_PNS = {"980-9IAM2-00X001", "980-9IAM1-00X001", "NMA4OPT-XRJALMU0"}` and consider a module to be in this special class when its `vendor_pn` is in this set.  
- For modules whose `vendor_pn` is in `CHANNEL_MONITOR_DISABLED_VENDOR_PNS`:
  - **Skip ChannelMonitorValues checks** (Tx/Rx optical power) that are not supported by these modules.
- Kept the existing DOM and ChannelMonitorValues checks **unchanged** for all other non–flat memory modules.

#### How did you verify/test it?

- Ran `test_check_sfp_eeprom.py` on a testbed where some ports use **XODIN cables with vendor part numbers in `CHANNEL_MONITOR_DISABLED_VENDOR_PNS`** and confirmed:
  - The test no longer fails due to ChannelMonitorValues access on those ports.
  - EEPROM checks still run and pass for other optics/cables whose vendor part numbers are **not** in `CHANNEL_MONITOR_DISABLED_VENDOR_PNS`.

#### Any platform specific information?

- Applies to **Mellanox platforms** using XODIN cables with vendor part numbers in `CHANNEL_MONITOR_DISABLED_VENDOR_PNS`.  
- Behavior for modules not in this list and for other platforms is unchanged.

#### Supported testbed topology if it's a new test case?

- Not a new test case.  
- Same topologies where `test_check_sfp_eeprom.py` is currently supported.

---

### Documentation

- Not required.  
- This change only adjusts the **test logic** for EEPROM verification and does not modify SONiC runtime behavior or user-facing interfaces.