### PR TITLE
Invoke wait_for_bridges_cleanup in destroy_bridges

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -502,6 +502,9 @@ class VMTopology(object):
                 bridge_count += 1
                 self.destroy_ovs_bridge(fp_br_name)
 
+        # Wait the bridges to be cleaned up
+        self.wait_for_bridges_cleanup(bridge_count)
+
     def destroy_ovs_bridge(self, bridge_name):
         logging.info('=== Destroy bridge %s ===' % bridge_name)
         VMTopology.cmd('ovs-vsctl --if-exists del-br %s' % bridge_name)


### PR DESCRIPTION
Summary: Invoke wait_for_bridges_cleanup in destroy_bridges
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
PR #21727 added the `wait_for_bridges_cleanup` helper but missed the call site in destroy_bridges, so the helper was never executed. As a result destroy_bridges still returns before all OVS bridges are actually removed, which on large topologies (e.g. t0-isolated-d2u510s2) leaves stale bridges that break the subsequent add-topo step.

#### How did you do it?
Call `self.wait_for_bridges_cleanup(bridge_count)` at the end of destroy_bridges so it blocks until cleanup is confirmed.

#### How did you verify/test it?
Deploy testbed success

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
