### PR TITLE
Add test cases for supporting PDB

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -702,6 +702,37 @@ def frontend_asic_index_with_portchannel(request, duthosts, tbinfo):
         return None
 
 
+def get_pdb_num(duthost):
+    """Return pdb_num from chassis_info in STATE_DB."""
+    command = 'sonic-db-cli STATE_DB HGET "CHASSIS_INFO|chassis 1" pdb_num'
+    result = duthost.shell(command, module_ignore_errors=True)
+    if result['rc'] != 0:
+        stderr = result.get('stderr', '').strip()
+        logger.warning("Failed to query pdb_num on '%s' via '%s': rc=%s, stderr=%s",
+                       duthost.hostname, command, result['rc'], stderr)
+        raise RuntimeError(
+            "Failed to query pdb_num from STATE_DB on '{}'".format(duthost.hostname)
+        )
+
+    pdb_num_str = result['stdout'].strip()
+    if pdb_num_str and pdb_num_str.isdigit():
+        return int(pdb_num_str)
+    return 0
+
+
+def check_pdb_support(duthost):
+    """Check if duthost has PDB by querying STATE_DB. Returns True if pdb_num > 0."""
+    return get_pdb_num(duthost) > 0
+
+
+@pytest.fixture(scope='module')
+def is_support_pdb(duthosts, rand_one_dut_hostname):
+    """
+    Check if dut has PDB (Power Distribution Board) by querying chassis_info in STATE_DB.
+    """
+    return check_pdb_support(duthosts[rand_one_dut_hostname])
+
+
 def separated_dscp_to_tc_map_on_uplink(dut_qos_maps_module):
     """
     A helper function to check if separated DSCP_TO_TC_MAP is applied to

--- a/tests/common/helpers/pdb_mocker.py
+++ b/tests/common/helpers/pdb_mocker.py
@@ -1,0 +1,100 @@
+import logging
+
+from tests.common.helpers.mellanox_thermal_control_test_helper import MockerHelper
+
+logger = logging.getLogger(__name__)
+
+
+class PdbData(object):
+    PDB_PRESENCE_FILE_CANDIDATES = [
+        '/run/hw-management/system/pdb{}_status',
+        '/run/hw-management/system/pdb{}_present'
+    ]
+
+    def __init__(self, mock_helper, index):
+        self.helper = mock_helper
+        self.index = index
+        self.name = f'PDB {self.index}'
+        self.presence_file = self._detect_presence_file()
+
+    def _detect_presence_file(self):
+        for file_path in [candidate.format(self.index) for candidate in self.PDB_PRESENCE_FILE_CANDIDATES]:
+            out = self.helper.dut.stat(path=file_path)
+            if out['stat']['exists']:
+                logger.info("Detected PDB presence file '%s' for %s", file_path, self.name)
+                return file_path
+        logger.warning(
+            "No PDB presence file found for %s. Checked candidates: %s",
+            self.name,
+            [candidate.format(self.index) for candidate in self.PDB_PRESENCE_FILE_CANDIDATES]
+        )
+        return None
+
+    def mock_presence(self, status):
+        if self.presence_file is None:
+            logger.warning("Unable to mock presence for %s: no supported presence sysfs file detected", self.name)
+            return False
+
+        value = 1 if status else 0
+        logger.info("Mocking %s presence via '%s' with value '%s'", self.name, self.presence_file, value)
+        self.helper.mock_value(self.presence_file, str(value))
+        return True
+
+    def mock_status(self, status):
+        value = 1 if status else 0
+        power_status_file = f'/run/hw-management/system/pdb{self.index}_pwr_status'
+        self.helper.mock_value(power_status_file, str(value))
+
+
+class MellanoxPdbMocker(object):
+    def __init__(self, dut):
+        self.mock_helper = MockerHelper(dut)
+        self.pdb_data = self._init_pdb_data()
+
+    def _init_pdb_data(self):
+        for i in range(1, 5):
+            pdb_file = f'/run/hw-management/system/pdb{i}_pwr_status'
+            out = self.mock_helper.dut.stat(path=pdb_file)
+            if out['stat']['exists']:
+                return PdbData(self.mock_helper, i)
+        return None
+
+    def deinit(self):
+        self.mock_helper.deinit()
+
+    def mock_pdb_status(self, status):
+        if self.pdb_data is None:
+            logger.warning(
+                "Unable to mock PDB power status: no PDB data discovered on '%s'",
+                self.mock_helper.dut.hostname
+            )
+            return False, None
+
+        self.pdb_data.mock_status(status)
+        logger.info("Mocked PDB power status for %s to '%s'", self.pdb_data.name, status)
+        return True, self.pdb_data.name
+
+    def mock_pdb_presence(self, status):
+        if self.pdb_data is None:
+            logger.warning(
+                "Unable to mock PDB presence: no PDB data discovered on '%s'",
+                self.mock_helper.dut.hostname
+            )
+            return False, None
+
+        mock_result = self.pdb_data.mock_presence(status)
+        if not mock_result:
+            logger.warning(
+                "PDB presence mock is not supported for %s on '%s'",
+                self.pdb_data.name, self.mock_helper.dut.hostname
+            )
+            return False, self.pdb_data.name
+
+        logger.info("Mocked PDB presence for %s to '%s'", self.pdb_data.name, status)
+        return True, self.pdb_data.name
+
+
+def create_pdb_mocker(dut):
+    if 'mellanox' in dut.facts['asic_type']:
+        return MellanoxPdbMocker(dut)
+    return None

--- a/tests/common/helpers/platform_api/chassis.py
+++ b/tests/common/helpers/platform_api/chassis.py
@@ -139,6 +139,18 @@ def get_psu(conn, index):
     return chassis_api(conn, 'get_psu', [index])
 
 
+def get_num_pdbs(conn):
+    return chassis_api(conn, 'get_num_pdbs')
+
+
+def get_all_pdbs(conn):
+    return chassis_api(conn, 'get_all_pdbs')
+
+
+def get_pdb(conn, index):
+    return chassis_api(conn, 'get_pdb', [index])
+
+
 def get_num_thermals(conn):
     return chassis_api(conn, 'get_num_thermals')
 

--- a/tests/common/helpers/platform_api/pdb.py
+++ b/tests/common/helpers/platform_api/pdb.py
@@ -1,0 +1,103 @@
+"""
+This module provides an interface to remotely interact with the power
+distribution boards (PDB) of the DUT via platform API
+"""
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def pdb_api(conn, pdb_id, name, args=None):
+    if args is None:
+        args = []
+    conn.request('POST', f'/platform/chassis/pdb/{pdb_id}/{name}', json.dumps({'args': args}))
+    resp = conn.getresponse()
+    res = json.loads(resp.read())['res']
+    logger.info(f'Executing PDB API: "{name}", arguments: "{args}", result: "{res}"')
+    return res
+
+
+#
+# Methods inherited from DeviceBase class
+#
+
+def get_name(conn, index):
+    return pdb_api(conn, index, 'get_name')
+
+
+def get_presence(conn, index):
+    return pdb_api(conn, index, 'get_presence')
+
+
+def get_model(conn, index):
+    return pdb_api(conn, index, 'get_model')
+
+
+def get_serial(conn, index):
+    return pdb_api(conn, index, 'get_serial')
+
+
+def get_revision(conn, index):
+    return pdb_api(conn, index, 'get_revision')
+
+
+def get_status(conn, index):
+    return pdb_api(conn, index, 'get_status')
+
+
+def get_position_in_parent(conn, pdb_id):
+    return pdb_api(conn, pdb_id, 'get_position_in_parent')
+
+
+def is_replaceable(conn, pdb_id):
+    return pdb_api(conn, pdb_id, 'is_replaceable')
+
+#
+# Methods defined in PdbBase class
+#
+
+
+def get_input_voltage(conn, pdb_id):
+    return pdb_api(conn, pdb_id, 'get_input_voltage')
+
+
+def get_input_current(conn, pdb_id):
+    return pdb_api(conn, pdb_id, 'get_input_current')
+
+
+def get_input_power(conn, pdb_id):
+    return pdb_api(conn, pdb_id, 'get_input_power')
+
+
+def get_output_voltage(conn, pdb_id):
+    return pdb_api(conn, pdb_id, 'get_output_voltage')
+
+
+def get_output_current(conn, pdb_id):
+    return pdb_api(conn, pdb_id, 'get_output_current')
+
+
+def get_output_power(conn, pdb_id):
+    return pdb_api(conn, pdb_id, 'get_output_power')
+
+
+def get_maximum_supplied_power(conn, pdb_id):
+    return pdb_api(conn, pdb_id, 'get_maximum_supplied_power')
+
+
+def get_temperature(conn, pdb_id):
+    return pdb_api(conn, pdb_id, 'get_temperature')
+
+
+def get_num_thermals(conn, pdb_id):
+    return pdb_api(conn, pdb_id, 'get_num_thermals')
+
+
+def get_all_thermals(conn, pdb_id):
+    return pdb_api(conn, pdb_id, 'get_all_thermals')
+
+
+def get_thermal(conn, pdb_id, index):
+    return pdb_api(conn, pdb_id, 'get_thermal', [index])

--- a/tests/common/helpers/platform_api/pdb.py
+++ b/tests/common/helpers/platform_api/pdb.py
@@ -71,18 +71,6 @@ def get_input_power(conn, pdb_id):
     return pdb_api(conn, pdb_id, 'get_input_power')
 
 
-def get_output_voltage(conn, pdb_id):
-    return pdb_api(conn, pdb_id, 'get_output_voltage')
-
-
-def get_output_current(conn, pdb_id):
-    return pdb_api(conn, pdb_id, 'get_output_current')
-
-
-def get_output_power(conn, pdb_id):
-    return pdb_api(conn, pdb_id, 'get_output_power')
-
-
 def get_maximum_supplied_power(conn, pdb_id):
     return pdb_api(conn, pdb_id, 'get_maximum_supplied_power')
 

--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -89,7 +89,9 @@ def get_dut_psu_line_pattern(dut):
     elif dut.facts['platform'] == "x86_64-dellemc_z9332f_d1508-r0":
         psu_line_pattern = re.compile(r"PSU\s+(\d+).*?(OK|NOT OK|NOT PRESENT|WARNING)\s+(N/A)")
     elif dut.facts["asic_type"] in ["mellanox"]:
-        psu_line_pattern = re.compile(r"PSU\s+(\d+).*?(OK|NOT OK|NOT PRESENT|WARNING)\s+(green|amber|red|off|N/A)")
+        psu_line_pattern = re.compile(
+            r"(?:PSU|PDB)\s+(\d+).*?(OK|NOT OK|NOT PRESENT|WARNING)\s+(green|amber|red|off|N/A)"
+        )
     else:
         # Changed the pattern to match different PSU name formats and status patterns.
         # Supports various PSU naming conventions:
@@ -102,9 +104,10 @@ def get_dut_psu_line_pattern(dut):
         #     psutray0.psu1  N/A      N/A               12.01           4.12        49.50  OK        green
         # example 3:
         #     PSU 9  PSU6.3KW-20A-HV  DTM273501QU      1.00  55.052         11.359         626.386      OK        green
-        #
+        # Supports PSU and PDB naming conventions:
+        #   PSU 1, PSU 9, PDB 1, PDB 2, psu1, etc.
         psu_line_pattern = re.compile(
-            r"^(PSU\s+\d+|\S+)\s+.*?(OK|NOT OK|NOT PRESENT|WARNING)\s+(green|amber|red|off|N/A)")
+            r"^(PSU\s+\d+|PDB\s+\d+|\S+)\s+.*?(OK|NOT OK|NOT PRESENT|WARNING)\s+(green|amber|red|off|N/A)")
     return psu_line_pattern
 
 

--- a/tests/platform_tests/api/power_api_test_base.py
+++ b/tests/platform_tests/api/power_api_test_base.py
@@ -1,0 +1,180 @@
+import logging
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.platform_api import chassis
+from tests.platform_tests.cli.util import get_skip_mod_list
+from tests.common.utilities import skip_release
+
+from .platform_api_test_base import PlatformApiTestBase
+
+
+###################################################
+# TODO: Remove this after we transition to Python 3
+import sys
+if sys.version_info.major >= 3:
+    STRING_TYPE = str
+else:
+    STRING_TYPE = basestring    # noqa: F821
+# END Remove this after we transition to Python 3
+###################################################
+
+
+logger = logging.getLogger(__name__)
+
+
+class TestPowerApi(PlatformApiTestBase):
+    """Shared platform API tests for PSU/PDB-like power units."""
+
+    num_power_units = None
+
+    power_unit_api = None
+    power_unit_label = ""
+    facts_key = ""
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, platform_api_conn, duthosts, enum_rand_one_per_hwsku_hostname):  # noqa: F811
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        if self.num_power_units is None:
+            try:
+                self.num_power_units = int(self._get_num_power_units(platform_api_conn))
+            except Exception:
+                self._handle_num_power_units_exception(duthost)
+            else:
+                if self.num_power_units == 0:
+                    self._handle_no_power_units(duthost)
+
+        self.power_unit_skip_list = get_skip_mod_list(duthost, [self.facts_key])
+
+    def _get_num_power_units(self, conn):
+        return chassis.get_num_psus(conn)
+
+    def _handle_num_power_units_exception(self, duthost):
+        pytest.fail(f"num_{self.facts_key} is not an integer")
+
+    def _handle_no_power_units(self, duthost):
+        pytest.skip(f"No {self.facts_key} found on device")
+
+    def _skip_absent_power_unit(self, pu_id, platform_api_conn):
+        name = self.power_unit_api.get_name(platform_api_conn, pu_id)
+        if name in self.power_unit_skip_list:
+            logger.info("Skipping %s %s since it is in skip list", self.power_unit_label, name)
+            return True
+        return False
+
+    def compare_value_with_platform_facts(self, duthost, key, value, pu_idx):
+        expected_value = None
+        chassis_facts = duthost.facts.get("chassis")
+        if chassis_facts:
+            expected_units = chassis_facts.get(self.facts_key)
+            if expected_units:
+                expected_value = expected_units[pu_idx].get(key)
+            else:
+                logger.warning("duthost.facts['chassis'] has no '%s' key. Available keys: %s",
+                               self.facts_key, list(chassis_facts.keys()))
+        else:
+            logger.warning("duthost.facts has no 'chassis' key. Available keys: %s",
+                           list(duthost.facts.keys()))
+
+        if self.expect(expected_value is not None,
+                       f"Unable to get expected value for '{key}' from platform.json file for "
+                       f"{self.power_unit_label} {pu_idx}"):
+            self.expect(value == expected_value,
+                        f"'{key}' value is incorrect. Got '{value}', expected '{expected_value}' "
+                        f"for {self.power_unit_label} {pu_idx}")
+
+    #
+    # Functions to test methods inherited from DeviceBase class
+    #
+
+    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa: F811
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        for i in range(self.num_power_units):
+            if self._skip_absent_power_unit(i, platform_api_conn):
+                continue
+            name = self.power_unit_api.get_name(platform_api_conn, i)
+            if self.expect(name is not None, f"Unable to retrieve {self.power_unit_label} {i} name"):
+                self.expect(isinstance(name, STRING_TYPE),
+                            f"{self.power_unit_label} {i} name appears incorrect")
+                self.compare_value_with_platform_facts(duthost, 'name', name, i)
+        self.assert_expectations()
+
+    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa: F811
+        for i in range(self.num_power_units):
+            presence = self.power_unit_api.get_presence(platform_api_conn, i)
+            name = self.power_unit_api.get_name(platform_api_conn, i)
+            if self.expect(presence is not None,
+                           f"Unable to retrieve {self.power_unit_label} {i} presence"):
+                if self.expect(isinstance(presence, bool),
+                               f"{self.power_unit_label} {i} presence appears incorrect"):
+                    if name not in self.power_unit_skip_list:
+                        self.expect(presence is True, f"{self.power_unit_label} {i} is not present")
+        self.assert_expectations()
+
+    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):   # noqa: F811
+        for i in range(self.num_power_units):
+            if self._skip_absent_power_unit(i, platform_api_conn):
+                continue
+            model = self.power_unit_api.get_model(platform_api_conn, i)
+            if self.expect(model is not None, f"Unable to retrieve {self.power_unit_label} {i} model"):
+                self.expect(isinstance(model, STRING_TYPE),
+                            f"{self.power_unit_label} {i} model appears incorrect")
+        self.assert_expectations()
+
+    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa: F811
+        for i in range(self.num_power_units):
+            if self._skip_absent_power_unit(i, platform_api_conn):
+                continue
+            serial = self.power_unit_api.get_serial(platform_api_conn, i)
+            if self.expect(serial is not None,
+                           f"Unable to retrieve {self.power_unit_label} {i} serial number"):
+                self.expect(isinstance(serial, STRING_TYPE),
+                            f"{self.power_unit_label} {i} serial number appears incorrect")
+        self.assert_expectations()
+
+    def test_get_revision(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa: F811
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release(duthost, ["201811", "201911", "202012"])
+        for i in range(self.num_power_units):
+            if self._skip_absent_power_unit(i, platform_api_conn):
+                continue
+            revision = self.power_unit_api.get_revision(platform_api_conn, i)
+            if self.expect(revision is not None,
+                           f"Unable to retrieve {self.power_unit_label} {i} revision"):
+                self.expect(isinstance(revision, STRING_TYPE),
+                            f"{self.power_unit_label} {i} revision appears incorrect")
+        self.assert_expectations()
+
+    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa: F811
+        for i in range(self.num_power_units):
+            if self._skip_absent_power_unit(i, platform_api_conn):
+                continue
+            status = self.power_unit_api.get_status(platform_api_conn, i)
+            if self.expect(status is not None, f"Unable to retrieve {self.power_unit_label} {i} status"):
+                self.expect(isinstance(status, bool),
+                            f"{self.power_unit_label} {i} status appears incorrect")
+                self.expect(status is True,
+                            f"{self.power_unit_label} {i} status is not True (Power Not Good)")
+        self.assert_expectations()
+
+    def test_thermals(self, platform_api_conn):   # noqa: F811
+        for device_id in range(self.num_power_units):
+            if self._skip_absent_power_unit(device_id, platform_api_conn):
+                continue
+            try:
+                num_thermals = int(self.power_unit_api.get_num_thermals(platform_api_conn, device_id))
+            except Exception:
+                pytest.fail(f"{self.power_unit_label} {device_id}: num_thermals is not an integer")
+
+            thermal_list = self.power_unit_api.get_all_thermals(platform_api_conn, device_id)
+            pytest_assert(thermal_list is not None,
+                          f"Failed to retrieve thermals for {self.power_unit_label} {device_id}")
+            pytest_assert(isinstance(thermal_list, list) and len(thermal_list) == num_thermals,
+                          f"Thermals appear to be incorrect for {self.power_unit_label} {device_id}")
+
+            for i in range(num_thermals):
+                thermal = self.power_unit_api.get_thermal(platform_api_conn, device_id, i)
+                self.expect(thermal and thermal == thermal_list[i],
+                            f"Thermal {i} is incorrect for {self.power_unit_label} {device_id}")
+
+        self.assert_expectations()

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -418,6 +418,47 @@ class TestChassisApi(PlatformApiTestBase):
             self.expect(psu and psu == psu_list[i], "PSU {} is incorrect".format(i))
         self.assert_expectations()
 
+    def test_pdbs(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa: F811
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        platform_expects_pdbs = (duthost.facts.get("chassis") and
+                                 duthost.facts["chassis"].get("pdbs"))
+        num_pdbs = None
+        try:
+            num_pdbs_raw = chassis.get_num_pdbs(platform_api_conn)
+            if num_pdbs_raw is None:
+                if platform_expects_pdbs:
+                    pytest.fail("get_num_pdbs returned None but platform.json has pdbs defined")
+                pytest.skip("get_num_pdbs API not supported on this platform")
+            num_pdbs = int(num_pdbs_raw)
+        except Exception:
+            if platform_expects_pdbs:
+                pytest.fail("num_pdbs is not an integer")
+            pytest.skip("get_num_pdbs API not supported on this platform")
+
+        if num_pdbs is None:
+            pytest.fail("num_pdbs should have been initialized")
+
+        if duthost.facts.get("chassis") and duthost.facts["chassis"].get("pdbs"):
+            expected_num_pdbs = len(duthost.facts["chassis"]["pdbs"])
+            pytest_assert(num_pdbs == expected_num_pdbs,
+                          f"Number of PDBs ({num_pdbs}) does not match expected number "
+                          f"({expected_num_pdbs})")
+        else:
+            pytest_assert(num_pdbs == 0,
+                          f"platform.json has no pdbs array but get_num_pdbs() returned {num_pdbs}")
+
+        if num_pdbs == 0:
+            pytest.skip("No PDBs found on device (PSU platform)")
+
+        pdb_list = chassis.get_all_pdbs(platform_api_conn)
+        pytest_assert(pdb_list is not None, "Failed to retrieve PDBs")
+        pytest_assert(isinstance(pdb_list, list) and len(pdb_list) == num_pdbs, "PDBs appear to be incorrect")
+
+        for i in range(num_pdbs):
+            single_pdb = chassis.get_pdb(platform_api_conn, i)
+            self.expect(single_pdb and single_pdb == pdb_list[i], f"PDB {i} is incorrect")
+        self.assert_expectations()
+
     def test_thermals(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa: F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         try:

--- a/tests/platform_tests/api/test_pdb.py
+++ b/tests/platform_tests/api/test_pdb.py
@@ -1,0 +1,150 @@
+import logging
+import pytest
+
+from tests.common.helpers.platform_api import chassis, pdb
+from tests.common.utilities import wait_until
+from tests.common.fixtures.duthost_utils import check_pdb_support
+from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service    # noqa: F401
+from .power_api_test_base import TestPowerApi
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any'),
+]
+
+POWER_TOLERANCE = 0.1
+
+
+class TestPdbApi(TestPowerApi):
+    """Platform API test cases for the PDB class.
+
+    Inherits shared power-unit tests (name, presence, model, serial, revision,
+    status, thermals) from TestPowerApi.
+    Overrides PSU-specific tests and adds PDB-specific ones.
+    """
+
+    power_unit_api = pdb
+    power_unit_label = "PDB"
+    facts_key = "pdbs"
+
+    def _get_num_power_units(self, conn):
+        return chassis.get_num_pdbs(conn)
+
+    def _handle_num_power_units_exception(self, duthost):
+        if check_pdb_support(duthost):
+            pytest.fail("get_num_pdbs returned non-integer but STATE_DB shows PDB is supported")
+        pytest.skip("get_num_pdbs API not supported on this platform")
+
+    def _handle_no_power_units(self, duthost):
+        if check_pdb_support(duthost):
+            pytest.fail("get_num_pdbs returned 0 but STATE_DB shows PDB is supported")
+        pytest.skip("No PDBs found on device")
+
+    # ------------------------------------------------------------------
+    # Overridden tests with PDB-specific logic
+    # ------------------------------------------------------------------
+
+    def test_is_replaceable(self, platform_api_conn):  # noqa: F811
+        """PDB: only check API returns successfully (not None)."""
+        logger.info(f"test_is_replaceable: Starting for {self.num_power_units} PDB(s)")
+        for pdb_id in range(self.num_power_units):
+            if self._skip_absent_power_unit(pdb_id, platform_api_conn):
+                continue
+            logger.info(f"test_is_replaceable: Checking PDB {pdb_id}")
+            replaceable = self.power_unit_api.is_replaceable(platform_api_conn, pdb_id)
+            logger.info(f"test_is_replaceable: PDB {pdb_id} is_replaceable={replaceable}")
+            self.expect(replaceable is not None,
+                        f"Failed to perform is_replaceable for {self.power_unit_label} {pdb_id}")
+        self.assert_expectations()
+
+    def test_temperature(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa: F811
+        """PDB temperature: check float in reasonable range (no threshold API)."""
+        logger.info(f"test_temperature: Starting for {self.num_power_units} PDB(s)")
+        for pdb_id in range(self.num_power_units):
+            if self._skip_absent_power_unit(pdb_id, platform_api_conn):
+                continue
+            logger.info(f"test_temperature: Reading temperature for PDB {pdb_id}")
+            temperature = self.power_unit_api.get_temperature(platform_api_conn, pdb_id)
+            logger.info(f"test_temperature: PDB {pdb_id} temperature={temperature}")
+            if self.expect(temperature is not None,
+                           f"Failed to retrieve temperature of {self.power_unit_label} {pdb_id}"):
+                if self.expect(isinstance(temperature, float),
+                               f"{self.power_unit_label} {pdb_id} temperature appears incorrect"):
+                    self.expect(-20.0 <= temperature <= 150.0,
+                                f"{self.power_unit_label} {pdb_id} temperature {temperature} "
+                                "is out of reasonable range")
+        self.assert_expectations()
+
+    def test_power(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa: F811
+        """PDB power: input/output voltage, current, power and max supplied power."""
+        logger.info(f"test_power: Starting for {self.num_power_units} PDB(s)")
+        in_voltage = in_current = in_power = None
+        out_voltage = out_current = out_power = None
+
+        def check_pdb_power(failure_count):
+            nonlocal in_voltage, in_current, in_power
+            nonlocal out_voltage, out_current, out_power
+
+            in_voltage = pdb.get_input_voltage(platform_api_conn, pdb_id)
+            in_current = pdb.get_input_current(platform_api_conn, pdb_id)
+            in_power = pdb.get_input_power(platform_api_conn, pdb_id)
+            out_voltage = pdb.get_output_voltage(platform_api_conn, pdb_id)
+            out_current = pdb.get_output_current(platform_api_conn, pdb_id)
+            out_power = pdb.get_output_power(platform_api_conn, pdb_id)
+
+            logger.info(
+                f"test_power: PDB {pdb_id} readings - "
+                f"input(V={in_voltage}, I={in_current}, P={in_power}) "
+                f"output(V={out_voltage}, I={out_current}, P={out_power})"
+            )
+
+            failure_occurred = self.get_len_failed_expectations() > failure_count
+
+            for label, val in [("input voltage", in_voltage), ("input current", in_current),
+                               ("input power", in_power), ("output voltage", out_voltage),
+                               ("output current", out_current), ("output power", out_power)]:
+                if self.expect(val is not None,
+                               f"Failed to retrieve {label} of PDB {pdb_id}"):
+                    self.expect(isinstance(val, float),
+                                f"PDB {pdb_id} {label} appears incorrect")
+
+            for v, c, p, side in [(in_voltage, in_current, in_power, "input"),
+                                  (out_voltage, out_current, out_power, "output")]:
+                if v and c and p:
+                    is_within_tolerance = abs(p - (v * c)) < p * POWER_TOLERANCE
+                    if not failure_occurred and not is_within_tolerance:
+                        logger.info(f"test_power: PDB {pdb_id} {side} tolerance check failed, will retry")
+                        return False
+                    self.expect(is_within_tolerance,
+                                f"PDB {pdb_id} {side} readings do not make sense "
+                                f"(power:{p}, voltage:{v}, current:{c})")
+
+            return True
+
+        for pdb_id in range(self.num_power_units):
+            if self._skip_absent_power_unit(pdb_id, platform_api_conn):
+                continue
+            logger.info(f"test_power: Checking power readings for PDB {pdb_id}")
+            failure_count = self.get_len_failed_expectations()
+            in_voltage = in_current = in_power = None
+            out_voltage = out_current = out_power = None
+
+            check_result = wait_until(30, 10, 0, check_pdb_power, failure_count)
+            self.expect(check_result,
+                        f"PDB {pdb_id} readings do not make sense "
+                        f"(in: V={in_voltage}, I={in_current}, P={in_power} / "
+                        f"out: V={out_voltage}, I={out_current}, P={out_power})")
+
+            logger.info(f"test_power: Checking maximum supplied power for PDB {pdb_id}")
+            max_power = pdb.get_maximum_supplied_power(platform_api_conn, pdb_id)
+            logger.info(f"test_power: PDB {pdb_id} max_supplied_power={max_power}")
+            if self.expect(max_power is not None,
+                           f"Failed to retrieve maximum supplied power of PDB {pdb_id}"):
+                self.expect(isinstance(max_power, float),
+                            f"PDB {pdb_id} maximum supplied power appears incorrect")
+                if out_power and isinstance(max_power, float):
+                    self.expect(max_power >= out_power,
+                                f"PDB {pdb_id} max_power ({max_power}) < output_power ({out_power})")
+
+        self.assert_expectations()

--- a/tests/platform_tests/api/test_pdb.py
+++ b/tests/platform_tests/api/test_pdb.py
@@ -77,48 +77,39 @@ class TestPdbApi(TestPowerApi):
         self.assert_expectations()
 
     def test_power(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa: F811
-        """PDB power: input/output voltage, current, power and max supplied power."""
+        """PDB power: input voltage, current, power and max supplied power."""
         logger.info(f"test_power: Starting for {self.num_power_units} PDB(s)")
         in_voltage = in_current = in_power = None
-        out_voltage = out_current = out_power = None
 
         def check_pdb_power(failure_count):
             nonlocal in_voltage, in_current, in_power
-            nonlocal out_voltage, out_current, out_power
 
             in_voltage = pdb.get_input_voltage(platform_api_conn, pdb_id)
             in_current = pdb.get_input_current(platform_api_conn, pdb_id)
             in_power = pdb.get_input_power(platform_api_conn, pdb_id)
-            out_voltage = pdb.get_output_voltage(platform_api_conn, pdb_id)
-            out_current = pdb.get_output_current(platform_api_conn, pdb_id)
-            out_power = pdb.get_output_power(platform_api_conn, pdb_id)
 
             logger.info(
                 f"test_power: PDB {pdb_id} readings - "
-                f"input(V={in_voltage}, I={in_current}, P={in_power}) "
-                f"output(V={out_voltage}, I={out_current}, P={out_power})"
+                f"input(V={in_voltage}, I={in_current}, P={in_power})"
             )
 
             failure_occurred = self.get_len_failed_expectations() > failure_count
 
             for label, val in [("input voltage", in_voltage), ("input current", in_current),
-                               ("input power", in_power), ("output voltage", out_voltage),
-                               ("output current", out_current), ("output power", out_power)]:
+                               ("input power", in_power)]:
                 if self.expect(val is not None,
                                f"Failed to retrieve {label} of PDB {pdb_id}"):
                     self.expect(isinstance(val, float),
                                 f"PDB {pdb_id} {label} appears incorrect")
 
-            for v, c, p, side in [(in_voltage, in_current, in_power, "input"),
-                                  (out_voltage, out_current, out_power, "output")]:
-                if v and c and p:
-                    is_within_tolerance = abs(p - (v * c)) < p * POWER_TOLERANCE
-                    if not failure_occurred and not is_within_tolerance:
-                        logger.info(f"test_power: PDB {pdb_id} {side} tolerance check failed, will retry")
-                        return False
-                    self.expect(is_within_tolerance,
-                                f"PDB {pdb_id} {side} readings do not make sense "
-                                f"(power:{p}, voltage:{v}, current:{c})")
+            if in_voltage and in_current and in_power:
+                is_within_tolerance = abs(in_power - (in_voltage * in_current)) < in_power * POWER_TOLERANCE
+                if not failure_occurred and not is_within_tolerance:
+                    logger.info(f"test_power: PDB {pdb_id} input tolerance check failed, will retry")
+                    return False
+                self.expect(is_within_tolerance,
+                            f"PDB {pdb_id} input readings do not make sense "
+                            f"(power:{in_power}, voltage:{in_voltage}, current:{in_current})")
 
             return True
 
@@ -128,13 +119,11 @@ class TestPdbApi(TestPowerApi):
             logger.info(f"test_power: Checking power readings for PDB {pdb_id}")
             failure_count = self.get_len_failed_expectations()
             in_voltage = in_current = in_power = None
-            out_voltage = out_current = out_power = None
 
             check_result = wait_until(30, 10, 0, check_pdb_power, failure_count)
             self.expect(check_result,
-                        f"PDB {pdb_id} readings do not make sense "
-                        f"(in: V={in_voltage}, I={in_current}, P={in_power} / "
-                        f"out: V={out_voltage}, I={out_current}, P={out_power})")
+                        f"PDB {pdb_id} input readings do not make sense "
+                        f"(V={in_voltage}, I={in_current}, P={in_power})")
 
             logger.info(f"test_power: Checking maximum supplied power for PDB {pdb_id}")
             max_power = pdb.get_maximum_supplied_power(platform_api_conn, pdb_id)
@@ -143,8 +132,8 @@ class TestPdbApi(TestPowerApi):
                            f"Failed to retrieve maximum supplied power of PDB {pdb_id}"):
                 self.expect(isinstance(max_power, float),
                             f"PDB {pdb_id} maximum supplied power appears incorrect")
-                if out_power and isinstance(max_power, float):
-                    self.expect(max_power >= out_power,
-                                f"PDB {pdb_id} max_power ({max_power}) < output_power ({out_power})")
+                if in_power and isinstance(max_power, float):
+                    self.expect(max_power >= in_power,
+                                f"PDB {pdb_id} max_power ({max_power}) < input_power ({in_power})")
 
         self.assert_expectations()

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -1,26 +1,11 @@
 import logging
 import pytest
 
-from tests.common.helpers.assertions import pytest_assert
-from tests.common.helpers.platform_api import chassis, psu
+from tests.common.helpers.platform_api import psu
 from tests.common.mellanox_data import is_mellanox_device
-from tests.common.utilities import skip_release
-from tests.platform_tests.cli.util import get_skip_mod_list
-from .platform_api_test_base import PlatformApiTestBase
 from tests.common.utilities import skip_release_for_platform, wait_until
-from tests.platform_tests.api.conftest import skip_absent_psu
 from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service    # noqa: F401
-
-
-###################################################
-# TODO: Remove this after we transition to Python 3
-import sys
-if sys.version_info.major >= 3:
-    STRING_TYPE = str
-else:
-    STRING_TYPE = basestring    # noqa: F821
-# END Remove this after we transition to Python 3
-###################################################
+from .power_api_test_base import TestPowerApi, STRING_TYPE
 
 
 logger = logging.getLogger(__name__)
@@ -35,39 +20,12 @@ STATUS_LED_COLOR_RED = "red"
 STATUS_LED_COLOR_OFF = "off"
 
 
-class TestPsuApi(PlatformApiTestBase):
+class TestPsuApi(TestPowerApi):
     ''' Platform API test cases for the PSU class'''
 
-    num_psus = None
-    chassis_facts = None
-
-    @pytest.fixture(scope="function", autouse=True)
-    def setup(self, platform_api_conn, duthosts, enum_rand_one_per_hwsku_hostname):  # noqa: F811
-        if self.num_psus is None:
-            try:
-                self.num_psus = int(chassis.get_num_psus(platform_api_conn))
-            except Exception:
-                pytest.fail("num_psus is not an integer")
-            else:
-                if self.num_psus == 0:
-                    pytest.skip("No psus found on device")
-
-        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        self.psu_skip_list = get_skip_mod_list(duthost, ['psus'])
-
-    def compare_value_with_platform_facts(self, duthost, key, value, psu_idx):
-        expected_value = None
-        if duthost.facts.get("chassis"):
-            expected_psus = duthost.facts.get("chassis").get("psus")
-            if expected_psus:
-                expected_value = expected_psus[psu_idx].get(key)
-
-        if self.expect(expected_value is not None,
-                       "Unable to get expected value for '{}' from platform.json file for PSU {}"
-                       .format(key, psu_idx)):
-            self.expect(value == expected_value,
-                        "'{}' value is incorrect. Got '{}', expected '{}' for PSU {}"
-                        .format(key, value, expected_value, psu_idx))
+    power_unit_api = psu
+    power_unit_label = "PSU"
+    facts_key = "psus"
 
     def get_psu_facts(self, duthost, psu_idx, def_value, *keys):
         if duthost.facts.get("chassis"):
@@ -90,9 +48,9 @@ class TestPsuApi(PlatformApiTestBase):
             data = get_data(psu_info["api"], psu_info["psu_id"])
             if not is_mellanox_device(self.duthost):
                 if self.expect(
-                        data is not None, "Failed to retrieve {} of PSU {}".format(message, psu_info["psu_id"])):
+                        data is not None, f"Failed to retrieve {message} of PSU {psu_info['psu_id']}"):
                     self.expect(
-                        isinstance(data, float), "PSU {} {} appears incorrect".format(psu_info["psu_id"], message))
+                        isinstance(data, float), f"PSU {psu_info['psu_id']} {message} appears incorrect")
 
         return data
 
@@ -100,89 +58,26 @@ class TestPsuApi(PlatformApiTestBase):
     # Functions to test methods inherited from DeviceBase class
     #
 
-    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa: F811
-        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        for i in range(self.num_psus):
-            if skip_absent_psu(i, platform_api_conn, self.psu_skip_list, logger):
-                continue
-            name = psu.get_name(platform_api_conn, i)
-            if self.expect(name is not None, "Unable to retrieve PSU {} name".format(i)):
-                self.expect(isinstance(name, STRING_TYPE), "PSU {} name appears incorrect".format(i))
-                self.compare_value_with_platform_facts(duthost, 'name', name, i)
-        self.assert_expectations()
-
-    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa: F811
-        for i in range(self.num_psus):
-            presence = psu.get_presence(platform_api_conn, i)
-            name = psu.get_name(platform_api_conn, i)
-            if self.expect(presence is not None, "Unable to retrieve PSU {} presence".format(i)):
-                if self.expect(isinstance(presence, bool), "PSU {} presence appears incorrect".format(i)):
-                    if name not in self.psu_skip_list:
-                        self.expect(presence is True, "PSU {} is not present".format(i))
-                    # NOTE: It is possible for a PSU to be populated but not being
-                    #       connected to external power, we therefore cannot assert
-                    #       that the psu is not present when in the skip list
-        self.assert_expectations()
-
-    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):   # noqa: F811
-        for i in range(self.num_psus):
-            if skip_absent_psu(i, platform_api_conn, self.psu_skip_list, logger):
-                continue
-            model = psu.get_model(platform_api_conn, i)
-            if self.expect(model is not None, "Unable to retrieve PSU {} model".format(i)):
-                self.expect(isinstance(model, STRING_TYPE), "PSU {} model appears incorrect".format(i))
-        self.assert_expectations()
-
-    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa: F811
-        for i in range(self.num_psus):
-            if skip_absent_psu(i, platform_api_conn, self.psu_skip_list, logger):
-                continue
-            serial = psu.get_serial(platform_api_conn, i)
-            if self.expect(serial is not None, "Unable to retrieve PSU {} serial number".format(i)):
-                self.expect(isinstance(serial, STRING_TYPE), "PSU {} serial number appears incorrect".format(i))
-        self.assert_expectations()
-
-    def test_get_revision(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa: F811
-        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        skip_release(duthost, ["201811", "201911", "202012"])
-        for i in range(self.num_psus):
-            if skip_absent_psu(i, platform_api_conn, self.psu_skip_list, logger):
-                continue
-            revision = psu.get_revision(platform_api_conn, i)
-            if self.expect(revision is not None, "Unable to retrieve PSU {} serial number".format(i)):
-                self.expect(isinstance(revision, STRING_TYPE), "PSU {} serial number appears incorrect".format(i))
-        self.assert_expectations()
-
-    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa: F811
-        for i in range(self.num_psus):
-            if skip_absent_psu(i, platform_api_conn, self.psu_skip_list, logger):
-                continue
-            status = psu.get_status(platform_api_conn, i)
-            if self.expect(status is not None, "Unable to retrieve PSU {} status".format(i)):
-                self.expect(isinstance(status, bool), "PSU {} status appears incorrect".format(i))
-                self.expect(status is True, "PSU {} status is not True (Power Not Good)".format(i))
-        self.assert_expectations()
-
     def test_get_position_in_parent(self, platform_api_conn):     # noqa: F811
-        for psu_id in range(self.num_psus):
-            if skip_absent_psu(psu_id, platform_api_conn, self.psu_skip_list, logger):
+        for device_id in range(self.num_power_units):
+            if self._skip_absent_power_unit(device_id, platform_api_conn):
                 continue
-            position = psu.get_position_in_parent(platform_api_conn, psu_id)
+            position = self.power_unit_api.get_position_in_parent(platform_api_conn, device_id)
             if self.expect(position is not None,
-                           "Failed to perform get_position_in_parent for psu id {}".format(psu_id)):
+                           f"Failed to perform get_position_in_parent for {self.power_unit_label} {device_id}"):
                 self.expect(isinstance(position, int),
-                            "Position value must be an integer value for psu id {}".format(psu_id))
+                            f"Position value must be an integer value for {self.power_unit_label} {device_id}")
         self.assert_expectations()
 
     def test_is_replaceable(self, platform_api_conn):     # noqa: F811
-        for psu_id in range(self.num_psus):
-            if skip_absent_psu(psu_id, platform_api_conn, self.psu_skip_list, logger):
+        for device_id in range(self.num_power_units):
+            if self._skip_absent_power_unit(device_id, platform_api_conn):
                 continue
-            replaceable = psu.is_replaceable(platform_api_conn, psu_id)
+            replaceable = self.power_unit_api.is_replaceable(platform_api_conn, device_id)
             if self.expect(replaceable is not None,
-                           "Failed to perform is_replaceable for psu id {}".format(psu_id)):
+                           f"Failed to perform is_replaceable for {self.power_unit_label} {device_id}"):
                 self.expect(isinstance(replaceable, bool),
-                            "Replaceable value must be a bool value for psu id {}".format(psu_id))
+                            f"Replaceable value must be a bool value for {self.power_unit_label} {device_id}")
         self.assert_expectations()
 
     #
@@ -191,21 +86,21 @@ class TestPsuApi(PlatformApiTestBase):
 
     def test_fans(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa: F811
         ''' PSU fan test '''
-        for psu_id in range(self.num_psus):
+        for psu_id in range(self.num_power_units):
             try:
                 num_fans = int(psu.get_num_fans(platform_api_conn, psu_id))
             except Exception:
                 pytest.fail("num_fans is not an integer!")
 
             fan_list = psu.get_all_fans(platform_api_conn, psu_id)
-            if self.expect(fan_list is not None, "Failed to retrieve fans of PSU {}".format(psu_id)):
+            if self.expect(fan_list is not None, f"Failed to retrieve fans of PSU {psu_id}"):
                 self.expect(isinstance(fan_list, list) and len(fan_list) == num_fans,
-                            "Fans of PSU {} appear to be incorrect".format(psu_id))
+                            f"Fans of PSU {psu_id} appear to be incorrect")
 
             for i in range(num_fans):
                 fan = psu.get_fan(platform_api_conn, psu_id, i)
-                if self.expect(fan is not None, "Failed to retrieve fan {} of PSU {}".format(i, psu_id)):
-                    self.expect(fan and fan == fan_list[i], "Fan {} of PSU {} is incorrect".format(i, psu_id))
+                if self.expect(fan is not None, f"Failed to retrieve fan {i} of PSU {psu_id}"):
+                    self.expect(fan and fan == fan_list[i], f"Fan {i} of PSU {psu_id} is incorrect")
         self.assert_expectations()
 
     def test_power(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):   # noqa: F811
@@ -237,21 +132,23 @@ class TestPsuApi(PlatformApiTestBase):
                 if not failure_occured and not is_within_tolerance:
                     return False
 
-                self.expect(is_within_tolerance, "PSU {} reading does not make sense \
-                    (power:{}, voltage:{}, current:{})".format(psu_id, power, voltage, current))
+                self.expect(is_within_tolerance,
+                            f"PSU {psu_id} reading does not make sense "
+                            f"(power:{power}, voltage:{voltage}, current:{current})")
 
             return True
 
-        for psu_id in range(self.num_psus):
+        for psu_id in range(self.num_power_units):
             failure_count = self.get_len_failed_expectations()
             psu_info['psu_id'] = psu_id
             name = psu.get_name(platform_api_conn, psu_id)
-            if name in self.psu_skip_list:
-                logger.info("skipping check for {}".format(name))
+            if name in self.power_unit_skip_list:
+                logger.info(f"skipping check for {name}")
             else:
                 check_result = wait_until(30, 10, 0, check_psu_power, failure_count)
-                self.expect(check_result, "PSU {} reading does not make sense \
-                (power:{}, voltage:{}, current:{})".format(psu_id, power, voltage, current))
+                self.expect(check_result,
+                            f"PSU {psu_id} reading does not make sense "
+                            f"(power:{power}, voltage:{voltage}, current:{current})")
 
                 # This platform doesn't support this API.
                 if "arm64-c8220tg_48a_o" not in duthost.facts['platform']:
@@ -260,8 +157,8 @@ class TestPsuApi(PlatformApiTestBase):
 
                 powergood_status = psu.get_powergood_status(platform_api_conn, psu_id)
                 if self.expect(powergood_status is not None,
-                               "Failed to retrieve operational status of PSU {}".format(psu_id)):
-                    self.expect(powergood_status is True, "PSU {} is not operational".format(psu_id))
+                               f"Failed to retrieve operational status of PSU {psu_id}"):
+                    self.expect(powergood_status is True, f"PSU {psu_id} is not operational")
 
                 high_threshold = self.get_psu_parameter(psu_info, "voltage_high_threshold",
                                                         psu.get_voltage_high_threshold, "high voltage threshold")
@@ -271,8 +168,8 @@ class TestPsuApi(PlatformApiTestBase):
                 if not is_mellanox_device(self.duthost):
                     if high_threshold and low_threshold:
                         self.expect(voltage < high_threshold and voltage > low_threshold,
-                                    "Voltage {} of PSU {} is not in between {} and {}"
-                                    .format(voltage, psu_id, low_threshold, high_threshold))
+                                    f"Voltage {voltage} of PSU {psu_id} is not in between "
+                                    f"{low_threshold} and {high_threshold}")
 
         self.assert_expectations()
 
@@ -282,31 +179,31 @@ class TestPsuApi(PlatformApiTestBase):
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista"])
         psus_skipped = 0
 
-        for psu_id in range(self.num_psus):
+        for psu_id in range(self.num_power_units):
             name = psu.get_name(platform_api_conn, psu_id)
-            if name in self.psu_skip_list:
-                logger.info("skipping check for {}".format(name))
+            if name in self.power_unit_skip_list:
+                logger.info(f"skipping check for {name}")
             else:
                 temperature_supported = self.get_psu_facts(duthost, psu_id, True, "temperature")
                 if not temperature_supported:
-                    logger.info("test_set_fans_speed: Skipping chassis fan {} (speed not controllable)".format(psu_id))
+                    logger.info(f"test_set_fans_speed: Skipping chassis fan {psu_id} (speed not controllable)")
                     psus_skipped += 1
                     continue
 
                 temperature = psu.get_temperature(platform_api_conn, psu_id)
-                if self.expect(temperature is not None, "Failed to retrieve temperature of PSU {}".format(psu_id)):
-                    self.expect(isinstance(temperature, float), "PSU {} temperature appears incorrect".format(psu_id))
+                if self.expect(temperature is not None, f"Failed to retrieve temperature of PSU {psu_id}"):
+                    self.expect(isinstance(temperature, float), f"PSU {psu_id} temperature appears incorrect")
 
                 temp_threshold = psu.get_temperature_high_threshold(platform_api_conn, psu_id)
                 if self.expect(temp_threshold is not None,
-                               "Failed to retrieve temperature threshold of PSU {}".format(psu_id)):
+                               f"Failed to retrieve temperature threshold of PSU {psu_id}"):
                     if self.expect(isinstance(temp_threshold, float),
-                                   "PSU {} temperature high threshold appears incorrect".format(psu_id)):
+                                   f"PSU {psu_id} temperature high threshold appears incorrect"):
                         self.expect(temperature < temp_threshold,
-                                    "Temperature {} of PSU {} is over the threshold {}"
-                                    .format(temperature, psu_id, temp_threshold))
+                                    f"Temperature {temperature} of PSU {psu_id} is over the "
+                                    f"threshold {temp_threshold}")
 
-        if psus_skipped == self.num_psus:
+        if psus_skipped == self.num_power_units:
             pytest.skip("skipped as all chassis psus' temperature sensor is not supported")
 
         self.assert_expectations()
@@ -343,15 +240,15 @@ class TestPsuApi(PlatformApiTestBase):
         }
 
         psus_skipped = 0
-        for psu_id in range(self.num_psus):
-            if skip_absent_psu(psu_id, platform_api_conn, self.psu_skip_list, logger):
+        for psu_id in range(self.num_power_units):
+            if self._skip_absent_power_unit(psu_id, platform_api_conn):
                 continue
             name = psu.get_name(platform_api_conn, psu_id)
             led_support = duthost.facts.get("chassis").get("psus")[psu_id].get("led")
             if led_support == "N/A":
-                logger.info("led not supported for this psu {}".format(name))
-            elif name in self.psu_skip_list:
-                logger.info("skipping check for {}".format(name))
+                logger.info(f"led not supported for this psu {name}")
+            elif name in self.power_unit_skip_list:
+                logger.info(f"skipping check for {name}")
                 psus_skipped += 1
             else:
                 led_controllable = self.get_psu_facts(duthost, psu_id, True, "status_led", "controllable")
@@ -364,8 +261,9 @@ class TestPsuApi(PlatformApiTestBase):
                             led_type = set(led_type) & set(led_supported_colors)
                             if not led_type:
                                 logger.warning(
-                                    "test_status_led: Skipping PSU {} set status_led to {} (No supported colors)"
-                                    .format(psu_id, LED_COLOR_TYPES_DICT[index]))
+                                    f"test_status_led: Skipping PSU {psu_id} set status_led to "
+                                    f"{LED_COLOR_TYPES_DICT[index]} (No supported colors)"
+                                )
                                 led_type_skipped += 1
                                 continue
 
@@ -373,54 +271,33 @@ class TestPsuApi(PlatformApiTestBase):
                         for color in led_type:
                             result = psu.set_status_led(platform_api_conn, psu_id, color)
                             if self.expect(result is not None,
-                                           "Failed to perform set_status_led of PSU {}".format(psu_id)):
+                                           f"Failed to perform set_status_led of PSU {psu_id}"):
                                 led_type_result = result or led_type_result
                             if ((result is None) or (not result)):
                                 continue
                             color_actual = psu.get_status_led(platform_api_conn, psu_id)
                             if self.expect(color_actual is not None,
-                                           "Failed to retrieve status_led of PSU {}".format(psu_id)):
+                                           f"Failed to retrieve status_led of PSU {psu_id}"):
                                 if self.expect(isinstance(color_actual, STRING_TYPE),
-                                               "PSU {} status LED color appears incorrect".format(psu_id)):
+                                               f"PSU {psu_id} status LED color appears incorrect"):
                                     self.expect(color == color_actual,
-                                                "Status LED color incorrect (expected: {}, actual: {}) from PSU {}"
-                                                .format(color, color_actual, psu_id))
+                                                f"Status LED color incorrect (expected: {color}, "
+                                                f"actual: {color_actual}) from PSU {psu_id}")
                         self.expect(led_type_result is True,
-                                    "Failed to set status_led of PSU {} to {}"
-                                    .format(psu_id, LED_COLOR_TYPES_DICT[index]))
+                                    f"Failed to set status_led of PSU {psu_id} to "
+                                    f"{LED_COLOR_TYPES_DICT[index]}")
 
                     if led_type_skipped == len(LED_COLOR_TYPES):
-                        logger.info("test_status_led: Skipping PSU {} (no supported colors for all types)"
-                                    .format(psu_id))
+                        logger.info(f"test_status_led: Skipping PSU {psu_id} "
+                                    "(no supported colors for all types)")
                         psus_skipped += 1
 
                 else:
-                    logger.info("test_status_led: Skipping PSU {} (LED is not controllable)".format(psu_id))
+                    logger.info(f"test_status_led: Skipping PSU {psu_id} (LED is not controllable)")
                     psus_skipped += 1
 
-        if psus_skipped == self.num_psus:
+        if psus_skipped == self.num_power_units:
             pytest.skip("skipped as all PSUs' LED is not controllable/no supported colors/in skip list")
-
-        self.assert_expectations()
-
-    def test_thermals(self, platform_api_conn):   # noqa: F811
-        for psu_id in range(self.num_psus):
-            if skip_absent_psu(psu_id, platform_api_conn, self.psu_skip_list, logger):
-                continue
-            try:
-                num_thermals = int(psu.get_num_thermals(platform_api_conn, psu_id))
-            except Exception:
-                pytest.fail("PSU {}: num_thermals is not an integer".format(psu_id))
-
-            thermal_list = psu.get_all_thermals(platform_api_conn, psu_id)
-            pytest_assert(thermal_list is not None, "Failed to retrieve thermals for psu {}".format(psu_id))
-            pytest_assert(isinstance(thermal_list, list) and len(thermal_list) == num_thermals,
-                          "Thermals appear to be incorrect for psu {}".format(psu_id))
-
-            for i in range(num_thermals):
-                thermal = psu.get_thermal(platform_api_conn, psu_id, i)
-                self.expect(thermal and thermal == thermal_list[i],
-                            "Thermal {} is incorrect for psu {}".format(i, psu_id))
 
         self.assert_expectations()
 
@@ -451,8 +328,8 @@ class TestPsuApi(PlatformApiTestBase):
             2: "off"
         }
         supported_colors = []
-        if self.num_psus == 0:
-            pytest.skip("No psus found on device skipping for device {}".format(duthost))
+        if self.num_power_units == 0:
+            pytest.skip(f"No psus found on device skipping for device {duthost}")
 
         supported_colors = duthost.facts.get("chassis").get("master_psu_led_color")
         if supported_colors:
@@ -461,9 +338,9 @@ class TestPsuApi(PlatformApiTestBase):
                     if color not in supported_colors:
                         LED_COLOR_TYPES[index].remove(color)
 
-        for psu_id in range(self.num_psus):
+        for psu_id in range(self.num_power_units):
             name = psu.get_name(platform_api_conn, psu_id)
-            if name in self.psu_skip_list:
+            if name in self.power_unit_skip_list:
                 continue
             for index, led_type in enumerate(LED_COLOR_TYPES):
                 led_type_result = False
@@ -479,9 +356,9 @@ class TestPsuApi(PlatformApiTestBase):
                         if self.expect(isinstance(color_actual, STRING_TYPE),
                                        "Status of master LED color appears incorrect"):
                             self.expect(color == color_actual,
-                                        "Status LED color incorrect (expected: {}, actual: {}) for master led"
-                                        .format(color, color_actual))
+                                        f"Status LED color incorrect (expected: {color}, "
+                                        f"actual: {color_actual}) for master led")
                     self.expect(led_type_result is True,
-                                "Failed to set status_led of master LED to {}".format(LED_COLOR_TYPES_DICT[index]))
+                                f"Failed to set status_led of master LED to {LED_COLOR_TYPES_DICT[index]}")
 
             self.assert_expectations()

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -22,7 +22,7 @@ from tests.common.platform.device_utils import get_dut_psu_line_pattern
 from tests.common.utilities import get_inventory_files, get_host_visible_vars
 from tests.common.utilities import skip_release_for_platform
 from tests.common.utilities import wait_until
-from tests.common.fixtures.duthost_utils import is_support_fan, is_support_psu  # noqa F401
+from tests.common.fixtures.duthost_utils import is_support_fan, is_support_psu, is_support_pdb, check_pdb_support  # noqa F401
 
 
 pytestmark = [
@@ -333,12 +333,12 @@ def test_show_platform_syseeprom(duthosts, enum_rand_one_per_hwsku_hostname, dut
             pytest.fail(error_msg)
 
 
-def test_show_platform_psustatus(duthosts, rand_one_dut_hostname, is_support_psu):  # noqa F811
+def test_show_platform_psustatus(duthosts, rand_one_dut_hostname, is_support_psu, is_support_pdb):  # noqa F811
     """
     @summary: Verify output of `show platform psustatus`
     """
-    if not is_support_psu:
-        pytest.skip("No PSU support, skip the case")
+    if not is_support_psu and not is_support_pdb:
+        pytest.skip("No PSU or PDB support, skip the case")
 
     duthost = duthosts[rand_one_dut_hostname]
 
@@ -349,33 +349,40 @@ def test_show_platform_psustatus(duthosts, rand_one_dut_hostname, is_support_psu
     )
     cmd = " ".join([CMD_SHOW_PLATFORM, "psustatus"])
 
-    logging.info("Verifying output of '{}' on '{}' ...".format(cmd, duthost.hostname))
+    logging.info(f"Verifying output of '{cmd}' on '{duthost.hostname}' ...")
     psu_status_output = duthost.command(cmd, module_ignore_errors=True)
-    assert psu_status_output['rc'] == 0, "Run command '{}' failed".format(cmd)
+    assert psu_status_output['rc'] == 0, f"Run command '{cmd}' failed"
 
     psu_status_output_lines = psu_status_output["stdout_lines"]
 
     psu_line_pattern = get_dut_psu_line_pattern(duthost)
 
-    # Check that all PSUs are showing valid status and also at least one PSU is OK
+    # Check that all PSUs/PDBs are showing valid status and at least one of each is OK
     num_psu_ok = 0
+    num_pdb_ok = 0
 
     for line in psu_status_output_lines[2:]:
         psu_match = psu_line_pattern.match(line)
-        pytest_assert(psu_match, "Unexpected PSU status output: '{}' on '{}'".format(line, duthost.hostname))
+        pytest_assert(psu_match, f"Unexpected PSU status output: '{line}' on '{duthost.hostname}'")
         psu_status = psu_match.group(2)
         if psu_status == "OK":
-            num_psu_ok += 1
+            if line.lstrip().startswith("PDB"):
+                num_pdb_ok += 1
+            else:
+                num_psu_ok += 1
 
-    pytest_assert(num_psu_ok > 0, "No PSUs are displayed with OK status on '{}'".format(duthost.hostname))
+    if is_support_psu:
+        pytest_assert(num_psu_ok > 0, f"No PSUs are displayed with OK status on '{duthost.hostname}'")
+    if is_support_pdb:
+        pytest_assert(num_pdb_ok > 0, f"No PDBs are displayed with OK status on '{duthost.hostname}'")
 
 
-def test_show_platform_psustatus_json(duthosts, rand_one_dut_hostname, is_support_psu):  # noqa F811
+def test_show_platform_psustatus_json(duthosts, rand_one_dut_hostname, is_support_psu, is_support_pdb):  # noqa F811
     """
     @summary: Verify output of `show platform psustatus --json`
     """
-    if not is_support_psu:
-        pytest.skip("No PSU support, skip the case")
+    if not is_support_psu and not is_support_pdb:
+        pytest.skip("No PSU or PDB support, skip the case")
 
     duthost = duthosts[rand_one_dut_hostname]
 
@@ -389,9 +396,9 @@ def test_show_platform_psustatus_json(duthosts, rand_one_dut_hostname, is_suppor
 
     cmd = " ".join([CMD_SHOW_PLATFORM, "psustatus", "--json"])
 
-    logging.info("Verifying output of '{}' ...".format(cmd))
+    logging.info(f"Verifying output of '{cmd}' ...")
     psu_status_output = duthost.command(cmd, module_ignore_errors=True)
-    assert psu_status_output['rc'] == 0, "Run command '{}' failed".format(cmd)
+    assert psu_status_output['rc'] == 0, f"Run command '{cmd}' failed"
 
     psu_status_output = psu_status_output["stdout"]
 
@@ -402,15 +409,27 @@ def test_show_platform_psustatus_json(duthosts, rand_one_dut_hostname, is_suppor
         led_status_list = ["N/A"]
     else:
         led_status_list = ["green", "amber", "red", "off", "N/A"]
+
+    pdb_entries = [e for e in psu_info_list if e.get("name", "").startswith("PDB")]
+
     for psu_info in psu_info_list:
         expected_keys = ["index", "name", "presence", "status", "led_status", "model", "serial", "voltage", "current",
                          "power"]
         pytest_assert(all(key in psu_info for key in expected_keys), "Expected key(s) missing from JSON output: '{}'".
                       format(psu_status_output))
-        pytest_assert(psu_info["status"] in ["OK", "NOT OK", "NOT PRESENT"], "Unexpected PSU status value: '{}'".
+        pytest_assert(psu_info["status"] in ["OK", "NOT OK", "NOT PRESENT", "WARNING"],
+                      "Unexpected PSU status value: '{}'".
                       format(psu_info["status"]))
         pytest_assert(psu_info["led_status"] in led_status_list, "Unexpected PSU led_status value: '{}'".
                       format(psu_info["led_status"]))
+
+    if is_support_pdb:
+        pytest_assert(pdb_entries,
+                      f"Expected PDB entries in '{cmd}' JSON output on '{duthost.hostname}'")
+        pdb_led_values = {e["led_status"] for e in pdb_entries}
+        pytest_assert(len(pdb_led_values) == 1,
+                      "All PDB entries should share a single front-panel power LED, "
+                      f"but found different led_status values: {pdb_led_values}")
 
 
 def verify_show_platform_fan_output(duthost, raw_output_lines):
@@ -589,11 +608,18 @@ def test_show_platform_temperature(duthosts, enum_rand_one_per_hwsku_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     cmd = " ".join([CMD_SHOW_PLATFORM, "temperature"])
 
-    logging.info("Verifying output of '{}' on '{}'...".format(cmd, duthost.hostname))
+    logging.info(f"Verifying output of '{cmd}' on '{duthost.hostname}'...")
     temperature_output_lines = duthost.command(cmd)["stdout_lines"]
     verify_show_platform_temperature_output(temperature_output_lines, duthost.hostname)
 
-    # TODO: Test values against platform-specific expected data
+    if check_pdb_support(duthost):
+        pdb_temp_pattern = re.compile(r"PDB[\s-]*\d+\s+Temp", re.IGNORECASE)
+        pdb_thermal_rows = [line for line in temperature_output_lines
+                            if pdb_temp_pattern.search(line)]
+        pytest_assert(len(pdb_thermal_rows) > 0,
+                      "PDB platform detected but no PDB thermal rows found in "
+                      f"'show platform temperature' output on '{duthost.hostname}'")
+        logging.info(f"Found {len(pdb_thermal_rows)} PDB thermal row(s) in temperature output")
 
 
 def test_show_platform_ssdhealth(duthosts, rand_one_dut_hostname):

--- a/tests/platform_tests/daemon/test_psud.py
+++ b/tests/platform_tests/daemon/test_psud.py
@@ -12,6 +12,7 @@ import time
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.fixtures.duthost_utils import get_pdb_num
 from tests.common.platform.daemon_utils import check_pmon_daemon_enable_status
 from tests.common.platform.processes_utils import check_critical_processes
 from tests.common.utilities import compose_dict_from_cli, skip_release, wait_until
@@ -86,11 +87,21 @@ def collect_data(duthost):
     dev_data = {}
     for k in keys:
         data = duthost.shell(
-            'sonic-db-cli STATE_DB HGETALL "{}"'.format(k))['stdout']
+            f'sonic-db-cli STATE_DB HGETALL "{k}"')['stdout']
         data = compose_dict_from_cli(data)
         dev_data[k] = data
 
-    return {'keys': keys, 'data': dev_data}
+    temp_keys = duthost.shell(
+        'sonic-db-cli STATE_DB KEYS "TEMPERATURE_INFO|PDB*"')['stdout_lines']
+    temp_data = {}
+    for k in temp_keys:
+        data = duthost.shell(
+            f'sonic-db-cli STATE_DB HGETALL "{k}"')['stdout']
+        data = compose_dict_from_cli(data)
+        temp_data[k] = data
+
+    return {'keys': keys, 'data': dev_data,
+            'temp_keys': temp_keys, 'temp_data': temp_data}
 
 
 def wait_data(duthost):
@@ -122,7 +133,7 @@ def verify_data(data_before, data_after):
     """
     ignore_fields = ["power", "temp", "current",
                      "voltage", "input_current", "input_voltage"]
