### PR TITLE
Bump expected mgmt VRF table ID from 5000 to 6000

### DIFF
--- a/tests/mvrf/test_mgmtvrf.py
+++ b/tests/mvrf/test_mgmtvrf.py
@@ -196,7 +196,7 @@ def verify_show_command(duthost, mvrf=True):
     mvrf_interfaces = {}
     if mvrf:
         mvrf_interfaces["mgmt"] = r"\d+:\s+mgmt:\s+<NOARP,MASTER,UP,LOWER_UP> mtu\s+\d+\s+qdisc\s+noqueue\s+state\s+UP"
-        mvrf_interfaces["vrf_table"] = "vrf table 5000"
+        mvrf_interfaces["vrf_table"] = "vrf table 6000"
         mvrf_interfaces["eth0"] = r"\d+:\s+eth0+:\s+<BROADCAST,MULTICAST,UP,LOWER_UP>.*master mgmt\s+state\s+UP "
         mvrf_interfaces["lo"] = r"\d+:\s+lo-m:\s+<BROADCAST,NOARP,UP,LOWER_UP>.*master mgmt"
         if "ManagementVRF : Enabled" not in show_mgmt_vrf:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #24386 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

The mgmt VRF table ID got bumped from 5000 to 6000 (https://github.com/sonic-net/sonic-buildimage/pull/26410). But `verify_show_command`, a function called as part of the module's test setup, was failing because it still expected the mgmt VRF table ID to be 5000. This caused the entirety of `tests/mvrf/test_mgmtvrf.py` tests to fail.

#### How did you do it?

Updated `verify_show_command` to expect 6000 as the mgmt VRF table ID

#### How did you verify/test it?

Run `tests/mvrf/test_mgmtvrf.py` on a DUT; the tests should run normally.
Without the changes, the following error shows up. 
```sh
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
    def verify_show_command(duthost, mvrf=True):
        show_mgmt_vrf = duthost.shell("show mgmt-vrf")["stdout"]
        mvrf_interfaces = {}
        if mvrf:
            mvrf_interfaces["mgmt"] = r"\d+:\s+mgmt:\s+<NOARP,MASTER,UP,LOWER_UP> mtu\s+\d+\s+qdisc\s+noqueue\s+state\s+UP"
            mvrf_interfaces["vrf_table"] = "vrf table 5000"
            mvrf_interfaces["eth0"] = r"\d+:\s+eth0+:\s+<BROADCAST,MULTICAST,UP,LOWER_UP>.*master mgmt\s+state\s+UP "
            mvrf_interfaces["lo"] = r"\d+:\s+lo-m:\s+<BROADCAST,NOARP,UP,LOWER_UP>.*master mgmt"
            if "ManagementVRF : Enabled" not in show_mgmt_vrf:
                raise Exception("'ManagementVRF : Enabled' not in output of 'show mgmt vrf'")
            for _, pattern in list(mvrf_interfaces.items()):
                if not re.search(pattern, show_mgmt_vrf):
>                   raise Exception("Unexpected output for MgmtVRF=enabled")
E                   Exception: Unexpected output for MgmtVRF=enabled
_          = 'vrf_table'
pattern    = 'vrf table 5000'
mvrf/test_mgmtvrf.py:245: Exception
```

#### Any platform specific information?

n/a

#### Supported testbed topology if it's a new test case?

n/a

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
