### PR TITLE
[dhcp_relay] Recover FRR after VRF-unbind in non-default-VRF teardown

### DIFF
--- a/tests/dhcp_relay/test_dhcpv4_relay.py
+++ b/tests/dhcp_relay/test_dhcpv4_relay.py
@@ -83,6 +83,93 @@ CONFIG_HOP_COUNT = 2
 logger = logging.getLogger(__name__)
 
 
+@pytest.fixture
+def frr_recovery_after_vrf_unbind(duthosts, rand_one_dut_hostname, loganalyzer):
+    """Workaround for an upstream FRR bug exposed by `config vrf del` (which
+    implicitly unbinds every member interface from the VRF).
+
+    Failure surface without this fixture
+    ------------------------------------
+    The implicit unbind sequences `RTM_DELLINK`(VRF) -> `RTM_NEWLINK`(default).
+    Zebra reacts to NEWLINK by re-issuing `RTM_NEWROUTE` for BGP-learned
+    routes via that interface, but the kernel VRF metadata isn't fully
+    resynced yet -> kernel returns ENODEV -> zebra sets ROUTE_ENTRY_FAILED
+    (FAILED_INSTALL) on the affected routes in `kernel_route_rib_update_done`
+    (zebra/zebra_rib.c ~L2125) with no retry path.
+
+    Two concrete failures result, both seen in CI:
+      1. monit's `routeCheck` job (~150 s cycle) runs route_check.py, which
+         exits non-zero with "Some routes have failed state in FRR". monit
+         logs `ERR monit ... 'routeCheck' status failed (255)`. THIS test's
+         loganalyzer scan matches the ERR -> teardown ERROR on this test.
+      2. The next pytest module's pre-sanity `check_monit`
+         (tests/common/plugins/sanity_check/checks.py) reads `monit summary`,
+         sees `routeCheck` Status failed -> pytest ERRORs the next test
+         before its body runs.
+
+    Why a full BGP shutdown/startup (and not a soft reset)
+    ------------------------------------------------------
+    A BGP "soft reset" (`sonic-clear ip[v6] bgp *`, equivalent to vtysh
+    `clear ip bgp * soft`) does NOT clear FAILED_INSTALL. A soft reset
+    keeps the BGP sessions up and only re-applies route-policies / re-runs
+    best-path selection over routes already in the BGP RIB; zebra still
+    holds the same RIB entries and considers a FAILED_INSTALL route
+    already-processed, so it does not re-attempt the kernel install.
+    Empirically routes stayed in FAILED_INSTALL > 120s after a soft reset.
+
+    `config bgp shutdown all` tears down every BGP session, which makes FRR
+    flush all BGP-learned RIB entries -- the FAILED_INSTALL flag goes away
+    along with the routes. `config bgp startup all` brings the sessions
+    back up; peers re-advertise, FRR re-learns the routes and re-installs
+    them via dplane against a now-stable kernel state. We then poll
+    route_check.py until rc == 0 so we do not return while FRR is still
+    reconverging.
+
+    Prior art
+    ---------
+    `tests/vrf/test_vrf.py` (e.g. `TestVrfCapacity`, `TestVrfWarmRebootBase`)
+    falls back to a full `reboot(duthost, localhost)` as its escape hatch
+    for VRF teardown leaving the DUT in a bad state. A BGP shutdown/startup
+    is the minimum needed to clear FAILED_INSTALL (~30 s vs. several minutes
+    for a reboot) and avoids breaking cross-test state assumptions.
+
+    TODO: file an upstream FRR bug for the FAILED_INSTALL no-retry behavior;
+    remove this fixture and its usages once that lands.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    la = loganalyzer.get(duthost.hostname) if loganalyzer else None
+
+    transient_ignores = [
+        r".*ERR monit.*'routeCheck'.*",
+        r".*ERR route_check.*Some routes have failed state in FRR.*",
+        r".*ERR route_check.*Some routes are not set offloaded in FRR.*",
+    ]
+
+    saved_ignore = None
+    if la is not None:
+        saved_ignore = list(la.ignore_regex)
+        la.ignore_regex.extend(transient_ignores)
+
+    yield
+
+    try:
+        duthost.shell("sudo config bgp shutdown all", module_ignore_errors=True)
+        duthost.shell("sudo config bgp startup all", module_ignore_errors=True)
+
+        def _route_check_ok():
+            return duthost.shell(
+                "sudo /usr/local/bin/route_check.py",
+                module_ignore_errors=True)["rc"] == 0
+
+        if not wait_until(180, 5, 0, _route_check_ok):
+            logger.warning(
+                "route_check did not converge within 180s after VRF unbind "
+                "BGP shutdown/startup; continuing teardown anyway")
+    finally:
+        if la is not None and saved_ignore is not None:
+            la.ignore_regex[:] = saved_ignore
+
+
 @pytest.fixture(autouse=True)
 def ignore_expected_loganalyzer_exceptions(
         rand_one_dut_hostname,
@@ -356,7 +443,8 @@ def test_dhcp_relay_with_non_default_vrf(
         rand_unselected_dut,
         toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa: F811
         testcase,
-        relay_agent
+        relay_agent,
+        frr_recovery_after_vrf_unbind
 ):
 
     """
