### PR TITLE
[topo] Add t0-isolated-d128u64s2 topology with 128 downlinks, 64 uplink, and 2 peer links

### DIFF
--- a/ansible/generate_topo.py
+++ b/ansible/generate_topo.py
@@ -204,6 +204,12 @@ hw_port_cfg = {
                          "peer_ports": [509, 510],
                          "skip_ports": [],
                          "panel_port_step": 1},
+    'd128u64s2':        {"ds_breakout": 2, "us_breakout": 1, "ds_link_step": 1, "us_link_step": 1,
+                         'uplink_ports': [],
+                         'peer_ports': [64, 65],
+                         'skip_ports': [],
+                         'ds_us_combined': True,
+                         "panel_port_step": 1},
 }
 
 overwrite_file_name = {
@@ -566,6 +572,31 @@ def generate_topo(role: str,
             link_step = port_cfg['ds_link_step']
             link_type = 'down'
 
+        if port_cfg.get('ds_us_combined', False) and link_type == 'down':
+            # For t0: vm_role_cfg is None, downlinks become HostInterface
+            ds_end = link_id_start + port_cfg['ds_breakout']
+            for link_id in range(link_id_start, ds_end):
+                if vm_role_cfg is None:
+                    # t0 path: downlinks are host interfaces
+                    hostif = HostInterface(link_id)
+                    downlinkif_list.append(hostif)
+
+            # Process uplinks from same panel port, T1 VMs
+            uplink_role_cfg = dut_role_cfg["uplink"]
+            us_start = ds_end
+            us_end = us_start + port_cfg['us_breakout']
+            for link_id in range(us_start, us_end):
+                per_role_vm_count[uplink_role_cfg["role"]] += 1
+                uplink_role_cfg["asn"] += uplink_role_cfg.get("asn_increment", 1)
+                uplink_role_cfg["asn_v6"] += uplink_role_cfg.get("asn_increment", 1)
+                vm = VM([link_id], len(vm_list), per_role_vm_count[uplink_role_cfg["role"]], tornum,
+                        dut_role_cfg["asn"], dut_role_cfg["asn_v6"], uplink_role_cfg, link_id)
+                vm_list.append(vm)
+                uplinkif_list.append(link_id)
+
+            link_id_start = us_end
+            continue
+
         is_lag_port, lag_port = _find_lag_port(panel_port_id)
 
         if panel_port_id in lag_port_assigned:
@@ -738,6 +769,7 @@ def main(role: str, keyword: str, template: str, port_count: int, uplinks: str, 
     - ./generate_topo.py -r lt2 -k p32o64 -t lt2_p32o64 -c 64 -l 'p32o64lt2'
     - ./generate_topo.py -r t0 -k f2 -t t0 -c 64 -l 'p32v128f2'
     - ./generate_topo.py -r t1 -k f2 -t t1 -c 64 -l 'p32o64f2'
+    - ./generate_topo.py -r t0 -k isolated -t t0-isolated -c 64 -l 'd128u64s2'
     """
     uplink_ports = [int(port) for port in uplinks.split(",")] if uplinks != "" else \
         hw_port_cfg[link_cfg]['uplink_ports']

--- a/ansible/vars/topo_t0-isolated-d128u64s2.yml
+++ b/ansible/vars/topo_t0-isolated-d128u64s2.yml
@@ -1,0 +1,1785 @@
+topology:
+  host_interfaces:
+    - 0
+    - 1
+    - 3
+    - 4
+    - 6
+    - 7
+    - 9
+    - 10
+    - 12
+    - 13
+    - 15
+    - 16
+    - 18
+    - 19
+    - 21
+    - 22
+    - 24
+    - 25
+    - 27
+    - 28
+    - 30
+    - 31
+    - 33
+    - 34
+    - 36
+    - 37
+    - 39
+    - 40
+    - 42
+    - 43
+    - 45
+    - 46
+    - 48
+    - 49
+    - 51
+    - 52
+    - 54
+    - 55
+    - 57
+    - 58
+    - 60
+    - 61
+    - 63
+    - 64
+    - 66
+    - 67
+    - 69
+    - 70
+    - 72
+    - 73
+    - 75
+    - 76
+    - 78
+    - 79
+    - 81
+    - 82
+    - 84
+    - 85
+    - 87
+    - 88
+    - 90
+    - 91
+    - 93
+    - 94
+    - 96
+    - 97
+    - 99
+    - 100
+    - 102
+    - 103
+    - 105
+    - 106
+    - 108
+    - 109
+    - 111
+    - 112
+    - 114
+    - 115
+    - 117
+    - 118
+    - 120
+    - 121
+    - 123
+    - 124
+    - 126
+    - 127
+    - 129
+    - 130
+    - 132
+    - 133
+    - 135
+    - 136
+    - 138
+    - 139
+    - 141
+    - 142
+    - 144
+    - 145
+    - 147
+    - 148
+    - 150
+    - 151
+    - 153
+    - 154
+    - 156
+    - 157
+    - 159
+    - 160
+    - 162
+    - 163
+    - 165
+    - 166
+    - 168
+    - 169
+    - 171
+    - 172
+    - 174
+    - 175
+    - 177
+    - 178
+    - 180
+    - 181
+    - 183
+    - 184
+    - 186
+    - 187
+    - 189
+    - 190
+  VMs:
+    ARISTA01T1:
+      vlans:
+        - 2
+      vm_offset: 0
+    ARISTA02T1:
+      vlans:
+        - 5
+      vm_offset: 1
+    ARISTA03T1:
+      vlans:
+        - 8
+      vm_offset: 2
+    ARISTA04T1:
+      vlans:
+        - 11
+      vm_offset: 3
+    ARISTA05T1:
+      vlans:
+        - 14
+      vm_offset: 4
+    ARISTA06T1:
+      vlans:
+        - 17
+      vm_offset: 5
+    ARISTA07T1:
+      vlans:
+        - 20
+      vm_offset: 6
+    ARISTA08T1:
+      vlans:
+        - 23
+      vm_offset: 7
+    ARISTA09T1:
+      vlans:
+        - 26
+      vm_offset: 8
+    ARISTA10T1:
+      vlans:
+        - 29
+      vm_offset: 9
+    ARISTA11T1:
+      vlans:
+        - 32
+      vm_offset: 10
+    ARISTA12T1:
+      vlans:
+        - 35
+      vm_offset: 11
+    ARISTA13T1:
+      vlans:
+        - 38
+      vm_offset: 12
+    ARISTA14T1:
+      vlans:
+        - 41
+      vm_offset: 13
+    ARISTA15T1:
+      vlans:
+        - 44
+      vm_offset: 14
+    ARISTA16T1:
+      vlans:
+        - 47
+      vm_offset: 15
+    ARISTA17T1:
+      vlans:
+        - 50
+      vm_offset: 16
+    ARISTA18T1:
+      vlans:
+        - 53
+      vm_offset: 17
+    ARISTA19T1:
+      vlans:
+        - 56
+      vm_offset: 18
+    ARISTA20T1:
+      vlans:
+        - 59
+      vm_offset: 19
+    ARISTA21T1:
+      vlans:
+        - 62
+      vm_offset: 20
+    ARISTA22T1:
+      vlans:
+        - 65
+      vm_offset: 21
+    ARISTA23T1:
+      vlans:
+        - 68
+      vm_offset: 22
+    ARISTA24T1:
+      vlans:
+        - 71
+      vm_offset: 23
+    ARISTA25T1:
+      vlans:
+        - 74
+      vm_offset: 24
+    ARISTA26T1:
+      vlans:
+        - 77
+      vm_offset: 25
+    ARISTA27T1:
+      vlans:
+        - 80
+      vm_offset: 26
+    ARISTA28T1:
+      vlans:
+        - 83
+      vm_offset: 27
+    ARISTA29T1:
+      vlans:
+        - 86
+      vm_offset: 28
+    ARISTA30T1:
+      vlans:
+        - 89
+      vm_offset: 29
+    ARISTA31T1:
+      vlans:
+        - 92
+      vm_offset: 30
+    ARISTA32T1:
+      vlans:
+        - 95
+      vm_offset: 31
+    ARISTA33T1:
+      vlans:
+        - 98
+      vm_offset: 32
+    ARISTA34T1:
+      vlans:
+        - 101
+      vm_offset: 33
+    ARISTA35T1:
+      vlans:
+        - 104
+      vm_offset: 34
+    ARISTA36T1:
+      vlans:
+        - 107
+      vm_offset: 35
+    ARISTA37T1:
+      vlans:
+        - 110
+      vm_offset: 36
+    ARISTA38T1:
+      vlans:
+        - 113
+      vm_offset: 37
+    ARISTA39T1:
+      vlans:
+        - 116
+      vm_offset: 38
+    ARISTA40T1:
+      vlans:
+        - 119
+      vm_offset: 39
+    ARISTA41T1:
+      vlans:
+        - 122
+      vm_offset: 40
+    ARISTA42T1:
+      vlans:
+        - 125
+      vm_offset: 41
+    ARISTA43T1:
+      vlans:
+        - 128
+      vm_offset: 42
+    ARISTA44T1:
+      vlans:
+        - 131
+      vm_offset: 43
+    ARISTA45T1:
+      vlans:
+        - 134
+      vm_offset: 44
+    ARISTA46T1:
+      vlans:
+        - 137
+      vm_offset: 45
+    ARISTA47T1:
+      vlans:
+        - 140
+      vm_offset: 46
+    ARISTA48T1:
+      vlans:
+        - 143
+      vm_offset: 47
+    ARISTA49T1:
+      vlans:
+        - 146
+      vm_offset: 48
+    ARISTA50T1:
+      vlans:
+        - 149
+      vm_offset: 49
+    ARISTA51T1:
+      vlans:
+        - 152
+      vm_offset: 50
+    ARISTA52T1:
+      vlans:
+        - 155
+      vm_offset: 51
+    ARISTA53T1:
+      vlans:
+        - 158
+      vm_offset: 52
+    ARISTA54T1:
+      vlans:
+        - 161
+      vm_offset: 53
+    ARISTA55T1:
+      vlans:
+        - 164
+      vm_offset: 54
+    ARISTA56T1:
+      vlans:
+        - 167
+      vm_offset: 55
+    ARISTA57T1:
+      vlans:
+        - 170
+      vm_offset: 56
+    ARISTA58T1:
+      vlans:
+        - 173
+      vm_offset: 57
+    ARISTA59T1:
+      vlans:
+        - 176
+      vm_offset: 58
+    ARISTA60T1:
+      vlans:
+        - 179
+      vm_offset: 59
+    ARISTA61T1:
+      vlans:
+        - 182
+      vm_offset: 60
+    ARISTA62T1:
+      vlans:
+        - 185
+      vm_offset: 61
+    ARISTA63T1:
+      vlans:
+        - 188
+      vm_offset: 62
+    ARISTA64T1:
+      vlans:
+        - 191
+      vm_offset: 63
+    ARISTA01PT0:
+      vlans:
+        - 192
+      vm_offset: 64
+    ARISTA02PT0:
+      vlans:
+        - 193
+      vm_offset: 65
+  DUT:
+    vlan_configs:
+      default_vlan_config: one_vlan_a
+      one_vlan_a:
+        Vlan1000:
+          id: 1000
+          intfs: [0, 1, 3, 4, 6, 7, 9, 10, 12, 13, 15, 16, 18, 19, 21, 22, 24, 25, 27, 28, 30, 31, 33, 34, 36, 37, 39, 40, 42, 43, 45, 46, 48, 49, 51, 52, 54, 55, 57, 58, 60, 61, 63, 64, 66, 67, 69, 70, 72, 73, 75, 76, 78, 79, 81, 82, 84, 85, 87, 88, 90, 91, 93, 94, 96, 97, 99, 100, 102, 103, 105, 106, 108, 109, 111, 112, 114, 115, 117, 118, 120, 121, 123, 124, 126, 127, 129, 130, 132, 133, 135, 136, 138, 139, 141, 142, 144, 145, 147, 148, 150, 151, 153, 154, 156, 157, 159, 160, 162, 163, 165, 166, 168, 169, 171, 172, 174, 175, 177, 178, 180, 181, 183, 184, 186, 187, 189, 190]
+          prefix: 192.168.0.1/21
+          prefix_v6: fc02:1000::1/64
+          tag: 1000
+      two_vlan_a:
+        Vlan1000:
+          id: 1000
+          intfs: [0, 1, 3, 4, 6, 7, 9, 10, 12, 13, 15, 16, 18, 19, 21, 22, 24, 25, 27, 28, 30, 31, 33, 34, 36, 37, 39, 40, 42, 43, 45, 46, 48, 49, 51, 52, 54, 55, 57, 58, 60, 61, 63, 64, 66, 67, 69, 70, 72, 73, 75, 76, 78, 79, 81, 82, 84, 85, 87, 88, 90, 91, 93, 94]
+          prefix: 192.168.0.1/22
+          prefix_v6: fc02:100::1/64
+          tag: 1000
+        Vlan1100:
+          id: 1100
+          intfs: [96, 97, 99, 100, 102, 103, 105, 106, 108, 109, 111, 112, 114, 115, 117, 118, 120, 121, 123, 124, 126, 127, 129, 130, 132, 133, 135, 136, 138, 139, 141, 142, 144, 145, 147, 148, 150, 151, 153, 154, 156, 157, 159, 160, 162, 163, 165, 166, 168, 169, 171, 172, 174, 175, 177, 178, 180, 181, 183, 184, 186, 187, 189, 190]
+          prefix: 192.168.4.1/22
+          prefix_v6: fc02:101::1/64
+          tag: 1100
+      four_vlan_a:
+        Vlan1000:
+          id: 1000
+          intfs: [0, 1, 3, 4, 6, 7, 9, 10, 12, 13, 15, 16, 18, 19, 21, 22, 24, 25, 27, 28, 30, 31, 33, 34, 36, 37, 39, 40, 42, 43, 45, 46]
+          prefix: 192.168.0.1/22
+          prefix_v6: fc02:100::1/64
+          tag: 1000
+        Vlan1100:
+          id: 1100
+          intfs: [48, 49, 51, 52, 54, 55, 57, 58, 60, 61, 63, 64, 66, 67, 69, 70, 72, 73, 75, 76, 78, 79, 81, 82, 84, 85, 87, 88, 90, 91, 93, 94]
+          prefix: 192.168.4.1/22
+          prefix_v6: fc02:101::1/64
+          tag: 1100
+        Vlan1200:
+          id: 1200
+          intfs: [96, 97, 99, 100, 102, 103, 105, 106, 108, 109, 111, 112, 114, 115, 117, 118, 120, 121, 123, 124, 126, 127, 129, 130, 132, 133, 135, 136, 138, 139, 141, 142]
+          prefix: 192.168.8.1/22
+          prefix_v6: fc02:102::1/64
+          tag: 1200
+        Vlan1300:
+          id: 1300
+          intfs: [144, 145, 147, 148, 150, 151, 153, 154, 156, 157, 159, 160, 162, 163, 165, 166, 168, 169, 171, 172, 174, 175, 177, 178, 180, 181, 183, 184, 186, 187, 189, 190]
+          prefix: 192.168.12.1/22
+          prefix_v6: fc02:103::1/64
+          tag: 1300
+
+configuration_properties:
+  common:
+    dut_asn: 65100
+    dut_type: ToRRouter
+    nhipv4: 10.10.246.254
+    nhipv6: FC0A::FF
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 128
+    spine_asn: 65534
+    leaf_asn_start: 64600
+    tor_asn_start: 65500
+    failure_rate: 0
+  tor:
+    swrole: tor
+  leaf:
+    swrole: leaf
+
+configuration:
+  ARISTA01T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.4
+          - fc00::9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.3/32
+        ipv6: 2064:100:0:3::/128
+      Ethernet1:
+        ipv4: 10.0.0.5/31
+        ipv6: fc00::a/126
+    bp_interface:
+      ipv4: 10.10.246.4/22
+      ipv6: fc0a::4/64
+  ARISTA02T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.10
+          - fc00::15
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.6/32
+        ipv6: 2064:100:0:6::/128
+      Ethernet1:
+        ipv4: 10.0.0.11/31
+        ipv6: fc00::16/126
+    bp_interface:
+      ipv4: 10.10.246.7/22
+      ipv6: fc0a::7/64
+  ARISTA03T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.16
+          - fc00::21
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.9/32
+        ipv6: 2064:100:0:9::/128
+      Ethernet1:
+        ipv4: 10.0.0.17/31
+        ipv6: fc00::22/126
+    bp_interface:
+      ipv4: 10.10.246.10/22
+      ipv6: fc0a::a/64
+  ARISTA04T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.22
+          - fc00::2d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.12/32
+        ipv6: 2064:100:0:c::/128
+      Ethernet1:
+        ipv4: 10.0.0.23/31
+        ipv6: fc00::2e/126
+    bp_interface:
+      ipv4: 10.10.246.13/22
+      ipv6: fc0a::d/64
+  ARISTA05T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.28
+          - fc00::39
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.15/32
+        ipv6: 2064:100:0:f::/128
+      Ethernet1:
+        ipv4: 10.0.0.29/31
+        ipv6: fc00::3a/126
+    bp_interface:
+      ipv4: 10.10.246.16/22
+      ipv6: fc0a::10/64
+  ARISTA06T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.34
+          - fc00::45
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.18/32
+        ipv6: 2064:100:0:12::/128
+      Ethernet1:
+        ipv4: 10.0.0.35/31
+        ipv6: fc00::46/126
+    bp_interface:
+      ipv4: 10.10.246.19/22
+      ipv6: fc0a::13/64
+  ARISTA07T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.40
+          - fc00::51
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.21/32
+        ipv6: 2064:100:0:15::/128
+      Ethernet1:
+        ipv4: 10.0.0.41/31
+        ipv6: fc00::52/126
+    bp_interface:
+      ipv4: 10.10.246.22/22
+      ipv6: fc0a::16/64
+  ARISTA08T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.46
+          - fc00::5d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.24/32
+        ipv6: 2064:100:0:18::/128
+      Ethernet1:
+        ipv4: 10.0.0.47/31
+        ipv6: fc00::5e/126
+    bp_interface:
+      ipv4: 10.10.246.25/22
+      ipv6: fc0a::19/64
+  ARISTA09T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.52
+          - fc00::69
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.27/32
+        ipv6: 2064:100:0:1b::/128
+      Ethernet1:
+        ipv4: 10.0.0.53/31
+        ipv6: fc00::6a/126
+    bp_interface:
+      ipv4: 10.10.246.28/22
+      ipv6: fc0a::1c/64
+  ARISTA10T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.58
+          - fc00::75
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.30/32
+        ipv6: 2064:100:0:1e::/128
+      Ethernet1:
+        ipv4: 10.0.0.59/31
+        ipv6: fc00::76/126
+    bp_interface:
+      ipv4: 10.10.246.31/22
+      ipv6: fc0a::1f/64
+  ARISTA11T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.64
+          - fc00::81
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.33/32
+        ipv6: 2064:100:0:21::/128
+      Ethernet1:
+        ipv4: 10.0.0.65/31
+        ipv6: fc00::82/126
+    bp_interface:
+      ipv4: 10.10.246.34/22
+      ipv6: fc0a::22/64
+  ARISTA12T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.70
+          - fc00::8d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.36/32
+        ipv6: 2064:100:0:24::/128
+      Ethernet1:
+        ipv4: 10.0.0.71/31
+        ipv6: fc00::8e/126
+    bp_interface:
+      ipv4: 10.10.246.37/22
+      ipv6: fc0a::25/64
+  ARISTA13T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.76
+          - fc00::99
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.39/32
+        ipv6: 2064:100:0:27::/128
+      Ethernet1:
+        ipv4: 10.0.0.77/31
+        ipv6: fc00::9a/126
+    bp_interface:
+      ipv4: 10.10.246.40/22
+      ipv6: fc0a::28/64
+  ARISTA14T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.82
+          - fc00::a5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.42/32
+        ipv6: 2064:100:0:2a::/128
+      Ethernet1:
+        ipv4: 10.0.0.83/31
+        ipv6: fc00::a6/126
+    bp_interface:
+      ipv4: 10.10.246.43/22
+      ipv6: fc0a::2b/64
+  ARISTA15T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.88
+          - fc00::b1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.45/32
+        ipv6: 2064:100:0:2d::/128
+      Ethernet1:
+        ipv4: 10.0.0.89/31
+        ipv6: fc00::b2/126
+    bp_interface:
+      ipv4: 10.10.246.46/22
+      ipv6: fc0a::2e/64
+  ARISTA16T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.94
+          - fc00::bd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.48/32
+        ipv6: 2064:100:0:30::/128
+      Ethernet1:
+        ipv4: 10.0.0.95/31
+        ipv6: fc00::be/126
+    bp_interface:
+      ipv4: 10.10.246.49/22
+      ipv6: fc0a::31/64
+  ARISTA17T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.100
+          - fc00::c9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.51/32
+        ipv6: 2064:100:0:33::/128
+      Ethernet1:
+        ipv4: 10.0.0.101/31
+        ipv6: fc00::ca/126
+    bp_interface:
+      ipv4: 10.10.246.52/22
+      ipv6: fc0a::34/64
+  ARISTA18T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.106
+          - fc00::d5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.54/32
+        ipv6: 2064:100:0:36::/128
+      Ethernet1:
+        ipv4: 10.0.0.107/31
+        ipv6: fc00::d6/126
+    bp_interface:
+      ipv4: 10.10.246.55/22
+      ipv6: fc0a::37/64
+  ARISTA19T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.112
+          - fc00::e1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.57/32
+        ipv6: 2064:100:0:39::/128
+      Ethernet1:
+        ipv4: 10.0.0.113/31
+        ipv6: fc00::e2/126
+    bp_interface:
+      ipv4: 10.10.246.58/22
+      ipv6: fc0a::3a/64
+  ARISTA20T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.118
+          - fc00::ed
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.60/32
+        ipv6: 2064:100:0:3c::/128
+      Ethernet1:
+        ipv4: 10.0.0.119/31
+        ipv6: fc00::ee/126
+    bp_interface:
+      ipv4: 10.10.246.61/22
+      ipv6: fc0a::3d/64
+  ARISTA21T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.124
+          - fc00::f9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.63/32
+        ipv6: 2064:100:0:3f::/128
+      Ethernet1:
+        ipv4: 10.0.0.125/31
+        ipv6: fc00::fa/126
+    bp_interface:
+      ipv4: 10.10.246.64/22
+      ipv6: fc0a::40/64
+  ARISTA22T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.130
+          - fc00::105
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.66/32
+        ipv6: 2064:100:0:42::/128
+      Ethernet1:
+        ipv4: 10.0.0.131/31
+        ipv6: fc00::106/126
+    bp_interface:
+      ipv4: 10.10.246.67/22
+      ipv6: fc0a::43/64
+  ARISTA23T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.136
+          - fc00::111
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.69/32
+        ipv6: 2064:100:0:45::/128
+      Ethernet1:
+        ipv4: 10.0.0.137/31
+        ipv6: fc00::112/126
+    bp_interface:
+      ipv4: 10.10.246.70/22
+      ipv6: fc0a::46/64
+  ARISTA24T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.142
+          - fc00::11d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.72/32
+        ipv6: 2064:100:0:48::/128
+      Ethernet1:
+        ipv4: 10.0.0.143/31
+        ipv6: fc00::11e/126
+    bp_interface:
+      ipv4: 10.10.246.73/22
+      ipv6: fc0a::49/64
+  ARISTA25T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.148
+          - fc00::129
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.75/32
+        ipv6: 2064:100:0:4b::/128
+      Ethernet1:
+        ipv4: 10.0.0.149/31
+        ipv6: fc00::12a/126
+    bp_interface:
+      ipv4: 10.10.246.76/22
+      ipv6: fc0a::4c/64
+  ARISTA26T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.154
+          - fc00::135
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.78/32
+        ipv6: 2064:100:0:4e::/128
+      Ethernet1:
+        ipv4: 10.0.0.155/31
+        ipv6: fc00::136/126
+    bp_interface:
+      ipv4: 10.10.246.79/22
+      ipv6: fc0a::4f/64
+  ARISTA27T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.160
+          - fc00::141
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.81/32
+        ipv6: 2064:100:0:51::/128
+      Ethernet1:
+        ipv4: 10.0.0.161/31
+        ipv6: fc00::142/126
+    bp_interface:
+      ipv4: 10.10.246.82/22
+      ipv6: fc0a::52/64
+  ARISTA28T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.166
+          - fc00::14d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.84/32
+        ipv6: 2064:100:0:54::/128
+      Ethernet1:
+        ipv4: 10.0.0.167/31
+        ipv6: fc00::14e/126
+    bp_interface:
+      ipv4: 10.10.246.85/22
+      ipv6: fc0a::55/64
+  ARISTA29T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.172
+          - fc00::159
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.87/32
+        ipv6: 2064:100:0:57::/128
+      Ethernet1:
+        ipv4: 10.0.0.173/31
+        ipv6: fc00::15a/126
+    bp_interface:
+      ipv4: 10.10.246.88/22
+      ipv6: fc0a::58/64
+  ARISTA30T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.178
+          - fc00::165
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.90/32
+        ipv6: 2064:100:0:5a::/128
+      Ethernet1:
+        ipv4: 10.0.0.179/31
+        ipv6: fc00::166/126
+    bp_interface:
+      ipv4: 10.10.246.91/22
+      ipv6: fc0a::5b/64
+  ARISTA31T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.184
+          - fc00::171
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.93/32
+        ipv6: 2064:100:0:5d::/128
+      Ethernet1:
+        ipv4: 10.0.0.185/31
+        ipv6: fc00::172/126
+    bp_interface:
+      ipv4: 10.10.246.94/22
+      ipv6: fc0a::5e/64
+  ARISTA32T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.190
+          - fc00::17d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.96/32
+        ipv6: 2064:100:0:60::/128
+      Ethernet1:
+        ipv4: 10.0.0.191/31
+        ipv6: fc00::17e/126
+    bp_interface:
+      ipv4: 10.10.246.97/22
+      ipv6: fc0a::61/64
+  ARISTA33T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.196
+          - fc00::189
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.99/32
+        ipv6: 2064:100:0:63::/128
+      Ethernet1:
+        ipv4: 10.0.0.197/31
+        ipv6: fc00::18a/126
+    bp_interface:
+      ipv4: 10.10.246.100/22
+      ipv6: fc0a::64/64
+  ARISTA34T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.202
+          - fc00::195
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.102/32
+        ipv6: 2064:100:0:66::/128
+      Ethernet1:
+        ipv4: 10.0.0.203/31
+        ipv6: fc00::196/126
+    bp_interface:
+      ipv4: 10.10.246.103/22
+      ipv6: fc0a::67/64
+  ARISTA35T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.208
+          - fc00::1a1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.105/32
+        ipv6: 2064:100:0:69::/128
+      Ethernet1:
+        ipv4: 10.0.0.209/31
+        ipv6: fc00::1a2/126
+    bp_interface:
+      ipv4: 10.10.246.106/22
+      ipv6: fc0a::6a/64
+  ARISTA36T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.214
+          - fc00::1ad
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.108/32
+        ipv6: 2064:100:0:6c::/128
+      Ethernet1:
+        ipv4: 10.0.0.215/31
+        ipv6: fc00::1ae/126
+    bp_interface:
+      ipv4: 10.10.246.109/22
+      ipv6: fc0a::6d/64
+  ARISTA37T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.220
+          - fc00::1b9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.111/32
+        ipv6: 2064:100:0:6f::/128
+      Ethernet1:
+        ipv4: 10.0.0.221/31
+        ipv6: fc00::1ba/126
+    bp_interface:
+      ipv4: 10.10.246.112/22
+      ipv6: fc0a::70/64
+  ARISTA38T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.226
+          - fc00::1c5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.114/32
+        ipv6: 2064:100:0:72::/128
+      Ethernet1:
+        ipv4: 10.0.0.227/31
+        ipv6: fc00::1c6/126
+    bp_interface:
+      ipv4: 10.10.246.115/22
+      ipv6: fc0a::73/64
+  ARISTA39T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.232
+          - fc00::1d1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.117/32
+        ipv6: 2064:100:0:75::/128
+      Ethernet1:
+        ipv4: 10.0.0.233/31
+        ipv6: fc00::1d2/126
+    bp_interface:
+      ipv4: 10.10.246.118/22
+      ipv6: fc0a::76/64
+  ARISTA40T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.238
+          - fc00::1dd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.120/32
+        ipv6: 2064:100:0:78::/128
+      Ethernet1:
+        ipv4: 10.0.0.239/31
+        ipv6: fc00::1de/126
+    bp_interface:
+      ipv4: 10.10.246.121/22
+      ipv6: fc0a::79/64
+  ARISTA41T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.244
+          - fc00::1e9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.123/32
+        ipv6: 2064:100:0:7b::/128
+      Ethernet1:
+        ipv4: 10.0.0.245/31
+        ipv6: fc00::1ea/126
+    bp_interface:
+      ipv4: 10.10.246.124/22
+      ipv6: fc0a::7c/64
+  ARISTA42T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.250
+          - fc00::1f5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.126/32
+        ipv6: 2064:100:0:7e::/128
+      Ethernet1:
+        ipv4: 10.0.0.251/31
+        ipv6: fc00::1f6/126
+    bp_interface:
+      ipv4: 10.10.246.127/22
+      ipv6: fc0a::7f/64
+  ARISTA43T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.1.0
+          - fc00::201
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.129/32
+        ipv6: 2064:100:0:81::/128
+      Ethernet1:
+        ipv4: 10.0.1.1/31
+        ipv6: fc00::202/126
+    bp_interface:
+      ipv4: 10.10.246.130/22
+      ipv6: fc0a::82/64
+  ARISTA44T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.1.6
+          - fc00::20d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.132/32
+        ipv6: 2064:100:0:84::/128
+      Ethernet1:
+        ipv4: 10.0.1.7/31
+        ipv6: fc00::20e/126
+    bp_interface:
+      ipv4: 10.10.246.133/22
+      ipv6: fc0a::85/64
+  ARISTA45T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.1.12
+          - fc00::219
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.135/32
+        ipv6: 2064:100:0:87::/128
+      Ethernet1:
+        ipv4: 10.0.1.13/31
+        ipv6: fc00::21a/126
+    bp_interface:
+      ipv4: 10.10.246.136/22
+      ipv6: fc0a::88/64
+  ARISTA46T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.1.18
+          - fc00::225
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.138/32
+        ipv6: 2064:100:0:8a::/128
+      Ethernet1:
+        ipv4: 10.0.1.19/31
+        ipv6: fc00::226/126
+    bp_interface:
+      ipv4: 10.10.246.139/22
+      ipv6: fc0a::8b/64
+  ARISTA47T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.1.24
+          - fc00::231
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.141/32
+        ipv6: 2064:100:0:8d::/128
+      Ethernet1:
+        ipv4: 10.0.1.25/31
+        ipv6: fc00::232/126
+    bp_interface:
+      ipv4: 10.10.246.142/22
+      ipv6: fc0a::8e/64
+  ARISTA48T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.1.30
+          - fc00::23d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.144/32
+        ipv6: 2064:100:0:90::/128
+      Ethernet1:
+        ipv4: 10.0.1.31/31
+        ipv6: fc00::23e/126
+    bp_interface:
+      ipv4: 10.10.246.145/22
+      ipv6: fc0a::91/64
+  ARISTA49T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.1.36
+          - fc00::249
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.147/32
+        ipv6: 2064:100:0:93::/128
+      Ethernet1:
+        ipv4: 10.0.1.37/31
+        ipv6: fc00::24a/126
+    bp_interface:
+      ipv4: 10.10.246.148/22
+      ipv6: fc0a::94/64
+  ARISTA50T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.1.42
+          - fc00::255
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.150/32
+        ipv6: 2064:100:0:96::/128
+      Ethernet1:
+        ipv4: 10.0.1.43/31
+        ipv6: fc00::256/126
+    bp_interface:
+      ipv4: 10.10.246.151/22
+      ipv6: fc0a::97/64
+  ARISTA51T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.1.48
+          - fc00::261
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.153/32
+        ipv6: 2064:100:0:99::/128
+      Ethernet1:
+        ipv4: 10.0.1.49/31
+        ipv6: fc00::262/126
+    bp_interface:
+      ipv4: 10.10.246.154/22
+      ipv6: fc0a::9a/64
+  ARISTA52T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.1.54
+          - fc00::26d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.156/32
+        ipv6: 2064:100:0:9c::/128
+      Ethernet1:
+        ipv4: 10.0.1.55/31
+        ipv6: fc00::26e/126
+    bp_interface:
+      ipv4: 10.10.246.157/22
+      ipv6: fc0a::9d/64
+  ARISTA53T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.1.60
+          - fc00::279
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.159/32
+        ipv6: 2064:100:0:9f::/128
+      Ethernet1:
+        ipv4: 10.0.1.61/31
+        ipv6: fc00::27a/126
+    bp_interface:
+      ipv4: 10.10.246.160/22
+      ipv6: fc0a::a0/64
+  ARISTA54T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.1.66
+          - fc00::285
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.162/32
+        ipv6: 2064:100:0:a2::/128
+      Ethernet1:
+        ipv4: 10.0.1.67/31
+        ipv6: fc00::286/126
+    bp_interface:
+      ipv4: 10.10.246.163/22
+      ipv6: fc0a::a3/64
+  ARISTA55T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.1.72
+          - fc00::291
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.165/32
+        ipv6: 2064:100:0:a5::/128
+      Ethernet1:
+        ipv4: 10.0.1.73/31
+        ipv6: fc00::292/126
+    bp_interface:
+      ipv4: 10.10.246.166/22
+      ipv6: fc0a::a6/64
+  ARISTA56T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.1.78
+          - fc00::29d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.168/32
+        ipv6: 2064:100:0:a8::/128
+      Ethernet1:
+        ipv4: 10.0.1.79/31
+        ipv6: fc00::29e/126
+    bp_interface:
+      ipv4: 10.10.246.169/22
+      ipv6: fc0a::a9/64
+  ARISTA57T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.1.84
+          - fc00::2a9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.171/32
+        ipv6: 2064:100:0:ab::/128
+      Ethernet1:
+        ipv4: 10.0.1.85/31
+        ipv6: fc00::2aa/126
+    bp_interface:
+      ipv4: 10.10.246.172/22
+      ipv6: fc0a::ac/64
+  ARISTA58T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.1.90
+          - fc00::2b5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.174/32
+        ipv6: 2064:100:0:ae::/128
+      Ethernet1:
+        ipv4: 10.0.1.91/31
+        ipv6: fc00::2b6/126
+    bp_interface:
+      ipv4: 10.10.246.175/22
+      ipv6: fc0a::af/64
+  ARISTA59T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.1.96
+          - fc00::2c1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.177/32
+        ipv6: 2064:100:0:b1::/128
+      Ethernet1:
+        ipv4: 10.0.1.97/31
+        ipv6: fc00::2c2/126
+    bp_interface:
+      ipv4: 10.10.246.178/22
+      ipv6: fc0a::b2/64
+  ARISTA60T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.1.102
+          - fc00::2cd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.180/32
+        ipv6: 2064:100:0:b4::/128
+      Ethernet1:
+        ipv4: 10.0.1.103/31
+        ipv6: fc00::2ce/126
+    bp_interface:
+      ipv4: 10.10.246.181/22
+      ipv6: fc0a::b5/64
+  ARISTA61T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.1.108
+          - fc00::2d9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.183/32
+        ipv6: 2064:100:0:b7::/128
+      Ethernet1:
+        ipv4: 10.0.1.109/31
+        ipv6: fc00::2da/126
+    bp_interface:
+      ipv4: 10.10.246.184/22
+      ipv6: fc0a::b8/64
+  ARISTA62T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.1.114
+          - fc00::2e5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.186/32
+        ipv6: 2064:100:0:ba::/128
+      Ethernet1:
+        ipv4: 10.0.1.115/31
+        ipv6: fc00::2e6/126
+    bp_interface:
+      ipv4: 10.10.246.187/22
+      ipv6: fc0a::bb/64
+  ARISTA63T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.1.120
+          - fc00::2f1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.189/32
+        ipv6: 2064:100:0:bd::/128
+      Ethernet1:
+        ipv4: 10.0.1.121/31
+        ipv6: fc00::2f2/126
+    bp_interface:
+      ipv4: 10.10.246.190/22
+      ipv6: fc0a::be/64
+  ARISTA64T1:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.1.126
+          - fc00::2fd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.192/32
+        ipv6: 2064:100:0:c0::/128
+      Ethernet1:
+        ipv4: 10.0.1.127/31
+        ipv6: fc00::2fe/126
+    bp_interface:
+      ipv4: 10.10.246.193/22
+      ipv6: fc0a::c1/64
+  ARISTA01PT0:
+    properties:
+    - common
+    - tor
+    bgp:
+      asn: 65101
+      peers:
+        65100:
+          - 10.0.1.128
+          - fc00::301
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.193/32
+        ipv6: 2064:100:0:c1::/128
+      Ethernet1:
+        ipv4: 10.0.1.129/31
+        ipv6: fc00::302/126
+    bp_interface:
+      ipv4: 10.10.246.194/22
+      ipv6: fc0a::c2/64
+  ARISTA02PT0:
+    properties:
+    - common
+    - tor
+    bgp:
+      asn: 65102
+      peers:
+        65100:
+          - 10.0.1.130
+          - fc00::305
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.194/32
+        ipv6: 2064:100:0:c2::/128
+      Ethernet1:
+        ipv4: 10.0.1.131/31
+        ipv6: fc00::306/126
+    bp_interface:
+      ipv4: 10.10.246.195/22
+      ipv6: fc0a::c3/64


### PR DESCRIPTION
---

### Description of PR

Summary: Add new `t0-isolated-d128u64s2` topology supporting 128 downlinks, 64 uplinks, and 2 peer links for hardware with mixed-role breakout ports (each panel port produces both downlink and uplink links).

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Existing topology configurations assume each panel port serves a single role (downlink OR uplink). New hardware (64 ETPs with 2×400G downlinks + 1×800G uplink per port, plus ETP65 with 2 peer links) requires mixed-role breakout where a single panel port produces both downlink and uplink links.

#### How did you do it?

- Added `d128u64s2` entry to `hw_port_cfg` in generate_topo.py with `ds_breakout: 2`, `us_breakout: 1`, and new `ds_us_combined: True` flag
- Added `ds_us_combined` processing logic in `generate_topo()` that handles downlink links first, then uplink links from the same panel port before advancing to the next port
- Generated topo_t0-isolated-d128u64s2.yml (128 host interfaces, 64 T1 VMs, 2 PT0 VMs)
- Registered the topology in veos, testcases.yml, tests_mark_conditions.yaml, and __init__.py

#### How did you verify/test it?

- Verified generated YAML has correct link ID pattern (0,1=host, 2=VM, 3,4=host, 5=VM, ...) with non-overlapping IPs and correct ASNs
- Ran `generate_topo.py -r t0 -k isolated -t t0-isolated -c 64 -l 'd128u64s2'` and confirmed output matches committed YAML

#### Any platform specific information?

Targets hardware with 64 panel ports (ETP1–ETP64) each broken out into 3 links (2 downlinks + 1 uplink), plus ETP65 with 2 peer links.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A