### PR TITLE
[HA][smartswitch] HA add test FNIC steady state and planned shutdown

### DIFF
--- a/tests/ha/configs/privatelink_config.py
+++ b/tests/ha/configs/privatelink_config.py
@@ -1,6 +1,7 @@
-from dash_api.eni_pb2 import State
+from dash_api.eni_pb2 import State, EniMode
 from dash_api.route_type_pb2 import ActionType, EncapType, RoutingType
 from dash_api.types_pb2 import IpVersion
+from dash_api.outbound_port_map_range_pb2 import PortMapRangeAction
 
 VNET = "vnet"
 VNET_ENCAP = "vnet_encap"
@@ -21,6 +22,13 @@ PL_OVERLAY_SIP = "fd41:108:20:abc:abc::0"
 PL_OVERLAY_SIP_MASK = "ffff:ffff:ffff:ffff:ffff:ffff::"
 PL_OVERLAY_DIP = "2603:10e1:100:2::3401:203"
 PL_OVERLAY_DIP_MASK = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"
+PL_REDIRECT_OVERLAY_DIP = "2603:10e1:100:2::0"
+PL_REDIRECT_OVERLAY_DIP_MASK = "ffff:ffff:ffff:ffff:ffff:ffff::"
+PL_REDIRECT_BACKEND_PORT_BASE = 42001
+PL_REDIRECT_BACKEND_IP = "60.60.60.1"
+PORT_MAP_1 = "portmap_1"
+PORT_MAP_1_RANGE_START = 8001
+PORT_MAP_1_RANGE_END = 9000
 
 APPLIANCE_ID = "100"
 LOCAL_REGION_ID = "100"
@@ -32,6 +40,7 @@ VNET2 = "Vnet2"
 VNET1_VNI = "2001"
 VNET1_GUID = "559c6ce8-26ab-4193-b946-ccc6e8f930b2"
 VNET2_GUID = "559c6ce8-26ab-4193-b946-ccc6e8f930b3"
+PORTMAP_GUID = "600c6ce8-26ab-4193-b946-ccc6e8f93001"
 VM_MAC = "44:E3:9F:EF:C4:6E"
 ENI_MAC = "F4:93:9F:EF:C4:7E"
 ENI_MAC_STRING = ENI_MAC.replace(":", "")
@@ -41,14 +50,34 @@ REMOTE_MAC_STRING = REMOTE_MAC.replace(":", "")
 ENI_ID = "497f23d7-f0ac-4c99-a98f-59b470e8c7bd"
 ROUTE_GROUP1 = "RouteGroup1"
 ROUTE_GROUP2 = "RouteGroup2"
+ROUTE_GROUP3 = "RouteGroup3"
 ROUTE_GROUP1_GUID = "48af6ce8-26cc-4293-bfa6-0126e8fcdeb2"
 ROUTE_GROUP2_GUID = "58cf62e0-22cc-4693-baa6-012358fcdec9"
+ROUTE_GROUP3_GUID = "68cf62e0-22cc-4693-baa6-012358fcdec9"
 OUTBOUND_DIR_LOOKUP = "dst_mac"
+TUNNEL1 = "Tunnel1"
 ENI_ID2 = "497f23d7-f0ac-4c99-a98f-59b470e8c7bd"
+TUNNEL1_ENDPOINT_IP = "40.40.40.40"
+TUNNEL2 = "Tunnel2"
+TUNNEL1_ENDPOINT_IPS = [TUNNEL1_ENDPOINT_IP]
+TUNNEL2_ENDPOINT_IPS = ["60.60.60.60", "70.70.70.70"]
+TUNNEL3 = "Tunnel3"
+TUNNEL3_ENDPOINT_IP = "80.80.80.80"
+TUNNEL3_ENDPOINT_IPS = ["80.80.80.80"]
+TUNNEL4 = "Tunnel4"
+TUNNEL4_ENDPOINT_IPS = ["90.90.90.90", "10.10.10.10"]
 ENI_TRUSTED_VNI = "800"
 METER_POLICY_V4 = "MeterPolicyV4"
