### PR TITLE
[vrf] Support topologies with Ethernet links and no PortChannels

### DIFF
--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -126,6 +126,9 @@ def get_vrf_intfs(cfg_facts):
     for table in intf_tables:
         for intf, attrs in list(cfg_facts.get(table, {}).items()):
             if "|" not in intf:
+                if "vrf_name" not in attrs:
+                    logger.warning("Interface %s in %s has no vrf_name, skipping", intf, table)
+                    continue
                 vrf = attrs["vrf_name"]
                 if vrf not in vrf_intfs:
                     vrf_intfs[vrf] = {}
@@ -140,6 +143,13 @@ def get_vrf_ports(cfg_facts):
     """
 
     vlan_member = list(cfg_facts["VLAN_MEMBER"].keys())
+    if "PORTCHANNEL_MEMBER" not in cfg_facts:
+        logger.warning(
+            "PORTCHANNEL_MEMBER table missing from cfg_facts. "
+            "Expected on topologies with direct Ethernet links, "
+            "but requires further debugging on topologies with PortChannel."
+        )
+    pc_member = list(cfg_facts.get("PORTCHANNEL_MEMBER", {}).keys())
     pc_member = list(cfg_facts["PORTCHANNEL_MEMBER"].keys())
     member = vlan_member + pc_member
 
@@ -153,9 +163,13 @@ def get_vrf_ports(cfg_facts):
         vrf_member_port_indices[vrf] = []
 
         for intf in intfs:
-            vrf_intf_member_port_indices[vrf][intf] = natsorted(
-                [cfg_facts["config_port_indices"][m.split("|")[1]] for m in [m for m in member if intf in m]]
-            )
+            if intf.startswith("Ethernet") and intf in cfg_facts["config_port_indices"]:
+                # Direct Ethernet uplinks: the interface IS the port (no membership table)
+                vrf_intf_member_port_indices[vrf][intf] = [cfg_facts["config_port_indices"][intf]]
+            else:
+                vrf_intf_member_port_indices[vrf][intf] = natsorted(
+                    [cfg_facts["config_port_indices"][m.split("|")[1]] for m in [m for m in member if intf in m]]
+                )
             vrf_member_port_indices[vrf].extend(vrf_intf_member_port_indices[vrf][intf])
 
         vrf_member_port_indices[vrf] = natsorted(vrf_member_port_indices[vrf])
@@ -266,7 +280,22 @@ def setup_vrf_cfg(duthost, localhost, cfg_facts):
     # Use integer division for Python 3 compatibility
     vlan_ports = {"Vlan1000": ports[:len(ports) // 2], "Vlan2000": ports[len(ports) // 2:]}
 
-    extra_vars = {"cfg_t0": cfg_t0, "vlan_ports": vlan_ports}
+    # Compute interface-to-VRF map by matching peer IPs to BGP neighbors
+    intf_vrf_map = {}
+    if "INTERFACE" in cfg_t0 and "BGP_NEIGHBOR" in cfg_t0:
+        unique_names = sorted(set(v['name'] for v in cfg_t0['BGP_NEIGHBOR'].values()))
+        vrf1_names = set(unique_names[:(len(unique_names) + 1) // 2])
+        neigh_vrf = {n: "Vrf1" if cfg_t0['BGP_NEIGHBOR'][n]['name'] in vrf1_names else "Vrf2"
+                     for n in cfg_t0['BGP_NEIGHBOR']}
+        for key in cfg_t0["INTERFACE"]:
+            if "|" in key:
+                intf, ip_str = key.split("|", 1)
+                if intf not in intf_vrf_map:
+                    peer_ip = str(IPNetwork(ip_str).ip + 1)
+                    if peer_ip in neigh_vrf:
+                        intf_vrf_map[intf] = neigh_vrf[peer_ip]
+
+    extra_vars = {"cfg_t0": cfg_t0, "vlan_ports": vlan_ports, "intf_vrf_map": intf_vrf_map}
 
     duthost.host.options["variable_manager"].extra_vars.update(extra_vars)
 
@@ -419,10 +448,21 @@ def gen_vrf_fib_file(
 
 def get_default_vrf_fib_dst_intfs(vrf, tbinfo):
     """
