### PR TITLE
add program static route test case to identify churn

### DIFF
--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -6,6 +6,7 @@ import logging
 import natsort
 import random
 import six
+import re
 from collections import defaultdict
 from contextlib import contextmanager
 
@@ -22,6 +23,7 @@ from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.constants import ARP_RESPONDER_DEFAULT_CONFIG, UPSTREAM_NEIGHBOR_MAP
 from tests.common import config_reload
 from tests.common.reboot import reboot
+from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
 import ptf.testutils as testutils
 import ptf.mask as mask
 import ptf.packet as packet
@@ -37,6 +39,27 @@ pytestmark = [
     pytest.mark.topology('t0', 'm0', 'mx'),
     pytest.mark.device_type('vs')
 ]
+
+logger = logging.getLogger(__name__)
+allure.logger = logger
+
+added_routes = set()
+
+
+@pytest.fixture(scope='function', autouse=False)
+def clear_static_route(rand_selected_dut):
+    """Clear route configuration
+
+    Args:
+        rand_selected_dut (object): DUT object
+    """
+    try:
+        yield
+    finally:
+        for route in added_routes:
+            rand_selected_dut.shell('config route del prefix {} nexthop {}'.format(
+                route[0], route[1]), module_ignore_errors=True)
+        added_routes.clear()
 
 
 def is_dualtor(tbinfo):
@@ -944,3 +967,82 @@ def test_static_route_blackhole_removal_after_config_reload(rand_selected_dut, r
         remove_blackhole_route(ipv4_prefix)
         remove_blackhole_route(ipv6_prefix)
         duthost.shell('config save -y')
+
+
+@pytest.mark.parametrize("ipv6", [False, True], ids=["ipv4", "ipv6"])
+def test_static_route_no_bgp_churn(rand_selected_dut, clear_static_route, tbinfo, ipv6):
+
+    def _get_bgp_neighbor_ip(duthost, ipv6):
+        """Get next hop from BGP neighbors
+
+        Args:
+            duthost (object): DUT object
+            ipv6 (bool): True if getting IPv6 nexthop
+
+        Returns:
+            str: Nexthop IP
+        """
+        if ipv6:
+            cmd = 'show ipv6 bgp summary'
+        else:
+            cmd = 'show ip bgp summary'
+        parse_result = duthost.show_and_parse(cmd)
+        if not parse_result:
+            return None
+        if 'neighbor' in parse_result[0]:
+            return parse_result[0]['neighbor']
+        else:
+            return parse_result[0]['neighbhor']
+
+    def _add_route(duthost, prefix, nexthop):
+        """Add static route
+
+        Args:
+            duthost (object): DUT object
+            prefix (str): Route prefix
+            nexthop (str): Route nexthop
+        """
+        duthost.shell(
+            'config route add prefix {} nexthop {}'.format(prefix, nexthop))
+        added_routes.add((prefix, nexthop))
+
+    def _routes_from_swss_delta(delta):
+        """ROUTE_TABLE:<prefix> segments in delta order."""
+        return re.findall(r"ROUTE_TABLE:([^|]+)", delta)
+
+    """When adding N static routes, swss.rec delta must be exactly N non-empty lines of
+    ROUTE_TABLE|SET matching prefixes."""
+    if not ipv6 and is_ipv6_only_topology(tbinfo):
+        pytest.skip("Will not program IPv4 static route on IPv6-only topology")
+
+    duthost = rand_selected_dut
+    if ipv6:
+        prefixes = [f"2000:1:{i}::/64" for i in range(1, 3)]  # noqa: E231
+    else:
+        prefixes = [f"1.1.{i}.0/24" for i in range(1, 3)]
+    nexthop = _get_bgp_neighbor_ip(duthost, ipv6)
+    if not nexthop:
+        pytest.fail("No valid BGP neighbors found")
+    wait_time = 3
+
+    with allure.step("Record swss.rec baseline then add static routes {}".format(prefixes)):
+        mark = int(duthost.shell("sudo stat -c %s /var/log/swss/swss.rec")["stdout"].strip())
+        for p in prefixes:
+            _add_route(duthost, p, nexthop)
+
+    tail_offset = mark + 1
+    with allure.step("Wait then dump swss.rec incremental content"):
+        time.sleep(wait_time)
+        delta = duthost.shell(
+            f"sudo tail -c +{tail_offset} /var/log/swss/swss.rec")["stdout"]
+
+        non_empty_lines = [ln for ln in delta.splitlines() if ln.strip() and 'eth0' not in ln]
+        logger.info(
+            f"swss.rec new content after static routes: {len(non_empty_lines)} non-empty line(s)")
+
+        routes = _routes_from_swss_delta(delta)
+        pytest_assert(
+            set(routes) == set(prefixes),
+            f"Routes from swss delta {routes} do not match expected prefixes {prefixes}")
+        logger.info(f"swss.rec ROUTE_TABLE prefixes: {routes}")
+        logger.info(f"swss.rec delta raw:\n{delta}")  # noqa: E231


### PR DESCRIPTION
### Description of PR

Summary:

In issue https://github.com/sonic-net/sonic-buildimage/issues/24290, when programming static route, duplicated route update for BGP route can be observed and cause unexpected delay in following commands. We observe it in our environment due to a command timeout in flow counter test.

This bug should be fixed from 202505 https://github.com/FRRouting/frr/pull/19788, we add this test case to identify the bgp churn when adding static routes. 

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
tested on 202605: 
<img width="887" height="66" alt="image" src="https://github.com/user-attachments/assets/74e229d8-f131-456e-8939-9cd6e55a8639" />


### Approach
#### What is the motivation for this PR?
In some scenarios, the adding static route operation will flap bgp routes, causing performance issue. We plan to add a test case to guarantee that such issue won't happen again.

#### How did you do it?
Program several static routes, compare the content in swss.rec with the routes

#### How did you verify/test it?
The number and content of the routes should be the same, the swss.rec should only contains the new entry

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
N/A