### PR TITLE
[bgp/sentinel]: Support deny-all FROM route-map in test_bgp_sentinel

### DIFF
--- a/tests/bgp/test_bgp_sentinel.py
+++ b/tests/bgp/test_bgp_sentinel.py
@@ -174,8 +174,9 @@ def is_from_routemap_deny_all(duthost, routemap_name):
         "vtysh -c 'show route-map {}' 2>/dev/null".format(routemap_name),
         module_ignore_errors=True,
     )
-    output = result.get("stdout", "")
-    return "permit" not in output
+    if result['rc'] != 0 or not result.get("stdout", "").strip():
+        return False
+    return "permit" not in result["stdout"]
 
 
 def add_route_to_dut_lo(ptfhost, spine_bp_addr, lo_ipv4_addr, lo_ipv6_addr, is_ipv6_only=False, ptf_bp_v6=None):
@@ -505,7 +506,8 @@ def bgp_community(sentinel_community, request):
 
 
 @pytest.fixture(scope="module", params=['IPv4', 'IPv6'])
-def prepare_bgp_sentinel_routes(rand_selected_dut, common_setup_teardown, bgp_community, from_deny_all, request, tbinfo):
+def prepare_bgp_sentinel_routes(rand_selected_dut, common_setup_teardown,
+                                bgp_community, from_deny_all, request, tbinfo):
     duthost = rand_selected_dut
     ptfip, lo_ipv4_addr, lo_ipv6_addr, ipv4_nh, ipv6_nh, ibgp_sessions, ptf_bp_v4, ptf_bp_v6 = common_setup_teardown
     is_ipv6_only = is_ipv6_only_topology(tbinfo)

