### PR TITLE
[mmu probing] Add ProbingBase step-size env UT coverage

### DIFF
--- a/tests/saitests/mock/ut/test_probing_base.py
+++ b/tests/saitests/mock/ut/test_probing_base.py
@@ -624,6 +624,30 @@ class TestProbingBaseSetUp:
         assert pb.use_pg_drop_counter is False
         print("[OK] use_pg_drop_counter defaults to False")
 
+    @pytest.mark.order(941)
+    def test_setUp_applies_point_probing_step_size_env(self):
+        """Test real setUp() applies POINT_PROBING_STEP_SIZE from environment"""
+        print("\n=== Testing setUp() - Real POINT_PROBING_STEP_SIZE Env ===")
+
+        class MockThriftInterfaceDataPlane:
+            @staticmethod
+            def setUp(_test):
+                return None
+
+        pb = ConcreteProbingBase()
+        pb.clients = Mock()
+
+        with patch('probing_base.sai_base_test.ThriftInterfaceDataPlane',
+                   MockThriftInterfaceDataPlane):
+            with patch('probing_base.switch_init'):
+                with patch('probing_base.time.sleep'):
+                    with patch('probing_observer.ProbingObserver.trace'):
+                        with patch.dict(os.environ, {'POINT_PROBING_STEP_SIZE': '4'}, clear=True):
+                            pb.setUp()
+
+        assert pb.POINT_PROBING_STEP_SIZE == 4
+        print("[OK] real setUp() applies POINT_PROBING_STEP_SIZE")
+
 
 class TestProbingBaseTearDown:
     """Test tearDown() method (simplified - no parent call needed in UT)"""


### PR DESCRIPTION
### Description of PR
Add unit test coverage for the real `ProbingBase.setUp()` environment parsing path for `POINT_PROBING_STEP_SIZE`.

This follows reviewer guidance to improve mock UT coverage for existing supported behavior instead of adding edge-case tests that may force unfinished algorithm behavior.

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Test case improvement

### Approach
#### What is the motivation for this PR?
Improve coverage for the real `ProbingBase.setUp()` path. Existing tests simulated the environment parsing logic directly, but did not execute `setUp()` itself.

#### How did you do it?
Added a mock-friendly UT that calls `ProbingBase.setUp()` and verifies `POINT_PROBING_STEP_SIZE` is applied from the environment, while mocking PTF/switch initialization dependencies.

#### How did you verify/test it?
Mock UT/IT result:

```text
cd tests/saitests/mock/ut
python3 -m pytest -v test_probing_base.py::TestProbingBaseSetUp::test_setUp_applies_point_probing_step_size_env
  -> passed

cd tests/saitests/mock/ut
python3 -m pytest -v .
  -> 446 passed, 1 failed, 4 warnings

cd tests/saitests/mock/it
python3 -m pytest -v .
  -> 75 passed
```

Failure note:

The single full mock UT failure is unrelated to this PR and reproducible on the baseline branch:

```text
test_probing_base.py::TestProbingBaseGetRxPort::test_get_rx_port_wrapper
AssertionError: Should log before and after
assert 1 == 2
```

That baseline test expects two `log_message()` calls from `ProbingBase.get_rx_port()`. Current code emits one `log_message()` call and uses `ProbingObserver.trace()` for the retry/resolution path. This PR only adds `ProbingBase.setUp()` env parsing coverage and does not touch `get_rx_port()`.