### PR TITLE
[conditional_mark] Fix IndexError in test_po_voq skip condition when minigraph_portchannels is empty

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4022,7 +4022,7 @@ pc/test_po_voq.py:
   skip:
     reason: "Skip for non t2 or Skip since there is no portchannel configured or no portchannel member exists in current topology."
     conditions:
-      - "'t2' not in topo_name or num_asic == 0 or len(minigraph_portchannels[list(minigraph_portchannels.keys())[0]]['members']) == 0 or asic_type in ['cisco-8000']"
+      - "'t2' not in topo_name or num_asic == 0 or len(minigraph_portchannels) == 0 or len(minigraph_portchannels[list(minigraph_portchannels.keys())[0]]['members']) == 0 or asic_type in ['cisco-8000']"
 
 pc/test_retry_count.py:
   skip:


### PR DESCRIPTION
### Description of PR
Summary:
On testbeds where no portchannels are configured (e.g. FT2, t2 topology with Arista 7060x6), `test_po_voq.py` was failing with an `INTERNALERROR` during pytest collection:

```
INTERNALERROR> RuntimeError: Failed to evaluate condition, raw_condition='t2' not in topo_name or num_asic == 0 or len(minigraph_portchannels[list(minigraph_portchannels.keys())[0]]['members']) == 0 or asic_type in ['cisco-8000']
```

The skip condition for `pc/test_po_voq.py` in `tests_mark_conditions.yaml` accessed `minigraph_portchannels[list(minigraph_portchannels.keys())[0]]` without first checking if the dict is empty. When `minigraph_portchannels` is empty, `list(...)[0]` raises an `IndexError`, which gets wrapped as a `RuntimeError` by the conditional mark plugin.

Added `len(minigraph_portchannels) == 0 or` guard before the key access, consistent with the existing pattern in the `test_po_update.py` condition.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Prevent `INTERNALERROR` crash during pytest collection on testbeds with no portchannels configured.

#### How did you do it?
Added an empty-dict guard `len(minigraph_portchannels) == 0 or` before accessing the first key of `minigraph_portchannels` in the skip condition for `pc/test_po_voq.py`.

#### How did you verify/test it?
Reproduced the `IndexError` by evaluating the original condition with an empty `minigraph_portchannels` dict; confirmed the fixed condition short-circuits correctly.

#### Any platform specific information?
Observed on FT2 testbed (t2 topology, Arista 7060x6).

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A