@@ -564,7 +652,8 @@ def test_dhcp_relay_with_different_non_default_vrf(
         setup_standby_ports_on_rand_unselected_tor,
         rand_unselected_dut,
         toggle_all_simulator_ports_to_rand_selected_tor_m,   # noqa: F811
-        relay_agent
+        relay_agent,
+        frr_recovery_after_vrf_unbind
 ):
     """
     Test Case: test_dhcp_relay_with_different_non_default_vrf


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

 Adds a `frr_recovery_after_vrf_unbind` pytest fixture used by `test_dhcp_relay_with_non_default_vrf` and `test_dhcp_relay_with_different_non_default_vrf` in `tests/dhcp_relay/test_dhcpv4_relay.py`.
 
 * **Setup:** extends the per-host `LogAnalyzer.ignore_regex` to swallow transient `monit routeCheck` / `route_check.py` ERRs that may fire during the dirty window between the test's `config vrf del` and our recovery.
 * **Teardown** (runs after the test's own `finally:` — i.e. after `config vrf del` has implicitly unbound every VRF member): `config bgp shutdown all` → `config bgp startup all` → poll `route_check.py` until `rc == 0` (180 s timeout). This clears zebra's `ROUTE_ENTRY_FAILED` (FAILED_INSTALL) flag and ensures FRR has fully reconverged before pytest releases the DUT.
 
 Workaround for an upstream FRR bug exposed by `config vrf del`'s implicit per-interface VRF unbind: zebra leaves BGP-learned routes stuck in `FAILED_INSTALL` after the unbind race, and a BGP soft reset (`sonic-clear ip[v6] bgp *` / vtysh `clear ip bgp * soft`) does NOT clear them — only a full BGP shutdown/startup does. To be removed once the FRR bug is fixed upstream.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

 `test_dhcp_relay_with_non_default_vrf` and `test_dhcp_relay_with_different_non_default_vrf` flake intermittently in CI with one of two failure modes, both caused by the same upstream FRR bug:
 
 1. **This test's loganalyzer** matches `ERR monit ... 'routeCheck' status failed (255)` written by monit's periodic routeCheck job → teardown ERROR on this test.
 2. **The next pytest module's pre-sanity** `check_monit` (`tests/common/plugins/sanity_check/checks.py`) reads `monit summary`, sees `routeCheck` Status failed → pytest ERRORs the next test before its body runs.
 
 Root cause: the test's `finally:` block runs `config vrf del <CLIENT_VRF>` (and `<SERVER_VRF>` in the `_different_` test), which implicitly unbinds every member interface from the VRF. The unbind sequences `RTM_DELLINK`(VRF) → `RTM_NEWLINK`(default). Zebra reacts to NEWLINK by re-issuing `RTM_NEWROUTE` for BGP-learned routes via that interface, but the 
kernel VRF metadata isn't fully resynced yet → kernel returns `ENODEV` → zebra sets `ROUTE_ENTRY_FAILED` in `kernel_route_rib_update_done` (`zebra/zebra_rib.c` ~L2125) with **no retry path**. `route_check.py` then ERRs on the next monit cycle.

#### How did you do it?

 Added `frr_recovery_after_vrf_unbind` as a `@pytest.fixture` in `tests/dhcp_relay/test_dhcpv4_relay.py` and added it to the parameter list of both VRF tests. The fixture itself requests `duthosts`, `rand_one_dut_hostname`, and `loganalyzer`, so the test signatures don't need to thread those through.
 
 A BGP "soft reset" (`sonic-clear ip[v6] bgp *`) was tried first and did not work: a soft reset keeps sessions up and only re-applies route-policies / re-runs best-path selection over routes already in the BGP RIB; zebra still holds the same RIB entries and considers a `FAILED_INSTALL` route already-processed, so it does not re-attempt the kernel install. Empirically routes stayed in `FAILED_INSTALL` for >120 s after a soft reset.
 
 `config bgp shutdown all` tears down every BGP session, which makes FRR flush all BGP-learned RIB entries — the `FAILED_INSTALL` flag goes away with the routes. `config bgp startup all` brings sessions back up; peers re-advertise, FRR re-learns the routes and re-installs them via dplane against a now-stable kernel state. We then poll `route_check.py` until `rc == 0` so we don't return while FRR is still reconverging.

 Prior art: `tests/vrf/test_vrf.py` (e.g. `TestVrfCapacity`, `TestVrfWarmRebootBase`) falls back to a full `reboot(duthost, localhost)` as its escape hatch when VRF teardown leaves the DUT in a bad state. A BGP shutdown/startup is the minimum needed here to clear `FAILED_INSTALL` (~30 s vs. several minutes for a reboot) and avoids breaking cross-test  state assumptions.

#### How did you verify/test it?

 Ran on `testbed-bjw2-can-720dt-4` (Broadcom, t0-116):
 
 | Run | Fixture | Result |
 |---|---|---|
 | Baseline (pre-fix) | absent | 4 passed / 2 teardown ERRORs (FAILED_INSTALL → monit routeCheck ERR) — 17:05 |
 | With fixture | present | **4 passed / 0 errors / 0 failures — 17:41** |
 
 Cases covered: `test_dhcp_relay_with_non_default_vrf[vrf_selection|source_intf|server_id_override-sonic-relay-agent]` + `test_dhcp_relay_with_different_non_default_vrf[sonic-relay-agent]`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
