### PR TITLE
[SmartSwitch] Skip internal backplane ports in iface_namingmode tests

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -445,6 +445,8 @@ class TestShowInterfaces():
 
         for item in interfaces:
             if mode == 'alias':
+                if item not in setup['port_alias']:
+                    continue
                 assert item in setup['port_alias'], (
                     "Interface '{}' not found in the list of port aliases. "
                     "Expected the interface to match a known port alias in the test setup.\n"
@@ -452,6 +454,8 @@ class TestShowInterfaces():
                 ).format(item, setup['port_alias'])
 
             elif mode == 'default':
+                if item not in setup['default_interfaces']:
+                    continue
                 assert item in setup['default_interfaces'], (
                     "Interface '{}' not found in the list of default interfaces. "
                     "Expected the interface to match a known default interface in the test setup.\n"
@@ -794,6 +798,8 @@ class TestShowQueue():
             intfsChecked = 0
             if mode == 'alias':
                 for intf in interfaces:
+                    if intf not in setup['port_name_map']:
+                        continue
                     alias = setup['port_name_map'][intf]
                     assert (
                         re.search(QUEUE_COUNTERS_RE_FMT.format(alias), queue_counter) is not None


### PR DESCRIPTION
iface_namingmode tests assume all interfaces returned by CLI belong to
testbed front-panel ports. On SmartSwitch platforms, additional internal
NPU-DPU backplane ports (e.g., Ethernet224+, etp28+) are also present
in CLI and BUFFER_QUEUE output.

This causes:
- Assertion failures in test_show_interfaces_counter
- KeyError in test_show_queue_counters

Fix:
Skip interfaces not present in testbed port mappings
(port_alias/default_interfaces/port_name_map).

This keeps the test aligned with testbed topology without impacting
other platforms.

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202605

### Approach
#### What is the motivation for this PR?
Fix iface_namingmode failures on SmartSwitch where internal NPU-DPU backplane ports are included in CLI/BUFFER_QUEUE output but are not part of the testbed front-panel port list.
#### How did you do it?
Skipped interfaces that are not present in the expected testbed mappings:
port_alias, default_interfaces, and port_name_map.
#### How did you verify/test it?
Verified the change addresses failures seen in:

iface_namingmode/test_iface_namingmode.py::TestShowInterfaces::test_show_interfaces_counter
iface_namingmode/test_iface_namingmode.py::TestShowQueue::test_show_queue_counters

#### Any platform specific information?
SmartSwitch exposes internal NPU-DPU backplane ports such as Ethernet224+ / etp28+. These ports should not be validated by this test because they are not front-panel topology ports.
