### PR TITLE
Skip max-power API for cisco console server.

### DIFF
--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -253,8 +253,10 @@ class TestPsuApi(PlatformApiTestBase):
                 self.expect(check_result, "PSU {} reading does not make sense \
                 (power:{}, voltage:{}, current:{})".format(psu_id, power, voltage, current))
 
-                self.get_psu_parameter(psu_info, "max_power", psu.get_maximum_supplied_power,
-                                       "maximum supplied power")
+                # This platform doesn't support this API.
+                if "arm64-c8220tg_48a_o" not in duthost.facts['platform']:
+                    self.get_psu_parameter(psu_info, "max_power", psu.get_maximum_supplied_power,
+                                           "maximum supplied power")
 
                 powergood_status = psu.get_powergood_status(platform_api_conn, psu_id)
                 if self.expect(powergood_status is not None,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
platform_tests/api/test_psu.py::TestPsuApi::test_power fails in cisco consoler server since the platform doesn't support the max power API.
This PR is to skip that check.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
Failure of platform_tests/api/test_psu.py::TestPsuApi::test_power.

#### How did you do it?
Skip the max power check for this platform.

#### How did you verify/test it?
Ran it on our platform testbed. 
Before PR:
```
self = <tests.platform_tests.api.test_psu.TestPsuApi object at 0x72e8a2b3d760>

    def assert_expectations(self):
        """
        Checks if there are any error messages waiting in failed_expectations.
        If so, it will fail an assert and pass a concatenation of all pending
        error messages. It will also clear failed_expectations to prepare it
        for the next use.
        """
        if len(self.failed_expectations) > 0:
            err_msg = ", ".join(self.failed_expectations)
            # TODO: When we move to Python 3.3+, we can use self.failed_expectations.clear() instead
            del self.failed_expectations[:]
>           pytest_assert(False, err_msg)
E           Failed: Failed to retrieve maximum supplied power of PSU 0, Failed to retrieve maximum supplied power of PSU 1

err_msg    = 'Failed to retrieve maximum supplied power of PSU 0, Failed to retrieve maximum supplied power of PSU 1'
self       = <tests.platform_tests.api.test_psu.TestPsuApi object at 0x72e8a2b3d760>

platform_tests/api/platform_api_test_base.py:32: Failed
================================================================================================ warnings summary ================================================================================================
../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-------------------------------------------- generated xml file: /run_logs/c0lo/power/2026-04-30-05-12-28/platform_tests/api/test_psu.py::TestPsuApi::test_power.xml ---------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
============================================================================================ short test summary info =============================================================================================
FAILED platform_tests/api/test_psu.py::TestPsuApi::test_power[c0lo-dut] - Failed: Failed to retrieve maximum supplied power of PSU 0, Failed to retrieve maximum supplied power of PSU 1
==================================================================================== 1 failed, 1 warning in 102.24s (0:01:42) ====================================================================================
sonic@arctos_cicd_all_202603:/data/tests$

```
After PR:
================================================================================================ warnings summary ================================================================================================
../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================================== PASSES =====================================================================================================
________________________________________________________________________________________ TestPsuApi.test_power[c0lo-dut] _________________________________________________________________________________________
------------------------------------------ generated xml file: /run_logs/c0lo/power-pdu/2026-04-30-05-16-04/platform_tests/api/test_psu.py::TestPsuApi::test_power.xml -------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
============================================================================================ short test summary info =============================================================================================
PASSED platform_tests/api/test_psu.py::TestPsuApi::test_power[c0lo-dut]
==================================================================================== 1 passed, 1 warning in 92.81s (0:01:32) =====================================================================================
sonic@arctos_cicd_all_202603:/data/tests$
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
