### PR TITLE
Add PORT_PHY_ATTR_TYPE and PORT_PHY_ATTR

### DIFF
--- a/tests/common/constants.py
+++ b/tests/common/constants.py
@@ -37,6 +37,8 @@ class CounterpollConstants:
     QUEUE = 'queue'
     PORT_STAT_TYPE = 'PORT_STAT'
     PORT = 'port'
+    PORT_PHY_ATTR_TYPE = 'PHY'
+    PORT_PHY_ATTR = 'phy'
     PORT_BUFFER_DROP_TYPE = 'PORT_BUFFER_DROP'
     PORT_BUFFER_DROP = 'port-buffer-drop'
     RIF_STAT_TYPE = 'RIF_STAT'
@@ -50,6 +52,7 @@ class CounterpollConstants:
     COUNTERPOLL_MAPPING = {PG_DROP_STAT_TYPE: PG_DROP,
                            QUEUE_STAT_TYPE: QUEUE,
                            PORT_STAT_TYPE: PORT,
+                           PORT_PHY_ATTR_TYPE: PORT_PHY_ATTR,
                            PORT_BUFFER_DROP_TYPE: PORT_BUFFER_DROP,
                            RIF_STAT_TYPE: RIF,
                            BUFFER_POOL_WATERMARK_STAT_TYPE: WATERMARK,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add PORT_PHY_ATTR_TYPE and PORT_PHY_ATTR constants to CounterpollConstants in tests/common/constants.py, and register the new PHY counter type in COUNTERPOLL_MAPPING. This aligns the test framework with the PORT PHY attribute collection feature introduced in https://github.com/sonic-net/sonic-buildimage/pull/25327 (back port: https://github.com/sonic-net/sonic-buildimage/pull/26178).

The fix is already there in master, created PR for 202511

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