-METER_RULE_V4_PREFIX1 = "48.10.5.0/24"
-METER_RULE_V4_PREFIX2 = "92.6.0.0/16"
+METER_RULE_V4_PREFIX1 = VM_CA_SUBNET
+METER_RULE_V4_PREFIX2 = PE_CA_SUBNET
+ROUTE_METERCLASS_OR = "2566"
+ROUTE_METERCLASS_AND_MASK = "4080"
+MAPPING_METERCLASS_OR = "1038"
+METERCLASSOR_RESULT = "3598"
+METERCLASSAND_RESULT = "2560"
+METERCLASSANDOR_RESULT = "3584"
+ENI_METERPOLICY_CLASS = "520"
+
 
 APPLIANCE_CONFIG = {
     f"DASH_APPLIANCE_TABLE:{APPLIANCE_ID}": {
@@ -59,6 +88,15 @@ APPLIANCE_CONFIG = {
     }
 }
 
+APPLIANCE_FNIC_CONFIG = {
+    f"DASH_APPLIANCE_TABLE:{APPLIANCE_ID}": {
+        "sip": APPLIANCE_VIP,
+        "vm_vni": VM_VNI,
+        "outbound_direction_lookup": OUTBOUND_DIR_LOOKUP,
+        "local_region_id": LOCAL_REGION_ID,
+        "trusted_vnis_list": [ENCAP_VNI]
+    }
+}
 
 VNET_CONFIG = {
     f"DASH_VNET_TABLE:{VNET1}": {
@@ -67,7 +105,6 @@ VNET_CONFIG = {
     }
 }
 
-
 VNET2_CONFIG = {
     f"DASH_VNET_TABLE:{VNET2}": {
         "vni": VM_VNI,
@@ -75,6 +112,34 @@ VNET2_CONFIG = {
     }
 }
 
+ENI_FNIC_CONFIG = {
+    f"DASH_ENI_TABLE:{ENI_ID}": {
+        "vnet": VNET1,
+        "underlay_ip": VM1_PA,
+        "mac_address": ENI_MAC,
+        "eni_id": ENI_ID2,
+        "admin_state": State.STATE_ENABLED,
+        "pl_underlay_sip": APPLIANCE_VIP,
+        "pl_sip_encoding": f"{PL_ENCODING_IP}/{PL_ENCODING_MASK}",
+        "eni_mode": EniMode.MODE_FNIC,
+        "v4_meter_policy_id": METER_POLICY_V4,
+        "trusted_vnis_list": [ENI_TRUSTED_VNI],
+    }
+}
+
+ENI_FNIC_PL_CONFIG = {
+    f"DASH_ENI_TABLE:{ENI_ID}": {
+        "vnet": VNET1,
+        "underlay_ip": VM1_PA,
+        "mac_address": ENI_MAC,
+        "eni_id": ENI_ID2,
+        "admin_state": State.STATE_ENABLED,
+        "pl_underlay_sip": APPLIANCE_VIP,
+        "pl_sip_encoding": f"{PL_ENCODING_IP}/{PL_ENCODING_MASK}",
+        "eni_mode": EniMode.MODE_FNIC,
+        "trusted_vnis_list": [VNET1_VNI],
+    }
+}
 
 ENI_CONFIG = {
     f"DASH_ENI_TABLE:{ENI_ID}": {
@@ -96,34 +161,176 @@ PE_VNET_MAPPING_CONFIG = {
         "underlay_ip": PE_PA,
         "overlay_sip_prefix": f"{PL_OVERLAY_SIP}/{PL_OVERLAY_SIP_MASK}",
         "overlay_dip_prefix": f"{PL_OVERLAY_DIP}/{PL_OVERLAY_DIP_MASK}",
-        "metering_class_or": "1586",
     }
 }
 
+VM_VNET_MAPPING_CONFIG = {
+    f"DASH_VNET_MAPPING_TABLE:{VNET1}:{VM1_CA}": {
+        "routing_type": RoutingType.ROUTING_TYPE_VNET,
+        "underlay_ip": VM1_PA,
+        "mac_address": VM_MAC,
+    }
+}
+
+VM_VNET_MAPPING_CONFIG = {
+    f"DASH_VNET_MAPPING_TABLE:{VNET1}:{VM1_CA}": {
+        "routing_type": RoutingType.ROUTING_TYPE_VNET,
+        "underlay_ip": VM1_PA,
+        "mac_address": VM_MAC,
+    }
+}
+
+PE_PLNSG_SINGLE_ENDPOINT_VNET_MAPPING_CONFIG = {
+    f"DASH_VNET_MAPPING_TABLE:{VNET1}:{PE_CA}": {
+        "routing_type": RoutingType.ROUTING_TYPE_PRIVATELINK,
+        "underlay_ip": PE_PA,
+        "overlay_sip_prefix": f"{PL_OVERLAY_SIP}/{PL_OVERLAY_SIP_MASK}",
+        "overlay_dip_prefix": f"{PL_OVERLAY_DIP}/{PL_OVERLAY_DIP_MASK}",
+        "tunnel": TUNNEL3,
+    }
+}
+
+PE_PLNSG_MULTI_ENDPOINT_VNET_MAPPING_CONFIG = {
+    f"DASH_VNET_MAPPING_TABLE:{VNET1}:{PE_CA}": {
+        "routing_type": RoutingType.ROUTING_TYPE_PRIVATELINK,
+        "underlay_ip": PE_PA,
+        "overlay_sip_prefix": f"{PL_OVERLAY_SIP}/{PL_OVERLAY_SIP_MASK}",
+        "overlay_dip_prefix": f"{PL_OVERLAY_DIP}/{PL_OVERLAY_DIP_MASK}",
+        "tunnel": TUNNEL4,
+    }
+}
+
+TUNNEL1_CONFIG = {
+    f"DASH_TUNNEL_TABLE:{TUNNEL1}": {
+        "endpoints": TUNNEL1_ENDPOINT_IPS,
+        "vni": ENCAP_VNI,
+        "encap_type": EncapType.ENCAP_TYPE_VXLAN
+    }
+}
+
+TUNNEL2_CONFIG = {
+    f"DASH_TUNNEL_TABLE:{TUNNEL2}": {
+        "endpoints": TUNNEL2_ENDPOINT_IPS,
+        "encap_type": EncapType.ENCAP_TYPE_VXLAN,
+        "vni": ENCAP_VNI,
+    }
+}
+
+TUNNEL3_CONFIG = {
+    f"DASH_TUNNEL_TABLE:{TUNNEL3}": {
+        "endpoints": TUNNEL3_ENDPOINT_IPS,
+        "vni": NSG_OUTBOUND_VNI,
+        "encap_type": EncapType.ENCAP_TYPE_VXLAN,
+    }
+}
+
+TUNNEL4_CONFIG = {
+    f"DASH_TUNNEL_TABLE:{TUNNEL4}": {
+        "endpoints": TUNNEL4_ENDPOINT_IPS,
+        "vni": NSG_OUTBOUND_VNI,
+        "encap_type": EncapType.ENCAP_TYPE_VXLAN,
+    }
+}
+PL_REDIRECT_BACKEND_IP_ROUTE_RULE_CONFIG = {
+    f"DASH_ROUTE_RULE_TABLE:{ENI_ID}:{ENCAP_VNI}:{PL_REDIRECT_BACKEND_IP}/32": {
+        "action_type": ActionType.ACTION_TYPE_DECAP,
+        "priority": 0
+    }
+}
 
 INBOUND_VNI_ROUTE_RULE_CONFIG = {
     f"DASH_ROUTE_RULE_TABLE:{ENI_ID}:{ENCAP_VNI}:{PE_PA}/32": {
         "action_type": ActionType.ACTION_TYPE_DECAP,
-        "priority": 1
+        "priority": 0
     }
 }
 
+# For floating NIC, outbound packet will pass through inbound pipeline first before going to the outbound pipeline
+# Need this route rule entry to prevent the packet from being dropped in the inbound pipeline
+TRUSTED_VNI_ROUTE_RULE_CONFIG = {
+    f"DASH_ROUTE_RULE_TABLE:{ENI_ID}:{ENI_TRUSTED_VNI}:{VM1_PA}/32": {
+        "action_type": ActionType.ACTION_TYPE_DECAP,
+        "priority": 0
+    }
+}
+
+VM_SUBNET_ROUTE_WITH_TUNNEL_MULTI_ENDPOINT = {
+    f"DASH_ROUTE_TABLE:{ROUTE_GROUP1}:{VM_CA_SUBNET}": {
+        "routing_type": RoutingType.ROUTING_TYPE_DIRECT,
+        "tunnel": TUNNEL2
+    }
+}
+
+VM_SUBNET_ROUTE_WITH_TUNNEL_SINGLE_ENDPOINT = {
+    f"DASH_ROUTE_TABLE:{ROUTE_GROUP1}:{VM_CA_SUBNET}": {
+        "routing_type": RoutingType.ROUTING_TYPE_DIRECT,
+        "tunnel": TUNNEL1
+    }
+}
+
+RG2_VM_SUBNET_ROUTE_WITH_TUNNEL_SINGLE_ENDPOINT = {
+    f"DASH_ROUTE_TABLE:{ROUTE_GROUP2}:{VM_CA_SUBNET}": {
+        "routing_type": RoutingType.ROUTING_TYPE_DIRECT,
+        "tunnel": TUNNEL1
+    }
+}
+
+RG2_VM_SUBNET_ROUTE_WITH_TUNNEL_MULTI_ENDPOINT = {
+    f"DASH_ROUTE_TABLE:{ROUTE_GROUP2}:{VM_CA_SUBNET}": {
+        "routing_type": RoutingType.ROUTING_TYPE_DIRECT,
+        "tunnel": TUNNEL2
+    }
+}
+
+RG3_VM_SUBNET_ROUTE_WITH_TUNNEL_SINGLE_ENDPOINT = {
+    f"DASH_ROUTE_TABLE:{ROUTE_GROUP3}:{VM_CA_SUBNET}": {
+        "routing_type": RoutingType.ROUTING_TYPE_DIRECT,
+        "tunnel": TUNNEL1
+    }
+}
+
+RG3_VM_SUBNET_ROUTE_WITH_TUNNEL_MULTI_ENDPOINT = {
+    f"DASH_ROUTE_TABLE:{ROUTE_GROUP3}:{VM_CA_SUBNET}": {
+        "routing_type": RoutingType.ROUTING_TYPE_DIRECT,
+        "tunnel": TUNNEL2
+    }
+}
+
+VM_VNI_ROUTE_RULE_CONFIG = {
+    f"DASH_ROUTE_RULE_TABLE:{ENI_ID}:{VM_VNI}:{VM1_PA}/32": {
+        "action_type": ActionType.ACTION_TYPE_DECAP,
+        "priority": 0
+    }
+}
 
 PE_SUBNET_ROUTE_CONFIG = {
     f"DASH_ROUTE_TABLE:{ROUTE_GROUP1}:{PE_CA_SUBNET}": {
         "routing_type": RoutingType.ROUTING_TYPE_VNET,
-        "vnet": VNET1,
-        "metering_class_or": "2048",
-        "metering_class_and": "4095",
+        "vnet": VNET1
+    }
+}
+
+METERCLASSOR_PE_SUBNET_ROUTE_CONFIG = {
+    f"DASH_ROUTE_TABLE:{ROUTE_GROUP2}:{PE_CA_SUBNET}": {
+        "routing_type": RoutingType.ROUTING_TYPE_VNET,
+        "metering_class_or": ROUTE_METERCLASS_OR,
+        "vnet": VNET1
+    }
+}
+
+METERCLASSAND_PE_SUBNET_ROUTE_CONFIG = {
+    f"DASH_ROUTE_TABLE:{ROUTE_GROUP3}:{PE_CA_SUBNET}": {
+        "routing_type": RoutingType.ROUTING_TYPE_VNET,
+        "metering_class_or": ROUTE_METERCLASS_OR,
+        "metering_class_and": ROUTE_METERCLASS_AND_MASK,
+        "vnet": VNET1
     }
 }
 
 VM_SUBNET_ROUTE_CONFIG = {
     f"DASH_ROUTE_TABLE:{ROUTE_GROUP1}:{VM_CA_SUBNET}": {
         "routing_type": RoutingType.ROUTING_TYPE_VNET,
-        "vnet": VNET1,
-        "metering_class_or": "2048",
-        "metering_class_and": "4095",
+        "vnet": VNET1
     }
 }
 
@@ -163,11 +370,38 @@ ROUTE_GROUP1_CONFIG = {
     }
 }
 
+ROUTE_GROUP2_CONFIG = {
+    f"DASH_ROUTE_GROUP_TABLE:{ROUTE_GROUP2}": {
+        "guid": ROUTE_GROUP2_GUID,
+        "version": "rg_version"
+    }
+}
+
+ROUTE_GROUP3_CONFIG = {
+    f"DASH_ROUTE_GROUP_TABLE:{ROUTE_GROUP3}": {
+        "guid": ROUTE_GROUP3_GUID,
+        "version": "rg_version"
+    }
+}
+
 ENI_ROUTE_GROUP1_CONFIG = {
     f"DASH_ENI_ROUTE_TABLE:{ENI_ID}": {
         "group_id": ROUTE_GROUP1
     }
 }
+
+ENI_ROUTE_GROUP2_CONFIG = {
+    f"DASH_ENI_ROUTE_TABLE:{ENI_ID}": {
+        "group_id": ROUTE_GROUP2
+    }
+}
+
+ENI_ROUTE_GROUP3_CONFIG = {
+    f"DASH_ENI_ROUTE_TABLE:{ENI_ID}": {
+        "group_id": ROUTE_GROUP3
+    }
+}
+
 
 METER_POLICY_V4_CONFIG = {
     f"DASH_METER_POLICY_TABLE:{METER_POLICY_V4}": {
@@ -179,14 +413,51 @@ METER_RULE1_V4_CONFIG = {
     f"DASH_METER_RULE_TABLE:{METER_POLICY_V4}:1": {
         "priority": "10",
         "ip_prefix": f"{METER_RULE_V4_PREFIX1}",
-        "metering_class": 1,
+        "metering_class": 512
     }
 }
 
 METER_RULE2_V4_CONFIG = {
     f"DASH_METER_RULE_TABLE:{METER_POLICY_V4}:2": {
-        "priority": "10",
+        "priority": "20",
         "ip_prefix": f"{METER_RULE_V4_PREFIX2}",
-        "metering_class": 2,
+        "metering_class": 520
+    }
+}
+
+PL_REDIRECT_PE_VNET_MAPPING_CONFIG = {
+    f"DASH_VNET_MAPPING_TABLE:{VNET1}:{PE_CA}": {
+        "routing_type": RoutingType.ROUTING_TYPE_PRIVATELINK,
+        "underlay_ip": PE_PA,
+        "overlay_sip_prefix": f"{PL_OVERLAY_SIP}/{PL_OVERLAY_SIP_MASK}",
+        "overlay_dip_prefix": f"{PL_OVERLAY_DIP}/{PL_OVERLAY_DIP_MASK}",
+        "metering_class_or": "1586",
+        "port_map": PORT_MAP_1,
+    }
+}
+
+RD_PORTMAP_CONFIG = {
+        f"DASH_OUTBOUND_PORT_MAP_TABLE:{PORT_MAP_1}": {
+              "guid": f"{PORTMAP_GUID}"
+        }
+}
+
+RD_PORTMAP_RANGE_CONFIG = {
+     f"DASH_OUTBOUND_PORT_MAP_RANGE_TABLE:{PORT_MAP_1}:{PORT_MAP_1_RANGE_START}-{PORT_MAP_1_RANGE_END}": {
+         "action": PortMapRangeAction.ACTION_MAP_PRIVATE_LINK_SERVICE,
+         "backend_ip": PL_REDIRECT_BACKEND_IP,
+         "backend_port_base": PL_REDIRECT_BACKEND_PORT_BASE
+     }
+}
+
+PL_REDIRECT_PE_PLNSG_SINGLE_ENDPOINT_VNET_MAPPING_CONFIG = {
+    f"DASH_VNET_MAPPING_TABLE:{VNET1}:{PE_CA}": {
+        "routing_type": RoutingType.ROUTING_TYPE_PRIVATELINK,
+        "underlay_ip": PE_PA,
+        "overlay_sip_prefix": f"{PL_OVERLAY_SIP}/{PL_OVERLAY_SIP_MASK}",
+        "overlay_dip_prefix": f"{PL_OVERLAY_DIP}/{PL_OVERLAY_DIP_MASK}",
+        "metering_class_or": "1586",
+        "tunnel": TUNNEL3,
+        "port_map": PORT_MAP_1,
     }
 }

--- a/tests/ha/configs/privatelink_config.py
+++ b/tests/ha/configs/privatelink_config.py
@@ -172,14 +172,6 @@ VM_VNET_MAPPING_CONFIG = {
     }
 }
 
-VM_VNET_MAPPING_CONFIG = {
-    f"DASH_VNET_MAPPING_TABLE:{VNET1}:{VM1_CA}": {
-        "routing_type": RoutingType.ROUTING_TYPE_VNET,
-        "underlay_ip": VM1_PA,
-        "mac_address": VM_MAC,
-    }
-}
-
 PE_PLNSG_SINGLE_ENDPOINT_VNET_MAPPING_CONFIG = {
     f"DASH_VNET_MAPPING_TABLE:{VNET1}:{PE_CA}": {
         "routing_type": RoutingType.ROUTING_TYPE_PRIVATELINK,

--- a/tests/ha/ha_dash_flow_utils.py
+++ b/tests/ha/ha_dash_flow_utils.py
@@ -66,8 +66,11 @@ def compare_flow_tables_pdsctl(dpuhost1, dpuhost2):
     logger.info(f"flows on primary: {flow_table1}")
     logger.info(f"flows on standby: {flow_table2}")
 
-    if flow_table1 == flow_table2:
-        logger.info(f" flows for {dpuhost1.hostname} and {dpuhost2.hostname} are identical")
+    def without_session(flow_list):
+        return [{k: v for k, v in entry.items() if k != 'Session'} for entry in flow_list]
+
+    if without_session(flow_table1) == without_session(flow_table2):
+        logger.info(f" flows for {dpuhost1.hostname} and {dpuhost2.hostname} are identical (ignoring Session id)")
         return True
     else:
         logger.warning(f" flows for {dpuhost1.hostname} and {dpuhost2.hostname} are different")

--- a/tests/ha/packets.py
+++ b/tests/ha/packets.py
@@ -7,9 +7,43 @@ import ptf.testutils as testutils
 from configs import privatelink_config as pl
 from constants import VXLAN_UDP_BASE_SRC_PORT, VXLAN_UDP_SRC_PORT_MASK, \
         DUT_MAC, LOCAL_PTF_MAC, REMOTE_PTF_MAC
-from ptf.mask import Mask
+from ptf.mask import Mask, MaskException
 
 logger = logging.getLogger(__name__)
+
+
+def set_do_not_care_layer(mask, layer, field_name, n=1):
+    """
+    Zeroes out the mask for 'field' in the nth occurrence of the specified layer.
+    """
+    header_offset = mask.size - len(mask.exp_pkt.getlayer(layer, n))
+
+    try:
+        fields_desc = [
+            field
+            for field in layer.fields_desc
+            if field.name in mask.exp_pkt[layer].__class__(bytes(mask.exp_pkt[layer])).fields.keys()
+        ]  # build & parse packet to be sure all fields are correctly filled
+    except Exception:  # noqa
+        raise MaskException("Can not build or decode Packet")
+
+    if field_name not in [x.name for x in fields_desc]:
+        raise MaskException("Field %s does not exist in frame" % field_name)
+
+    field_offset = 0
+    bitwidth = 0
+    for f in fields_desc:
+        try:
+            bits = f.size
+        except Exception:  # noqa
+            bits = 8 * f.sz
+        if f.name == field_name:
+            bitwidth = bits
+            break
+        else:
+            field_offset += bits
+
+    mask.set_do_not_care(header_offset * 8 + field_offset, bitwidth)
 
 
 def generate_inner_packet(packet_type, ipv6=False):
@@ -59,8 +93,15 @@ def get_pl_overlay_dip(orig_dip, ol_dip, ol_mask):
 
 def inbound_pl_packets(
     config, floating_nic=False, inner_packet_type="udp", vxlan_udp_dport=4789, inner_sport=4567, inner_dport=6789,
-    vxlan_udp_base_src_port=VXLAN_UDP_BASE_SRC_PORT, vxlan_udp_src_port_mask=VXLAN_UDP_SRC_PORT_MASK
+    vxlan_udp_base_src_port=VXLAN_UDP_BASE_SRC_PORT, vxlan_udp_src_port_mask=VXLAN_UDP_SRC_PORT_MASK, exp_vni=None,
+    tcp_flag_syn=False, tcp_flag_ack=False, tcp_flag_fin=False,
+    tcp_seq_num=None, tcp_ack_num=None
 ):
+    if exp_vni is not None:
+        expected_vni = int(exp_vni)
+    else:
+        expected_vni = int(pl.ENCAP_VNI if floating_nic else pl.VM_VNI)
+
     inner_sip = get_pl_overlay_dip(  # not a typo, inner DIP/SIP are reversed for inbound direction
         pl.PE_CA, pl.PL_OVERLAY_DIP, pl.PL_OVERLAY_DIP_MASK
     )
@@ -79,6 +120,21 @@ def inbound_pl_packets(
     )
     inner_packet[l4_protocol_key].sport = inner_sport
     inner_packet[l4_protocol_key].dport = inner_dport
+
+    if inner_packet_type == "tcp":
+        tcp_flags = ''
+        if tcp_seq_num is not None:
+            inner_packet[l4_protocol_key].seq = tcp_seq_num
+        if tcp_ack_num is not None:
+            inner_packet[l4_protocol_key].ack = tcp_ack_num
+        if tcp_flag_syn:
+            tcp_flags += 'S'
+        if tcp_flag_ack:
+            tcp_flags += 'A'
+        if tcp_flag_fin:
+            tcp_flags += 'F'
+        if tcp_flags:
+            inner_packet[l4_protocol_key].flags = tcp_flags
 
     gre_packet = testutils.simple_gre_packet(
         eth_dst=config[DUT_MAC],
@@ -109,7 +165,7 @@ def inbound_pl_packets(
         ip_id=0,
         udp_dport=vxlan_udp_dport,
         udp_sport=vxlan_udp_base_src_port,
-        vxlan_vni=pl.ENCAP_VNI if floating_nic else int(pl.VNET1_VNI),
+        vxlan_vni=expected_vni,
         inner_frame=exp_inner_packet,
     )
 
@@ -123,8 +179,7 @@ def inbound_pl_packets(
     if floating_nic:
         # As destination IP is not fixed in case of return path ECMP,
         # we need to mask the checksum and destination IP
-        masked_exp_packet.set_do_not_care_packet(scapy.IP, "dst")
-        masked_exp_packet.set_do_not_care(400, 48)  # Inner dst MAC
+        set_do_not_care_layer(masked_exp_packet, scapy.Ether, "dst", 2)
 
     return gre_packet, masked_exp_packet
 
@@ -140,7 +195,12 @@ def outbound_pl_packets(
         VXLAN_UDP_BASE_SRC_PORT + 2**VXLAN_UDP_SRC_PORT_MASK - 1),
     inner_sport=6789,
     inner_dport=4567,
-    vni=None
+    vni=None,
+    tcp_flag_syn=False,
+    tcp_flag_ack=False,
+    tcp_flag_fin=False,
+    tcp_seq_num=None,
+    tcp_ack_num=None
 ):
     outer_vni = int(vni if vni else pl.VM_VNI)
 
@@ -154,6 +214,21 @@ def outbound_pl_packets(
     )
     inner_packet[l4_protocol_key].sport = inner_sport
     inner_packet[l4_protocol_key].dport = inner_dport
+
+    if inner_packet_type == "tcp":
+        tcp_flags = ''
+        if tcp_seq_num is not None:
+            inner_packet[l4_protocol_key].seq = tcp_seq_num
+        if tcp_ack_num is not None:
+            inner_packet[l4_protocol_key].ack = tcp_ack_num
+        if tcp_flag_syn:
+            tcp_flags += 'S'
+        if tcp_flag_ack:
+            tcp_flags += 'A'
+        if tcp_flag_fin:
+            tcp_flags += 'F'
+        if tcp_flags:
+            inner_packet[l4_protocol_key].flags = tcp_flags
 
     if outer_encap == "vxlan":
         outer_packet = testutils.simple_vxlan_packet(
@@ -174,7 +249,7 @@ def outbound_pl_packets(
             ip_src=pl.VM1_PA,
             ip_dst=pl.APPLIANCE_VIP,
             gre_key_present=True,
-            gre_key=(outer_vni << 8) if floating_nic else (int(pl.VNET1_VNI) << 8),
+            gre_key=(outer_vni << 8) if floating_nic else (int(pl.VM_VNI) << 8),
             inner_frame=inner_packet,
         )
     else:

--- a/tests/ha/test_ha_planned_shutdown_fnic.py
+++ b/tests/ha/test_ha_planned_shutdown_fnic.py
@@ -14,7 +14,7 @@ from gnmi_utils import apply_messages
 from packets import outbound_pl_packets
 from tests.common.config_reload import config_reload
 from ha_utils import activate_primary_dash_ha, activate_secondary_dash_ha, \
-         verify_ha_state, set_dead_dash_ha_scope
+         verify_ha_state, set_dash_ha_scope, set_dead_dash_ha_scope
 
 logger = logging.getLogger(__name__)
 
@@ -167,6 +167,7 @@ def test_ha_planned_shutdown(
     logging.info(f"HA: Primary shutdown all {send_count} packets received")
 
     # Re-activate primary
+    set_dash_ha_scope(localhost, duthosts[0], ptfhost, primary_vdpu_key, "dead", ha_owner, disabled=True)
     pytest_assert(activate_primary_dash_ha(localhost, duthosts[0], ptfhost, primary_vdpu_key, "activate_role"),
                   "Failed to re-activate HA on primary")
 
@@ -217,5 +218,6 @@ def test_ha_planned_shutdown(
     logging.info(f"HA: standby shutdown all {send_count} packets received")
 
     # Re-activate standby
+    set_dash_ha_scope(localhost, duthosts[1], ptfhost, standby_vdpu_key, "dead", ha_owner, disabled=True)
     pytest_assert(activate_secondary_dash_ha(localhost, duthosts[1], ptfhost, standby_vdpu_key, "activate_role",
                                              owner=ha_owner), "Failed to re-activate HA on standby")

--- a/tests/ha/test_ha_planned_shutdown_fnic.py
+++ b/tests/ha/test_ha_planned_shutdown_fnic.py
@@ -1,0 +1,221 @@
+import logging
+import concurrent.futures
+import random
+
+import configs.privatelink_config as pl
+import ptf.testutils as testutils
+import pytest
+import time
+import threading
+import queue
+from tests.common.helpers.assertions import pytest_assert
+from constants import LOCAL_PTF_INTF, REMOTE_PTF_RECV_INTF
+from gnmi_utils import apply_messages
+from packets import outbound_pl_packets
+from tests.common.config_reload import config_reload
+from ha_utils import activate_primary_dash_ha, activate_secondary_dash_ha, \
+         verify_ha_state, set_dead_dash_ha_scope
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('t1-smartswitch-ha'),
+    pytest.mark.skip_check_dut_health
+]
+
+
+def reload_config_for_host(dpuhost):
+    logger.info(f"config reload on {dpuhost.hostname}")
+    config_reload(dpuhost, safe_reload=True, yang_validate=False)
+
+
+@pytest.fixture(autouse=True, scope="function")
+def common_setup_teardown(
+    localhost,
+    duthosts,
+    ptfhost,
+    skip_config,
+    dpuhosts,
+    setup_ha_config,
+    setup_dash_ha_from_json,
+    ha_owner,
+    setup_gnmi_server,
+    set_vxlan_udp_sport_range,
+    setup_npu_dpu  # noqa: F811
+):
+    if skip_config:
+        return
+
+    for i in range(len(duthosts)):
+        duthost = duthosts[i]
+        dpuhost = dpuhosts[i]
+        base_config_messages = {
+            **pl.APPLIANCE_FNIC_CONFIG,
+            **pl.ROUTING_TYPE_PL_CONFIG,
+            **pl.ROUTING_TYPE_VNET_CONFIG,
+            **pl.VNET_CONFIG,
+            **pl.ROUTE_GROUP1_CONFIG,
+            **pl.METER_POLICY_V4_CONFIG,
+            **pl.TUNNEL1_CONFIG,
+        }
+        logger.info(f"configure on {duthost.hostname} dpu {dpuhost.dpu_index} {base_config_messages}")
+
+        apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index)
+
+        route_and_mapping_messages = {
+            **pl.PE_VNET_MAPPING_CONFIG,
+            **pl.PE_SUBNET_ROUTE_CONFIG,
+            **pl.VM_VNET_MAPPING_CONFIG,
+            **pl.VM_SUBNET_ROUTE_WITH_TUNNEL_SINGLE_ENDPOINT,
+        }
+
+        logger.info(route_and_mapping_messages)
+        apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index)
+
+        if 'pensando' not in dpuhost.facts['asic_type']:
+            route_rule_messages = {
+                **pl.VM_VNI_ROUTE_RULE_CONFIG,
+                **pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
+                **pl.TRUSTED_VNI_ROUTE_RULE_CONFIG,
+            }
+            logger.info(route_rule_messages)
+            apply_messages(localhost, duthost, ptfhost, route_rule_messages, dpuhost.dpu_index)
+
+        meter_rule_messages = {
+            **pl.METER_RULE1_V4_CONFIG,
+            **pl.METER_RULE2_V4_CONFIG,
+        }
+        logger.info(meter_rule_messages)
+        apply_messages(localhost, duthost, ptfhost, meter_rule_messages, dpuhost.dpu_index)
+
+        logger.info(pl.ENI_FNIC_CONFIG)
+        apply_messages(localhost, duthost, ptfhost, pl.ENI_FNIC_CONFIG, dpuhost.dpu_index)
+
+        logger.info(pl.ENI_ROUTE_GROUP1_CONFIG)
+        apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index)
+
+    yield
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(dpuhosts)) as executor:
+        executor.map(reload_config_for_host, dpuhosts)
+
+
+def test_ha_planned_shutdown(
+    ptfadapter,
+    localhost,
+    duthosts,
+    dpuhosts,
+    ptfhost,
+    activate_dash_ha_from_json,
+    ha_owner,
+    dash_pl_config,
+    primary_vdpu_key,
+    standby_vdpu_key
+):
+    encap_proto = "vxlan"
+    rate_pps = 10  # packets per second
+    initial_send_count = 10
+    delay = 1.0 / rate_pps
+
+    rcv_outbound_pl_ports = dash_pl_config[0][REMOTE_PTF_RECV_INTF] + dash_pl_config[1][REMOTE_PTF_RECV_INTF]
+
+    packet_sending_flag = queue.Queue(1)
+
+    def primary_ha_action():
+        # wait for packets sending started, then set primary to dead
+        while packet_sending_flag.empty() or (not packet_sending_flag.get()):
+            time.sleep(0.2)
+        logging.info("HA: Set primary to dead")
+        set_dead_dash_ha_scope(localhost, duthosts[0], ptfhost, primary_vdpu_key)
+
+    t = threading.Thread(target=primary_ha_action, name="primary_ha_action_thread")
+    t.start()
+    t_max = time.time() + 60
+    # Calculate the delay between packets based on the desired rate
+    reached_max_time = False
+    ptfadapter.dataplane.flush()
+    time.sleep(1)
+    send_count = 0
+    while not reached_max_time:
+        sport = random.randint(49152, 65535)
+        dport = random.randint(49152, 65535)
+        vm_to_dpu_pkt, exp_dpu_to_pe_pkt = outbound_pl_packets(
+            dash_pl_config[0], encap_proto, floating_nic=True,
+            inner_sport=sport, inner_dport=dport, vni=pl.ENI_TRUSTED_VNI
+        )
+        testutils.send(ptfadapter, dash_pl_config[0][LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
+        testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, rcv_outbound_pl_ports)
+        if send_count == 0:
+            logger.info("HA: First packet received")
+        send_count += 1
+        # After we send initial_send_count packets, awake perform_ha_action thread
+        if send_count == initial_send_count:
+            logging.info("HA: awake action thread")
+            packet_sending_flag.put(True)
+
+        time.sleep(delay)
+        reached_max_time = time.time() > t_max
+
+    t.join()
+    time.sleep(2)
+
+    pytest_assert(verify_ha_state(duthosts[0], primary_vdpu_key, "dead"),
+                  "Primary HA state is not dead")
+    pytest_assert(verify_ha_state(duthosts[1], standby_vdpu_key, "standalone"),
+                  "Standby HA state is not standalone")
+
+    logging.info(f"HA: Primary shutdown all {send_count} packets received")
+
+    # Re-activate primary
+    pytest_assert(activate_primary_dash_ha(localhost, duthosts[0], ptfhost, primary_vdpu_key, "activate_role"),
+                  "Failed to re-activate HA on primary")
+
+    packet_sending_flag = queue.Queue(1)
+
+    def standby_ha_action():
+        # wait for packets sending started, then set standby to dead
+        while packet_sending_flag.empty() or (not packet_sending_flag.get()):
+            time.sleep(0.2)
+        logging.info("HA: Set standby to dead")
+        set_dead_dash_ha_scope(localhost, duthosts[1], ptfhost, standby_vdpu_key)
+
+    t = threading.Thread(target=standby_ha_action, name="standby_ha_action_thread")
+    t.start()
+    t_max = time.time() + 60
+    reached_max_time = False
+    ptfadapter.dataplane.flush()
+    time.sleep(1)
+    send_count = 0
+
+    while not reached_max_time:
+        sport = random.randint(49152, 65535)
+        dport = random.randint(49152, 65535)
+        vm_to_dpu_pkt, exp_dpu_to_pe_pkt = outbound_pl_packets(
+            dash_pl_config[0], encap_proto, floating_nic=True,
+            inner_sport=sport, inner_dport=dport, vni=pl.ENI_TRUSTED_VNI
+        )
+        testutils.send(ptfadapter, dash_pl_config[0][LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
+        testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, rcv_outbound_pl_ports)
+        if send_count == 0:
+            logger.info("HA: First packet received")
+        send_count += 1
+        # After we send initial_send_count packets, awake perform_ha_action thread
+        if send_count == initial_send_count:
+            logging.info("HA: awake action thread")
+            packet_sending_flag.put(True)
+        time.sleep(delay)
+        reached_max_time = time.time() > t_max
+
+    t.join()
+    time.sleep(2)
+
+    pytest_assert(verify_ha_state(duthosts[1], standby_vdpu_key, "dead"),
+                  "Standby HA state is not dead")
+    pytest_assert(verify_ha_state(duthosts[0], primary_vdpu_key, "standalone"),
+                  "Primary HA state is not standalone")
+
+    logging.info(f"HA: standby shutdown all {send_count} packets received")
+
+    # Re-activate standby
+    pytest_assert(activate_secondary_dash_ha(localhost, duthosts[1], ptfhost, standby_vdpu_key, "activate_role",
+                                             owner=ha_owner), "Failed to re-activate HA on standby")

--- a/tests/ha/test_ha_steady_state_fnic.py
+++ b/tests/ha/test_ha_steady_state_fnic.py
@@ -1,0 +1,163 @@
+import logging
+import random
+import concurrent.futures
+
+import configs.privatelink_config as pl
+import ptf.testutils as testutils
+import pytest
+from tests.common.helpers.assertions import pytest_assert
+from constants import LOCAL_PTF_INTF, REMOTE_PTF_RECV_INTF, REMOTE_PTF_SEND_INTF
+from gnmi_utils import apply_messages
+from packets import outbound_pl_packets, inbound_pl_packets
+from tests.common.config_reload import config_reload
+from ha_dash_flow_utils import compare_flow_tables_pdsctl
+from tests.common.dash_utils import verify_tunnel_packets
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('t1-smartswitch-ha'),
+    pytest.mark.skip_check_dut_health
+]
+
+"""
+Test prerequisites:
+- Assign IPs to DPU-NPU dataplane interfaces
+"""
+
+NUM_PACKETS = 5
+
+
+def reload_config_for_host(dpuhost):
+    logger.info(f"config reload on {dpuhost.hostname}")
+    config_reload(dpuhost, safe_reload=True, yang_validate=False)
+
+
+def _build_fnic_pkt_set(config, encap_proto, ptfadapter):
+    """Build a list of NUM_PACKETS fnic packet tuples for a given DPU config."""
+    pkt_sets = []
+    for _ in range(NUM_PACKETS):
+        sport = random.randint(49152, 65535)
+        dport = random.randint(49152, 65535)
+        vm_to_dpu_pkt, exp_dpu_to_pe_pkt = outbound_pl_packets(
+            config, encap_proto, floating_nic=True,
+            inner_sport=sport, inner_dport=dport, vni=pl.ENI_TRUSTED_VNI
+        )
+        pe_to_dpu_pkt, exp_dpu_to_vm_pkt = inbound_pl_packets(
+            config, floating_nic=True, inner_sport=dport, inner_dport=sport
+        )
+        exp_dpu_to_vm_pkt = ptfadapter.update_payload(exp_dpu_to_vm_pkt)
+        pkt_sets.append((vm_to_dpu_pkt, exp_dpu_to_pe_pkt, pe_to_dpu_pkt, exp_dpu_to_vm_pkt))
+    return pkt_sets
+
+
+@pytest.fixture(autouse=True, scope="module")
+def common_setup_teardown(
+    localhost,
+    duthosts,
+    ptfhost,
+    dpu_index,
+    skip_config,
+    dpuhosts,
+    setup_ha_config,
+    ha_owner,
+    setup_gnmi_server,
+    set_vxlan_udp_sport_range,
+    setup_npu_dpu  # noqa: F811
+):
+    if skip_config:
+        return
+
+    for i in range(len(duthosts)):
+        duthost = duthosts[i]
+        dpuhost = dpuhosts[i]
+        base_config_messages = {
+            **pl.APPLIANCE_FNIC_CONFIG,
+            **pl.ROUTING_TYPE_PL_CONFIG,
+            **pl.ROUTING_TYPE_VNET_CONFIG,
+            **pl.VNET_CONFIG,
+            **pl.ROUTE_GROUP1_CONFIG,
+            **pl.METER_POLICY_V4_CONFIG,
+            **pl.TUNNEL1_CONFIG,
+        }
+        logger.info(f"configure on {duthost.hostname} dpu {dpuhost.dpu_index} {base_config_messages}")
+        apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index)
+
+        route_and_mapping_messages = {
+            **pl.PE_VNET_MAPPING_CONFIG,
+            **pl.PE_SUBNET_ROUTE_CONFIG,
+            **pl.VM_VNET_MAPPING_CONFIG,
+            **pl.VM_SUBNET_ROUTE_WITH_TUNNEL_SINGLE_ENDPOINT,
+        }
+        logger.info(route_and_mapping_messages)
+        apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index)
+
+        if 'pensando' not in dpuhost.facts['asic_type']:
+            route_rule_messages = {
+                **pl.VM_VNI_ROUTE_RULE_CONFIG,
+                **pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
+                **pl.TRUSTED_VNI_ROUTE_RULE_CONFIG,
+            }
+            logger.info(route_rule_messages)
+            apply_messages(localhost, duthost, ptfhost, route_rule_messages, dpuhost.dpu_index)
+
+        meter_rule_messages = {
+            **pl.METER_RULE1_V4_CONFIG,
+            **pl.METER_RULE2_V4_CONFIG,
+        }
+        logger.info(meter_rule_messages)
+        apply_messages(localhost, duthost, ptfhost, meter_rule_messages, dpuhost.dpu_index)
+
+        logger.info(pl.ENI_FNIC_CONFIG)
+        apply_messages(localhost, duthost, ptfhost, pl.ENI_FNIC_CONFIG, dpuhost.dpu_index)
+
+        logger.info(pl.ENI_ROUTE_GROUP1_CONFIG)
+        apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index)
+
+    yield
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(dpuhosts)) as executor:
+        executor.map(reload_config_for_host, dpuhosts)
+
+
+@pytest.mark.parametrize("encap_proto", ["vxlan", "gre"])
+def test_fnic_basic_transform(
+    ptfadapter,
+    dpuhosts,
+    activate_dash_ha_from_json,
+    ha_owner,
+    dash_pl_config,
+    encap_proto
+):
+    tunnel_endpoint_counts = {ip: 0 for ip in pl.TUNNEL1_ENDPOINT_IPS}
+
+    # traffic to active DPU
+    pkt_sets = _build_fnic_pkt_set(dash_pl_config[0], encap_proto, ptfadapter)
+    ptfadapter.dataplane.flush()
+    for vm_to_dpu_pkt, exp_dpu_to_pe_pkt, pe_to_dpu_pkt, exp_dpu_to_vm_pkt in pkt_sets:
+        testutils.send(ptfadapter, dash_pl_config[0][LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
+        testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, dash_pl_config[0][REMOTE_PTF_RECV_INTF])
+        testutils.send(ptfadapter, dash_pl_config[0][REMOTE_PTF_SEND_INTF], pe_to_dpu_pkt, 1)
+        verify_tunnel_packets(ptfadapter, dash_pl_config[0][LOCAL_PTF_INTF], exp_dpu_to_vm_pkt, tunnel_endpoint_counts)
+
+    flow_op = compare_flow_tables_pdsctl(dpuhosts[0], dpuhosts[1])
+    pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
+
+    # traffic to standby DPU (forwarded through active for processing)
+    pkt_sets = _build_fnic_pkt_set(dash_pl_config[1], encap_proto, ptfadapter)
+    ptfadapter.dataplane.flush()
+    for vm_to_dpu_pkt, exp_dpu_to_pe_pkt, pe_to_dpu_pkt, exp_dpu_to_vm_pkt in pkt_sets:
+        testutils.send(ptfadapter, dash_pl_config[1][LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
+        testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, dash_pl_config[0][REMOTE_PTF_RECV_INTF])
+        testutils.send(ptfadapter, dash_pl_config[1][REMOTE_PTF_SEND_INTF], pe_to_dpu_pkt, 1)
+        verify_tunnel_packets(ptfadapter, dash_pl_config[0][LOCAL_PTF_INTF], exp_dpu_to_vm_pkt, tunnel_endpoint_counts)
+
+    flow_op = compare_flow_tables_pdsctl(dpuhosts[0], dpuhosts[1])
+    pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
+
+    total_expected = NUM_PACKETS * 2
+    recvd_pkts = sum(tunnel_endpoint_counts.values())
+    logger.info(f"Received packets: {recvd_pkts}, Tunnel endpoint counts: {tunnel_endpoint_counts}")
+    pytest_assert(
+        recvd_pkts == total_expected,
+        f"Expected {total_expected} packets, but received {recvd_pkts} packets. Counts: {tunnel_endpoint_counts}",
+    )

--- a/tests/ha/test_ha_steady_state_fnic.py
+++ b/tests/ha/test_ha_steady_state_fnic.py
@@ -3,13 +3,15 @@ import random
 import concurrent.futures
 
 import configs.privatelink_config as pl
+import ptf.packet as scapy
 import ptf.testutils as testutils
 import pytest
 from tests.common.helpers.assertions import pytest_assert
-from constants import LOCAL_PTF_INTF, REMOTE_PTF_RECV_INTF
+from constants import LOCAL_PTF_INTF, REMOTE_PTF_RECV_INTF, REMOTE_PTF_SEND_INTF
 from gnmi_utils import apply_messages
-from packets import outbound_pl_packets
+from packets import inbound_pl_packets, outbound_pl_packets
 from tests.common.config_reload import config_reload
+from tests.common.dash_utils import verify_tunnel_packets
 from ha_dash_flow_utils import compare_flow_tables_pdsctl
 
 logger = logging.getLogger(__name__)
@@ -29,7 +31,7 @@ def reload_config_for_host(dpuhost):
 
 
 def _build_fnic_pkt_set(config, encap_proto, ptfadapter):
-    """Build a list of NUM_PACKETS fnic packet tuples for a given DPU config."""
+    """Build a list of NUM_PACKETS bidirectional fnic packet tuples for a given DPU config."""
     pkt_sets = []
     for _ in range(NUM_PACKETS):
         sport = random.randint(49152, 65535)
@@ -38,7 +40,12 @@ def _build_fnic_pkt_set(config, encap_proto, ptfadapter):
             config, encap_proto, floating_nic=True,
             inner_sport=sport, inner_dport=dport, vni=pl.ENI_TRUSTED_VNI
         )
-        pkt_sets.append((vm_to_dpu_pkt, exp_dpu_to_pe_pkt))
+        pe_to_dpu_pkt, exp_dpu_to_vm_pkt = inbound_pl_packets(
+            config, floating_nic=True, inner_sport=dport, inner_dport=sport
+        )
+        exp_dpu_to_vm_pkt.set_do_not_care_packet(scapy.IP, "dst")
+        exp_dpu_to_vm_pkt = ptfadapter.update_payload(exp_dpu_to_vm_pkt)
+        pkt_sets.append((vm_to_dpu_pkt, exp_dpu_to_pe_pkt, pe_to_dpu_pkt, exp_dpu_to_vm_pkt))
     return pkt_sets
 
 
@@ -113,29 +120,52 @@ def common_setup_teardown(
 @pytest.mark.parametrize("encap_proto", ["vxlan", "gre"])
 def test_fnic_basic_transform(
     ptfadapter,
+    duthosts,
     dpuhosts,
     activate_dash_ha_from_json,
     ha_owner,
     dash_pl_config,
+    get_t2_info,
     encap_proto
 ):
+    active_t2_ports = get_t2_info[duthosts[0].hostname]
 
     # traffic to active DPU
     pkt_sets = _build_fnic_pkt_set(dash_pl_config[0], encap_proto, ptfadapter)
+    tunnel_endpoint_counts = {ip: 0 for ip in pl.TUNNEL1_ENDPOINT_IPS}
     ptfadapter.dataplane.flush()
-    for vm_to_dpu_pkt, exp_dpu_to_pe_pkt in pkt_sets:
+    for vm_to_dpu_pkt, exp_dpu_to_pe_pkt, pe_to_dpu_pkt, exp_dpu_to_vm_pkt in pkt_sets:
         testutils.send(ptfadapter, dash_pl_config[0][LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
         testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, dash_pl_config[0][REMOTE_PTF_RECV_INTF])
+        testutils.send(ptfadapter, dash_pl_config[0][REMOTE_PTF_SEND_INTF], pe_to_dpu_pkt, 1)
+        verify_tunnel_packets(
+            ptfadapter,
+            active_t2_ports,
+            exp_dpu_to_vm_pkt,
+            tunnel_endpoint_counts,
+        )
+
+    pytest_assert(sum(tunnel_endpoint_counts.values()) == NUM_PACKETS, "Expected active return-path packets")
 
     flow_op = compare_flow_tables_pdsctl(dpuhosts[0], dpuhosts[1])
     pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
 
     # traffic to standby DPU (forwarded through active for processing)
     pkt_sets = _build_fnic_pkt_set(dash_pl_config[1], encap_proto, ptfadapter)
+    tunnel_endpoint_counts = {ip: 0 for ip in pl.TUNNEL1_ENDPOINT_IPS}
     ptfadapter.dataplane.flush()
-    for vm_to_dpu_pkt, exp_dpu_to_pe_pkt in pkt_sets:
+    for vm_to_dpu_pkt, exp_dpu_to_pe_pkt, pe_to_dpu_pkt, exp_dpu_to_vm_pkt in pkt_sets:
         testutils.send(ptfadapter, dash_pl_config[1][LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
         testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, dash_pl_config[0][REMOTE_PTF_RECV_INTF])
+        testutils.send(ptfadapter, dash_pl_config[1][REMOTE_PTF_SEND_INTF], pe_to_dpu_pkt, 1)
+        verify_tunnel_packets(
+            ptfadapter,
+            active_t2_ports,
+            exp_dpu_to_vm_pkt,
+            tunnel_endpoint_counts,
+        )
+
+    pytest_assert(sum(tunnel_endpoint_counts.values()) == NUM_PACKETS, "Expected standby return-path packets")
 
     flow_op = compare_flow_tables_pdsctl(dpuhosts[0], dpuhosts[1])
     pytest_assert(flow_op, "Expected identical flow tables on primary and standby")

--- a/tests/ha/test_ha_steady_state_fnic.py
+++ b/tests/ha/test_ha_steady_state_fnic.py
@@ -6,12 +6,11 @@ import configs.privatelink_config as pl
 import ptf.testutils as testutils
 import pytest
 from tests.common.helpers.assertions import pytest_assert
-from constants import LOCAL_PTF_INTF, REMOTE_PTF_RECV_INTF, REMOTE_PTF_SEND_INTF
+from constants import LOCAL_PTF_INTF, REMOTE_PTF_RECV_INTF
 from gnmi_utils import apply_messages
-from packets import outbound_pl_packets, inbound_pl_packets
+from packets import outbound_pl_packets
 from tests.common.config_reload import config_reload
 from ha_dash_flow_utils import compare_flow_tables_pdsctl
-from tests.common.dash_utils import verify_tunnel_packets
 
 logger = logging.getLogger(__name__)
 
@@ -20,10 +19,6 @@ pytestmark = [
     pytest.mark.skip_check_dut_health
 ]
 
-"""
-Test prerequisites:
-- Assign IPs to DPU-NPU dataplane interfaces
-"""
 
 NUM_PACKETS = 5
 
@@ -43,11 +38,7 @@ def _build_fnic_pkt_set(config, encap_proto, ptfadapter):
             config, encap_proto, floating_nic=True,
             inner_sport=sport, inner_dport=dport, vni=pl.ENI_TRUSTED_VNI
         )
-        pe_to_dpu_pkt, exp_dpu_to_vm_pkt = inbound_pl_packets(
-            config, floating_nic=True, inner_sport=dport, inner_dport=sport
-        )
-        exp_dpu_to_vm_pkt = ptfadapter.update_payload(exp_dpu_to_vm_pkt)
-        pkt_sets.append((vm_to_dpu_pkt, exp_dpu_to_pe_pkt, pe_to_dpu_pkt, exp_dpu_to_vm_pkt))
+        pkt_sets.append((vm_to_dpu_pkt, exp_dpu_to_pe_pkt))
     return pkt_sets
 
 
@@ -128,16 +119,13 @@ def test_fnic_basic_transform(
     dash_pl_config,
     encap_proto
 ):
-    tunnel_endpoint_counts = {ip: 0 for ip in pl.TUNNEL1_ENDPOINT_IPS}
 
     # traffic to active DPU
     pkt_sets = _build_fnic_pkt_set(dash_pl_config[0], encap_proto, ptfadapter)
     ptfadapter.dataplane.flush()
-    for vm_to_dpu_pkt, exp_dpu_to_pe_pkt, pe_to_dpu_pkt, exp_dpu_to_vm_pkt in pkt_sets:
+    for vm_to_dpu_pkt, exp_dpu_to_pe_pkt in pkt_sets:
         testutils.send(ptfadapter, dash_pl_config[0][LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
         testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, dash_pl_config[0][REMOTE_PTF_RECV_INTF])
-        testutils.send(ptfadapter, dash_pl_config[0][REMOTE_PTF_SEND_INTF], pe_to_dpu_pkt, 1)
-        verify_tunnel_packets(ptfadapter, dash_pl_config[0][LOCAL_PTF_INTF], exp_dpu_to_vm_pkt, tunnel_endpoint_counts)
 
     flow_op = compare_flow_tables_pdsctl(dpuhosts[0], dpuhosts[1])
     pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
@@ -145,19 +133,9 @@ def test_fnic_basic_transform(
     # traffic to standby DPU (forwarded through active for processing)
     pkt_sets = _build_fnic_pkt_set(dash_pl_config[1], encap_proto, ptfadapter)
     ptfadapter.dataplane.flush()
-    for vm_to_dpu_pkt, exp_dpu_to_pe_pkt, pe_to_dpu_pkt, exp_dpu_to_vm_pkt in pkt_sets:
+    for vm_to_dpu_pkt, exp_dpu_to_pe_pkt in pkt_sets:
         testutils.send(ptfadapter, dash_pl_config[1][LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
         testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, dash_pl_config[0][REMOTE_PTF_RECV_INTF])
-        testutils.send(ptfadapter, dash_pl_config[1][REMOTE_PTF_SEND_INTF], pe_to_dpu_pkt, 1)
-        verify_tunnel_packets(ptfadapter, dash_pl_config[0][LOCAL_PTF_INTF], exp_dpu_to_vm_pkt, tunnel_endpoint_counts)
 
     flow_op = compare_flow_tables_pdsctl(dpuhosts[0], dpuhosts[1])
     pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
-
-    total_expected = NUM_PACKETS * 2
-    recvd_pkts = sum(tunnel_endpoint_counts.values())
-    logger.info(f"Received packets: {recvd_pkts}, Tunnel endpoint counts: {tunnel_endpoint_counts}")
-    pytest_assert(
-        recvd_pkts == total_expected,
-        f"Expected {total_expected} packets, but received {recvd_pkts} packets. Counts: {tunnel_endpoint_counts}",
-    )


### PR DESCRIPTION
Summary:
This change is adding the HA steady state traffic and planned shutdown tests with FNIC packets.
For steady state:
- There are 5 packets sent to create multiple flows and traffic is sent to both primary and standby.
- The verification is that all flows are identical on Primary and Standby and all packets are received.
For planned shutdown:
- each packet sent is using a random source and destination port resulting in a big number of flows
- packets are sent to primary and either primary or standby are set to dead
- we expect packets to be received with no loss

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [] 202511

### Approach
#### What is the motivation for this PR?
Need to test HA with FNIC traffic 

#### How did you do it?
Added a new test file for HA FNIC traffic

#### How did you verify/test it?
Tested on smartswitch in HA topology:
```
----------------------------------------------- generated xml file: /data/sonic-mgmt/tests/logs/ha/test_ha_steady_state_fnic.xml -----------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
---------------------------------------------------------------------------- live log sessionfinish ----------------------------------------------------------------------------
INFO     root:__init__.py:67 Can not get Allure report URL. Please check logs
================================================================= 2 passed, 579 warnings in 1267.66s (0:21:07) =================================================================

--------------------------------------------- generated xml file: /data/sonic-mgmt/tests/logs/ha/test_ha_planned_shutdown_fnic.xml ---------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
---------------------------------------------------------------------------- live log sessionfinish ----------------------------------------------------------------------------
INFO     root:__init__.py:67 Can not get Allure report URL. Please check logs
================================================================= 1 passed, 511 warnings in 824.24s (0:13:44) ==================================================================
```

#### Any platform specific information?
Smartswitch

#### Supported testbed topology if it's a new test case?
HA topology

### Documentation
N/A
