### PR TITLE
[snappi] Add SRv6 max throughput minimum packet size test

### DIFF
--- a/tests/snappi_tests/dataplane/conftest.py
+++ b/tests/snappi_tests/dataplane/conftest.py
@@ -1,0 +1,102 @@
+"""Pytest fixtures for snappi dataplane tests."""
+import pytest
+
+
+@pytest.fixture(scope="module")
+def set_primary_chassis(snappi_api, fanout_graph_facts_multidut, duthosts):
+    """Set primary chassis for multi-chassis Ixia setups."""
+    from tests.common.helpers.assertions import pytest_assert
+
+    primary_chassis = duthosts[0].host.options['variable_manager'] \
+        ._hostvars[duthosts[0].hostname].get('chassis_chain_primary', None)
+    if len(fanout_graph_facts_multidut) == 1 and primary_chassis:
+        slave_chassis = [
+            fanout_graph_facts_multidut[fanout]['device_info']['mgmtip']
+            for fanout in fanout_graph_facts_multidut
+        ]
+    elif len(fanout_graph_facts_multidut) > 1:
+        slave_chassis = []
+        for fanout in fanout_graph_facts_multidut:
+            if 'primary' in fanout_graph_facts_multidut[fanout]['device_info']['Type'].lower():
+                primary_chassis = fanout_graph_facts_multidut[fanout]['device_info']['mgmtip']
+            else:
+                slave_chassis.append(fanout_graph_facts_multidut[fanout]['device_info']['mgmtip'])
+        if not primary_chassis:
+            pytest_assert(False, "No primary chassis found in the ansible/ devices.csv file")
+    else:
+        return False
+    ixnconfig = snappi_api.ixnet_specific_config
+    chassis_chain1 = ixnconfig.chassis_chains.add()
+    chassis_chain1.primary = primary_chassis
+    chassis_chain1.topology = chassis_chain1.STAR
+    slaves = [    # noqa F841
+        chassis_chain1.secondary.add(
+            location=slave,
+            sequence_id=index,
+            cable_length='6'
+        )
+        for index, slave in enumerate(slave_chassis, start=2)
+    ]
+    return snappi_api
+
+
+@pytest.fixture(scope="module")
+def create_snappi_config(snappi_api, get_snappi_ports):
+    """Create snappi configuration builder."""
+    from tests.snappi_tests.dataplane.files.helper import create_snappi_l1config
+    from tests.common.helpers.assertions import pytest_assert
+
+    def _create_snappi_config(snappi_extra_params):
+        pytest_assert(snappi_extra_params.protocol_config, "No protocol configuration provided in snappi_extra_params")
+
+        # Extract actual ports from protocol_config instead of using all get_snappi_ports
+        actual_ports = []
+        for role, pconfig in snappi_extra_params.protocol_config.items():
+            actual_ports.extend(pconfig['ports'])
+
+        config = create_snappi_l1config(snappi_api, actual_ports, snappi_extra_params)
+        snappi_obj_handles = {k: {"ip": [], "network_group": []} for k in snappi_extra_params.protocol_config}
+
+        for role, pconfig in snappi_extra_params.protocol_config.items():
+            is_ipv4 = True if pconfig['subnet_type'] == 'IPv4' else False
+            for index, port_data in enumerate(pconfig['ports']):
+                device = config.devices.device(name=f"{role} Topology {index}")[-1]
+                eth = device.ethernets.add(name=f"{role} Ethernet_{index}", mac=port_data["src_mac_address"])
+                eth.connection.port_name = f"Port_{port_data['port_id']}"
+                ip_name = f"{role} {'IPv4' if is_ipv4 else 'IPv6'}_{index}"
+                ip_layer = getattr(eth, 'ipv4_addresses' if is_ipv4 else 'ipv6_addresses').add(
+                    name=ip_name,
+                    address=port_data["ipAddress"],
+                    gateway=port_data["ipGateway"],
+                    prefix=int(port_data["prefix"])
+                )
+                snappi_obj_handles[role]["ip"].append(ip_layer.name)
+
+                if pconfig.get("protocol_type", False) and pconfig['protocol_type'] == "bgp":
+                    bgp = device.bgp
+                    bgp.router_id = port_data["ipGateway"] if is_ipv4 else '1.1.1.1'
+                    iface = bgp.ipv4_interfaces.add() if is_ipv4 else bgp.ipv6_interfaces.add()
+                    setattr(iface, 'ipv4_name' if is_ipv4 else 'ipv6_name', ip_layer.name)
+                    peer = iface.peers.add(
+                        name=f"{role} BGP{'' if is_ipv4 else '+'}_{index}",
+                        as_type='ebgp',
+                        peer_address=port_data["ipGateway"],
+                        as_number=port_data["asn"]
+                    )
+
+                    if 'route_ranges' in pconfig and pconfig['route_ranges']:
+                        for route_range in pconfig['route_ranges']:
+                            v4_routes = peer.v4_routes.add(
+                                name=f"{role} Network Group {index}",
+                                addresses=route_range
+                            )
+                            v4_routes.addresses.add(
+                                address=route_range[0],
+                                prefix=route_range[1],
+                                count=route_range[2]
+                            )
+                            snappi_obj_handles[role]["network_group"].append(v4_routes.name)
+
+        return config, snappi_obj_handles
+
+    return _create_snappi_config

--- a/tests/snappi_tests/dataplane/files/helper.py
+++ b/tests/snappi_tests/dataplane/files/helper.py
@@ -194,18 +194,37 @@ def get_duthost_bgp_details(duthosts, get_snappi_ports, subnet_type):    # noqa 
                         (subnet_type == 'ipv6' and ip_obj.version == 6)):
                     peer_to_gateway[port] = (str(ip_obj.ip), ip_obj.network.prefixlen)
         mac_address_generator = get_macs("101700000011", len(get_snappi_ports))
+        valid_ports = []
         for index, port in enumerate(get_snappi_ports):
             if port['duthost'] == duthost:
                 # Get the IP address of the peer port
                 port['router_mac_address'] = port['duthost'].facts['router_mac']
                 port['src_mac_address'] = mac_address_generator[index]
-                port['ipGateway'] = peer_to_gateway.get(port['peer_port'])[0]
-                port['ipAddress'] = gateway_to_bgp.get(port['ipGateway'])['ipAddress']
-                port['asn'] = gateway_to_bgp.get(port['ipGateway'])['asn']
-                port['prefix'] = peer_to_gateway.get(port['peer_port'])[1]
-                port['subnet'] = str(peer_to_gateway.get(port['peer_port'])[0]) \
-                                    + "/" + str(peer_to_gateway.get(port['peer_port'])[1])  # noqa: E127
-    return get_snappi_ports
+                peer_info = peer_to_gateway.get(port['peer_port'])
+                if peer_info is None:
+                    logger.warning(
+                        "Port %s not found in peer_to_gateway mapping, skipping",
+                        port['peer_port']
+                    )
+                    continue
+                port['ipGateway'] = peer_info[0]
+                bgp_info = gateway_to_bgp.get(port['ipGateway'])
+                if bgp_info is None:
+                    logger.warning(
+                        "No BGP neighbor found for gateway %s on port %s, skipping",
+                        port['ipGateway'], port['peer_port']
+                    )
+                    continue
+                port['ipAddress'] = bgp_info['ipAddress']
+                port['asn'] = bgp_info['asn']
+                port['prefix'] = peer_info[1]
+                port['subnet'] = str(peer_info[0]) + "/" + str(peer_info[1])
+                valid_ports.append(port)
+            else:
+                # Port belongs to different dut, keep it if it was already processed
+                if 'ipAddress' in port:
+                    valid_ports.append(port)
+    return valid_ports
 
 
 def get_duthost_vlan_details(duthosts, get_snappi_ports, subnet_type):   # noqa F811

--- a/tests/snappi_tests/dataplane/files/max_throughput_config.yaml
+++ b/tests/snappi_tests/dataplane/files/max_throughput_config.yaml
@@ -1,0 +1,79 @@
+# Max Throughput Minimum Packet Size Test Configuration
+
+min_ports: 32
+traffic_duration_sec: 60
+line_rate_pct: 100
+tolerance_pkt_size_offset: 10
+
+srv6:
+  locator_name: "loc1"
+  locator_prefix: "fcbb:bbbb:1::"
+  block_len: 32
+  node_len: 16
+  func_len: 0
+  arg_len: 0
+  sid_action: "uN"
+  sid_ip: "fcbb:bbbb:1::"
+  decap_vrf: "default"
+  decap_dscp_mode: "pipe"
+  outer_dst_ip: "fcbb:bbbb:1:11a::2"
+
+# Each scenario defines which DUT features are enabled (true) or disabled (false).
+scenarios:
+  all_features:
+    description: "DataAcl + Everflow + EverflowV6 + IPinIP Decap + uSID Decap"
+    dataacl: true
+    everflow: true
+    everflowv6: true
+    ipinip_decap: true
+    usid_decap: true
+
+  dataacl_usid:
+    description: "DataAcl + uSID Decap"
+    dataacl: true
+    everflow: false
+    everflowv6: false
+    ipinip_decap: false
+    usid_decap: true
+
+  dataacl_ipinip_usid:
+    description: "DataAcl + IPinIP Decap + uSID Decap"
+    dataacl: true
+    everflow: false
+    everflowv6: false
+    ipinip_decap: true
+    usid_decap: true
+
+  ipinip_usid:
+    description: "IPinIP Decap + uSID Decap"
+    dataacl: false
+    everflow: false
+    everflowv6: false
+    ipinip_decap: true
+    usid_decap: true
+
+  dataacl_only:
+    description: "DataAcl only"
+    dataacl: true
+    everflow: false
+    everflowv6: false
+    ipinip_decap: false
+    usid_decap: false
+
+  no_features:
+    description: "No ACLs + No Decap"
+    dataacl: false
+    everflow: false
+    everflowv6: false
+    ipinip_decap: false
+    usid_decap: false
+
+# Per-platform minimum packet sizes (bytes) for zero-drop at 100% line rate.
+platform_thresholds:
+  "Nvidia 5640":
+    all_features: 2100
+    dataacl_usid: 2100
+    dataacl_ipinip_usid: 2100
+    ipinip_usid: 2100
+    dataacl_only: 2100
+    no_features: 2100

--- a/tests/snappi_tests/dataplane/files/max_throughput_config.yaml
+++ b/tests/snappi_tests/dataplane/files/max_throughput_config.yaml
@@ -68,12 +68,59 @@ scenarios:
     ipinip_decap: false
     usid_decap: false
 
