### PR TITLE
[C1] Increase delay_factor for console_loopback tests for Nokia-7215-C1 platform

### DIFF
--- a/tests/console/test_console_loopback.py
+++ b/tests/console/test_console_loopback.py
@@ -72,6 +72,8 @@ def test_console_loopback_echo(setup_c0, creds, conn_graph_facts, baud_rate, flo
         console_fanout.command("config console flow_control {} {}".format(flow_control, target_line))
         console_fanout.set_loopback(target_line, baud_rate, flow_control_bool)
         delay_factor = 3.2
+        if duthost.facts['platform'] in ['arm64-nokia_ixs7215_c1xa-r0']:
+            delay_factor *= 10.0
     if duthost.facts['platform'] in ['arm64-c8220tg_48a_o-r0']:
         delay_factor *= 25.0
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Increased delay_factor in loopback testcases to account for the processing time of the packets on top of the time for the packet to return. This fixes flakiness of test_console_loopback on Nokia-7215-C1 platforms
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fixes test_console_loopback flakiness on Nokia-7215-C1 platform
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
On Nokia-7215-C1, console_loopback tests sometimes fails due to packet not received on the given timeout
#### How did you do it?
Increase delay_factor for Nokia-7215-C1 platforms
#### How did you verify/test it?
Run console_loopback testcase on Nokia-7215-C1 platform on topo c0 and c0-lo
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
