### PR TITLE
[202511] [OCS] Limit the inventory for conn_graph_facts on L1/snappi testbeds (#24294)

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -73,6 +73,10 @@
       set_fact:
         is_ixia_testbed: "{{ true if ptf_image == 'docker-keysight-api-server' else false }}"
 
+    - name: check if testbed has L1 switches
+      set_fact:
+        is_l1_testbed: "{{ testbed_facts.l1s is defined and (testbed_facts.l1s | length > 0) }}"
+
     - block:
         - name: Set L1 connection script path
           set_fact:
@@ -115,10 +119,10 @@
   - topo_facts: topo={{ topo }} hwsku={{ hwsku }} testbed_name={{ testbed_name | default(None) }} asics_present={{ asics_present | default([]) }} card_type={{ card_type | default('fixed') }}
     delegate_to: localhost
 
-  - name: override group_file for route-conv
+  - name: override group_file for snappi testbed
     set_fact:
       conn_graph_group: "{{ testbed_facts['inv_name'] }}"
-    when: is_ixia_testbed
+    when: is_ixia_testbed or is_l1_testbed
 
   - name: get connection graph if defined for dut (ignore any errors)
     conn_graph_facts:

--- a/ansible/roles/testbed/nut/tasks/device_prepare_config.yml
+++ b/ansible/roles/testbed/nut/tasks/device_prepare_config.yml
@@ -5,8 +5,19 @@
     dest: /tmp/config_patch.json
     remote_src: false
 
-- name: preserve key configurations from existing config_db.json using jq
-  shell: "jq '{ {{ tables_to_keep | join(',') }} }' /etc/sonic/config_db.json | sed 's/\\bnull\\b/{}/' > /tmp/config_db_keep.json"
+- name: backup config_db.json to /tmp before rebuilding it
+  copy:
+    src: /etc/sonic/config_db.json
+    dest: /tmp/config_db_old.json
+    remote_src: true
+
+- name: preserve key configurations from backed up config_db.json using jq
+  shell: |
+    set -o pipefail
+    jq '{ {{ tables_to_keep | join(',') }} }' /tmp/config_db_old.json \
+      | jq 'with_entries(if .value == null then .value = {} else . end)' > /tmp/config_db_keep.json
+  args:
+    executable: /bin/bash
   vars:
     tables_to_keep:
       - DEVICE_METADATA

--- a/ansible/roles/testbed/nut/tasks/testbed_facts.yml
+++ b/ansible/roles/testbed/nut/tasks/testbed_facts.yml
@@ -17,7 +17,13 @@
   debug:
     var: testbed_facts
 
+- name: override group_file to use testbed specific group file
+  set_fact:
+    conn_graph_group: "{{ testbed_facts['inv_name'] }}"
+
 - name: get connection graph if defined for dut
   conn_graph_facts:
-    hosts: "{{ testbed_facts['duts'] + testbed_facts['tgs'] + testbed_facts['l1s'] }}"
+    hosts: "{{ (testbed_facts.duts | default([])) + (testbed_facts.tgs | default([])) + (testbed_facts.l1s | default([])) }}"
+    group: "{{ conn_graph_group if conn_graph_group is defined else omit }}"
+    forced_mgmt_routes: "{{ forced_mgmt_routes | default([]) }}"
   delegate_to: localhost


### PR DESCRIPTION
Cherry-pick of #24294 to the `202511` branch.

Original PR: https://github.com/sonic-net/sonic-mgmt/pull/24294

### Description of PR
Backport of "[OCS] Limit the inventory for conn_graph_facts on L1/snappi testbeds" to 202511.

Marked with the `Approved for 202511 branch` label and had a `Cherry Pick Conflict_202511` flag, so this is a manual cherry-pick.

### Conflict resolution notes
Three files had conflicts during cherry-pick:

1. `ansible/config_sonic_basedon_testbed.yml` — master adds `is_stc_testbed` to the `when:` clause, but `is_stc_testbed` is not defined on 202511. Used `is_ixia_testbed or is_l1_testbed` (both facts exist on 202511).
2. `ansible/roles/testbed/nut/tasks/device_prepare_config.yml` — took the master version (backup + jq `with_entries` pipeline).
3. `ansible/roles/testbed/nut/tasks/testbed_facts.yml` — took the master version (`default([])` guards + `group:` + `forced_mgmt_routes:`).

### Type of change
- [x] Testbed and Framework (sonic-mgmt)

### Back port request
- [x] 202511

### Approach
#### What is the motivation for this PR?
Backport approved fix for L1/snappi testbed inventory handling in `conn_graph_facts` and the null→empty conversion in NUT device prep.

#### How did you do it?
Cherry-picked master commit `cfb2adc21` and resolved conflicts as noted above.

#### How did you verify/test it?
N/A — backport only. Logic preserved from the original PR.
