### PR TITLE
 [dhcp_relay] Add missing enable_sonic_dhcpv4_relay_agent fixture to stress tests

### DIFF
--- a/tests/dhcp_relay/test_dhcp_counter_stress.py
+++ b/tests/dhcp_relay/test_dhcp_counter_stress.py
@@ -43,7 +43,8 @@ def ignore_expected_loganalyzer_exceptions(rand_one_dut_hostname, loganalyzer):
 
 
 @pytest.mark.parametrize('dhcp_type', ['discover', 'offer', 'request', 'ack'])
-def test_dhcpmon_relay_counters_stress(ptfhost, relay_agent, ptfadapter, dut_dhcp_relay_data, validate_dut_routes_exist,
+def test_dhcpmon_relay_counters_stress(ptfhost, relay_agent, enable_sonic_dhcpv4_relay_agent,    # noqa: F811
+                                       ptfadapter, dut_dhcp_relay_data, validate_dut_routes_exist,
                                        testing_config, setup_standby_ports_on_rand_unselected_tor,
                                        toggle_all_simulator_ports_to_rand_selected_tor_m,     # noqa F811
                                        dhcp_type, clean_processes_after_stress_test,

--- a/tests/dhcp_relay/test_dhcp_relay_stress.py
+++ b/tests/dhcp_relay/test_dhcp_relay_stress.py
@@ -23,7 +23,7 @@ DEFAULT_DHCP_SERVER_PORT = 67
 
 
 def test_dhcp_relay_restart_with_stress(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist,
-                                        testing_config, relay_agent,
+                                        testing_config, relay_agent, enable_sonic_dhcpv4_relay_agent,    # noqa: F811
                                         request, setup_standby_ports_on_rand_unselected_tor,
                                         toggle_all_simulator_ports_to_rand_selected_tor_m):      # noqa F811
     """
@@ -111,7 +111,7 @@ def test_dhcp_relay_restart_with_stress(ptfhost, dut_dhcp_relay_data, validate_d
 
 @pytest.mark.parametrize('dhcp_type', ['discover', 'offer', 'request', 'ack'])
 def test_dhcp_relay_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_dut_routes_exist,
-                           testing_config, relay_agent,
+                           testing_config, relay_agent, enable_sonic_dhcpv4_relay_agent,    # noqa: F811
                            setup_standby_ports_on_rand_unselected_tor,
                            toggle_all_simulator_ports_to_rand_selected_tor_m,     # noqa F811
                            dhcp_type, clean_processes_after_stress_test):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

PR #23886 added "sonic-relay-agent" to the relay_agent pytestmark parametrize in test_dhcp_relay_stress.py (and an analogous earlier change did the same in test_dhcp_counter_stress.py) and imported the enable_sonic_dhcpv4_relay_agent fixture (with # noqa F401), but never added the fixture as a parameter to any of the test functions. As a result, when 
relay_agent="sonic-relay-agent":

 - has_sonic_dhcpv4_relay is never set in CONFIG_DB,
 - dhcp4relay never starts; ISC dhcrelay continues running,
 - PTF (in ansible/.../dhcp_relay_test.py) builds option-82 circuit-id with the sonic-style :Vlan1000 suffix while ISC produces the legacy form,
 - check_relayed_pkts_on_server_side does an exact-byte match and finds 0 packets while expecting 48 → the test fails.

Mirrors the existing pattern in test_dhcp_relay.py and test_dhcpv4_relay.py where each test function takes enable_sonic_dhcpv4_relay_agent as an explicit fixture parameter so the feature flag is enabled for sonic-relay-agent runs.

Files fixed:

 - tests/dhcp_relay/test_dhcp_relay_stress.py — test_dhcp_relay_restart_with_stress, test_dhcp_relay_stress
 - tests/dhcp_relay/test_dhcp_counter_stress.py — test_dhcpmon_relay_counters_stress

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

The sonic-relay-agent variants of the dhcp_relay stress tests have been failing in nightly because the feature-flag fixture that switches the relay implementation from ISC dhcrelay to SONiC dhcp4relay was imported but never wired into the test signatures. The tests run with ISC under the hood while PTF builds packets matching the SONiC option-82 format,
producing a guaranteed mismatch.

#### How did you do it?

Added enable_sonic_dhcpv4_relay_agent to the parameter list of each affected test function. No other logic change. This matches the pattern already used by test_dhcp_relay.py and test_dhcpv4_relay.py, where the fixture is taken explicitly so the has_sonic_dhcpv4_relay flag is enabled before the test body runs.

#### How did you verify/test it?

Ran test_dhcp_relay_restart_with_stress[sonic-relay-agent] on a real-hardware T0 testbed (Arista 720DT-G48S4, broadcom asic, SONiC.20251110). Test now passes (previously failed with AssertionError: 0 != 48).

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
