### PR TITLE
[202511] Fix deploy-l1 error: remove unsupported forced_mgmt_routes from conn_graph_facts

### DIFF
--- a/ansible/roles/testbed/nut/tasks/testbed_facts.yml
+++ b/ansible/roles/testbed/nut/tasks/testbed_facts.yml
@@ -25,5 +25,4 @@
   conn_graph_facts:
     hosts: "{{ (testbed_facts.duts | default([])) + (testbed_facts.tgs | default([])) + (testbed_facts.l1s | default([])) }}"
     group: "{{ conn_graph_group if conn_graph_group is defined else omit }}"
-    forced_mgmt_routes: "{{ forced_mgmt_routes | default([]) }}"
   delegate_to: localhost


### PR DESCRIPTION
### Description of PR

Fix issue https://github.com/sonic-net/sonic-mgmt/issues/24370

it's a sync error introduced in backport PR #24343.

`forced_mgmt_routes` was carried over from master when resolving the cherry-pick conflict in `ansible/roles/testbed/nut/tasks/testbed_facts.yml`, but on `202511` the `conn_graph_facts` module does not accept this parameter, which causes a sync/runtime error. Removing the line.

### Type of change
- [x] Bug fix
- [x] Testbed and Framework (sonic-mgmt)

### Back port request
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fix sync error in 202511 caused by an unsupported parameter passed to `conn_graph_facts`.

#### How did you do it?
Removed the `forced_mgmt_routes:` line from the `conn_graph_facts` task in `nut/tasks/testbed_facts.yml`.

#### How did you verify/test it?
Internal testing on 202511.