### PR TITLE
Fix monit socket timeout after restore/restart

### DIFF
--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -27,7 +27,7 @@ pytestmark = [
 CONTAINER_STOP_THRESHOLD_SECS = 200
 CONTAINER_RESTART_THRESHOLD_SECS = 180
 CONTAINER_CHECK_INTERVAL_SECS = 1
-MONIT_RESTART_THRESHOLD_SECS = 320
+MONIT_RESTART_THRESHOLD_SECS = 400
 MONIT_CHECK_INTERVAL_SECS = 5
 WAITING_SYSLOG_MSG_SECS = 30
 MONIT_MEMORY_CHECK_TIMEOUT = 700
@@ -131,17 +131,29 @@ def restore_monit_config_files(duthost):
 
 
 def check_monit_running(duthost):
-    """Checks whether Monit is running or not.
+    """Checks whether Monit is running with all services in ready state.
 
     Args:
         duthost: The AnsibleHost object of DuT.
 
     Returns:
-        Returns True if Monit is running; Otherwist, returns False.
+        Returns True if all services are ready; Otherwise, returns False.
     """
     monit_services_status = duthost.get_monit_services_status()
     if not monit_services_status:
         return False
+
+    # Validate each service is in expected state
+    for service_name, service_info in monit_services_status.items():
+        service_type = service_info.get("service_type", "")
+        state = service_info.get("service_status", "")
+        if state in ["Not monitored", "OK"]:
+            continue
+        # Check expected states per service type
+        if ((service_type == "Filesystem" and state != "Accessible")
+                or (service_type == "Process" and state != "Running")
+                or (service_type == "Program" and state != "Status ok")):
+            return False
 
     return True
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

The `memory_checker` test modifies monit configuration files during testing. During cleanup, the test **restores the original configuration from backup** (`/tmp/monit` → `/etc/monit`) and **restarts the monit
   service** (`systemctl restart monit`). This triggers two critical timing issues:

  1. **Insufficient timeout**: After restore and restart, the monit socket `/var/run/monit.sock` becomes inaccessible for a long time upto  300 seconds. The current 320-second timeout provides only a 20-second buffer.

  2. **No state validation**: `check_monit_running()` only verifies the socket is accessible (by checking if `monit status` succeeds), not that individual services have completed initialization. It returns True
   while services are still in "Initializing" state, causing downstream sanity check failures.

  This PR fixes both issues by increasing the timeout to 400 seconds and adding validation to ensure all services reach their expected operational states before proceeding.


Summary:
Fixes #24231 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

The `memory_checker` test fails intermittently on dual-ToR testbeds during post-test sanity checks with monit services stuck in "Initializing" state. The fix addresses a timing issue and implements a condition for monit services to be in a 
Ready State

#### How did you do it?
- Changed `MONIT_RESTART_THRESHOLD_SECS` from 320 to 400 seconds
-  Modified `check_monit_running()` to validate each service is in the correct state 
    - Iterates through `monit_services_status` and checks service_type:
        Filesystem → must be "Accessible"
        Process → must be "Running"  
        Program → must be "Status ok"
     - Allows "Not monitored" and "OK" (intentional configurations)
     - Returns False if any service still "Initializing" or in error state

#### How did you verify/test it?
Validated with 15 consecutive successful runs of the test 

#### Any platform specific information?
No 
#### Supported testbed topology if it's a new test case?
No 
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
