### PR TITLE
Ecmp test and vnet vxlan subintf test improvements

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/vxlan_ecmp_ptftest.py
+++ b/ansible/roles/test/files/ptftests/py3/vxlan_ecmp_ptftest.py
@@ -44,8 +44,17 @@ class VxlanEcmpTest(BaseTest):
             with open(params["macs_file"], "r") as f:
                 self.mac_list = json.load(f)
         else:
-            self.mac_list = params.get("mac_address", [])
+            self.mac_list = params.get("mac_address", ["00:aa:bb:cc:dd:ee"] * len(self.endpoints))
+        self.mac_list = self.mac_list + [self.mac_list[-1]] * (len(self.endpoints) - len(self.mac_list))  # pad if shorter than endpoints
 
+        if "vni_file" in params and os.path.exists(params["vni_file"]):
+            with open(params["vni_file"], "r") as f:
+                self.vni_list = json.load(f)
+        else:
+            self.vni_list = params.get("vni", [0] * len(self.endpoints))
+        self.vni_list = self.vni_list + [self.vni_list[-1]] * (len(self.endpoints) - len(self.vni_list))  # pad if shorter than endpoints
+
+        self.endpoints_mac_vni_tuple_list = list(zip(self.endpoints, self.mac_list, self.vni_list))
         self.dst_ip = params.get("dst_ip")
         self.src_ip = params.get("ptf_src_ip")
         self.dut_vtep = params.get("dut_vtep")
@@ -54,7 +63,6 @@ class VxlanEcmpTest(BaseTest):
         self.vxlan_port = int(params.get("vxlan_port", 4789))
         self.send_port = int(params.get("ptf_ingress_port", 0))
         self.mac_vni_verify = params.get("mac_vni_verify", "") == "yes"
-        self.vni = params.get("vni")
         self.deleted_endpoints = params.get("deleted_endpoints", [])
         self.modified_mac_index = params.get("modified_mac_index")
         self.modified_mac_value = params.get("modified_mac_value")
@@ -109,7 +117,7 @@ class VxlanEcmpTest(BaseTest):
             udp_sport=12345,
             udp_dport=self.vxlan_port,
             with_udp_chksum=False,
-            vxlan_vni=self.vni,
+            vxlan_vni=self.vni_list[idx],
             inner_frame=inner_exp,
         )
         encap[scapy.IP].flags = 0x2
@@ -128,7 +136,7 @@ class VxlanEcmpTest(BaseTest):
     def verify_mac_vni_encap(self):
         logger.info("=== MAC+VNI multi-endpoint ECMP validation ===")
         src_mac = self.dataplane.get_mac(0, self.send_port)
-        endpoint_hits = {ep: 0 for ep in self.endpoints}
+        endpoint_mac_vni_hits = [0 for _ in range(len(self.endpoints))]
         mismatch_count = 0
         if self.modified_mac_index is not None:
             self.mac_list[self.modified_mac_index] = self.modified_mac_value
@@ -168,12 +176,20 @@ class VxlanEcmpTest(BaseTest):
                 if outer_dst not in self.endpoints:
                     logger.error(f"Received VXLAN pkt to unexpected endpoint {outer_dst}")
                     continue
+                dst_mac = pkt[scapy.VXLAN][scapy.Ether].dst
+                if dst_mac not in self.mac_list:
+                    logger.error(f"Received VXLAN pkt with unexpected dst MAC {dst_mac}")
+                    continue
+                received_vni = pkt[scapy.VXLAN].vni
+                if received_vni not in self.vni_list:
+                    logger.error(f"Received VXLAN pkt with unexpected VNI {received_vni}")
+                    continue
 
-                idx = self.endpoints.index(outer_dst)
+                idx = self.endpoints_mac_vni_tuple_list.index((outer_dst, dst_mac, received_vni))
                 exp = self._build_expected_for_index(idx, inner)
 
                 if exp.pkt_match(pkt):
-                    endpoint_hits[outer_dst] += 1
+                    endpoint_mac_vni_hits[idx] += 1
                     break
                 else:
                     mismatch_count += 1
@@ -182,14 +198,14 @@ class VxlanEcmpTest(BaseTest):
                         f"\n\nExpected:\n{exp}\n\nReceived:\n{pkt}\n\n"
                     )
 
-        logger.info(f"MAC+VNI Multi-endpoint validation counts: {endpoint_hits}")
+        logger.info(f"MAC+VNI Multi-endpoint validation counts: {endpoint_mac_vni_hits}")
         if mismatch_count > 0:
             raise AssertionError(f"{mismatch_count} packet(s) did NOT match expected MAC/VNI encapsulation")
-        used = [ep for ep, c in endpoint_hits.items() if c > 0]
+        used = [self.endpoints_mac_vni_tuple_list[idx] for idx, c in enumerate(endpoint_mac_vni_hits) if c > 0]
         if len(used) == 0:
             raise AssertionError("NO endpoints used VXLAN not working")
         if len(used) < len(self.endpoints):
-            missing = set(self.endpoints) - set(used)
+            missing = set(self.endpoints_mac_vni_tuple_list) - set(used)
             raise AssertionError(f"Missing endpoint hits: {missing}")
 
         logger.info("MAC+VNI multi-endpoint ECMP validation PASSED.")

--- a/ansible/roles/test/files/ptftests/py3/vxlan_ecmp_ptftest.py
+++ b/ansible/roles/test/files/ptftests/py3/vxlan_ecmp_ptftest.py
@@ -45,14 +45,16 @@ class VxlanEcmpTest(BaseTest):
                 self.mac_list = json.load(f)
         else:
             self.mac_list = params.get("mac_address", ["00:aa:bb:cc:dd:ee"] * len(self.endpoints))
-        self.mac_list = self.mac_list + [self.mac_list[-1]] * (len(self.endpoints) - len(self.mac_list))  # pad if shorter than endpoints
+        self.mac_list = self.mac_list + [self.mac_list[-1]] * \
+            (len(self.endpoints) - len(self.mac_list))  # pad if shorter than endpoints
 
         if "vni_file" in params and os.path.exists(params["vni_file"]):
             with open(params["vni_file"], "r") as f:
                 self.vni_list = json.load(f)
         else:
             self.vni_list = params.get("vni", [0] * len(self.endpoints))
-        self.vni_list = self.vni_list + [self.vni_list[-1]] * (len(self.endpoints) - len(self.vni_list))  # pad if shorter than endpoints
+        self.vni_list = self.vni_list + [self.vni_list[-1]] * \
+            (len(self.endpoints) - len(self.vni_list))  # pad if shorter than endpoints
 
         self.endpoints_mac_vni_tuple_list = list(zip(self.endpoints, self.mac_list, self.vni_list))
         self.dst_ip = params.get("dst_ip")

--- a/ansible/roles/test/files/ptftests/py3/vxlan_ecmp_ptftest.py
+++ b/ansible/roles/test/files/ptftests/py3/vxlan_ecmp_ptftest.py
@@ -140,6 +140,7 @@ class VxlanEcmpTest(BaseTest):
         src_mac = self.dataplane.get_mac(0, self.send_port)
         endpoint_mac_vni_hits = [0 for _ in range(len(self.endpoints))]
         mismatch_count = 0
+        missing_count = 0
         if self.modified_mac_index is not None:
             self.mac_list[self.modified_mac_index] = self.modified_mac_value
 
@@ -160,6 +161,7 @@ class VxlanEcmpTest(BaseTest):
             )
 
             send_packet(self, self.send_port, inner)
+            found_packet = False
 
             # Poll for VXLAN packets
             poll_start = datetime.now()
@@ -192,6 +194,7 @@ class VxlanEcmpTest(BaseTest):
 
                 if exp.pkt_match(pkt):
                     endpoint_mac_vni_hits[idx] += 1
+                    found_packet = True
                     break
                 else:
                     mismatch_count += 1
@@ -200,9 +203,13 @@ class VxlanEcmpTest(BaseTest):
                         f"\n\nExpected:\n{exp}\n\nReceived:\n{pkt}\n\n"
                     )
 
+            if not found_packet:
+                missing_count += 1
+                logger.error(f"No matching VXLAN packet found for packet with TCP dport {dport}")
+
         logger.info(f"MAC+VNI Multi-endpoint validation counts: {endpoint_mac_vni_hits}")
-        if mismatch_count > 0:
-            raise AssertionError(f"{mismatch_count} packet(s) did NOT match expected MAC/VNI encapsulation")
+        if mismatch_count > 0 or missing_count > 0:
+            raise AssertionError(f"{mismatch_count} packet(s) did NOT match expected MAC/VNI encapsulation, {missing_count} packet(s) were missing.")
         used = [self.endpoints_mac_vni_tuple_list[idx] for idx, c in enumerate(endpoint_mac_vni_hits) if c > 0]
         if len(used) == 0:
             raise AssertionError("NO endpoints used VXLAN not working")
@@ -212,10 +219,7 @@ class VxlanEcmpTest(BaseTest):
 
         logger.info("MAC+VNI multi-endpoint ECMP validation PASSED.")
 
-    def runTest(self):
-        if self.mac_vni_verify:
-            self.verify_mac_vni_encap()
-            return
+    def verify_ecmp_encap(self):
         counts = {}
         src_mac = self.dataplane.get_mac(0, self.send_port)
 
@@ -292,6 +296,14 @@ class VxlanEcmpTest(BaseTest):
             f"VXLAN ECMP test passed: all {len(self.endpoints)} endpoints hit, "
             f"{total_received}/{self.num_packets} packets received, no loss."
         )
+
+    def runTest(self):
+        if self.mac_vni_verify:
+            self.verify_mac_vni_encap()
+        else:
+            self.verify_ecmp_encap()
+
+        self.tearDown()
 
     def tearDown(self):
         self.dataplane.flush()

--- a/tests/common/ptf_gnmic.py
+++ b/tests/common/ptf_gnmic.py
@@ -140,3 +140,65 @@ class PtfGnmic:
 
     def __repr__(self):
         return self.__str__()
+    
+    def set(self, path: str, value: str, encoding: str = "json_ietf", timeout: int = 90, metadata: str = None, filename: str = "value") -> Dict:
+        """
+        Set a value on the target device using gNMI Set operation.
+
+        Args:
+            path: gNMI path string
+            value: Value to set, formatted according to the specified encoding
+            encoding: Encoding format (default: "json_ietf")
+            timeout: Timeout for the gNMI Set operation (default: 10 seconds)
+            metadata: Optional metadata for the gNMI Set operation
+
+        Returns:
+            Dictionary containing the gNMI Set response
+
+        Raises:
+            GnmicConnectionError: If connection to target fails (refused, TLS errors)
+            GnmicCallError: If gnmic exits with non-zero code or returns invalid JSON
+        """
+        # put value into temp file
+        value_content = json.dumps(value, indent=2)
+        value_file = f"/tmp/{filename}.json"
+        self.ptfhost.copy(content=value_content, dest=value_file)
+    
+        cmd = f"{self._gnmic_path} -a {self.target}"
+
+        if self.plaintext:
+            cmd += " --insecure"
+        elif self.ca_cert and self.client_cert and self.client_key:
+            cmd += f" --tls-ca {self.ca_cert} --tls-cert {self.client_cert} --tls-key {self.client_key}"
+
+        cmd += f" set --prefix 'sonic-db:' --update-path {path} --update-file {value_file} --encoding {encoding} --timeout={timeout}s"
+
+        if metadata:
+            cmd += f" --metadata '{metadata}'"
+
+        logger.debug(f"Executing gnmic command: {cmd}")
+        result = self.ptfhost.shell(cmd, module_ignore_errors=True)
+
+        rc = result["rc"]
+        stdout = result.get("stdout", "").strip()
+        stderr = result.get("stderr", "").strip()
+
+        if rc != 0:
+            # Check for connection-related error keywords
+            stderr_lower = stderr.lower()
+            if any(kw in stderr_lower for kw in _CONNECTION_KEYWORDS):
+                raise GnmicConnectionError(
+                    f"gnmic connection failed to {self.target}: {stderr}"
+                )
+            raise GnmicCallError(
+                f"gnmic set failed (rc={rc}): {stderr}"
+            )
+
+        # Parse JSON output
+        try:
+            return json.loads(stdout)
+        except (json.JSONDecodeError, ValueError) as e:
+            raise GnmicCallError(
+                f"gnmic returned invalid JSON: {e}\nOutput: {stdout}"
+            )
+

--- a/tests/common/ptf_gnmic.py
+++ b/tests/common/ptf_gnmic.py
@@ -140,7 +140,7 @@ class PtfGnmic:
 
     def __repr__(self):
         return self.__str__()
-    
+
     def set(self, path: str, value: str, encoding: str = "json_ietf", timeout: int = 90, metadata: str = None, filename: str = "value") -> Dict:
         """
         Set a value on the target device using gNMI Set operation.
@@ -163,7 +163,7 @@ class PtfGnmic:
         value_content = json.dumps(value, indent=2)
         value_file = f"/tmp/{filename}.json"
         self.ptfhost.copy(content=value_content, dest=value_file)
-    
+
         cmd = f"{self._gnmic_path} -a {self.target}"
 
         if self.plaintext:

--- a/tests/common/ptf_gnmic.py
+++ b/tests/common/ptf_gnmic.py
@@ -202,3 +202,57 @@ class PtfGnmic:
                 f"gnmic returned invalid JSON: {e}\nOutput: {stdout}"
             )
 
+    def get(self, path: str, encoding: str = "json_ietf", timeout: int = 90, metadata: str = None) -> Dict:
+        """
+        Get a value from the target device using gNMI Get operation.
+
+        Args:
+            path: gNMI path string
+            encoding: Encoding format (default: "json_ietf")
+            timeout: Timeout for the gNMI Get operation (default: 10 seconds)
+            metadata: Optional metadata for the gNMI Get operation
+
+        Returns:
+            Dictionary containing the gNMI Get response
+
+        Raises:
+            GnmicConnectionError: If connection to target fails (refused, TLS errors)
+            GnmicCallError: If gnmic exits with non-zero code or returns invalid JSON
+        """
+        cmd = f"{self._gnmic_path} -a {self.target}"
+
+        if self.plaintext:
+            cmd += " --insecure"
+        elif self.ca_cert and self.client_cert and self.client_key:
+            cmd += f" --tls-ca {self.ca_cert} --tls-cert {self.client_cert} --tls-key {self.client_key}"
+
+        cmd += f" get --prefix 'sonic-db:' --path {path} --encoding {encoding} --timeout={timeout}s"
+
+        if metadata:
+            cmd += f" --metadata '{metadata}'"
+
+        logger.debug(f"Executing gnmic command: {cmd}")
+        result = self.ptfhost.shell(cmd, module_ignore_errors=True)
+
+        rc = result["rc"]
+        stdout = result.get("stdout", "").strip()
+        stderr = result.get("stderr", "").strip()
+
+        if rc != 0:
+            # Check for connection-related error keywords
+            stderr_lower = stderr.lower()
+            if any(kw in stderr_lower for kw in _CONNECTION_KEYWORDS):
+                raise GnmicConnectionError(
+                    f"gnmic connection failed to {self.target}: {stderr}"
+                )
+            raise GnmicCallError(
+                f"gnmic get failed (rc={rc}): {stderr}"
+            )
+
+        # Parse JSON output
+        try:
+            return json.loads(stdout)
+        except (json.JSONDecodeError, ValueError) as e:
+            raise GnmicCallError(
+                f"gnmic returned invalid JSON: {e}\nOutput: {stdout}"
+            )

--- a/tests/common/ptf_gnmic.py
+++ b/tests/common/ptf_gnmic.py
@@ -141,7 +141,8 @@ class PtfGnmic:
     def __repr__(self):
         return self.__str__()
 
-    def set(self, path: str, value: str, encoding: str = "json_ietf", timeout: int = 90, metadata: str = None, filename: str = "value") -> Dict:
+    def set(self, path: str, value: str, encoding: str = "json_ietf",
+            timeout: int = 90, metadata: str = None, filename: str = "value") -> Dict:
         """
         Set a value on the target device using gNMI Set operation.
 
@@ -171,7 +172,8 @@ class PtfGnmic:
         elif self.ca_cert and self.client_cert and self.client_key:
             cmd += f" --tls-ca {self.ca_cert} --tls-cert {self.client_cert} --tls-key {self.client_key}"
 
-        cmd += f" set --prefix 'sonic-db:' --update-path {path} --update-file {value_file} --encoding {encoding} --timeout={timeout}s"
+        cmd += f" set --prefix 'sonic-db:' --update-path '{path}' --update-file '{value_file}' \
+            --encoding {encoding} --timeout={timeout}s"
 
         if metadata:
             cmd += f" --metadata '{metadata}'"
@@ -226,7 +228,7 @@ class PtfGnmic:
         elif self.ca_cert and self.client_cert and self.client_key:
             cmd += f" --tls-ca {self.ca_cert} --tls-cert {self.client_cert} --tls-key {self.client_key}"
 
-        cmd += f" get --prefix 'sonic-db:' --path {path} --encoding {encoding} --timeout={timeout}s"
+        cmd += f" get --prefix 'sonic-db:' --path '{path}' --encoding {encoding} --timeout={timeout}s"
 
         if metadata:
             cmd += f" --metadata '{metadata}'"

--- a/tests/vxlan/test_scale_ecmp.py
+++ b/tests/vxlan/test_scale_ecmp.py
@@ -11,6 +11,7 @@ from tests.ptf_runner import ptf_runner
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa:F401
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
 from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.fixtures.grpc_fixtures import gnmi_tls
 
 logger = logging.getLogger(__name__)
 ecmp_utils = Ecmp_Utils()
@@ -39,27 +40,28 @@ def get_loopback_ip(cfg_facts):
     pytest.fail("Cannot find IPv4 Loopback0 address in LOOPBACK_INTERFACE")
 
 
-def apply_chunk(duthost, payload, name):
-    content = json.dumps(payload, indent=2)
-    dest = f"/tmp/{name}.json"
-    duthost.copy(content=content, dest=dest)
-    duthost.shell(f"sonic-cfggen -j {dest} --write-to-db")
+def gnmic_set_with_bypass(gnmi_tls, path, payload, name):
+    gnmi_tls.gnmic.set(path, payload, metadata="x-sonic-ss-bypass-validation=true", filename=name)
 
 
-def _update_vxlan_endpoints(duthost, vnet, prefix, endpoints, vni, mac_address=None):
+def _update_vxlan_endpoints(gnmi_tls, vnet, prefix, endpoints, vni, mac_address=None):
     ep_str = ",".join(endpoints)
     logger.info(
         f"Updating VNET_ROUTE_TUNNEL {vnet}|{prefix} "
         f"with {len(endpoints)} endpoints, vni={vni}, mac={mac_address}"
     )
-    cmd = (
-        f"sonic-db-cli CONFIG_DB hmset 'VNET_ROUTE_TUNNEL|{vnet}|{prefix}' "
-        f"endpoint '{ep_str}' vni '{vni}'"
-    )
-    if mac_address:
-        cmd += f" mac_address '{mac_address}'"
 
-    duthost.shell(cmd)
+    value = {"endpoint": ep_str, "vni": str(vni)}
+    if mac_address:
+        value["mac_address"] = mac_address
+
+    gnmic_set_with_bypass(
+        gnmi_tls,
+        f"CONFIG_DB/localhost/VNET_ROUTE_TUNNEL/{vnet}\|{prefix.replace('/', '~1')}",
+        value,
+        name=f"update_{vnet}_{prefix.replace('/', '_')}"
+    )
+
     time.sleep(3)
 
 
@@ -100,7 +102,7 @@ def get_available_vlan_id_and_ports(cfg_facts, num_ports_needed):
 
 # ---------- Single-VNET setup ----------
 def vxlan_setup_one_vnet(duthost, ptfhost, tbinfo, cfg_facts,
-                         config_facts, dut_indx, vxlan_port):
+                         config_facts, dut_indx, vxlan_port, gnmi_tls):
     ports = get_available_vlan_id_and_ports(config_facts, 1)
     pytest_assert(ports and len(ports) >= 1, "Not enough ports for VNET setup")
 
@@ -120,16 +122,17 @@ def vxlan_setup_one_vnet(duthost, ptfhost, tbinfo, cfg_facts,
 
     dut_vtep = get_loopback_ip(cfg_facts)
     logger.info(f"Creating VXLAN tunnel {TUNNEL_NAME} with source {dut_vtep}")
-    apply_chunk(duthost, {"VXLAN_TUNNEL": {TUNNEL_NAME: {"src_ip": dut_vtep}}}, "vxlan_tunnel")
-    apply_chunk(duthost, {"VNET": {VNET_NAME: {"vni": str(VNI), "vxlan_tunnel": TUNNEL_NAME}}}, "vnet")
+    gnmic_set_with_bypass(gnmi_tls, "CONFIG_DB/localhost/VXLAN_TUNNEL", {TUNNEL_NAME: {"src_ip": dut_vtep}}, "vxlan_tunnel")
+    gnmic_set_with_bypass(gnmi_tls, "CONFIG_DB/localhost/VNET", {VNET_NAME: {"vni": str(VNI), "vxlan_tunnel": TUNNEL_NAME}}, "vnet")
 
     ptf_port_index = port_indexes[ingress_if]
     port_name = ptf_ports_available_in_topo[ptf_port_index]
 
     dut_ip = "201.0.1.1"
-    apply_chunk(
-        duthost,
-        {"INTERFACE": {ingress_if: {"vnet_name": VNET_NAME}, f"{ingress_if}|{dut_ip}/24": {}}},
+    gnmic_set_with_bypass(
+        gnmi_tls,
+        "CONFIG_DB/localhost/INTERFACE",
+        {ingress_if: {"vnet_name": VNET_NAME}, f"{ingress_if}|{dut_ip}/24": {}},
         "intf_bind",
     )
 
@@ -140,9 +143,10 @@ def vxlan_setup_one_vnet(duthost, ptfhost, tbinfo, cfg_facts,
     ptfhost.shell(f"ip link set {port_name} up")
 
     logger.info(f"Programming route {PREFIX} -> {','.join(INITIAL_ENDPOINTS)}")
-    apply_chunk(
-        duthost,
-        {"VNET_ROUTE_TUNNEL": {f"{VNET_NAME}|{PREFIX}": {"endpoint": ",".join(INITIAL_ENDPOINTS)}}},
+    gnmic_set_with_bypass(
+        gnmi_tls,
+        "CONFIG_DB/localhost/VNET_ROUTE_TUNNEL",
+        {f"{VNET_NAME}|{PREFIX}": {"endpoint": ",".join(INITIAL_ENDPOINTS)}},
         "route_tunnel",
     )
     time.sleep(5)
@@ -167,7 +171,8 @@ def one_vnet_setup_teardown(
     tbinfo,
     localhost,
     request,
-    scaled_vnet_params
+    scaled_vnet_params,
+    gnmi_tls
 ):
     """
     Module-level setup:
@@ -184,7 +189,7 @@ def one_vnet_setup_teardown(
 
         num_endpoints = scaled_vnet_params.get("num_endpoints", 511) or 511
         setup_params = vxlan_setup_one_vnet(duthost, ptfhost, tbinfo, cfg_facts,
-                                            config_facts, dut_indx, vxlan_port)
+                                            config_facts, dut_indx, vxlan_port, gnmi_tls)
         setup_params["num_endpoints"] = int(num_endpoints)
     except Exception as e:
         logger.error("Exception raised in setup: {}".format(repr(e)))
@@ -246,10 +251,10 @@ def test_ecmp_two_endpoints(ptfhost, one_vnet_setup_teardown):
     )
 
 
-def test_ecmp_change_endpoints(ptfhost, one_vnet_setup_teardown):
+def test_ecmp_change_endpoints(ptfhost, one_vnet_setup_teardown, gnmi_tls):
     logger.info("Running test_ecmp_change_endpoints")
     setup, duthost, _ = one_vnet_setup_teardown
-    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, CHANGED_ENDPOINTS, VNI)
+    _update_vxlan_endpoints(gnmi_tls, VNET_NAME, PREFIX, CHANGED_ENDPOINTS, VNI)
     run_vxlan_ptf_test(
         ptfhost,
         CHANGED_ENDPOINTS,
@@ -258,14 +263,14 @@ def test_ecmp_change_endpoints(ptfhost, one_vnet_setup_teardown):
     )
 
 
-def test_ecmp_scale(ptfhost, one_vnet_setup_teardown):
+def test_ecmp_scale(ptfhost, one_vnet_setup_teardown, gnmi_tls):
     logger.info("Running test_ecmp_scale")
     setup, duthost, _ = one_vnet_setup_teardown
     num_endpoints = setup["num_endpoints"]
 
     base_ip = int(IPv4Address("100.0.10.1"))
     endpoints = [str(IPv4Address(base_ip + i)) for i in range(num_endpoints)]
-    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, endpoints, VNI)
+    _update_vxlan_endpoints(gnmi_tls, VNET_NAME, PREFIX, endpoints, VNI)
     time.sleep(20)
 
     num_packets = num_endpoints * PACKET_MULTIPLIER
@@ -277,7 +282,7 @@ def test_ecmp_scale(ptfhost, one_vnet_setup_teardown):
     )
 
 
-def test_ecmp_mac_vni(ptfhost, one_vnet_setup_teardown):
+def test_ecmp_mac_vni(ptfhost, one_vnet_setup_teardown, gnmi_tls):
     """
     Validate that endpoint[i] → mac_address[i] mapping is honored
     for a single prefix with multiple endpoints.
@@ -303,7 +308,7 @@ def test_ecmp_mac_vni(ptfhost, one_vnet_setup_teardown):
 
     # --- Program into VNET_ROUTE_TUNNEL table ---
     _update_vxlan_endpoints(
-        duthost,
+        gnmi_tls,
         VNET_NAME,
         PREFIX,
         endpoints,
@@ -332,12 +337,12 @@ def test_ecmp_mac_vni(ptfhost, one_vnet_setup_teardown):
     logger.info("MAC+VNI multi-endpoint scale test completed successfully")
 
 
-def test_ecmp_same_endpoint_diff_mac_vni(ptfhost, one_vnet_setup_teardown):
+def test_ecmp_same_endpoint_diff_mac_vni(ptfhost, one_vnet_setup_teardown, gnmi_tls):
     """
     Validate single prefix ecmp route with same endpoints but different mac and vni
     """
 
-    setup, duthost, _ = one_vnet_setup_teardown
+    setup, _, _ = one_vnet_setup_teardown
     num_endpoints = setup["num_endpoints"]
 
     logger.info(f"Running SAME ENDPOINTS DIFF MAC+VNI scale test with {num_endpoints} endpoints")
@@ -358,7 +363,7 @@ def test_ecmp_same_endpoint_diff_mac_vni(ptfhost, one_vnet_setup_teardown):
 
     # --- Program into VNET_ROUTE_TUNNEL table ---
     _update_vxlan_endpoints(
-        duthost,
+        gnmi_tls,
         VNET_NAME,
         PREFIX,
         endpoints,
@@ -387,15 +392,15 @@ def test_ecmp_same_endpoint_diff_mac_vni(ptfhost, one_vnet_setup_teardown):
     logger.info("MAC+VNI multi-endpoint scale test completed successfully")
 
 
-def test_ecmp_scale_add_endpoint(ptfhost, one_vnet_setup_teardown):
-    setup, duthost, _ = one_vnet_setup_teardown
+def test_ecmp_scale_add_endpoint(ptfhost, one_vnet_setup_teardown, gnmi_tls):
+    setup, _, _ = one_vnet_setup_teardown
     num = setup["num_endpoints"]
 
     base_ip = int(IPv4Address("100.0.10.1"))
 
     # Step 1 — Program initial endpoints
     initial_endpoints = [str(IPv4Address(base_ip + i)) for i in range(num)]
-    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, initial_endpoints, VNI)
+    _update_vxlan_endpoints(gnmi_tls, VNET_NAME, PREFIX, initial_endpoints, VNI)
     time.sleep(5)
 
     # Step 2 — Modify: add one endpoint
@@ -403,7 +408,7 @@ def test_ecmp_scale_add_endpoint(ptfhost, one_vnet_setup_teardown):
     logger.info(f"Adding new endpoint: {new_endpoint}")
     modified_endpoints = initial_endpoints + [new_endpoint]
 
-    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, modified_endpoints, VNI)
+    _update_vxlan_endpoints(gnmi_tls, VNET_NAME, PREFIX, modified_endpoints, VNI)
     time.sleep(5)
     logger.info(f"Updated endpoint list programmed, total now = {len(modified_endpoints)}")
 
@@ -417,15 +422,15 @@ def test_ecmp_scale_add_endpoint(ptfhost, one_vnet_setup_teardown):
     )
 
 
-def test_ecmp_scale_delete_endpoint(ptfhost, one_vnet_setup_teardown):
-    setup, duthost, _ = one_vnet_setup_teardown
+def test_ecmp_scale_delete_endpoint(ptfhost, one_vnet_setup_teardown, gnmi_tls):
+    setup, _, _ = one_vnet_setup_teardown
     num = setup["num_endpoints"]
 
     base_ip = int(IPv4Address("100.0.10.1"))
 
     # Step 1 — Initial endpoints
     endpoints = [str(IPv4Address(base_ip + i)) for i in range(num)]
-    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, endpoints, VNI)
+    _update_vxlan_endpoints(gnmi_tls, VNET_NAME, PREFIX, endpoints, VNI)
     time.sleep(5)
 
     # Step 2 — Random endpoint delete
@@ -434,7 +439,7 @@ def test_ecmp_scale_delete_endpoint(ptfhost, one_vnet_setup_teardown):
     logger.info(f"Deleting endpoint at index {del_idx}: {deleted_ep}")
     modified_endpoints = endpoints[:del_idx] + endpoints[del_idx + 1:]
 
-    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, modified_endpoints, VNI)
+    _update_vxlan_endpoints(gnmi_tls, VNET_NAME, PREFIX, modified_endpoints, VNI)
     time.sleep(10)
     logger.info(f"Updated endpoint list programmed, remaining endpoints = {len(modified_endpoints)}")
 
@@ -453,15 +458,15 @@ def test_ecmp_scale_delete_endpoint(ptfhost, one_vnet_setup_teardown):
     )
 
 
-def test_ecmp_scale_modify_endpoint(ptfhost, one_vnet_setup_teardown):
-    setup, duthost, _ = one_vnet_setup_teardown
+def test_ecmp_scale_modify_endpoint(ptfhost, one_vnet_setup_teardown, gnmi_tls):
+    setup, _, _ = one_vnet_setup_teardown
     num = setup["num_endpoints"]
 
     base_ip = int(IPv4Address("100.0.10.1"))
 
     # Step 1 — Initial endpoints
     endpoints = [str(IPv4Address(base_ip + i)) for i in range(num)]
-    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, endpoints, VNI)
+    _update_vxlan_endpoints(gnmi_tls, VNET_NAME, PREFIX, endpoints, VNI)
     time.sleep(5)
 
     # Step 2 — Random index choose to remove
@@ -473,7 +478,7 @@ def test_ecmp_scale_modify_endpoint(ptfhost, one_vnet_setup_teardown):
     logger.info(f"Replacing endpoint at index {mod_idx}: {removed_ep} → {new_ep}")
     modified_endpoints = endpoints[:mod_idx] + [new_ep] + endpoints[mod_idx + 1:]
 
-    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, modified_endpoints, VNI)
+    _update_vxlan_endpoints(gnmi_tls, VNET_NAME, PREFIX, modified_endpoints, VNI)
     time.sleep(5)
     logger.info(f"Modified endpoint list programmed, total endpoints = {len(modified_endpoints)}")
     ptf_params = {
@@ -491,15 +496,15 @@ def test_ecmp_scale_modify_endpoint(ptfhost, one_vnet_setup_teardown):
     )
 
 
-def test_ecmp_scale_modify_mac(ptfhost, one_vnet_setup_teardown):
-    setup, duthost, _ = one_vnet_setup_teardown
+def test_ecmp_scale_modify_mac(ptfhost, one_vnet_setup_teardown, gnmi_tls):
+    setup, _, _ = one_vnet_setup_teardown
     num = setup["num_endpoints"]
 
     base_ip = int(IPv4Address("100.0.10.1"))
 
     # Step 1 — Initial endpoints
     endpoints = [str(IPv4Address(base_ip + i)) for i in range(num)]
-    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, endpoints, VNI)
+    _update_vxlan_endpoints(gnmi_tls, VNET_NAME, PREFIX, endpoints, VNI)
     time.sleep(5)
 
     # Step 2 — Initial MAC list
@@ -507,7 +512,7 @@ def test_ecmp_scale_modify_mac(ptfhost, one_vnet_setup_teardown):
     mac_string = ",".join(mac_list)
 
     # Push initial MAC list
-    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, endpoints, VNI, mac_address=mac_string)
+    _update_vxlan_endpoints(gnmi_tls, VNET_NAME, PREFIX, endpoints, VNI, mac_address=mac_string)
     time.sleep(5)
 
     # Step 3 — Random index to modify
@@ -520,7 +525,7 @@ def test_ecmp_scale_modify_mac(ptfhost, one_vnet_setup_teardown):
     mac_string2 = ",".join(mac_list)
 
     # Push modified MAC list
