### PR TITLE
[OCS] Limit the inventory for conn_graph_facts on L1/snappi testbeds

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -167,6 +167,10 @@
       set_fact:
         is_ixia_testbed: "{{ true if ptf_image == 'docker-keysight-api-server' else false }}"
 
+    - name: check if testbed has L1 switches
+      set_fact:
+        is_l1_testbed: "{{ testbed_facts.l1s is defined and (testbed_facts.l1s | length > 0) }}"
+
     - block:
         - name: Set L1 connection script path
           set_fact:
@@ -236,10 +240,10 @@
   - topo_facts: topo={{ topo }} hwsku={{ hwsku }} testbed_name={{ testbed_name | default(None) }} asics_present={{ asics_present | default([]) }} card_type={{ card_type | default('fixed') }}
     delegate_to: localhost
 
-  - name: override group_file for route-conv
+  - name: override group_file for snappi testbed
     set_fact:
       conn_graph_group: "{{ testbed_facts['inv_name'] }}"
-    when: is_ixia_testbed or is_stc_testbed
+    when: is_ixia_testbed or is_stc_testbed or is_l1_testbed
 
   - name: get connection graph if defined for dut (ignore any errors)
     conn_graph_facts:

--- a/ansible/roles/testbed/nut/tasks/device_prepare_config.yml
+++ b/ansible/roles/testbed/nut/tasks/device_prepare_config.yml
@@ -15,7 +15,7 @@
   shell: |
     set -o pipefail
     jq '{ {{ tables_to_keep | join(',') }} }' /tmp/config_db_old.json \
-      | sed 's/\\bnull\\b/{}/' > /tmp/config_db_keep.json
+      | jq 'with_entries(if .value == null then .value = {} else . end)' > /tmp/config_db_keep.json
   args:
     executable: /bin/bash
   vars:

--- a/ansible/roles/testbed/nut/tasks/testbed_facts.yml
+++ b/ansible/roles/testbed/nut/tasks/testbed_facts.yml
@@ -17,8 +17,13 @@
   debug:
     var: testbed_facts
 
+- name: override group_file to use testbed specific group file
+  set_fact:
+    conn_graph_group: "{{ testbed_facts['inv_name'] }}"
+
 - name: get connection graph if defined for dut
   conn_graph_facts:
     hosts: "{{ (testbed_facts.duts | default([])) + (testbed_facts.tgs | default([])) + (testbed_facts.l1s | default([])) }}"
+    group: "{{ conn_graph_group if conn_graph_group is defined else omit }}"
     forced_mgmt_routes: "{{ forced_mgmt_routes | default([]) }}"
   delegate_to: localhost


### PR DESCRIPTION
### Description of PR

Two improvements for snappi/L1 testbed configuration:

1. **`config_sonic_basedon_testbed.yml`** — When a testbed has L1 switches (`l1s` defined and non-empty), use the testbed-specific connection graph group file.

2. **`roles/testbed/nut/tasks/testbed_facts.yml`** — use testbed-specific group file for `conn_graph_facts` so the right inventory-specific connection graph is loaded for DUTs, TGs, and L1 switches.

3. **`roles/testbed/nut/tasks/device_prepare_config.yml`** — Minor fix to support when OCS has no cross-connect yet.

Summary:
MSFT ADO \#37655574

Current `conn_graph_facts` will gather links info from all available inventory files.
However, with L1 switch, we may define links in multiple inventory. e.g.   DUT-fanout link in `lab` inventory, but DUT-IXIA links in `ixia` inventory.
When links are defined in multiple files, only links in one inventory file will be retained in current conn_graph_facts logic, which may result in error.
This change will limit `conn_graph_facts` to only parse the relevant inventory files so reduce the noise.

e.g.
in `sonic_ixia_links.csv` inventory, 
```
dut-1,Ethernet104,ixia-1,Card1/Port13,400000,,Access,,,,,,,,,
```

in `sonic_lab_links.csv` inventory, 
```
dut-1,Ethernet104,fanout-1,Ethernet104,400000,,Access,,,,,,,,,
```


### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

use the same DUT to test both nightly and IXIA testing.

#### How did you do it?

Limit the conn_graph_facts to specific inventory for L1 and snappi testbeds. 

#### How did you verify/test it?

Validated on physical testbed.

#### Any platform specific information?

None.

#### Supported testbed topology if it's a new test case?

N/A — testbed framework change.

### Documentation
N/A.