### PR TITLE
[tests/console]: parametrize test_console_reversessh_custom_default_escape_character over multiple chars

### DIFF
--- a/tests/console/test_console_reversessh.py
+++ b/tests/console/test_console_reversessh.py
@@ -12,7 +12,7 @@ from tests.common.helpers.console_helper import (
 )
 
 pytestmark = [
-    pytest.mark.topology('c0', 'c0-lo')
+    pytest.mark.topology('c0', 'c0-lo', 'bmc')
 ]
 
 
@@ -29,11 +29,23 @@ def _dut_lowest_console_line(conn_graph_facts, duthost):  # noqa: F811
 
 
 @pytest.fixture(scope="function")
-def custom_default_escape_char(duthost):
+def custom_default_escape_char(duthost, escape_char):
     """
-    Fixture to set custom escape character and clear it after test
+    Fixture that sets ``escape_char`` (supplied by ``@pytest.mark.parametrize``)
+    as the DUT-side default console escape character and restores the
+    pre-test value on teardown so ``core_dump_and_config_check`` doesn't
+    flag drift on ``CONSOLE_SWITCH|console_mgmt.default_escape_char``.
     """
-    escape_char = "b"
+    # Capture pre-test default_escape_char so we can restore it; empty
+    # string means the field is absent from CONFIG_DB and we should
+    # ``clear`` instead of setting a value back.
+    try:
+        res = duthost.command(
+            "sonic-db-cli CONFIG_DB hget 'CONSOLE_SWITCH|console_mgmt' default_escape_char",
+            module_ignore_errors=True)
+        orig_escape_char = (res.get('stdout') or '').strip()
+    except Exception:
+        orig_escape_char = ""
 
     # Set escape character for all lines
     try:
@@ -43,9 +55,12 @@ def custom_default_escape_char(duthost):
 
     yield escape_char
 
-    # Clear escape character (restore to default)
+    # Restore pre-test state.
     try:
-        duthost.shell('sudo config console default_escape clear')
+        if orig_escape_char:
+            duthost.shell('sudo config console default_escape {}'.format(orig_escape_char))
+        else:
+            duthost.shell('sudo config console default_escape clear')
     except Exception as e:
         pytest.fail("Not able to restore custom default escape character: {}".format(e))
 
@@ -133,8 +148,22 @@ def test_console_reversessh_force_interrupt(duthost, creds, conn_graph_facts):  
         pytest.fail("Console session not exit correctly: {}".format(e))
 
 
+# Custom default-escape characters to exercise. Each letter is sent as
+# Ctrl-<letter> when triggering the picocom escape sequence, so the choice
+# avoids:
+#   - 'a' (picocom default; this test verifies a *different* char overrides it)
+#   - 'x' (picocom's exit-command char; escape sequence is Ctrl-<escape> Ctrl-x)
+#   - 'c'/'z'/'d'/'s'/'q'/'\\' (SIGINT/SIGTSTP/EOF/XOFF/XON/SIGQUIT — eaten by
+#     signal or TTY layer before reaching picocom)
+#   - 'r'/'l'/'u'/'w'/'t' (common readline / shell hotkeys)
+# Selected chars map to readline editing actions (back-char, bell,
+# next-history, prev-history, yank) that picocom sees cleanly.
+CUSTOM_ESCAPE_CHARS = ["b", "g", "n", "p", "y"]
+
+
+@pytest.mark.parametrize("escape_char", CUSTOM_ESCAPE_CHARS)
 def test_console_reversessh_custom_default_escape_character(duthost, creds, conn_graph_facts,  # noqa: F811
-                                                            custom_default_escape_char):
+                                                            escape_char, custom_default_escape_char):
     """
     Test reverse SSH with custom escape character.
     Verify that default escape keys don't work when escape character is changed,
@@ -169,8 +198,8 @@ def test_console_reversessh_custom_default_escape_character(duthost, creds, conn
             check_target_line_status(duthost, target_line, "BUSY"),
             "Target line {} exited with default escape keys when custom escape char is set".format(target_line))
 
-        # Send custom escape sequence (ctrl-B + ctrl-X) - should exit
-        client.sendcontrol(custom_default_escape_char.lower())
+        # Send custom escape sequence (Ctrl-<escape_char> + Ctrl-X) - should exit
+        client.sendcontrol(custom_default_escape_char)
         client.sendcontrol('x')
     except Exception as e:
         pytest.fail("Not able to do reverse SSH to remote host via DUT: {}".format(e))


### PR DESCRIPTION
### Description of PR

Three small changes to `test_console_reversessh.py`, all scoped to `test_console_reversessh_custom_default_escape_character`:

1. **Parametrize over multiple custom escape chars** instead of the previously hardcoded single char (`b`).
2. **Save and restore the pre-test `default_escape_char`** in CONFIG_DB so `core_dump_and_config_check` doesn't flag drift on teardown.
3. **Extend the topology marker** to include `bmc` so this test runs on BMC testbeds too.

### Char selection: `b, g, n, p, y`

All five map to readline editing actions (back-char, bell, next-history, prev-history, yank) and are not intercepted by signal handlers or the TTY layer, so `picocom` on the DUT sees `Ctrl-<char>` cleanly.

#### Avoided

| char | reason |
| --- | --- |
| `a` | picocom default — the whole point of the test is to verify a *different* char overrides the default |
| `x` | picocom's exit-command char (escape sequence is `Ctrl-<escape> Ctrl-x`) |
| `c` | SIGINT — eaten by signal layer |
| `z` | SIGTSTP — eaten by signal layer |
| `d` | EOF / logout |
| `s` / `q` | XOFF / XON flow control — eaten by TTY layer |
| `\` | SIGQUIT |
| `r` / `l` / `u` / `w` / `t` | common readline / shell hotkeys |

### CONFIG_DB save/restore

Mirrors the inline pattern from #24172 / #24270: read `CONFIG_DB CONSOLE_SWITCH|console_mgmt.default_escape_char` before mutating, restore on teardown. If the field was unset pre-test, fall back to `config console default_escape clear`. Without this, the fixture's unconditional `clear` on teardown would surface as a teardown drift warning whenever the DUT had a `default_escape_char` configured before the test ran.

### Topology

`@pytest.mark.topology('c0', 'c0-lo', 'bmc')` — adds `bmc` to the existing `c0` / `c0-lo` so BMC testbeds exercise this test as well.

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework (new/improvement)
- [x] Test case(new/improvement)

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach

#### What is the motivation?
Single-char coverage didn't exercise the configurability the feature offers. Parametrizing widens the test surface for ~3 minutes of additional wall time. Test IDs read `[b]`, `[g]`, `[n]`, `[p]`, `[y]` — easy to grep / `-k` filter.

#### How did you do it?
- `@pytest.mark.parametrize("escape_char", CUSTOM_ESCAPE_CHARS)` on the test (`CUSTOM_ESCAPE_CHARS` defined as a module constant with explanatory comment).
- `custom_default_escape_char` fixture takes `escape_char` from the parametrize axis, captures pre-test value via `sonic-db-cli CONFIG_DB hget`, and restores on teardown.
- Test body otherwise unchanged.

#### How did you verify it?
- `flake8 --max-line-length=120` clean.
- AST parses.
- Live verification on a physical c0-lo testbed: **5 passed, 0 errors in 5:09**, no teardown drift warning.

### Documentation
N/A.
