### PR TITLE
Add support for using Debian as a host OS

### DIFF
--- a/ansible/roles/vm_set/library/sonic_kickstart.py
+++ b/ansible/roles/vm_set/library/sonic_kickstart.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 from ansible.module_utils.basic import AnsibleModule
-from telnetlib import Telnet  # nosemgrep: telnetlib
+from telnetlib3 import Telnet
 import logging
 from ansible.module_utils.debug_utils import config_module_logging
 

--- a/ansible/roles/vm_set/tasks/docker.yml
+++ b/ansible/roles/vm_set/tasks/docker.yml
@@ -14,39 +14,48 @@
     msg: "Docker repository does not exist"
   when: docker_repo.matched == 0
 
-- name: Add docker official GPG key
-  apt_key: url=https://download.docker.com/linux/ubuntu/gpg state=present
-  become: yes
-  environment: "{{ proxy_env | default({}) }}"
+- name: Add docker repository
+  block:
+  - name: Add docker repository for Ubuntu
+    block:
+    - name: Add docker official GPG key
+      apt_key: url=https://download.docker.com/linux/ubuntu/gpg state=present
+      become: yes
+      environment: "{{ proxy_env | default({}) }}"
+  
+    - name: Add docker repository for 22.04
+      apt_repository:
+        repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu jammy stable
+        state: present
+      become: yes
+      when: ansible_distribution_version == "22.04"
+  
+    - name: Add docker repository for 24.04
+      apt_repository:
+        repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu noble stable
+        state: present
+      become: yes
+      when: ansible_distribution_version == "24.04"
+    when: ansible_distribution == "Ubuntu"
+  
+  - name: Add docker repository for Debian
+    block:
+    - name: Add docker repository for Trixie
+      deb822_repository:
+        name: Docker
+        types: deb
+        uris: https://download.docker.com/linux/debian
+        suites: trixie
+        components: stable
+        signed_by: https://download.docker.com/linux/debian/gpg
+      become: yes
+      when: ansible_distribution_release == "trixie"
+    when: ansible_distribution == "Debian"
   when: docker_repo.matched == 0
 
-- name: Add docker repository for 22.04
-  apt_repository:
-    repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu jammy stable
-    state: present
-  become: yes
-  when: host_distribution_version.stdout == "22.04" and docker_repo.matched == 0
-
-- name: Add docker repository for 24.04
-  apt_repository:
-    repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu noble stable
-    state: present
-  become: yes
-  when: host_distribution_version.stdout == "24.04" and docker_repo.matched == 0
-
-# In ansible 2.8, there isn't update_cache_retries option in apt module,
-# we can manually run update as a separate and retryable step.
-- name: Run the "apt-get update" as a separate and retryable step
-  apt:
-    update_cache: yes
-  become: yes
-  environment: "{{ proxy_env | default({}) }}"
-  register: apt_update_res
-  until: apt_update_res.cache_updated is defined and apt_update_res.cache_updated
-  retries: 5
-  delay: 10
-
 - name: Install docker-ce
-  apt: pkg=docker-ce
+  apt:
+    name: docker-ce
+    update_cache: yes
   become: yes
   environment: "{{ proxy_env | default({}) }}"

--- a/ansible/roles/vm_set/tasks/docker.yml
+++ b/ansible/roles/vm_set/tasks/docker.yml
@@ -22,14 +22,14 @@
       apt_key: url=https://download.docker.com/linux/ubuntu/gpg state=present
       become: yes
       environment: "{{ proxy_env | default({}) }}"
-  
+
     - name: Add docker repository for 22.04
       apt_repository:
         repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu jammy stable
         state: present
       become: yes
       when: ansible_distribution_version == "22.04"
-  
+
     - name: Add docker repository for 24.04
       apt_repository:
         repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu noble stable
@@ -37,7 +37,7 @@
       become: yes
       when: ansible_distribution_version == "24.04"
     when: ansible_distribution == "Ubuntu"
-  
+
   - name: Add docker repository for Debian
     block:
     - name: Add docker repository for Trixie

--- a/ansible/roles/vm_set/tasks/ensure_python_env.yml
+++ b/ansible/roles/vm_set/tasks/ensure_python_env.yml
@@ -21,11 +21,15 @@
     mode: '0755'
   become: yes
 
+- name: Check if venv exists
+  stat:
+    path: "{{ sonic_testbed_venv }}/bin/python"
+  register: venv_stat
+
 - name: Create Python venv with system site-packages
-  command:
-    cmd: uv venv --python /usr/bin/python3 --system-site-packages {{ sonic_testbed_venv }}
-    creates: "{{ sonic_testbed_venv }}/bin/python"
+  command: uv venv --python /usr/bin/python3 --system-site-packages {{ sonic_testbed_venv }}
   become: yes
+  when: not venv_stat.stat.exists
 
 - name: Check installed versions of pinned Python packages
   command: >-

--- a/ansible/roles/vm_set/tasks/ensure_python_env.yml
+++ b/ansible/roles/vm_set/tasks/ensure_python_env.yml
@@ -21,20 +21,16 @@
     mode: '0755'
   become: yes
 
-- name: Check if venv exists
-  stat:
-    path: "{{ sonic_testbed_venv }}/bin/python"
-  register: venv_stat
-
 - name: Create Python venv with system site-packages
-  command: uv venv --python /usr/bin/python3 --system-site-packages {{ sonic_testbed_venv }}
+  command:
+    cmd: uv venv --python /usr/bin/python3 --system-site-packages {{ sonic_testbed_venv }}
+    creates: "{{ sonic_testbed_venv }}/bin/python"
   become: yes
