### PR TITLE
[202511] bgp: fix test_bgp_vnet failures

### DIFF
--- a/tests/bgp/test_bgp_vnet.py
+++ b/tests/bgp/test_bgp_vnet.py
@@ -1,3 +1,4 @@
+import ipaddress
 import sys
 import time
 from copy import deepcopy
@@ -11,6 +12,7 @@ import pytest
 
 from tests.common.reboot import reboot
 from tests.common.storage_backend.backend_utils import skip_test_module_over_backend_topologies     # noqa F401
+from tests.common.utilities import wait_until
 import ptf.testutils as testutils
 from ptf.mask import Mask
 from scapy.all import IP, Ether
@@ -101,6 +103,14 @@ def setup_vnet_cfg(duthost, localhost, cfg_facts):
     duthost.shell("cp /tmp/config_db_vnet.json /etc/sonic/config_db.json")
 
     reboot(duthost, localhost)
+
+    bgp_asn = cfg_facts.get('DEVICE_METADATA', {}).get('localhost', {}).get('bgp_asn', '')
+    duthost.shell(
+        "vtysh "
+        "-c 'configure terminal' "
+        "-c 'router bgp {} vrf Vnet2' "
+        "-c 'address-family ipv4 unicast' "
+        "-c 'neighbor BGPSLBPassive allowas-in 1'".format(bgp_asn))
 
 
 # fixtures
@@ -323,6 +333,11 @@ def dynamic_range_add_delete(duthost, template):
         duthost, static_peers, dynamic_peer)
 
     for static_peer in static_peers:
+        # The assertion delta (2 × 10 s) matches the minimum wall-clock time
+        # that elapses between the two uptime snapshots: one time.sleep(10)
+        # before this point plus the time.sleep(10) inside
+        # modify_dynamic_peer_cfg.  If either peer restarts its uptime resets
+        # to near zero, making uptime_after < uptime_before + delta.
         assert static_peer_uptime_after[static_peer] >= static_peer_uptime_before[static_peer] + 2*10*1000, \
             f"Static peer {static_peer} should not flap when a different dynamic range is added/deleted!"
     assert dynamic_peer_uptime_after >= dynamic_peer_uptime_before + 2*10*1000, \
@@ -342,6 +357,107 @@ def get_core_dumps(duthost):
 
     # If result is empty, no core dumps exist, otherwise core dumps are present
     return result.split('\n') if result else []
