### PR TITLE
[pfcwd] Fix flaky IPv6 failures due to PTF neigh flush error

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -442,8 +442,8 @@ class SetupPfcwdFunc(object):
             ptf_port = 'eth%s' % self.pfc_wd['test_port_id']
             if self.pfc_wd['test_port_vlan_id'] is not None:
                 ptf_port += (constants.VLAN_SUB_INTERFACE_SEPARATOR + self.pfc_wd['test_port_vlan_id'])
-            self.ptf.command("ip neigh flush all")
-            self.ptf.command("ip -6 neigh flush all")
+            self.ptf.command("ip neigh flush all", module_ignore_errors=True)
+            self.ptf.command("ip -6 neigh flush all", module_ignore_errors=True)
             self.dut.command("ip neigh flush all")
             self.dut.command("ip -6 neigh flush all")
             if ip_version == "IPv4":


### PR DESCRIPTION
### Description of PR

Summary:
Fix flaky IPv6 failures in `test_pfcwd_function.py` where `ip neigh flush all` on the PTF host fails with `"Failed to send flush request: No such file or directory"` (rc=1), causing test_pfcwd_actions, test_pfcwd_multi_port, and test_pfcwd_mmu_change to abort during setup.

The `remove_ip.sh` script that runs immediately prior can leave the PTF in a state where the neighbor table references deleted interfaces. When `ip neigh flush all` attempts to flush entries for those interfaces, iproute2 returns a non-zero exit code. Since the flush is a best-effort cleanup step (the subsequent ping/arping will correctly re-establish needed ARP/NDP entries regardless), the command should tolerate errors.

### Type of change

- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

`test_pfcwd_function` IPv6 tests are intermittently failing on the 7060X6 T0 testbed (`vms91-t0-7060x6-moby-512-3`) because `ip neigh flush all` on the PTF returns rc=1 with `"Failed to send flush request: No such file or directory"`. This is a non-critical cleanup command that should not cause test failure. The actual PFCwd functionality is not impacted, all IPv4 tests pass, and the DUT is healthy throughout.

#### How did you do it?

Added `module_ignore_errors=True` to the `ip neigh flush all` and `ip -6 neigh flush all` commands on the PTF host in the `resolve_arp` method. These commands are purely preparatory cleanup; the immediately following ping and arping/ping6 commands are what actually establish the required neighbor entries.

#### How did you verify/test it?

Re-ran `test_pfcwd_function.py` on the same testbed (`vms91-t0-7060x6-moby-512-3`, 7060X6, internal-202511 image). All 10 test items passed (8 passed, 2 skipped as expected for non-cisco-8000 platform).

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A 