### PR TITLE
[SmartSwitch HA] Always apply the HA golden config regardless of dut numbers

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -823,12 +823,6 @@ class GenerateGoldenConfigDBModule(object):
         self.dut_loopbacks (dict with 'ipv4' and 'ipv6' lists from topology).
         """
         switch_id = self.npu_index
-        if not self.duts_list or len(self.duts_list) != 2:
-            logger.warning(
-                "HA config generation skipped: duts_list must have "
-                "exactly 2 entries, got %d",
-                len(self.duts_list) if self.duts_list else 0)
-            return {}
 
         if switch_id not in (0, 1):
             logger.warning(


### PR DESCRIPTION
### Description of PR

Summary:
Always apply the HA golden config regardless of dut numbers.
We have the DPUs in the testbed.yaml dut list in smartswitch-ha testbed,
because we need them to generate the dpuhosts in the HA tests.

We should remove the logic to prevent applying HA config if the number of duts is not exactly 2.(It's not really needed because the HA config is applied only when the topo is t1-smartswitch-ha)
Otherwise the HA config will not be applied on a Smartswitch HA testbed like this:

```
conf-name: sonic-SN4280-01-03-ha-t1-smartswitch-ha
  group-name: vm-t2
  topo: t1-smartswitch-ha
  ptf_image_name: docker-ptf-mlnx
  ptf: ptf-r-SN4280-01
  ptf_ip: x.x.x.x/16
  ptf_ipv6:
  server: server_72
  vm_base: VM3701
  dut:
    - r-SN4280-01
    - r-SN4280-03
    - r-SN4280-01-dpu-0
    - r-SN4280-01-dpu-1
    - r-SN4280-01-dpu-2
    - r-SN4280-01-dpu-3
    - r-SN4280-03-dpu-0
    - r-SN4280-03-dpu-1
    - r-SN4280-03-dpu-2
    - r-SN4280-03-dpu-3
  inv_name: lab
  comment: Smartswitch HA testbed
```

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

### Approach
#### What is the motivation for this PR?
Always apply the HA golden config regardless of dut numbers for smartswitch HA testing.
#### How did you do it?
Removing the logic to prevent applying HA config if the number of
duts is not exactly 2
#### How did you verify/test it?
Deploy minigraph on SN4280 HA testbeds, and run the steady state test, all passed.
#### Any platform specific information?
Change is only for smartswitch.
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A