-  when: not venv_stat.stat.exists
 
 - name: Check installed versions of pinned Python packages
   command: >-
     {{ sonic_testbed_venv }}/bin/python -c
-    "import requests, docker; print(requests.__version__); print(docker.__version__)"
+    "import requests, docker, telnetlib3; print(requests.__version__); print(docker.__version__); print(telnetlib3.__version__)"
   register: pkg_versions
   changed_when: false
   failed_when: false
@@ -43,8 +39,8 @@
   command: >-
     uv pip install
     --python {{ sonic_testbed_venv }}/bin/python
-    requests==2.33.1 docker==7.1.0
+    requests==2.33.1 docker==7.1.0 telnetlib3==4.0.2 six
   become: yes
   environment: "{{ proxy_env | default({}) }}"
   when: pkg_versions.rc != 0
-        or pkg_versions.stdout_lines != ['2.33.1', '7.1.0']
+        or pkg_versions.stdout_lines != ['2.33.1', '7.1.0', '4.0.2']

--- a/ansible/roles/vm_set/tasks/host_setup.yml
+++ b/ansible/roles/vm_set/tasks/host_setup.yml
@@ -18,7 +18,6 @@
       - apt-transport-https
       - ca-certificates
       - curl
-      - software-properties-common
       - libvirt-clients
       - python3-libvirt
       - python3-lxml

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -22,34 +22,33 @@
 # downloaded from the URLs defined in the variables. Please update the URLs to the actual URLs of the image files in
 # your environment.
 
-# ---- Distribution detection ----
-- name: get host distribution
-  shell: grep ^NAME /etc/os-release | awk -F '=' '{print $2}' | tr -d '"'
-  register: host_distribution
-  changed_when: False
-
-- name: get host distribution version
-  shell: grep ^VERSION_ID /etc/os-release | awk -F '=' '{print $2}' | tr -d '"'
-  register: host_distribution_version
-  changed_when: False
-
-# ---- Fail if Ubuntu < 22.04 ----
-- name: Fail if distribution is not Ubuntu
+# ---- Fail if Ubuntu < 22.04 or Debian < 13 ----
+- name: Fail if distribution is not Ubuntu or Debian
   fail:
     msg: >-
-      Distribution '{{ host_distribution.stdout }}' is not supported.
-      Only Ubuntu 22.04 and 24.04 are supported.
+      Distribution '{{ ansible_distribution }}' is not supported.
+      Only Ubuntu 22.04, Ubuntu 24.04, and Debian 13 (Trixie) are supported.
   when:
-    - host_distribution.stdout != "Ubuntu"
+    - ansible_distribution != "Ubuntu"
+    - ansible_distribution != "Debian"
 
 - name: Fail if Ubuntu version is not supported
   fail:
     msg: >-
-      Ubuntu {{ host_distribution_version.stdout }} is not supported.
+      Ubuntu {{ ansible_distribution_version}} is not supported.
       Minimum required version is 22.04.
   when:
-    - host_distribution.stdout == "Ubuntu"
-    - host_distribution_version.stdout is version("22.04", "<")
+    - ansible_distribution == "Ubuntu"
+    - ansible_distribution_version is version("22.04", "<")
+
+- name: Fail if Debian version is not supported
+  fail:
+    msg: >-
+      Debian {{ ansible_distribution_version}} is not supported.
+      Minimum required version is 13.
+  when:
+    - ansible_distribution == "Debian"
+    - ansible_distribution_version is version("13.0", "<")
 
 # ---- Host setup gating ----
 - name: Pick package_installation from env

--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -31,7 +31,6 @@
 # -e netns_mgmt_ip=10.255.0.254/23 - the ip address and prefix of netns mgmt interface, only for dualtor topo with ports in active-active cable type
 
 - hosts: servers:&vm_host
-  gather_facts: no
   pre_tasks:
   - set_fact: ansible_user="{{ vm_host_user }}"
     when:

--- a/ansible/testbed_remove_vm_topology.yml
+++ b/ansible/testbed_remove_vm_topology.yml
@@ -15,7 +15,6 @@
 # -e ptf_imagename=docker-ptf - name of a docker-image which will be used for the ptf docker container
 
 - hosts: servers:&vm_host
-  gather_facts: no
   vars_files:
     - vars/docker_registry.yml
   pre_tasks:

--- a/ansible/testbed_start_VMs.yml
+++ b/ansible/testbed_start_VMs.yml
@@ -16,7 +16,6 @@
 #
 
 - hosts: servers:&vm_host
-  gather_facts: no
   tasks:
   roles:
     - { role: vm_set, vm_set_action: 'start' }

--- a/ansible/testbed_stop_VMs.yml
+++ b/ansible/testbed_stop_VMs.yml
@@ -11,6 +11,5 @@
 #
 
 - hosts: servers:&vm_host
-  gather_facts: no
   roles:
   - { role: vm_set, vm_set_action: 'stop' }


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

The current checks done in our ansible scripts assume that Ubuntu is being used as the host/base OS, but these steps can work on other distros as well.

#### How did you do it?

Add support for using Debian as a host OS. For now, only support for Debian Trixie is added (since the Docker repo is different for each version of Debian).

Additionally, Debian Trixie uses Python 3.13, which removes the telnetlib module. As a short-term workaround, install the telnetlib3 package which packages a copy of the telnetlib module.

#### How did you verify/test it?

Tested on a Debian 13 system.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
