### PR TITLE
fix(qos): block L2 noise on fanout during headroom pool tests

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -3100,9 +3100,10 @@ class QosSaiBase(QosBase):
                     vm_host.no_lacp_time_multiplier(neighbor_lag_member)
 
     @pytest.fixture(scope="function", autouse=False)
-    def block_non_test_traffic_on_fanout(self, get_src_dst_asic_and_duts, tbinfo,
-                                  nbrhosts, dutConfig, fanouthosts,
-                                  conn_graph_facts, request):
+    def permit_only_test_traffic_on_fanout(
+            self, get_src_dst_asic_and_duts, tbinfo,
+            nbrhosts, dutConfig, fanouthosts,
+            conn_graph_facts, request):
         """
         Block non-test traffic (LACP, ARP, LLDP, etc.) from reaching DUT ingress ports
         during QoS headroom pool tests to prevent false InDiscard counter increments.
@@ -3139,9 +3140,10 @@ class QosSaiBase(QosBase):
             if idx in dutConfig.get('dutInterfaces', {}):
                 src_interfaces.append(dutConfig['dutInterfaces'][idx])
 
-        logger.debug("block_non_test_traffic_on_fanout: testPorts = %s", dutConfig.get('testPorts', {}))
-        logger.info("block_non_test_traffic_on_fanout: protecting %d ports: %s",
-                     len(src_interfaces), src_interfaces)
+        logger.debug("permit_only_test_traffic_on_fanout: testPorts = %s", dutConfig.get('testPorts', {}))
+        logger.info(
+            "permit_only_test_traffic_on_fanout: protecting %d ports: %s",
+            len(src_interfaces), src_interfaces)
 
         # Find LAG names containing any of the protected interfaces
         portchannels = src_mgfacts.get('minigraph_portchannels', {})
@@ -3153,15 +3155,16 @@ class QosSaiBase(QosBase):
                 if member in src_interfaces:
                     if port_ch not in lag_names:
                         lag_names.append(port_ch)
-                        logger.debug("block_non_test_traffic_on_fanout: %s is member of %s", member, port_ch)
+                        logger.debug("permit_only_test_traffic_on_fanout: %s is member of %s", member, port_ch)
                     break
 
         # --- Step 1 & 2: LACP-specific (only when ports are in LAG) ---
         eos_restore_list = []
         lacpd_stopped = False
         if lag_names:
-            logger.info("block_non_test_traffic_on_fanout: found %d LAGs, stopping lacpd and setting timer",
-                         len(lag_names))
+            logger.info(
+                "permit_only_test_traffic_on_fanout: found %d LAGs, "
+                "stopping lacpd and setting timer", len(lag_names))
             # Step 1: Stop DUT teamd lacpd (use asic-aware docker name for multi-ASIC)
             teamd_docker = src_asic.get_docker_name("teamd")
             src_dut.command("docker exec {} supervisorctl stop lacpd".format(teamd_docker),
@@ -3185,12 +3188,12 @@ class QosSaiBase(QosBase):
                         continue
                     vm_host = nbrhosts[peer_device]['host']
                     if isinstance(vm_host, EosHost):
-                        logger.info("block_non_test_traffic_on_fanout: setting LACP multiplier 600 on %s %s",
+                        logger.info("permit_only_test_traffic_on_fanout: setting LACP multiplier 600 on %s %s",
                                     peer_device, neighbor_port)
                         vm_host.set_interface_lacp_time_multiplier(neighbor_port, 600)
                         eos_restore_list.append((vm_host, neighbor_port))
         else:
-            logger.info("block_non_test_traffic_on_fanout: no LAGs found, skipping LACP steps")
+            logger.info("permit_only_test_traffic_on_fanout: no LAGs found, skipping LACP steps")
 
         # --- Step 3: Disable LLDP + egress MAC ACL on fanout DUT-facing ports ---
         fanout_restore_list = []
@@ -3236,17 +3239,19 @@ class QosSaiBase(QosBase):
                             parents=['interface %s' % fanout_port]
                         )
                         fanout_restore_list.append((fanout, fanout_name, fanout_port, fanout_os))
-                        logger.info("block_non_test_traffic_on_fanout: protected %s %s",
+                        logger.info("permit_only_test_traffic_on_fanout: protected %s %s",
                                     fanout_name, fanout_port)
                     except Exception as e:
-                        logger.warning("block_non_test_traffic_on_fanout: failed on fanout %s: %s",
+                        logger.warning("permit_only_test_traffic_on_fanout: failed on fanout %s: %s",
                                        fanout_name, str(e))
                 elif fanout_os == 'sonic':
-                    logger.warning("block_non_test_traffic_on_fanout: SONiC fanout not supported, "
-                                   "skipping %s", fanout_name)
+                    logger.warning(
+                        "permit_only_test_traffic_on_fanout: SONiC fanout not supported, "
+                        "skipping %s", fanout_name)
 
-        logger.info("block_non_test_traffic_on_fanout: setup complete — %d ports protected, "
-                     "%d LACP timers set", len(fanout_restore_list), len(eos_restore_list))
+        logger.info(
+            "permit_only_test_traffic_on_fanout: setup complete — %d ports protected, "
+            "%d LACP timers set", len(fanout_restore_list), len(eos_restore_list))
 
         yield
 
@@ -3254,7 +3259,7 @@ class QosSaiBase(QosBase):
         # Step 1 reverse: restart DUT lacpd FIRST (before timer restore)
         if lacpd_stopped:
             teamd_docker = src_asic.get_docker_name("teamd")
-            logger.info("block_non_test_traffic_on_fanout: restarting lacpd in %s", teamd_docker)
+            logger.info("permit_only_test_traffic_on_fanout: restarting lacpd in %s", teamd_docker)
             src_dut.command("docker exec {} supervisorctl start lacpd".format(teamd_docker),
                             module_ignore_errors=True)
 
@@ -3263,7 +3268,7 @@ class QosSaiBase(QosBase):
             try:
                 vm_host.no_lacp_time_multiplier(neighbor_port)
             except Exception as e:
-                logger.warning("block_non_test_traffic_on_fanout: failed to restore LACP timer: %s", str(e))
+                logger.warning("permit_only_test_traffic_on_fanout: failed to restore LACP timer: %s", str(e))
 
         # Step 3 reverse: unbind ACL from all ports, then delete ACL once per fanout
         for fanout, fanout_name, fanout_port, fanout_os in fanout_restore_list:
@@ -3274,7 +3279,7 @@ class QosSaiBase(QosBase):
                     parents=['interface %s' % fanout_port]
                 )
             except Exception as e:
-                logger.warning("block_non_test_traffic_on_fanout: failed to unbind ACL from %s: %s",
+                logger.warning("permit_only_test_traffic_on_fanout: failed to unbind ACL from %s: %s",
                                fanout_port, str(e))
 
         for fanout_name in acl_created_fanouts:
@@ -3282,10 +3287,10 @@ class QosSaiBase(QosBase):
                 fanout = fanouthosts[fanout_name]
                 fanout.host.eos_config(lines=['no mac access-list %s' % acl_name])
             except Exception as e:
-                logger.warning("block_non_test_traffic_on_fanout: failed to delete ACL on %s: %s",
+                logger.warning("permit_only_test_traffic_on_fanout: failed to delete ACL on %s: %s",
                                fanout_name, str(e))
 
-        logger.info("block_non_test_traffic_on_fanout: teardown complete")
+        logger.info("permit_only_test_traffic_on_fanout: teardown complete")
 
     def copy_set_cir_script_cisco_8000(self, dut, ports, asic="", speed="10000000"):
         dshell_script = '''

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -3099,6 +3099,194 @@ class QosSaiBase(QosBase):
                         "Changing lacp timer multiplier to default for %s in %s" % (neighbor_lag_member, vm_host))
                     vm_host.no_lacp_time_multiplier(neighbor_lag_member)
 
+    @pytest.fixture(scope="function", autouse=False)
+    def block_lag_noise_on_fanout(self, get_src_dst_asic_and_duts, tbinfo,
+                                  nbrhosts, dutConfig, fanouthosts,
+                                  conn_graph_facts, request):
+        """
+        Block non-test traffic (LACP, ARP, LLDP, etc.) from reaching DUT ingress ports
+        during QoS headroom pool tests to prevent false InDiscard counter increments.
+
+        This fixture:
+        1. Stops DUT teamd lacpd to prevent LACP timeout detection
+        2. Sets EOS neighbor LACP timer multiplier to 600 to prevent EOS-side timeout
+        3. Disables LLDP and applies egress MAC ACL on fanout DUT-facing ports
+
+        Background:
+        On t1-lag topologies, LLDP (from EOS fanout/vEOS neighbors) and LACP PDUs
+        arrive at DUT ports during headroom pool fill. With the shared buffer full,
+        these L2 packets are dropped on PG0, incrementing InDiscard. The test asserts
+        InDiscard == baseline and fails. See PR#22871 for analysis.
+
+        Note: Currently only supports EOS fanout switches. SONiC fanout is not yet
+        implemented; the fixture will log a warning and skip ACL configuration.
+        """
+        if request.config.getoption("--neighbor_type") == "sonic":
+            yield
+            return
+
+        src_dut = get_src_dst_asic_and_duts['src_dut']
+        src_asic = get_src_dst_asic_and_duts['src_asic']
+        src_mgfacts = src_dut.get_extended_minigraph_facts(tbinfo)
+
+        # Protect ALL test ports from noise. The actual src_port_ids used by PTF
+        # come from qos.yml hdrm_pool_size (e.g., [17,18]) which differs from
+        # dutConfig.testPorts.src_port_id (e.g., 2). Apply to all dutInterfaces.
+        src_port_indices = sorted(dutConfig.get('dutInterfaces', {}).keys())
+
+        src_interfaces = []
+        for idx in src_port_indices:
+            if idx in dutConfig.get('dutInterfaces', {}):
+                src_interfaces.append(dutConfig['dutInterfaces'][idx])
+
+        logger.debug("block_lag_noise_on_fanout: testPorts = %s", dutConfig.get('testPorts', {}))
+        logger.info("block_lag_noise_on_fanout: protecting %d ports: %s",
+                     len(src_interfaces), src_interfaces)
+
+        # Find LAG names containing any of the protected interfaces
+        portchannels = src_mgfacts.get('minigraph_portchannels', {})
+
+        lag_names = []
+        for port_ch, port_intf in portchannels.items():
+            members = port_intf.get('members', [])
+            for member in members:
+                if member in src_interfaces:
+                    if port_ch not in lag_names:
+                        lag_names.append(port_ch)
+                        logger.debug("block_lag_noise_on_fanout: %s is member of %s", member, port_ch)
+                    break
+
+        # --- Step 1 & 2: LACP-specific (only when ports are in LAG) ---
+        eos_restore_list = []
+        lacpd_stopped = False
+        if lag_names:
+            logger.info("block_lag_noise_on_fanout: found %d LAGs, stopping lacpd and setting timer",
+                         len(lag_names))
+            # Step 1: Stop DUT teamd lacpd (use asic-aware docker name for multi-ASIC)
+            teamd_docker = src_asic.get_docker_name("teamd")
+            src_dut.command("docker exec {} supervisorctl stop lacpd".format(teamd_docker),
+                            module_ignore_errors=True)
+            lacpd_stopped = True
+
+            # Step 2: Set EOS neighbor LACP timer multiplier to 600
+            lag_facts = src_dut.lag_facts(host=src_dut.hostname)['ansible_facts']['lag_facts']
+            vm_neighbors = src_mgfacts.get('minigraph_neighbors', {})
+
+            for lag_name in lag_names:
+                if lag_name not in lag_facts.get('lags', {}):
+                    continue
+                po_interfaces = lag_facts['lags'][lag_name]['po_config']['ports']
+                for po_intf in po_interfaces:
+                    if po_intf not in vm_neighbors:
+                        continue
+                    peer_device = vm_neighbors[po_intf]['name']
+                    neighbor_port = vm_neighbors[po_intf]['port']
+                    if peer_device not in nbrhosts:
+                        continue
+                    vm_host = nbrhosts[peer_device]['host']
+                    if isinstance(vm_host, EosHost):
+                        logger.info("block_lag_noise_on_fanout: setting LACP multiplier 600 on %s %s",
+                                    peer_device, neighbor_port)
+                        vm_host.set_interface_lacp_time_multiplier(neighbor_port, 600)
+                        eos_restore_list.append((vm_host, neighbor_port))
+        else:
+            logger.info("block_lag_noise_on_fanout: no LAGs found, skipping LACP steps")
+
+        # --- Step 3: Disable LLDP + egress MAC ACL on fanout DUT-facing ports ---
+        fanout_restore_list = []
+        acl_created_fanouts = set()
+        dev_conn = conn_graph_facts.get('device_conn', {})
+        acl_name = "QOS_TEST_WHITELIST"
+
+        for dut_name, ethernet_ports in dev_conn.items():
+            for dut_port, fanout_rec in ethernet_ports.items():
+                if dut_port not in src_interfaces:
+                    continue
+                fanout_name = str(fanout_rec['peerdevice'])
+                fanout_port = str(fanout_rec['peerport'])
+
+                if fanout_name not in fanouthosts:
+                    continue
+
+                fanout = fanouthosts[fanout_name]
+                fanout_os = fanout.get_fanout_os()
+
+                if fanout_os == 'eos':
+                    try:
+                        # Disable LLDP on fanout port facing DUT
+                        fanout.host.eos_config(
+                            lines=['no lldp transmit', 'no lldp receive'],
+                            parents=['interface %s' % fanout_port]
+                        )
+                        # Create MAC ACL once per fanout
+                        if fanout_name not in acl_created_fanouts:
+                            fanout.host.eos_config(
+                                lines=[
+                                    'permit any any ip',
+                                    'permit any any ipv6',
+                                    'permit any any arp',
+                                    'deny any any',
+                                ],
+                                parents=['mac access-list %s' % acl_name]
+                            )
+                            acl_created_fanouts.add(fanout_name)
+                        # Bind egress MAC ACL (out = fanout→DUT direction)
+                        fanout.host.eos_config(
+                            lines=['mac access-group %s out' % acl_name],
+                            parents=['interface %s' % fanout_port]
+                        )
+                        fanout_restore_list.append((fanout, fanout_name, fanout_port, fanout_os))
+                        logger.info("block_lag_noise_on_fanout: protected %s %s",
+                                    fanout_name, fanout_port)
+                    except Exception as e:
+                        logger.warning("block_lag_noise_on_fanout: failed on fanout %s: %s",
+                                       fanout_name, str(e))
+                elif fanout_os == 'sonic':
+                    logger.warning("block_lag_noise_on_fanout: SONiC fanout not supported, "
+                                   "skipping %s", fanout_name)
+
+        logger.info("block_lag_noise_on_fanout: setup complete — %d ports protected, "
+                     "%d LACP timers set", len(fanout_restore_list), len(eos_restore_list))
+
+        yield
+
+        # --- Teardown: reverse all changes (safe order) ---
+        # Step 1 reverse: restart DUT lacpd FIRST (before timer restore)
+        if lacpd_stopped:
+            teamd_docker = src_asic.get_docker_name("teamd")
+            logger.info("block_lag_noise_on_fanout: restarting lacpd in %s", teamd_docker)
+            src_dut.command("docker exec {} supervisorctl start lacpd".format(teamd_docker),
+                            module_ignore_errors=True)
+
+        # Step 2 reverse: restore EOS LACP timer (safe now, DUT is sending LACP)
+        for vm_host, neighbor_port in eos_restore_list:
+            try:
+                vm_host.no_lacp_time_multiplier(neighbor_port)
+            except Exception as e:
+                logger.warning("block_lag_noise_on_fanout: failed to restore LACP timer: %s", str(e))
+
+        # Step 3 reverse: unbind ACL from all ports, then delete ACL once per fanout
+        for fanout, fanout_name, fanout_port, fanout_os in fanout_restore_list:
+            try:
+                fanout.host.eos_config(
+                    lines=['lldp transmit', 'lldp receive',
+                           'no mac access-group %s out' % acl_name],
+                    parents=['interface %s' % fanout_port]
+                )
+            except Exception as e:
+                logger.warning("block_lag_noise_on_fanout: failed to unbind ACL from %s: %s",
+                               fanout_port, str(e))
+
+        for fanout_name in acl_created_fanouts:
+            try:
+                fanout = fanouthosts[fanout_name]
+                fanout.host.eos_config(lines=['no mac access-list %s' % acl_name])
+            except Exception as e:
+                logger.warning("block_lag_noise_on_fanout: failed to delete ACL on %s: %s",
+                               fanout_name, str(e))
+
+        logger.info("block_lag_noise_on_fanout: teardown complete")
+
     def copy_set_cir_script_cisco_8000(self, dut, ports, asic="", speed="10000000"):
         dshell_script = '''
 from common import *

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -3141,7 +3141,7 @@ class QosSaiBase(QosBase):
                           for idx in sorted(dutConfig.get('dutInterfaces', {}).keys())]
 
         logger.debug("permit_only_test_traffic_on_fanout: testPorts = %s",
-                      dutConfig.get('testPorts', {}))
+                     dutConfig.get('testPorts', {}))
         logger.info(
             "permit_only_test_traffic_on_fanout: protecting %d ports: %s",
             len(src_interfaces), src_interfaces)

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -3170,6 +3170,9 @@ class QosSaiBase(QosBase):
             src_dut.command("docker exec {} supervisorctl stop lacpd".format(teamd_docker),
                             module_ignore_errors=True)
             lacpd_stopped = True
+            # Brief wait for any in-flight LACP PDU to be processed before proceeding
+            import time
+            time.sleep(2)
 
             # Step 2: Set EOS neighbor LACP timer multiplier to 600
             lag_facts = src_dut.lag_facts(host=src_dut.hostname)['ansible_facts']['lag_facts']
@@ -3260,8 +3263,14 @@ class QosSaiBase(QosBase):
         if lacpd_stopped:
             teamd_docker = src_asic.get_docker_name("teamd")
             logger.info("permit_only_test_traffic_on_fanout: restarting lacpd in %s", teamd_docker)
-            src_dut.command("docker exec {} supervisorctl start lacpd".format(teamd_docker),
-                            module_ignore_errors=True)
+            result = src_dut.command(
+                "docker exec {} supervisorctl start lacpd".format(teamd_docker),
+                module_ignore_errors=True)
+            if result.get('failed', False) or result.get('rc', 0) != 0:
+                logger.error(
+                    "permit_only_test_traffic_on_fanout: lacpd restart FAILED — "
+                    "DUT may be left without LACP. Output: %s",
+                    result.get('stdout', result.get('stderr', 'unknown')))
 
         # Step 2 reverse: restore EOS LACP timer (safe now, DUT is sending LACP)
         for vm_host, neighbor_port in eos_restore_list:

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -3100,7 +3100,7 @@ class QosSaiBase(QosBase):
                     vm_host.no_lacp_time_multiplier(neighbor_lag_member)
 
     @pytest.fixture(scope="function", autouse=False)
-    def block_lag_noise_on_fanout(self, get_src_dst_asic_and_duts, tbinfo,
+    def block_non_test_traffic_on_fanout(self, get_src_dst_asic_and_duts, tbinfo,
                                   nbrhosts, dutConfig, fanouthosts,
                                   conn_graph_facts, request):
         """
