### PR TITLE
Bug fix: conditional mark stop working after Pytest 9.0

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -697,6 +697,10 @@ def pytest_collection_modifyitems(session, config, items):
         nodeid = item.nodeid
         if nodeid.startswith(root_prefix):
             nodeid = nodeid[len(root_prefix):]
+        nodeid = item.nodeid
+        # Strip tests/ prefix if present (pytest includes it when running from tests/ directory)
+        if nodeid.startswith("tests/"):
+            nodeid = nodeid[6:]  # len("tests/") = 6
         all_matches = find_all_matches(nodeid, conditions, session, dynamic_update_skip_reason, basic_facts)
 
         if all_matches:


### PR DESCRIPTION
<!--
   
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: conditional mark stop working due to Pytest upgrade
Fixes # 
  1. Original State (2022-2026):                                                                                                                                                              
    - YAML patterns created without tests/ prefix: platform_tests/cli/test_show_platform.py::...                                                                                              
    - Tests ran with older pytest versions                                                                                                                                                    
    - Conditional marks WORKED because pytest didn't include tests/ in nodeids                                                                                                                
  2. Pytest 9.0 Upgrade (March 2026):                                                                                                                                                         
    - Pytest 9.0 started including tests/ prefix in nodeids                                                                                                                                   
    - This BROKE all 155 conditional marks in platform_tests YAML                                                                                                                             
    - Commit af742a494 (March 17, 2026) added a fix to strip the prefix        

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
=================================================================== short test summary info ===================================================================
PASSED platform_tests/cli/test_show_platform.py::test_show_platform_summary[MtFuji-dut-dpu-0]
PASSED platform_tests/cli/test_show_platform.py::test_platform_serial_no[MtFuji-dut-dpu-0]
PASSED platform_tests/cli/test_show_platform.py::test_show_platform_syseeprom[MtFuji-dut-dpu-0]
PASSED platform_tests/cli/test_show_platform.py::test_show_platform_temperature[MtFuji-dut-dpu-0]
PASSED platform_tests/cli/test_show_platform.py::test_show_platform_firmware_status[MtFuji-dut-dpu-0]
PASSED platform_tests/cli/test_show_platform.py::test_show_platform_pcieinfo[MtFuji-dut-dpu-0]
PASSED platform_tests/cli/test_show_platform.py::test_show_platform_fan[MtFuji-dut-dpu-0]
SKIPPED [2] platform_tests/cli/test_show_platform.py: Test should be skipped on DPU for it doesn't have PSUs.
SKIPPED [1] platform_tests/cli/test_show_platform.py:518: Disk Type  MMC is not supported


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
