### PR TITLE
modify config_reload() parameters for test_container_autorestart() testcase

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -62,7 +62,7 @@ def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname, tb
     # Config reload should set the auto restart back to state before test started
     for hostname in selected_rand_one_per_hwsku_hostname:
         duthost = duthosts[hostname]
-        config_reload(duthost, config_source='config_db', safe_reload=True)
+        config_reload(duthost, config_source='config_db', safe_reload=True, wait_for_bgp=True)
         if hostname in dhcp_server_hosts:
             duthost.shell("docker rm %s" % DHCP_SERVER, module_ignore_errors=True)
 

--- a/tests/common/plugins/memory_utilization/memory_utilization.py
+++ b/tests/common/plugins/memory_utilization/memory_utilization.py
@@ -112,7 +112,7 @@ class MemoryMonitor:
                         # If threshold type is percentage,
                         # Express increase value in percentage instead of MB
                         if increase_threshold_raw['type'] == 'percentage':
-                            increase = (increase * 100)/current_value
+                            increase = (increase * 100)/previous_value
                         self._handle_memory_threshold_exceeded(
                             name, mem_item, increase, increase_fail_threshold_raw,
                             previous_values, current_values, is_increase=True

--- a/tests/snmp/test_snmp_link_local.py
+++ b/tests/snmp/test_snmp_link_local.py
@@ -14,7 +14,7 @@ def config_reload_after_test(duthosts, localhost, creds_all_duts,
                              enum_rand_one_per_hwsku_frontend_hostname):
     yield
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True)
+    config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
 
     hostip = duthost.host.options['inventory_manager'].get_host(
         duthost.hostname).vars['ansible_host']

--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -81,7 +81,7 @@ def check_image_version(duthost):
 @pytest.fixture(autouse=True, scope='module')
 def config_reload_after_tests(duthost):
     yield
-    config_reload(duthost)
+    config_reload(duthost, safe_reload=True, wait_for_bgp=True)
 
 
 @pytest.fixture(scope="function")

--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -81,7 +81,7 @@ def check_image_version(duthost):
 @pytest.fixture(autouse=True, scope='module')
 def config_reload_after_tests(duthost):
     yield
-    config_reload(duthost, safe_reload=True, wait_for_bgp=True)
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

The test_containers_autorestart test case was failing due to memory-utilization plugin check where "free -m" used memory increase the threshold by more than 20%. This is due to the fact that the previous memory snapshot was taken when the system was still initializing after config_reload after previous test case run. Also there was an issue with displaying the increase threshold, increase threshold was calculated with current_value instead of previous value of memory readings. Fixed both config_reload() issue and increased threshold percentage issue. 

Also, similar test cases which require change in params to config_reload() is being addressed.

Summary:
Fixes # (issue)

Fixes increase threshold of system memory usage on running test_containers_autorestart() issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

To fix the increase threshold percentage issue on running the test case.

#### How did you do it?

Modified the fix related to config_reload parameters and increase-threshold display issue.

#### How did you verify/test it?

Ran the test case multiple times by running the sanity and verified it does not fail.

#### Any platform specific information?

This is not a platform specific issue.

#### Supported testbed topology if it's a new test case?

This is not a topology specific issue.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
