### PR TITLE
[test_fib] Fix false failures of test_nvgre_hash / test_vxlan_hash on packet chassis

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -960,6 +960,11 @@ class VxlanHashTest(HashTest):
             masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "ttl")
             masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
             masked_exp_pkt.set_do_not_care_scapy(scapy.TCP, "chksum")
+        # Outer IPv6 hlim may be decremented multiple times on chassis
+        # (across ingress/egress LCs); also mask inner TCP chksum.
+        if self.ignore_ttl and version == 'IPv6':
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "hlim")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.TCP, "chksum")
         return masked_exp_pkt
 
     def check_ip_route(self, hash_key, src_port, dst_port_lists, outer_src_ip,
@@ -1097,6 +1102,12 @@ class NvgreHashTest(HashTest):
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
         if version == 'IPv6':
             masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "hlim")
+        # Outer TTL may be decremented multiple times on chassis
+        # (across ingress/egress LCs). Mask outer IP ttl and chksum
+        # when ignore_ttl is set.
+        if self.ignore_ttl and version == 'IP':
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "ttl")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
         return masked_exp_pkt
 
     def create_pkt(

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -722,6 +722,7 @@ def test_vxlan_hash(add_default_route_to_dut, duthost, duthosts,                
     else:
         src_ip_range = SRC_IPV6_RANGE
         dst_ip_range = DST_IPV6_RANGE
+    switch_type = duthosts[0].facts.get('switch_type')
     ptf_runner(ptfhost,
                "ptftests",
                "hash_test.VxlanHashTest",
@@ -738,6 +739,7 @@ def test_vxlan_hash(add_default_route_to_dut, duthost, duthosts,                
                        "vlan_ids": VLANIDS,
                        "ignore_ttl": ignore_ttl,
                        "single_fib_for_duts": single_fib_for_duts,
+                       "switch_type": switch_type,
                        "ipver": vxlan_ipver,
                        "topo_name": tbinfo['topo']['name'],
                        "topo_type": tbinfo['topo']['type'],
@@ -787,6 +789,7 @@ def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                
     else:
         src_ip_range = SRC_IPV6_RANGE
         dst_ip_range = DST_IPV6_RANGE
+    switch_type = duthosts[0].facts.get('switch_type')
     ptf_runner(ptfhost,
                "ptftests",
                "hash_test.NvgreHashTest",
@@ -802,6 +805,7 @@ def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                
                        "vlan_ids": VLANIDS,
                        "ignore_ttl": ignore_ttl,
                        "single_fib_for_duts": single_fib_for_duts,
+                       "switch_type": switch_type,
                        "ipver": nvgre_ipver,
                        "topo_name": tbinfo['topo']['name'],
                        "topo_type": tbinfo['topo']['type'],


### PR DESCRIPTION
### Description of PR

Summary:
On packet-chassis platforms (e.g. cisco-8000 with 3 LCs × 3 ASICs), `test_nvgre_hash` and `test_vxlan_hash` (IPv6 inner) intermittently fail with "expected packet not received" even when the DUT is forwarding/hashing correctly.

Root cause:
1. The outer header TTL/HopLimit is decremented more than once when a packet traverses multiple ASICs/LCs on a packet chassis (typical 64 → 62 instead of 63). PTF compares the outer header byte-by-byte and drops "mismatching" packets, which causes the test to misreport ECMP imbalance / missing packets.
   - `HashTest` and `IPinIPHashTest` already mask `ttl`/`hlim` (and checksum) when `ignore_ttl` is set, but `NvgreHashTest` (IPv4 outer) and `VxlanHashTest` (IPv6 outer) were missing the same masks.
2. `test_nvgre_hash` and `test_vxlan_hash` did not forward `switch_type` to the PTF script, so `check_balancing()` could not apply the chassis-packet specific filtering (`check_same_asic`) and produced misleading balance results.

Fixes # 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

`test_nvgre_hash` (and `test_vxlan_hash` with IPv6 inner) was failing on packet-chassis testbeds (cisco-8000) due to two missing pieces that already exist for the regular `HashTest`/`IPinIPHashTest` path: outer TTL/HopLimit masking under `ignore_ttl`, and propagation of `switch_type` so that PTF balancing logic can apply chassis-packet semantics.

#### How did you do it?

- `ansible/roles/test/files/ptftests/py3/hash_test.py`
  - `NvgreHashTest.check_ipv4_route` / `check_ipv6_route` (outer IPv4): when `ignore_ttl` is set, mask outer `IP.ttl` and `IP.chksum` on the expected packet (mirrors `HashTest`).
  - `VxlanHashTest.check_ipv6_route` (outer IPv6): when `ignore_ttl` is set, mask outer `IPv6.hlim` and inner `TCP.chksum` (mirrors the IPv4 outer path that was already correct).
- `tests/fib/test_fib.py`
  - `test_nvgre_hash` / `test_vxlan_hash`: read `switch_type = duthosts[0].facts.get('switch_type')` and pass it to `ptf_runner` so PTF's `check_balancing()` can correctly handle `chassis-packet`.

No behavior change for non-chassis platforms (`switch_type` is `None`/`'voq'` etc., and the `ignore_ttl` mask is only applied when the existing flag is set).

#### How did you verify/test it?

Verified on a real cisco-8000 packet-chassis testbed (3 LCs × 3 ASICs, 96 PTF ports):

- Before fix: `test_nvgre_hash` reported only 4–5 of 15 ECMP nexthops being hit and failed `check_balancing` (false negative caused by TTL mask filtering out cross-ASIC packets).
- After fix: all 15 ECMP members receive traffic and `check_balancing` passes within `balancing_range=0.25`.
- Captured outer GRE packets with `tcpdump -i any -nn -vvv -e 'ip proto 47'` and confirmed outer TTL is 62 (decremented twice) on chassis, which is now correctly tolerated.

Also re-ran `test_vxlan_hash` (v4 and v6 inner) and `test_basic_fib` to make sure non-chassis paths still pass.

#### Any platform specific information?

Targets packet-chassis platforms (verified on `cisco-8000`, `switch_type='chassis-packet'`). The change is gated by `ignore_ttl` and by passing `switch_type`, so single-ASIC / VoQ chassis behavior is unchanged.

#### Supported testbed topology if it's a new test case?

N/A — bug fix to existing tests. Verified on `t2` packet-chassis topology.

### Documentation

N/A — bug fix; no doc/wiki changes needed.