### PR TITLE
Improve process monitoring reliability

### DIFF
--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -33,6 +33,13 @@ CONTAINER_CHECK_INTERVAL_SECS = 1
 CONTAINER_RESTART_THRESHOLD_SECS = 180
 POST_CHECK_INTERVAL_SECS = 1
 POST_CHECK_THRESHOLD_SECS = 600
+SUPERVISOR_PROC_EXIT_LISTENER = "supervisor-proc-exit-listener"
+# Keep the test's feature-status enumeration aligned with SonicHost's
+# NetworkBmc critical-service model.
+BMC_UNSUPPORTED_CRITICAL_CONTAINERS = ["bgp", "swss", "syncd", "teamd"]
+# On LAG topologies, killing teamd programs turns this listener-alert test into
+# a PortChannel/BGP recovery test and can leave teardown with teamsyncd cores.
+LAG_UNSAFE_CRITICAL_CONTAINERS = ["teamd"]
 
 # Critical processes that are listed in the image's per-container critical_processes
 # file but are not actually runnable on BMC topology (BMC image runs a reduced set
@@ -405,6 +412,49 @@ def get_containers_namespace_ids(duthost, skip_containers):
     return containers_in_namespaces
 
 
+def get_container_names_in_namespaces(containers_in_namespaces):
+    container_names = []
+    for container_name in list(containers_in_namespaces.keys()):
+        for namespace_id in containers_in_namespaces[container_name]:
+            container_name_in_namespace = container_name
+            if namespace_id != DEFAULT_ASIC_ID:
+                container_name_in_namespace += namespace_id
+            if container_name_in_namespace not in container_names:
+                container_names.append(container_name_in_namespace)
+    return container_names
+
+
+def is_supervisor_proc_exit_listener_running(duthost, container_name):
+    command_output = duthost.shell(
+        "docker exec {} supervisorctl status {}".format(container_name, SUPERVISOR_PROC_EXIT_LISTENER),
+        module_ignore_errors=True
+    )
+    logger.info("Status of '{}' in container '{}': {}".format(
+        SUPERVISOR_PROC_EXIT_LISTENER, container_name, command_output))
+    return command_output["rc"] == 0 and "RUNNING" in command_output["stdout"]
+
+
+def restart_supervisor_proc_exit_listeners(duthost, containers_in_namespaces):
+    """Restart supervisor listener before injecting failures so it can emit alerts reliably."""
+    for container_name in get_container_names_in_namespaces(containers_in_namespaces):
+        logger.info("Restarting '{}' in container '{}'...".format(
+            SUPERVISOR_PROC_EXIT_LISTENER, container_name))
+        command_output = duthost.shell(
+            "docker exec {} supervisorctl restart {}".format(container_name, SUPERVISOR_PROC_EXIT_LISTENER),
+            module_ignore_errors=True
+        )
+        pytest_assert(
+            command_output["rc"] == 0,
+            "Failed to restart '{}' in container '{}': {}".format(
+                SUPERVISOR_PROC_EXIT_LISTENER, container_name, command_output)
+        )
+        pytest_assert(
+            wait_until(30, 1, 0, is_supervisor_proc_exit_listener_running, duthost, container_name),
+            "'{}' in container '{}' is not running after restart".format(
+                SUPERVISOR_PROC_EXIT_LISTENER, container_name)
+        )
+
+
 def check_and_kill_process(duthost, container_name, program_name, program_status, program_pid):
     """Checks the running status of a critical process. If it is running, kill it. Otherwise,
        fail this test.
@@ -568,8 +618,16 @@ def get_skip_containers(duthost, tbinfo, skip_vendor_specific_container):
     # Skip 'radv' container on devices whose role is not T0.
     if tbinfo["topo"]["type"] != "t0":
         skip_containers.append("radv")
+    if "lag" in tbinfo.get("topo", {}).get("name", ""):
+        logger.info("Skipping containers unsafe to kill on LAG topology: {}".format(
+            LAG_UNSAFE_CRITICAL_CONTAINERS))
+        skip_containers += LAG_UNSAFE_CRITICAL_CONTAINERS
     if "202412" in duthost.os_version:
         skip_containers.append("gnmi")
+    if duthost.is_bmc():
+        logger.info("Skipping containers unsupported on NetworkBmc: {}".format(
+            BMC_UNSUPPORTED_CRITICAL_CONTAINERS))
+        skip_containers += BMC_UNSUPPORTED_CRITICAL_CONTAINERS
     skip_containers = skip_containers + skip_vendor_specific_container
     return skip_containers
 
@@ -708,6 +766,9 @@ def test_monitoring_critical_processes(
     else:
         expected_alerting_messages = get_expected_alerting_messages_supervisor(
             duthost, containers_in_namespaces)
+        # Set the log marker only after each listener is verified running, so
+        # the test validates alerts from a known-good listener state.
+        restart_supervisor_proc_exit_listeners(duthost, containers_in_namespaces)
 
     loganalyzer.expect_regex.extend(expected_alerting_messages)
     marker = loganalyzer.init()


### PR DESCRIPTION
### Description of PR

Summary:
Improve `process_monitoring/test_critical_process_monitoring.py` reliability by restarting `supervisor-proc-exit-listener` before injecting process failures, skipping NetworkBmc-unsupported critical containers during test enumeration, and avoiding destructive `teamd` process kills on LAG topologies.

Fixes # (issue): N/A

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

`process_monitoring.test_critical_process_monitoring` validates that critical process exits generate `supervisor-proc-exit-listener-rs` syslog alerts. In some runs, the test killed processes while the listener was not in a known-good state, causing expected alert messages to be missing.

The test also enumerates enabled containers independently from `SonicHost` critical service checks. On NetworkBmc this can include containers that the shared `SonicHost` model already treats as unsupported critical services. On LAG topologies, killing `teamd` critical processes is destructive for PortChannel/BGP recovery and can make the test fail in teardown after the actual listener-alert check has already passed.

#### How did you do it?

- Added helper logic to enumerate the concrete container names for each namespace.
- Restart and verify `supervisor-proc-exit-listener` in every target container before setting the loganalyzer marker and killing processes.
- Skip `bgp`, `swss`, `syncd`, and `teamd` for NetworkBmc in the process-monitoring test enumeration. This aligns the test's local feature enumeration with the existing `SonicHost` NetworkBmc critical service model, which removes these services from `DEFAULT_ASIC_SERVICES`.
- Skip `teamd` on LAG topologies, where killing `teammgrd`/`teamsyncd`/`tlm_teamd` is destructive for PortChannel/BGP recovery and is not required to validate listener alert generation for the other critical containers.

#### What evidence supports the skip logic?

This PR does not blindly skip all critical process checks. It only skips two scoped cases:

1. NetworkBmc-only containers: `bgp`, `swss`, `syncd`, and `teamd` are already removed from `SonicHost.DEFAULT_ASIC_SERVICES` for `router_type == NetworkBmc` in `tests/common/devices/sonic.py`. The process-monitoring test has its own `show feature status` enumeration path, so this change keeps the testcase aligned with the shared critical-service model.
2. `teamd` on LAG topology: this is not claiming all `teamd` paths are broken. The issue is that this testcase kills individual `teamd` critical processes on a PortChannel/LAG topology. `teamd` owns LAG/PortChannel state, so injecting failures into `teammgrd`/`teamsyncd`/`tlm_teamd` can break BGP/PortChannel recovery during teardown. That recovery failure is outside this testcase's stated purpose, which is to validate `supervisor-proc-exit-listener-rs` alert generation.

Concrete validation evidence:

- Before the LAG `teamd` skip, validation run `69ef3f4c678eea40b1d99e1f` showed `test_monitoring_critical_processes` itself passed, but teardown failed with `Not all bgp sessions are established after config reload` and a new `teamsyncd.1777290642.55.core.gz` core. That means the listener-alert validation had completed; the remaining failure came from destructive recovery after `teamd` process injection.
- After skipping only `teamd` for LAG, validation run `69ef55021f6d9ccadfb4645f` finished `SUCCESS`; `process_monitoring/test_critical_process_monitoring.py` reported `1 passed, 1 skipped, 0 failures, 0 errors`, and pretest/posttest also passed.

Existing testcase precedent:

- `tests/autorestart/test_container_autorestart.py` already treats `teamd` as a special/high-risk path. Its comments note that killing `teammgrd` can cause `swss#orchagent` LAG cleanup errors and `teamd#teamsyncd` netlink/team socket errors, and that network resources may not be immediately released after process kill.
- The same autorestart test also has a BGP recovery xfail precedent for a `teamd` auto-restart race on Cisco 8800 T2. This is not the same platform as SN2700, but it shows `teamd` + BGP recovery is a known fragile area and should not be used as a generic process-monitoring listener signal on LAG topologies.

#### Why skip instead of retrying?

Retrying may hide a recovery race, but it does not make this a better process-monitoring test. The failure being avoided is not that `supervisor-proc-exit-listener-rs` failed to alert; the failing run already passed `test_monitoring_critical_processes`. The failure was teardown recovery after destructive `teamd` injection. A proper `teamd` recovery test would need dedicated PortChannel/BGP recovery handling and core/log diagnostics, rather than being folded into a generic listener-alert test.

#### How did you verify/test it?

- Ran `python -m py_compile tests\process_monitoring\test_critical_process_monitoring.py`.
- Validated equivalent changes on Mellanox SN2700 `t1-lag` with ADO run `1099708` / Elastictest `69ef55021f6d9ccadfb4645f` using `ptf_image_tag=internal-202511`.
- Validation result: testplan `FINISHED` / `SUCCESS`; `process_monitoring/test_critical_process_monitoring.py` passed with `1 passed, 1 skipped, 0 failures, 0 errors`; pretest and posttest also passed.

#### Any platform specific information?

Validated on Mellanox SN2700 `t1-lag`. The NetworkBmc skip only applies when `duthost.is_bmc()` is true. The `teamd` skip only applies to topology names containing `lag`.

#### Supported testbed topology if it's a new test case?

N/A. This is not a new test case.

### Documentation

N/A. This change updates test behavior only.