### PR TITLE
Fix test_mgmt_ipv6_only to skip when IPv6 reachability unavailable

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -837,7 +837,8 @@ def duthosts_ipv6_mgmt_only(duthosts, backup_and_restore_config_db_on_duts):
         if not ipv6_address[duthost.hostname]:
             pytest.skip(f"{duthost.hostname} doesn't have IPv6 Management IP address")
         if not has_available_ipv6_addr:
-            pytest.skip(f"{duthost.hostname} doesn't have available IPv6 Management IP address")
+            pytest.skip(f"{duthost.hostname} IPv6 Management IP is not reachable from the test runner. "
+                        "This test requires IPv6 connectivity to the DUT management interface.")
 
     # Remove IPv4 mgmt-ip
     for duthost in duthosts.nodes:


### PR DESCRIPTION
### Description of PR

Summary:
Fix `duthosts_ipv6_mgmt_only` fixture to skip instead of fail when the DUT management IP is not reachable over IPv6 from the test runner.

Fixes test_mgmt_ipv6_only erroring with `AssertionError` on testbeds where the test runner lacks IPv6 connectivity to the DUT management network.

### Type of change

- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
`ip/test_mgmt_ipv6_only.py` was failing with `AssertionError` on testbeds where the test runner does not have IPv6 connectivity to the DUT management interface. The test should be skipped gracefully in this case rather than reporting an error.

#### How did you do it?
In `tests/common/fixtures/duthost_utils.py`, changed `pt_assert(has_available_ipv6_addr, ...)` to `pytest.skip(...)` so the test is cleanly skipped when IPv6 reachability is not available.

#### How did you verify/test it?
Verified on testbed `vms73-t0-7060x6-2`: `ip/test_mgmt_ipv6_only.py` now correctly reports `SKIPPED` instead of `ERROR`.

#### Any platform specific information?
Affects any testbed where the test runner does not have IPv6 connectivity to the DUT management interface.

### Documentation
N/A
