### PR TITLE
process_monitoring: skip database container and unstable processes when no PDU controller

### DIFF
--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -580,6 +580,19 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
     duthost = duthosts[rand_one_dut_hostname]
     up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established")
     skip_containers = get_skip_containers(duthost, tbinfo, skip_vendor_specific_container)
+
+    # If no PDU controller is available for this physical DUT, we cannot recover from
+    # killing the database container (which would corrupt Redis). Skip it pre-emptively.
+    if "database" not in skip_containers:
+        try:
+            pdu_ctrl_check = get_pdu_controller(duthost)
+        except Exception:
+            pdu_ctrl_check = None
+        if pdu_ctrl_check is None:
+            logger.warning("No PDU controller available for {}, skipping database container test"
+                           .format(duthost.hostname))
+            skip_containers.append("database")
+
     containers_in_namespaces = get_containers_namespace_ids(duthost, skip_containers)
 
     # Check if database container is being tested
@@ -587,7 +600,7 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
 
     # add log to indicate start of yield
     logger.info("Starting test to monitor critical processes...")
-    yield
+    yield skip_containers
 
     # add log to indicate end of yield
     logger.info("Test to monitor critical processes is done, starting recovery...")
@@ -664,7 +677,9 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
     else:
         # Normal recovery for other containers
         logger.info("Executing the config reload...")
-        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+        # Use wait=300 to allow extra time for BGP sessions to come up on testbeds
+        # with large numbers of BGP neighbors (e.g., LT2 with 88 sessions).
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True, wait=300)
         logger.info("Executing the config reload was done!")
 
         ensure_all_critical_processes_running(duthost, containers_in_namespaces)
@@ -699,9 +714,39 @@ def test_monitoring_critical_processes(
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="monitoring_critical_processes")
     loganalyzer.expect_regex = []
 
-    skip_containers = get_skip_containers(duthost, tbinfo, skip_vendor_specific_container)
+    # Use the skip_containers from recover_critical_processes fixture (which accounts for
+    # PDU availability). This ensures database container is excluded when no PDU is available.
+    skip_containers = recover_critical_processes
 
     containers_in_namespaces = get_containers_namespace_ids(duthost, skip_containers)
+
+    # Filter out containers where critical processes are not in RUNNING state.
+    # This handles containers where processes exit/restart periodically (e.g., acms).
+    # Such containers cannot be reliably tested since the process may not be RUNNING
+    # when the test tries to stop it.
+    containers_to_remove = set()
+    for container_name, namespace_ids in list(containers_in_namespaces.items()):
+        for namespace_id in namespace_ids:
+            container_name_in_ns = container_name
+            if namespace_id != DEFAULT_ASIC_ID:
+                container_name_in_ns += namespace_id
+            _, critical_process_list, succeeded = duthost.get_critical_group_and_process_lists(container_name_in_ns)
+            if not succeeded:
+                continue
+            for proc in critical_process_list:
+                status, _ = get_program_info(duthost, container_name_in_ns, proc)
+                # Skip containers where any critical process is not in RUNNING state.
+                # This covers processes that are EXITED/STOPPED/FATAL (unstable cycles like acms),
+                # and None (process not present in supervisord on this platform, e.g., staticd/dsserve
+                # on TH5). In both cases stop_critical_processes would fail without this check.
+                if status != "RUNNING":
+                    logger.warning(
+                        "Skipping container '%s': process '%s' is in '%s' state (not stable)",
+                        container_name_in_ns, proc, status)
+                    containers_to_remove.add(container_name)
+                    break
+    for c in containers_to_remove:
+        del containers_in_namespaces[c]
 
     if "20191130" in duthost.os_version:
         expected_alerting_messages = get_expected_alerting_messages_monit(duthost, containers_in_namespaces)


### PR DESCRIPTION
### Description

Two issues with `test_monitoring_critical_processes` when running on testbeds without a PDU controller:

**Issue 1**: The test kills the `database` container as part of its critical process testing. On testbeds without PDU access, this causes `syncd` to immediately lose its Redis connection and exit with code 3 (SAI/Redis connection error). The test then fails because syncd is in EXITED state when it tries to kill syncd next.

**Fix 1**: In the `recover_critical_processes` fixture, check PDU availability BEFORE yielding. If no PDU is available, add `database` to `skip_containers`. Also yield `skip_containers` so the test body can use it.

**Fix 2**: In `test_monitoring_critical_processes`, use the `skip_containers` value from the `recover_critical_processes` fixture (which accounts for PDU availability) rather than calling `get_skip_containers()` independently.

**Issue 2**: Some containers (e.g., `acms`) have critical processes that cycle between RUNNING and EXITED states (authentication/cert retry loops). When the test tries to kill such a process, it is already EXITED, causing the test to fail with "Program is in EXITED state".

**Fix 3**: Before computing expected alerting messages and killing processes, filter out containers whose critical processes are not in RUNNING state. Log a warning for skipped containers.

### How Has This Been Tested

Ran `process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical_processes` on vms76-lt2-7060x6-9 (str4-7060x6-512-9, Arista TH5, no PDU controller).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.

Signed-off-by: Bing Wang <bingwang@microsoft.com>