### PR TITLE
syslog: increase rsyslogd restart timeout for high-latency platforms

### DIFF
--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -270,7 +270,7 @@ def get_host_rsyslogd_pid(duthost):
 
 
 @contextlib.contextmanager
-def expect_host_rsyslog_restart(duthost, timeout=30):
+def expect_host_rsyslog_restart(duthost, timeout=60):
     current_pid = get_host_rsyslogd_pid(duthost)
 
     yield


### PR DESCRIPTION
### Description

The `expect_host_rsyslog_restart()` function had a hardcoded 30-second timeout. On high-latency platforms such as Arista 7060X6 (TH5), the rsyslogd service can take longer than 30 seconds to restart after sending SIGHUP, causing spurious test failures.

**Fix**: Increase the default timeout from 30 to 60 seconds.

### How Has This Been Tested

Ran `syslog/test_syslog_rate_limit.py` on vms76-lt2-7060x6-9 (str4-7060x6-512-9, Arista TH5). Test now PASSES.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.

Signed-off-by: Bing Wang <bingwang@microsoft.com>