### PR TITLE
[202511] chore: set ptf_imagetag to latest

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -7,7 +7,7 @@
 # By using this practice, we suggest to add different tags for different PTF image versions in docker registry.
 - name: Set default value for ptf_imagetag
   set_fact:
-    ptf_imagetag: "202511"
+    ptf_imagetag: "latest"
   when: ptf_imagetag is not defined
 
 - name: set "PTF" container type, by default


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Currently docker-ptf is using different releases for different feature branch. Which gives the effort of maintain and address vulnerability cumbersome.

This PR will consolidate ptf image tag of feature branch to use the latest. This will make it easier for the team to manage and fix security vulnerability.


Fixes # (issue) 37730545

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Consolidate docker-ptf image to use latest for release branch

#### How did you do it?
Modify add-topo ptf_imagetag variable.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
