### PR TITLE
[202511] tests: clean up PTF residue from VRF and ARP-responder tests

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -627,6 +627,10 @@ def populate_vlan_arp_entries(setup, ptfhost, duthosts, rand_one_dut_hostname, i
 
     logging.info("Stopping ARP responder")
     ptfhost.shell("supervisorctl stop arp_responder", module_ignore_errors=True)
+    # Remove the rendered arp_responder config we wrote above so it can't be
+    # picked up by a stale invocation in a later test and so /tmp doesn't
+    # accumulate state that mis-leads on-PTF debugging.
+    ptfhost.file(path="/tmp/from_t1.json", state="absent")
 
     for dut in duthosts:
         dut.command("sonic-clear fdb all")

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -257,6 +257,11 @@ def setup_vlan_arp_responder(ptfhost, rand_selected_dut, tbinfo):
     yield vlan, ipv4_base, ipv6_base, ip_offset
 
     ptfhost.command('supervisorctl stop arp_responder')
+    # Remove the rendered config so it can't mislead diagnostics or be picked up
+    # by a later, stale invocation of arp_responder. The supervisor unit file
+    # itself is intentionally left in place because the autouse fixture re-renders
+    # it on every module setup; deleting only the data file is enough.
+    ptfhost.file(path=CFG_FILE, state="absent")
 
 
 def _ptf_portmap_file(duthost, ptfhost, tbinfo):

--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -465,6 +465,9 @@ def arp_responder(ptfhost, testbed_params, tbinfo):
 
     logging.info("Stopping ARP responder")
     ptfhost.shell("supervisorctl stop arp_responder", module_ignore_errors=True)
+    # Drop the rendered config we wrote earlier in this fixture so the next
+    # arp_responder invocation cannot inherit our IP/MAC mapping by default.
+    ptfhost.file(path="/tmp/from_t1.json", state="absent")
 
 
 @pytest.fixture

--- a/tests/dualtor/conftest.py
+++ b/tests/dualtor/conftest.py
@@ -113,6 +113,10 @@ def run_arp_responder_ipv6(rand_selected_dut, ptfhost, tbinfo, apply_mock_dual_t
     yield
 
     ptfhost.shell('supervisorctl stop arp_responder', module_ignore_errors=True)
+    # Drop the rendered config so the next test that uses arp_responder cannot
+    # accidentally pick up our IP/MAC mapping (and so /tmp doesn't collect stale
+    # state that misleads diagnostics).
+    ptfhost.file(path='/tmp/from_t1.json', state='absent')
 
 
 @pytest.fixture(scope="module")
@@ -121,6 +125,7 @@ def run_arp_responder(rand_selected_dut, ptfhost, tbinfo):
     yield
 
     ptfhost.shell('supervisorctl stop arp_responder', module_ignore_errors=True)
+    ptfhost.file(path='/tmp/from_t1.json', state='absent')
 
 
 @pytest.fixture(scope="module")

--- a/tests/ecmp/test_fgnhg.py
+++ b/tests/ecmp/test_fgnhg.py
@@ -606,6 +606,10 @@ def fg_ecmp_to_regular_ecmp_transitions(ptfhost, duthost, router_mac, net_ports,
 def cleanup(duthost, ptfhost):
     logger.info("Start cleanup")
     ptfhost.command('rm -f /tmp/fg_ecmp_persist_map.json')
+    # Stop arp_responder and remove the rendered config so a stale invocation
+    # in a later test cannot inherit our IP/MAC mapping for /tmp/from_t1.json.
+    ptfhost.command('supervisorctl stop arp_responder', module_ignore_errors=True)
+    ptfhost.command('rm -f /tmp/from_t1.json')
     config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
 
 

--- a/tests/pc/test_lag_member.py
+++ b/tests/pc/test_lag_member.py
@@ -141,6 +141,10 @@ def ptf_teardown(ptfhost, ptf_ports):
                                                  ptf_ports[ATTR_PORT_NOT_BEHIND_LAG]["port_name"]))
     ptfhost.ptf_nn_agent()
     ptfhost.shell('supervisorctl stop arp_responder', module_ignore_errors=True)
+    # Remove the arp_responder config rendered during setup_ptf_lag so it cannot
+    # be re-used by a subsequent test that starts arp_responder with the default
+    # config path.
+    ptfhost.file(path="/tmp/from_t1.json", state="absent")
 
 
 def setup_dut_lag(duthost, dut_ports, vlan, src_vlan_id):

--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -81,6 +81,10 @@ def del_ipaddr(ptfhost, nexthop_addrs, prefix_len, nexthop_devs, ipv6=False):
             )
     else:
         ptfhost.shell('supervisorctl stop arp_responder', module_ignore_errors=True)
