### PR TITLE
tests: introduce shared constants for the /tmp/from_t1.json arp_responder config path

### DIFF
--- a/ansible/roles/test/files/helpers/arp_responder.py
+++ b/ansible/roles/test/files/helpers/arp_responder.py
@@ -17,6 +17,13 @@ except ImportError:
     import scapy.arch.libpcap   # noqa: F401
 
 
+# Canonical default config path for the arp_responder helper. This must stay in
+# lock-step with tests.common.helpers.constants.ARP_RESPONDER_DEFAULT_CONFIG;
+# we don't import it here because this script runs inside the PTF container,
+# where the sonic-mgmt test tree is not on sys.path.
+DEFAULT_CONFIG_PATH = '/tmp/from_t1.json'
+
+
 def hexdump(data):
     print(" ".join("%02x" % ord(d) for d in data))
 
@@ -153,7 +160,7 @@ class ARPResponder(object):
 def parse_args():
     parser = argparse.ArgumentParser(description='ARP autoresponder')
     parser.add_argument('--conf', '-c', type=str, dest='conf',
-                        default='/tmp/from_t1.json', help='path to json file with configuration')
+                        default=DEFAULT_CONFIG_PATH, help='path to json file with configuration')
     parser.add_argument('--extended', '-e', action='store_true',
                         dest='extended', default=False, help='enable extended mode')
     args = parser.parse_args()

--- a/ansible/roles/test/files/helpers/bfd_responder.py
+++ b/ansible/roles/test/files/helpers/bfd_responder.py
@@ -17,6 +17,13 @@ BFD_FLAG_P_BIT = 5
 BFD_FLAG_F_BIT = 4
 UDP_BFD_PKT_LEN = 32
 
