### PR TITLE
[tests/console]: Ignore errors for rmmod/modprobe in cleanup_modules

### DIFF
--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -71,17 +71,19 @@ def cleanup_modules(setup_c0):
     other programs can leave the lines inaccessible.
     '''
     duthost, console_fanout = setup_c0
-    duthost.shell("rmmod nim_async_lite; rmmod tty_async; modprobe nim_async_lite ")
+    duthost.shell("rmmod nim_async_lite; rmmod tty_async; modprobe nim_async_lite ", module_ignore_errors=True)
     duthost.shell("sudo killall socat", module_ignore_errors=True)
 
     if console_fanout != duthost:
-        console_fanout.shell("rmmod nim_async_lite; rmmod tty_async; modprobe nim_async_lite ")
+        console_fanout.shell("rmmod nim_async_lite; rmmod tty_async; modprobe nim_async_lite ",
+                             module_ignore_errors=True)
         console_fanout.shell("sudo killall socat", module_ignore_errors=True)
 
     yield
     duthost.shell("sudo killall socat", module_ignore_errors=True)
-    duthost.shell("rmmod nim_async_lite; rmmod tty_async; modprobe nim_async_lite ")
+    duthost.shell("rmmod nim_async_lite; rmmod tty_async; modprobe nim_async_lite ", module_ignore_errors=True)
 
     if console_fanout != duthost:
         console_fanout.shell("sudo killall socat", module_ignore_errors=True)
-        console_fanout.shell("rmmod nim_async_lite; rmmod tty_async; modprobe nim_async_lite ")
+        console_fanout.shell("rmmod nim_async_lite; rmmod tty_async; modprobe nim_async_lite ",
+                             module_ignore_errors=True)


### PR DESCRIPTION
### Description of PR

Summary:
The `cleanup_modules` fixture in `tests/console/conftest.py` runs `rmmod nim_async_lite; rmmod tty_async; modprobe nim_async_lite` on the DUT (and the console fanout, when different) both before and after the test. `rmmod` can legitimately return a non-zero exit status when the target module is not currently loaded, which causes the Ansible `shell` task — and therefore the entire fixture — to fail before/after the test body runs.

The adjacent `sudo killall socat` invocations already use `module_ignore_errors=True` for the same robustness reason. This PR makes the four `rmmod`/`modprobe` calls consistent with that pattern, so transient/expected non-zero exits from module load/unload no longer cause the cleanup fixture to fail.

Fixes # (n/a)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?
`cleanup_modules` aborts (and causes console tests to error) when `rmmod` returns non-zero because the module isn't currently loaded. The adjacent `killall socat` already tolerates this with `module_ignore_errors=True`; the `rmmod`/`modprobe` lines should behave the same way.

#### How did you do it?
Added `module_ignore_errors=True` to the four `*.shell("rmmod nim_async_lite; rmmod tty_async; modprobe nim_async_lite ")` calls in `tests/console/conftest.py` (DUT + console_fanout, before-yield + after-yield). No other changes.

#### How did you verify/test it?
- Static review of the diff: only the 4 intended lines change; the existing `killall socat` lines are unchanged and already used the same pattern.
- The change is purely additive at the call site (extra kwarg) and matches the established style in the same fixture.

#### Any platform specific information?
None. Affects only the console test's cleanup behavior.

#### Supported testbed topology if it's a new test case?
N/A — not a new test case. Affects existing console tests on `c0` / `c0-lo` topologies.

### Documentation

N/A — no user-facing or wiki-facing change.
