### PR TITLE
[C1] Skip pfc-storm event test in telemetry for Nokia-7215-C1 platforms

### DIFF
--- a/tests/common/nokia_data.py
+++ b/tests/common/nokia_data.py
@@ -1,2 +1,5 @@
 def is_nokia_device(dut):
     return ('nokia' in dut.facts["hwsku"].lower())
+
+
+NO_QOS_HWSKUS = ['Nokia-7215-C1']

--- a/tests/telemetry/events/swss_events.py
+++ b/tests/telemetry/events/swss_events.py
@@ -46,7 +46,7 @@ def test_event(duthost, tbinfo, gnxi_path, ptfhost, ptfadapter, data_dir, valida
         skip_pfc_hwskus = [*BROADCOM_LOSSY_ONLY_HWSKUS, *BROADCOM_NO_QOS_HWSKUS]
     elif asic_type == "marvell-prestera":
         skip_pfc_hwskus = MARVELL_PRESTERA_NO_QOS_HWSKUS
-    elif asic_type == "marvell-prestera":
+    elif asic_type == "nokia-vs":
         skip_pfc_hwskus = NOKIA_NO_QOS_HWSKUS
     else:
         skip_pfc_hwskus = []

--- a/tests/telemetry/events/swss_events.py
+++ b/tests/telemetry/events/swss_events.py
@@ -11,6 +11,7 @@ from tests.common.broadcom_data import LOSSY_ONLY_HWSKUS as BROADCOM_LOSSY_ONLY_
 from tests.common.mellanox_data import NO_QOS_HWSKUS as MELLANOX_NO_QOS_HWSKUS
 from tests.common.broadcom_data import NO_QOS_HWSKUS as BROADCOM_NO_QOS_HWSKUS
 from tests.common.marvell_prestera_data import NO_QOS_HWSKUS as MARVELL_PRESTERA_NO_QOS_HWSKUS
+from tests.common.nokia_data import NO_QOS_HWSKUS as NOKIA_NO_QOS_HWSKUS
 from tests.common.utilities import wait_until
 
 random.seed(10)
@@ -45,6 +46,8 @@ def test_event(duthost, tbinfo, gnxi_path, ptfhost, ptfadapter, data_dir, valida
         skip_pfc_hwskus = [*BROADCOM_LOSSY_ONLY_HWSKUS, *BROADCOM_NO_QOS_HWSKUS]
     elif asic_type == "marvell-prestera":
         skip_pfc_hwskus = MARVELL_PRESTERA_NO_QOS_HWSKUS
+    elif asic_type == "marvell-prestera":
+        skip_pfc_hwskus = NOKIA_NO_QOS_HWSKUS
     else:
         skip_pfc_hwskus = []
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Skipping PFC storm event in telemetry/test_events.py for Nokia-7215-C1 platforms by adding platform into nokia_data.py NO_QOS_HWSKUS list
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Skipping PFC-storm event on Nokia-7215-C1 as it is not supported
#### How did you do it?
Added platform to NO_QOS_HWSKUS in common/nokia_data.py
#### How did you verify/test it?
Run telemetry/test_events.py on Nokia-7215-C1 platform
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
