### PR TITLE
[bfd] Fix test_bfd_basic showing xfail_expected on unsupported platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -285,6 +285,7 @@ bfd/test_bfd.py::test_bfd_basic:
     reason: "Test might failed due to https://github.com/sonic-net/sonic-mgmt/issues/19519"
     conditions:
       - https://github.com/sonic-net/sonic-mgmt/issues/19519
+      - "platform in ['x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn5600-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-nvidia_sn4280-r0', 'x86_64-8102_28fh_dpu_o-r0']"
 
 bfd/test_bfd.py::test_bfd_echo_mode:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -283,6 +283,7 @@ bfd/test_bfd.py::test_bfd_basic:
       - "asic_type in ['vs']"
   xfail:
     reason: "Test might failed due to https://github.com/sonic-net/sonic-mgmt/issues/19519"
+    conditions_logical_operator: and
     conditions:
       - https://github.com/sonic-net/sonic-mgmt/issues/19519
       - "platform in ['x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn5600-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-nvidia_sn4280-r0', 'x86_64-8102_28fh_dpu_o-r0', 'x86_64-kvm_x86_64-r0']"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -285,7 +285,7 @@ bfd/test_bfd.py::test_bfd_basic:
     reason: "Test might failed due to https://github.com/sonic-net/sonic-mgmt/issues/19519"
     conditions:
       - https://github.com/sonic-net/sonic-mgmt/issues/19519
-      - "platform in ['x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn5600-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-nvidia_sn4280-r0', 'x86_64-8102_28fh_dpu_o-r0']"
+      - "platform in ['x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn5600-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-nvidia_sn4280-r0', 'x86_64-8102_28fh_dpu_o-r0', 'x86_64-kvm_x86_64-r0']"
 
 bfd/test_bfd.py::test_bfd_echo_mode:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -283,7 +283,7 @@ bfd/test_bfd.py::test_bfd_basic:
       - "asic_type in ['vs']"
   xfail:
     reason: "Test might failed due to https://github.com/sonic-net/sonic-mgmt/issues/19519"
-    conditions_logical_operator: and
+    conditions_logical_operator: or
     conditions:
       - https://github.com/sonic-net/sonic-mgmt/issues/19519
       - "platform in ['x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn5600-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-nvidia_sn4280-r0', 'x86_64-8102_28fh_dpu_o-r0', 'x86_64-kvm_x86_64-r0']"


### PR DESCRIPTION
### Description of PR

The `bfd/test_bfd.py::test_bfd_basic` xfail condition (for issue #19519) fires on all platforms, including those already skipped by the platform allowlist. This causes the test to appear as `xfail_expected` on Grafana dashboards for platforms like Arista 7060X6 where it should simply show as `skipped`.

This PR:
- Scopes the xfail to only platforms where the test would actually run

### Type of change

- [x] Testbed and Framework(new/improvement)

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ x ] 202511

### Approach
#### What is the motivation for this PR?
On unsupported platforms, `test_bfd_basic` reports `xfail_expected` instead of `skipped` because the xfail mark (tied to open issue #19519) has no platform guard and fires alongside the skip mark.

#### How did you do it?
Added `conditions_logical_operator: and` with a platform-in-allowlist condition to the xfail block. 

#### How did you verify/test it?
Confirmed via test collection (`--collect-only`) that on non-allowlisted platforms only the `skip` mark is applied, and on allowlisted platforms both `skip` (if applicable) and `xfail` behave correctly.

#### Any platform specific information?
Affects dashboard reporting for all platforms not in the BFD allowlist (currently only Nvidia and Cisco platforms are supported).

#### Supported testbed topology if it's a new test case?
N/A 