### PR TITLE
[ARP][test_arp_update] Fix subnet mismatch between PTF and DUT VLAN IP

### DIFF
--- a/tests/arp/arp_utils.py
+++ b/tests/arp/arp_utils.py
@@ -2,7 +2,7 @@ import re
 import logging
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
-from ipaddress import ip_interface, ip_network, IPv4Network
+from ipaddress import ip_address, ip_interface, ip_network, IPv4Network
 
 
 logger = logging.getLogger(__name__)
@@ -113,3 +113,21 @@ def get_vlan_last_ipv4(config_facts):
         if intf_ipv4 is not None:
             return intf_ipv4
     return None, None
+
+
+def get_vlan_ipv4_for_subnet(config_facts, target_ip):
+    """
+    Find the VLAN interface whose IPv4 subnet contains target_ip.
+    Returns (vlan_name, vlan_ip, prefix_len) or (None, None, None).
+    """
+    target = ip_address(str(target_ip))
+    vlan_intfs = config_facts.get("VLAN_INTERFACE", {})
+    for intf, addrs in vlan_intfs.items():
+        for addr in addrs:
+            try:
+                iface = ip_interface(addr)
+                if isinstance(iface.network, IPv4Network) and target in iface.network:
+                    return intf, iface.ip, iface.network.prefixlen
+            except ValueError:
+                continue
+    return None, None, None

--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -5,7 +5,8 @@ import ptf.testutils as testutils
 import pytest
 import random
 
-from tests.arp.arp_utils import clear_dut_arp_cache, fdb_cleanup, get_dut_mac, fdb_has_mac, get_vlan_last_ipv4
+from tests.arp.arp_utils import (clear_dut_arp_cache, fdb_cleanup, get_dut_mac,
+                                 fdb_has_mac, get_vlan_last_ipv4, get_vlan_ipv4_for_subnet)
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa: F401
 from tests.common.fixtures.ptfhost_utils import setup_vlan_arp_responder, run_icmp_responder  # noqa: F401
 from tests.common.helpers.assertions import pytest_assert as pt_assert
@@ -55,19 +56,28 @@ def ptf_interface_info(ip_and_intf_info, ptfadapter):
 
 
 @pytest.fixture
-def dut_interface_info(rand_selected_dut, config_facts, tbinfo):
+def dut_interface_info(rand_selected_dut, config_facts, tbinfo, ptf_interface_info):
     """
-    Get DUT interface information
+    Get DUT interface information, matching the VLAN subnet that contains the PTF IP.
     """
     duthost = rand_selected_dut
     dut_mac = get_dut_mac(duthost, config_facts, tbinfo)
-    vlan_name, dut_ipv4 = get_vlan_last_ipv4(config_facts)
+
+    # Find the VLAN IP in the same subnet as PTF
+    vlan_name, dut_ipv4, prefix_len = get_vlan_ipv4_for_subnet(config_facts, ptf_interface_info['ip'])
+    if vlan_name is None:
+        # Fallback if no matching subnet found
+        vlan_name, dut_ipv4 = get_vlan_last_ipv4(config_facts)
+        prefix_len = 24
+        logger.warning("No VLAN subnet match for PTF IP %s, falling back to %s/%s",
+                       ptf_interface_info['ip'], dut_ipv4, prefix_len)
 
     return {
         'host': duthost,
         'mac': dut_mac,
         'vlan_name': vlan_name,
-        'ipv4': dut_ipv4
+        'ipv4': dut_ipv4,
+        'prefix_len': prefix_len
     }
 
 
@@ -89,19 +99,22 @@ def clean_environment(rand_selected_dut, ptfadapter):
 
 
 @pytest.fixture
-def ptf_with_ip_config(ptf_interface_info, ptfhost):
+def ptf_with_ip_config(ptf_interface_info, dut_interface_info, ptfhost):
     """
-    Configure IP on PTF interface and cleanup afterwards
+    Configure IP on PTF interface using the correct prefix length from the DUT VLAN subnet.
     """
     ptf_info = ptf_interface_info
+    prefix_len = dut_interface_info.get('prefix_len', 24)
 
     # Configure IP on PTF interface
-    ptfhost.shell(f"ip addr add {ptf_info['ip']}/21 dev {ptf_info['interface']}", module_ignore_errors=True)
+    ptfhost.shell(f"ip addr add {ptf_info['ip']}/{prefix_len} dev {ptf_info['interface']}",
+                  module_ignore_errors=True)
 
     yield ptf_info
 
     # Cleanup: remove IP from PTF interface
-    ptfhost.shell(f"ip addr del {ptf_info['ip']}/21 dev {ptf_info['interface']}", module_ignore_errors=True)
+    ptfhost.shell(f"ip addr del {ptf_info['ip']}/{prefix_len} dev {ptf_info['interface']}",
+                  module_ignore_errors=True)
 
 
 def neighbor_learned(dut, target_ip):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The test_ptf_arp_learns_mac and test_dut_ping_learns_mac tests fail on physical testbeds because:
1. dut_interface_info used get_vlan_last_ipv4() which could return a VLAN IP not in the same subnet as the PTF interface IP
2. ptf_with_ip_config hardcoded /21 prefix which may not match the actual VLAN subnet configuration

#### How did you do it?
- Adding get_vlan_ipv4_for_subnet() to find the VLAN interface whose subnet contains the PTF IP
- Updating dut_interface_info to select the matching VLAN IP and expose the correct prefix_len
- Updating ptf_with_ip_config to use the dynamic prefix_len instead of hardcoded /21

#### How did you verify/test it?
```
--------------------------------------------- generated xml file: /data/sonic-mgmt-int/tests/logs/arp/test_arp_update.xml ---------------------------------------------
----------------------------------------------------------------------- live log sessionfinish ------------------------------------------------------------------------
INFO     root:__init__.py:67 Can not get Allure report URL. Please check logs
============================================================= 5 passed, 215 warnings in 377.63s (0:06:17) =============================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_dut_ping_learns_mac[str2-msn4600c-acs-03-None]>
```
#### Any platform specific information?
msn4600c
#### Supported testbed topology if it's a new test case?
t0-64
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
