### PR TITLE
[gnmi] Backdate test cert notBefore to tolerate clock skew; better assert msg

### DIFF
--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timedelta, timezone
 
 logger = logging.getLogger(__name__)
 
@@ -256,6 +257,33 @@ def create_gnmi_certs(duthost, localhost, ptfhost):
     copy_certificate_to_ptf(ptfhost)
 
 
+def _openssl_not_before_arg(localhost, days_back=1):
+    """
+    Build an OpenSSL ``-not_before`` argument that backdates the certificate
+    by ``days_back`` days, when the local OpenSSL version supports it
+    (OpenSSL >= 3.2). When the flag is not supported, return an empty string
+    so the caller falls back to the default behavior (notBefore = "now").
+
+    Backdating ``notBefore`` makes freshly-minted test certificates tolerant
+    of small clock skew between the cert generator (sonic-mgmt host), the
+    DUT (gNMI server) and the PTF (gNMI client). Without it, a PTF whose
+    clock trails the sonic-mgmt host by even a few seconds rejects the
+    server cert with ``CERTIFICATE_VERIFY_FAILED: certificate is not yet
+    valid`` during the TLS handshake.
+    """
+    try:
+        help_out = localhost.shell("openssl x509 -help 2>&1", module_ignore_errors=True)
+        combined = (help_out.get("stdout", "") or "") + (help_out.get("stderr", "") or "")
+        if "-not_before" not in combined:
+            return ""
+    except Exception as e:
+        logger.warning("Failed to probe openssl for -not_before support: %s", e)
+        return ""
+
+    backdated = datetime.now(timezone.utc) - timedelta(days=days_back)
+    return "-not_before {}".format(backdated.strftime("%Y%m%d%H%M%SZ"))
+
+
 def prepare_root_cert(localhost, days="1825"):
     create_root_key(localhost)
     create_root_cert(localhost, days)
@@ -267,6 +295,7 @@ def create_root_key(localhost):
 
 
 def create_root_cert(localhost, days):
+    not_before = _openssl_not_before_arg(localhost)
     local_command = "openssl req \
                             -x509 \
                             -new \
@@ -274,8 +303,9 @@ def create_root_cert(localhost, days):
                             -key gnmiCA.key \
                             -sha256 \
                             -days {} \
+                            {} \
                             -subj '/CN=test.gnmi.sonic' \
-                            -out gnmiCA.pem".format(days)
+                            -out gnmiCA.pem".format(days, not_before)
     localhost.shell(local_command)
 
 
@@ -301,6 +331,7 @@ def create_server_csr(localhost):
 
 def sign_server_certificate(duthost, localhost, days):
     create_ext_conf(duthost.mgmt_ip, "extfile.cnf")
+    not_before = _openssl_not_before_arg(localhost)
     local_command = "openssl x509 \
                             -req \
                             -in gnmiserver.csr \
@@ -309,9 +340,10 @@ def sign_server_certificate(duthost, localhost, days):
                             -CAcreateserial \
                             -out gnmiserver.crt \
                             -days {} \
+                            {} \
                             -sha256 \
                             -extensions req_ext \
-                            -extfile extfile.cnf".format(days)
+                            -extfile extfile.cnf".format(days, not_before)
     localhost.shell(local_command)
 
 
@@ -341,6 +373,7 @@ def create_client_csr(localhost, revoke=False):
 def sign_client_certificate(localhost, days="825", revoke=False, extension_file=None):
     revoke_suffix = "revoked." if revoke else ""
     extensions = "-extensions req_ext -extfile {}".format(extension_file) if extension_file else ""
+    not_before = _openssl_not_before_arg(localhost)
     local_command = "openssl x509 \
                             -req \
                             -in gnmiclient.{}csr \
@@ -349,7 +382,8 @@ def sign_client_certificate(localhost, days="825", revoke=False, extension_file=
                             -CAcreateserial \
                             -out gnmiclient.{}crt \
                             -days {} \
-                            -sha256 {}".format(revoke_suffix, revoke_suffix, days, extensions)
+                            {} \
+                            -sha256 {}".format(revoke_suffix, revoke_suffix, days, not_before, extensions)
     localhost.shell(local_command)
 
 

--- a/tests/gnmi/test_gnmi_appldb.py
+++ b/tests/gnmi/test_gnmi_appldb.py
@@ -31,19 +31,25 @@ def test_gnmi_appldb_01(duthosts, rand_one_dut_hostname, ptfhost):
     path_list1 = ["/sonic-db:APPL_DB/localhost/DASH_VNET_TABLE/Vnet1/vni"]
     path_list2 = ["/sonic-db:APPL_DB/localhost/_DASH_VNET_TABLE/Vnet1/vni"]
     output = None
+    path1_err = None
+    path2_err = None
     try:
         msg_list1 = gnmi_get(duthost, ptfhost, path_list1)
     except Exception as e:
