### PR TITLE
[dhcp_relay]  refactor restart_dhcp_service to explicitly target the active relay agent

### DIFF
--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -25,23 +25,68 @@ def restart_dhcp_service(duthost, relay_types):
     Restart dhcp_relay and wait until the requested relay agent(s) are ready.
 
     relay_types: a non-empty iterable of agent identifiers. Each entry must be one of:
-        'isc'          -> every isc-dhcpv4-relay-<Vlan> supervisord entry currently
-                          present in the dhcp_relay container is RUNNING (legacy /
-                          external mode, built from dockers/docker-dhcp-relay/
-                          dhcpv4-relay.agents.j2). The set of expected entries is
-                          read from supervisord at poll time, not predicted from
-                          CONFIG_DB - a VLAN with v6-only dhcp_servers or no IPv4
-                          interface won't have an isc-dhcpv4-relay-<Vlan> entry,
-                          and we shouldn't wait for one.
-        'isc-internal' -> exactly one consolidated `dhcrelay -iu docker0 ...` proc
-                          spawned by dhcprelayd (mx internal mode; per-VLAN
-                          supervisord entries stay STOPPED by design).
-                          See dhcprelayd._start_dhcrelay_process in
-                          src/sonic-dhcp-utilities/dhcp_utilities/dhcprelayd/dhcprelayd.py.
-        'sonic'        -> the single `dhcp4relay` supervisord entry RUNNING
-                          (built from dockers/docker-dhcp-relay/dhcpv4-sonic-relay.agents.j2;
-                          one consolidated `/usr/sbin/dhcp4relay` proc handles all v4 VLANs).
-        'v6'           -> dhcp6relay supervisord entry RUNNING.
+        'isc'          -> Legacy / external v4 relay layout
+                          (dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2).
+                          Required RUNNING:
+                            - every isc-dhcpv4-relay-<Vlan> supervisord entry
+                            - every dhcpmon-<Vlan> supervisord entry (paired
+                              1:1 with the isc helpers via
+                              dhcp-relay.monitors.j2)
+                          Notes:
+                            - The expected per-Vlan entries are read from
+                              supervisord at poll time (parsed from
+                              `supervisorctl status`), not derived from
+                              CONFIG_DB's VLAN / DHCP_RELAY config. The j2
+                              template only renders an isc-dhcpv4-relay-<Vlan>
+                              + dhcpmon-<Vlan> pair for Vlans that actually
+                              have v4 dhcp_servers configured, so supervisord
+                              is the authoritative source for which entries
+                              we wait on.
+                            - If no Vlan has v4 dhcp_servers defined, the
+                              matching set of isc-dhcpv4-relay-<Vlan> /
+                              dhcpmon-<Vlan> entries is empty, the loops
+                              iterate over nothing, and the 'isc' check
+                              passes immediately. This is intentional:
+                              there is genuinely nothing to wait for.
+
+        'isc-internal' -> mx internal mode. dhcprelayd consolidates v4 relay
+                          into a single `dhcrelay -iu docker0 ...` proc
+                          (not a supervisord entry).
+                          Required:
+                            - exactly one such dhcrelay proc
+                          Not checked:
+                            - isc-dhcpv4-relay-<Vlan> supervisord entries
+                              (stay STOPPED by design in this mode)
+                            - dhcpmon-<Vlan> supervisord entries (also stay
+                              STOPPED today: dhcpmon does not yet support
+                              the mx/isc-internal layout, so when dhcprelayd
+                              takes over the v4 relay it does not (re)spawn
+                              dhcpmon)
+                          TODO: extend this check once dhcpmon supports the
+                          mx/isc-internal layout (when a single dhcpmon can
+                          monitor the consolidated `dhcrelay -iu docker0`
+                          proc); at that point we should require dhcpmon
+                          RUNNING here too, mirroring the 'isc' check.
+
+        'sonic'        -> Consolidated v4 relay layout
+                          (dockers/docker-dhcp-relay/dhcpv4-sonic-relay.agents.j2).
+                          One `/usr/sbin/dhcp4relay` proc handles all v4 VLANs.
+                          Required RUNNING:
+                            - the single `dhcp4relay` supervisord entry
+                          Not checked:
+                            - dhcpmon-<Vlan> supervisord entries (dhcp4relay
+                              publishes its own counters, so per-Vlan dhcpmon
+                              is not part of this layout)
+
+        'v6'           -> IPv6 relay.
+                          Required RUNNING:
+                            - the `dhcp6relay` supervisord entry
+                          Not checked:
+                            - any dhcpv6mon / dhcp6mon equivalent. No such
+                              daemon ships today; when one lands this check
+                              will need to be extended to mirror the 'isc'
+                              dhcpmon-<Vlan> check above.
+                          TODO: revisit when dhcpv6mon ships.
 
     The orchestrator (`dhcprelayd`) is always required RUNNING. There is intentionally
     no default; each caller must declare which agent(s) it expects to be active.
