### PR TITLE
[tests/console]: Refactor test_console_reversessh to use *_serial_links.csv

### DIFF
--- a/tests/console/test_console_reversessh.py
+++ b/tests/console/test_console_reversessh.py
@@ -7,7 +7,7 @@ from tests.common.helpers.console_helper import check_target_line_status
 from tests.common.utilities import wait_until
 
 pytestmark = [
-    pytest.mark.topology('c0', 'c0-lo', 'bmc')
+    pytest.mark.topology('c0', 'c0-lo')
 ]
 
 

--- a/tests/console/test_console_reversessh.py
+++ b/tests/console/test_console_reversessh.py
@@ -11,7 +11,7 @@ pytestmark = [
 ]
 
 
-def _dut_lowest_console_line(conn_graph_facts, duthost):
+def _dut_lowest_console_line(conn_graph_facts, duthost):  # noqa: F811
     """Return the lowest console line number recorded for ``duthost`` in
     ``ansible/files/*_serial_links.csv`` (exposed via ``conn_graph_facts``).
     """

--- a/tests/console/test_console_reversessh.py
+++ b/tests/console/test_console_reversessh.py
@@ -1,18 +1,27 @@
 import pytest
 import pexpect
-import random
 
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts  # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.console_helper import check_target_line_status
 from tests.common.utilities import wait_until
 
-from tests.common.helpers.console_helper import check_target_line_status
-
 pytestmark = [
-    pytest.mark.topology('c0', 'c0-lo')
+    pytest.mark.topology('c0', 'c0-lo', 'bmc')
 ]
 
 
-console_lines = list(map(str, range(1, 49)))
+def _dut_lowest_console_line(conn_graph_facts, duthost):
+    """Return the lowest console line number recorded for ``duthost`` in
+    ``ansible/files/*_serial_links.csv`` (exposed via ``conn_graph_facts``).
+    """
+    serial_links = conn_graph_facts.get("device_serial_link", {}).get(duthost.hostname, {})
+    pytest_assert(
+        serial_links,
+        "No serial-link entry found for DUT '{}' in conn_graph_facts; check *_serial_links.csv".format(
+            duthost.hostname))
+    lines = sorted(int(line) for line in serial_links.keys())
+    return str(lines[0])
 
 
 @pytest.fixture(scope="function")
@@ -37,12 +46,14 @@ def custom_default_escape_char(duthost):
         pytest.fail("Not able to restore custom default escape character: {}".format(e))
 
 
-@pytest.mark.parametrize("target_line", random.sample(console_lines, 2))
-def test_console_reversessh_connectivity(duthost, creds, target_line):
+def test_console_reversessh_connectivity(duthost, creds, conn_graph_facts):  # noqa: F811
     """
     Test reverse SSH is working as expect.
-    Verify serial session is available after connect DUT via reverse SSH
+    Verify serial session is available after connect DUT via reverse SSH.
+    The lowest-numbered console line recorded for the DUT in
+    ``*_serial_links.csv`` is used.
     """
+    target_line = _dut_lowest_console_line(conn_graph_facts, duthost)
     dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
     dutuser = creds['sonicadmin_user']
     dutpass = creds['sonicadmin_password']
@@ -52,6 +63,7 @@ def test_console_reversessh_connectivity(duthost, creds, target_line):
         "Target line {} is busy before reverse SSH session start".format(target_line))
 
     ressh_user = "{}:{}".format(dutuser, target_line)
+    client = None
     try:
         client = pexpect.spawn('ssh {}@{} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
                                .format(ressh_user, dutip))
@@ -62,25 +74,27 @@ def test_console_reversessh_connectivity(duthost, creds, target_line):
         pytest_assert(
             check_target_line_status(duthost, target_line, "BUSY"),
             "Target line {} is idle while reverse SSH session is up".format(target_line))
-
     except Exception as e:
         pytest.fail("Not able to do reverse SSH to remote host via DUT: {}".format(e))
     finally:
         # Send escape sequence to exit reverse SSH session
-        client.sendcontrol('a')
-        client.sendcontrol('x')
+        if client is not None:
+            client.sendcontrol('a')
+            client.sendcontrol('x')
 
     pytest_assert(
         wait_until(10, 1, 0, check_target_line_status, duthost, target_line, "IDLE"),
         "Target line {} is busy after exited reverse SSH session".format(target_line))
 
 
