### PR TITLE
Count RJ45 as part of sfp count for cisco console platform.

### DIFF
--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -476,6 +476,10 @@ class TestChassisApi(PlatformApiTestBase):
         pytest_assert(sfp_list is not None, "Failed to retrieve SFPs")
         pytest_assert(isinstance(sfp_list, list) and len(sfp_list) == num_sfps, "SFPs appear to be incorrect")
 
+        if duthost.facts.get("platform").startswith('arm64-c8220tg_48a_o'):
+            # Index 0 is not SFP in cisco-console.
+            list_sfps.pop(0)
+
         for i in range(len(list_sfps)):
             index = list_sfps[i]
             sfp = chassis.get_sfp(platform_api_conn, index)

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -462,8 +462,9 @@ class TestChassisApi(PlatformApiTestBase):
         if duthost.facts.get("chassis"):
             expected_num_sfps = len(duthost.facts.get("chassis").get('sfps'))
             interface_facts = duthost.show_interface(command='status')['ansible_facts']['int_status']
-            if duthost.facts.get("platform") == 'x86_64-nvidia_sn2201-r0':
-                # On SN2201, there are 48 RJ45 ports which are also counted in SFP object lists
+            if (duthost.facts.get("platform") == 'x86_64-nvidia_sn2201-r0' or
+                    duthost.facts.get("platform").startswith('arm64-c8220tg_48a_o')):
+                # On SN2201 and cisco-console, there are 48 RJ45 ports which are also counted in SFP object lists
                 # So we need to adjust test case accordingly
                 for port, data in list(interface_facts.items()):
                     if data['type'] == 'RJ45':
@@ -475,10 +476,6 @@ class TestChassisApi(PlatformApiTestBase):
         sfp_list = chassis.get_all_sfps(platform_api_conn)
         pytest_assert(sfp_list is not None, "Failed to retrieve SFPs")
         pytest_assert(isinstance(sfp_list, list) and len(sfp_list) == num_sfps, "SFPs appear to be incorrect")
-
-        if duthost.facts.get("platform").startswith('arm64-c8220tg_48a_o'):
-            # Index 0 is not SFP in cisco-console.
-            list_sfps.pop(0)
 
         for i in range(len(list_sfps)):
             index = list_sfps[i]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
We should skip test_sfps for Ethernet1 for cisco console platform, since its RJ45.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
test_sfps is failing in cisco console platform.
#### How did you do it?
Removed the index 0 in the list of sfps.

#### How did you verify/test it?
Ran it on our testbeds:
```
====================================================================================================== PASSES =======================================================================================================
_______________________________________________________________________________________ TestChassisApi.test_sfps[sirc0lo-dut] _______________________________________________________________________________________
--------------------------------------- generated xml file: /run_logs/sir-c0lo/test_sfp/2026-05-02-21-56-23/platform_tests/api/test_chassis.py::TestChassisApi::test_sfps.xml ---------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
============================================================================================== short test summary info ==============================================================================================
PASSED platform_tests/api/test_chassis.py::TestChassisApi::test_sfps[sirc0lo-dut]
===================================================================================== 1 passed, 1 warning in 101.48s (0:01:41) ======================================================================================
sonic@arctos_cicd_all_202603:/data/tests$ 
```
#### Any platform specific information?
Specific to cisco console only.