### PR TITLE
[dhcp_relay] Fix stale parametrized keys in dhcp_relay conditional_mark

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1060,14 +1060,14 @@ dhcp_relay/test_dhcp_counter_stress.py::test_dhcpmon_relay_counters_stress:
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
 
-dhcp_relay/test_dhcp_counter_stress.py::test_dhcpmon_relay_counters_stress[discover]:
+dhcp_relay/test_dhcp_counter_stress.py::test_dhcpmon_relay_counters_stress[discover:
   xfail:
     reason: "Need to skip for discover test cases on dualtor"
     conditions:
       - "'dualtor' in topo_name"
       - "https://github.com/sonic-net/sonic-mgmt/issues/19230"
 
-dhcp_relay/test_dhcp_counter_stress.py::test_dhcpmon_relay_counters_stress[request]:
+dhcp_relay/test_dhcp_counter_stress.py::test_dhcpmon_relay_counters_stress[request:
   xfail:
     reason: "Need to skip for request test cases on dualtor"
     conditions:
@@ -1194,13 +1194,13 @@ dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - "asic_type in ['vs']"
 
-dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress[discover]:
+dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress[discover:
   skip:
     reason: "Testcase ignored due to github issue: https://github.com/sonic-net/sonic-mgmt/issues/14851"
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/14851"
 
-dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress[request]:
+dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress[request:
   skip:
     reason: "Testcase ignored due to github issue: https://github.com/sonic-net/sonic-mgmt/issues/14851"
     conditions:


### PR DESCRIPTION
The four parametrized dhcp_relay stress entries

  test_dhcp_counter_stress.py::test_dhcpmon_relay_counters_stress[discover]
  test_dhcp_counter_stress.py::test_dhcpmon_relay_counters_stress[request]
  test_dhcp_relay_stress.py::test_dhcp_relay_stress[discover]
  test_dhcp_relay_stress.py::test_dhcp_relay_stress[request]

stopped matching any collected test node id after the relay-agent parametrize change made these tests run as

  ...[discover-isc-relay-agent], ...[discover-sonic-relay-agent]
  ...[request-isc-relay-agent],  ...[request-sonic-relay-agent]

Conditional_mark uses prefix matching (nodeid.startswith(entry)). By dropping the closing ] from the four keys, the entries match both the historical bare nodeids and all current/future relay-agent variants (isc, sonic, ...), so the original xfail/skip intent is preserved on both agents without enumerating each one.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

 Four entries in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` stopped matching any collected test node id after the relay-agent parametrize change:
 
 | Existing key | Mark | Issue |
 |---|---|---|
 | `test_dhcp_counter_stress.py::test_dhcpmon_relay_counters_stress[discover]` | xfail on dualtor | #19230 |
 | `test_dhcp_counter_stress.py::test_dhcpmon_relay_counters_stress[request]`  | xfail on dualtor | #19230 |
 | `test_dhcp_relay_stress.py::test_dhcp_relay_stress[discover]`               | skip (unconditional) | #14851 |
 | `test_dhcp_relay_stress.py::test_dhcp_relay_stress[request]`                | skip (unconditional) | #14851 |
 
 The actual collected node ids are now:

...[discover-isc-relay-agent], ...[discover-sonic-relay-agent] ...[request-isc-relay-agent], ...[request-sonic-relay-agent]

 
 So the marks are silently dead — both `isc` and `sonic` variants of the listed `discover`/`request` tests are running unmarked.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach

 `conditional_mark` uses prefix matching (`nodeid.startswith(entry)`, see `tests/common/plugins/conditional_mark/__init__.py:460`). Dropping the trailing `]` from each key turns it into a prefix that matches **all** of:
 
 - the historical bare nodeid (`...[discover]`)
 - both current relay-agent variants (`...[discover-isc-relay-agent]`, `...[discover-sonic-relay-agent]`)
 - any future `[discover-*]` variant
 
 The longest-match rule still applies, so the more specific `[discover` / `[request` keys correctly shadow the generic `test_dhcp_relay_stress:` / `test_dhcpmon_relay_counters_stress:` parents — same precedence as before.

This open-prefix [xxx: convention is already widely used in the same file (e.g. L513, L1886, L3146).

#### What is the motivation for this PR?

 After the relay-agent parametrize landed, the four `[discover]`/`[request]` keys in `tests_mark_conditions.yaml` no longer matched any test node id, silently disabling `xfail` (#19230) and `skip` (#14851) on both `isc` and `sonic` variants.

#### How did you do it?

 Dropped the trailing `]` so each key becomes a `startswith` prefix that covers both the original bare nodeid and every `relay-agent` parametrization.

#### How did you verify/test it?

 - Validated end-to-end on `testbed-bjw2-can-720dt-4` (single-asic t0): both `[discover-isc-relay-agent]` and `[discover-sonic-relay-agent]` of `test_dhcp_relay_stress` failed without the mark, while `[offer-*]` and `[ack-*]` passed — confirming the existing `[discover|request]` scope is still correct, and the same flake hits both isc and sonic agents.
 - The `[discover|request]` xfail entries on `test_dhcpmon_relay_counters_stress` are dualtor-only (`'dualtor' in topo_name`); not exercised on this testbed but the prefix-match key change is structurally identical.
 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
