### PR TITLE
test_po_update.py - cannot remove the last IP entry of interface Port…

### DIFF
--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -204,6 +204,22 @@ def test_po_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
             or wait_until(10, 10, 0, pc_active, asichost, tmp_portchannel))
     finally:
         # Recover all states
+        # The T1 topology golden config (smartswitch_t1.json) installs a static route
+        # "10.2.0.1/32 via 18.0.202.1" whose nexthop is resolved recursively. While
+        # PortChannel999 is operationally up and holds the 10.0.0.0/31 subnet, FRR
+        # resolves that static route through PortChannel999. sonic-utilities
+        # config/main.py checks "show ip route vrf all static" before removing the
+        # last IP on an interface and raises:
+        #   "Cannot remove the last IP entry of interface PortChannel999.
+        #    A static ip route is still bound to the RIF."
+        # Issuing admin-down on PortChannel999 first drops the LAG link, tears down
+        # BGP, and causes FRR to withdraw PortChannel999 from the recursive nexthop
+        # resolution. A brief sleep allows FRR to update its routing table before
+        # the IP removal is attempted, preserving the original cleanup order
+        # (IP removed before members).
+        if create_tmp_portchannel:
+            asichost.shutdown_interface(tmp_portchannel)
+            time.sleep(5)
         if add_tmp_portchannel_ip:
             asichost.config_ip_intf(tmp_portchannel, portchannel_ip + "/" + prefix_len, "remove")
 
@@ -396,6 +412,22 @@ def test_po_update_io_no_loss(
                       "Packets lost rate > {} during pc members add/removal, send_count: {}, match_count: {}".format(
                           max_loss_rate, send_count, match_count))
     finally:
+        # The T1 topology golden config (smartswitch_t1.json) installs a static route
+        # "10.2.0.1/32 via 18.0.202.1" whose nexthop is resolved recursively. While
+        # PortChannel999 is operationally up and holds the 10.0.0.0/31 subnet, FRR
+        # resolves that static route through PortChannel999. sonic-utilities
+        # config/main.py checks "show ip route vrf all static" before removing the
+        # last IP on an interface and raises:
+        #   "Cannot remove the last IP entry of interface PortChannel999.
+        #    A static ip route is still bound to the RIF."
+        # Issuing admin-down on PortChannel999 first drops the LAG link, tears down
+        # BGP, and causes FRR to withdraw PortChannel999 from the recursive nexthop
+        # resolution. A brief sleep allows FRR to update its routing table before
+        # the IP removal is attempted, preserving the original cleanup order
+        # (IP removed before members).
+        if create_tmp_pc:
+            asichost.shutdown_interface(tmp_pc)
+            time.sleep(5)
         if add_tmp_pc_ip:
             asichost.config_ip_intf(tmp_pc, pc_ip + "/31", "remove")
             wait_until(10, 2, 2, _check_ip_removed, asichost, tmp_pc)


### PR DESCRIPTION
Fix PortChannel999 IP removal failure due to T1 golden config static route

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Issuing config interface shutdown PortChannel999 drops the LAG link operationally. This causes:
The BGP session over PortChannel999 tears down
FRR withdraws PortChannel999 from the recursive nexthop resolution of 10.2.0.1/32
show ip route vrf all static no longer lists PortChannel999
The sonic-utilities pre-flight check passes cleanly
config interface ip remove PortChannel999 10.0.0.0/31 succeeds
A time.sleep(5) after admin-down is used to allow FRR time to complete BGP session teardown and routing table convergence before the IP removal is attempted.

Summary:
Fixes # 40146

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
When running test_po_update and test_po_update_io_no_loss on T1 hardware topologies, the test teardown consistently fails with:

Error: Cannot remove the last IP entry of interface PortChannel999.
A static ip route is still bound to the RIF.
This causes PortChannel999 to be left behind on the DUT after the test, which then causes the next run to fail with a cascading error:

Error: PortChannel999 already exists!
The T1 testbed golden config (ansible/golden_config_db/smartswitch_t1.json) installs a persistent static route:
"STATIC_ROUTE": {
"default|10.2.0.1/32": {
"nexthop": "18.0.202.1",
"ifname": ""
}
}
Because ifname is empty, FRR resolves the nexthop 18.0.202.1 recursively via whichever PortChannel currently holds the 10.0.0.0/31 subnet. During the test, PortChannel999 is assigned that subnet. While it remains operationally up, FRR lists PortChannel999 as a resolved path in show ip route vrf all static:

S> 10.2.0.1/32 [1/0] via 18.0.202.1 (recursive)
* via 10.0.0.1, PortChannel999
* via 10.0.0.5, PortChannel105
...
sonic-utilities config/main.py checks that output before deleting the last IP on any interface. Since PortChannel999 appears as a resolved nexthop, the pre-flight check raises the error and the config interface ip remove command is rejected.

admin@MtFuji-dut:~$ sonic-db-cli CONFIG_DB keys "STATIC_ROUTE*"
STATIC_ROUTE|default|10.2.0.1/32

admin@MtFuji-dut:~$ sonic-db-cli CONFIG_DB hgetall "STATIC_ROUTE|default|10.2.0.1/32"
{'blackhole': 'false', 'distance': '0', 'ifname': '', 'nexthop': '18.0.202.1', 'nexthop-vrf': 'default'}

admin@MtFuji-dut:~$ show ip route vrf all static
Codes: K - kernel route, C - connected, L - local, S - static,
R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
f - OpenFabric, t - Table-Direct,
> - selected route, * - FIB route, q - queued, r - rejected, b - backup
t - trapped, o - offload failure

IPv4 unicast VRF default:
S> 10.2.0.1/32 [1/0] via 18.0.202.1 (recursive), weight 1, 05:43:36
    *. via 10.0.0.1, PortChannel999, weight 1, 05:43:36
    * via 10.0.0.5, PortChannel105, weight 1, 05:43:36
    * via 10.0.0.9, PortChannel108, weight 1, 05:43:36
    *  via 10.0.0.13, PortChannel111, weight 1, 05:43:36

admin@MtFuji-dut:~$ show ip route 10.2.0.1/32
Routing entry for 10.2.0.1/32
Known via "static", distance 1, metric 0, best
Last update 05:44:26 ago

18.0.202.1 (recursive)
10.0.0.1, via PortChannel999
10.0.0.5, via PortChannel105
10.0.0.9, via PortChannel108
10.0.0.13, via PortChannel111

admin@MtFuji-dut:~$ show ip route 18.0.202.1
Routing entry for 0.0.0.0/0
Known via "bgp", distance 20, metric 0, best
Last update 05:46:26 ago

10.0.0.1, via PortChannel999
10.0.0.5, via PortChannel105
10.0.0.9, via PortChannel108
10.0.0.13, via PortChannel111

#### How did you do it?
a shutdown_interface (admin-down) step is inserted at the very top of each finally block, immediately before the existing IP removal. This preserves the original cleanup sequence (IP → members → delete PortChannel) unchanged.

duthost.shutdown_interface(PortChannel999) ← NEW: admin-down the LAG
time.sleep(5) ← NEW: wait for FRR BGP convergence
config interface ip remove PortChannel999 ← original step (unchanged)
time.sleep(5)
config portchannel member del ← original step (unchanged)
_wait_until_pc_members_removed
config portchannel del PortChannel999 ← original step (unchanged)

#### How did you verify/test it?
Run the test script test_po_update.py in the T1 smartswitch having golden config (Cisco-8102-28FH-DPU-O)

#### Any platform specific information?
T1 Smartswitch - Cisco-8102-28FH-DPU-O

#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
