### PR TITLE
[202511][conditional_mark] Skip high_frequency_telemetry on T2 topology

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3018,10 +3018,12 @@ hash/test_generic_hash.py::test_reboot[CRC_CCITT-IP_PROTOCOL-ipv4:
 #######################################
 high_frequency_telemetry:
   skip:
-    reason: "High frequency telemetry isn't supported in this platform"
+    reason: "High frequency telemetry isn't supported in this platform or on T2 topology"
     conditions_logical_operator: or
     conditions:
       - "platform not in ['x86_64-nvidia_sn5600-r0', 'x86_64-nvidia_sn5640-r0', 'x86_64-arista_7060x6_64pe_b']"
+      - "'bmc' in topo_type"
+      - "'t2' in topo_type"
 
 high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_full_counters:
   skip:


### PR DESCRIPTION
### Description of PR

Summary:
Backport PR #23496 to 202511. This skips high_frequency_telemetry on T2 topology because HFT is not yet supported there.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

HFT is not yet supported on T2 topology. Without this conditional mark, HFT tests may be scheduled on unsupported T2 testbeds.

#### How did you do it?

Cherry-picked the original PR #23496 to 202511 and resolved the conditional mark YAML conflict by adding the T2 topology skip condition under `high_frequency_telemetry`.

#### How did you verify/test it?

Parsed `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` with PyYAML.

#### Any platform specific information?

Applies to T2 topology.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.

Original PR: https://github.com/sonic-net/sonic-mgmt/pull/23496