### PR TITLE
Update tty pattern for cisco console server.

### DIFF
--- a/tests/dut_console/test_console_baud_rate.py
+++ b/tests/dut_console/test_console_baud_rate.py
@@ -29,7 +29,11 @@ def get_expected_baud_rate(duthost):
 
 def test_console_baud_rate_config(duthost):
     expected_baud_rate = get_expected_baud_rate(duthost)
-    res = duthost.shell("cat /proc/cmdline | grep -Eo 'console=ttyS[0-9]+,[0-9]+' | cut -d ',' -f2")
+    if duthost.facts['platform'] == "arm64-c8220tg_48a_o-r0":
+        res = duthost.shell("cat /proc/cmdline | grep -Eo 'console=tty[A-Z]*[0-9]+,[0-9]+' | cut -d ',' -f2")
+    else:
+        res = duthost.shell("cat /proc/cmdline | grep -Eo 'console=ttyS[0-9]+,[0-9]+' | cut -d ',' -f2")
+
     pytest_require(res["stdout"] != "", "Cannot get baud rate")
     if res["stdout"] != str(expected_baud_rate):
         global pass_config_test


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
test_console_baud_rate.py is skipping since the tty format looks different in cisco console server. This PR addresses it by changing the pattern for this platform.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
The script completely skips for this platform.

#### How did you do it?
Modified the pattern to search for in cisco-console platform.

#### How did you verify/test it?
Ran it on my DUT:
```
===================================================================================================== PASSES =====================================================================================================
_________________________________________________________________________________________ test_console_baud_rate_config __________________________________________________________________________________________
________________________________________________________________________________________ test_console_escape[sirc0-dut1] _________________________________________________________________________________________
____________________________________________________________________________________________ test_timeout[sirc0-dut1] ____________________________________________________________________________________________
___________________________________________________________________________________ test_commands_output_is_ascii[sirc0-dut1] ____________________________________________________________________________________
-------------------------------------------------------------- generated xml file: /run_logs/sir-c0/dut-console/2026-04-25-01-39-04/dut_console.xml --------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
============================================================================================ short test summary info =============================================================================================
PASSED dut_console/test_console_baud_rate.py::test_console_baud_rate_config
PASSED dut_console/test_escape_character.py::test_console_escape[sirc0-dut1]
PASSED dut_console/test_idle_timeout.py::test_timeout[sirc0-dut1]
PASSED dut_console/test_non_ascii_output.py::test_commands_output_is_ascii[sirc0-dut1]
SKIPPED [1] dut_console/test_console_baud_rate.py:104: Unsupported console type: telnet
SKIPPED [1] dut_console/test_console_baud_rate.py:109: Unsupported console type: telnet
SKIPPED [1] dut_console/test_console_chassis_conn.py: test requires topology in Mark(name='topology', args=('t2',), kwargs={})
============================================================================== 4 passed, 3 skipped, 2 warnings in 547.83s (0:09:07) ==============================================================================
sonic@arctos_cicd_all_202603:/data/tests$ 
```
#### Any platform specific information?
This check is only for cisco console platform.