-    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, endpoints, VNI, mac_address=mac_string2)
+    _update_vxlan_endpoints(gnmi_tls, VNET_NAME, PREFIX, endpoints, VNI, mac_address=mac_string2)
     time.sleep(10)
 
     ptf_params = {

--- a/tests/vxlan/test_scale_ecmp.py
+++ b/tests/vxlan/test_scale_ecmp.py
@@ -142,7 +142,7 @@ def vxlan_setup_one_vnet(duthost, ptfhost, tbinfo, cfg_facts,
     logger.info(f"Programming route {PREFIX} -> {','.join(INITIAL_ENDPOINTS)}")
     apply_chunk(
         duthost,
-        {"VNET_ROUTE_TUNNEL": {f"{VNET_NAME}|{PREFIX}": {"endpoint": ",".join(INITIAL_ENDPOINTS), "vni": str(VNI)}}},
+        {"VNET_ROUTE_TUNNEL": {f"{VNET_NAME}|{PREFIX}": {"endpoint": ",".join(INITIAL_ENDPOINTS)}}},
         "route_tunnel",
     )
     time.sleep(5)
@@ -199,7 +199,7 @@ def one_vnet_setup_teardown(
 
 
 # ---------- PTF runner helper ----------
-def run_vxlan_ptf_test(ptfhost, endpoints, params, num_packets, mac_list=None):
+def run_vxlan_ptf_test(ptfhost, endpoints, params, num_packets, mac_list=None, vni_list=None):
     logger.info(f"Calling VXLAN ECMP PTF test: {len(endpoints)} endpoints, {num_packets} packets")
 
     endpoints_file = "/tmp/ptf_endpoints.json"
@@ -214,6 +214,12 @@ def run_vxlan_ptf_test(ptfhost, endpoints, params, num_packets, mac_list=None):
         ptfhost.copy(content=json.dumps(mac_list), dest=macs_file)
         ptf_params.update({
             "macs_file": macs_file,
+        })
+    if vni_list:
+        vni_file = "/tmp/ptf_vni.json"
+        ptfhost.copy(content=json.dumps(vni_list), dest=vni_file)
+        ptf_params.update({
+            "vni_file": vni_file,
         })
     params_path = "/tmp/ptf_params.json"
     ptfhost.copy(content=json.dumps(ptf_params), dest=params_path)
@@ -271,7 +277,7 @@ def test_ecmp_scale(ptfhost, one_vnet_setup_teardown):
     )
 
 
-def test_vxlan_mac_vni(ptfhost, one_vnet_setup_teardown):
+def test_ecmp_mac_vni(ptfhost, one_vnet_setup_teardown):
     """
     Validate that endpoint[i] → mac_address[i] mapping is honored
     for a single prefix with multiple endpoints.
@@ -310,7 +316,6 @@ def test_vxlan_mac_vni(ptfhost, one_vnet_setup_teardown):
     ptf_params = setup.copy()
     ptf_params.update({
         "mac_vni_verify": "yes",
-        "vni": updated_vni,
     })
 
     logger.info("Calling PTF for MAC+VNI multi-endpoint validation...")
@@ -320,7 +325,63 @@ def test_vxlan_mac_vni(ptfhost, one_vnet_setup_teardown):
         endpoints,
         ptf_params,
         num_packets=num_packets,
-        mac_list=mac_list
+        mac_list=mac_list,
+        vni_list=[updated_vni]
+    )
+
+    logger.info("MAC+VNI multi-endpoint scale test completed successfully")
+
+
+def test_ecmp_same_endpoint_diff_mac_vni(ptfhost, one_vnet_setup_teardown):
+    """
+    Validate single prefix ecmp route with same endpoints but different mac and vni
+    """
+
+    setup, duthost, _ = one_vnet_setup_teardown
+    num_endpoints = setup["num_endpoints"]
+
+    logger.info(f"Running SAME ENDPOINTS DIFF MAC+VNI scale test with {num_endpoints} endpoints")
+
+    # --- Build endpoints list ---
+    base_ip = int(IPv4Address("100.0.50.1"))
+    endpoints = [str(IPv4Address(base_ip)) for _ in range(num_endpoints)]
+
+    # --- Build deterministic MAC list ---
+    # 52:54:00:00:xx:yy (unique per endpoint)
+    mac_list = [f"52:54:00:{i//256:02x}:{i%256:02x}:aa" for i in range(num_endpoints)]
+    mac_list_str = ",".join(mac_list)
+    vni_list = [5000 + i for i in range(num_endpoints)]
+    vni_list_str = ",".join(str(vni) for vni in vni_list)
+
+    logger.info(f"Generated {len(endpoints)} endpoints + {len(mac_list)} MACs")
+    logger.info(f"MAC list: {mac_list_str}")
+
+    # --- Program into VNET_ROUTE_TUNNEL table ---
+    _update_vxlan_endpoints(
+        duthost,
+        VNET_NAME,
+        PREFIX,
+        endpoints,
+        vni_list_str,
+        mac_address=mac_list_str
+    )
+
+    # --- Prepare PTF params ---
+    num_packets = num_endpoints * PACKET_MULTIPLIER
+    ptf_params = setup.copy()
+    ptf_params.update({
+        "mac_vni_verify": "yes",
+    })
+
+    logger.info("Calling PTF for MAC+VNI multi-endpoint validation...")
+
+    run_vxlan_ptf_test(
+        ptfhost,
+        endpoints,
+        ptf_params,
+        num_packets=num_packets,
+        mac_list=mac_list,
+        vni_list=vni_list
     )
 
     logger.info("MAC+VNI multi-endpoint scale test completed successfully")
@@ -467,7 +528,6 @@ def test_ecmp_scale_modify_mac(ptfhost, one_vnet_setup_teardown):
         "mac_vni_verify": "yes",
         "modified_mac_index": mod_idx,
         "modified_mac_value": new_mac,
-        "vni": VNI,
     }
 
     num_packets = num * PACKET_MULTIPLIER
@@ -477,5 +537,6 @@ def test_ecmp_scale_modify_mac(ptfhost, one_vnet_setup_teardown):
         endpoints,
         ptf_params,
         num_packets=num_packets,
-        mac_list=mac_list
+        mac_list=mac_list,
+        vni_list=[VNI]
     )

--- a/tests/vxlan/test_scale_ecmp.py
+++ b/tests/vxlan/test_scale_ecmp.py
@@ -11,7 +11,7 @@ from tests.ptf_runner import ptf_runner
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa:F401
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
 from tests.common.helpers.assertions import pytest_assert, pytest_require
-from tests.common.fixtures.grpc_fixtures import gnmi_tls
+from tests.common.fixtures.grpc_fixtures import gnmi_tls    # noqa: F401
 
 logger = logging.getLogger(__name__)
 ecmp_utils = Ecmp_Utils()
@@ -40,11 +40,11 @@ def get_loopback_ip(cfg_facts):
     pytest.fail("Cannot find IPv4 Loopback0 address in LOOPBACK_INTERFACE")
 
 
-def gnmic_set_with_bypass(gnmi_tls, path, payload, name):
+def gnmic_set_with_bypass(gnmi_tls, path, payload, name):   # noqa: F811
     gnmi_tls.gnmic.set(path, payload, metadata="x-sonic-ss-bypass-validation=true", filename=name)
 
 
-def _update_vxlan_endpoints(gnmi_tls, vnet, prefix, endpoints, vni, mac_address=None):
+def _update_vxlan_endpoints(gnmi_tls, vnet, prefix, endpoints, vni, mac_address=None):    # noqa: F811
     ep_str = ",".join(endpoints)
     logger.info(
         f"Updating VNET_ROUTE_TUNNEL {vnet}|{prefix} "
@@ -57,7 +57,7 @@ def _update_vxlan_endpoints(gnmi_tls, vnet, prefix, endpoints, vni, mac_address=
 
     gnmic_set_with_bypass(
         gnmi_tls,
-        f"CONFIG_DB/localhost/VNET_ROUTE_TUNNEL/{vnet}\|{prefix.replace('/', '~1')}",
+        f"CONFIG_DB/localhost/VNET_ROUTE_TUNNEL/{vnet}|{prefix.replace('/', '~1')}",
         value,
         name=f"update_{vnet}_{prefix.replace('/', '_')}"
     )
@@ -102,7 +102,7 @@ def get_available_vlan_id_and_ports(cfg_facts, num_ports_needed):
 
 # ---------- Single-VNET setup ----------
 def vxlan_setup_one_vnet(duthost, ptfhost, tbinfo, cfg_facts,
-                         config_facts, dut_indx, vxlan_port, gnmi_tls):
+                         config_facts, dut_indx, vxlan_port, gnmi_tls):     # noqa: F811
     ports = get_available_vlan_id_and_ports(config_facts, 1)
     pytest_assert(ports and len(ports) >= 1, "Not enough ports for VNET setup")
 
@@ -122,8 +122,10 @@ def vxlan_setup_one_vnet(duthost, ptfhost, tbinfo, cfg_facts,
 
     dut_vtep = get_loopback_ip(cfg_facts)
     logger.info(f"Creating VXLAN tunnel {TUNNEL_NAME} with source {dut_vtep}")
-    gnmic_set_with_bypass(gnmi_tls, "CONFIG_DB/localhost/VXLAN_TUNNEL", {TUNNEL_NAME: {"src_ip": dut_vtep}}, "vxlan_tunnel")
-    gnmic_set_with_bypass(gnmi_tls, "CONFIG_DB/localhost/VNET", {VNET_NAME: {"vni": str(VNI), "vxlan_tunnel": TUNNEL_NAME}}, "vnet")
+    gnmic_set_with_bypass(gnmi_tls, "CONFIG_DB/localhost/VXLAN_TUNNEL",
+                          {TUNNEL_NAME: {"src_ip": dut_vtep}}, "vxlan_tunnel")
+    gnmic_set_with_bypass(gnmi_tls, "CONFIG_DB/localhost/VNET",
+                          {VNET_NAME: {"vni": str(VNI), "vxlan_tunnel": TUNNEL_NAME}}, "vnet")
 
     ptf_port_index = port_indexes[ingress_if]
     port_name = ptf_ports_available_in_topo[ptf_port_index]
@@ -172,7 +174,7 @@ def one_vnet_setup_teardown(
     localhost,
     request,
     scaled_vnet_params,
-    gnmi_tls
+    gnmi_tls     # noqa: F811
 ):
     """
     Module-level setup:
@@ -251,7 +253,7 @@ def test_ecmp_two_endpoints(ptfhost, one_vnet_setup_teardown):
     )
 
 
-def test_ecmp_change_endpoints(ptfhost, one_vnet_setup_teardown, gnmi_tls):
+def test_ecmp_change_endpoints(ptfhost, one_vnet_setup_teardown, gnmi_tls):      # noqa: F811
     logger.info("Running test_ecmp_change_endpoints")
     setup, duthost, _ = one_vnet_setup_teardown
     _update_vxlan_endpoints(gnmi_tls, VNET_NAME, PREFIX, CHANGED_ENDPOINTS, VNI)
@@ -263,7 +265,7 @@ def test_ecmp_change_endpoints(ptfhost, one_vnet_setup_teardown, gnmi_tls):
     )
 
 
-def test_ecmp_scale(ptfhost, one_vnet_setup_teardown, gnmi_tls):
+def test_ecmp_scale(ptfhost, one_vnet_setup_teardown, gnmi_tls):      # noqa: F811
     logger.info("Running test_ecmp_scale")
     setup, duthost, _ = one_vnet_setup_teardown
     num_endpoints = setup["num_endpoints"]
@@ -282,7 +284,7 @@ def test_ecmp_scale(ptfhost, one_vnet_setup_teardown, gnmi_tls):
     )
 
 
-def test_ecmp_mac_vni(ptfhost, one_vnet_setup_teardown, gnmi_tls):
+def test_ecmp_mac_vni(ptfhost, one_vnet_setup_teardown, gnmi_tls):     # noqa: F811
     """
     Validate that endpoint[i] → mac_address[i] mapping is honored
     for a single prefix with multiple endpoints.
@@ -337,7 +339,7 @@ def test_ecmp_mac_vni(ptfhost, one_vnet_setup_teardown, gnmi_tls):
     logger.info("MAC+VNI multi-endpoint scale test completed successfully")
 
 
-def test_ecmp_same_endpoint_diff_mac_vni(ptfhost, one_vnet_setup_teardown, gnmi_tls):
+def test_ecmp_same_endpoint_diff_mac_vni(ptfhost, one_vnet_setup_teardown, gnmi_tls):     # noqa: F811
     """
     Validate single prefix ecmp route with same endpoints but different mac and vni
     """
@@ -392,7 +394,7 @@ def test_ecmp_same_endpoint_diff_mac_vni(ptfhost, one_vnet_setup_teardown, gnmi_
     logger.info("MAC+VNI multi-endpoint scale test completed successfully")
 
 
-def test_ecmp_scale_add_endpoint(ptfhost, one_vnet_setup_teardown, gnmi_tls):
+def test_ecmp_scale_add_endpoint(ptfhost, one_vnet_setup_teardown, gnmi_tls):     # noqa: F811
     setup, _, _ = one_vnet_setup_teardown
     num = setup["num_endpoints"]
 
@@ -422,7 +424,7 @@ def test_ecmp_scale_add_endpoint(ptfhost, one_vnet_setup_teardown, gnmi_tls):
     )
 
 
-def test_ecmp_scale_delete_endpoint(ptfhost, one_vnet_setup_teardown, gnmi_tls):
+def test_ecmp_scale_delete_endpoint(ptfhost, one_vnet_setup_teardown, gnmi_tls):      # noqa: F811
     setup, _, _ = one_vnet_setup_teardown
     num = setup["num_endpoints"]
 
@@ -458,7 +460,7 @@ def test_ecmp_scale_delete_endpoint(ptfhost, one_vnet_setup_teardown, gnmi_tls):
     )
 
 
-def test_ecmp_scale_modify_endpoint(ptfhost, one_vnet_setup_teardown, gnmi_tls):
+def test_ecmp_scale_modify_endpoint(ptfhost, one_vnet_setup_teardown, gnmi_tls):     # noqa: F811
     setup, _, _ = one_vnet_setup_teardown
     num = setup["num_endpoints"]
 
@@ -496,7 +498,7 @@ def test_ecmp_scale_modify_endpoint(ptfhost, one_vnet_setup_teardown, gnmi_tls):
     )
 
 
-def test_ecmp_scale_modify_mac(ptfhost, one_vnet_setup_teardown, gnmi_tls):
+def test_ecmp_scale_modify_mac(ptfhost, one_vnet_setup_teardown, gnmi_tls):     # noqa: F811
     setup, _, _ = one_vnet_setup_teardown
     num = setup["num_endpoints"]
 

--- a/tests/vxlan/test_scale_ecmp.py
+++ b/tests/vxlan/test_scale_ecmp.py
@@ -336,6 +336,38 @@ def test_ecmp_mac_vni(ptfhost, one_vnet_setup_teardown, gnmi_tls):     # noqa: F
         vni_list=[updated_vni]
     )
 
+    logger.info("Modifying MAC+VNI mapping for all endpoints in MAC+VNI multi-endpoint scale test")
+
+    # --- Build deterministic MAC list ---
+    # 52:54:00:00:xx:yy (unique per endpoint)
+    mac_list = [f"52:54:00:{i//256:02x}:{i%256:02x}:bb" for i in range(num_endpoints)]
+    mac_list_str = ",".join(mac_list)
+    updated_vni = 6001
+
+    logger.info(f"Generated {len(endpoints)} endpoints + {len(mac_list)} MACs")
+    logger.info(f"MAC list: {mac_list_str}")
+
+    # --- Program into VNET_ROUTE_TUNNEL table ---
+    _update_vxlan_endpoints(
+        gnmi_tls,
+        VNET_NAME,
+        PREFIX,
+        endpoints,
+        updated_vni,
+        mac_address=mac_list_str
+    )
+
+    logger.info("Calling PTF for MAC+VNI multi-endpoint validation after MAC+VNI modification...")
+
+    run_vxlan_ptf_test(
+        ptfhost,
+        endpoints,
+        ptf_params,
+        num_packets=num_packets,
+        mac_list=mac_list,
+        vni_list=[updated_vni]
+    )
+
     logger.info("MAC+VNI multi-endpoint scale test completed successfully")
 
 
@@ -380,7 +412,40 @@ def test_ecmp_same_endpoint_diff_mac_vni(ptfhost, one_vnet_setup_teardown, gnmi_
         "mac_vni_verify": "yes",
     })
 
-    logger.info("Calling PTF for MAC+VNI multi-endpoint validation...")
+    logger.info("Calling PTF for MAC+VNI same endpoint validation...")
+
+    run_vxlan_ptf_test(
+        ptfhost,
+        endpoints,
+        ptf_params,
+        num_packets=num_packets,
+        mac_list=mac_list,
+        vni_list=vni_list
+    )
+
+    logger.info("Modifying MAC+VNI mapping for all endpoints in SAME ENDPOINTS DIFF MAC+VNI scale test")
+
+    # --- Build deterministic MAC list ---
+    # 52:54:00:00:xx:yy (unique per endpoint)
+    mac_list = [f"52:54:00:{i//256:02x}:{i%256:02x}:bb" for i in range(num_endpoints)]
+    mac_list_str = ",".join(mac_list)
+    vni_list = [6000 + i for i in range(num_endpoints)]
+    vni_list_str = ",".join(str(vni) for vni in vni_list)
+
+    logger.info(f"Generated {len(endpoints)} endpoints + {len(mac_list)} MACs")
+    logger.info(f"MAC list: {mac_list_str}")
+
+    # --- Program into VNET_ROUTE_TUNNEL table ---
+    _update_vxlan_endpoints(
+        gnmi_tls,
+        VNET_NAME,
+        PREFIX,
+        endpoints,
+        vni_list_str,
+        mac_address=mac_list_str
+    )
+
+    logger.info("Calling PTF for MAC+VNI same endpoint validation...")
 
     run_vxlan_ptf_test(
         ptfhost,

--- a/tests/vxlan/test_vxlan_tunnel_route_scale.py
+++ b/tests/vxlan/test_vxlan_tunnel_route_scale.py
@@ -1,10 +1,12 @@
 import json
 import random
+import re
 import sys
 import time
 import logging
 import pytest
 import traceback
+from datetime import datetime
 from tests.common.config_reload import config_reload
 from tests.common.utilities import wait_until
 from ipaddress import IPv4Address
@@ -88,6 +90,130 @@ def all_vnet_routes_in_state_db(duthost, num_vnets, routes_per_vnet):
 
     except Exception as e:
         logger.warning(f"Error checking STATE_DB route readiness: {e}")
+        return False
+
+
+def verify_vnet_routes_in_asic_db(duthost, num_vnets, routes_per_vnet, vnet_base,
+                                  mac_fn=None, vni_fn=None, endpoint_offset=0, base_mac="52:54:aa", vni_offset=0):
+    """
+    Verify that all VNET routes are programmed in ASIC DB with the expected
+    endpoint IP, MAC address, and VNI on each next hop.
+
+    Args:
+        duthost: DUT host handle
+        num_vnets: number of VNETs configured
+        routes_per_vnet: number of /32 routes per VNET
+        vnet_base: base VNI (VNET VNI = vnet_base + vnet_id)
+        mac_fn: optional callable(vnet_id, route_index) -> expected MAC string.
+                If None, MAC check is skipped.
+        vni_fn: optional callable(vnet_id, route_index) -> expected VNI int.
+                If None, the VNET-level VNI (vnet_base + vnet_id) is expected.
+        endpoint_offset: passed to generate_routes_and_endpoint to
+                         reproduce the expected endpoint list.
+        base_mac: base MAC address for generating expected MACs.
+        vni_offset: offset to add to the VNET-level VNI for each route.
+
+    Returns:
+        True if every route matches; False otherwise (details logged).
+    """
+    logger.warning(f"Verifying VNET routes in ASIC DB at time {datetime.now()}.")
+    try:
+        # Dump route entries and next hops separately using key filters
+        route_text = duthost.shell(
+            "redis-dump -d 1 -k 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY*'"
+        )["stdout"]
+        nh_text = duthost.shell(
+            "redis-dump -d 1 -k 'ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP:*'"
+        )["stdout"]
+
+        route_db = json.loads(route_text) if route_text.strip() else {}
+        nh_db = json.loads(nh_text) if nh_text.strip() else {}
+
+        # Build route map: dest prefix -> NH OID
+        route_nh_map = {}
+        for key, entry in route_db.items():
+            m = re.search(r'"dest"\s*:\s*"([^"]+)"', key)
+            if m:
+                value = entry.get("value", {})
+                route_nh_map[m.group(1)] = value.get("SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "")
+
+        # Build NH cache: OID -> {endpoint, vni, mac}
+        nh_cache = {}
+        for key, entry in nh_db.items():
+            value = entry.get("value", {})
+            if value.get("SAI_NEXT_HOP_ATTR_TYPE") != "SAI_NEXT_HOP_TYPE_TUNNEL_ENCAP":
+                continue
+            oid = key.split("SAI_OBJECT_TYPE_NEXT_HOP:")[-1]
+            nh_cache[oid] = {
+                "endpoint": value.get("SAI_NEXT_HOP_ATTR_IP", ""),
+                "vni": value.get("SAI_NEXT_HOP_ATTR_TUNNEL_VNI", ""),
+                "mac": value.get("SAI_NEXT_HOP_ATTR_TUNNEL_MAC", ""),
+            }
+
+        # Verify each expected route
+        missing = 0
+        mismatched = 0
+        total = num_vnets * routes_per_vnet
+
+        for idx in range(num_vnets):
+            vnet_id = idx + 1
+            vnet_name = f"Vnet{vnet_id}"
+            default_vni = vnet_base + vnet_id
+            routes, endpoints = generate_routes_and_endpoint(
+                vnet_id, routes_per_vnet, endpoint_offset
+            )
+
+            for i in range(routes_per_vnet):
+                dest = routes[i]
+                expected_ep = endpoints[i]
+                expected_mac = mac_fn(vnet_id, i, base_mac) if mac_fn else None
+                expected_vni = vni_fn(vnet_id, i, offset=vni_offset) if vni_fn else default_vni
+
+                if dest not in route_nh_map:
+                    missing += 1
+                    continue
+
+                nh_oid = route_nh_map[dest]
+                if nh_oid not in nh_cache:
+                    missing += 1
+                    continue
+
+                nh = nh_cache[nh_oid]
+
+                if nh["endpoint"] != expected_ep:
+                    mismatched += 1
+                    if mismatched <= 5:
+                        logger.info(
+                            f"{vnet_name}|{dest}: endpoint expected={expected_ep}, "
+                            f"actual={nh['endpoint']}"
+                        )
+
+                elif expected_vni is not None and str(nh["vni"]) != str(expected_vni):
+                    mismatched += 1
+                    if mismatched <= 5:
+                        logger.info(
+                            f"{vnet_name}|{dest}: VNI expected={expected_vni}, "
+                            f"actual={nh['vni']}"
+                        )
+
+                elif expected_mac is not None and nh["mac"].lower() != expected_mac.lower():
+                    mismatched += 1
+                    if mismatched <= 5:
+                        logger.info(
+                            f"{vnet_name}|{dest}: MAC expected={expected_mac}, "
+                            f"actual={nh['mac']}"
+                        )
+
+        ok = missing == 0 and mismatched == 0
+        logger.warning(
+            f"ASIC DB verification: {total - missing - mismatched}/{total} correct, "
+            f"{missing} missing, {mismatched} mismatched"
+        )
+        return ok
+
+    except Exception as e:
+        logger.warning(f"Error verifying ASIC DB routes: {e}")
+        logger.warning(traceback.format_exc())
         return False
 
 
@@ -305,7 +431,7 @@ def vxlan_setup_config(config_facts, cfg_facts, duthost, dut_indx, ptfhost,
 
     logger.info("Waiting for all VNET routes to appear in STATE_DB (max 120s)")
     ready_state = wait_until(
-        120, 10, 0,
+        1000, 10, 0,
         all_vnet_routes_in_state_db,
         duthost,
         num_vnets,
@@ -459,6 +585,7 @@ def test_vxlan_scale_mac_vni(vxlan_scale_setup_teardown, ptfhost):
 
     vnet_base = setup["vnet_base"]
     routes_per_vnet = setup["routes_per_vnet"]
+    num_vnets = setup["num_vnets"]
 
     logger.info("Updating ALL VNET routes with deterministic MAC + VNI (cfggen batch mode)...")
 
@@ -512,7 +639,22 @@ def test_vxlan_scale_mac_vni(vxlan_scale_setup_teardown, ptfhost):
             vnis=all_vnis_for_vnet
         )
 
-    time.sleep(20)
+    ready_state = wait_until(
+        1000, 60, 0,
+        verify_vnet_routes_in_asic_db,
+        duthost,
+        num_vnets,
+        routes_per_vnet,
+        vnet_base,
+        gen_mac,
+        gen_vni,
+        0
+    )
+    if not ready_state:
+        logger.warning("Timeout waiting for all VNET routes in ASIC_DB")
+        pytest.fail("ASIC_DB programming incomplete after 1000 sec")
+    else:
+        logger.info("All VNET routes detected in ASIC_DB")
 
     logger.info("All route MAC+VNI updates applied via batch cfggen.")
 
@@ -573,7 +715,24 @@ def test_vxlan_scale_mac_vni(vxlan_scale_setup_teardown, ptfhost):
             vnis=all_vnis_for_vnet
         )
 
-    time.sleep(20)
+    ready_state = wait_until(
+        1000, 60, 0,
+        verify_vnet_routes_in_asic_db,
+        duthost,
+        num_vnets,
+        routes_per_vnet,
+        vnet_base,
+        gen_mac,
+        gen_vni,
+        1,
+        "52:54:bb",
+        1
+    )
+    if not ready_state:
+        logger.warning("Timeout waiting for all VNET routes rewrite in ASIC_DB")
+        pytest.fail("ASIC_DB rewrite programming incomplete after 1000 sec")
+    else:
+        logger.info("All rewritten VNET routes detected in ASIC_DB")
 
     logger.info("All route MAC+VNI updates applied via batch cfggen.")
 

--- a/tests/vxlan/test_vxlan_vnet_bgp_subintf.py
+++ b/tests/vxlan/test_vxlan_vnet_bgp_subintf.py
@@ -327,13 +327,14 @@ def generate_vnet_routes(vnet_vnis, start_prefix_int, start_endpoint_int, start_
     routes = {vni: [] for vni in vnet_vnis}
     for i, vni in enumerate(vnet_vnis):
         for j in range(1, num_routes_per_vnet + 1):
-            prefix_int = start_prefix_int + (i << 8) + j + offset
+            prefix_int = start_prefix_int + (i << 8) + j
             endpoint_int = start_endpoint_int + (i << 8) + j + offset
             route = {
                 "prefix": convert_ip_int_to_str(prefix_int, 32),
                 "endpoint": convert_ip_int_to_str(endpoint_int).split('/')[0],
                 "vni": start_vni + (i * num_routes_per_vnet) + j,
-                "mac_address": f"52:54:00:{(i << 8 + j + offset)//256:02x}:{(i << 8 + j + offset)%256:02x}:aa"
+                "mac_address": f"52:54:00:{(i << 8 + j + offset)//256:02x}:{(i << 8 + j + offset)%256:02x}:aa",
+                "vnet_vni": vni
             }
             routes[vni].append(route)
 
@@ -342,7 +343,8 @@ def generate_vnet_routes(vnet_vnis, start_prefix_int, start_endpoint_int, start_
                 "prefix": "0.0.0.0/0",
                 "endpoint": convert_ip_int_to_str(start_endpoint_int).split('/')[0],
                 "vni": start_vni,
-                "mac_address": f"52:54:00:00:00:00"
+                "mac_address": f"52:54:00:00:00:00",
+                "vnet_vni": vni
             }
             routes[vni].append(route)
 
@@ -427,11 +429,12 @@ def setup_vnet_routes(vnet_vnis, vni_to_routes, gnmi_tls):
     # Check vnet routes are set
     time.sleep(5)
     for vni in vnet_vnis:
-        route_key = f"STATE_DB/localhost/VNET_ROUTE_TUNNEL_TABLE"
-        route_status = gnmi_tls.gnmic.get(route_key)[0].get("updates")[0].get("values", {}).get(route_key, {})\
-            .get(f"Vnet{vni}|0.0.0.0/0", {}).get("state", "")
-        pytest_assert(route_status.lower() == "active",
-                      f"VNET route tunnel for Vnet{vni} not active.")
+        for route in vni_to_routes[vni]:
+            route_key = f"STATE_DB/localhost/VNET_ROUTE_TUNNEL_TABLE"
+            route_status = gnmi_tls.gnmic.get(route_key)[0].get("updates")[0].get("values", {}).get(route_key, {})\
+                .get(f"Vnet{vni}|{route['prefix']}", {}).get("state", "")
+            pytest_assert(route_status.lower() == "active",
+                        f"VNET route tunnel for Vnet{vni}|{route['prefix']} not active.")
 
 
 def setup_bgp(duthost, ptfhost, vnet_vnis, dut_ips, ptf_ips, subnet_ip, loopback_ip, bgp_port, vnet_route_ip, gnmi_tls):
@@ -519,8 +522,8 @@ def setup_portchannel_subintfs(duthost, ptfhost, portchannel_info, vnet_vnis, ba
                 has_subintfs = True
             else:
                 gnmic_set_with_bypass(
-                    gnmi_tls, 
-                    f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}", 
+                    gnmi_tls,
+                    f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}",
                     {
                         "admin_status": "up",
                         "vlan": str(base_vlan + i),
@@ -528,9 +531,9 @@ def setup_portchannel_subintfs(duthost, ptfhost, portchannel_info, vnet_vnis, ba
                     },
                     subintf_name)
                 gnmic_set_with_bypass(
-                    gnmi_tls, 
-                    f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}\|{dut_ips[j][i].replace('/','~1')}", 
-                    {}, 
+                    gnmi_tls,
+                    f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}\|{dut_ips[j][i].replace('/','~1')}",
+                    {},
                     f"{subintf_name}_ip")
 
             # Configure ptf port commands
@@ -616,8 +619,8 @@ def setup_portchannels(duthost, ptfhost, config_facts, port_indexes, ptf_ports_a
         portchannel_key = f"STATE_DB/localhost/LAG_TABLE/{portchannel_name}"
         portchannel_status = gnmi_tls.gnmic.get(portchannel_key)[0].get("updates")[0].get("values", {})\
             .get(portchannel_key, {})
-        
-        pytest_assert(portchannel_status.get("admin_status", "").lower() == "up" 
+
+        pytest_assert(portchannel_status.get("admin_status", "").lower() == "up"
                       and portchannel_status.get("oper_status", "").lower() == "up",
                       f"Portchannel {portchannel_name} not up in state db.")
 
@@ -789,20 +792,80 @@ def common_setup_and_teardown(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, 
             "vlan": val["vlan"],
             "vni": val["vnet_vni"],
             "outgoing_port": val["ptf_port_index"],
-            "expected_ports": t1_ptf_port_nums
+            "expected_ports": t1_ptf_port_nums,
+            "route": route
         } for _, val in subintfs_info.items() for route in vnet_routes[val["vnet_vni"]]
     ]
-    yield duthost, ptfadapter, encap_test_configs, decap_test_configs
+    yield duthost, ptfadapter, gnmi_tls, encap_test_configs, decap_test_configs
 
     # Cleanup
     cleanup(duthost, ptfhost, localhost, wl_portchannel_info, subintfs_info)
 
 
+def modify_routes_mac_vni(gnmi_tls, encap_test_configs, offset=0):
+    modified_routes = set()
+    acl_rule_value = {}
+
+    for config in encap_test_configs:
+        route = config["route"]
+
+        if route["prefix"] not in modified_routes:
+            route["vni"] += offset
+            route["mac_address"] = route["mac_address"][:-2] + \
+                "{:02x}".format((int(route["mac_address"][-2:], 16) + offset) % 256)
+            route["endpoint"] = convert_ip_int_to_str(
+                convert_str_to_ip_int(route["endpoint"])[0] + offset
+            ).split('/')[0]
+
+            gnmic_set_with_bypass(
+                gnmi_tls,
+                f"{GNMI_PATH_PREFIX}/VNET_ROUTE_TUNNEL/Vnet{route['vnet_vni']}\|{route['prefix'].replace('/','~1')}",
+                {
+                    "endpoint": route["endpoint"],
+                    "vni": route["vni"],
+                    "mac_address": route["mac_address"]
+                },
+                f"vnet_route_{route['vnet_vni']}_{route['prefix'].replace('/','_')}"
+            )
+            acl_rule_value[f"{ACL_TABLE_NAME}|rule_{route['vni']}"] = {
+                "INNER_SRC_IP": f"{INNER_SRC_IP}/32",
+                "INNER_SRC_MAC_REWRITE_ACTION": INNER_SRC_MAC,
+                "TUNNEL_VNI": f"{route['vni']}",
+                "PRIORITY": f"{route['vni']}"
+            }
+
+            modified_routes.add(route["prefix"])
+
+        config["expected_vni"] = route["vni"]
+        config["expected_dst_mac"] = route["mac_address"]
+        config["expected_dst_ip"] = route["endpoint"]
+
+    # Update src mac rewrite acl to match new vnis
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/ACL_RULE", acl_rule_value, "acl_rule")
+
+    # Check vnet routes are updated
+    time.sleep(5)
+    for config in encap_test_configs:
+        route_key = f"STATE_DB/localhost/VNET_ROUTE_TUNNEL_TABLE"
+        route_status = gnmi_tls.gnmic.get(route_key)[0].get("updates")[0].get("values", {}).get(route_key, {})\
+            .get(f"Vnet{config['route']['vnet_vni']}|{config['route']['prefix']}", {}).get("state", "")
+        pytest_assert(route_status.lower() == "active",
+                      f"VNET route tunnel for Vnet{config['route']['vnet_vni']}|\
+                        {config['route']['prefix']} not active.")
+
+
 def test_vnet_with_bgp_intf_smacrewrite(common_setup_and_teardown):
-    duthost, ptfadapter, encap_test_configs, decap_test_configs = common_setup_and_teardown
+    duthost, ptfadapter, gnmi_tls, encap_test_configs, decap_test_configs = common_setup_and_teardown
 
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     logger.debug("post-setup config_facts: {}".format(config_facts))
+
+    validate_decap_t1_to_wl(duthost, ptfadapter, decap_test_configs)
+
+    validate_encap_wl_to_t1(duthost, ptfadapter, encap_test_configs)
+
+    # Test datapath after modifying route mac and vni
+    modify_routes_mac_vni(gnmi_tls, encap_test_configs, offset=1)
 
     validate_decap_t1_to_wl(duthost, ptfadapter, decap_test_configs)
 

--- a/tests/vxlan/test_vxlan_vnet_bgp_subintf.py
+++ b/tests/vxlan/test_vxlan_vnet_bgp_subintf.py
@@ -42,20 +42,20 @@ GNMI_PATH_PREFIX = "CONFIG_DB/localhost"
 temp_files = []
 
 
-def validate_encap_wl_to_t1(duthost, ptfadapter, wl_portchannel_info, subintfs_info, test_configs):
+def validate_encap_wl_to_t1(duthost, ptfadapter, test_configs):
     logger.info("Starting WL to T1 VXLAN encapsulation test...")
 
-    for _, val in subintfs_info.items():
+    for configs in test_configs:
         # Build inner TCP packet to inject from southbound side
         pkt_opts = {
             "eth_dst": duthost.facts['router_mac'],
-            "eth_src": ptfadapter.dataplane.get_mac(0, val["ptf_port_index"]),
-            "ip_dst": "150.0.0.10",
+            "eth_src": ptfadapter.dataplane.get_mac(0, configs["outgoing_port"]),
+            "ip_dst": configs["inner_dst_ip"],
             "ip_src": INNER_SRC_IP,
             "ip_id": 105,
             "ip_ttl": 64,
             "dl_vlan_enable": True,
-            "vlan_vid": val["vlan"],
+            "vlan_vid": configs["vlan"],
             "tcp_sport": 1234,
             "tcp_dport": 5000,
             "pktlen": 100
@@ -64,9 +64,8 @@ def validate_encap_wl_to_t1(duthost, ptfadapter, wl_portchannel_info, subintfs_i
         inner_pkt = testutils.simple_tcp_packet(**pkt_opts)
 
         # Build expected packet
-        vxlan_router_mac = duthost.shell("sonic-db-cli APPL_DB HGET 'SWITCH_TABLE:switch' 'vxlan_router_mac'")
         pkt_opts["eth_src"] = INNER_SRC_MAC  # expected rewritten inner src mac
-        pkt_opts["eth_dst"] = vxlan_router_mac['stdout'].strip()
+        pkt_opts["eth_dst"] = configs["expected_dst_mac"]
         pkt_opts["ip_ttl"] = 63
         pkt_opts["dl_vlan_enable"] = False
         pkt_opts["pktlen"] = 96  # 100 - 4, remove vlan tag length
@@ -76,14 +75,14 @@ def validate_encap_wl_to_t1(duthost, ptfadapter, wl_portchannel_info, subintfs_i
         expected_pkt = testutils.simple_vxlan_packet(
             eth_dst="aa:bb:cc:dd:ee:ff",
             eth_src=duthost.facts['router_mac'],
-            ip_src=test_configs["loopback_ip"],
-            ip_dst=TUNNEL_ENDPOINT,
+            ip_src=configs["expected_src_ip"],
+            ip_dst=configs["expected_dst_ip"],
             ip_id=0,
             ip_flags=0x2,
             udp_sport=1234,
             udp_dport=VXLAN_PORT,
             with_udp_chksum=False,
-            vxlan_vni=int(val["vnet_vni"]),
+            vxlan_vni=int(configs["expected_vni"]),
             inner_frame=inner_exp_pkt
         )
 
@@ -102,30 +101,23 @@ def validate_encap_wl_to_t1(duthost, ptfadapter, wl_portchannel_info, subintfs_i
         ptfadapter.dataplane.flush()
 
         # Send TCP packet from WL port
-        testutils.send(ptfadapter, val['ptf_port_index'], inner_pkt)
+        testutils.send(ptfadapter, configs["outgoing_port"], inner_pkt)
 
         # Verify VXLAN encapsulated pkt on T1 port with rewritten inner src MAC
-        testutils.verify_packet_any_port(ptfadapter, masked_expected_pkt, test_configs["t1_ptf_port_nums"], timeout=2)
+        testutils.verify_packet_any_port(ptfadapter, masked_expected_pkt, configs["expected_ports"], timeout=2)
 
     logger.info("WL to T1 VXLAN encapsulation test passed.")
 
 
-def validate_decap_t1_to_wl(duthost, ptfadapter, wl_portchannel_info, subintfs_info, test_configs):
+def validate_decap_t1_to_wl(duthost, ptfadapter, test_configs):
     logger.info("Starting T1 to WL VXLAN decapsulation test...")
 
-    ports_per_vnet = {}
-    for _, val in subintfs_info.items():
-        vni = val["vnet_vni"]
-        if vni not in ports_per_vnet:
-            ports_per_vnet[vni] = []
-        ports_per_vnet[vni].append(val["ptf_port_index"])
-
-    for _, val in subintfs_info.items():
+    for configs in test_configs:
         pkt_opts = {
             "eth_dst": "aa:bb:cc:dd:ee:ff",
             "eth_src": duthost.facts['router_mac'],
             "ip_src": "8.8.8.8",
-            "ip_dst": "10.11.255.255",
+            "ip_dst": configs["inner_dst_ip"],
             "tcp_sport": 1234,
             "tcp_dport": 4321,
             "pktlen": 100
@@ -137,18 +129,18 @@ def validate_decap_t1_to_wl(duthost, ptfadapter, wl_portchannel_info, subintfs_i
         # Build VXLAN encapsulated packet to inject from T1 side
         vxlan_pkt = testutils.simple_vxlan_packet(
             eth_dst=duthost.facts['router_mac'],
-            eth_src=ptfadapter.dataplane.get_mac(0, test_configs["t1_ptf_port_nums"][0]),
+            eth_src=ptfadapter.dataplane.get_mac(0, configs["outgoing_port"]),
             ip_src="1.1.1.1",
-            ip_dst=test_configs["loopback_ip"],
+            ip_dst=configs["expected_dst_ip"],
             udp_sport=1234,
             udp_dport=VXLAN_PORT,
             with_udp_chksum=False,
-            vxlan_vni=int(val["vnet_vni"]),
+            vxlan_vni=int(configs["vni"]),
             inner_frame=inner_pkt
         )
 
         # Build expected inner packet after decapsulation
-        pkt_opts["vlan_vid"] = val["vlan"]
+        pkt_opts["vlan_vid"] = configs["vlan"]
         pkt_opts["dl_vlan_enable"] = True
         pkt_opts["pktlen"] = 104     # 100 + 4, add vlan tag length
         expected_inner_pkt = testutils.simple_tcp_packet(**pkt_opts)
@@ -167,10 +159,10 @@ def validate_decap_t1_to_wl(duthost, ptfadapter, wl_portchannel_info, subintfs_i
         ptfadapter.dataplane.flush()
 
         # Send VXLAN encapsulated pkt from T1 port
-        testutils.send(ptfadapter, test_configs["t1_ptf_port_nums"][0], vxlan_pkt)
+        testutils.send(ptfadapter, configs["outgoing_port"], vxlan_pkt)
 
         # Verify decapsulated unencapsulated packet on southbound port
-        testutils.verify_packet_any_port(ptfadapter, masked_expected_pkt, ports_per_vnet[val["vnet_vni"]], timeout=2)
+        testutils.verify_packet_any_port(ptfadapter, masked_expected_pkt, configs["expected_ports"], timeout=2)
 
     logger.info("T1 to WL VXLAN decapsulation test passed.")
 
@@ -327,6 +319,36 @@ def generate_subintfs_ips(num_vnets, num_portchannels, start_ip_int, prefix_size
     return all_subintf_ips, all_ptf_ips
 
 
+def generate_vnet_routes(vnet_vnis, start_prefix_int, start_endpoint_int, start_vni,
+                         num_routes_per_vnet, include_default_route=True, offset=0):
+    """
+    Generate vnet routes with prefix, endpoint, mac, and vni.
+    """
+    routes = {vni: [] for vni in vnet_vnis}
+    for i, vni in enumerate(vnet_vnis):
+        for j in range(1, num_routes_per_vnet + 1):
+            prefix_int = start_prefix_int + (i << 8) + j + offset
+            endpoint_int = start_endpoint_int + (i << 8) + j + offset
+            route = {
+                "prefix": convert_ip_int_to_str(prefix_int, 32),
+                "endpoint": convert_ip_int_to_str(endpoint_int).split('/')[0],
+                "vni": start_vni + (i * num_routes_per_vnet) + j,
+                "mac_address": f"52:54:00:{(i << 8 + j + offset)//256:02x}:{(i << 8 + j + offset)%256:02x}:aa"
+            }
+            routes[vni].append(route)
+
+        if include_default_route:
+            route = {
+                "prefix": "0.0.0.0/0",
+                "endpoint": convert_ip_int_to_str(start_endpoint_int).split('/')[0],
+                "vni": start_vni,
+                "mac_address": f"52:54:00:00:00:00"
+            }
+            routes[vni].append(route)
+
+    return routes
+
+
 def gnmic_set_with_bypass(gnmi_tls, path, value, filename="test_config"):
     """
     Send GNMI set request with bypass.
