### PR TITLE
[TEST ONLY - DO NOT MERGE] Validate KVM VS probe test on standard CI

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4400,8 +4400,8 @@ qos/test_qos_probe.py:
     reason: "Buffer threshold probing tests need platform-specific validation. Tracked by per-ASIC GitHub issues."
     conditions_logical_operator: or
     conditions:
-      # Virtual Switch support
-      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/22599"
+      # Virtual Switch support — [TEST ONLY] Commented out to validate KVM probe tests
+      # - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/22599"
       # Cisco-8000 GB series (8102/8101 GB SKUs)
       - "hwsku in ['Cisco-8102-C64', 'Cisco-8101-O8C48', 'Cisco-8102-28FH-DPU-O'] and https://github.com/sonic-net/sonic-mgmt/issues/22601"
       # Cisco-8000 GR/GR2 series (8101 GR/GR2 SKUs)

--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -1,4 +1,5 @@
 """SAI thrift-based buffer threshold probing tests for SONiC.
+# [TEST ONLY - DO NOT MERGE] Trigger CI to validate KVM VS probe tests.
 
 This module contains probe-based tests for buffer threshold detection, including:
 - testQosPfcXoffProbe: PFC XOFF threshold probing


### PR DESCRIPTION
## ⚠️ TEST ONLY - DO NOT MERGE ⚠️

This PR temporarily comments out the VS platform skip entry for `test_qos_probe.py` in `tests_mark_conditions.yaml` to trigger standard CI automation and validate KVM VS probe test behavior.

### Changes
1. **`tests_mark_conditions.yaml`** — Commented out VS platform skip for `test_qos_probe.py` (line referencing issue #22599)
2. **`tests/qos/test_qos_probe.py`** — Added test-only comment to ensure CI picks up the change

### What is NOT changed
- Multi-ASIC T1 skip (`tests_mark_conditions_vs_t1_multiasic.yaml`) — **kept as-is**
- T2 skip (`tests_mark_conditions_vs_t2.yaml`) — **kept as-is**

### Purpose
Validate that probe tests pass on standard KVM VS (single-ASIC T0/T1) CI after all framework PRs have been merged (#22547, #23649, #24024).

### Expected CI Behavior
- KVM T0 (single_asic): Should PASS
- KVM T1 (single_asic): Should PASS
- KVM T1 multi-ASIC: Still SKIPPED (mark_conditions kept)
- KVM T2: Still SKIPPED (mark_conditions kept)

This PR will be **closed without merging** after CI results are reviewed.