-    msg = 'Data_before_restart {} dont match data_after_restart {} for field {}'
+    temp_ignore_fields = ["temperature", "maximum_temperature", "timestamp"]
     for psu_key in data_before['data']:
         for field in data_before['data'][psu_key]:
             if field not in ignore_fields:
@@ -134,7 +145,21 @@ def verify_data(data_before, data_after):
 
                 value_after = data_after['data'][psu_key][field]
                 if value_before != value_after:
-                    logger.info(msg.format(value_before, value_after, field))
+                    logger.info(f"Data_before_restart {value_before} dont match "
+                                f"data_after_restart {value_after} for field {field}")
+                    return False
+
+    for temp_key in data_before.get('temp_data', {}):
+        for field in data_before['temp_data'][temp_key]:
+            if field not in ignore_fields and field not in temp_ignore_fields:
+                value_before = data_before['temp_data'][temp_key][field]
+                if temp_key not in data_after.get("temp_data", {}) or \
+                        field not in data_after["temp_data"][temp_key]:
+                    return False
+                value_after = data_after['temp_data'][temp_key][field]
+                if value_before != value_after:
+                    logger.info(f"Data_before_restart {value_before} dont match "
+                                f"data_after_restart {value_after} for field {field}")
                     return False
     return True
 
@@ -144,23 +169,61 @@ def get_and_verify_data(duthost, data_before_restart):
     return verify_data(data_before_restart, data_after_restart)
 
 
