### PR TITLE
[tests/console]: extract shared helpers from per-file boilerplate

### DIFF
--- a/tests/common/helpers/console_helper.py
+++ b/tests/common/helpers/console_helper.py
@@ -4,6 +4,9 @@ import re
 import string
 import random
 
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
+
 
 def assert_expect_text(client, text, target_line, timeout_sec=0.1):
     index = client.expect_exact([text, pexpect.EOF, pexpect.TIMEOUT], timeout=timeout_sec)
@@ -72,3 +75,57 @@ def generate_random_string(length):
 def check_target_line_status(duthost, line, expect_status):
     console_facts = duthost.console_facts()['ansible_facts']['console_facts']
     return console_facts['lines'][line]['state'] == expect_status
+
+
+def get_dut_ip_and_creds(duthost, creds):
+    """Return ``(ip, user, password)`` for ``duthost`` using the inventory and
+    the ``creds`` fixture. Centralizes the inventory dance every console test
+    used to repeat verbatim.
+    """
+    ip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
+    return ip, creds['sonicadmin_user'], creds['sonicadmin_password']
+
+
+def get_dut_console_lines(conn_graph_facts, duthost):
+    """Return the DUT's console line numbers (as strings) sorted ascending by
+    numeric value, sourced from the ``*_serial_links.csv`` inventory exposed
+    via ``conn_graph_facts['device_serial_link']``.
+    """
+    dut_serial_links = conn_graph_facts.get('device_serial_link', {}).get(duthost.hostname, {})
+    return sorted(dut_serial_links.keys(), key=int)
+
+
+def disconnect_picocom_client(client):
+    """Send the picocom escape sequence (``Ctrl-A`` ``Ctrl-X``) to release the
+    console line. Safe to call with ``None`` and swallows teardown errors so
+    the caller's ``finally`` block can chain other cleanup work.
+    """
+    if client is None:
+        return
+    try:
+        client.sendcontrol('a')
+        client.sendcontrol('x')
+    except Exception:
+        # Best-effort during teardown; the line-IDLE check that typically
+        # follows will surface any session that did not actually release.
+        pass
+
+
+def wait_for_line_idle(host, target_line, timeout_sec=10, error_msg=None):
+    """Wait up to ``timeout_sec`` seconds for ``target_line`` on ``host`` to
+    return to the ``IDLE`` state, asserting via ``pytest_assert`` if not.
+    """
+    if error_msg is None:
+        error_msg = "Target line {} is busy after waiting {}s for IDLE".format(target_line, timeout_sec)
+    pytest_assert(
+        wait_until(timeout_sec, 1, 0, check_target_line_status, host, target_line, "IDLE"),
+        error_msg)
+
+
+def configure_console_line(host, line, baud_rate, flow_control=None):
+    """Apply the standard ``config console`` knobs to a single line. If
+    ``flow_control`` is ``None`` only the baud rate is set.
+    """
+    host.command("config console baud {} {}".format(line, baud_rate))
+    if flow_control is not None:
+        host.command("config console flow_control {} {}".format(flow_control, line))

--- a/tests/common/helpers/console_helper.py
+++ b/tests/common/helpers/console_helper.py
@@ -77,12 +77,13 @@ def check_target_line_status(duthost, line, expect_status):
     return console_facts['lines'][line]['state'] == expect_status
 
 
-def get_dut_ip_and_creds(duthost, creds):
-    """Return ``(ip, user, password)`` for ``duthost`` using the inventory and
-    the ``creds`` fixture. Centralizes the inventory dance every console test
-    used to repeat verbatim.
+def get_host_ip_and_creds(host, creds):
+    """Return ``(ip, user, password)`` for ``host`` using the inventory and
+    the ``creds`` fixture. Works for any host registered in the inventory
+    (DUT, console fanout, etc.); centralizes the inventory dance every
+    console test used to repeat verbatim.
     """
-    ip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
+    ip = host.host.options['inventory_manager'].get_host(host.hostname).vars['ansible_host']
     return ip, creds['sonicadmin_user'], creds['sonicadmin_password']
 
 
@@ -95,15 +96,18 @@ def get_dut_console_lines(conn_graph_facts, duthost):
     return sorted(dut_serial_links.keys(), key=int)
 
 
-def disconnect_picocom_client(client):
-    """Send the picocom escape sequence (``Ctrl-A`` ``Ctrl-X``) to release the
-    console line. Safe to call with ``None`` and swallows teardown errors so
-    the caller's ``finally`` block can chain other cleanup work.
+def disconnect_console_client(client, escape_char='a'):
+    """Send the escape sequence (``Ctrl-<escape_char>`` then ``Ctrl-X``) to
+    release the console line. Defaults to ``'a'`` to match the ``picocom``
+    default; pass a different ``escape_char`` if the test changed the line's
+    default escape character. Safe to call with ``None`` and swallows
+    teardown errors so the caller's ``finally`` block can chain other
+    cleanup work.
     """
     if client is None:
         return
     try:
-        client.sendcontrol('a')
+        client.sendcontrol(escape_char)
         client.sendcontrol('x')
     except Exception:
         # Best-effort during teardown; the line-IDLE check that typically

--- a/tests/console/test_console_availability.py
+++ b/tests/console/test_console_availability.py
@@ -3,7 +3,7 @@ import pexpect
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.helpers.console_helper import get_dut_ip_and_creds
+from tests.common.helpers.console_helper import get_host_ip_and_creds
 
 pytestmark = [
     pytest.mark.topology("any"),
@@ -17,7 +17,7 @@ def test_console_availability(duthost, creds, target_line):
     Test console are well functional.
     Verify console access is available after connecting from DUT
     """
-    dutip, dutuser, dutpass = get_dut_ip_and_creds(duthost, creds)
+    dutip, dutuser, dutpass = get_host_ip_and_creds(duthost, creds)
     hostip, hostuser = "172.17.0.1", getpass.getuser()
 
     res = duthost.shell("which socat", module_ignore_errors=True)

--- a/tests/console/test_console_availability.py
+++ b/tests/console/test_console_availability.py
@@ -3,6 +3,7 @@ import pexpect
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.console_helper import get_dut_ip_and_creds
 
 pytestmark = [
     pytest.mark.topology("any"),
@@ -16,8 +17,7 @@ def test_console_availability(duthost, creds, target_line):
     Test console are well functional.
     Verify console access is available after connecting from DUT
     """
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    dutuser, dutpass = creds['sonicadmin_user'], creds['sonicadmin_password']
+    dutip, dutuser, dutpass = get_dut_ip_and_creds(duthost, creds)
     hostip, hostuser = "172.17.0.1", getpass.getuser()
 
     res = duthost.shell("which socat", module_ignore_errors=True)

--- a/tests/console/test_console_link_wiring.py
+++ b/tests/console/test_console_link_wiring.py
@@ -1,7 +1,15 @@
 import pytest
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.helpers.console_helper import assert_expect_text, create_ssh_client, ensure_console_session_up
-from tests.common.helpers.console_helper import generate_random_string, check_target_line_status
+from tests.common.helpers.console_helper import (
+    assert_expect_text,
+    check_target_line_status,
+    configure_console_line,
+    create_ssh_client,
+    disconnect_picocom_client,
+    ensure_console_session_up,
+    generate_random_string,
+    get_dut_ip_and_creds,
+)
 
 pytestmark = [
     pytest.mark.topology('c0')
@@ -26,21 +34,14 @@ def test_console_link_wiring(setup_c0, creds, target_line):
     same_host = duthost is console_fanout
 
     baud_rate = 9600  # The default baud rate for console lines, we will set it explicitly just in case
-    duthost.command("config console baud {} {}".format(target_line, baud_rate))
-    duthost.command("config console flow_control disable {}".format(target_line))
+    configure_console_line(duthost, target_line, baud_rate, "disable")
     if not same_host:
-        console_fanout.command("config console baud {} {}".format(target_line, baud_rate))
-        console_fanout.command("config console flow_control disable {}".format(target_line))
+        configure_console_line(console_fanout, target_line, baud_rate, "disable")
 
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    dutuser = creds['sonicadmin_user']
-    dutpass = creds['sonicadmin_password']
+    dutip, dutuser, dutpass = get_dut_ip_and_creds(duthost, creds)
 
     if not same_host:
-        fanoutip = console_fanout.host.options['inventory_manager'].get_host(
-            console_fanout.hostname).vars['ansible_host']
-        fanoutuser = creds['sonicadmin_user']
-        fanoutpass = creds['sonicadmin_password']
+        fanoutip, fanoutuser, fanoutpass = get_dut_ip_and_creds(console_fanout, creds)
 
     packet_size = 64
     delay_factor = 3.2
@@ -77,12 +78,9 @@ def test_console_link_wiring(setup_c0, creds, target_line):
     except Exception as e:
         pytest.fail("Not able to communicate DUT via reverse SSH: {}".format(e))
     finally:
-        if dut_client is not None:
-            dut_client.sendcontrol('a')
-            dut_client.sendcontrol('x')
-        if fanout_client is not None and not same_host:
-            fanout_client.sendcontrol('a')
-            fanout_client.sendcontrol('x')
+        disconnect_picocom_client(dut_client)
+        if not same_host:
+            disconnect_picocom_client(fanout_client)
         pytest_assert(
             check_target_line_status(duthost, target_line, "IDLE"),
             "Target line {} of dut is busy after exited reverse SSH session".format(target_line))

--- a/tests/console/test_console_link_wiring.py
+++ b/tests/console/test_console_link_wiring.py
@@ -5,10 +5,10 @@ from tests.common.helpers.console_helper import (
     check_target_line_status,
     configure_console_line,
     create_ssh_client,
-    disconnect_picocom_client,
+    disconnect_console_client,
     ensure_console_session_up,
     generate_random_string,
-    get_dut_ip_and_creds,
+    get_host_ip_and_creds,
 )
 
 pytestmark = [
@@ -38,10 +38,10 @@ def test_console_link_wiring(setup_c0, creds, target_line):
     if not same_host:
         configure_console_line(console_fanout, target_line, baud_rate, "disable")
 
-    dutip, dutuser, dutpass = get_dut_ip_and_creds(duthost, creds)
+    dutip, dutuser, dutpass = get_host_ip_and_creds(duthost, creds)
 
     if not same_host:
-        fanoutip, fanoutuser, fanoutpass = get_dut_ip_and_creds(console_fanout, creds)
+        fanoutip, fanoutuser, fanoutpass = get_host_ip_and_creds(console_fanout, creds)
 
     packet_size = 64
     delay_factor = 3.2
@@ -78,9 +78,9 @@ def test_console_link_wiring(setup_c0, creds, target_line):
     except Exception as e:
         pytest.fail("Not able to communicate DUT via reverse SSH: {}".format(e))
     finally:
-        disconnect_picocom_client(dut_client)
+        disconnect_console_client(dut_client)
         if not same_host:
-            disconnect_picocom_client(fanout_client)
+            disconnect_console_client(fanout_client)
         pytest_assert(
             check_target_line_status(duthost, target_line, "IDLE"),
             "Target line {} of dut is busy after exited reverse SSH session".format(target_line))

--- a/tests/console/test_console_loopback.py
+++ b/tests/console/test_console_loopback.py
@@ -2,30 +2,21 @@ import pytest
 
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts  # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import wait_until
 from tests.common.helpers.console_helper import (
     assert_expect_text,
+    configure_console_line,
     create_ssh_client,
+    disconnect_picocom_client,
     ensure_console_session_up,
-)
-from tests.common.helpers.console_helper import (
     generate_random_string,
-    check_target_line_status,
+    get_dut_console_lines,
+    get_dut_ip_and_creds,
+    wait_for_line_idle,
 )
 
 pytestmark = [
     pytest.mark.topology('c0', 'c0-lo')
 ]
-
-
-def _dut_console_lines(conn_graph_facts, duthost):  # noqa: F811
-    """
-    Return the DUT's console line numbers (as strings) sorted ascending by
-    numeric value, sourced from the ``*_serial_links.csv`` inventory exposed
-    via ``conn_graph_facts['device_serial_link']``.
-    """
-    dut_serial_links = conn_graph_facts.get('device_serial_link', {}).get(duthost.hostname, {})
-    return sorted(dut_serial_links.keys(), key=int)
 
 
 @pytest.mark.parametrize("baud_rate", ["9600", "115200"])
@@ -40,7 +31,7 @@ def test_console_loopback_echo(setup_c0, creds, conn_graph_facts, baud_rate, flo
     duthost, console_fanout = setup_c0
     same_host = duthost is console_fanout
 
-    lines = _dut_console_lines(conn_graph_facts, duthost)
+    lines = get_dut_console_lines(conn_graph_facts, duthost)
     pytest_assert(
         len(lines) >= 1,
         "Echo test requires at least 1 console line for DUT '{}', got none in *_serial_links.csv".format(
@@ -49,8 +40,7 @@ def test_console_loopback_echo(setup_c0, creds, conn_graph_facts, baud_rate, flo
     target_line = lines[0]
     flow_control_bool = (flow_control == "enable")
 
-    duthost.command("config console baud {} {}".format(target_line, baud_rate))
-    duthost.command("config console flow_control {} {}".format(flow_control, target_line))
+    configure_console_line(duthost, target_line, baud_rate, flow_control)
     if same_host:
         delay_factor = 1.6
     else:
@@ -60,9 +50,7 @@ def test_console_loopback_echo(setup_c0, creds, conn_graph_facts, baud_rate, flo
     if duthost.facts['platform'] in ['arm64-c8220tg_48a_o-r0']:
         delay_factor *= 25.0
 
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    dutuser = creds['sonicadmin_user']
-    dutpass = creds['sonicadmin_password']
+    dutip, dutuser, dutpass = get_dut_ip_and_creds(duthost, creds)
 
     packet_size = 64
 
@@ -82,12 +70,10 @@ def test_console_loopback_echo(setup_c0, creds, conn_graph_facts, baud_rate, flo
     except Exception as e:
         pytest.fail("Not able to communicate DUT via reverse SSH: {}".format(e))
     finally:
-        if client is not None:
-            client.sendcontrol('a')
-            client.sendcontrol('x')
-        pytest_assert(
-            wait_until(10, 1, 0, check_target_line_status, duthost, target_line, "IDLE"),
-            "Target line {} is busy after exited reverse SSH session".format(target_line))
+        disconnect_picocom_client(client)
+        wait_for_line_idle(
+            duthost, target_line,
+            error_msg="Target line {} is busy after exited reverse SSH session".format(target_line))
         if not same_host:
             console_fanout.unset_loopback(target_line)
 
@@ -110,22 +96,18 @@ def test_console_loopback_pingpong(setup_c0, creds, conn_graph_facts, baud_rate,
             "so the bridging socat process and the reverse-SSH picocom would contend for the same tty device".format(
                 duthost.hostname))
 
-    lines = _dut_console_lines(conn_graph_facts, duthost)
+    lines = get_dut_console_lines(conn_graph_facts, duthost)
     if len(lines) < 2:
         pytest.skip("Not enough console ports to run the ping-pong test on DUT '{}' (need at least 2, got {})".format(
             duthost.hostname, len(lines)))
     src_line, dst_line = lines[0], lines[1]
     flow_control_bool = (flow_control == "enable")
 
-    duthost.command("config console baud {} {}".format(src_line, baud_rate))
-    duthost.command("config console baud {} {}".format(dst_line, baud_rate))
-    duthost.command("config console flow_control {} {}".format(flow_control, src_line))
-    duthost.command("config console flow_control {} {}".format(flow_control, dst_line))
+    configure_console_line(duthost, src_line, baud_rate, flow_control)
+    configure_console_line(duthost, dst_line, baud_rate, flow_control)
     console_fanout.bridge(src_line, dst_line, baud_rate, flow_control_bool)
 
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    dutuser = creds['sonicadmin_user']
-    dutpass = creds['sonicadmin_password']
+    dutip, dutuser, dutpass = get_dut_ip_and_creds(duthost, creds)
 
     sender = None
     receiver = None
@@ -144,16 +126,12 @@ def test_console_loopback_pingpong(setup_c0, creds, conn_graph_facts, baud_rate,
     except Exception:
         pytest.fail("Not able to communicate DUT via reverse SSH")
     finally:
-        if sender is not None:
-            sender.sendcontrol('a')
-            sender.sendcontrol('x')
-        if receiver is not None:
-            receiver.sendcontrol('a')
-            receiver.sendcontrol('x')
-        pytest_assert(
-            wait_until(10, 1, 0, check_target_line_status, duthost, src_line, "IDLE"),
-            "Target line {} of dut is busy after exited reverse SSH session".format(src_line))
-        pytest_assert(
-            wait_until(10, 1, 0, check_target_line_status, console_fanout, dst_line, "IDLE"),
-            "Target line {} of fanout is busy after exited reverse SSH session".format(dst_line))
+        disconnect_picocom_client(sender)
+        disconnect_picocom_client(receiver)
+        wait_for_line_idle(
+            duthost, src_line,
+            error_msg="Target line {} of dut is busy after exited reverse SSH session".format(src_line))
+        wait_for_line_idle(
+            console_fanout, dst_line,
+            error_msg="Target line {} of fanout is busy after exited reverse SSH session".format(dst_line))
         console_fanout.unbridge(src_line, dst_line)

--- a/tests/console/test_console_loopback.py
+++ b/tests/console/test_console_loopback.py
@@ -6,11 +6,11 @@ from tests.common.helpers.console_helper import (
     assert_expect_text,
     configure_console_line,
     create_ssh_client,
-    disconnect_picocom_client,
+    disconnect_console_client,
     ensure_console_session_up,
     generate_random_string,
     get_dut_console_lines,
-    get_dut_ip_and_creds,
+    get_host_ip_and_creds,
     wait_for_line_idle,
 )
 
@@ -50,7 +50,7 @@ def test_console_loopback_echo(setup_c0, creds, conn_graph_facts, baud_rate, flo
     if duthost.facts['platform'] in ['arm64-c8220tg_48a_o-r0']:
         delay_factor *= 25.0
 
-    dutip, dutuser, dutpass = get_dut_ip_and_creds(duthost, creds)
+    dutip, dutuser, dutpass = get_host_ip_and_creds(duthost, creds)
 
     packet_size = 64
 
@@ -70,7 +70,7 @@ def test_console_loopback_echo(setup_c0, creds, conn_graph_facts, baud_rate, flo
     except Exception as e:
         pytest.fail("Not able to communicate DUT via reverse SSH: {}".format(e))
     finally:
-        disconnect_picocom_client(client)
+        disconnect_console_client(client)
         wait_for_line_idle(
             duthost, target_line,
             error_msg="Target line {} is busy after exited reverse SSH session".format(target_line))
@@ -107,7 +107,7 @@ def test_console_loopback_pingpong(setup_c0, creds, conn_graph_facts, baud_rate,
     configure_console_line(duthost, dst_line, baud_rate, flow_control)
     console_fanout.bridge(src_line, dst_line, baud_rate, flow_control_bool)
 
-    dutip, dutuser, dutpass = get_dut_ip_and_creds(duthost, creds)
+    dutip, dutuser, dutpass = get_host_ip_and_creds(duthost, creds)
 
     sender = None
     receiver = None
@@ -126,8 +126,8 @@ def test_console_loopback_pingpong(setup_c0, creds, conn_graph_facts, baud_rate,
     except Exception:
         pytest.fail("Not able to communicate DUT via reverse SSH")
     finally:
-        disconnect_picocom_client(sender)
-        disconnect_picocom_client(receiver)
+        disconnect_console_client(sender)
+        disconnect_console_client(receiver)
         wait_for_line_idle(
             duthost, src_line,
             error_msg="Target line {} of dut is busy after exited reverse SSH session".format(src_line))

--- a/tests/console/test_console_reversessh.py
+++ b/tests/console/test_console_reversessh.py
@@ -5,9 +5,9 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts  # noqa: F40
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.console_helper import (
     check_target_line_status,
-    disconnect_picocom_client,
+    disconnect_console_client,
     get_dut_console_lines,
-    get_dut_ip_and_creds,
+    get_host_ip_and_creds,
     wait_for_line_idle,
 )
 
@@ -58,7 +58,7 @@ def test_console_reversessh_connectivity(duthost, creds, conn_graph_facts):  # n
     ``*_serial_links.csv`` is used.
     """
     target_line = _dut_lowest_console_line(conn_graph_facts, duthost)
-    dutip, dutuser, dutpass = get_dut_ip_and_creds(duthost, creds)
+    dutip, dutuser, dutpass = get_host_ip_and_creds(duthost, creds)
 
     pytest_assert(
         check_target_line_status(duthost, target_line, "IDLE"),
@@ -80,7 +80,7 @@ def test_console_reversessh_connectivity(duthost, creds, conn_graph_facts):  # n
         pytest.fail("Not able to do reverse SSH to remote host via DUT: {}".format(e))
     finally:
         # Send escape sequence to exit reverse SSH session
-        disconnect_picocom_client(client)
+        disconnect_console_client(client)
 
     wait_for_line_idle(
         duthost, target_line,
@@ -95,7 +95,7 @@ def test_console_reversessh_force_interrupt(duthost, creds, conn_graph_facts):  
     ``*_serial_links.csv`` is used.
     """
     target_line = _dut_lowest_console_line(conn_graph_facts, duthost)
-    dutip, dutuser, dutpass = get_dut_ip_and_creds(duthost, creds)
+    dutip, dutuser, dutpass = get_host_ip_and_creds(duthost, creds)
 
     pytest_assert(
         check_target_line_status(duthost, target_line, "IDLE"),
@@ -142,7 +142,7 @@ def test_console_reversessh_custom_default_escape_character(duthost, creds, conn
     recorded for the DUT in ``*_serial_links.csv`` is used.
     """
     target_line = _dut_lowest_console_line(conn_graph_facts, duthost)
-    dutip, dutuser, dutpass = get_dut_ip_and_creds(duthost, creds)
+    dutip, dutuser, dutpass = get_host_ip_and_creds(duthost, creds)
 
     pytest_assert(
         check_target_line_status(duthost, target_line, "IDLE"),

--- a/tests/console/test_console_reversessh.py
+++ b/tests/console/test_console_reversessh.py
@@ -3,8 +3,13 @@ import pexpect
 
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts  # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.helpers.console_helper import check_target_line_status
-from tests.common.utilities import wait_until
+from tests.common.helpers.console_helper import (
+    check_target_line_status,
+    disconnect_picocom_client,
+    get_dut_console_lines,
+    get_dut_ip_and_creds,
+    wait_for_line_idle,
+)
 
 pytestmark = [
     pytest.mark.topology('c0', 'c0-lo')
@@ -15,13 +20,12 @@ def _dut_lowest_console_line(conn_graph_facts, duthost):  # noqa: F811
     """Return the lowest console line number recorded for ``duthost`` in
     ``ansible/files/*_serial_links.csv`` (exposed via ``conn_graph_facts``).
     """
-    serial_links = conn_graph_facts.get("device_serial_link", {}).get(duthost.hostname, {})
+    lines = get_dut_console_lines(conn_graph_facts, duthost)
     pytest_assert(
-        serial_links,
+        lines,
         "No serial-link entry found for DUT '{}' in conn_graph_facts; check *_serial_links.csv".format(
             duthost.hostname))
-    lines = sorted(int(line) for line in serial_links.keys())
-    return str(lines[0])
+    return lines[0]
 
 
 @pytest.fixture(scope="function")
@@ -54,9 +58,7 @@ def test_console_reversessh_connectivity(duthost, creds, conn_graph_facts):  # n
     ``*_serial_links.csv`` is used.
     """
     target_line = _dut_lowest_console_line(conn_graph_facts, duthost)
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    dutuser = creds['sonicadmin_user']
-    dutpass = creds['sonicadmin_password']
+    dutip, dutuser, dutpass = get_dut_ip_and_creds(duthost, creds)
 
     pytest_assert(
         check_target_line_status(duthost, target_line, "IDLE"),
@@ -78,13 +80,11 @@ def test_console_reversessh_connectivity(duthost, creds, conn_graph_facts):  # n
         pytest.fail("Not able to do reverse SSH to remote host via DUT: {}".format(e))
     finally:
         # Send escape sequence to exit reverse SSH session
-        if client is not None:
-            client.sendcontrol('a')
-            client.sendcontrol('x')
+        disconnect_picocom_client(client)
 
-    pytest_assert(
-        wait_until(10, 1, 0, check_target_line_status, duthost, target_line, "IDLE"),
-        "Target line {} is busy after exited reverse SSH session".format(target_line))
+    wait_for_line_idle(
+        duthost, target_line,
+        error_msg="Target line {} is busy after exited reverse SSH session".format(target_line))
 
 
 def test_console_reversessh_force_interrupt(duthost, creds, conn_graph_facts):  # noqa: F811
@@ -95,9 +95,7 @@ def test_console_reversessh_force_interrupt(duthost, creds, conn_graph_facts):  
     ``*_serial_links.csv`` is used.
     """
     target_line = _dut_lowest_console_line(conn_graph_facts, duthost)
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    dutuser = creds['sonicadmin_user']
-    dutpass = creds['sonicadmin_password']
+    dutip, dutuser, dutpass = get_dut_ip_and_creds(duthost, creds)
 
     pytest_assert(
         check_target_line_status(duthost, target_line, "IDLE"),
@@ -125,9 +123,9 @@ def test_console_reversessh_force_interrupt(duthost, creds, conn_graph_facts):  
         pytest.fail("Not able to do clear line for DUT: {}".format(e))
 
     # Check the session ended within 5s and the line state is idle
-    pytest_assert(
-        wait_until(5, 1, 0, check_target_line_status, duthost, target_line, "IDLE"),
-        "Target line {} not toggle to IDLE state after force clear command sent".format(target_line))
+    wait_for_line_idle(
+        duthost, target_line, timeout_sec=5,
+        error_msg="Target line {} not toggle to IDLE state after force clear command sent".format(target_line))
 
     try:
         client.expect("Picocom was killed")
@@ -144,9 +142,7 @@ def test_console_reversessh_custom_default_escape_character(duthost, creds, conn
     recorded for the DUT in ``*_serial_links.csv`` is used.
     """
     target_line = _dut_lowest_console_line(conn_graph_facts, duthost)
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    dutuser = creds['sonicadmin_user']
-    dutpass = creds['sonicadmin_password']
+    dutip, dutuser, dutpass = get_dut_ip_and_creds(duthost, creds)
 
     pytest_assert(
         check_target_line_status(duthost, target_line, "IDLE"),
@@ -180,6 +176,7 @@ def test_console_reversessh_custom_default_escape_character(duthost, creds, conn
         pytest.fail("Not able to do reverse SSH to remote host via DUT: {}".format(e))
 
     # Check the session ended and the line state is idle
-    pytest_assert(
-        wait_until(10, 1, 0, check_target_line_status, duthost, target_line, "IDLE"),
-        "Target line {} is busy after exited reverse SSH session with custom escape keys".format(target_line))
+    wait_for_line_idle(
+        duthost, target_line,
+        error_msg="Target line {} is busy after exited reverse SSH session with custom escape keys".format(
+            target_line))

--- a/tests/console/test_console_stress.py
+++ b/tests/console/test_console_stress.py
@@ -24,7 +24,7 @@ from tests.common.helpers.console_helper import (
     create_ssh_client,
     ensure_console_session_up,
     get_dut_console_lines,
-    get_dut_ip_and_creds,
+    get_host_ip_and_creds,
 )
 from tests.common.utilities import wait_until
 
@@ -165,7 +165,7 @@ def test_console_load(setup_c0, creds, conn_graph_facts, baud_rate, flow_control
         check_target_line_status(duthost, target_line, "IDLE"),
         "Target line {} is busy before stress test starts".format(target_line))
 
-    dutip, dutuser, dutpass = get_dut_ip_and_creds(duthost, creds)
+    dutip, dutuser, dutpass = get_host_ip_and_creds(duthost, creds)
     ressh_user = "{}:{}".format(dutuser, target_line)
 
     # Unique per-run sentinels so that ambient console output (banners, prompts,

--- a/tests/console/test_console_stress.py
+++ b/tests/console/test_console_stress.py
@@ -23,6 +23,8 @@ from tests.common.helpers.console_helper import (
     check_target_line_status,
     create_ssh_client,
     ensure_console_session_up,
+    get_dut_console_lines,
+    get_dut_ip_and_creds,
 )
 from tests.common.utilities import wait_until
 
@@ -54,15 +56,6 @@ _NO_PROGRESS_TIMEOUT = 60.0
 # Emit a "still receiving" log line at this interval while waiting for the
 # end sentinel to arrive on the receive side.
 _RECV_PROGRESS_LOG_INTERVAL = 30.0
-
-
-def _dut_console_lines(conn_graph_facts, duthost):  # noqa: F811
-    """Return the DUT's console line numbers (as strings) sorted ascending,
-    sourced from the ``*_serial_links.csv`` inventory exposed via
-    ``conn_graph_facts['device_serial_link']``.
-    """
-    dut_serial_links = conn_graph_facts.get('device_serial_link', {}).get(duthost.hostname, {})
-    return sorted(dut_serial_links.keys(), key=int)
 
 
 def _bit_error_summary(expected, actual, max_report=10):
@@ -134,7 +127,7 @@ def test_console_load(setup_c0, creds, conn_graph_facts, baud_rate, flow_control
     # console_fanout to configure.
     duthost, _ = setup_c0
 
-    lines = _dut_console_lines(conn_graph_facts, duthost)
+    lines = get_dut_console_lines(conn_graph_facts, duthost)
     pytest_assert(
         len(lines) >= 1,
         "Stress test requires at least 1 console line; got none in *_serial_links.csv")
@@ -172,9 +165,7 @@ def test_console_load(setup_c0, creds, conn_graph_facts, baud_rate, flow_control
         check_target_line_status(duthost, target_line, "IDLE"),
         "Target line {} is busy before stress test starts".format(target_line))
 
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    dutuser = creds['sonicadmin_user']
-    dutpass = creds['sonicadmin_password']
+    dutip, dutuser, dutpass = get_dut_ip_and_creds(duthost, creds)
     ressh_user = "{}:{}".format(dutuser, target_line)
 
     # Unique per-run sentinels so that ambient console output (banners, prompts,


### PR DESCRIPTION
### Description of PR

Pure refactor across `tests/console/`. Extracts five small helpers into `tests/common/helpers/console_helper.py` and applies them across the existing console test files. **No behavior change** — same commands, same fixtures, same assertions.

#### New helpers

| helper | replaces (what was repeated) | call sites consolidated |
| --- | --- | --- |
| `get_dut_ip_and_creds(duthost, creds)` | the 3-line `duthost.host.options['inventory_manager']...` + `creds['sonicadmin_user']` + `creds['sonicadmin_password']` block | 7 sites in 5 files |
| `get_dut_console_lines(conn_graph_facts, duthost)` | local `_dut_console_lines()` / `_dut_lowest_console_line()` re-implementations of the same `device_serial_link` traversal | 3 files |
| `disconnect_picocom_client(client)` | `if client is not None: client.sendcontrol('a'); client.sendcontrol('x')` in `finally` blocks; safe with `None`; swallows teardown exceptions | 6 sites |
| `wait_for_line_idle(host, line, timeout_sec=10, error_msg=None)` | `pytest_assert(wait_until(10, 1, 0, check_target_line_status, host, line, "IDLE"), ...)` idiom | 5 sites |
| `configure_console_line(host, line, baud_rate, flow_control=None)` | the two adjacent `config console baud …` and `config console flow_control …` commands; `flow_control=None` skips the second one | 6 sites in 3 files |

#### Files touched

```
tests/common/helpers/console_helper.py    | helpers added
tests/console/test_console_availability.py | dutip/creds extraction
tests/console/test_console_link_wiring.py  | configure + disconnect helpers
tests/console/test_console_loopback.py     | drops local _dut_console_lines, all 5 helpers
tests/console/test_console_reversessh.py   | _dut_lowest now thin wrapper, dutip/creds, disconnect, idle wait
tests/console/test_console_stress.py       | drops local _dut_console_lines, dutip/creds extraction
```

`test_console_driver.py` and `test_console_udevrule.py` are unchanged — they don't share these patterns.

### Summary
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework (new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach

#### What is the motivation for this PR?
The console test files had each grown their own copies of the same boilerplate (inventory + creds lookup, picocom escape, line-IDLE waits, baud/flow config). The recently-merged `test_console_stress.py` (PR #24172) made this duplication especially visible. Extracting these into the shared helper:
- Cuts ~80 lines of repeated boilerplate.
- Makes it harder for new tests to drift (e.g. forgetting to handle `client is None` in teardown).
- Is a prerequisite for a follow-up refactor that will tackle behavioral knobs (`delaybeforesend = None` opt-in on `create_ssh_client`, CONFIG_DB save/restore as a context manager).

#### How did you verify/test it?
- `python3 -m flake8 --max-line-length=120 tests/common/helpers/console_helper.py tests/console/*.py` clean.
- AST parses on all touched files.
- Behavior preservation is by construction (every replacement is a literal extraction of the prior code path).
- Live verification: planned full sweep on a physical testbed for `test_console_stress.py` (the file with the most diff churn) on the internal mirror.

#### Any platform specific information?
None — same as the existing console test suite.

#### Supported testbed topology if it's a new test case?
N/A — refactor only.

### Documentation
N/A.