+        # Remove the arp_responder config that add_ipaddr() wrote earlier so it
+        # cannot be picked up by a later test invoking arp_responder with its
+        # default config path.
+        ptfhost.file(path="/tmp/from_t1.json", state="absent")
 
 
 def clear_arp_ndp(duthost, ipv6=False):

--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -290,6 +290,11 @@ def setup_vlan_peer(duthost, ptfhost, cfg_facts):
     vlan_peer_ips = {}
     vlan_peer_vrf2ns_map = {}
 
+    # Defensive: wipe any residue from a previously crashed run so that the
+    # macvlan/netns add commands below cannot fail with EEXIST and leave half
+    # the state behind (which is what produces leaks across runs).
+    cleanup_vlan_peer(ptfhost)
+
     for vlan in list(cfg_facts["VLAN"].keys()):
         ns = "ns" + vlan.strip("Vlan")
         vrf = cfg_facts["VLAN_INTERFACE"][vlan]["vrf_name"]
@@ -325,11 +330,73 @@ def setup_vlan_peer(duthost, ptfhost, cfg_facts):
     return vlan_peer_ips, vlan_peer_vrf2ns_map
 
 
-def cleanup_vlan_peer(ptfhost, vlan_peer_vrf2ns_map, vlan_peer_ips):
-    for _, vlan_peer_port in vlan_peer_ips.keys():
-        ptfhost.shell(f"ip link del e{vlan_peer_port}mv1 || true")
-    for vrf, ns in list(vlan_peer_vrf2ns_map.items()):
-        ptfhost.shell(f"ip netns del {ns}")
+def cleanup_vlan_peer(ptfhost, vlan_peer_vrf2ns_map=None, vlan_peer_ips=None):
+    """Tear down VRF VLAN-peer state that setup_vlan_peer / gen_vrf_*_file create
+    on the PTF host.
+
+    Failure to clean up macvlan children (e<N>mv1) and their namespaces (ns<vid>)
+    leaks an extra L3 endpoint that holds the same IP as the VLAN SVI's first
+    neighbor (e.g. 192.168.0.2/21 on Vlan1000). Because macvlan-bridge mode
+    forwards ARP requests for that IP to the child interface, the in-namespace
+    kernel answers with the macvlan's auto-assigned locally-administered MAC.
+    Any later test on the same testbed that legitimately uses the same neighbor
+    IP (e.g. tests/bgp/test_bgp_update_replication.py's route_injector pinned to
+    192.168.0.2) will then race two ARP answerers on every DUT probe and see
+    intermittent BGP flaps when the DUT's neighbor entry is overwritten.
+
+    This function is intentionally defensive:
+      * idempotent: missing interfaces/namespaces/files are not errors;
+      * discovery-based: it sweeps any e<N>mv<N>/ns<N> residue that this run
+        didn't track (e.g. left over from a previously killed run), so leaks
+        cannot accumulate across runs;
+      * file-aware: it removes the rendered /tmp/vrf*_neigh.txt and
+        /tmp/vrf*_fib.txt artifacts so they cannot be misread as live state by
+        the next test or by an operator triaging the PTF.
+    """
+    # 1) Remove tracked macvlan children + namespaces from this run.
+    if vlan_peer_ips:
+        for _, vlan_peer_port in vlan_peer_ips.keys():
+            ptfhost.shell("ip link del e{}mv1 || true".format(vlan_peer_port),
+                          module_ignore_errors=True)
+    if vlan_peer_vrf2ns_map:
+        for _, ns in list(vlan_peer_vrf2ns_map.items()):
+            ptfhost.shell("ip netns del {} || true".format(ns),
+                          module_ignore_errors=True)
+
+    # 2) Defensive sweep: any residue from a previously crashed/killed run.
+    ptfhost.shell(
+        "for d in $(ip -o link show 2>/dev/null | awk -F': ' '{print $2}' "
+        "| awk -F'@' '{print $1}' | grep -E '^e[0-9]+mv[0-9]+$'); do "
+        "ip link del \"$d\" || true; done",
+        module_ignore_errors=True,
+    )
+    ptfhost.shell(
+        "for n in $(ip -o netns list 2>/dev/null | awk '{print $1}' "
+        "| grep -E '^ns[0-9]+$'); do ip netns del \"$n\" || true; done",
+        module_ignore_errors=True,
+    )
+
+    # 3) Remove generated PTF state files so stale neigh files cannot poison
+    # the next test's IP plan or mislead diagnostics. This list is the union of
+    # everything any class in tests/vrf/* writes under /tmp via gen_vrf_neigh_file,
+    # gen_vrf_fib_file, gen_specific_neigh_file, and the per-class shell scripts.
+    ptfhost.shell(
+        "rm -f "
+        # gen_vrf_neigh_file / gen_vrf_fib_file (test_vrf.py + test_vrf_attr.py)
+        "/tmp/vrf1_neigh.txt /tmp/vrf2_neigh.txt "
+        "/tmp/vrf1_fib.txt /tmp/vrf2_fib.txt "
+        # vrf_capacity tests
+        "/tmp/vrf_capability_fwd.txt "
+        # TestVrfAclRedirect (test_vrf.py)
+        "/tmp/pc01_neigh_ipv4.txt /tmp/pc01_neigh_ipv6.txt "
+        "/tmp/redirect_pc01_neigh_ipv4.txt /tmp/redirect_pc01_neigh_ipv6.txt "
+        # TestVrfUnbindIntf (test_vrf.py)
+        "/tmp/unbindvrf_neigh_1.txt /tmp/unbindvrf_neigh_2.txt "
+        "/tmp/unbindvrf_fib_1.txt /tmp/unbindvrf_fib_2.txt "
+        # TestVrfRebindIntf (test_vrf.py)
+        "/tmp/rebindvrf_vrf1_fib.txt",
+        module_ignore_errors=True,
+    )
 
 
 def gen_vrf_fib_file(
@@ -480,6 +547,18 @@ def cfg_facts(duthosts, rand_one_dut_hostname):
 
 
 def restore_config_db(localhost, duthost, ptfhost):
+    # PTF-side cleanup is independent of the DUT and is the source of cross-test
+    # ARP/MAC pollution if it leaks (see cleanup_vlan_peer docstring). Run it in
+    # a try/finally so a slow or failing DUT reboot below cannot skip it.
+    try:
+        cleanup_vlan_peer(
+            ptfhost,
+            g_vars.get('vlan_peer_vrf2ns_map', {}),
+            g_vars.get('vlan_peer_ips', {}),
+        )
+    except Exception as e:
+        logger.warning("PTF VRF cleanup raised an exception (continuing to DUT restore): %s", e)
+
     # In case something went wrong in previous reboot, wait until the DUT is accessible to ensure that
     # the `mv /etc/sonic/config_db.json.bak /etc/sonic/config_db.json` is executed on DUT.
     # If the DUT is still inaccessible after timeout, we may have already lose the DUT. Something sad happened.
@@ -488,12 +567,6 @@ def restore_config_db(localhost, duthost, ptfhost):
     )  # Similiar approach to increase the chance that the next line get executed.
     duthost.shell("mv /etc/sonic/config_db.json.bak /etc/sonic/config_db.json")
     reboot(duthost, localhost)
