### PR TITLE
Enhance BGP link-local test: Ethernet variant, VRF support, FRR isolation

### DIFF
--- a/tests/bgp/test_bgp_link_local.py
+++ b/tests/bgp/test_bgp_link_local.py
@@ -617,26 +617,39 @@ def configure_unnumbered_bgp(request, setup_info):
     # FRR numbered fallback. Use the actual prefix length captured from
     # config_facts during setup so the remove command matches what was
     # configured (don't rely on module_ignore_errors to mask a mismatch).
-    dut_ipv4_prefixlen = setup_info.get('dut_ipv4_prefixlen')
-    dut_ipv6_prefixlen = setup_info.get('dut_ipv6_prefixlen')
-    if dut_ipv4:
-        pytest_assert(dut_ipv4_prefixlen,
-                      "IPv4 prefix length missing from config_facts for {}".format(dut_intf))
-        result = duthost.shell("sudo config interface ip remove {} {}/{}".format(
-            dut_intf, dut_ipv4, dut_ipv4_prefixlen))
-        pytest_assert(result['rc'] == 0,
-                      "Failed to remove IPv4 {}/{} from {}: {}".format(
-                          dut_ipv4, dut_ipv4_prefixlen, dut_intf,
-                          result.get('stderr', '')))
-    if dut_ipv6:
-        pytest_assert(dut_ipv6_prefixlen,
-                      "IPv6 prefix length missing from config_facts for {}".format(dut_intf))
-        result = duthost.shell("sudo config interface ip remove {} {}/{}".format(
-            dut_intf, dut_ipv6, dut_ipv6_prefixlen))
-        pytest_assert(result['rc'] == 0,
-                      "Failed to remove IPv6 {}/{} from {}: {}".format(
-                          dut_ipv6, dut_ipv6_prefixlen, dut_intf,
-                          result.get('stderr', '')))
+    #
+    # Only the portchannel variant needs this: the DUT L3 IPs sit on the
+    # Port-Channel, and here dut_intf is that Port-Channel. For the ethernet
+    # variant, break_lag_to_ethernet() already ran "config portchannel del",
+    # which removes the Port-Channel's IPs as a side effect; dut_intf is the
+    # freed member Ethernet that never carried those IPs, so issuing
+    # "config interface ip remove <member> <pc_ip>/<prefix>" would fail with a
+    # non-zero rc and trip the assert below. Skip the block for ethernet.
+    if intf_type != 'ethernet':
+        dut_ipv4_prefixlen = setup_info.get('dut_ipv4_prefixlen')
+        dut_ipv6_prefixlen = setup_info.get('dut_ipv6_prefixlen')
+        if dut_ipv4:
+            pytest_assert(dut_ipv4_prefixlen,
+                          "IPv4 prefix length missing from config_facts for {}".format(dut_intf))
+            result = duthost.shell("sudo config interface ip remove {} {}/{}".format(
+                dut_intf, dut_ipv4, dut_ipv4_prefixlen))
+            pytest_assert(result['rc'] == 0,
+                          "Failed to remove IPv4 {}/{} from {}: {}".format(
+                              dut_ipv4, dut_ipv4_prefixlen, dut_intf,
+                              result.get('stderr', '')))
+        if dut_ipv6:
+            pytest_assert(dut_ipv6_prefixlen,
+                          "IPv6 prefix length missing from config_facts for {}".format(dut_intf))
+            result = duthost.shell("sudo config interface ip remove {} {}/{}".format(
+                dut_intf, dut_ipv6, dut_ipv6_prefixlen))
+            pytest_assert(result['rc'] == 0,
+                          "Failed to remove IPv6 {}/{} from {}: {}".format(
+                              dut_ipv6, dut_ipv6_prefixlen, dut_intf,
+                              result.get('stderr', '')))
+    else:
+        logger.info("Skipping DUT IP removal on %s: Port-Channel deletion in "
+                    "break_lag_to_ethernet already cleared the L3 addresses",
+                    dut_intf)
 
     # Configure unnumbered BGP on DUT
     if stop_bgpcfgd:

--- a/tests/bgp/test_bgp_link_local.py
+++ b/tests/bgp/test_bgp_link_local.py
@@ -145,15 +145,23 @@ def setup_info(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):
             neigh_ipv6 = neigh_ip
             break
 
-    # Get DUT's addresses on this PortChannel
+    # Get DUT's addresses on this PortChannel (preserve prefix length
+    # so teardown removes with the exact same prefix it was configured with)
     dut_ipv4 = None
     dut_ipv6 = None
+    dut_ipv4_prefixlen = None
+    dut_ipv6_prefixlen = None
     for addr_key in config_facts.get('PORTCHANNEL_INTERFACE', {}).get(selected['pc'], {}):
-        addr = addr_key.split('/')[0] if '/' in addr_key else addr_key
+        if '/' in addr_key:
+            addr, prefixlen = addr_key.split('/', 1)
+        else:
+            addr, prefixlen = addr_key, None
         if ':' in addr:
             dut_ipv6 = addr
+            dut_ipv6_prefixlen = prefixlen
         else:
             dut_ipv4 = addr
+            dut_ipv4_prefixlen = prefixlen
 
     # Get DUT's link-local on this PortChannel
     result = duthost.shell("ip -6 addr show dev {} scope link".format(selected['pc']))
@@ -206,6 +214,8 @@ def setup_info(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):
         'neigh_ipv4': selected['neigh_ipv4'],
         'neigh_ipv6': neigh_ipv6,
         'neigh_pc_intf': neigh_pc_intf,
