### PR TITLE
Increase pfcwd storm wait time per port

### DIFF
--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -237,7 +237,7 @@ class TestPfcwdAllPortStorm(object):
 
             # Scale timeout with port count to allow sufficient time on high port-count platforms.
             num_ports = len(stormed_ports_list) if stormed_ports_list else len(selected_test_ports)
-            timeout = max(60, num_ports * 2)
+            timeout = max(60, num_ports * 3)
             # LT2/FT2 topologies need at least 120s because the traffic generator
             # takes longer to spin up on those setups.
             if tbinfo and tbinfo['topo']['type'] in ["lt2", "ft2"]:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Storm generation is reliant on CEOS fanouts, which is hosted by the test server.
Currently, the test assumes 2 seconds to generate PFC frames for a port. This is a bit too low for slower testservers.

Bumping it to 3 seconds.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The test is failing on checking port storm states on slower test servers.

#### How did you do it?
Increase the timeout to 3 seconds per port for storm generation.

#### How did you verify/test it?
Test no longer fails on a slower test server.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
