### PR TITLE
chore: ignore lognalyzer opening connection remote peer test_syslog

### DIFF
--- a/tests/generic_config_updater/test_syslog.py
+++ b/tests/generic_config_updater/test_syslog.py
@@ -298,9 +298,17 @@ def syslog_server_tc1_remove(duthost):
         delete_tmpfile(duthost, tmpfile)
 
 
-def test_syslog_server_tc1_suite(rand_selected_dut, cfg_facts):
+def test_syslog_server_tc1_suite(rand_selected_dut, cfg_facts, loganalyzer):
     """ Test syslog server config from clean config
     """
+    # Adding/removing syslog servers may cause rsyslog omrelp to attempt connections to
+    # unreachable peers, which logs ERR messages that are expected and harmless here.
+    if loganalyzer:
+        ignoreRegex = [
+            r".*omrelp\[.*\]: error 'error opening connection to remote peer'.*",
+        ]
+        loganalyzer[rand_selected_dut.hostname].ignore_regex.extend(ignoreRegex)
+
     syslog_config_cleanup(rand_selected_dut, cfg_facts)
     syslog_server_tc1_add_init(rand_selected_dut)
     syslog_server_tc1_add_duplicate(rand_selected_dut)

--- a/tests/syslog/test_syslog.py
+++ b/tests/syslog/test_syslog.py
@@ -16,6 +16,15 @@ pytestmark = [
                           ("fd82:b34f:cc99::100", "7.0.80.166"),
                           ("fd82:b34f:cc99::100", "fd82:b34f:cc99::200")])
 def test_syslog(rand_selected_dut, dummy_syslog_server_ip_a, dummy_syslog_server_ip_b,
-                check_default_route      # noqa: F811
+                check_default_route,     # noqa: F811
+                loganalyzer
                 ):
+    # Configuring syslog servers may cause rsyslog omrelp to attempt connections to
+    # unreachable peers, which logs ERR messages that are expected and harmless here.
+    if loganalyzer:
+        ignoreRegex = [
+            r".*omrelp\[.*\]: error 'error opening connection to remote peer'.*",
+        ]
+        loganalyzer[rand_selected_dut.hostname].ignore_regex.extend(ignoreRegex)
+
     run_syslog(rand_selected_dut, dummy_syslog_server_ip_a, dummy_syslog_server_ip_b, check_default_route)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Currently, we're seeing a lot of failure pattern as

```
E               2026 Apr 27 01:00:05.653725 vlab-08 ERR swss3#rsyslogd: omrelp[240.127.1.1:2514]: error 'error opening connection to remote peer', object  'conn to srvr 240.127.1.1:2514' - action may not work as intended [v8.2302.0 try https://www.rsyslog.com/e/2353 ]
```

Ignore is suggested by @saiarcot895:

> This test case causes rsyslogd on the host to restart. When this happens, TCP connections from the container rsyslogd processes will break. If those containers want to send a syslog during the time that rsyslogd is still restarting, they will not be able to establish a connection, thus resulting in this error.
 
> This error message is fine only when rsyslogd is being restarted. In all other cases, if this error message appears, then that suggests there's some underlying issue that needs to be fixed; otherwise, logs messages will be getting delayed or dropped.


Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Ignore the log analyzer pattern for this specific test case

#### How did you do it?

Add to ignore pattern

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
