### PR TITLE
Change to Ethernet1 for cisco console platform in test_neighbor_mac.

### DIFF
--- a/tests/arp/test_neighbor_mac.py
+++ b/tests/arp/test_neighbor_mac.py
@@ -37,6 +37,8 @@ class TestNeighborMac:
                 None
         """
         duthost = duthosts[rand_one_dut_hostname]
+        if duthost.facts['platform'].startswith('arm64-c8220tg_48a_o'):
+            self.DUT_ETH_IF = "Ethernet1"
 
         intfStatus = duthost.show_interface(command="status")["ansible_facts"]["int_status"]
         if self.DUT_ETH_IF not in intfStatus:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Cisco console platform has no "Ethernet0". test_neighbor_mac.py looks for this and skips, since it is not present. In this PR, we change it to Ethernet1.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
To enable test_neighbor_mac for cisco console platform.

#### How did you do it?
Check for the platform type and enable Ethernet1 instead of Ethernet0.

#### How did you verify/test it?
Ran it on our testbeds:
```====================================================================================================== PASSES =======================================================================================================
________________________________________________________________________________________ TestNeighborMac.testNeighborMac[0] _________________________________________________________________________________________
________________________________________________________________________________________ TestNeighborMac.testNeighborMac[1] _________________________________________________________________________________________
------------------------------------------------------------- generated xml file: /run_logs/c0lo/neighbor/2026-05-04-18-15-08/arp/test_neighbor_mac.xml -------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
============================================================================================== short test summary info ==============================================================================================
PASSED arp/test_neighbor_mac.py::TestNeighborMac::testNeighborMac[0]
PASSED arp/test_neighbor_mac.py::TestNeighborMac::testNeighborMac[1]
===================================================================================== 2 passed, 1 warning in 224.45s (0:03:44) ======================================================================================
sonic@arctos_cicd_all_202603:/data/tests$ 
```
#### Any platform specific information?
Specific to cisco console platform.