### PR TITLE
add-topo: Create vm dirs without root permissions

### DIFF
--- a/ansible/roles/vm_set/tasks/start_sonic_vm.yml
+++ b/ansible/roles/vm_set/tasks/start_sonic_vm.yml
@@ -18,14 +18,12 @@
   file: path={{ item }} state=directory mode=0755
   with_items:
     - "{{ sonic_vm_storage_location }}/images"
-  become: yes
   when: not images_folder_stat.stat.exists
 
 - name: Create directory for vm disks
   file: path={{ item }} state=directory mode=0755
   with_items:
     - "{{ sonic_vm_storage_location }}/disks"
-  become: yes
   when: not discs_folder_stat.stat.exists
 
 - set_fact:


### PR DESCRIPTION
After #21950, directories for vm images and vm disks are created with elevated permissions. This breaks copying images to these directories later in the add-topo flow.

Remove privilege elevation to address the issue.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
