### PR TITLE
Increase default GCU timeout from 600s to 900s

### DIFF
--- a/tests/common/gu_utils.py
+++ b/tests/common/gu_utils.py
@@ -668,6 +668,6 @@ def get_gcu_timeout(duthost):
     """Return the GCU apply-patch timeout (in seconds) for this platform.
 
     Platforms listed in GCUTIMEOUT_MAP get a custom value; everything
-    else defaults to 600 s.
+    else defaults to 900 s.
     """
-    return GCUTIMEOUT_MAP.get(duthost.facts['platform'], 600)
+    return GCUTIMEOUT_MAP.get(duthost.facts['platform'], 900)


### PR DESCRIPTION
Increase default GCU timeout from 600s to 900s

### Description of PR

Summary:
Fixes test failures caused by timeouts during test_dynamic_acl Scale rule test, as well as other timeouts caused by overly restrictive default timeout.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Increase GCU timeout for test cases by small amount so that scale rule test stops failing after barely going over the ten minute timeout
#### How did you do it?
Increased the GCU default timeout
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
