### PR TITLE
[Probe] Add xfail for HeadroomPool probe test on SPC1 and SPC3

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4419,6 +4419,12 @@ qos/test_qos_probe.py:
       # Mellanox SPC3 (Spectrum 3)
       - "hwsku in ['Mellanox-SN4600C-C64'] and https://github.com/sonic-net/sonic-mgmt/issues/22608"
 
+qos/test_qos_probe.py::TestQosProbe::testQosHeadroomPoolProbe:
+  xfail:
+    reason: "SPC1 HeadroomPool probe: pg=4 PFC not triggered and headroom total mismatch. Tracked by #24215."
+    conditions:
+      - "asic_gen == 'spc1'"
+
 qos/test_qos_sai.py:
   skip:
     reason: "qos_sai tests not supported on t1 topo / M* topo does not support qos and It is skipped for '202412' for now"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4421,9 +4421,9 @@ qos/test_qos_probe.py:
 
 qos/test_qos_probe.py::TestQosProbe::testQosHeadroomPoolProbe:
   xfail:
-    reason: "SPC1 HeadroomPool probe: pg=4 PFC not triggered and headroom total mismatch. Tracked by #24215."
+    reason: "HeadroomPool probe fails on Mellanox SPC1 and SPC3 starting at iteration #2: all packets sent to pg=4 (immediately after a successful pg=3 probe on the same src port) are ingress-dropped, so the probe algorithm cannot find a PFC threshold for pg=4. Tracked by #24558 (SPC1+SPC3) and #24215 (SPC1)."
     conditions:
-      - "asic_gen == 'spc1'"
+      - "asic_gen in ['spc1', 'spc3']"
 
 qos/test_qos_sai.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4423,7 +4423,7 @@ qos/test_qos_probe.py::TestQosProbe::testQosHeadroomPoolProbe:
   xfail:
     reason: "HeadroomPool probe fails on Mellanox SPC1 and SPC3 starting at iteration #2: all packets sent to pg=4 (immediately after a successful pg=3 probe on the same src port) are ingress-dropped, so the probe algorithm cannot find a PFC threshold for pg=4. Tracked by #24558 (SPC1+SPC3) and #24215 (SPC1)."
     conditions:
-      - "asic_gen in ['spc1', 'spc3']"
+      - "asic_gen in ['spc1', 'spc3'] and https://github.com/sonic-net/sonic-mgmt/issues/24558"
 
 qos/test_qos_sai.py:
   skip:


### PR DESCRIPTION
### Description of PR

Summary:
Add an xfail mark for `qos/test_qos_probe.py::TestQosProbe::testQosHeadroomPoolProbe` on Mellanox **SPC1** (`Mellanox-SN2700`) and **SPC3** (`Mellanox-SN4600C-C64`) platforms. The xfail condition is **gated on issue #24558 being open**, so it will automatically deactivate once the underlying platform issue is fixed and the issue is closed.

On both SPC1 and SPC3 the test fails at iteration #2 (the first `pg=4` iteration on a given src port, immediately after a successful `pg=3` probe on the same src port): all packets sent to pg=4 are ingress-dropped, so the probe algorithm cannot find a PFC threshold for pg=4 and the iteration is skipped / errored.

Gated on #24558 (this PR intentionally does **not** close it — the issue must stay open for the xfail to apply). Once the underlying platform issue is fixed and #24558 is closed, the xfail condition evaluates to false and the test runs normally again.

Related: #24215 (original SPC1-only tracking issue, kept for SPC1-specific history).

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

`testQosHeadroomPoolProbe` fails consistently on Mellanox SPC1 and SPC3 testbeds due to a platform-level issue: the buffer for pg=4 immediately ingress-drops all traffic as soon as the probe algorithm switches from pg=3 to pg=4 on the same src port. The probe algorithm has no way to recover (it assumes PFC will eventually trigger, but it never does because the packets are dropped instead of buffered).

The platform issue is being tracked in #24558 (with raw counter trace evidence) and the SPC1-specific subset in #24215, for vendor investigation. Until that is fixed, we mark the test as expected-fail on these platforms so that the rest of the QoS probe suite can still be enabled.

#### How did you do it?

Added xfail entry for `testQosHeadroomPoolProbe` in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`:

```yaml
qos/test_qos_probe.py::TestQosProbe::testQosHeadroomPoolProbe:
  xfail:
    reason: "HeadroomPool probe fails on Mellanox SPC1 and SPC3 starting at iteration #2: all packets sent to pg=4 (immediately after a successful pg=3 probe on the same src port) are ingress-dropped, so the probe algorithm cannot find a PFC threshold for pg=4. Tracked by #24558 (SPC1+SPC3) and #24215 (SPC1)."
    conditions:
      - "asic_gen in ['spc1', 'spc3'] and https://github.com/sonic-net/sonic-mgmt/issues/24558"
```

The `and https://github.com/sonic-net/sonic-mgmt/issues/24558` part is the same idiom already used elsewhere in this file (e.g. the existing entry at line 4420 referencing #22608). When the issue is open the condition evaluates to true and xfail applies; when the issue is closed it evaluates to false and the test runs normally.

#### How did you verify/test it?

- **SPC1** (`testbed-bjw-can-2700-2`, 2026-04-25 / 2026-04-28): Manual `run_tests.sh` of `testQosHeadroomPoolProbe`. Verified per-iteration counter trace via `[PFC Debug]` log lines added to `pfc_xoff_probing_executor.py`. Raw evidence (9 attempts of exp growth, `INGRESS_DROP` grows by ~100% of packets sent each attempt) is included in issue #24558.
- **SPC3** (`testbed-bjw2-can-t0-4600c-1`, 2026-05-08): Manual `run_tests.sh` of `testQosHeadroomPoolProbe`. Same iteration #2 failure pattern observed (algorithm-level error message differs slightly, but the test failure point is the same).
- **xfail condition syntax**: `asic_gen in [...]` and `... and https://github.com/.../issues/N` are both idioms already in use elsewhere in `tests_mark_conditions.yaml`. `asic_gen` is computed by the `conditional_mark` plugin from `read_asic_name(hwsku)` and verified to return `'spc3'` for `Mellanox-SN4600C-C64`.

End-to-end XFAIL-vs-FAIL verification on the physical SPC3 testbed is pending — the recent `run_tests.sh` attempts on `testbed-bjw2-can-t0-4600c-1` errored at setup (`Not all critical processes are healthy` on the DUT) before the probe could run, so the test never reached the failing iteration. The yaml change itself is small and uses well-tested condition syntax already present in this file.

#### Any platform specific information?

This PR only affects Mellanox Spectrum-1 (`Mellanox-SN2700`) and Spectrum-3 (`Mellanox-SN4600C-C64`) platforms. All other platforms (Broadcom, Cisco, other Mellanox SKUs) are unaffected — they continue to run `testQosHeadroomPoolProbe` normally.

#### Supported testbed topology if it's a new test case?

N/A — this is not a new test case, it is an xfail mark for an existing test.

### Documentation

N/A — no documentation change. The xfail `reason` field self-documents the failure mode and links to the tracking issues.


