### PR TITLE
Filter out dpu DUT in duts_list for npu ha config.

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -886,7 +886,7 @@
           npu_index: "{{ dut_index | default(0) | int }}"
           bgp_confd_asn: "{{ bgp_confd_asn }}"
           bgp_confd_peers: "{{ bgp_confd_peers }}"
-          duts_list: "{{ testbed_facts['duts'] | default([]) }}"
+          duts_list: "{{ testbed_facts['duts'] | default([]) | reject('search', '-dpu-') | list }}"
           dut_loopbacks: "{{ topology.DUT.loopback | default({}) }}"
           console_ports: "{{ device_serial_link[inventory_hostname] | default(omit) if 'c0' in topo else omit }}"
         become: true


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
In the HA testbed, 8 DPU are included as part of the DUT list. However in generate_golden_config_db, it is expecting exactly two DUT corresponding to two the NPU / switch: https://github.com/sonic-net/sonic-mgmt/blob/60946b31e0c731108416bfb8603301f6ac6eafbf/ansible/library/generate_golden_config_db.py#L561 This golden config_db is used for NPU side, so the DPU listed in the topo file can be filtered out. If they are not golden config is not applied to the DUT since there are more DUT than expected when the DPU are included.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Fix dut_list so that golden config is applied as expected.

#### How did you do it?
Filter out the DPU when populating the duts_list.

#### How did you verify/test it?
Ran the HA testsuite on HA testbed with this fix, golden config is applied successfully.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
