### PR TITLE
[platform] Skip check_interface_status_of_up_ports on BMC

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -58,6 +58,11 @@ def check_interface_status_of_up_ports(duthost):
     if duthost.facts['asic_type'] == 'vs' and duthost.is_supervisor_node():
         return True
 
+    # SONiC BMC images have no front-panel ports, so CONFIG_DB has no PORT
+    # table. Treat as "no admin-up ports to check".
+    if duthost.is_bmc():
+        return True
+
     if duthost.is_multi_asic:
         up_ports = []
         for asic in duthost.frontend_asics:


### PR DESCRIPTION
### Description of PR

Summary:
SONiC BMC images have **no front-panel ports**, so `CONFIG_DB` does not contain a `PORT` table.

Before this change, `check_interface_status_of_up_ports()` (in `tests/common/platform/interface_utils.py`) blindly accessed `cfg_facts['PORT']` and raised `KeyError: 'PORT'` on BMC. The exception was silently swallowed inside `wait_until()` in `config_reload(check_intf_up_ports=True)`, causing the retry loop to run for the full `wait + 300` (~7-minute) timeout before `pytest_assert` fired with `"Not all ports that are admin up on are operationally up"` — wasted time and produced false setup/teardown ERRORs.

This change adds an early `return True` for `duthost.is_bmc()`, mirroring the existing short-circuit for `vs` supervisor nodes. The gate uses the existing `SonicHost.is_bmc()` helper (`router_type == 'NetworkBmc'`), keeping the convention consistent with other BMC-aware code paths in this repo (e.g. `cacl/test_cacl_function.py`, `process_monitoring/test_critical_process_monitoring.py`, `common/devices/multi_asic.py`).

**The fix is intentionally narrow**: platforms that *should* have a `PORT` table will still surface a real `KeyError` if their `CONFIG_DB` is in a bad state, preserving the current diagnostic behaviour.

### Affected tests (observed on a BMC testbed)

All test bodies pass; only the setup/teardown errored, with ~7 minutes wasted per case before the assert:
- `cacl/test_cacl_application.py::test_cacl_scale_rules_ipv4` (teardown)
- `cacl/test_cacl_application.py::test_cacl_scale_rules_ipv6` (teardown)
- `cacl/test_cacl_application.py::test_cacl_acl_loader` (teardown)
- `dns/test_dns_resolv_conf.py::test_dns_resolv_conf` (teardown)
- `golden_config_infra/test_config_reload_with_rendered_golden_config.py::test_rendered_golden_config_override` (setup + teardown — same root cause raised in both phases)
- `gnmi/test_gnoi_file.py::test_file_transfer_to_remote` (teardown)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Avoid a 7-minute wait + spurious setup/teardown error on BMC platforms (which legitimately have no front-panel ports), without masking real `PORT`-table-missing bugs on switching platforms.

#### How did you do it?
Added a short-circuit `if duthost.is_bmc(): return True` at the top of `check_interface_status_of_up_ports()`, alongside the existing `vs + supervisor_node` early return. The body of the function is unchanged, so any non-BMC DUT whose `CONFIG_DB` lacks a `PORT` table will still hit the original `KeyError` (and ultimately the existing `pytest_assert`) — that diagnostic behaviour is preserved on purpose.

#### How did you verify/test it?
- Reproduced the original `KeyError: 'PORT'` and 7-minute wait on a BMC testbed by running:
  - `tests/cacl/test_cacl_application.py` — three teardown errors
  - `tests/dns/test_dns_resolv_conf.py` — one teardown error
  - `tests/golden_config_infra/test_config_reload_with_rendered_golden_config.py` — one setup + one teardown error
  - `tests/gnmi/test_gnoi_file.py` — one teardown error
  All emitted `"Not all ports that are admin up on are operationally up"` after ~7 minutes of polling.
- After the patch the same setup/teardowns short-circuit immediately on BMC.
- For non-BMC DUTs the function path is byte-for-byte identical to before.

#### Any platform specific information?
The fix targets SONiC BMC images (`router_type == 'NetworkBmc'`).

#### Supported testbed topology if it's a new test case?
N/A (bug fix).

Signed-off-by: zitingguo <zitingguo@microsoft.com>