-@pytest.mark.parametrize("target_line", random.sample(console_lines, 2))
-def test_console_reversessh_force_interrupt(duthost, creds, target_line):
+def test_console_reversessh_force_interrupt(duthost, creds, conn_graph_facts):  # noqa: F811
     """
     Test reverse SSH is working as expect.
-    Verify active serial session can be shut by DUT
+    Verify active serial session can be shut by DUT.
+    The lowest-numbered console line recorded for the DUT in
+    ``*_serial_links.csv`` is used.
     """
+    target_line = _dut_lowest_console_line(conn_graph_facts, duthost)
     dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
     dutuser = creds['sonicadmin_user']
     dutpass = creds['sonicadmin_password']
@@ -90,6 +104,7 @@ def test_console_reversessh_force_interrupt(duthost, creds, target_line):
         "Target line {} is busy before reverse SSH session start".format(target_line))
 
     ressh_user = "{}:{}".format(dutuser, target_line)
+    client = None
     try:
         client = pexpect.spawn('ssh {}@{} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
                                .format(ressh_user, dutip))
@@ -112,7 +127,7 @@ def test_console_reversessh_force_interrupt(duthost, creds, target_line):
     # Check the session ended within 5s and the line state is idle
     pytest_assert(
         wait_until(5, 1, 0, check_target_line_status, duthost, target_line, "IDLE"),
-        "Target line {} not toggle to IDLE state after force clear command sent")
+        "Target line {} not toggle to IDLE state after force clear command sent".format(target_line))
 
     try:
         client.expect("Picocom was killed")
@@ -120,13 +135,15 @@ def test_console_reversessh_force_interrupt(duthost, creds, target_line):
         pytest.fail("Console session not exit correctly: {}".format(e))
 
 
-@pytest.mark.parametrize("target_line", random.sample(console_lines, 4))
-def test_console_reversessh_custom_default_escape_character(duthost, creds, target_line, custom_default_escape_char):
+def test_console_reversessh_custom_default_escape_character(duthost, creds, conn_graph_facts,  # noqa: F811
+                                                            custom_default_escape_char):
     """
     Test reverse SSH with custom escape character.
     Verify that default escape keys don't work when escape character is changed,
-    and custom escape keys work correctly
+    and custom escape keys work correctly. The lowest-numbered console line
+    recorded for the DUT in ``*_serial_links.csv`` is used.
     """
+    target_line = _dut_lowest_console_line(conn_graph_facts, duthost)
     dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
     dutuser = creds['sonicadmin_user']
     dutpass = creds['sonicadmin_password']


### PR DESCRIPTION
## Description of PR

Refactor `tests/console/test_console_reversessh.py` so the three reverse-SSH tests pick the line under test from the per-DUT serial-link inventory instead of randomly sampling from a hard-coded `range(1, 49)`.

### Changes

- Add a small `_dut_lowest_console_line(conn_graph_facts, duthost)` helper that reads `conn_graph_facts["device_serial_link"][hostname]` (sourced from `ansible/files/*_serial_links.csv`) and returns the lowest-numbered line as a string.
- `test_console_reversessh_connectivity`, `test_console_reversessh_force_interrupt`, and `test_console_reversessh_custom_default_escape_character` now run **once** against the lowest-numbered console line recorded for the DUT instead of `random.sample(console_lines, 2)` / `random.sample(console_lines, 4)`. Different hardware exposes a different number of console ports, so the previous random sample could pick a line that does not exist.
- Add the `bmc` topology marker (alongside `c0` / `c0-lo`) so these tests can run on BMC testbeds, matching #24166 / #24168.
- Move the `finally` cleanup in `test_console_reversessh_connectivity` behind a `client is not None` guard so we do not crash if `pexpect.spawn` itself failed.
- Drop the now-unused `random` import.

### Approach
#### What is the motivation for this PR?
Same motivation as #24166 (driver test) and #24168 (loopback test): the hard-coded line list does not match real hardware and the random sample is wasteful and flaky.

#### How did you do it?
Same pattern as the loopback / driver refactor PRs — leverage `conn_graph_facts` and pick the lowest-numbered line.

#### How did you verify/test it?
Will verify on internal testbed once draft is reviewed.

### co-authorship statement

```text
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
```
