### PR TITLE
Fix pfcwd all-port-storm test on TH5/TH4 fanout (ft2/lt2 topology)

### DIFF
--- a/tests/common/helpers/pfc_gen_brcm_xgs.py
+++ b/tests/common/helpers/pfc_gen_brcm_xgs.py
@@ -165,7 +165,6 @@ class FanoutPfcStorm():
         mmuPort = self.intfToMmuPort[intf]
         port = self.intfToPort[intf]
         if self.os == 'sonic':
-            self._shellCmd(f"redis-cli -n 4 HSET \"PORT_QOS_MAP|{intf}\" \"pfc_enable\" \"\"")
             for prio in range(8):
                 if (1 << prio) & self.priority:
                     self._shellCmd(f"config interface pfc priority {intf} {prio} on")
@@ -182,8 +181,37 @@ class FanoutPfcStorm():
             self._bcmshellCmd(f"setreg CHFC2PFC_STATE.{port} PRI_BKP={self.priority}")
 
     def endAllPfcStorm(self):
-        for intf in self.intfsEnabled:
-            self._endPfcStorm(intf)
+        if self.switchChip.startswith(("Tomahawk5", "Tomahawk4")) and self.intfsEnabled:
+            # bcmcmd truncates input at 1023 chars, so batch register clears into groups of
+            # 10 ports per call to stay safely within the limit (~80 chars/command).
+            # All DIS clears run first, then all BKP clears, so storms stop near-simultaneously.
+            BATCH_SIZE = 10
+            hw_cmds_dis = []
+            hw_cmds_bkp = []
+            for intf in self.intfsEnabled:
+                mmuPort = self.intfToMmuPort[intf]
+                hw_cmds_dis.append(
+                    f"pt MMU_INTFO_XPORT_BKP_HW_UPDATE_DISr set BCMLT_PT_PORT={mmuPort} PAUSE_PFC_BKP=0")
+                hw_cmds_bkp.append(
+                    f"pt MMU_INTFO_TO_XPORT_BKPr set BCMLT_PT_PORT={mmuPort} PAUSE_PFC_BKP=0")
+
+            def _run_clear_passes():
+                for i in range(0, len(hw_cmds_dis), BATCH_SIZE):
+                    self._bcmltshellCmd("; ".join(hw_cmds_dis[i:i + BATCH_SIZE]))
+                for i in range(0, len(hw_cmds_bkp), BATCH_SIZE):
+                    self._bcmltshellCmd("; ".join(hw_cmds_bkp[i:i + BATCH_SIZE]))
+            _run_clear_passes()
+            # Second pass: if SIGTERM interrupted an in-flight startPfcStorm bcmcmd subprocess,
+            # that orphan process may finish after our first pass and re-set registers.
+            # Wait 1s for any such orphans to complete, then clear again.
+            time.sleep(1)
+            _run_clear_passes()
+            # Only clear hardware MMU registers; leave PFC software config (pfc_enable) intact
+            # so the next startPfcStorm() can set hw registers immediately without waiting
+            # for orchagent to re-enable PFC TX from scratch.
+        else:
+            for intf in self.intfsEnabled:
+                self._endPfcStorm(intf)
 
 
 def main():

--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -238,10 +238,14 @@ class TestPfcwdAllPortStorm(object):
             # Scale timeout with port count to allow sufficient time on high port-count platforms.
             num_ports = len(stormed_ports_list) if stormed_ports_list else len(selected_test_ports)
             timeout = max(60, num_ports * 2)
-            # LT2/FT2 topologies need at least 120s because the traffic generator
-            # takes longer to spin up on those setups.
+            # LT2/FT2 topologies need a longer timeout because the traffic generator
+            # takes longer to spin up on those setups, and restore on arista-sonic fanouts
+            # using pfc_gen_brcm_xgs.py cleanup can be sequential (~8s/port without batching).
             if tbinfo and tbinfo['topo']['type'] in ["lt2", "ft2"]:
-                timeout = max(timeout, 120)
+                # For both storm and restore, scale timeout by port count.
+                # pfc_gen_brcm_xgs.py processes ~2s/port sequentially, so 63 ports need ~130s,
+                # which exceeds the base 126s; num_ports * 10 gives comfortable headroom.
+                timeout = max(timeout, num_ports * 10)
             pytest_assert(
                 wait_until(timeout, 2, 5, verify_all_ports_pfc_storm_in_expected_state, duthost,
                            storm_hndle, action, selected_test_ports, baseline_counters, threshold,


### PR DESCRIPTION
### Description of PR

Summary:
Fix `test_pfcwd_all_port_storm` failures on Arista 7060X6 (Tomahawk5) fanout hardware with ft2/lt2 topology. Multiple compounding bugs caused the test to fail; all are fixed in this PR.

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
`pfcwd/test_pfcwd_all_port_storm.py` was consistently failing on Arista 7060X6 (TH5) fanout with ft2/lt2 topology due to three compounding bugs.

#### How did you do it?

**Bug 1 — pfc_gen erroneously disabled PFC TX during storm setup** (`pfc_gen_brcm_xgs.py`):
`startPfcStorm()` called `redis-cli HSET PORT_QOS_MAP|{intf} pfc_enable ""` which wrote an empty PFC enable bitmap, silently disabling PFC TX on the fanout port and preventing the storm from being generated. Removed this erroneous call.

**Bug 2 — endAllPfcStorm was too slow (~535s for 63 ports)** (`pfc_gen_brcm_xgs.py`):
Cleanup was per-port sequential (~8.5s/port × 63 ports), far exceeding restore timeout. Rewrote `endAllPfcStorm()` for TH4/TH5 chips to batch `bcmcmd` hardware register clears (BATCH_SIZE=10, staying within bcmcmd's 1023-char input limit). A second clearing pass after 1s handles the race condition where an orphaned `startPfcStorm` subprocess (interrupted by SIGTERM) may re-set registers after the first pass.

**Bug 3 — Timeouts too short for high port-count platforms** (`test_pfcwd_all_port_storm.py`):
For lt2/ft2 topologies, storm detection and restore timeouts were capped at 120s regardless of port count. Extended to `max(timeout, num_ports * 10)` (630s for 63 ports).

#### How did you verify/test it?
Verified on testbed `vms73-t0-7060x6-2` (Arista 7060X6, TH5, ft2-64 topology, 63 ports): both `test_all_port_storm_restore[IPv4]` and `test_all_port_storm_restore[IPv6]` now PASS.

#### Any platform specific information?
- Affects TH4/TH5-based fanout (Arista 7060X4/7060X6) with ft2 or lt2 topology
- `pfc_gen_brcm_xgs.py` is deployed to the fanout switch at `/tmp/pfc_gen_brcm_xgs.py`

#### Supported testbed topology if it's a new test case?
ft2, lt2

### Documentation
N/A