-        logger.info("Failed to read path1: " + str(e))
+        path1_err = str(e)
+        logger.info("Failed to read path1: " + path1_err)
     else:
         output = msg_list1[0]
     try:
         msg_list2 = gnmi_get(duthost, ptfhost, path_list2)
     except Exception as e:
-        logger.info("Failed to read path2: " + str(e))
+        path2_err = str(e)
+        logger.info("Failed to read path2: " + path2_err)
     else:
         output = msg_list2[0]
-    assert output == "\"1000\"", "Unexpected output: '{}'".format(output)
+    assert output == "\"1000\"", (
+        "Unexpected output: '{}'. path1_err={}, path2_err={}".format(output, path1_err, path2_err)
+    )
 
     # Remove DASH_VNET_TABLE
     delete_list = ["/sonic-db:APPL_DB/localhost/DASH_VNET_TABLE/Vnet1"]


### PR DESCRIPTION
### Description of PR

Summary:
Fixes intermittent `test_gnmi_appldb_01` failure that surfaces as a bare `AssertionError: None` on testbeds with mild clock drift between the sonic-mgmt host and the PTF.

`tests/gnmi/conftest.py::setup_gnmi_server` -> `create_gnmi_certs` generates the gNMI root/server/client certs on the **sonic-mgmt host** with `notBefore = now`. The PTF gNMI client then opens a TLS connection to the DUT gNMI server. When the PTF clock trails the sonic-mgmt host by even a few seconds, the TLS handshake aborts with:

```
Tls handshake failed (TSI_PROTOCOL_FAILURE):
SSL_ERROR_SSL: error:1000007d:SSL routines:OPENSSL_internal:
CERTIFICATE_VERIFY_FAILED: certificate is not yet valid
```

The existing `setup_gnmi_ntp_client_server` fixture only checks the DUT clock, so cross-host skew between sonic-mgmt and PTF is invisible to it. In `test_gnmi_appldb_01` both `gnmi_get` calls then raise, the exceptions are swallowed into `logger.info`, `output` stays `None`, and the only thing left for the user is `AssertionError: None` thousands of lines into `test.log`.

Fixes # (N/A — observed in NightlyTest)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

Two related issues observed on a NightlyTest run for `vms61-t1-8101-05`:

1. `test_gnmi_appldb_01` failed at the final assert with `AssertionError: None`. The real cause — a TLS `CERTIFICATE_VERIFY_FAILED: certificate is not yet valid` raised by both `gnmi_get` calls — was only discoverable by grepping ~6 MB of `test.log`, because the test swallows the exceptions into `logger.info(...)` and asserts on a `None` `output`.
2. The underlying cert-not-yet-valid error itself is caused by the cert generator using `notBefore = now`, which is fragile to even a few seconds of skew between the sonic-mgmt host and the PTF / DUT.

#### How did you do it?

1. `tests/common/helpers/gnmi_utils.py`
   * New `_openssl_not_before_arg(localhost, days_back=1)` helper. It probes `openssl x509 -help` once for `-not_before` (added in OpenSSL 3.2) and, when supported, returns `-not_before YYYYMMDDHHMMSSZ` backdated by 1 day. On older OpenSSL it returns `""` so behavior is unchanged.
   * `create_root_cert`, `sign_server_certificate`, `sign_client_certificate` now inject that argument into their openssl invocations. This eliminates the entire class of "cert not yet valid" failure on testbeds with sub-day clock skew, with **zero behavior change** on hosts whose OpenSSL pre-dates 3.2.

2. `tests/gnmi/test_gnmi_appldb.py::test_gnmi_appldb_01`
   * Capture `path1_err` / `path2_err` from the swallowed exceptions and include them in the final `assert` message. Future failures now say:
     ```
     AssertionError: Unexpected output: 'None'.
         path1_err=... certificate is not yet valid ...
         path2_err=... certificate is not yet valid ...
     ```
     instead of `AssertionError: None`.

#### How did you verify/test it?

* `python -c "import ast; ast.parse(open(...).read())"` passes for both files.
* Logic for the OpenSSL-version branch:
  * On OpenSSL >= 3.2 (e.g. Ubuntu 24.04), `openssl x509 -help` contains `-not_before` -> the helper returns the backdated arg and the cert's `notBefore` is `now - 1 day`.
  * On OpenSSL < 3.2 (e.g. Debian Bookworm / Ubuntu 22.04 PTF image), the helper returns `""` and the openssl command is byte-identical to today's.
* Success path of `test_gnmi_appldb_01` is unchanged; only the failure-message text is augmented.

#### Any platform specific information?

None. The cert change is purely on the sonic-mgmt host where OpenSSL is invoked. The 1-day backdate is well within all certs' validity windows (root 1825 d, leaf 825 d in the upstream helpers).

#### Supported testbed topology if it's a new test case?

N/A — bug fix / test improvement, not a new test case.

### Documentation

N/A — internal cert helper plus assert-message change; no user-visible API or doc surface impacted.