### PR TITLE
[gnmi] Increase wait_critical_processes timeout to 360s for warm reboot test

### DIFF
--- a/tests/gnmi/test_gnoi_system_reboot.py
+++ b/tests/gnmi/test_gnoi_system_reboot.py
@@ -133,7 +133,8 @@ def test_gnoi_system_reboot_warm(duthosts, rand_one_dut_hostname, localhost, gnm
     logging.info("System is back up after reboot")
 
     # Wait for critical processes before ending
-    wait_critical_processes(duthost)
+    # Warm reboot takes longer for containers to restart; use an extended timeout
+    wait_critical_processes(duthost, timeout=360)
 
     # Wait for gNMI container to be running
     wait_until(120, 10, 0, is_gnmi_container_running, duthost)


### PR DESCRIPTION
### Description of PR

Increase the `wait_critical_processes` timeout from 300s to 360s specifically for `test_gnoi_system_reboot_warm`.

Fixes: warm reboot test consistently timing out on Arista-7060CX platforms.
ADO: 37297420

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach

#### What is the motivation for this PR?

`test_gnoi_system_reboot_warm` has been failing 100% of the time on Arista-7060CX-32S-C32 (t0) since image `20251110.17`. Root cause analysis across 3 retries of plan `69eaeac00aae266263d6531c` (image `20251110.22`) confirmed:

- After warm reboot, pmon container is absent briefly (`No such container: pmon`)
- pmon consistently recovers at T+320-330s post-reboot, which is 20-30s past the 300s deadline
- The margin is thin but deterministic across every retry

Root cause chain:
1. `check_system_warm_boot()` queries STATE_DB after kexec — DB is reachable but empty — returns `""` not `"true"` → incorrectly treats warm boot as cold boot
2. This triggers `_restart_services()` in sonic-utilities
3. `_restart_services()` (sonic-utilities PR #4325) added monit waits totaling ~100s, delaying container restarts
4. Combined effect: pmon starts at T+320-330s, exceeding the 300s timeout by 20-30s

Kusto regression data:
- Last good image: `20251110.15` (all passes)
- First bad image: `20251110.17` (100% failure rate)
- Still failing as of `20251110.22`: 102 failures, 0 passes

#### How did you do it?

Changed `wait_critical_processes(duthost)` → `wait_critical_processes(duthost, timeout=360)` only for `test_gnoi_system_reboot_warm`. The `timeout` parameter already exists in `wait_critical_processes()` in `tests/common/platform/processes_utils.py`.

The cold reboot test (`test_gnoi_system_reboot_cold`) retains the default 300s timeout — cold reboot does not trigger `_restart_services()` and recovers well within 300s.

#### How did you verify/test it?

Analyzed 3 retry logs from failing plan `69eaeac00aae266263d6531c` (image `20251110.22`):

| Try | SSH Up   | Timeout  | pmon UP  | Over by |
|-----|----------|----------|----------|---------|
| 1   | 09:08:11 | 09:13:32 | 09:13:41 | ~21s    |
| 2   | 09:26:30 | 09:31:41 | 09:31:50 | ~11s    |
| 3   | 09:48:06 | 09:53:22 | 09:53:31 | ~16s    |

360s provides a 30-40s safety margin above the observed worst-case pmon recovery time.

**Elastictest Jobs** — `gnmi/test_gnoi_system_reboot.py` on 7060CX T0 testbeds (Round 8):

| Testbed | Topo | Plan ID |
|---------|------|---------|
| testbed-bjw3-can-t0-7060-3 | t0 | [69eeba036d4fb688a4e17f55](https://elastictest.org/scheduler/testplan/69eeba036d4fb688a4e17f55) |
| testbed-bjw3-can-t0-7060-4 | t0 | [69eeba0d678eea40b1d99d4b](https://elastictest.org/scheduler/testplan/69eeba0d678eea40b1d99d4b) |
| testbed-bjw3-can-t0-7060-5 | t0 | [69eeba1031dfe846706839d2](https://elastictest.org/scheduler/testplan/69eeba1031dfe846706839d2) |
| testbed-bjw3-can-t0-7060-6 | t0 | [69eeba151f6d9ccadfb46380](https://elastictest.org/scheduler/testplan/69eeba151f6d9ccadfb46380) |
| testbed-bjw3-can-t0-7060-7 | t0 | [69eeba196d4fb688a4e17f57](https://elastictest.org/scheduler/testplan/69eeba196d4fb688a4e17f57) |
| testbed-bjw3-can-t0-7060-8 | t0 | [69eeba1d31dfe846706839d4](https://elastictest.org/scheduler/testplan/69eeba1d31dfe846706839d4) |
| testbed-bjw2-can-t0-7060-9 | t0 | [69eeba2231dfe846706839d6](https://elastictest.org/scheduler/testplan/69eeba2231dfe846706839d6) |
| testbed-bjw2-can-t0-7060-10 | t0 | [69eeba272ecee1601aca1819](https://elastictest.org/scheduler/testplan/69eeba272ecee1601aca1819) |
| vms63-t0-7060-1 | t0 | [69eeba2c31dfe846706839d8](https://elastictest.org/scheduler/testplan/69eeba2c31dfe846706839d8) |
| vms63-t0-7060-2 | t0 | [69eeba320aae266263d65660](https://elastictest.org/scheduler/testplan/69eeba320aae266263d65660) |
| vms6-t0-7060 | t0 | [69eeba371f6d9ccadfb46382](https://elastictest.org/scheduler/testplan/69eeba371f6d9ccadfb46382) |
| vms20-t0-7060 | t0 | [69eeba3e275c1d63b5518528](https://elastictest.org/scheduler/testplan/69eeba3e275c1d63b5518528) |

Branch: `dev/xuliping/20260425_gnoi_warm_reboot_timeout_360_internal-202511` | Image: `internal-202511` (legacy-th)

#### Any platform specific information?

Confirmed on `Arista-7060CX-32S-C32` (t0 topology). Likely affects other platforms where `_restart_services()` is triggered incorrectly during warm reboot.

#### Supported testbed topology if it's a new test case?

N/A — improvement to existing test case.

### Documentation

No documentation changes required.