### PR TITLE
[smartswitch] re-enable the DASH tests on 202511

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -707,12 +707,6 @@ crm/test_crm_available.py:
 #######################################
 #####           dash              #####
 #######################################
-dash:
-  skip:
-    reason: "Not supported on this DUT topology."
-    conditions:
-      - "'dpu' not in topo_name"
-
 dash/crm/test_dash_crm.py:
   skip:
     reason: "Currently dash tests are not supported on KVM"


### PR DESCRIPTION
Summary:
Need to re-enable the DASH tests on 202511 branch. They were disabled in this PR: https://github.com/sonic-net/sonic-mgmt/pull/20752 along with others but there is not reason not to have them run in the smartswitch topology which doesn't have DPU in the name.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
DASH tests were skipped on smartswitch

#### How did you do it?
Re-enabled the DASH tests directory
#### How did you verify/test it?
Run some tests

#### Any platform specific information?
smartswitch

#### Supported testbed topology if it's a new test case?
t1
### Documentation
N/A