### PR TITLE
BGP t0/t1 enhancement to run nightly regression

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -12,6 +12,7 @@ import csv
 import json
 import os
 from copy import copy
+from tests.common.utilities import wait_until
 from tests.common.errors import RunAnsibleModuleFail
 from ipaddress import ip_address, IPv4Address, IPv6Address
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa: F401
@@ -32,6 +33,17 @@ _next_system_id = 1
 
 macsec_enabled_port = {}
 macsec_profile_name = ""
+
+speed_type = {
+    '10000': 'speed_10_gbps',
+    '25000': 'speed_25_gbps',
+    '40000': 'speed_40_gbps',
+    '50000': 'speed_50_gbps',
+    '100000': 'speed_100_gbps',
+    '200000': 'speed_200_gbps',
+    '400000': 'speed_400_gbps',
+    '800000': 'speed_800_gbps',
+}
 
 
 @pytest.fixture(scope="module")
@@ -650,16 +662,215 @@ def _tgen_ports_from_portchannel(duthost, conn_graph_facts, fanout_graph_facts, 
     Used when --bgp_pc_config is set (port-channels preconfigured on testbed).
     Returns same format as tgen_ports (INTERFACE path).
     """
-    speed_type = {
-        '10000': 'speed_10_gbps',
-        '25000': 'speed_25_gbps',
-        '40000': 'speed_40_gbps',
-        '50000': 'speed_50_gbps',
-        '100000': 'speed_100_gbps',
-        '200000': 'speed_200_gbps',
-        '400000': 'speed_400_gbps',
-        '800000': 'speed_800_gbps',
-    }
+    pc_interface = config_facts.get('PORTCHANNEL_INTERFACE') or {}
+    pc_member = config_facts.get('PORTCHANNEL_MEMBER') or {}
+    if not pc_interface or not pc_member:
+        return None
+    # Normalize PORTCHANNEL_INTERFACE: keys may be "PortChannel1" or "PortChannel1|1.1.1.1/24"
+    pc_ips = {}
+    for key, val in list(pc_interface.items()):
+        if '|' in key:
+            pc_name, addr = key.split('|', 1)
+            pc_ips.setdefault(pc_name, []).append(addr)
+        else:
+            addrs = list(val.keys()) if isinstance(val, dict) else list(val)
+            pc_ips[key] = addrs
+    # PortChannel names in stable order (PortChannel1, PortChannel2, ...)
+    pc_names = sorted(
+        pc_ips.keys(),
+        key=lambda x: (
+            int(x.replace('PortChannel', ''))
+            if x.replace('PortChannel', '').isdigit()
+            else 0
+        )
+    )
+    snappi_fanouts = get_peer_snappi_chassis(conn_data=conn_graph_facts, dut_hostname=duthost.hostname)
+    if snappi_fanouts is None:
+        return None
+    snappi_fanout_list = SnappiFanoutManager(fanout_graph_facts)
+    for snappi_fanout in snappi_fanouts:
+        snappi_fanout_id = list(fanout_graph_facts.keys()).index(snappi_fanout)
+        snappi_fanout_list.get_fanout_device_details(device_number=snappi_fanout_id)
+        snappi_ports = snappi_fanout_list.get_ports(peer_device=duthost.hostname)
+        break
+    else:
+        return None
+    port_speeds = {int(p['speed']) for p in snappi_ports}
+    if len(port_speeds) != 1:
+        return None
+    port_speed = port_speeds.pop()
+    peer_port_to_snappi = {p['peer_port']: p for p in snappi_ports}
+    # BGP_NEIGHBOR: key = neighbor (TGEN) IP, value has 'local_addr' = DUT IP
+    # Map local_addr -> neighbor_ip to get TGEN IP from DUT IP on the port-channel
+    bgp_neighbors = config_facts.get('BGP_NEIGHBOR') or {}
+    local_to_neighbor = {}
+    for neighbor_ip, props in list(bgp_neighbors.items()):
+        local_addr = props.get('local_addr')
+        # Changing IP addresses esp IPv6 to lower case.
+        if local_addr:
+            local_to_neighbor[local_addr.lower()] = neighbor_ip.lower()
+    bgp_merged = _merged_bgp_neighbor_table(config_facts)
+    dm_local = (config_facts.get('DEVICE_METADATA') or {}).get('localhost') or {}
+    dut_asn_global = _normalize_sonic_config_asn(dm_local.get('bgp_asn'))
+    pytest_assert(
+        dut_asn_global is not None,
+        'DEVICE_METADATA localhost bgp_asn missing; cannot attach ASN fields to tgen_ports')
+    result = []
+    for port_id, pc_name in enumerate(pc_names):
+        members = pc_member.get(pc_name)
+        if members is None:
+            members = [m.split('|', 1)[1] for m in list(pc_member.keys()) if m.startswith(pc_name + '|')]
+        else:
+            members = list(members.keys()) if isinstance(members, dict) else members
+        # Skip portchannel if it has no ports or has more than 2 ports as members.
+        if (not members) or (len(members) >= 2):
+            continue
+        pc_port_member = members[0]
+        sp = peer_port_to_snappi.get(pc_port_member)
+        if sp is None:
+            continue
+        addrs = pc_ips.get(pc_name, [])
+        peer_ip = peer_ipv6 = prefix = ipv6_prefix = None
+        for a in addrs:
+            if ':' in a:
+                peer_ipv6, ipv6_prefix = a.split('/')
+            else:
+                peer_ip, prefix = a.split('/')
+        if peer_ip is None and peer_ipv6 is None:
+            continue
+        entry = {
+            'card_id': sp.get('card_id', '1'),
+            'location': sp['location'],
+            'peer_device': duthost.hostname,
+            'peer_port': pc_name,
+            'port_id': str(port_id),
+            'speed': speed_type.get(str(port_speed), sp.get('speed', 'speed_400_gbps')),
+        }
+        if peer_ip:
+            entry['peer_ip'] = peer_ip
+            entry['prefix'] = prefix
+            # Prefer BGP_NEIGHBOR (neighbor IP = TGEN side) when local_addr matches DUT IP
+            entry['ip'] = local_to_neighbor.get(peer_ip) or get_addrs_in_subnet(
+                peer_ip + '/' + prefix, 1, exclude_ips=[peer_ip])[0]
+        else:
+            entry['peer_ip'] = ''
+            entry['prefix'] = '24'
+            entry['ip'] = ''
+        if peer_ipv6:
+            entry['peer_ipv6'] = peer_ipv6.lower()
+            entry['ipv6_prefix'] = ipv6_prefix
+            # Prefer BGP_NEIGHBOR (neighbor IP = TGEN side) when local_addr matches DUT IPv6
+            entry['ipv6'] = local_to_neighbor.get(peer_ipv6.lower()) or get_addrs_in_subnet(
+                peer_ipv6 + '/' + ipv6_prefix, 1, exclude_ips=[peer_ipv6])[0]
+        else:
+            entry['peer_ipv6'] = ''
+            entry['ipv6_prefix'] = '64'
+            entry['ipv6'] = ''
+        asn4 = _peer_asn_from_bgp_neighbor_table(bgp_merged, entry.get('ip') or '')
+        asn6 = _peer_asn_from_bgp_neighbor_table(bgp_merged, entry.get('ipv6') or '')
+        if asn4 is not None and asn6 is not None:
+            pytest_assert(
+                asn4 == asn6,
+                'BGP neighbor ASN mismatch for {}: IPv4 TGEN {} asn {} vs IPv6 TGEN {} asn {}'.format(
+                    pc_name, entry.get('ip'), asn4, entry.get('ipv6'), asn6))
+        peer_asn = asn4 if asn4 is not None else asn6
+        pytest_assert(
+            peer_asn is not None,
+            'No BGP neighbor asn for {} (TGEN ip={}, ipv6={})'.format(
+                pc_name, entry.get('ip'), entry.get('ipv6')))
+        entry['dut_asn'] = dut_asn_global
+        entry['peer_asn'] = peer_asn
+        result.append(entry)
+    return result if result else None
+
+
+def _peer_asn_from_bgp_neighbor_table(bgp_table, neighbor_ip):  # noqa: F811
+    if not neighbor_ip:
+        return None
+    ent = bgp_table.get(str(neighbor_ip))
+    if not ent:
+        return None
+    return _normalize_sonic_config_asn(ent.get('asn'))
+
+
+def convert_to_routed_port(duthost, snappi_ports):
+    """
+    Checks if the ports defined in links.csv is part of vlan or portchannel and
+    removes them from the respective vlan/portchannel to avoid any conflict while testing with snappi.
+    Args:
+        duthost (pytest fixture): duthost fixture
+        snappi_ports (list): list of snappi ports info
+    Return:
+        Boolean: True
+    """
+    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    pc_facts = mg_facts['minigraph_portchannels']
+    vlan_facts = mg_facts['minigraph_vlans']
+    if not pc_facts and not vlan_facts:
+        return True
+    pc_members = {k: v['members'] for k, v in pc_facts.items()}
+    for sp in snappi_ports:
+        for pc, members in pc_members.items():
+            if sp['peer_port'] in members:
+                logger.warning(f"Removing port {sp['peer_port']} from portchannel {pc} for snappi testing")
+                duthost.command(
+                    f"sudo config portchannel member del {pc} {sp['peer_port']}"
+                )
+    vlan_members = {k: v['members'] for k, v in vlan_facts.items()}
+    for sp in snappi_ports:
+        for vlan, members in vlan_members.items():
+            if sp['peer_port'] in members:
+                logger.warning(f"Removing port {sp['peer_port']} from vlan {vlan.split('Vlan')[-1]} for snappi testing")
+                duthost.command(
+                    f"sudo config vlan member del {vlan.split('Vlan')[-1]} {sp['peer_port']}"
+                )
+    return True
+
+
+@pytest.fixture(scope="module")
+def setup_bgp_testbed(duthost):     # noqa: F811
+    """
+    Fixture to backup and restore config for bgp tests. This is required as we are making changes to
+    DUT config in bgp tests and we want to restore the original config after the test is done.
+    Args:
+    duthost (pytest fixture): duthost fixture
+    """
+    duthost.command("sudo cp /etc/sonic/config_db.json /etc/sonic/bgp_backup.json \n")
+    logger.info('Backing up the initial config to /etc/sonic/bgp_backup.json \n')
+    yield
+    logger.info('\n Restoring the initial config as part of teardown \n')
+    error = duthost.command("sudo config reload /etc/sonic/bgp_backup.json -f -y \n")['stderr']
+    if 'Error' in error:
+        pytest_assert('Error' not in duthost.shell("sudo config reload /etc/sonic/bgp_backup.json -y \n")['stderr'],
+                      'Error while reloading config in {} !!!!!'.format(duthost.hostname))
+    logger.info("Wait until the system is stable")
+    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
+                  "Not all critical services are fully started")
+    duthost.command("sudo cp /etc/sonic/bgp_backup.json /etc/sonic/config_db.json \n")
+
+
+def _normalize_sonic_config_asn(asn_field):  # noqa: F811
+    if asn_field is None:
+        return None
+    if isinstance(asn_field, bytes):
+        return int(asn_field.decode('utf-8'))
+    return int(asn_field)
+
+
+def _merged_bgp_neighbor_table(config_facts):   # noqa: F811
+    nbrs = {}
+    nbrs.update(config_facts.get('BGP_NEIGHBOR') or {})
+    nbrs.update(config_facts.get('BGP_INTERNAL_NEIGHBOR') or {})
+    nbrs.update(config_facts.get('BGP_VOQ_CHASSIS_NEIGHBOR') or {})
+    return nbrs
+
+
+def _tgen_ports_from_portchannel(duthost, conn_graph_facts, fanout_graph_facts, config_facts):       # noqa: F811
+    """
+    Build tgen_ports list from config_db PORTCHANNEL and PORTCHANNEL_INTERFACE.
+    Used when --bgp_pc_config is set (port-channels preconfigured on testbed).
+    Returns same format as tgen_ports (INTERFACE path).
+    """
     pc_interface = config_facts.get('PORTCHANNEL_INTERFACE') or {}
     pc_member = config_facts.get('PORTCHANNEL_MEMBER') or {}
     if not pc_interface or not pc_member:
@@ -783,11 +994,12 @@ def _tgen_ports_from_portchannel(duthost, conn_graph_facts, fanout_graph_facts, 
 
 
 @pytest.fixture(scope="module")
-def tgen_ports(duthost, conn_graph_facts, fanout_graph_facts, request):      # noqa: F811
+def tgen_ports(duthost, get_snappi_ports, conn_graph_facts, fanout_graph_facts, request):      # noqa: F811
     """
     Populate tgen ports info of T0 testbed and returns as a list
     Args:
         duthost (pytest fixture): duthost fixture
+        get_snappi_ports (pytest fixture): snappi ports
         conn_graph_facts (pytest fixture): connection graph
         fanout_graph_facts (pytest fixture): fanout graph
     Return:
@@ -827,19 +1039,12 @@ def tgen_ports(duthost, conn_graph_facts, fanout_graph_facts, request):      # n
         pytest_assert(tgen_ports_list is not None,
                       'Failed to build tgen_ports from port-channel (PORTCHANNEL_INTERFACE / PORTCHANNEL_MEMBER)')
         return tgen_ports_list
-
-    speed_type = {
-                  '10000': 'speed_10_gbps',
-                  '25000': 'speed_25_gbps',
-                  '40000': 'speed_40_gbps',
-                  '50000': 'speed_50_gbps',
-                  '100000': 'speed_100_gbps',
-                  '200000': 'speed_200_gbps',
-                  '400000': 'speed_400_gbps',
-                  '800000': 'speed_800_gbps'}
+    gs = get_snappi_ports
+    convert_to_routed_port(duthost, gs)
     snappi_fanouts = get_peer_snappi_chassis(conn_data=conn_graph_facts,
                                              dut_hostname=duthost.hostname)
     pytest_assert(snappi_fanouts is not None, 'Fail to get snappi_fanout')
+    dut_port_table = config_facts.get('PORT', {})
     snappi_fanout_list = SnappiFanoutManager(fanout_graph_facts)
     for snappi_fanout in snappi_fanouts:
         snappi_fanout_id = list(fanout_graph_facts.keys()).index(snappi_fanout)
@@ -855,22 +1060,23 @@ def tgen_ports(duthost, conn_graph_facts, fanout_graph_facts, request):      # n
         dutv6Ips = create_ip_list(dut_ipv6_start, len(snappi_ports), mask=v6_prefix_length)
         tgenv6Ips = create_ip_list(snappi_ipv6_start, len(snappi_ports), mask=v6_prefix_length)
         for port_id, port in enumerate(snappi_ports):
+            port['port_id'] = str(port_id + 1)
+            dut_port_info = dut_port_table.get(port['peer_port'], {})
+            port['autoneg'] = dut_port_info.get('autoneg') == 'on'
+            port['fec'] = str(dut_port_info.get('fec', '')).strip().lower().startswith('rs')
+            link_training_value = str(dut_port_info.get('link_training', '')).strip().lower()
+            port['link_training'] = link_training_value in ['on', 'true', 'yes', '1']
             port['speed'] = speed_type.get(str(port_speed), port['speed'])
             peer_port = port['peer_port']
-            int_addrs = list(config_facts['INTERFACE'][peer_port].keys())
+            entry = bool(config_facts.get('INTERFACE', {}).get(peer_port))
             for ipver, addr_type in (("ipv4", "IPv4"), ("ipv6", "IPv6")):
-                entry = next((a for a in int_addrs if (":" in a) == (ipver == "ipv6")), None)
                 if ipver == "ipv4":
                     dut_list, tgen_list, mask = dutIps, tgenIps, prefix_length
                     peer_ip_key, prefix_key, ip_key = "peer_ip", "prefix", "ip"
                 else:
                     dut_list, tgen_list, mask = dutv6Ips, tgenv6Ips, v6_prefix_length
                     peer_ip_key, prefix_key, ip_key = "peer_ipv6", "ipv6_prefix", "ipv6"
-                if entry:
-                    # Already configured on DUT
-                    port[peer_ip_key], port[prefix_key] = entry.split("/")
-                    port[ip_key] = get_addrs_in_subnet(entry, 1, exclude_ips=[entry.split("/")[0]])[0]
-                else:
+                if not entry:
                     # Assign and configure new IPs
                     port[peer_ip_key] = dut_list[port_id]
                     port[prefix_key] = mask
@@ -888,6 +1094,11 @@ def tgen_ports(duthost, conn_graph_facts, fanout_graph_facts, request):      # n
                             f"Unable to configure {addr_type} on {peer_port}: {e}",
                             pytrace=False,
                         )
