### PR TITLE
[conditional_mark] Skip gnmi/test_gnmic.py

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2965,6 +2965,12 @@ gnmi/test_gnmi_smartswitch.py:
     conditions:
       - "'bmc' in topo_type"
 
+gnmi/test_gnmic.py:
+  skip:
+    reason: "gnmic binary is being removed from docker-ptf to reduce attack surface"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/24328"
+
 gnmi/test_gnoi_killprocess.py:
   skip:
     reason: "Test noisy due to restart issue not relevant to GNOI. Disabling them to rewrite."


### PR DESCRIPTION
## Description of PR

Add a conditional-mark `skip` for `tests/gnmi/test_gnmic.py` while the `gnmic` binary is being removed from `docker-ptf`.

This is a precondition for the companion `docker-ptf` change that drops `gnmic` from the image. `tests/gnmi/test_gnmic.py` is the only test in this repo that invokes `/usr/local/bin/gnmic` directly (via `PtfGnmic.capabilities()`); without this skip, that test would start failing on the next `docker-ptf` rebuild.

## Summary
Fixes # (issue): sonic-net/sonic-mgmt#24328

## Type of change
- [x] Test case (verification of existing or new feature)

## Back port request
- [ ] Request back port to applicable release branches (master only — no behavior change for release branches that don't run this test)

## Approach

### What is the motivation for this PR?
Reduce `docker-ptf` supply-chain surface. `gnoic` was removed in [sonic-buildimage#27055](https://github.com/sonic-net/sonic-buildimage/pull/27055); `gnmic` is the next candidate because it has only one consumer in sonic-mgmt and that consumer can be skipped without losing coverage of any production behavior — `gnmi_tls.gnoi.*` and `pygnmi` cover the actual gNMI/gNOI surfaces under test.

### How did you do it?
Added an entry under the `gnmi/` section of `tests_mark_conditions.yaml` that skips the test while sonic-net/sonic-mgmt#24328 is open. When the issue closes, the skip lifts — by then we should have either deleted the test outright or restored `gnmic`.

### How did you verify/test it?
- `yaml.safe_load` parses the file cleanly with the new entry present.
- conditional_mark plugin uses `pytest_collection_modifyitems`; no test execution required to confirm marker application — the existing `unit_test/` suite under `tests/common/plugins/conditional_mark/` covers that mechanism.

## Any platform specific information?
None.

## Supported testbed topology if it's a new test case?
N/A — no test added.

## Documentation
N/A.