### PR TITLE
Fix potential NoneType error in interface_utils.py

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -401,8 +401,10 @@ import sonic_platform.platform as P
 num_sfps = P.Platform().get_chassis().get_num_sfps()
 port_indexes_with_flat_memory = []
 for i in range(1, num_sfps + 1):
-    is_flat_memory = P.Platform().get_chassis().get_sfp(i).get_xcvr_api().is_flat_memory()
-    if is_flat_memory:
+    xcvr_api = P.Platform().get_chassis().get_sfp(i).get_xcvr_api()
+    if xcvr_api is None:
+        continue
+    if xcvr_api.is_flat_memory():
         port_indexes_with_flat_memory.append(i)
 print(port_indexes_with_flat_memory)
 EOF


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix potential NoneType error in tests/common/platform/interface_utils.py by adding a null check for xcvr_api before calling is_flat_memory(). In get_port_indexes_with_flat_memory(), the original code calls get_xcvr_api().is_flat_memory() in a single chained expression. When a SFP slot is empty or the transceiver is not yet initialized, get_xcvr_api() returns None, which causes an AttributeError: 'NoneType' object has no attribute 'is_flat_memory'. This fix splits the call and adds a guard check to skip ports where xcvr_api is None. Fixes potential AttributeError when iterating over SFP ports with empty or uninitialized transceiver slots.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

During SFP information collection in test cases, get_port_indexes_with_flat_memory() iterates over all SFP port indexes and calls get_xcvr_api().is_flat_memory() in a single chained expression. When a SFP slot is empty or the transceiver is not properly initialized, get_xcvr_api() returns None, causing an AttributeError that crashes the test.

#### How did you do it?

1. First retrieve xcvr_api from get_sfp(i).get_xcvr_api()
2. Check if xcvr_api is None — if so, continue to skip that port
3. Only then call xcvr_api.is_flat_memory()

#### How did you verify/test it?

Verified on a testbed with partially populated SFP slots. Before the fix, the test failed with AttributeError: 'NoneType' object has no attribute 'is_flat_memory'. After the fix, empty ports are gracefully skipped and the function returns the correct list of flat-memory port indexes.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
