### PR TITLE
Fix daemon kill_and_start_status tests to use wait_until instead of time.sleep(10)

### DIFF
--- a/tests/platform_tests/daemon/test_pcied.py
+++ b/tests/platform_tests/daemon/test_pcied.py
@@ -86,6 +86,11 @@ def check_daemon_status(duthosts, rand_one_dut_hostname):
         time.sleep(10)
 
 
+def check_expected_daemon_status(duthost, expected_daemon_status):
+    daemon_status, _ = duthost.get_pmon_daemon_status(daemon_name)
+    return daemon_status == expected_daemon_status
+
+
 def check_pcie_devices_table_ready(duthost):
     if duthost.shell("sonic-db-cli STATE_DB KEYS '*' | grep PCIE_DEVICES"):
         return True
@@ -249,7 +254,7 @@ def test_pmon_pcied_kill_and_start_status(check_daemon_status, duthosts, rand_on
     pytest_assert(daemon_status != expected_running_status,
                   "{} unexpected killed status is not {}".format(daemon_name, daemon_status))
 
-    time.sleep(10)
+    wait_until(120, 10, 0, check_expected_daemon_status, duthost, expected_running_status)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(post_daemon_status == expected_running_status,

--- a/tests/platform_tests/daemon/test_syseepromd.py
+++ b/tests/platform_tests/daemon/test_syseepromd.py
@@ -219,7 +219,7 @@ def test_pmon_syseepromd_kill_and_start_status(check_daemon_status, duthosts,
     pytest_assert(daemon_status != expected_running_status,
                   "{} unexpected killed status is not {}".format(daemon_name, daemon_status))
 
-    time.sleep(10)
+    wait_until(120, 10, 0, check_expected_daemon_status, duthost, expected_running_status)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(post_daemon_status == expected_running_status,


### PR DESCRIPTION
### Description of PR

Summary:
Replace bare `time.sleep(10)` with `wait_until(120, 10, 0, ...)` in `test_pmon_syseepromd_kill_and_start_status` and `test_pmon_pcied_kill_and_start_status`. After a SIGKILL the supervisor restarts the daemon asynchronously, so a fixed 10-second sleep is insufficient on slower platforms and the daemon may still be in `STARTING` state when the status check runs, causing:
```
Failed: syseepromd expected restarted status is RUNNING but is STARTING
```
Also adds the missing `check_expected_daemon_status` helper to `test_pcied.py`, consistent with the pattern already used in `test_syseepromd.py` and `test_psud.py`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
`time.sleep(10)` is a fixed delay that is not reliable. On some platforms the daemon takes longer than 10s to restart after SIGKILL, leaving it in `STARTING` state when the assert runs.

#### How did you do it?
Replace `time.sleep(10)` with `wait_until(120, 10, 0, check_expected_daemon_status, duthost, expected_running_status)` which polls up to 120s until the daemon reaches `RUNNING` state. This is consistent with how `test_psud.py` handles the same scenario.

#### How did you verify/test it?
Verified on Arista-7060X6-64PE platform — both `test_pmon_syseepromd_kill_and_start_status` and `test_pmon_pcied_kill_and_start_status` pass.

#### Any platform specific information?
Reproduced on Arista-7060X6-64PE.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A