### PR TITLE
feat: enable route tests for t1-lag-vpp

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -706,6 +706,7 @@ t1-lag-vpp:
   - route/test_route_flap.py
   - route/test_route_perf.py
   - route/test_route_bgp_ecmp.py
+  - route/test_route_map_check.py
   - srv6/test_srv6_dataplane.py
   - srv6/test_srv6_static_config.py
   - vxlan/test_vxlan_ecmp.py

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -633,16 +633,6 @@ read_mac/test_read_mac_metadata.py::ReadMACMetadata:
       - "asic_type in ['vpp']"
 
 #######################################
-#####           Route             #####
-#######################################
-route/test_route_flow_counter.py:
-  skip:
-    reason: "per route counter is not supported in sonic-vpp but is supported in vpp dataplane. To be included after per route counter support is added in sonic-vpp."
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-#######################################
 #####           SNMP              #####
 #######################################
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Enable more route tests for SONiC VPP to increase the t1-lag-vpp coverage:
- route/test_route_flow_counter.py
- route/test_route_map_check.py

The rest `route/` tests have already been enabled for t1-lag-vpp

Summary:
Fixes # (issue) https://github.com/sonic-net/sonic-buildimage/issues/25772

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
We want to enable all data plane testing on VPP KVM testbed.

#### How did you do it?
Enable the skipped route tests and ensure they can pass.

#### How did you verify/test it?
All enabled route tests have passed
<img width="773" height="858" alt="image" src="https://github.com/user-attachments/assets/21c33dd6-e882-400d-858f-da5819aeb209" />

<img width="2705" height="770" alt="image" src="https://github.com/user-attachments/assets/a4858a97-bb82-4009-8a3c-89d966de873a" />

<img width="2180" height="946" alt="image" src="https://github.com/user-attachments/assets/b3e3d7a8-b5d2-4e50-8c94-90c6b5f1e199" />


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
t1-lag-vpp

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