+def _get_pdb_keys(data):
+    """Return PSU_INFO keys that belong to PDB entries (e.g. 'PSU_INFO|PDB 1')."""
+    return [k for k in data.get('keys', []) if '|PDB ' in k]
+
+
 def test_pmon_psud_running_status(duthosts, enum_supervisor_dut_hostname, data_before_restart):
     """
     @summary: This test case is to check psud status on dut
     """
     duthost = duthosts[enum_supervisor_dut_hostname]
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
-    logger.info("{} daemon is {} with pid {}".format(daemon_name, daemon_status, daemon_pid))
+    logger.info(f"{daemon_name} daemon is {daemon_status} with pid {daemon_pid}")
     pytest_assert(daemon_status == expected_running_status,
-                  "{} expected running status is {} but is {}"
-                  .format(daemon_name, expected_running_status, daemon_status))
+                  f"{daemon_name} expected running status is {expected_running_status} "
+                  f"but is {daemon_status}")
     pytest_assert(daemon_pid != -1,
-                  "{} expected pid is a positive integer but is {}".format(daemon_name, daemon_pid))
+                  f"{daemon_name} expected pid is a positive integer but is {daemon_pid}")
 
     pytest_assert(data_before_restart['keys'],
                   "DB keys is not available on daemon running")
     pytest_assert(data_before_restart['data'],
                   "DB data is not available on daemon running")