-
-    cleanup_vlan_peer(
-        ptfhost,
-        g_vars["vlan_peer_vrf2ns_map"] if "vlan_peer_vrf2ns_map" in g_vars else {},
-        g_vars["vlan_peer_ips"] if "vlan_peer_ips" in g_vars else {},
-    )
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/vrf/test_vrf_attr.py
+++ b/tests/vrf/test_vrf_attr.py
@@ -44,12 +44,20 @@ class TestVrfAttrSrcMac():
         yield
 
         # -------- Teardown ----------
-        extra_vars = {'router_mac': dut_facts['router_mac']}
-        duthost.host.options['variable_manager'].extra_vars.update(extra_vars)
-        duthost.template(src="vrf/vrf_attr_src_mac.j2",
-                         dest="/tmp/vrf_attr_src_mac.json")
+        try:
+            extra_vars = {'router_mac': dut_facts['router_mac']}
+            duthost.host.options['variable_manager'].extra_vars.update(extra_vars)
+            duthost.template(src="vrf/vrf_attr_src_mac.j2",
+                             dest="/tmp/vrf_attr_src_mac.json")
 
-        duthost.shell("config load -y /tmp/vrf_attr_src_mac.json")
+            duthost.shell("config load -y /tmp/vrf_attr_src_mac.json")
+        finally:
+            # Remove the rendered VRF neighbor files we generated above. The
+            # module-level setup_vrf teardown removes them too via cleanup_vlan_peer,
+            # but doing it here as well guarantees no residue if the DUT teardown
+            # path errors out and the test framework skips the module finalizer.
+            ptfhost.shell("rm -f /tmp/vrf1_neigh.txt /tmp/vrf2_neigh.txt",
+                          module_ignore_errors=True)
 
     def test_vrf_src_mac_cfg(self, duthosts, rand_one_dut_hostname):
         duthost = duthosts[rand_one_dut_hostname]