--- a/tests/bgp/test_bgp_sentinel.py
+++ b/tests/bgp/test_bgp_sentinel.py
@@ -169,6 +169,15 @@ def is_route_advertised_to_ebgp_peers(duthost, route, ibgp_sessions, is_ipv6_onl
     return False
 
 
+def is_from_routemap_deny_all(duthost, routemap_name):
+    result = duthost.shell(
+        "vtysh -c 'show route-map {}' 2>/dev/null".format(routemap_name),
+        module_ignore_errors=True,
+    )
+    output = result.get("stdout", "")
+    return "permit" not in output
+
+
 def add_route_to_dut_lo(ptfhost, spine_bp_addr, lo_ipv4_addr, lo_ipv6_addr, is_ipv6_only=False, ptf_bp_v6=None):
     ipv4_nh, ipv6_nh = None, None
     for _, v in spine_bp_addr.items():
@@ -405,6 +414,17 @@ def common_setup_teardown(rand_selected_dut, ptf_setup_teardown, ptfhost, tbinfo
 
 
 @pytest.fixture(scope="module")
+def from_deny_all(rand_selected_dut, dut_setup_teardown):
+    duthost = rand_selected_dut
+    _, _, _, _, _, case_type = dut_setup_teardown
+    if case_type == 'BGPSentinel':
+        return is_from_routemap_deny_all(duthost, "FROM_BGP_SENTINEL")
+    elif case_type == 'BGPMonV6':
+        return is_from_routemap_deny_all(duthost, "FROM_BGPMON_V6")
+    return False
+
+
+@pytest.fixture(scope="module")
 def sentinel_community(duthost):
     constants_stat = duthost.stat(path=CONSTANTS_FILE)
     if not constants_stat['stat']['exists']:
@@ -485,7 +505,7 @@ def bgp_community(sentinel_community, request):
 
 
 @pytest.fixture(scope="module", params=['IPv4', 'IPv6'])
-def prepare_bgp_sentinel_routes(rand_selected_dut, common_setup_teardown, bgp_community, request, tbinfo):
+def prepare_bgp_sentinel_routes(rand_selected_dut, common_setup_teardown, bgp_community, from_deny_all, request, tbinfo):
     duthost = rand_selected_dut
     ptfip, lo_ipv4_addr, lo_ipv6_addr, ipv4_nh, ipv6_nh, ibgp_sessions, ptf_bp_v4, ptf_bp_v6 = common_setup_teardown
     is_ipv6_only = is_ipv6_only_topology(tbinfo)
@@ -553,7 +573,12 @@ def prepare_bgp_sentinel_routes(rand_selected_dut, common_setup_teardown, bgp_co
         output = json.loads(duthost.shell(cmd)['stdout'])
         logger.debug("route: {}, status: {}".format(route, output))
 
-        if 'no-export' in community:
+        if from_deny_all:
+            pytest_assert(
+                is_route_advertised_to_ebgp_peers(duthost, route, ibgp_sessions, is_ipv6_only),
+                "Route {} should still be advertised (sentinel denied at ingress)".format(route),
+            )
+        elif 'no-export' in community:
             pytest_assert(
                 not is_route_advertised_to_ebgp_peers(duthost, route, ibgp_sessions, is_ipv6_only),
                 "Route {} should not be advertised to bgp peers".format(route),
@@ -565,9 +590,9 @@ def prepare_bgp_sentinel_routes(rand_selected_dut, common_setup_teardown, bgp_co
             )
 
     if request.param == "IPv4":
-        yield ptf_bp_v4, ipv4_routes + ipv6_routes, ibgp_sessions, community
+        yield ptf_bp_v4, ipv4_routes + ipv6_routes, ibgp_sessions, community, from_deny_all
     else:
-        yield ptf_bp_v6, ipv4_routes + ipv6_routes, ibgp_sessions, community
+        yield ptf_bp_v6, ipv4_routes + ipv6_routes, ibgp_sessions, community, from_deny_all
 
     # Withdraw routes from bgp sentinel
     if request.param == "IPv4":
@@ -595,7 +620,7 @@ def prepare_bgp_sentinel_routes(rand_selected_dut, common_setup_teardown, bgp_co
 @pytest.mark.parametrize("reset_type", ["none", "soft", "hard"])
 def test_bgp_sentinel(rand_selected_dut, prepare_bgp_sentinel_routes, reset_type, tbinfo):
     duthost = rand_selected_dut
-    ibgp_nbr, target_routes, ibgp_sessions, community = prepare_bgp_sentinel_routes
+    ibgp_nbr, target_routes, ibgp_sessions, community, deny_all = prepare_bgp_sentinel_routes
     is_ipv6_only = is_ipv6_only_topology(tbinfo)
 
     if reset_type == "none":
@@ -612,7 +637,12 @@ def test_bgp_sentinel(rand_selected_dut, prepare_bgp_sentinel_routes, reset_type
 
     # Check if the routes are not announced to ebgp peers
     for route in target_routes:
-        if 'no-export' in community:
+        if deny_all:
+            pytest_assert(
+                is_route_advertised_to_ebgp_peers(duthost, route, ibgp_sessions, is_ipv6_only),
+                "Route {} should still be advertised (sentinel denied at ingress)".format(route),
+            )
+        elif 'no-export' in community:
             pytest_assert(
                 not is_route_advertised_to_ebgp_peers(duthost, route, ibgp_sessions, is_ipv6_only),
                 "Route {} should not be advertised to bgp peers".format(route),


### PR DESCRIPTION
## Description of PR

**Summary:**
Update test_bgp_sentinel.py to support both old (permit-based) and new (deny-all) FROM_BGP_SENTINEL / FROM_BGPMON_V6 route-map templates. The test now detects the DUT's route-map configuration at runtime and adjusts assertions accordingly.

ADO: 37506139
## Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Test case improvement

## Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

## Approach

### What is the motivation for this PR?

see ADO: 37506139, buildimage PR #15368871 changes `FROM_BGP_SENTINEL` and `FROM_BGPMON_V6` from permit-with-community-match to `deny 100` (deny all inbound) as part of the BGP aggregation community-tagging feature. This breaks `test_bgp_sentinel` because the test expects sentinel routes with `no-export` community to be permitted inbound, then suppressed via the community mechanism. The test must work on both old and new images.

### How did you do it?

Added runtime detection via `vtysh -c 'show route-map <name>'` following the existing pattern from `test_bgp_aggregate_address_community_tagging_msft_internal.py`. When the route-map is deny-all (no `permit` entries), assertions expect routes to remain advertised since the sentinel signal is blocked at ingress and the original upstream path is unaffected. When permit-based (old images), existing assertions run unchanged.

Changes:
1. Added `is_from_routemap_deny_all()` helper function
2. Added `from_deny_all` module-scoped fixture that detects BGPSentinel vs BGPMonV6 route-map type
3. Modified `prepare_bgp_sentinel_routes` fixture assertions to handle deny-all case
4. Modified `test_bgp_sentinel` function assertions to handle deny-all case

### How did you verify/test it?

Verified against build pipeline log from buildimage PR #15368871 (`kvmtest-t1-lag`). The failing test case `test_bgp_sentinel[IPv4-BGPSentinel-no-export-none]` hits line 557 assertion because `FROM_BGP_SENTINEL deny 100` blocks sentinel route ingress. With the fix, the test detects deny-all and asserts routes remain advertised via the original upstream path.

### Any platform specific information?

No platform-specific dependencies. The runtime detection works on any SONiC image regardless of template version.

### Supported testbed topology if it's a new test case?

t1 (unchanged — existing `@pytest.mark.topology('t1')`)