### PR TITLE
Multi Asic QoS: Randomize source and dest asic selection

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -853,8 +853,12 @@ class QosSaiBase(QosBase):
                 pytest.skip(
                     "Did not find any frontend node that is multi-asic - so can't run single_dut_multi_asic tests")
             dst_dut_index = src_dut_index
-            src_asic_index = 0
-            dst_asic_index = 1
+            # Randomize ASIC selection
+            selected_dut = duthosts.frontend_nodes[src_dut_index]
+            num_frontend_asics = len(selected_dut.frontend_asics)
+            asic_indices = list(range(num_frontend_asics))
+            src_asic_index, dst_asic_index = random.sample(asic_indices, 2)
+            logger.info(f"Selected src asic index: {src_asic_index} and dest asic index: {dst_asic_index}")
 
         else:
             # Dealing with multi-dut
@@ -974,6 +978,9 @@ class QosSaiBase(QosBase):
         dst_dut_port_ips = testPortIps[dst_dut_idx]
         dst_test_port_ips = dst_dut_port_ips[dst_asic_idx]
 
+        # Determine if source and destination are on the same ASIC
+        sameSrcDestDutAndAsic = src_dut_idx == dst_dut_idx and src_asic_idx == dst_asic_idx
+
         if dstPorts is None:
             if dst_port_ids:
                 pytest_assert(
@@ -982,15 +989,24 @@ class QosSaiBase(QosBase):
                     "Dest port id passed in qos.yml not valid"
                 )
                 dstPorts = dst_port_ids
-            elif len(dst_test_port_ids) >= 4:
-                dstPorts = [0, 2, 3]
-                if (get_src_dst_asic_and_duts["src_asic"].sonichost.facts["asic_type"]
-                        in ['cisco-8000']):
-                    dstPorts = [2, 3, 4]
-            elif len(dst_test_port_ids) == 3:
-                dstPorts = [0, 2, 2]
+            # When src and dst are on same ASIC, they share the same port list.
+            elif sameSrcDestDutAndAsic:
+                if len(dst_test_port_ids) >= 4:
+                    dstPorts = [0, 2, 3]
+                    if (get_src_dst_asic_and_duts["src_asic"].sonichost.facts["asic_type"]
+                            in ['cisco-8000']):
+                        dstPorts = [2, 3, 4]
+                elif len(dst_test_port_ids) == 3:
+                    dstPorts = [0, 2, 2]
+                else:
+                    dstPorts = [0, 0, 0]
             else:
-                dstPorts = [0, 0, 0]
+                if len(dst_test_port_ids) >= 3:
+                    dstPorts = [0, 1, 2]
+                elif len(dst_test_port_ids) == 2:
+                    dstPorts = [0, 1, 1]
+                else:
+                    dstPorts = [0, 0, 0]
 
         if srcPorts is None:
             if src_port_ids:
@@ -1027,14 +1043,28 @@ class QosSaiBase(QosBase):
         )
         logging.debug("Test Port dst:{}, src:{}".format(dstPorts, srcPorts))
 
-        pytest_assert(
-            len(set(dstPorts).intersection(set(srcPorts))) == 0,
-            "Duplicate destination and source ports '{0}'".format(
-                set(dstPorts).intersection(set(srcPorts))
+        # Only check for port index overlap when source and destination are on the same ASIC.
+        # When on different ASICs, they use separate port lists, so index overlap doesn't
+        # imply physical port overlap.
+        if sameSrcDestDutAndAsic:
+            overlap = set(dstPorts).intersection(set(srcPorts))
+            pytest_assert(
+                len(overlap) == 0,
+                "Port index overlap detected on DUT[{0}] ASIC[{1}]: "
+                "source indices {2}, destination indices {3}, overlap {4}. "
+                "Since source and destination are on the same ASIC, this means the same "
+                "physical port(s) would be used for both source and destination, which is invalid.".format(
+                    src_dut_idx,
+                    src_asic_idx,
+                    set(srcPorts),
+                    set(dstPorts),
+                    overlap
+                )
             )
-        )
 
-        # TODO: Randomize port selection
+        random.shuffle(dstPorts)
+        random.shuffle(srcPorts)
+
         dstPort = dstPorts[0] if dst_port_ids else dst_test_port_ids[dstPorts[0]]
         dstVlan = dst_test_port_ips[dstPort]['vlan_id'] if 'vlan_id' in dst_test_port_ips[dstPort] else None
         dstPort2 = dstPorts[1] if dst_port_ids else dst_test_port_ids[dstPorts[1]]


### PR DESCRIPTION
Instead of hardcoding 0 and 1 as src and dst respectively, we now randomize the selection. Additionally I fix the default src and dest port selection with this change and randomize the src and dest ports.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
* Improve test coverage of QoS tests on multi asic by randomizing the src and dest asic selected instead of using hardcoded values.
* Improve test coverage of QoS tests on all platforms by also shuffling the src and dest ports selected.
* Fix the assumption that we can't use dest port index 1 when we use that for the src port index, but this does not apply to multi asic systems which have 2 separate port lists

#### How did you do it?
* randomize asic and port selection
* fix the logic for default port selection

#### How did you verify/test it?
* reran the QoS tests to see them pass on multi asic and single asic devices

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
