### PR TITLE
[202511] Fix KeyError in counterpoll restore by adding missing counter types

### DIFF
--- a/tests/common/constants.py
+++ b/tests/common/constants.py
@@ -47,6 +47,18 @@ class CounterpollConstants:
     BUFFER_POOL_WATERMARK_STAT_TYPE = 'BUFFER_POOL_WATERMARK_STAT'
     ACL = 'acl'
     ACL_TYPE = "ACL"
+    WRED_ECN_QUEUE_STAT_TYPE = 'WRED_ECN_QUEUE_STAT'
+    WRED_QUEUE = 'wredqueue'
+    WRED_ECN_PORT_STAT_TYPE = 'WRED_ECN_PORT_STAT'
+    WRED_PORT = 'wredport'
+    PHY_TYPE = 'PHY'
+    PHY = 'phy'
+    FLOW_CNT_ROUTE_STAT_TYPE = 'FLOW_CNT_ROUTE_STAT'
+    FLOW_CNT_ROUTE = 'flowcnt-route'
+    SRV6_STAT_TYPE = 'SRV6_STAT'
+    SRV6 = 'srv6'
+    SWITCH_STAT_TYPE = 'SWITCH_STAT'
+    SWITCH = 'switch'
     COUNTERPOLL_MAPPING = {PG_DROP_STAT_TYPE: PG_DROP,
                            QUEUE_STAT_TYPE: QUEUE,
                            PORT_STAT_TYPE: PORT,
@@ -55,7 +67,13 @@ class CounterpollConstants:
                            BUFFER_POOL_WATERMARK_STAT_TYPE: WATERMARK,
                            QUEUE_WATERMARK_STAT_TYPE: WATERMARK,
                            PG_WATERMARK_STAT_TYPE: WATERMARK,
-                           ACL_TYPE: ACL}
+                           ACL_TYPE: ACL,
+                           WRED_ECN_QUEUE_STAT_TYPE: WRED_QUEUE,
+                           WRED_ECN_PORT_STAT_TYPE: WRED_PORT,
+                           PHY_TYPE: PHY,
+                           FLOW_CNT_ROUTE_STAT_TYPE: FLOW_CNT_ROUTE,
+                           SRV6_STAT_TYPE: SRV6,
+                           SWITCH_STAT_TYPE: SWITCH}
     PORT_BUFFER_DROP_INTERVAL = '10000'
     COUNTERPOLL_INTERVAL = {PORT_BUFFER_DROP: 10000}
     SX_SDK = 'sx_sdk'

--- a/tests/common/constants.py
+++ b/tests/common/constants.py
@@ -47,18 +47,8 @@ class CounterpollConstants:
     BUFFER_POOL_WATERMARK_STAT_TYPE = 'BUFFER_POOL_WATERMARK_STAT'
     ACL = 'acl'
     ACL_TYPE = "ACL"
-    WRED_ECN_QUEUE_STAT_TYPE = 'WRED_ECN_QUEUE_STAT'
-    WRED_QUEUE = 'wredqueue'
-    WRED_ECN_PORT_STAT_TYPE = 'WRED_ECN_PORT_STAT'
-    WRED_PORT = 'wredport'
     PHY_TYPE = 'PHY'
     PHY = 'phy'
-    FLOW_CNT_ROUTE_STAT_TYPE = 'FLOW_CNT_ROUTE_STAT'
-    FLOW_CNT_ROUTE = 'flowcnt-route'
-    SRV6_STAT_TYPE = 'SRV6_STAT'
-    SRV6 = 'srv6'
-    SWITCH_STAT_TYPE = 'SWITCH_STAT'
-    SWITCH = 'switch'
     COUNTERPOLL_MAPPING = {PG_DROP_STAT_TYPE: PG_DROP,
                            QUEUE_STAT_TYPE: QUEUE,
                            PORT_STAT_TYPE: PORT,
@@ -68,12 +58,7 @@ class CounterpollConstants:
                            QUEUE_WATERMARK_STAT_TYPE: WATERMARK,
                            PG_WATERMARK_STAT_TYPE: WATERMARK,
                            ACL_TYPE: ACL,
-                           WRED_ECN_QUEUE_STAT_TYPE: WRED_QUEUE,
-                           WRED_ECN_PORT_STAT_TYPE: WRED_PORT,
-                           PHY_TYPE: PHY,
-                           FLOW_CNT_ROUTE_STAT_TYPE: FLOW_CNT_ROUTE,
-                           SRV6_STAT_TYPE: SRV6,
-                           SWITCH_STAT_TYPE: SWITCH}
+                           PHY_TYPE: PHY}
     PORT_BUFFER_DROP_INTERVAL = '10000'
     COUNTERPOLL_INTERVAL = {PORT_BUFFER_DROP: 10000}
     SX_SDK = 'sx_sdk'


