### PR TITLE
Cleanup leftovers from removed test_dhcp_relay_on_dualtor_standby

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -1284,27 +1284,6 @@ class DHCPTest(DataplaneBaseTest):
                     self.dest_mac_address, self.client_udp_src_port)
 
 
-class DHCPPacketsServerToClientTest(DHCPTest):
-    """
-    Only Test DHCP packets from server to client, including offer, ack, nak and unknown.
-    """
-    def runTest(self):
-        # Start sniffer process for each server port to capture DHCP packet
-        for interface_index in self.server_port_indices:
-            t1 = Thread(target=self.Sniffer, args=(
-                "eth"+str(interface_index),))
-            t1.start()
-
-        self.server_send_offer()
-        self.verify_offer_received()
-        self.server_send_ack()
-        self.verify_ack_received()
-        self.server_send_unknown()
-        self.verify_relayed_unknown_on_client_side()
-        self.server_send_nak()
-        self.verify_relayed_nak()
-
-
 class DHCPInvalidChecksumTest(DHCPTest):
     """
     Test DHCP packets with invalid checksum.

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1117,12 +1117,6 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_monitor_checksum_validation:
     conditions:
       - "https://github.com/sonic-net/sonic-buildimage/issues/24402 and asic_type in ['mellanox', 'nvidia']"
 
-dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_on_dualtor_standby:
-  skip:
-    reason: "Test requires dualtor topology (uses rand_unselected_dut which returns None on non-dualtor)"
-    conditions:
-      - "'dualtor' not in topo_name"
-
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_random_sport:
   skip:
     reason: "Skip test_dhcp_relay_random_sport on dualtor in 201811 and 201911 or platform x86_64-8111_32eh_o-r0"


### PR DESCRIPTION
PR #22214 (cherry-picked as #23063) removed the
test_dhcp_relay_on_dualtor_standby function but left behind two pieces of infrastructure that were added solely for it by PR #20353. These are both now dead code with zero remaining callers anywhere in sonic-mgmt:

1. tests/common/plugins/conditional_mark/tests_mark_conditions.yaml: the skip rule keyed on the removed test name.

2. ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py: the DHCPPacketsServerToClientTest PTF class, a DHCPTest subclass whose runTest only exercises the server-to-client direction (offer/ack/nak/unknown). It was only ever invoked via ptf_runner from the removed test.

Verified with grep across the full tree: zero remaining references to DHCPPacketsServerToClientTest or test_dhcp_relay_on_dualtor_standby.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

 PR #22214 (cherry-picked as #23063) removed the
 `test_dhcp_relay_on_dualtor_standby` function but left behind two pieces of
 infrastructure that were added solely for it by PR #20353. These are both now
 dead code with zero remaining callers anywhere in sonic-mgmt:
 
 1. `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`: the
    skip rule keyed on the removed test name.
 
 2. `ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py`: the
    `DHCPPacketsServerToClientTest` PTF class, a `DHCPTest` subclass whose
    `runTest` only exercises the server-to-client direction
    (offer/ack/nak/unknown). It was only ever invoked via `ptf_runner` from
    the removed test.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

 PR #22214 removed `test_dhcp_relay_on_dualtor_standby` from
 `tests/dhcp_relay/test_dhcp_relay.py`, but only the test function itself was
 deleted. Two pieces of infrastructure that PR #20353 had added specifically
 to support that test were left behind:
 
 - A `conditional_mark` skip rule keyed on the now-nonexistent test name. With
   the test gone, the rule does nothing — pytest never sees the test id, so
   the rule is unreachable.
 - A `DHCPPacketsServerToClientTest` PTF class that only does the server→client
   direction the deleted test exercised. No other Python test in the repo
   invokes it (verified via grep), and PTF classes have no auto-discovery —
   they only run when explicitly named in `ptf_runner(...)`.
 
 Both are pure dead code today. Cleaning them up keeps the test inventory and
 the PTF library consistent with what is actually exercised.

#### How did you do it?

 Two surgical deletions:
 
 1. Removed the `dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_on_dualtor_standby`
    stanza from `tests_mark_conditions.yaml` (5 lines + blank).
 2. Removed the entire `class DHCPPacketsServerToClientTest(DHCPTest)` block
    from `ptftests/py3/dhcp_relay_test.py` (21 lines).
 
 Total: 27 lines deleted, 0 added, across 2 files. No imports or other helpers
 needed to be touched — the class only used symbols that the parent
 `DHCPTest` class still requires (`Thread`, `self.Sniffer`, etc.).

#### How did you verify/test it?

Run tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
