### PR TITLE
202511: Add t2_single_node_max and t2_single_node_max_64p_v2 to q3d qos params

### DIFF
--- a/tests/qos/files/qos_params.q3d.yaml
+++ b/tests/qos/files/qos_params.q3d.yaml
@@ -72,63 +72,63 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 373323
-                    pkts_num_trig_ingr_drp: 932731
+                    pkts_num_trig_pfc: 774650
+                    pkts_num_trig_ingr_drp: 1488048
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 373323
-                    pkts_num_trig_ingr_drp: 932731
+                    pkts_num_trig_pfc: 774650
+                    pkts_num_trig_ingr_drp: 1488048
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [3, 4]
                     ecn: 1
                     pgs: [3, 4]
                     src_port_ids: [0]
-                    dst_port_id: 0
+                    dst_port_id: 18
                     pgs_num: 2
-                    packet_size: 1246
+                    packet_size: 2430
                     cell_size: 4096
-                    pkts_num_trig_pfc: 32312
-                    pkts_num_hdrm_full: 48354
-                    pkts_num_hdrm_partial: 48162
-                    margin: 1000
+                    pkts_num_trig_pfc: 33952
+                    pkts_num_hdrm_full: 32218
+                    pkts_num_hdrm_partial: 32208
+                    margin: 10
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 373323
-                    pkts_num_trig_ingr_drp: 932731
+                    pkts_num_trig_pfc: 774650
+                    pkts_num_trig_ingr_drp: 1488048
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 373323
-                    pkts_num_dismiss_pfc: 12983
+                    pkts_num_trig_pfc: 774650
+                    pkts_num_dismiss_pfc: 12982
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 373323
-                    pkts_num_dismiss_pfc: 12983
+                    pkts_num_trig_pfc: 774650
+                    pkts_num_dismiss_pfc: 12982
                     pkts_num_margin: 150
                 lossy_queue_1:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_trig_egr_drp: 534000
-                    pkts_num_margin: 1000
+                    pkts_num_trig_egr_drp: 2019146
+                    pkts_num_margin: 100
                 wm_pg_shared_lossless:
                     dscp: 3
                     ecn: 1
                     pg: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_pfc: 373323
+                    pkts_num_trig_pfc: 774650
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -137,7 +137,7 @@ qos_params:
                     ecn: 1
                     pg: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 534000
+                    pkts_num_trig_egr_drp: 2019146
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -146,33 +146,14 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 932731
-                    cell_size: 4096
-                wm_buf_pool_lossless:
-                    dscp: 3
-                    ecn: 1
-                    pg: 3
-                    queue: 3
-                    pkts_num_fill_ingr_min: 0
-                    pkts_num_trig_pfc: 373323
-                    pkts_num_trig_ingr_drp: 932731
-                    pkts_num_fill_egr_min: 8
+                    pkts_num_trig_ingr_drp: 1488048
                     cell_size: 4096
                 wm_q_shared_lossy:
                     dscp: 8
                     ecn: 1
                     queue: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 534000
-                    cell_size: 4096
-                wm_buf_pool_lossy:
-                    dscp: 8
-                    ecn: 1
-                    pg: 0
-                    queue: 0
-                    pkts_num_fill_ingr_min: 0
-                    pkts_num_trig_egr_drp: 534000
-                    pkts_num_fill_egr_min: 0
+                    pkts_num_trig_egr_drp: 2019146
                     cell_size: 4096
             100000_120000m:
                 pkts_num_leak_out: 5
@@ -288,63 +269,63 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 373323
-                    pkts_num_trig_ingr_drp: 377917
+                    pkts_num_trig_pfc: 774650
+                    pkts_num_trig_ingr_drp: 787523
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 373323
-                    pkts_num_trig_ingr_drp: 377917
+                    pkts_num_trig_pfc: 774650
+                    pkts_num_trig_ingr_drp: 787523
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [3, 4]
                     ecn: 1
                     pgs: [3, 4]
                     src_port_ids: [0]
