### PR TITLE
[202511] Fix false memory alarm caused by monit stale cache

### DIFF
--- a/tests/common/plugins/memory_utilization/__init__.py
+++ b/tests/common/plugins/memory_utilization/__init__.py
@@ -52,6 +52,10 @@ def pytest_runtest_setup(item):
         if duthost.topo_type == 't2':
             continue
 
+        # Trigger monit to refresh its cache so subsequent collection reads fresh data
+        logger.info("Triggering monit refresh on {} before collecting memory data".format(duthost.hostname))
+        memory_monitors[duthost.hostname].execute_command("sudo monit validate")
+
         # Initial memory check for all registered commands
         for name, cmd, memory_params, memory_check in memory_monitors[duthost.hostname].commands:
             try:
@@ -90,6 +94,10 @@ def pytest_runtest_teardown(item, nextitem):
     for duthost in duthosts:
         if duthost.topo_type == 't2':
             continue
+
+        # Trigger monit to refresh its cache so subsequent collection reads fresh data
+        logger.info("Triggering monit refresh on {} before collecting memory data".format(duthost.hostname))
+        memory_monitors[duthost.hostname].execute_command("sudo monit validate")
 
         # memory check for all registered commands
         for name, cmd, memory_params, memory_check in memory_monitors[duthost.hostname].commands:

--- a/tests/common/plugins/memory_utilization/memory_utilization.py
+++ b/tests/common/plugins/memory_utilization/memory_utilization.py
@@ -388,7 +388,8 @@ class MemoryMonitor:
                     'name': name,
                     'cmd': command,
                     'memory_params': memory_params,
-                    'memory_check_fn': memory_check_fn
+                    'memory_check_fn': memory_check_fn,
+                    'order': item.get('order', 0)
                 }
 
         with open(MEMORY_UTILIZATION_DEPENDENCE_JSON_FILE, 'r') as file:
@@ -403,7 +404,8 @@ class MemoryMonitor:
                     'name': name,
                     'cmd': command,
                     'memory_params': memory_params,
-                    'memory_check_fn': memory_check_fn
+                    'memory_check_fn': memory_check_fn,
+                    'order': item.get('order', parameter_dict.get(name, {}).get('order', 0))
                 }
 
             if hwsku:
@@ -435,10 +437,11 @@ class MemoryMonitor:
                                         'name': name,
                                         'cmd': command,
                                         'memory_params': memory_params,
-                                        'memory_check_fn': memory_check_fn
+                                        'memory_check_fn': memory_check_fn,
+                                        'order': item.get('order', 0)
                                     }
 
-        for param in parameter_dict.values():
+        for param in sorted(parameter_dict.values(), key=lambda x: x.get('order', 0)):
             # Normalize thresholds in memory_params to ensure consistent behavior
             for mem_item, thresholds in param['memory_params'].items():
                 param['memory_params'][mem_item] = self._normalize_thresholds(thresholds)

--- a/tests/common/plugins/memory_utilization/memory_utilization_common.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_common.json
@@ -2,7 +2,8 @@
   "COMMON": [
     {
       "name": "monit",
-      "cmd": "sudo monit validate",
+      "order": 100,
+      "cmd": "sudo monit status",
       "memory_params": {
         "memory_usage": {
           "memory_increase_threshold": {

--- a/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
@@ -44,7 +44,8 @@
     },
     {
       "name": "monit",
-      "cmd": "sudo monit validate",
+      "order": 100,
+      "cmd": "sudo monit status",
       "memory_params": {
         "memory_usage": {
           "memory_increase_threshold": {
@@ -206,7 +207,7 @@
   "Arista-7050QX": [
     {
       "name": "monit",
-      "cmd": "sudo monit validate",
+      "cmd": "sudo monit status",
       "memory_params": {
         "memory_usage": {
           "memory_increase_threshold": {
@@ -225,7 +226,7 @@
   "Mellanox-SN4600C": [
     {
       "name": "monit",
-      "cmd": "sudo monit validate",
+      "cmd": "sudo monit status",
       "memory_params": {
         "memory_usage": {
           "memory_increase_threshold": {


### PR DESCRIPTION
### Description of PR

Backport of #24122 to 202511.

`sudo monit validate` returns stale pre-validate cached data in its output, not the freshly-collected metrics. This causes false memory alarms when a transient peak is captured by the monit daemon during the test, and then teardown reads that stale snapshot via `monit validate` output.

Fixes false positive memory alarm failures on 202511 branch.

### Type of change
- [x] Bug fix

### Back port request
- [x] 202511

### Approach

#### What is the motivation for this PR?
False memory alarm failures on `202511` caused by `sudo monit validate` reading stale cached metrics instead of live data.

#### How did you do it?
- Always prepend an unconditional `sudo monit validate` before the configured command collection loop in both setup and teardown hooks (`__init__.py`). This triggers a fresh monit data collection cycle.
- Replace `sudo monit validate` in all JSON config files with `sudo monit status`, which reads the freshly-collected cache populated by the pre-validate step above.
- Add an `order` field to JSON config entries so commands can be sorted before execution. Default order is `0`; monit is assigned `order: 100` to guarantee it always runs last regardless of dict insertion order.
- Update `memory_utilization.py` to sort commands by `order` field.

#### How did you verify/test it?
Verified by reviewing the code changes match the intent of the original PR #24122.

#### Any platform specific information?
For `202511`, only the 7 platforms present in the branch are updated:
- HWSKU, COMMON, Arista-7050QX, Mellanox-SN4600C, Arista-7060X6, Mellanox-SN5640, Arista-7260CX3

#### Supported testbed topology if it's a new test case?
N/A — bug fix to existing memory utilization plugin.

### Documentation
N/A