### PR TITLE
Disable routeCheck on DUT during BGP scale test on T1 topo

### DIFF
--- a/tests/bgp/test_ipv6_bgp_scale.py
+++ b/tests/bgp/test_ipv6_bgp_scale.py
@@ -16,6 +16,8 @@ import time
 from copy import deepcopy
 from threading import Thread, Event
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.fixtures.duthost_utils import start_route_checker_on_duthost, \
+        stop_route_checker_on_duthost
 import ptf
 import ptf.packet as scapy
 from ptf.testutils import simple_icmpv6_packet
@@ -54,6 +56,23 @@ ICMP_TYPE_MAX = 125
 _icmp_type_generator = itertools.cycle(range(ICMP_TYPE_MIN, ICMP_TYPE_MAX + 1))
 test_results = {}
 current_test = ""
+
+
+@pytest.fixture(autouse=True)
+def disable_route_check_in_setup_and_call(tbinfo, duthost):
+    topo_type = tbinfo['topo']['type']
+    allowed_topos = {"t1"}
+    if topo_type in allowed_topos:
+        stop_route_checker_on_duthost(duthost)
+        logger.info(f"The routeCheck is disabled on DUT {duthost}")
+    else:
+        logger.warning(f"Skip disable routeCheck on topo {topo_type}")
+
+    yield
+
+    if topo_type in allowed_topos:
+        start_route_checker_on_duthost(duthost)
+        logger.info(f"The routeCheck is enabled on DUT {duthost}")
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -114,7 +114,7 @@ def start_route_checker_on_duthost(duthost, wait_for_status=False):
     duthost.command("sudo monit start routeCheck", module_ignore_errors=True)
     if wait_for_status:
         pt_assert(
-            wait_until(900, 20, 0, _is_route_checker_in_status, duthost, ("status ok",)),
+            wait_until(900, 20, 0, _is_route_checker_in_status, duthost, ("status ok", "ok",)),
             "routeCheck service did not start on {}".format(duthost.hostname),
         )
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Fix route check failure in BGP scale test on T1 topo

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The routeCheck utility runs periodically on the DUT every 5 minutes. During BGP scale tests involving a large volume of route updates, the transient discrepancies can occur between databases. If routeCheck runs during these windows, it logs failures to the syslog, causing the loganalyzer to fail the test.

This fix disables routeCheck during the setup and test execution phases and re-enables it during the teardown stage before the loganalyzer runs. The fix also adds 'ok' as additional expected status while waiting for monit routeCheck to be up and running.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
