### PR TITLE
Xfail case test_check_sfputil_reset and test_restart_swss due to github

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4186,6 +4186,12 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_info:
     conditions:
     - "https://github.com/sonic-net/sonic-buildimage/issues/23426 and ('sn4700' in platform or 'sn4280' in platform)"
 
+platform_tests/sfp/test_sfputil.py::test_check_sfputil_reset:
+  xfail:
+    reason: "Testcase xfailed due to https://github.com/sonic-net/sonic-buildimage/issues/21603 on sn4700 platform"
+    conditions:
+    - "https://github.com/sonic-net/sonic-buildimage/issues/21603 and 'sn4700' in platform"
+
 platform_tests/test_reboot.py:
   skip:
     reason: "Found regression issues on multi-asic topology, temperarily skip this test case until the issues are addressed."
@@ -4235,6 +4241,12 @@ platform_tests/test_reload_config.py::test_reload_configuration_checks:
     conditions:
       - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
       - "https://github.com/sonic-net/sonic-buildimage/issues/24543 and asic_type in ['mellanox'] and 'sn4280' in platform"
+
+platform_tests/test_sequential_restart.py::test_restart_swss:
+  xfail:
+    reason: "Xfail due to https://github.com/sonic-net/sonic-buildimage/issues/21603 on sn4700 platform"
+    conditions:
+    - "https://github.com/sonic-net/sonic-buildimage/issues/21603 and 'sn4700' in platform"
 
 portstat/test_portstat.py:
   skip:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Xfail cases due to
https://github.com/sonic-net/sonic-buildimage/issues/21603 on sn4700 1.platform_tests/sfp/test_sfputil.py::test_check_sfputil_reset 2.platform_tests/test_sequential_restart.py::test_restart_swss


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Case failure due to https://github.com/sonic-net/sonic-buildimage/issues/21603 
#### How did you do it?
Add xfail
#### How did you verify/test it?
Run it locally
#### Any platform specific information?
Mellanox sn4700
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
