### PR TITLE
[smartswitch]: Quiet retry-time noise in check_dpu_critical_processes

### DIFF
--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -451,40 +451,67 @@ def get_dpuhost_for_dpu(dpuhosts, dpu_id):
     return None
 
 
-def check_dpu_critical_processes(dpuhosts, dpu_id):
+# Track DPUs we've already warned about being absent from `dpuhosts`, so the
+# wait_until retry loop doesn't repeat the same warning every interval.
+_WARNED_MISSING_DPUHOSTS = set()
 
+
+def check_dpu_critical_processes(dpuhosts, dpu_id):
     """
-    Checks all critical processes are UP on DPU
-    If not, fails the case
+    Checks all critical processes are UP on DPU.
+
+    Designed to be called repeatedly from `wait_until`. Transient "not OK"
+    entries are logged at DEBUG level so they don't produce intermittent
+    ERROR/WARNING noise while waiting for the DPU to settle. Only the final
+    failure (when wait_until gives up) needs to be visible to the caller via
+    the returned False.
+
     Args:
        dpuhosts: DPU Host handle
        dpu_id: DPU ID
     Returns:
-       True if check passes or DPU not in dpuhosts (skip), False if a critical process failed
+       True if check passes (or DPU not in dpuhosts, skipped),
+       False if a critical process is not OK.
     """
     dpuhost = get_dpuhost_for_dpu(dpuhosts, dpu_id)
     if dpuhost is None:
-        logging.warning(
-            "DPU%d not in dpuhosts (len=%d); skipping critical process check. "
-            "Testbed may not have SSH access to this DPU.",
-            dpu_id, len(dpuhosts)
-        )
+        if dpu_id not in _WARNED_MISSING_DPUHOSTS:
+            _WARNED_MISSING_DPUHOSTS.add(dpu_id)
+            logging.info(
+                "DPU%d not in dpuhosts (len=%d); skipping critical process check. "
+                "Testbed may not have SSH access to this DPU.",
+                dpu_id, len(dpuhosts)
+            )
         return True
-    cmd = "sudo show system-health detail"
-    output_dpu_process = dpuhost.show_and_parse(cmd)
 
-    for index in range(len(output_dpu_process)):
-        parse_output = output_dpu_process[index]
-        if parse_output['status'].lower() == 'ok':
+    cmd = "sudo show system-health detail"
+    try:
+        output_dpu_process = dpuhost.show_and_parse(cmd)
+    except Exception as e:
+        # SSH/transport hiccups while DPU is still coming up are expected; let
+        # wait_until retry without escalating to ERROR.
+        logging.debug("DPU%d: '%s' failed transiently: %s", dpu_id, cmd, e)
+        return False
+
+    failing = []
+    for parse_output in output_dpu_process:
+        status = (parse_output.get('status') or '').lower()
+        if status == 'ok':
             continue
-        name = parse_output.get("name", "")
-        logging.error(
-            "DPU%d critical process not OK: name=%r status=%r state-detail=%r state-value=%r",
-            dpu_id,
+        name = (parse_output.get('name') or '').strip()
+        failing.append((
             name,
-            parse_output.get("status"),
-            parse_output.get("state-detail"),
-            parse_output.get("state-value"),
+            parse_output.get('status'),
+            parse_output.get('state-detail'),
+            parse_output.get('state-value'),
+        ))
+
+    if failing:
+        # Use DEBUG so retries don't spam the log; the caller's wait_until
+        # will surface a single assertion if this never converges.
+        logging.debug(
+            "DPU%d critical process check pending (%d not OK): %s",
+            dpu_id, len(failing), failing,
         )
         return False
     return True


### PR DESCRIPTION
### Description of PR

Summary:
`check_dpu_critical_processes` is invoked repeatedly by `wait_until` while waiting for DPUs to come up after reboot/startup. Previously every retry iteration logged ERROR/WARNING lines for transient not-OK entries and missing dpuhost entries, producing noisy/intermittent errors in test logs even when the wait ultimately succeeded.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Reduce intermittent ERROR/WARNING log spam emitted by `check_dpu_critical_processes` while `wait_until` is polling. The transient failures are expected during DPU bring-up and shouldn't appear as errors when the wait eventually succeeds.

#### How did you do it?
- Demoted per-iteration "process not OK" logs from ERROR to a single aggregated DEBUG line. The final failure (when `wait_until` actually times out) is still surfaced via the caller's `pytest_assert`.
- Logged the missing-dpuhost case at INFO level and only once per `dpu_id` (tracked via a module-level set), instead of WARNING on every retry interval.
- Wrapped `show_and_parse` in `try/except` so transient SSH/transport hiccups during DPU bring-up cause a retry instead of raising mid-wait.
- Used safe `.get()` access for `status`/`name` fields to avoid `AttributeError` on missing data.

#### How did you verify/test it?
Verified on a SmartSwitch testbed by running DPU platform tests (`test_reboot_cause`, `test_system_health_summary`); logs no longer contain repeated ERROR/WARNING lines during the DPU readiness wait while the test still correctly asserts on real, persistent failures.

#### Any platform specific information?
SmartSwitch (DPU-capable) testbeds only.

#### Supported testbed topology if it's a new test case?
N/A (test infrastructure improvement, not a new test case).

### Documentation
N/A
