### PR TITLE
[202511] Fix count_file name for test_dhcp_counter_stress.py

### DIFF
--- a/tests/dhcp_relay/test_dhcp_counter_stress.py
+++ b/tests/dhcp_relay/test_dhcp_counter_stress.py
@@ -86,7 +86,7 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
             "testing_mode": testing_mode,
             "kvm_support": True
         }
-        count_file = '/tmp/dhcp_stress_test_{}.json'.format(dhcp_type)
+        count_file = '/tmp/dhcp_stress_test_{}'.format(dhcp_type)
 
         def _check_count_file_exists():
             command = 'ls {} > /dev/null 2>&1 && echo exists || echo missing'.format(count_file)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
https://github.com/sonic-net/sonic-mgmt/pull/22040 This PR changed count_file name generated in ptf test file, and fixed for test_dhcp_relay_stress.py, but forgot test_dhcp_counter_stress.py
This leads to count_file check failure and exceeding memory threshold error because assertion prevents capture_and_check_packet_on_dut from killing tcpdump processes
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
count_file check failure and exceeding memory threshold error due to missing change in https://github.com/sonic-net/sonic-mgmt/pull/22040

#### How did you do it?
Correct count_file name

#### How did you verify/test it?
Test passed without failure and exceeding memory threshold error

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