@@ -3139,8 +3139,8 @@ class QosSaiBase(QosBase):
             if idx in dutConfig.get('dutInterfaces', {}):
                 src_interfaces.append(dutConfig['dutInterfaces'][idx])
 
-        logger.debug("block_lag_noise_on_fanout: testPorts = %s", dutConfig.get('testPorts', {}))
-        logger.info("block_lag_noise_on_fanout: protecting %d ports: %s",
+        logger.debug("block_non_test_traffic_on_fanout: testPorts = %s", dutConfig.get('testPorts', {}))
+        logger.info("block_non_test_traffic_on_fanout: protecting %d ports: %s",
                      len(src_interfaces), src_interfaces)
 
         # Find LAG names containing any of the protected interfaces
@@ -3153,14 +3153,14 @@ class QosSaiBase(QosBase):
                 if member in src_interfaces:
                     if port_ch not in lag_names:
                         lag_names.append(port_ch)
-                        logger.debug("block_lag_noise_on_fanout: %s is member of %s", member, port_ch)
+                        logger.debug("block_non_test_traffic_on_fanout: %s is member of %s", member, port_ch)
                     break
 
         # --- Step 1 & 2: LACP-specific (only when ports are in LAG) ---
         eos_restore_list = []
         lacpd_stopped = False
         if lag_names:
-            logger.info("block_lag_noise_on_fanout: found %d LAGs, stopping lacpd and setting timer",
+            logger.info("block_non_test_traffic_on_fanout: found %d LAGs, stopping lacpd and setting timer",
                          len(lag_names))
             # Step 1: Stop DUT teamd lacpd (use asic-aware docker name for multi-ASIC)
             teamd_docker = src_asic.get_docker_name("teamd")
@@ -3185,12 +3185,12 @@ class QosSaiBase(QosBase):
                         continue
                     vm_host = nbrhosts[peer_device]['host']
                     if isinstance(vm_host, EosHost):
-                        logger.info("block_lag_noise_on_fanout: setting LACP multiplier 600 on %s %s",
+                        logger.info("block_non_test_traffic_on_fanout: setting LACP multiplier 600 on %s %s",
                                     peer_device, neighbor_port)
                         vm_host.set_interface_lacp_time_multiplier(neighbor_port, 600)
                         eos_restore_list.append((vm_host, neighbor_port))
         else:
-            logger.info("block_lag_noise_on_fanout: no LAGs found, skipping LACP steps")
+            logger.info("block_non_test_traffic_on_fanout: no LAGs found, skipping LACP steps")
 
         # --- Step 3: Disable LLDP + egress MAC ACL on fanout DUT-facing ports ---
         fanout_restore_list = []
@@ -3236,16 +3236,16 @@ class QosSaiBase(QosBase):
                             parents=['interface %s' % fanout_port]
                         )
                         fanout_restore_list.append((fanout, fanout_name, fanout_port, fanout_os))
-                        logger.info("block_lag_noise_on_fanout: protected %s %s",
+                        logger.info("block_non_test_traffic_on_fanout: protected %s %s",
                                     fanout_name, fanout_port)
                     except Exception as e:
-                        logger.warning("block_lag_noise_on_fanout: failed on fanout %s: %s",
+                        logger.warning("block_non_test_traffic_on_fanout: failed on fanout %s: %s",
                                        fanout_name, str(e))
                 elif fanout_os == 'sonic':
-                    logger.warning("block_lag_noise_on_fanout: SONiC fanout not supported, "
+                    logger.warning("block_non_test_traffic_on_fanout: SONiC fanout not supported, "
                                    "skipping %s", fanout_name)
 
-        logger.info("block_lag_noise_on_fanout: setup complete — %d ports protected, "
+        logger.info("block_non_test_traffic_on_fanout: setup complete — %d ports protected, "
                      "%d LACP timers set", len(fanout_restore_list), len(eos_restore_list))
 
         yield
@@ -3254,7 +3254,7 @@ class QosSaiBase(QosBase):
         # Step 1 reverse: restart DUT lacpd FIRST (before timer restore)
         if lacpd_stopped:
             teamd_docker = src_asic.get_docker_name("teamd")
-            logger.info("block_lag_noise_on_fanout: restarting lacpd in %s", teamd_docker)
+            logger.info("block_non_test_traffic_on_fanout: restarting lacpd in %s", teamd_docker)
             src_dut.command("docker exec {} supervisorctl start lacpd".format(teamd_docker),
                             module_ignore_errors=True)
 
@@ -3263,7 +3263,7 @@ class QosSaiBase(QosBase):
             try:
                 vm_host.no_lacp_time_multiplier(neighbor_port)
             except Exception as e:
-                logger.warning("block_lag_noise_on_fanout: failed to restore LACP timer: %s", str(e))
+                logger.warning("block_non_test_traffic_on_fanout: failed to restore LACP timer: %s", str(e))
 
         # Step 3 reverse: unbind ACL from all ports, then delete ACL once per fanout
         for fanout, fanout_name, fanout_port, fanout_os in fanout_restore_list:
@@ -3274,7 +3274,7 @@ class QosSaiBase(QosBase):
                     parents=['interface %s' % fanout_port]
                 )
             except Exception as e:
-                logger.warning("block_lag_noise_on_fanout: failed to unbind ACL from %s: %s",
+                logger.warning("block_non_test_traffic_on_fanout: failed to unbind ACL from %s: %s",
                                fanout_port, str(e))
 
         for fanout_name in acl_created_fanouts:
@@ -3282,10 +3282,10 @@ class QosSaiBase(QosBase):
                 fanout = fanouthosts[fanout_name]
                 fanout.host.eos_config(lines=['no mac access-list %s' % acl_name])
             except Exception as e:
-                logger.warning("block_lag_noise_on_fanout: failed to delete ACL on %s: %s",
+                logger.warning("block_non_test_traffic_on_fanout: failed to delete ACL on %s: %s",
                                fanout_name, str(e))
 
-        logger.info("block_lag_noise_on_fanout: teardown complete")
+        logger.info("block_non_test_traffic_on_fanout: teardown complete")
 
     def copy_set_cir_script_cisco_8000(self, dut, ports, asic="", speed="10000000"):
         dshell_script = '''

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -3105,22 +3105,25 @@ class QosSaiBase(QosBase):
             nbrhosts, dutConfig, fanouthosts,
             conn_graph_facts, request):
         """
-        Block non-test traffic (LACP, ARP, LLDP, etc.) from reaching DUT ingress ports
-        during QoS headroom pool tests to prevent false InDiscard counter increments.
+        Block non-test L2 traffic from reaching DUT ingress ports during QoS
+        headroom pool tests to prevent false InDiscard counter increments.
 
-        This fixture:
-        1. Stops DUT teamd lacpd to prevent LACP timeout detection
-        2. Sets EOS neighbor LACP timer multiplier to 600 to prevent EOS-side timeout
-        3. Disables LLDP and applies egress MAC ACL on fanout DUT-facing ports
+        Configures the EOS fanout switch to only forward IP/IPv6/ARP frames
+        toward the DUT, blocking LLDP (0x88CC), LACP (0x8809), and other
+        non-test ethertypes via an egress MAC ACL whitelist.
 
-        Background:
-        On t1-lag topologies, LLDP (from EOS fanout/vEOS neighbors) and LACP PDUs
-        arrive at DUT ports during headroom pool fill. With the shared buffer full,
-        these L2 packets are dropped on PG0, incrementing InDiscard. The test asserts
-        InDiscard == baseline and fails. See PR#22871 for analysis.
+        Steps:
+        1. Stop DUT teamd lacpd (prevents LACP timeout detection)
+        2. Set EOS neighbor LACP timer multiplier to 600 (prevents EOS-side timeout)
+        3. Disable LLDP TX/RX + apply egress MAC ACL on fanout DUT-facing ports
 
-        Note: Currently only supports EOS fanout switches. SONiC fanout is not yet
-        implemented; the fixture will log a warning and skip ACL configuration.
+        Note on change_lag_lacp_timer interaction: that fixture only activates
+        for broadcom-dnx platforms and operates on dst_port LAGs. This fixture
+        operates on src_port LAGs for Broadcom TH (7060CX), so there is no
+        overlap on the affected platform.
+
+        Note: Currently supports EOS fanout only. SONiC fanout support is
+        tracked in issue #24236.
         """
         if request.config.getoption("--neighbor_type") == "sonic":
             yield
@@ -3133,171 +3136,225 @@ class QosSaiBase(QosBase):
         # Protect ALL test ports from noise. The actual src_port_ids used by PTF
         # come from qos.yml hdrm_pool_size (e.g., [17,18]) which differs from
         # dutConfig.testPorts.src_port_id (e.g., 2). Apply to all dutInterfaces.
-        src_port_indices = sorted(dutConfig.get('dutInterfaces', {}).keys())
+        # TODO: optimize to only protect actual src/dst ports (tracked in #24236)
+        src_interfaces = [dutConfig['dutInterfaces'][idx]
+                          for idx in sorted(dutConfig.get('dutInterfaces', {}).keys())]
 
-        src_interfaces = []
-        for idx in src_port_indices:
-            if idx in dutConfig.get('dutInterfaces', {}):
-                src_interfaces.append(dutConfig['dutInterfaces'][idx])
-
-        logger.debug("permit_only_test_traffic_on_fanout: testPorts = %s", dutConfig.get('testPorts', {}))
+        logger.debug("permit_only_test_traffic_on_fanout: testPorts = %s",
+                      dutConfig.get('testPorts', {}))
         logger.info(
             "permit_only_test_traffic_on_fanout: protecting %d ports: %s",
             len(src_interfaces), src_interfaces)
 
         # Find LAG names containing any of the protected interfaces
         portchannels = src_mgfacts.get('minigraph_portchannels', {})
-
         lag_names = []
         for port_ch, port_intf in portchannels.items():
-            members = port_intf.get('members', [])
-            for member in members:
+            for member in port_intf.get('members', []):
                 if member in src_interfaces:
                     if port_ch not in lag_names:
                         lag_names.append(port_ch)
-                        logger.debug("permit_only_test_traffic_on_fanout: %s is member of %s", member, port_ch)
+                        logger.debug("permit_only_test_traffic_on_fanout: "
+                                     "%s is member of %s", member, port_ch)
                     break
 
-        # --- Step 1 & 2: LACP-specific (only when ports are in LAG) ---
+        # State tracking for teardown
         eos_restore_list = []
-        lacpd_stopped = False
-        if lag_names:
-            logger.info(
-                "permit_only_test_traffic_on_fanout: found %d LAGs, "
-                "stopping lacpd and setting timer", len(lag_names))
-            # Step 1: Stop DUT teamd lacpd (use asic-aware docker name for multi-ASIC)
-            teamd_docker = src_asic.get_docker_name("teamd")
-            src_dut.command("docker exec {} supervisorctl stop lacpd".format(teamd_docker),
-                            module_ignore_errors=True)
-            lacpd_stopped = True
-            # Brief wait for any in-flight LACP PDU to be processed before proceeding
-            import time
-            time.sleep(2)
-
-            # Step 2: Set EOS neighbor LACP timer multiplier to 600
-            lag_facts = src_dut.lag_facts(host=src_dut.hostname)['ansible_facts']['lag_facts']
-            vm_neighbors = src_mgfacts.get('minigraph_neighbors', {})
-
-            for lag_name in lag_names:
-                if lag_name not in lag_facts.get('lags', {}):
-                    continue
-                po_interfaces = lag_facts['lags'][lag_name]['po_config']['ports']
-                for po_intf in po_interfaces:
-                    if po_intf not in vm_neighbors:
-                        continue
-                    peer_device = vm_neighbors[po_intf]['name']
-                    neighbor_port = vm_neighbors[po_intf]['port']
-                    if peer_device not in nbrhosts:
-                        continue
-                    vm_host = nbrhosts[peer_device]['host']
-                    if isinstance(vm_host, EosHost):
-                        logger.info("permit_only_test_traffic_on_fanout: setting LACP multiplier 600 on %s %s",
-                                    peer_device, neighbor_port)
-                        vm_host.set_interface_lacp_time_multiplier(neighbor_port, 600)
-                        eos_restore_list.append((vm_host, neighbor_port))
-        else:
-            logger.info("permit_only_test_traffic_on_fanout: no LAGs found, skipping LACP steps")
-
-        # --- Step 3: Disable LLDP + egress MAC ACL on fanout DUT-facing ports ---
         fanout_restore_list = []
         acl_created_fanouts = set()
-        dev_conn = conn_graph_facts.get('device_conn', {})
+        lacpd_stopped = False
         acl_name = "QOS_TEST_WHITELIST"
+        teamd_docker = src_asic.get_docker_name("teamd")
 
-        for dut_name, ethernet_ports in dev_conn.items():
-            for dut_port, fanout_rec in ethernet_ports.items():
-                if dut_port not in src_interfaces:
-                    continue
-                fanout_name = str(fanout_rec['peerdevice'])
-                fanout_port = str(fanout_rec['peerport'])
+        try:
+            # --- Step 1 & 2: LACP-specific (only when ports are in LAG) ---
+            if lag_names:
+                logger.info(
+                    "permit_only_test_traffic_on_fanout: found %d LAGs, "
+                    "stopping lacpd and setting timer", len(lag_names))
 
-                if fanout_name not in fanouthosts:
-                    continue
-
-                fanout = fanouthosts[fanout_name]
-                fanout_os = fanout.get_fanout_os()
-
-                if fanout_os == 'eos':
-                    try:
-                        # Disable LLDP on fanout port facing DUT
-                        fanout.host.eos_config(
-                            lines=['no lldp transmit', 'no lldp receive'],
-                            parents=['interface %s' % fanout_port]
-                        )
-                        # Create MAC ACL once per fanout
-                        if fanout_name not in acl_created_fanouts:
-                            fanout.host.eos_config(
-                                lines=[
-                                    'permit any any ip',
-                                    'permit any any ipv6',
-                                    'permit any any arp',
-                                    'deny any any',
-                                ],
-                                parents=['mac access-list %s' % acl_name]
-                            )
-                            acl_created_fanouts.add(fanout_name)
-                        # Bind egress MAC ACL (out = fanout→DUT direction)
-                        fanout.host.eos_config(
-                            lines=['mac access-group %s out' % acl_name],
-                            parents=['interface %s' % fanout_port]
-                        )
-                        fanout_restore_list.append((fanout, fanout_name, fanout_port, fanout_os))
-                        logger.info("permit_only_test_traffic_on_fanout: protected %s %s",
-                                    fanout_name, fanout_port)
-                    except Exception as e:
-                        logger.warning("permit_only_test_traffic_on_fanout: failed on fanout %s: %s",
-                                       fanout_name, str(e))
-                elif fanout_os == 'sonic':
+                # Step 1: Stop DUT teamd lacpd
+                result = src_dut.command(
+                    "docker exec {} supervisorctl stop lacpd".format(teamd_docker),
+                    module_ignore_errors=True)
+                if result.get('failed', False) or result.get('rc', 0) != 0:
                     logger.warning(
-                        "permit_only_test_traffic_on_fanout: SONiC fanout not supported, "
-                        "skipping %s", fanout_name)
+                        "permit_only_test_traffic_on_fanout: lacpd stop may have "
+                        "failed (rc=%s), proceeding anyway", result.get('rc', '?'))
+                else:
+                    lacpd_stopped = True
+                # Brief wait for any in-flight LACP PDU to drain
+                time.sleep(2)
+
+                # Step 2: Set EOS neighbor LACP timer multiplier to 600
+                lag_facts = src_dut.lag_facts(
+                    host=src_dut.hostname)['ansible_facts']['lag_facts']
+                vm_neighbors = src_mgfacts.get('minigraph_neighbors', {})
+
+                for lag_name in lag_names:
+                    if lag_name not in lag_facts.get('lags', {}):
+                        continue
+                    po_interfaces = lag_facts['lags'][lag_name]['po_config']['ports']
+                    for po_intf in po_interfaces:
+                        if po_intf not in vm_neighbors:
+                            continue
+                        peer_device = vm_neighbors[po_intf]['name']
+                        neighbor_port = vm_neighbors[po_intf]['port']
+                        if peer_device not in nbrhosts:
+                            continue
+                        vm_host = nbrhosts[peer_device]['host']
+                        if isinstance(vm_host, EosHost):
+                            logger.info(
+                                "permit_only_test_traffic_on_fanout: "
+                                "setting LACP multiplier 600 on %s %s",
+                                peer_device, neighbor_port)
+                            vm_host.set_interface_lacp_time_multiplier(
+                                neighbor_port, 600)
+                            eos_restore_list.append((vm_host, neighbor_port))
+            else:
+                logger.info("permit_only_test_traffic_on_fanout: "
+                            "no LAGs found, skipping LACP steps")
+
+            # --- Step 3: Disable LLDP + egress MAC ACL on fanout ports ---
+            # Egress MAC ACL permits only IP (0x0800), IPv6 (0x86DD), and ARP
+            # (0x0806). All other ethertypes — including LLDP (0x88CC), LACP
+            # (0x8809), and other broadcast/multicast L2 frames — are denied.
+            # PFC (0x8808) is DUT-originated and travels DUT→fanout, so the
+            # egress (fanout→DUT) ACL does not affect it.
+            dev_conn = conn_graph_facts.get('device_conn', {})
+
+            for dut_name, ethernet_ports in dev_conn.items():
+                for dut_port, fanout_rec in ethernet_ports.items():
+                    if dut_port not in src_interfaces:
+                        continue
+                    fanout_name = str(fanout_rec['peerdevice'])
+                    fanout_port = str(fanout_rec['peerport'])
+
+                    if fanout_name not in fanouthosts:
+                        continue
+
+                    fanout = fanouthosts[fanout_name]
+                    fanout_os = fanout.get_fanout_os()
+
+                    if fanout_os == 'eos':
+                        try:
+                            # Disable LLDP first; record immediately for restore
+                            fanout.host.eos_config(
+                                lines=['no lldp transmit', 'no lldp receive'],
+                                parents=['interface %s' % fanout_port])
+                            fanout_restore_list.append(
+                                (fanout, fanout_name, fanout_port))
+                        except Exception as e:
+                            logger.warning(
+                                "permit_only_test_traffic_on_fanout: "
+                                "LLDP disable failed on %s %s: %s",
+                                fanout_name, fanout_port, str(e))
+                            continue
+
+                        try:
+                            # Create MAC ACL once per fanout
+                            if fanout_name not in acl_created_fanouts:
+                                fanout.host.eos_config(
+                                    lines=[
+                                        'permit any any ip',
+                                        'permit any any ipv6',
+                                        'permit any any arp',
+                                        'deny any any',
+                                    ],
+                                    parents=['mac access-list %s' % acl_name])
+                                acl_created_fanouts.add(fanout_name)
+                            # Bind egress MAC ACL (out = fanout→DUT direction)
+                            fanout.host.eos_config(
+                                lines=['mac access-group %s out' % acl_name],
+                                parents=['interface %s' % fanout_port])
+                            logger.info(
+                                "permit_only_test_traffic_on_fanout: "
+                                "protected %s %s", fanout_name, fanout_port)
+                        except Exception as e:
+                            logger.warning(
+                                "permit_only_test_traffic_on_fanout: "
+                                "ACL config failed on %s %s: %s",
+                                fanout_name, fanout_port, str(e))
+
+                    elif fanout_os == 'sonic':
+                        # SONiC fanout support tracked in #24236
+                        logger.warning(
+                            "permit_only_test_traffic_on_fanout: "
+                            "SONiC fanout not supported, skipping %s",
+                            fanout_name)
+
+        except Exception as e:
+            # Setup failed partway — run teardown for anything already configured
+            logger.error(
+                "permit_only_test_traffic_on_fanout: setup failed: %s. "
+                "Running partial teardown.", str(e))
+            self._teardown_test_traffic_filter(
+                src_dut, teamd_docker, lacpd_stopped,
+                eos_restore_list, fanout_restore_list,
+                acl_created_fanouts, acl_name, fanouthosts)
+            raise
 
         logger.info(
-            "permit_only_test_traffic_on_fanout: setup complete — %d ports protected, "
-            "%d LACP timers set", len(fanout_restore_list), len(eos_restore_list))
+            "permit_only_test_traffic_on_fanout: setup complete — "
+            "%d ports protected, %d LACP timers set",
+            len(fanout_restore_list), len(eos_restore_list))
 
         yield
 
-        # --- Teardown: reverse all changes (safe order) ---
+        self._teardown_test_traffic_filter(
+            src_dut, teamd_docker, lacpd_stopped,
+            eos_restore_list, fanout_restore_list,
+            acl_created_fanouts, acl_name, fanouthosts)
+
+    def _teardown_test_traffic_filter(
+            self, src_dut, teamd_docker, lacpd_stopped,
+            eos_restore_list, fanout_restore_list,
+            acl_created_fanouts, acl_name, fanouthosts):
+        """Reverse all changes made by permit_only_test_traffic_on_fanout."""
         # Step 1 reverse: restart DUT lacpd FIRST (before timer restore)
         if lacpd_stopped:
-            teamd_docker = src_asic.get_docker_name("teamd")
-            logger.info("permit_only_test_traffic_on_fanout: restarting lacpd in %s", teamd_docker)
+            logger.info("permit_only_test_traffic_on_fanout: "
+                        "restarting lacpd in %s", teamd_docker)
             result = src_dut.command(
                 "docker exec {} supervisorctl start lacpd".format(teamd_docker),
                 module_ignore_errors=True)
             if result.get('failed', False) or result.get('rc', 0) != 0:
                 logger.error(
-                    "permit_only_test_traffic_on_fanout: lacpd restart FAILED — "
-                    "DUT may be left without LACP. Output: %s",
+                    "permit_only_test_traffic_on_fanout: lacpd restart "
+                    "FAILED — DUT may be left without LACP. Output: %s",
                     result.get('stdout', result.get('stderr', 'unknown')))
 
-        # Step 2 reverse: restore EOS LACP timer (safe now, DUT is sending LACP)
+        # Step 2 reverse: restore EOS LACP timer
         for vm_host, neighbor_port in eos_restore_list:
             try:
                 vm_host.no_lacp_time_multiplier(neighbor_port)
             except Exception as e:
-                logger.warning("permit_only_test_traffic_on_fanout: failed to restore LACP timer: %s", str(e))
+                logger.warning(
+                    "permit_only_test_traffic_on_fanout: "
+                    "failed to restore LACP timer: %s", str(e))
 
-        # Step 3 reverse: unbind ACL from all ports, then delete ACL once per fanout
-        for fanout, fanout_name, fanout_port, fanout_os in fanout_restore_list:
+        # Step 3 reverse: restore LLDP + unbind ACL from all ports
+        for fanout, fanout_name, fanout_port in fanout_restore_list:
             try:
                 fanout.host.eos_config(
                     lines=['lldp transmit', 'lldp receive',
                            'no mac access-group %s out' % acl_name],
-                    parents=['interface %s' % fanout_port]
-                )
+                    parents=['interface %s' % fanout_port])
             except Exception as e:
-                logger.warning("permit_only_test_traffic_on_fanout: failed to unbind ACL from %s: %s",
-                               fanout_port, str(e))
+                logger.warning(
+                    "permit_only_test_traffic_on_fanout: "
+                    "failed to restore %s: %s", fanout_port, str(e))
 
+        # Delete ACL definition once per fanout
         for fanout_name in acl_created_fanouts:
             try:
                 fanout = fanouthosts[fanout_name]
-                fanout.host.eos_config(lines=['no mac access-list %s' % acl_name])
+                fanout.host.eos_config(
+                    lines=['no mac access-list %s' % acl_name])
             except Exception as e:
-                logger.warning("permit_only_test_traffic_on_fanout: failed to delete ACL on %s: %s",
-                               fanout_name, str(e))
+                logger.warning(
+                    "permit_only_test_traffic_on_fanout: "
+                    "failed to delete ACL on %s: %s", fanout_name, str(e))
 
         logger.info("permit_only_test_traffic_on_fanout: teardown complete")
 

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -782,8 +782,8 @@ class TestQosSai(QosSaiBase):
 
     def testQosSaiHeadroomPoolSize(
         self, duthosts, get_src_dst_asic_and_duts, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-            ingressLosslessProfile, iptables_drop_ipv6_tx, change_lag_lacp_timer,
-            block_non_test_traffic_on_fanout):                # noqa: F811
+            ingressLosslessProfile, iptables_drop_ipv6_tx, change_lag_lacp_timer,  # noqa: F811
+            permit_only_test_traffic_on_fanout):
         # NOTE: cisco-8800 will skip this test since there are no headroom pool
         """
             Test QoS SAI Headroom pool size
@@ -997,7 +997,7 @@ class TestQosSai(QosSaiBase):
     def testQosSaiHeadroomPoolWatermark(
         self, duthosts, get_src_dst_asic_and_duts,  ptfhost, dutTestParams,
         dutConfig, dutQosConfig, ingressLosslessProfile, sharedHeadroomPoolSize,
-        resetWatermark, block_non_test_traffic_on_fanout
+        resetWatermark, permit_only_test_traffic_on_fanout
     ):
         # NOTE: cisco 8800 will skip this test since there is no headroom pool
         """

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -782,7 +782,8 @@ class TestQosSai(QosSaiBase):
 
     def testQosSaiHeadroomPoolSize(
         self, duthosts, get_src_dst_asic_and_duts, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-            ingressLosslessProfile, iptables_drop_ipv6_tx, change_lag_lacp_timer):                # noqa: F811
+            ingressLosslessProfile, iptables_drop_ipv6_tx, change_lag_lacp_timer,
+            block_lag_noise_on_fanout):                # noqa: F811
         # NOTE: cisco-8800 will skip this test since there are no headroom pool
         """
             Test QoS SAI Headroom pool size
@@ -996,7 +997,7 @@ class TestQosSai(QosSaiBase):
     def testQosSaiHeadroomPoolWatermark(
         self, duthosts, get_src_dst_asic_and_duts,  ptfhost, dutTestParams,
         dutConfig, dutQosConfig, ingressLosslessProfile, sharedHeadroomPoolSize,
-        resetWatermark
+        resetWatermark, block_lag_noise_on_fanout
     ):
         # NOTE: cisco 8800 will skip this test since there is no headroom pool
         """

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -783,7 +783,7 @@ class TestQosSai(QosSaiBase):
     def testQosSaiHeadroomPoolSize(
         self, duthosts, get_src_dst_asic_and_duts, ptfhost, dutTestParams, dutConfig, dutQosConfig,
             ingressLosslessProfile, iptables_drop_ipv6_tx, change_lag_lacp_timer,
-            block_lag_noise_on_fanout):                # noqa: F811
+            block_non_test_traffic_on_fanout):                # noqa: F811
         # NOTE: cisco-8800 will skip this test since there are no headroom pool
         """
             Test QoS SAI Headroom pool size
@@ -997,7 +997,7 @@ class TestQosSai(QosSaiBase):
     def testQosSaiHeadroomPoolWatermark(
         self, duthosts, get_src_dst_asic_and_duts,  ptfhost, dutTestParams,
         dutConfig, dutQosConfig, ingressLosslessProfile, sharedHeadroomPoolSize,
-        resetWatermark, block_lag_noise_on_fanout
+        resetWatermark, block_non_test_traffic_on_fanout
     ):
         # NOTE: cisco 8800 will skip this test since there is no headroom pool
         """


### PR DESCRIPTION
### Description of PR

Summary:
Add `block_lag_noise_on_fanout` fixture to prevent false `InDiscard` counter increments caused by broadcast/multicast noise during `testQosSaiHeadroomPoolSize` and `testQosSaiHeadroomPoolWatermark` tests.

On t1-lag topologies, non-test L2 traffic (LLDP from EOS fanout/vEOS neighbors, LACP PDUs from LAG peers) arrives at DUT ports during the buffer-full phase of headroom pool tests. With the shared ingress buffer pool intentionally filled to capacity, these L2 packets are dropped on PG0 (no headroom), incrementing `InDiscard` and `InNonUcPkt` counters. The test asserts `InDiscard == baseline` and fails with "unexpected N packet drop".

Counter evidence confirms: `InDiscard delta == InNonUcPkt delta` on all affected ports — zero test-traffic drops. The failure is 100% exclusive to t1-lag topology (t0 has 0% failure rate).

Related: PR #22871 added `ignore_ingress_drop_caused_by_nonunicast_noise()` which filters noise at the PTF assertion level for PFCtest, PFCXonTest, and LossyQueueTest. However, `HdrmPoolSizeTest` does not call this filter. This fix takes a complementary approach: instead of tolerating noise at the assertion layer, prevent noise from reaching DUT at the network layer.

### Type of change

- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505
- [x] 202511

### Approach

#### What is the motivation for this PR?

`testQosSaiHeadroomPoolSize` and `testQosSaiHeadroomPoolWatermark` have a persistent 0% pass rate on t1-lag topologies over the past 30+ days, while passing 100% on t0. The root cause is environmental L2 noise (LLDP, LACP) causing false InDiscard increments during the headroom pool fill phase.

#### How did you do it?

Added a `block_lag_noise_on_fanout` pytest fixture (function scope, non-autouse) with three layers of protection:

1. **Stop DUT lacpd** — Prevents LACP timeout detection when LACP PDUs are blocked. Uses `src_asic.get_docker_name("teamd")` for multi-ASIC compatibility.
2. **Set EOS neighbor LACP timer multiplier to 600** — Prevents EOS-side LAG timeout while DUT lacpd is stopped.
3. **Disable LLDP + egress MAC ACL on fanout DUT-facing ports** — `no lldp transmit/receive` stops fanout-originated LLDP; egress MAC ACL (permit IP/IPv6/ARP, deny all) blocks VM-forwarded L2 noise.

All changes are automatically restored in fixture teardown (safe order: restart lacpd → restore timer → remove ACL).

The fixture is applied to all `dutInterfaces` ports because the actual `src_port_ids` used by PTF (from `qos.yml hdrm_pool_size`) differ from `dutConfig.testPorts.src_port_id` and are not available at fixture execution time.

#### How did you verify/test it?

Validated on a physical t1-lag testbed with Broadcom TH ASIC and EOS fanout:
- **Before fix**: Both tests FAIL consistently (InDiscard delta 3-5, InNonUcPkt delta 3)
- **After fix**: Both tests PASS (InDiscard delta 0, zero noise detected)

#### Any platform specific information?

The fixture currently supports EOS fanout switches only. SONiC fanout is not yet implemented (logs a warning and skips). All affected testbeds in scope use EOS fanout.

#### Supported testbed topology if it's a new test case?

N/A (bug fix for existing tests on t1-lag topology)

### Documentation

N/A