### PR TITLE
[Smartswitch] Enable loganalyzer on DPUs

### DIFF
--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -85,15 +85,30 @@ def loganalyzer(duthosts, request, log_rotate_modular_chassis):
     should_rotate_log = request.config.getoption("--loganalyzer_rotate_logs")
     is_modular_chassis = duthosts[0].get_facts().get("modular_chassis") if duthosts else False
 
+    # Import here, not at module load: conftest imports common before loganalyzer
+    # finishes loading; a top-level import creates a circular import.
+    try:
+        from tests.conftest import get_specified_dpus
+        # Get dpuhosts if the --dpu-pattern is provided to enable loganalyzer on dpus
+        dpuhosts = request.getfixturevalue("dpuhosts") if get_specified_dpus(request) else []
+    except Exception:
+        dpuhosts = []
+
+    analyzer_hosts = []
+    for duthost in duthosts:
+        analyzer_hosts.append(duthost)
+    for dpuhost in dpuhosts:
+        analyzer_hosts.append(dpuhost)
+
     # We make sure only run logrotate as "function" scope for non-modular chassis for optimisation purpose.
     # For modular chassis please refer to "log_rotate_modular_chassis" fixture
     if should_rotate_log and not is_modular_chassis:
-        parallel_run(analyzer_logrotate, [], {}, duthosts, timeout=120)
-    for duthost in duthosts:
+        parallel_run(analyzer_logrotate, [], {}, analyzer_hosts, timeout=120)
+    for duthost in analyzer_hosts:
         analyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=request.node.name, request=request)
         analyzer.load_common_config()
         analyzers[duthost.hostname] = analyzer
-    markers = parallel_run(analyzer_add_marker, [analyzers], {}, duthosts, timeout=120)
+    markers = parallel_run(analyzer_add_marker, [analyzers], {}, analyzer_hosts, timeout=120)
 
     yield analyzers
 
@@ -101,16 +116,20 @@ def loganalyzer(duthosts, request, log_rotate_modular_chassis):
     if "rep_call" in request.node.__dict__ and request.node.rep_call.skipped or \
             "rep_setup" in request.node.__dict__ and request.node.rep_setup.skipped:
         return
+
+    # It's possible we modify the analyzers in tests to skip some duthosts
+    analyzer_hosts = [duthost for duthost in analyzer_hosts if duthost.hostname in analyzers]
+
     logging.info("Starting to analyse on all DUTs")
     la_results = parallel_run(
         analyze_logs,
         [analyzers, markers],
         {'fail_test': fail_test, 'store_la_logs': store_la_logs},
-        duthosts,
+        analyzer_hosts,
         timeout=240
     )
     consolidated_bughandler = get_bughandler_instance({"type": "consolidated"})
-    consolidated_bughandler.bug_handler_wrapper(analyzers, duthosts, la_results)
+    consolidated_bughandler.bug_handler_wrapper(analyzers, analyzer_hosts, la_results)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -333,7 +333,12 @@ def pytest_addoption(parser):
     ############################
     #   SmartSwitch options    #
     ############################
-    parser.addoption("--dpu-pattern", action="store", default="all", help="dpu host name")
+    parser.addoption(
+        "--dpu-pattern",
+        action="store",
+        default="None",
+        help="Smartswitch dpus that should be involved in the test (e.g. 'dut-dpu-0,dut-dpu-1')"
+    )
     parser.addoption(
         "--ss_target_index",
         action="store",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enable the loganalyzer on DPUs when --dpu-pattern is provided.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
This PR is to enable the loganalyzer on DPUs when --dpu-pattern is provided.
For the smartswitch tests in which the DPUs are involved(dash, smartswitch platform, dash-ha, etc.), we want to enable the loganalyzer on DPUs to catch unexpected errors.

#### How did you do it?
In those tests, the dpu ansible hosts are provided by the param "--dpu-pattern" in the pytest command. Add the dpuhosts in the --dpu-pattern to the loganalyzer hosts, so the loganalyzer will be enable on the DPUs automatically.
And I change the default value of "--dpu-pattern" to None so when the param is not provided, the DPUs are ignored.

#### How did you verify/test it?
Run some smartswitch and non-smartswitch tests on SN4280 smartswitch testbed and SN4700 non-smartrswitch testbed, the loganalyzer is working well as expected.
#### Any platform specific information?
The change is only for smartswitch and is compatible with non-smartswitch testbed.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
