### PR TITLE
[dhcp_relay] Fix agent_relay_mode: align test docstring with short-form enum values

### DIFF
--- a/tests/dhcp_relay/test_dhcpv4_relay.py
+++ b/tests/dhcp_relay/test_dhcpv4_relay.py
@@ -374,9 +374,8 @@ def test_dhcp_relay_agent_mode(
 
     Relay Modes Tested:
         - "discard": Drops packets containing Option 82.
-        - "forward_untouched": Forwards packets with Option 82 unmodified.
-        - "forward_and_replace": Replaces existing Option 82 with new data before forwarding.
-        - "forward_and_append": Appends a new Option 82 to packets that already have it.
+        - "replace": Replaces existing Option 82 with new data before forwarding.
+        - "append": Appends a new Option 82 to packets that already have it.
 
     Key Actions:
         - Configures the device under test (DUT) with the selected relay mode.


### PR DESCRIPTION
## Description

Fix `test_dhcp_relay_agent_mode` docstring to use the canonical short-form enum values (`discard`, `replace`, `append`) instead of the old long-form names that were never valid in the YANG schema or daemon.

The parametrize values and CONFIG_DB writes in this test were already using the correct short-form names; only the docstring listed the wrong old names (`forward_untouched`, `forward_and_replace`, `forward_and_append`).

## Related issue

Fixes https://github.com/sonic-net/sonic-mgmt/issues/24052

## Motivation and Context

A three-way inconsistency existed across the SONiC DHCPv4 relay stack:

| Layer | Old values | New (canonical) values |
|---|---|---|
| YANG (`sonic-types.yang`) | `forward_and_append`, `forward_and_replace`, `forward_untouched`, `discard` | `append`, `replace`, `forward`, `discard` |
| CLI (`dhcp_relay.py`) | `discard`, `append`, `replace` | `discard`, `append`, `replace`, `forward` |
| Daemon (`dhcp4relay.cpp`) | `append`, `replace`, (implicit discard) | `append`, `replace`, `forward`, `discard` |

The YANG schema was rejecting the CLI/daemon values, causing `libyang[0]: Invalid value "append" in "agent_relay_mode" element.`

The coordinated fix across the stack:
- **sonic-dhcp-relay** – add explicit `forward` and `discard` cases in `dhcp4relay.cpp`; add unit tests
- **sonic-buildimage** – rename YANG enum values to short-form; add `forward` to CLI; sync submodule
- **SONiC (HLD)** – update design doc to reflect new values and `replace` default

This PR aligns the sonic-mgmt test docstring with those changes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test

`tests/dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_agent_mode` — docstring-only change; no functional test logic modified.