### PR TITLE
202511 - Preliminary Cisco8223 QOS enablement

### DIFF
--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -45,6 +45,7 @@ cisco-8000_gb_hwskus: ["Cisco-8102-C64", "Cisco-8101-T32", "Cisco-8101-O32", "Ci
 cisco-8000_gr_hwskus: ["Cisco-8111-O32", "Cisco-8111-O64"]
 cisco-8000_gr2_hwskus: ["Cisco-8122-O64", "Cisco-8122-O64S2", "Cisco-8122-O128", "Cisco-8122-O128S2"]
 cisco-8000_pac_hwskus: ["Cisco-8800-LC-48H-C48"]
+cisco-8000_p200_hwskus: ["Cisco-8223-P64S2", "Cisco-8223-O128S2", "Cisco-8223-P32O64S2"]
 
 ## Note:
 ## Docker volumes should be list instead of dict. However, if we want to keep code DRY, we

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3857,7 +3857,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark:
     conditions:
       - "platform in ['x86_64-nokia_ixr7250e_36x400g-r0', 'x86_64-arista_7800r3_48cq2_lc', 'x86_64-arista_7800r3_48cqm2_lc', 'x86_64-arista_7800r3a_36d2_lc', 'x86_64-arista_7800r3a_36dm2_lc','x86_64-arista_7800r3ak_36dm2_lc']"
       - "topo_type in ['m0', 'mx', 'm1']"
-      - "topo_name not in constants['QOS_SAI_TOPO'] and asic_type not in ['mellanox']"
+      - "topo_name not in (constants['QOS_SAI_TOPO'] + ['t2_single_node_max', 't2_single_node_min']) and asic_type not in ['mellanox']"
       - "topo_type not in ['t0'] and asic_type in ['marvell-teralynx']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pPgMapping:
@@ -3964,7 +3964,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq:
     reason: "Unsupported testbed type."
     conditions_logical_operator: or
     conditions:
-      - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
+      - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_') or platform.startswith('x86_64-8223_')"
       - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in constants['QOS_SAI_TOPO'] and asic_type not in ['mellanox']"
 
@@ -3973,7 +3973,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq:
     reason: "Unsupported testbed type."
     conditions_logical_operator: or
     conditions:
-      - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
+      - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_') or platform.startswith('x86_64-8223_')"
       - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in constants['QOS_SAI_TOPO'] and asic_type not in ['mellanox']"
 
@@ -3982,7 +3982,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoqMultiSrc:
     reason: "Unsupported testbed type."
     conditions_logical_operator: or
     conditions:
-      - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
+      - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_') or platform.startswith('x86_64-8223_')"
       - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in constants['QOS_SAI_TOPO'] and asic_type not in ['mellanox']"
 

--- a/tests/pfcwd/cisco/default_pfc_time.py
+++ b/tests/pfcwd/cisco/default_pfc_time.py
@@ -1,11 +1,11 @@
 # Verified on Q200 @ 100G port speed. e.g. 687 is bit time to pause for 50ms (clock at 900Mhz).
-from common import is_graphene2, tree, is_gr, port_to_sai_lane_map, \
+from common import is_graphene2, is_palladium2, tree, is_gr, port_to_sai_lane_map, \
     sai_lane_to_slice_ifg_pif, dd0, is_pac, is_gb, sdk, get_mac_port, d0
 
 
 def get_ifg_reg_list(slice_idx):
     ''' Gr2 does not have an ifg list, listify '''
-    if is_graphene2:                                 # noqa: F821
+    if is_graphene2 or is_palladium2:                 # noqa: F821
         ifg_root = [tree.slice[slice_idx].ifg]       # noqa: F821
     else:
         ifg_root = tree.slice[slice_idx].ifg       # noqa: F821
@@ -15,7 +15,7 @@ def get_ifg_reg_list(slice_idx):
 def get_ifgb(ifg_root):
     ''' Complex tree register differences for ifgb per asic.
             Takes tree.slice[slice_idx].ifg[ifg_idx] '''
-    if is_graphene2:                               # noqa: F821
+    if is_graphene2 or is_palladium2:               # noqa: F821
         ifgb = ifg_root.ifgbe_ra
     elif is_gr:                               # noqa: F821
         ifgb = ifg_root.ifgbe_mac
@@ -50,11 +50,11 @@ def compute_fractional_512bit_value(mac_freq_khz, port_gbps):
 bit_time = None
 if is_pac or is_gb:                                                       # noqa: F821
     bit_time = 5
-elif is_gr or is_graphene2:                                               # noqa: F821
+elif is_gr or is_graphene2 or is_palladium2:                              # noqa: F821
     mac_freq_khz = d0.get_int_property(sdk.la_device_property_e_MAC_FREQUENCY)      # noqa: F821
     print("Mac frequency khz: {}".format(mac_freq_khz))
 
-    mac_port = get_mac_port(INTERFACE)                                    # noqa: F821
+    mac_port = get_mac_port("INTERFACE")                                    # noqa: F821
     mac_port_speed_enum_val = mac_port.get_speed()
 
     # Find matching speed enum
@@ -72,6 +72,9 @@ elif is_gr or is_graphene2:                                               # noqa
     gbps_str = speed[:-1]
     assert gbps_str.isdigit(), "Non-digit speed {}".format(gbps_str)
     gbps = int(gbps_str)
+    if is_palladium2 and gbps == 800:
+        print("Reducing 800G to 400G for P200 PFC 512 bit time calculation")
+        gbps = 400
     print("Port speed gbps: {}".format(gbps))
     bit_time = compute_fractional_512bit_value(mac_freq_khz, gbps)
 

--- a/tests/pfcwd/cisco/set_pfc_time.py
+++ b/tests/pfcwd/cisco/set_pfc_time.py
@@ -1,5 +1,5 @@
 import math
-from common import is_graphene2, tree, is_gr, port_to_sai_lane_map, \
+from common import is_graphene2, is_palladium2, tree, is_gr, port_to_sai_lane_map, \
     sai_lane_to_slice_ifg_pif, dd0, is_pac, is_gb, sdk, d0
 
 
@@ -9,7 +9,7 @@ arg_interface = "INTERFACE"
 
 def get_ifg_reg_list(slice_idx):
     ''' Gr2 does not have an ifg list, listify '''
-    if is_graphene2:                               # noqa: F821
+    if is_graphene2 or is_palladium2:               # noqa: F821
         ifg_root = [tree.slice[slice_idx].ifg]     # noqa: F821
     else:
         ifg_root = tree.slice[slice_idx].ifg     # noqa: F821
@@ -19,7 +19,7 @@ def get_ifg_reg_list(slice_idx):
 def get_ifgb(ifg_root):
     ''' Complex tree register differences for ifgb per asic.
             Takes tree.slice[slice_idx].ifg[ifg_idx] '''
-    if is_graphene2:                             # noqa: F821
+    if is_graphene2 or is_palladium2:             # noqa: F821
         ifgb = ifg_root.ifgbe_ra
     elif is_gr:                                 # noqa: F821
         ifgb = ifg_root.ifgbe_mac
@@ -43,7 +43,7 @@ def set_pfc512_bit_sec(interface, time_sec):
     if is_gb or is_pac:          # noqa: F821
         khz = d0.get_int_property(sdk.la_device_property_e_DEVICE_FREQUENCY)       # noqa: F821
         print("Device frequency khz: {}".format(khz))
-    elif is_gr or is_graphene2:                                                 # noqa: F821
+    elif is_gr or is_graphene2 or is_palladium2:                                # noqa: F821
         khz = d0.get_int_property(sdk.la_device_property_e_MAC_FREQUENCY)      # noqa: F821
         print("Mac frequency khz: {}".format(khz))
     else:
@@ -53,7 +53,7 @@ def set_pfc512_bit_sec(interface, time_sec):
 
     if is_gb or is_pac:                                                      # noqa: F821
         bit_time = math.ceil(num_clocks_float)
-    elif is_gr or is_graphene2:                                           # noqa: F821
+    elif is_gr or is_graphene2 or is_palladium2:                          # noqa: F821
         int_part = int(num_clocks_float)
         float_part = num_clocks_float - int_part
         print("Integer: {}".format(int_part))

--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -56,11 +56,16 @@ class QosParamCisco(object):
         # TODO: topo-t2 support
         # Per-asic variable description:
         # 0: Max queue depth in bytes
-        # 1: Flow control configuration on this device, either 'separate' or 'shared'.
-        # 2: Number of packets margin for the quantized queue watermark tests.
+        # 1: Number of packets margin for the quantized queue watermark tests.
+        # 2: Bytes per buffer
+        # 3: Packet size preferred by the asic to increase test stability
+        # 4: Number of packets added to the pause threshold to line up with theoretical predictions
+        # 5: Number of packets added to the lossless drop threshold to line up with theoretical predictions
+        # 6: Number of packets added to the lossy drop threshold to line up with theoretical predictions
         asic_params = {"gb": (6144000, 3072, 384, 1350, 2, 3, 0),
                        "gr": (24576000, 18000, 384, 1350, 2, 3, 0),
-                       "gr2": (None, 2, 512, 64, 3, 4, -40)}
+                       "gr2": (None, 2, 512, 64, 3, 4, -40),
+                       "p200": (None, 1, 512, 64, 2, 2, 0)}
         self.supports_autogen = dutAsic in asic_params and topo == "topo-any"
         if self.supports_autogen:
             # Asic dependent parameters
