### PR TITLE
[gnmi][202511] Increase wait_critical_processes timeout to 360s for warm reboot test

### DIFF
--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -63,16 +63,18 @@ def check_critical_processes(dut, watch_secs=0):
         watch_secs = watch_secs - 5
 
 
-def wait_critical_processes(dut):
+def wait_critical_processes(dut, timeout=None):
     """
     @summary: wait until all critical processes are healthy.
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
+    @param timeout: customized timeout value in seconds. If specified, overwrites inventory value.
     """
-    timeout = reset_timeout(dut)
-    # No matter what we set in inventory file, we always set sup timeout to 900
-    # because most SUPs have 10+ dockers that need to come up
-    if dut.is_supervisor_node():
-        timeout = 900
+    if timeout is None:
+        timeout = reset_timeout(dut)
+        # No matter what we set in inventory file, we always set sup timeout to 900
+        # because most SUPs have 10+ dockers that need to come up
+        if dut.is_supervisor_node():
+            timeout = 900
     logging.info("Wait until all critical processes are healthy in {} sec"
                  .format(timeout))
     pytest_assert(wait_until(timeout, 20, 0, _all_critical_processes_healthy, dut),

--- a/tests/gnmi/test_gnoi_system_reboot.py
+++ b/tests/gnmi/test_gnoi_system_reboot.py
@@ -145,7 +145,8 @@ def test_gnoi_system_reboot_warm(duthosts, rand_one_dut_hostname, localhost):
     logging.info("System is back up after reboot")
 
     # Wait for critical processes before ending
-    wait_critical_processes(duthost)
+    # Warm reboot takes longer for containers to restart; use an extended timeout
+    wait_critical_processes(duthost, timeout=360)
 
     # Wait for gNMI container to be running
     wait_until(120, 10, 0, is_gnmi_container_running, duthost)


### PR DESCRIPTION
### Description of PR
Summary:
Increase `wait_critical_processes` timeout to 360 seconds specifically for the gNOI warm reboot test (`test_gnoi_system_reboot_warm`).

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

Warm reboot triggers `_restart_services()` in pmon, which runs additional monit waits. On some platforms (e.g. Arista-7060CX-32S-C32), this causes pmon and other containers to recover at ~320–330s post-reboot, consistently exceeding the default 300s timeout in `wait_critical_processes`.

Root cause: pmon delayed by extra monit waits introduced in sonic-utilities PR #4325, causing a consistent 20–30s overshoot on Arista-7060CX platforms (first bad image: `20251110.17`).

#### How did you do it?

1. Added an optional `timeout` parameter to `wait_critical_processes()` in `tests/common/platform/processes_utils.py`. When `timeout=None` (default), existing inventory-based logic is unchanged. When specified, the caller's value overrides the inventory value.
2. Called `wait_critical_processes(duthost, timeout=360)` in `test_gnoi_system_reboot_warm` to provide a 60-second margin over the observed ~330s recovery time. The cold reboot test retains the default 300s.

#### How did you verify/test it?

Validated on Arista-7060CX-32S-C32 testbed with image `20251110.17` and later builds; the warm reboot test now passes consistently.

#### Any platform specific information?

Issue observed on Arista-7060CX-32S-C32 where pmon runs extra monit waits during warm reboot. Other platforms are unaffected since the default timeout path is unchanged.

#### Supported testbed topology if it's a new test case?

N/A — existing test improvement.

### Documentation
N/A
