### PR TITLE
fix led color issue in mellanox

### DIFF
--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -8,6 +8,7 @@ import re
 from pkg_resources import parse_version
 from tests.common import config_reload
 from tests.common.utilities import wait_until
+from tests.common.mellanox_data import is_mellanox_device
 from tests.common.helpers.assertions import pytest_require
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.helpers.thermal_control_test_helper import disable_thermal_policy     # noqa F401
@@ -432,6 +433,11 @@ def get_system_health_config(duthost, key, default):
         cmd = 'cat {}'.format(config_file)
         output = duthost.shell(cmd)
         content = output['stdout'].strip()
+
+        # For mellanox devices, both amber and red are displayed as red in the show system-health summary output
+        if is_mellanox_device(duthost):
+            content = content.replace('amber', 'red')
+
         json_obj = json.loads(content)
         return json_obj[key]
     except Exception:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

On mellanox devices, both amber and red are displayed as red in the show system-health summary output. If not handle well, test might fail due to color inconsistent

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
solve the inconsistent of led color

#### How did you do it?
replace led color amber with red on mellanox device, treat them as same color as CLI output

#### How did you verify/test it?
run test on single setup

#### Any platform specific information?
Issue is seen on Mellanox, but test case updates should not effect other platforms.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