### PR DESCRIPTION
### Description of PR

**Backport of #24026 to 202511 branch.**

Summary: On SONiC images (202511.17+), `counterpoll show` reports the `PHY` counter type introduced by [sonic-net/sonic-utilities#4106](https://github.com/sonic-net/sonic-utilities/pull/4106) (cherry-picked as #4291). These types were not present in `CounterpollConstants.COUNTERPOLL_MAPPING`, causing a `KeyError: 'PHY'` during teardown of `test_cpu_memory_usage_counterpoll` when `restore_counterpoll_status()` attempts to look up each type.

This PR adds the missing PHY counter type constant and its mapping entry.

Note: The master PR #24026 also added 5 other types (WRED_ECN_QUEUE, WRED_ECN_PORT, FLOW_CNT_ROUTE, SRV6, SWITCH). These are intentionally excluded from this backport because the 202511 branch's `verify_counterpoll_status` in `test_counterpoll_watermark.py` uses substring matching ([`if k in type`](https://github.com/sonic-net/sonic-mgmt/blob/c0236c9970ee3bcb65a1874e1ed146143eb9c69f/tests/platform_tests/counterpoll/test_counterpoll_watermark.py#L249)) instead of exact matching ([`if k == type`](https://github.com/sonic-net/sonic-mgmt/blob/ee58edbcb00d38ec7fb41938d9abecc1e673b03a/tests/platform_tests/counterpoll/test_counterpoll_watermark.py#L281) on master). Adding WRED_ECN_QUEUE_STAT causes 'QUEUE_STAT' in 'WRED_ECN_QUEUE_STAT' to match as True, incorrectly overwriting the queue counterpoll status and failing KVM tests with `queue is disable. expected to be enable`. PHY is safe because it is not a substring of any other type name. The remaining types can be added once the substring matching fix (in replaced with ==) is backported to 202511.


- **Related ADO**: [37209542](https://msazure.visualstudio.com/One/_workitems/edit/37209542)
- **Failed test**: `platform_tests/test_cpu_memory_usage.py`
- **Verification**: [ElasticTest test plan](https://elastictest.org/scheduler/testplan/69decd28a2ac2651eecd1de7?leftSideViewMode=detail&testcase=platform_tests%2ftest_cpu_memory_usage.py&type=console)

### Type of change

- [x] Bug fix

### Approach

#### What is the motivation for this PR?

SONiC 202511.17 introduced the PHY counterpoll type via [sonic-net/sonic-utilities#4106](https://github.com/sonic-net/sonic-utilities/pull/4106) (cherry-picked as #4291), but sonic-mgmt's `COUNTERPOLL_MAPPING` was not updated,  causing `KeyError: 'PHY' in restore_counterpoll_status()`.


#### How did you do it?

 Added `PHY_TYPE = 'PHY'` and `PHY = 'phy'` constants, and a `PHY_TYPE: PHY` entry in COUNTERPOLL_MAPPING in `tests/common/constants.py`.

Other types present in the master PR (WRED_ECN_QUEUE, WRED_ECN_PORT, FLOW_CNT_ROUTE, SRV6, SWITCH) are excluded — see the note above for details.

#### How did you verify/test it?

Re-ran `platform_tests/test_cpu_memory_usage.py` on affected Mellanox testbeds. The test passed with no teardown errors.

#### Any platform specific information?

This issue primarily affects Mellanox platforms on SONiC 202511.17+.