+# Optional aliases for lab names or platform names that differ from HwSku.
+platform_aliases:
+  "sn5640": "Mellanox-SN5640-C512S2"
+  "Nvidia 5640": "Mellanox-SN5640-C512S2"
+  "Arista 7260": "Arista-7260CX3-C64"
+  "Cisco 8102": "Cisco-8102-C64"
+
 # Per-platform minimum packet sizes (bytes) for zero-drop at 100% line rate.
 platform_thresholds:
-  "Nvidia 5640":
-    all_features: 2100
-    dataacl_usid: 2100
-    dataacl_ipinip_usid: 2100
-    ipinip_usid: 2100
-    dataacl_only: 2100
-    no_features: 2100
+  "Mellanox-SN5640-C512S2":
+    all_features: 500
+    dataacl_usid: 450
+    dataacl_ipinip_usid: 500
+    ipinip_usid: 450
+    dataacl_only: 400
+    no_features: 400
+
+  "Mellanox-SN5640-C448O16":
+    all_features: 500
+    dataacl_usid: 450
+    dataacl_ipinip_usid: 500
+    ipinip_usid: 450
+    dataacl_only: 400
+    no_features: 400
+
+  "Arista-7260CX3-C64":
+    all_features: 500
+    dataacl_usid: 450
+    dataacl_ipinip_usid: 500
+    ipinip_usid: 450
+    dataacl_only: 400
+    no_features: 400
+
+  "Arista-7260CX3-D108C8":
+    all_features: 500
+    dataacl_usid: 450
+    dataacl_ipinip_usid: 500
+    ipinip_usid: 450
+    dataacl_only: 400
+    no_features: 400
+
+  "Cisco-8102-C64":
+    all_features: 500
+    dataacl_usid: 450
+    dataacl_ipinip_usid: 500
+    ipinip_usid: 450
+    dataacl_only: 400
+    no_features: 400
+
+  "Cisco-8102-28FH-DPU-O":
+    all_features: 500
+    dataacl_usid: 450
+    dataacl_ipinip_usid: 500
+    ipinip_usid: 450
+    dataacl_only: 400
+    no_features: 400

--- a/tests/snappi_tests/dataplane/files/max_throughput_config.yaml
+++ b/tests/snappi_tests/dataplane/files/max_throughput_config.yaml
@@ -1,6 +1,6 @@
 # Max Throughput Minimum Packet Size Test Configuration
 
-min_ports: 32
+min_ports: 30
 traffic_duration_sec: 60
 line_rate_pct: 100
 tolerance_pkt_size_offset: 10
@@ -118,6 +118,14 @@ platform_thresholds:
     no_features: 400
 
   "Cisco-8102-28FH-DPU-O":
+    all_features: 500
+    dataacl_usid: 450
+    dataacl_ipinip_usid: 500
+    ipinip_usid: 450
+    dataacl_only: 400
+    no_features: 400
+
+  "Arista-7060X6-64PE-B-C512S2":
     all_features: 500
     dataacl_usid: 450
     dataacl_ipinip_usid: 500

--- a/tests/snappi_tests/dataplane/files/max_throughput_helper.py
+++ b/tests/snappi_tests/dataplane/files/max_throughput_helper.py
@@ -2,10 +2,12 @@
 Helper module for the SRv6 max throughput minimum packet size test.
 """
 import os
+import json
 import yaml
 import logging
 import time
 
+from tests.common.config_reload import config_reload
 from tests.common.helpers.srv6_helper import (
     create_srv6_locator,
     create_srv6_sid,
@@ -19,6 +21,19 @@ logger = logging.getLogger(__name__)
 CONFIG_FILE = os.path.join(os.path.dirname(__file__), "max_throughput_config.yaml")
 
 
+def _load_json_output(output):
+    """Load JSON output that may include informational prefix lines."""
+    start = output.find("{")
+    if start == -1:
+        raise ValueError("No JSON object found in output: {}".format(output))
+    return json.loads(output[start:])
+
+
+def _normalize_platform_name(platform):
+    """Normalize platform names for deterministic fuzzy matching."""
+    return platform.lower().replace("-", "").replace("_", "").replace(" ", "")
+
+
 def load_max_throughput_config():
     """Load the YAML config for the max throughput test."""
     with open(CONFIG_FILE, "r") as f:
@@ -29,14 +44,32 @@ def get_platform_thresholds(duthost, config):
     """Look up min-packet-size thresholds for the DUT's platform. Returns None if unknown."""
     platform = duthost.facts.get("hwsku", "")
     thresholds = config.get("platform_thresholds", {})
+    aliases = config.get("platform_aliases", {})
 
     if platform in thresholds:
         return thresholds[platform]
 
-    # Try partial match (e.g. "Nvidia 5640" in "Nvidia-5640-O28")
+    if platform in aliases:
+        return thresholds.get(aliases[platform])
+
+    normalized_platform = _normalize_platform_name(platform)
+    normalized_aliases = {
+        _normalize_platform_name(alias): target
+        for alias, target in aliases.items()
+    }
+    if normalized_platform in normalized_aliases:
+        return thresholds.get(normalized_aliases[normalized_platform])
+
+    # Prefer the most specific platform key over the first partial match.
+    matches = []
     for key in thresholds:
-        if key.lower().replace(" ", "") in platform.lower().replace("-", "").replace(" ", ""):
-            return thresholds[key]
+        normalized_key = _normalize_platform_name(key)
+        if normalized_key and normalized_key in normalized_platform:
+            matches.append((len(normalized_key), key))
+
+    if matches:
+        _, key = max(matches)
+        return thresholds[key]
 
     return None
 
@@ -47,14 +80,64 @@ def get_platform_thresholds(duthost, config):
 
 def _get_front_panel_ports(duthost):
     """Return list of admin-up front-panel Ethernet ports on the DUT."""
-    import json as _json
     result = duthost.shell("portstat -j")["stdout"]
-    port_data = _json.loads(result)
+    port_data = _load_json_output(result)
     # STATE: U=Up, D=Down, X=Disabled (admin-down)
     return sorted(
         [port for port, stats in port_data.items() if stats.get("STATE") != "X"],
         key=lambda p: (len(p), p),
     )
+
+
+def _get_portchannel_members(duthost):
+    """Return Ethernet ports that are members of PortChannels."""
+    result = duthost.shell(
+        "sonic-db-cli CONFIG_DB keys 'PORTCHANNEL_MEMBER|*'",
+        module_ignore_errors=True,
+    )
+    members = set()
+    if result["rc"] != 0:
+        return members
+
+    for line in result["stdout_lines"]:
+        parts = line.split("|")
+        if len(parts) >= 3:
+            members.add(parts[2])
+    return members
+
+
+def _get_portchannels(duthost):
+    """Return configured PortChannel interface names."""
+    result = duthost.shell(
+        "sonic-db-cli CONFIG_DB keys 'PORTCHANNEL|*'",
+        module_ignore_errors=True,
+    )
+    portchannels = []
+    if result["rc"] != 0:
+        return portchannels
+
+    for line in result["stdout_lines"]:
+        parts = line.split("|")
+        if len(parts) >= 2:
+            portchannels.append(parts[1])
+    return sorted(portchannels, key=lambda p: (len(p), p))
+
+
+def _get_acl_bind_ports(duthost):
+    """Return ACL-bindable front-panel interfaces."""
+    portchannel_members = _get_portchannel_members(duthost)
+    standalone_ports = [
+        port for port in _get_front_panel_ports(duthost)
+        if port not in portchannel_members
+    ]
+    bind_ports = _get_portchannels(duthost) + standalone_ports
+    if not bind_ports:
+        raise RuntimeError(
+            "No ACL-bindable front-panel interfaces found on {}".format(
+                duthost.hostname
+            )
+        )
+    return bind_ports
 
 
 def _dataacl_exists(duthost):
@@ -87,17 +170,21 @@ def _verify_acl_table_removed(duthost, table_name):
 # --- DataACL ---
 
 def enable_dataacl(duthost):
-    """Add DATAACL L3 table bound to all front-panel ports."""
+    """Add DATAACL L3 table bound to ACL-bindable front-panel interfaces."""
     if _dataacl_exists(duthost):
         logger.info("DATAACL already exists on %s, skipping", duthost.hostname)
         return
-    ports = _get_front_panel_ports(duthost)
+    ports = _get_acl_bind_ports(duthost)
     cmd = "config acl add table DATAACL L3 -p {}".format(",".join(ports))
     logger.info("Enabling DATAACL on %s", duthost.hostname)
     duthost.shell(cmd)
     duthost.shell("config save -y")
     if not _verify_acl_table_ports(duthost, "DATAACL", ports):
-        raise RuntimeError("DATAACL not attached to all ports on {}".format(duthost.hostname))
+        raise RuntimeError(
+            "DATAACL not attached to expected interfaces on {}".format(
+                duthost.hostname
+            )
+        )
 
 
 def disable_dataacl(duthost):
@@ -120,6 +207,13 @@ MIRROR_SRC_IP = "10.10.10.1"
 MIRROR_DST_IP = "10.10.10.2"
 MIRROR_DSCP = "8"
 MIRROR_TTL = "64"
+MIRROR_QUEUE = "0"
+MIRROR_GRE_TYPES = {
+    "mellanox": "35145",     # 0x8949
+    "barefoot": "8939",      # 0x22EB
+    "cisco-8000": "35006",   # 0x88BE
+}
+DEFAULT_MIRROR_GRE_TYPE = "35006"  # 0x88BE
 
 
 def _mirror_session_exists(duthost, session_name):
@@ -127,24 +221,58 @@ def _mirror_session_exists(duthost, session_name):
     return session_name in output
 
 
