### PR TITLE
[gnmi] Skip test_gnmi_latency_01 on BMC (no PORT table)

### DIFF
--- a/tests/gnmi/test_gnmi_stress.py
+++ b/tests/gnmi/test_gnmi_stress.py
@@ -41,6 +41,8 @@ def test_gnmi_latency_01(duthosts, rand_one_dut_hostname, ptfhost):
     duthost = duthosts[rand_one_dut_hostname]
     if duthost.is_supervisor_node():
         pytest.skip("gnmi test relies on port data not present on supervisor card '%s'" % rand_one_dut_hostname)
+    if duthost.is_bmc():
+        pytest.skip("gnmi test requires a PORT table which is absent on BMC '%s'" % rand_one_dut_hostname)
     interface = get_first_interface(duthost)
     if interface is None:
         pytest.skip("No valid interface found on DUT '%s'" % rand_one_dut_hostname)


### PR DESCRIPTION
### Description of PR

Summary:
SONiC BMC images have **no front-panel ports**, so `CONFIG_DB` does not contain a `PORT` table. The local helper `get_first_interface()` in `tests/gnmi/test_gnmi_stress.py` indexes `cfg_facts["PORT"]` directly:

```python
def get_first_interface(duthost):
    cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
    port_table = cfg_facts["PORT"]   # <- KeyError on BMC
```

This raises `KeyError: 'PORT'` and fails `test_gnmi_latency_01` in the test body.

Even with a defensive lookup, the test is fundamentally inapplicable to BMC: it loops `gnmi_set` against `/sonic-db:CONFIG_DB/localhost/PORT/<intf>/description` ten times and times the round-trip — measuring GNMI native-write latency on a real physical port. BMC has no `PORT` table, no `orchagent`/`portsyncd`, and no SAI port objects to write to. There is nothing on BMC for the test to exercise.

This change adds an `is_bmc()` skip alongside the existing `is_supervisor_node()` skip — narrow, explicit, and consistent with other BMC-aware code paths (e.g. `cacl/test_cacl_function.py`, `process_monitoring/test_critical_process_monitoring.py`, and the recent #24271). No defensive `.get()` is used, so any non-BMC platform whose `CONFIG_DB` is missing a `PORT` table will still surface a real `KeyError` and aid diagnosis.

### Note: sibling file already BMC-safe
`tests/gnmi/test_gnmi_configdb.py` uses a different local `get_first_interface()` that parses `show interface status` and gracefully returns `None` when `Admin`/`Lanes` columns are absent — its tests already `pytest.skip` cleanly on BMC via `if interface is None: pytest.skip(...)`. **Only `test_gnmi_stress.py` needs the explicit gate.**

### Affected tests (observed on a BMC testbed)

- `gnmi/test_gnmi_stress.py::test_gnmi_latency_01` — fails in test body with `KeyError: 'PORT'`.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Make `test_gnmi_latency_01` skip cleanly on BMC platforms, which legitimately have no front-panel ports and no PORT-related machinery for the test to exercise.

#### How did you do it?
Added `if duthost.is_bmc(): pytest.skip(...)` immediately after the existing `is_supervisor_node()` skip in `test_gnmi_latency_01`. Two lines, no other changes. The body of the test and `get_first_interface()` are untouched.

#### How did you verify/test it?
- Reproduced the original `KeyError: 'PORT'` on a BMC testbed.
- After the patch, `test_gnmi_latency_01` skips immediately on BMC with the new reason string.
- For non-BMC DUTs the test is byte-for-byte identical to before (the new `if` is False and falls through).

#### Any platform specific information?
The skip targets SONiC BMC images (`router_type == 'NetworkBmc'`).

#### Supported testbed topology if it's a new test case?
N/A (test gating only).

Signed-off-by: zitingguo <zitingguo@microsoft.com>