### PR TITLE
Add missing qos test support for q3d

### DIFF
--- a/tests/qos/files/vs/dutConfig.json
+++ b/tests/qos/files/vs/dutConfig.json
@@ -2873,6 +2873,749 @@
           }
         }
       },
+      "q3d": {
+        "topo-any": {
+          "100000_120000m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 18,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 18,
+              "pkts_num_hdrm_full": 362,
+              "pkts_num_hdrm_partial": 182,
+              "pkts_num_trig_pfc": 37549,
+              "src_port_ids": [
+                0,
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16
+              ]
+            },
+            "internal_hdr_size": 48,
+            "lossy_queue_1": {
+              "dscp": 7,
+              "ecn": 1,
+              "pg": 1,
+              "pkts_num_margin": 200,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "pkts_num_leak_out": 5,
+            "wm_buf_pool_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_ingr_drp": 216064,
+              "pkts_num_trig_pfc": 37549,
+              "queue": 3
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 0,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "wm_pg_headroom": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 30,
+              "pkts_num_trig_ingr_drp": 216064,
+              "pkts_num_trig_pfc": 37449
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 51,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_pfc": 37449
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 51,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 216064,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 216064,
+              "pkts_num_trig_pfc": 37449
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 216064,
+              "pkts_num_trig_pfc": 37449
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 37449
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 37449
+            }
+          },
+          "100000_2000m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 18,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 18,
+              "pkts_num_hdrm_full": 362,
+              "pkts_num_hdrm_partial": 182,
+              "pkts_num_trig_pfc": 35208,
+              "src_port_ids": [
+                0,
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16
+              ]
+            },
+            "internal_hdr_size": 48,
+            "lossy_queue_1": {
+              "dscp": 7,
+              "ecn": 1,
+              "pg": 1,
+              "pkts_num_margin": 200,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "pkts_num_leak_out": 5,
+            "wm_buf_pool_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_ingr_drp": 38619,
+              "pkts_num_trig_pfc": 35108,
+              "queue": 3
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 0,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "wm_pg_headroom": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 30,
+              "pkts_num_trig_ingr_drp": 38619,
+              "pkts_num_trig_pfc": 35108
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 51,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_pfc": 9874
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 51,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 38619,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 38619,
+              "pkts_num_trig_pfc": 35108
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 38619,
+              "pkts_num_trig_pfc": 35108
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 35108
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 35108
+            }
+          },
+          "100000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 18,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 18,
+              "pkts_num_hdrm_full": 362,
+              "pkts_num_hdrm_partial": 182,
+              "pkts_num_trig_pfc": 9974,
+              "src_port_ids": [
+                0,
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16
+              ]
+            },
+            "internal_hdr_size": 48,
+            "lossy_queue_1": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_margin": 200,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "pkts_num_leak_out": 5,
+            "wm_buf_pool_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_ingr_drp": 10861,
+              "pkts_num_trig_pfc": 9974,
+              "queue": 3
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 0,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "wm_pg_headroom": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 30,
+              "pkts_num_trig_ingr_drp": 10861,
+              "pkts_num_trig_pfc": 9874
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 51,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_pfc": 9874
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 51,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 10861,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 10861,
+              "pkts_num_trig_pfc": 9874
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 10861,
+              "pkts_num_trig_pfc": 9874
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 9874
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 9874
+            }
+          },
+          "400000_120000m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 18,
+              "ecn": 1,
+              "margin": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 18,
+              "pkts_num_hdrm_full": 362,
+              "pkts_num_hdrm_partial": 182,
+              "pkts_num_trig_pfc": 37549,
+              "src_port_ids": [
+                0,
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16
+              ]
+            },
+            "internal_hdr_size": 48,
+            "lossy_queue_1": {
+              "dscp": 7,
+              "ecn": 1,
+              "pg": 1,
+              "pkts_num_margin": 3500,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "pkts_num_leak_out": 140,
+            "wm_buf_pool_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_ingr_drp": 750848,
+              "pkts_num_trig_pfc": 28160,
+              "queue": 3
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 0,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "wm_pg_headroom": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 30,
+              "pkts_num_trig_ingr_drp": 750848,
+              "pkts_num_trig_pfc": 37449
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 71,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_pfc": 37449
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 71,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 750848,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 750848,
+              "pkts_num_trig_pfc": 37449
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 750848,
+              "pkts_num_trig_pfc": 37449
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 37449
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 37449
+            }
+          },
+          "400000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 18,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 18,
+              "pkts_num_hdrm_full": 362,
+              "pkts_num_hdrm_partial": 182,
+              "pkts_num_trig_pfc": 28260,
+              "src_port_ids": [
+                0,
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16
+              ]
+            },
+            "internal_hdr_size": 48,
+            "lossy_queue_1": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_margin": 3500,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "pkts_num_leak_out": 71,
+            "wm_buf_pool_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_ingr_drp": 28187,
+              "pkts_num_trig_pfc": 28160,
+              "queue": 3
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 0,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "wm_pg_headroom": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 30,
+              "pkts_num_trig_ingr_drp": 28187,
+              "pkts_num_trig_pfc": 28160
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 71,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_pfc": 28160
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 71,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 28187,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 28187,
+              "pkts_num_trig_pfc": 28160
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 28187,
+              "pkts_num_trig_pfc": 28160
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 28160
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 28160
+            }
+          },
+          "cell_size": 4096,
+          "ecn_1": {
+            "cell_size": 4096,
+            "dscp": 8,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_2": {
+            "cell_size": 4096,
+            "dscp": 8,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "ecn_3": {
+            "cell_size": 4096,
+            "dscp": 0,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_4": {
+            "cell_size": 4096,
+            "dscp": 0,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "hdrm_pool_wm_multiplier": 1,
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 140,
+            "q1_num_of_pkts": 140,
+            "q2_num_of_pkts": 140,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 140,
+            "q6_num_of_pkts": 140
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 150,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 80,
+            "q1_num_of_pkts": 80,
+            "q2_num_of_pkts": 80,
+            "q3_num_of_pkts": 300,
+            "q4_num_of_pkts": 300,
+            "q5_num_of_pkts": 80,
+            "q6_num_of_pkts": 80
+          }
+        }
+      },
       "mellanox": {
         "topo-any": {
           "ecn_1": {

--- a/tests/qos/tunnel_qos_remap_base.py
+++ b/tests/qos/tunnel_qos_remap_base.py
@@ -275,7 +275,7 @@ def _lossless_profile_name(dut, port_name, pgs='2-4'):
 def qos_config(rand_selected_dut, tbinfo, dut_config):
     duthost = rand_selected_dut
     SUPPORTED_ASIC_LIST = ["gb", "td2", "th", "th2",
-                           "spc1", "spc2", "spc3", "td3", "th3", "j2c+", "jr2"]
+                           "spc1", "spc2", "spc3", "td3", "th3", "j2c+", "jr2", "q3d"]
 
     qos_configs = {}
     with open(r"qos/files/qos.yml") as file:


### PR DESCRIPTION
Add VS params and q3d to list of supported asics

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