+                else:
+                    int_addrs = list(config_facts['INTERFACE'][peer_port].keys())
+                    entry = next((a for a in int_addrs if (":" in a) == (ipver == "ipv6")), None)
+                    port[peer_ip_key], port[prefix_key] = entry.split("/")
+                    port[ip_key] = get_addrs_in_subnet(entry, 1, exclude_ips=[entry.split("/")[0]])[0]
     return snappi_ports
 
 
@@ -1662,10 +1873,6 @@ def multidut_snappi_ports_for_bgp(duthosts,                                # noq
     Return:
         return tuple of duts and snappi ports
     """
-    speed_type = {'50000': 'speed_50_gbps',
-                  '100000': 'speed_100_gbps',
-                  '200000': 'speed_200_gbps',
-                  '400000': 'speed_400_gbps'}
     multidut_snappi_ports = []
 
     for duthost in duthosts:
@@ -1704,15 +1911,6 @@ def get_snappi_ports_single_dut(duthosts,  # noqa: F811
                                 rand_one_dut_hostname,
                                 rand_one_dut_portname_oper_up
                                 ):  # noqa: F811
-    speed_type = {
-                  '10000': 'speed_10_gbps',
-                  '25000': 'speed_25_gbps',
-                  '40000': 'speed_40_gbps',
-                  '50000': 'speed_50_gbps',
-                  '100000': 'speed_100_gbps',
-                  '200000': 'speed_200_gbps',
-                  '400000': 'speed_400_gbps',
-                  '800000': 'speed_800_gbps'}
 
     if is_snappi_multidut(duthosts):
         return []
@@ -1790,15 +1988,6 @@ def get_snappi_ports_multi_dut(duthosts,  # noqa: F811
             'speed': '100000'
         }]
     """
-    speed_type = {
-                  '10000': 'speed_10_gbps',
-                  '25000': 'speed_25_gbps',
-                  '40000': 'speed_40_gbps',
-                  '50000': 'speed_50_gbps',
-                  '100000': 'speed_100_gbps',
-                  '200000': 'speed_200_gbps',
-                  '400000': 'speed_400_gbps',
-                  '800000': 'speed_800_gbps'}
     multidut_snappi_ports = []
 
     if not is_snappi_multidut(duthosts):

--- a/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
@@ -1,7 +1,7 @@
 import logging
 from tabulate import tabulate
 from statistics import mean
-from tests.common.utilities import (wait, wait_until)
+from tests.common.utilities import wait
 from tests.common.helpers.assertions import pytest_assert
 logger = logging.getLogger(__name__)
 
@@ -73,9 +73,6 @@ def run_bgp_local_link_failover_test(snappi_api,
                                             number_of_routes,
                                             route_type,)
 
-    """ Cleanup the dut configs after getting the convergence numbers """
-    cleanup_config(duthost)
-
 
 def run_bgp_remote_link_failover_test(snappi_api,
                                       duthost,
@@ -119,9 +116,6 @@ def run_bgp_remote_link_failover_test(snappi_api,
                                              number_of_routes,
                                              route_type,)
 
-    """ Cleanup the dut configs after getting the convergence numbers """
-    cleanup_config(duthost)
-
 
 def run_rib_in_convergence_test(snappi_api,
                                 duthost,
@@ -131,7 +125,6 @@ def run_rib_in_convergence_test(snappi_api,
                                 number_of_routes,
                                 route_type,
                                 timeout=None,
-                                skip_cleanup=None,
                                 skip_duthost_bgp_config=False,):
     """
     Run RIB-IN Convergence test
@@ -145,9 +138,9 @@ def run_rib_in_convergence_test(snappi_api,
         number_of_routes:  Number of IPv4/IPv6 Routes
         route_type: IPv4 or IPv6 routes
         timeout: optional timeout in seconds for convergence steps (default: TIMEOUT)
-        skip_cleanup: Skip the cleanup integrated in the test since main test does revert of config.
         skip_duthost_bgp_config: Use existing config from config_db to run test.
     """
+
     if timeout is None:
         timeout = TIMEOUT
 
@@ -183,10 +176,6 @@ def run_rib_in_convergence_test(snappi_api,
                            route_type,
                            timeout,)
 
-    if not skip_cleanup:
-        """ Cleanup the dut configs after getting the convergence numbers """
-        cleanup_config(duthost)
-
 
 def run_RIB_IN_capacity_test(snappi_api,
                              duthost,
@@ -221,9 +210,6 @@ def run_RIB_IN_capacity_test(snappi_api,
                         step_value,
                         route_type,)
 
-    """ Cleanup the dut configs after getting the convergence numbers """
-    cleanup_config(duthost)
-
 
 def duthost_bgp_config(duthost,
                        tgen_ports,
@@ -239,9 +225,6 @@ def duthost_bgp_config(duthost,
         multipath: ECMP value for BGP config
         route_type: IPv4 or IPv6 routes
     """
-    duthost.command("sudo config save -y")
-    duthost.command("sudo cp {} {}".format(
-        "/etc/sonic/config_db.json", "/etc/sonic/config_db_backup.json"))
     global temp_tg_port
     temp_tg_port = tgen_ports
     for i in range(0, port_count):
@@ -263,7 +246,8 @@ def duthost_bgp_config(duthost,
             "sudo config interface ip add PortChannel%s %s/%s\n"
         )
         portchannel_config %= (i+1, i+1, tgen_ports[i]['peer_port'], i+1, tgen_ports[i]
-                               ['peer_ip'], tgen_ports[i]['prefix'], i+1, tgen_ports[i]['peer_ipv6'], 64)
+                               ['peer_ip'], tgen_ports[i]['prefix'], i+1, tgen_ports[i]['peer_ipv6'],
+                               tgen_ports[i]['ipv6_prefix'])
         logger.info('Configuring %s to PortChannel%s with IPs %s,%s' % (
             tgen_ports[i]['peer_port'], i+1, tgen_ports[i]['peer_ip'], tgen_ports[i]['peer_ipv6']))
         duthost.shell(portchannel_config)
@@ -326,7 +310,7 @@ def __tgen_bgp_config(snappi_api,
         route_type: IPv4 or IPv6 routes
         skip_duthost_bgp_config: boolean (true) if DUT is preconfigured
     """
-    global NG_LIST
+    global NG_LIST  # noqa: F824
     config = snappi_api.config()
 
     if skip_duthost_bgp_config and port_count > 0:
@@ -355,19 +339,25 @@ def __tgen_bgp_config(snappi_api,
         else:
             m = hex(i).split('0x')[1]
         c_lag.protocol.lacp.actor_system_id = "00:10:00:00:00:%s" % m
+        c_lag.protocol.lacp.actor_system_priority = int(1)
+        c_lag.protocol.lacp.actor_key = int(1)
         lp.ethernet.name = "lag_Ethernet %s" % i
         lp.ethernet.mac = "00:10:01:00:00:%s" % m
+        lp.lacp.actor_port_number = int(1)
+        lp.lacp.actor_port_priority = int(1)
         config.devices.device(name='Topology %d' % i)
 
     config.options.port_options.location_preemption = True
-    layer1 = config.layer1.layer1()[-1]
-    layer1.name = 'port settings'
-    layer1.port_names = [port.name for port in config.ports]
-    layer1.ieee_media_defaults = False
-    layer1.auto_negotiation.rs_fec = False
-    layer1.auto_negotiation.link_training = False
-    layer1.speed = temp_tg_port[0]['speed']
-    layer1.auto_negotiate = False
+    for index, port_data in enumerate(temp_tg_port):
+        layer1 = config.layer1.layer1()[-1]
+        layer1.name = f"{index}_settings"
+        layer1.port_names = [config.ports[index].name]
+        layer1.speed = port_data['speed']
+        layer1.ieee_media_defaults = False
+        layer1.auto_negotiation.rs_fec = port_data.get('fec', False)
+        layer1.auto_negotiation.link_training = port_data.get('link_training', False)
+        layer1.speed = port_data['speed']
+        layer1.auto_negotiate = port_data.get('autoneg', False)
 
     def create_v4_topo():
         eth = config.devices[0].ethernets.add()
@@ -947,14 +937,16 @@ def get_RIB_IN_capacity(snappi_api,
             config.devices.device(name='Topology %d' % i)
 
         config.options.port_options.location_preemption = True
-        layer1 = config.layer1.layer1()[-1]
-        layer1.name = 'port settings'
-        layer1.port_names = [port.name for port in config.ports]
-        layer1.ieee_media_defaults = False
-        layer1.auto_negotiation.rs_fec = False
-        layer1.auto_negotiation.link_training = False
-        layer1.speed = temp_tg_port[0]['speed']
-        layer1.auto_negotiate = False
+        for index, port_data in enumerate(temp_tg_port):
+            layer1 = config.layer1.layer1()[-1]
+            layer1.name = f"{index}_settings"
+            layer1.port_names = [config.ports[index].name]
+            layer1.speed = port_data['speed']
+            layer1.ieee_media_defaults = False
+            layer1.auto_negotiation.rs_fec = port_data.get('fec', False)
+            layer1.auto_negotiation.link_training = port_data.get('link_training', False)
+            layer1.speed = port_data['speed']
+            layer1.auto_negotiate = port_data.get('autoneg', False)
 
         def create_v4_topo():
             eth = config.devices[0].ethernets.add()
@@ -1132,32 +1124,16 @@ def get_RIB_IN_capacity(snappi_api,
             cs = snappi_api.control_state()
             cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.STOP
             snappi_api.set_control_state(cs)
-            wait(TIMEOUT-20, "For Traffic To stop")
+            wait(TIMEOUT, "For Traffic To stop")
             """ Stopping Protocols """
             logger.info("Stopping all protocols ...")
             cs = snappi_api.control_state()
             cs.protocol.all.state = cs.protocol.all.START
             snappi_api.set_control_state(cs)
-            wait(TIMEOUT-20, "For Protocols To STOP")
+            wait(TIMEOUT, "For Protocols To STOP")
     except Exception as e:
         logger.info(e)
     finally:
         columns = ['Test Name', 'Maximum no. of Routes']
         logger.info("\n%s" % tabulate(
             [['RIB-IN Capacity Test', max_routes]], headers=columns, tablefmt="psql"))
-
-
-def cleanup_config(duthost):
-    """
-    Cleaning up dut config at the end of the test
-
-    Args:
-        duthost (pytest fixture): duthost fixture
-    """
-    duthost.command("sudo cp {} {}".format(
-        "/etc/sonic/config_db_backup.json", "/etc/sonic/config_db.json"))
-    duthost.shell("sudo config reload -y \n")
-    logger.info("Wait until all critical services are fully started")
-    pytest_assert(wait_until(360, 10, 1, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
-    logger.info('Convergence Test Completed')

--- a/tests/snappi_tests/bgp/files/bgp_test_gap_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_test_gap_helper.py
@@ -1,7 +1,8 @@
 from tabulate import tabulate
-from tests.common.utilities import (wait, wait_until)
+from tests.common.utilities import (wait)
 from tests.common.helpers.assertions import pytest_assert
 import logging
+import json
 logger = logging.getLogger(__name__)
 
 TGEN_AS_NUM = 65200
@@ -34,12 +35,12 @@ def run_bgp_convergence_performance(snappi_api,
         stop_routes: ending route count value
         route_type: IPv4 or IPv6 routes
     """
-    port_count = multipath + 1
+
     """ Create bgp config on dut """
 
-    duthost_bgp_3port_config(duthost,
-                             tgen_ports,
-                             port_count,)
+    """ Create bgp config on dut """
+    duthost_bgp_scalability_config(duthost, tgen_ports, multipath)
+
     """
         Run the convergence test by withdrawing all the route ranges
         one by one and calculate the convergence values
@@ -51,9 +52,6 @@ def run_bgp_convergence_performance(snappi_api,
                                              stop_routes,
                                              route_type,
                                              duthost,)
-
-    """ Cleanup the dut configs after getting the convergence numbers """
-    cleanup_config(duthost)
 
 
 def run_bgp_scalability_v4_v6(snappi_api,
@@ -79,6 +77,9 @@ def run_bgp_scalability_v4_v6(snappi_api,
 
     port_count = multipath + 1
 
+    """ Create bgp config on dut """
+    duthost_bgp_scalability_config(duthost, tgen_ports, multipath)
+
     if ipv4_routes == 0 and ipv6_routes == 0:
         assert False, "Both v4 and v6 route counts can't be zero"
     elif ipv4_routes > 0 and ipv6_routes > 0:
@@ -103,93 +104,6 @@ def run_bgp_scalability_v4_v6(snappi_api,
     get_bgp_scalability_result(snappi_api, localhost, tgen_bgp_config, limit_flag, duthost)
 
 
-def duthost_bgp_3port_config(duthost,
-                             tgen_ports,
-                             port_count,):
-    """
-    Configures BGP on the DUT with N-1 ecmp
-
-    Args:
-        duthost (pytest fixture): duthost fixture
-        tgen_ports (pytest fixture): Ports mapping info of T0 testbed
-        port_count:multipath + 1
-    """
-    duthost.command('sudo crm config polling interval 30')
-    duthost.command('sudo crm config thresholds ipv4 route high 85')
-    duthost.command('sudo crm config thresholds ipv4 route low 70')
-    duthost.command("sudo config save -y")
-    duthost.command("sudo cp {} {}".format("/etc/sonic/config_db.json", "/etc/sonic/config_db_backup.json"))
-    global temp_tg_port
-    temp_tg_port = tgen_ports
-    for i in range(0, port_count):
-        intf_config = (
-            "sudo config interface ip remove %s %s/%s \n"
-            "sudo config interface ip remove %s %s/%s \n"
-        )
-        intf_config %= (
-            tgen_ports[i]['peer_port'],
-            tgen_ports[i]['peer_ip'], tgen_ports[i]['prefix'],
-            tgen_ports[i]['peer_port'], tgen_ports[i]['peer_ipv6'],
-            tgen_ports[i]['ipv6_prefix']
-        )
-        logger.info('Removing configured IP and IPv6 Address from %s' % (tgen_ports[i]['peer_port']))
-        duthost.shell(intf_config)
-
-    for i in range(0, port_count):
-        portchannel_config = (
-            "sudo config portchannel add PortChannel%s \n"
-            "sudo config portchannel member add PortChannel%s %s\n"
-            "sudo config interface ip add PortChannel%s %s/%s\n"
-            "sudo config interface ip add PortChannel%s %s/%s\n"
-        )
-        portchannel_config %= (
-            i + 1,
-            i + 1,
-            tgen_ports[i]['peer_port'],
-            i + 1,
-            tgen_ports[i]['peer_ip'],
-            tgen_ports[i]['prefix'],
-            i + 1,
-            tgen_ports[i]['peer_ipv6'],
-            64
-        )
-        logger.info('Configuring %s to PortChannel%s with IPs %s,%s' % (tgen_ports[i]['peer_port'],
-                    i + 1, tgen_ports[i]['peer_ip'], tgen_ports[i]['peer_ipv6']))
-        duthost.shell(portchannel_config)
-
-    bgp_config = (
-        "vtysh "
-        "-c 'configure terminal' "
-        "-c 'router bgp %s' "
-        "-c 'no bgp ebgp-requires-policy' "
-        "-c 'bgp bestpath as-path multipath-relax' "
-        "-c 'maximum-paths %s' "
-        "-c 'exit' "
-    )
-    bgp_config %= (DUT_AS_NUM, port_count-1)
-    duthost.shell(bgp_config)
-
-    for i in range(1, port_count):
-        bgp_config_neighbor = (
-            "vtysh "
-            "-c 'configure terminal' "
-            "-c 'router bgp %s' "
-            "-c 'neighbor %s remote-as %s' "
-            "-c 'address-family ipv4 unicast' "
-            "-c 'neighbor %s activate' "
-            "-c 'neighbor %s remote-as %s' "
-            "-c 'address-family ipv6 unicast' "
-            "-c 'neighbor %s activate' "
-            "-c 'exit' "
-        )
-        bgp_config_neighbor %= (
-            DUT_AS_NUM, tgen_ports[i]['ip'], TGEN_AS_NUM, tgen_ports[i]['ip'],
-            tgen_ports[i]['ipv6'], TGEN_AS_NUM, tgen_ports[i]['ipv6'])
-        logger.info('Configuring BGP v4 Neighbor {}, v6 Neighbor {}'.format(tgen_ports[i]['ip'],
-                    tgen_ports[i]['ipv6']))
-        duthost.shell(bgp_config_neighbor)
-
-
 def duthost_bgp_scalability_config(duthost, tgen_ports, multipath):
     """
     Configures BGP on the DUT with N-1 ecmp
@@ -202,63 +116,79 @@ def duthost_bgp_scalability_config(duthost, tgen_ports, multipath):
     duthost.command('sudo crm config polling interval 30')
     duthost.command('sudo crm config thresholds ipv4 route high 85')
     duthost.command('sudo crm config thresholds ipv4 route low 70')
-    duthost.command("sudo config save -y")
-    duthost.command("sudo cp {} {}".format("/etc/sonic/config_db.json", "/etc/sonic/config_db_backup.json"))
     temp_tg_port = tgen_ports
-    for i in range(0, port_count):
+    for i in range(port_count):
+        port = tgen_ports[i]
         intf_config = (
-            "sudo config interface ip remove %s %s/%s \n"
-            "sudo config interface ip remove %s %s/%s \n"
+            f"sudo config interface ip remove {port['peer_port']} {port['peer_ip']}/{port['prefix']}\n"
+            f"sudo config interface ip remove {port['peer_port']} {port['peer_ipv6']}/{port['ipv6_prefix']}\n"
         )
-        intf_config %= (tgen_ports[i]['peer_port'], tgen_ports[i]['peer_ip'], tgen_ports[i]['prefix'],
-                        tgen_ports[i]['peer_port'], tgen_ports[i]['peer_ipv6'], tgen_ports[i]['ipv6_prefix'])
-        logger.info('Removing configured IP and IPv6 Address from %s' % (tgen_ports[i]['peer_port']))
+        logger.info(f"Removing IPs from {port['peer_port']}")
         duthost.shell(intf_config)
 
-    for i in range(0, port_count):
+    for i in range(port_count):
+        port = tgen_ports[i]
+        idx = i + 1
         portchannel_config = (
-            "sudo config portchannel add PortChannel%s \n"
-            "sudo config portchannel member add PortChannel%s %s\n"
-            "sudo config interface ip add PortChannel%s %s/%s\n"
-            "sudo config interface ip add PortChannel%s %s/%s\n"
+            f"sudo config portchannel add PortChannel{idx} \n"
+            f"sudo config portchannel member add PortChannel{idx} {port['peer_port']}\n"
+            f"sudo config interface ip add PortChannel{idx} {port['peer_ip']}/{port['prefix']}\n"
+            f"sudo config interface ip add PortChannel{idx} {port['peer_ipv6']}/{port['ipv6_prefix']}\n"
         )
-        portchannel_config %= (i + 1, i + 1, tgen_ports[i]['peer_port'], i + 1, tgen_ports[i]['peer_ip'],
-                               tgen_ports[i]['prefix'], i + 1, tgen_ports[i]['peer_ipv6'],
-                               tgen_ports[i]['ipv6_prefix'])
-        logger.info('Configuring %s to PortChannel%s' % (tgen_ports[i]['peer_port'], i + 1))
+        logger.info(f"Configuring {port['peer_port']} to PortChannel{idx}")
         duthost.shell(portchannel_config)
 
-    bgp_config = (
-        "vtysh "
-        "-c 'configure terminal' "
-        "-c 'router bgp %s' "
-        "-c 'no bgp ebgp-requires-policy' "
-        "-c 'bgp bestpath as-path multipath-relax' "
-        "-c 'maximum-paths %s' "
-        "-c 'exit' "
-    )
-    bgp_config %= (DUT_AS_NUM, port_count-1)
-    duthost.shell(bgp_config)
+    duthost.command("sudo config save -y")
+    # BGP Configuration
+    loopback_interfaces = {
+        "Loopback0": {},
+        "Loopback0|1.1.1.1/32": {},
+        "Loopback0|1::1/128": {},
+    }
+    config_db = json.loads(duthost.shell("sonic-cfggen -d --print-data")['stdout'])
+    bgp_neighbors = {
+        addr: {
+            "asn": TGEN_AS_NUM,
+            "holdtime": "180",
+            "keepalive": "60",
+            "local_addr": ip_version,
+            "name": "snappi-sonic",
+            "nhopself": "0",
+            "rrclient": "0",
+        }
+        for port in tgen_ports
+        for addr, ip_version in [(port['ip'], port['peer_ip']), (port['ipv6'], port['peer_ipv6'])]
+    }
 
-    for i in range(1, port_count):
-        bgp_config_neighbor = (
-            "vtysh "
-            "-c 'configure terminal' "
-            "-c 'router bgp %s' "
-            "-c 'neighbor %s remote-as %s' "
-            "-c 'address-family ipv4 unicast' "
-            "-c 'neighbor %s activate' "
-            "-c 'neighbor %s remote-as %s' "
-            "-c 'address-family ipv6 unicast' "
-            "-c 'neighbor %s activate' "
-            "-c 'exit' "
-        )
-        bgp_config_neighbor %= (
-            DUT_AS_NUM, tgen_ports[i]['ip'], TGEN_AS_NUM, tgen_ports[i]['ip'],
-            tgen_ports[i]['ipv6'], TGEN_AS_NUM, tgen_ports[i]['ipv6'])
-        logger.info('Configuring BGP v4 Neighbor {}, v6 Neighbor {}'.format(tgen_ports[i]['ip'],
-                    tgen_ports[i]['ipv6']))
-        duthost.shell(bgp_config_neighbor)
+    device_neighbors = {
+        port['peer_port']: {
+            "name": "snappi-sonic",
+            "port": "Ethernet1"
+        }
+        for port in tgen_ports
+    }
+
+    device_neighbor_metadatas = {
+        "snappi-sonic": {
+            "hwsku": "snappi-sonic",
+            "mgmt_addr": "172.16.149.206",
+            "type": "ToRRouter"
+        }
+    }
+    config_db.setdefault("LOOPBACK_INTERFACE", {}).update(loopback_interfaces)
+    config_db.setdefault("BGP_NEIGHBOR", {}).update(bgp_neighbors)
+    config_db.setdefault("DEVICE_NEIGHBOR_METADATA", {}).update(device_neighbor_metadatas)
+    config_db.setdefault("DEVICE_NEIGHBOR", {}).update(device_neighbors)
+    with open("/tmp/temp_config.json", 'w') as fp:
+        json.dump(config_db, fp, indent=4)
+    duthost.copy(src="/tmp/temp_config.json", dest="/etc/sonic/config_db.json")
+    logger.info("Reloading config on DUT {}".format(duthost.hostname))
+    error = duthost.command("sudo config reload -f -y \n")['stderr']
+    if 'Error' in error:
+        pytest_assert('Error' not in duthost.shell("sudo config reload -y \n")['stderr'],
+                      'Error while reloading config in {} !!!!!'.format(duthost.hostname))
+    wait(60, "For DUT to come back online after config reload")
+    logger.info('Config Reload Successful in {} !!!'.format(duthost.hostname))
 
 
 def __tgen_bgp_config(snappi_api,
@@ -302,10 +232,10 @@ def __tgen_bgp_config(snappi_api,
     layer1.name = 'port settings'
     layer1.port_names = [port.name for port in config.ports]
     layer1.ieee_media_defaults = False
-    layer1.auto_negotiation.rs_fec = False
-    layer1.auto_negotiation.link_training = False
+    layer1.auto_negotiation.rs_fec = temp_tg_port[0].get('fec', False)
+    layer1.auto_negotiation.link_training = temp_tg_port[0].get('link_training', False)
     layer1.speed = temp_tg_port[0]['speed']
-    layer1.auto_negotiate = False
+    layer1.auto_negotiate = temp_tg_port[0].get('autoneg', False)
 
     # Source
     config.devices.device(name='Tx')
@@ -417,7 +347,7 @@ def get_convergence_for_remote_link_failover(snappi_api,
         route_type: IPv4 or IPv6 routes
     """
     table = []
-    global NG_LIST
+    global NG_LIST  # noqa: F824
 
     def tgen_config(routes):
         config = snappi_api.config()
@@ -440,10 +370,10 @@ def get_convergence_for_remote_link_failover(snappi_api,
         layer1.name = 'port settings'
         layer1.port_names = [port.name for port in config.ports]
         layer1.ieee_media_defaults = False
-        layer1.auto_negotiation.rs_fec = False
-        layer1.auto_negotiation.link_training = False
+        layer1.auto_negotiation.rs_fec = temp_tg_port[0].get('fec', False)
+        layer1.auto_negotiation.link_training = temp_tg_port[0].get('link_training', False)
         layer1.speed = temp_tg_port[0]['speed']
-        layer1.auto_negotiate = False
+        layer1.auto_negotiate = temp_tg_port[0].get('autoneg', False)
 
         def create_v4_topo():
             eth = config.devices[0].ethernets.add()
@@ -701,18 +631,3 @@ def get_bgp_scalability_result(snappi_api, localhost, bgp_config, flag, duthost)
     else:
         assert float(flow_stats[0].loss) <= 0.1, "FAIL: Loss observerd in traffic item"
         logger.info('PASSED : No Loss observerd in traffic item and {}'.format(msg))
-
-
-def cleanup_config(duthost):
-    """
-    Cleaning up dut config at the end of the test
-
-    Args:
-        duthost (pytest fixture): duthost fixture
-    """
-    duthost.command("sudo cp {} {}".format("/etc/sonic/config_db_backup.json", "/etc/sonic/config_db.json"))
-    duthost.shell("sudo config reload -y \n")
-    logger.info("Wait until all critical services are fully started")
-    pytest_assert(wait_until(360, 10, 1, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
-    logger.info('Convergence Test Completed')

--- a/tests/snappi_tests/bgp/test_bgp_convergence_performance.py
+++ b/tests/snappi_tests/bgp/test_bgp_convergence_performance.py
@@ -1,5 +1,6 @@
 from tests.common.snappi_tests.snappi_fixtures import (                           # noqa: F401
-    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
+    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports, is_snappi_multidut,
+    get_snappi_ports_single_dut, get_snappi_ports, setup_bgp_testbed)
 from tests.snappi_tests.bgp.files.bgp_test_gap_helper import run_bgp_convergence_performance
 from tests.common.fixtures.conn_graph_facts import (                        # noqa: F401
     conn_graph_facts, fanout_graph_facts)
@@ -11,10 +12,12 @@ pytestmark = [pytest.mark.topology('tgen')]
 @pytest.mark.parametrize('multipath', [2])
 @pytest.mark.parametrize('start_routes', [1000])
 @pytest.mark.parametrize('routes_step', [1000])
-@pytest.mark.parametrize('stop_routes', [16000])
+@pytest.mark.parametrize('stop_routes', [3000])
 @pytest.mark.parametrize('route_type', ['IPv4'])
 def test_bgp_convergence_performance(snappi_api,               # noqa: F811
                                      duthost,
+                                     setup_bgp_testbed,    # noqa: F811
+                                     get_snappi_ports,     # noqa: F811
                                      tgen_ports,            # noqa: F811
                                      multipath,
                                      start_routes,

--- a/tests/snappi_tests/bgp/test_bgp_local_link_failover.py
+++ b/tests/snappi_tests/bgp/test_bgp_local_link_failover.py
@@ -1,5 +1,6 @@
 from tests.common.snappi_tests.snappi_fixtures import (                           # noqa: F401
-    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
+    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports, is_snappi_multidut,
+    get_snappi_ports_single_dut, get_snappi_ports, setup_bgp_testbed)
 from tests.snappi_tests.bgp.files.bgp_convergence_helper import run_bgp_local_link_failover_test
 from tests.common.fixtures.conn_graph_facts import (                        # noqa: F401
     conn_graph_facts, fanout_graph_facts)
@@ -14,6 +15,8 @@ pytestmark = [pytest.mark.topology('tgen')]
 @pytest.mark.parametrize('route_type', ['IPv4'])
 def test_bgp_convergence_for_local_link_failover(snappi_api,                   # noqa: F811
                                                  duthost,
+                                                 setup_bgp_testbed,   # noqa: F811
+                                                 get_snappi_ports,   # noqa: F811
                                                  tgen_ports,                # noqa: F811
                                                  conn_graph_facts,          # noqa: F811
                                                  fanout_graph_facts,        # noqa: F811

--- a/tests/snappi_tests/bgp/test_bgp_remote_link_failover.py
+++ b/tests/snappi_tests/bgp/test_bgp_remote_link_failover.py
@@ -1,5 +1,6 @@
 from tests.common.snappi_tests.snappi_fixtures import (                           # noqa: F401
-    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
+    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports, is_snappi_multidut,
+    get_snappi_ports_single_dut, get_snappi_ports, setup_bgp_testbed)
 from tests.snappi_tests.bgp.files.bgp_convergence_helper import run_bgp_remote_link_failover_test
 from tests.common.fixtures.conn_graph_facts import (                        # noqa: F401
     conn_graph_facts, fanout_graph_facts)
@@ -14,6 +15,8 @@ pytestmark = [pytest.mark.topology('tgen')]
 @pytest.mark.parametrize('route_type', ['IPv4'])
 def test_bgp_convergence_for_remote_link_failover(snappi_api,                  # noqa: F811
                                                   duthost,
+                                                  setup_bgp_testbed,   # noqa: F811
+                                                  get_snappi_ports,    # noqa: F811
                                                   tgen_ports,               # noqa: F811
                                                   conn_graph_facts,         # noqa: F811
                                                   fanout_graph_facts,       # noqa: F811

--- a/tests/snappi_tests/bgp/test_bgp_rib_in_capacity.py
+++ b/tests/snappi_tests/bgp/test_bgp_rib_in_capacity.py
@@ -1,5 +1,6 @@
 from tests.common.snappi_tests.snappi_fixtures import (                           # noqa: F401
-    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
+    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports, is_snappi_multidut,
+    get_snappi_ports_single_dut, get_snappi_ports, setup_bgp_testbed)
 from tests.snappi_tests.bgp.files.bgp_convergence_helper import run_RIB_IN_capacity_test
 from tests.common.fixtures.conn_graph_facts import (                        # noqa: F401
     conn_graph_facts, fanout_graph_facts)
@@ -14,6 +15,8 @@ pytestmark = [pytest.mark.topology('tgen')]
 @pytest.mark.parametrize('route_type', ['IPv4'])
 def test_RIB_IN_capacity(snappi_api,                   # noqa: F811
                          duthost,
+                         setup_bgp_testbed,   # noqa: F811
+                         get_snappi_ports,    # noqa: F811
                          tgen_ports,                # noqa: F811
                          conn_graph_facts,          # noqa: F811
                          fanout_graph_facts,        # noqa: F811

--- a/tests/snappi_tests/bgp/test_bgp_rib_in_convergence.py
+++ b/tests/snappi_tests/bgp/test_bgp_rib_in_convergence.py
@@ -1,5 +1,6 @@
 from tests.common.snappi_tests.snappi_fixtures import (                           # noqa: F401
-    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
+    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports, is_snappi_multidut,
+    get_snappi_ports_single_dut, get_snappi_ports, setup_bgp_testbed)
 from tests.snappi_tests.bgp.files.bgp_convergence_helper import run_rib_in_convergence_test
 from tests.common.fixtures.conn_graph_facts import (                        # noqa: F401
     conn_graph_facts, fanout_graph_facts)
@@ -14,6 +15,8 @@ pytestmark = [pytest.mark.topology('tgen')]
 @pytest.mark.parametrize('route_type', ['IPv4'])
 def test_rib_in_convergence(snappi_api,                    # noqa: F811
                             duthost,
+                            setup_bgp_testbed,      # noqa: F811
+                            get_snappi_ports,       # noqa: F811
                             tgen_ports,                 # noqa: F811
                             conn_graph_facts,           # noqa: F811
                             fanout_graph_facts,         # noqa: F811

--- a/tests/snappi_tests/bgp/test_bgp_scalability.py
+++ b/tests/snappi_tests/bgp/test_bgp_scalability.py
@@ -1,7 +1,7 @@
 from tests.common.snappi_tests.snappi_fixtures import (                           # noqa: F401
-    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
-from tests.snappi_tests.bgp.files.bgp_test_gap_helper import duthost_bgp_scalability_config, \
-    run_bgp_scalability_v4_v6, cleanup_config
+    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports,
+    is_snappi_multidut, get_snappi_ports_single_dut, get_snappi_ports, setup_bgp_testbed)
+from tests.snappi_tests.bgp.files.bgp_test_gap_helper import run_bgp_scalability_v4_v6
 from tests.common.fixtures.conn_graph_facts import (                        # noqa: F401
     conn_graph_facts, fanout_graph_facts)
 import pytest
@@ -10,16 +10,13 @@ pytestmark = [pytest.mark.topology('tgen')]
 
 
 @pytest.mark.parametrize('multipath', [1])
-def test_duthost_bgp_scalability_config(duthost, tgen_ports, multipath):        # noqa: F811
-    duthost_bgp_scalability_config(duthost, tgen_ports, multipath)
-
-
-@pytest.mark.parametrize('multipath', [1])
 @pytest.mark.parametrize('ipv4_routes', [16000])
 @pytest.mark.parametrize('ipv6_routes', [1])
 @pytest.mark.parametrize('ipv6_prefix', [64])
 def test_bgp_scalability_16k_v4_routes(snappi_api,             # noqa: F811
                                        duthost,
+                                       setup_bgp_testbed,     # noqa: F811
+                                       get_snappi_ports,      # noqa: F811
                                        localhost,
                                        tgen_ports,          # noqa: F811
                                        multipath,
@@ -43,6 +40,8 @@ def test_bgp_scalability_16k_v4_routes(snappi_api,             # noqa: F811
 @pytest.mark.parametrize('ipv6_prefix', [64])
 def test_bgp_scalability_8k_v6_routes(snappi_api,              # noqa: F811
                                       duthost,
+                                      setup_bgp_testbed,   # noqa: F811
+                                      get_snappi_ports,   # noqa: F811
                                       localhost,
                                       tgen_ports,           # noqa: F811
                                       multipath,
@@ -66,6 +65,8 @@ def test_bgp_scalability_8k_v6_routes(snappi_api,              # noqa: F811
 @pytest.mark.parametrize('ipv6_prefix', [128])
 def test_bgp_scalability_256_v6_routes(snappi_api,             # noqa: F811
                                        duthost,
+                                       setup_bgp_testbed,   # noqa: F811
+                                       get_snappi_ports,   # noqa: F811
                                        localhost,
                                        tgen_ports,          # noqa: F811
                                        multipath,
@@ -89,6 +90,8 @@ def test_bgp_scalability_256_v6_routes(snappi_api,             # noqa: F811
 @pytest.mark.parametrize('ipv6_prefix', [64])
 def test_bgp_scalability_8kv4_4kv6_routes(snappi_api,          # noqa: F811
                                           duthost,
+                                          setup_bgp_testbed,   # noqa: F811
+                                          get_snappi_ports,   # noqa: F811
                                           localhost,
                                           tgen_ports,       # noqa: F811
                                           multipath,
@@ -112,6 +115,8 @@ def test_bgp_scalability_8kv4_4kv6_routes(snappi_api,          # noqa: F811
 @pytest.mark.parametrize('ipv6_prefix', [64])
 def test_bgp_scalability_100kv4_25kv6_routes(snappi_api,       # noqa: F811
                                              duthost,
+                                             setup_bgp_testbed,   # noqa: F811
+                                             get_snappi_ports,   # noqa: F811
                                              localhost,
                                              tgen_ports,    # noqa: F811
                                              multipath,
@@ -127,7 +132,3 @@ def test_bgp_scalability_100kv4_25kv6_routes(snappi_api,       # noqa: F811
                               ipv4_routes,
                               ipv6_routes,
                               ipv6_prefix)
-
-
-def test_cleanup_config(duthost):
-    cleanup_config(duthost)

--- a/tests/snappi_tests/lacp/files/lacp_dut_helper.py
+++ b/tests/snappi_tests/lacp/files/lacp_dut_helper.py
@@ -62,9 +62,6 @@ def duthost_bgp_config(duthost,
         tgen_ports (pytest fixture): Ports mapping info of T0 testbed
         port_count: total number of ports used in test
     """
-    duthost.command("sudo config save -y")
-    duthost.command("sudo cp {} {}".format(
-        "/etc/sonic/config_db.json", "/etc/sonic/config_db_backup.json"))
     global temp_tg_port
     temp_tg_port = tgen_ports
     for i in range(0, port_count):
@@ -340,7 +337,7 @@ def get_lacp_add_remove_link_from_dut(snappi_api,
             for flow in flows:
                 tx_frate.append(flow.frames_tx_rate)
                 rx_frate.append(flow.frames_tx_rate)
-            assert sum(tx_frate) == sum(rx_frate),\
+            assert sum(tx_frate) == sum(rx_frate), \
                 "Traffic has not converged after link flap: TxFrameRate:{},RxFrameRate:{}"\
                 .format(sum(tx_frate), sum(rx_frate))
             logger.info("Traffic has converged after link flap with no loss")

--- a/tests/snappi_tests/lacp/files/lacp_physical_helper.py
+++ b/tests/snappi_tests/lacp/files/lacp_physical_helper.py
@@ -108,9 +108,6 @@ def duthost_bgp_config(duthost,
         tgen_ports (pytest fixture): Ports mapping info of T0 testbed
         port_count: total number of ports used in test
     """
-    duthost.command("sudo config save -y")
-    duthost.command("sudo cp {} {}".format(
-        "/etc/sonic/config_db.json", "/etc/sonic/config_db_backup.json"))
     global temp_tg_port
     temp_tg_port = tgen_ports
     for i in range(0, port_count):
@@ -377,7 +374,7 @@ def get_lacp_add_remove_link_physically(snappi_api,
             for flow in flows:
                 tx_frate.append(flow.frames_tx_rate)
                 rx_frate.append(flow.frames_tx_rate)
-            assert sum(tx_frate) == sum(rx_frate),\
+            assert sum(tx_frate) == sum(rx_frate), \
                 "Traffic has not converged after link flap: TxFrameRate:{},RxFrameRate:{}"\
                 .format(sum(tx_frate), sum(rx_frate))
             logger.info("Traffic has converged after link flap")

--- a/tests/snappi_tests/lacp/test_add_remove_link_from_dut.py
+++ b/tests/snappi_tests/lacp/test_add_remove_link_from_dut.py
@@ -1,6 +1,6 @@
-from tests.common.snappi_tests.snappi_fixtures import snappi_api     # noqa: F401
-from tests.common.snappi_tests.snappi_fixtures import (                       # noqa: F401
-    snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
+from tests.common.snappi_tests.snappi_fixtures import (                           # noqa: F401
+    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports,
+    get_snappi_ports_single_dut, get_snappi_ports, setup_bgp_testbed)
 from tests.snappi_tests.lacp.files.lacp_dut_helper import run_lacp_add_remove_link_from_dut
 from tests.common.fixtures.conn_graph_facts import (                    # noqa: F401
     conn_graph_facts, fanout_graph_facts)
@@ -14,6 +14,8 @@ pytestmark = [pytest.mark.topology('tgen')]
 @pytest.mark.parametrize('iterations', [1])
 def test_lacp_add_remove_link_from_dut(snappi_api,                      # noqa: F811
                                        duthost,
+                                       setup_bgp_testbed,   # noqa: F811
+                                       get_snappi_ports,   # noqa: F811
                                        tgen_ports,                      # noqa: F811
                                        iterations,
                                        conn_graph_facts,                # noqa: F811

--- a/tests/snappi_tests/lacp/test_add_remove_link_physically.py
+++ b/tests/snappi_tests/lacp/test_add_remove_link_physically.py
@@ -1,8 +1,8 @@
-from tests.common.snappi_tests.snappi_fixtures import snappi_api             # noqa: F401
-from tests.common.snappi_tests.snappi_fixtures import (                   # noqa: F401
-    snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
-from tests.snappi_tests.lacp.files.lacp_physical_helper import run_lacp_add_remove_link_physically
-from tests.common.fixtures.conn_graph_facts import (                # noqa: F401
+from tests.common.snappi_tests.snappi_fixtures import (                           # noqa: F401
+    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports,
+    get_snappi_ports_single_dut, get_snappi_ports, setup_bgp_testbed)
+from tests.snappi_tests.lacp.files.lacp_dut_helper import run_lacp_add_remove_link_from_dut
+from tests.common.fixtures.conn_graph_facts import (                    # noqa: F401
     conn_graph_facts, fanout_graph_facts)
 import pytest
 
@@ -12,14 +12,16 @@ pytestmark = [pytest.mark.topology('tgen')]
 @pytest.mark.parametrize('port_count', [4])
 @pytest.mark.parametrize('number_of_routes', [1000])
 @pytest.mark.parametrize('iterations', [1])
-def test_lacp_add_remove_link_physically(snappi_api,                   # noqa: F811
-                                         duthost,
-                                         tgen_ports,                # noqa: F811
-                                         iterations,
-                                         conn_graph_facts,          # noqa: F811
-                                         fanout_graph_facts,        # noqa: F811
-                                         port_count,
-                                         number_of_routes,):
+def test_lacp_add_remove_link_from_dut(snappi_api,                      # noqa: F811
+                                       duthost,
+                                       setup_bgp_testbed,   # noqa: F811
+                                       get_snappi_ports,   # noqa: F811
+                                       tgen_ports,                      # noqa: F811
+                                       iterations,
+                                       conn_graph_facts,                # noqa: F811
+                                       fanout_graph_facts,              # noqa: F811
+                                       port_count,
+                                       number_of_routes,):
     """
     Topo:
     LAG1 --- DUT --- LAG2 (N-1 TGEN Ports)
@@ -30,8 +32,7 @@ def test_lacp_add_remove_link_physically(snappi_api,                   # noqa: F
     3) Send Traffic from LAG1 to LAG2
     4) Simulate link failure by bringing down one of the LAG2 Ports
     5) Ensure that packets are rerouted to rest of the LAG2 ports with no loss
-    6) Measure the convergence time
-    7) Clean up the BGP config on the dut
+    6) Clean up the BGP config on the dut
 
     Verification:
     1) Send traffic without flapping any link
@@ -47,13 +48,11 @@ def test_lacp_add_remove_link_physically(snappi_api,                   # noqa: F
         port_count: Total no of ports used in the test
         iterations: no of iterations to run the link flap test
         number_of_routes:  Number of IPv4/IPv6 Routes
-        lacpdu_interval_period: LACP update packet interval ( 0 - Auto, 1- Fast, 30 - Slow )
-        lacpdu_timeout: LACP Timeout value (0 - Auto, 3 - Short, 90 - Long)
     """
     # port_count, number_of_routes ,iterations and port_speed parameters can be modified as per user preference
-    run_lacp_add_remove_link_physically(snappi_api,
-                                        duthost,
-                                        tgen_ports,
-                                        iterations,
-                                        port_count,
-                                        number_of_routes,)
+    run_lacp_add_remove_link_from_dut(snappi_api,
+                                      duthost,
+                                      tgen_ports,
+                                      iterations,
+                                      port_count,
+                                      number_of_routes,)

--- a/tests/snappi_tests/lacp/test_add_remove_link_physically.py
+++ b/tests/snappi_tests/lacp/test_add_remove_link_physically.py
@@ -1,8 +1,8 @@
 from tests.common.snappi_tests.snappi_fixtures import (                           # noqa: F401
     snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports,
     get_snappi_ports_single_dut, get_snappi_ports, setup_bgp_testbed)
-from tests.snappi_tests.lacp.files.lacp_dut_helper import run_lacp_add_remove_link_from_dut
-from tests.common.fixtures.conn_graph_facts import (                    # noqa: F401
+from tests.snappi_tests.lacp.files.lacp_physical_helper import run_lacp_add_remove_link_physically
+from tests.common.fixtures.conn_graph_facts import (                # noqa: F401
     conn_graph_facts, fanout_graph_facts)
 import pytest
 
@@ -12,16 +12,16 @@ pytestmark = [pytest.mark.topology('tgen')]
 @pytest.mark.parametrize('port_count', [4])
 @pytest.mark.parametrize('number_of_routes', [1000])
 @pytest.mark.parametrize('iterations', [1])
-def test_lacp_add_remove_link_from_dut(snappi_api,                      # noqa: F811
-                                       duthost,
-                                       setup_bgp_testbed,   # noqa: F811
-                                       get_snappi_ports,   # noqa: F811
-                                       tgen_ports,                      # noqa: F811
-                                       iterations,
-                                       conn_graph_facts,                # noqa: F811
-                                       fanout_graph_facts,              # noqa: F811
-                                       port_count,
-                                       number_of_routes,):
+def test_lacp_add_remove_link_physically(snappi_api,                   # noqa: F811
+                                         duthost,
+                                         setup_bgp_testbed,   # noqa: F811
+                                         get_snappi_ports,   # noqa: F811
+                                         tgen_ports,                # noqa: F811
+                                         iterations,
+                                         conn_graph_facts,          # noqa: F811
+                                         fanout_graph_facts,        # noqa: F811
+                                         port_count,
+                                         number_of_routes,):
     """
     Topo:
     LAG1 --- DUT --- LAG2 (N-1 TGEN Ports)
@@ -32,7 +32,8 @@ def test_lacp_add_remove_link_from_dut(snappi_api,                      # noqa: 
     3) Send Traffic from LAG1 to LAG2
     4) Simulate link failure by bringing down one of the LAG2 Ports
     5) Ensure that packets are rerouted to rest of the LAG2 ports with no loss
-    6) Clean up the BGP config on the dut
+    6) Measure the convergence time
+    7) Clean up the BGP config on the dut
 
     Verification:
     1) Send traffic without flapping any link
@@ -48,11 +49,13 @@ def test_lacp_add_remove_link_from_dut(snappi_api,                      # noqa: 
         port_count: Total no of ports used in the test
         iterations: no of iterations to run the link flap test
         number_of_routes:  Number of IPv4/IPv6 Routes
+        lacpdu_interval_period: LACP update packet interval ( 0 - Auto, 1- Fast, 30 - Slow )
+        lacpdu_timeout: LACP Timeout value (0 - Auto, 3 - Short, 90 - Long)
     """
     # port_count, number_of_routes ,iterations and port_speed parameters can be modified as per user preference
-    run_lacp_add_remove_link_from_dut(snappi_api,
-                                      duthost,
-                                      tgen_ports,
-                                      iterations,
-                                      port_count,
-                                      number_of_routes,)
+    run_lacp_add_remove_link_physically(snappi_api,
+                                        duthost,
+                                        tgen_ports,
+                                        iterations,
+                                        port_count,
+                                        number_of_routes,)

--- a/tests/snappi_tests/lacp/test_lacp_timers_effect.py
+++ b/tests/snappi_tests/lacp/test_lacp_timers_effect.py
@@ -1,8 +1,8 @@
-from tests.common.snappi_tests.snappi_fixtures import snappi_api         # noqa: F401
-from tests.common.snappi_tests.snappi_fixtures import (               # noqa: F401
-    snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
-from tests.snappi_tests.lacp.files.lacp_physical_helper import run_lacp_timers_effect
-from tests.common.fixtures.conn_graph_facts import (            # noqa: F401
+from tests.common.snappi_tests.snappi_fixtures import (                           # noqa: F401
+    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports,
+    get_snappi_ports_single_dut, get_snappi_ports, setup_bgp_testbed)
+from tests.snappi_tests.lacp.files.lacp_dut_helper import run_lacp_add_remove_link_from_dut
+from tests.common.fixtures.conn_graph_facts import (                    # noqa: F401
     conn_graph_facts, fanout_graph_facts)
 import pytest
 
@@ -12,31 +12,27 @@ pytestmark = [pytest.mark.topology('tgen')]
 @pytest.mark.parametrize('port_count', [4])
 @pytest.mark.parametrize('number_of_routes', [1000])
 @pytest.mark.parametrize('iterations', [1])
-@pytest.mark.parametrize('lacpdu_interval_period', [1])
-@pytest.mark.parametrize('lacpdu_timeout', [90])
-def test_lacp_timers(snappi_api,                       # noqa: F811
-                     duthost,
-                     tgen_ports,                    # noqa: F811
-                     iterations,
-                     conn_graph_facts,              # noqa: F811
-                     fanout_graph_facts,            # noqa: F811
-                     port_count,
-                     number_of_routes,
-                     lacpdu_interval_period,
-                     lacpdu_timeout,):
+def test_lacp_add_remove_link_from_dut(snappi_api,                      # noqa: F811
+                                       duthost,
+                                       setup_bgp_testbed,   # noqa: F811
+                                       get_snappi_ports,   # noqa: F811
+                                       tgen_ports,                      # noqa: F811
+                                       iterations,
+                                       conn_graph_facts,                # noqa: F811
+                                       fanout_graph_facts,              # noqa: F811
+                                       port_count,
+                                       number_of_routes,):
     """
     Topo:
     LAG1 --- DUT --- LAG2 (N-1 TGEN Ports)
 
     Steps:
     1) Create BGP config on DUT and TGEN respectively
-    2) Update the required LACP timers as required for the test
-    3) Create a flow from LAG1 (TGEN1) to LAG2 ((N-1) TGEN ports)
-    4) Send Traffic from LAG1 to LAG2
-    5) Simulate link failure by bringing down one of the LAG2 Ports
-    6) Ensure that packets are re-routed to rest of the LAG2 ports with no loss
-    7) Measure the convergence time
-    8) Clean up the BGP config on the dut
+    2) Create a flow from LAG1 (TGEN1) to LAG2 ((N-1) TGEN ports)
+    3) Send Traffic from LAG1 to LAG2
+    4) Simulate link failure by bringing down one of the LAG2 Ports
+    5) Ensure that packets are rerouted to rest of the LAG2 ports with no loss
+    6) Clean up the BGP config on the dut
 
     Verification:
     1) Send traffic without flapping any link
@@ -52,16 +48,11 @@ def test_lacp_timers(snappi_api,                       # noqa: F811
         port_count: Total no of ports used in the test
         iterations: no of iterations to run the link flap test
         number_of_routes:  Number of IPv4/IPv6 Routes
-        lacpdu_interval_period: LACP update packet interval ( 0 - Auto, 1- Fast, 30 - Slow )
-        lacpdu_timeout: LACP Timeout value (0 - Auto, 3 - Short, 90 - Long)
     """
-    # port_count, number_of_routes ,iterations, port_speed, lacpdu_interval_period,
-    # lacpdu_timeout parameters can be modified as per user preference
-    run_lacp_timers_effect(snappi_api,
-                           duthost,
-                           tgen_ports,
-                           iterations,
-                           port_count,
-                           number_of_routes,
-                           lacpdu_interval_period,
-                           lacpdu_timeout,)
+    # port_count, number_of_routes ,iterations and port_speed parameters can be modified as per user preference
+    run_lacp_add_remove_link_from_dut(snappi_api,
+                                      duthost,
+                                      tgen_ports,
+                                      iterations,
+                                      port_count,
+                                      number_of_routes,)

--- a/tests/snappi_tests/lacp/test_lacp_timers_effect.py
+++ b/tests/snappi_tests/lacp/test_lacp_timers_effect.py
@@ -1,8 +1,8 @@
 from tests.common.snappi_tests.snappi_fixtures import (                           # noqa: F401
     snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports,
     get_snappi_ports_single_dut, get_snappi_ports, setup_bgp_testbed)
-from tests.snappi_tests.lacp.files.lacp_dut_helper import run_lacp_add_remove_link_from_dut
-from tests.common.fixtures.conn_graph_facts import (                    # noqa: F401
+from tests.snappi_tests.lacp.files.lacp_physical_helper import run_lacp_timers_effect
+from tests.common.fixtures.conn_graph_facts import (            # noqa: F401
     conn_graph_facts, fanout_graph_facts)
 import pytest
 
@@ -12,27 +12,33 @@ pytestmark = [pytest.mark.topology('tgen')]
 @pytest.mark.parametrize('port_count', [4])
 @pytest.mark.parametrize('number_of_routes', [1000])
 @pytest.mark.parametrize('iterations', [1])
-def test_lacp_add_remove_link_from_dut(snappi_api,                      # noqa: F811
-                                       duthost,
-                                       setup_bgp_testbed,   # noqa: F811
-                                       get_snappi_ports,   # noqa: F811
-                                       tgen_ports,                      # noqa: F811
-                                       iterations,
-                                       conn_graph_facts,                # noqa: F811
-                                       fanout_graph_facts,              # noqa: F811
-                                       port_count,
-                                       number_of_routes,):
+@pytest.mark.parametrize('lacpdu_interval_period', [1])
+@pytest.mark.parametrize('lacpdu_timeout', [90])
+def test_lacp_timers(snappi_api,                       # noqa: F811
+                     duthost,
+                     tgen_ports,                    # noqa: F811
+                     setup_bgp_testbed,   # noqa: F811
+                     get_snappi_ports,   # noqa: F811
+                     iterations,
+                     conn_graph_facts,              # noqa: F811
+                     fanout_graph_facts,            # noqa: F811
+                     port_count,
+                     number_of_routes,
+                     lacpdu_interval_period,
+                     lacpdu_timeout,):
     """
     Topo:
     LAG1 --- DUT --- LAG2 (N-1 TGEN Ports)
 
     Steps:
     1) Create BGP config on DUT and TGEN respectively
-    2) Create a flow from LAG1 (TGEN1) to LAG2 ((N-1) TGEN ports)
-    3) Send Traffic from LAG1 to LAG2
-    4) Simulate link failure by bringing down one of the LAG2 Ports
-    5) Ensure that packets are rerouted to rest of the LAG2 ports with no loss
-    6) Clean up the BGP config on the dut
+    2) Update the required LACP timers as required for the test
+    3) Create a flow from LAG1 (TGEN1) to LAG2 ((N-1) TGEN ports)
+    4) Send Traffic from LAG1 to LAG2
+    5) Simulate link failure by bringing down one of the LAG2 Ports
+    6) Ensure that packets are re-routed to rest of the LAG2 ports with no loss
+    7) Measure the convergence time
+    8) Clean up the BGP config on the dut
 
     Verification:
     1) Send traffic without flapping any link
@@ -48,11 +54,16 @@ def test_lacp_add_remove_link_from_dut(snappi_api,                      # noqa: 
         port_count: Total no of ports used in the test
         iterations: no of iterations to run the link flap test
         number_of_routes:  Number of IPv4/IPv6 Routes
+        lacpdu_interval_period: LACP update packet interval ( 0 - Auto, 1- Fast, 30 - Slow )
+        lacpdu_timeout: LACP Timeout value (0 - Auto, 3 - Short, 90 - Long)
     """
-    # port_count, number_of_routes ,iterations and port_speed parameters can be modified as per user preference
-    run_lacp_add_remove_link_from_dut(snappi_api,
-                                      duthost,
-                                      tgen_ports,
-                                      iterations,
-                                      port_count,
-                                      number_of_routes,)
+    # port_count, number_of_routes ,iterations, port_speed, lacpdu_interval_period,
+    # lacpdu_timeout parameters can be modified as per user preference
+    run_lacp_timers_effect(snappi_api,
+                           duthost,
+                           tgen_ports,
+                           iterations,
+                           port_count,
+                           number_of_routes,
+                           lacpdu_interval_period,
+                           lacpdu_timeout,)

--- a/tests/snappi_tests/reboot/files/reboot_helper.py
+++ b/tests/snappi_tests/reboot/files/reboot_helper.py
@@ -64,7 +64,7 @@ def duthost_bgp_config(duthost, tgen_ports):
     """
     global temp_tg_port
     temp_tg_port = tgen_ports
-    for i in range(1, 4):
+    for i in range(0, 3):
         intf_config = (
             "sudo config interface ip remove %s %s/%s \n"
             "sudo config interface ip remove %s %s/%s \n"
@@ -84,9 +84,9 @@ def duthost_bgp_config(duthost, tgen_ports):
         'sudo config interface ip add Vlan1000 192.168.1.1/16\n'
         'sudo config interface ip add Vlan1000 5001::1/64\n'
     )
-    vlan_config %= (tgen_ports[3]['peer_port'], tgen_ports[2]['peer_port'])
+    vlan_config %= (tgen_ports[2]['peer_port'], tgen_ports[1]['peer_port'])
     logger.info('Adding %s and %s to Vlan 1000' %
-                (tgen_ports[3]['peer_port'], tgen_ports[2]['peer_port']))
+                (tgen_ports[2]['peer_port'], tgen_ports[1]['peer_port']))
     duthost.shell(vlan_config)
     portchannel_config = (
         "sudo config portchannel add PortChannel1 \n"
@@ -94,14 +94,15 @@ def duthost_bgp_config(duthost, tgen_ports):
         "sudo config interface ip add PortChannel1 %s/%s\n"
         "sudo config interface ip add PortChannel1 %s/%s\n"
     )
-    portchannel_config %= (tgen_ports[1]['peer_port'],
-                           tgen_ports[1]['peer_ip'],
-                           tgen_ports[1]['prefix'],
-                           tgen_ports[1]['peer_ipv6'], 64)
+    portchannel_config %= (tgen_ports[0]['peer_port'],
+                           tgen_ports[0]['peer_ip'],
+                           tgen_ports[0]['prefix'],
+                           tgen_ports[0]['peer_ipv6'],
+                           tgen_ports[0]['ipv6_prefix'])
     logger.info('Configuring %s to PortChannel1' %
-                (tgen_ports[1]['peer_port']))
+                (tgen_ports[0]['peer_port']))
     logger.info('Portchannel1 (IPv4,IPv6)  : ({},{})'.format(
-        tgen_ports[1]['peer_ip'], tgen_ports[1]['peer_ipv6']))
+        tgen_ports[0]['peer_ip'], tgen_ports[0]['peer_ipv6']))
     duthost.shell(portchannel_config)
     loopback = (
         "sudo config interface ip add Loopback0 1.1.1.1/32\n"
@@ -118,22 +119,22 @@ def duthost_bgp_config(duthost, tgen_ports):
     device_neighbor_metadatas = dict()
     bgp_neighbor = \
         {
-            tgen_ports[1]['ip']:
+            tgen_ports[0]['ip']:
             {
                 "asn": TGEN_AS_NUM,
                 "holdtime": "180",
                 "keepalive": "60",
-                "local_addr": tgen_ports[1]['peer_ip'],
+                "local_addr": tgen_ports[0]['peer_ip'],
                 "name": "snappi-sonic",
                 "nhopself": "0",
                 "rrclient": "0"
             },
-            tgen_ports[1]['ipv6']:
+            tgen_ports[0]['ipv6']:
             {
                 "asn": TGEN_AS_NUM,
                 "holdtime": "180",
                 "keepalive": "60",
-                "local_addr": tgen_ports[1]['peer_ipv6'],
+                "local_addr": tgen_ports[0]['peer_ipv6'],
                 "name": "snappi-sonic",
                 "nhopself": "0",
                 "rrclient": "0"
@@ -231,9 +232,9 @@ def __tgen_bgp_config(snappi_api, ):
     snappi_api.enable_scaling(True)
 
     p1, p2, p3 = (
-        config.ports.port(name="t1", location=temp_tg_port[1]['location'])
-        .port(name="server2", location=temp_tg_port[2]['location'])
-        .port(name="server1", location=temp_tg_port[3]['location'])
+        config.ports.port(name="t1", location=temp_tg_port[0]['location'])
+        .port(name="server2", location=temp_tg_port[1]['location'])
+        .port(name="server1", location=temp_tg_port[2]['location'])
     )
     lag3 = config.lags.lag(name="lag1")[-1]
     lp3 = lag3.ports.port(port_name=p1.name)[-1]
@@ -246,10 +247,10 @@ def __tgen_bgp_config(snappi_api, ):
     layer1.name = 'port settings'
     layer1.port_names = [port.name for port in config.ports]
     layer1.ieee_media_defaults = False
-    layer1.auto_negotiation.rs_fec = False
-    layer1.auto_negotiation.link_training = False
-    layer1.speed = temp_tg_port[1]['speed']
-    layer1.auto_negotiate = False
+    layer1.auto_negotiation.rs_fec = temp_tg_port[0].get('fec', False)
+    layer1.auto_negotiation.link_training = temp_tg_port[0].get('link_training', False)
+    layer1.speed = temp_tg_port[0]['speed']
+    layer1.auto_negotiate = temp_tg_port[0].get('autoneg', False)
 
     conf_values = dict()
     num_of_devices = 1000
@@ -304,23 +305,23 @@ def __tgen_bgp_config(snappi_api, ):
     eth_3.mac = "00:14:01:00:00:01"
     ipv4_3 = eth_3.ipv4_addresses.add()
     ipv4_3.name = 'IPv4 3'
-    ipv4_3.address = temp_tg_port[1]['ip']
-    ipv4_3.gateway = temp_tg_port[1]['peer_ip']
-    ipv4_3.prefix = 24
+    ipv4_3.address = temp_tg_port[0]['ip']
+    ipv4_3.gateway = temp_tg_port[0]['peer_ip']
+    ipv4_3.prefix = temp_tg_port[0]['prefix']
     ipv6_3 = eth_3.ipv6_addresses.add()
     ipv6_3.name = 'IPv6 3'
-    ipv6_3.address = temp_tg_port[1]['ipv6']
-    ipv6_3.gateway = temp_tg_port[1]['peer_ipv6']
-    ipv6_3.prefix = 64
+    ipv6_3.address = temp_tg_port[0]['ipv6']
+    ipv6_3.gateway = temp_tg_port[0]['peer_ipv6']
+    ipv6_3.prefix = temp_tg_port[0]['ipv6_prefix']
 
     bgpv4_stack = d3.bgp
-    bgpv4_stack.router_id = temp_tg_port[1]['peer_ip']
+    bgpv4_stack.router_id = temp_tg_port[0]['peer_ip']
     bgpv4_int = bgpv4_stack.ipv4_interfaces.add()
     bgpv4_int.ipv4_name = ipv4_3.name
     bgpv4_peer = bgpv4_int.peers.add()
     bgpv4_peer.name = 'BGP 3'
     bgpv4_peer.as_type = BGP_TYPE
-    bgpv4_peer.peer_address = temp_tg_port[1]['peer_ip']
+    bgpv4_peer.peer_address = temp_tg_port[0]['peer_ip']
     bgpv4_peer.as_number = int(TGEN_AS_NUM)
     route_range1 = bgpv4_peer.v4_routes.add(name="Network Group 1")
     route_range1.addresses.add(address='200.1.0.1', prefix=32, count=4000)
@@ -330,13 +331,13 @@ def __tgen_bgp_config(snappi_api, ):
     as_path_segment.as_numbers = aspaths
 
     bgpv6_stack = d3.bgp
-    bgpv6_stack.router_id = temp_tg_port[1]['peer_ip']
+    bgpv6_stack.router_id = temp_tg_port[0]['peer_ip']
     bgpv6_int = bgpv6_stack.ipv6_interfaces.add()
     bgpv6_int.ipv6_name = ipv6_3.name
     bgpv6_peer = bgpv6_int.peers.add()
     bgpv6_peer.name = 'BGP+ 3'
     bgpv6_peer.as_type = BGP_TYPE
-    bgpv6_peer.peer_address = temp_tg_port[1]['peer_ipv6']
+    bgpv6_peer.peer_address = temp_tg_port[0]['peer_ipv6']
     bgpv6_peer.as_number = int(TGEN_AS_NUM)
     route_range2 = bgpv6_peer.v6_routes.add(name="Network Group 2")
     route_range2.addresses.add(address='3000::1', prefix=128, count=3000)
@@ -509,10 +510,10 @@ def get_convergence_for_reboot_test(duthost,
         bgp_config: __tgen_bgp_config
         reboot_type: Type of reboot
     """
-    global bgp_up_start_timer
-    global bgp_down_start_timer
-    global loopback_up_start_timer
-    global loopback_down_start_timer
+    global bgp_up_start_timer    # noqa: F824
+    global bgp_down_start_timer   # noqa: F824
+    global loopback_up_start_timer  # noqa: F824
+    global loopback_down_start_timer  # noqa: F824
     table, dp = [], []
     bgp_config.events.cp_events.enable = True
     bgp_config.events.dp_events.enable = True

--- a/tests/snappi_tests/reboot/test_cold_reboot.py
+++ b/tests/snappi_tests/reboot/test_cold_reboot.py
@@ -1,6 +1,6 @@
-from tests.common.snappi_tests.snappi_fixtures import snappi_api     # noqa: F401
-from tests.common.snappi_tests.snappi_fixtures import (           # noqa: F401
-    snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
+from tests.common.snappi_tests.snappi_fixtures import (                           # noqa: F401
+    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports,
+    get_snappi_ports_single_dut, get_snappi_ports, setup_bgp_testbed)
 from tests.snappi_tests.reboot.files.reboot_helper import run_reboot_test
 from tests.common.fixtures.conn_graph_facts import (        # noqa: F401
     conn_graph_facts, fanout_graph_facts)
@@ -14,6 +14,8 @@ pytestmark = [pytest.mark.topology('tgen')]
 @pytest.mark.parametrize('reboot_type', ['cold'])
 def test_reboot(snappi_api,                # noqa: F811
                 duthost,
+                setup_bgp_testbed,     # noqa: F811
+                get_snappi_ports,      # noqa: F811
                 localhost,
                 tgen_ports,             # noqa: F811
                 conn_graph_facts,       # noqa: F811

--- a/tests/snappi_tests/reboot/test_fast_reboot.py
+++ b/tests/snappi_tests/reboot/test_fast_reboot.py
@@ -1,6 +1,6 @@
-from tests.common.snappi_tests.snappi_fixtures import snappi_api     # noqa: F401
-from tests.common.snappi_tests.snappi_fixtures import (           # noqa: F401
-    snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
+from tests.common.snappi_tests.snappi_fixtures import (                           # noqa: F401
+    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports,
+    get_snappi_ports_single_dut, get_snappi_ports, setup_bgp_testbed)
 from tests.snappi_tests.reboot.files.reboot_helper import run_reboot_test
 from tests.common.fixtures.conn_graph_facts import (        # noqa: F401
     conn_graph_facts, fanout_graph_facts)
@@ -14,6 +14,8 @@ pytestmark = [pytest.mark.topology('tgen')]
 @pytest.mark.parametrize('reboot_type', ['fast'])
 def test_reboot(snappi_api,                # noqa: F811
                 duthost,
+                setup_bgp_testbed,  # noqa: F811
+                get_snappi_ports,  # noqa: F811
                 localhost,
                 tgen_ports,             # noqa: F811
                 conn_graph_facts,       # noqa: F811

--- a/tests/snappi_tests/reboot/test_soft_reboot.py
+++ b/tests/snappi_tests/reboot/test_soft_reboot.py
@@ -1,6 +1,6 @@
-from tests.common.snappi_tests.snappi_fixtures import snappi_api     # noqa: F401
-from tests.common.snappi_tests.snappi_fixtures import (           # noqa: F401
-    snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
+from tests.common.snappi_tests.snappi_fixtures import (                           # noqa: F401
+    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports,
+    get_snappi_ports_single_dut, get_snappi_ports, setup_bgp_testbed)
 from tests.snappi_tests.reboot.files.reboot_helper import run_reboot_test
 from tests.common.fixtures.conn_graph_facts import (        # noqa: F401
     conn_graph_facts, fanout_graph_facts)
@@ -14,6 +14,8 @@ pytestmark = [pytest.mark.topology('tgen')]
 @pytest.mark.parametrize('reboot_type', ['soft'])
 def test_reboot(snappi_api,                # noqa: F811
                 duthost,
+                setup_bgp_testbed,  # noqa: F811
+                get_snappi_ports,  # noqa: F811
                 localhost,
                 tgen_ports,             # noqa: F811
                 conn_graph_facts,       # noqa: F811

--- a/tests/snappi_tests/reboot/test_warm_reboot.py
+++ b/tests/snappi_tests/reboot/test_warm_reboot.py
@@ -1,6 +1,6 @@
-from tests.common.snappi_tests.snappi_fixtures import snappi_api     # noqa: F401
-from tests.common.snappi_tests.snappi_fixtures import (           # noqa: F401
-    snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
+from tests.common.snappi_tests.snappi_fixtures import (                           # noqa: F401
+    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports,
+    get_snappi_ports_single_dut, get_snappi_ports, setup_bgp_testbed)
 from tests.snappi_tests.reboot.files.reboot_helper import run_reboot_test
 from tests.common.fixtures.conn_graph_facts import (        # noqa: F401
     conn_graph_facts, fanout_graph_facts)
@@ -13,6 +13,8 @@ pytestmark = [pytest.mark.topology('tgen')]
 @pytest.mark.parametrize('reboot_type', ['warm'])
 def test_reboot(snappi_api,                # noqa: F811
                 duthost,
+                setup_bgp_testbed,  # noqa: F811
+                get_snappi_ports,  # noqa: F811
                 localhost,
                 tgen_ports,             # noqa: F811
                 conn_graph_facts,       # noqa: F811


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: BGP t0/t1 enhancement to run nightly regression
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
BGP t0/t1 enhancement to run nightly regression
#### How did you do it?
Removes the ports from porchannel or vlan if they are part of them, and make them routed port before start of the test
#### How did you verify/test it?
Tested with t0/t1 like config from minigraph.xml
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
t0/t1
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
### Output
Output
---------------------------------------------------------------------------------- live log setup ----------------------------------------------------------------------------------
INFO root:init.py:53 Completeness level not set during test execution. Setting to default level: 1
INFO root:init.py:151 Test has no defined levels. Continue without test completeness checks
INFO tests.conftest:conftest.py:411 Inventory file: ['../ansible/snappi-sonic']
INFO tests.common.fixtures.ptfhost_utils:ptfhost_utils.py:326 Skip running icmp_responder at session level, it is only for dualtor testbed with active-active mux ports.
INFO tests.common.helpers.dut_utils:dut_utils.py:623 dut sonic-s6100-dut1 belongs to groups ['snappi-sonic', 'sonic', 'sonic_dell64_40', 'fanout']
INFO root:dut_utils.py:648 skip empty var file /root/sonic-mgmt/tests/common/helpers/../../../ansible/group_vars/all/corefile_uploader.yml
INFO root:dut_utils.py:648 skip empty var file /root/sonic-mgmt/tests/common/helpers/../../../ansible/group_vars/all/env.yml
INFO paramiko.transport:transport.py:1938 Connected (version 2.0, client OpenSSH_8.4p1)
INFO paramiko.transport:transport.py:1938 Authentication (password) successful!
INFO tests.common.plugins.sanity_check:init.py:448 Skip sanity check according to command line argument
INFO tests.conftest:conftest.py:2949 Dumping Disk and Memory Space information before test on sonic-s6100-dut1
INFO tests.conftest:conftest.py:2953 Collecting core dumps before test on sonic-s6100-dut1
INFO tests.conftest:conftest.py:2962 Collecting running config before test on sonic-s6100-dut1
INFO tests.conftest:conftest.py:3248 Skipping temporarily_disable_route_check fixture
INFO root:conftest.py:1709 Using DUTs ['sonic-s6100-dut1'] in testbed 'vms-snappi-sonic'
INFO tests.conftest:conftest.py:706 Randomly select dut sonic-s6100-dut1 for testing
INFO root:init.py:69 -------------------- fixture snappi_api_serv_ip setup starts --------------------
INFO root:init.py:76 -------------------- fixture snappi_api_serv_ip setup ends --------------------
INFO root:init.py:69 -------------------- fixture snappi_api_serv_port setup starts --------------------
INFO root:init.py:76 -------------------- fixture snappi_api_serv_port setup ends --------------------
INFO root:init.py:81 -------------------- fixture snappi_api setup starts --------------------
WARNING snappi:snappi.py:106 Version check is disabled
INFO root:init.py:85 -------------------- fixture snappi_api setup ends --------------------
INFO root:init.py:69 -------------------- fixture get_snappi_ports setup starts --------------------
INFO tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:1622 Selecting snappi port fixture: get_snappi_ports_single_dut
INFO tests.conftest:conftest.py:742 Randomly select dut sonic-s6100-dut1 for testing
INFO root:init.py:69 -------------------- fixture get_snappi_ports_single_dut setup starts --------------------
INFO root:init.py:76 -------------------- fixture get_snappi_ports_single_dut setup ends --------------------
INFO root:init.py:76 -------------------- fixture get_snappi_ports setup ends --------------------
INFO root:init.py:69 -------------------- fixture tgen_ports setup starts --------------------
WARNING tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:623 Removing port Ethernet68 from portchannel PortChannel2 for snappi testing
WARNING tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:623 Removing port Ethernet72 from portchannel PortChannel3 for snappi testing
WARNING tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:623 Removing port Ethernet76 from portchannel PortChannel4 for snappi testing
INFO tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:733 Pre-configuring IPv4: sonic-s6100-dut1 port Ethernet68 -> 20.1.1.0/31
INFO tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:733 Pre-configuring IPv6: sonic-s6100-dut1 port Ethernet68 -> 3000:1::1/126
INFO tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:733 Pre-configuring IPv4: sonic-s6100-dut1 port Ethernet72 -> 20.1.1.2/31
INFO tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:733 Pre-configuring IPv6: sonic-s6100-dut1 port Ethernet72 -> 3000:1::5/126
INFO tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:733 Pre-configuring IPv4: sonic-s6100-dut1 port Ethernet76 -> 20.1.1.4/31
INFO tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:733 Pre-configuring IPv6: sonic-s6100-dut1 port Ethernet76 -> 3000:1::9/126
INFO root:init.py:76 -------------------- fixture tgen_ports setup ends --------------------
INFO root:init.py:77 Log analyzer is disabled
INFO tests.common.plugins.memory_utilization:init.py:130 Memory utilization monitoring is disabled
INFO root:init.py:81 -------------------- fixture setup_bgp_testbed setup starts --------------------
INFO tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:641 Backing up the initial config to /etc/sonic/bgp_backup.json

INFO root:init.py:85 -------------------- fixture setup_bgp_testbed setup ends --------------------
INFO root:conftest.py:3766 skip setup dualtor mux cables on non-dualtor testbed
---------------------------------------------------------------------------------- live log call -----------------------------------------------------------------------------------
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:214 Removing configured IP and IPv6 Address from Ethernet68
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:214 Removing configured IP and IPv6 Address from Ethernet72
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:214 Removing configured IP and IPv6 Address from Ethernet76
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:227 Configuring Ethernet68 to PortChannel1 with IPs 20.1.1.0,3000:1::1
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:227 Configuring Ethernet72 to PortChannel2 with IPs 20.1.1.2,3000:1::5
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:227 Configuring Ethernet76 to PortChannel3 with IPs 20.1.1.4,3000:1::9
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:254 Configuring BGP v4 Neighbor 20.1.1.3
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:254 Configuring BGP v4 Neighbor 20.1.1.5
WARNING ixnetwork_restpy.connection:connection.py:351 Verification of certificates is disabled
INFO ixnetwork_restpy.connection:connection.py:348 Determining the platform and rest_port using the 10.36.77.53 address...
INFO ixnetwork_restpy.connection:connection.py:348 Connection established to http://10.36.77.53:11009 on windows
INFO ixnetwork_restpy.connection:connection.py:348 Using IxNetwork api server version 10.80.2412.6
INFO ixnetwork_restpy.connection:connection.py:348 User info IxNetwork/WIN-11RK5TNKNAN/8010
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 snappi-1.40.0
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 snappi_ixnetwork-1.42.1
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 ixnetwork_restpy-1.9.0
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Config validation 0.007s
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Ports configuration 0.054s
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Captures configuration 0.027s
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Location hosts ready [10.36.78.53] 0.014s
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Speed conversion is not require for (port.name, speed) : [('Test_Port_1', 'novusHundredGigNonFanOut'), ('Test_Port_2', 'novusHundredGigNonFanOut'), ('Test_Port_3', 'novusHundredGigNonFanOut')]
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Aggregation mode speed change 0.370s
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Location configuration 0.454s
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Layer1 configuration 0.052s
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Lag Configuration 1.557s
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Lag Ethernet Configuration 0.170s
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Lag Protocol Configuration 0.893s
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Convert device config : 0.117s
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Create IxNetwork device config : 0.001s
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Push IxNetwork device config : 1.091s
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Devices configuration 1.217s
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Flows configuration 0.589s
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Start interfaces 0.512s
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 IxNet - One or more destination MACs or VPNs are invalid or unreachable and the packets configured to be sent to them were not created
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:566 Starting all protocols ...
INFO tests.common.utilities:utilities.py:121 Pause 30 seconds, reason: For Protocols To start
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:572 |---- Network_Group2 Route Withdraw Iteration : 1 ----|
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:575 Starting Traffic
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Flows generate/apply 6.809s
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Flows clear statistics 13.617s
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Captures start 0.000s
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Flows start 2.527s
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 IxNet - If ports in a lag are down, please enable Transmit Ignore Link Status port property in order to successfully start traffic or clear statistics.
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 IxNet - The Rate Monitoring Jitter Window Size was decreased to support the incoming frame rate
INFO tests.common.utilities:utilities.py:121 Pause 30 seconds, reason: For Traffic To start
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:585 Withdrawing Routes from Network_Group2
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Setting route state 0.626s
INFO tests.common.utilities:utilities.py:121 Pause 30 seconds, reason: For routes to be withdrawn
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:598 Traffic has converged after route withdraw
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:605 CP/DP Convergence Time (ms): 486.021
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Setting route state 0.621s
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:615 Readvertise Network_Group2 routes back at the end of iteration 1
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:617 Stopping Traffic
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Flows stop 5.313s
INFO tests.common.utilities:utilities.py:121 Pause 30 seconds, reason: For Traffic To Stop
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:566 Starting all protocols ...
INFO tests.common.utilities:utilities.py:121 Pause 30 seconds, reason: For Protocols To start
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:572 |---- Network_Group3 Route Withdraw Iteration : 1 ----|
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:575 Starting Traffic
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Flows clear statistics 9.873s
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Captures start 0.000s
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Flows start 3.026s
INFO tests.common.utilities:utilities.py:121 Pause 30 seconds, reason: For Traffic To start
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:585 Withdrawing Routes from Network_Group3
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Setting route state 0.615s
INFO tests.common.utilities:utilities.py:121 Pause 30 seconds, reason: For routes to be withdrawn
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:598 Traffic has converged after route withdraw
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:605 CP/DP Convergence Time (ms): 503.167
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Setting route state 0.612s
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:615 Readvertise Network_Group3 routes back at the end of iteration 1
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:617 Stopping Traffic
INFO snappi_ixnetwork.snappi_api:snappi_api.py:1516 Flows stop 5.307s
INFO tests.common.utilities:utilities.py:121 Pause 30 seconds, reason: For Traffic To Stop
INFO tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:636
+-------------------------------+--------------+-----------------+--------------+----------------+---------------------------------------------------+
| Event Name | Route Type | No. of Routes | Iterations | Frames Delta | Avg Control to Data Plane Convergence Time (ms) |
|-------------------------------+--------------+-----------------+--------------+----------------+---------------------------------------------------|
| Network_Group2 route withdraw | IPv4 | 1000 | 1 | 32 | 486 |
| Network_Group3 route withdraw | IPv4 | 1000 | 1 | 32 | 503 |
+-------------------------------+--------------+-----------------+--------------+----------------+---------------------------------------------------+

-------------------------------------------------------------------------------- live log logreport --------------------------------------------------------------------------------
INFO tests.snappi_tests.bgp.conftest:conftest.py:33 Test tests/snappi_tests/bgp/test_bgp_remote_link_failover.py::test_bgp_convergence_for_remote_link_failover[IPv4-1000-1-2] finished with result: passed

-------------------------------------------------------------------------------- live log teardown ---------------------------------------------------------------------------------
INFO root:init.py:93 -------------------- fixture setup_bgp_testbed teardown starts --------------------
INFO tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:643
Restoring the initial config as part of teardown

INFO root:init.py:102 -------------------- fixture setup_bgp_testbed teardown ends --------------------
INFO root:init.py:93 -------------------- fixture snappi_api teardown starts --------------------
INFO root:init.py:102 -------------------- fixture snappi_api teardown ends --------------------
INFO tests.conftest:conftest.py:3250 Skipping temporarily_disable_route_check fixture
INFO tests.conftest:conftest.py:3031 Dumping Disk and Memory Space information after test on sonic-s6100-dut1
INFO tests.conftest:conftest.py:3035 Collecting core dumps after test on sonic-s6100-dut1
INFO tests.conftest:conftest.py:3046 Collecting running config after test on sonic-s6100-dut1
WARNING tests.conftest:conftest.py:3187 Core dump or config check failed for test_bgp_remote_link_failover.py, results: {"core_dump_check": {"failed": false, "new_core_dumps": {"sonic-s6100-dut1": []}}, "config_db_check": {"failed": true, "pre_only_config": {"sonic-s6100-dut1": {"null": {"LOOPBACK_INTERFACE": {"Loopback0": {}, "Loopback0|2.2.2.2/32": {}}}}}, "cur_only_config": {"sonic-s6100-dut1": {"null": {"PORTCHANNEL_MEMBER": {"PortChannel2|Ethernet68": {}, "PortChannel3|Ethernet72": {}, "PortChannel4|Ethernet76": {}}, "VLAN_MEMBER": {"Vlan1709|Ethernet112": {"tagging_mode": "untagged"}, "Vlan1709|Ethernet124": {"tagging_mode": "tagged"}}}}}, "inconsistent_config": {"sonic-s6100-dut1": {"null": {"VLAN": {"pre_value": {"Vlan100": {"vlanid": "100"}}, "cur_value": {"Vlan100": {"vlanid": "100"}, "Vlan1709": {"vlanid": "1709"}}}, "DEVICE_METADATA": {"pre_value": {"localhost": {"buffer_model": "traditional", "default_bgp_status": "up", "default_pfcwd_status": "disable", "docker_routing_config_mode": "split", "frr_mgmt_framework_config": "true", "hostname": "sonic", "hwsku": "Accton-AS7726-32X", "mac": "90:3c:b3:94:ad:7e", "platform": "x86_64-accton_as7726_32x-r0", "synchronous_mode": "enable", "type": "LeafRouter"}}, "cur_value": {"localhost": {"bgp_asn": "65100", "buffer_model": "traditional", "default_bgp_status": "up", "default_pfcwd_status": "disable", "docker_routing_config_mode": "split", "frr_mgmt_framework_config": "true", "hostname": "sonic", "hwsku": "Accton-AS7726-32X", "mac": "90:3c:b3:94:ad:7e", "platform": "x86_64-accton_as7726_32x-r0", "synchronous_mode": "enable", "type": "ToRRouter"}}}, "INTERFACE": {"pre_value": {"Ethernet0": {}, "Ethernet4": {}, "Ethernet64": {}, "Ethernet68": {}, "Ethernet72": {}, "Ethernet76": {}, "Ethernet0|10.1.1.1/24": {}, "Ethernet4|10.2.1.1/24": {}, "Ethernet64|2001::1/64": {}, "Ethernet64|21.1.1.1/24": {}, "Ethernet68|2002::1/64": {}, "Ethernet68|22.1.1.1/24": {}, "Ethernet72|2003::1/64": {}, "Ethernet72|23.1.1.1/24": {}, "Ethernet76|2004::1/64": {}, "Ethernet76|24.1.1.1/24": {}}, "cur_value": {"Ethernet0": {}, "Ethernet4": {}, "Ethernet0|10.1.1.1/24": {}, "Ethernet4|10.2.1.1/24": {}}}, "PORTCHANNEL": {"pre_value": {"PortChannel2": {"admin_status": "up", "fast_rate": "false", "lacp_key": "auto", "min_links": "1", "mix_speed": "false", "mtu": "9100"}}, "cur_value": {"PortChannel1": {"admin_status": "up", "fast_rate": "false", "lacp_key": "auto", "min_links": "1", "mix_speed": "false", "mtu": "9100"}, "PortChannel2": {"admin_status": "up", "fast_rate": "false", "lacp_key": "auto", "min_links": "1", "mix_speed": "false", "mtu": "9100"}, "PortChannel3": {"admin_status": "up", "fast_rate": "false", "lacp_key": "auto", "min_links": "1", "mix_speed": "false", "mtu": "9100"}, "PortChannel4": {"admin_status": "up", "fast_rate": "false", "lacp_key": "auto", "min_links": "1", "mix_speed": "false", "mtu": "9100"}}}, "PORTCHANNEL_INTERFACE": {"pre_value": {"PortChannel1": {}, "PortChannel1|2000:1::1/126": {}}, "cur_value": {"PortChannel2": {}, "PortChannel3": {}, "PortChannel4": {}, "PortChannel2|22.1.1.1/24": {}, "PortChannel2|3002::2/126": {}, "PortChannel3|23.1.1.1/24": {}, "PortChannel3|3003::2/126": {}, "PortChannel4|24.1.1.1/24": {}, "PortChannel4|3004::2/126": {}}}}}}}}
tests/snappi_tests/bgp/test_bgp_remote_link_failover.py::test_bgp_convergence_for_remote_link_failover[IPv4-1000-1-2] ✓ 100% ██████████
================================================================================= warnings summary =================================================================================
../../../opt/venv/lib/python3.12/site-packages/_pytest/config/init.py:852
/opt/venv/lib/python3.12/site-packages/_pytest/config/init.py:852: PytestAssertRewriteWarning: Module already imported so cannot be rewritten; tests.common.plugins.ptfadapter
self.import_plugin(import_spec)

../../../opt/venv/lib/python3.12/site-packages/_pytest/config/init.py:852
/opt/venv/lib/python3.12/site-packages/_pytest/config/init.py:852: PytestAssertRewriteWarning: Module already imported so cannot be rewritten; tests.common.plugins.ansible_fixtures
self.import_plugin(import_spec)

../../../opt/venv/lib/python3.12/site-packages/_pytest/config/init.py:852
/opt/venv/lib/python3.12/site-packages/_pytest/config/init.py:852: PytestAssertRewriteWarning: Module already imported so cannot be rewritten; tests.common.plugins.loganalyzer
self.import_plugin(import_spec)

../../../opt/venv/lib/python3.12/site-packages/_pytest/config/init.py:852
/opt/venv/lib/python3.12/site-packages/_pytest/config/init.py:852: PytestAssertRewriteWarning: Module already imported so cannot be rewritten; tests.common.plugins.sanity_check
self.import_plugin(import_spec)

../../../opt/venv/lib/python3.12/site-packages/_pytest/config/init.py:852
/opt/venv/lib/python3.12/site-packages/_pytest/config/init.py:852: PytestAssertRewriteWarning: Module already imported so cannot be rewritten; tests.common.plugins.test_completeness
self.import_plugin(import_spec)

../../../opt/venv/lib/python3.12/site-packages/_pytest/config/init.py:852
/opt/venv/lib/python3.12/site-packages/_pytest/config/init.py:852: PytestAssertRewriteWarning: Module already imported so cannot be rewritten; tests.common.dualtor
self.import_plugin(import_spec)

../../../opt/venv/lib/python3.12/site-packages/_pytest/config/init.py:852
/opt/venv/lib/python3.12/site-packages/_pytest/config/init.py:852: PytestAssertRewriteWarning: Module already imported so cannot be rewritten; tests.common.fixtures.duthost_utils
self.import_plugin(import_spec)

:488
:488: DeprecationWarning: Type google._upb._message.MessageMapContainer uses PyType_Spec with a metaclass that has custom tp_new. This is deprecated and will no longer be allowed in Python 3.14.

:488
:488: DeprecationWarning: Type google._upb._message.ScalarMapContainer uses PyType_Spec with a metaclass that has custom tp_new. This is deprecated and will no longer be allowed in Python 3.14.

../../../opt/venv/lib/python3.12/site-packages/google/protobuf/internal/well_known_types.py:93
/opt/venv/lib/python3.12/site-packages/google/protobuf/internal/well_known_types.py:93: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
_EPOCH_DATETIME_NAIVE = datetime.datetime.utcfromtimestamp(0)

ptf_runner.py:3
/root/sonic-mgmt/tests/ptf_runner.py:3: DeprecationWarning: 'pipes' is deprecated and slated for removal in Python 3.13
import pipes

tests/snappi_tests/bgp/test_bgp_remote_link_failover.py::test_bgp_convergence_for_remote_link_failover[IPv4-1000-1-2]
/opt/venv/lib/python3.12/site-packages/pytest_ansible/host_manager/v213.py:13: DeprecationWarning: Host management is deprecated and will be removed in a future release
class HostManagerV213(BaseHostManager):

tests/snappi_tests/bgp/test_bgp_remote_link_failover.py::test_bgp_convergence_for_remote_link_failover[IPv4-1000-1-2]
tests/snappi_tests/bgp/test_bgp_remote_link_failover.py::test_bgp_convergence_for_remote_link_failover[IPv4-1000-1-2]
tests/snappi_tests/bgp/test_bgp_remote_link_failover.py::test_bgp_convergence_for_remote_link_failover[IPv4-1000-1-2]
tests/snappi_tests/bgp/test_bgp_remote_link_failover.py::test_bgp_convergence_for_remote_link_failover[IPv4-1000-1-2]
tests/snappi_tests/bgp/test_bgp_remote_link_failover.py::test_bgp_convergence_for_remote_link_failover[IPv4-1000-1-2]
/opt/venv/lib/python3.12/site-packages/ansible/plugins/loader.py:1485: UserWarning: AnsibleCollectionFinder has already been configured
warnings.warn('AnsibleCollectionFinder has already been configured')

tests/snappi_tests/bgp/test_bgp_remote_link_failover.py: 45 warnings
/usr/lib/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=236032) is multi-threaded, use of fork() may lead to deadlocks in the child.
self.pid = os.fork()

tests/snappi_tests/bgp/test_bgp_remote_link_failover.py::test_bgp_convergence_for_remote_link_failover[IPv4-1000-1-2]
/opt/venv/lib/python3.12/site-packages/snappi_ixnetwork/snappi_api.py:1047: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
import pkg_resources

tests/snappi_tests/bgp/test_bgp_remote_link_failover.py: 12 warnings
/opt/venv/lib/python3.12/site-packages/ixnetwork_restpy/assistants/statistics/row.py:22: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
self._sample_time = datetime.datetime.utcnow()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------------------------------------------------------ live log sessionfinish ------------------------------------------------------------------------------
INFO root:init.py:67 Can not get Allure report URL. Please check logs

Results (398.60s (0:06:38)):
1 passed
INFO:root:Can not get Allure report URL. Please check logs