### PR TITLE
dut_console: enable for cisco console platform.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -219,7 +219,7 @@ dut_console/test_console_baud_rate.py:
             Failed/Errored: To be included
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['vpp']"
+      - "asic_type in ['vpp'] and (not platform.startswith('arm64-c8220tg_48a_o'))"
 
 dut_console/test_console_chassis_conn.py:
   skip:
@@ -227,7 +227,7 @@ dut_console/test_console_chassis_conn.py:
             Failed/Errored: To be included
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['vpp']"
+      - "asic_type in ['vpp'] and (not platform.startswith('arm64-c8220tg_48a_o'))"
 
 dut_console/test_escape_character.py:
   skip:
@@ -235,7 +235,7 @@ dut_console/test_escape_character.py:
             Failed/Errored: To be included
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['vpp']"
+      - "asic_type in ['vpp'] and (not platform.startswith('arm64-c8220tg_48a_o'))"
 
 dut_console/test_idle_timeout.py:
   skip:
@@ -243,7 +243,7 @@ dut_console/test_idle_timeout.py:
             Failed/Errored: To be included
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['vpp']"
+      - "asic_type in ['vpp'] and (not platform.startswith('arm64-c8220tg_48a_o'))"
 
 #######################################
 #####         Everflow            #####

--- a/tests/dut_console/test_console_baud_rate.py
+++ b/tests/dut_console/test_console_baud_rate.py
@@ -29,7 +29,11 @@ def get_expected_baud_rate(duthost):
 
 def test_console_baud_rate_config(duthost):
     expected_baud_rate = get_expected_baud_rate(duthost)
-    res = duthost.shell("cat /proc/cmdline | grep -Eo 'console=ttyS[0-9]+,[0-9]+' | cut -d ',' -f2")
+    if duthost.facts['platform'] == "arm64-c8220tg_48a_o-r0":
+        res = duthost.shell("cat /proc/cmdline | grep -Eo 'console=tty[A-Z]*[0-9]+,[0-9]+' | cut -d ',' -f2")
+    else:
+        res = duthost.shell("cat /proc/cmdline | grep -Eo 'console=ttyS[0-9]+,[0-9]+' | cut -d ',' -f2")
+
     pytest_require(res["stdout"] != "", "Cannot get baud rate")
     if res["stdout"] != str(expected_baud_rate):
         global pass_config_test


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Currently all scripts in dut_console folder is skipped for vpp platforms. This PR is to enable them all for cisco-console platform.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
To enable dut_console folder for cisco console platform.

#### How did you do it?
Added a check for cisco-console platform in the vpp conditional skips file.

#### How did you verify/test it?
Ran the dut_console folder on our platform:
```
===================================================================================================== PASSES =====================================================================================================
_________________________________________________________________________________________ test_console_baud_rate_config __________________________________________________________________________________________
_________________________________________________________________________________________ test_console_escape[c0lo-dut] __________________________________________________________________________________________
_____________________________________________________________________________________________ test_timeout[c0lo-dut] _____________________________________________________________________________________________
____________________________________________________________________________________ test_commands_output_is_ascii[c0lo-dut] _____________________________________________________________________________________
--------------------------------------------------------------- generated xml file: /run_logs/c0lo/dutconsole/2026-04-28-20-47-20/dut_console.xml ----------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
============================================================================================ short test summary info =============================================================================================
PASSED dut_console/test_console_baud_rate.py::test_console_baud_rate_config
PASSED dut_console/test_escape_character.py::test_console_escape[c0lo-dut]
PASSED dut_console/test_idle_timeout.py::test_timeout[c0lo-dut]
PASSED dut_console/test_non_ascii_output.py::test_commands_output_is_ascii[c0lo-dut]
SKIPPED [1] dut_console/test_console_baud_rate.py:104: Unsupported console type: telnet
SKIPPED [1] dut_console/test_console_baud_rate.py:109: Unsupported console type: telnet
SKIPPED [1] dut_console/test_console_chassis_conn.py: test requires topology in Mark(name='topology', args=('t2',), kwargs={})
============================================================================== 4 passed, 3 skipped, 2 warnings in 557.10s (0:09:17) ==============================================================================
sonic@arctos_cicd_all_202603:/data/tests$ 
```
#### Any platform specific information?
Specific to cisco console platform.