+
+
+BGP_VNET_PEER_WAIT_TIMEOUT = 60
+BGP_VNET_PEER_WAIT_INTERVAL = 10
+
+
+def _check_vnet_bgp_peers_established(duthost, cfg_facts, route_count):
+    """
+    Return True when every IPv4 BGP peer in every VNET VRF has received at
+    least route_count prefixes (i.e. is Established and has learned routes).
+    Used with wait_until() to absorb the transient period right after reboot
+    while VRF-scoped BGP sessions come up.
+    """
+    try:
+        for vnet in cfg_facts.get('VNET', {}):
+            summary_str = duthost.shell(
+                "vtysh -c 'show bgp vrf {} summary json'".format(vnet))['stdout']
+            bgp_summary = json.loads(summary_str)
+            for info, info_data in bgp_summary.items():
+                for peer, attr in info_data.get('peers', {}).items():
+                    if ((info == "ipv4Unicast" and attr.get('idType') == 'ipv6') or
+                            (info == "ipv6Unicast" and attr.get('idType') == 'ipv4')):
+                        continue
+                    if int(attr.get('pfxRcd', 0)) < route_count:
+                        return False
+        return True
+    except Exception:
+        return False
+
+
+def _check_vnet1_routes_installed(duthost):
+    """
+    Return True when at least one BGP route has been installed in the Linux
+    kernel FIB for the Vnet1 VRF.  Used with wait_until() to gate traffic
+    tests until the BGP → Zebra → kernel FIB pipeline has completed.
+    """
+    try:
+        result = duthost.shell(
+            "ip route show vrf Vnet1 proto bgp | wc -l",
+            module_ignore_errors=True)
+        return result['rc'] == 0 and int(result['stdout'].strip()) > 0
+    except Exception:
+        return False
+
+
+def _get_vnet1_bgp_dst_ip(duthost):
+    """
+    Return a usable host IP derived from the first BGP prefix installed in
+    the Vnet1 kernel FIB.  Called after wait_until(_check_vnet1_routes_installed)
+    has confirmed that routes are present, so the returned IP is guaranteed
+    to be reachable via the data plane.
+
+    This avoids the need for a topology-hardcoded destination IP constant.
+    """
+    result = duthost.shell(
+        "ip route show vrf Vnet1 proto bgp | grep -E '^[0-9]' | head -1 | awk '{print $1}'")
+    prefix = result['stdout'].strip()
+    if not prefix:
+        raise RuntimeError("No usable BGP prefix found in Vnet1 kernel FIB")
+    net = ipaddress.ip_network(prefix, strict=False)
+    hosts = list(net.hosts())
+    return str(hosts[0]) if hosts else str(net.network_address)
+
+
+def _check_vnet2_dynamic_peer_established(duthost, dynamic_peer):
+    """
+    Return True when the given dynamic peer IP is present in Vnet2's BGP
+    summary and is in the Established state.
+    """
+    try:
+        summary_str = duthost.shell(
+            "vtysh -c 'show bgp vrf Vnet2 summary json'")['stdout']
+        bgp_summary = json.loads(summary_str)
+        peers = bgp_summary.get('ipv4Unicast', {}).get('peers', {})
+        return (dynamic_peer in peers and
+                peers[dynamic_peer].get('state') == 'Established')
+    except Exception:
+        return False
+
+
+def _check_vnet2_all_dynamic_peers_established(duthost):
+    """
+    Return True when every dynamic peer IP configured in Vnet2 is present
+    in the BGP summary and in the Established state.  Used with wait_until()
+    in stress tests after re-adding the peer range to ensure all peers have
+    fully reconnected before taking uptime snapshots or moving to the next
+    iteration.
+    """
+    try:
+        summary_str = duthost.shell(
+            "vtysh -c 'show bgp vrf Vnet2 summary json'")['stdout']
+        bgp_summary = json.loads(summary_str)
+        peers = bgp_summary.get('ipv4Unicast', {}).get('peers', {})
+        for peer_ip in g_vars["vnet2"]["dynamic"].values():
+            if not peer_ip:
+                continue
+            if peer_ip not in peers or peers[peer_ip].get('state') != 'Established':
+                return False
+        return True
+    except Exception:
+        return False
 
 
 def get_ptf_port_index(interface_name):
@@ -401,6 +517,21 @@ def test_dynamic_peer_vnet(duthosts, rand_one_dut_hostname, cfg_facts):
         route_count = props['podset_number'] * \
             props['tor_number'] * props['tor_subnet_number']
 
+        # After the post-reboot setup the VRF-scoped BGP sessions need extra
+        # time to reach Established and learn routes.  Poll until all peers
+        # across every VNET VRF report the expected prefix count before
+        # running the assertions.
+        assert wait_until(
+            BGP_VNET_PEER_WAIT_TIMEOUT,
+            BGP_VNET_PEER_WAIT_INTERVAL,
+            0,
+            _check_vnet_bgp_peers_established,
+            duthost,
+            cfg_facts,
+            route_count,
+        ), "Timed out waiting for VRF BGP peers to reach {} prefixes".format(
+            route_count)
+
         # Validate static and dynamic peers are established and have correct route counts inside VNET.
         for vnet in cfg_facts['VNET']:
             bgp_summary_string = duthost.shell(
@@ -415,7 +546,7 @@ def test_dynamic_peer_vnet(duthosts, rand_one_dut_hostname, cfg_facts):
                             (info == "ipv6Unicast" and attr['idType'] == 'ipv4')):
                         continue
                     else:
