### PR TITLE
test_everflow_ipv6 should wait for ACL rules to be programmed

### DIFF
--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -13,6 +13,8 @@ import random
 from .everflow_test_utilities import setup_info, skip_ipv6_everflow_tests                                 # noqa: F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor    # noqa: F401
 from tests.common.macsec.macsec_helper import MACSEC_INFO
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
 
 pytestmark = [
     pytest.mark.topology("t0", "t1", "t2", "lt2", "ft2", "m0", "m1")
@@ -223,6 +225,9 @@ class EverflowIPv6Tests(BaseEverflowTest):
             self.apply_acl_rule_config(duthost, table_name, setup_mirror_session["session_name"],
                                        config_method, rules=EVERFLOW_V6_RULES)
             self.apply_ip_type_rule(duthost, 6)
+            # Wait for ACL rules to be programmed
+            pytest_assert(wait_until(120, 2, 0, everflow_utils.validate_acl_rules_in_asic_db, duthost),
+                          "ACL rules are not programmed")
 
         yield
 


### PR DESCRIPTION
### Description of PR
test_everflow_ip6 tests are failing sometimes since the ACL rules are not programmed completely in hardware before that tests are run. Need to add a proper wait to validate all ACL rules are programmed.

Summary:
Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/issues/24221

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
test_everflow_ipv6 fails intermittently

#### How did you do it?
Added a wait condition to verify ACL rule programming completed.

#### How did you verify/test it?
Test consistently passes with the fix

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