+# Canonical default config path for the bfd_responder helper. Kept in lock-step
+# with tests.common.helpers.constants.ARP_RESPONDER_DEFAULT_CONFIG (the sister
+# arp_responder helper uses the same path); we don't import it here because
+# this script runs inside the PTF container, where the sonic-mgmt test tree is
+# not on sys.path.
+DEFAULT_CONFIG_PATH = '/tmp/from_t1.json'
+
 
 def get_mac(ifname):
     """
@@ -159,7 +166,7 @@ class BFDResponder(object):
 
 def parse_args():
     parser = argparse.ArgumentParser(description='ARP autoresponder')
-    parser.add_argument('--conf', '-c', type=str, dest='conf', default='/tmp/from_t1.json',
+    parser.add_argument('--conf', '-c', type=str, dest='conf', default=DEFAULT_CONFIG_PATH,
                         help='path to json file with configuration')
     args = parser.parse_args()
     return args

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -89,6 +89,15 @@ from host_device import HostDevice
 
 PHYSICAL_PORT = "physical_port"
 
+# Canonical default config path for the arp_responder helper. These are kept in
+# lock-step with tests.common.helpers.constants.ARP_RESPONDER_DEFAULT_CONFIG and
+# ARP_RESPONDER_PER_SUFFIX_CONFIG_FMT; we don't import them here because this
+# module runs inside the PTF container, where the sonic-mgmt test tree is not on
+# sys.path. The per-suffix variant adds the logfile suffix between the stem and
+# the extension.
+ARP_RESPONDER_CONFIG_PATH = "/tmp/from_t1.json"
+ARP_RESPONDER_CONFIG_PATH_FMT = "/tmp/from_t1_%s.json"
+
 
 class StateMachine():
     def __init__(self, init_state='init'):
@@ -483,7 +492,8 @@ class ReloadTest(BaseTest):
 
     def dump_arp_responder_config(self, dump):
         # save data for arp_replay process
-        filename = "/tmp/from_t1.json" if self.logfile_suffix is None else "/tmp/from_t1_%s.json" % self.logfile_suffix
+        filename = ARP_RESPONDER_CONFIG_PATH if self.logfile_suffix is None \
+            else ARP_RESPONDER_CONFIG_PATH_FMT % self.logfile_suffix
         with open(filename, "w") as fp:
             json.dump(dump, fp)
 

--- a/ansible/roles/test/files/ptftests/py3/vlan_test.py
+++ b/ansible/roles/test/files/ptftests/py3/vlan_test.py
@@ -14,6 +14,13 @@ from ptf.testutils import test_params_get, send, simple_icmp_packet, verify_pack
 from ptf.mask import Mask
 
 
+# Canonical default config path for the arp_responder helper. Kept in lock-step
+# with tests.common.helpers.constants.ARP_RESPONDER_DEFAULT_CONFIG; we don't
+# import that here because this module runs inside the PTF container, where the
+# sonic-mgmt test tree is not on sys.path.
+ARP_RESPONDER_CONFIG_PATH = '/tmp/from_t1.json'
+
+
 class VlanTest(BaseTest):
     def __init__(self):
         BaseTest.__init__(self)
@@ -78,7 +85,7 @@ class VlanTest(BaseTest):
                         vlan_port["port_index"], permit_vlanid)
                 d[iface].append(vlan_port["permit_vlanid"]
                                 [str(permit_vlanid)]["peer_ip"])
-        with open('/tmp/from_t1.json', 'w') as file:
+        with open(ARP_RESPONDER_CONFIG_PATH, 'w') as file:
             json.dump(d, file)
 
     # --------------------------------------------------------------------------

--- a/ansible/roles/test/tasks/ptf_runner_reboot.yml
+++ b/ansible/roles/test/tasks/ptf_runner_reboot.yml
@@ -32,6 +32,10 @@
     - name: Copy arp responder supervisor configuration to the PTF container. Specifying args when there is a preboot type
       template: src=arp_responder.conf.j2 dest=/etc/supervisor/conf.d/arp_responder.conf
       vars:
+        # NOTE: keep this path in sync with tests.common.helpers.constants
+        # ARP_RESPONDER_PER_SUFFIX_CONFIG_FMT (= /tmp/from_t1_%s.json). The
+        # literal stays here because Jinja templates have no Python import
+        # surface; convert via Ansible vars/set_fact if a refactor is desired.
         - arp_responder_args: '-e -c /tmp/from_t1_{{ item }}.json'
       delegate_to: "{{ ptf_host }}"
       when: item and item != 'None'

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -24,7 +24,7 @@ from tests.common.config_reload import config_reload
 from tests.common.fixtures.ptfhost_utils import \
     copy_arp_responder_py, run_garp_service, change_mac_addresses   # noqa: F401
 from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr     # noqa: F401
-from tests.common.helpers.constants import DEFAULT_NAMESPACE
+from tests.common.helpers.constants import ARP_RESPONDER_DEFAULT_CONFIG, DEFAULT_NAMESPACE
 from tests.common.utilities import wait_until, check_msg_in_syslog
 from tests.common.utilities import get_all_upstream_neigh_type, get_all_downstream_neigh_type
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts         # noqa: F401
@@ -608,9 +608,9 @@ def populate_vlan_arp_entries(setup, ptfhost, duthosts, rand_one_dut_hostname, i
     for port in vlan_host_map:
         arp_responder_conf['eth{}'.format(port)] = vlan_host_map[port]
 
-    with open("/tmp/from_t1.json", "w") as ar_config:
+    with open(ARP_RESPONDER_DEFAULT_CONFIG, "w") as ar_config:
         json.dump(arp_responder_conf, ar_config)
-    ptfhost.copy(src="/tmp/from_t1.json", dest="/tmp/from_t1.json")
+    ptfhost.copy(src=ARP_RESPONDER_DEFAULT_CONFIG, dest=ARP_RESPONDER_DEFAULT_CONFIG)
 
     ptfhost.host.options["variable_manager"].extra_vars.update({"arp_responder_args": "-e"})
     ptfhost.template(src="templates/arp_responder.conf.j2", dest="/etc/supervisor/conf.d/arp_responder.conf")
@@ -638,7 +638,7 @@ def populate_vlan_arp_entries(setup, ptfhost, duthosts, rand_one_dut_hostname, i
     # Remove the rendered arp_responder config we wrote above so it can't be
     # picked up by a stale invocation in a later test and so /tmp doesn't
     # accumulate state that mis-leads on-PTF debugging.
-    ptfhost.file(path="/tmp/from_t1.json", state="absent")
+    ptfhost.file(path=ARP_RESPONDER_DEFAULT_CONFIG, state="absent")
 
     for dut in duthosts:
         dut.command("sonic-clear fdb all")

--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -23,7 +23,7 @@ from tests.common import config_reload
 from bgp_helpers import define_config, apply_default_bgp_config, DUT_TMP_DIR, TEMPLATE_DIR, BGP_PLAIN_TEMPLATE,\
     BGP_NO_EXPORT_TEMPLATE, DUMP_FILE, CUSTOM_DUMP_SCRIPT, CUSTOM_DUMP_SCRIPT_DEST,\
     BGPMON_TEMPLATE_FILE, BGPMON_CONFIG_FILE, BGP_MONITOR_NAME, BGP_MONITOR_PORT
-from tests.common.helpers.constants import DEFAULT_NAMESPACE
+from tests.common.helpers.constants import ARP_RESPONDER_DEFAULT_CONFIG, DEFAULT_NAMESPACE
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common import constants
 from tests.common.devices.eos import EosHost
@@ -257,7 +257,7 @@ def _setup_arp_responder(duthost, ptfhost, tbinfo, is_v6_topo):
         "eth%s" % minigraph_ptf_indices[port]: [config[ip_type].split("/")[0]]
         for port, config in list(mux_config.items())
     }
-    ptfhost.copy(content=json.dumps(arp_responder_conf, indent=4), dest="/tmp/from_t1.json")
+    ptfhost.copy(content=json.dumps(arp_responder_conf, indent=4), dest=ARP_RESPONDER_DEFAULT_CONFIG)
     ptfhost.copy(src="scripts/arp_responder.py", dest="/opt")
     ptfhost.host.options["variable_manager"].extra_vars.update({"arp_responder_args": ""})
     ptfhost.template(src="templates/arp_responder.conf.j2",

--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -14,6 +14,7 @@ import ptf.testutils as testutils
 from itertools import groupby
 
 from tests.common.dualtor.dual_tor_common import CableType
+from tests.common.helpers.constants import ARP_RESPONDER_DEFAULT_CONFIG
 from tests.common.utilities import wait_until, convert_scapy_packet_to_bytes
 from natsort import natsorted
 from collections import defaultdict
@@ -217,9 +218,9 @@ class DualTorIO:
         arp_responder_conf = {}
         for intf, ip in list(self.ptf_intf_to_server_ip_map.items()):
             arp_responder_conf['eth{}'.format(intf)] = [ip]
-        with open("/tmp/from_t1.json", "w") as fp:
+        with open(ARP_RESPONDER_DEFAULT_CONFIG, "w") as fp:
             json.dump(arp_responder_conf, fp, indent=4, sort_keys=True)
-        self.ptfhost.copy(src="/tmp/from_t1.json", dest="/tmp/from_t1.json", force=True)
+        self.ptfhost.copy(src=ARP_RESPONDER_DEFAULT_CONFIG, dest=ARP_RESPONDER_DEFAULT_CONFIG, force=True)
         self.ptfhost.shell("supervisorctl reread && supervisorctl update")
         self.ptfhost.shell("supervisorctl restart arp_responder")
         logger.info("arp_responder restarted")

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -27,6 +27,7 @@ from scapy.layers.inet6 import IPv6
 from tests.common import constants
 from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert as pt_assert
+from tests.common.helpers.constants import ARP_RESPONDER_DEFAULT_CONFIG
 from tests.common.helpers.dut_ports import encode_dut_port_name
 from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR
 from tests.common.dualtor.nic_simulator_control import restart_nic_simulator                            # noqa: F401
@@ -1658,7 +1659,8 @@ def config_dualtor_arp_responder(tbinfo, duthost, mux_config, ptfhost):     # no
             str(ipaddress.ip_interface(config_vals["SERVER"]["IPv4"]).ip),
             str(ipaddress.ip_interface(config_vals["SERVER"]["IPv6"]).ip)]
 
-    ptfhost.copy(content=json.dumps(arp_responder_conf, indent=4, sort_keys=True), dest="/tmp/from_t1.json")
+    ptfhost.copy(content=json.dumps(arp_responder_conf, indent=4, sort_keys=True),
+                 dest=ARP_RESPONDER_DEFAULT_CONFIG)
     ptfhost.host.options["variable_manager"].extra_vars.update({"arp_responder_args": ""})
     ptfhost.template(src="templates/arp_responder.conf.j2", dest="/etc/supervisor/conf.d/arp_responder.conf")
 

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -16,6 +16,7 @@ from tests.common.reboot import reboot as rebootDut
 from tests.common.helpers.sad_path import SadOperation
 from tests.ptf_runner import ptf_runner
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.constants import ARP_RESPONDER_PER_SUFFIX_CONFIG_FMT
 from tests.common.utilities import InterruptableThread
 from tests.common.dualtor.data_plane_utils import get_peerhost
 from tests.common.dualtor.dual_tor_utils import show_muxcable_status
@@ -342,7 +343,7 @@ class AdvancedReboot:
         """
         arp_responder_args = '-e'
         if item is not None:
