### PR TITLE
[dhcp_server] skip dhcpmon in dhcp_relay readiness when SONiC dhcp relay agent enabled

### DIFF
--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -25,9 +25,17 @@ def restart_dhcp_service(duthost):
     duthost.shell('systemctl restart dhcp_relay')
     duthost.shell('systemctl reset-failed dhcp_relay')
 
+    # In SONiC dhcp relay agent mode, dhcprelayd stops dhcpmon by design,
+    # so exclude it from the readiness check (dhcprelayd.py refresh_dhcrelay TODO).
+    has_sonic_relay = duthost.shell(
+        'sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "has_sonic_dhcpv4_relay"',
+        module_ignore_errors=True)['stdout'].strip() == 'True'
+
     def _is_dhcp_relay_ready():
-        output = duthost.shell('docker exec dhcp_relay supervisorctl status | grep dhc | awk \'{print $2}\'',
-                               module_ignore_errors=True)
+        filter_cmd = 'grep dhc | grep -v dhcpmon' if has_sonic_relay else 'grep dhc'
+        output = duthost.shell(
+            "docker exec dhcp_relay supervisorctl status | {} | awk '{{print $2}}'".format(filter_cmd),
+            module_ignore_errors=True)
         return (not output['rc'] and output['stderr'] == '' and len(output['stdout_lines']) != 0 and
                 all(element == 'RUNNING' for element in output['stdout_lines']))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: The restart_dhcp_service helper in tests/common/dhcp_relay_utils.py waits for every supervisor program matching dhc* to be RUNNING. When the SONiC dhcp relay agent is enabled (DEVICE_METADATA.localhost.has_sonic_dhcpv4_relay = True), dhcprelayd intentionally stops dhcpmon (see TODO in sonic-buildimage 
src/sonic-dhcp-utilities/dhcp_utilities/dhcprelayd/dhcprelayd.py:refresh_dhcrelay), but the supervisord template still emits [program:dhcpmon-<vlan>]. The result: dhcpmon-<vlan> stays STOPPED forever and the predicate times out at 120 s with dhcp_relay is not ready after restarting, breaking any test that flips into SONiC dhcp relay mode (e.g. dhcp_server
parametrized with [gcu-sonic-relay-agent] / [cli-sonic-relay-agent]).

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

The dhcp_server suite hits a deterministic 120 s setup timeout on every parametrize variant that enables the SONiC dhcp relay agent, because the readiness check requires a process that the agent intentionally keeps stopped.

#### How did you do it?

Read has_sonic_dhcpv4_relay from CONFIG_DB once before the wait loop. When True, exclude dhcpmon-* from the supervisorctl status filter. ISC-mode behavior (and the readiness contract for dhcp4relay, dhcp6relay, dhcprelayd) is unchanged.

#### How did you verify/test it?

 - Reproduced on testbed-bjw2-can-7215-4 (Nokia-7215, SONiC.20251110.23): observed the gcu-sonic-relay-agent / cli-sonic-relay-agent setup errors with the exact dhcp_relay is not ready after restarting message.
 - Root-cause confirmed by manually flipping has_sonic_dhcpv4_relay=True and restarting dhcp_relay; supervisord syslog shows dhcpmon-Vlan1000 enter RUNNING, then dhcprelayd issuing supervisorctl stop dhcpmon:dhcpmon-Vlan1000 ~2 s later, with steady state RUNNING/RUNNING/RUNNING/STOPPED.
 - Verified the master sonic-buildimage dhcprelayd.py and dhcp-relay.monitors.j2 still produce the same behavior, so the fix belongs on the test side.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
