### PR TITLE
[C1]Watchdog reboot parameters for Nokia-7215-C1 platform

### DIFF
--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -38,6 +38,7 @@ class TestWatchdogApi(PlatformApiTestBase):
         if (
             duthost.facts['platform'] == 'armhf-nokia_ixs7215_52x-r0'
             or duthost.facts['platform'] == 'arm64-nokia_ixs7215_52xb-r0'
+            or duthost.facts['platform'] == 'arm64-nokia_ixs7215_c1xa-r0'
             or duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_dpu")
         ):
             duthost.shell("watchdogutil disarm")
@@ -53,7 +54,8 @@ class TestWatchdogApi(PlatformApiTestBase):
             watchdog.disarm(platform_api_conn)
 
             if duthost.facts['platform'] == 'armhf-nokia_ixs7215_52x-r0' or \
-                    duthost.facts['platform'] == 'arm64-nokia_ixs7215_52xb-r0':
+                    duthost.facts['platform'] == 'arm64-nokia_ixs7215_52xb-r0' or \
+                    duthost.facts['platform'] == 'arm64-nokia_ixs7215_c1xa-r0':
                 duthost.shell("systemctl start cpu_wdt.service")
             elif duthost.facts["platform"].startswith("x86_64-nexthop_"):
                 duthost.shell("systemctl enable watchdog.timer --now")

--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -118,6 +118,13 @@ arm64-nokia_ixs7215_52xb-r0:
     greater_timeout: 170
     too_big_timeout: 400
 
+# Nokia IXS-7215-C1 watchdog
+arm64-nokia_ixs7215_c1xa-r0:
+  default:
+    valid_timeout: 30
+    greater_timeout: 170
+    too_big_timeout: 400
+
 # Nokia IXR-7220-D4 watchdog
 x86_64-nokia_ixr7220_d4-r0:
   default:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Added Watchdog parameters for Nokia-7215-C1 platform  and conditions to facilitate arm/disarm in watchdog reboot tests
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fixes watchdog reboot test failures for Nokia-7215-C1 platforms
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Fix failures for watchdog reboot testcases on Nokia-7215-C1 platforms
#### How did you do it?
Added watchdog parameters in watchdog.yml and conditions in testcases to facilitate correct arm/disarm commands on this platform
#### How did you verify/test it?
Run api/test_watchdog testcases on Nokia-7215-C1 platforms
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
