### PR TITLE
Fix ft2 upstream neighbor map to use lt2 instead of ut2

### DIFF
--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -38,8 +38,8 @@ UPSTREAM_ALL_NEIGHBOR_MAP = {
     "m0_vlan": ["m1"],
     "m0_l3": ["m1"],
     'lt2': ['ut2'],
-    'ft2': ['ut2'],
-    "c0": ["m1"]
+    "c0": ["m1"],
+    'ft2': ['lt2']
 }
 
 # Describe downstream neighbor of dut in different topos


### PR DESCRIPTION
### Description of PR

Summary:
Fix `ft2` entry in `UPSTREAM_ALL_NEIGHBOR_MAP` from `['ut2']` to `['lt2']`.

The `ft2` topology connects to `lt2` (leaf tier 2) upstream neighbors, not `ut2`. The incorrect mapping caused `ntp/test_ntp.py` and `route/test_default_route.py` to fail on ft2 testbeds because they could not find the correct upstream neighbor.

### Type of change

- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
`ntp/test_ntp.py` and `route/test_default_route.py` fail on `ft2` topology testbeds because the upstream neighbor type is wrong in `UPSTREAM_ALL_NEIGHBOR_MAP`.

#### How did you do it?
Changed `'ft2': ['ut2']` to `'ft2': ['lt2']` in `tests/common/helpers/constants.py`.

#### How did you verify/test it?
Verified on testbed `vms73-t0-7060x6-2` (ft2-64 topology, Arista 7060X6): `ntp/test_ntp.py` and `route/test_default_route.py` both pass.

#### Any platform specific information?
Specific to `ft2` topology (Arista fanout, 64-port).

### Documentation
N/A
