### PR TITLE
[common]: increase default critical-process wait timeout from 300s to 360s

### DIFF
--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -35,16 +35,16 @@ def check_pmon_uptime_minutes(duthost, minimal_runtime=6):
 def reset_timeout(duthost):
     """
     return: if timeout is specified in inventory file for this dut, return new timeout
-            if not specified, return 300 sec as default timeout
+            if not specified, return 360 sec as default timeout
     e.g.
         processes_utils.py:
           timeout: 400
           wait: 60
     """
-    reset_timeout = 300
+    reset_timeout = 360
     plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, 'processes_utils.py', 'cold')
     if plt_reboot_ctrl:
-        reset_timeout = plt_reboot_ctrl.get('timeout', 300)
+        reset_timeout = plt_reboot_ctrl.get('timeout', 360)
     return reset_timeout
 
 


### PR DESCRIPTION
### Description of PR
Summary:
Increase the default critical-process wait timeout in `reset_timeout()` from 300s to 360s.

On Arista-7060CX-32S-C32, after a warm reboot, `pmon` consistently recovers at T+320–330s (due to `_restart_services()` being triggered by `check_system_warm_boot()` misdetecting the warm boot as cold after kexec, plus ~100s of monit waits added by sonic-utilities PR #4325). The current 300s deadline causes `wait_critical_processes()` to time out before pmon is up.

Related PR: #24200 (targeted fix for `test_gnoi_system_reboot_warm` only)

### Type of change
- [x] Bug fix
- [x] Testbed and Framework(new/improvement)

### Back port request
- [x] 202511

### Approach
#### What is the motivation for this PR?
`wait_critical_processes()` uses `reset_timeout()` which returns 300s as the default. On Arista-7060CX-32S-C32 after warm reboot, `pmon` takes 320–330s to recover, causing spurious test failures across any test that calls `wait_critical_processes()` without an explicit timeout.

#### How did you do it?
Changed the default timeout in `reset_timeout()` from 300s to 360s (both the hardcoded value and the platform config fallback). This gives a ~30s safety margin over the observed worst-case (330s).

#### How did you verify/test it?
Confirmed via log analysis of 3 consecutive test_gnoi_system_reboot_warm failures on Arista-7060CX-32S-C32 (elastictest plan `69eaeac00aae266263d6531c`): pmon recovered at T+320s, T+325s, T+330s — all within 360s.

#### Any platform specific information?
Observed on Arista-7060CX-32S-C32. Note: supervisor nodes always use 900s (hardcoded), unaffected by this change.

#### Supported testbed topology if it's a new test case?
N/A — framework change affecting all topologies.

### Documentation
N/A