### PR TITLE
[tests/console]: Make test_console_link_wiring c0-lo aware

### DIFF
--- a/tests/console/test_console_link_wiring.py
+++ b/tests/console/test_console_link_wiring.py
@@ -18,19 +18,29 @@ def test_console_link_wiring(setup_c0, creds, target_line):
     Verify data can go out through the dut console port and go in through the fanout console port
     """
     duthost, console_fanout = setup_c0
+    # In the c0-lo topology, setup_c0 returns the same object for both
+    # `duthost` and `console_fanout` (the DUT loops its own console lines).
+    # Treat that case specially so we don't duplicate config, don't try to
+    # open a second reverse-SSH session to the same line (which would
+    # collide with the first one), and don't duplicate cleanup.
+    same_host = duthost is console_fanout
+
     baud_rate = 9600  # The default baud rate for console lines, we will set it explicitly just in case
     duthost.command("config console baud {} {}".format(target_line, baud_rate))
-    console_fanout.command("config console baud {} {}".format(target_line, baud_rate))
     duthost.command("config console flow_control disable {}".format(target_line))
-    console_fanout.command("config console flow_control disable {}".format(target_line))
+    if not same_host:
+        console_fanout.command("config console baud {} {}".format(target_line, baud_rate))
+        console_fanout.command("config console flow_control disable {}".format(target_line))
 
     dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
     dutuser = creds['sonicadmin_user']
     dutpass = creds['sonicadmin_password']
 
-    fanoutip = console_fanout.host.options['inventory_manager'].get_host(console_fanout.hostname).vars['ansible_host']
-    fanoutuser = creds['sonicadmin_user']
-    fanoutpass = creds['sonicadmin_password']
+    if not same_host:
+        fanoutip = console_fanout.host.options['inventory_manager'].get_host(
+            console_fanout.hostname).vars['ansible_host']
+        fanoutuser = creds['sonicadmin_user']
+        fanoutpass = creds['sonicadmin_password']
 
     packet_size = 64
     delay_factor = 3.2
@@ -40,14 +50,24 @@ def test_console_link_wiring(setup_c0, creds, target_line):
     # Estimate a reasonable data transfer time based on configured baud rate
     timeout_sec = (packet_size * 10) * delay_factor / int(baud_rate)
     dut_ressh_user = "{}:{}".format(dutuser, target_line)
-    fanout_ressh_user = "{}:{}".format(fanoutuser, target_line)
+    if not same_host:
+        fanout_ressh_user = "{}:{}".format(fanoutuser, target_line)
 
+    dut_client = None
+    fanout_client = None
     try:
         dut_client = create_ssh_client(dutip, dut_ressh_user, dutpass)
         ensure_console_session_up(dut_client, target_line)
 
-        fanout_client = create_ssh_client(fanoutip, fanout_ressh_user, fanoutpass)
-        ensure_console_session_up(fanout_client, target_line)
+        if same_host:
+            # On c0-lo the line is looped back to itself; opening a second
+            # reverse-SSH session against the same line on the same host
+            # would always fail because the DUT side is already attached.
+            # Reuse the existing client to receive the looped-back data.
+            fanout_client = dut_client
+        else:
+            fanout_client = create_ssh_client(fanoutip, fanout_ressh_user, fanoutpass)
+            ensure_console_session_up(fanout_client, target_line)
 
         # Generate a random strings to send
         text = generate_random_string(packet_size)
@@ -57,13 +77,16 @@ def test_console_link_wiring(setup_c0, creds, target_line):
     except Exception as e:
         pytest.fail("Not able to communicate DUT via reverse SSH: {}".format(e))
     finally:
-        dut_client.sendcontrol('a')
-        dut_client.sendcontrol('x')
-        fanout_client.sendcontrol('a')
-        fanout_client.sendcontrol('x')
+        if dut_client is not None:
+            dut_client.sendcontrol('a')
+            dut_client.sendcontrol('x')
+        if fanout_client is not None and not same_host:
+            fanout_client.sendcontrol('a')
+            fanout_client.sendcontrol('x')
         pytest_assert(
             check_target_line_status(duthost, target_line, "IDLE"),
             "Target line {} of dut is busy after exited reverse SSH session".format(target_line))
-        pytest_assert(
-            check_target_line_status(console_fanout, target_line, "IDLE"),
-            "Target line {} of fanout is busy after exited reverse SSH session".format(target_line))
+        if not same_host:
+            pytest_assert(
+                check_target_line_status(console_fanout, target_line, "IDLE"),
+                "Target line {} of fanout is busy after exited reverse SSH session".format(target_line))


### PR DESCRIPTION
### Description of PR

Summary:
Make `tests/console/test_console_link_wiring.py` aware of the `c0-lo` topology, where the `setup_c0` fixture returns the *same* host object for both `duthost` and `console_fanout` because the DUT loops its own console lines back to itself.

In that case the current implementation:

* Re-runs the per-line `config console baud` / `config console flow_control disable` commands twice against the same DUT.
* Opens a second reverse-SSH session to the same DUT/line as the first session — which is guaranteed to fail because the line is already attached on the DUT side.
* In the `finally` block, sends the `Ctrl-A`/`Ctrl-X` cleanup twice to the same session and asserts the per-line `IDLE` status twice against the same host.

This PR detects the same-host case (`duthost is console_fanout`) and:

1. Skips the duplicate `config console baud`/`flow_control` calls on `console_fanout`.
2. Reuses the DUT-side reverse-SSH client as the "fanout" client (`fanout_client = dut_client`) instead of opening a second colliding session — the looped-back data is read on the same client.
3. Sends the `Ctrl-A`/`Ctrl-X` cleanup only once and runs the `IDLE` assertion only once.

Also initializes `dut_client` / `fanout_client` to `None` before `try` so an early failure in `create_ssh_client` doesn't raise a confusing `NameError` from the `finally` block.

Behavior on the existing `c0` topology (where `duthost` and `console_fanout` are different physical hosts) is unchanged.

Fixes # (n/a)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?
On the `c0-lo` topology, `setup_c0` deliberately sets `console_fanout = duthost` (the DUT loops its console lines back to itself). The test currently treats `duthost` and `console_fanout` as two separate boxes, which causes:

* Wasted duplicate config commands on the same line.
* A guaranteed failure when opening a second reverse-SSH session against a line the first session already owns.
* Double cleanup / double assertion on the same host/line.

The fix makes the test correctly handle the loopback case while leaving normal `c0` behavior untouched.

#### How did you do it?
Introduced a `same_host = duthost is console_fanout` check and used it to:

* Gate the second set of `config console ...` commands on `console_fanout`.
* Gate the `console_fanout` IP/credentials lookup and the second `create_ssh_client(...)` call. When `same_host`, set `fanout_client = dut_client`.
* In `finally`, only run the second `sendcontrol` block when `fanout_client is not dut_client`, and only run the second `check_target_line_status` assertion when `not same_host`.
* Pre-initialized `dut_client` / `fanout_client` to `None` so the `finally` block is robust if `create_ssh_client` fails.

No change to imports, no change to `pytestmark`, no change to the `c0` codepath.

#### How did you verify/test it?
* Reviewed the diff: the `c0` codepath (`same_host == False`) is structurally identical to the original — same config calls, same two `create_ssh_client` calls, same two cleanup blocks, same two IDLE assertions.
* For the `c0-lo` codepath (`same_host == True`): the duplicate config calls, the colliding second SSH session, the duplicate cleanup, and the duplicate IDLE assertion are all skipped.
* Static syntax check.
* Tested on physical c0-lo testbed and got test passed

#### Any platform specific information?
None — the fix is purely topology-aware and does not change platform-specific code paths (the existing `arm64-c8220tg_48a_o` `delay_factor` adjustment is preserved as-is).

#### Supported testbed topology if it's a new test case?
N/A — not a new test. The change makes the existing test correct on `c0-lo` in addition to `c0`.

### Documentation

N/A — no user-facing or wiki documentation change required.