-                        assert int(prefix_count) >= 6000, "%s should received %s route prefixes!" % (
+                        assert int(prefix_count) >= route_count, "%s should received %s route prefixes!" % (
                             peer, route_count)
                         if 'dynamicPeer' in attr:
                             validate_state_db_entry(duthost, peer, vnet, True)
@@ -434,8 +565,8 @@ def test_dynamic_peer_vnet(duthosts, rand_one_dut_hostname, cfg_facts):
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
     except Exception as e:
         logger.error("Exception raised in test_setup_vnet: {}".format(repr(e)))
-        pytest.fail("Vnet testing setup failed")
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+        pytest.fail("Vnet testing setup failed: {}".format(repr(e)))
 
 
 def test_bgp_vnet_route_forwarding(ptfadapter, duthosts, rand_one_dut_hostname, cfg_facts):
@@ -447,10 +578,28 @@ def test_bgp_vnet_route_forwarding(ptfadapter, duthosts, rand_one_dut_hostname, 
     '''
     try:
         duthost = duthosts[rand_one_dut_hostname]
+
+        # Wait for BGP routes to be installed in the Vnet1 kernel FIB before
+        # sending traffic.  Checking the BGP RIB (pfxRcd) is not sufficient;
+        # routes must have propagated through BGP → Zebra → FIB before the
+        # data plane can forward packets.
+        assert wait_until(
+            BGP_VNET_PEER_WAIT_TIMEOUT,
+            BGP_VNET_PEER_WAIT_INTERVAL,
+            0,
+            _check_vnet1_routes_installed,
+            duthost,
+        ), "Timed out waiting for Vnet1 BGP routes to be installed in kernel FIB"
+
         router_mac = duthost.facts["router_mac"]
-        # Destination IP is one of the routes learned via bgp in Vnet1
-        dst_ip = "193.11.248.129"
+        # Discover the destination IP from the live FIB so the test is not
+        # tied to a topology-specific hardcoded address.
+        dst_ip = _get_vnet1_bgp_dst_ip(duthost)
         expected_ports, unexpected_ports = get_expected_unexpected_ptf_ports(cfg_facts, "Vnet1", "Vnet2")
+        assert expected_ports, \
+            "No PTF ports found for Vnet1; check PORTCHANNEL_INTERFACE vnet_name in cfg_facts"
+        assert unexpected_ports, \
+            "No PTF ports found for Vnet2; check PORTCHANNEL_INTERFACE vnet_name in cfg_facts"
         send_port = expected_ports[0]
         src_mac = ptfadapter.dataplane.get_mac(0, send_port)
 
@@ -479,8 +628,8 @@ def test_bgp_vnet_route_forwarding(ptfadapter, duthosts, rand_one_dut_hostname, 
         testutils.verify_no_packet_any(ptfadapter, expected_pkt, unexpected_ports)
     except Exception as e:
         logger.error("Exception raised in test_bgp_vnet_route_forwarding: {}".format(repr(e)))
-        pytest.fail("Packet test for per vnet BGP failed")
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+        pytest.fail("Packet test for per vnet BGP failed: {}".format(repr(e)))
 
 
 def test_add_delete_ip_range(duthosts, rand_one_dut_hostname):
@@ -492,7 +641,18 @@ def test_add_delete_ip_range(duthosts, rand_one_dut_hostname):
         # Prepare initial config
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_del')
 
-        # Verify adding a new dynamic range
+        # Verify adding a new dynamic range.  Wait for the dynamic peer to be
+        # Established before measuring uptime / checking prefix counts so that
+        # a slow post-reboot convergence does not cause a spurious KeyError.
+        dynamic_peer = g_vars["vnet2"]["dynamic"]["ARISTA03T1"]
+        assert wait_until(
+            BGP_VNET_PEER_WAIT_TIMEOUT,
+            BGP_VNET_PEER_WAIT_INTERVAL,
+            0,
+            _check_vnet2_dynamic_peer_established,
+            duthost,
+            dynamic_peer,
+        ), "Timed out waiting for Vnet2 dynamic peer {} to establish".format(dynamic_peer)
         dynamic_range_add_delete(duthost, 'vnet_dynamic_peer_add')
 
         # Verify deleting a dynamic range
@@ -502,8 +662,8 @@ def test_add_delete_ip_range(duthosts, rand_one_dut_hostname):
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
     except Exception as e:
         logger.error("Exception raised in test_add_delete_ip_range: {}".format(repr(e)))
-        pytest.fail("Adding/deleting IP range for dynamic peers failed")
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+        pytest.fail("Adding/deleting IP range for dynamic peers failed: {}".format(repr(e)))
 
 
 def test_dynamic_peer_group_delete(duthosts, rand_one_dut_hostname):
@@ -532,8 +692,8 @@ def test_dynamic_peer_group_delete(duthosts, rand_one_dut_hostname):
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
     except Exception as e:
         logger.error("Exception raised in test_dynamic_peer_group_delete: {}".format(repr(e)))
-        pytest.fail("Dynamic peer group deletion test failed")
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+        pytest.fail("Dynamic peer group deletion test failed: {}".format(repr(e)))
 
 
 def test_dynamic_peer_modify_stress(duthosts, rand_one_dut_hostname):
@@ -554,6 +714,17 @@ def test_dynamic_peer_modify_stress(duthosts, rand_one_dut_hostname):
             modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_del')
             modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
 
+        # After rapid del/add cycling the dynamic peer may not yet be
+        # Established.  Wait before snapshotting uptime to avoid a KeyError
+        # from get_bgp_peer_uptime if the peer is absent from the summary.
+        assert wait_until(
+            BGP_VNET_PEER_WAIT_TIMEOUT,
+            BGP_VNET_PEER_WAIT_INTERVAL,
+            0,
+            _check_vnet2_all_dynamic_peers_established,
+            duthost,
+        ), "Timed out waiting for Vnet2 dynamic peers to re-establish after stress loop"
+
         static_peer_uptime_after, dynamic_peer_uptime_after = get_bgp_peer_uptime(
             duthost, static_peers, dynamic_peer)
 
@@ -569,8 +740,8 @@ def test_dynamic_peer_modify_stress(duthosts, rand_one_dut_hostname):
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
     except Exception as e:
         logger.error("Exception raised in test_dynamic_peer_modify_stress: {}".format(repr(e)))
-        pytest.fail("Stress test for dynamic peer group modification failed")
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+        pytest.fail("Stress test for dynamic peer group modification failed: {}".format(repr(e)))
 
 
 def test_dynamic_peer_delete_stress(duthosts, rand_one_dut_hostname):
@@ -590,9 +761,17 @@ def test_dynamic_peer_delete_stress(duthosts, rand_one_dut_hostname):
             duthost.shell(redis_cmd)
             time.sleep(10)
             modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
-            bgp_summary_string = duthost.shell("vtysh -c 'show bgp vrf Vnet2 summary json'")['stdout']
-            bgp_summary = json.loads(bgp_summary_string)
-            validate_dynamic_peer_established(bgp_summary, 'vnet_dynamic_peer_add')
+            # After re-adding the peer range give FRR time to re-establish all
+            # dynamic peers before the next del/add iteration.  A fixed 10 s
+            # sleep (inside modify_dynamic_peer_cfg) is not enough; use
+            # wait_until to poll until both peers are back in Established state.
+            assert wait_until(
+                BGP_VNET_PEER_WAIT_TIMEOUT,
+                BGP_VNET_PEER_WAIT_INTERVAL,
+                0,
+                _check_vnet2_all_dynamic_peers_established,
+                duthost,
+            ), "Timed out waiting for Vnet2 dynamic peers to re-establish (iteration {})".format(i)
 
         static_peer_uptime_after = get_bgp_peer_uptime(duthost, static_peers)
         for static_peer in static_peers:
@@ -604,5 +783,5 @@ def test_dynamic_peer_delete_stress(duthosts, rand_one_dut_hostname):
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
     except Exception as e:
         logger.error("Exception raised in test_dynamic_peer_delete_stress: {}".format(repr(e)))
-        pytest.fail("Stress test for dynamic peer group deletion failed")
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+        pytest.fail("Stress test for dynamic peer group deletion failed: {}".format(repr(e)))


### PR DESCRIPTION
Backport of #24074 to the 202511 branch (originally merged to master in d7266a20d).

---

### Description of PR

Summary:
Fixes four flaky `tests/bgp/test_bgp_vnet.py` cases on the t0-64 testbed:
`test_add_delete_ip_range`, `test_bgp_vnet_route_forwarding`,
`test_dynamic_peer_group_delete`, and `test_dynamic_peer_vnet`.

Fixes # (N/A - no upstream issue filed)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Four `test_bgp_vnet` cases were failing on the t0-64 testbed.

Two root causes were identified:

1. **BGP convergence race (3 tests)** — after the post-reboot VNET config
   setup, VRF-scoped BGP sessions take longer to establish than
   default-VRF sessions. The tests were asserting immediately after setup
   completed, racing against BGP convergence and seeing peers still in
   `Active` state with `pfxRcd: 0`, or missing from the BGP summary
   entirely (causing `KeyError`).

2. **Missing `allowas-in` on dynamic peer-group (`test_dynamic_peer_vnet`)** —
   `test_dynamic_peer_vnet` expected 6400 prefixes from all peers, but
   dynamic peers only learned 6002. `bgpcfgd` automatically applies
   `allowas-in 1` to the `PEER_V4` peer-group (used by static peers) but
   does **not** apply it to `BGPSLBPassive` (used by dynamic peers). With
   the t0-64 topology, 398 of 6400 advertised routes carry the DUT's own
   ASN (64601) in their AS path. Static peers accept all 6400 routes;
   dynamic peers reject the 398 looped routes and learn only 6002.

Evidence confirming each root cause:
- `show bgp vrf Vnet1 summary json`: static peers showed `pfxRcd: 6400`.
- `show bgp vrf Vnet2 summary json`: dynamic IPv4 peers showed `pfxRcd: 6002`.
- `show running-config`: `PEER_V4` has `allowas-in 1`, `BGPSLBPassive` does not.
- `bgpd.log`: dynamic peers sent End-of-RIB with prefix count flat at 6002,
  confirming routes were never learned.
- `announce_routes.py` + `topo_t0-64.yml`: confirmed exactly 398 routes
  carry the DUT's ASN in their AS path.

#### How did you do it?

Fix 1 — `wait_until` polling for BGP convergence (fixes 3 tests):
Added `wait_until` polling loops (60 s timeout, 10 s interval) before the
first assertion that requires peers to be up:
- `test_dynamic_peer_vnet`: wait for all VNET VRF peers to receive the
  expected prefix count.
- `test_bgp_vnet_route_forwarding`: wait for BGP routes to be installed in
  the Vnet1 kernel FIB (`ip route show vrf Vnet1 proto bgp`) before
  sending PTF traffic; this reliably gates on data-plane readiness.
- `test_add_delete_ip_range`: wait for the Vnet2 dynamic peer (`ARISTA03T1`)
  to be `Established` before calling `get_bgp_peer_uptime`.

This also addresses `test_dynamic_peer_group_delete` since it shares the
same convergence dependency.

Fix 2 — Configure `allowas-in` on the dynamic peer-group:
In `setup_vnet_cfg`, after the DUT reboots with VNET config, a `vtysh`
command now configures `allowas-in 1` on the `BGPSLBPassive` peer-group
in Vnet2. This gives dynamic peers the same route-acceptance behavior as
static peers, allowing them to learn all 6400 prefixes as the test
expects.

Additional improvements:
- Replace the topology-hardcoded destination IP (`"193.11.248.129"`) in
  `test_bgp_vnet_route_forwarding` with a runtime lookup of an installed
  BGP prefix in the Vnet1 kernel FIB.
- Include `repr(e)` in `pytest.fail` messages for clearer failure context.
- Reorder `except` handlers so `modify_dynamic_peer_cfg(..., 'vnet_dynamic_peer_add')`
runs before `pytest.fail` (previously unreachable after the fail call).
- Add `wait_until` in the `test_dynamic_peer_delete_stress` and
`test_dynamic_peer_modify_stress` loops for dynamic peer re-establishment.

#### How did you verify/test it?

Re-ran the full `tests/bgp/test_bgp_vnet.py` suite on a t0-64 testbed:

- All 6 test cases pass.
- `test_add_delete_ip_range`, `test_bgp_vnet_route_forwarding`, and
  `test_dynamic_peer_group_delete` no longer hit convergence race
  conditions.
- Dynamic peers now show `pfxRcd: 6400` (matching static peers).
- `show running-config` shows `allowas-in 1` under `BGPSLBPassive`
  peer-group after setup.

#### Any platform specific information?

No platform-specific changes. The fix is testbed-topology sensitive (the
route-count check is driven by topology properties rather than a
hardcoded `>= 6000`).

#### Supported testbed topology if it's a new test case?

Not a new test case. Existing `t0` topology (validated on `t0-64`).

### Documentation

No documentation changes required.