### PR TITLE
[tests/console]: Refactor test_console_driver to use *_serial_links.csv

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -2889,7 +2889,7 @@ Totals               6450                 6449
         res: ShellResult = self.shell(f"sudo lsof {device_path}", module_ignore_errors=True)
         return True if res["stdout"] else False
 
-    def _get_serial_device_prefix(self) -> str:
+    def get_serial_device_prefix(self) -> str:
         """
         Get the serial device prefix for the platform.
 
@@ -2934,7 +2934,7 @@ print(device_prefix)
         Returns:
             str: The full device path (e.g., "/dev/C0-1", "/dev/ttyUSB1")
         """
-        device_prefix = self._get_serial_device_prefix()
+        device_prefix = self.get_serial_device_prefix()
         return f"{device_prefix}{port}"
 
     def set_loopback(self, port: int, baud_rate: int = 9600, flow_control: bool = False) -> None:
@@ -3207,7 +3207,7 @@ print(device_prefix)
             logging.error(error_msg)
             raise RuntimeError(error_msg)
 
-        device_prefix = self._get_serial_device_prefix()
+        device_prefix = self.get_serial_device_prefix()
         pattern = f"{device_prefix}*"
 
         # Find all related serial port processes

--- a/tests/console/test_console_driver.py
+++ b/tests/console/test_console_driver.py
@@ -1,23 +1,43 @@
 import pytest
 
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts  # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
-    pytest.mark.topology('c0', 'c0-lo')
+    pytest.mark.topology('c0', 'c0-lo', 'bmc')
 ]
 
 
-def test_console_driver(duthost, tbinfo, setup_c0):
+def test_console_driver(duthost, conn_graph_facts):  # noqa: F811
     """
-    Test console driver are well installed.
-    Verify ttyUSB(0-47) are presented in DUT
-    Both c0 and c0-lo have 48 console lines
-    """
-    topo_console_intfs = tbinfo["topo"]["properties"]["topology"]["console_interfaces"]
+    Verify that the console driver on the DUT exposes a tty device node for
+    every serial line wired to the DUT.
 
-    ls_out = duthost.shell('ls {}*'.format(duthost._get_serial_device_prefix()), module_ignore_errors=True)['stdout']
-    num_ttys = len(ls_out.split())
-    pytest_assert(num_ttys > 0, "No virtual tty devices been created by console driver")
-    pytest_assert(num_ttys >= len(topo_console_intfs),
-                  "Number of virtual tty devices [{}] is less than expected [{}]"
-                  .format(num_ttys, len(topo_console_intfs)))
+    For each line recorded for this DUT in ``ansible/files/*_serial_links.csv``
+    (exposed via the ``conn_graph_facts`` fixture), assert that a tty device
+    with a matching line-number suffix exists on the DUT, and that no extra
+    tty devices with the same prefix are present.
+    """
+    dut_serial_links = conn_graph_facts.get('device_serial_link', {}).get(duthost.hostname, {})
+    pytest_assert(
+        dut_serial_links,
+        "No serial links found for DUT '{}' in *_serial_links.csv".format(duthost.hostname),
+    )
+
+    device_prefix = duthost.get_serial_device_prefix()
+    ls_out = duthost.shell('ls {}*'.format(device_prefix), module_ignore_errors=True)['stdout']
+    existing_ttys = set(ls_out.split())
+    pytest_assert(
+        existing_ttys,
+        "No tty devices matching prefix '{}' were created by the console driver on DUT '{}'".format(
+            device_prefix, duthost.hostname),
+    )
+
+    expected_ttys = {"{}{}".format(device_prefix, line_number) for line_number in dut_serial_links.keys()}
+    missing_ttys = sorted(expected_ttys - existing_ttys)
+    extra_ttys = sorted(existing_ttys - expected_ttys)
+    pytest_assert(
+        not missing_ttys and not extra_ttys,
+        "tty device set does not match the serial-link inventory: missing={}, extra={}".format(
+            missing_ttys, extra_ttys),
+    )


### PR DESCRIPTION
### Description of PR

Refactor `tests/console/test_console_driver.py` so that the expected set of
tty device nodes on the DUT is derived from the per-DUT serial-link inventory
in `ansible/files/*_serial_links.csv` (via the `conn_graph_facts` fixture)
instead of from the topology's static `console_interfaces` list (which is
hard-coded to 48 lines for both `c0` and `c0-lo`).

For every line that the CSV records as wired to the DUT, the test now
verifies that the corresponding tty device node (with a suffix that matches
the line number) exists on the DUT.

#### Why
* Different console-switch hardware exposes a different number of serial
  ports, so a fixed "48 lines" check derived from the topology is not
  accurate.
* The previous check only compared a count and could not catch the case
  where a device existed but with the wrong line-number suffix.

#### Summary
Fixes # (issue)

##### Approach

###### What is the motivation for this PR?

Make `test_console_driver` accurately reflect the wiring of the actual DUT
so it works for any console-switch hardware, regardless of how many serial
ports it has.

###### How did you do it?

* Added the `conn_graph_facts` fixture to the test.
* Looked up `device_serial_link[duthost.hostname]` (built from the
  `*_serial_links.csv` file by `graph_utils`) and built the expected set of
  tty device paths as `<prefix><line_number>` for every line wired to the
  DUT.
* Listed the tty devices on the DUT using `_get_serial_device_prefix()`
  (same source as before) and asserted that every expected device is
  present.
* Dropped the now-unused `tbinfo` parameter and the `setup_c0` fixture –
  the driver/device-node check is independent of the per-line
  baud/flow-control configuration that `setup_c0` enforces.

###### How did you verify/test it?

To be verified on a `c0-lo` testbed (e.g. `testbed-bjw3-can-7215c1-2`).
Marked as **draft** until the test run completes.

###### Any platform specific information?

No. The test now uses `_get_serial_device_prefix()` (already platform-aware)
and the per-DUT serial-link CSV, so it adapts to whatever hardware/prefix
the DUT exposes.

###### Supported testbed topology if it's a new test case?

`c0`, `c0-lo` (unchanged from before).

##### Documentation

N/A