+
+    pdb_num = get_pdb_num(duthost)
+    if pdb_num > 0:
+        pdb_keys = _get_pdb_keys(data_before_restart)
+        pytest_assert(len(pdb_keys) > 0,
+                      "PDB platform detected but no PSU_INFO|PDB * keys found in STATE_DB")
+        pytest_assert(pdb_num == len(pdb_keys),
+                      f"chassis_info pdb_num ({pdb_num}) does not match PSU_INFO|PDB * count "
+                      f"({len(pdb_keys)})")
+        logger.info(f"PDB keys found in STATE_DB: {pdb_keys}")
+
+        for pdb_key in pdb_keys:
+            pdb_data = data_before_restart['data'][pdb_key]
+            pytest_assert('presence' in pdb_data,
+                          f"PDB entry {pdb_key} missing 'presence' field")
+            pytest_assert('status' in pdb_data,
+                          f"PDB entry {pdb_key} missing 'status' field")
+
+        pdb_temp_keys = data_before_restart.get('temp_keys', [])
+        pytest_assert(len(pdb_temp_keys) > 0,
+                      "PDB platform detected but no TEMPERATURE_INFO|PDB * keys found")
+        logger.info(f"PDB temperature keys found: {pdb_temp_keys}")
+
+        temp_required_fields = ["temperature", "maximum_temperature", "timestamp"]
+        temp_threshold_alternatives = ["high_threshold", "critical_high_threshold"]
+        for tk in pdb_temp_keys:
+            td = data_before_restart['temp_data'][tk]
+            for field in temp_required_fields:
+                pytest_assert(field in td,
+                              f"PDB temperature entry {tk} missing '{field}' field")
+            pytest_assert(any(f in td for f in temp_threshold_alternatives),
+                          f"PDB temperature entry {tk} missing threshold field "
+                          f"(expected one of {temp_threshold_alternatives})")
 
 
 def test_pmon_psud_psu_status_and_led(duthosts, enum_supervisor_dut_hostname, data_before_restart):

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -20,6 +20,8 @@ from tests.common.helpers.sensor_control_test_helper import mocker_factory  # no
 from tests.common.helpers.thermal_control_test_helper import ThermalPolicyFileContext, \
     check_cli_output_with_mocker, restart_thermal_control_daemon, check_thermal_algorithm_status, \
     disable_thermal_policy  # noqa: F401