-                    dst_port_id: 0
+                    dst_port_id: 18
                     pgs_num: 2
-                    packet_size: 1246
+                    packet_size: 2430
                     cell_size: 4096
-                    pkts_num_trig_pfc: 32312
-                    pkts_num_hdrm_full: 397
-                    pkts_num_hdrm_partial: 205
-                    margin: 1000
+                    pkts_num_trig_pfc: 33952
+                    pkts_num_hdrm_full: 581
+                    pkts_num_hdrm_partial: 571
+                    margin: 10
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 373323
-                    pkts_num_trig_ingr_drp: 377917
+                    pkts_num_trig_pfc: 774650
+                    pkts_num_trig_ingr_drp: 787523
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 373323
-                    pkts_num_dismiss_pfc: 12983
+                    pkts_num_trig_pfc: 774650
+                    pkts_num_dismiss_pfc: 12982
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 373323
-                    pkts_num_dismiss_pfc: 12983
+                    pkts_num_trig_pfc: 774650
+                    pkts_num_dismiss_pfc: 12982
                     pkts_num_margin: 150
                 lossy_queue_1:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_trig_egr_drp: 534000
-                    pkts_num_margin: 1000
+                    pkts_num_trig_egr_drp: 2019146
+                    pkts_num_margin: 100
                 wm_pg_shared_lossless:
                     dscp: 3
                     ecn: 1
                     pg: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_pfc: 373323
+                    pkts_num_trig_pfc: 774650
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -353,7 +334,7 @@ qos_params:
                     ecn: 1
                     pg: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 534000
+                    pkts_num_trig_egr_drp: 2019146
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -362,33 +343,181 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 377917
-                    cell_size: 4096
-                wm_buf_pool_lossless:
-                    dscp: 3
-                    ecn: 1
-                    pg: 3
-                    queue: 3
-                    pkts_num_fill_ingr_min: 0
-                    pkts_num_trig_pfc: 373323
-                    pkts_num_trig_ingr_drp: 377917
-                    pkts_num_fill_egr_min: 8
+                    pkts_num_trig_ingr_drp: 787523
                     cell_size: 4096
                 wm_q_shared_lossy:
                     dscp: 8
                     ecn: 1
                     queue: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 534000
+                    pkts_num_trig_egr_drp: 2019146
                     cell_size: 4096
-                wm_buf_pool_lossy:
+            800000_30m:
+                pkts_num_leak_out: 140
+                internal_hdr_size: 48
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 1503732
+                    pkts_num_trig_ingr_drp: 1529185
+                    pkts_num_margin: 150
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 1503732
+                    pkts_num_trig_ingr_drp: 1529185
+                    pkts_num_margin: 150
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 1503732
+                    pkts_num_trig_ingr_drp: 1529185
+                    cell_size: 4096
+                    pkts_num_margin: 30
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 1503732
+                    pkts_num_dismiss_pfc: 25964
+                    pkts_num_margin: 150
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 1503732
+                    pkts_num_dismiss_pfc: 25964
+                    pkts_num_margin: 150
+                lossy_queue_1:
                     dscp: 8
                     ecn: 1
                     pg: 0
+                    pkts_num_trig_egr_drp: 2019146
+                    pkts_num_margin: 100
+                wm_pg_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_pfc: 1503732
+                    packet_size: 64
+                    cell_size: 4096
+                    pkts_num_margin: 40
+                wm_pg_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 2019146
+                    packet_size: 64
+                    cell_size: 4096
+                    pkts_num_margin: 40
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 1529185
+                    cell_size: 4096
+                wm_q_shared_lossy:
+                    dscp: 8
+                    ecn: 1
                     queue: 0
