### PR TITLE
[C1] Skipping fast/soft/warm reboot for Nokia-7215-C1 platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1446,7 +1446,7 @@ platform_tests/test_reboot.py::test_soft_reboot:
   skip:
     reason: "Skip test_soft_reboot for M* and test is supported only on S6100 hwsku"
     conditions:
-      - "topo_type in ['m0', 'mx', 'm1'] or hwsku not in ['Force10-S6100']"
+      - "topo_type in ['m0', 'mx', 'm1'] or hwsku not in ['Force10-S6100'] or hwsku in ['Nokia-7215-C1', 'Nokia-7215-C1-G3']"
   xfail:
     reason: "case failed and waiting for fix"
     conditions:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Added condition to skip platform_tests/fast/soft/warm reboot testcases for Nokia-7215-C1 platforms as they are not supported
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Skip fast/warm/soft reboot for Nokia-7215-C1
#### How did you do it?
Added skip conditions in plugins/test_mark_conditions_platform_tests.yaml
#### How did you verify/test it?
Run platform_tests/test_reboot.py on Nokia-7215-C1 platform
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
