### PR TITLE
Update qos watermark margin for Nvidia platform from 0.001 to 0.002

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -502,6 +502,9 @@ class VMTopology(object):
                 bridge_count += 1
                 self.destroy_ovs_bridge(fp_br_name)
 
+        # Wait the bridges to be cleaned up
+        self.wait_for_bridges_cleanup(bridge_count)
+
     def destroy_ovs_bridge(self, bridge_name):
         logging.info('=== Destroy bridge %s ===' % bridge_name)
         VMTopology.cmd('ovs-vsctl --if-exists del-br %s' % bridge_name)

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -502,9 +502,6 @@ class VMTopology(object):
                 bridge_count += 1
                 self.destroy_ovs_bridge(fp_br_name)
 
-        # Wait the bridges to be cleaned up
-        self.wait_for_bridges_cleanup(bridge_count)
-
     def destroy_ovs_bridge(self, bridge_name):
         logging.info('=== Destroy bridge %s ===' % bridge_name)
         VMTopology.cmd('ovs-vsctl --if-exists del-br %s' % bridge_name)

--- a/tests/qos/files/mellanox/qos_param_generator.py
+++ b/tests/qos/files/mellanox/qos_param_generator.py
@@ -300,7 +300,7 @@ class QosParamMellanox(object):
             margin_ratio = 0.02
             self.qos_params_mlnx['lossy_queue_1']['pkts_num_margin'] = int(
                 self.qos_params_mlnx['lossy_queue_1']['pkts_num_trig_egr_drp'] * margin_ratio)
-            wm_margin_ratio = 0.001
+            wm_margin_ratio = 0.002
             self.qos_params_mlnx['wm_pg_shared_lossy']['pkts_num_margin'] = max(
                 self.qos_params_mlnx['wm_pg_shared_lossy']['pkts_num_margin'],
                 int(self.qos_params_mlnx['wm_pg_shared_lossy']['pkts_num_trig_egr_drp'] * wm_margin_ratio))


### PR DESCRIPTION
Summary: Update qos watermark margin for Nvidia platform from 0.001 to 0.002
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The Nvidia architector confirmed the margin on Nvidia platform exceeding the threshold could due to the micro-architecture, since the synchronizations take some time.

#### How did you do it?
Adjust the margin percentage range from 0.001 to 0.002.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