-                    pkts_num_fill_ingr_min: 0
-                    pkts_num_trig_egr_drp: 534000
-                    pkts_num_fill_egr_min: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 2019146
+                    cell_size: 4096
+            800000_120000m:
+                pkts_num_leak_out: 140
+                internal_hdr_size: 48
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 1503732
+                    pkts_num_trig_ingr_drp: 2930200
+                    pkts_num_margin: 150
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 1503732
+                    pkts_num_trig_ingr_drp: 2930200
+                    pkts_num_margin: 150
+                hdrm_pool_size:
+                    dscps: [3, 4]
+                    ecn: 1
+                    pgs: [3, 4]
+                    src_port_ids: [0]
+                    dst_port_id: 18
+                    pgs_num: 2
+                    packet_size: 2286
+                    cell_size: 4096
+                    pkts_num_trig_pfc: 68086
+                    pkts_num_hdrm_full: 68392
+                    pkts_num_hdrm_partial: 68382
+                    margin: 10
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 1503732
+                    pkts_num_trig_ingr_drp: 2930200
+                    cell_size: 4096
+                    pkts_num_margin: 30
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 1503732
+                    pkts_num_dismiss_pfc: 25964
+                    pkts_num_margin: 150
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 1503732
+                    pkts_num_dismiss_pfc: 25964
+                    pkts_num_margin: 150
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_trig_egr_drp: 2019146
+                    pkts_num_margin: 100
+                wm_pg_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_pfc: 1503732
+                    packet_size: 64
+                    cell_size: 4096
+                    pkts_num_margin: 40
+                wm_pg_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 2019146
+                    packet_size: 64
+                    cell_size: 4096
+                    pkts_num_margin: 40
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 2930200
+                    cell_size: 4096
+                wm_q_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    queue: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 2019146
                     cell_size: 4096
             wrr:
                 dscp_list: [0, 47, 3, 4, 46, 44]
@@ -404,8 +533,40 @@ qos_params:
                 lossy_weight: 8
                 q_list: [0, 1, 3, 4, 5, 6]
                 q_pkt_cnt: [80, 100, 300, 100, 100, 700]
+            ecn_1:
+                dscp: 8
+                ecn: 0
+                num_of_pkts: 5000
+                limit: 182000
+                min_limit: 180000
+                cell_size: 4096
+            ecn_2:
+                dscp: 8
+                ecn: 1
+                num_of_pkts: 2047
+                limit: 182320
+                min_limit: 0
+                cell_size: 4096
+            ecn_3:
+                dscp: 0
+                ecn: 0
+                num_of_pkts: 5000
+                limit: 182000
+                min_limit: 180000
+                cell_size: 4096
+            ecn_4:
+                dscp: 0
+                ecn: 1
+                num_of_pkts: 2047
+                limit: 182320
+                min_limit: 0
+                cell_size: 4096
+            hdrm_pool_wm_multiplier: 1
+            cell_size: 4096
         topo-t2-single-node-min: *topo-t2_single_node_min
+        topo-t2_single_node_max: *topo-t2_single_node_min
         topo-t2-single-node-max-64p: *topo-t2_single_node_min
         topo-t2_single_node_max_64p: *topo-t2_single_node_min
+        topo-t2_single_node_max_64p_v2: *topo-t2_single_node_min
         topo-any:
             cell_size: 4096


### PR DESCRIPTION
* Fix min topology name to use underscores `_` instead of dashes `-`
* Add the 2 topologies to the Q3D qos params (`t2_single_node_max` and `t2_single_node_max_64p_v2`)
* Update the t2_single_node_min topo with 800G speed and other fresh params

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
This is the 202511 backport of https://github.com/sonic-net/sonic-mgmt/pull/24283

### Approach
#### What is the motivation for this PR?
Add 2 more topologies using Q3D to enable QoS tests on them
Update the existing topology with correct test parameters

#### How did you do it?
Computed the values based on the Q3D buffer sizes.

#### How did you verify/test it?
Ran the qos/ test library of sonic-mgmt without error

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
