### PR TITLE
voq/test_voq_counter: fix Q3D ASIC detection for single asic platforms

### DIFF
--- a/tests/voq/test_voq_counter.py
+++ b/tests/voq/test_voq_counter.py
@@ -3,6 +3,7 @@ import pytest
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until
 from tests.common.gu_utils import get_asic_name
+from tests.common.plugins.conditional_mark import read_asic_name
 
 
 logger = logging.getLogger(__name__)
@@ -38,6 +39,9 @@ def test_voq_queue_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     duthost.shell("sonic-clear queuecounters")
 
     asic_name = get_asic_name(duthost).lower()
+    if asic_name == "unknown":
+        hwsku = duthost.facts.get("hwsku", "")
+        asic_name = (read_asic_name(hwsku) or "unknown").lower()
     is_q3d_single_asic = ("q3d" in asic_name) and (not duthost.is_multi_asic)
 
     if is_q3d_single_asic:


### PR DESCRIPTION

---

### Description of PR

**Summary:**

Fix `test_voq_queue_counter` failure on single-ASIC Q3D VOQ platforms by adding a fallback for ASIC generation detection.

**Background:**

PR [#23047](https://github.com/sonic-net/sonic-mgmt/pull/23047) added Q3D single-ASIC support to test_voq_counter.py, using `get_asic_name()` from `gu_utils` to detect whether the DUT is a Q3D platform. `get_asic_name()` works by reading the GCU config file (`gcu_field_operation_validators.conf.json`) on the DUT and looking up the hwsku in the `broadcom_asics` mapping to determine the ASIC generation.

However, on certain Q3D single-ASIC VOQ platforms, the GCU config's `q3d` hwsku list does not include all Q3D hwskus. This causes `get_asic_name()` to return `"unknown"`, which makes `is_q3d_single_asic` evaluate to `False`. The test then incorrectly takes the multi-asic/SFI port toggling code path instead of the Q3D register path (`DISABLE_FABRIC_MSGS`). Since these single-ASIC platforms have no SFI/fabric ports to toggle, the Credit-WD-Del counters never increment and the test fails after the 300-second timeout.

**Root cause on the buildimage side:**

The proper long-term fix is to add the missing Q3D hwskus to the `q3d` list in `sonic-utilities`'s `gcu_field_operation_validators.conf.json`. This is a data gap — certain hwskus were never added when the platform was onboarded. A separate PR will be submitted to `sonic-net/sonic-utilities` to address this. Once that lands, the fallback added here will no longer be needed (but will remain harmless).

**What this PR does:**

Adds a fallback to `read_asic_name()` from the `conditional_mark` module when `get_asic_name()` returns `"unknown"`. `read_asic_name()` uses `ansible/group_vars/sonic/variables` on the test server, which has a more complete mapping of hwskus to ASIC generations. This fallback only triggers when `get_asic_name()` fails — existing platforms where `get_asic_name()` already works are completely unaffected.

Fixes # N/A (regression from #23047)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

`test_voq_queue_counter` fails on Q3D single-ASIC VOQ platforms in nightly runs. The failure was introduced by PR #23047 which added Q3D-specific handling but relied on `get_asic_name()` for detection. `get_asic_name()` depends on the GCU config on the DUT, which does not include all Q3D hwskus. This is a data gap on the `sonic-buildimage`/`sonic-utilities` side (a separate PR will be filed to add the missing hwskus to the GCU config).

#### How did you do it?

Added a fallback mechanism: when `get_asic_name()` returns `"unknown"`, the test falls back to `read_asic_name()` from the `conditional_mark` module. This function uses `ansible/group_vars/sonic/variables` (maintained in the sonic-mgmt repo) which has a more complete hwsku-to-ASIC-generation mapping.

The fallback is scoped to only trigger when the primary lookup fails, so no existing platform behavior is changed.

#### How did you verify/test it?

- Tested on a single-ASIC Q3D broadcom-dnx VOQ platform with t2_single_node_max_64p topology
- **Before fix:** FAILED — `get_asic_name()` returned `"unknown"`, test took the SFI code path, Credit-WD-Del counters never incremented (300s timeout)
- **After fix:** PASSED — fallback detected Q3D, test used the `DISABLE_FABRIC_MSGS` register path, Credit-WD-Del counters incremented within seconds
- Also manually verified on the DUT that the Q3D register approach correctly triggers Credit-WD-Del counter increments on VOQ7

#### Any platform specific information?

- **Affected:** Q3D single-ASIC VOQ platforms whose hwsku is not listed in the GCU config's `q3d` entry
- **Not affected:** Platforms already listed in the GCU config, multi-ASIC chassis platforms
- **Companion fix needed:** `sonic-net/sonic-utilities` — add missing Q3D hwskus to `gcu_field_operation_validators.conf.json`

#### Supported testbed topology if it's a new test case?

N/A — existing test case fix. Test runs on `t2` topology.

### Documentation

N/A