### PR TITLE
Update the show platform leak command keyword

### DIFF
--- a/tests/common/helpers/liquid_leakage_control_test_helper.py
+++ b/tests/common/helpers/liquid_leakage_control_test_helper.py
@@ -60,7 +60,7 @@ def get_leakage_status(dut):
     :param dut: DUT object representing a SONiC switch under test.
     :return: The leakage status of the DUT.
     """
-    return dut.show_and_parse("show platform leakage status")
+    return dut.show_and_parse("show platform leak status")
 
 
 def get_leakage_status_in_health_system(dut):


### PR DESCRIPTION
Summary:
Update the show platform leak command keyword in tests/common/helpers/liquid_leakage_control_test_helper.py

This is based on PR : https://github.com/sonic-net/sonic-utilities/pull/4417 once it is merged


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
