### PR TITLE
[macsec] Add regression test for non-key-server MACsec establishment …

### DIFF
--- a/tests/macsec/test_non_key_server.py
+++ b/tests/macsec/test_non_key_server.py
@@ -1,0 +1,60 @@
+import pytest
+import logging
+
+from tests.common.utilities import wait_until
+from tests.common.devices.eos import EosHost
+from tests.common.macsec.macsec_helper import check_wpa_supplicant_process, check_appl_db
+from tests.common.macsec.macsec_config_helper import (
+    set_macsec_profile, enable_macsec_port, cleanup_macsec_configuration
+)
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.macsec_required,
+    pytest.mark.topology("t0", "t2", "t0-sonic"),
+]
+
+
+class TestMacsecNonKeyServer:
+
+    def test_non_key_server_macsec_establishment(self, duthost, ctrl_links,
+                                                  profile_name, default_priority,
+                                                  cipher_suite, primary_cak,
+                                                  primary_ckn, policy, send_sci,
+                                                  macsec_feature):
+        if not ctrl_links:
+            pytest.skip("No controlled MACsec links available")
+
+        ctrl_link = dict([next(iter(ctrl_links.items()))])
+        port_name, nbr = next(iter(ctrl_link.items()))
+        non_key_server_profile = "{}_NON_KEY_SERVER".format(profile_name)
+
+        try:
+            # Set DUT as the non-key server by giving it a numerically higher
+            # key-server priority than the neighbor.
+            set_macsec_profile(duthost, port_name, non_key_server_profile,
+                               default_priority + 1,
+                               cipher_suite, primary_cak, primary_ckn,
+                               policy, send_sci)
+            set_macsec_profile(nbr["host"], nbr["port"], non_key_server_profile,
+                               default_priority,
+                               cipher_suite, primary_cak, primary_ckn,
+                               policy, send_sci)
+
+            enable_macsec_port(duthost, port_name, non_key_server_profile)
+            enable_macsec_port(nbr["host"], nbr["port"], non_key_server_profile)
+
+            assert wait_until(300, 3, 0,
+                              lambda: duthost.iface_macsec_ok(port_name) and
+                                      nbr["host"].iface_macsec_ok(nbr["port"]))
+
+            assert wait_until(300, 6, 12,
+                              check_appl_db, duthost, ctrl_link,
+                              policy, cipher_suite, send_sci)
+
+            check_wpa_supplicant_process(duthost, port_name)
+            if not isinstance(nbr["host"], EosHost):
+                check_wpa_supplicant_process(nbr["host"], nbr["port"])
+        finally:
+            cleanup_macsec_configuration(duthost, ctrl_link, non_key_server_profile)


### PR DESCRIPTION
###Summary

- Adds a MACsec regression test for non-key-server establishment around issue 22732.
- Verifies that a DUT can still form a MACsec session when it is configured with a higher key-server priority than its neighbor.
- Ensures coverage for MACsec session establishment and APP DB validation in this non-key-server case.


###Fixes

- Fixes #22732


###Type of change

- Bug fix
- Testbed and Framework (improvement)
- New Test case
- Skipped for non-supported platforms
- Test case improvement

##Approach

###What is the motivation for this PR?

- Prevent regressions for MACsec cases where the DUT is not the key server.
- Ensure the MACsec non-key-server workflow is tested, especially for SAK/SAK-USE session churn and delayed establishment.

###How did you do it?

- Added a new pytest test file: [tests/macsec/test_non_key_server.py](vscode-file://vscode-app/c:/Users/sumalatha.g/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Used existing MACsec helpers and fixtures to:
    1. configure a new MACsec profile with DUT configured as non-key-server
    2. enable MACsec on both DUT and neighbor ports
    3. validate interface MACsec readiness
    4. verify APP DB MACsec session state
    5. confirm wpa_supplicant processes are running

- Used [cleanup_macsec_configuration()](vscode-file://vscode-app/c:/Users/sumalatha.g/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for proper teardown after the test.

###How did you verify/test it?

- Validated Python syntax with:
             python3 -m py_compile tests/macsec/test_non_key_server.py
- Branch created and pushed to remote for PR creation.
- Intended verification is through targeted MACsec regression runs on supported topology.

###Any platform specific information?

- This test is only meaningful for MACsec-supported platforms.
- It uses the [macsec_required](vscode-file://vscode-app/c:/Users/sumalatha.g/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) marker so it is skipped when MACsec is not enabled.
- It is designed to run with existing SONiC MACsec test infrastructure and uses platform-agnostic MACsec helpers.

###Supported testbed topology if it's a new test case

- t0
- t2
- t0-sonic


###Documentation

- No external documentation changes were required.
- The regression coverage is added via a new test file in the MACsec test suite.