+from tests.common.helpers.pdb_mocker import create_pdb_mocker
+from tests.common.fixtures.duthost_utils import is_support_pdb, check_pdb_support  # noqa: F401
 
 pytestmark = [
     pytest.mark.topology('any'),
@@ -83,8 +85,15 @@ SKIP_ERROR_LOG_PSU_ABSENCE = [
     r'.*ERR pmon#sensord: Error getting sensor data: pmbus\/#\d: Can\'t read',
     r'.*ERR pmon#sensord: Error getting sensor data: dps\d+\/#\d: Kernel interface error']
 
+SKIP_ERROR_LOG_PDB_ABSENCE = [
+    r'.*ERR pmon#psud.*PDB.*not present.*',
+    r'.*ERR pmon#psud.*PDB.*out of power.*',
+    r'.*ERR pmon#psud.*Failed to read.*PDB.*',
+    r'.*WARNING pmon#psud.*PDB.*absence.*']
+
 SKIP_ERROR_LOG_SHOW_PLATFORM_TEMP.extend(SKIP_ERROR_LOG_COMMON)
 SKIP_ERROR_LOG_PSU_ABSENCE.extend(SKIP_ERROR_LOG_COMMON)
+SKIP_ERROR_LOG_PDB_ABSENCE.extend(SKIP_ERROR_LOG_COMMON)
 
 
 def check_sensord_status(ans_host):
@@ -219,6 +228,9 @@ def check_vendor_specific_psustatus(dut, psu_status_line, psu_line_pattern):
     @summary: Vendor specific psu status check
     """
     if dut.facts["asic_type"] in ["mellanox"]:
+        if get_power_status_line_type(psu_status_line) != "PSU":
+            return
+
         from .mellanox.check_sysfs import check_psu_sysfs
 
         psu_match = psu_line_pattern.match(psu_status_line)
@@ -226,6 +238,13 @@ def check_vendor_specific_psustatus(dut, psu_status_line, psu_line_pattern):
         psu_status = psu_match.group(2)
 
         check_psu_sysfs(dut, psu_id, psu_status)
+
+
+def get_power_status_line_type(psu_status_line):
+    """
+    @summary: Return the device type for a shared psustatus CLI row.
+    """
+    return "PDB" if psu_status_line.lstrip().startswith("PDB") else "PSU"
 
 
 def get_psu_name_and_check_skip(psu_identifier, skip_psu_list):
@@ -392,6 +411,8 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_h
             cli_psu_status = duthost.command(CMD_PLATFORM_PSUSTATUS)
 
             for line in cli_psu_status["stdout_lines"][2:]:
+                if get_power_status_line_type(line) != "PSU":
+                    continue
                 psu_match = psu_line_pattern.match(line)
                 pytest_assert(psu_match, "Unexpected PSU status output")
                 # Skip PSUs that are in the skip list
@@ -412,6 +433,8 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_h
 
             cli_psu_status = duthost.command(CMD_PLATFORM_PSUSTATUS)
             for line in cli_psu_status["stdout_lines"][2:]:
+                if get_power_status_line_type(line) != "PSU":
+                    continue
                 psu_match = psu_line_pattern.match(line)
                 pytest_assert(psu_match, "Unexpected PSU status output")
                 # Skip PSUs that are in the skip list
@@ -624,3 +647,77 @@ def test_thermal_control_fan_status(duthosts, enum_rand_one_per_hwsku_hostname, 
             single_fan_mocker.mock_normal_speed()
             check_cli_output_with_mocker(
                 duthost, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 2)
+
+
+@pytest.mark.disable_loganalyzer
+def test_pdb_error_status_and_log(duthosts, enum_rand_one_per_hwsku_hostname):
+    """
+    @summary: Mock PDB power status error via sysfs, verify CLI status, then restore.
+    PDB is not removable, so mock sysfs power status is used.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    if not check_pdb_support(duthost):
+        pytest.skip("No PDB support on this platform, skip the case")
+    device_mocker = create_pdb_mocker(duthost)
+    if device_mocker is None:
+        pytest.skip("No PDB mocker defined for this platform")
+    psu_line_pattern = get_dut_psu_line_pattern(duthost)
+
+    try:
+        loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix='pdb_error')
+        loganalyzer.expect_regex = [r'.*PDB.*out of power.*']
+        loganalyzer.ignore_regex = [p for p in SKIP_ERROR_LOG_PDB_ABSENCE if 'out of power' not in p]
+        marker = loganalyzer.init()
+
+        # Step 1: Mock PDB power status bad
+        mock_result, pdb_name = device_mocker.mock_pdb_status(False)
+        if not mock_result:
+            pytest.skip("Platform does not support PDB status mock, skipping")
+
+        logging.info(f'Mocked PDB power error for {pdb_name}, waiting for effect...')
+        time.sleep(PDU_WAIT_TIME)
+
+        # Step 2: Check CLI shows the PDB error
+        psu_status_output = duthost.command(CMD_PLATFORM_PSUSTATUS, module_ignore_errors=True)
+        pytest_assert(psu_status_output['rc'] == 0,
+                      f"Run command '{CMD_PLATFORM_PSUSTATUS}' failed")
+
+        pdb_found_error = False
+        for line in psu_status_output["stdout_lines"][2:]:
+            match = psu_line_pattern.match(line)
+            if match and line.lstrip().startswith("PDB") and match.group(1).strip() in (pdb_name, pdb_name.split()[-1]):
+                status = match.group(2)
+                if status in ("NOT OK", "NOT PRESENT", "WARNING"):
+                    pdb_found_error = True
+                    logging.info(f"PDB {pdb_name} shows error status: {status}")
+                break
+
+        pytest_assert(pdb_found_error,
+                      f"Expected PDB {pdb_name} to show error status after mock power failure")
+
+        # Step 3: Restore PDB power status
+        mock_result, pdb_name = device_mocker.mock_pdb_status(True)
+        logging.info(f'Restored PDB power for {pdb_name}, waiting for recovery...')
+        time.sleep(PDU_WAIT_TIME)
+
+        # Step 4: Verify PDB status recovers to OK
+        psu_status_output = duthost.command(CMD_PLATFORM_PSUSTATUS, module_ignore_errors=True)
+        pytest_assert(psu_status_output['rc'] == 0,
+                      f"Run command '{CMD_PLATFORM_PSUSTATUS}' failed")
+
+        pdb_recovered = False
+        for line in psu_status_output["stdout_lines"][2:]:
+            match = psu_line_pattern.match(line)
+            if match and line.lstrip().startswith("PDB") and match.group(1).strip() in (pdb_name, pdb_name.split()[-1]):
+                status = match.group(2)
+                if status == "OK":
+                    pdb_recovered = True
+                    logging.info(f"PDB {pdb_name} recovered to OK status")
+                break
+
+        pytest_assert(pdb_recovered,
+                      f"Expected PDB {pdb_name} to recover to OK status after restoring power")
+
+        loganalyzer.analyze(marker)
+    finally:
+        device_mocker.deinit()

