### PR TITLE
cisco console: modify the timeout increase to check startswith instead of exact match for platform name.

### DIFF
--- a/tests/console/test_console_link_wiring.py
+++ b/tests/console/test_console_link_wiring.py
@@ -45,7 +45,7 @@ def test_console_link_wiring(setup_c0, creds, target_line):
 
     packet_size = 64
     delay_factor = 3.2
-    if duthost.facts['platform'] in ["arm64-c8220tg_48a_o"]:
+    if duthost.facts['platform'].startswith("arm64-c8220tg_48a"):
         delay_factor *= 25.0
 
     # Estimate a reasonable data transfer time based on configured baud rate

--- a/tests/console/test_console_loopback.py
+++ b/tests/console/test_console_loopback.py
@@ -72,7 +72,7 @@ def test_console_loopback_echo(setup_c0, creds, conn_graph_facts, baud_rate, flo
         console_fanout.command("config console flow_control {} {}".format(flow_control, target_line))
         console_fanout.set_loopback(target_line, baud_rate, flow_control_bool)
         delay_factor = 3.2
-    if duthost.facts['platform'] in ['arm64-c8220tg_48a_o-r0']:
+    if duthost.facts['platform'].startswith('arm64-c8220tg_48a'):
         delay_factor *= 25.0
 
     dutip, dutuser, dutpass = get_host_ip_and_creds(duthost, creds)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
There is a timeout increase for cisco console server in console_loopback and console_link_wiring tests. Unfortunately the if condition for platform fails sometimes - the platform name contains a revision tag at the end, that might not be same for all devices. To fix this, in this PR, the platform check is changed to "startswith" function instead of exact match.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The platform check failing due to different revision number for platform.

#### How did you do it?
Changed the exact match check to "startswith" check.

#### How did you verify/test it?
Ran it in our testbeds:
| console/test_console_availability.py | 0  | 0 | 0 | 4 | 4  |
|--------------------------------------|----|---|---|---|----|
| console/test_console_driver.py       | 1  | 0 | 0 | 0 | 1  |
| console/test_console_link_wiring.py  | 47 | 1 | 0 | 0 | 48 |
| console/test_console_loopback.py     | 8  | 0 | 0 | 0 | 8  |
| console/test_console_reversessh.py   | 7  | 0 | 0 | 0 | 7  |
| console/test_console_stress.py       | 0  | 0 | 0 | 8 | 8  |

#### Any platform specific information?
Specific to cisco console.
