### PR TITLE
fix: ensure sonic-vm dirs are writable

### DIFF
--- a/ansible/roles/vm_set/tasks/start_sonic_vm.yml
+++ b/ansible/roles/vm_set/tasks/start_sonic_vm.yml
@@ -18,14 +18,12 @@
   file: path={{ item }} state=directory mode=0755
   with_items:
     - "{{ sonic_vm_storage_location }}/images"
-  become: yes
   when: not images_folder_stat.stat.exists
 
 - name: Create directory for vm disks
   file: path={{ item }} state=directory mode=0755
   with_items:
     - "{{ sonic_vm_storage_location }}/disks"
-  become: yes
   when: not discs_folder_stat.stat.exists
 
 - set_fact:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Ensure the SONiC VM image and disk storage directories are created with ownership assigned to the Ansible user. This also fixes existing directories that may have been created previously with root ownership, preventing permission errors when copying VM disk images

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The playbook created the VM storage directories with root permissions so the later image copy action will fail due to insufficient permissions. Besides, the playbook only created the VM storage directories when they did not already exist. If the directories already existed but were owned by root or another user, the setup task was skipped and later VM image operations could fail due to insufficient permissions.

Example failure log:
```
TASK [vm_set : Copy sonic disk image for vlab-01] ******* fatal: [STR-ACS-VSERV-01]: FAILED! => {"changed": false, "msg": "Destination /home/cyw233/sonic-vm/disks not writable"}
```

#### How did you do it?
- Update SONiC VM storage directory setup to ensure both images and disks directories exist.
- Set directory ownership to the Ansible user, falling back to ansible_ssh_user when ansible_user is not defined.
- Combine the image and disk directory setup into a single idempotent task.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