+        'dut_ipv4_prefixlen': dut_ipv4_prefixlen,
+        'dut_ipv6_prefixlen': dut_ipv6_prefixlen,
     }
 
     logger.info("Setup: DUT %s (%s) <-> %s (%s) via %s/%s",
@@ -297,10 +307,33 @@ def break_lag_to_ethernet(duthost, neigh_host, setup_info):
     except Exception as e:
         logger.warning("Could not detect VRF on %s: %s", neigh_pc_intf, e)
 
-    # Derive EOS Ethernet from Port-Channel number
-    # EOS Port-Channel1 members are typically Ethernet1, etc.
-    pc_num = ''.join(c for c in neigh_pc_intf if c.isdigit())
-    eos_eth_intf = "Ethernet{}".format(pc_num)
+    # Determine the actual Ethernet member of the EOS Port-Channel.
+    # Port-Channel<N> -> Ethernet<N> is only a naming convention; the real
+    # active member could be any Ethernet, so query the device.
+    eos_eth_intf = None
+    try:
+        pc_info = neigh_host.eos_command(
+            commands=["show port-channel {} | json".format(neigh_pc_intf)])
+        port_channels = (pc_info.get('stdout', [{}])[0] or {}).get(
+            'portChannels', {})
+        active_ports = (port_channels.get(neigh_pc_intf, {}) or {}).get(
+            'activePorts', {})
+        if active_ports:
+            # Pick the deterministic first active member (sorted)
+            eos_eth_intf = sorted(active_ports.keys())[0]
+            logger.info("Selected EOS PC member %s for %s (active members: %s)",
+                        eos_eth_intf, neigh_pc_intf, sorted(active_ports.keys()))
+    except Exception as e:
+        logger.warning("Could not query port-channel members of %s: %s",
+                       neigh_pc_intf, e)
+
+    if not eos_eth_intf:
+        # Fallback: derive Ethernet from Port-Channel number
+        pc_num = ''.join(c for c in neigh_pc_intf if c.isdigit())
+        eos_eth_intf = "Ethernet{}".format(pc_num)
+        logger.warning(
+            "Falling back to name-derived EOS member %s for %s",
+            eos_eth_intf, neigh_pc_intf)
 
     # Remove Port-Channel on EOS and configure freed Ethernet
     logger.info("Breaking LAG: removing EOS %s, configuring %s",
@@ -479,8 +512,10 @@ def configure_unnumbered_bgp(request, setup_info):
         if eos_config_backup:
             restore_eos_full_config(neigh_host, eos_config_backup)
         if stop_bgpcfgd:
-            duthost.shell("docker exec bgp supervisorctl start bgpcfgd",
-                          module_ignore_errors=True)
+            for daemon in ["bgpcfgd", "frrcfgd"]:
+                duthost.shell(
+                    "docker exec bgp supervisorctl start {}".format(daemon),
+                    module_ignore_errors=True)
         config_reload(duthost, wait=120, wait_for_bgp=True)
 
         # Wait for all original BGP sessions to re-establish
@@ -527,11 +562,16 @@ def configure_unnumbered_bgp(request, setup_info):
     logger.info("Initial prefix count from %s: %d (v4), %d (v6)",
                 neigh_ipv4, initial_prefixes, initial_prefixes_v6)
 
-    # Optionally stop bgpcfgd to isolate FRR behavior for regression testing
+    # Optionally stop bgp config daemon(s) to isolate FRR behavior for
+    # regression testing. Depending on frr_mgmt_framework_config, the active
+    # daemon is either bgpcfgd (legacy) or frrcfgd (new framework). Stop both
+    # with module_ignore_errors so the inactive one's failure is harmless.
     if stop_bgpcfgd:
-        logger.info("Stopping bgpcfgd (FRR isolation mode)")
-        duthost.shell("docker exec bgp supervisorctl stop bgpcfgd",
-                      module_ignore_errors=True)
+        logger.info("Stopping bgp config daemons (FRR isolation mode)")
+        for daemon in ["bgpcfgd", "frrcfgd"]:
+            duthost.shell(
+                "docker exec bgp supervisorctl stop {}".format(daemon),
+                module_ignore_errors=True)
 
     # For ethernet variant: break LAG and prepare freed Ethernet
     if intf_type == 'ethernet':
@@ -574,13 +614,29 @@ def configure_unnumbered_bgp(request, setup_info):
     wait_until(30, 3, 0, old_neighbor_removed)
 
     # Remove IPv4/IPv6 addresses from DUT interface to prevent
-    # FRR numbered fallback
+    # FRR numbered fallback. Use the actual prefix length captured from
+    # config_facts during setup so the remove command matches what was
+    # configured (don't rely on module_ignore_errors to mask a mismatch).
+    dut_ipv4_prefixlen = setup_info.get('dut_ipv4_prefixlen')
+    dut_ipv6_prefixlen = setup_info.get('dut_ipv6_prefixlen')
     if dut_ipv4:
-        duthost.shell("sudo config interface ip remove {} {}/31".format(
-            dut_intf, dut_ipv4), module_ignore_errors=True)
+        pytest_assert(dut_ipv4_prefixlen,
+                      "IPv4 prefix length missing from config_facts for {}".format(dut_intf))
+        result = duthost.shell("sudo config interface ip remove {} {}/{}".format(
+            dut_intf, dut_ipv4, dut_ipv4_prefixlen))
+        pytest_assert(result['rc'] == 0,
+                      "Failed to remove IPv4 {}/{} from {}: {}".format(
+                          dut_ipv4, dut_ipv4_prefixlen, dut_intf,
+                          result.get('stderr', '')))
     if dut_ipv6:
-        duthost.shell("sudo config interface ip remove {} {}/126".format(
-            dut_intf, dut_ipv6), module_ignore_errors=True)
+        pytest_assert(dut_ipv6_prefixlen,
+                      "IPv6 prefix length missing from config_facts for {}".format(dut_intf))
+        result = duthost.shell("sudo config interface ip remove {} {}/{}".format(
+            dut_intf, dut_ipv6, dut_ipv6_prefixlen))
+        pytest_assert(result['rc'] == 0,
+                      "Failed to remove IPv6 {}/{} from {}: {}".format(
+                          dut_ipv6, dut_ipv6_prefixlen, dut_intf,
+                          result.get('stderr', '')))
 
     # Configure unnumbered BGP on DUT
     if stop_bgpcfgd:

--- a/tests/bgp/test_bgp_link_local.py
+++ b/tests/bgp/test_bgp_link_local.py
@@ -468,6 +468,32 @@ def configure_unnumbered_bgp(request, setup_info):
 
     # --- Setup ---
 
+    # Clear any stale EOS config sessions before starting.
+    # cEOS has a limited session pool (~6) and prior test runs may leave
+    # uncommitted sessions that block new eos_config calls with
+    # "Maximum number of pending sessions reached".
+    try:
+        sessions_out = neigh_host.eos_command(
+            commands=["show configuration sessions"])
+        sessions_text = sessions_out['stdout'][0] if isinstance(
+            sessions_out['stdout'], list) else sessions_out['stdout']
+        logger.info("EOS config sessions before cleanup:\n%s",
+                    sessions_text)
+        # Abort any pending sessions (session names vary)
+        if isinstance(sessions_text, str):
+            for line in sessions_text.split('\n'):
+                parts = line.split()
+                if parts and parts[0] not in ['Name', '----', '']:
+                    sess_name = parts[0]
+                    logger.info("Aborting stale EOS session: %s",
+                                sess_name)
+                    neigh_host.eos_command(
+                        commands=["configure session {}".format(
+                            sess_name), "abort"])
+    except Exception as e:
+        # Non-fatal: session cleanup is best-effort
+        logger.warning("Could not clean EOS config sessions: %s", e)
+
     # Save EOS running-config for reliable teardown via configure replace
     eos_config_backup = save_eos_running_config(neigh_host)
 

--- a/tests/bgp/test_bgp_link_local.py
+++ b/tests/bgp/test_bgp_link_local.py
@@ -19,6 +19,7 @@ Addresses issue: https://github.com/sonic-net/sonic-mgmt/issues/18431
 
 import json
 import logging
+import time
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
@@ -547,26 +548,43 @@ def configure_unnumbered_bgp(request, setup_info):
         duthost.shell("sudo config interface ip remove {} {}/126".format(
             dut_intf, dut_ipv6), module_ignore_errors=True)
 
-    # Configure unnumbered BGP on DUT via vtysh
-    logger.info("Configure unnumbered BGP on DUT via %s", dut_intf)
-    vtysh_add = [
-        'config',
-        'router bgp {}'.format(dut_asn),
-        'neighbor {} interface v6only remote-as {}'.format(
-            dut_intf, neigh_asn),
-        'address-family ipv4 unicast',
-        'neighbor {} activate'.format(dut_intf),
-        'exit-address-family',
-        'address-family ipv6 unicast',
-        'neighbor {} activate'.format(dut_intf),
-        'exit-address-family',
-    ]
-    cmd = 'vtysh ' + ' '.join(
-        ['-c "{}"'.format(c) for c in vtysh_add])
-    result = duthost.shell(cmd)
-    pytest_assert(result['rc'] == 0,
-                  "Failed to configure unnumbered BGP on {}: {}".format(
-                      dut_intf, result.get('stderr', '')))
+    # Configure unnumbered BGP on DUT
+    if stop_bgpcfgd:
+        # FRR isolation mode: configure directly via vtysh
+        logger.info("Configure unnumbered BGP on DUT via vtysh (FRR isolation) on %s", dut_intf)
+        vtysh_add = [
+            'config',
+            'router bgp {}'.format(dut_asn),
+            'neighbor {} interface v6only remote-as {}'.format(
+                dut_intf, neigh_asn),
+            'address-family ipv4 unicast',
+            'neighbor {} activate'.format(dut_intf),
+            'exit-address-family',
+            'address-family ipv6 unicast',
+            'neighbor {} activate'.format(dut_intf),
+            'exit-address-family',
+        ]
+        cmd = 'vtysh ' + ' '.join(
+            ['-c "{}"'.format(c) for c in vtysh_add])
+        result = duthost.shell(cmd)
+        pytest_assert(result['rc'] == 0,
+                      "Failed to configure unnumbered BGP on {}: {}".format(
+                          dut_intf, result.get('stderr', '')))
+    else:
+        # Full-stack path: configure via CONFIG_DB (bgpcfgd should push to FRR)
+        # CONFIG_DB BGP_NEIGHBOR table uses IP keys — there is currently no
+        # schema support for interface-based (unnumbered) neighbors.
+        # This path exercises the production stack and is expected to fail
+        # until sonic-buildimage#26960 is implemented.
+        logger.info("Configure unnumbered BGP on DUT via CONFIG_DB on %s", dut_intf)
+        duthost.shell(
+            'sonic-db-cli CONFIG_DB HSET "BGP_NEIGHBOR|{}" "asn" "{}" "name" "{}"'.format(
+                dut_intf, neigh_asn, setup_info['neigh_name']),
+            module_ignore_errors=True)
+        # Give bgpcfgd time to process the CONFIG_DB change
+        time.sleep(10)
+        logger.info("CONFIG_DB BGP_NEIGHBOR entry added for %s "
+                    "(bgpcfgd should configure FRR)", dut_intf)
 
     # Configure unnumbered BGP on EOS
     eos_peer_group = configure_unnumbered_eos(

--- a/tests/bgp/test_bgp_link_local.py
+++ b/tests/bgp/test_bgp_link_local.py
@@ -401,6 +401,34 @@ def configure_unnumbered_eos(neigh_host, neigh_asn, dut_asn,
     return eos_peer_group
 
 
+def _cleanup_eos_sessions(neigh_host):
+    """Abort any stale EOS config sessions to free the session pool.
+
+    cEOS has a limited pool (~6 pending sessions). Prior test runs that
+    errored out may leave uncommitted sessions that block new eos_config
+    calls with 'Maximum number of pending sessions reached'.
+    """
+    try:
+        sessions_out = neigh_host.eos_command(
+            commands=["show configuration sessions"])
+        sessions_text = sessions_out['stdout'][0] if isinstance(
+            sessions_out['stdout'], list) else sessions_out['stdout']
+        logger.info("EOS config sessions:\n%s", sessions_text)
+        if isinstance(sessions_text, str):
+            for line in sessions_text.split('\n'):
+                parts = line.split()
+                if parts and parts[0] not in ['Name', '----', '']:
+                    sess_name = parts[0]
+                    logger.info("Aborting stale EOS session: %s",
+                                sess_name)
+                    neigh_host.eos_command(
+                        commands=["configure session {}".format(
+                            sess_name), "abort"])
+    except Exception as e:
+        # Non-fatal: session cleanup is best-effort
+        logger.warning("Could not clean EOS config sessions: %s", e)
+
+
 @pytest.fixture(scope='function',
                 params=['portchannel', 'ethernet',
                         'portchannel-frrtest'],
@@ -446,6 +474,8 @@ def configure_unnumbered_bgp(request, setup_info):
 
     # --- Teardown (registered first via addfinalizer) ---
     def _full_cleanup():
+        # Clean up stale EOS config sessions before restoring
+        _cleanup_eos_sessions(neigh_host)
         if eos_config_backup:
             restore_eos_full_config(neigh_host, eos_config_backup)
         if stop_bgpcfgd:
@@ -468,31 +498,8 @@ def configure_unnumbered_bgp(request, setup_info):
 
     # --- Setup ---
 
-    # Clear any stale EOS config sessions before starting.
-    # cEOS has a limited session pool (~6) and prior test runs may leave
-    # uncommitted sessions that block new eos_config calls with
-    # "Maximum number of pending sessions reached".
-    try:
-        sessions_out = neigh_host.eos_command(
-            commands=["show configuration sessions"])
-        sessions_text = sessions_out['stdout'][0] if isinstance(
-            sessions_out['stdout'], list) else sessions_out['stdout']
-        logger.info("EOS config sessions before cleanup:\n%s",
-                    sessions_text)
-        # Abort any pending sessions (session names vary)
-        if isinstance(sessions_text, str):
-            for line in sessions_text.split('\n'):
-                parts = line.split()
-                if parts and parts[0] not in ['Name', '----', '']:
-                    sess_name = parts[0]
-                    logger.info("Aborting stale EOS session: %s",
-                                sess_name)
-                    neigh_host.eos_command(
-                        commands=["configure session {}".format(
-                            sess_name), "abort"])
-    except Exception as e:
-        # Non-fatal: session cleanup is best-effort
-        logger.warning("Could not clean EOS config sessions: %s", e)
+    # Clear stale EOS config sessions before starting
+    _cleanup_eos_sessions(neigh_host)
 
     # Save EOS running-config for reliable teardown via configure replace
     eos_config_backup = save_eos_running_config(neigh_host)

--- a/tests/bgp/test_bgp_link_local.py
+++ b/tests/bgp/test_bgp_link_local.py
@@ -245,8 +245,8 @@ def bgp_unnumbered_established(duthost, portchannel):
 
 def save_eos_running_config(neigh_host, filename="pre-test-config"):
     """Save EOS running-config to flash for later restore via configure replace."""
-    neigh_host.eos_command(
-        commands=["copy running-config flash:{}".format(filename)])
+    neigh_host.eos_config(
+        lines=["copy running-config flash:{}".format(filename)])
     logger.info("Saved EOS running-config to flash:%s", filename)
     return "flash:{}".format(filename)
 
@@ -254,8 +254,8 @@ def save_eos_running_config(neigh_host, filename="pre-test-config"):
 def restore_eos_full_config(neigh_host, saved_config_path):
     """Restore EOS config from saved file via configure replace."""
     try:
-        neigh_host.eos_command(
-            commands=["configure replace {}".format(saved_config_path)])
+        neigh_host.eos_config(
+            lines=["configure replace {}".format(saved_config_path)])
         logger.info("Restored EOS config from %s", saved_config_path)
     except Exception as e:
         logger.error("EOS configure replace failed: %s", e)
@@ -302,19 +302,19 @@ def break_lag_to_ethernet(duthost, neigh_host, setup_info):
     pc_num = ''.join(c for c in neigh_pc_intf if c.isdigit())
     eos_eth_intf = "Ethernet{}".format(pc_num)
 
-    # Remove Port-Channel on EOS and configure freed Ethernet (single session)
+    # Remove Port-Channel on EOS and configure freed Ethernet
     logger.info("Breaking LAG: removing EOS %s, configuring %s",
                 neigh_pc_intf, eos_eth_intf)
-    eos_config_lines = [
-        "configure",
-        "no interface {}".format(neigh_pc_intf),
-        "interface {}".format(eos_eth_intf),
-        "no switchport",
-        "ipv6 enable",
-    ]
+    # Step 1: remove Port-Channel
+    neigh_host.eos_config(
+        lines=["no interface {}".format(neigh_pc_intf)])
+    # Step 2: configure freed Ethernet for L3
+    eos_intf_lines = ["no switchport", "ipv6 enable"]
     if pc_vrf:
-        eos_config_lines.append("vrf {}".format(pc_vrf))
-    neigh_host.eos_command(commands=eos_config_lines)
+        eos_intf_lines.insert(0, "vrf {}".format(pc_vrf))
+    neigh_host.eos_config(
+        lines=eos_intf_lines,
+        parents="interface {}".format(eos_eth_intf))
     logger.info("EOS %s configured (VRF=%s)", eos_eth_intf, pc_vrf)
 
     # Remove PortChannel member and PortChannel on DUT
@@ -339,8 +339,8 @@ def configure_unnumbered_eos(neigh_host, neigh_asn, dut_asn,
                              eos_intf, eos_vrf=None):
     """Configure unnumbered BGP on EOS using interface-based peer-group.
 
-    Uses a single eos_command(configure) call to avoid exhausting cEOS's
-    limited session pool (default 6 pending sessions).
+    Minimizes eos_config calls to avoid exhausting cEOS session pool
+    (default ~6 pending sessions). Uses 4 calls total.
 
     Applies:
     - IPv6 RA enablement (required for FRR peer discovery)
@@ -349,47 +349,47 @@ def configure_unnumbered_eos(neigh_host, neigh_asn, dut_asn,
     - RFC 5549 extended next-hop for IPv4 NLRI over IPv6 session
     """
     eos_peer_group = "LINK_LOCAL_PG"
-
-    # Build a single configure block to minimize EOS sessions
-    config_lines = [
-        "configure",
-        # Enable IPv6 RAs on the interface
-        "interface {}".format(eos_intf),
-        "no ipv6 nd ra disabled",
-        "exit",
-        # Global RFC 5549 knob
-        "ip routing ipv6 interfaces",
-    ]
-
-    # BGP section — handle VRF if present
-    config_lines.append("router bgp {}".format(neigh_asn))
+    bgp_parent = "router bgp {}".format(neigh_asn)
     if eos_vrf:
-        config_lines.append("vrf {}".format(eos_vrf))
+        bgp_parent = ["router bgp {}".format(neigh_asn),
+                      "vrf {}".format(eos_vrf)]
+    bgp_parents_list = bgp_parent if isinstance(bgp_parent, list) \
+        else [bgp_parent]
 
-    config_lines.extend([
-        "neighbor {} peer group".format(eos_peer_group),
-        "neighbor {} remote-as {}".format(eos_peer_group, dut_asn),
-        "neighbor interface {} peer-group {}".format(
-            eos_intf, eos_peer_group),
-        # IPv4 address-family
-        "address-family ipv4",
-        "neighbor {} activate".format(eos_peer_group),
-        "neighbor {} next-hop address-family ipv6 originate".format(
-            eos_peer_group),
-        "exit-address-family",
-        # IPv6 address-family
-        "address-family ipv6",
-        "neighbor {} activate".format(eos_peer_group),
-        "exit-address-family",
-    ])
+    # Call 1: Enable IPv6 RAs + global RFC 5549
+    logger.info("Enable IPv6 RAs on EOS %s + RFC 5549", eos_intf)
+    neigh_host.eos_config(
+        lines=["no ipv6 nd ra disabled"],
+        parents="interface {}".format(eos_intf))
+    neigh_host.eos_config(lines=["ip routing ipv6 interfaces"])
 
-    logger.info("Configure unnumbered BGP on EOS %s (peer-group %s, VRF=%s)",
-                eos_intf, eos_peer_group, eos_vrf)
-    logger.info("EOS config block:\n%s", "\n".join(config_lines))
+    # Call 3: BGP peer-group + interface neighbor
+    logger.info("Configure BGP peer-group %s on EOS via %s",
+                eos_peer_group, eos_intf)
+    neigh_host.eos_config(
+        lines=[
+            "neighbor {} peer group".format(eos_peer_group),
+            "neighbor {} remote-as {}".format(eos_peer_group, dut_asn),
+            "neighbor interface {} peer-group {}".format(
+                eos_intf, eos_peer_group),
+        ],
+        parents=bgp_parent)
 
-    neigh_host.eos_command(commands=config_lines)
+    # Call 3: IPv4 AF — activate + RFC 5549 next-hop
+    neigh_host.eos_config(
+        lines=[
+            "neighbor {} activate".format(eos_peer_group),
+            "neighbor {} next-hop address-family ipv6 originate".format(
+                eos_peer_group),
+        ],
+        parents=bgp_parents_list + ["address-family ipv4"])
 
-    # Verify config accepted (single eos_command call)
+    # Call 4: IPv6 AF — activate
+    neigh_host.eos_config(
+        lines=["neighbor {} activate".format(eos_peer_group)],
+        parents=bgp_parents_list + ["address-family ipv6"])
+
+    # Verify config accepted
     eos_bgp_cfg = neigh_host.eos_command(
         commands=["show running-config section bgp"])
     eos_cfg_text = eos_bgp_cfg['stdout'][0] if isinstance(
@@ -530,10 +530,9 @@ def configure_unnumbered_bgp(request, setup_info):
         if dut_ipv6:
             remove_lines.append("no neighbor {}".format(dut_ipv6))
         if remove_lines:
-            neigh_host.eos_command(
-                commands=["configure",
-                          "router bgp {}".format(neigh_asn)]
-                + remove_lines)
+            neigh_host.eos_config(
+                lines=remove_lines,
+                parents="router bgp {}".format(neigh_asn))
 
     # Wait for old neighbor to be removed from DUT BGP
     def old_neighbor_removed():

--- a/tests/bgp/test_bgp_link_local.py
+++ b/tests/bgp/test_bgp_link_local.py
@@ -245,8 +245,8 @@ def bgp_unnumbered_established(duthost, portchannel):
 
 def save_eos_running_config(neigh_host, filename="pre-test-config"):
     """Save EOS running-config to flash for later restore via configure replace."""
-    neigh_host.eos_config(
-        lines=["copy running-config flash:{}".format(filename)])
+    neigh_host.eos_command(
+        commands=["copy running-config flash:{}".format(filename)])
     logger.info("Saved EOS running-config to flash:%s", filename)
     return "flash:{}".format(filename)
 
@@ -254,8 +254,8 @@ def save_eos_running_config(neigh_host, filename="pre-test-config"):
 def restore_eos_full_config(neigh_host, saved_config_path):
     """Restore EOS config from saved file via configure replace."""
     try:
-        neigh_host.eos_config(
-            lines=["configure replace {}".format(saved_config_path)])
+        neigh_host.eos_command(
+            commands=["configure replace {}".format(saved_config_path)])
         logger.info("Restored EOS config from %s", saved_config_path)
     except Exception as e:
         logger.error("EOS configure replace failed: %s", e)
@@ -302,19 +302,20 @@ def break_lag_to_ethernet(duthost, neigh_host, setup_info):
     pc_num = ''.join(c for c in neigh_pc_intf if c.isdigit())
     eos_eth_intf = "Ethernet{}".format(pc_num)
 
-    # Remove Port-Channel on EOS (frees member Ethernets)
-    logger.info("Breaking LAG: removing EOS %s", neigh_pc_intf)
-    neigh_host.eos_config(
-        lines=["no interface {}".format(neigh_pc_intf)])
-
-    # Configure freed Ethernet on EOS for L3 unnumbered peering
-    eos_intf_lines = ["no switchport", "ipv6 enable"]
+    # Remove Port-Channel on EOS and configure freed Ethernet (single session)
+    logger.info("Breaking LAG: removing EOS %s, configuring %s",
+                neigh_pc_intf, eos_eth_intf)
+    eos_config_lines = [
+        "configure",
+        "no interface {}".format(neigh_pc_intf),
+        "interface {}".format(eos_eth_intf),
+        "no switchport",
+        "ipv6 enable",
+    ]
     if pc_vrf:
-        eos_intf_lines.insert(0, "vrf {}".format(pc_vrf))
-    neigh_host.eos_config(
-        lines=eos_intf_lines,
-        parents="interface {}".format(eos_eth_intf))
-    logger.info("EOS %s configured: %s", eos_eth_intf, eos_intf_lines)
+        eos_config_lines.append("vrf {}".format(pc_vrf))
+    neigh_host.eos_command(commands=eos_config_lines)
+    logger.info("EOS %s configured (VRF=%s)", eos_eth_intf, pc_vrf)
 
     # Remove PortChannel member and PortChannel on DUT
     duthost.shell("sudo config portchannel member del {} {}".format(
@@ -338,6 +339,9 @@ def configure_unnumbered_eos(neigh_host, neigh_asn, dut_asn,
                              eos_intf, eos_vrf=None):
     """Configure unnumbered BGP on EOS using interface-based peer-group.
 
+    Uses a single eos_command(configure) call to avoid exhausting cEOS's
+    limited session pool (default 6 pending sessions).
+
     Applies:
     - IPv6 RA enablement (required for FRR peer discovery)
     - Interface-based peer-group with remote-as
@@ -345,50 +349,47 @@ def configure_unnumbered_eos(neigh_host, neigh_asn, dut_asn,
     - RFC 5549 extended next-hop for IPv4 NLRI over IPv6 session
     """
     eos_peer_group = "LINK_LOCAL_PG"
-    bgp_parent = "router bgp {}".format(neigh_asn)
+
+    # Build a single configure block to minimize EOS sessions
+    config_lines = [
+        "configure",
+        # Enable IPv6 RAs on the interface
+        "interface {}".format(eos_intf),
+        "no ipv6 nd ra disabled",
+        "exit",
+        # Global RFC 5549 knob
+        "ip routing ipv6 interfaces",
+    ]
+
+    # BGP section — handle VRF if present
+    config_lines.append("router bgp {}".format(neigh_asn))
     if eos_vrf:
-        bgp_parent = ["router bgp {}".format(neigh_asn),
-                      "vrf {}".format(eos_vrf)]
+        config_lines.append("vrf {}".format(eos_vrf))
 
-    # Enable IPv6 RAs (FRR discovers peer link-local via RAs)
-    logger.info("Enable IPv6 RAs on EOS %s", eos_intf)
-    neigh_host.eos_config(
-        lines=["no ipv6 nd ra disabled"],
-        parents="interface {}".format(eos_intf))
-
-    # Configure interface-based peer-group
-    logger.info("Configure BGP peer-group %s on EOS via %s",
-                eos_peer_group, eos_intf)
-    pg_lines = [
+    config_lines.extend([
         "neighbor {} peer group".format(eos_peer_group),
         "neighbor {} remote-as {}".format(eos_peer_group, dut_asn),
         "neighbor interface {} peer-group {}".format(
             eos_intf, eos_peer_group),
-    ]
-    if isinstance(bgp_parent, list):
-        neigh_host.eos_config(lines=pg_lines, parents=bgp_parent)
-    else:
-        neigh_host.eos_config(lines=pg_lines, parents=bgp_parent)
+        # IPv4 address-family
+        "address-family ipv4",
+        "neighbor {} activate".format(eos_peer_group),
+        "neighbor {} next-hop address-family ipv6 originate".format(
+            eos_peer_group),
+        "exit-address-family",
+        # IPv6 address-family
+        "address-family ipv6",
+        "neighbor {} activate".format(eos_peer_group),
+        "exit-address-family",
+    ])
 
-    # Enable address families
-    for af in ["ipv4", "ipv6"]:
-        af_parents = bgp_parent if isinstance(bgp_parent, list) else [bgp_parent]
-        neigh_host.eos_config(
-            lines=["neighbor {} activate".format(eos_peer_group)],
-            parents=af_parents + ["address-family {}".format(af)])
+    logger.info("Configure unnumbered BGP on EOS %s (peer-group %s, VRF=%s)",
+                eos_intf, eos_peer_group, eos_vrf)
+    logger.info("EOS config block:\n%s", "\n".join(config_lines))
 
-    # RFC 5549 — IPv4 NLRI over IPv6 next-hop
-    logger.info("Enable RFC 5549 on EOS for %s", eos_peer_group)
-    neigh_host.eos_config(lines=["ip routing ipv6 interfaces"])
-    af4_parents = bgp_parent if isinstance(bgp_parent, list) else [bgp_parent]
-    neigh_host.eos_config(
-        lines=[
-            "neighbor {} next-hop address-family ipv6 originate".format(
-                eos_peer_group),
-        ],
-        parents=af4_parents + ["address-family ipv4"])
+    neigh_host.eos_command(commands=config_lines)
 
-    # Verify config accepted
+    # Verify config accepted (single eos_command call)
     eos_bgp_cfg = neigh_host.eos_command(
         commands=["show running-config section bgp"])
     eos_cfg_text = eos_bgp_cfg['stdout'][0] if isinstance(
@@ -529,9 +530,10 @@ def configure_unnumbered_bgp(request, setup_info):
         if dut_ipv6:
             remove_lines.append("no neighbor {}".format(dut_ipv6))
         if remove_lines:
-            neigh_host.eos_config(
-                lines=remove_lines,
-                parents="router bgp {}".format(neigh_asn))
+            neigh_host.eos_command(
+                commands=["configure",
+                          "router bgp {}".format(neigh_asn)]
+                + remove_lines)
 
     # Wait for old neighbor to be removed from DUT BGP
     def old_neighbor_removed():

--- a/tests/bgp/test_bgp_link_local.py
+++ b/tests/bgp/test_bgp_link_local.py
@@ -184,6 +184,13 @@ def setup_info(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):
     pytest_assert(neigh_pc_intf,
                   "Could not determine neighbor's Port-Channel interface")
 
+    # Find first member Ethernet of the selected PortChannel (for ethernet variant)
+    member_ethernet = None
+    pc_members = portchannel_members.get(selected['pc'], {})
+    if pc_members:
+        member_ethernet = sorted(pc_members.keys())[0]
+    logger.info("PortChannel %s member Ethernet: %s", selected['pc'], member_ethernet)
+
     info = {
         'duthost': duthost,
         'dut_asn': dut_asn,
@@ -191,6 +198,7 @@ def setup_info(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):
         'dut_ipv6': dut_ipv6,
         'dut_link_local': dut_link_local,
         'portchannel': selected['pc'],
+        'member_ethernet': member_ethernet,
         'neigh_name': selected['neigh_name'],
         'neigh_host': neigh_host,
         'neigh_asn': selected['neigh_asn'],
@@ -234,20 +242,192 @@ def bgp_unnumbered_established(duthost, portchannel):
     return False
 
 
-@pytest.fixture(scope='function')
-def configure_unnumbered_bgp(setup_info):
+def save_eos_running_config(neigh_host, filename="pre-test-config"):
+    """Save EOS running-config to flash for later restore via configure replace."""
+    neigh_host.eos_config(
+        lines=["copy running-config flash:{}".format(filename)])
+    logger.info("Saved EOS running-config to flash:%s", filename)
+    return "flash:{}".format(filename)
+
+
+def restore_eos_full_config(neigh_host, saved_config_path):
+    """Restore EOS config from saved file via configure replace."""
+    try:
+        neigh_host.eos_config(
+            lines=["configure replace {}".format(saved_config_path)])
+        logger.info("Restored EOS config from %s", saved_config_path)
+    except Exception as e:
+        logger.error("EOS configure replace failed: %s", e)
+        raise
+
+
+def break_lag_to_ethernet(duthost, neigh_host, setup_info):
+    """Break a LAG and prepare the freed Ethernet for unnumbered BGP.
+
+    Steps:
+    1. Detect VRF on EOS Port-Channel (for converged peers)
+    2. Remove Port-Channel on EOS
+    3. Configure freed Ethernet: no switchport, ipv6 enable, VRF
+    4. Remove PortChannel member + PortChannel on DUT
+
+    Returns:
+        (eos_eth_intf, pc_vrf): EOS Ethernet interface name and VRF (or None)
+    """
+    portchannel = setup_info['portchannel']
+    member_ethernet = setup_info['member_ethernet']
+    neigh_pc_intf = setup_info['neigh_pc_intf']
+
+    pytest_assert(member_ethernet,
+                  "No member Ethernet found for {}".format(portchannel))
+
+    # Detect VRF on EOS Port-Channel (converged peers use VRFs)
+    pc_vrf = None
+    try:
+        vrf_out = neigh_host.eos_command(
+            commands=["show interfaces {} | json".format(neigh_pc_intf)])
+        intf_data = vrf_out['stdout'][0] if isinstance(
+            vrf_out['stdout'], list) else vrf_out['stdout']
+        if isinstance(intf_data, dict):
+            for intf_info in intf_data.get('interfaces', {}).values():
+                vrf_membership = intf_info.get('vrfMembership', '')
+                if vrf_membership:
+                    pc_vrf = vrf_membership
+                    logger.info("EOS %s is in VRF %s", neigh_pc_intf, pc_vrf)
+    except Exception as e:
+        logger.warning("Could not detect VRF on %s: %s", neigh_pc_intf, e)
+
+    # Derive EOS Ethernet from Port-Channel number
+    # EOS Port-Channel1 members are typically Ethernet1, etc.
+    pc_num = ''.join(c for c in neigh_pc_intf if c.isdigit())
+    eos_eth_intf = "Ethernet{}".format(pc_num)
+
+    # Remove Port-Channel on EOS (frees member Ethernets)
+    logger.info("Breaking LAG: removing EOS %s", neigh_pc_intf)
+    neigh_host.eos_config(
+        lines=["no interface {}".format(neigh_pc_intf)])
+
+    # Configure freed Ethernet on EOS for L3 unnumbered peering
+    eos_intf_lines = ["no switchport", "ipv6 enable"]
+    if pc_vrf:
+        eos_intf_lines.insert(0, "vrf {}".format(pc_vrf))
+    neigh_host.eos_config(
+        lines=eos_intf_lines,
+        parents="interface {}".format(eos_eth_intf))
+    logger.info("EOS %s configured: %s", eos_eth_intf, eos_intf_lines)
+
+    # Remove PortChannel member and PortChannel on DUT
+    duthost.shell("sudo config portchannel member del {} {}".format(
+        portchannel, member_ethernet), module_ignore_errors=True)
+    duthost.shell("sudo config portchannel del {}".format(portchannel),
+                  module_ignore_errors=True)
+
+    # Verify DUT Ethernet has link-local address
+    result = duthost.shell(
+        "ip -6 addr show dev {} scope link".format(member_ethernet),
+        module_ignore_errors=True)
+    if 'fe80' in result.get('stdout', ''):
+        logger.info("DUT %s has link-local address", member_ethernet)
+    else:
+        logger.warning("DUT %s may not have link-local yet", member_ethernet)
+
+    return eos_eth_intf, pc_vrf
+
+
+def configure_unnumbered_eos(neigh_host, neigh_asn, dut_asn,
+                             eos_intf, eos_vrf=None):
+    """Configure unnumbered BGP on EOS using interface-based peer-group.
+
+    Applies:
+    - IPv6 RA enablement (required for FRR peer discovery)
+    - Interface-based peer-group with remote-as
+    - Address-family activation (IPv4 + IPv6)
+    - RFC 5549 extended next-hop for IPv4 NLRI over IPv6 session
+    """
+    eos_peer_group = "LINK_LOCAL_PG"
+    bgp_parent = "router bgp {}".format(neigh_asn)
+    if eos_vrf:
+        bgp_parent = ["router bgp {}".format(neigh_asn),
+                      "vrf {}".format(eos_vrf)]
+
+    # Enable IPv6 RAs (FRR discovers peer link-local via RAs)
+    logger.info("Enable IPv6 RAs on EOS %s", eos_intf)
+    neigh_host.eos_config(
+        lines=["no ipv6 nd ra disabled"],
+        parents="interface {}".format(eos_intf))
+
+    # Configure interface-based peer-group
+    logger.info("Configure BGP peer-group %s on EOS via %s",
+                eos_peer_group, eos_intf)
+    pg_lines = [
+        "neighbor {} peer group".format(eos_peer_group),
+        "neighbor {} remote-as {}".format(eos_peer_group, dut_asn),
+        "neighbor interface {} peer-group {}".format(
+            eos_intf, eos_peer_group),
+    ]
+    if isinstance(bgp_parent, list):
+        neigh_host.eos_config(lines=pg_lines, parents=bgp_parent)
+    else:
+        neigh_host.eos_config(lines=pg_lines, parents=bgp_parent)
+
+    # Enable address families
+    for af in ["ipv4", "ipv6"]:
+        af_parents = bgp_parent if isinstance(bgp_parent, list) else [bgp_parent]
+        neigh_host.eos_config(
+            lines=["neighbor {} activate".format(eos_peer_group)],
+            parents=af_parents + ["address-family {}".format(af)])
+
+    # RFC 5549 — IPv4 NLRI over IPv6 next-hop
+    logger.info("Enable RFC 5549 on EOS for %s", eos_peer_group)
+    neigh_host.eos_config(lines=["ip routing ipv6 interfaces"])
+    af4_parents = bgp_parent if isinstance(bgp_parent, list) else [bgp_parent]
+    neigh_host.eos_config(
+        lines=[
+            "neighbor {} next-hop address-family ipv6 originate".format(
+                eos_peer_group),
+        ],
+        parents=af4_parents + ["address-family ipv4"])
+
+    # Verify config accepted
+    eos_bgp_cfg = neigh_host.eos_command(
+        commands=["show running-config section bgp"])
+    eos_cfg_text = eos_bgp_cfg['stdout'][0] if isinstance(
+        eos_bgp_cfg['stdout'], list) else eos_bgp_cfg['stdout']
+    logger.info("EOS BGP config after setup:\n%s", eos_cfg_text)
+    if eos_peer_group not in eos_cfg_text:
+        pytest.fail("EOS did not accept the interface-based BGP config. "
+                    "Running config:\n{}".format(eos_cfg_text))
+    return eos_peer_group
+
+
+@pytest.fixture(scope='function',
+                params=['portchannel', 'ethernet',
+                        'portchannel-frrtest'],
+                ids=['portchannel', 'ethernet',
+                     'portchannel-frrtest'])
+def configure_unnumbered_bgp(request, setup_info):
     """Configure unnumbered BGP peering and restore original config afterward.
 
+    Params:
+    - portchannel: unnumbered BGP on existing PortChannel (full stack)
+    - ethernet: break LAG, unnumbered BGP on member Ethernet (full stack)
+    - portchannel-frrtest: stops bgpcfgd to isolate FRR regression testing
+
     Setup:
-        1. Verify existing BGP session is up
-        2. Remove existing global-IP BGP sessions on both DUT and neighbor
-        3. Configure unnumbered BGP on DUT
-        4. Configure link-local neighbor on EOS peer
+        1. Save EOS running-config for reliable teardown
+        2. Verify existing BGP session is up
+        3. Remove existing global-IP BGP sessions on both DUT and neighbor
+        4. Configure unnumbered BGP on DUT (vtysh)
+        5. Configure link-local neighbor on EOS peer
     Teardown:
-        1. Remove link-local neighbor from EOS and restore original neighbors
-        2. Config reload on DUT
-        3. Wait for original BGP sessions to re-establish
+        1. Restore EOS via configure replace (saved running-config)
+        2. Restart bgpcfgd if stopped
+        3. Config reload on DUT
+        4. Wait for original BGP sessions to re-establish
     """
+    param = request.param
+    stop_bgpcfgd = param.endswith('-frrtest')
+    intf_type = param.replace('-frrtest', '')
+
     duthost = setup_info['duthost']
     neigh_host = setup_info['neigh_host']
     portchannel = setup_info['portchannel']
@@ -258,12 +438,40 @@ def configure_unnumbered_bgp(setup_info):
     dut_ipv4 = setup_info['dut_ipv4']
     dut_ipv6 = setup_info['dut_ipv6']
     neigh_pc_intf = setup_info['neigh_pc_intf']
+    eos_config_backup = None
+    eos_eth_intf = None
+    pc_vrf = None
+
+    # --- Teardown (registered first via addfinalizer) ---
+    def _full_cleanup():
+        if eos_config_backup:
+            restore_eos_full_config(neigh_host, eos_config_backup)
+        if stop_bgpcfgd:
+            duthost.shell("docker exec bgp supervisorctl start bgpcfgd",
+                          module_ignore_errors=True)
+        config_reload(duthost, wait=120, wait_for_bgp=True)
+
+        # Wait for all original BGP sessions to re-establish
+        original_neighbors = [neigh_ipv4]
+        if neigh_ipv6:
+            original_neighbors.append(neigh_ipv6)
+        if not wait_until(WAIT_TIMEOUT, POLL_INTERVAL, 0,
+                          duthost.check_bgp_session_state,
+                          original_neighbors):
+            logger.error(
+                "BGP sessions did not re-establish after cleanup")
+        else:
+            logger.info("Original config restored, all sessions up")
+    request.addfinalizer(_full_cleanup)
 
     # --- Setup ---
 
-    # Wait for the selected BGP session to be established (it was established
-    # at module setup time, but may have temporarily dropped)
-    logger.info("Waiting for BGP session to %s to be established", neigh_ipv4)
+    # Save EOS running-config for reliable teardown via configure replace
+    eos_config_backup = save_eos_running_config(neigh_host)
+
+    # Wait for the selected BGP session to be established
+    logger.info("Waiting for BGP session to %s to be established",
+                neigh_ipv4)
     pytest_assert(
         wait_until(60, 5, 0, lambda: duthost.bgp_facts()['ansible_facts']
                    .get('bgp_neighbors', {}).get(neigh_ipv4, {})
@@ -272,18 +480,33 @@ def configure_unnumbered_bgp(setup_info):
 
     bgp_facts = duthost.bgp_facts()['ansible_facts']
     initial_prefixes = int(
-        bgp_facts['bgp_neighbors'][neigh_ipv4].get('accepted prefixes', 0))
+        bgp_facts['bgp_neighbors'][neigh_ipv4].get(
+            'accepted prefixes', 0))
     initial_prefixes_v6 = 0
     if neigh_ipv6:
         initial_prefixes_v6 = int(
             bgp_facts['bgp_neighbors'].get(neigh_ipv6, {})
             .get('accepted prefixes', 0))
-    # Stash baselines so the test can assert the unnumbered session preserves
-    # the full IPv4 (and IPv6) advertisement set, not just that prefixes > 0.
     setup_info['initial_ipv4_prefixes'] = initial_prefixes
     setup_info['initial_ipv6_prefixes'] = initial_prefixes_v6
     logger.info("Initial prefix count from %s: %d (v4), %d (v6)",
                 neigh_ipv4, initial_prefixes, initial_prefixes_v6)
+
+    # Optionally stop bgpcfgd to isolate FRR behavior for regression testing
+    if stop_bgpcfgd:
+        logger.info("Stopping bgpcfgd (FRR isolation mode)")
+        duthost.shell("docker exec bgp supervisorctl stop bgpcfgd",
+                      module_ignore_errors=True)
+
+    # For ethernet variant: break LAG and prepare freed Ethernet
+    if intf_type == 'ethernet':
+        eos_eth_intf, pc_vrf = break_lag_to_ethernet(
+            duthost, neigh_host, setup_info)
+        dut_intf = setup_info['member_ethernet']
+        eos_intf = eos_eth_intf
+    else:
+        dut_intf = portchannel
+        eos_intf = neigh_pc_intf
 
     # Remove existing BGP sessions on DUT
     logger.info("Remove existing BGP neighbor %s on DUT", neigh_ipv4)
@@ -291,222 +514,104 @@ def configure_unnumbered_bgp(setup_info):
                     'no neighbor {}'.format(neigh_ipv4)]
     if neigh_ipv6:
         vtysh_remove.append('no neighbor {}'.format(neigh_ipv6))
-    cmd = 'vtysh ' + ' '.join(['-c "{}"'.format(c) for c in vtysh_remove])
+    cmd = 'vtysh ' + ' '.join(
+        ['-c "{}"'.format(c) for c in vtysh_remove])
     duthost.shell(cmd, module_ignore_errors=True)
 
-    # Remove existing BGP session on EOS neighbor
-    logger.info("Remove DUT neighbors on EOS peer")
-    remove_lines = []
-    if dut_ipv4:
-        remove_lines.append("no neighbor {}".format(dut_ipv4))
-    if dut_ipv6:
-        remove_lines.append("no neighbor {}".format(dut_ipv6))
-    if remove_lines:
-        neigh_host.eos_config(lines=remove_lines,
-                              parents="router bgp {}".format(neigh_asn))
+    # Remove existing BGP session on EOS neighbor (only for portchannel,
+    # ethernet variant already removed neighbors via break_lag_to_ethernet)
+    if intf_type != 'ethernet':
+        logger.info("Remove DUT neighbors on EOS peer")
+        remove_lines = []
+        if dut_ipv4:
+            remove_lines.append("no neighbor {}".format(dut_ipv4))
+        if dut_ipv6:
+            remove_lines.append("no neighbor {}".format(dut_ipv6))
+        if remove_lines:
+            neigh_host.eos_config(
+                lines=remove_lines,
+                parents="router bgp {}".format(neigh_asn))
 
-    # Wait for old neighbor to be removed from DUT BGP before proceeding
+    # Wait for old neighbor to be removed from DUT BGP
     def old_neighbor_removed():
         facts = duthost.bgp_facts()['ansible_facts']
         return neigh_ipv4 not in facts.get('bgp_neighbors', {})
-
     wait_until(30, 3, 0, old_neighbor_removed)
 
-    # Configure unnumbered BGP on DUT.
-    # NOTE: 'v6only' is required — without it FRR auto-picks the peer's IPv4
-    # address from the /31 on the PortChannel (since SONiC configures both
-    # IPv4 and IPv6 on inter-switch links) and tries to open a numbered IPv4
-    # session instead of a link-local unnumbered session.
-    logger.info("Configure unnumbered BGP on DUT via %s", portchannel)
+    # Remove IPv4/IPv6 addresses from DUT interface to prevent
+    # FRR numbered fallback
+    if dut_ipv4:
+        duthost.shell("sudo config interface ip remove {} {}/31".format(
+            dut_intf, dut_ipv4), module_ignore_errors=True)
+    if dut_ipv6:
+        duthost.shell("sudo config interface ip remove {} {}/126".format(
+            dut_intf, dut_ipv6), module_ignore_errors=True)
+
+    # Configure unnumbered BGP on DUT via vtysh
+    logger.info("Configure unnumbered BGP on DUT via %s", dut_intf)
     vtysh_add = [
         'config',
         'router bgp {}'.format(dut_asn),
-        'neighbor {} interface v6only remote-as {}'.format(portchannel, neigh_asn),
+        'neighbor {} interface v6only remote-as {}'.format(
+            dut_intf, neigh_asn),
         'address-family ipv4 unicast',
-        'neighbor {} activate'.format(portchannel),
+        'neighbor {} activate'.format(dut_intf),
         'exit-address-family',
         'address-family ipv6 unicast',
-        'neighbor {} activate'.format(portchannel),
+        'neighbor {} activate'.format(dut_intf),
         'exit-address-family',
     ]
-    cmd = 'vtysh ' + ' '.join(['-c "{}"'.format(c) for c in vtysh_add])
+    cmd = 'vtysh ' + ' '.join(
+        ['-c "{}"'.format(c) for c in vtysh_add])
     result = duthost.shell(cmd)
     pytest_assert(result['rc'] == 0,
-                  "Failed to configure unnumbered BGP: {}".format(
-                      result.get('stderr', '')))
+                  "Failed to configure unnumbered BGP on {}: {}".format(
+                      dut_intf, result.get('stderr', '')))
 
-    # Configure BGP peering on EOS using interface-based (unnumbered) config.
-    # EOS does not support raw fe80:: addresses as BGP neighbors.
-    # Instead, EOS uses: neighbor interface <intf> peer-group <pg>
-    # with the peer-group configured for the remote AS.
-    #
-    # NOTE: cEOS defaults Port-Channel interfaces to 'ipv6 nd ra disabled'.
-    # FRR's unnumbered peering on the DUT side relies on receiving IPv6 RAs
-    # from the peer to discover its link-local address; without RAs the DUT
-    # stays in '(unspec)' state and never opens TCP/179. We therefore enable
-    # RAs on the peer Port-Channel as part of the peering setup.
-    eos_peer_group = "LINK_LOCAL_PG"
-    logger.info("Enable IPv6 RAs on EOS %s (required for FRR unnumbered peer discovery)",
-                neigh_pc_intf)
-    neigh_host.eos_config(
-        lines=["no ipv6 nd ra disabled"],
-        parents="interface {}".format(neigh_pc_intf))
-
-    logger.info("Configure interface-based BGP peering on EOS via %s (peer-group %s)",
-                neigh_pc_intf, eos_peer_group)
-    neigh_host.eos_config(
-        lines=[
-            "neighbor {} peer group".format(eos_peer_group),
-            "neighbor {} remote-as {}".format(eos_peer_group, dut_asn),
-            "neighbor interface {} peer-group {}".format(neigh_pc_intf, eos_peer_group),
-        ],
-        parents="router bgp {}".format(neigh_asn))
-
-    # Enable address families for the peer-group
-    for af in ["ipv4", "ipv6"]:
-        neigh_host.eos_config(
-            lines=[
-                "neighbor {} activate".format(eos_peer_group),
-            ],
-            parents=["router bgp {}".format(neigh_asn),
-                     "address-family {}".format(af)])
-
-    # Enable RFC 5549 (extended next-hop encoding) on EOS so it can advertise
-    # IPv4 NLRI with an IPv6 next-hop over the link-local session. Without
-    # these two knobs, cEOS passively receives the capability from FRR but
-    # never advertises it, then drops all outbound IPv4 updates with
-    # "IPv4 local address not available" since the TCP session has no IPv4
-    # local address. Required since EOS 4.22.1F (multi-agent model).
-    logger.info("Enable RFC 5549 extended next-hop on EOS for %s",
-                eos_peer_group)
-    neigh_host.eos_config(lines=["ip routing ipv6 interfaces"])
-    neigh_host.eos_config(
-        lines=[
-            "neighbor {} next-hop address-family ipv6 originate".format(
-                eos_peer_group),
-        ],
-        parents=["router bgp {}".format(neigh_asn),
-                 "address-family ipv4"])
-
-    # Verify EOS accepted the config
-    eos_bgp_cfg = neigh_host.eos_command(
-        commands=["show running-config section bgp"])
-    eos_cfg_text = eos_bgp_cfg['stdout'][0] if isinstance(
-        eos_bgp_cfg['stdout'], list) else eos_bgp_cfg['stdout']
-    logger.info("EOS BGP config after setup:\n%s", eos_cfg_text)
-    if eos_peer_group not in eos_cfg_text:
-        pytest.fail("EOS did not accept the interface-based BGP config. "
-                    "Running config:\n{}".format(eos_cfg_text))
+    # Configure unnumbered BGP on EOS
+    eos_peer_group = configure_unnumbered_eos(
+        neigh_host, neigh_asn, dut_asn, eos_intf,
+        eos_vrf=pc_vrf)
 
     yield {
         'initial_prefixes': initial_prefixes,
         'eos_peer_group': eos_peer_group,
+        'dut_intf': dut_intf,
     }
-
-    # --- Teardown ---
-    logger.info("Teardown: Restoring original configuration")
-
-    # Remove interface-based peering from EOS and restore originals.
-    # Order matters: remove interface neighbor first, then deactivate
-    # from address-families, then remove the peer-group itself.
-    eos_peer_group = "LINK_LOCAL_PG"
-    try:
-        # Step 1: remove interface neighbor (must precede peer-group removal)
-        neigh_host.eos_config(
-            lines=["no neighbor interface {}".format(neigh_pc_intf)],
-            parents="router bgp {}".format(neigh_asn))
-        # Step 2: revert RFC 5549 knobs and deactivate from address-families
-        neigh_host.eos_config(
-            lines=[
-                "no neighbor {} next-hop address-family ipv6 originate".format(
-                    eos_peer_group),
-                "no neighbor {} activate".format(eos_peer_group),
-            ],
-            parents=["router bgp {}".format(neigh_asn),
-                     "address-family ipv4"])
-        neigh_host.eos_config(
-            lines=["no neighbor {} activate".format(eos_peer_group)],
-            parents=["router bgp {}".format(neigh_asn),
-                     "address-family ipv6"])
-        neigh_host.eos_config(lines=["no ip routing ipv6 interfaces"])
-        # Step 3: remove the peer-group
-        neigh_host.eos_config(
-            lines=["no neighbor {} peer group".format(eos_peer_group)],
-            parents="router bgp {}".format(neigh_asn))
-        # Step 4: restore original numbered neighbors
-        restore_lines = []
-        if dut_ipv4:
-            restore_lines.append(
-                "neighbor {} remote-as {}".format(dut_ipv4, dut_asn))
-        if dut_ipv6:
-            restore_lines.append(
-                "neighbor {} remote-as {}".format(dut_ipv6, dut_asn))
-        if restore_lines:
-            neigh_host.eos_config(lines=restore_lines,
-                                  parents="router bgp {}".format(neigh_asn))
-        # Step 5: re-activate the restored v6 neighbor under address-family
-        # ipv6. EOS does NOT auto-activate IPv6 peers (unlike IPv4), so without
-        # this the original v6 session stays Idle after teardown even though
-        # the 'remote-as' line is back. (IPv4 peers are activated by default.)
-        if dut_ipv6:
-            neigh_host.eos_config(
-                lines=["neighbor {} activate".format(dut_ipv6)],
-                parents=["router bgp {}".format(neigh_asn),
-                         "address-family ipv6"])
-    except Exception as e:
-        logger.error("EOS cleanup failed: %s", e)
-        # Still proceed to config_reload below, but fail the teardown afterward
-        # so the error is visible rather than silently swallowed.
-        eos_cleanup_failed = True
-    else:
-        eos_cleanup_failed = False
-
-    # Config reload on DUT to restore everything
-    config_reload(duthost, wait=120, wait_for_bgp=True)
-
-    # Wait for all original BGP sessions to re-establish
-    original_neighbors = [neigh_ipv4]
-    if neigh_ipv6:
-        original_neighbors.append(neigh_ipv6)
-    if not wait_until(WAIT_TIMEOUT, POLL_INTERVAL, 0,
-                      duthost.check_bgp_session_state, original_neighbors):
-        pytest_assert(False,
-                      "BGP sessions did not re-establish after config reload")
-    else:
-        logger.info("Original configuration restored, all sessions up")
-
-    if eos_cleanup_failed:
-        pytest.fail("EOS cleanup failed during teardown - neighbor may still "
-                    "have stale link-local configuration")
 
 
 @pytest.mark.disable_loganalyzer
-def test_bgp_link_local_ipv6(setup_info, configure_unnumbered_bgp):
+def test_bgp_link_local(setup_info, configure_unnumbered_bgp):
     """
     Test BGP peering over IPv6 link-local addresses (unnumbered).
 
+    Parametrized variants:
+    - [portchannel]: unnumbered BGP on LAG interface (full stack)
+    - [ethernet]: break LAG, unnumbered BGP on plain Ethernet (full stack)
+    - [portchannel-frrtest]: bgpcfgd stopped, isolates FRR regressions
+
     Validates that:
-    1. Unnumbered BGP session can be established via a PortChannel interface
-    2. Routes are exchanged over the link-local session
+    1. Unnumbered BGP session can be established
+    2. Full prefix set is exchanged (RFC 5549 validated)
     3. The session uses IPv6 link-local addressing
     """
     duthost = setup_info['duthost']
-    portchannel = setup_info['portchannel']
+    dut_intf = configure_unnumbered_bgp['dut_intf']
     initial_prefixes = configure_unnumbered_bgp['initial_prefixes']
 
     # Wait for BGP session to establish
     logger.info("Waiting for unnumbered BGP session to establish (timeout=%ds)",
                 WAIT_TIMEOUT)
     established = wait_until(WAIT_TIMEOUT, POLL_INTERVAL, 0,
-                             bgp_unnumbered_established, duthost, portchannel)
+                             bgp_unnumbered_established, duthost, dut_intf)
 
     if not established:
-        # Debug output before skipping
+        # Debug output before failing
         summary = duthost.shell("vtysh -c 'show bgp summary'",
                                 module_ignore_errors=True)
         logger.error("BGP summary:\n%s", summary.get('stdout', ''))
         detail = duthost.shell(
-            "vtysh -c 'show bgp neighbors {}'".format(portchannel),
+            "vtysh -c 'show bgp neighbors {}'".format(dut_intf),
             module_ignore_errors=True)
         logger.error("Neighbor detail:\n%s", detail.get('stdout', ''))
         try:
@@ -523,7 +628,7 @@ def test_bgp_link_local_ipv6(setup_info, configure_unnumbered_bgp):
             "Unnumbered BGP session via {} did not establish within {}s. "
             "This could indicate a neighbor compatibility issue — the peer "
             "may not support BGP peering over IPv6 link-local addresses."
-            .format(portchannel, WAIT_TIMEOUT))
+            .format(dut_intf, WAIT_TIMEOUT))
 
     logger.info("Unnumbered BGP session established!")
 
@@ -535,9 +640,9 @@ def test_bgp_link_local_ipv6(setup_info, configure_unnumbered_bgp):
     expected_v4 = setup_info.get('initial_ipv4_prefixes', 0)
     expected_v6 = setup_info.get('initial_ipv6_prefixes', 0)
 
-    def routes_received_via_unnumbered(duthost, portchannel,
+    def routes_received_via_unnumbered(duthost, dut_intf,
                                        exp_v4, exp_v6):
-        """Check that the unnumbered peer on `portchannel` has received the
+        """Check that the unnumbered peer on `dut_intf` has received the
         full expected prefix count in BOTH IPv4 and IPv6 address-families.
 
         Requiring both AFs validates that RFC 5549 extended next-hop is
@@ -556,7 +661,7 @@ def test_bgp_link_local_ipv6(setup_info, configure_unnumbered_bgp):
             for af in ok:
                 for peer, data in bgp_summary.get(af, {}).get(
                         'peers', {}).items():
-                    if portchannel.lower() in peer.lower() \
+                    if dut_intf.lower() in peer.lower() \
                             and data.get('pfxRcd', 0) >= thresholds[af]:
                         ok[af] = True
                         break
@@ -567,12 +672,12 @@ def test_bgp_link_local_ipv6(setup_info, configure_unnumbered_bgp):
 
     pytest_assert(
         wait_until(60, 5, 0, routes_received_via_unnumbered,
-                   duthost, portchannel, expected_v4, expected_v6),
+                   duthost, dut_intf, expected_v4, expected_v6),
         "Unnumbered BGP on {} did not receive the full advertisement set "
         "(expected >={} IPv4 and >={} IPv6 prefixes, as observed on the "
         "numbered baseline). RFC 5549 extended next-hop may not be "
         "negotiated, or peer is dropping updates."
-        .format(portchannel, expected_v4, expected_v6))
+        .format(dut_intf, expected_v4, expected_v6))
 
     # Get the actual route count for logging
     result = duthost.shell("vtysh -c 'show bgp summary json'",
@@ -584,7 +689,7 @@ def test_bgp_link_local_ipv6(setup_info, configure_unnumbered_bgp):
             for af in ['ipv4Unicast', 'ipv6Unicast']:
                 for peer, data in bgp_summary.get(af, {}).get(
                         'peers', {}).items():
-                    if portchannel.lower() in peer.lower():
+                    if dut_intf.lower() in peer.lower():
                         pfx = data.get('pfxRcd', 0)
                         if pfx > 0:
                             route_count = pfx
@@ -601,7 +706,7 @@ def test_bgp_link_local_ipv6(setup_info, configure_unnumbered_bgp):
     # Verify session details using JSON output for robustness across FRR versions
     logger.info("Verify session details")
     detail_json = duthost.shell(
-        "vtysh -c 'show bgp neighbors {} json'".format(portchannel),
+        "vtysh -c 'show bgp neighbors {} json'".format(dut_intf),
         module_ignore_errors=True)
     if detail_json['rc'] == 0:
         try:
@@ -612,22 +717,22 @@ def test_bgp_link_local_ipv6(setup_info, configure_unnumbered_bgp):
                 if state == 'Established':
                     session_established = True
                     logger.info("Session detail confirmed: %s is Established via %s",
-                                nbr_key, portchannel)
+                                nbr_key, dut_intf)
                     break
             pytest_assert(session_established,
-                          "BGP neighbor detail does not show Established state for {}".format(portchannel))
+                          "BGP neighbor detail does not show Established state for {}".format(dut_intf))
         except (json.JSONDecodeError, KeyError) as e:
             logger.warning("Failed to parse neighbor JSON, falling back to text check: %s", e)
             detail = duthost.shell(
-                "vtysh -c 'show bgp neighbors {}'".format(portchannel),
+                "vtysh -c 'show bgp neighbors {}'".format(dut_intf),
                 module_ignore_errors=True)
             pytest_assert('Established' in detail.get('stdout', ''),
                           "BGP neighbor detail does not show Established state")
     else:
         # JSON form not available, fall back to text
         detail = duthost.shell(
-            "vtysh -c 'show bgp neighbors {}'".format(portchannel),
+            "vtysh -c 'show bgp neighbors {}'".format(dut_intf),
             module_ignore_errors=True)
         pytest_assert('Established' in detail.get('stdout', ''),
                       "BGP neighbor detail does not show Established state")
-        logger.info("Session detail confirmed: Established via %s", portchannel)
+        logger.info("Session detail confirmed: Established via %s", dut_intf)

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -438,6 +438,18 @@ bgp/test_bgp_gr_helper.py::test_bgp_gr_helper_routes_perserved:
     conditions:
       - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
 
+bgp/test_bgp_link_local.py::test_bgp_link_local[ethernet]:
+  skip:
+    reason: "bgpcfgd lacks unnumbered BGP support via CONFIG_DB (sonic-buildimage#26960)"
+    conditions:
+      - https://github.com/sonic-net/sonic-buildimage/issues/26960
+
+bgp/test_bgp_link_local.py::test_bgp_link_local[portchannel]:
+  skip:
+    reason: "bgpcfgd lacks unnumbered BGP support via CONFIG_DB (sonic-buildimage#26960)"
+    conditions:
+      - https://github.com/sonic-net/sonic-buildimage/issues/26960
+
 bgp/test_bgp_max_route.py::test_bgp_max_prefix_behavior:
   xfail:
     reason: "Test failed on multi-asic PR tests"


### PR DESCRIPTION
### Description of PR

Summary:
Enhance `test_bgp_link_local` (from #24197) with Ethernet variant, VRF support for converged peers, FRR isolation variant, `configure replace` teardown, and EOS config session cleanup. Three parametrized variants test both the production CONFIG_DB path (skipped in CI) and FRR directly (runs in CI as regression guard).

Supersedes #24135.

Fixes #18431
Fixes #24134

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

PR #24197 (merged) added the initial `test_bgp_link_local_ipv6` test for PortChannel-only unnumbered BGP. This PR extends it with:

1. **Ethernet variant** — breaks LAG, tests unnumbered BGP on plain Ethernet (requires `no switchport` + `ipv6 enable` on EOS after LAG removal)
2. **VRF-aware LAG breakout** — detects VRF on Port-Channel before removal, assigns freed Ethernet to same VRF (required for converged peer topologies)
3. **FRR isolation variant** (`portchannel-frrtest`) — stops bgpcfgd to test FRR directly, guards against FRR regressions
4. **CONFIG_DB path for vanilla variants** — exercises production stack (CONFIG_DB → bgpcfgd → FRR), skipped in CI until sonic-buildimage#26960 is resolved
5. **`configure replace` teardown** — saves EOS running-config before test, restores atomically (more robust than step-by-step teardown)
6. **EOS config session cleanup** — clears stale pending sessions before setup and after teardown to prevent cEOS session pool exhaustion

#### How did you do it?

- **Three parametrized test variants** via `configure_unnumbered_bgp` fixture:
  - `[portchannel]`: CONFIG_DB path on PortChannel — **skipped** (bgpcfgd can't configure unnumbered)
  - `[ethernet]`: CONFIG_DB path on Ethernet (breaks LAG first) — **skipped** (same reason)
  - `[portchannel-frrtest]`: Stops bgpcfgd, configures FRR via vtysh — **runs in CI**
- **New helpers**: `break_lag_to_ethernet()`, `configure_unnumbered_eos()`, `save_eos_running_config()`, `restore_eos_full_config()`, `_cleanup_eos_sessions()`
- **Conditional skip** via `tests_mark_conditions.yaml` referencing sonic-buildimage#26960

#### How did you verify/test it?

Locally verified on KVM T0 testbed (P520-1, converged 4 cEOS, FRR 10.5.1):

**v32 (3-variant, CONFIG_DB for vanilla, after cEOS restart):**
- `[portchannel]` FAILED (expected — CONFIG_DB can't express unnumbered neighbor)
- `[ethernet]` FAILED (expected — same reason)
- `[portchannel-frrtest]` PASSED ✅ (bgpcfgd stopped, FRR configured directly)
- 4/4 BGP Established post-test ✅

flake8 clean (max-line-length=120).

#### Any platform specific information?

Requires EOS/cEOS neighbors. Topology: t0.

#### Supported testbed topology if it's a new test case?

t0

### Documentation
N/A