-            arp_responder_args += ' -c /tmp/from_t1_{0}.json'.format(item)
+            arp_responder_args += ' -c ' + ARP_RESPONDER_PER_SUFFIX_CONFIG_FMT % item
         self.ptfhost.host.options['variable_manager'].extra_vars.update({'arp_responder_args': arp_responder_args})
 
         logger.info('Copying arp responder config file to {0}'.format(self.ptfhost.hostname))

--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -10,6 +10,22 @@ CUSTOM_MSG_PREFIX = "sonic_custom_msg"
 DUT_CHECK_NAMESPACE = "dut_check_result"
 PTF_TIMEOUT = 60
 
+# Canonical default config path for the PTF arp_responder helper
+# (ansible/roles/test/files/helpers/arp_responder.py and tests/scripts/arp_responder.py).
+# It is the argparse default for the responder's --conf flag, so any test fixture that
+# pre-renders the responder config without overriding --conf must write to exactly this
+# path on the PTF. Use this constant in test-side code instead of hardcoding the literal
+# so the canonical value lives in one place.
+ARP_RESPONDER_DEFAULT_CONFIG = "/tmp/from_t1.json"
+
+# Per-suffix variant used by the advanced-reboot family of tests when a logfile suffix
+# differentiates one run's responder config from another (e.g. preboot/inboot operations).
+# The format takes a single %s placeholder for the suffix and is consumed both inside the
+# PTF runner (ansible/roles/test/files/ptftests/py3/advanced-reboot.py) and by the host-
+# side fixture that passes `-c <path>` to the responder. Update both sides together if
+# the file naming scheme ever changes; the PTF runner keeps a module-local mirror.
+ARP_RESPONDER_PER_SUFFIX_CONFIG_FMT = "/tmp/from_t1_%s.json"
+
 # Describe upstream neighbor of dut in different topos
 UPSTREAM_NEIGHBOR_MAP = {
     "t0": "t1",

--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -23,6 +23,7 @@ from netaddr import EUI
 
 from . import configurable_drop_counters as cdc
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.constants import ARP_RESPONDER_DEFAULT_CONFIG
 from tests.common.utilities import wait_until
 from tests.common.utilities import is_ipv6_only_topology
 from tests.common.platform.device_utils import fanout_switch_port_lookup
@@ -461,9 +462,9 @@ def arp_responder(ptfhost, testbed_params, tbinfo):
         arp_responder_conf = {"eth%s" % k: v for k, v in list(vlan_host_map.items())}
 
     logging.info("Copying ARP responder topology to PTF")
-    with open("/tmp/from_t1.json", "w") as ar_config:
+    with open(ARP_RESPONDER_DEFAULT_CONFIG, "w") as ar_config:
         json.dump(arp_responder_conf, ar_config)
-    ptfhost.copy(src="/tmp/from_t1.json", dest="/tmp/from_t1.json")
+    ptfhost.copy(src=ARP_RESPONDER_DEFAULT_CONFIG, dest=ARP_RESPONDER_DEFAULT_CONFIG)
 
     logging.info("Copying ARP responder to PTF container")
 
@@ -482,7 +483,7 @@ def arp_responder(ptfhost, testbed_params, tbinfo):
     ptfhost.shell("supervisorctl stop arp_responder", module_ignore_errors=True)
     # Drop the rendered config we wrote earlier in this fixture so the next
     # arp_responder invocation cannot inherit our IP/MAC mapping by default.
-    ptfhost.file(path="/tmp/from_t1.json", state="absent")
+    ptfhost.file(path=ARP_RESPONDER_DEFAULT_CONFIG, state="absent")
 
 
 @pytest.fixture

--- a/tests/dualtor/conftest.py
+++ b/tests/dualtor/conftest.py
@@ -9,6 +9,7 @@ from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common.helpers import bgp
 from tests.common.helpers.assertions import pytest_assert as py_assert
 from tests.common.helpers.assertions import pytest_require as py_require
+from tests.common.helpers.constants import ARP_RESPONDER_DEFAULT_CONFIG
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses, run_garp_service, \
                                                 copy_arp_responder_py   # noqa: F401
 from tests.common.dualtor.dual_tor_mock import *                        # noqa: F401, F403
@@ -98,7 +99,7 @@ def _setup_arp_responder(rand_selected_dut, ptfhost, tbinfo, ip_type):
     else:
         arp_responder_conf = {"eth%s" % minigraph_ptf_indices[port]: [config["server_ipv6"].split("/")[0]]
                               for port, config in list(mux_config.items())}
-    ptfhost.copy(content=json.dumps(arp_responder_conf, indent=4), dest="/tmp/from_t1.json")
+    ptfhost.copy(content=json.dumps(arp_responder_conf, indent=4), dest=ARP_RESPONDER_DEFAULT_CONFIG)
 
     ptfhost.host.options["variable_manager"].extra_vars.update({"arp_responder_args": ""})
     ptfhost.template(src="templates/arp_responder.conf.j2", dest="/etc/supervisor/conf.d/arp_responder.conf")
@@ -116,7 +117,7 @@ def run_arp_responder_ipv6(rand_selected_dut, ptfhost, tbinfo, apply_mock_dual_t
     # Drop the rendered config so the next test that uses arp_responder cannot
     # accidentally pick up our IP/MAC mapping (and so /tmp doesn't collect stale
     # state that misleads diagnostics).
-    ptfhost.file(path='/tmp/from_t1.json', state='absent')
+    ptfhost.file(path=ARP_RESPONDER_DEFAULT_CONFIG, state='absent')
 
 
 @pytest.fixture(scope="module")
@@ -125,7 +126,7 @@ def run_arp_responder(rand_selected_dut, ptfhost, tbinfo):
     yield
 
     ptfhost.shell('supervisorctl stop arp_responder', module_ignore_errors=True)
-    ptfhost.file(path='/tmp/from_t1.json', state='absent')
+    ptfhost.file(path=ARP_RESPONDER_DEFAULT_CONFIG, state='absent')
 
 
 @pytest.fixture(scope="module")

--- a/tests/ecmp/test_fgnhg.py
+++ b/tests/ecmp/test_fgnhg.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from tests.ptf_runner import ptf_runner
 from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.helpers.constants import DEFAULT_NAMESPACE
+from tests.common.helpers.constants import ARP_RESPONDER_DEFAULT_CONFIG, DEFAULT_NAMESPACE
 from tests.common.utilities import wait_until
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
@@ -147,10 +147,10 @@ def setup_arpresponder(ptfhost, ip_to_port):
         iface = "eth{}".format(port)
         d[iface].append(ip)
 
-    with open('/tmp/from_t1.json', 'w') as file:
+    with open(ARP_RESPONDER_DEFAULT_CONFIG, 'w') as file:
         json.dump(d, file)
 
-    ptfhost.copy(src='/tmp/from_t1.json', dest='/tmp/from_t1.json')
+    ptfhost.copy(src=ARP_RESPONDER_DEFAULT_CONFIG, dest=ARP_RESPONDER_DEFAULT_CONFIG)
 
     extra_vars = {
             'arp_responder_args': ''
@@ -655,9 +655,10 @@ def cleanup(duthost, ptfhost):
     logger.info("Start cleanup")
     ptfhost.command('rm -f /tmp/fg_ecmp_persist_map.json')
     # Stop arp_responder and remove the rendered config so a stale invocation
-    # in a later test cannot inherit our IP/MAC mapping for /tmp/from_t1.json.
+    # in a later test cannot inherit our IP/MAC mapping for the default
+    # arp_responder config path.
     ptfhost.command('supervisorctl stop arp_responder', module_ignore_errors=True)
-    ptfhost.command('rm -f /tmp/from_t1.json')
+    ptfhost.command('rm -f {}'.format(ARP_RESPONDER_DEFAULT_CONFIG))
     config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
 
 

--- a/tests/pc/test_lag_member.py
+++ b/tests/pc/test_lag_member.py
@@ -8,6 +8,7 @@ import sys
 from collections import Counter
 
 from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.helpers.constants import ARP_RESPONDER_DEFAULT_CONFIG
 from tests.ptf_runner import ptf_runner
 from tests.common.utilities import wait_until
 from tests.common.fixtures.ptfhost_utils import \
@@ -144,7 +145,7 @@ def ptf_teardown(ptfhost, ptf_ports):
     # Remove the arp_responder config rendered during setup_ptf_lag so it cannot
     # be re-used by a subsequent test that starts arp_responder with the default
     # config path.
-    ptfhost.file(path="/tmp/from_t1.json", state="absent")
+    ptfhost.file(path=ARP_RESPONDER_DEFAULT_CONFIG, state="absent")
 
 
 def setup_dut_lag(duthost, dut_ports, vlan, src_vlan_id):
@@ -228,9 +229,9 @@ def setup_arp_responder(ptf_ports, ptfhost):
     arp_responder_conf[PTF_LAG_NAME] = [ptf_ports["ip"]["lag"].split("/")[0]]
     arp_responder_conf[ptf_ports[ATTR_PORT_NOT_BEHIND_LAG]["port_name"]] = \
         [ptf_ports["ip"]["port_not_behind_lag"].split("/")[0]]
-    with open("/tmp/from_t1.json", "w") as ar_config:
+    with open(ARP_RESPONDER_DEFAULT_CONFIG, "w") as ar_config:
         json.dump(arp_responder_conf, ar_config)
-    ptfhost.copy(src="/tmp/from_t1.json", dest="/tmp/from_t1.json")
+    ptfhost.copy(src=ARP_RESPONDER_DEFAULT_CONFIG, dest=ARP_RESPONDER_DEFAULT_CONFIG)
     ptfhost.host.options["variable_manager"].extra_vars.update({"arp_responder_args": ""})
     ptfhost.template(src="templates/arp_responder.conf.j2", dest="/etc/supervisor/conf.d/arp_responder.conf")
 

--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -19,7 +19,7 @@ from tests.common.utilities import wait_until, get_intf_by_sub_intf, is_ipv6_onl
 from tests.common.utilities import get_neighbor_ptf_port_list
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
-from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP
+from tests.common.helpers.constants import ARP_RESPONDER_DEFAULT_CONFIG, UPSTREAM_NEIGHBOR_MAP
 from tests.common import config_reload
 from tests.common.reboot import reboot
 import ptf.testutils as testutils
@@ -62,9 +62,9 @@ def add_ipaddr(ptfadapter, ptfhost, nexthop_addrs, prefix_len, nexthop_interface
         for port in vlan_host_map:
             arp_responder_conf['eth{}'.format(port)] = vlan_host_map[port]
 
-        with open("/tmp/from_t1.json", "w") as ar_config:
+        with open(ARP_RESPONDER_DEFAULT_CONFIG, "w") as ar_config:
             json.dump(arp_responder_conf, ar_config)
-        ptfhost.copy(src="/tmp/from_t1.json", dest="/tmp/from_t1.json")
+        ptfhost.copy(src=ARP_RESPONDER_DEFAULT_CONFIG, dest=ARP_RESPONDER_DEFAULT_CONFIG)
         ptfhost.host.options["variable_manager"].extra_vars.update({"arp_responder_args": "-e"})
         ptfhost.template(src="templates/arp_responder.conf.j2", dest="/etc/supervisor/conf.d/arp_responder.conf")
 
@@ -86,7 +86,7 @@ def del_ipaddr(ptfhost, nexthop_addrs, prefix_len, nexthop_devs, ipv6=False):
         # Remove the arp_responder config that add_ipaddr() wrote earlier so it
         # cannot be picked up by a later test invoking arp_responder with its
         # default config path.
-        ptfhost.file(path="/tmp/from_t1.json", state="absent")
+        ptfhost.file(path=ARP_RESPONDER_DEFAULT_CONFIG, state="absent")
 
 
 def clear_arp_ndp(duthost, ipv6=False):

--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -12,6 +12,13 @@ scapy.conf.use_pcap = True
 logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
 
 
+# Canonical default config path for the arp_responder helper. Kept in lock-step
+# with tests.common.helpers.constants.ARP_RESPONDER_DEFAULT_CONFIG; we don't
+# import that here because this script is distributed to and executed inside
+# the PTF container, where the sonic-mgmt test tree is not on sys.path.
+DEFAULT_CONFIG_PATH = '/tmp/from_t1.json'
+
+
 class ARPResponder(object):
     ARP_OP_REQUEST = 1
     ip_sets = {}
@@ -92,7 +99,7 @@ class ARPResponder(object):
 def parse_args():
     parser = argparse.ArgumentParser(description='ARP autoresponder')
     parser.add_argument('--conf', '-c', type=str, dest='conf',
-                        default='/tmp/from_t1.json', help='path to json file with configuration')
+                        default=DEFAULT_CONFIG_PATH, help='path to json file with configuration')
     parser.add_argument('--extended', '-e', action='store_true',
                         dest='extended', default=False, help='enable extended mode')
     args = parser.parse_args()


### PR DESCRIPTION
### Description of PR

Follow-up to #24218, addressing reviewer @ZhaohuiS's review suggestion (https://github.com/sonic-net/sonic-mgmt/pull/24218#discussion_r3146975828):

> A minor suggestion, I saw many places using this file `/tmp/from_t1.json`, is it better to define a variable to replace this hardcode across many files?

Across the repo, the `arp_responder` config path was hardcoded in many places — the no-suffix `/tmp/from_t1.json` (the responder script's argparse default for `--conf`) and a per-suffix sibling `/tmp/from_t1_<suffix>.json` (used by the advanced-reboot family). This PR consolidates both literals into named constants and rewrites the call sites to consume them.

Summary:
Define two constants in `tests/common/helpers/constants.py`:

```
ARP_RESPONDER_DEFAULT_CONFIG       = "/tmp/from_t1.json"
ARP_RESPONDER_PER_SUFFIX_CONFIG_FMT = "/tmp/from_t1_%s.json"
```

Convert all test-side call sites (10 files) to import and use the constants, and add module-local mirrors with a lock-step comment in the 5 PTF-side scripts that cannot import from the test tree (they execute inside the PTF container, where `sonic-mgmt/` is not on `sys.path`).

Fixes # (issue) — N/A (cosmetic refactor; addresses an accepted review comment from #24218).

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
  - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

(No backport — cosmetic refactor with no behavior change; the existing PTF-side argparse defaults and write paths are preserved byte-for-byte.)

### Approach

#### What is the motivation for this PR?

The reviewer of #24218 noted that `/tmp/from_t1.json` appears in many files as a raw literal. Consolidating it into a single named constant means:

1. A future change to the default config path only needs to touch one place in test-side code (with a documented set of PTF-side mirrors that must be updated together).
2. A grep for the constant name produces a clean, navigable inventory of every site that depends on the contract.
3. New code that needs the path has an obvious "right way" to reference it (import the constant), which prevents the spread from re-emerging — e.g. PR #23952 added a fresh occurrence in `tests/bgp/conftest.py` after #24218 was opened; this PR catches it on the same sweep.

#### How did you do it?

**Test-side files** (10) — import `ARP_RESPONDER_DEFAULT_CONFIG` (or `ARP_RESPONDER_PER_SUFFIX_CONFIG_FMT` for the one suffixed site) from `tests.common.helpers.constants` and replace the literal at every call site:

- `tests/acl/test_acl.py`
- `tests/bgp/conftest.py` (new occurrence introduced by #23952)
- `tests/common/dualtor/dual_tor_io.py`
- `tests/common/dualtor/dual_tor_utils.py`
- `tests/common/fixtures/advanced_reboot.py` (per-suffix variant)
- `tests/drop_packets/test_configurable_drop_counters.py`
- `tests/dualtor/conftest.py`
- `tests/ecmp/test_fgnhg.py`
- `tests/pc/test_lag_member.py`
- `tests/route/test_static_route.py`

**PTF-side scripts** (5) — define a module-local constant with the same value, and a comment naming the canonical name in `tests.common.helpers.constants` as the lock-step partner so future renames stay in sync. These cannot `import` from the test tree because they run inside the PTF container where the sonic-mgmt source is not on `sys.path`:

- `ansible/roles/test/files/helpers/arp_responder.py` — `DEFAULT_CONFIG_PATH` (argparse default for `--conf`)
- `ansible/roles/test/files/helpers/bfd_responder.py` — `DEFAULT_CONFIG_PATH` (argparse default for `--conf`)
- `ansible/roles/test/files/ptftests/py3/vlan_test.py` — `ARP_RESPONDER_CONFIG_PATH` (written before responder start)
- `ansible/roles/test/files/ptftests/py3/advanced-reboot.py` — `ARP_RESPONDER_CONFIG_PATH` and `ARP_RESPONDER_CONFIG_PATH_FMT` (preserves the per-suffix variant `/tmp/from_t1_<suffix>.json`)
- `tests/scripts/arp_responder.py` — `DEFAULT_CONFIG_PATH` (argparse default for `--conf`; the script is copied to `/opt` on the PTF and executed there)

**Ansible task** (1) — `ansible/roles/test/tasks/ptf_runner_reboot.yml` carries the per-suffix literal inside a Jinja template (there is no Python import surface for an Ansible vars block to consume the constant). Rather than introduce an Ansible-side mechanism just for this single occurrence, the literal is left in place with an inline `NOTE` comment naming `ARP_RESPONDER_PER_SUFFIX_CONFIG_FMT` as the canonical value to keep in sync.

The single host-side per-suffix call site (`tests/common/fixtures/advanced_reboot.py:345`) is rewritten from `'.format(item)` to `% item` to match the `%s`-style of the existing `ARP_RESPONDER_CONFIG_PATH_FMT` PTF-side mirror; both formatters produce byte-identical output for any string `item`.

Behavior change: none. Every constant resolves to the same string value as the literal it replaces; the responder's argparse defaults are unchanged; the file-rendering paths are unchanged.

#### How did you verify/test it?

- `python3 -m py_compile` clean on all 16 touched Python files (the 17th touched file is the YAML).
- `python3 -m flake8 --max-line-length=120` — no new warnings introduced. The handful of pre-existing warnings on adjacent lines (`vlan_test.py:12` E231 on an existing import, `bgp/conftest.py:23-24` E231 on existing `bgp_helpers` import lines, `dual_tor_utils.py:313/340` E721, `ecmp/test_fgnhg.py:51` F824) were already present on master and are unrelated to this change.
- AST-extracted string equality check on every constant definition confirms all 7 constant sites resolve to exactly `"/tmp/from_t1.json"` (or `"/tmp/from_t1_%s.json"` for the per-suffix `_FMT`).
- Runtime check that `'/tmp/from_t1_%s.json' % item` produces byte-identical output to the previous `'/tmp/from_t1_{0}.json'.format(item)` for sample suffixes.
- Repo-wide grep for `from_t1` in `*.py` shows the literal only appears in the 7 named-constant definitions and unrelated `self.from_t1*` attribute names (semantic references to "packets from T1 routers", not file-path literals).

#### Any platform specific information?

None. Pure code-organization change in the test framework; no DUT- or PTF-side runtime behavior is affected.

#### Supported testbed topology if it's a new test case?

N/A — refactor, no new tests.

### Documentation

N/A — internal constant rollout; no user-visible behavior or framework API changes.