### PR TITLE
[console] Fix setup_c0 fixture for console test

### DIFF
--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -45,7 +45,7 @@ def setup_c0(request, duthost, tbinfo):
                                       fanouthosts.values()))
         if len(console_fanouts) != 1:
             pytest.fail("Test requires exactly one console switch fanout device (could be dut itself)")
-        console_fanout = console_fanouts[0]
+        console_fanout = console_fanouts[0].host
     elif tbinfo["topo"]["name"] == "c0-lo":
         console_fanout = duthost
     else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Fix below console test failure:

```
console/test_console_link_wiring.py::test_console_link_wiring[1] 
-------------------------------- live log call ---------------------------------
20/04/2026 11:01:02 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
  File "/opt/venv/lib/python3.12/site-packages/_pytest/python.py", line 1720, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/opt/venv/lib/python3.12/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/pluggy/_callers.py", line 167, in _multicall
    raise exception
  File "/opt/venv/lib/python3.12/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/_pytest/python.py", line 166, in pytest_pyfunc_call
    result = testfunction(**testargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/src/sonic-mgmt_testbed-bjw3-can-8220-1/tests/console/test_console_link_wiring.py", line 31, in test_console_link_wiring
    fanoutip = console_fanout.host.options['inventory_manager'].get_host(console_fanout.hostname).vars['ansible_host']
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/src/sonic-mgmt_testbed-bjw3-can-8220-1/tests/common/devices/base.py", line 78, in __getattr__
    raise AttributeError(
AttributeError: '<class 'tests.common.devices.sonic.SonicHost'>' object has no attribute 'options'
```

#### How did you do it?
`console_fanouts[0]` is a FanoutHost wrapper — its `.host` attribute returns the inner `SonicHost`.

#### How did you verify/test it?
Verified on C0 testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