-    Get default vrf fib destination interfaces(PortChannels) according to the given vrf.
-    The test configuration is dynamic and can work with 4 and 8 PCs as the number of VMs.
-    The first half of PCs are related to Vrf1 and the second to Vrf2.
+    Get default vrf fib destination interfaces according to the given vrf.
+    On standard t0 with PortChannels, returns PortChannel names.
+    On isolated topologies with direct Ethernet uplinks, returns Ethernet interface names.
+    The first half of uplink interfaces are related to Vrf1 and the second to Vrf2.
     """
+    # If vrf_intfs is populated, derive uplink interfaces from it (works for both topologies)
+    if g_vars.get("vrf_intfs") and vrf in g_vars["vrf_intfs"]:
+        dst_intfs = [
+            intf for intf in g_vars["vrf_intfs"][vrf]
+            if not intf.startswith("Vlan") and not intf.startswith("Loopback")
+        ]
+        if dst_intfs:
+            return natsorted(dst_intfs)
+
+    # Fallback: original PortChannel-based logic for standard t0
     dst_intfs = []
     vms_num = len(tbinfo["topo"]["properties"]["topology"]["VMs"])
     if vrf == "Vrf1":

--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -150,7 +150,6 @@ def get_vrf_ports(cfg_facts):
             "but requires further debugging on topologies with PortChannel."
         )
     pc_member = list(cfg_facts.get("PORTCHANNEL_MEMBER", {}).keys())
-    pc_member = list(cfg_facts["PORTCHANNEL_MEMBER"].keys())
     member = vlan_member + pc_member
 
     vrf_intf_member_port_indices = {}

--- a/tests/vrf/vrf_config_db.j2
+++ b/tests/vrf/vrf_config_db.j2
@@ -2,20 +2,21 @@
 {% for k in cfg_t0 %}
 {%     if k == 'BGP_NEIGHBOR' %}
     "BGP_NEIGHBOR": {
+{%         set ns = namespace(names=[]) %}
+{%         for neigh in cfg_t0['BGP_NEIGHBOR'] %}
+{%             set name = cfg_t0['BGP_NEIGHBOR'][neigh]['name'] %}
+{%             if name not in ns.names %}
+{%                 set ns.names = ns.names + [name] %}
+{%             endif %}
+{%         endfor %}
+{%         set sorted_names = ns.names | sort %}
+{%         set half = (sorted_names | length + 1) // 2 %}
+{%         set vrf1_names = sorted_names[:half] %}
 {%         for neigh in cfg_t0['BGP_NEIGHBOR'] | sort %}
-{#     to detect number of pcs, used multiplier 2, because each neigh have ipv4 and ipv6 key #}
-{%             if cfg_t0['BGP_NEIGHBOR'] | length == 8  %}
-{%                 if cfg_t0['BGP_NEIGHBOR'][neigh]['name'] in ['ARISTA01T1', 'ARISTA02T1'] %}
+{%             if cfg_t0['BGP_NEIGHBOR'][neigh]['name'] in vrf1_names %}
         "Vrf1|{{ neigh }}": {{ cfg_t0['BGP_NEIGHBOR'][neigh] | to_nice_json | indent(width=8) }}
-{%-                else %}
-        "Vrf2|{{ neigh }}": {{ cfg_t0['BGP_NEIGHBOR'][neigh] | to_nice_json | indent(width=8) }}
-{%-                endif %}
 {%-            else %}
-{%                 if cfg_t0['BGP_NEIGHBOR'][neigh]['name'] in ['ARISTA01T1', 'ARISTA02T1', 'ARISTA03T1', 'ARISTA04T1'] %}
-        "Vrf1|{{ neigh }}": {{ cfg_t0['BGP_NEIGHBOR'][neigh] | to_nice_json | indent(width=8) }}
-{%-                else %}
         "Vrf2|{{ neigh }}": {{ cfg_t0['BGP_NEIGHBOR'][neigh] | to_nice_json | indent(width=8) }}
-{%-                endif %}
 {%-            endif %}
 {%-            if not loop.last %},{%endif %}
 
@@ -56,6 +57,18 @@
         "Loopback0|FC00:1::32/128": {},
         "Loopback2|10.1.0.32/32": {},
         "Loopback2|FC00:1::32/128": {}
+    },
+{%     elif k == 'INTERFACE' %}
+    "INTERFACE": {
+{%         for intf in cfg_t0['INTERFACE'] | sort %}
+{%             if '|' not in intf %}
+        "{{ intf }}": {"vrf_name": "{{ intf_vrf_map[intf] }}"}
+{%-            else %}
+        "{{ intf }}": {}
+{%-            endif %}
+{%-            if not loop.last %},{% endif %}
+
+{%         endfor %}
     },
 {%     elif k == 'PORTCHANNEL_INTERFACE' %}
     "PORTCHANNEL_INTERFACE": {


### PR DESCRIPTION
### Description of PR

Summary:
The VRF test module (`test_vrf.py`) and its Jinja2 template (`vrf_config_db.j2`) assumed a standard t0 topology
with PortChannel-based BGP uplinks and hardcoded neighbor names (ARISTA01T1 - ARISTA04T1/08T1).
This breaks on isolated topologies (e.g. `t0-isolated-d96u32s2`) where uplinks are direct Ethernet
interfaces

This PR makes VRF test setup topology-agnostic by:
1. Dynamically splitting BGP neighbors into Vrf1/Vrf2 by sorted name (first half -> Vrf1, second half -> Vrf2)
   instead of hardcoding ARISTA0xT1 names.
2. Handling direct Ethernet uplink interfaces in `get_vrf_ports()` and `get_default_vrf_fib_dst_intfs()`.
3. Adding an `INTERFACE` section to `vrf_config_db.j2` that assigns VRF membership to Ethernet uplinks
   based on which BGP neighbor peer IP they connect to.
4. Making `PORTCHANNEL_MEMBER` table access defensive (`.get()`) since it's absent on isolated topologies.
5. Skipping interfaces without `vrf_name` in `get_vrf_intfs()` to avoid KeyError on unbound interfaces.

Fixes test_vrf failures on platforms using t0-isolated topologies (e.g. Arista-7060X6-16PE-384C).

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
VRF tests (`tests/vrf/test_vrf.py`) fail on t0-isolated topologies because:
- `PORTCHANNEL_MEMBER` table doesn't exist (KeyError)
- BGP neighbor-to-VRF mapping was hardcoded to specific ARISTA0xT1 names
- `vrf_config_db.j2` had no INTERFACE section for Ethernet uplinks with VRF binding
- Port index resolution assumed all uplinks go through VLAN_MEMBER or PORTCHANNEL_MEMBER

#### How did you do it?
- **`vrf_config_db.j2`**: Replaced hardcoded 4/8-neighbor detection with dynamic sorted-name splitting. Added `INTERFACE` section that renders VRF bindings for direct Ethernet uplinks using `intf_vrf_map` computed in Python.
- **`test_vrf.py` / `setup_vrf_cfg()`**: Computes `intf_vrf_map` by matching interface peer IPs to BGP neighbors and their VRF assignment, then passes it to the template.
- **`test_vrf.py` / `get_vrf_ports()`**: Uses `.get()` for PORTCHANNEL_MEMBER; handles direct Ethernet interfaces that are their own port (no membership indirection).
- **`test_vrf.py` / `get_vrf_intfs()`**: Skips interfaces missing `vrf_name` attribute.
- **`test_vrf.py` / `get_default_vrf_fib_dst_intfs()`**: Derives uplink interfaces from `g_vars["vrf_intfs"]` when available, falling back to original PortChannel logic.

#### How did you verify/test it?
- Verified on `vms92-t0-7060x6-moby-512-2` testbed (Arista-7060X6-16PE-384C, t0-isolated-d96u32s2 topology) where the tests previously failed with KeyError on PORTCHANNEL_MEMBER.
- Standard t0 topology behavior preserved via fallback paths and defensive `.get()` calls.

#### Any platform specific information?
Affects platforms using t0-isolated topologies with direct Ethernet uplinks (no PortChannels). Standard t0 with PortChannels is unaffected (fallback logic).

#### Supported testbed topology if it's a new test case?
N/A 