@@ -78,7 +83,7 @@ class QosParamCisco(object):
             if "dynamic_th" in lossless_prof:
                 dynamic_th = int(lossless_prof["dynamic_th"])
                 alpha = 2 ** dynamic_th
-                if dutAsic == "gr2":
+                if dutAsic in ["gr2", "p200"]:
                     attempted_pause = int((self.ingress_pool_size - self.ingress_pool_headroom) * alpha / (1. + alpha))
                 else:
                     attempted_pause = alpha * self.ingress_pool_size
@@ -89,7 +94,8 @@ class QosParamCisco(object):
 
             # Calculate real lossless/lossy thresholds while accounting for maxes
             if max_queue_depth is None:
-                egress_pool_reserved_buffer = 12582912  # 12MB reserve of the pool
+                egress_pool_reserved_buffer = {"gr2": 12 * 1024 * 1024,
+                                               "p200": 5 * 1024 * 1024}.get(dutAsic, 0)
                 dynamic_th = int(self.bufferConfig["BUFFER_PROFILE"]["egress_lossy_profile"]["dynamic_th"])
                 alpha = 2 ** dynamic_th
                 profile_reserved_memory = int(self.bufferConfig["BUFFER_PROFILE"]["egress_lossy_profile"]["size"])
@@ -107,7 +113,7 @@ class QosParamCisco(object):
                 self.log("Max pause thr bytes:       {}".format(max_pause))
                 pre_pad_pause = min(attempted_pause, max_pause)
 
