### PR TITLE
[loganalyzer] Ignore ctrmgrd Docker/k8s version warnings in global LogAnalyzer ignore list

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -490,3 +490,7 @@ r, ".* ERR syncd\d*#syncd: :- collectData: Failed to get port attr for VID 0x[0-
 r, ".* ERR auditd.*: queue to plugins is full - dropping event"
 r, ".* ERR auditd.*: message repeated .*: \[ queue to plugins is full - dropping event\]"
 r, ".* ERR auditd.*: auditd queue full reporting limit reached - ending dropped event notifications"
+
+# ctrmgrd k8s join warnings (old k8s version incompatibility with Docker 28.x)
+r, ".* ERR ctrmgrd\.py: Refer file .* for troubleshooting tips.*"
+r, ".* ERR ctrmgrd\.py:.*\[WARNING SystemVerification\]:.*Docker version is not on the list of validated versions.*"


### PR DESCRIPTION
Add two global LogAnalyzer ignore patterns for ctrmgrd ERR lines that are emitted
when kubeadm reports Docker version incompatibility (Docker 28.x vs old k8s cluster).
These warnings bleed into downstream test LogAnalyzer windows, causing false failures.

### Description of PR

Summary:

When `test_kubesonic_join_and_disjoin` runs (or fails and retries), `ctrmgrd` calls
`kubeadm join`, which emits Docker/kubelet version warnings to syslog as ERR lines:

```
ERR ctrmgrd.py: Refer file /tmp/tmpXXXXkube_hints_ for troubleshooting tips
ERR ctrmgrd.py: [WARNING SystemVerification]: Docker version is not on the list of
  validated versions: 28.2.2. Latest validated version: 20.10
```

These ERR lines appear ~seconds after the kubesonic test completes and fall inside the
**next test's** LogAnalyzer window, causing false failures in unrelated tests such as
`snmp/test_snmp_queue.py::test_snmp_queues`.

Root cause: Docker 28.x is not on kubeadm's validated versions list for the currently
deployed k8s version. This is a known infra limitation (k8s upgrade is in progress).

Fix: add the two patterns to `loganalyzer_common_ignore.txt` (global, not per-test)
because any test following a kubesonic join test may be affected.

This is the defense-in-depth complement to #24159 (which fixes kubesonic teardown to
call `config kube server disable on`, stopping ctrmgrd from retrying k8s join).

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach

#### What is the motivation for this PR?
Docker 28.x (installed on test hosts) is not on kubeadm's validated versions list for
the k8s version currently deployed in the test environment. This causes ctrmgrd to emit
ERR-level log lines when kubesonic join/disjoin runs. These ERR lines fall inside
downstream LogAnalyzer windows and cause false failures. The k8s team is working on an
upgrade; this ignore list entry prevents false failures in the interim.

#### How did you do it?
Added 2 regex patterns to `ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt`:
```
r, ".* ERR ctrmgrd\.py: Refer file .* for troubleshooting tips.*"
r, ".* ERR ctrmgrd\.py:.*\[WARNING SystemVerification\]:.*Docker version is not on the list of validated versions.*"
```
Patterns are scoped to ctrmgrd Docker/kubelet version warnings and do not suppress
unrelated ctrmgrd errors.

#### How did you verify/test it?
Confirmed via log analysis of nightly job
[69e79fb88e43924279229609](https://elastictest.org/scheduler/testplan/69e79fb88e43924279229609)
that these two exact lines triggered the LogAnalyzer failure in test_snmp_queues teardown.

#### Any platform specific information?
None - global ignore entry affects all platforms.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation

N/A

ADO: https://msazure.visualstudio.com/One/_workitems/edit/37717660