### PR TITLE
[dhcp_relay] Ignore KVM-only e1000 "Reset adapter" syslog noise in test_dhcpv4_relay

### DIFF
--- a/tests/dhcp_relay/test_dhcpv4_relay.py
+++ b/tests/dhcp_relay/test_dhcpv4_relay.py
@@ -181,7 +181,8 @@ def ignore_expected_loganalyzer_exceptions(
         ignoreRegex = [
             r".*ERR snmp#snmp-subagent.*",
             r".*ERR rsyslogd: omfwd: socket (\d+): error (\d+) sending via udp: Network is (unreachable|down).*",
-            r".*ERR rsyslogd: omfwd/udp: socket (\d+): sendto\(\) error: Network is (unreachable|down).*"
+            r".*ERR rsyslogd: omfwd/udp: socket (\d+): sendto\(\) error: Network is (unreachable|down).*",
+            r".*ERR kernel.*e1000.*Reset adapter.*"
         ]
         loganalyzer[rand_one_dut_hostname].ignore_regex.extend(ignoreRegex)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Suppress a KVM-only e1000 emulated-NIC syslog line that causes false-positive loganalyzer failures in tests/dhcp_relay/test_dhcpv4_relay.py.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

test_dhcp_relay_agent_mode[discard-sonic-relay-agent] intermittently fails on KVM testbeds with the loganalyzer matching:

 ERR kernel: e1000 0000:02:02.0 eth0: Reset adapter unexpectedly

This is a qemu emulated-NIC artifact (the e1000 model resets under TX pressure during container restart) and is not a SONiC bug. It does not occur on physical hardware.

#### How did you do it?

Appended one regex to the existing ignore_expected_loganalyzer_exceptions fixture in test_dhcpv4_relay.py so the noisy line is ignored only for this module. Same pattern is already used in tests/drop_packets/test_drop_counters.py (KVMIgnoreRegex) and tests/generic_config_updater/conftest.py.

#### How did you verify/test it?

 - Reproduced the failure on KVM (sonic-relay-agent variant only).
 - Ran test_dhcp_relay_agent_mode (3 variants) on real 720dt hardware (bjw2-can-720dt-4): all PASSED, and DUT syslog over the test window contained 0 kernel: / 0 NIC reset entries — confirming the message is qemu-only.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
