### PR TITLE
[Arista] Increment QSFP-DD port names by 4 instead of 8

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -372,13 +372,8 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
                 port_alias_to_name_map["etp{}".format(i)] = sonic_name
         elif hwsku in ["Arista-7280R4-32QF-32DF-64O",
                        "Arista-7280R4K-32QF-32DF-64O"]:
-            portNum = 0
             for i in range(1, 65):
-                port_alias_to_name_map["Ethernet{}/{}".format(i, 1)] = "Ethernet%d" % portNum
-                if i > 16 and i < 49:
-                    portNum += 4
-                else:
-                    portNum += 8
+                port_alias_to_name_map["Ethernet{}/{}".format(i, 1)] = "Ethernet%d" % ((i - 1) * 4)
         elif hwsku == "Arista-7800R3A-36DM2-C72" or\
                 hwsku == "Arista-7800R3A-36D-C72" or\
                 hwsku == "Arista-7800R3A-36P-C72" or\


### PR DESCRIPTION
SKU: x86_64-arista_7280r4_32qf_32df

This is the sonic-mgmt change that goes along with the sonic-buildimage change: https://github.com/sonic-net/sonic-buildimage/pull/27149

### Description of PR
For SKU `x86_64-arista_7280r4_32qf_32df` increment the QSFP-DD port names based on their number of system lanes instead of number of line lanes.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
MSFT requested we increment the port names based on the number of system-side lanes instead of number of line-side lanes.

#### How did you do it?
Changed the `get_port_alias_to_name_map` function in port_utils.py for this SKU to increment by 4 for all ports on `x86_64-arista_7280r4_32qf_32df` SKU

#### How did you verify/test it?
Ran sonic-mgmt against this change and saw no related regressions.

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