@@ -334,7 +356,7 @@ def gnmic_set_with_bypass(gnmi_tls, path, value, filename="test_config"):
     gnmi_tls.gnmic.set(path, value, metadata="x-sonic-ss-bypass-validation=true", filename=filename)
 
 
-def setup_acl_config(duthost, ports, vnet_vnis, gnmi_tls):
+def setup_acl_config(duthost, ports, vnet_vnis, vnet_routes, gnmi_tls):
     """
     Add a custom ACL table type definition to CONFIG_DB.
     """
@@ -365,12 +387,12 @@ def setup_acl_config(duthost, ports, vnet_vnis, gnmi_tls):
     }, "acl_table")
 
     gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/ACL_RULE", {
-        f"{ACL_TABLE_NAME}|rule_{vni}": {
+        f"{ACL_TABLE_NAME}|rule_{route['vni']}": {
             "INNER_SRC_IP": f"{INNER_SRC_IP}/32",
             "INNER_SRC_MAC_REWRITE_ACTION": INNER_SRC_MAC,
-            "TUNNEL_VNI": f"{vni}",
-            "PRIORITY": f"{vni}"
-        } for vni in vnet_vnis
+            "TUNNEL_VNI": f"{route['vni']}",
+            "PRIORITY": f"{route['vni']}"
+        } for vni in vnet_vnis for route in vnet_routes[vni]
     }, "acl_rule")
 
     # Check acl table and rules are set
@@ -383,20 +405,23 @@ def setup_acl_config(duthost, ports, vnet_vnis, gnmi_tls):
         rule_key = f"STATE_DB/localhost/ACL_RULE_TABLE"
         acl_rules = gnmi_tls.gnmic.get(rule_key)[0].get("updates")[0].get("values", {}).get(rule_key, {})
         for vni in vnet_vnis:
-            acl_rule_status = acl_rules.get(f"{ACL_TABLE_NAME}|rule_{vni}", {}).get("status", "")
-            if acl_rule_status.lower() != "active":
-                return False
+            for route in vnet_routes[vni]:
+                acl_rule_status = acl_rules.get(f"{ACL_TABLE_NAME}|rule_{route['vni']}", {}).get("status", "")
+                if acl_rule_status.lower() != "active":
+                    return False
         return True
 
     pytest_assert(wait_until(60, 2, 0, _acl_table_and_rule_active, duthost),
                   f"ACL table {ACL_TABLE_NAME} or its rules not active after 60 seconds.")
 
 
-def setup_vnet_routes(duthost, vnet_vnis, gnmi_tls):
+def setup_vnet_routes(vnet_vnis, vni_to_routes, gnmi_tls):
     gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/VNET_ROUTE_TUNNEL", {
-        f"Vnet{vni}|0.0.0.0/0": {
-            "endpoint": TUNNEL_ENDPOINT
-        } for vni in vnet_vnis
+        f"Vnet{vni}|{route['prefix']}": {
+            "endpoint": route["endpoint"],
+            "vni": route["vni"],
+            "mac_address": route["mac_address"]
+        } for vni in vnet_vnis for route in vni_to_routes[vni]
     }, "vnet_routes")
 
     # Check vnet routes are set
@@ -701,11 +726,14 @@ def common_setup_and_teardown(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, 
             gnmi_tls=gnmi_tls)
 
         # Set up vnet routes
-        setup_vnet_routes(duthost, vnet_vnis, gnmi_tls)
+        vnet_routes = generate_vnet_routes(vnet_vnis, start_prefix_int=convert_str_to_ip_int("30.0.0.0")[0],
+                                           start_endpoint_int=convert_str_to_ip_int(TUNNEL_ENDPOINT)[0],
+                                           start_vni=10000, num_routes_per_vnet=5)
+        setup_vnet_routes(vnet_vnis, vnet_routes, gnmi_tls)
 
         # Setup acl configs
         config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
-        setup_acl_config(duthost, list(config_facts.get("PORTCHANNEL", {}).keys()), vnet_vnis, gnmi_tls)
+        setup_acl_config(duthost, list(config_facts.get("PORTCHANNEL", {}).keys()), vnet_vnis, vnet_routes, gnmi_tls)
 
         # Configure vxlan port
         ecmp_utils.configure_vxlan_switch(duthost, VXLAN_PORT, "00:12:34:56:78:9a")