@@ -115,6 +160,14 @@ def wait_dhcp_relay_ready(duthost, relay_types):
             # specific helpers should pair with their own config setup).
             for name, state in states.items():
                 if name.startswith('isc-dhcpv4-relay-') and state != 'RUNNING':
+                    return False
+            # Same layout-driven rule for dhcpmon-Vlan*: each entry is paired
+            # 1:1 with isc-dhcpv4-relay-<Vlan> in the same supervisord conf
+            # and must be RUNNING. Intentionally NOT checked in 'isc-internal'
+            # / 'sonic' / 'v6' modes - see the docstring for the per-mode
+            # rationale (and the v6 TODO for the upcoming dhcpv6mon).
+            for name, state in states.items():
+                if name.startswith('dhcpmon-') and state != 'RUNNING':
                     return False
         if 'isc-internal' in relay_types:
             internal = duthost.shell(

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -20,26 +20,108 @@ SUPPORTED_DHCPV6_TYPE = [
 SUPPORTED_DIR = ["TX", "RX"]
 
 
-def restart_dhcp_service(duthost):
+def restart_dhcp_service(duthost, relay_types):
+    """
+    Restart dhcp_relay and wait until the requested relay agent(s) are ready.
+
+    relay_types: a non-empty iterable of agent identifiers. Each entry must be one of:
+        'isc'          -> per-VLAN isc-dhcpv4-relay-<Vlan> supervisord entry RUNNING
+                          for every VLAN with v4 helpers (legacy / external mode,
+                          built from dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2).
+        'isc-internal' -> exactly one consolidated `dhcrelay -iu docker0 ...` proc
+                          spawned by dhcprelayd (mx internal mode; per-VLAN
+                          supervisord entries stay STOPPED by design).
+                          See dhcprelayd._start_dhcrelay_process in
+                          src/sonic-dhcp-utilities/dhcp_utilities/dhcprelayd/dhcprelayd.py.
+        'sonic'        -> the single `dhcp4relay` supervisord entry RUNNING
+                          (built from dockers/docker-dhcp-relay/dhcpv4-sonic-relay.agents.j2;
+                          one consolidated `/usr/sbin/dhcp4relay` proc handles all v4 VLANs).
+        'v6'           -> dhcp6relay supervisord entry RUNNING.
+    The orchestrator (`dhcprelayd`) is always required RUNNING. There is intentionally
+    no default; each caller must declare which agent(s) it expects to be active.
+    """
+    if not relay_types:
+        raise ValueError("restart_dhcp_service: relay_types must be a non-empty iterable")
+
     duthost.shell('systemctl reset-failed dhcp_relay')
     duthost.shell('systemctl restart dhcp_relay')
     duthost.shell('systemctl reset-failed dhcp_relay')
 
-    # In SONiC dhcp relay agent mode, dhcprelayd stops dhcpmon by design,
-    # so exclude it from the readiness check (dhcprelayd.py refresh_dhcrelay TODO).
-    has_sonic_relay = duthost.shell(
-        'sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "has_sonic_dhcpv4_relay"',
-        module_ignore_errors=True)['stdout'].strip() == 'True'
+    wait_dhcp_relay_ready(duthost, relay_types)
+
+
+def wait_dhcp_relay_ready(duthost, relay_types):
+    """
+    Wait (without restarting) until the requested relay agent(s) are ready.
+
+    Same `relay_types` contract as `restart_dhcp_service`. Use this when the caller
+    has already restarted dhcp_relay (or applied config that triggers a restart)
+    and only needs to block on readiness.
+    """
+    if not relay_types:
+        raise ValueError("wait_dhcp_relay_ready: relay_types must be a non-empty iterable")
+    relay_types = list(relay_types)
+    valid = {'isc', 'isc-internal', 'sonic', 'v6'}
+    bad = [t for t in relay_types if t not in valid]
+    if bad:
+        raise ValueError("wait_dhcp_relay_ready: invalid relay_types %s; allowed %s"
+                         % (bad, sorted(valid)))
+
+    # Discover which VLANs have v4 helpers configured (used by 'isc' only).
+    v4_vlans = []
+    if 'isc' in relay_types:
+        try:
+            vlan_json = duthost.shell('sonic-cfggen -d --var-json VLAN',
+                                      module_ignore_errors=True)['stdout']
+            if vlan_json.strip():
+                for vlan, attrs in json.loads(vlan_json).items():
+                    if attrs.get('dhcp_servers'):
+                        v4_vlans.append(vlan)
+        except Exception as e:
+            logger.warning("Failed to parse VLAN table for v4 helpers: %s", e)
+    logger.info("DHCP readiness expecting relay_types=%s v4_vlans=%s",
+                relay_types, v4_vlans)
+
+    def _supervisor_status_map():
+        out = duthost.shell('docker exec dhcp_relay supervisorctl status',
+                            module_ignore_errors=True)['stdout_lines']
+        states = {}
+        for line in out:
+            parts = line.split()
+            if len(parts) >= 2:
+                # Strip optional "group:" prefix (e.g. "dhcp-relay:dhcprelayd" -> "dhcprelayd").
+                states[parts[0].split(':')[-1]] = parts[1]
+        return states
 
     def _is_dhcp_relay_ready():
-        filter_cmd = 'grep dhc | grep -v dhcpmon' if has_sonic_relay else 'grep dhc'
-        output = duthost.shell(
-            "docker exec dhcp_relay supervisorctl status | {} | awk '{{print $2}}'".format(filter_cmd),
-            module_ignore_errors=True)
-        return (not output['rc'] and output['stderr'] == '' and len(output['stdout_lines']) != 0 and
-                all(element == 'RUNNING' for element in output['stdout_lines']))
+        states = _supervisor_status_map()
+        if states.get('dhcprelayd') != 'RUNNING':
+            return False
+        if 'v6' in relay_types and states.get('dhcp6relay') != 'RUNNING':
+            return False
+        if 'isc' in relay_types and v4_vlans:
+            for vlan in v4_vlans:
+                if states.get('isc-dhcpv4-relay-{}'.format(vlan)) != 'RUNNING':
+                    return False
+        if 'isc-internal' in relay_types:
+            # mx internal mode: dhcprelayd consolidates into a single
+            # `dhcrelay ... -iu docker0 ...` proc. Match exactly one,
+            # parallel to tests/mx/test_kea_dhcp_server_internal_only.py.
+            internal = duthost.shell(
+                "docker exec dhcp_relay pgrep -af '/usr/sbin/dhcrelay.*-iu docker0' || true",
+                module_ignore_errors=True)['stdout_lines']
+            internal = [line for line in internal if line.strip()]
+            if len(internal) != 1:
+                return False
+        if 'sonic' in relay_types:
+            if states.get('dhcp4relay') != 'RUNNING':
+                return False
+        return True
 
-    pytest_assert(wait_until(120, 1, 10, _is_dhcp_relay_ready), "dhcp_relay is not ready after restarting")
+    pytest_assert(
+        wait_until(120, 1, 10, _is_dhcp_relay_ready),
+        "dhcp_relay is not ready (relay_types=%s v4_vlans=%s)"
+        % (relay_types, v4_vlans))
 
 
 def init_dhcpmon_counters(duthost, is_v6=False):
@@ -405,7 +487,7 @@ def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
 
     # Save the config and restart DHCP relay service
     duthost.shell('sudo config save -y', module_ignore_errors=True)
-    restart_dhcp_service(duthost)
+    restart_dhcp_service(duthost, ['sonic'] if dhcpv4_config_flag else ['isc'])
 
 
 @pytest.fixture()

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -20,6 +20,31 @@ SUPPORTED_DHCPV6_TYPE = [
 SUPPORTED_DIR = ["TX", "RX"]
 
 
+def _validate_relay_types(caller, relay_types):
+    """
+    Validate relay_types up front and return it as a list.
+
+    Enforces the shared contract (non-empty, known agent identifiers, at most one
+    v4 mode) so both restart_dhcp_service and wait_dhcp_relay_ready reject bad input
+    *before* any side effect (e.g. restarting dhcp_relay).
+    """
+    if not relay_types:
+        raise ValueError("%s: relay_types must be a non-empty iterable" % caller)
+    relay_types = list(relay_types)
+    valid = {'isc', 'isc-internal', 'sonic', 'v6'}
+    bad = [t for t in relay_types if t not in valid]
+    if bad:
+        raise ValueError("%s: invalid relay_types %s; allowed %s"
+                         % (caller, bad, sorted(valid)))
+    v4_modes = [t for t in relay_types if t in {'isc', 'isc-internal', 'sonic'}]
+    if len(v4_modes) > 1:
+        raise ValueError(
+            "%s: at most one of {'isc', 'isc-internal', 'sonic'} "
+            "may be requested per call (mutually exclusive in the relay container); got %s"
+            % (caller, v4_modes))
+    return relay_types
+
+
 def restart_dhcp_service(duthost, relay_types):
     """
     Restart dhcp_relay and wait until the requested relay agent(s) are ready.
@@ -95,8 +120,7 @@ def restart_dhcp_service(duthost, relay_types):
     container layout makes them mutually exclusive (driven by has_sonic_dhcpv4_relay
     + mx internal mode), so any combination is unsatisfiable and is rejected up front.
     """
-    if not relay_types:
-        raise ValueError("restart_dhcp_service: relay_types must be a non-empty iterable")
+    relay_types = _validate_relay_types('restart_dhcp_service', relay_types)
 
     duthost.shell('systemctl reset-failed dhcp_relay')
     duthost.shell('systemctl restart dhcp_relay')
@@ -114,20 +138,7 @@ def wait_dhcp_relay_ready(duthost, relay_types):
     `config reload`, `config load_minigraph`, GCU `apply-patch`) and only needs to
     block on readiness.
     """
-    if not relay_types:
-        raise ValueError("wait_dhcp_relay_ready: relay_types must be a non-empty iterable")
-    relay_types = list(relay_types)
-    valid = {'isc', 'isc-internal', 'sonic', 'v6'}
-    bad = [t for t in relay_types if t not in valid]
-    if bad:
-        raise ValueError("wait_dhcp_relay_ready: invalid relay_types %s; allowed %s"
-                         % (bad, sorted(valid)))
-    v4_modes = [t for t in relay_types if t in {'isc', 'isc-internal', 'sonic'}]
-    if len(v4_modes) > 1:
-        raise ValueError(
-            "wait_dhcp_relay_ready: at most one of {'isc', 'isc-internal', 'sonic'} "
-            "may be requested per call (mutually exclusive in the relay container); got %s"
-            % v4_modes)
+    relay_types = _validate_relay_types('wait_dhcp_relay_ready', relay_types)
 
     last_state = {'states': {}, 'internal_procs': []}
 

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -25,9 +25,14 @@ def restart_dhcp_service(duthost, relay_types):
     Restart dhcp_relay and wait until the requested relay agent(s) are ready.
 
     relay_types: a non-empty iterable of agent identifiers. Each entry must be one of:
-        'isc'          -> per-VLAN isc-dhcpv4-relay-<Vlan> supervisord entry RUNNING
-                          for every VLAN with v4 helpers (legacy / external mode,
-                          built from dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2).
+        'isc'          -> every isc-dhcpv4-relay-<Vlan> supervisord entry currently
+                          present in the dhcp_relay container is RUNNING (legacy /
+                          external mode, built from dockers/docker-dhcp-relay/
+                          dhcpv4-relay.agents.j2). The set of expected entries is
+                          read from supervisord at poll time, not predicted from
+                          CONFIG_DB - a VLAN with v6-only dhcp_servers or no IPv4
+                          interface won't have an isc-dhcpv4-relay-<Vlan> entry,
+                          and we shouldn't wait for one.
         'isc-internal' -> exactly one consolidated `dhcrelay -iu docker0 ...` proc
                           spawned by dhcprelayd (mx internal mode; per-VLAN
                           supervisord entries stay STOPPED by design).
@@ -37,8 +42,13 @@ def restart_dhcp_service(duthost, relay_types):
                           (built from dockers/docker-dhcp-relay/dhcpv4-sonic-relay.agents.j2;
                           one consolidated `/usr/sbin/dhcp4relay` proc handles all v4 VLANs).
         'v6'           -> dhcp6relay supervisord entry RUNNING.
+
     The orchestrator (`dhcprelayd`) is always required RUNNING. There is intentionally
     no default; each caller must declare which agent(s) it expects to be active.
+
+    At most one of {'isc', 'isc-internal', 'sonic'} may appear in relay_types: the
+    container layout makes them mutually exclusive (driven by has_sonic_dhcpv4_relay
+    + mx internal mode), so any combination is unsatisfiable and is rejected up front.
     """
     if not relay_types:
         raise ValueError("restart_dhcp_service: relay_types must be a non-empty iterable")
@@ -55,8 +65,9 @@ def wait_dhcp_relay_ready(duthost, relay_types):
     Wait (without restarting) until the requested relay agent(s) are ready.
 
     Same `relay_types` contract as `restart_dhcp_service`. Use this when the caller
-    has already restarted dhcp_relay (or applied config that triggers a restart)
-    and only needs to block on readiness.
+    has already restarted dhcp_relay (or applied config that triggers a restart, e.g.
+    `config reload`, `config load_minigraph`, GCU `apply-patch`) and only needs to
+    block on readiness.
     """
     if not relay_types:
         raise ValueError("wait_dhcp_relay_ready: relay_types must be a non-empty iterable")
@@ -66,23 +77,19 @@ def wait_dhcp_relay_ready(duthost, relay_types):
     if bad:
         raise ValueError("wait_dhcp_relay_ready: invalid relay_types %s; allowed %s"
                          % (bad, sorted(valid)))
+    v4_modes = [t for t in relay_types if t in {'isc', 'isc-internal', 'sonic'}]
+    if len(v4_modes) > 1:
+        raise ValueError(
+            "wait_dhcp_relay_ready: at most one of {'isc', 'isc-internal', 'sonic'} "
+            "may be requested per call (mutually exclusive in the relay container); got %s"
+            % v4_modes)
 
-    # Discover which VLANs have v4 helpers configured (used by 'isc' only).
-    v4_vlans = []
-    if 'isc' in relay_types:
-        try:
-            vlan_json = duthost.shell('sonic-cfggen -d --var-json VLAN',
-                                      module_ignore_errors=True)['stdout']
-            if vlan_json.strip():
-                for vlan, attrs in json.loads(vlan_json).items():
-                    if attrs.get('dhcp_servers'):
-                        v4_vlans.append(vlan)
-        except Exception as e:
-            logger.warning("Failed to parse VLAN table for v4 helpers: %s", e)
-    logger.info("DHCP readiness expecting relay_types=%s v4_vlans=%s",
-                relay_types, v4_vlans)
+    last_state = {'states': {}, 'internal_procs': []}
 
     def _supervisor_status_map():
+        # supervisorctl returns rc != 0 if ANY entry is not RUNNING (e.g. the one-shot
+        # 'start' / 'dependent-startup' entries are EXITED by design). Ignore the rc and
+        # parse stdout - the per-entry RUNNING checks below are the real readiness gate.
         out = duthost.shell('docker exec dhcp_relay supervisorctl status',
                             module_ignore_errors=True)['stdout_lines']
         states = {}
@@ -95,22 +102,26 @@ def wait_dhcp_relay_ready(duthost, relay_types):
 
     def _is_dhcp_relay_ready():
         states = _supervisor_status_map()
+        last_state['states'] = states
         if states.get('dhcprelayd') != 'RUNNING':
             return False
         if 'v6' in relay_types and states.get('dhcp6relay') != 'RUNNING':
             return False
-        if 'isc' in relay_types and v4_vlans:
-            for vlan in v4_vlans:
-                if states.get('isc-dhcpv4-relay-{}'.format(vlan)) != 'RUNNING':
+        if 'isc' in relay_types:
+            # Drive from supervisord's actual layout: every isc-dhcpv4-relay-*
+            # entry currently present must be RUNNING. If none are present,
+            # the container has no v4 helpers configured for this layout and
+            # the 'isc' check is a no-op (legitimately so - callers expecting
+            # specific helpers should pair with their own config setup).
+            for name, state in states.items():
+                if name.startswith('isc-dhcpv4-relay-') and state != 'RUNNING':
                     return False
         if 'isc-internal' in relay_types:
-            # mx internal mode: dhcprelayd consolidates into a single
-            # `dhcrelay ... -iu docker0 ...` proc. Match exactly one,
-            # parallel to tests/mx/test_kea_dhcp_server_internal_only.py.
             internal = duthost.shell(
-                "docker exec dhcp_relay pgrep -af '/usr/sbin/dhcrelay.*-iu docker0' || true",
-                module_ignore_errors=True)['stdout_lines']
+                "docker exec dhcp_relay pgrep -af '/usr/sbin/dhcrelay.*-iu docker0' || true"
+            )['stdout_lines']
             internal = [line for line in internal if line.strip()]
+            last_state['internal_procs'] = internal
             if len(internal) != 1:
                 return False
         if 'sonic' in relay_types:
@@ -119,9 +130,9 @@ def wait_dhcp_relay_ready(duthost, relay_types):
         return True
 
     pytest_assert(
-        wait_until(120, 1, 10, _is_dhcp_relay_ready),
-        "dhcp_relay is not ready (relay_types=%s v4_vlans=%s)"
-        % (relay_types, v4_vlans))
+        wait_until(240, 5, 10, _is_dhcp_relay_ready),
+        "dhcp_relay is not ready (relay_types=%s last_supervisor_states=%s isc_internal_procs=%s)"
+        % (relay_types, last_state['states'], last_state['internal_procs']))
 
 
 def init_dhcpmon_counters(duthost, is_v6=False):

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -20,7 +20,7 @@ from tests.common import config_reload
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.dhcp_relay_utils import check_routes_to_dhcp_server
-from tests.common.dhcp_relay_utils import restart_dhcp_service
+from tests.common.dhcp_relay_utils import restart_dhcp_service, wait_dhcp_relay_ready
 from tests.common.dhcp_relay_utils import enable_sonic_dhcpv4_relay_agent  # noqa: F401
 
 pytestmark = [
@@ -155,6 +155,7 @@ def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data,
             config_reload(duthost)
             wait_critical_processes(duthost)
             pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
+            wait_dhcp_relay_ready(duthost, ['isc'])
         output = duthost.shell("docker exec -t dhcp_relay ss -nlp | grep dhcrelay", module_ignore_errors=True)["stdout"]
         logger.info(output)
         for dhcp_relay in dut_dhcp_relay_data:

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -122,7 +122,7 @@ def enable_source_port_ip_in_relay(duthosts, rand_one_dut_hostname, tbinfo, requ
             create_checkpoint(duthost, check_point)
             output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
             expect_op_success(duthost, output)
-            restart_dhcp_service(duthost)
+            restart_dhcp_service(duthost, ['isc'])
 
             def dhcp_ready(enable_source_port_ip_in_relay):
                 dhcp_relay_running = duthost.is_service_fully_started("dhcp_relay")
@@ -143,7 +143,7 @@ def enable_source_port_ip_in_relay(duthosts, rand_one_dut_hostname, tbinfo, requ
             logger.info("Rolled back to original checkpoint")
             rollback_or_reload(duthost, check_point)
             delete_checkpoint(duthost, check_point)
-            restart_dhcp_service(duthost)
+            restart_dhcp_service(duthost, ['isc'])
             pytest_assert(wait_until(60, 2, 0, dhcp_ready, False), "Source port ip in relay is not disabled!")
 
 
@@ -334,9 +334,10 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
 
     if not skip_dhcpmon:
         # Clean up - Restart DHCP relay service on DUT to recover original dhcpmon setting
-        restart_dhcp_service(duthost)
+        relay_types = ['sonic' if relay_agent == 'sonic-relay-agent' else 'isc']
+        restart_dhcp_service(duthost, relay_types)
         if testing_mode == DUAL_TOR_MODE:
-            restart_dhcp_service(standby_duthost)
+            restart_dhcp_service(standby_duthost, relay_types)
             pytest_assert(wait_until(120, 5, 0, check_interface_status, standby_duthost, relay_agent))
         pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost, relay_agent))
 
@@ -455,9 +456,10 @@ def test_dhcp_relay_with_source_port_ip_in_relay_enabled(
 
     if not skip_dhcpmon:
         # Clean up - Restart DHCP relay service on DUT to recover original dhcpmon setting
-        restart_dhcp_service(duthost)
+        relay_types = ['sonic' if relay_agent == 'sonic-relay-agent' else 'isc']
+        restart_dhcp_service(duthost, relay_types)
         if testing_mode == DUAL_TOR_MODE:
-            restart_dhcp_service(standby_duthost)
+            restart_dhcp_service(standby_duthost, relay_types)
             pytest_assert(wait_until(120, 5, 0, check_interface_status, standby_duthost, relay_agent))
         pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost, relay_agent))
 

--- a/tests/dhcp_relay/test_dhcp_relay_stress.py
+++ b/tests/dhcp_relay/test_dhcp_relay_stress.py
@@ -66,7 +66,7 @@ def test_dhcp_relay_restart_with_stress(ptfhost, dut_dhcp_relay_data, validate_d
                    log_file="/tmp/dhcp_relay_stress_test.DHCPContinuousStressTest.log", is_python3=True,
                    async_mode=True)
 
-        restart_dhcp_service(duthost)
+        restart_dhcp_service(duthost, ['sonic' if relay_agent == 'sonic-relay-agent' else 'isc'])
 
         # Wait packets send during and after dhcrelay starting
         time.sleep(10)

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -306,7 +306,7 @@ def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data,
 
     try:
         duthost.shell_cmds(cmds=delete_cmds)
-        restart_dhcp_service(duthost)
+        restart_dhcp_service(duthost, ['v6'])
         time.sleep(10)
 
         output = duthost.shell("docker exec -t dhcp_relay ss -nlp | grep dhcp6relay")["stdout"]
@@ -548,7 +548,7 @@ class TestDhcpv6RelayWithMultipleVlan:
     def restart_dhcp_relay_after_test(self, duthost):
 
         yield
-        restart_dhcp_service(duthost)
+        restart_dhcp_service(duthost, ['v6'])
 
     @pytest.mark.parametrize("setup_multiple_vlans_and_teardown", [3], indirect=True)
     def test_dhcp_relay_default(self, ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
@@ -564,7 +564,7 @@ class TestDhcpv6RelayWithMultipleVlan:
         pytest_assert(len(dut_dhcp_relay_data) > 0, "No VLAN data")
         common_dhcp_relay_data = dut_dhcp_relay_data[0]
 
-        restart_dhcp_service(duthost)  # restart dhcp_relay to make new vlans config take into effect
+        restart_dhcp_service(duthost, ['v6'])  # restart dhcp_relay to make new vlans config take into effect
         for vlan_info in vlans_info:
             vlan_name = vlan_info['vlan_name']
             exp_link_addr = vlan_info['interface_ipv6'].split('/')[0]

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -246,7 +246,7 @@ def ensure_client_reachability(duthost, vlan_name):
     logger.info(f"Ensuring client reachability on VLAN {vlan_name}")
 
     # Send multicast ping to discover all link-local addresses on the segment
-    duthost.shell(f"ping6 -I {vlan_name} -c 3 ff02::1", module_ignore_errors=True)
+    duthost.shell("ping6 -I {} -c 3 ff02::1".format(vlan_name), module_ignore_errors=True)
 
     # Wait a moment for ND table to be populated
     time.sleep(2)

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -5,7 +5,7 @@ import time
 import netaddr
 import logging
 
-from tests.common.dhcp_relay_utils import restart_dhcp_service
+from tests.common.dhcp_relay_utils import restart_dhcp_service, wait_dhcp_relay_ready
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
 from tests.common.fixtures.split_vlan import setup_multiple_vlans_and_teardown  # noqa F401
@@ -277,6 +277,7 @@ def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data,
         config_reload(duthost)
         wait_critical_processes(duthost)
         pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
+        wait_dhcp_relay_ready(duthost, ['v6'])
 
     # Cmds to delete LLA for all Vlans
     delete_cmds = ["ip -6 address del {} dev {}"

--- a/tests/generic_config_updater/test_dhcp_relay.py
+++ b/tests/generic_config_updater/test_dhcp_relay.py
@@ -117,7 +117,7 @@ def default_setup(duthost, vlan_intfs_list):
 
     duthost.shell_cmds(cmds=cmds)
 
-    restart_dhcp_service(duthost)
+    restart_dhcp_service(duthost, ['isc'])
 
     logger.info("default setup expected_content_dict {}".format(expected_content_dict))
     for vlanid in expected_content_dict:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Reworks restart_dhcp_service in tests/common/dhcp_relay_utils.py so DHCP relay readiness is checked against the specific relay agent the test actually
exercises, instead of the long-standing grep dhc | awk '{print $2}' heuristic (and its later grep -v dhcpmon patch) that asserts every supervisord entry
whose name contains dhc is RUNNING.

The original check has two structural problems that have only become more painful as the relay container grew new modes:

 1. It is implicit. Whether the assertion is correct depends entirely on which entries supervisord happens to expose at that moment, not on what the test cares about. The introduction of has_sonic_dhcpv4_relay mode (single dhcp4relay proc, no per-VLAN procs) already required a one-off patch (grep -v dhcpmon) to keep it working, and a similar patch would be needed every time a new agent variant is added.
 2. There is no readiness API for callers that have already triggered a restart via other means (config load_minigraph, GCU patch apply, VLAN add/remove). Tests that need to wait without restarting again have been growing private polling helpers (e.g. is_dhcrelay_forwarder_running in the mx internal-mode test).

This PR replaces the implicit "everything matching dhc is RUNNING" rule with an explicit, named contract — the caller declares which relay agent variants it expects (isc, isc-internal, sonic, v6) — and exposes the wait-only half of the function for callers that already restarted the service themselves.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

### Tested branch
- [x] master
- [x] 202605

### Test result
- master: 35 passed, 1 failed — the single failure (`test_dhcp_relay_restart_with_stress[sonic-relay-agent]`) is a pre-existing `dhcp4relay` flap under the test's own DHCP flood; it reproduces without this change (see "How did you verify/test it?" below).
- 202605: `SONiC.20260510.06` — full `tests/dhcp_relay` module on `testbed-bjw2-can-720dt-5` (720dt, `m0`). The new `restart_dhcp_service(duthost, relay_types)` (required/validated arg) and `wait_dhcp_relay_ready(duthost, relay_types)` executed cleanly on hardware across all three mappings — `['isc']`, `['sonic']`, `['v6']` — with no `TypeError` / missing-argument / validation errors; control-plane cases (interface binding, counter/stress, packet-recv) passed. A subset of packet-forwarding cases failed, traced to a local testbed uplink/LACP infrastructure issue (several uplink PortChannels not forming on the fanout) and unrelated to this test-only change — the same cases fail on the unmodified baseline. Evidence: https://github.com/sonic-net/sonic-mgmt/pull/24403#issuecomment-4998944761

### Approach
#### What is the motivation for this PR?

The historical readiness check assumes a specific supervisord layout (per-VLAN isc-dhcpv4-relay-VlanX + dhcprelayd + dhcp6relay + dhcpmon-VlanX) andasserts they are all RUNNING. As soon as the container layout changed:

 - has_sonic_dhcpv4_relay=True mode replaces N per-VLAN isc-dhcpv4-relay-VlanX procs with a single consolidated dhcp4relay and intentionally stops dhcpmon. The original grep dhc would forever see at least one STOPPED line (dhcpmon-VlanX) and time out. A grep -v dhcpmon patch was added to keep it limping along, but it is just paper over a broken model.
 - mx internal-only mode (dhcprelayd consolidating to dhcrelay -iu docker0 ...) leaves the per-VLAN supervisord entries STOPPED by design, so the same heuristic cannot be reused at all — the mx test had to grow its own is_dhcrelay_forwarder_running poller.

The right fix is to stop guessing and let each call site say what it expects.

#### How did you do it?

 - restart_dhcp_service(duthost, relay_types) now takes a required, explicit iterable. Each entry must be one of 'isc', 'isc-internal', 'sonic', 'v6'. 
 - The orchestrator (dhcprelayd) is always required RUNNING. There is no default — every caller declares its own contract.
 - New wait_dhcp_relay_ready(duthost, relay_types) exposes the wait-only path for callers that already triggered a restart by other means (GCU apply, config load_minigraph, VLAN config edits).
 - Updated all 12 call sites under tests/dhcp_relay/, tests/generic_config_updater/, and the inner call inside sonic_dhcpv4_flag_config_and_unconfig to pass the appropriate relay_types based on the test's parametrization.
 - 'isc-internal' has no public consumer in sonic-mgmt (no tests/mx); it is included so the common utility is complete and the parallel mx test in sonic-mgmt-int can rely on it without further utils churn.

#### How did you verify/test it?

 - bjw2-can-t0-7260-8 (Arista 7260, master image): full dhcp_relay suite — tests/dhcp_relay/test_dhcp_relay.py, test_dhcpv6_relay.py, 
test_dhcp_relay_stress.py, tests/generic_config_updater/test_dhcp_relay.py — 35 passed, 1 failed. The single failure 
(test_dhcp_relay_restart_with_stress[sonic-relay-agent]) is dhcp4relay flapping under the test's own DHCP packet flood (76 STOPPED / 2 STARTING / 20 
RUNNING samples across the 120s wait); reproduces with the pre-refactor check too, tracked separately.
 - mx coverage validated using the parallel internal mx test on bjw2-can-720dt-2 (Mellanox 2700) and bjw2-can-7215-4 (Marvell armhf), 4/4 passed each.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

##### Work item tracking
- Microsoft ADO (number only): 38699914