-            if dutAsic in ["gr", "gr2"]:
+            if dutAsic in ["gr", "gr2", "p200"]:
                 refined_pause_thr = (self.gr_get_hw_thr_buffs(pre_pad_pause // self.buffer_size) *
                                      self.buffer_size)
                 self.log("{} pre-pad pause threshold changed from {} to {}".format(dutAsic, pre_pad_pause,
@@ -130,6 +136,20 @@ class QosParamCisco(object):
                 # can divide by buffer size later to get the correct packet count.
                 advertised_hr = packets_hr * self.buffer_size
                 pre_pad_drop = pre_pad_pause + advertised_hr
+            elif dutAsic == "p200":
+                # P200 uses a variant of mantissa/exponent rounding for HR thresholds.
+                xoff_bytes = int(lossless_prof["xoff"])
+                mantissa_len = 4
+                exponent = max(xoff_bytes.bit_length() - mantissa_len, 0)
+                mantissa = xoff_bytes >> exponent
+                if (mantissa << exponent) < xoff_bytes:
+                    mantissa += 1
+                hw_hr_bytes = mantissa << exponent
+                hw_hr_buffers = hw_hr_bytes // self.buffer_size
+                self.log("P200 HR threshold: xoff {} bytes -> {} buffers (mantissa={}, exp={})".format(
+                    xoff_bytes, hw_hr_buffers, mantissa, exponent))
+                advertised_hr = hw_hr_buffers * self.buffer_size
+                pre_pad_drop = pre_pad_pause + advertised_hr
             else:
                 pre_pad_drop = pre_pad_pause + int(lossless_prof["xoff"])
 
@@ -140,8 +160,9 @@ class QosParamCisco(object):
                                                       self.buffer_size))
 
             # Hysteresis calculations depending on asic
-            if dutAsic == "gr2":
-                assert "xon_offset" in lossless_prof, "gr2 missing xon_offset from lossless buffer profile"
+            if dutAsic in ["gr2", "p200"]:
+                assert "xon_offset" in lossless_prof, \
+                    "{} missing xon_offset from lossless buffer profile".format(dutAsic)
                 xon_offset = int(lossless_prof["xon_offset"])
                 self.log("Pre-pad hysteresis bytes: {}".format(xon_offset))
                 # Determine difference between pause thr and hysteresis thr.
@@ -320,7 +341,7 @@ class QosParamCisco(object):
         mantissa_len = 5
         exponent = max(thr.bit_length() - mantissa_len, 0)
         mantissa = thr >> exponent
-        if is_lossy:
+        if is_lossy and self.dutAsic == "gr2":
             # gr2 lossy egress drop threshold is 1 off due to queue occupancy is quantized
             mantissa += 1
         return mantissa, exponent
@@ -329,7 +350,7 @@ class QosParamCisco(object):
         ''' thr must be in units of buffers '''
         if self.dutAsic == "gr":
             mantissa, exp = self.gr_get_mantissa_exp(thr)
-        elif self.dutAsic == "gr2":
+        elif self.dutAsic in ["gr2", "p200"]:
             mantissa, exp = self.gr2_get_mantissa_exp(thr, is_lossy)
         else:
             assert False, "Invalid asic {} for gr_get_hw_thr_buffs".format(self.dutAsic)

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -60,7 +60,7 @@ class QosBase:
                           "t1-isolated-d56u1-lag", "t1-isolated-v6-d56u1-lag", "t1-isolated-d128", "t1-isolated-d32",
                           "t1-isolated-d448u15-lag", "t1-isolated-v6-d448u15-lag"]
     SUPPORTED_PTF_TOPOS = ['ptf32', 'ptf64']
