### PR TITLE
fix(ntp_helper): use ntpsec orphan mode on PTF instead of removed LOCL refclock

### DIFF
--- a/tests/common/helpers/ntp_helper.py
+++ b/tests/common/helpers/ntp_helper.py
@@ -29,12 +29,13 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
         ntp_service_name = 'ntp'
 
     if ntp_daemon_type in (NtpDaemon.NTPSEC, NtpDaemon.NTP):
-        # Limit listening to the mgmt interface, to prevent socket allocation
-        # exhaustion
+        # Limit listening to the mgmt and loopback interfaces, to prevent socket
+        # allocation exhaustion on PTF hosts with many test interfaces.
+        # The loopback interface is required so that ntpstat can query ntpd via
+        # 127.0.0.1 to verify the service is running.
         ptfhost.lineinfile(path=ntp_conf_path, line="interface ignore wildcard")
+        ptfhost.lineinfile(path=ntp_conf_path, line="interface listen lo")
         ptfhost.lineinfile(path=ntp_conf_path, line="interface listen mgmt")
-
-    ptfhost.lineinfile(path=ntp_conf_path, line="server 127.127.1.0 prefer")
 
     # Comment out the default pool configuration
     ptfhost.lineinfile(
@@ -52,7 +53,15 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
     ptfhost.lineinfile(
         path=ntp_conf_path, line="#tos minclock 4 minsane 3", regexp="^tos.*minclock.*minsane.*")
 
-    ptfhost.lineinfile(path=ntp_conf_path, line="server 127.127.1.0 prefer")
+    if ntp_daemon_type == NtpDaemon.NTPSEC:
+        # ntpsec removed the LOCL (undisciplined local clock) refclock driver, so
+        # "server 127.127.1.0 prefer" has no effect and ntpd stays in INIT state
+        # indefinitely.  Use orphan mode instead: ntpd immediately self-synchronises
+        # at the given stratum so that ntpstat and the DUT can treat it as a valid
+        # time source.  orphanwait 0 skips the default 300-second delay.
+        ptfhost.lineinfile(path=ntp_conf_path, line="tos orphan 10 orphanwait 0")
+    else:
+        ptfhost.lineinfile(path=ntp_conf_path, line="server 127.127.1.0 prefer")
 
     # restart ntp server
     ntp_en_res = ptfhost.service(name=ntp_service_name, state="restarted")
@@ -98,10 +107,14 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
     ptfhost.lineinfile(
         path=ntp_conf_path, line="pool 3.debian.pool.ntp.org iburst", regexp="#pool.*3.debian.*pool.*ntp.*org.*")
 
-    ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^server.*127.127.1.0.*prefer")
+    if ntp_daemon_type == NtpDaemon.NTPSEC:
+        ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^tos.*orphan.*orphanwait")
+    else:
+        ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^server.*127.127.1.0.*prefer")
 
     if ntp_daemon_type in (NtpDaemon.NTPSEC, NtpDaemon.NTP):
         ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^interface.ignore.wildcard")
+        ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^interface.listen.lo")
         ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^interface.listen.mgmt")
 
     # reset ntp client configuration


### PR DESCRIPTION
### Description of PR

Fix `test_ntp_ipv6_only` failing with "NTP server was not started in PTF container" on Debian 12 PTF hosts using ntpsec 1.2.2.

Fixes # (no issue filed)

### Type of change

- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

`setup_ntp_context` configures `server 127.127.1.0 prefer` (the NTP LOCL undisciplined local clock refclock, type 1) as the PTF ntpd time source. This worked with classic ntp4 but **ntpsec removed the LOCL refclock driver**. As a result:

1. ntpd silently ignores `server 127.127.1.0 prefer`
2. The pool servers are commented out, and there is no internet NTP access from the PTF lab network
3. ntpd stays in INIT state indefinitely (stratum 0, never synchronizes)
4. ntpd in INIT state does not respond to NTP mode 6 (control) queries
5. `ntpstat` always times out (rc=2), so `check_ntp_status` always returns False
6. The 120-second `wait_until(check_ntp_status)` assertion fails

**Observed failure** in `ip/test_mgmt_ipv6_only.py::test_ntp_ipv6_only` on testbed `vms13-lt2-7060x6-8` (Debian 12, ntpsec 1.2.2):
```
Failed: NTP server was not started in PTF container vms13-1;
NTP service start result {"name": "ntpsec", "state": "started", "changed": True, ...}
```

#### How did you do it?

For ntpsec, replace `server 127.127.1.0 prefer` with `tos orphan 10 orphanwait 0`:

- **Orphan mode** (`tos orphan 10`) makes ntpd self-synchronise using its local clock at stratum 10 when no external sources are reachable. The DUT treats this as a valid time source (stratum < 16).
- **`orphanwait 0`** skips the default 300-second delay before claiming orphan stratum, so ntpd is ready immediately on startup — well within the existing 120-second `wait_until` timeout.

Classic ntp4 continues to use `server 127.127.1.0 prefer` unchanged.

Also remove a duplicate `lineinfile` call for `server 127.127.1.0 prefer` that was present in the original code.

#### How did you verify/test it?

Verified by live investigation on PTF container `vms13-1` (testbed `vms13-lt2-7060x6-8`, Debian 12, ntpsec 1.2.2):

- Confirmed ntpsec ignores `server 127.127.1.0 prefer` (LOCL driver removed) → ntpd never syncs → `ntpstat` always times out
- Confirmed `tos orphan 10 orphanwait 0` causes ntpd to self-synchronise at stratum 10 **immediately** (observed at t=0s after service start)
- Confirmed `ntpstat` returns rc=0 and `ntpq -c sysinfo` reports `root dispersion: 0.0` once orphan mode is active

#### Any platform specific information?

Affects PTF containers running Debian 12 (Bookworm) with ntpsec >= 1.2.x (LOCL refclock driver removed). Does not affect PTF containers using classic ntp4.

#### Supported testbed topology if it's a new test case?

N/A — this is a bug fix in test infrastructure, not a new test case.

### Documentation

N/A