--- a/tests/system_health/device_mocker.py
+++ b/tests/system_health/device_mocker.py
@@ -32,6 +32,12 @@ class DeviceMocker:
     def mock_fan_direction(self, good):
         return False, None
 
+    def mock_pdb_presence(self, status):
+        return False, None
+
+    def mock_pdb_status(self, status):
+        return False, None
+
 
 @pytest.fixture
 def device_mocker_factory():

--- a/tests/system_health/mellanox/mellanox_device_mocker.py
+++ b/tests/system_health/mellanox/mellanox_device_mocker.py
@@ -1,10 +1,14 @@
+import logging
+
 from ..device_mocker import DeviceMocker
 from pkg_resources import parse_version
 from tests.common.mellanox_data import get_platform_data, get_hw_management_version
+from tests.common.helpers.pdb_mocker import PdbData
 from tests.common.helpers.mellanox_thermal_control_test_helper import MockerHelper, FanDrawerData, FanData, \
     FAN_NAMING_RULE
 
 HW_MANAGE_VER = '7.0030.2003'
+logger = logging.getLogger(__name__)
 
 
 class AsicData(object):
@@ -36,7 +40,7 @@ class PsuData(object):
     def __init__(self, mock_helper, index):
         self.helper = mock_helper
         self.index = index
