### PR TITLE
Skip root fanout config for flat fanout topologies

### DIFF
--- a/ansible/roles/fanout/tasks/rootfanout_connect.yml
+++ b/ansible/roles/fanout/tasks/rootfanout_connect.yml
@@ -44,11 +44,12 @@
   with_dict: "{{ lab_devices }}"
   when: item.value['Type'] == 'FanoutRoot'
 
-- set_fact:
-    root_conn: "{{ lab.ansible_facts['device_conn'][root_dev] }}"
-
-- name: Change root fanout port vlan
-  action: apswitch template=roles/fanout/templates/arista_7260_connect.j2
-  connection: switch
-  args:
-    login: "{{ switch_login['Arista'] }}"
+- block:
+    - set_fact:
+        root_conn: "{{ lab.ansible_facts['device_conn'][root_dev] }}"
+    - name: Change root fanout port vlan
+      action: apswitch template=roles/fanout/templates/arista_7260_connect.j2
+      connection: switch
+      args:
+        login: "{{ switch_login['Arista'] }}"
+  when: root_dev is defined


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip the root fanout port-VLAN configuration in rootfanout_connect.yml when
the connection graph contains no FanoutRoot device, so add-topo works on
flat-fanout labs instead of failing with "'root_dev' is undefined".

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
add-topo fails for lab topologies that use flat-fanout model as the playbook assumes presence of root fanout. 

#### How did you do it?
Add guard so the playbook is a no-op for flat-fanout topologies

#### How did you verify/test it?
Validated add-topo works in a lab topo without root fanout.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
