### PR TITLE
Add route rule for backend IP for PL redirect

### DIFF
--- a/tests/dash/configs/privatelink_config.py
+++ b/tests/dash/configs/privatelink_config.py
@@ -231,6 +231,12 @@ TUNNEL4_CONFIG = {
         "encap_type": EncapType.ENCAP_TYPE_VXLAN,
     }
 }
+PL_REDIRECT_BACKEND_IP_ROUTE_RULE_CONFIG = {
+    f"DASH_ROUTE_RULE_TABLE:{ENI_ID}:{ENCAP_VNI}:{PL_REDIRECT_BACKEND_IP}/32": {
+        "action_type": ActionType.ACTION_TYPE_DECAP,
+        "priority": 0
+    }
+}
 
 INBOUND_VNI_ROUTE_RULE_CONFIG = {
     f"DASH_ROUTE_RULE_TABLE:{ENI_ID}:{ENCAP_VNI}:{PE_PA}/32": {

--- a/tests/dash/test_dash_privatelink_redirect.py
+++ b/tests/dash/test_dash_privatelink_redirect.py
@@ -503,6 +503,7 @@ def privatelink_redirect_fnic_config(
     if 'pensando' not in dpuhost.facts['asic_type']:
         route_rule_messages = {
             **pl.VM_VNI_ROUTE_RULE_CONFIG,
+            **pl.PL_REDIRECT_BACKEND_IP_ROUTE_RULE_CONFIG,
             **pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
             **pl.TRUSTED_VNI_ROUTE_RULE_CONFIG
         }
@@ -591,6 +592,7 @@ def privatelink_redirect_nsg_config(
     if 'pensando' not in dpuhost.facts['asic_type']:
         route_rule_messages = {
             **pl.VM_VNI_ROUTE_RULE_CONFIG,
+            **pl.PL_REDIRECT_BACKEND_IP_ROUTE_RULE_CONFIG,
             **pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
         }
         logger.info(route_rule_messages)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add backend IP for return packet for PL redirect, as the packet returns with the backend_ip as the source, so this configuration is added to make sure packets are not dropped
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
As inbound route rules are required for packets incoming to the DPU, route rule is added for backend IP, as the returning packet from PL endpoint will have underlay ip set to backend ip in case of PL redirect

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