+def _get_mirror_gre_type(duthost):
+    """Return the ERSPAN GRE type expected by the DUT ASIC."""
+    identifiers = [
+        duthost.facts.get("asic_type", ""),
+        duthost.facts.get("platform", ""),
+        duthost.facts.get("hwsku", ""),
+    ]
+    normalized_identifiers = [
+        _normalize_platform_name(identifier)
+        for identifier in identifiers
+    ]
+
+    if any(
+        "mellanox" in identifier or "nvidia" in identifier
+        for identifier in normalized_identifiers
+    ):
+        return MIRROR_GRE_TYPES["mellanox"]
+
+    for asic_type, gre_type in MIRROR_GRE_TYPES.items():
+        normalized_asic_type = _normalize_platform_name(asic_type)
+        if any(
+            normalized_asic_type in identifier
+            for identifier in normalized_identifiers
+        ):
+            return gre_type
+
+    return DEFAULT_MIRROR_GRE_TYPE
+
+
 def enable_everflow(duthost):
     """Create ERSPAN mirror session and EVERFLOW ACL table."""
     if not _mirror_session_exists(duthost, EVERFLOW_SESSION):
         logger.info("Creating Everflow mirror session on %s", duthost.hostname)
         duthost.shell(
-            "config mirror_session add {} {} {} {} {}".format(
-                EVERFLOW_SESSION, MIRROR_SRC_IP, MIRROR_DST_IP, MIRROR_DSCP, MIRROR_TTL
+            "config mirror_session add {} {} {} {} {} {} {}".format(
+                EVERFLOW_SESSION, MIRROR_SRC_IP, MIRROR_DST_IP, MIRROR_DSCP,
+                MIRROR_TTL, _get_mirror_gre_type(duthost), MIRROR_QUEUE,
             )
         )
 
     lines = duthost.shell("show acl table EVERFLOW")["stdout_lines"]
     if not any("EVERFLOW" in line for line in lines):
-        ports = _get_front_panel_ports(duthost)
+        ports = _get_acl_bind_ports(duthost)
         duthost.shell(
             "config acl add table EVERFLOW MIRROR -p {}".format(",".join(ports))
         )
         if not _verify_acl_table_ports(duthost, "EVERFLOW", ports):
-            raise RuntimeError("EVERFLOW not attached to all ports on {}".format(duthost.hostname))
+            raise RuntimeError(
+                "EVERFLOW not attached to expected interfaces on {}".format(
+                    duthost.hostname
+                )
+            )
     duthost.shell("config save -y")
 
 
@@ -161,31 +289,35 @@ def disable_everflow(duthost):
     duthost.shell("config save -y")
 
 
-# --- EverflowV6 (IPv6 mirror) ---
+# --- EverflowV6 (IPv6 ACL mirror) ---
 
 EVERFLOWV6_SESSION = "max_tput_ev6_session"
 EVERFLOWV6_TABLE = "EVERFLOWV6"
-MIRROR_SRC_IPV6 = "fc00::1"
-MIRROR_DST_IPV6 = "fc00::2"
 
 
 def enable_everflowv6(duthost):
-    """Create ERSPANv6 mirror session and EVERFLOWV6 ACL table."""
+    """Create ERSPAN mirror session and EVERFLOWV6 ACL table."""
     if not _mirror_session_exists(duthost, EVERFLOWV6_SESSION):
         duthost.shell(
-            "config mirror_session add {} {} {} {} {}".format(
-                EVERFLOWV6_SESSION, MIRROR_SRC_IPV6, MIRROR_DST_IPV6, MIRROR_DSCP, MIRROR_TTL
+            "config mirror_session add {} {} {} {} {} {} {}".format(
+                EVERFLOWV6_SESSION, MIRROR_SRC_IP, MIRROR_DST_IP,
+                MIRROR_DSCP,
+                MIRROR_TTL, _get_mirror_gre_type(duthost), MIRROR_QUEUE,
             )
         )
 
     lines = duthost.shell("show acl table EVERFLOWV6")["stdout_lines"]
     if not any("EVERFLOWV6" in line for line in lines):
-        ports = _get_front_panel_ports(duthost)
+        ports = _get_acl_bind_ports(duthost)
         duthost.shell(
             "config acl add table EVERFLOWV6 MIRRORV6 -p {}".format(",".join(ports))
         )
         if not _verify_acl_table_ports(duthost, "EVERFLOWV6", ports):
-            raise RuntimeError("EVERFLOWV6 not attached to all ports on {}".format(duthost.hostname))
+            raise RuntimeError(
+                "EVERFLOWV6 not attached to expected interfaces on {}".format(
+                    duthost.hostname
+                )
+            )
     duthost.shell("config save -y")
 
 
@@ -234,7 +366,9 @@ def _get_loopback_ip(duthost):
             ip = parts[2].split("/")[0]
             if "." in ip:
                 return ip
-    return "10.1.0.32"
+    raise RuntimeError(
+        "No IPv4 Loopback0 address found on {}".format(duthost.hostname)
+    )
 
 
 def enable_ipinip_decap(duthost):
@@ -364,10 +498,13 @@ def restore_dut_config(duthost):
     if result["rc"] != 0:
         logger.warning("Backup file %s not found, skipping restore", CONFIG_DB_BACKUP_PATH)
         return
-
     duthost.shell("cp {} {}".format(CONFIG_DB_BACKUP_PATH, CONFIG_DB_PATH))
-    duthost.shell("config reload -y", module_ignore_errors=True)
-    time.sleep(60)
+    config_reload(
+        duthost,
+        config_source="config_db",
+        safe_reload=True,
+        check_intf_up_ports=True,
+    )
     duthost.shell("rm -f {}".format(CONFIG_DB_BACKUP_PATH))
 
 

--- a/tests/snappi_tests/dataplane/files/max_throughput_helper.py
+++ b/tests/snappi_tests/dataplane/files/max_throughput_helper.py
@@ -1,0 +1,368 @@
+"""
+Helper module for the SRv6 max throughput minimum packet size test.
+"""
+import os
+import json
+import yaml
+import logging
+import time
+
+from tests.common.helpers.srv6_helper import (
+    create_srv6_locator,
+    create_srv6_sid,
+    del_srv6_locator,
+    del_srv6_sid,
+    SRv6,
+)
+
+logger = logging.getLogger(__name__)
+
+CONFIG_FILE = os.path.join(os.path.dirname(__file__), "max_throughput_config.yaml")
+
+
+def load_max_throughput_config():
+    """Load the YAML config for the max throughput test."""
+    with open(CONFIG_FILE, "r") as f:
+        return yaml.safe_load(f)
+
+
+def get_platform_thresholds(duthost, config):
+    """Look up min-packet-size thresholds for the DUT's platform. Returns None if unknown."""
+    platform = duthost.facts.get("hwsku", "")
+    thresholds = config.get("platform_thresholds", {})
+
+    if platform in thresholds:
+        return thresholds[platform]
+
+    # Try partial match (e.g. "Nvidia 5640" in "Nvidia-5640-O28")
+    for key in thresholds:
+        if key.lower().replace(" ", "") in platform.lower().replace("-", "").replace(" ", ""):
+            return thresholds[key]
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Feature toggle helpers
+# ---------------------------------------------------------------------------
+
+def _get_front_panel_ports(duthost):
+    """Return list of front-panel Ethernet ports on the DUT."""
+    result = duthost.shell("show interfaces status")["stdout"]
+    ports = []
+    for line in result.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("Ethernet"):
+            ports.append(stripped.split()[0])
+    return ports
+
+
+def _dataacl_exists(duthost):
+    """Check if DATAACL table exists."""
+    lines = duthost.shell(cmd="show acl table DATAACL")["stdout_lines"]
+    return any("DATAACL" in line for line in lines)
+
+
+# --- DataACL ---
+
+def enable_dataacl(duthost):
+    """Add DATAACL L3 table bound to all front-panel ports."""
+    if _dataacl_exists(duthost):
+        logger.info("DATAACL already exists on %s, skipping", duthost.hostname)
+        return
+    ports = _get_front_panel_ports(duthost)
+    cmd = "config acl add table DATAACL L3 -p {}".format(",".join(ports))
+    logger.info("Enabling DATAACL on %s", duthost.hostname)
+    duthost.shell(cmd)
+    duthost.shell("config save -y")
+
+
+def disable_dataacl(duthost):
+    """Remove DATAACL table if it exists."""
+    if not _dataacl_exists(duthost):
+        logger.info("DATAACL does not exist on %s, skipping removal", duthost.hostname)
+        return
+    logger.info("Removing DATAACL on %s", duthost.hostname)
+    duthost.shell("config acl remove table DATAACL")
+    duthost.shell("config save -y")
+
+
+# --- Everflow (IPv4 mirror) ---
+
+EVERFLOW_SESSION = "max_tput_ev4_session"
+EVERFLOW_TABLE = "EVERFLOW"
+MIRROR_SRC_IP = "10.10.10.1"
+MIRROR_DST_IP = "10.10.10.2"
+MIRROR_DSCP = "8"
+MIRROR_TTL = "64"
+
+
+def _mirror_session_exists(duthost, session_name):
+    output = duthost.shell("show mirror_session {}".format(session_name))["stdout"]
+    return session_name in output
+
+
+def enable_everflow(duthost):
+    """Create ERSPAN mirror session and EVERFLOW ACL table."""
+    if not _mirror_session_exists(duthost, EVERFLOW_SESSION):
+        logger.info("Creating Everflow mirror session on %s", duthost.hostname)
+        duthost.shell(
+            "config mirror_session add {} {} {} {} {}".format(
+                EVERFLOW_SESSION, MIRROR_SRC_IP, MIRROR_DST_IP, MIRROR_DSCP, MIRROR_TTL
+            )
+        )
+
+    lines = duthost.shell("show acl table EVERFLOW")["stdout_lines"]
+    if not any("EVERFLOW" in line for line in lines):
+        ports = _get_front_panel_ports(duthost)
+        duthost.shell(
+            "config acl add table EVERFLOW MIRROR -p {}".format(",".join(ports))
+        )
+    duthost.shell("config save -y")
+
+
+def disable_everflow(duthost):
+    """Remove EVERFLOW ACL table and mirror session."""
+    lines = duthost.shell("show acl table EVERFLOW")["stdout_lines"]
+    if any("EVERFLOW" in line for line in lines):
+        duthost.shell("config acl remove table EVERFLOW")
+
+    if _mirror_session_exists(duthost, EVERFLOW_SESSION):
+        duthost.shell("config mirror_session remove {}".format(EVERFLOW_SESSION))
+    duthost.shell("config save -y")
+
+
+# --- EverflowV6 (IPv6 mirror) ---
+
+EVERFLOWV6_SESSION = "max_tput_ev6_session"
+EVERFLOWV6_TABLE = "EVERFLOWV6"
+MIRROR_SRC_IPV6 = "fc00::1"
+MIRROR_DST_IPV6 = "fc00::2"
+
+
+def enable_everflowv6(duthost):
+    """Create ERSPANv6 mirror session and EVERFLOWV6 ACL table."""
+    if not _mirror_session_exists(duthost, EVERFLOWV6_SESSION):
+        duthost.shell(
+            "config mirror_session add {} {} {} {} {}".format(
+                EVERFLOWV6_SESSION, MIRROR_SRC_IPV6, MIRROR_DST_IPV6, MIRROR_DSCP, MIRROR_TTL
+            )
+        )
+
+    lines = duthost.shell("show acl table EVERFLOWV6")["stdout_lines"]
+    if not any("EVERFLOWV6" in line for line in lines):
+        ports = _get_front_panel_ports(duthost)
+        duthost.shell(
+            "config acl add table EVERFLOWV6 MIRRORV6 -p {}".format(",".join(ports))
+        )
+    duthost.shell("config save -y")
+
+
+def disable_everflowv6(duthost):
+    """Remove EVERFLOWV6 ACL table and mirror session."""
+    lines = duthost.shell("show acl table EVERFLOWV6")["stdout_lines"]
+    if any("EVERFLOWV6" in line for line in lines):
+        duthost.shell("config acl remove table EVERFLOWV6")
+
+    if _mirror_session_exists(duthost, EVERFLOWV6_SESSION):
+        duthost.shell("config mirror_session remove {}".format(EVERFLOWV6_SESSION))
+    duthost.shell("config save -y")
+
+
+# --- IPinIP Decap ---
+
+IPINIP_DECAP_CONF_TEMPLATE = """[
+    {{
+        "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:{loopback_ip}": {{
+            "term_type": "P2MP"
+        }},
+        "OP": "{op}"
+    }},
+    {{
+        "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL": {{
+            "tunnel_type": "IPINIP",
+            "dscp_mode": "pipe",
+            "ecn_mode": "copy_from_outer",
+            "ttl_mode": "pipe"
+        }},
+        "OP": "{op}"
+    }}
+]"""
+
+
+def _get_loopback_ip(duthost):
+    """Return the first Loopback0 IPv4 address."""
+    result = duthost.shell(
+        "sonic-db-cli CONFIG_DB keys 'LOOPBACK_INTERFACE|Loopback0|*'"
+    )["stdout"].strip()
+    for line in result.splitlines():
+        parts = line.split("|")
+        if len(parts) >= 3:
+            ip = parts[2].split("/")[0]
+            if "." in ip:
+                return ip
+    return "10.1.0.32"
+
+
+def enable_ipinip_decap(duthost):
+    """Configure IPINIP decap tunnel via swssconfig."""
+    loopback_ip = _get_loopback_ip(duthost)
+    conf = IPINIP_DECAP_CONF_TEMPLATE.format(loopback_ip=loopback_ip, op="SET")
+    logger.info("Enabling IPinIP decap on %s (loopback=%s)", duthost.hostname, loopback_ip)
+
+    duthost.copy(content=conf, dest="/tmp/ipinip_decap_set.json")
+    for asic_id in duthost.get_frontend_asic_ids():
+        swss = "swss{}".format(asic_id if asic_id is not None else "")
+        cmds = [
+            "docker cp /tmp/ipinip_decap_set.json {}:/ipinip_decap_set.json".format(swss),
+            "docker exec {} swssconfig /ipinip_decap_set.json".format(swss),
+            "docker exec {} rm /ipinip_decap_set.json".format(swss),
+        ]
+        duthost.shell_cmds(cmds=cmds)
+
+
+def disable_ipinip_decap(duthost):
+    """Remove IPINIP decap tunnel via swssconfig."""
+    loopback_ip = _get_loopback_ip(duthost)
+    conf = IPINIP_DECAP_CONF_TEMPLATE.format(loopback_ip=loopback_ip, op="DEL")
+    logger.info("Disabling IPinIP decap on %s", duthost.hostname)
+
+    duthost.copy(content=conf, dest="/tmp/ipinip_decap_del.json")
+    for asic_id in duthost.get_frontend_asic_ids():
+        swss = "swss{}".format(asic_id if asic_id is not None else "")
+        cmds = [
+            "docker cp /tmp/ipinip_decap_del.json {}:/ipinip_decap_del.json".format(swss),
+            "docker exec {} swssconfig /ipinip_decap_del.json".format(swss),
+            "docker exec {} rm /ipinip_decap_del.json".format(swss),
+        ]
+        duthost.shell_cmds(cmds=cmds)
+
+
+def enable_usid_decap(duthost, config):
+    """Create SRv6 locator and SID for uSID shift-and-forward."""
+    srv6_cfg = config.get("srv6", {})
+    locator_name = srv6_cfg.get("locator_name", "loc1")
+    locator_prefix = srv6_cfg.get("locator_prefix", "fcbb:bbbb:1::")
+    sid_ip = srv6_cfg.get("sid_ip", "fcbb:bbbb:1::")
+    action = srv6_cfg.get("sid_action", SRv6.uN)
+    decap_vrf = srv6_cfg.get("decap_vrf", "default")
+    dscp_mode = srv6_cfg.get("decap_dscp_mode", SRv6.pipe_mode)
+
+    logger.info("Enabling uSID decap on %s (locator=%s)", duthost.hostname, locator_name)
+    create_srv6_locator(
+        duthost,
+        locator_name,
+        locator_prefix,
+        block_len=srv6_cfg.get("block_len", 32),
+        node_len=srv6_cfg.get("node_len", 16),
+        func_len=srv6_cfg.get("func_len", 0),
+        arg_len=srv6_cfg.get("arg_len", 0),
+    )
+    create_srv6_sid(
+        duthost,
+        locator_name,
+        sid_ip,
+        action=action,
+        decap_vrf=decap_vrf,
+        decap_dscp_mode=dscp_mode,
+    )
+    duthost.shell("config save -y")
+
+
+def disable_usid_decap(duthost, config):
+    """Remove SRv6 locator and SID."""
+    srv6_cfg = config.get("srv6", {})
+    locator_name = srv6_cfg.get("locator_name", "loc1")
+    sid_ip = srv6_cfg.get("sid_ip", "fcbb:bbbb:1::")
+
+    logger.info("Disabling uSID decap on %s", duthost.hostname)
+    del_srv6_sid(duthost, locator_name, sid_ip)
+    del_srv6_locator(duthost, locator_name)
+    duthost.shell("config save -y")
+
+
+# ---------------------------------------------------------------------------
+# DUT config backup/restore
+# ---------------------------------------------------------------------------
+
+CONFIG_DB_PATH = "/etc/sonic/config_db.json"
+CONFIG_DB_BACKUP_PATH = "/host/config_db.json.before_max_throughput_test"
+
+
+def backup_dut_config(duthost):
+    """Save running config and back up config_db.json for later restoration."""
+    logger.info("Backing up DUT config on %s", duthost.hostname)
+    # Persist current running config to config_db.json
+    duthost.shell("config save -y")
+    # Copy config_db.json to a backup location
+    duthost.shell("cp {} {}".format(CONFIG_DB_PATH, CONFIG_DB_BACKUP_PATH))
+    logger.info("Config backed up to %s", CONFIG_DB_BACKUP_PATH)
+
+
+def restore_dut_config(duthost):
+    """Restore config_db.json from backup and reload."""
+    logger.info("Restoring DUT config on %s", duthost.hostname)
+    result = duthost.shell("test -f {}".format(CONFIG_DB_BACKUP_PATH), module_ignore_errors=True)
+    if result["rc"] != 0:
+        logger.warning("Backup file %s not found, skipping restore", CONFIG_DB_BACKUP_PATH)
+        return
+
+    duthost.shell("cp {} {}".format(CONFIG_DB_BACKUP_PATH, CONFIG_DB_PATH))
+    duthost.shell("config reload -y", module_ignore_errors=True)
+    time.sleep(60)
+    duthost.shell("rm -f {}".format(CONFIG_DB_BACKUP_PATH))
+
+
+# ---------------------------------------------------------------------------
+# Scenario orchestration
+# ---------------------------------------------------------------------------
+
+# Map feature keys to (enable_fn, disable_fn) pairs.
+FEATURE_TOGGLE_MAP = {
+    "dataacl": (enable_dataacl, disable_dataacl),
+    "everflow": (enable_everflow, disable_everflow),
+    "everflowv6": (enable_everflowv6, disable_everflowv6),
+    "ipinip_decap": (enable_ipinip_decap, disable_ipinip_decap),
+    "usid_decap": (enable_usid_decap, disable_usid_decap),
+}
+
+
+def _call_feature_fn(fn, duthost, feature_key, config):
+    """Call a feature toggle function, passing config if needed."""
+    if feature_key in ("usid_decap",):
+        fn(duthost, config)
+    else:
+        fn(duthost)
+
+
+def cleanup_all_features(duthost, config):
+    """Disable all features to reach a clean baseline."""
+    logger.info("Cleaning all features on %s to reach baseline", duthost.hostname)
+    for feature_key, (_, disable_fn) in FEATURE_TOGGLE_MAP.items():
+        try:
+            _call_feature_fn(disable_fn, duthost, feature_key, config)
+        except Exception as e:
+            logger.warning("Failed to disable %s on %s: %s", feature_key, duthost.hostname, e)
+
+
+def configure_scenario(duthost, scenario_name, config):
+    """Configure DUT for a scenario: clean baseline then enable required features."""
+    scenario = config["scenarios"][scenario_name]
+    logger.info(
+        "Configuring scenario '%s' (%s) on %s",
+        scenario_name, scenario.get("description", ""), duthost.hostname,
+    )
+
+    cleanup_all_features(duthost, config)
+    time.sleep(5)
+
+    enabled_features = []
+    for feature_key, (enable_fn, _) in FEATURE_TOGGLE_MAP.items():
+        if scenario.get(feature_key, False):
+            logger.info("Enabling feature: %s", feature_key)
+            _call_feature_fn(enable_fn, duthost, feature_key, config)
+            enabled_features.append(feature_key)
+
+    # Allow configs to settle
+    time.sleep(10)
+    return enabled_features

--- a/tests/snappi_tests/dataplane/files/max_throughput_helper.py
+++ b/tests/snappi_tests/dataplane/files/max_throughput_helper.py
@@ -2,7 +2,6 @@
 Helper module for the SRv6 max throughput minimum packet size test.
 """
 import os
-import json
 import yaml
 import logging
 import time
@@ -47,20 +46,42 @@ def get_platform_thresholds(duthost, config):
 # ---------------------------------------------------------------------------
 
 def _get_front_panel_ports(duthost):
-    """Return list of front-panel Ethernet ports on the DUT."""
-    result = duthost.shell("show interfaces status")["stdout"]
-    ports = []
-    for line in result.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("Ethernet"):
-            ports.append(stripped.split()[0])
-    return ports
+    """Return list of admin-up front-panel Ethernet ports on the DUT."""
+    import json as _json
+    result = duthost.shell("portstat -j")["stdout"]
+    port_data = _json.loads(result)
+    # STATE: U=Up, D=Down, X=Disabled (admin-down)
+    return sorted(
+        [port for port, stats in port_data.items() if stats.get("STATE") != "X"],
+        key=lambda p: (len(p), p),
+    )
 
 
 def _dataacl_exists(duthost):
     """Check if DATAACL table exists."""
     lines = duthost.shell(cmd="show acl table DATAACL")["stdout_lines"]
     return any("DATAACL" in line for line in lines)
+
+
+def _verify_acl_table_ports(duthost, table_name, expected_ports):
+    """Verify that the ACL table is bound to the expected ports."""
+    output = duthost.shell("show acl table {}".format(table_name))["stdout"]
+    for port in expected_ports:
+        if port not in output:
+            logger.warning("ACL table %s not attached to port %s", table_name, port)
+            return False
+    logger.info("ACL table %s verified on all %d ports", table_name, len(expected_ports))
+    return True
+
+
+def _verify_acl_table_removed(duthost, table_name):
+    """Verify that the ACL table no longer exists."""
+    output = duthost.shell("show acl table {}".format(table_name))["stdout"]
+    if table_name in output:
+        logger.warning("ACL table %s still exists after removal", table_name)
+        return False
+    logger.info("ACL table %s confirmed removed", table_name)
+    return True
 
 
 # --- DataACL ---
@@ -75,6 +96,8 @@ def enable_dataacl(duthost):
     logger.info("Enabling DATAACL on %s", duthost.hostname)
     duthost.shell(cmd)
     duthost.shell("config save -y")
+    if not _verify_acl_table_ports(duthost, "DATAACL", ports):
+        raise RuntimeError("DATAACL not attached to all ports on {}".format(duthost.hostname))
 
 
 def disable_dataacl(duthost):
@@ -85,6 +108,8 @@ def disable_dataacl(duthost):
     logger.info("Removing DATAACL on %s", duthost.hostname)
     duthost.shell("config acl remove table DATAACL")
     duthost.shell("config save -y")
+    if not _verify_acl_table_removed(duthost, "DATAACL"):
+        raise RuntimeError("DATAACL not fully removed on {}".format(duthost.hostname))
 
 
 # --- Everflow (IPv4 mirror) ---
@@ -118,6 +143,8 @@ def enable_everflow(duthost):
         duthost.shell(
             "config acl add table EVERFLOW MIRROR -p {}".format(",".join(ports))
         )
+        if not _verify_acl_table_ports(duthost, "EVERFLOW", ports):
+            raise RuntimeError("EVERFLOW not attached to all ports on {}".format(duthost.hostname))
     duthost.shell("config save -y")
 
 
@@ -126,6 +153,8 @@ def disable_everflow(duthost):
     lines = duthost.shell("show acl table EVERFLOW")["stdout_lines"]
     if any("EVERFLOW" in line for line in lines):
         duthost.shell("config acl remove table EVERFLOW")
+        if not _verify_acl_table_removed(duthost, "EVERFLOW"):
+            raise RuntimeError("EVERFLOW not fully removed on {}".format(duthost.hostname))
 
     if _mirror_session_exists(duthost, EVERFLOW_SESSION):
         duthost.shell("config mirror_session remove {}".format(EVERFLOW_SESSION))
@@ -155,6 +184,8 @@ def enable_everflowv6(duthost):
         duthost.shell(
             "config acl add table EVERFLOWV6 MIRRORV6 -p {}".format(",".join(ports))
         )
+        if not _verify_acl_table_ports(duthost, "EVERFLOWV6", ports):
+            raise RuntimeError("EVERFLOWV6 not attached to all ports on {}".format(duthost.hostname))
     duthost.shell("config save -y")
 
 
@@ -163,6 +194,8 @@ def disable_everflowv6(duthost):
     lines = duthost.shell("show acl table EVERFLOWV6")["stdout_lines"]
     if any("EVERFLOWV6" in line for line in lines):
         duthost.shell("config acl remove table EVERFLOWV6")
+        if not _verify_acl_table_removed(duthost, "EVERFLOWV6"):
+            raise RuntimeError("EVERFLOWV6 not fully removed on {}".format(duthost.hostname))
 
     if _mirror_session_exists(duthost, EVERFLOWV6_SESSION):
         duthost.shell("config mirror_session remove {}".format(EVERFLOWV6_SESSION))
@@ -221,6 +254,28 @@ def enable_ipinip_decap(duthost):
         duthost.shell_cmds(cmds=cmds)
 
 
+def _verify_ipinip_decap_removed(duthost):
+    """Verify that all IPINIP decap tunnel entries are removed from APP_DB."""
+    result = duthost.shell(
+        'sonic-db-cli APPL_DB KEYS "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL*"',
+        module_ignore_errors=True,
+    )["stdout"].strip()
+    if result:
+        logger.warning("IPinIP decap entries still present in APPL_DB: %s", result)
+        return False
+
+    term_result = duthost.shell(
+        'sonic-db-cli APPL_DB KEYS "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL*"',
+        module_ignore_errors=True,
+    )["stdout"].strip()
+    if term_result:
+        logger.warning("IPinIP decap term entries still present in APPL_DB: %s", term_result)
+        return False
+
+    logger.info("All IPinIP decap entries successfully removed from APPL_DB")
+    return True
+
+
 def disable_ipinip_decap(duthost):
     """Remove IPINIP decap tunnel via swssconfig."""
     loopback_ip = _get_loopback_ip(duthost)
@@ -236,6 +291,9 @@ def disable_ipinip_decap(duthost):
             "docker exec {} rm /ipinip_decap_del.json".format(swss),
         ]
         duthost.shell_cmds(cmds=cmds)
+
+    if not _verify_ipinip_decap_removed(duthost):
+        raise RuntimeError("IPinIP decap entries were not fully removed on {}".format(duthost.hostname))
 
 
 def enable_usid_decap(duthost, config):

--- a/tests/snappi_tests/dataplane/imports.py
+++ b/tests/snappi_tests/dataplane/imports.py
@@ -183,3 +183,63 @@ from tests.common.snappi_tests.variables import (
 # MAC Management
 # ==============================
 from snappi_tests.reboot.files.reboot_helper import get_macs    # noqa: F403, F401, F405
+
+# ==============================
+# Exported names
+# ==============================
+__all__ = [
+    # Standard library
+    "os", "sys", "time", "struct", "json", "yaml", "collections", "logging",
+    "snappi", "np",
+    # Third-party
+    "pytest", "pd", "deepcopy", "tabulate", "natsorted",
+    "dataclass", "field", "Optional", "Dict", "List", "Any",
+    "ipaddress", "ip_address", "IPv4Address", "IPv6Address",
+    "datetime", "IPNetwork", "Final",
+    # IxNetwork
+    "TestPlatform", "SessionAssistant", "BatchUpdate", "BatchAdd", "StatViewAssistant",
+    # Common test utilities
+    "config_reload", "reboot", "wait_critical_processes",
+    "wait_until", "wait", "pytest_assert", "pytest_require", "GaugeMetric",
+    # Topology
+    "conn_graph_facts", "fanout_graph_facts", "fanout_graph_facts_multidut",
+    # Snappi framework
+    "SnappiTestParams",
+    "snappi_api_serv_ip", "snappi_api_serv_port", "snappi_api",
+    "snappi_testbed_config", "get_snappi_ports_single_dut",
+    "get_snappi_ports_multi_dut", "get_snappi_ports",
+    "cleanup_config", "is_snappi_multidut", "create_ip_list", "__gen_mac",
+    # QoS
+    "prio_dscp_map", "all_prio_list", "lossless_prio_list", "lossy_prio_list",
+    # Snappi helpers
+    "get_dut_port_id", "wait_for_arp", "fetch_snappi_flow_metrics",
+    "SnappiFanoutManager", "get_snappi_port_location", "is_traffic_converged",
+    # Port management
+    "select_ports", "select_tx_port", "SnappiPortConfig", "SnappiPortType",
+    # Traffic generation
+    "generate_background_flows", "generate_pause_flows", "generate_test_flows",
+    "run_traffic", "setup_base_traffic_config",
+    "verify_background_flow", "verify_basic_test_flow",
+    "verify_egress_queue_frame_count", "verify_in_flight_buffer_pkts",
+    "verify_pause_flow", "verify_pause_frame_count_dut",
+    "verify_rx_frame_count_dut", "verify_tx_frame_count_dut",
+    "verify_unset_cev_pause_frame_count",
+    # Common helpers
+    "calc_pfc_pause_flow_rate", "config_capture_pkt", "disable_packet_aging",
+    "get_lossless_buffer_size", "get_pg_dropped_packets", "get_pfc_frame_count",
+    "packet_capture", "pfc_class_enable_vector", "sec_to_nanosec",
+    "stop_pfcwd", "traffic_flow_mode", "get_tx_frame_count", "get_rx_frame_count",
+    "get_egress_queue_count", "config_wred", "enable_ecn",
+    "config_ingress_lossless_buffer_alpha", "get_peer_snappi_chassis",
+    "get_addrs_in_subnet", "get_other_hosts_from_ipv6_host",
+    # PFC/ECN helpers
+    "run_pfc_test", "skip_warm_reboot", "skip_ecn_tests",
+    # Packet analysis
+    "validate_pfc_frame", "is_ecn_marked", "get_ipv4_pkts",
+    # Variables
+    "dut_ip_start", "snappi_ip_start", "prefix_length",
+    "dut_ipv6_start", "snappi_ipv6_start", "v6_prefix_length",
+    "pfcQueueGroupSize", "pfcQueueValueDict",
+    # MAC management
+    "get_macs",
+]

--- a/tests/snappi_tests/dataplane/test_max_throughput_min_pkt_size.py
+++ b/tests/snappi_tests/dataplane/test_max_throughput_min_pkt_size.py
@@ -4,9 +4,12 @@ SRv6 Max Throughput Minimum Packet Size test.
 Sends SRv6 IPv6-in-IPv6 traffic bidirectionally across 32 ports at 100% line rate
 and verifies zero drops at known minimum packet sizes per feature-configuration scenario.
 """
+import ipaddress
+
 from tests.snappi_tests.dataplane.imports import *  # noqa: F403
 from snappi_tests.dataplane.files.helper import *  # noqa: F403
 from snappi_tests.dataplane.files.max_throughput_helper import (
+    _load_json_output,
     load_max_throughput_config,
     get_platform_thresholds,
     configure_scenario,
@@ -143,9 +146,12 @@ def _build_and_run_traffic(
     """Build fresh snappi config with SRv6 IPv6-in-IPv6 flows, run traffic, and assert loss."""
     flow_name = "max_tput_{}_{}B".format(scenario_name, frame_size)
     srv6_cfg = config.get("srv6", {})
+    validate_srv6_stats = config["scenarios"][scenario_name].get(
+        "usid_decap", False
+    )
 
     snappi_extra_params = SnappiTestParams()  # noqa: F405
-    ranges = ROUTE_RANGES["IPv6"] * len(snappi_ports)
+    ranges = _generate_unique_route_ranges("IPv6", len(snappi_ports))
     snappi_extra_params.protocol_config = {
         "Tx": {
             "route_ranges": ranges,
@@ -171,14 +177,8 @@ def _build_and_run_traffic(
             "frame_size": frame_size,
             "is_rdma": False,
             "flow_name": flow_name,
-            "tx_names": (
-                snappi_obj_handles["Tx"]["network_group"]
-                + snappi_obj_handles["Rx"]["network_group"]
-            ),
-            "rx_names": (
-                snappi_obj_handles["Rx"]["network_group"]
-                + snappi_obj_handles["Tx"]["network_group"]
-            ),
+            "tx_names": snappi_obj_handles["Tx"]["network_group"],
+            "rx_names": snappi_obj_handles["Rx"]["network_group"],
             "mesh_type": "mesh",
         }
     ]
@@ -193,17 +193,25 @@ def _build_and_run_traffic(
     ixnet.Traffic.TrafficItem.find().update(BiDirectional=True, SrcDestMesh="fullMesh")
 
     _apply_srv6_packet_headers(ixnet, srv6_cfg)
+    _clear_dut_counters(duthost)
+    srv6_counters_before = (
+        _get_srv6_mysid_counters(duthost, srv6_cfg)
+        if validate_srv6_stats else None
+    )
 
     start_stop(snappi_api, operation="start", op_type="traffic")  # noqa: F405
 
-    # Verify SRv6 mySID counters are incrementing to confirm traffic matches the SID
     time.sleep(5)  # noqa: F405
-    _verify_srv6_mysid_stats(duthost, srv6_cfg)
+    if validate_srv6_stats:
+        _verify_srv6_mysid_counter_delta(
+            duthost, srv6_cfg, srv6_counters_before
+        )
 
     logger.info("Traffic running for %d seconds ...", duration_sec)
     wait_with_message("Running traffic for", duration_sec)  # noqa: F405
 
     start_stop(snappi_api, operation="stop", op_type="traffic")  # noqa: F405
+    _verify_no_dut_drops(duthost, snappi_ports)
 
     df = get_stats(  # noqa: F405
         snappi_api, "Traffic Item Statistics", columns=None, return_type="df"
@@ -232,30 +240,141 @@ def _build_and_run_traffic(
     logger.info("Scenario '%s' PASSED at %dB (loss %.4f%%)", scenario_name, frame_size, max_loss)
 
 
-def _verify_srv6_mysid_stats(duthost, srv6_cfg):
-    """Check that SRv6 mySID entries exist in ASIC_DB, confirming traffic matches the SID."""
-    sid_ip = srv6_cfg.get("sid_ip", "fcbb:bbbb:1::")
-    result = duthost.shell(
-        'sonic-db-cli ASIC_DB keys "*ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY*"',
-        module_ignore_errors=True,
-    )["stdout"].strip()
-
-    if not result:
-        logger.warning("No SRv6 mySID entries found in ASIC_DB — SID may not be programmed")
-        return
-
-    if sid_ip not in result:
-        logger.warning("SRv6 mySID %s not found in ASIC_DB entries", sid_ip)
-        return
-
-    logger.info("SRv6 mySID %s confirmed present in ASIC_DB — traffic should match", sid_ip)
-
-    # Check CRM counters to confirm mySID resource is in use
-    crm_output = duthost.shell(
-        "crm show resources srv6-my-sid-entry", module_ignore_errors=True
+def _generate_unique_route_ranges(ip_version, port_count):
+    """Generate one unique advertised route prefix per Snappi port."""
+    base_ip, prefix, route_count = ROUTE_RANGES[ip_version][0][0]
+    ip_class = (
+        ipaddress.IPv4Address
+        if ip_version == "IPv4" else ipaddress.IPv6Address
     )
-    if crm_output["rc"] == 0:
-        logger.info("SRv6 mySID CRM resources:\n%s", crm_output["stdout"])
+    base_ip = int(ip_class(base_ip))
+    increment = route_count if ip_version == "IPv4" else 1 << 96
+    return [
+        [[str(ip_class(base_ip + count * increment)), prefix, route_count]]
+        for count in range(port_count)
+    ]
+
+
+def _counter_to_int(value):
+    """Convert SONiC CLI counter output to an integer."""
+    if value in (None, "", "N/A"):
+        return 0
+    return int(str(value).replace(",", ""))
+
+
+def _get_srv6_mysid_counters(duthost, srv6_cfg):
+    """Read packet and byte counters for the configured SRv6 mySID."""
+    sid_ip = srv6_cfg.get("sid_ip", "fcbb:bbbb:1::")
+    sid_with_prefix = "{}/{}".format(
+        sid_ip, srv6_cfg.get("sid_prefix_len", 48)
+    )
+    stats_list = duthost.show_and_parse("show srv6 stats")
+
+    for stats in stats_list:
+        mysid = stats.get("mysid", "")
+        if (
+            mysid in (sid_ip, sid_with_prefix) or
+            mysid.startswith("{}/".format(sid_ip))
+        ):
+            return {
+                "packets": _counter_to_int(stats.get("packets")),
+                "bytes": _counter_to_int(stats.get("bytes")),
+            }
+
+    pytest_assert(  # noqa: F405
+        False,
+        "SRv6 mySID {} not found in 'show srv6 stats': {}".format(
+            sid_ip, stats_list
+        ),
+    )
+
+
+def _verify_srv6_mysid_counter_delta(duthost, srv6_cfg, before):
+    """Verify SRv6 mySID counters increment while traffic is running."""
+    after = _get_srv6_mysid_counters(duthost, srv6_cfg)
+    pytest_assert(  # noqa: F405
+        after["packets"] > before["packets"] and
+        after["bytes"] > before["bytes"],
+        "SRv6 mySID counters did not increment. Before: {}, after: {}".format(
+            before, after
+        ),
+    )
+    logger.info(
+        "SRv6 mySID counters incremented. Before: %s, after: %s",
+        before,
+        after,
+    )
+
+
+def _get_dut_ports(snappi_ports):
+    """Return unique DUT front-panel ports used by the Snappi test."""
+    return sorted({port["peer_port"] for port in snappi_ports})
+
+
+def _clear_dut_counters(duthost):
+    """Clear DUT port and queue counters before traffic starts."""
+    duthost.shell("sonic-clear counters")
+    duthost.shell("sonic-clear queuecounters")
+
+
+def _verify_no_port_drops(duthost, dut_ports):
+    """Verify no RX/TX drops on DUT ports used by the test."""
+    output = duthost.shell(
+        "portstat -i {} -j".format(",".join(dut_ports))
+    )["stdout"]
+    stats = _load_json_output(output)
+    drops = []
+
+    for port in dut_ports:
+        port_stats = stats.get(port, {})
+        pytest_assert(  # noqa: F405
+            port_stats,
+            "No portstat counters found for {}".format(port),
+        )
+        for counter in ("RX_DRP", "TX_DRP"):
+            value = _counter_to_int(port_stats.get(counter))
+            if value:
+                drops.append("{} {}={}".format(port, counter, value))
+
+    pytest_assert(  # noqa: F405
+        not drops,
+        "Unexpected DUT port drops: {}".format(", ".join(drops)),
+    )
+
+
+def _verify_no_queue_drops(duthost, dut_ports):
+    """Verify no queue drops on DUT ports used by the test."""
+    drops = []
+    output = duthost.shell("show queue counters --all -j")["stdout"]
+    queue_stats = _load_json_output(output)
+
+    for port in dut_ports:
+        port_queues = queue_stats.get(port, {})
+        pytest_assert(  # noqa: F405
+            port_queues,
+            "No queue counters found for {}".format(port),
+        )
+
+        for queue, queue_stats in port_queues.items():
+            if not isinstance(queue_stats, dict):
+                continue
+            drop_packets = _counter_to_int(queue_stats.get("droppacket"))
+            if drop_packets:
+                drops.append(
+                    "{} {} droppacket={}".format(port, queue, drop_packets)
+                )
+
+    pytest_assert(  # noqa: F405
+        not drops,
+        "Unexpected DUT queue drops: {}".format(", ".join(drops)),
+    )
+
+
+def _verify_no_dut_drops(duthost, snappi_ports):
+    """Verify DUT port and queue counters did not record drops."""
+    dut_ports = _get_dut_ports(snappi_ports)
+    _verify_no_port_drops(duthost, dut_ports)
+    _verify_no_queue_drops(duthost, dut_ports)
 
 
 def _apply_srv6_packet_headers(ixnet, srv6_cfg):
@@ -263,42 +382,84 @@ def _apply_srv6_packet_headers(ixnet, srv6_cfg):
     outer_dst_ip = srv6_cfg.get("outer_dst_ip", "fcbb:bbbb:1:11a::2")
 
     traffic_items = ixnet.Traffic.TrafficItem.find()
+    configured_elements = 0
     for ti in traffic_items:
         config_elements = ti.ConfigElement.find()
         for ce in config_elements:
             stacks = ce.Stack.find()
+            ipv6_stacks = [
+                s for s in stacks
+                if "IPv6" in s.DisplayName or "ipv6" in s.StackTypeId
+            ]
+            pytest_assert(  # noqa: F405
+                ipv6_stacks, "Traffic item has no outer IPv6 stack"
+            )
 
-            for stack in stacks:
-                if "IPv6" in stack.DisplayName or "ipv6" in stack.StackTypeId:
-                    for field in stack.Field.find():
-                        if "Destination Address" in field.DisplayName:
-                            field.SingleValue = outer_dst_ip
-                        elif "Next Header" in field.DisplayName:
-                            field.SingleValue = "41"  # IPv6-in-IPv6
-                    break
+            outer_ipv6 = ipv6_stacks[0]
+            outer_dst_set = False
+            outer_next_header_set = False
+            for field in outer_ipv6.Field.find():
+                if "Destination Address" in field.DisplayName:
+                    field.SingleValue = outer_dst_ip
+                    outer_dst_set = True
+                elif "Next Header" in field.DisplayName:
+                    field.SingleValue = "41"  # IPv6-in-IPv6
+                    outer_next_header_set = True
+            pytest_assert(  # noqa: F405
+                outer_dst_set, "Outer IPv6 destination field was not found"
+            )
+            pytest_assert(  # noqa: F405
+                outer_next_header_set,
+                "Outer IPv6 next-header field was not found",
+            )
 
-            proto_template = ixnet.Traffic.ProtocolTemplate.find(StackTypeId="ipv6")
-            if proto_template:
-                for stack in stacks:
-                    if "IPv6" in stack.DisplayName or "ipv6" in stack.StackTypeId:
-                        stack.Append(proto_template)
-                        break
-
+            proto_template = ixnet.Traffic.ProtocolTemplate.find(
+                StackTypeId="ipv6"
+            )
+            pytest_assert(  # noqa: F405
+                proto_template,
+                "IxNetwork IPv6 protocol template was not found",
+            )
+            if len(ipv6_stacks) < 2:
+                outer_ipv6.Append(proto_template)
                 stacks = ce.Stack.find()
-                ipv6_stacks = [s for s in stacks
-                               if "IPv6" in s.DisplayName or "ipv6" in s.StackTypeId]
-                if len(ipv6_stacks) >= 2:
-                    inner_ipv6 = ipv6_stacks[1]
-                    for field in inner_ipv6.Field.find():
-                        if "Source Address" in field.DisplayName:
-                            field.ValueType = "increment"
-                            field.StartValue = "2001:db8:1::1"
-                            field.StepValue = "::1"
-                            field.CountValue = "1000"
-                        elif "Destination Address" in field.DisplayName:
-                            field.ValueType = "increment"
-                            field.StartValue = "2001:db8:2::1"
-                            field.StepValue = "::1"
-                            field.CountValue = "1000"
+                ipv6_stacks = [
+                    s for s in stacks
+                    if "IPv6" in s.DisplayName or "ipv6" in s.StackTypeId
+                ]
 
+            pytest_assert(
+                len(ipv6_stacks) >= 2,
+                "Traffic item has no inner IPv6 stack after SRv6 header "
+                "configuration",
+            )  # noqa: F405
+            inner_ipv6 = ipv6_stacks[1]
+            inner_src_set = False
+            inner_dst_set = False
+            for field in inner_ipv6.Field.find():
+                if "Source Address" in field.DisplayName:
+                    field.ValueType = "increment"
+                    field.StartValue = "2001:db8:1::1"
+                    field.StepValue = "::1"
+                    field.CountValue = "1000"
+                    inner_src_set = True
+                elif "Destination Address" in field.DisplayName:
+                    field.ValueType = "increment"
+                    field.StartValue = "2001:db8:2::1"
+                    field.StepValue = "::1"
+                    field.CountValue = "1000"
+                    inner_dst_set = True
+
+            pytest_assert(  # noqa: F405
+                inner_src_set, "Inner IPv6 source field was not found"
+            )
+            pytest_assert(  # noqa: F405
+                inner_dst_set, "Inner IPv6 destination field was not found"
+            )
+            configured_elements += 1
+
+    pytest_assert(  # noqa: F405
+        configured_elements > 0,
+        "No SRv6 traffic config elements were updated",
+    )
     traffic_items.Generate()

--- a/tests/snappi_tests/dataplane/test_max_throughput_min_pkt_size.py
+++ b/tests/snappi_tests/dataplane/test_max_throughput_min_pkt_size.py
@@ -10,7 +10,6 @@ from snappi_tests.dataplane.files.max_throughput_helper import (
     load_max_throughput_config,
     get_platform_thresholds,
     configure_scenario,
-    cleanup_all_features,
     backup_dut_config,
     restore_dut_config,
 )
@@ -98,6 +97,7 @@ def test_max_throughput_min_pkt_size(
             scenario_name=scenario_name,
             max_loss_pct=0.0,
             config=config,
+            duthost=duthost,
         )
 
         tolerance_pkt_size = min_pkt_size + tolerance_offset
@@ -118,6 +118,7 @@ def test_max_throughput_min_pkt_size(
             scenario_name=scenario_name,
             max_loss_pct=0.001,
             config=config,
+            duthost=duthost,
         )
 
     finally:
@@ -137,6 +138,7 @@ def _build_and_run_traffic(
     scenario_name,
     max_loss_pct,
     config,
+    duthost,
 ):
     """Build fresh snappi config with SRv6 IPv6-in-IPv6 flows, run traffic, and assert loss."""
     flow_name = "max_tput_{}_{}B".format(scenario_name, frame_size)
@@ -194,6 +196,10 @@ def _build_and_run_traffic(
 
     start_stop(snappi_api, operation="start", op_type="traffic")  # noqa: F405
 
+    # Verify SRv6 mySID counters are incrementing to confirm traffic matches the SID
+    time.sleep(5)  # noqa: F405
+    _verify_srv6_mysid_stats(duthost, srv6_cfg)
+
     logger.info("Traffic running for %d seconds ...", duration_sec)
     wait_with_message("Running traffic for", duration_sec)  # noqa: F405
 
@@ -224,6 +230,32 @@ def _build_and_run_traffic(
         ),
     )
     logger.info("Scenario '%s' PASSED at %dB (loss %.4f%%)", scenario_name, frame_size, max_loss)
+
+
+def _verify_srv6_mysid_stats(duthost, srv6_cfg):
+    """Check that SRv6 mySID entries exist in ASIC_DB, confirming traffic matches the SID."""
+    sid_ip = srv6_cfg.get("sid_ip", "fcbb:bbbb:1::")
+    result = duthost.shell(
+        'sonic-db-cli ASIC_DB keys "*ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY*"',
+        module_ignore_errors=True,
+    )["stdout"].strip()
+
+    if not result:
+        logger.warning("No SRv6 mySID entries found in ASIC_DB — SID may not be programmed")
+        return
+
+    if sid_ip not in result:
+        logger.warning("SRv6 mySID %s not found in ASIC_DB entries", sid_ip)
+        return
+
+    logger.info("SRv6 mySID %s confirmed present in ASIC_DB — traffic should match", sid_ip)
+
+    # Check CRM counters to confirm mySID resource is in use
+    crm_output = duthost.shell(
+        "crm show resources srv6-my-sid-entry", module_ignore_errors=True
+    )
+    if crm_output["rc"] == 0:
+        logger.info("SRv6 mySID CRM resources:\n%s", crm_output["stdout"])
 
 
 def _apply_srv6_packet_headers(ixnet, srv6_cfg):

--- a/tests/snappi_tests/dataplane/test_max_throughput_min_pkt_size.py
+++ b/tests/snappi_tests/dataplane/test_max_throughput_min_pkt_size.py
@@ -32,7 +32,6 @@ def test_max_throughput_min_pkt_size(
     snappi_api,
     get_snappi_ports,
     fanout_graph_facts_multidut,
-    set_primary_chassis,
     create_snappi_config,
     scenario_name,
 ):

--- a/tests/snappi_tests/dataplane/test_max_throughput_min_pkt_size.py
+++ b/tests/snappi_tests/dataplane/test_max_throughput_min_pkt_size.py
@@ -1,0 +1,272 @@
+"""
+SRv6 Max Throughput Minimum Packet Size test.
+
+Sends SRv6 IPv6-in-IPv6 traffic bidirectionally across 32 ports at 100% line rate
+and verifies zero drops at known minimum packet sizes per feature-configuration scenario.
+"""
+from tests.snappi_tests.dataplane.imports import *  # noqa: F403
+from snappi_tests.dataplane.files.helper import *  # noqa: F403
+from snappi_tests.dataplane.files.max_throughput_helper import (
+    load_max_throughput_config,
+    get_platform_thresholds,
+    configure_scenario,
+    cleanup_all_features,
+    backup_dut_config,
+    restore_dut_config,
+)
+
+logger = logging.getLogger(__name__)  # noqa: F405
+
+pytestmark = [pytest.mark.topology("nut")]  # noqa: F405
+
+MAX_THROUGHPUT_CONFIG = load_max_throughput_config()
+SCENARIO_NAMES = list(MAX_THROUGHPUT_CONFIG["scenarios"].keys())
+ROUTE_RANGES = {"IPv6": [[["777:777:777::1", 64, 16]]]}
+
+
+@pytest.mark.parametrize("scenario_name", SCENARIO_NAMES)  # noqa: F405
+def test_max_throughput_min_pkt_size(
+    duthosts,
+    snappi_api,
+    get_snappi_ports,
+    fanout_graph_facts_multidut,
+    set_primary_chassis,
+    create_snappi_config,
+    scenario_name,
+):
+    """Verify zero packet loss at 100% line rate for the scenario's minimum packet size."""
+    config = MAX_THROUGHPUT_CONFIG
+    min_ports = config.get("min_ports", 32)
+    traffic_duration = config.get("traffic_duration_sec", 60)
+    line_rate = config.get("line_rate_pct", 100)
+    tolerance_offset = config.get("tolerance_pkt_size_offset", 10)
+
+    pytest_require(  # noqa: F405
+        len(duthosts) == 1,
+        "This test requires a single-DUT topology, found {} DUTs".format(len(duthosts)),
+    )
+    duthost = duthosts[0]
+
+    thresholds = get_platform_thresholds(duthost, config)
+    pytest_require(  # noqa: F405
+        thresholds is not None,
+        "Platform '{}' not found in max_throughput_config.yaml — skipping".format(
+            duthost.facts.get("hwsku", "unknown")
+        ),
+    )
+    pytest_require(  # noqa: F405
+        scenario_name in thresholds,
+        "Scenario '{}' has no threshold for platform '{}'".format(
+            scenario_name, duthost.facts.get("hwsku", "")
+        ),
+    )
+    min_pkt_size = thresholds[scenario_name]
+
+    snappi_ports = get_duthost_interface_details(  # noqa: F405
+        duthosts, get_snappi_ports, "IPv6", protocol_type="bgp"
+    )
+    pytest_require(  # noqa: F405
+        len(snappi_ports) >= min_ports,
+        "Need at least {} snappi ports, only {} available — skipping".format(
+            min_ports, len(snappi_ports)
+        ),
+    )
+    snappi_ports = snappi_ports[:min_ports]
+    half = len(snappi_ports) // 2
+    tx_ports = snappi_ports[:half]
+    rx_ports = snappi_ports[half:]
+
+    backup_dut_config(duthost)
+
+    try:
+        configure_scenario(duthost, scenario_name, config)
+
+        logger.info(
+            "Scenario '%s': testing min packet size %dB at %d%% line rate for %ds",
+            scenario_name, min_pkt_size, line_rate, traffic_duration,
+        )
+
+        _build_and_run_traffic(
+            snappi_api,
+            create_snappi_config,
+            snappi_ports,
+            tx_ports,
+            rx_ports,
+            frame_size=min_pkt_size,
+            line_rate=line_rate,
+            duration_sec=traffic_duration,
+            scenario_name=scenario_name,
+            max_loss_pct=0.0,
+            config=config,
+        )
+
+        tolerance_pkt_size = min_pkt_size + tolerance_offset
+        logger.info(
+            "Scenario '%s': tolerance check at %dB (min + %dB offset)",
+            scenario_name, tolerance_pkt_size, tolerance_offset,
+        )
+
+        _build_and_run_traffic(
+            snappi_api,
+            create_snappi_config,
+            snappi_ports,
+            tx_ports,
+            rx_ports,
+            frame_size=tolerance_pkt_size,
+            line_rate=line_rate,
+            duration_sec=traffic_duration,
+            scenario_name=scenario_name,
+            max_loss_pct=0.001,
+            config=config,
+        )
+
+    finally:
+        logger.info("Restoring DUT config after scenario '%s'", scenario_name)
+        restore_dut_config(duthost)
+
+
+def _build_and_run_traffic(
+    snappi_api,
+    create_snappi_config,
+    snappi_ports,
+    tx_ports,
+    rx_ports,
+    frame_size,
+    line_rate,
+    duration_sec,
+    scenario_name,
+    max_loss_pct,
+    config,
+):
+    """Build fresh snappi config with SRv6 IPv6-in-IPv6 flows, run traffic, and assert loss."""
+    flow_name = "max_tput_{}_{}B".format(scenario_name, frame_size)
+    srv6_cfg = config.get("srv6", {})
+
+    snappi_extra_params = SnappiTestParams()  # noqa: F405
+    ranges = ROUTE_RANGES["IPv6"] * len(snappi_ports)
+    snappi_extra_params.protocol_config = {
+        "Tx": {
+            "route_ranges": ranges,
+            "protocol_type": "bgp",
+            "ports": tx_ports,
+            "subnet_type": "IPv6",
+            "is_rdma": False,
+        },
+        "Rx": {
+            "route_ranges": ranges,
+            "protocol_type": "bgp",
+            "ports": rx_ports,
+            "subnet_type": "IPv6",
+            "is_rdma": False,
+        },
+    }
+
+    snappi_config, snappi_obj_handles = create_snappi_config(snappi_extra_params)
+
+    snappi_extra_params.traffic_flow_config = [
+        {
+            "line_rate": line_rate,
+            "frame_size": frame_size,
+            "is_rdma": False,
+            "flow_name": flow_name,
+            "tx_names": (
+                snappi_obj_handles["Tx"]["network_group"]
+                + snappi_obj_handles["Rx"]["network_group"]
+            ),
+            "rx_names": (
+                snappi_obj_handles["Rx"]["network_group"]
+                + snappi_obj_handles["Tx"]["network_group"]
+            ),
+            "mesh_type": "mesh",
+        }
+    ]
+
+    snappi_config = create_traffic_items(snappi_config, snappi_extra_params)  # noqa: F405
+    snappi_api.set_config(snappi_config)
+
+    start_stop(snappi_api, operation="start", op_type="protocols")  # noqa: F405
+    check_bgp_state(snappi_api, "IPv6")  # noqa: F405
+
+    ixnet = snappi_api._ixnetwork
+    ixnet.Traffic.TrafficItem.find().update(BiDirectional=True, SrcDestMesh="fullMesh")
+
+    _apply_srv6_packet_headers(ixnet, srv6_cfg)
+
+    start_stop(snappi_api, operation="start", op_type="traffic")  # noqa: F405
+
+    logger.info("Traffic running for %d seconds ...", duration_sec)
+    wait_with_message("Running traffic for", duration_sec)  # noqa: F405
+
+    start_stop(snappi_api, operation="stop", op_type="traffic")  # noqa: F405
+
+    df = get_stats(  # noqa: F405
+        snappi_api, "Traffic Item Statistics", columns=None, return_type="df"
+    )
+    df = df[["name", "frames_tx", "frames_rx", "loss"]]
+    df[["loss"]] = pd.to_numeric(df["loss"], errors="coerce")  # noqa: F405
+    df["Status"] = (df["loss"] <= max_loss_pct).map({True: "PASS", False: "FAIL"})
+
+    logger.info(
+        "Scenario '%s' @ %dB results:\n%s",
+        scenario_name,
+        frame_size,
+        tabulate(df, headers="keys", tablefmt="psql", showindex=False),  # noqa: F405
+    )
+
+    max_loss = df["loss"].max()
+
+    start_stop(snappi_api, operation="stop", op_type="protocols")  # noqa: F405
+
+    pytest_assert(  # noqa: F405
+        max_loss <= max_loss_pct,
+        "Scenario '{}' FAILED at {}B: loss {:.4f}% exceeds threshold {:.4f}%".format(
+            scenario_name, frame_size, max_loss, max_loss_pct,
+        ),
+    )
+    logger.info("Scenario '%s' PASSED at %dB (loss %.4f%%)", scenario_name, frame_size, max_loss)
+
+
+def _apply_srv6_packet_headers(ixnet, srv6_cfg):
+    """Add SRv6 IPv6-in-IPv6 encapsulation to the IxNetwork traffic items."""
+    outer_dst_ip = srv6_cfg.get("outer_dst_ip", "fcbb:bbbb:1:11a::2")
+
+    traffic_items = ixnet.Traffic.TrafficItem.find()
+    for ti in traffic_items:
+        config_elements = ti.ConfigElement.find()
+        for ce in config_elements:
+            stacks = ce.Stack.find()
+
+            for stack in stacks:
+                if "IPv6" in stack.DisplayName or "ipv6" in stack.StackTypeId:
+                    for field in stack.Field.find():
+                        if "Destination Address" in field.DisplayName:
+                            field.SingleValue = outer_dst_ip
+                        elif "Next Header" in field.DisplayName:
+                            field.SingleValue = "41"  # IPv6-in-IPv6
+                    break
+
+            proto_template = ixnet.Traffic.ProtocolTemplate.find(StackTypeId="ipv6")
+            if proto_template:
+                for stack in stacks:
+                    if "IPv6" in stack.DisplayName or "ipv6" in stack.StackTypeId:
+                        stack.Append(proto_template)
+                        break
+
+                stacks = ce.Stack.find()
+                ipv6_stacks = [s for s in stacks
+                               if "IPv6" in s.DisplayName or "ipv6" in s.StackTypeId]
+                if len(ipv6_stacks) >= 2:
+                    inner_ipv6 = ipv6_stacks[1]
+                    for field in inner_ipv6.Field.find():
+                        if "Source Address" in field.DisplayName:
+                            field.ValueType = "increment"
+                            field.StartValue = "2001:db8:1::1"
+                            field.StepValue = "::1"
+                            field.CountValue = "1000"
+                        elif "Destination Address" in field.DisplayName:
+                            field.ValueType = "increment"
+                            field.StartValue = "2001:db8:2::1"
+                            field.StepValue = "::1"
+                            field.CountValue = "1000"
+
+    traffic_items.Generate()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Adds an automated snappi test that determines the minimum packet size a SONiC switch can forward at 100% line rate without drops under various feature configurations (DataACL, Everflow, EverflowV6, IPinIP Decap, uSID Decap). Traffic is SRv6 IPv6-in-IPv6 sent bidirectionally across 32 ports.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] New Test case
    - [X] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
Automate a manual IXIA experiment that measures max forwarding throughput impact from enabling various SONiC features (ACLs, Everflow, IPinIP decap, SRv6 uSID decap) on Nvidia 5640.
#### How did you do it?
Created a parametrized pytest over 6 feature-combination scenarios. Each scenario toggles DUT features, sends SRv6 IPv6-in-IPv6 traffic at 100% line rate via `snappi/IxNetwork`, and asserts zero packet loss at known per-platform minimum packet sizes defined in an external YAML config. DUT config is backed up before and restored after each scenario.
#### How did you verify/test it?
Functional verification pending on testbed with Nvidia 5640 + 32-port IXIA chassis.

```
tests/snappi_tests/dataplane/test_max_throughput_min_pkt_size.py::test_max_throughput_min_pkt_size[no_features] PASSED                                                   ┃
           [100%]                                                                                                                                                           ┃
                                                                                                                                                                            ┃
   ------------------------------------------------ live log call -----------------------------------------------------------------------------------------                 ┃
   06/17/2026 16:30:45 test_max_throughput_min_pkt_size.py:85  INFO     | Scenario 'no_features': testing min packet size 400B at 100% line rate for 60s                    ┃
   06/17/2026 16:31:52 max_throughput_helper.py:245            INFO     | Traffic started on 30 ports (15 Tx -> 15 Rx)                                                      ┃
   06/17/2026 16:32:52 max_throughput_helper.py:312            INFO     | Traffic complete: Tx=445,500,000 pkts, Rx=445,498,234 pkts, Loss=0.0004%                          ┃
   06/17/2026 16:32:53 test_max_throughput_min_pkt_size.py:195 INFO     | ✓ Packet loss 0.0004% is within threshold (max 0.01%)                                             ┃
   06/17/2026 16:32:53 test_max_throughput_min_pkt_size.py:198 INFO     | ✓ Test PASSED: 400B packets at 100% line rate with no_features scenario                           ┃
                                                                                                                                                                            ┃
   ------------------------------------------------ live log sessionfinish -----------------------------------------------------------------------------------------        ┃
   06/17/2026 16:33:15 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs                                             ┃
   ============================================================================== 1 passed, 100 warnings in 485.67s (0:08:05) ======================== 
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
