### PR TITLE
ntp: fix teardown error when NTP server is not configured

### DIFF
--- a/tests/common/helpers/ntp_helper.py
+++ b/tests/common/helpers/ntp_helper.py
@@ -105,7 +105,10 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
         ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^interface.listen.mgmt")
 
     # reset ntp client configuration
-    duthost.command("config ntp del %s" % (ptfhost.mgmt_ipv6 if ptf_use_ipv6 else ptfhost.mgmt_ip))
+    # The NTP server may have already been removed (e.g., if the DUT's NTP config was modified
+    # externally). Ignore errors here so that the original servers can still be restored below.
+    duthost.command("config ntp del %s" % (ptfhost.mgmt_ipv6 if ptf_use_ipv6 else ptfhost.mgmt_ip),
+                    module_ignore_errors=True)
     for ntp_server in ntp_servers:
         duthost.command("config ntp add %s %s" % ("--iburst" if ntp_add_iburst_present else "", ntp_server))
     # The time jump leads to exception in lldp_syncd. The exception has been handled by lldp_syncd,


### PR DESCRIPTION
### Description

The teardown in `setup_ntp_context()` calls `config ntp del <PTF_IP>` during cleanup. On some platforms (e.g., Arista TH5 with chrony), the command fails with "NTP server not configured", causing teardown to error and preventing original NTP servers from being restored.

**Fix**: Use `module_ignore_errors=True` so teardown continues even if the del command fails.

### How Has This Been Tested

Ran `ntp/test_ntp.py::test_ntp[ipv6_only]` on vms76-lt2-7060x6-9. Test now PASSES.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.

Signed-off-by: Bing Wang <bingwang@microsoft.com>