-        self.name = 'PSU {}'.format(self.index)
+        self.name = f'PSU {self.index}'
         power_status_file = PsuData.PSU_POWER_STATUS_FILE.format(index)
         out = self.helper.dut.stat(path=power_status_file)
         if out['stat']['exists']:
@@ -86,6 +90,16 @@ class MellanoxDeviceMocker(DeviceMocker):
             self.psu_data = PsuData(self.mock_helper, i + 1)
             if self.psu_data.power_on:
                 break
+
+        self.pdb_data = self._init_pdb_data()
+
+    def _init_pdb_data(self):
+        for i in range(1, 5):
+            pdb_file = f'/run/hw-management/system/pdb{i}_pwr_status'
+            out = self.mock_helper.dut.stat(path=pdb_file)
+            if out['stat']['exists']:
+                return PdbData(self.mock_helper, i)
+        return None
 
     def deinit(self):
         self.mock_helper.deinit()
@@ -154,6 +168,30 @@ class MellanoxDeviceMocker(DeviceMocker):
     def mock_psu_voltage(self, good):
         # Not Supported for now
         return False, None
+
+    def mock_pdb_status(self, status):
+        if self.pdb_data is None:
+            logger.warning("Unable to mock PDB power status: no PDB data discovered on '%s'",
+                           self.mock_helper.dut.hostname)
+            return False, None
+        self.pdb_data.mock_status(status)
+        logger.info("Mocked PDB power status for %s to '%s'", self.pdb_data.name, status)
+        return True, self.pdb_data.name
+
+    def mock_pdb_presence(self, status):
+        if self.pdb_data is None:
+            logger.warning("Unable to mock PDB presence: no PDB data discovered on '%s'",
+                           self.mock_helper.dut.hostname)
+            return False, None
+
+        mock_result = self.pdb_data.mock_presence(status)
+        if not mock_result:
+            logger.warning("PDB presence mock is not supported for %s on '%s'",
+                           self.pdb_data.name, self.mock_helper.dut.hostname)
+            return False, self.pdb_data.name
+
+        logger.info("Mocked PDB presence for %s to '%s'", self.pdb_data.name, status)
+        return True, self.pdb_data.name
 
     def mock_fan_direction(self, good):
         platform_data = get_platform_data(self.mock_helper.dut)