@@ -734,22 +762,51 @@ def common_setup_and_teardown(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, 
         cleanup(duthost, ptfhost, localhost, wl_portchannel_info, subintfs_info)
         pytest.fail(f"Setup failed: {repr(e)}")
 
-    test_configs = {"vnet_vnis": vnet_vnis, "t1_ptf_port_nums": t1_ptf_port_nums, "loopback_ip": loopback_ip}
-    yield duthost, ptfadapter, wl_portchannel_info, subintfs_info, test_configs
+    ports_per_vnet = {}
+    for _, val in subintfs_info.items():
+        vni = val["vnet_vni"]
+        if vni not in ports_per_vnet:
+            ports_per_vnet[vni] = []
+        ports_per_vnet[vni].append(val["ptf_port_index"])
+
+    decap_test_configs = [
+        {
+            "inner_dst_ip": "10.11.255.255",
+            "expected_dst_ip": loopback_ip,
+            "vni": val["vnet_vni"],
+            "vlan": val["vlan"],
+            "outgoing_port": t1_ptf_port_nums[0],
+            "expected_ports": ports_per_vnet[val["vnet_vni"]]
+        } for _, val in subintfs_info.items()
+    ]
+    encap_test_configs = [
+        {
+            "inner_dst_ip": route["prefix"].split('/')[0] if route["prefix"] != "0.0.0.0/0" else "150.0.0.10",
+            "expected_dst_mac": route["mac_address"],
+            "expected_vni": route["vni"],
+            "expected_dst_ip": route["endpoint"],
+            "expected_src_ip": loopback_ip,
+            "vlan": val["vlan"],
+            "vni": val["vnet_vni"],
+            "outgoing_port": val["ptf_port_index"],
+            "expected_ports": t1_ptf_port_nums
+        } for _, val in subintfs_info.items() for route in vnet_routes[val["vnet_vni"]]
+    ]
+    yield duthost, ptfadapter, encap_test_configs, decap_test_configs
 
     # Cleanup
     cleanup(duthost, ptfhost, localhost, wl_portchannel_info, subintfs_info)
 
 
 def test_vnet_with_bgp_intf_smacrewrite(common_setup_and_teardown):
-    duthost, ptfadapter, wl_portchannel_info, subintfs_info, test_configs = common_setup_and_teardown
+    duthost, ptfadapter, encap_test_configs, decap_test_configs = common_setup_and_teardown
 
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     logger.debug("post-setup config_facts: {}".format(config_facts))
 
-    validate_decap_t1_to_wl(duthost, ptfadapter, wl_portchannel_info, subintfs_info, test_configs)
+    validate_decap_t1_to_wl(duthost, ptfadapter, decap_test_configs)
 
-    validate_encap_wl_to_t1(duthost, ptfadapter, wl_portchannel_info, subintfs_info, test_configs)
+    validate_encap_wl_to_t1(duthost, ptfadapter, encap_test_configs)
 
     # Test datapath again after config reload
     duthost.shell("config save -y")
@@ -759,6 +816,6 @@ def test_vnet_with_bgp_intf_smacrewrite(common_setup_and_teardown):
     # Configure vxlan port
     ecmp_utils.configure_vxlan_switch(duthost, VXLAN_PORT, "00:12:34:56:78:9a")
 
-    validate_decap_t1_to_wl(duthost, ptfadapter, wl_portchannel_info, subintfs_info, test_configs)
+    validate_decap_t1_to_wl(duthost, ptfadapter, decap_test_configs)
 
-    validate_encap_wl_to_t1(duthost, ptfadapter, wl_portchannel_info, subintfs_info, test_configs)
+    validate_encap_wl_to_t1(duthost, ptfadapter, encap_test_configs)

--- a/tests/vxlan/test_vxlan_vnet_bgp_subintf.py
+++ b/tests/vxlan/test_vxlan_vnet_bgp_subintf.py
@@ -6,14 +6,11 @@ from ptf.packet import Ether, IP, UDP, TCP
 import ptf.testutils as testutils
 import pytest
 import time
-from tests.common.gnmi_setup import apply_cert_config, recover_cert_config
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.config_reload import config_reload
 from tests.common.utilities import wait_until
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
-from tests.common.helpers.dut_utils import check_container_state
-from tests.common.helpers.gnmi_utils import GNMIEnvironment, gnmi_container, create_gnmi_certs, \
-    delete_gnmi_certs
+from tests.common.fixtures.grpc_fixtures import gnmi_tls
 
 ecmp_utils = Ecmp_Utils()
 
@@ -40,7 +37,7 @@ NUM_VNETS = 2
 ACL_TYPE_NAME = "INNER_SRC_MAC_REWRITE_TYPE"
 ACL_TABLE_NAME = "INNER_SRC_MAC_REWRITE_TABLE"
 
-GNMI_PATH_PREFIX = "/CONFIG_DB/localhost"
+GNMI_PATH_PREFIX = "CONFIG_DB/localhost"
 
 temp_files = []
 
@@ -192,9 +189,6 @@ def cleanup(duthost, ptfhost, localhost, wl_portchannel_info, subintfs_info):
     duthost.shell(f"mv {CONFIG_DB_PATH}.bak {CONFIG_DB_PATH}")
     config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
 
-    # clean up gnmi server
-    recover_cert_config(duthost)
-
     cmds = []
     # Remove sub port
     try:
@@ -244,9 +238,6 @@ fi
     for file in temp_files:
         if os.path.exists(file):
             os.remove(file)
-
-    # cleanup gnmi cert files
-    delete_gnmi_certs(localhost)
 
 
 def get_available_vlan_id_and_ports(cfg_facts, num_ports_needed):
@@ -336,33 +327,18 @@ def generate_subintfs_ips(num_vnets, num_portchannels, start_ip_int, prefix_size
     return all_subintf_ips, all_ptf_ips
 
 
-def gnmi_set_update_config_db_json(duthost, ptfhost, path, value, filename="test_config"):
+def gnmic_set_with_bypass(gnmi_tls, path, value, filename="test_config"):
     """
-    Send GNMI set request with GNMI client. This helper will only send add/update requests with a json value format.
+    Send GNMI set request with bypass.
     """
-    filename += ".txt"
-    with open(filename, 'w') as file:
-        file.write(json.dumps(value))
-    ptfhost.copy(src=filename, dest='/tmp')
-
-    env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
-    ip = duthost.mgmt_ip
-    port = env.gnmi_port
-
-    cmd = f"/root/env-python3/bin/python /root/gnxi/gnmi_cli_py/py_gnmicli.py \
-        --timeout 10 -t {ip} -p {port} -xo sonic-db -rcert /root/gnmiCA.pem \
-        -pkey /root/gnmiclient.key -cchain /root/gnmiclient.crt -m set-update \
-        --xpath \"{path}\" --value \"@/tmp/{filename}\""
-    ptfhost.shell(cmd)
-
-    temp_files.append(filename)
+    gnmi_tls.gnmic.set(path, value, metadata="x-sonic-ss-bypass-validation=true", filename=filename)
 
 
-def setup_acl_config(duthost, ptfhost, ports, vnet_vnis):
+def setup_acl_config(duthost, ports, vnet_vnis, gnmi_tls):
     """
     Add a custom ACL table type definition to CONFIG_DB.
     """
-    gnmi_set_update_config_db_json(duthost, ptfhost, f"{GNMI_PATH_PREFIX}/ACL_TABLE_TYPE", {
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/ACL_TABLE_TYPE", {
         ACL_TYPE_NAME: {
             "BIND_POINTS": [
                 "PORT",
@@ -379,7 +355,7 @@ def setup_acl_config(duthost, ptfhost, ports, vnet_vnis):
         }
     }, "acl_type")
 
-    gnmi_set_update_config_db_json(duthost, ptfhost, f"{GNMI_PATH_PREFIX}/ACL_TABLE", {
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/ACL_TABLE", {
         ACL_TABLE_NAME: {
             "policy_desc": ACL_TABLE_NAME,
             "ports": ports,
@@ -388,7 +364,7 @@ def setup_acl_config(duthost, ptfhost, ports, vnet_vnis):
         }
     }, "acl_table")
 
-    gnmi_set_update_config_db_json(duthost, ptfhost, f"{GNMI_PATH_PREFIX}/ACL_RULE", {
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/ACL_RULE", {
         f"{ACL_TABLE_NAME}|rule_{vni}": {
             "INNER_SRC_IP": f"{INNER_SRC_IP}/32",
             "INNER_SRC_MAC_REWRITE_ACTION": INNER_SRC_MAC,
@@ -399,17 +375,16 @@ def setup_acl_config(duthost, ptfhost, ports, vnet_vnis):
 
     # Check acl table and rules are set
     def _acl_table_and_rule_active(duthost):
-        acl_table = duthost.shell(
-            f"sonic-db-cli STATE_DB HGET 'ACL_TABLE_TABLE|{ACL_TABLE_NAME}' 'status'",
-            module_ignore_errors=True)
-        if acl_table.get('stdout', '').strip().lower() != "active":
+        table_key = f"STATE_DB/localhost/ACL_TABLE_TABLE/{ACL_TABLE_NAME}/status"
+        acl_table_status = gnmi_tls.gnmic.get(table_key)[0].get("updates")[0].get("values", {}).get(table_key, {})
+        if acl_table_status.lower() != "active":
             return False
 
+        rule_key = f"STATE_DB/localhost/ACL_RULE_TABLE"
+        acl_rules = gnmi_tls.gnmic.get(rule_key)[0].get("updates")[0].get("values", {}).get(rule_key, {})
         for vni in vnet_vnis:
-            acl_rule = duthost.shell(
-                f"sonic-db-cli STATE_DB HGET 'ACL_RULE_TABLE|{ACL_TABLE_NAME}|rule_{vni}' 'status'",
-                module_ignore_errors=True)
-            if acl_rule.get('stdout', '').strip().lower() != "active":
+            acl_rule_status = acl_rules.get(f"{ACL_TABLE_NAME}|rule_{vni}", {}).get("status", "")
+            if acl_rule_status.lower() != "active":
                 return False
         return True
 
@@ -417,8 +392,8 @@ def setup_acl_config(duthost, ptfhost, ports, vnet_vnis):
                   f"ACL table {ACL_TABLE_NAME} or its rules not active after 60 seconds.")
 
 
-def setup_vnet_routes(duthost, ptfhost, vnet_vnis):
-    gnmi_set_update_config_db_json(duthost, ptfhost, f"{GNMI_PATH_PREFIX}/VNET_ROUTE_TUNNEL", {
+def setup_vnet_routes(duthost, vnet_vnis, gnmi_tls):
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/VNET_ROUTE_TUNNEL", {
         f"Vnet{vni}|0.0.0.0/0": {
             "endpoint": TUNNEL_ENDPOINT
         } for vni in vnet_vnis
@@ -427,23 +402,22 @@ def setup_vnet_routes(duthost, ptfhost, vnet_vnis):
     # Check vnet routes are set
     time.sleep(5)
     for vni in vnet_vnis:
-        route_tunnel = duthost.shell(f"sonic-db-cli STATE_DB HGET \
-                                     'VNET_ROUTE_TUNNEL_TABLE|Vnet{vni}|0.0.0.0/0' 'state'")
-        pytest_assert(route_tunnel['stdout'].strip().lower() == "active",
+        route_key = f"STATE_DB/localhost/VNET_ROUTE_TUNNEL_TABLE"
+        route_status = gnmi_tls.gnmic.get(route_key)[0].get("updates")[0].get("values", {}).get(route_key, {})\
+            .get(f"Vnet{vni}|0.0.0.0/0", {}).get("state", "")
+        pytest_assert(route_status.lower() == "active",
                       f"VNET route tunnel for Vnet{vni} not active.")
 
 
-def setup_bgp(duthost, ptfhost, vnet_vnis, dut_ips, ptf_ips, subnet_ip, loopback_ip, bgp_port, vnet_route_ip):
+def setup_bgp(duthost, ptfhost, vnet_vnis, dut_ips, ptf_ips, subnet_ip, loopback_ip, bgp_port, vnet_route_ip, gnmi_tls):
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     dut_asn = config_facts['DEVICE_METADATA']['localhost']['bgp_asn']
     neighbors = config_facts['BGP_NEIGHBOR']
     peer_asn = list(neighbors.values())[0]["asn"]
 
     for vni in vnet_vnis:
-        gnmi_set_update_config_db_json(
-            duthost,
-            ptfhost,
-            f"{GNMI_PATH_PREFIX}/BGP_PEER_RANGE/Vnet{vni}|WLPARTNER_PASSIVE_V4",
+        gnmic_set_with_bypass(gnmi_tls,
+            f"{GNMI_PATH_PREFIX}/BGP_PEER_RANGE/Vnet{vni}\|WLPARTNER_PASSIVE_V4",
             {
                 "ip_range": [subnet_ip],
                 "name": "WLPARTNER_PASSIVE_V4",
@@ -495,7 +469,7 @@ neighbor {dut_ip.split('/')[0]} {{
                           and int(val["state/pfxrcd"]) > 0, f"BGP neighbor not found for vnet Vnet{vni}.")
 
 
-def setup_portchannel_subintfs(duthost, ptfhost, portchannel_info, vnet_vnis, base_vlan, dut_ips, ptf_ips):
+def setup_portchannel_subintfs(duthost, ptfhost, portchannel_info, vnet_vnis, base_vlan, dut_ips, ptf_ips, gnmi_tls):
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     has_subintfs = len(config_facts.get("VLAN_SUB_INTERFACE", {})) > 0
 
@@ -509,7 +483,7 @@ def setup_portchannel_subintfs(duthost, ptfhost, portchannel_info, vnet_vnis, ba
             subintf_name = f"Po{po_num}.{base_vlan + i}"
 
             if not has_subintfs:
-                gnmi_set_update_config_db_json(duthost, ptfhost, f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE", {
+                gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE", {
                     subintf_name: {
                         "admin_status": "up",
                         "vlan": str(base_vlan + i),
@@ -519,21 +493,19 @@ def setup_portchannel_subintfs(duthost, ptfhost, portchannel_info, vnet_vnis, ba
                 }, subintf_name)
                 has_subintfs = True
             else:
-                gnmi_set_update_config_db_json(
-                    duthost,
-                    ptfhost,
-                    f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}",
+                gnmic_set_with_bypass(
+                    gnmi_tls, 
+                    f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}", 
                     {
                         "admin_status": "up",
                         "vlan": str(base_vlan + i),
                         "vnet_name": f"Vnet{vnet_vnis[i]}"
                     },
                     subintf_name)
-                gnmi_set_update_config_db_json(
-                    duthost,
-                    ptfhost,
-                    f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}|{dut_ips[j][i].replace('/','~1')}",
-                    {},
+                gnmic_set_with_bypass(
+                    gnmi_tls, 
+                    f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}\|{dut_ips[j][i].replace('/','~1')}", 
+                    {}, 
                     f"{subintf_name}_ip")
 
             # Configure ptf port commands
@@ -557,10 +529,21 @@ def setup_portchannel_subintfs(duthost, ptfhost, portchannel_info, vnet_vnis, ba
     ptfhost.shell("supervisorctl restart ptf_nn_agent")
     time.sleep(5)
 
+    # Check subinterfaces are up in state db
+    interfaces_key = f"STATE_DB/localhost/INTERFACE_TABLE"
+    interfaces = gnmi_tls.gnmic.get(interfaces_key)[0].get("updates")[0].get("values", {}).get(interfaces_key, {})
+    for subintf, values in subintfs_info.items():
+        subintf_vnet = interfaces.get(subintf, {}).get("vrf", "")
+        subintf_status = interfaces.get(f"{subintf}|{values['dut_ip']}", {}).get("state", "")
+
+        pytest_assert(subintf_vnet.lower() == values["vnet"].lower(), f"Subinterface {subintf} not in correct vnet. \
+                      Expected {values['vnet']}, got {subintf_vnet}.")
+        pytest_assert(subintf_status.lower() == "ok", f"Subinterface {subintf} not in ok state.")
+
     return subintfs_info
 
 
-def setup_portchannels(duthost, ptfhost, config_facts, port_indexes, ptf_ports_available_in_topo):
+def setup_portchannels(duthost, ptfhost, config_facts, port_indexes, ptf_ports_available_in_topo, gnmi_tls):
     vlan_id, ports = get_available_vlan_id_and_ports(config_facts, len(PORTCHANNEL_NAMES))
     pytest_assert(len(ports) == len(PORTCHANNEL_NAMES),
                   f"Found {len(ports)} available ports. Needed {len(PORTCHANNEL_NAMES)} ports for the test.")
@@ -570,13 +553,12 @@ def setup_portchannels(duthost, ptfhost, config_facts, port_indexes, ptf_ports_a
     for i in range(len(PORTCHANNEL_NAMES)):
         duthost.shell(f'config vlan member del {vlan_id} {ports[i]}')
 
-        gnmi_set_update_config_db_json(duthost, ptfhost, f"{GNMI_PATH_PREFIX}/PORTCHANNEL/{PORTCHANNEL_NAMES[i]}", {
+        gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/PORTCHANNEL/{PORTCHANNEL_NAMES[i]}", {
             "admin_status": "up"
         }, PORTCHANNEL_NAMES[i])
-        gnmi_set_update_config_db_json(
-            duthost,
-            ptfhost,
-            f"{GNMI_PATH_PREFIX}/PORTCHANNEL_MEMBER/{PORTCHANNEL_NAMES[i]}|{ports[i]}",
+        gnmic_set_with_bypass(
+            gnmi_tls,
+            f"{GNMI_PATH_PREFIX}/PORTCHANNEL_MEMBER/{PORTCHANNEL_NAMES[i]}\|{ports[i]}",
             {},
             f"{PORTCHANNEL_NAMES[i]}_member")
 
@@ -604,43 +586,48 @@ def setup_portchannels(duthost, ptfhost, config_facts, port_indexes, ptf_ports_a
     ptfhost.shell("supervisorctl restart ptf_nn_agent")
     time.sleep(5)
 
+    # Validate portchannel is up in state db
+    for portchannel_name in PORTCHANNEL_NAMES:
+        portchannel_key = f"STATE_DB/localhost/LAG_TABLE/{portchannel_name}"
+        portchannel_status = gnmi_tls.gnmic.get(portchannel_key)[0].get("updates")[0].get("values", {})\
+            .get(portchannel_key, {})
+        
+        pytest_assert(portchannel_status.get("admin_status", "").lower() == "up" 
+                      and portchannel_status.get("oper_status", "").lower() == "up",
+                      f"Portchannel {portchannel_name} not up in state db.")
+
     return wl_portchannel_mapping_info
 
 
-def setup_vnets(duthost, ptfhost, num_vnets, tunnel, base_vni):
-    gnmi_set_update_config_db_json(duthost, ptfhost, f"{GNMI_PATH_PREFIX}/VNET", {
+def setup_vnets(num_vnets, tunnel, base_vni, gnmi_tls):
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/VNET", {
         f"Vnet{base_vni + i}": {
             "vni": f"{base_vni + i}",
             "vxlan_tunnel": tunnel
         } for i in range(num_vnets)
     }, "vnet")
 
+    # Validate vnet is set in state db
+    for i in range(num_vnets):
+        vnet_name = f"Vnet{base_vni + i}"
+        vnet_key = f"STATE_DB/localhost/VRF_TABLE/{vnet_name}/state"
+        vnet_status = gnmi_tls.gnmic.get(vnet_key)[0].get("updates")[0].get("values", {}).get(vnet_key, {})
+
+        pytest_assert(vnet_status.lower() == "ok", f"Vnet {vnet_name} not in ok state.")
+
     return [base_vni + i for i in range(num_vnets)]
 
 
-def setup_vxlan_tunnel(duthost, ptfhost, name, src_ip):
-    gnmi_set_update_config_db_json(duthost, ptfhost, f"{GNMI_PATH_PREFIX}/VXLAN_TUNNEL", {
+def setup_vxlan_tunnel(name, src_ip, gnmi_tls):
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/VXLAN_TUNNEL", {
         name: {
             "src_ip": src_ip
         }
     }, "vxlan")
 
 
-def setup_gnmi_server(duthost, localhost, ptfhost):
-    '''
-    Setup GNMI server with client certificates
-    '''
-    # Check if GNMI is enabled on the device
-    pytest_require(
-        check_container_state(duthost, gnmi_container(duthost), should_be_running=True),
-        "Test was not supported on devices which do not support GNMI!")
-
-    create_gnmi_certs(duthost, localhost, ptfhost)
-    apply_cert_config(duthost)
-
-
 @pytest.fixture(scope="module")
-def common_setup_and_teardown(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, ptfadapter, localhost):
+def common_setup_and_teardown(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, ptfadapter, localhost, gnmi_tls):
     duthost = duthosts[rand_one_dut_hostname]
 
     # backup config_db.json for cleanup
@@ -667,9 +654,6 @@ def common_setup_and_teardown(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, 
                 "name": "eth{}".format(int(key))
             }
 
-        # setup gnmi server
-        setup_gnmi_server(duthost, localhost, ptfhost)
-
         # Remove everflow acl tables
         duthost.remove_acl_table("EVERFLOW")
         duthost.remove_acl_table("EVERFLOWV6")
@@ -682,14 +666,14 @@ def common_setup_and_teardown(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, 
         subnet_ip_int, _ = convert_str_to_ip_int(subnet_ip)
 
         # Set up vxlan
-        setup_vxlan_tunnel(duthost, ptfhost, "tunnel_v4", loopback_ip)
+        setup_vxlan_tunnel("tunnel_v4", loopback_ip, gnmi_tls)
 
         #  Set up vnets
-        vnet_vnis = setup_vnets(duthost, ptfhost, NUM_VNETS, "tunnel_v4", BASE_VNI)
+        vnet_vnis = setup_vnets(NUM_VNETS, "tunnel_v4", BASE_VNI, gnmi_tls)
 
         # Set up portchannels
         wl_portchannel_info = setup_portchannels(duthost, ptfhost, config_facts,
-                                                 port_indexes, ptf_ports_available_in_topo)
+                                                 port_indexes, ptf_ports_available_in_topo, gnmi_tls)
 
         # Set up subintfs
         dut_ips, ptf_ips = generate_subintfs_ips(NUM_VNETS, len(PORTCHANNEL_NAMES), start_ip_int=subnet_ip_int)
@@ -700,7 +684,8 @@ def common_setup_and_teardown(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, 
             vnet_vnis,
             base_vlan=10,
             dut_ips=dut_ips,
-            ptf_ips=ptf_ips)
+            ptf_ips=ptf_ips,
+            gnmi_tls=gnmi_tls)
 
         # Set up bgps
         setup_bgp(
@@ -712,14 +697,15 @@ def common_setup_and_teardown(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, 
             subnet_ip,
             loopback_ip,
             bgp_port=EXABGP_PORT,
-            vnet_route_ip=subnet_ip)
+            vnet_route_ip=subnet_ip,
+            gnmi_tls=gnmi_tls)
 
         # Set up vnet routes
-        setup_vnet_routes(duthost, ptfhost, vnet_vnis)
+        setup_vnet_routes(duthost, vnet_vnis, gnmi_tls)
 
         # Setup acl configs
         config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
-        setup_acl_config(duthost, ptfhost, list(config_facts.get("PORTCHANNEL", {}).keys()), vnet_vnis)
+        setup_acl_config(duthost, list(config_facts.get("PORTCHANNEL", {}).keys()), vnet_vnis, gnmi_tls)
 
         # Configure vxlan port
         ecmp_utils.configure_vxlan_switch(duthost, VXLAN_PORT, "00:12:34:56:78:9a")

--- a/tests/vxlan/test_vxlan_vnet_bgp_subintf.py
+++ b/tests/vxlan/test_vxlan_vnet_bgp_subintf.py
@@ -1,5 +1,4 @@
 import logging
-import json
 import os
 from ptf.mask import Mask
 from ptf.packet import Ether, IP, UDP, TCP
@@ -10,7 +9,7 @@ from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.config_reload import config_reload
 from tests.common.utilities import wait_until
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
-from tests.common.fixtures.grpc_fixtures import gnmi_tls
+from tests.common.fixtures.grpc_fixtures import gnmi_tls    # noqa: F401
 
 ecmp_utils = Ecmp_Utils()
 
@@ -343,7 +342,7 @@ def generate_vnet_routes(vnet_vnis, start_prefix_int, start_endpoint_int, start_
                 "prefix": "0.0.0.0/0",
                 "endpoint": convert_ip_int_to_str(start_endpoint_int).split('/')[0],
                 "vni": start_vni,
-                "mac_address": f"52:54:00:00:00:00",
+                "mac_address": "52:54:00:00:00:00",
                 "vnet_vni": vni
             }
             routes[vni].append(route)
@@ -351,14 +350,14 @@ def generate_vnet_routes(vnet_vnis, start_prefix_int, start_endpoint_int, start_
     return routes
 
 
-def gnmic_set_with_bypass(gnmi_tls, path, value, filename="test_config"):
+def gnmic_set_with_bypass(gnmi_tls, path, value, filename="test_config"):     # noqa: F811
     """
     Send GNMI set request with bypass.
     """
     gnmi_tls.gnmic.set(path, value, metadata="x-sonic-ss-bypass-validation=true", filename=filename)
 
 
-def setup_acl_config(duthost, ports, vnet_vnis, vnet_routes, gnmi_tls):
+def setup_acl_config(duthost, ports, vnet_vnis, vnet_routes, gnmi_tls):     # noqa: F811
     """
     Add a custom ACL table type definition to CONFIG_DB.
     """
@@ -404,7 +403,7 @@ def setup_acl_config(duthost, ports, vnet_vnis, vnet_routes, gnmi_tls):
         if acl_table_status.lower() != "active":
             return False
 
-        rule_key = f"STATE_DB/localhost/ACL_RULE_TABLE"
+        rule_key = "STATE_DB/localhost/ACL_RULE_TABLE"
         acl_rules = gnmi_tls.gnmic.get(rule_key)[0].get("updates")[0].get("values", {}).get(rule_key, {})
         for vni in vnet_vnis:
             for route in vnet_routes[vni]:
@@ -417,7 +416,7 @@ def setup_acl_config(duthost, ports, vnet_vnis, vnet_routes, gnmi_tls):
                   f"ACL table {ACL_TABLE_NAME} or its rules not active after 60 seconds.")
 
 
-def setup_vnet_routes(vnet_vnis, vni_to_routes, gnmi_tls):
+def setup_vnet_routes(vnet_vnis, vni_to_routes, gnmi_tls):     # noqa: F811
     gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/VNET_ROUTE_TUNNEL", {
         f"Vnet{vni}|{route['prefix']}": {
             "endpoint": route["endpoint"],
@@ -430,22 +429,24 @@ def setup_vnet_routes(vnet_vnis, vni_to_routes, gnmi_tls):
     time.sleep(5)
     for vni in vnet_vnis:
         for route in vni_to_routes[vni]:
-            route_key = f"STATE_DB/localhost/VNET_ROUTE_TUNNEL_TABLE"
+            route_key = "STATE_DB/localhost/VNET_ROUTE_TUNNEL_TABLE"
             route_status = gnmi_tls.gnmic.get(route_key)[0].get("updates")[0].get("values", {}).get(route_key, {})\
                 .get(f"Vnet{vni}|{route['prefix']}", {}).get("state", "")
             pytest_assert(route_status.lower() == "active",
-                        f"VNET route tunnel for Vnet{vni}|{route['prefix']} not active.")
+                          f"VNET route tunnel for Vnet{vni}|{route['prefix']} not active.")
 
 
-def setup_bgp(duthost, ptfhost, vnet_vnis, dut_ips, ptf_ips, subnet_ip, loopback_ip, bgp_port, vnet_route_ip, gnmi_tls):
+def setup_bgp(duthost, ptfhost, vnet_vnis, dut_ips, ptf_ips,
+              subnet_ip, loopback_ip, bgp_port, vnet_route_ip, gnmi_tls):     # noqa: F811
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     dut_asn = config_facts['DEVICE_METADATA']['localhost']['bgp_asn']
     neighbors = config_facts['BGP_NEIGHBOR']
     peer_asn = list(neighbors.values())[0]["asn"]
 
     for vni in vnet_vnis:
-        gnmic_set_with_bypass(gnmi_tls,
-            f"{GNMI_PATH_PREFIX}/BGP_PEER_RANGE/Vnet{vni}\|WLPARTNER_PASSIVE_V4",
+        gnmic_set_with_bypass(
+            gnmi_tls,
+            f"{GNMI_PATH_PREFIX}/BGP_PEER_RANGE/Vnet{vni}|WLPARTNER_PASSIVE_V4",
             {
                 "ip_range": [subnet_ip],
                 "name": "WLPARTNER_PASSIVE_V4",
@@ -497,7 +498,8 @@ neighbor {dut_ip.split('/')[0]} {{
                           and int(val["state/pfxrcd"]) > 0, f"BGP neighbor not found for vnet Vnet{vni}.")
 
 
-def setup_portchannel_subintfs(duthost, ptfhost, portchannel_info, vnet_vnis, base_vlan, dut_ips, ptf_ips, gnmi_tls):
+def setup_portchannel_subintfs(duthost, ptfhost, portchannel_info,
+                               vnet_vnis, base_vlan, dut_ips, ptf_ips, gnmi_tls):     # noqa: F811
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     has_subintfs = len(config_facts.get("VLAN_SUB_INTERFACE", {})) > 0
 
@@ -532,7 +534,7 @@ def setup_portchannel_subintfs(duthost, ptfhost, portchannel_info, vnet_vnis, ba
                     subintf_name)
                 gnmic_set_with_bypass(
                     gnmi_tls,
-                    f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}\|{dut_ips[j][i].replace('/','~1')}",
+                    f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}|{dut_ips[j][i].replace('/','~1')}",
                     {},
                     f"{subintf_name}_ip")
 
@@ -558,7 +560,7 @@ def setup_portchannel_subintfs(duthost, ptfhost, portchannel_info, vnet_vnis, ba
     time.sleep(5)
 
     # Check subinterfaces are up in state db
-    interfaces_key = f"STATE_DB/localhost/INTERFACE_TABLE"
+    interfaces_key = "STATE_DB/localhost/INTERFACE_TABLE"
     interfaces = gnmi_tls.gnmic.get(interfaces_key)[0].get("updates")[0].get("values", {}).get(interfaces_key, {})
     for subintf, values in subintfs_info.items():
         subintf_vnet = interfaces.get(subintf, {}).get("vrf", "")
@@ -571,7 +573,8 @@ def setup_portchannel_subintfs(duthost, ptfhost, portchannel_info, vnet_vnis, ba
     return subintfs_info
 
 
-def setup_portchannels(duthost, ptfhost, config_facts, port_indexes, ptf_ports_available_in_topo, gnmi_tls):
+def setup_portchannels(duthost, ptfhost, config_facts, port_indexes,
+                       ptf_ports_available_in_topo, gnmi_tls):     # noqa: F811
     vlan_id, ports = get_available_vlan_id_and_ports(config_facts, len(PORTCHANNEL_NAMES))
     pytest_assert(len(ports) == len(PORTCHANNEL_NAMES),
                   f"Found {len(ports)} available ports. Needed {len(PORTCHANNEL_NAMES)} ports for the test.")
@@ -586,7 +589,7 @@ def setup_portchannels(duthost, ptfhost, config_facts, port_indexes, ptf_ports_a
         }, PORTCHANNEL_NAMES[i])
         gnmic_set_with_bypass(
             gnmi_tls,
-            f"{GNMI_PATH_PREFIX}/PORTCHANNEL_MEMBER/{PORTCHANNEL_NAMES[i]}\|{ports[i]}",
+            f"{GNMI_PATH_PREFIX}/PORTCHANNEL_MEMBER/{PORTCHANNEL_NAMES[i]}|{ports[i]}",
             {},
             f"{PORTCHANNEL_NAMES[i]}_member")
 
@@ -627,7 +630,7 @@ def setup_portchannels(duthost, ptfhost, config_facts, port_indexes, ptf_ports_a
     return wl_portchannel_mapping_info
 
 
-def setup_vnets(num_vnets, tunnel, base_vni, gnmi_tls):
+def setup_vnets(num_vnets, tunnel, base_vni, gnmi_tls):     # noqa: F811
     gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/VNET", {
         f"Vnet{base_vni + i}": {
             "vni": f"{base_vni + i}",
@@ -646,7 +649,7 @@ def setup_vnets(num_vnets, tunnel, base_vni, gnmi_tls):
     return [base_vni + i for i in range(num_vnets)]
 
 
-def setup_vxlan_tunnel(name, src_ip, gnmi_tls):
+def setup_vxlan_tunnel(name, src_ip, gnmi_tls):     # noqa: F811
     gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/VXLAN_TUNNEL", {
         name: {
             "src_ip": src_ip
@@ -655,7 +658,8 @@ def setup_vxlan_tunnel(name, src_ip, gnmi_tls):
 
 
 @pytest.fixture(scope="module")
-def common_setup_and_teardown(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, ptfadapter, localhost, gnmi_tls):
+def common_setup_and_teardown(tbinfo, duthosts, rand_one_dut_hostname,
+                              ptfhost, ptfadapter, localhost, gnmi_tls):     # noqa: F811
     duthost = duthosts[rand_one_dut_hostname]
 
     # backup config_db.json for cleanup
@@ -796,13 +800,13 @@ def common_setup_and_teardown(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, 
             "route": route
         } for _, val in subintfs_info.items() for route in vnet_routes[val["vnet_vni"]]
     ]
-    yield duthost, ptfadapter, gnmi_tls, encap_test_configs, decap_test_configs
+    yield duthost, ptfadapter, encap_test_configs, decap_test_configs
 
     # Cleanup
     cleanup(duthost, ptfhost, localhost, wl_portchannel_info, subintfs_info)
 
 
-def modify_routes_mac_vni(gnmi_tls, encap_test_configs, offset=0):
+def modify_routes_mac_vni(gnmi_tls, encap_test_configs, offset=0):     # noqa: F811
     modified_routes = set()
     acl_rule_value = {}
 
@@ -819,7 +823,7 @@ def modify_routes_mac_vni(gnmi_tls, encap_test_configs, offset=0):
 
             gnmic_set_with_bypass(
                 gnmi_tls,
-                f"{GNMI_PATH_PREFIX}/VNET_ROUTE_TUNNEL/Vnet{route['vnet_vni']}\|{route['prefix'].replace('/','~1')}",
+                f"{GNMI_PATH_PREFIX}/VNET_ROUTE_TUNNEL/Vnet{route['vnet_vni']}|{route['prefix'].replace('/','~1')}",
                 {
                     "endpoint": route["endpoint"],
                     "vni": route["vni"],
@@ -846,7 +850,7 @@ def modify_routes_mac_vni(gnmi_tls, encap_test_configs, offset=0):
     # Check vnet routes are updated
     time.sleep(5)
     for config in encap_test_configs:
-        route_key = f"STATE_DB/localhost/VNET_ROUTE_TUNNEL_TABLE"
+        route_key = "STATE_DB/localhost/VNET_ROUTE_TUNNEL_TABLE"
         route_status = gnmi_tls.gnmic.get(route_key)[0].get("updates")[0].get("values", {}).get(route_key, {})\
             .get(f"Vnet{config['route']['vnet_vni']}|{config['route']['prefix']}", {}).get("state", "")
         pytest_assert(route_status.lower() == "active",
@@ -854,8 +858,8 @@ def modify_routes_mac_vni(gnmi_tls, encap_test_configs, offset=0):
                         {config['route']['prefix']} not active.")
 
 
-def test_vnet_with_bgp_intf_smacrewrite(common_setup_and_teardown):
-    duthost, ptfadapter, gnmi_tls, encap_test_configs, decap_test_configs = common_setup_and_teardown
+def test_vnet_with_bgp_intf_smacrewrite(common_setup_and_teardown, gnmi_tls):     # noqa: F811
+    duthost, ptfadapter, encap_test_configs, decap_test_configs = common_setup_and_teardown
 
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     logger.debug("post-setup config_facts: {}".format(config_facts))

--- a/tests/vxlan/test_vxlan_vnet_bgp_subintf.py
+++ b/tests/vxlan/test_vxlan_vnet_bgp_subintf.py
@@ -1,15 +1,18 @@
+import ipaddress
 import logging
 import os
-from ptf.mask import Mask
-from ptf.packet import Ether, IP, UDP, TCP
-import ptf.testutils as testutils
-import pytest
 import time
-from tests.common.helpers.assertions import pytest_assert, pytest_require
+
+import pytest
+from ptf.mask import Mask
+from ptf.packet import Ether, IP, IPv6, UDP, TCP
+import ptf.testutils as testutils
+
 from tests.common.config_reload import config_reload
+from tests.common.fixtures.grpc_fixtures import gnmi_tls    # noqa: F401
+from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
-from tests.common.fixtures.grpc_fixtures import gnmi_tls    # noqa: F401
 
 ecmp_utils = Ecmp_Utils()
 
@@ -28,63 +31,147 @@ EXABGP_PORT = 5100
 PORTCHANNEL_NAMES = ["PortChannel1031", "PortChannel1032"]
 VXLAN_PORT = 4789
 TUNNEL_ENDPOINT = "100.0.1.10"
-INNER_SRC_MAC = "00:11:22:33:44:55"
 INNER_SRC_IP = "2.2.2.2"
+INNER_SRC_MAC = "00:11:22:33:44:55"
+INNER_SRC_IPV6 = "2001:db8:2::2"
+
 BASE_VNI = 1000
 NUM_VNETS = 2
 
-ACL_TYPE_NAME = "INNER_SRC_MAC_REWRITE_TYPE"
-ACL_TABLE_NAME = "INNER_SRC_MAC_REWRITE_TABLE"
+V6_SUBINT_BASE = "fc00:11::"
+
+VNET_V6_PREFIX_BASE = "2001:db8:30::"
+BGP_V6_DECAP_ROUTE = "2001:db8:40::/64"
+BGP_V6_DECAP_IP = "2001:db8:40::1"
 
 GNMI_PATH_PREFIX = "CONFIG_DB/localhost"
 
+ACL_TYPE_NAME = "INNER_SRC_MAC_REWRITE_TYPE"
+ACL_TABLE_NAME = "INNER_SRC_MAC_REWRITE_TABLE"
+ACL_TYPE_NAME_V6 = "INNER_SRC_MAC_REWRITE_TYPE_V6"
+ACL_TABLE_NAME_V6 = "INNER_SRC_MAC_REWRITE_TABLE_V6"
+
 temp_files = []
+
+RA_SEND_SCRIPT = '''#!/usr/bin/env python3
+"""Send periodic IPv6 Router Advertisements out an interface.
+Replaces radvd for unnumbered-BGP testing where the peer (FRR) needs to
+learn our LL via RA but we don't want radvd / sysctl forwarding=1."""
+import argparse
+import time
+
+from scapy.all import (
+    sendp, get_if_hwaddr, in6_getifaddr,
+    Ether, IPv6, ICMPv6ND_RA, ICMPv6NDOptSrcLLAddr,
+)
+
+
+def get_iface_ll(iface):
+    for addr, _scope, ifname in in6_getifaddr():
+        if ifname == iface and addr.lower().startswith("fe80"):
+            return addr
+    raise RuntimeError("No fe80::/10 address on %s — bring it up first" % iface)
+
+
+def build_ra(iface):
+    src_mac = get_if_hwaddr(iface)
+    src_ll = get_iface_ll(iface)
+    return (
+        Ether(src=src_mac, dst="33:33:00:00:00:01")
+        / IPv6(src=src_ll, dst="ff02::1", hlim=255)        # hlim=255 REQUIRED
+        / ICMPv6ND_RA(chlim=64, M=0, O=0,
+                      routerlifetime=1800, reachabletime=0, retranstimer=0)
+        / ICMPv6NDOptSrcLLAddr(lladdr=src_mac)             # populate peer NDP
+    ), src_ll, src_mac
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("iface")
+    ap.add_argument("--interval", type=float, default=3.0)
+    ap.add_argument("--count", type=int, default=0)
+    args = ap.parse_args()
+
+    pkt, src_ll, src_mac = build_ra(args.iface)
+    print("[ra_send] iface=%s src_ll=%s src_mac=%s interval=%ss" % (
+        args.iface, src_ll, src_mac, args.interval), flush=True)
+
+    sent = 0
+    while True:
+        sendp(pkt, iface=args.iface, verbose=False)
+        sent += 1
+        if args.count and sent >= args.count:
+            break
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    main()
+'''
 
 
 def validate_encap_wl_to_t1(duthost, ptfadapter, test_configs):
+    """
+    Test WL→T1 VXLAN encap with IPv4 and IPv6.
+    """
     logger.info("Starting WL to T1 VXLAN encapsulation test...")
 
     for configs in test_configs:
-        # Build inner TCP packet to inject from southbound side
-        pkt_opts = {
-            "eth_dst": duthost.facts['router_mac'],
-            "eth_src": ptfadapter.dataplane.get_mac(0, configs["outgoing_port"]),
-            "ip_dst": configs["inner_dst_ip"],
-            "ip_src": INNER_SRC_IP,
-            "ip_id": 105,
-            "ip_ttl": 64,
-            "dl_vlan_enable": True,
-            "vlan_vid": configs["vlan"],
-            "tcp_sport": 1234,
-            "tcp_dport": 5000,
-            "pktlen": 100
-        }
+        for addr_family in ["v4", "v6"]:
+            # Build inner TCP packet
+            if addr_family == "v4":
+                pkt_opts = {
+                    "eth_dst": duthost.facts['router_mac'],
+                    "eth_src": ptfadapter.dataplane.get_mac(0, configs["outgoing_port"]),
+                    "ip_dst": configs["inner_dst_ip_v4"],
+                    "ip_src": INNER_SRC_IP,
+                    "ip_id": 105,
+                    "ip_ttl": 64,
+                    "dl_vlan_enable": True,
+                    "vlan_vid": configs["vlan"],
+                    "tcp_sport": 1234,
+                    "tcp_dport": 5000,
+                    "pktlen": 100,
+                }
+                inner_pkt = testutils.simple_tcp_packet(**pkt_opts)
+            else:
+                pkt_opts = {
+                    "eth_dst": duthost.facts['router_mac'],
+                    "eth_src": ptfadapter.dataplane.get_mac(0, configs["outgoing_port"]),
+                    "ipv6_dst": configs["inner_dst_ip_v6"],
+                    "ipv6_src": INNER_SRC_IPV6,
+                    "ipv6_hlim": 64,
+                    "dl_vlan_enable": True,
+                    "vlan_vid": configs["vlan"],
+                    "tcp_sport": 1234,
+                    "tcp_dport": 5000,
+                    "pktlen": 100,
+                }
+                inner_pkt = testutils.simple_tcpv6_packet(**pkt_opts)
 
-        inner_pkt = testutils.simple_tcp_packet(**pkt_opts)
-
-        # Build expected packet
-        pkt_opts["eth_src"] = INNER_SRC_MAC  # expected rewritten inner src mac
+        pkt_opts["eth_src"] = INNER_SRC_MAC    # expected rewritten inner src MAC
         pkt_opts["eth_dst"] = configs["expected_dst_mac"]
-        pkt_opts["ip_ttl"] = 63
         pkt_opts["dl_vlan_enable"] = False
-        pkt_opts["pktlen"] = 96  # 100 - 4, remove vlan tag length
+        pkt_opts.pop("vlan_vid", None)
+        pkt_opts["pktlen"] = 96
 
-        inner_exp_pkt = testutils.simple_tcp_packet(**pkt_opts)
+        if addr_family == "v4":
+            pkt_opts["ip_ttl"] = 63
+            inner_exp_pkt = testutils.simple_tcp_packet(**pkt_opts)
+        else:
+            pkt_opts["ipv6_hlim"] = 63
+            inner_exp_pkt = testutils.simple_tcpv6_packet(**pkt_opts)
 
         expected_pkt = testutils.simple_vxlan_packet(
             eth_dst="aa:bb:cc:dd:ee:ff",
             eth_src=duthost.facts['router_mac'],
             ip_src=configs["expected_src_ip"],
             ip_dst=configs["expected_dst_ip"],
-            ip_id=0,
-            ip_flags=0x2,
-            udp_sport=1234,
-            udp_dport=VXLAN_PORT,
-            with_udp_chksum=False,
+            ip_id=0, ip_flags=0x2,
+            udp_sport=1234, udp_dport=VXLAN_PORT, with_udp_chksum=False,
             vxlan_vni=int(configs["expected_vni"]),
-            inner_frame=inner_exp_pkt
+            inner_frame=inner_exp_pkt,
         )
-
         masked_expected_pkt = Mask(expected_pkt)
         masked_expected_pkt.set_ignore_extra_bytes()
         masked_expected_pkt.set_do_not_care_packet(Ether, 'dst')
@@ -96,72 +183,82 @@ def validate_encap_wl_to_t1(duthost, ptfadapter, test_configs):
         masked_expected_pkt.set_do_not_care_packet(IP, "len")
         masked_expected_pkt.set_do_not_care_packet(IP, "tos")
 
-        # Clear packet queue on all ports and get initial acl counter
         ptfadapter.dataplane.flush()
-
-        # Send TCP packet from WL port
         testutils.send(ptfadapter, configs["outgoing_port"], inner_pkt)
-
-        # Verify VXLAN encapsulated pkt on T1 port with rewritten inner src MAC
         testutils.verify_packet_any_port(ptfadapter, masked_expected_pkt, configs["expected_ports"], timeout=2)
 
-    logger.info("WL to T1 VXLAN encapsulation test passed.")
+    logger.info("WL to T1 VXLAN encapsulation test (IPv6 inner) passed.")
 
 
 def validate_decap_t1_to_wl(duthost, ptfadapter, test_configs):
+    """
+    Test T1→WL VXLAN decap with IPv4 and IPv6.
+    """
     logger.info("Starting T1 to WL VXLAN decapsulation test...")
 
     for configs in test_configs:
-        pkt_opts = {
-            "eth_dst": "aa:bb:cc:dd:ee:ff",
-            "eth_src": duthost.facts['router_mac'],
-            "ip_src": "8.8.8.8",
-            "ip_dst": configs["inner_dst_ip"],
-            "tcp_sport": 1234,
-            "tcp_dport": 4321,
-            "pktlen": 100
-        }
+        for addr_family in ["v4", "v6"]:
+            # Build inner TCP packet
+            if addr_family == "v4":
+                pkt_opts = {
+                    "eth_dst": "aa:bb:cc:dd:ee:ff",
+                    "eth_src": duthost.facts['router_mac'],
+                    "ip_src": "8.8.8.8",
+                    "ip_dst": configs["inner_dst_ip_v4"],
+                    "tcp_sport": 1234,
+                    "tcp_dport": 4321,
+                    "pktlen": 100,
+                }
+                inner_pkt = testutils.simple_tcp_packet(**pkt_opts)
+            else:
+                pkt_opts = {
+                    "eth_dst": "aa:bb:cc:dd:ee:ff",
+                    "eth_src": duthost.facts['router_mac'],
+                    "ipv6_src": "2001:db8:1::1",
+                    "ipv6_dst": configs["inner_dst_ip_v6"],
+                    "tcp_sport": 1234,
+                    "tcp_dport": 4321,
+                    "pktlen": 100,
+                }
+                inner_pkt = testutils.simple_tcpv6_packet(**pkt_opts)
 
-        # Build inner TCP packet expected on WL port
-        inner_pkt = testutils.simple_tcp_packet(**pkt_opts)
+            # Build VXLAN encapsulated packet to inject from T1 side
+            vxlan_pkt = testutils.simple_vxlan_packet(
+                eth_dst=duthost.facts['router_mac'],
+                eth_src=ptfadapter.dataplane.get_mac(0, configs["outgoing_port"]),
+                ip_src="1.1.1.1",
+                ip_dst=configs["expected_dst_ip"],
+                udp_sport=1234, udp_dport=VXLAN_PORT, with_udp_chksum=False,
+                vxlan_vni=int(configs["vni"]),
+                inner_frame=inner_pkt,
+            )
 
-        # Build VXLAN encapsulated packet to inject from T1 side
-        vxlan_pkt = testutils.simple_vxlan_packet(
-            eth_dst=duthost.facts['router_mac'],
-            eth_src=ptfadapter.dataplane.get_mac(0, configs["outgoing_port"]),
-            ip_src="1.1.1.1",
-            ip_dst=configs["expected_dst_ip"],
-            udp_sport=1234,
-            udp_dport=VXLAN_PORT,
-            with_udp_chksum=False,
-            vxlan_vni=int(configs["vni"]),
-            inner_frame=inner_pkt
-        )
+            pkt_opts["vlan_vid"] = configs["vlan"]
+            pkt_opts["dl_vlan_enable"] = True
+            pkt_opts["pktlen"] = 104        # 100 + 4, add vlan tag length
 
-        # Build expected inner packet after decapsulation
-        pkt_opts["vlan_vid"] = configs["vlan"]
-        pkt_opts["dl_vlan_enable"] = True
-        pkt_opts["pktlen"] = 104     # 100 + 4, add vlan tag length
-        expected_inner_pkt = testutils.simple_tcp_packet(**pkt_opts)
+            if addr_family == "v4":
+                expected_inner_pkt = testutils.simple_tcp_packet(**pkt_opts)
+                masked_expected_pkt = Mask(expected_inner_pkt)
+                masked_expected_pkt.set_ignore_extra_bytes()
+                masked_expected_pkt.set_do_not_care_packet(Ether, 'dst')
+                masked_expected_pkt.set_do_not_care_packet(IP, "ttl")
+                masked_expected_pkt.set_do_not_care_packet(IP, "chksum")
+                masked_expected_pkt.set_do_not_care_packet(IP, "id")
+                masked_expected_pkt.set_do_not_care_packet(IP, "len")
+                masked_expected_pkt.set_do_not_care_packet(IP, "tos")
+                masked_expected_pkt.set_do_not_care_packet(TCP, 'chksum')
+            else:
+                expected_inner_pkt = testutils.simple_tcpv6_packet(**pkt_opts)
+                masked_expected_pkt = Mask(expected_inner_pkt)
+                masked_expected_pkt.set_ignore_extra_bytes()
+                masked_expected_pkt.set_do_not_care_packet(Ether, 'dst')
+                masked_expected_pkt.set_do_not_care_packet(IPv6, 'hlim')
+                masked_expected_pkt.set_do_not_care_packet(TCP, 'chksum')
 
-        masked_expected_pkt = Mask(expected_inner_pkt)
-        masked_expected_pkt.set_ignore_extra_bytes()
-        masked_expected_pkt.set_do_not_care_packet(Ether, 'dst')
-        masked_expected_pkt.set_do_not_care_packet(IP, "ttl")
-        masked_expected_pkt.set_do_not_care_packet(IP, "chksum")
-        masked_expected_pkt.set_do_not_care_packet(IP, "id")
-        masked_expected_pkt.set_do_not_care_packet(TCP, 'chksum')
-        masked_expected_pkt.set_do_not_care_packet(IP, "len")
-        masked_expected_pkt.set_do_not_care_packet(IP, "tos")
-
-        # Clear packet queue on all ports
-        ptfadapter.dataplane.flush()
-
-        # Send VXLAN encapsulated pkt from T1 port
-        testutils.send(ptfadapter, configs["outgoing_port"], vxlan_pkt)
-
-        # Verify decapsulated unencapsulated packet on southbound port
-        testutils.verify_packet_any_port(ptfadapter, masked_expected_pkt, configs["expected_ports"], timeout=2)
+            ptfadapter.dataplane.flush()
+            testutils.send(ptfadapter, configs["outgoing_port"], vxlan_pkt)
+            testutils.verify_packet_any_port(ptfadapter, masked_expected_pkt, configs["expected_ports"], timeout=2)
 
     logger.info("T1 to WL VXLAN decapsulation test passed.")
 
@@ -169,44 +266,40 @@ def validate_decap_t1_to_wl(duthost, ptfadapter, test_configs):
 def cleanup(duthost, ptfhost, localhost, wl_portchannel_info, subintfs_info):
     """
     Return duthost and ptfhost to original state.
-
     Args:
         duthost: DUT host
         ptfhost: PTF host
-        bond_port_mapping: map of bond port name (bond#) to ptf port name (eth#)
+        wl_portchannel_info: map of WL portchannel info
+        subintfs_info: map of sub-interface info
     """
-    # Restore config db
     logger.debug("cleanup: Loading backup config db json.")
     duthost.shell(f"mv {CONFIG_DB_PATH}.bak {CONFIG_DB_PATH}")
     config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
 
     cmds = []
-    # Remove sub port
-    try:
-        for _, val in subintfs_info.items():
-            sub_port = val["bond_name"]
-            ip = val['ptf_ip']
-            cmds.append("ip address del {} dev {}".format(ip, sub_port))
-            cmds.append("ip link del {}".format(sub_port))
-        ptfhost.shell_cmds(cmds=cmds)
-    except Exception as e:
-        logger.error(f"Error occurred while cleaning up sub interfaces: {e}")
+    if subintfs_info:
+        try:
+            for _, val in subintfs_info.items():
+                sub_port = val["bond_name"]
+                cmds.append("ip link del {}".format(sub_port))
+            ptfhost.shell_cmds(cmds=cmds)
+        except Exception as e:
+            logger.error(f"Error occurred while cleaning up sub interfaces: {e}")
 
     cmds = []
-    # Remove bond ports
-    try:
-        for key, val in wl_portchannel_info.items():
-            bond_port = val["bond_port"]
-            port_name = val["ptf_port_name"]
-            cmds.append("ip link set {} nomaster".format(bond_port))
-            cmds.append("ip link set {} nomaster".format(port_name))
-            cmds.append("ip link set {} up".format(port_name))
-            cmds.append("ip link del {}".format(bond_port))
-        ptfhost.shell_cmds(cmds=cmds)
-    except Exception as e:
-        logger.error(f"Error occurred while cleaning up bond interfaces: {e}")
+    if wl_portchannel_info:
+        try:
+            for key, val in wl_portchannel_info.items():
+                bond_port = val["bond_port"]
+                port_name = val["ptf_port_name"]
+                cmds.append("ip link set {} nomaster".format(bond_port))
+                cmds.append("ip link set {} nomaster".format(port_name))
+                cmds.append("ip link set {} up".format(port_name))
+                cmds.append("ip link del {}".format(bond_port))
+            ptfhost.shell_cmds(cmds=cmds)
+        except Exception as e:
+            logger.error(f"Error occurred while cleaning up bond interfaces: {e}")
 
-    # Stop exabgp process
     kill_exabgp = f"""
 MAIN_PID=$(pgrep -f "exabgp {EXABGP_CONFIG_PATH}")
 if [ -n "$MAIN_PID" ]; then
@@ -225,7 +318,15 @@ fi
 """
     ptfhost.shell(kill_http_api, module_ignore_errors=True)
 
-    # Remove tmp files
+    kill_ra_send = """
+RA_SEND_PIDS=$(pgrep -f "/tmp/ra_send.py")
+if [ -n "$RA_SEND_PIDS" ]; then
+    echo "Killing RA sender processes"
+    kill -9 $RA_SEND_PIDS 2>/dev/null
+fi
+"""
+    ptfhost.shell(kill_ra_send, module_ignore_errors=True)
+
     for file in temp_files:
         if os.path.exists(file):
             os.remove(file)
@@ -234,26 +335,19 @@ fi
 def get_available_vlan_id_and_ports(cfg_facts, num_ports_needed):
     """
     Return vlan id and available ports in that vlan if there are enough ports available.
-
-    Args:
-        cfg_facts: DUT config facts
-        num_ports_needed: number of available ports needed for test
     """
     port_status = cfg_facts["PORT"]
     vlan_id = -1
     available_ports = []
     pytest_require("VLAN_MEMBER" in cfg_facts, "Can't get vlan member")
     for vlan_name, members in list(cfg_facts["VLAN_MEMBER"].items()):
-        # Number of members in vlan is insufficient
         if len(members) < num_ports_needed:
             continue
 
-        # Get available ports in vlan
         possible_ports = []
         for vlan_member in members:
             if port_status[vlan_member].get("admin_status", "down") != "up":
                 continue
-
             possible_ports.append(vlan_member)
             if len(possible_ports) == num_ports_needed:
                 available_ports = possible_ports[:]
@@ -267,58 +361,48 @@ def get_available_vlan_id_and_ports(cfg_facts, num_ports_needed):
     return vlan_id, available_ports
 
 
-def convert_ip_int_to_str(ip_int, prefix_size=31):
+def check_vrf_bgp_sessions_established(duthost, vnet_vnis):
+    for vni in vnet_vnis:
+        for addr_family in ["ip", "ipv6"]:
+            vnet_bgps = duthost.show_and_parse(f"show {addr_family} bgp vrf Vnet{vni} summary")
+            pytest_assert(len(vnet_bgps) > 0, f"No BGP sessions found for vnet Vnet{vni}.")
+            for val in vnet_bgps:
+                pytest_assert(val["neighborname"] == "WL_PARTNER_ROUTER" and val["state/pfxrcd"].isdigit()
+                              and int(val["state/pfxrcd"]) > 0, f"BGP neighbor not found for vnet Vnet{vni}.")
+
+
+def generate_vnet_routes_v6(vnet_vnis, start_vni, num_routes_per_vnet, include_default_route=True):
     """
-    Convert integer IP to string format with prefix size.
+    Generate VNET tunnel routes with IPv6 overlay prefixes and IPv4 VTEP endpoints.
     """
-    return f"{ip_int >> 24 & 0xFF}.{ip_int >> 16 & 0xFF}.{ip_int >> 8 & 0xFF}.{ip_int & 0xFF}/{prefix_size}"
+    base = int(ipaddress.IPv6Address(VNET_V6_PREFIX_BASE))
+    endpoint_base = int(ipaddress.IPv4Address(TUNNEL_ENDPOINT))
+    routes = {vni: [] for vni in vnet_vnis}
+    for i, vni in enumerate(vnet_vnis):
+        for j in range(1, num_routes_per_vnet + 1):
+            prefix_addr = ipaddress.IPv6Address(base + (i << 8) + j)
+            endpoint_int = endpoint_base + (i << 8) + j
+            route = {
+                "prefix": f"{prefix_addr}/128",
+                "endpoint": str(ipaddress.IPv4Address(endpoint_int)),
+                "vni": start_vni + (i * num_routes_per_vnet) + j,
+                "mac_address": f"52:54:00:{(i << 8 + j) // 256:02x}:{(i << 8 + j) % 256:02x}:aa",
+                "vnet_vni": vni,
+            }
+            routes[vni].append(route)
+        if include_default_route:
+            route = {
+                "prefix": "::/0",
+                "endpoint": str(ipaddress.IPv4Address(endpoint_base)),
+                "vni": start_vni,
+                "mac_address": "52:54:00:00:00:00",
+                "vnet_vni": vni,
+            }
+            routes[vni].append(route)
+    return routes
 
 
-def convert_str_to_ip_int(ip_str):
-    """
-    Convert string IP to integer format.
-    """
-    ip_parts = ip_str.split('/')
-    ip = ip_parts[0]
-    octets = ip.split('.')
-    ip_int = int(octets[0]) << 24 | int(octets[1]) << 16 | int(octets[2]) << 8 | int(octets[3])
-    prefix = int(ip_parts[1]) if len(ip_parts) > 1 else 32
-    return ip_int, prefix
-
-
-def generate_subintfs_ips(num_vnets, num_portchannels, start_ip_int, prefix_size=31):
-    """
-    Generate subnets for subintfs, incrementing third octect for each vnet, and fourth octet for each portchannel.
-    """
-    num_ips_per_prefix = 2 ** (32 - prefix_size)
-    pytest_assert(num_ips_per_prefix * num_portchannels + (start_ip_int & 0xFF) < 0xFF,
-                  "Not enough IP addresses in last octet to allocate for subinterfaces.")
-    pytest_assert(num_vnets + (start_ip_int >> 8 & 0xFF) < 0xFF,
-                  "Not enough IP addresses in third octet to allocate for subinterfaces.")
-
-    all_subintf_ips = []
-    all_ptf_ips = []
-
-    for i in range(num_portchannels):
-        subintf_ips = []
-        ptf_ips = []
-        fourth_octet_offset = i * num_ips_per_prefix
-        for j in range(num_vnets):
-            ip_int = start_ip_int + fourth_octet_offset + (j << 8)
-            subintf_ips.append(
-                convert_ip_int_to_str(ip_int, prefix_size)
-            )
-            ptf_ips.append(
-                convert_ip_int_to_str(ip_int + 1, prefix_size)
-            )
-
-        all_subintf_ips.append(subintf_ips)
-        all_ptf_ips.append(ptf_ips)
-
-    return all_subintf_ips, all_ptf_ips
-
-
-def generate_vnet_routes(vnet_vnis, start_prefix_int, start_endpoint_int, start_vni,
+def generate_vnet_routes_v4(vnet_vnis, start_prefix_int, start_endpoint_int, start_vni,
                          num_routes_per_vnet, include_default_route=True, offset=0):
     """
     Generate vnet routes with prefix, endpoint, mac, and vni.
@@ -329,8 +413,8 @@ def generate_vnet_routes(vnet_vnis, start_prefix_int, start_endpoint_int, start_
             prefix_int = start_prefix_int + (i << 8) + j
             endpoint_int = start_endpoint_int + (i << 8) + j + offset
             route = {
-                "prefix": convert_ip_int_to_str(prefix_int, 32),
-                "endpoint": convert_ip_int_to_str(endpoint_int).split('/')[0],
+                "prefix": f"{ipaddress.IPv4Address(prefix_int)}/32",
+                "endpoint": str(ipaddress.IPv4Address(endpoint_int)),
                 "vni": start_vni + (i * num_routes_per_vnet) + j,
                 "mac_address": f"52:54:00:{(i << 8 + j + offset)//256:02x}:{(i << 8 + j + offset)%256:02x}:aa",
                 "vnet_vni": vni
@@ -340,7 +424,7 @@ def generate_vnet_routes(vnet_vnis, start_prefix_int, start_endpoint_int, start_
         if include_default_route:
             route = {
                 "prefix": "0.0.0.0/0",
-                "endpoint": convert_ip_int_to_str(start_endpoint_int).split('/')[0],
+                "endpoint": str(ipaddress.IPv4Address(start_endpoint_int)),
                 "vni": start_vni,
                 "mac_address": "52:54:00:00:00:00",
                 "vnet_vni": vni
@@ -357,24 +441,78 @@ def gnmic_set_with_bypass(gnmi_tls, path, value, filename="test_config"):     # 
     gnmi_tls.gnmic.set(path, value, metadata="x-sonic-ss-bypass-validation=true", filename=filename)
 
 
-def setup_acl_config(duthost, ports, vnet_vnis, vnet_routes, gnmi_tls):     # noqa: F811
+def get_link_local_ipv6_on_interface(duthost, interface_name):
     """
-    Add a custom ACL table type definition to CONFIG_DB.
+    Return the link-local IPv6 address (without prefix) on an interface.
+    """
+    result = duthost.shell(f"ip -6 -o addr show dev {interface_name} scope link")
+    for line in result.get("stdout_lines", []):
+        fields = line.split()
+        if "inet6" in fields:
+            return fields[fields.index("inet6") + 1].split("/")[0]
+
+    pytest.fail(f"No link-local IPv6 found on interface {interface_name}.")
+
+
+def get_ptf_link_local_ipv6_on_interface(ptfhost, interface_name):
+    """
+    Return the PTF link-local IPv6 address with prefix from `ip -6 -br` output.
+    """
+    result = ptfhost.shell(f"ip -6 -br addr show dev {interface_name}")
+    for line in result.get("stdout_lines", []):
+        fields = line.split()
+        for field in fields[2:]:
+            if field.startswith("fe80::") and "/" in field:
+                return field
+
+    pytest.fail(f"No PTF link-local IPv6 found on interface {interface_name}.")
+
+
+def ensure_localhost_deployment_id(duthost, gnmi_tls, deployment_id="26"):
+    """
+    Ensure DEVICE_METADATA localhost deployment_id is set to the expected value.
+    """
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    localhost_metadata = config_facts.get("DEVICE_METADATA", {}).get("localhost", {})
+    if localhost_metadata.get("deployment_id") == deployment_id:
+        return
+
+    gnmic_set_with_bypass(
+        gnmi_tls,
+        f"{GNMI_PATH_PREFIX}/DEVICE_METADATA/localhost/deployment_id",
+        deployment_id,
+        "device_metadata"
+    )
+
+    duthost.shell("config save -y")
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, yang_validate=False)
+    time.sleep(10)
+
+
+def ensure_device_neighbor_metadata(duthost, gnmi_tls):
+    """
+    Ensure the WL partner neighbor metadata exists in CONFIG_DB.
+    """
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    device_neighbor_metadata = config_facts.get("DEVICE_NEIGHBOR_METADATA", {})
+    if "WL_PARTNER_ROUTER" in device_neighbor_metadata:
+        return
+
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/DEVICE_NEIGHBOR_METADATA/WL_PARTNER_ROUTER", {
+        "type": "WlPartnerRouter"
+    }, "device_neighbor_metadata")
+
+
+def setup_acl_config(duthost, ports, vnet_vnis, vnet_routes_v4, vnet_routes_v6, gnmi_tls):     # noqa: F811
+    """
+    Configure a single ACL table for inner src MAC rewrite — both IPv4 and IPv6 rules in one table.
+    Each rule matches one IP type (INNER_SRC_IP for v4, INNER_SRC_IPV6 for v6) + TUNNEL_VNI.
     """
     gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/ACL_TABLE_TYPE", {
         ACL_TYPE_NAME: {
-            "BIND_POINTS": [
-                "PORT",
-                "PORTCHANNEL"
-            ],
-            "MATCHES": [
-                "INNER_SRC_IP",
-                "TUNNEL_VNI"
-            ],
-            "ACTIONS": [
-                "COUNTER",
-                "INNER_SRC_MAC_REWRITE_ACTION"
-            ]
+            "BIND_POINTS": ["PORT", "PORTCHANNEL"],
+            "MATCHES": ["INNER_SRC_IP", "INNER_SRC_IPV6", "TUNNEL_VNI"],
+            "ACTIONS": ["COUNTER", "INNER_SRC_MAC_REWRITE_ACTION"]
         }
     }, "acl_type")
 
@@ -387,33 +525,43 @@ def setup_acl_config(duthost, ports, vnet_vnis, vnet_routes, gnmi_tls):     # no
         }
     }, "acl_table")
 
-    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/ACL_RULE", {
-        f"{ACL_TABLE_NAME}|rule_{route['vni']}": {
-            "INNER_SRC_IP": f"{INNER_SRC_IP}/32",
-            "INNER_SRC_MAC_REWRITE_ACTION": INNER_SRC_MAC,
-            "TUNNEL_VNI": f"{route['vni']}",
-            "PRIORITY": f"{route['vni']}"
-        } for vni in vnet_vnis for route in vnet_routes[vni]
-    }, "acl_rule")
+    acl_rules = {}
+    for vni in vnet_vnis:
+        for route in vnet_routes_v4[vni]:
+            if route["prefix"] == "0.0.0.0/0":
+                continue
+            acl_rules[f"{ACL_TABLE_NAME}|rule_{route['vni']}_v4"] = {
+                "INNER_SRC_IP": f"{INNER_SRC_IP}/32",
+                "INNER_SRC_MAC_REWRITE_ACTION": INNER_SRC_MAC,
+                "TUNNEL_VNI": f"{route['vni']}",
+                "PRIORITY": f"{route['vni']}"
+            }
+        for route in vnet_routes_v6[vni]:
+            if route["prefix"] == "::/0":
+                continue
+            acl_rules[f"{ACL_TABLE_NAME}|rule_{route['vni']}_v6"] = {
+                "INNER_SRC_IPV6": f"{INNER_SRC_IPV6}/128",
+                "INNER_SRC_MAC_REWRITE_ACTION": INNER_SRC_MAC,
+                "TUNNEL_VNI": f"{route['vni']}",
+                "PRIORITY": f"{route['vni']}"
+            }
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/ACL_RULE", acl_rules, "acl_rule")
 
-    # Check acl table and rules are set
-    def _acl_table_and_rule_active(duthost):
-        table_key = f"STATE_DB/localhost/ACL_TABLE_TABLE/{ACL_TABLE_NAME}/status"
-        acl_table_status = gnmi_tls.gnmic.get(table_key)[0].get("updates")[0].get("values", {}).get(table_key, {})
-        if acl_table_status.lower() != "active":
-            return False
-
+    def _acl_tables_and_rules_active(duthost):
         rule_key = "STATE_DB/localhost/ACL_RULE_TABLE"
-        acl_rules = gnmi_tls.gnmic.get(rule_key)[0].get("updates")[0].get("values", {}).get(rule_key, {})
-        for vni in vnet_vnis:
-            for route in vnet_routes[vni]:
-                acl_rule_status = acl_rules.get(f"{ACL_TABLE_NAME}|rule_{route['vni']}", {}).get("status", "")
-                if acl_rule_status.lower() != "active":
-                    return False
+        acl_rule_states = gnmi_tls.gnmic.get(rule_key)[0].get("updates")[0].get("values", {}).get(rule_key, {})
+        table_key = f"STATE_DB/localhost/ACL_TABLE_TABLE/{ACL_TABLE_NAME}/status"
+        status = gnmi_tls.gnmic.get(table_key)[0].get("updates")[0].get("values", {}).get(table_key, {})
+        if status.lower() != "active":
+            return False
+        for rule_key_name in acl_rules:
+            rule_name = rule_key_name.split("|", 1)[1]
+            if acl_rule_states.get(f"{ACL_TABLE_NAME}|{rule_name}", {}).get("status", "").lower() != "active":
+                return False
         return True
 
-    pytest_assert(wait_until(60, 2, 0, _acl_table_and_rule_active, duthost),
-                  f"ACL table {ACL_TABLE_NAME} or its rules not active after 60 seconds.")
+    pytest_assert(wait_until(60, 2, 0, _acl_tables_and_rules_active, duthost),
+                  f"ACL tables or rules not active after 60 seconds.")
 
 
 def setup_vnet_routes(vnet_vnis, vni_to_routes, gnmi_tls):     # noqa: F811
@@ -425,7 +573,6 @@ def setup_vnet_routes(vnet_vnis, vni_to_routes, gnmi_tls):     # noqa: F811
         } for vni in vnet_vnis for route in vni_to_routes[vni]
     }, "vnet_routes")
 
-    # Check vnet routes are set
     time.sleep(5)
     for vni in vnet_vnis:
         for route in vni_to_routes[vni]:
@@ -436,24 +583,65 @@ def setup_vnet_routes(vnet_vnis, vni_to_routes, gnmi_tls):     # noqa: F811
                           f"VNET route tunnel for Vnet{vni}|{route['prefix']} not active.")
 
 
-def setup_bgp(duthost, ptfhost, vnet_vnis, dut_ips, ptf_ips,
-              subnet_ip, loopback_ip, bgp_port, vnet_route_ip, gnmi_tls):     # noqa: F811
+def setup_ra_sender(ptfhost, subintfs_info):
+    """
+    Deploy IPv6 RA sender script to PTF and start it for all subinterfaces.
+    Sends periodic Router Advertisements to help BGP link-local peer discovery.
+    """
+    # Write the RA sender script to a temp file locally, then copy to PTF
+    ra_script_local = "/tmp/ra_send.py"
+    with open(ra_script_local, "w") as f:
+        f.write(RA_SEND_SCRIPT)
+    temp_files.append(ra_script_local)
+
+    # Copy to PTF
+    ptfhost.copy(src=ra_script_local, dest="/tmp/ra_send.py")
+    ptfhost.shell("chmod +x /tmp/ra_send.py")
+
+    # Start RA sender for each subinterface
+    for subintf, values in subintfs_info.items():
+        bond_name = values["bond_name"]
+        logger.info(f"Starting RA sender on {bond_name}")
+        ptfhost.shell(
+            f"nohup python3 /tmp/ra_send.py {bond_name} --interval 3 > /var/log/exabgp_vnet.log 2>&1 &",
+            module_ignore_errors=True
+        )
+    
+    time.sleep(2)
+
+
+def setup_bgp(duthost, ptfhost, vnet_vnis, subint_info,
+              subnet_ip, bgp_port, gnmi_tls):     # noqa: F811
+    """
+    Setup MP-BGP peer range WLPARTNER_PASSIVE_V4 per VNET for dual-stack decap testing.
+    """
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     dut_asn = config_facts['DEVICE_METADATA']['localhost']['bgp_asn']
     neighbors = config_facts['BGP_NEIGHBOR']
     peer_asn = list(neighbors.values())[0]["asn"]
 
-    for vni in vnet_vnis:
+    for subint, value in subint_info.items():
         gnmic_set_with_bypass(
             gnmi_tls,
-            f"{GNMI_PATH_PREFIX}/BGP_PEER_RANGE/Vnet{vni}|WLPARTNER_PASSIVE_V4",
+            f"{GNMI_PATH_PREFIX}/BGP_NEIGHBOR/Vnet{value['vnet_vni']}|{subint}",
             {
-                "ip_range": [subnet_ip],
-                "name": "WLPARTNER_PASSIVE_V4",
-                "peer_asn": peer_asn,
-                "src_address": loopback_ip
+                "admin_status": "up",
+                "name": "WL_PARTNER_ROUTER",
+                "asn": peer_asn,
             },
-            f"bgp_peer_{vni}")
+            f"bgp_peer_{value['vnet_vni']}_{subint}")
+        
+    prefix_lists = {}
+    for vni in vnet_vnis:
+        prefix_lists[f"IPV4_DOWNSTREAM_PREFIXES_VNET_Vnet{vni}|{subnet_ip}"] = {"action": "permit"}
+        prefix_lists[f"IPV6_DOWNSTREAM_PREFIXES_VNET_Vnet{vni}|{BGP_V6_DECAP_ROUTE}"] = {"action": "permit"}
+
+    gnmic_set_with_bypass(
+        gnmi_tls,
+        f"{GNMI_PATH_PREFIX}/PREFIX_LIST",
+        prefix_lists,
+        f"prefix_list_vnet{vni}"
+    )
 
     exabgp_config = f"""
 process api-vnets {{
@@ -462,12 +650,15 @@ process api-vnets {{
 }}
 """
 
-    for dut_ips_per_portchannel, ptf_ips_per_portchannel in zip(dut_ips, ptf_ips):
-        for dut_ip, ptf_ip in zip(dut_ips_per_portchannel, ptf_ips_per_portchannel):
-            exabgp_config += f"""
-neighbor {dut_ip.split('/')[0]} {{
-    router-id {ptf_ip.split('/')[0]};
-    local-address {ptf_ip.split('/')[0]};
+    # MP-BGP neighbors: IPv4 session advertising both IPv4 WL subnet and IPv6 decap route.
+    # The IPv6 route uses the PTF subinterface IPv6 address as next-hop (RFC 4760).
+    for subint, value in subint_info.items():
+        dut_ipv6 = value["dut_ipv6"]
+        ptf_ipv6 = value["ptf_ipv6"]
+        exabgp_config += f"""
+neighbor {dut_ipv6.split('/')[0]}%{value['bond_name']} {{
+    router-id 10.10.10.10;
+    local-address {ptf_ipv6.split('/')[0]}%{value['bond_name']};
     local-as {peer_asn};
     peer-as {dut_asn};
     api {{
@@ -475,9 +666,11 @@ neighbor {dut_ip.split('/')[0]} {{
     }}
     family {{
         ipv4 unicast;
+        ipv6 unicast;
     }}
     static {{
-        route {vnet_route_ip} next-hop {ptf_ip.split('/')[0]};
+        route {subnet_ip} next-hop {ptf_ipv6.split('/')[0]};
+        route {BGP_V6_DECAP_ROUTE} next-hop {ptf_ipv6.split('/')[0]};
     }}
 }}
 """
@@ -488,18 +681,9 @@ neighbor {dut_ip.split('/')[0]} {{
     ptfhost.copy(src='/tmp/exabgp_update.conf', dest=EXABGP_CONFIG_PATH)
     ptfhost.shell(f"nohup exabgp {EXABGP_CONFIG_PATH} > /var/log/exabgp_all_vnets.log 2>&1 &")
 
-    # Check vrf bgp session is up
-    time.sleep(40)
-    for vni in vnet_vnis:
-        vnet_bgps = duthost.show_and_parse(f"show ip bgp vrf Vnet{vni} summary")
-        pytest_assert(len(vnet_bgps) > 0, f"No BGP sessions found for vnet Vnet{vni}.")
-        for val in vnet_bgps:
-            pytest_assert(val["neighborname"] == "WLPARTNER_PASSIVE_V4" and val["state/pfxrcd"].isdigit()
-                          and int(val["state/pfxrcd"]) > 0, f"BGP neighbor not found for vnet Vnet{vni}.")
-
 
 def setup_portchannel_subintfs(duthost, ptfhost, portchannel_info,
-                               vnet_vnis, base_vlan, dut_ips, ptf_ips, gnmi_tls):     # noqa: F811
+                               vnet_vnis, base_vlan, gnmi_tls):     # noqa: F811
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     has_subintfs = len(config_facts.get("VLAN_SUB_INTERFACE", {})) > 0
 
@@ -517,9 +701,9 @@ def setup_portchannel_subintfs(duthost, ptfhost, portchannel_info,
                     subintf_name: {
                         "admin_status": "up",
                         "vlan": str(base_vlan + i),
-                        "vnet_name": f"Vnet{vnet_vnis[i]}"
-                    },
-                    f"{subintf_name}|{dut_ips[j][i]}": {}
+                        "vnet_name": f"Vnet{vnet_vnis[i]}",
+                        "ipv6_use_link_local_only": "enable"
+                    }
                 }, subintf_name)
                 has_subintfs = True
             else:
@@ -529,18 +713,15 @@ def setup_portchannel_subintfs(duthost, ptfhost, portchannel_info,
                     {
                         "admin_status": "up",
                         "vlan": str(base_vlan + i),
-                        "vnet_name": f"Vnet{vnet_vnis[i]}"
+                        "vnet_name": f"Vnet{vnet_vnis[i]}",
+                        "ipv6_use_link_local_only": "enable"
                     },
                     subintf_name)
-                gnmic_set_with_bypass(
-                    gnmi_tls,
-                    f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}|{dut_ips[j][i].replace('/','~1')}",
-                    {},
-                    f"{subintf_name}_ip")
+
+            dut_link_local_ipv6 = get_link_local_ipv6_on_interface(duthost, subintf_name)
 
             # Configure ptf port commands
             cmds.append(f"ip link add link {bond_port} name {bond_port}.{base_vlan + i} type vlan id {base_vlan + i}")
-            cmds.append(f"ip address add {ptf_ips[j][i]} dev {bond_port}.{base_vlan + i}")
             cmds.append(f"ip link set {bond_port}.{base_vlan + i} up")
 
             subintfs_info[subintf_name] = {
@@ -548,8 +729,8 @@ def setup_portchannel_subintfs(duthost, ptfhost, portchannel_info,
                 "portchannel_num": po_num,
                 "ptf_port_index": val["ptf_port_index"],
                 "bond_name": f"{bond_port}.{base_vlan + i}",
-                "dut_ip": dut_ips[j][i],
-                "ptf_ip": ptf_ips[j][i],
+                "dut_ipv6": dut_link_local_ipv6,
+                "ptf_ipv6": "",
                 "vlan": base_vlan + i,
                 "vnet": f"Vnet{vnet_vnis[i]}",
                 "vnet_vni": vnet_vnis[i],
@@ -559,16 +740,16 @@ def setup_portchannel_subintfs(duthost, ptfhost, portchannel_info,
     ptfhost.shell("supervisorctl restart ptf_nn_agent")
     time.sleep(5)
 
-    # Check subinterfaces are up in state db
+    for subintf, values in subintfs_info.items():
+        values["ptf_ipv6"] = get_ptf_link_local_ipv6_on_interface(ptfhost, values["bond_name"])
+
     interfaces_key = "STATE_DB/localhost/INTERFACE_TABLE"
     interfaces = gnmi_tls.gnmic.get(interfaces_key)[0].get("updates")[0].get("values", {}).get(interfaces_key, {})
     for subintf, values in subintfs_info.items():
         subintf_vnet = interfaces.get(subintf, {}).get("vrf", "")
-        subintf_status = interfaces.get(f"{subintf}|{values['dut_ip']}", {}).get("state", "")
 
-        pytest_assert(subintf_vnet.lower() == values["vnet"].lower(), f"Subinterface {subintf} not in correct vnet. \
-                      Expected {values['vnet']}, got {subintf_vnet}.")
-        pytest_assert(subintf_status.lower() == "ok", f"Subinterface {subintf} not in ok state.")
+        pytest_assert(subintf_vnet.lower() == values["vnet"].lower(),
+                      f"Subinterface {subintf} not in correct vnet. Expected {values['vnet']}, got {subintf_vnet}.")
 
     return subintfs_info
 
@@ -580,6 +761,20 @@ def setup_portchannels(duthost, ptfhost, config_facts, port_indexes,
                   f"Found {len(ports)} available ports. Needed {len(PORTCHANNEL_NAMES)} ports for the test.")
 
     cmds = []
+    # Pre-cleanup: remove stale bonds from previous interrupted runs
+    pre_cleanup = []
+    for i in range(len(PORTCHANNEL_NAMES)):
+        dut_port_index = port_indexes.get(ports[i])
+        if dut_port_index is not None and dut_port_index in ptf_ports_available_in_topo:
+            ptf_port_name = ptf_ports_available_in_topo[dut_port_index]["name"]
+            ptf_port_index = ptf_ports_available_in_topo[dut_port_index]["index"]
+            bond_port = 'bond{}'.format(ptf_port_index)
+            pre_cleanup.append(f"ip link set {ptf_port_name} nomaster 2>/dev/null || true")
+            pre_cleanup.append(f"ip link del {bond_port} 2>/dev/null || true")
+            pre_cleanup.append(f"ip link set {ptf_port_name} up 2>/dev/null || true")
+    if pre_cleanup:
+        ptfhost.shell_cmds(cmds=pre_cleanup)
+
     wl_portchannel_mapping_info = {}
     for i in range(len(PORTCHANNEL_NAMES)):
         duthost.shell(f'config vlan member del {vlan_id} {ports[i]}')
@@ -593,7 +788,6 @@ def setup_portchannels(duthost, ptfhost, config_facts, port_indexes,
             {},
             f"{PORTCHANNEL_NAMES[i]}_member")
 
-        # Configure ptf port commands
         dut_port_index = port_indexes[ports[i]]
         ptf_port_name = ptf_ports_available_in_topo[dut_port_index]["name"]
         ptf_port_index = ptf_ports_available_in_topo[dut_port_index]["index"]
@@ -617,7 +811,6 @@ def setup_portchannels(duthost, ptfhost, config_facts, port_indexes,
     ptfhost.shell("supervisorctl restart ptf_nn_agent")
     time.sleep(5)
 
-    # Validate portchannel is up in state db
     for portchannel_name in PORTCHANNEL_NAMES:
         portchannel_key = f"STATE_DB/localhost/LAG_TABLE/{portchannel_name}"
         portchannel_status = gnmi_tls.gnmic.get(portchannel_key)[0].get("updates")[0].get("values", {})\
@@ -638,12 +831,10 @@ def setup_vnets(num_vnets, tunnel, base_vni, gnmi_tls):     # noqa: F811
         } for i in range(num_vnets)
     }, "vnet")
 
-    # Validate vnet is set in state db
     for i in range(num_vnets):
         vnet_name = f"Vnet{base_vni + i}"
         vnet_key = f"STATE_DB/localhost/VRF_TABLE/{vnet_name}/state"
         vnet_status = gnmi_tls.gnmic.get(vnet_key)[0].get("updates")[0].get("values", {}).get(vnet_key, {})
-
         pytest_assert(vnet_status.lower() == "ok", f"Vnet {vnet_name} not in ok state.")
 
     return [base_vni + i for i in range(num_vnets)]
@@ -662,7 +853,6 @@ def common_setup_and_teardown(tbinfo, duthosts, rand_one_dut_hostname,
                               ptfhost, ptfadapter, localhost, gnmi_tls):     # noqa: F811
     duthost = duthosts[rand_one_dut_hostname]
 
-    # backup config_db.json for cleanup
     duthost.shell(f"cp {CONFIG_DB_PATH} {CONFIG_DB_PATH}.bak")
 
     ecmp_utils.Constants["KEEP_TEMP_FILES"] = False
@@ -674,73 +864,88 @@ def common_setup_and_teardown(tbinfo, duthosts, rand_one_dut_hostname,
     try:
         config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
 
-        port_indexes = config_facts['port_index_map']  # map of dut port name to dut port index
+        port_indexes = config_facts['port_index_map']
         duts_map = tbinfo["duts_map"]
         dut_indx = duts_map[duthost.hostname]
-        # Get available ports in PTF
-        host_interfaces = tbinfo["topo"]["ptf_map"][str(dut_indx)]  # map of ptf port index to dut port index
+        host_interfaces = tbinfo["topo"]["ptf_map"][str(dut_indx)]
         ptf_ports_available_in_topo = {}
         for key in host_interfaces:
-            ptf_ports_available_in_topo[host_interfaces[key]] = {  # map of dut port index to ptf port info
+            ptf_ports_available_in_topo[host_interfaces[key]] = {
                 "index": int(key),
                 "name": "eth{}".format(int(key))
             }
 
+        # This test uses features that require deployment_id 26
+        ensure_localhost_deployment_id(duthost, gnmi_tls, "26")
+
+        # Ensure DEVICE_NEIGHBOR_METADATA for bgp neighbor exists in CONFIG_DB
+        ensure_device_neighbor_metadata(duthost, gnmi_tls)
+
         # Remove everflow acl tables
         duthost.remove_acl_table("EVERFLOW")
         duthost.remove_acl_table("EVERFLOWV6")
+        duthost.remove_acl_table(ACL_TABLE_NAME_V6)
 
         # Create loopback interface
         duthost.shell("config int ip add Loopback6 10.10.1.1")
+        duthost.shell("config int ip add Loopback7 10.10.2.2")
         loopback_ip = "10.10.1.1"
 
         subnet_ip = "10.11.0.0/16"
-        subnet_ip_int, _ = convert_str_to_ip_int(subnet_ip)
 
         # Set up vxlan
         setup_vxlan_tunnel("tunnel_v4", loopback_ip, gnmi_tls)
 
-        #  Set up vnets
+        # Set up vnets
         vnet_vnis = setup_vnets(NUM_VNETS, "tunnel_v4", BASE_VNI, gnmi_tls)
 
         # Set up portchannels
         wl_portchannel_info = setup_portchannels(duthost, ptfhost, config_facts,
                                                  port_indexes, ptf_ports_available_in_topo, gnmi_tls)
 
-        # Set up subintfs
-        dut_ips, ptf_ips = generate_subintfs_ips(NUM_VNETS, len(PORTCHANNEL_NAMES), start_ip_int=subnet_ip_int)
+        # Set up subintfs (IPv4 + IPv6 addresses for MP-BGP next-hop resolution)
         subintfs_info = setup_portchannel_subintfs(
             duthost,
             ptfhost,
             wl_portchannel_info,
             vnet_vnis,
             base_vlan=10,
-            dut_ips=dut_ips,
-            ptf_ips=ptf_ips,
             gnmi_tls=gnmi_tls)
 
         # Set up bgps
-        setup_bgp(
-            duthost,
+        setup_bgp(duthost,
             ptfhost,
             vnet_vnis,
-            dut_ips,
-            ptf_ips,
-            subnet_ip,
-            loopback_ip,
+            subintfs_info,
+            subnet_ip=subnet_ip,
             bgp_port=EXABGP_PORT,
-            vnet_route_ip=subnet_ip,
             gnmi_tls=gnmi_tls)
+        
+        # Start IPv6 RA sender on subinterfaces for peer NDP discovery
+        setup_ra_sender(ptfhost, subintfs_info)
 
-        # Set up vnet routes
-        vnet_routes = generate_vnet_routes(vnet_vnis, start_prefix_int=convert_str_to_ip_int("30.0.0.0")[0],
-                                           start_endpoint_int=convert_str_to_ip_int(TUNNEL_ENDPOINT)[0],
-                                           start_vni=10000, num_routes_per_vnet=5)
-        setup_vnet_routes(vnet_vnis, vnet_routes, gnmi_tls)
+        # Check bgp sessions are up
+        time.sleep(30)
+        check_vrf_bgp_sessions_established(duthost, vnet_vnis)
+
+        # Generate and setup vnet routes
+        vnet_routes_v6 = generate_vnet_routes_v6(vnet_vnis, start_vni=10000, num_routes_per_vnet=5,
+                                                  include_default_route=False)
+        vnet_routes_v4 = generate_vnet_routes_v4(
+            vnet_vnis,
+            start_prefix_int=int(ipaddress.IPv4Address("30.0.0.0")),
+            start_endpoint_int=int(ipaddress.IPv4Address(TUNNEL_ENDPOINT)),
+            start_vni=10000, num_routes_per_vnet=5)
+        all_vnet_routes = {vni: vnet_routes_v4[vni] + vnet_routes_v6[vni] for vni in vnet_vnis}
+        setup_vnet_routes(vnet_vnis, all_vnet_routes, gnmi_tls)
 
         # Setup acl configs
         config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
-        setup_acl_config(duthost, list(config_facts.get("PORTCHANNEL", {}).keys()), vnet_vnis, vnet_routes, gnmi_tls)
+        setup_acl_config(duthost, list(config_facts.get("PORTCHANNEL", {}).keys()),
+                         vnet_vnis, vnet_routes_v4, vnet_routes_v6, gnmi_tls)
+
+        # Install IPv6 overlay routes after ACL setup
+        setup_vnet_routes(vnet_vnis, vnet_routes_v6, gnmi_tls)
 
         # Configure vxlan port
         ecmp_utils.configure_vxlan_switch(duthost, VXLAN_PORT, "00:12:34:56:78:9a")
@@ -749,14 +954,12 @@ def common_setup_and_teardown(tbinfo, duthosts, rand_one_dut_hostname,
         t1_ptf_port_nums = []
         portchannel_members = config_facts.get("PORTCHANNEL_MEMBER", {})
         for key in portchannel_members:
-            members = list(portchannel_members[key].keys())
-            for intf in members:
+            for intf in list(portchannel_members[key].keys()):
                 dut_port_idx = port_indexes.get(intf)
                 if dut_port_idx is None:
                     continue
                 ptf_port = ptf_ports_available_in_topo.get(dut_port_idx)
                 if ptf_port is None:
-                    # Port not in this DUT's ptf_map (e.g. dualtor: port on other ToR)
                     continue
                 if key not in wl_portchannel_info:
                     t1_ptf_port_nums.append(ptf_port["index"])
@@ -776,60 +979,67 @@ def common_setup_and_teardown(tbinfo, duthosts, rand_one_dut_hostname,
             ports_per_vnet[vni] = []
         ports_per_vnet[vni].append(val["ptf_port_index"])
 
+    # Unified configs: each entry carries both IPv4 and IPv6 inner dst fields.
+    # v4 functions use "inner_dst_ip_v4", v6 functions use "inner_dst_ip_v6".
+    # Both share same VNI/endpoint/outer tunnel — only inner packet type differs.
     decap_test_configs = [
         {
-            "inner_dst_ip": "10.11.255.255",
+            "inner_dst_ip_v4": "10.11.255.255",
+            "inner_dst_ip_v6": BGP_V6_DECAP_IP,
             "expected_dst_ip": loopback_ip,
             "vni": val["vnet_vni"],
             "vlan": val["vlan"],
             "outgoing_port": t1_ptf_port_nums[0],
-            "expected_ports": ports_per_vnet[val["vnet_vni"]]
+            "expected_ports": ports_per_vnet[val["vnet_vni"]],
         } for _, val in subintfs_info.items()
     ]
     encap_test_configs = [
         {
-            "inner_dst_ip": route["prefix"].split('/')[0] if route["prefix"] != "0.0.0.0/0" else "150.0.0.10",
-            "expected_dst_mac": route["mac_address"],
-            "expected_vni": route["vni"],
-            "expected_dst_ip": route["endpoint"],
+            "inner_dst_ip_v4": route_v4["prefix"].split('/')[0] if route_v4["prefix"] != "0.0.0.0/0" else "150.0.0.10",
+            "inner_dst_ip_v6": route_v6["prefix"].split('/')[0] if route_v6["prefix"] != "::/0" else "2000:db8:1::10",
+            "expected_dst_mac": route_v4["mac_address"],
+            "expected_vni": route_v4["vni"],
+            "expected_dst_ip": route_v4["endpoint"],
             "expected_src_ip": loopback_ip,
             "vlan": val["vlan"],
             "vni": val["vnet_vni"],
             "outgoing_port": val["ptf_port_index"],
             "expected_ports": t1_ptf_port_nums,
-            "route": route
-        } for _, val in subintfs_info.items() for route in vnet_routes[val["vnet_vni"]]
+            "route_v4": route_v4,
+            "route_v6": route_v6,
+        }
+        for _, val in subintfs_info.items()
+        for route_v4, route_v6 in zip(
+            vnet_routes_v4[val["vnet_vni"]],
+            vnet_routes_v6[val["vnet_vni"]]
+        )
     ]
-    yield duthost, ptfadapter, encap_test_configs, decap_test_configs
+
+    yield duthost, ptfhost, ptfadapter, vnet_vnis, subintfs_info, encap_test_configs, decap_test_configs
 
     # Cleanup
     cleanup(duthost, ptfhost, localhost, wl_portchannel_info, subintfs_info)
 
 
-def modify_routes_mac_vni(gnmi_tls, encap_test_configs, offset=0):     # noqa: F811
+def modify_routes_mac_vni_v4(gnmi_tls, encap_test_configs, offset=0):
+    """
+    Modify IPv4 VNET tunnel route VNI, endpoint, and MAC by offset.
+    """
     modified_routes = set()
     acl_rule_value = {}
 
     for config in encap_test_configs:
-        route = config["route"]
-
+        route = config["route_v4"]
         if route["prefix"] not in modified_routes:
             route["vni"] += offset
             route["mac_address"] = route["mac_address"][:-2] + \
                 "{:02x}".format((int(route["mac_address"][-2:], 16) + offset) % 256)
-            route["endpoint"] = convert_ip_int_to_str(
-                convert_str_to_ip_int(route["endpoint"])[0] + offset
-            ).split('/')[0]
-
+            route["endpoint"] = str(ipaddress.IPv4Address(int(ipaddress.IPv4Address(route["endpoint"])) + offset))
             gnmic_set_with_bypass(
                 gnmi_tls,
                 f"{GNMI_PATH_PREFIX}/VNET_ROUTE_TUNNEL/Vnet{route['vnet_vni']}|{route['prefix'].replace('/','~1')}",
-                {
-                    "endpoint": route["endpoint"],
-                    "vni": route["vni"],
-                    "mac_address": route["mac_address"]
-                },
-                f"vnet_route_{route['vnet_vni']}_{route['prefix'].replace('/','_')}"
+                {"endpoint": route["endpoint"], "vni": route["vni"], "mac_address": route["mac_address"]},
+                f"vnet_route_{route['vnet_vni']}_{route['prefix'].replace('/','_')}",
             )
             acl_rule_value[f"{ACL_TABLE_NAME}|rule_{route['vni']}"] = {
                 "INNER_SRC_IP": f"{INNER_SRC_IP}/32",
@@ -837,9 +1047,7 @@ def modify_routes_mac_vni(gnmi_tls, encap_test_configs, offset=0):     # noqa: F
                 "TUNNEL_VNI": f"{route['vni']}",
                 "PRIORITY": f"{route['vni']}"
             }
-
             modified_routes.add(route["prefix"])
-
         config["expected_vni"] = route["vni"]
         config["expected_dst_mac"] = route["mac_address"]
         config["expected_dst_ip"] = route["endpoint"]
@@ -851,25 +1059,79 @@ def modify_routes_mac_vni(gnmi_tls, encap_test_configs, offset=0):     # noqa: F
     time.sleep(5)
     for config in encap_test_configs:
         route_key = "STATE_DB/localhost/VNET_ROUTE_TUNNEL_TABLE"
+        route = config["route_v4"]
         route_status = gnmi_tls.gnmic.get(route_key)[0].get("updates")[0].get("values", {}).get(route_key, {})\
-            .get(f"Vnet{config['route']['vnet_vni']}|{config['route']['prefix']}", {}).get("state", "")
+            .get(f"Vnet{route['vnet_vni']}|{route['prefix']}", {}).get("state", "")
         pytest_assert(route_status.lower() == "active",
-                      f"VNET route tunnel for Vnet{config['route']['vnet_vni']}|\
-                        {config['route']['prefix']} not active.")
+                      f"VNET route tunnel for Vnet{route['vnet_vni']}|"
+                      f"{route['prefix']} not active after mac/vni update.")
+
+
+def modify_routes_mac_vni_v6(gnmi_tls, encap_test_configs, offset=1):
+    """
+    Modify IPv6 VNET tunnel route VNI, endpoint, and MAC by offset.
+    """
+    modified_routes = set()
+    acl_rule_value = {}
+
+    for config in encap_test_configs:
+        route = config["route_v6"]
+
+        if route["prefix"] not in modified_routes:
+            route["vni"] += offset
+            route["mac_address"] = route["mac_address"][:-2] + \
+                "{:02x}".format((int(route["mac_address"][-2:], 16) + offset) % 256)
+            route["endpoint"] = str(ipaddress.IPv4Address(int(ipaddress.IPv4Address(route["endpoint"])) + offset))
+
+            gnmic_set_with_bypass(
+                gnmi_tls,
+                f"{GNMI_PATH_PREFIX}/VNET_ROUTE_TUNNEL/Vnet{route['vnet_vni']}|{route['prefix'].replace('/','~1')}",
+                {
+                    "endpoint": route["endpoint"],
+                    "vni": route["vni"],
+                    "mac_address": route["mac_address"],
+                },
+                f"vnet_route_{route['vnet_vni']}_{route['prefix'].replace('/','_')}",
+            )
+            acl_rule_value[f"{ACL_TABLE_NAME}|rule_{route['vni']}_v6"] = {
+                "INNER_SRC_IPV6": f"{INNER_SRC_IPV6}/128",
+                "INNER_SRC_MAC_REWRITE_ACTION": INNER_SRC_MAC,
+                "TUNNEL_VNI": f"{route['vni']}",
+                "PRIORITY": f"{route['vni']}"
+            }
+            modified_routes.add(route["prefix"])
+
+        config["expected_vni"] = route["vni"]
+        config["expected_dst_mac"] = route["mac_address"]
+        config["expected_dst_ip"] = route["endpoint"]
+
+    # Update src mac rewrite acl to match new vnis
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/ACL_RULE", acl_rule_value, "acl_rule_v6")
+
+    # Check vnet routes are updated
+    time.sleep(5)
+    for config in encap_test_configs:
+        route_key = "STATE_DB/localhost/VNET_ROUTE_TUNNEL_TABLE"
+        route = config["route_v6"]
+        route_status = gnmi_tls.gnmic.get(route_key)[0].get("updates")[0].get("values", {}).get(route_key, {})\
+            .get(f"Vnet{route['vnet_vni']}|{route['prefix']}", {}).get("state", "")
+        pytest_assert(route_status.lower() == "active",
+                      f"VNET route tunnel for Vnet{route['vnet_vni']}|"
+                      f"{route['prefix']} not active after mac/vni update.")
 
 
 def test_vnet_with_bgp_intf_smacrewrite(common_setup_and_teardown, gnmi_tls):     # noqa: F811
-    duthost, ptfadapter, encap_test_configs, decap_test_configs = common_setup_and_teardown
 
-    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
-    logger.debug("post-setup config_facts: {}".format(config_facts))
+    duthost, ptfhost, ptfadapter, vnet_vnis, subintfs_info, encap_test_configs, decap_test_configs = common_setup_and_teardown
 
     validate_decap_t1_to_wl(duthost, ptfadapter, decap_test_configs)
 
     validate_encap_wl_to_t1(duthost, ptfadapter, encap_test_configs)
 
     # Test datapath after modifying route mac and vni
-    modify_routes_mac_vni(gnmi_tls, encap_test_configs, offset=1)
+    modify_routes_mac_vni_v4(gnmi_tls, encap_test_configs, offset=1)
+    modify_routes_mac_vni_v6(gnmi_tls, encap_test_configs, offset=1)
+    time.sleep(5)
 
     validate_decap_t1_to_wl(duthost, ptfadapter, decap_test_configs)
 
@@ -880,7 +1142,13 @@ def test_vnet_with_bgp_intf_smacrewrite(common_setup_and_teardown, gnmi_tls):   
     config_reload(duthost, safe_reload=True, check_intf_up_ports=True, yang_validate=False)
     time.sleep(10)
 
-    # Configure vxlan port
+    # Start IPv6 RA sender
+    setup_ra_sender(ptfhost, subintfs_info)
+
+    # Check bgp sessions are up
+    time.sleep(30)
+    check_vrf_bgp_sessions_established(duthost, vnet_vnis)
+
     ecmp_utils.configure_vxlan_switch(duthost, VXLAN_PORT, "00:12:34:56:78:9a")
 
     validate_decap_t1_to_wl(duthost, ptfadapter, decap_test_configs)

--- a/tests/vxlan/test_vxlan_vnet_bgp_subintf_v4_v6_src_mac_rewrite_routes.py
+++ b/tests/vxlan/test_vxlan_vnet_bgp_subintf_v4_v6_src_mac_rewrite_routes.py
@@ -1,0 +1,1147 @@
+import ipaddress
+import logging
+import os
+import time
+
+import pytest
+from ptf.mask import Mask
+from ptf.packet import Ether, IP, IPv6, UDP, TCP
+import ptf.testutils as testutils
+
+from tests.common.config_reload import config_reload
+from tests.common.fixtures.grpc_fixtures import gnmi_tls    # noqa: F401
+from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.utilities import wait_until
+from tests.common.vxlan_ecmp_utils import Ecmp_Utils
+
+ecmp_utils = Ecmp_Utils()
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology("t0"),
+    pytest.mark.device_type('physical'),
+    pytest.mark.asic('cisco-8000')
+]
+
+CONFIG_DB_PATH = '/etc/sonic/config_db.json'
+EXABGP_CONFIG_PATH = "/etc/exabgp/exabgp_vnet_bgp.conf"
+EXABGP_PORT = 5100
+
+PORTCHANNEL_NAMES = ["PortChannel1031", "PortChannel1032"]
+VXLAN_PORT = 4789
+TUNNEL_ENDPOINT = "100.0.1.10"
+INNER_SRC_IP = "2.2.2.2"
+INNER_SRC_MAC = "00:11:22:33:44:55"
+INNER_SRC_IPV6 = "2001:db8:2::2"
+
+BASE_VNI = 1000
+NUM_VNETS = 2
+
+V6_SUBINT_BASE = "fc00:11::"
+
+VNET_V6_PREFIX_BASE = "2001:db8:30::"
+BGP_V6_DECAP_ROUTE = "2001:db8:40::/64"
+BGP_V6_DECAP_IP = "2001:db8:40::1"
+
+GNMI_PATH_PREFIX = "CONFIG_DB/localhost"
+
+ACL_TYPE_NAME = "INNER_SRC_MAC_REWRITE_TYPE"
+ACL_TABLE_NAME = "INNER_SRC_MAC_REWRITE_TABLE"
+ACL_TYPE_NAME_V6 = "INNER_SRC_MAC_REWRITE_TYPE_V6"
+ACL_TABLE_NAME_V6 = "INNER_SRC_MAC_REWRITE_TABLE_V6"
+
+temp_files = []
+
+
+def validate_encap_wl_to_t1_v6(duthost, ptfadapter, test_configs):
+    """
+    Test WL→T1 VXLAN encap with IPv6 inner packets.
+    """
+    logger.info("Starting WL to T1 VXLAN encapsulation test (IPv6 inner)...")
+
+    for configs in test_configs:
+        pkt_opts = {
+            "eth_dst": duthost.facts['router_mac'],
+            "eth_src": ptfadapter.dataplane.get_mac(0, configs["outgoing_port"]),
+            "ipv6_dst": configs["inner_dst_ip_v6"],
+            "ipv6_src": INNER_SRC_IPV6,
+            "ipv6_hlim": 64,
+            "dl_vlan_enable": True,
+            "vlan_vid": configs["vlan"],
+            "tcp_sport": 1234,
+            "tcp_dport": 5000,
+            "pktlen": 100,
+        }
+        inner_pkt = testutils.simple_tcpv6_packet(**pkt_opts)
+
+        pkt_opts["eth_src"] = INNER_SRC_MAC
+        pkt_opts["eth_dst"] = configs["expected_dst_mac"]
+        pkt_opts["ipv6_hlim"] = 63
+        pkt_opts["dl_vlan_enable"] = False
+        pkt_opts.pop("vlan_vid", None)
+        pkt_opts["pktlen"] = 96
+        inner_exp_pkt = testutils.simple_tcpv6_packet(**pkt_opts)
+
+        expected_pkt = testutils.simple_vxlan_packet(
+            eth_dst="aa:bb:cc:dd:ee:ff",
+            eth_src=duthost.facts['router_mac'],
+            ip_src=configs["expected_src_ip"],
+            ip_dst=configs["expected_dst_ip"],
+            ip_id=0, ip_flags=0x2,
+            udp_sport=1234, udp_dport=VXLAN_PORT, with_udp_chksum=False,
+            vxlan_vni=int(configs["expected_vni"]),
+            inner_frame=inner_exp_pkt,
+        )
+        masked_expected_pkt = Mask(expected_pkt)
+        masked_expected_pkt.set_ignore_extra_bytes()
+        masked_expected_pkt.set_do_not_care_packet(Ether, 'dst')
+        masked_expected_pkt.set_do_not_care_packet(UDP, 'sport')
+        masked_expected_pkt.set_do_not_care_packet(UDP, 'chksum')
+        masked_expected_pkt.set_do_not_care_packet(IP, "ttl")
+        masked_expected_pkt.set_do_not_care_packet(IP, "chksum")
+        masked_expected_pkt.set_do_not_care_packet(IP, "id")
+        masked_expected_pkt.set_do_not_care_packet(IP, "len")
+        masked_expected_pkt.set_do_not_care_packet(IP, "tos")
+
+        ptfadapter.dataplane.flush()
+        testutils.send(ptfadapter, configs["outgoing_port"], inner_pkt)
+        testutils.verify_packet_any_port(ptfadapter, masked_expected_pkt, configs["expected_ports"], timeout=2)
+
+    logger.info("WL to T1 VXLAN encapsulation test (IPv6 inner) passed.")
+
+
+def validate_encap_wl_to_t1_v4(duthost, ptfadapter, test_configs):
+    """
+    Test WL→T1 VXLAN encap with IPv4 inner packets.
+    """
+    logger.info("Starting WL to T1 VXLAN encapsulation test (IPv4 inner)...")
+
+    for configs in test_configs:
+        pkt_opts = {
+            "eth_dst": duthost.facts['router_mac'],
+            "eth_src": ptfadapter.dataplane.get_mac(0, configs["outgoing_port"]),
+            "ip_dst": configs["inner_dst_ip_v4"],
+            "ip_src": INNER_SRC_IP,
+            "ip_id": 105,
+            "ip_ttl": 64,
+            "dl_vlan_enable": True,
+            "vlan_vid": configs["vlan"],
+            "tcp_sport": 1234,
+            "tcp_dport": 5000,
+            "pktlen": 100,
+        }
+        inner_pkt = testutils.simple_tcp_packet(**pkt_opts)
+
+        pkt_opts["eth_src"] = INNER_SRC_MAC  # expected rewritten inner src MAC (IPv4 only)
+        pkt_opts["eth_dst"] = configs["expected_dst_mac"]
+        pkt_opts["ip_ttl"] = 63
+        pkt_opts["dl_vlan_enable"] = False
+        pkt_opts.pop("vlan_vid", None)
+        pkt_opts["pktlen"] = 96
+        inner_exp_pkt = testutils.simple_tcp_packet(**pkt_opts)
+
+        expected_pkt = testutils.simple_vxlan_packet(
+            eth_dst="aa:bb:cc:dd:ee:ff",
+            eth_src=duthost.facts['router_mac'],
+            ip_src=configs["expected_src_ip"],
+            ip_dst=configs["expected_dst_ip"],
+            ip_id=0, ip_flags=0x2,
+            udp_sport=1234, udp_dport=VXLAN_PORT, with_udp_chksum=False,
+            vxlan_vni=int(configs["expected_vni"]),
+            inner_frame=inner_exp_pkt,
+        )
+        masked_expected_pkt = Mask(expected_pkt)
+        masked_expected_pkt.set_ignore_extra_bytes()
+        masked_expected_pkt.set_do_not_care_packet(Ether, 'dst')
+        masked_expected_pkt.set_do_not_care_packet(UDP, 'sport')
+        masked_expected_pkt.set_do_not_care_packet(UDP, 'chksum')
+        masked_expected_pkt.set_do_not_care_packet(IP, "ttl")
+        masked_expected_pkt.set_do_not_care_packet(IP, "chksum")
+        masked_expected_pkt.set_do_not_care_packet(IP, "id")
+        masked_expected_pkt.set_do_not_care_packet(IP, "len")
+        masked_expected_pkt.set_do_not_care_packet(IP, "tos")
+
+        ptfadapter.dataplane.flush()
+        testutils.send(ptfadapter, configs["outgoing_port"], inner_pkt)
+        testutils.verify_packet_any_port(ptfadapter, masked_expected_pkt, configs["expected_ports"], timeout=2)
+
+    logger.info("WL to T1 VXLAN encapsulation test (IPv4 inner) passed.")
+
+
+def validate_decap_t1_to_wl_v6(duthost, ptfadapter, test_configs):
+    """
+    Test T1→WL VXLAN decap with IPv6 inner packets.
+    """
+    logger.info("Starting T1 to WL VXLAN decapsulation test (IPv6 inner)...")
+
+    for configs in test_configs:
+        pkt_opts = {
+            "eth_dst": "aa:bb:cc:dd:ee:ff",
+            "eth_src": duthost.facts['router_mac'],
+            "ipv6_src": "2001:db8:1::1",
+            "ipv6_dst": configs["inner_dst_ip_v6"],
+            "tcp_sport": 1234,
+            "tcp_dport": 4321,
+            "pktlen": 100,
+        }
+        # Build inner TCP packet expected on WL port
+        inner_pkt = testutils.simple_tcpv6_packet(**pkt_opts)
+
+        # Build VXLAN encapsulated packet to inject from T1 side
+        vxlan_pkt = testutils.simple_vxlan_packet(
+            eth_dst=duthost.facts['router_mac'],
+            eth_src=ptfadapter.dataplane.get_mac(0, configs["outgoing_port"]),
+            ip_src="1.1.1.1",
+            ip_dst=configs["expected_dst_ip"],
+            udp_sport=1234, udp_dport=VXLAN_PORT, with_udp_chksum=False,
+            vxlan_vni=int(configs["vni"]),
+            inner_frame=inner_pkt,
+        )
+        pkt_opts["vlan_vid"] = configs["vlan"]
+        pkt_opts["dl_vlan_enable"] = True
+        pkt_opts["pktlen"] = 104        # 100 + 4, add vlan tag length
+        expected_inner_pkt = testutils.simple_tcpv6_packet(**pkt_opts)
+        masked_expected_pkt = Mask(expected_inner_pkt)
+        masked_expected_pkt.set_ignore_extra_bytes()
+        masked_expected_pkt.set_do_not_care_packet(Ether, 'dst')
+        masked_expected_pkt.set_do_not_care_packet(IPv6, 'hlim')
+        masked_expected_pkt.set_do_not_care_packet(TCP, 'chksum')
+        ptfadapter.dataplane.flush()
+        testutils.send(ptfadapter, configs["outgoing_port"], vxlan_pkt)
+        testutils.verify_packet_any_port(ptfadapter, masked_expected_pkt, configs["expected_ports"], timeout=2)
+
+    logger.info("T1 to WL VXLAN decapsulation test (IPv6 inner) passed.")
+
+
+def validate_decap_t1_to_wl_v4(duthost, ptfadapter, test_configs):
+    """
+    Test T1→WL VXLAN decap with IPv4 inner packets.
+    """
+    logger.info("Starting T1 to WL VXLAN decapsulation test (IPv4 inner)...")
+
+    for configs in test_configs:
+        pkt_opts = {
+            "eth_dst": "aa:bb:cc:dd:ee:ff",
+            "eth_src": duthost.facts['router_mac'],
+            "ip_src": "8.8.8.8",
+            "ip_dst": configs["inner_dst_ip_v4"],
+            "tcp_sport": 1234,
+            "tcp_dport": 4321,
+            "pktlen": 100,
+        }
+        inner_pkt = testutils.simple_tcp_packet(**pkt_opts)
+        vxlan_pkt = testutils.simple_vxlan_packet(
+            eth_dst=duthost.facts['router_mac'],
+            eth_src=ptfadapter.dataplane.get_mac(0, configs["outgoing_port"]),
+            ip_src="1.1.1.1",
+            ip_dst=configs["expected_dst_ip"],
+            udp_sport=1234, udp_dport=VXLAN_PORT, with_udp_chksum=False,
+            vxlan_vni=int(configs["vni"]),
+            inner_frame=inner_pkt,
+        )
+        pkt_opts["vlan_vid"] = configs["vlan"]
+        pkt_opts["dl_vlan_enable"] = True
+        pkt_opts["pktlen"] = 104
+        expected_inner_pkt = testutils.simple_tcp_packet(**pkt_opts)
+        masked_expected_pkt = Mask(expected_inner_pkt)
+        masked_expected_pkt.set_ignore_extra_bytes()
+        masked_expected_pkt.set_do_not_care_packet(Ether, 'dst')
+        masked_expected_pkt.set_do_not_care_packet(IP, "ttl")
+        masked_expected_pkt.set_do_not_care_packet(IP, "chksum")
+        masked_expected_pkt.set_do_not_care_packet(IP, "id")
+        masked_expected_pkt.set_do_not_care_packet(IP, "len")
+        masked_expected_pkt.set_do_not_care_packet(IP, "tos")
+        masked_expected_pkt.set_do_not_care_packet(TCP, 'chksum')
+        ptfadapter.dataplane.flush()
+        testutils.send(ptfadapter, configs["outgoing_port"], vxlan_pkt)
+        testutils.verify_packet_any_port(ptfadapter, masked_expected_pkt, configs["expected_ports"], timeout=2)
+
+    logger.info("T1 to WL VXLAN decapsulation test (IPv4 inner) passed.")
+
+
+def cleanup(duthost, ptfhost, localhost, wl_portchannel_info, subintfs_info):
+    """
+    Return duthost and ptfhost to original state.
+    Args:
+        duthost: DUT host
+        ptfhost: PTF host
+        wl_portchannel_info: map of WL portchannel info
+        subintfs_info: map of sub-interface info
+    """
+    logger.debug("cleanup: Loading backup config db json.")
+    duthost.shell(f"mv {CONFIG_DB_PATH}.bak {CONFIG_DB_PATH}")
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
+
+    cmds = []
+    if subintfs_info:
+        try:
+            for _, val in subintfs_info.items():
+                sub_port = val["bond_name"]
+                ip = val['ptf_ip']
+                cmds.append("ip address del {} dev {}".format(ip, sub_port))
+                cmds.append("ip link del {}".format(sub_port))
+            ptfhost.shell_cmds(cmds=cmds)
+        except Exception as e:
+            logger.error(f"Error occurred while cleaning up sub interfaces: {e}")
+
+    cmds = []
+    if wl_portchannel_info:
+        try:
+            for key, val in wl_portchannel_info.items():
+                bond_port = val["bond_port"]
+                port_name = val["ptf_port_name"]
+                cmds.append("ip link set {} nomaster".format(bond_port))
+                cmds.append("ip link set {} nomaster".format(port_name))
+                cmds.append("ip link set {} up".format(port_name))
+                cmds.append("ip link del {}".format(bond_port))
+            ptfhost.shell_cmds(cmds=cmds)
+        except Exception as e:
+            logger.error(f"Error occurred while cleaning up bond interfaces: {e}")
+
+    kill_exabgp = f"""
+MAIN_PID=$(pgrep -f "exabgp {EXABGP_CONFIG_PATH}")
+if [ -n "$MAIN_PID" ]; then
+    echo "Killing test ExaBGP instance PID=$MAIN_PID"
+    kill -9 $MAIN_PID 2>/dev/null
+fi
+"""
+    ptfhost.shell(kill_exabgp, module_ignore_errors=True)
+
+    kill_http_api = f"""
+API_PID=$(pgrep -f "/usr/share/exabgp/http_api.py {EXABGP_PORT}")
+if [ -n "$API_PID" ]; then
+    echo "Killing test http_api.py PID=$API_PID"
+    kill -9 $API_PID 2>/dev/null
+fi
+"""
+    ptfhost.shell(kill_http_api, module_ignore_errors=True)
+
+    for file in temp_files:
+        if os.path.exists(file):
+            os.remove(file)
+
+
+def get_available_vlan_id_and_ports(cfg_facts, num_ports_needed):
+    """
+    Return vlan id and available ports in that vlan if there are enough ports available.
+    """
+    port_status = cfg_facts["PORT"]
+    vlan_id = -1
+    available_ports = []
+    pytest_require("VLAN_MEMBER" in cfg_facts, "Can't get vlan member")
+    for vlan_name, members in list(cfg_facts["VLAN_MEMBER"].items()):
+        if len(members) < num_ports_needed:
+            continue
+
+        possible_ports = []
+        for vlan_member in members:
+            if port_status[vlan_member].get("admin_status", "down") != "up":
+                continue
+            possible_ports.append(vlan_member)
+            if len(possible_ports) == num_ports_needed:
+                available_ports = possible_ports[:]
+                vlan_id = int(''.join([i for i in vlan_name if i.isdigit()]))
+                break
+
+        if vlan_id != -1:
+            break
+
+    logger.debug(f"Vlan {vlan_id} has available ports: {available_ports}")
+    return vlan_id, available_ports
+
+
+def convert_ip_int_to_str(ip_int, prefix_size=31):
+    """
+    Convert integer IP to string format with prefix size.
+    """
+    return f"{ip_int >> 24 & 0xFF}.{ip_int >> 16 & 0xFF}.{ip_int >> 8 & 0xFF}.{ip_int & 0xFF}/{prefix_size}"
+
+
+def convert_str_to_ip_int(ip_str):
+    """
+    Convert string IP to integer format.
+    """
+    ip_parts = ip_str.split('/')
+    ip = ip_parts[0]
+    octets = ip.split('.')
+    ip_int = int(octets[0]) << 24 | int(octets[1]) << 16 | int(octets[2]) << 8 | int(octets[3])
+    prefix = int(ip_parts[1]) if len(ip_parts) > 1 else 32
+    return ip_int, prefix
+
+
+def generate_subintfs_ips(num_vnets, num_portchannels, start_ip_int, prefix_size=31):
+    """
+    Generate subnets for subintfs, incrementing third octect for each vnet, and fourth octet for each portchannel.
+    """
+    num_ips_per_prefix = 2 ** (32 - prefix_size)
+    pytest_assert(num_ips_per_prefix * num_portchannels + (start_ip_int & 0xFF) < 0xFF,
+                  "Not enough IP addresses in last octet to allocate for subinterfaces.")
+    pytest_assert(num_vnets + (start_ip_int >> 8 & 0xFF) < 0xFF,
+                  "Not enough IP addresses in third octet to allocate for subinterfaces.")
+
+    all_subintf_ips = []
+    all_ptf_ips = []
+
+    for i in range(num_portchannels):
+        subintf_ips = []
+        ptf_ips = []
+        fourth_octet_offset = i * num_ips_per_prefix
+        for j in range(num_vnets):
+            ip_int = start_ip_int + fourth_octet_offset + (j << 8)
+            subintf_ips.append(convert_ip_int_to_str(ip_int, prefix_size))
+            ptf_ips.append(convert_ip_int_to_str(ip_int + 1, prefix_size))
+
+        all_subintf_ips.append(subintf_ips)
+        all_ptf_ips.append(ptf_ips)
+
+    return all_subintf_ips, all_ptf_ips
+
+
+def generate_subintfs_v6_ips(num_vnets, num_portchannels, prefix_size=127):
+    """
+    Generate IPv6 /127 subnets for subintfs, incrementing offset by 2 for each portchannel and vnet pair.
+    """
+    base = int(ipaddress.IPv6Address(V6_SUBINT_BASE))
+    all_dut, all_ptf = [], []
+    for j in range(num_portchannels):
+        dut_row, ptf_row = [], []
+        for i in range(num_vnets):
+            offset = (j * num_vnets + i) * 2
+            dut_row.append(f"{ipaddress.IPv6Address(base + offset)}/{prefix_size}")
+            ptf_row.append(f"{ipaddress.IPv6Address(base + offset + 1)}/{prefix_size}")
+        all_dut.append(dut_row)
+        all_ptf.append(ptf_row)
+    return all_dut, all_ptf
+
+
+def generate_vnet_routes_v6(vnet_vnis, start_vni, num_routes_per_vnet, include_default_route=True):
+    """
+    Generate VNET tunnel routes with IPv6 overlay prefixes and IPv4 VTEP endpoints.
+    """
+    base = int(ipaddress.IPv6Address(VNET_V6_PREFIX_BASE))
+    endpoint_base, _ = convert_str_to_ip_int(TUNNEL_ENDPOINT)
+    routes = {vni: [] for vni in vnet_vnis}
+    for i, vni in enumerate(vnet_vnis):
+        for j in range(1, num_routes_per_vnet + 1):
+            prefix_addr = ipaddress.IPv6Address(base + (i << 8) + j)
+            endpoint_int = endpoint_base + (i << 8) + j
+            route = {
+                "prefix": f"{prefix_addr}/128",
+                "endpoint": convert_ip_int_to_str(endpoint_int).split('/')[0],
+                "vni": start_vni + (i * num_routes_per_vnet) + j,
+                "mac_address": f"52:54:00:{(i << 8 + j) // 256:02x}:{(i << 8 + j) % 256:02x}:aa",
+                "vnet_vni": vni,
+            }
+            routes[vni].append(route)
+        if include_default_route:
+            route = {
+                "prefix": "::/0",
+                "endpoint": convert_ip_int_to_str(endpoint_base).split('/')[0],
+                "vni": start_vni,
+                "mac_address": "52:54:00:00:00:00",
+                "vnet_vni": vni,
+            }
+            routes[vni].append(route)
+    return routes
+
+
+def generate_vnet_routes_v4(vnet_vnis, start_prefix_int, start_endpoint_int, start_vni,
+                         num_routes_per_vnet, include_default_route=True, offset=0):
+    """
+    Generate vnet routes with prefix, endpoint, mac, and vni.
+    """
+    routes = {vni: [] for vni in vnet_vnis}
+    for i, vni in enumerate(vnet_vnis):
+        for j in range(1, num_routes_per_vnet + 1):
+            prefix_int = start_prefix_int + (i << 8) + j
+            endpoint_int = start_endpoint_int + (i << 8) + j + offset
+            route = {
+                "prefix": convert_ip_int_to_str(prefix_int, 32),
+                "endpoint": convert_ip_int_to_str(endpoint_int).split('/')[0],
+                "vni": start_vni + (i * num_routes_per_vnet) + j,
+                "mac_address": f"52:54:00:{(i << 8 + j + offset)//256:02x}:{(i << 8 + j + offset)%256:02x}:aa",
+                "vnet_vni": vni
+            }
+            routes[vni].append(route)
+
+        if include_default_route:
+            route = {
+                "prefix": "0.0.0.0/0",
+                "endpoint": convert_ip_int_to_str(start_endpoint_int).split('/')[0],
+                "vni": start_vni,
+                "mac_address": "52:54:00:00:00:00",
+                "vnet_vni": vni
+            }
+            routes[vni].append(route)
+
+    return routes
+
+
+def gnmic_set_with_bypass(gnmi_tls, path, value, filename="test_config"):     # noqa: F811
+    """
+    Send GNMI set request with bypass.
+    """
+    gnmi_tls.gnmic.set(path, value, metadata="x-sonic-ss-bypass-validation=true", filename=filename)
+
+
+def setup_vnet_routes(vnet_vnis, vni_to_routes, gnmi_tls):     # noqa: F811
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/VNET_ROUTE_TUNNEL", {
+        f"Vnet{vni}|{route['prefix']}": {
+            "endpoint": route["endpoint"],
+            "vni": route["vni"],
+            "mac_address": route["mac_address"]
+        } for vni in vnet_vnis for route in vni_to_routes[vni]
+    }, "vnet_routes")
+
+    time.sleep(5)
+    for vni in vnet_vnis:
+        for route in vni_to_routes[vni]:
+            route_key = "STATE_DB/localhost/VNET_ROUTE_TUNNEL_TABLE"
+            route_status = gnmi_tls.gnmic.get(route_key)[0].get("updates")[0].get("values", {}).get(route_key, {})\
+                .get(f"Vnet{vni}|{route['prefix']}", {}).get("state", "")
+            pytest_assert(route_status.lower() == "active",
+                          f"VNET route tunnel for Vnet{vni}|{route['prefix']} not active.")
+
+
+def setup_acl_config(duthost, ports, vnet_vnis, vnet_routes_v4, vnet_routes_v6, gnmi_tls):     # noqa: F811
+    """
+    Configure ACL tables for inner src MAC rewrite — both IPv4 and IPv6.
+
+    Both ACL_TABLE_TYPE entries must be sent in one gNMI patch.
+    """
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/ACL_TABLE_TYPE", {
+        ACL_TYPE_NAME: {
+            "BIND_POINTS": ["PORT", "PORTCHANNEL"],
+            "MATCHES": ["INNER_SRC_IP", "TUNNEL_VNI"],
+            "ACTIONS": ["COUNTER", "INNER_SRC_MAC_REWRITE_ACTION"]
+        },
+        ACL_TYPE_NAME_V6: {
+            "BIND_POINTS": ["PORT", "PORTCHANNEL"],
+            "MATCHES": ["INNER_SRC_IPV6", "TUNNEL_VNI"],
+            "ACTIONS": ["COUNTER", "INNER_SRC_MAC_REWRITE_ACTION"]
+        }
+    }, "acl_type")
+
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/ACL_TABLE", {
+        ACL_TABLE_NAME: {
+            "policy_desc": ACL_TABLE_NAME,
+            "ports": ports,
+            "stage": "egress",
+            "type": ACL_TYPE_NAME
+        },
+        ACL_TABLE_NAME_V6: {
+            "policy_desc": ACL_TABLE_NAME_V6,
+            "ports": ports,
+            "stage": "egress",
+            "type": ACL_TYPE_NAME_V6
+        }
+    }, "acl_table")
+
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/ACL_RULE", {
+        f"{ACL_TABLE_NAME}|rule_{route['vni']}": {
+            "INNER_SRC_IP": f"{INNER_SRC_IP}/32",
+            "INNER_SRC_MAC_REWRITE_ACTION": INNER_SRC_MAC,
+            "TUNNEL_VNI": f"{route['vni']}",
+            "PRIORITY": f"{route['vni']}"
+        } for vni in vnet_vnis for route in vnet_routes_v4[vni]
+    }, "acl_rule_v4")
+
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/ACL_RULE", {
+        f"{ACL_TABLE_NAME_V6}|rule_{route['vni']}": {
+            "INNER_SRC_IPV6": f"{INNER_SRC_IPV6}/128",
+            "INNER_SRC_MAC_REWRITE_ACTION": INNER_SRC_MAC,
+            "TUNNEL_VNI": f"{route['vni']}",
+            "PRIORITY": f"{route['vni']}"
+        } for vni in vnet_vnis for route in vnet_routes_v6[vni]
+    }, "acl_rule_v6")
+
+    def _acl_tables_and_rules_active(duthost):
+        rule_key = "STATE_DB/localhost/ACL_RULE_TABLE"
+        acl_rules = gnmi_tls.gnmic.get(rule_key)[0].get("updates")[0].get("values", {}).get(rule_key, {})
+        for table_name, routes in [(ACL_TABLE_NAME, vnet_routes_v4), (ACL_TABLE_NAME_V6, vnet_routes_v6)]:
+            table_key = f"STATE_DB/localhost/ACL_TABLE_TABLE/{table_name}/status"
+            status = gnmi_tls.gnmic.get(table_key)[0].get("updates")[0].get("values", {}).get(table_key, {})
+            if status.lower() != "active":
+                return False
+            for vni in vnet_vnis:
+                for route in routes[vni]:
+                    if acl_rules.get(f"{table_name}|rule_{route['vni']}", {}).get("status", "").lower() != "active":
+                        return False
+        return True
+
+    pytest_assert(wait_until(60, 2, 0, _acl_tables_and_rules_active, duthost),
+                  f"ACL tables or rules not active after 60 seconds.")
+
+
+def setup_bgp(duthost, ptfhost, vnet_vnis, dut_ips, ptf_ips, dut_ips_v6, ptf_ips_v6,
+              subnet_ip, loopback_ip, bgp_port, gnmi_tls):     # noqa: F811
+    """
+    Setup MP-BGP peer range WLPARTNER_PASSIVE_V4 per VNET for dual-stack decap testing.
+    """
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    dut_asn = config_facts['DEVICE_METADATA']['localhost']['bgp_asn']
+    neighbors = config_facts['BGP_NEIGHBOR']
+    peer_asn = list(neighbors.values())[0]["asn"]
+
+    for vni in vnet_vnis:
+        gnmic_set_with_bypass(
+            gnmi_tls,
+            f"{GNMI_PATH_PREFIX}/BGP_PEER_RANGE/Vnet{vni}|WLPARTNER_PASSIVE_V4",
+            {
+                "ip_range": [subnet_ip],
+                "name": "WLPARTNER_PASSIVE_V4",
+                "peer_asn": peer_asn,
+                "src_address": loopback_ip,
+            },
+            f"bgp_peer_v4_{vni}")
+        # bgpcfgd only adds 'activate' to IPv6 AF — add route-maps so IPv6 routes
+        # from the MP-BGP session are accepted with soft-reconfiguration inbound.
+        duthost.shell(
+            f"vtysh -c 'configure terminal' -c 'router bgp {dut_asn} vrf Vnet{vni}' "
+            f"-c 'address-family ipv6 unicast' "
+            f"-c 'neighbor WLPARTNER_PASSIVE_V4 soft-reconfiguration inbound' "
+            f"-c 'neighbor WLPARTNER_PASSIVE_V4 route-map FROM_BGP_SPEAKER in' "
+            f"-c 'neighbor WLPARTNER_PASSIVE_V4 route-map TO_BGP_SPEAKER out' "
+            f"-c 'exit-address-family' -c 'end'",
+            module_ignore_errors=True)
+
+    exabgp_config = f"""
+process api-vnets {{
+    run /usr/bin/python /usr/share/exabgp/http_api.py {bgp_port};
+    encoder json;
+}}
+"""
+
+    # MP-BGP neighbors: IPv4 session advertising both IPv4 WL subnet and IPv6 decap route.
+    # The IPv6 route uses the PTF subinterface IPv6 address as next-hop (RFC 4760).
+    for (dut_ips_pc, ptf_ips_pc), (dut_ips_v6_pc, ptf_ips_v6_pc) in zip(
+            zip(dut_ips, ptf_ips), zip(dut_ips_v6, ptf_ips_v6)):
+        for (dut_ip, ptf_ip), (_dut_ip_v6, ptf_ip_v6) in zip(
+                zip(dut_ips_pc, ptf_ips_pc), zip(dut_ips_v6_pc, ptf_ips_v6_pc)):
+            ptf_ipv4 = ptf_ip.split('/')[0]
+            ptf_ipv6 = ptf_ip_v6.split('/')[0]
+            exabgp_config += f"""
+neighbor {dut_ip.split('/')[0]} {{
+    router-id {ptf_ipv4};
+    local-address {ptf_ipv4};
+    local-as {peer_asn};
+    peer-as {dut_asn};
+    api {{
+        processes [api-vnets];
+    }}
+    family {{
+        ipv4 unicast;
+        ipv6 unicast;
+    }}
+    static {{
+        route {subnet_ip} next-hop {ptf_ipv4};
+        route {BGP_V6_DECAP_ROUTE} next-hop {ptf_ipv6};
+    }}
+}}
+"""
+
+    with open('/tmp/exabgp_update.conf', "w") as f:
+        f.write(exabgp_config)
+
+    ptfhost.copy(src='/tmp/exabgp_update.conf', dest=EXABGP_CONFIG_PATH)
+    ptfhost.shell(f"nohup exabgp {EXABGP_CONFIG_PATH} > /var/log/exabgp_all_vnets.log 2>&1 &")
+
+
+def setup_portchannel_subintfs(duthost, ptfhost, portchannel_info,
+                               vnet_vnis, base_vlan, dut_ips, ptf_ips,
+                               dut_ips_v6, ptf_ips_v6, gnmi_tls):     # noqa: F811
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    has_subintfs = len(config_facts.get("VLAN_SUB_INTERFACE", {})) > 0
+
+    subintfs_info = {}
+
+    cmds = []
+    for i in range(len(vnet_vnis)):
+        for j, (key, val) in enumerate(portchannel_info.items()):
+            po_num = val["portchannel_num"]
+            bond_port = val["bond_port"]
+            subintf_name = f"Po{po_num}.{base_vlan + i}"
+
+            if not has_subintfs:
+                gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE", {
+                    subintf_name: {
+                        "admin_status": "up",
+                        "vlan": str(base_vlan + i),
+                        "vnet_name": f"Vnet{vnet_vnis[i]}"
+                    },
+                    f"{subintf_name}|{dut_ips[j][i]}": {}
+                }, subintf_name)
+                has_subintfs = True
+            else:
+                gnmic_set_with_bypass(
+                    gnmi_tls,
+                    f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}",
+                    {
+                        "admin_status": "up",
+                        "vlan": str(base_vlan + i),
+                        "vnet_name": f"Vnet{vnet_vnis[i]}"
+                    },
+                    subintf_name)
+                gnmic_set_with_bypass(
+                    gnmi_tls,
+                    f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}|{dut_ips[j][i].replace('/','~1')}",
+                    {},
+                    f"{subintf_name}_ip")
+
+            # Add IPv6 address to sub-interface via gNMI (sonic-ip-prefix supports IPv6).
+            gnmic_set_with_bypass(
+                gnmi_tls,
+                f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}|{dut_ips_v6[j][i].replace('/','~1')}",
+                {},
+                f"{subintf_name}_ipv6")
+
+            cmds.append(f"ip link add link {bond_port} name {bond_port}.{base_vlan + i} type vlan id {base_vlan + i}")
+            cmds.append(f"ip address add {ptf_ips[j][i]} dev {bond_port}.{base_vlan + i}")
+            cmds.append(f"ip -6 address add {ptf_ips_v6[j][i]} dev {bond_port}.{base_vlan + i}")
+            cmds.append(f"ip link set {bond_port}.{base_vlan + i} up")
+
+            subintfs_info[subintf_name] = {
+                "portchannel_name": key,
+                "portchannel_num": po_num,
+                "ptf_port_index": val["ptf_port_index"],
+                "bond_name": f"{bond_port}.{base_vlan + i}",
+                "dut_ip": dut_ips[j][i],
+                "ptf_ip": ptf_ips[j][i],
+                "vlan": base_vlan + i,
+                "vnet": f"Vnet{vnet_vnis[i]}",
+                "vnet_vni": vnet_vnis[i],
+            }
+
+    ptfhost.shell_cmds(cmds=cmds)
+    ptfhost.shell("supervisorctl restart ptf_nn_agent")
+    time.sleep(5)
+
+    interfaces_key = "STATE_DB/localhost/INTERFACE_TABLE"
+    interfaces = gnmi_tls.gnmic.get(interfaces_key)[0].get("updates")[0].get("values", {}).get(interfaces_key, {})
+    for subintf, values in subintfs_info.items():
+        subintf_vnet = interfaces.get(subintf, {}).get("vrf", "")
+        subintf_status = interfaces.get(f"{subintf}|{values['dut_ip']}", {}).get("state", "")
+
+        pytest_assert(subintf_vnet.lower() == values["vnet"].lower(),
+                      f"Subinterface {subintf} not in correct vnet. Expected {values['vnet']}, got {subintf_vnet}.")
+        pytest_assert(subintf_status.lower() == "ok", f"Subinterface {subintf} not in ok state.")
+
+    return subintfs_info
+
+
+def setup_portchannels(duthost, ptfhost, config_facts, port_indexes,
+                       ptf_ports_available_in_topo, gnmi_tls):     # noqa: F811
+    vlan_id, ports = get_available_vlan_id_and_ports(config_facts, len(PORTCHANNEL_NAMES))
+    pytest_assert(len(ports) == len(PORTCHANNEL_NAMES),
+                  f"Found {len(ports)} available ports. Needed {len(PORTCHANNEL_NAMES)} ports for the test.")
+
+    cmds = []
+    # Pre-cleanup: remove stale bonds from previous interrupted runs
+    pre_cleanup = []
+    for i in range(len(PORTCHANNEL_NAMES)):
+        dut_port_index = port_indexes.get(ports[i])
+        if dut_port_index is not None and dut_port_index in ptf_ports_available_in_topo:
+            ptf_port_name = ptf_ports_available_in_topo[dut_port_index]["name"]
+            ptf_port_index = ptf_ports_available_in_topo[dut_port_index]["index"]
+            bond_port = 'bond{}'.format(ptf_port_index)
+            pre_cleanup.append(f"ip link set {ptf_port_name} nomaster 2>/dev/null || true")
+            pre_cleanup.append(f"ip link del {bond_port} 2>/dev/null || true")
+            pre_cleanup.append(f"ip link set {ptf_port_name} up 2>/dev/null || true")
+    if pre_cleanup:
+        ptfhost.shell_cmds(cmds=pre_cleanup)
+
+    wl_portchannel_mapping_info = {}
+    for i in range(len(PORTCHANNEL_NAMES)):
+        duthost.shell(f'config vlan member del {vlan_id} {ports[i]}')
+
+        gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/PORTCHANNEL/{PORTCHANNEL_NAMES[i]}", {
+            "admin_status": "up"
+        }, PORTCHANNEL_NAMES[i])
+        gnmic_set_with_bypass(
+            gnmi_tls,
+            f"{GNMI_PATH_PREFIX}/PORTCHANNEL_MEMBER/{PORTCHANNEL_NAMES[i]}|{ports[i]}",
+            {},
+            f"{PORTCHANNEL_NAMES[i]}_member")
+
+        dut_port_index = port_indexes[ports[i]]
+        ptf_port_name = ptf_ports_available_in_topo[dut_port_index]["name"]
+        ptf_port_index = ptf_ports_available_in_topo[dut_port_index]["index"]
+
+        bond_port = 'bond{}'.format(ptf_port_index)
+        cmds.append("ip link add {} type bond".format(bond_port))
+        cmds.append("ip link set {} type bond miimon 100 mode 802.3ad".format(bond_port))
+        cmds.append("ip link set {} down".format(ptf_port_name))
+        cmds.append("ip link set {} master {}".format(ptf_port_name, bond_port))
+        cmds.append("ip link set dev {} up".format(bond_port))
+        cmds.append("ifconfig {} mtu 9216 up".format(bond_port))
+
+        wl_portchannel_mapping_info[PORTCHANNEL_NAMES[i]] = {
+            "portchannel_num": ''.join(filter(str.isdigit, PORTCHANNEL_NAMES[i])),
+            "ptf_port_name": ptf_port_name,
+            "ptf_port_index": ptf_port_index,
+            "bond_port": bond_port,
+        }
+
+    ptfhost.shell_cmds(cmds=cmds)
+    ptfhost.shell("supervisorctl restart ptf_nn_agent")
+    time.sleep(5)
+
+    for portchannel_name in PORTCHANNEL_NAMES:
+        portchannel_key = f"STATE_DB/localhost/LAG_TABLE/{portchannel_name}"
+        portchannel_status = gnmi_tls.gnmic.get(portchannel_key)[0].get("updates")[0].get("values", {})\
+            .get(portchannel_key, {})
+
+        pytest_assert(portchannel_status.get("admin_status", "").lower() == "up"
+                      and portchannel_status.get("oper_status", "").lower() == "up",
+                      f"Portchannel {portchannel_name} not up in state db.")
+
+    return wl_portchannel_mapping_info
+
+
+def setup_vnets(num_vnets, tunnel, base_vni, gnmi_tls):     # noqa: F811
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/VNET", {
+        f"Vnet{base_vni + i}": {
+            "vni": f"{base_vni + i}",
+            "vxlan_tunnel": tunnel
+        } for i in range(num_vnets)
+    }, "vnet")
+
+    for i in range(num_vnets):
+        vnet_name = f"Vnet{base_vni + i}"
+        vnet_key = f"STATE_DB/localhost/VRF_TABLE/{vnet_name}/state"
+        vnet_status = gnmi_tls.gnmic.get(vnet_key)[0].get("updates")[0].get("values", {}).get(vnet_key, {})
+        pytest_assert(vnet_status.lower() == "ok", f"Vnet {vnet_name} not in ok state.")
+
+    return [base_vni + i for i in range(num_vnets)]
+
+
+def setup_vxlan_tunnel(name, src_ip, gnmi_tls):     # noqa: F811
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/VXLAN_TUNNEL", {
+        name: {
+            "src_ip": src_ip
+        }
+    }, "vxlan")
+
+
+@pytest.fixture(scope="module")
+def common_setup_and_teardown(tbinfo, duthosts, rand_one_dut_hostname,
+                              ptfhost, ptfadapter, localhost, gnmi_tls):     # noqa: F811
+    duthost = duthosts[rand_one_dut_hostname]
+
+    duthost.shell(f"cp {CONFIG_DB_PATH} {CONFIG_DB_PATH}.bak")
+
+    ecmp_utils.Constants["KEEP_TEMP_FILES"] = False
+    ecmp_utils.Constants["DEBUG"] = True
+
+    wl_portchannel_info = None
+    subintfs_info = None
+
+    try:
+        config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+
+        port_indexes = config_facts['port_index_map']
+        duts_map = tbinfo["duts_map"]
+        dut_indx = duts_map[duthost.hostname]
+        host_interfaces = tbinfo["topo"]["ptf_map"][str(dut_indx)]
+        ptf_ports_available_in_topo = {}
+        for key in host_interfaces:
+            ptf_ports_available_in_topo[host_interfaces[key]] = {
+                "index": int(key),
+                "name": "eth{}".format(int(key))
+            }
+
+        # Remove everflow acl tables
+        duthost.remove_acl_table("EVERFLOW")
+        duthost.remove_acl_table("EVERFLOWV6")
+        duthost.remove_acl_table(ACL_TABLE_NAME_V6)
+
+        # Create loopback interface
+        duthost.shell("config int ip add Loopback6 10.10.1.1")
+        loopback_ip = "10.10.1.1"
+
+        subnet_ip = "10.11.0.0/16"
+        subnet_ip_int, _ = convert_str_to_ip_int(subnet_ip)
+
+        # Set up vxlan
+        setup_vxlan_tunnel("tunnel_v4", loopback_ip, gnmi_tls)
+
+        # Set up vnets
+        vnet_vnis = setup_vnets(NUM_VNETS, "tunnel_v4", BASE_VNI, gnmi_tls)
+
+        # Set up portchannels
+        wl_portchannel_info = setup_portchannels(duthost, ptfhost, config_facts,
+                                                 port_indexes, ptf_ports_available_in_topo, gnmi_tls)
+
+        # Set up subintfs (IPv4 + IPv6 addresses for MP-BGP next-hop resolution)
+        dut_ips, ptf_ips = generate_subintfs_ips(NUM_VNETS, len(PORTCHANNEL_NAMES), start_ip_int=subnet_ip_int)
+        dut_ips_v6, ptf_ips_v6 = generate_subintfs_v6_ips(NUM_VNETS, len(PORTCHANNEL_NAMES))
+
+        subintfs_info = setup_portchannel_subintfs(
+            duthost,
+            ptfhost,
+            wl_portchannel_info,
+            vnet_vnis,
+            base_vlan=10,
+            dut_ips=dut_ips,
+            ptf_ips=ptf_ips,
+            dut_ips_v6=dut_ips_v6,
+            ptf_ips_v6=ptf_ips_v6,
+            gnmi_tls=gnmi_tls)
+
+        # Set up bgps
+        setup_bgp(duthost,
+            ptfhost,
+            vnet_vnis,
+            dut_ips,
+            ptf_ips,
+            dut_ips_v6,
+            ptf_ips_v6,
+            subnet_ip=subnet_ip,
+            loopback_ip=loopback_ip,
+            bgp_port=EXABGP_PORT,
+            gnmi_tls=gnmi_tls)
+
+        # Set up vnet routes (no IPv6 default ::/0 — would intercept BGP decap traffic)
+        vnet_routes_v6 = generate_vnet_routes_v6(vnet_vnis, start_vni=10000, num_routes_per_vnet=5,
+                                                  include_default_route=False)
+        vnet_routes_v4 = generate_vnet_routes_v4(
+            vnet_vnis,
+            start_prefix_int=convert_str_to_ip_int("30.0.0.0")[0],
+            start_endpoint_int=convert_str_to_ip_int(TUNNEL_ENDPOINT)[0],
+            start_vni=10000, num_routes_per_vnet=5)
+        setup_vnet_routes(vnet_vnis, vnet_routes_v4, gnmi_tls)
+
+        # Setup acl configs — both IPv4 and IPv6 in one call (types must be sent together)
+        config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+        setup_acl_config(duthost, list(config_facts.get("PORTCHANNEL", {}).keys()),
+                         vnet_vnis, vnet_routes_v4, vnet_routes_v6, gnmi_tls)
+
+        # Install IPv6 overlay routes after ACL setup
+        setup_vnet_routes(vnet_vnis, vnet_routes_v6, gnmi_tls)
+
+        # Configure vxlan port
+        ecmp_utils.configure_vxlan_switch(duthost, VXLAN_PORT, "00:12:34:56:78:9a")
+
+        # Get ptf eth of T1 portchannels
+        t1_ptf_port_nums = []
+        portchannel_members = config_facts.get("PORTCHANNEL_MEMBER", {})
+        for key in portchannel_members:
+            for intf in list(portchannel_members[key].keys()):
+                dut_port_idx = port_indexes.get(intf)
+                if dut_port_idx is None:
+                    continue
+                ptf_port = ptf_ports_available_in_topo.get(dut_port_idx)
+                if ptf_port is None:
+                    continue
+                if key not in wl_portchannel_info:
+                    t1_ptf_port_nums.append(ptf_port["index"])
+
+        # Check have enough T1 ports to run tests
+        pytest_assert(len(t1_ptf_port_nums) > 0, "No T1 side portchannel member ports found in PTF topo.")
+    except Exception as e:
+        # Cleanup on failure during setup
+        logger.error(f"Exception during setup: {repr(e)}.")
+        cleanup(duthost, ptfhost, localhost, wl_portchannel_info, subintfs_info)
+        pytest.fail(f"Setup failed: {repr(e)}")
+
+    ports_per_vnet = {}
+    for _, val in subintfs_info.items():
+        vni = val["vnet_vni"]
+        if vni not in ports_per_vnet:
+            ports_per_vnet[vni] = []
+        ports_per_vnet[vni].append(val["ptf_port_index"])
+
+    # Unified configs: each entry carries both IPv4 and IPv6 inner dst fields.
+    # v4 functions use "inner_dst_ip_v4", v6 functions use "inner_dst_ip_v6".
+    # Both share same VNI/endpoint/outer tunnel — only inner packet type differs.
+    decap_test_configs = [
+        {
+            "inner_dst_ip_v4": "10.11.255.255",
+            "inner_dst_ip_v6": BGP_V6_DECAP_IP,
+            "expected_dst_ip": loopback_ip,
+            "vni": val["vnet_vni"],
+            "vlan": val["vlan"],
+            "outgoing_port": t1_ptf_port_nums[0],
+            "expected_ports": ports_per_vnet[val["vnet_vni"]],
+        } for _, val in subintfs_info.items()
+    ]
+    encap_test_configs = [
+        {
+            "inner_dst_ip_v4": route_v4["prefix"].split('/')[0] if route_v4["prefix"] != "0.0.0.0/0" else "150.0.0.10",
+            "inner_dst_ip_v6": route_v6["prefix"].split('/')[0],
+            "expected_dst_mac": route_v4["mac_address"],
+            "expected_vni": route_v4["vni"],
+            "expected_dst_ip": route_v4["endpoint"],
+            "expected_src_ip": loopback_ip,
+            "vlan": val["vlan"],
+            "vni": val["vnet_vni"],
+            "outgoing_port": val["ptf_port_index"],
+            "expected_ports": t1_ptf_port_nums,
+            "route_v4": route_v4,
+            "route_v6": route_v6,
+        }
+        for _, val in subintfs_info.items()
+        for route_v4, route_v6 in zip(
+            vnet_routes_v4[val["vnet_vni"]],
+            vnet_routes_v6[val["vnet_vni"]]
+        )
+    ]
+
+    yield duthost, ptfadapter, encap_test_configs, decap_test_configs
+
+    # Cleanup
+    cleanup(duthost, ptfhost, localhost, wl_portchannel_info, subintfs_info)
+
+
+def modify_routes_mac_vni_v4(gnmi_tls, encap_test_configs, offset=0):
+    """
+    Modify IPv4 VNET tunnel route VNI, endpoint, and MAC by offset.
+    """
+    modified_routes = set()
+    acl_rule_value = {}
+
+    for config in encap_test_configs:
+        route = config["route_v4"]
+        if route["prefix"] not in modified_routes:
+            route["vni"] += offset
+            route["mac_address"] = route["mac_address"][:-2] + \
+                "{:02x}".format((int(route["mac_address"][-2:], 16) + offset) % 256)
+            route["endpoint"] = convert_ip_int_to_str(
+                convert_str_to_ip_int(route["endpoint"])[0] + offset
+            ).split('/')[0]
+            gnmic_set_with_bypass(
+                gnmi_tls,
+                f"{GNMI_PATH_PREFIX}/VNET_ROUTE_TUNNEL/Vnet{route['vnet_vni']}|{route['prefix'].replace('/','~1')}",
+                {"endpoint": route["endpoint"], "vni": route["vni"], "mac_address": route["mac_address"]},
+                f"vnet_route_{route['vnet_vni']}_{route['prefix'].replace('/','_')}",
+            )
+            acl_rule_value[f"{ACL_TABLE_NAME}|rule_{route['vni']}"] = {
+                "INNER_SRC_IP": f"{INNER_SRC_IP}/32",
+                "INNER_SRC_MAC_REWRITE_ACTION": INNER_SRC_MAC,
+                "TUNNEL_VNI": f"{route['vni']}",
+                "PRIORITY": f"{route['vni']}"
+            }
+            modified_routes.add(route["prefix"])
+        config["expected_vni"] = route["vni"]
+        config["expected_dst_mac"] = route["mac_address"]
+        config["expected_dst_ip"] = route["endpoint"]
+
+    # Update src mac rewrite acl to match new vnis
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/ACL_RULE", acl_rule_value, "acl_rule")
+
+    # Check vnet routes are updated
+    time.sleep(5)
+    for config in encap_test_configs:
+        route_key = "STATE_DB/localhost/VNET_ROUTE_TUNNEL_TABLE"
+        route = config["route_v4"]
+        route_status = gnmi_tls.gnmic.get(route_key)[0].get("updates")[0].get("values", {}).get(route_key, {})\
+            .get(f"Vnet{route['vnet_vni']}|{route['prefix']}", {}).get("state", "")
+        pytest_assert(route_status.lower() == "active",
+                      f"VNET route tunnel for Vnet{route['vnet_vni']}|"
+                      f"{route['prefix']} not active after mac/vni update.")
+
+
+def modify_routes_mac_vni_v6(gnmi_tls, encap_test_configs, offset=1):
+    """
+    Modify IPv6 VNET tunnel route VNI, endpoint, and MAC by offset.
+    """
+    modified_routes = set()
+    acl_rule_value = {}
+
+    for config in encap_test_configs:
+        route = config["route_v6"]
+
+        if route["prefix"] not in modified_routes:
+            route["vni"] += offset
+            route["mac_address"] = route["mac_address"][:-2] + \
+                "{:02x}".format((int(route["mac_address"][-2:], 16) + offset) % 256)
+            route["endpoint"] = convert_ip_int_to_str(
+                convert_str_to_ip_int(route["endpoint"])[0] + offset
+            ).split('/')[0]
+
+            gnmic_set_with_bypass(
+                gnmi_tls,
+                f"{GNMI_PATH_PREFIX}/VNET_ROUTE_TUNNEL/Vnet{route['vnet_vni']}|{route['prefix'].replace('/','~1')}",
+                {
+                    "endpoint": route["endpoint"],
+                    "vni": route["vni"],
+                    "mac_address": route["mac_address"],
+                },
+                f"vnet_route_{route['vnet_vni']}_{route['prefix'].replace('/','_')}",
+            )
+            acl_rule_value[f"{ACL_TABLE_NAME_V6}|rule_{route['vni']}"] = {
+                "INNER_SRC_IPV6": f"{INNER_SRC_IPV6}/128",
+                "INNER_SRC_MAC_REWRITE_ACTION": INNER_SRC_MAC,
+                "TUNNEL_VNI": f"{route['vni']}",
+                "PRIORITY": f"{route['vni']}"
+            }
+            modified_routes.add(route["prefix"])
+
+        config["expected_vni"] = route["vni"]
+        config["expected_dst_mac"] = route["mac_address"]
+        config["expected_dst_ip"] = route["endpoint"]
+
+    # Update src mac rewrite acl to match new vnis
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/ACL_RULE", acl_rule_value, "acl_rule_v6")
+
+    # Check vnet routes are updated
+    time.sleep(5)
+    for config in encap_test_configs:
+        route_key = "STATE_DB/localhost/VNET_ROUTE_TUNNEL_TABLE"
+        route = config["route_v6"]
+        route_status = gnmi_tls.gnmic.get(route_key)[0].get("updates")[0].get("values", {}).get(route_key, {})\
+            .get(f"Vnet{route['vnet_vni']}|{route['prefix']}", {}).get("state", "")
+        pytest_assert(route_status.lower() == "active",
+                      f"VNET route tunnel for Vnet{route['vnet_vni']}|"
+                      f"{route['prefix']} not active after mac/vni update.")
+
+
+def test_vnet_with_bgp_intf_v6_routes(common_setup_and_teardown, gnmi_tls):     # noqa: F811
+
+    duthost, ptfadapter, encap_test_configs, decap_test_configs = common_setup_and_teardown
+    vnet_vnis = list(dict.fromkeys(c["vni"] for c in decap_test_configs))
+
+    validate_decap_t1_to_wl_v4(duthost, ptfadapter, decap_test_configs)
+    validate_decap_t1_to_wl_v6(duthost, ptfadapter, decap_test_configs)
+
+    validate_encap_wl_to_t1_v4(duthost, ptfadapter, encap_test_configs)
+    validate_encap_wl_to_t1_v6(duthost, ptfadapter, encap_test_configs)
+
+    # Test datapath after modifying route mac and vni
+    modify_routes_mac_vni_v4(gnmi_tls, encap_test_configs, offset=1)
+    modify_routes_mac_vni_v6(gnmi_tls, encap_test_configs, offset=1)
+    time.sleep(20)
+
+    validate_decap_t1_to_wl_v4(duthost, ptfadapter, decap_test_configs)
+    validate_decap_t1_to_wl_v6(duthost, ptfadapter, decap_test_configs)
+
+    validate_encap_wl_to_t1_v4(duthost, ptfadapter, encap_test_configs)
+    validate_encap_wl_to_t1_v6(duthost, ptfadapter, encap_test_configs)
+
+    # Test datapath again after config reload
+    duthost.shell("config save -y")
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, yang_validate=False)
+    time.sleep(10)
+
+    ecmp_utils.configure_vxlan_switch(duthost, VXLAN_PORT, "00:12:34:56:78:9a")
+
+    reload_config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    reload_dut_asn = reload_config_facts['DEVICE_METADATA']['localhost']['bgp_asn']
+    for vni in vnet_vnis:
+        duthost.shell(
+            f"vtysh -c 'configure terminal' -c 'router bgp {reload_dut_asn} vrf Vnet{vni}' "
+            f"-c 'address-family ipv6 unicast' "
+            f"-c 'neighbor WLPARTNER_PASSIVE_V4 soft-reconfiguration inbound' "
+            f"-c 'neighbor WLPARTNER_PASSIVE_V4 route-map FROM_BGP_SPEAKER in' "
+            f"-c 'neighbor WLPARTNER_PASSIVE_V4 route-map TO_BGP_SPEAKER out' "
+            f"-c 'exit-address-family' -c 'end'",
+            module_ignore_errors=True)
+
+    time.sleep(30)
+
+    validate_decap_t1_to_wl_v4(duthost, ptfadapter, decap_test_configs)
+    validate_decap_t1_to_wl_v6(duthost, ptfadapter, decap_test_configs)
+
+    validate_encap_wl_to_t1_v4(duthost, ptfadapter, encap_test_configs)
+    validate_encap_wl_to_t1_v6(duthost, ptfadapter, encap_test_configs)

--- a/tests/vxlan/test_vxlan_vnet_bgp_subintf_v4_v6_src_mac_rewrite_routes.py
+++ b/tests/vxlan/test_vxlan_vnet_bgp_subintf_v4_v6_src_mac_rewrite_routes.py
@@ -1,0 +1,1138 @@
+import ipaddress
+import logging
+import os
+import time
+
+import pytest
+from ptf.mask import Mask
+from ptf.packet import Ether, IP, IPv6, UDP, TCP
+import ptf.testutils as testutils
+
+from tests.common.config_reload import config_reload
+from tests.common.fixtures.grpc_fixtures import gnmi_tls    # noqa: F401
+from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.utilities import wait_until
+from tests.common.vxlan_ecmp_utils import Ecmp_Utils
+
+ecmp_utils = Ecmp_Utils()
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology("t0"),
+    pytest.mark.device_type('physical'),
+    pytest.mark.asic('cisco-8000')
+]
+
+CONFIG_DB_PATH = '/etc/sonic/config_db.json'
+EXABGP_CONFIG_PATH = "/etc/exabgp/exabgp_vnet_bgp.conf"
+EXABGP_PORT = 5100
+
+PORTCHANNEL_NAMES = ["PortChannel1031", "PortChannel1032"]
+VXLAN_PORT = 4789
+TUNNEL_ENDPOINT = "100.0.1.10"
+INNER_SRC_IP = "2.2.2.2"
+INNER_SRC_MAC = "00:11:22:33:44:55"
+INNER_SRC_IPV6 = "2001:db8:2::2"
+
+BASE_VNI = 1000
+NUM_VNETS = 2
+
+V6_SUBINT_BASE = "fc00:11::"
+
+VNET_V6_PREFIX_BASE = "2001:db8:30::"
+BGP_V6_DECAP_ROUTE = "2001:db8:40::/64"
+BGP_V6_DECAP_IP = "2001:db8:40::1"
+
+GNMI_PATH_PREFIX = "CONFIG_DB/localhost"
+
+ACL_TYPE_NAME = "INNER_SRC_MAC_REWRITE_TYPE"
+ACL_TABLE_NAME = "INNER_SRC_MAC_REWRITE_TABLE"
+ACL_TYPE_NAME_V6 = "INNER_SRC_MAC_REWRITE_TYPE_V6"
+ACL_TABLE_NAME_V6 = "INNER_SRC_MAC_REWRITE_TABLE_V6"
+
+temp_files = []
+
+
+def validate_encap_wl_to_t1_v6(duthost, ptfadapter, test_configs):
+    """
+    Test WL→T1 VXLAN encap with IPv6 inner packets.
+    """
+    logger.info("Starting WL to T1 VXLAN encapsulation test (IPv6 inner)...")
+
+    for configs in test_configs:
+        pkt_opts = {
+            "eth_dst": duthost.facts['router_mac'],
+            "eth_src": ptfadapter.dataplane.get_mac(0, configs["outgoing_port"]),
+            "ipv6_dst": configs["inner_dst_ip_v6"],
+            "ipv6_src": INNER_SRC_IPV6,
+            "ipv6_hlim": 64,
+            "dl_vlan_enable": True,
+            "vlan_vid": configs["vlan"],
+            "tcp_sport": 1234,
+            "tcp_dport": 5000,
+            "pktlen": 100,
+        }
+        inner_pkt = testutils.simple_tcpv6_packet(**pkt_opts)
+
+        pkt_opts["eth_src"] = INNER_SRC_MAC
+        pkt_opts["eth_dst"] = configs["expected_dst_mac"]
+        pkt_opts["ipv6_hlim"] = 63
+        pkt_opts["dl_vlan_enable"] = False
+        pkt_opts.pop("vlan_vid", None)
+        pkt_opts["pktlen"] = 96
+        inner_exp_pkt = testutils.simple_tcpv6_packet(**pkt_opts)
+
+        expected_pkt = testutils.simple_vxlan_packet(
+            eth_dst="aa:bb:cc:dd:ee:ff",
+            eth_src=duthost.facts['router_mac'],
+            ip_src=configs["expected_src_ip"],
+            ip_dst=configs["expected_dst_ip"],
+            ip_id=0, ip_flags=0x2,
+            udp_sport=1234, udp_dport=VXLAN_PORT, with_udp_chksum=False,
+            vxlan_vni=int(configs["expected_vni"]),
+            inner_frame=inner_exp_pkt,
+        )
+        masked_expected_pkt = Mask(expected_pkt)
+        masked_expected_pkt.set_ignore_extra_bytes()
+        masked_expected_pkt.set_do_not_care_packet(Ether, 'dst')
+        masked_expected_pkt.set_do_not_care_packet(UDP, 'sport')
+        masked_expected_pkt.set_do_not_care_packet(UDP, 'chksum')
+        masked_expected_pkt.set_do_not_care_packet(IP, "ttl")
+        masked_expected_pkt.set_do_not_care_packet(IP, "chksum")
+        masked_expected_pkt.set_do_not_care_packet(IP, "id")
+        masked_expected_pkt.set_do_not_care_packet(IP, "len")
+        masked_expected_pkt.set_do_not_care_packet(IP, "tos")
+
+        ptfadapter.dataplane.flush()
+        testutils.send(ptfadapter, configs["outgoing_port"], inner_pkt)
+        testutils.verify_packet_any_port(ptfadapter, masked_expected_pkt, configs["expected_ports"], timeout=2)
+
+    logger.info("WL to T1 VXLAN encapsulation test (IPv6 inner) passed.")
+
+
+def validate_encap_wl_to_t1_v4(duthost, ptfadapter, test_configs):
+    """
+    Test WL→T1 VXLAN encap with IPv4 inner packets.
+    """
+    logger.info("Starting WL to T1 VXLAN encapsulation test (IPv4 inner)...")
+
+    for configs in test_configs:
+        pkt_opts = {
+            "eth_dst": duthost.facts['router_mac'],
+            "eth_src": ptfadapter.dataplane.get_mac(0, configs["outgoing_port"]),
+            "ip_dst": configs["inner_dst_ip_v4"],
+            "ip_src": INNER_SRC_IP,
+            "ip_id": 105,
+            "ip_ttl": 64,
+            "dl_vlan_enable": True,
+            "vlan_vid": configs["vlan"],
+            "tcp_sport": 1234,
+            "tcp_dport": 5000,
+            "pktlen": 100,
+        }
+        inner_pkt = testutils.simple_tcp_packet(**pkt_opts)
+
+        pkt_opts["eth_src"] = INNER_SRC_MAC  # expected rewritten inner src MAC (IPv4 only)
+        pkt_opts["eth_dst"] = configs["expected_dst_mac"]
+        pkt_opts["ip_ttl"] = 63
+        pkt_opts["dl_vlan_enable"] = False
+        pkt_opts.pop("vlan_vid", None)
+        pkt_opts["pktlen"] = 96
+        inner_exp_pkt = testutils.simple_tcp_packet(**pkt_opts)
+
+        expected_pkt = testutils.simple_vxlan_packet(
+            eth_dst="aa:bb:cc:dd:ee:ff",
+            eth_src=duthost.facts['router_mac'],
+            ip_src=configs["expected_src_ip"],
+            ip_dst=configs["expected_dst_ip"],
+            ip_id=0, ip_flags=0x2,
+            udp_sport=1234, udp_dport=VXLAN_PORT, with_udp_chksum=False,
+            vxlan_vni=int(configs["expected_vni"]),
+            inner_frame=inner_exp_pkt,
+        )
+        masked_expected_pkt = Mask(expected_pkt)
+        masked_expected_pkt.set_ignore_extra_bytes()
+        masked_expected_pkt.set_do_not_care_packet(Ether, 'dst')
+        masked_expected_pkt.set_do_not_care_packet(UDP, 'sport')
+        masked_expected_pkt.set_do_not_care_packet(UDP, 'chksum')
+        masked_expected_pkt.set_do_not_care_packet(IP, "ttl")
+        masked_expected_pkt.set_do_not_care_packet(IP, "chksum")
+        masked_expected_pkt.set_do_not_care_packet(IP, "id")
+        masked_expected_pkt.set_do_not_care_packet(IP, "len")
+        masked_expected_pkt.set_do_not_care_packet(IP, "tos")
+
+        ptfadapter.dataplane.flush()
+        testutils.send(ptfadapter, configs["outgoing_port"], inner_pkt)
+        testutils.verify_packet_any_port(ptfadapter, masked_expected_pkt, configs["expected_ports"], timeout=2)
+
+    logger.info("WL to T1 VXLAN encapsulation test (IPv4 inner) passed.")
+
+
+def validate_decap_t1_to_wl_v6(duthost, ptfadapter, test_configs):
+    """
+    Test T1→WL VXLAN decap with IPv6 inner packets.
+    """
+    logger.info("Starting T1 to WL VXLAN decapsulation test (IPv6 inner)...")
+
+    for configs in test_configs:
+        pkt_opts = {
+            "eth_dst": "aa:bb:cc:dd:ee:ff",
+            "eth_src": duthost.facts['router_mac'],
+            "ipv6_src": "2001:db8:1::1",
+            "ipv6_dst": configs["inner_dst_ip_v6"],
+            "tcp_sport": 1234,
+            "tcp_dport": 4321,
+            "pktlen": 100,
+        }
+        # Build inner TCP packet expected on WL port
+        inner_pkt = testutils.simple_tcpv6_packet(**pkt_opts)
+
+        # Build VXLAN encapsulated packet to inject from T1 side
+        vxlan_pkt = testutils.simple_vxlan_packet(
+            eth_dst=duthost.facts['router_mac'],
+            eth_src=ptfadapter.dataplane.get_mac(0, configs["outgoing_port"]),
+            ip_src="1.1.1.1",
+            ip_dst=configs["expected_dst_ip"],
+            udp_sport=1234, udp_dport=VXLAN_PORT, with_udp_chksum=False,
+            vxlan_vni=int(configs["vni"]),
+            inner_frame=inner_pkt,
+        )
+        pkt_opts["vlan_vid"] = configs["vlan"]
+        pkt_opts["dl_vlan_enable"] = True
+        pkt_opts["pktlen"] = 104        # 100 + 4, add vlan tag length
+        expected_inner_pkt = testutils.simple_tcpv6_packet(**pkt_opts)
+        masked_expected_pkt = Mask(expected_inner_pkt)
+        masked_expected_pkt.set_ignore_extra_bytes()
+        masked_expected_pkt.set_do_not_care_packet(Ether, 'dst')
+        masked_expected_pkt.set_do_not_care_packet(IPv6, 'hlim')
+        masked_expected_pkt.set_do_not_care_packet(TCP, 'chksum')
+        ptfadapter.dataplane.flush()
+        testutils.send(ptfadapter, configs["outgoing_port"], vxlan_pkt)
+        testutils.verify_packet_any_port(ptfadapter, masked_expected_pkt, configs["expected_ports"], timeout=2)
+
+    logger.info("T1 to WL VXLAN decapsulation test (IPv6 inner) passed.")
+
+
+def validate_decap_t1_to_wl_v4(duthost, ptfadapter, test_configs):
+    """
+    Test T1→WL VXLAN decap with IPv4 inner packets.
+    """
+    logger.info("Starting T1 to WL VXLAN decapsulation test (IPv4 inner)...")
+
+    for configs in test_configs:
+        pkt_opts = {
+            "eth_dst": "aa:bb:cc:dd:ee:ff",
+            "eth_src": duthost.facts['router_mac'],
+            "ip_src": "8.8.8.8",
+            "ip_dst": configs["inner_dst_ip_v4"],
+            "tcp_sport": 1234,
+            "tcp_dport": 4321,
+            "pktlen": 100,
+        }
+        inner_pkt = testutils.simple_tcp_packet(**pkt_opts)
+        vxlan_pkt = testutils.simple_vxlan_packet(
+            eth_dst=duthost.facts['router_mac'],
+            eth_src=ptfadapter.dataplane.get_mac(0, configs["outgoing_port"]),
+            ip_src="1.1.1.1",
+            ip_dst=configs["expected_dst_ip"],
+            udp_sport=1234, udp_dport=VXLAN_PORT, with_udp_chksum=False,
+            vxlan_vni=int(configs["vni"]),
+            inner_frame=inner_pkt,
+        )
+        pkt_opts["vlan_vid"] = configs["vlan"]
+        pkt_opts["dl_vlan_enable"] = True
+        pkt_opts["pktlen"] = 104
+        expected_inner_pkt = testutils.simple_tcp_packet(**pkt_opts)
+        masked_expected_pkt = Mask(expected_inner_pkt)
+        masked_expected_pkt.set_ignore_extra_bytes()
+        masked_expected_pkt.set_do_not_care_packet(Ether, 'dst')
+        masked_expected_pkt.set_do_not_care_packet(IP, "ttl")
+        masked_expected_pkt.set_do_not_care_packet(IP, "chksum")
+        masked_expected_pkt.set_do_not_care_packet(IP, "id")
+        masked_expected_pkt.set_do_not_care_packet(IP, "len")
+        masked_expected_pkt.set_do_not_care_packet(IP, "tos")
+        masked_expected_pkt.set_do_not_care_packet(TCP, 'chksum')
+        ptfadapter.dataplane.flush()
+        testutils.send(ptfadapter, configs["outgoing_port"], vxlan_pkt)
+        testutils.verify_packet_any_port(ptfadapter, masked_expected_pkt, configs["expected_ports"], timeout=2)
+
+    logger.info("T1 to WL VXLAN decapsulation test (IPv4 inner) passed.")
+
+
+def cleanup(duthost, ptfhost, localhost, wl_portchannel_info, subintfs_info):
+    """
+    Return duthost and ptfhost to original state.
+    Args:
+        duthost: DUT host
+        ptfhost: PTF host
+        wl_portchannel_info: map of WL portchannel info
+        subintfs_info: map of sub-interface info
+    """
+    logger.debug("cleanup: Loading backup config db json.")
+    duthost.shell(f"mv {CONFIG_DB_PATH}.bak {CONFIG_DB_PATH}")
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
+
+    cmds = []
+    if subintfs_info:
+        try:
+            for _, val in subintfs_info.items():
+                sub_port = val["bond_name"]
+                ip = val['ptf_ip']
+                cmds.append("ip address del {} dev {}".format(ip, sub_port))
+                cmds.append("ip link del {}".format(sub_port))
+            ptfhost.shell_cmds(cmds=cmds)
+        except Exception as e:
+            logger.error(f"Error occurred while cleaning up sub interfaces: {e}")
+
+    cmds = []
+    if wl_portchannel_info:
+        try:
+            for key, val in wl_portchannel_info.items():
+                bond_port = val["bond_port"]
+                port_name = val["ptf_port_name"]
+                cmds.append("ip link set {} nomaster".format(bond_port))
+                cmds.append("ip link set {} nomaster".format(port_name))
+                cmds.append("ip link set {} up".format(port_name))
+                cmds.append("ip link del {}".format(bond_port))
+            ptfhost.shell_cmds(cmds=cmds)
+        except Exception as e:
+            logger.error(f"Error occurred while cleaning up bond interfaces: {e}")
+
+    kill_exabgp = f"""
+MAIN_PID=$(pgrep -f "exabgp {EXABGP_CONFIG_PATH}")
+if [ -n "$MAIN_PID" ]; then
+    echo "Killing test ExaBGP instance PID=$MAIN_PID"
+    kill -9 $MAIN_PID 2>/dev/null
+fi
+"""
+    ptfhost.shell(kill_exabgp, module_ignore_errors=True)
+
+    kill_http_api = f"""
+API_PID=$(pgrep -f "/usr/share/exabgp/http_api.py {EXABGP_PORT}")
+if [ -n "$API_PID" ]; then
+    echo "Killing test http_api.py PID=$API_PID"
+    kill -9 $API_PID 2>/dev/null
+fi
+"""
+    ptfhost.shell(kill_http_api, module_ignore_errors=True)
+
+    for file in temp_files:
+        if os.path.exists(file):
+            os.remove(file)
+
+
+def get_available_vlan_id_and_ports(cfg_facts, num_ports_needed):
+    """
+    Return vlan id and available ports in that vlan if there are enough ports available.
+    """
+    port_status = cfg_facts["PORT"]
+    vlan_id = -1
+    available_ports = []
+    pytest_require("VLAN_MEMBER" in cfg_facts, "Can't get vlan member")
+    for vlan_name, members in list(cfg_facts["VLAN_MEMBER"].items()):
+        if len(members) < num_ports_needed:
+            continue
+
+        possible_ports = []
+        for vlan_member in members:
+            if port_status[vlan_member].get("admin_status", "down") != "up":
+                continue
+            possible_ports.append(vlan_member)
+            if len(possible_ports) == num_ports_needed:
+                available_ports = possible_ports[:]
+                vlan_id = int(''.join([i for i in vlan_name if i.isdigit()]))
+                break
+
+        if vlan_id != -1:
+            break
+
+    logger.debug(f"Vlan {vlan_id} has available ports: {available_ports}")
+    return vlan_id, available_ports
+
+
+def convert_ip_int_to_str(ip_int, prefix_size=31):
+    """
+    Convert integer IP to string format with prefix size.
+    """
+    return f"{ip_int >> 24 & 0xFF}.{ip_int >> 16 & 0xFF}.{ip_int >> 8 & 0xFF}.{ip_int & 0xFF}/{prefix_size}"
+
+
+def convert_str_to_ip_int(ip_str):
+    """
+    Convert string IP to integer format.
+    """
+    ip_parts = ip_str.split('/')
+    ip = ip_parts[0]
+    octets = ip.split('.')
+    ip_int = int(octets[0]) << 24 | int(octets[1]) << 16 | int(octets[2]) << 8 | int(octets[3])
+    prefix = int(ip_parts[1]) if len(ip_parts) > 1 else 32
+    return ip_int, prefix
+
+
+def generate_subintfs_ips(num_vnets, num_portchannels, start_ip_int, prefix_size=31):
+    """
+    Generate subnets for subintfs, incrementing third octect for each vnet, and fourth octet for each portchannel.
+    """
+    num_ips_per_prefix = 2 ** (32 - prefix_size)
+    pytest_assert(num_ips_per_prefix * num_portchannels + (start_ip_int & 0xFF) < 0xFF,
+                  "Not enough IP addresses in last octet to allocate for subinterfaces.")
+    pytest_assert(num_vnets + (start_ip_int >> 8 & 0xFF) < 0xFF,
+                  "Not enough IP addresses in third octet to allocate for subinterfaces.")
+
+    all_subintf_ips = []
+    all_ptf_ips = []
+
+    for i in range(num_portchannels):
+        subintf_ips = []
+        ptf_ips = []
+        fourth_octet_offset = i * num_ips_per_prefix
+        for j in range(num_vnets):
+            ip_int = start_ip_int + fourth_octet_offset + (j << 8)
+            subintf_ips.append(convert_ip_int_to_str(ip_int, prefix_size))
+            ptf_ips.append(convert_ip_int_to_str(ip_int + 1, prefix_size))
+
+        all_subintf_ips.append(subintf_ips)
+        all_ptf_ips.append(ptf_ips)
+
+    return all_subintf_ips, all_ptf_ips
+
+
+def generate_subintfs_v6_ips(num_vnets, num_portchannels, prefix_size=127):
+    """
+    Generate IPv6 /127 subnets for subintfs, incrementing offset by 2 for each portchannel and vnet pair.
+    """
+    base = int(ipaddress.IPv6Address(V6_SUBINT_BASE))
+    all_dut, all_ptf = [], []
+    for j in range(num_portchannels):
+        dut_row, ptf_row = [], []
+        for i in range(num_vnets):
+            offset = (j * num_vnets + i) * 2
+            dut_row.append(f"{ipaddress.IPv6Address(base + offset)}/{prefix_size}")
+            ptf_row.append(f"{ipaddress.IPv6Address(base + offset + 1)}/{prefix_size}")
+        all_dut.append(dut_row)
+        all_ptf.append(ptf_row)
+    return all_dut, all_ptf
+
+
+def generate_vnet_routes_v6(vnet_vnis, start_vni, num_routes_per_vnet, include_default_route=True):
+    """
+    Generate VNET tunnel routes with IPv6 overlay prefixes and IPv4 VTEP endpoints.
+    """
+    base = int(ipaddress.IPv6Address(VNET_V6_PREFIX_BASE))
+    endpoint_base, _ = convert_str_to_ip_int(TUNNEL_ENDPOINT)
+    routes = {vni: [] for vni in vnet_vnis}
+    for i, vni in enumerate(vnet_vnis):
+        for j in range(1, num_routes_per_vnet + 1):
+            prefix_addr = ipaddress.IPv6Address(base + (i << 8) + j)
+            endpoint_int = endpoint_base + (i << 8) + j
+            route = {
+                "prefix": f"{prefix_addr}/128",
+                "endpoint": convert_ip_int_to_str(endpoint_int).split('/')[0],
+                "vni": start_vni + (i * num_routes_per_vnet) + j,
+                "mac_address": f"52:54:00:{(i << 8 + j) // 256:02x}:{(i << 8 + j) % 256:02x}:aa",
+                "vnet_vni": vni,
+            }
+            routes[vni].append(route)
+        if include_default_route:
+            route = {
+                "prefix": "::/0",
+                "endpoint": convert_ip_int_to_str(endpoint_base).split('/')[0],
+                "vni": start_vni,
+                "mac_address": "52:54:00:00:00:00",
+                "vnet_vni": vni,
+            }
+            routes[vni].append(route)
+    return routes
+
+
+def generate_vnet_routes_v4(vnet_vnis, start_prefix_int, start_endpoint_int, start_vni,
+                         num_routes_per_vnet, include_default_route=True, offset=0):
+    """
+    Generate vnet routes with prefix, endpoint, mac, and vni.
+    """
+    routes = {vni: [] for vni in vnet_vnis}
+    for i, vni in enumerate(vnet_vnis):
+        for j in range(1, num_routes_per_vnet + 1):
+            prefix_int = start_prefix_int + (i << 8) + j
+            endpoint_int = start_endpoint_int + (i << 8) + j + offset
+            route = {
+                "prefix": convert_ip_int_to_str(prefix_int, 32),
+                "endpoint": convert_ip_int_to_str(endpoint_int).split('/')[0],
+                "vni": start_vni + (i * num_routes_per_vnet) + j,
+                "mac_address": f"52:54:00:{(i << 8 + j + offset)//256:02x}:{(i << 8 + j + offset)%256:02x}:aa",
+                "vnet_vni": vni
+            }
+            routes[vni].append(route)
+
+        if include_default_route:
+            route = {
+                "prefix": "0.0.0.0/0",
+                "endpoint": convert_ip_int_to_str(start_endpoint_int).split('/')[0],
+                "vni": start_vni,
+                "mac_address": "52:54:00:00:00:00",
+                "vnet_vni": vni
+            }
+            routes[vni].append(route)
+
+    return routes
+
+
+def gnmic_set_with_bypass(gnmi_tls, path, value, filename="test_config"):     # noqa: F811
+    """
+    Send GNMI set request with bypass.
+    """
+    gnmi_tls.gnmic.set(path, value, metadata="x-sonic-ss-bypass-validation=true", filename=filename)
+
+
+def setup_vnet_routes(vnet_vnis, vni_to_routes, gnmi_tls):     # noqa: F811
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/VNET_ROUTE_TUNNEL", {
+        f"Vnet{vni}|{route['prefix']}": {
+            "endpoint": route["endpoint"],
+            "vni": route["vni"],
+            "mac_address": route["mac_address"]
+        } for vni in vnet_vnis for route in vni_to_routes[vni]
+    }, "vnet_routes")
+
+    time.sleep(5)
+    for vni in vnet_vnis:
+        for route in vni_to_routes[vni]:
+            route_key = "STATE_DB/localhost/VNET_ROUTE_TUNNEL_TABLE"
+            route_status = gnmi_tls.gnmic.get(route_key)[0].get("updates")[0].get("values", {}).get(route_key, {})\
+                .get(f"Vnet{vni}|{route['prefix']}", {}).get("state", "")
+            pytest_assert(route_status.lower() == "active",
+                          f"VNET route tunnel for Vnet{vni}|{route['prefix']} not active.")
+
+
+def setup_acl_config(duthost, ports, vnet_vnis, vnet_routes_v4, vnet_routes_v6, gnmi_tls):     # noqa: F811
+    """
+    Configure a single ACL table for inner src MAC rewrite — both IPv4 and IPv6 rules in one table.
+    Each rule matches one IP type (INNER_SRC_IP for v4, INNER_SRC_IPV6 for v6) + TUNNEL_VNI.
+    """
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/ACL_TABLE_TYPE", {
+        ACL_TYPE_NAME: {
+            "BIND_POINTS": ["PORT", "PORTCHANNEL"],
+            "MATCHES": ["INNER_SRC_IP", "INNER_SRC_IPV6", "TUNNEL_VNI"],
+            "ACTIONS": ["COUNTER", "INNER_SRC_MAC_REWRITE_ACTION"]
+        }
+    }, "acl_type")
+
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/ACL_TABLE", {
+        ACL_TABLE_NAME: {
+            "policy_desc": ACL_TABLE_NAME,
+            "ports": ports,
+            "stage": "egress",
+            "type": ACL_TYPE_NAME
+        }
+    }, "acl_table")
+
+    acl_rules = {}
+    for vni in vnet_vnis:
+        for route in vnet_routes_v4[vni]:
+            if route["prefix"] == "0.0.0.0/0":
+                continue
+            acl_rules[f"{ACL_TABLE_NAME}|rule_{route['vni']}_v4"] = {
+                "INNER_SRC_IP": f"{INNER_SRC_IP}/32",
+                "INNER_SRC_MAC_REWRITE_ACTION": INNER_SRC_MAC,
+                "TUNNEL_VNI": f"{route['vni']}",
+                "PRIORITY": f"{route['vni']}"
+            }
+        for route in vnet_routes_v6[vni]:
+            if route["prefix"] == "::/0":
+                continue
+            acl_rules[f"{ACL_TABLE_NAME}|rule_{route['vni']}_v6"] = {
+                "INNER_SRC_IPV6": f"{INNER_SRC_IPV6}/128",
+                "INNER_SRC_MAC_REWRITE_ACTION": INNER_SRC_MAC,
+                "TUNNEL_VNI": f"{route['vni']}",
+                "PRIORITY": f"{route['vni']}"
+            }
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/ACL_RULE", acl_rules, "acl_rule")
+
+    def _acl_tables_and_rules_active(duthost):
+        rule_key = "STATE_DB/localhost/ACL_RULE_TABLE"
+        acl_rule_states = gnmi_tls.gnmic.get(rule_key)[0].get("updates")[0].get("values", {}).get(rule_key, {})
+        table_key = f"STATE_DB/localhost/ACL_TABLE_TABLE/{ACL_TABLE_NAME}/status"
+        status = gnmi_tls.gnmic.get(table_key)[0].get("updates")[0].get("values", {}).get(table_key, {})
+        if status.lower() != "active":
+            return False
+        for rule_key_name in acl_rules:
+            rule_name = rule_key_name.split("|", 1)[1]
+            if acl_rule_states.get(f"{ACL_TABLE_NAME}|{rule_name}", {}).get("status", "").lower() != "active":
+                return False
+        return True
+
+    pytest_assert(wait_until(60, 2, 0, _acl_tables_and_rules_active, duthost),
+                  f"ACL tables or rules not active after 60 seconds.")
+
+
+def setup_bgp(duthost, ptfhost, vnet_vnis, dut_ips, ptf_ips, dut_ips_v6, ptf_ips_v6,
+              subnet_ip, loopback_ip, bgp_port, gnmi_tls):     # noqa: F811
+    """
+    Setup MP-BGP peer range WLPARTNER_PASSIVE_V4 per VNET for dual-stack decap testing.
+    """
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    dut_asn = config_facts['DEVICE_METADATA']['localhost']['bgp_asn']
+    neighbors = config_facts['BGP_NEIGHBOR']
+    peer_asn = list(neighbors.values())[0]["asn"]
+
+    for vni in vnet_vnis:
+        gnmic_set_with_bypass(
+            gnmi_tls,
+            f"{GNMI_PATH_PREFIX}/BGP_PEER_RANGE/Vnet{vni}|WLPARTNER_PASSIVE_V4",
+            {
+                "ip_range": [subnet_ip],
+                "name": "WLPARTNER_PASSIVE_V4",
+                "peer_asn": peer_asn,
+                "src_address": loopback_ip,
+            },
+            f"bgp_peer_v4_{vni}")
+        # bgpcfgd only adds 'activate' to IPv6 AF — add route-maps so IPv6 routes
+        # from the MP-BGP session are accepted with soft-reconfiguration inbound.
+        duthost.shell(
+            f"vtysh -c 'configure terminal' -c 'router bgp {dut_asn} vrf Vnet{vni}' "
+            f"-c 'address-family ipv6 unicast' "
+            f"-c 'neighbor WLPARTNER_PASSIVE_V4 soft-reconfiguration inbound' "
+            f"-c 'neighbor WLPARTNER_PASSIVE_V4 route-map FROM_BGP_SPEAKER in' "
+            f"-c 'neighbor WLPARTNER_PASSIVE_V4 route-map TO_BGP_SPEAKER out' "
+            f"-c 'exit-address-family' -c 'end'",
+            module_ignore_errors=True)
+
+    exabgp_config = f"""
+process api-vnets {{
+    run /usr/bin/python /usr/share/exabgp/http_api.py {bgp_port};
+    encoder json;
+}}
+"""
+
+    # MP-BGP neighbors: IPv4 session advertising both IPv4 WL subnet and IPv6 decap route.
+    # The IPv6 route uses the PTF subinterface IPv6 address as next-hop (RFC 4760).
+    for (dut_ips_pc, ptf_ips_pc), (dut_ips_v6_pc, ptf_ips_v6_pc) in zip(
+            zip(dut_ips, ptf_ips), zip(dut_ips_v6, ptf_ips_v6)):
+        for (dut_ip, ptf_ip), (_dut_ip_v6, ptf_ip_v6) in zip(
+                zip(dut_ips_pc, ptf_ips_pc), zip(dut_ips_v6_pc, ptf_ips_v6_pc)):
+            ptf_ipv4 = ptf_ip.split('/')[0]
+            ptf_ipv6 = ptf_ip_v6.split('/')[0]
+            exabgp_config += f"""
+neighbor {dut_ip.split('/')[0]} {{
+    router-id {ptf_ipv4};
+    local-address {ptf_ipv4};
+    local-as {peer_asn};
+    peer-as {dut_asn};
+    api {{
+        processes [api-vnets];
+    }}
+    family {{
+        ipv4 unicast;
+        ipv6 unicast;
+    }}
+    static {{
+        route {subnet_ip} next-hop {ptf_ipv4};
+        route {BGP_V6_DECAP_ROUTE} next-hop {ptf_ipv6};
+    }}
+}}
+"""
+
+    with open('/tmp/exabgp_update.conf', "w") as f:
+        f.write(exabgp_config)
+
+    ptfhost.copy(src='/tmp/exabgp_update.conf', dest=EXABGP_CONFIG_PATH)
+    ptfhost.shell(f"nohup exabgp {EXABGP_CONFIG_PATH} > /var/log/exabgp_all_vnets.log 2>&1 &")
+
+
+def setup_portchannel_subintfs(duthost, ptfhost, portchannel_info,
+                               vnet_vnis, base_vlan, dut_ips, ptf_ips,
+                               dut_ips_v6, ptf_ips_v6, gnmi_tls):     # noqa: F811
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    has_subintfs = len(config_facts.get("VLAN_SUB_INTERFACE", {})) > 0
+
+    subintfs_info = {}
+
+    cmds = []
+    for i in range(len(vnet_vnis)):
+        for j, (key, val) in enumerate(portchannel_info.items()):
+            po_num = val["portchannel_num"]
+            bond_port = val["bond_port"]
+            subintf_name = f"Po{po_num}.{base_vlan + i}"
+
+            if not has_subintfs:
+                gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE", {
+                    subintf_name: {
+                        "admin_status": "up",
+                        "vlan": str(base_vlan + i),
+                        "vnet_name": f"Vnet{vnet_vnis[i]}"
+                    },
+                    f"{subintf_name}|{dut_ips[j][i]}": {}
+                }, subintf_name)
+                has_subintfs = True
+            else:
+                gnmic_set_with_bypass(
+                    gnmi_tls,
+                    f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}",
+                    {
+                        "admin_status": "up",
+                        "vlan": str(base_vlan + i),
+                        "vnet_name": f"Vnet{vnet_vnis[i]}"
+                    },
+                    subintf_name)
+                gnmic_set_with_bypass(
+                    gnmi_tls,
+                    f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}|{dut_ips[j][i].replace('/','~1')}",
+                    {},
+                    f"{subintf_name}_ip")
+
+            # Add IPv6 address to sub-interface via gNMI (sonic-ip-prefix supports IPv6).
+            gnmic_set_with_bypass(
+                gnmi_tls,
+                f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}|{dut_ips_v6[j][i].replace('/','~1')}",
+                {},
+                f"{subintf_name}_ipv6")
+
+            cmds.append(f"ip link add link {bond_port} name {bond_port}.{base_vlan + i} type vlan id {base_vlan + i}")
+            cmds.append(f"ip address add {ptf_ips[j][i]} dev {bond_port}.{base_vlan + i}")
+            cmds.append(f"ip -6 address add {ptf_ips_v6[j][i]} dev {bond_port}.{base_vlan + i}")
+            cmds.append(f"ip link set {bond_port}.{base_vlan + i} up")
+
+            subintfs_info[subintf_name] = {
+                "portchannel_name": key,
+                "portchannel_num": po_num,
+                "ptf_port_index": val["ptf_port_index"],
+                "bond_name": f"{bond_port}.{base_vlan + i}",
+                "dut_ip": dut_ips[j][i],
+                "ptf_ip": ptf_ips[j][i],
+                "vlan": base_vlan + i,
+                "vnet": f"Vnet{vnet_vnis[i]}",
+                "vnet_vni": vnet_vnis[i],
+            }
+
+    ptfhost.shell_cmds(cmds=cmds)
+    ptfhost.shell("supervisorctl restart ptf_nn_agent")
+    time.sleep(5)
+
+    interfaces_key = "STATE_DB/localhost/INTERFACE_TABLE"
+    interfaces = gnmi_tls.gnmic.get(interfaces_key)[0].get("updates")[0].get("values", {}).get(interfaces_key, {})
+    for subintf, values in subintfs_info.items():
+        subintf_vnet = interfaces.get(subintf, {}).get("vrf", "")
+        subintf_status = interfaces.get(f"{subintf}|{values['dut_ip']}", {}).get("state", "")
+
+        pytest_assert(subintf_vnet.lower() == values["vnet"].lower(),
+                      f"Subinterface {subintf} not in correct vnet. Expected {values['vnet']}, got {subintf_vnet}.")
+        pytest_assert(subintf_status.lower() == "ok", f"Subinterface {subintf} not in ok state.")
+
+    return subintfs_info
+
+
+def setup_portchannels(duthost, ptfhost, config_facts, port_indexes,
+                       ptf_ports_available_in_topo, gnmi_tls):     # noqa: F811
+    vlan_id, ports = get_available_vlan_id_and_ports(config_facts, len(PORTCHANNEL_NAMES))
+    pytest_assert(len(ports) == len(PORTCHANNEL_NAMES),
+                  f"Found {len(ports)} available ports. Needed {len(PORTCHANNEL_NAMES)} ports for the test.")
+
+    cmds = []
+    # Pre-cleanup: remove stale bonds from previous interrupted runs
+    pre_cleanup = []
+    for i in range(len(PORTCHANNEL_NAMES)):
+        dut_port_index = port_indexes.get(ports[i])
+        if dut_port_index is not None and dut_port_index in ptf_ports_available_in_topo:
+            ptf_port_name = ptf_ports_available_in_topo[dut_port_index]["name"]
+            ptf_port_index = ptf_ports_available_in_topo[dut_port_index]["index"]
+            bond_port = 'bond{}'.format(ptf_port_index)
+            pre_cleanup.append(f"ip link set {ptf_port_name} nomaster 2>/dev/null || true")
+            pre_cleanup.append(f"ip link del {bond_port} 2>/dev/null || true")
+            pre_cleanup.append(f"ip link set {ptf_port_name} up 2>/dev/null || true")
+    if pre_cleanup:
+        ptfhost.shell_cmds(cmds=pre_cleanup)
+
+    wl_portchannel_mapping_info = {}
+    for i in range(len(PORTCHANNEL_NAMES)):
+        duthost.shell(f'config vlan member del {vlan_id} {ports[i]}')
+
+        gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/PORTCHANNEL/{PORTCHANNEL_NAMES[i]}", {
+            "admin_status": "up"
+        }, PORTCHANNEL_NAMES[i])
+        gnmic_set_with_bypass(
+            gnmi_tls,
+            f"{GNMI_PATH_PREFIX}/PORTCHANNEL_MEMBER/{PORTCHANNEL_NAMES[i]}|{ports[i]}",
+            {},
+            f"{PORTCHANNEL_NAMES[i]}_member")
+
+        dut_port_index = port_indexes[ports[i]]
+        ptf_port_name = ptf_ports_available_in_topo[dut_port_index]["name"]
+        ptf_port_index = ptf_ports_available_in_topo[dut_port_index]["index"]
+
+        bond_port = 'bond{}'.format(ptf_port_index)
+        cmds.append("ip link add {} type bond".format(bond_port))
+        cmds.append("ip link set {} type bond miimon 100 mode 802.3ad".format(bond_port))
+        cmds.append("ip link set {} down".format(ptf_port_name))
+        cmds.append("ip link set {} master {}".format(ptf_port_name, bond_port))
+        cmds.append("ip link set dev {} up".format(bond_port))
+        cmds.append("ifconfig {} mtu 9216 up".format(bond_port))
+
+        wl_portchannel_mapping_info[PORTCHANNEL_NAMES[i]] = {
+            "portchannel_num": ''.join(filter(str.isdigit, PORTCHANNEL_NAMES[i])),
+            "ptf_port_name": ptf_port_name,
+            "ptf_port_index": ptf_port_index,
+            "bond_port": bond_port,
+        }
+
+    ptfhost.shell_cmds(cmds=cmds)
+    ptfhost.shell("supervisorctl restart ptf_nn_agent")
+    time.sleep(5)
+
+    for portchannel_name in PORTCHANNEL_NAMES:
+        portchannel_key = f"STATE_DB/localhost/LAG_TABLE/{portchannel_name}"
+        portchannel_status = gnmi_tls.gnmic.get(portchannel_key)[0].get("updates")[0].get("values", {})\
+            .get(portchannel_key, {})
+
+        pytest_assert(portchannel_status.get("admin_status", "").lower() == "up"
+                      and portchannel_status.get("oper_status", "").lower() == "up",
+                      f"Portchannel {portchannel_name} not up in state db.")
+
+    return wl_portchannel_mapping_info
+
+
+def setup_vnets(num_vnets, tunnel, base_vni, gnmi_tls):     # noqa: F811
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/VNET", {
+        f"Vnet{base_vni + i}": {
+            "vni": f"{base_vni + i}",
+            "vxlan_tunnel": tunnel
+        } for i in range(num_vnets)
+    }, "vnet")
+
+    for i in range(num_vnets):
+        vnet_name = f"Vnet{base_vni + i}"
+        vnet_key = f"STATE_DB/localhost/VRF_TABLE/{vnet_name}/state"
+        vnet_status = gnmi_tls.gnmic.get(vnet_key)[0].get("updates")[0].get("values", {}).get(vnet_key, {})
+        pytest_assert(vnet_status.lower() == "ok", f"Vnet {vnet_name} not in ok state.")
+
+    return [base_vni + i for i in range(num_vnets)]
+
+
+def setup_vxlan_tunnel(name, src_ip, gnmi_tls):     # noqa: F811
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/VXLAN_TUNNEL", {
+        name: {
+            "src_ip": src_ip
+        }
+    }, "vxlan")
+
+
+@pytest.fixture(scope="module")
+def common_setup_and_teardown(tbinfo, duthosts, rand_one_dut_hostname,
+                              ptfhost, ptfadapter, localhost, gnmi_tls):     # noqa: F811
+    duthost = duthosts[rand_one_dut_hostname]
+
+    duthost.shell(f"cp {CONFIG_DB_PATH} {CONFIG_DB_PATH}.bak")
+
+    ecmp_utils.Constants["KEEP_TEMP_FILES"] = False
+    ecmp_utils.Constants["DEBUG"] = True
+
+    wl_portchannel_info = None
+    subintfs_info = None
+
+    try:
+        config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+
+        port_indexes = config_facts['port_index_map']
+        duts_map = tbinfo["duts_map"]
+        dut_indx = duts_map[duthost.hostname]
+        host_interfaces = tbinfo["topo"]["ptf_map"][str(dut_indx)]
+        ptf_ports_available_in_topo = {}
+        for key in host_interfaces:
+            ptf_ports_available_in_topo[host_interfaces[key]] = {
+                "index": int(key),
+                "name": "eth{}".format(int(key))
+            }
+
+        # Remove everflow acl tables
+        duthost.remove_acl_table("EVERFLOW")
+        duthost.remove_acl_table("EVERFLOWV6")
+        duthost.remove_acl_table(ACL_TABLE_NAME_V6)
+
+        # Create loopback interface
+        duthost.shell("config int ip add Loopback6 10.10.1.1")
+        loopback_ip = "10.10.1.1"
+
+        subnet_ip = "10.11.0.0/16"
+        subnet_ip_int, _ = convert_str_to_ip_int(subnet_ip)
+
+        # Set up vxlan
+        setup_vxlan_tunnel("tunnel_v4", loopback_ip, gnmi_tls)
+
+        # Set up vnets
+        vnet_vnis = setup_vnets(NUM_VNETS, "tunnel_v4", BASE_VNI, gnmi_tls)
+
+        # Set up portchannels
+        wl_portchannel_info = setup_portchannels(duthost, ptfhost, config_facts,
+                                                 port_indexes, ptf_ports_available_in_topo, gnmi_tls)
+
+        # Set up subintfs (IPv4 + IPv6 addresses for MP-BGP next-hop resolution)
+        dut_ips, ptf_ips = generate_subintfs_ips(NUM_VNETS, len(PORTCHANNEL_NAMES), start_ip_int=subnet_ip_int)
+        dut_ips_v6, ptf_ips_v6 = generate_subintfs_v6_ips(NUM_VNETS, len(PORTCHANNEL_NAMES))
+
+        subintfs_info = setup_portchannel_subintfs(
+            duthost,
+            ptfhost,
+            wl_portchannel_info,
+            vnet_vnis,
+            base_vlan=10,
+            dut_ips=dut_ips,
+            ptf_ips=ptf_ips,
+            dut_ips_v6=dut_ips_v6,
+            ptf_ips_v6=ptf_ips_v6,
+            gnmi_tls=gnmi_tls)
+
+        # Set up bgps
+        setup_bgp(duthost,
+            ptfhost,
+            vnet_vnis,
+            dut_ips,
+            ptf_ips,
+            dut_ips_v6,
+            ptf_ips_v6,
+            subnet_ip=subnet_ip,
+            loopback_ip=loopback_ip,
+            bgp_port=EXABGP_PORT,
+            gnmi_tls=gnmi_tls)
+
+        # Set up vnet routes (no IPv6 default ::/0 — would intercept BGP decap traffic)
+        vnet_routes_v6 = generate_vnet_routes_v6(vnet_vnis, start_vni=10000, num_routes_per_vnet=5,
+                                                  include_default_route=False)
+        vnet_routes_v4 = generate_vnet_routes_v4(
+            vnet_vnis,
+            start_prefix_int=convert_str_to_ip_int("30.0.0.0")[0],
+            start_endpoint_int=convert_str_to_ip_int(TUNNEL_ENDPOINT)[0],
+            start_vni=10000, num_routes_per_vnet=5)
+        setup_vnet_routes(vnet_vnis, vnet_routes_v4, gnmi_tls)
+
+        # Setup acl configs — both IPv4 and IPv6 in one call (types must be sent together)
+        config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+        setup_acl_config(duthost, list(config_facts.get("PORTCHANNEL", {}).keys()),
+                         vnet_vnis, vnet_routes_v4, vnet_routes_v6, gnmi_tls)
+
+        # Install IPv6 overlay routes after ACL setup
+        setup_vnet_routes(vnet_vnis, vnet_routes_v6, gnmi_tls)
+
+        # Configure vxlan port
+        ecmp_utils.configure_vxlan_switch(duthost, VXLAN_PORT, "00:12:34:56:78:9a")
+
+        # Get ptf eth of T1 portchannels
+        t1_ptf_port_nums = []
+        portchannel_members = config_facts.get("PORTCHANNEL_MEMBER", {})
+        for key in portchannel_members:
+            for intf in list(portchannel_members[key].keys()):
+                dut_port_idx = port_indexes.get(intf)
+                if dut_port_idx is None:
+                    continue
+                ptf_port = ptf_ports_available_in_topo.get(dut_port_idx)
+                if ptf_port is None:
+                    continue
+                if key not in wl_portchannel_info:
+                    t1_ptf_port_nums.append(ptf_port["index"])
+
+        # Check have enough T1 ports to run tests
+        pytest_assert(len(t1_ptf_port_nums) > 0, "No T1 side portchannel member ports found in PTF topo.")
+    except Exception as e:
+        # Cleanup on failure during setup
+        logger.error(f"Exception during setup: {repr(e)}.")
+        cleanup(duthost, ptfhost, localhost, wl_portchannel_info, subintfs_info)
+        pytest.fail(f"Setup failed: {repr(e)}")
+
+    ports_per_vnet = {}
+    for _, val in subintfs_info.items():
+        vni = val["vnet_vni"]
+        if vni not in ports_per_vnet:
+            ports_per_vnet[vni] = []
+        ports_per_vnet[vni].append(val["ptf_port_index"])
+
+    # Unified configs: each entry carries both IPv4 and IPv6 inner dst fields.
+    # v4 functions use "inner_dst_ip_v4", v6 functions use "inner_dst_ip_v6".
+    # Both share same VNI/endpoint/outer tunnel — only inner packet type differs.
+    decap_test_configs = [
+        {
+            "inner_dst_ip_v4": "10.11.255.255",
+            "inner_dst_ip_v6": BGP_V6_DECAP_IP,
+            "expected_dst_ip": loopback_ip,
+            "vni": val["vnet_vni"],
+            "vlan": val["vlan"],
+            "outgoing_port": t1_ptf_port_nums[0],
+            "expected_ports": ports_per_vnet[val["vnet_vni"]],
+        } for _, val in subintfs_info.items()
+    ]
+    encap_test_configs = [
+        {
+            "inner_dst_ip_v4": route_v4["prefix"].split('/')[0] if route_v4["prefix"] != "0.0.0.0/0" else "150.0.0.10",
+            "inner_dst_ip_v6": route_v6["prefix"].split('/')[0] if route_v6["prefix"] != "::/0" else "2001:db8:fa::10",
+            "expected_dst_mac": route_v4["mac_address"],
+            "expected_vni": route_v4["vni"],
+            "expected_dst_ip": route_v4["endpoint"],
+            "expected_src_ip": loopback_ip,
+            "vlan": val["vlan"],
+            "vni": val["vnet_vni"],
+            "outgoing_port": val["ptf_port_index"],
+            "expected_ports": t1_ptf_port_nums,
+            "route_v4": route_v4,
+            "route_v6": route_v6,
+        }
+        for _, val in subintfs_info.items()
+        for route_v4, route_v6 in zip(
+            vnet_routes_v4[val["vnet_vni"]],
+            vnet_routes_v6[val["vnet_vni"]]
+        )
+    ]
+
+    yield duthost, ptfadapter, encap_test_configs, decap_test_configs
+
+    # Cleanup
+    cleanup(duthost, ptfhost, localhost, wl_portchannel_info, subintfs_info)
+
+
+def modify_routes_mac_vni_v4(gnmi_tls, encap_test_configs, offset=0):
+    """
+    Modify IPv4 VNET tunnel route VNI, endpoint, and MAC by offset.
+    """
+    modified_routes = set()
+    acl_rule_value = {}
+
+    for config in encap_test_configs:
+        route = config["route_v4"]
+        if route["prefix"] not in modified_routes:
+            route["vni"] += offset
+            route["mac_address"] = route["mac_address"][:-2] + \
+                "{:02x}".format((int(route["mac_address"][-2:], 16) + offset) % 256)
+            route["endpoint"] = convert_ip_int_to_str(
+                convert_str_to_ip_int(route["endpoint"])[0] + offset
+            ).split('/')[0]
+            gnmic_set_with_bypass(
+                gnmi_tls,
+                f"{GNMI_PATH_PREFIX}/VNET_ROUTE_TUNNEL/Vnet{route['vnet_vni']}|{route['prefix'].replace('/','~1')}",
+                {"endpoint": route["endpoint"], "vni": route["vni"], "mac_address": route["mac_address"]},
+                f"vnet_route_{route['vnet_vni']}_{route['prefix'].replace('/','_')}",
+            )
+            acl_rule_value[f"{ACL_TABLE_NAME}|rule_{route['vni']}_v4"] = {
+                "INNER_SRC_IP": f"{INNER_SRC_IP}/32",
+                "INNER_SRC_MAC_REWRITE_ACTION": INNER_SRC_MAC,
+                "TUNNEL_VNI": f"{route['vni']}",
+                "PRIORITY": f"{route['vni']}"
+            }
+            modified_routes.add(route["prefix"])
+        config["expected_vni"] = route["vni"]
+        config["expected_dst_mac"] = route["mac_address"]
+        config["expected_dst_ip"] = route["endpoint"]
+
+    # Update src mac rewrite acl to match new vnis
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/ACL_RULE", acl_rule_value, "acl_rule")
+
+    # Check vnet routes are updated
+    time.sleep(5)
+    for config in encap_test_configs:
+        route_key = "STATE_DB/localhost/VNET_ROUTE_TUNNEL_TABLE"
+        route = config["route_v4"]
+        route_status = gnmi_tls.gnmic.get(route_key)[0].get("updates")[0].get("values", {}).get(route_key, {})\
+            .get(f"Vnet{route['vnet_vni']}|{route['prefix']}", {}).get("state", "")
+        pytest_assert(route_status.lower() == "active",
+                      f"VNET route tunnel for Vnet{route['vnet_vni']}|"
+                      f"{route['prefix']} not active after mac/vni update.")
+
+
+def modify_routes_mac_vni_v6(gnmi_tls, encap_test_configs, offset=1):
+    """
+    Modify IPv6 VNET tunnel route VNI, endpoint, and MAC by offset.
+    """
+    modified_routes = set()
+    acl_rule_value = {}
+
+    for config in encap_test_configs:
+        route = config["route_v6"]
+
+        if route["prefix"] not in modified_routes:
+            route["vni"] += offset
+            route["mac_address"] = route["mac_address"][:-2] + \
+                "{:02x}".format((int(route["mac_address"][-2:], 16) + offset) % 256)
+            route["endpoint"] = convert_ip_int_to_str(
+                convert_str_to_ip_int(route["endpoint"])[0] + offset
+            ).split('/')[0]
+
+            gnmic_set_with_bypass(
+                gnmi_tls,
+                f"{GNMI_PATH_PREFIX}/VNET_ROUTE_TUNNEL/Vnet{route['vnet_vni']}|{route['prefix'].replace('/','~1')}",
+                {
+                    "endpoint": route["endpoint"],
+                    "vni": route["vni"],
+                    "mac_address": route["mac_address"],
+                },
+                f"vnet_route_{route['vnet_vni']}_{route['prefix'].replace('/','_')}",
+            )
+            acl_rule_value[f"{ACL_TABLE_NAME}|rule_{route['vni']}_v6"] = {
+                "INNER_SRC_IPV6": f"{INNER_SRC_IPV6}/128",
+                "INNER_SRC_MAC_REWRITE_ACTION": INNER_SRC_MAC,
+                "TUNNEL_VNI": f"{route['vni']}",
+                "PRIORITY": f"{route['vni']}"
+            }
+            modified_routes.add(route["prefix"])
+
+        config["expected_vni"] = route["vni"]
+        config["expected_dst_mac"] = route["mac_address"]
+        config["expected_dst_ip"] = route["endpoint"]
+
+    # Update src mac rewrite acl to match new vnis
+    gnmic_set_with_bypass(gnmi_tls, f"{GNMI_PATH_PREFIX}/ACL_RULE", acl_rule_value, "acl_rule_v6")
+
+    # Check vnet routes are updated
+    time.sleep(5)
+    for config in encap_test_configs:
+        route_key = "STATE_DB/localhost/VNET_ROUTE_TUNNEL_TABLE"
+        route = config["route_v6"]
+        route_status = gnmi_tls.gnmic.get(route_key)[0].get("updates")[0].get("values", {}).get(route_key, {})\
+            .get(f"Vnet{route['vnet_vni']}|{route['prefix']}", {}).get("state", "")
+        pytest_assert(route_status.lower() == "active",
+                      f"VNET route tunnel for Vnet{route['vnet_vni']}|"
+                      f"{route['prefix']} not active after mac/vni update.")
+
+
+def test_vnet_with_bgp_intf_v6_routes(common_setup_and_teardown, gnmi_tls):     # noqa: F811
+
+    duthost, ptfadapter, encap_test_configs, decap_test_configs = common_setup_and_teardown
+    vnet_vnis = list(dict.fromkeys(c["vni"] for c in decap_test_configs))
+
+    validate_decap_t1_to_wl_v4(duthost, ptfadapter, decap_test_configs)
+    validate_decap_t1_to_wl_v6(duthost, ptfadapter, decap_test_configs)
+
+    validate_encap_wl_to_t1_v4(duthost, ptfadapter, encap_test_configs)
+    validate_encap_wl_to_t1_v6(duthost, ptfadapter, encap_test_configs)
+
+    # Test datapath after modifying route mac and vni
+    modify_routes_mac_vni_v4(gnmi_tls, encap_test_configs, offset=1)
+    modify_routes_mac_vni_v6(gnmi_tls, encap_test_configs, offset=1)
+    time.sleep(20)
+
+    validate_decap_t1_to_wl_v4(duthost, ptfadapter, decap_test_configs)
+    validate_decap_t1_to_wl_v6(duthost, ptfadapter, decap_test_configs)
+
+    validate_encap_wl_to_t1_v4(duthost, ptfadapter, encap_test_configs)
+    validate_encap_wl_to_t1_v6(duthost, ptfadapter, encap_test_configs)
+
+    # Test datapath again after config reload
+    duthost.shell("config save -y")
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, yang_validate=False)
+    time.sleep(10)
+
+    ecmp_utils.configure_vxlan_switch(duthost, VXLAN_PORT, "00:12:34:56:78:9a")
+
+    reload_config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    reload_dut_asn = reload_config_facts['DEVICE_METADATA']['localhost']['bgp_asn']
+    for vni in vnet_vnis:
+        duthost.shell(
+            f"vtysh -c 'configure terminal' -c 'router bgp {reload_dut_asn} vrf Vnet{vni}' "
+            f"-c 'address-family ipv6 unicast' "
+            f"-c 'neighbor WLPARTNER_PASSIVE_V4 soft-reconfiguration inbound' "
+            f"-c 'neighbor WLPARTNER_PASSIVE_V4 route-map FROM_BGP_SPEAKER in' "
+            f"-c 'neighbor WLPARTNER_PASSIVE_V4 route-map TO_BGP_SPEAKER out' "
+            f"-c 'exit-address-family' -c 'end'",
+            module_ignore_errors=True)
+
+    time.sleep(30)
+
+    validate_decap_t1_to_wl_v4(duthost, ptfadapter, decap_test_configs)
+    validate_decap_t1_to_wl_v6(duthost, ptfadapter, decap_test_configs)
+
+    validate_encap_wl_to_t1_v4(duthost, ptfadapter, encap_test_configs)
+    validate_encap_wl_to_t1_v6(duthost, ptfadapter, encap_test_configs)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
ECMP test:
- new testcase for same endpoint, different mac and vni
- configure using gnmic with bypass

Vnet Vxlan Subintf test:
- test 5 vnet route tunnels with mac and vni
- test mac and vni rewrite
- configure and get with gnmic with bypass

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Adding more test cases for ecmp scale test and vnet vxlan subintf test to better match real use cases.

#### How did you do it?

#### How did you verify/test it?
Tested on physical cisco t0 testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
