### PR TITLE
Set missing mirror type for everflow v6 session

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -825,7 +825,7 @@ class BaseEverflowTest(object):
                 command = f"sonic-db-cli CONFIG_DB HSET 'MIRROR_SESSION|{session_info['session_name']}' \
                             'dscp' '{session_info['session_dscp']}' 'dst_ip' '{session_info['session_dst_ipv6']}' \
                             'gre_type' '{session_info['session_gre']}' 'src_ip' '{session_info['session_src_ipv6']}' \
-                            'ttl' '{session_info['session_ttl']}'"
+                            'ttl' '{session_info['session_ttl']}' 'type' 'ERSPAN'"
                 if policer:
                     command += f" 'policer' {policer}"
 


### PR DESCRIPTION
### Description of PR
everflow_test_utilities.py: apply_mirror_config creates ipv6 mirror session by directly populating CONFIG_DB instead of using CLI but is not passing mirror type. Without mirror type it defaults to non-ERSPAN and is causing tests to fail. Made change to pass in the type as well.
  
Summary:
Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/issues/24194

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
test_everflow_ipv6 tests failing

#### How did you do it?
See description.

#### How did you verify/test it?
test_everflow_ipv6 passes with this fix

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
