### PR TITLE
tests/pfcwd: ignore transient TACACS+ syslog noise in loganalyzer

### DIFF
--- a/tests/pfcwd/test_pfcwd_cli.py
+++ b/tests/pfcwd/test_pfcwd_cli.py
@@ -31,8 +31,18 @@ def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loga
     KVMIgnoreRegex = [
         ".*queryStatsCapability: failed to find switch.*",
     ]
+    # Transient TACACS+ noise unrelated to PFCWD. On testbeds where the configured
+    # TACACS+ server is temporarily unreachable, NSS-TACACS+ lookups invoked by
+    # background processes (e.g. iptables) emit ERR-level syslog lines that get
+    # picked up by loganalyzer during teardown. Other tests (srv6, metadata-scripts)
+    # already ignore these same patterns for the same reason.
+    TacacsIgnoreRegex = [
+        r".*tac_connect_single: .*",
+        r".*nss_tacplus: .*",
+    ]
     duthost = duthosts[rand_one_dut_hostname]
     if loganalyzer:  # Skip if loganalyzer is disabled
+        loganalyzer[duthost.hostname].ignore_regex.extend(TacacsIgnoreRegex)
         if duthost.facts["asic_type"] == "vs":
             loganalyzer[duthost.hostname].ignore_regex.extend(KVMIgnoreRegex)
 


### PR DESCRIPTION
### Description of PR

Summary:
Extend the autouse `ignore_expected_loganalyzer_exceptions` fixture in `tests/pfcwd/test_pfcwd_cli.py` to ignore transient TACACS+ syslog noise (`tac_connect_single` / `nss_tacplus`) that is unrelated to PFCWD functionality but causes spurious teardown failures under loganalyzer.

On testbeds where the configured TACACS+ server is temporarily unreachable, NSS-TACACS+ lookups invoked by background processes (e.g. `iptables`) emit ERR-level syslog lines such as:

```
ERR iptables: tac_connect_single: connection to <ip>:49 failed: Network is unreachable
ERR iptables: nss_tacplus: failed to connect TACACS+ server <ip>:49, ret=-9: Network is unreachable
```

These are picked up by loganalyzer during teardown of `test_pfcwd_show_stat`, producing failures like:

```
Failed: Got matched syslog in processes "analyze_logs--<MultiAsicSonicHost ...>" exit code:"1"
match: 8
expected_match: 0
```

The same testbed passes the test on other runs and other testbeds with the same software pass cleanly, confirming this is environmental noise rather than a PFCWD regression.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

Make `tests/pfcwd/test_pfcwd_cli.py` resilient to transient TACACS+ unreachability on testbeds, eliminating false-positive teardown failures that have no relationship to PFCWD behavior.

#### How did you do it?

Added a `TacacsIgnoreRegex` list in the existing autouse `ignore_expected_loganalyzer_exceptions` fixture and extended `loganalyzer[duthost.hostname].ignore_regex` with it. This mirrors the established pattern from:

- `tests/srv6/test_srv6_dataplane.py`
- `tests/metadata-scripts/test_metadata_postupgrade.py`

which already ignore the same `tac_connect_single` / `nss_tacplus` patterns for the same reason.

#### How did you verify/test it?

- Reviewed similar patterns already merged in srv6 and metadata-scripts tests.
- Diff is a no-op on testbeds where TACACS+ is reachable (no matching log lines, nothing to ignore).
- Will verify on the affected testbed (`bjw2-can-8102-4`) that `test_pfcwd_show_stat` no longer fails on teardown due to these messages.

#### Any platform specific information?

None. The change is platform-agnostic and only affects loganalyzer ignore patterns.

#### Supported testbed topology if it's a new test case?

N/A (not a new test case).

### Documentation

N/A.
