### PR TITLE
Fix check_docker_status on multi-asic to skip checking base name containers

### DIFF
--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -167,16 +167,6 @@ def execute_config_reload_cmd(duthost, timeout=120, check_interval=5):
         return False, None
 
 
-def check_docker_status(duthost):
-    containers = duthost.get_all_containers()
-    for container in containers:
-        if 'disabled' in duthost.get_feature_status()[0].get(container, ''):
-            continue
-        if not duthost.is_service_fully_started(container):
-            return False
-    return True
-
-
 def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname, delayed_services,
                                      localhost, conn_graph_facts, xcvr_skip_list):      # noqa: F811
     """
@@ -223,8 +213,8 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
 
     if not duthost.get_facts().get("modular_chassis"):
         # Check if all containers have started
-        assert wait_until(300, 10, 0, check_docker_status, duthost), (
-            "Not all Docker containers reached the 'fully started' state within 300 seconds "
+        assert wait_until(300, 10, 0, duthost.critical_services_fully_started), (
+            "Not all Docker containers reached the 'fully started' state within 300 seconds"
         )
 
         # To ensure the system is stable enough, wait for another 30s


### PR DESCRIPTION
### Description of PR

On multi-asic, base-name containers (`bgp, swss, syncd, ...`) are not run and are exited because systemd masks them in favour of per-asic instances (`bgp@0, bgp@1, ...`). 

The testcase `platform_tests/test_reload_config.py::test_reload_configuration_checks` uses helper function`check_docker_status` which currently iterates over all container given from `docker ps -a` and require all containers to be running which includes base-name containers. It always returned False since base-name container does not run on multi-asic. This cause timeout failing the test case on multi-asic.

Fixed it by using `critical_services_fully_started ` function to make sure critical services up and running.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

 The test case `platform_tests/test_reload_config.py::test_reload_configuration_checks` fails waiting at `check_docker_status` to return `true` which checks for waits and checks for if `bgp, swss, syncd..` docker containers are up which acutually does not run and hence fails to return true within 300 sec timeout.

### How did you do it?

Fixed it by using `critical_services_fully_started ` function to make sure critical services up and running.

#### How did you verify/test it?

Test case passes on both multi-asic  and single-asic systems 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
