### PR TITLE
test_reporting: fix JUnit XML discovery and CSV filename on Windows

### DIFF
--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -178,10 +178,7 @@ def validate_junit_xml_archive(directory_name, strict=False):
     roots = []
     metadata_source = None
     metadata = {}
-    doc_list = glob.glob(os.path.join(directory_name, "tr.xml"))
-    doc_list += glob.glob(os.path.join(directory_name, "*test*.xml"))
-    doc_list += glob.glob(os.path.join(directory_name, "**", "*test*.xml"), recursive=True)
-    doc_list = set(doc_list)
+    doc_list = set(glob.glob(os.path.join(directory_name, "**", "*.xml"), recursive=True))
 
     total_size = 0
     for document in doc_list:
@@ -740,7 +737,7 @@ python3 junit_xml_parser.py tests/files/sample_tr.xml
     else:
         print(output)
 
-    tstamp = datetime.now().strftime("%d-%b-%Y-%H:%M:%S.%f")
+    tstamp = datetime.now().strftime("%d-%b-%Y-%H-%M-%S.%f")
 
     if args.output_file:
         csv_file = open('report_{}_{}.csv'.format(args.output_file.split('.')[0], tstamp), "w+")


### PR DESCRIPTION
### Description of PR

Summary:
Two small fixes to `test_reporting/junit_xml_parser.py` so the script works
on Windows and accepts JUnit XML reports with arbitrary file names.

Fixes # (n/a)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

1. Directory-mode XML discovery used overly narrow globs (`tr.xml`,
   `*test*.xml`). Reports with other naming conventions
   (e.g. `tr-<host>-<timestamp>.xml`) were silently dropped, producing
   `provided directory ... does not contain any valid XML files`. Filtering
   JUnit reports by filename is a poor heuristic — the right discriminator
   is the XML content.

2. The CSV report timestamp used `%H:%M:%S`, which contains `:`. That
   character is illegal in Windows filenames and caused
   `OSError: [Errno 22] Invalid argument: 'report_06-May-2026-09:01:32.969895.csv'`
   when running the script on Windows.

#### How did you do it?

1. Replaced the three filename-pattern globs with a single recursive
   `**/*.xml` glob. Non-JUnit XMLs are still rejected by
   `validate_junit_xml_file` via the existing try/except in
   `validate_junit_xml_archive` (logged as
   `could not parse <file>: ... - skipping` in non-strict mode), so we
   filter by content instead of by filename.

2. Changed the CSV timestamp format from `%d-%b-%Y-%H:%M:%S.%f` to
   `%d-%b-%Y-%H-%M-%S.%f` so the resulting filename is valid on Windows
   (and still unambiguous on Linux).

#### How did you verify/test it?

* Reproduced the original `OSError` on Windows; confirmed the new format
  produces `report_06-May-2026-09-01-32.969895.csv` with no error.
* Reproduced the "does not contain any valid XML files" symptom by
  placing `tr-W6950-128OC-2026-04-27-22-17-31.xml` in a directory and
  running `python junit_xml_parser.py --directory --validate-only <dir>`.
  After the fix, the file is discovered and validated successfully.

#### Any platform specific information?

The CSV-filename fix is specifically for Windows; on Linux the previous
format also worked. The new format is portable.

#### Supported testbed topology if it's a new test case?

n/a — this is a fix to a reporting helper script, not a test case.

### Documentation

n/a
