### PR TITLE
Optimize J2C testQosSaiHeadroomPoolSize hdrm_pool_size params

### DIFF
--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -129,14 +129,14 @@ qos_params:
                     dscps: [3, 4]
                     ecn: 1
                     pgs: [3, 4]
-                    src_port_ids: [0, 2, 4, 6, 8, 10, 12, 14, 16]
+                    src_port_ids: [0]
                     dst_port_id: 18
-                    pgs_num: 18
-                    packet_size: 1246
+                    pgs_num: 2
+                    packet_size: 2430
                     cell_size: 4096
-                    pkts_num_trig_pfc: 60391
-                    pkts_num_hdrm_full: 1153
-                    pkts_num_hdrm_partial: 1143
+                    pkts_num_trig_pfc: 33415
+                    pkts_num_hdrm_full: 602
+                    pkts_num_hdrm_partial: 592
                     margin: 30
                 wm_pg_headroom:
                     dscp: 3
@@ -238,14 +238,14 @@ qos_params:
                     dscps: [3, 4]
                     ecn: 1
                     pgs: [3, 4]
-                    src_port_ids: [0, 2, 4, 6, 8, 10, 12, 14, 16]
+                    src_port_ids: [0]
                     dst_port_id: 18
-                    pgs_num: 18
-                    packet_size: 1246
+                    pgs_num: 2
+                    packet_size: 2430
                     cell_size: 4096
-                    pkts_num_trig_pfc: 60391
-                    pkts_num_hdrm_full: 61692
-                    pkts_num_hdrm_partial: 61682
+                    pkts_num_trig_pfc: 33415
+                    pkts_num_hdrm_full: 32239
+                    pkts_num_hdrm_partial: 32229
                     margin: 10
                 wm_pg_headroom:
                     dscp: 3
@@ -514,14 +514,14 @@ qos_params:
                     dscps: [3, 4]
                     ecn: 1
                     pgs: [3, 4]
-                    src_port_ids: [0, 2, 4, 6, 8, 10, 12, 14, 16]
+                    src_port_ids: [0]
                     dst_port_id: 18
-                    pgs_num: 18
-                    packet_size: 1246
+                    pgs_num: 2
+                    packet_size: 2430
                     cell_size: 4096
-                    pkts_num_trig_pfc: 60391
-                    pkts_num_hdrm_full: 1153
-                    pkts_num_hdrm_partial: 1143
+                    pkts_num_trig_pfc: 33415
+                    pkts_num_hdrm_full: 602
+                    pkts_num_hdrm_partial: 592
                     margin: 30
                 wm_pg_headroom:
                     dscp: 3
@@ -623,14 +623,14 @@ qos_params:
                     dscps: [3, 4]
                     ecn: 1
                     pgs: [3, 4]
-                    src_port_ids: [0, 2, 4, 6, 8, 10, 12, 14, 16]
+                    src_port_ids: [0]
                     dst_port_id: 18
-                    pgs_num: 18
-                    packet_size: 1246
+                    pgs_num: 2
+                    packet_size: 2430
                     cell_size: 4096
-                    pkts_num_trig_pfc: 60391
-                    pkts_num_hdrm_full: 61692
-                    pkts_num_hdrm_partial: 61682
+                    pkts_num_trig_pfc: 33415
+                    pkts_num_hdrm_full: 32239
+                    pkts_num_hdrm_partial: 32229
                     margin: 10
                 wm_pg_headroom:
                     dscp: 3


### PR DESCRIPTION
Alter the `tests/qos/files/qos_params.j2c.yaml`'s `hdrm_pool_size` params to use a single src port and larger packets **on `t2_single_node` topologies**

**3 benefits:**
[1] Speeds up the tests, fewer packets need to be sent (only filling one port's buffer is enough for the test)
[2] makes the test run more consistently, since multiple ports could belong to different cores (this alters the number of packets that would be needed to trigger PFC etc)
[3] makes the test more consistent with Q3D's QoS params (See: https://github.com/sonic-net/sonic-mgmt/pull/22156 which also uses a single port)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Speed up the testQosSaiHeadroomPoolSize and improve test-run consistency, and code consistency with Q3D.

#### How did you do it?
Changed to use a single src port and recalculated the params.

#### How did you verify/test it?
Reran testQosSaiHeadroomPoolSize on a J2C+ device running 202511, to see it pass with these params

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
