### PR TITLE
[ARP][test_arp_update] Verify MAC relearning after fdbclear (#22148)

### DIFF
--- a/tests/arp/arp_utils.py
+++ b/tests/arp/arp_utils.py
@@ -2,6 +2,7 @@ import re
 import logging
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
+from ipaddress import ip_interface
 
 
 logger = logging.getLogger(__name__)
@@ -71,3 +72,37 @@ def fdb_cleanup(duthost):
         duthost.command('fdbclear')
         pytest_assert(wait_until(200, 2, 0, lambda: fdb_table_has_no_dynamic_macs(duthost) is True),
                       "FDB Table Cleanup failed")
+
+
+def get_dut_mac(duthost, config_facts, tbinfo):
+    """
+    Get DUT MAC address
+    """
+    if 'dualtor' in tbinfo['topo']['name']:
+        for vlan_details in list(config_facts['VLAN'].values()):
+            return vlan_details['mac'].lower()
+    return duthost.shell("sonic-cfggen -d -v 'DEVICE_METADATA.localhost.mac'")["stdout_lines"][0]
+
+
+def fdb_has_mac(duthost, mac):
+    """
+    Check if FDB has specific MAC address
+    """
+    mac = mac.lower()
+    logger.info(f"Checking if FDB has MAC address {mac}")
+    mac_lines = [line for line in duthost.command("show mac")["stdout_lines"] if mac in line.lower()]
+    logger.info("Matched MAC entries:\n{}".format("\n".join(mac_lines) if mac_lines else "<none>"))
+    return any(mac in line.lower() for line in duthost.command("show mac")["stdout_lines"])
+
+
+def get_first_vlan_ipv4(config_facts):
+    """
+    Get first VLAN interface and its IPv4 address
+    """
+    vlan_intfs = config_facts.get("VLAN_INTERFACE", {})
+    for intf, addrs in vlan_intfs.items():
+        for addr in addrs:
+            if ":" in addr:
+                continue
+            return intf, ip_interface(addr).ip
+    return None, None

--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -1,12 +1,15 @@
 # Test cases to validate functionality of the arp_update script
 
 import logging
+import ptf.testutils as testutils
 import pytest
 import random
 
+from tests.arp.arp_utils import clear_dut_arp_cache, fdb_cleanup, get_dut_mac, fdb_has_mac, get_first_vlan_ipv4
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa: F401
-from tests.common.fixtures.ptfhost_utils import setup_vlan_arp_responder  # noqa: F401
+from tests.common.fixtures.ptfhost_utils import setup_vlan_arp_responder, run_icmp_responder  # noqa: F401
 from tests.common.helpers.assertions import pytest_assert as pt_assert
+from tests.common.helpers.constants import PTF_TIMEOUT
 from tests.common.utilities import wait_until
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 
@@ -27,6 +30,78 @@ def pause_arp_update(rand_selected_dut):
     yield
     cmds[0] = "docker exec swss supervisorctl start arp_update"
     rand_selected_dut.shell_cmds(cmds=cmds)
+
+
+@pytest.fixture
+def ptf_interface_info(ip_and_intf_info, ptfadapter):
+    """
+    Get PTF interface information
+    """
+    ptf_intf_ipv4_addr, _, _, _, ptf_intf_index = ip_and_intf_info
+    ptf_intf_mac = ptfadapter.dataplane.get_mac(0, ptf_intf_index)
+    if isinstance(ptf_intf_mac, (bytes, bytearray)):
+        ptf_intf_mac = ptf_intf_mac.decode()
+
+    ptf_iface = f"eth{ptf_intf_index}"
+    ptf_ip = str(ptf_intf_ipv4_addr)
+
+    return {
+        'ip': ptf_ip,
+        'ipv4_addr': ptf_intf_ipv4_addr,
+        'mac': ptf_intf_mac,
+        'index': ptf_intf_index,
+        'interface': ptf_iface
+    }
+
+
+@pytest.fixture
+def dut_interface_info(rand_selected_dut, config_facts, tbinfo):
+    """
+    Get DUT interface information
+    """
+    duthost = rand_selected_dut
+    dut_mac = get_dut_mac(duthost, config_facts, tbinfo)
+    vlan_name, dut_ipv4 = get_first_vlan_ipv4(config_facts)
+
+    return {
+        'host': duthost,
+        'mac': dut_mac,
+        'vlan_name': vlan_name,
+        'ipv4': dut_ipv4
+    }
+
+
+@pytest.fixture
+def clean_environment(rand_selected_dut, ptfadapter):
+    """
+    Cleanup FDB and DUT ARP cache before and after test run
+    """
+    duthost = rand_selected_dut
+
+    logger.info("Setting up clean environment: clearing FDB and ARP cache")
+    fdb_cleanup(duthost)
+    clear_dut_arp_cache(duthost)
+    ptfadapter.dataplane.flush()
+
+    yield
+
+    logger.info("Test completed, environment cleanup done")
+
+
+@pytest.fixture
+def ptf_with_ip_config(ptf_interface_info, ptfhost):
+    """
+    Configure IP on PTF interface and cleanup afterwards
+    """
+    ptf_info = ptf_interface_info
+
+    # Configure IP on PTF interface
+    ptfhost.shell(f"ip addr add {ptf_info['ip']}/21 dev {ptf_info['interface']}", module_ignore_errors=True)
+
+    yield ptf_info
+
+    # Cleanup: remove IP from PTF interface
+    ptfhost.shell(f"ip addr del {ptf_info['ip']}/21 dev {ptf_info['interface']}", module_ignore_errors=True)
 
 
 def neighbor_learned(dut, target_ip):
@@ -93,3 +168,122 @@ def test_kernel_asic_mac_mismatch(
     rand_selected_dut.shell("docker exec swss supervisorctl start arp_update")
 
     wait_until(10, 1, 0, lambda dut, ip: not neighbor_learned(dut, ip), rand_selected_dut, target_ip)
+
+
+def test_ptf_arp_learns_mac(
+    ptf_interface_info,
+    dut_interface_info,
+    clean_environment,
+    ptfadapter,
+    tbinfo
+):
+    """
+    After fdb_cleanup and clearing DUT ARP cache,
+    simulate ARP request from PTF to DUT,
+    verify DUT replies and learns PTF MAC in FDB
+    """
+    # Setup PTF and DUT info
+    ptf_info = ptf_interface_info
+    dut_info = dut_interface_info
+
+    logger.info("DUT VLAN IPv4: {}".format(dut_info['ipv4']))
+
+    # Simulate ARP request from PTF to DUT
+    arp_req = testutils.simple_arp_packet(
+        pktlen=60,
+        eth_dst='ff:ff:ff:ff:ff:ff',
+        eth_src=ptf_info['mac'],
+        vlan_pcp=0,
+        arp_op=1,
+        ip_snd=ptf_info['ip'],
+        ip_tgt=str(dut_info['ipv4']),
+        hw_snd=ptf_info['mac'],
+        hw_tgt='ff:ff:ff:ff:ff:ff'
+    )
+
+    # Expected ARP reply packet from DUT
+    arp_reply = testutils.simple_arp_packet(
+        eth_dst=ptf_info['mac'],
+        eth_src=dut_info['mac'],
+        arp_op=2,
+        ip_snd=str(dut_info['ipv4']),
+        ip_tgt=ptf_info['ip'],
+        hw_snd=dut_info['mac'],
+        hw_tgt=ptf_info['mac']
+    )
+
+    logger.info("Sending ARP request for target {} from PTF interface {}".format(
+        dut_info['ipv4'], ptf_info['index']))
+
+    # Send ARP request and verify ARP reply
+    testutils.send_packet(ptfadapter, ptf_info['index'], arp_req)
+    testutils.verify_packet(ptfadapter, arp_reply, ptf_info['index'], timeout=PTF_TIMEOUT)
+
+    # Confirm MAC is learned on DUT FDB
+    pt_assert(
+        wait_until(10, 1, 0, fdb_has_mac, dut_info['host'], ptf_info['mac']),
+        "FDB did not learn PTF MAC after ARP request"
+    )
+
+
+def test_dut_arping_learns_mac(
+    ptf_interface_info,
+    dut_interface_info,
+    clean_environment,
+    setup_vlan_arp_responder  # noqa: F811
+):
+    """
+    After fdb_cleanup and clearing DUT ARP cache,
+    enable PTF to respond to arping,
+    simulate arping from DUT to PTF,
+    verify DUT learns PTF MAC in FDB
+    """
+    # Setup PTF and DUT info
+    ptf_info = ptf_interface_info
+    dut_info = dut_interface_info
+
+    # Setup PTF responder info
+    vlan_name, ipv4_base, _, ip_offset = setup_vlan_arp_responder
+    ptf_responder_ip = str(ipv4_base.ip + ip_offset)
+    logger.info("PTF responder IP (setup_vlan_arp_responder): {}".format(ptf_responder_ip))
+    logger.info("DUT VLAN IPv4: {}".format(dut_info['ipv4']))
+
+    # Simulate arping from DUT to PTF interface
+    dut_info['host'].shell(f"arping -c 1 -I {dut_info['vlan_name']} {ptf_responder_ip}")
+
+    # Confirm MAC is learned on DUT FDB
+    pt_assert(
+        wait_until(10, 1, 0, fdb_has_mac, dut_info['host'], ptf_info['mac']),
+        "FDB did not learn PTF MAC after DUT arping"
+    )
+
+
+def test_dut_ping_learns_mac(
+    ptf_with_ip_config,
+    dut_interface_info,
+    clean_environment,
+    ptfhost
+):
+    """
+    Configure IP on PTF interface,
+    ping DUT from PTF,
+    then verify both sides learned MAC address
+    """
+    # Setup PTF and DUT info
+    ptf_info = ptf_with_ip_config
+    dut_info = dut_interface_info
+
+    # Ping DUT from PTF (3 times)
+    ping_res = ptfhost.shell(f"ping -c 3 {dut_info['ipv4']}", module_ignore_errors=True)
+    pt_assert(ping_res["rc"] == 0, f"PTF ping to DUT failed: {ping_res['stdout']}")
+
+    # DUT learns PTF MAC
+    pt_assert(
+        wait_until(10, 1, 0, fdb_has_mac, dut_info['host'], ptf_info['mac']),
+        "FDB did not learn PTF MAC after PTF ping"
+    )
+
+    # PTF learns DUT MAC
+    ptf_neigh = ptfhost.shell(f"ip neigh show {dut_info['ipv4']}")["stdout"]
+    pt_assert(dut_info['mac'].lower() in ptf_neigh.lower(),
+              f"PTF did not learn DUT MAC, ip neigh: {ptf_neigh}")

--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -8,6 +8,7 @@ ASICS_PRESENT = 'asics_present'
 RANDOM_SEED = 'random_seed'
 CUSTOM_MSG_PREFIX = "sonic_custom_msg"
 DUT_CHECK_NAMESPACE = "dut_check_result"
+PTF_TIMEOUT = 60
 
 # Describe upstream neighbor of dut in different topos
 UPSTREAM_NEIGHBOR_MAP = {

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -160,12 +160,30 @@ arp/test_arp_extended.py::test_proxy_arp[v4-:
     conditions:
       - "'-v6-' in topo_name"
 
+arp/test_arp_update.py::test_dut_arping_learns_mac:
+  skip:
+    reason: "Skip test_dut_arping_learns_mac on dualtor"
+    conditions:
+      - "'dualtor' in topo_name"
+
+arp/test_arp_update.py::test_dut_ping_learns_mac:
+  skip:
+    reason: "Skip test_dut_ping_learns_mac on dualtor"
+    conditions:
+      - "'dualtor' in topo_name"
+
 arp/test_arp_update.py::test_kernel_asic_mac_mismatch\[.*ipv4.*\]:
   regex: true
   skip:
     reason: "skip for IPv6-only topologies"
     conditions:
       - "'-v6-' in topo_name"
+
+arp/test_arp_update.py::test_ptf_arp_learns_mac:
+  skip:
+    reason: "Skip test_ptf_arp_learns_mac on dualtor"
+    conditions:
+      - "'dualtor' in topo_name"
 
 arp/test_neighbor_mac_noptf.py:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Manually resolve conflicts on 202511 #22148 
Fixes # (issue)
Add tests to validate that DUT can relearn MAC addresses after fdbclear via ARP request/response, arping, and ICMP ping traffic.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?
After ‘fdbclear’ on DUT
- Testcase `test_ptf_arp_learns_mac`: Simulate arp request/response from PTF and confirm Mac is learnt on DUT
- Testcase `test_dut_arping_learns_mac` Simulate arping from DUT and enable PTF to respond, confirm MAC is learnt on DUT
- Testcase `test_dut_ping_learns_mac` PTF sends an ARP request to DUT, DUT replies to ARP request, PTF then sends ICMP echo request to DUT, verify DUT learns PTF MAC in FDB.
#### How did you verify/test it?
```
---------------------------------------------------------------- generated xml file: /data/sonic-mgmt-int/tests/logs/arp/test_arp_update.xml -----------------------------------------------------------------
------------------------------------------------------------------------------------------- live log sessionfinish -------------------------------------------------------------------------------------------
01:36:45 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================================== 5 passed, 1 warning in 211.93s (0:03:31) ==================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_dut_ping_learns_mac[str4-sn5640-2-None]>
```
```
---------------------------------------------------------------- generated xml file: /data/sonic-mgmt-int/tests/logs/arp/test_arp_update.xml -----------------------------------------------------------------
------------------------------------------------------------------------------------------- live log sessionfinish -------------------------------------------------------------------------------------------
02:00:00 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================================== 5 passed, 1 warning in 193.20s (0:03:13) ==================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_dut_ping_learns_mac[str4-7060x6-512-1-None]>
```
#### Any platform specific information?
Nvidia SN5640, Arista 7060x6
#### Supported testbed topology if it's a new test case?
t0-isolated-d32u32s2
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