### PR DESCRIPTION
Backport of #24218 to `202511`. Same 8 per-suite commits, applied on top of `202511` via cherry-pick of the squash-merged change `ad0978e70` from `master`; auto-merge was clean on all 9 files. Added/removed lines are byte-identical to the master diff (verified by hash).

### Description of PR

Several test fixtures left state on the PTF after teardown. The most damaging case was `tests/vrf/test_vrf.py` leaking macvlan children (`e<N>mv1`) and their network namespaces (`ns<vid>`) on every aborted run. Because macvlan-bridge mode answers ARP for the in-namespace IP, this poisons the VLAN broadcast domain — a later test that legitimately uses `192.168.0.2` (e.g. `tests/bgp/test_bgp_update_replication.py`'s route injector) sees two ARP answerers and the DUT's neighbor entry flips between them, causing intermittent BGP session flaps several minutes into the run.

This PR fixes the leaks at the producer side so each test cleans up after itself. Changes are split into one commit per test suite for ownership-specific review.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
  - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

(This PR is itself the 202511 backport of #24218.)

### Approach

#### What is the motivation for this PR?

The VRF test suite was leaking PTF state across runs in a way that silently breaks unrelated BGP tests on the same testbed minutes later. Several other ARP-responder owners also leak `/tmp/from_t1.json` (and one similar file in the shared VLAN ARP-responder fixture). Producer-side cleanup is the right fix because it removes whole classes of cross-test pollution rather than chasing symptoms.

#### How did you do it?

Per-suite commits (in order):

* **tests/vrf** — `cleanup_vlan_peer` is now idempotent and discovery-based: it removes both tracked and leaked `e<N>mv<N>` / `ns<N>` residue, plus the rendered `/tmp/vrf*_neigh.txt`, `/tmp/vrf*_fib.txt`, `/tmp/vrf_capability_fwd.txt`, `/tmp/pc01_neigh_*.txt`, `/tmp/redirect_pc01_neigh_*.txt`, `/tmp/unbindvrf_*.txt`, and `/tmp/rebindvrf_vrf1_fib.txt` artifacts. `setup_vlan_peer` now calls it first so any pre-existing residue cannot make `ip netns add` fail with EEXIST. `restore_config_db` runs PTF cleanup before the DUT reboot, in a try/except, so a flaky reboot cannot skip PTF teardown. `TestVrfAttrSrcMac` removes its own `/tmp/vrf*_neigh.txt` files in a `finally` block.
* **tests/common/fixtures/ptfhost_utils** — `setup_vlan_arp_responder` removes `/tmp/arp_responder_vlan.json` (the `CFG_FILE` constant) on teardown.
* **tests/{acl,dualtor,drop_packets,ecmp,pc,route}** — each `arp_responder` owner that writes `/tmp/from_t1.json` during setup now removes it on teardown so a stale config cannot be picked up by a later `arp_responder` invocation. For `tests/ecmp/test_fgnhg.py` the cleanup fixture also stops the supervisor unit (it didn't before).

Teardown-only changes; no setup behavior changes for the happy path.

#### How did you verify/test it?

* Ran `tests/vrf/test_vrf.py` to completion on a t0 testbed and confirmed `/tmp/*.txt` and the `e<N>mv*` / `ns*` interfaces are absent on the PTF after teardown.
* Ran `tests/vrf/test_vrf_attr.py` and confirmed `/tmp/vrf{1,2}_neigh.txt` are removed.
* Ran `tests/bgp/test_bgp_update_replication.py` immediately after a VRF run and confirmed no intermittent BGP flap on the `192.168.0.2` peer.
* Sanity-ran one of `tests/acl/test_acl.py`, `tests/route/test_static_route.py`, `tests/dualtor/`, etc. and confirmed `/tmp/from_t1.json` is removed at module teardown.
* `py_compile` and `flake8 --max-line-length=120` clean on all touched files (no new warnings introduced).

#### Any platform specific information?

None. The leaks reproduce on any t0 testbed because they are a function of the PTF helper scripts, not of the DUT platform.

#### Supported testbed topology if it's a new test case?

N/A (bug fix; no new tests).

### Documentation

N/A — teardown hygiene only; no user-visible behavior or framework changes.