### PR TITLE
Fix top memory parser in memory_utilization when RES uses human-readable units (e.g. 1.6g) 

### DIFF
--- a/tests/common/plugins/memory_utilization/memory_utilization.py
+++ b/tests/common/plugins/memory_utilization/memory_utilization.py
@@ -490,6 +490,38 @@ class MemoryMonitor:
             self.register_command(param['name'], param['cmd'], param['memory_params'], eval(param['memory_check_fn']))
 
 
+# Parse top output for sufffix.
+_RES_WITH_SUFFIX_RE = re.compile(
+    r"^\s*(?P<num>[\d.]+)\s*(?P<suf>[kKmMgGtT]?)\s*$"
+)
+
+
+def _parse_top_res_to_mib(res_str):
+    """
+    Convert top's RES column to MiB.
+
+    Plain numeric (no suffix) is treated as KiB (procps default).
+    Suffixes: k=KiB, m=MiB, g=GiB, t=TiB (case-insensitive).
+    """
+    if res_str is None:
+        raise ValueError("RES is None")
+    m = _RES_WITH_SUFFIX_RE.match(str(res_str).strip())
+    if not m:
+        raise ValueError("unrecognized RES format: {!r}".format(res_str))
+    num = float(m.group("num"))
+    suf = (m.group("suf") or "").lower()
+
+    if suf in ("", "k"):
+        return num / 1024.0
+    if suf == "m":
+        return num
+    if suf == "g":
+        return num * 1024.0
+    if suf == "t":
+        return num * 1024.0 * 1024.0
+    raise ValueError("unrecognized RES format: {!r}".format(res_str))
+
+
 def parse_top_output(output, memory_params):
     """Parse the 'top' command output to extract memory usage information."""
     memory_values = {}
@@ -512,12 +544,14 @@ def parse_top_output(output, memory_params):
 
             for mem_item, thresholds in memory_params.items():
                 if mem_item in process_info["COMMAND"]:
+                    # Fixes issue 24178
+                    res_mib = _parse_top_res_to_mib(process_info["RES"])
                     if mem_item in memory_values:
                         memory_values[mem_item] = round(
-                            memory_values[mem_item] + float(int(process_info["RES"]) / 1024), 1
+                            memory_values[mem_item] + res_mib, 1
                         )
                     else:
-                        memory_values[mem_item] = round(float(int(process_info["RES"]) / 1024), 1)
+                        memory_values[mem_item] = round(res_mib, 1)
 
     logger.debug("Parsed memory values: {}".format(memory_values))
     return memory_values


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
After large RIB / BGP workloads or heavy memory-consuming testcases, the memory-utilization plugin can log:

Error collecting final memory data for top: invalid literal for int() with base 10: '1.6g'

parse_top_output in memory_utilization.py assumed that RES column was always a plain integer string in KiB and used int(process_info["RES"]).

However, top prints RES with scale suffixes (k / m / g / t), which raises during parsing. The teardown hook in memory_utilization/__init__.py catches that exception and stores an empty dict for top, so after_test shows 'top': {} even though other monitors still have data. Threshold tuning in tests never runs for top when that happens.

This change/fix parses both legacy plain-KiB RES values and suffixed human forms, converts everything to MiB consistently with the previous behavior, and keeps the existing outer try/except unchanged.

Summary:
Fixes # (issue)
#24178 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
- Restore reliable post-test top samples (bgpd, zebra, etc.) when top humanizes the RES column after memory growth.
- Avoid spurious empty after_test['top'] and misleading “missing data” / skipped threshold behavior caused by ValueError on int('1.6g').

#### How did you do it?
- Added _parse_top_res_to_mib() (and a small regex) in tests/common/plugins/memory_utilization/memory_utilization.py:
     - No suffix or k → treat as KiB → MiB = value / 1024 (same as before for integer RES).
     - Parse m / g / t → MiB / GiB / TiB → convert to MiB for aggregation.
- Updated parse_top_output to use this helper instead of int(process_info["RES"]) / 1024.
- Did not change __init__.py; the root fix is entirely in the parser.


#### How did you verify/test it?
Tested it in local clone based off of master:

Please note that output is broken into lines for better readability.
Before:
```
WARNING  tests.common.plugins.memory_utilization:__init__.py:100 Error collecting final memory data for top: invalid literal for int() with base 10: '1.6g'

INFO     tests.common.plugins.memory_utilization:__init__.py:124 After test: collected memory_values {
'before_test': {'XXXX-DVT1-08': {
'monit': {}, 
'top': {'zebra': 29.4, 'bgpd': 67.1}, 
'free': {'used': 3760}, 
'docker': {'snmp': 0.2, 'pmon': 0.6, 'lldp': 0.2, 'gnmi': 0.5, 'radv': 0.1, 'bgp': 0.6, 'syncd': 5.3, 'teamd': 0.3, 'swss': 1.3, 'database': 0.3}, 'frr_bgp': {'used': 63.3}, 'frr_zebra': {'used': 39.8}}}, 

'after_test': {'XXXX-DVT1-08': {
'monit': {'memory_usage': 19.5}, 
'top': {},  <<<<< this would be empty due to incorrect parsing.
'free': {'used': 6256}, 
'docker': {'snmp': 0.3, 'pmon': 0.6, 'lldp': 0.2, 'gnmi': 0.6, 'radv': 0.1, 'bgp': 6.8, 'syncd': 6.0, 'teamd': 0.3, 'swss': 1.7, 'database': 0.4}, 'frr_bgp': {'used': 65.0}, 'frr_zebra': {'used': 39.8}}}}
```

After the fix:
```
INFO     tests.common.plugins.memory_utilization:__init__.py:124 After test: collected memory_values {
'before_test': {'XXXX-DVT1-08': {
'monit': {}, 
'top': {'zebra': 18.8, 'bgpd': 67.1}, 
'free': {'used': 3787}, 
'docker': {'snmp': 0.2, 'pmon': 0.7, 'lldp': 0.2, 'gnmi': 0.4, 'radv': 0.1, 'bgp': 0.6, 'syncd': 5.3, 'teamd': 0.3, 'swss': 1.3, 'database': 0.3}, 'frr_bgp': {'used': 63.4}, 'frr_zebra': {'used': 40.2}}}, 

'after_test': {'XXXX-DVT1-08': {'
monit': {'memory_usage': 19.6}, 
'top': {'zebra': 203.0, 'bgpd': 1638.4},  <<< this is converted properly into 1600MiB format.
'free': {'used': 6255}, 
'docker': {'snmp': 0.3, 'pmon': 0.6, 'lldp': 0.2, 'gnmi': 0.6, 'radv': 0.1, 'bgp': 6.8, 'syncd': 6.1, 'teamd': 0.3, 'swss': 1.6, 'database': 0.4}, 'frr_bgp': {'used': 64.0}, 'frr_zebra': {'used': 40.2}}}}
```





#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