-    SUPPORTED_ASIC_LIST = ["pac", "gr", "gr2", "gb", "td2", "th", "th2", "spc1", "spc2", "spc3", "spc4", "spc5",
+    SUPPORTED_ASIC_LIST = ["pac", "gr", "gr2", "gb", "p200", "td2", "th", "th2", "spc1", "spc2", "spc3", "spc4", "spc5",
                            "td3", "th3", "j2c+", "jr2", "th5", "q3d"]
 
     BREAKOUT_SKUS = ['Arista-7050-QX-32S']

--- a/tests/qos/test_pfc_counters.py
+++ b/tests/qos/test_pfc_counters.py
@@ -91,8 +91,10 @@ def run_test(fanouthosts, duthost, conn_graph_facts, enum_fanout_graph_facts, le
                         int_status[intf]['admin_state'] == 'up' and
                         int_status[intf]['oper_state'] == 'up' and
                         intf in conn_facts]
-    only_lossless_rx_counters = "Cisco-8122" in asic.sonichost.facts["hwsku"]
-    no_xon_counters = "Cisco-8122" in asic.sonichost.facts["hwsku"]
+    only_lossless_rx_counters_hwskus = ["Cisco-8122", "Cisco-8223"]
+    only_lossless_rx_counters = any(sku in asic.sonichost.facts["hwsku"] for sku in only_lossless_rx_counters_hwskus)
+    no_xon_counters_hwskus = ["Cisco-8122", "Cisco-8223"]
+    no_xon_counters = any(sku in asic.sonichost.facts["hwsku"] for sku in no_xon_counters_hwskus)
     if only_lossless_rx_counters and asic_type != 'vs':
         config_facts = asic.config_facts(host=asic.hostname, source='persistent')['ansible_facts']
     if not check_continuous_pfc:

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1969,7 +1969,8 @@ class TestQosSai(QosSaiBase):
             skip_test_on_no_lossless_pg(portSpeedCableLength)
 
         if queueProfile == "wm_q_shared_lossless":
-            if dutTestParams["basicParams"]["sonic_asic_type"] == 'cisco-8000':
+            if dutTestParams["basicParams"]["sonic_asic_type"] == 'cisco-8000' and \
+                  not get_src_dst_asic_and_duts['single_asic_test']:
                 dstPortSpeedCableLength = get_portspeed_cablelen(
                     get_src_dst_asic_and_duts['dst_asic'])
                 if dstPortSpeedCableLength != portSpeedCableLength:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Initial set of changes needed to enable Cisco8223 switch for sonic-mgmt QOS and PFC-WD test cases. Not intended to provide full-pass rate, but enables some basics. 

Changes:
- Define P200 hwskus
- Enabling P200 for default_pfc_time and set_pfc_time scripts (used for PFC-WD). 
- Defining MMU thresholding characteristics in the parameter generator for Cisco. 
- Adding "p200" as a supported asic for QOS SAI. 
- Edit p200 PFC counter behavior to match g200.
- Unskip lossless queue watermark test
- Skip some voq tests specific to 8102 series asics. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

Validated partial pass rate on QOS SAI test cases on Cisco-8223-P64S2 hwsku:
Passed:
- testparameter
- pfcXoffLimit
- pfcXonLimit
- LossyQueue
- DscpQueueMapping
- pgSharedWatermark
- DscpToPgMapping

"set_pfc_time.py" works well:
```
DEBUG:tests.common.devices.base:/data/tests/common/devices/multi_asic.py::_run_on_asics#153: [titan-t0-dut] AnsibleModule::shell, args=["show platform npu script  -s set_pfc_time.py"], kwargs={}                                                                                                                                                             
Thursday 02 April 2026  18:51:59 +0000 (0:00:00.301)       0:01:32.282 ********                                                                                                                                                                                                                                                                                
DEBUG:tests.common.devices.base:/data/tests/common/devices/multi_asic.py::_run_on_asics#153: [titan-t0-dut] AnsibleModule::shell Result => {"changed": true, "stdout": "Setting PFC frame time to 50ms\nMac frequency khz: 996093\nInteger: 759\nFloat: 0.970244907301435\nMaxed out, setting bit time 262143 instead of 778209\nSetting bit_time (number of cl
ocks) to 262143", "stderr": "", "rc": 0, "cmd": "show platform npu script  -s set_pfc_time.py", "start": "2026-04-02 18:52:08.604512", "end": "2026-04-02 18:52:09.599298", "delta": "0:00:00.994786", "msg": "", "invocation": {"module_args": {"_raw_params": "show platform npu script  -s set_pfc_time.py", "_uses_shell": true, "warn": false, "stdin_add_
newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": ["Setting PFC frame time to 50ms", "Mac frequency khz: 996093", "Integer: 759", "Float: 0.970244907301435", "Maxed out, setting bit time 262143 instead of 778209", "Setting bit_time (number of 
clocks) to 262143"], "stderr_lines": [], "_ansible_no_log": null, "failed": false}  
```

"default_pfc_time.py" includes a fix to make it also work well:
```
DEBUG:tests.common.devices.base:/data/tests/common/devices/multi_asic.py::_run_on_asics#153: [titan-t0-dut] AnsibleModule::shell Result => {"changed": true, "stdout": "Mac frequency khz: 9960
93\nSpeed string: 800G\nReducing 800G to 400G for P200 PFC 512 bit time calculation\nPort speed gbps: 400\nCycles per 512bits: 1.27499904\nInteger: 1\nFraction: 0.27499904\nSetting 512bit reg
ister to normal value 1305\nDone", "stderr": "", "rc": 0, "cmd": "show platform npu script  -s default_pfc_time.py", "start": "2026-04-02 20:27:47.483600", "end": "2026-04-02 20:27:48.468981"
, "delta": "0:00:00.985381", "msg": "", "invocation": {"module_args": {"_raw_params": "show platform npu script  -s default_pfc_time.py", "_uses_shell": true, "warn": false, "stdin_add_newlin
e": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": ["Mac frequency khz: 996093", "Speed st
ring: 800G", "Reducing 800G to 400G for P200 PFC 512 bit time calculation", "Port speed gbps: 400", "Cycles per 512bits: 1.27499904", "Integer: 1", "Fraction: 0.27499904", "Setting 512bit reg
ister to normal value 1305", "Done"], "stderr_lines": [], "_ansible_no_log": null, "failed": false}                                                                                            
```

Clean boot original bit time for 800G confirmed to be 1305. 

#### Any platform specific information?

All changes are specific to Cisco TBs. 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
