### PR TITLE
[tests/snmp]: Fix multi-ASIC HGETALL parsing in queue counter test

### DIFF
--- a/tests/snmp/test_snmp_queue_counters.py
+++ b/tests/snmp/test_snmp_queue_counters.py
@@ -58,31 +58,19 @@ def get_redis_queue_count_with_types(duthost, interface, asic=None):
     Returns:
         Dictionary with 'total', 'unicast', and 'multicast' queue counts
     """
-    # Build the redis-cli commands with namespace support for multi-ASIC
-    if asic is not None and duthost.sonichost.is_multi_asic:
-        name_map_cmd = (
-            "sonic-db-cli -n {} COUNTERS_DB HGETALL COUNTERS_QUEUE_NAME_MAP"
-            .format(asic.namespace))
-        type_map_cmd = (
-            "sonic-db-cli -n {} COUNTERS_DB HGETALL COUNTERS_QUEUE_TYPE_MAP"
-            .format(asic.namespace))
-    else:
-        name_map_cmd = "redis-cli -n 2 HGETALL COUNTERS_QUEUE_NAME_MAP"
-        type_map_cmd = "redis-cli -n 2 HGETALL COUNTERS_QUEUE_TYPE_MAP"
+    if asic is None:
+        asic = duthost.asic_instance()
 
-    # Get queue name map (interface:queue -> SAI OID)
-    name_map_result = duthost.shell(name_map_cmd)['stdout_lines']
-
-    # Get queue type map (SAI OID -> queue type)
-    type_map_result = duthost.shell(type_map_cmd)['stdout_lines']
+    name_map_result = asic.run_redis_cmd(
+        argv=["redis-cli", "-n", 2, "HGETALL", "COUNTERS_QUEUE_NAME_MAP"])
+    type_map_result = asic.run_redis_cmd(
+        argv=["redis-cli", "-n", 2, "HGETALL", "COUNTERS_QUEUE_TYPE_MAP"])
 
     # Build type map dictionary (SAI OID -> type string)
     type_map = {}
     for i in range(0, len(type_map_result), 2):
         if i + 1 < len(type_map_result):
-            sai_oid = type_map_result[i]
-            queue_type = type_map_result[i + 1]
-            type_map[sai_oid] = queue_type
+            type_map[type_map_result[i]] = type_map_result[i + 1]
 
     # Count queues for the interface
     queue_count = {'total': 0, 'unicast': 0, 'multicast': 0}

--- a/tests/snmp/test_snmp_queue_counters.py
+++ b/tests/snmp/test_snmp_queue_counters.py
@@ -330,7 +330,7 @@ def test_snmp_queue_counters(duthosts,
     # cannot be modified dynamically. Hence, make sure the queue counters
     # before deletion and after deletion are same for broadcom-dnx voq chassis
     platform_asic = duthost.facts.get("platform_asic")
-    if platform_asic == "broadcom-dnx" and duthost.sonichost.is_multi_asic:
+    if platform_asic == "broadcom-dnx":
         pytest_assert(
             (queue_counters_cnt_pre == queue_counters_cnt_post),
             "Queue counters actual count {} differs from expected values {}"


### PR DESCRIPTION
### Description of PR

Fix https://github.com/sonic-net/sonic-mgmt/issues/24198

PR #23264 introduced `get_redis_queue_count_with_types()` which uses `sonic-db-cli -n <namespace> HGETALL` on multi-ASIC systems. However, `sonic-db-cli` returns HGETALL output as a Python dict string on a single line, while the parsing logic expects `redis-cli`'s alternating key/value line format. This causes the iteration guard to always be `False` for a list of length 1, resulting in zero queue counts and failing the test.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
`test_snmp_queue_counters.py` is failing with `Failed: Snmpwalk Queue counters actual count 64 differs from expected count 0 (UC queues: 0, MC queues: 0)`

#### How did you do it?
* Replaced `sonic-db-cli` / `redis-cli` command branching with `asic.run_redis_cmd()` which handles multi-ASIC transparently via `docker exec` into the database container
* This always returns consistent `redis-cli` alternating key/value output, eliminating the format mismatch

#### How did you verify/test it?
1. Dry runned `test_snmp_queue_counters`, need verification on a multi-ASIC DUT. The test should now pass with correct UC/MC queue counts

#### Any platform specific information?
Affects multi-ASIC platforms only. Single-ASIC path is unchanged.

#### Supported testbed topology if it's a new test case?
N/A — bug fix for existing test supporting `any` and `t1-multi-asic` topologies.

### Documentation
N/A