### PR TITLE
[tests/console]: restore CONSOLE_PORT CONFIG_DB state in test_console_loopback teardown

### DIFF
--- a/tests/console/test_console_loopback.py
+++ b/tests/console/test_console_loopback.py
@@ -19,6 +19,26 @@ pytestmark = [
 ]
 
 
+def _read_orig_console_port(host, line):
+    """Return ``(baud_rate, flow_control)`` from CONFIG_DB ``CONSOLE_PORT|<line>``,
+    falling back to SONiC defaults (9600, disable) on any error or empty value.
+    Used to capture pre-test state so the test can restore it during teardown
+    and avoid tripping ``core_dump_and_config_check``.
+    """
+    def _hget(field, default):
+        try:
+            res = host.command(
+                "sonic-db-cli CONFIG_DB hget 'CONSOLE_PORT|{}' {}".format(line, field),
+                module_ignore_errors=True)
+            val = (res.get('stdout') or '').strip()
+            return val if val else default
+        except Exception:
+            return default
+    orig_baud = _hget("baud_rate", "9600")
+    orig_fc_int = _hget("flow_control", "0")
+    return orig_baud, ("enable" if orig_fc_int == "1" else "disable")
+
+
 @pytest.mark.parametrize("baud_rate", ["9600", "115200"])
 @pytest.mark.parametrize("flow_control", ["enable", "disable"])
 def test_console_loopback_echo(setup_c0, creds, conn_graph_facts, baud_rate, flow_control,  # noqa: F811
@@ -39,6 +59,11 @@ def test_console_loopback_echo(setup_c0, creds, conn_graph_facts, baud_rate, flo
     )
     target_line = lines[0]
     flow_control_bool = (flow_control == "enable")
+
+    # Capture pre-test CONFIG_DB state so we can restore it in the finally
+    # block; otherwise core_dump_and_config_check flags the drift as an
+    # ERROR after the parametrized sweep.
+    orig_baud, orig_flow_control = _read_orig_console_port(duthost, target_line)
 
     configure_console_line(duthost, target_line, baud_rate, flow_control)
     if same_host:
@@ -76,6 +101,8 @@ def test_console_loopback_echo(setup_c0, creds, conn_graph_facts, baud_rate, flo
             error_msg="Target line {} is busy after exited reverse SSH session".format(target_line))
         if not same_host:
             console_fanout.unset_loopback(target_line)
+        # Restore pre-test CONFIG_DB state for this line.
+        configure_console_line(duthost, target_line, orig_baud, orig_flow_control)
 
 
 @pytest.mark.topology('c0')
@@ -102,6 +129,11 @@ def test_console_loopback_pingpong(setup_c0, creds, conn_graph_facts, baud_rate,
             duthost.hostname, len(lines)))
     src_line, dst_line = lines[0], lines[1]
     flow_control_bool = (flow_control == "enable")
+
+    # Capture pre-test CONFIG_DB state for both lines so we can restore on
+    # teardown; otherwise core_dump_and_config_check flags the drift.
+    orig_src_baud, orig_src_flow_control = _read_orig_console_port(duthost, src_line)
+    orig_dst_baud, orig_dst_flow_control = _read_orig_console_port(duthost, dst_line)
 
     configure_console_line(duthost, src_line, baud_rate, flow_control)
     configure_console_line(duthost, dst_line, baud_rate, flow_control)
@@ -135,3 +167,6 @@ def test_console_loopback_pingpong(setup_c0, creds, conn_graph_facts, baud_rate,
             console_fanout, dst_line,
             error_msg="Target line {} of fanout is busy after exited reverse SSH session".format(dst_line))
         console_fanout.unbridge(src_line, dst_line)
+        # Restore pre-test CONFIG_DB state for both lines.
+        configure_console_line(duthost, src_line, orig_src_baud, orig_src_flow_control)
+        configure_console_line(duthost, dst_line, orig_dst_baud, orig_dst_flow_control)


### PR DESCRIPTION
### Description of PR

Fixes the `test_console_loopback` teardown ERROR caused by CONFIG_DB drift.

`test_console_loopback_echo` and `test_console_loopback_pingpong` both mutate `CONFIG_DB CONSOLE_PORT|<line>` `baud_rate` and `flow_control` via `config console baud` / `config console flow_control`, but never restore the original values. Across parametrized iterations the CONFIG_DB drifts from the pre-test snapshot, and the module-scoped `core_dump_and_config_check` escalates the drift to a **teardown ERROR**.

Observed on a physical `c0-lo` testbed during a verification sweep:
```
config_db_check.failed = true
inconsistent_config: CONSOLE_PORT|1 pre={baud_rate: 9600,  flow_control: 0}
                     CONSOLE_PORT|1 cur={baud_rate: 115200, flow_control: 0}
```

### How

Inline save/restore in the test file — no new module-level helpers:

- A small `_read_orig_console_port(host, line)` function inside `test_console_loopback.py` reads `baud_rate` / `flow_control` from `CONFIG_DB CONSOLE_PORT|<line>` and falls back to SONiC defaults (`9600` / `disable`) on any error.
- Both tests now capture the originals before mutating, then restore them in the existing `finally` block via the existing `configure_console_line()` helper.
- `_pingpong` restores both `src_line` and `dst_line`.

Same intent as the inline pattern already in `test_console_stress.py` (PR #24172).

### Other tests checked

| file | status |
| --- | --- |
| `test_console_link_wiring.py` | writes `baud=9600 + flow_control=disable` — matches SONiC defaults, no drift in practice |
| `test_console_stress.py` | already restores inline (PR #24172) |
| `test_console_reversessh.py`, `test_console_availability.py`, `test_console_driver.py` | don't mutate baud / flow_control |

Only `test_console_loopback.py` needed the fix.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework (new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach

#### What is the motivation for this PR?
On any testbed that runs `core_dump_and_config_check`, this teardown ERROR is currently triggered after a sweep of `test_console_loopback_echo` (4 parametrized combos: `baud_rate × flow_control`) because the last iteration leaves `CONSOLE_PORT|<line>` at non-default values. Test logic itself passes, but the run is reported as having errored.

#### How did you verify it?
- `flake8 --max-line-length=120` clean.
- AST parses.
- Test bodies unchanged — only adds save/restore around the existing config commands. Same pattern proven in `test_console_stress.py`.

#### Any platform specific information?
None.

#### Supported testbed topology if it's a new test case?
N/A — bug fix on existing tests.

### Documentation
N/A.