--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -14,7 +14,13 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.helpers.thermal_control_test_helper import disable_thermal_policy     # noqa F401
 from .device_mocker import device_mocker_factory        # noqa F401
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.fixtures.duthost_utils import is_support_mock_asic, is_support_fan, is_support_psu, is_support_pdb, check_pdb_support    # noqa F401
+from tests.common.fixtures.duthost_utils import (  # noqa F401
+    check_pdb_support,
+    is_support_fan,
+    is_support_mock_asic,
+    is_support_pdb,
+    is_support_psu,
+)
 
 pytestmark = [
     pytest.mark.topology('any'),

--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -14,7 +14,7 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.helpers.thermal_control_test_helper import disable_thermal_policy     # noqa F401
 from .device_mocker import device_mocker_factory        # noqa F401
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.fixtures.duthost_utils import is_support_mock_asic, is_support_fan, is_support_psu    # noqa F401
+from tests.common.fixtures.duthost_utils import is_support_mock_asic, is_support_fan, is_support_psu, is_support_pdb, check_pdb_support    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('any'),
@@ -63,6 +63,8 @@ EXPECT_PSU_MISSING = '{} is missing or not available'
 EXPECT_PSU_NO_POWER = '{} is out of power'
 EXPECT_PSU_HOT = '{} temperature is too hot'
 EXPECT_PSU_INVALID_VOLTAGE = '{} voltage is out of range'
+EXPECT_PDB_MISSING = '{} is missing or not available'
+EXPECT_PDB_NO_POWER = '{} is out of power'
 
 DEFAULT_LED_CONFIG = {
     'fault': 'red',
@@ -318,6 +320,70 @@ def test_device_checker(duthosts, enum_rand_one_per_hwsku_hostname,
             assert wait_until(FAST_INTERVAL, 5, 2,
                               check_health_field_not_contains, duthost, psu_name, expect_value), \
                 'Mock PSU good voltage, but it is still invalid'
+
+
+@pytest.mark.disable_loganalyzer
+def test_pdb_device_checker(duthosts, enum_rand_one_per_hwsku_hostname,
+                            device_mocker_factory, disable_thermal_policy):        # noqa F811
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    if not check_pdb_support(duthost):
+        pytest.skip("Device does not support PDB")
+    device_mocker = device_mocker_factory(duthost)
+    wait_system_health_boot_up(duthost)
+    with ConfigFileContext(duthost, os.path.join(FILES_DIR, DEVICE_CHECK_CONFIG_FILE)):
+        time.sleep(DEFAULT_INTERVAL)
+
+        pdb_mock_result, pdb_name = device_mocker.mock_pdb_presence(False)
+        pdb_expect_value = f'{pdb_name} is missing or not available'
+        if pdb_mock_result:
+            logger.info(f'Mocked PDB absence for {pdb_name}')
+            logger.info(f'Waiting {THERMAL_CHECK_INTERVAL} seconds for it to take effect')
+            time.sleep(THERMAL_CHECK_INTERVAL)
+            value = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, pdb_name)
+            assert value and pdb_expect_value == value, \
+                f'Mock PDB absence, expect {pdb_expect_value}, but got {value}'
+        else:
+            logger.warning("Skipping PDB absence validation because presence mocking is unsupported for %s",
+                           pdb_name or "the detected PDB")
+
+        pdb_mock_result, pdb_name = device_mocker.mock_pdb_presence(True)
+        if pdb_mock_result:
+            logger.info(f'Mocked PDB presence for {pdb_name}')
+            logger.info(f'Waiting {THERMAL_CHECK_INTERVAL} seconds for it to take effect')
+            time.sleep(THERMAL_CHECK_INTERVAL)
+            value = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, pdb_name)
+            assert not value or pdb_expect_value != value, \
+                'Mock PDB presence, but it is still absence'
+        else:
+            logger.warning("Skipping PDB presence recovery validation because presence mocking is unsupported for %s",
+                           pdb_name or "the detected PDB")
+
+        pdb_mock_result, pdb_name = device_mocker.mock_pdb_status(False)
+        pdb_expect_value = f'{pdb_name} is out of power'
+        if pdb_mock_result:
+            logger.info(f'Mocked PDB no power for {pdb_name}')
+            logger.info(f'Waiting {THERMAL_CHECK_INTERVAL} seconds for it to take effect')
+            time.sleep(THERMAL_CHECK_INTERVAL)
+            value = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, pdb_name)
+            assert value and pdb_expect_value == value, \
+                f'Mock PDB no power, expect {pdb_expect_value}, but got {value}'
+
+        pdb_mock_result, pdb_name = device_mocker.mock_pdb_status(True)
+        if pdb_mock_result:
+            logger.info(f'Mocked PDB good power for {pdb_name}')
+            logger.info(f'Waiting {THERMAL_CHECK_INTERVAL} seconds for it to take effect')
+            time.sleep(THERMAL_CHECK_INTERVAL)
+            value = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, pdb_name)
+            assert not value or pdb_expect_value != value, \
+                'Mock PDB power good, but it is still out of power'
+
+        health_detail = duthost.shell('show system-health detail')['stdout']
+        pdb_type_pattern = re.compile(r'PDB\s+\d+.*\bPDB\b', re.IGNORECASE)
+        pdb_type_lines = [line for line in health_detail.splitlines()
+                          if pdb_type_pattern.search(line)]
+        logger.info(f'PDB entries in system-health detail: {pdb_type_lines}')
+        assert len(pdb_type_lines) > 0, \
+            "Expected PDB entries with Type=PDB in 'show system-health detail' but found none"
 
 
 def test_external_checker(duthosts, enum_rand_one_per_hwsku_hostname):


### PR DESCRIPTION
### Description of PR

Summary:
- Add PDB support helpers and shared power-unit API test infrastructure so PDB validation can reuse the existing PSU test flow.
- Add PDB-focused platform API, CLI, daemon, and platform information coverage.
- Extend system-health mockers and checker coverage to validate PDB presence and power-fault handling on supported platforms.

Fixes #27751

Test plan: #23028

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #27751
Failure type: other

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

### Approach
#### What is the motivation for this PR?

PDB platforms do not have dedicated platform API and validation coverage comparable to PSU coverage. This makes it difficult to validate PDB inventory, power, temperature, PMON state data, CLI output, and system-health behavior consistently.

#### How did you do it?

Added STATE_DB-based PDB capability helpers, shared power-unit test infrastructure, PDB platform API tests, chassis API validation, CLI and PMON coverage, system-health checks, and PDB presence and power-state mock support.

#### How did you verify/test it?

Confirmed the public PR CI passed after retry, including static analysis, test-case validation, and all currently reported impacted-area jobs.

#### Any platform specific information?

PDB-specific checks skip platforms that do not report PDB support.

#### Supported testbed topology if it's a new test case?

Applicable platform testbeds with PDB support.

### Documentation

Test plan: #23028