### PR TITLE
Fix compliance code check for test_sfp.py

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -310,23 +310,22 @@ class TestSfpApi(PlatformApiTestBase):
     def is_xcvr_optical(self, xcvr_info_dict):
         """Returns True if transceiver is optical, False if copper (DAC)"""
         # For QSFP-DD specification compliance will return type as passive or active
+        spec_compliance_dict = ast.literal_eval(xcvr_info_dict["specification_compliance"])
         if xcvr_info_dict["type_abbrv_name"] in ["QSFP-DD", "OSFP-8X", "QSFP+C", "BP", "SFP"]:
             if xcvr_info_dict["specification_compliance"] == "Passive Copper Cable" or \
                     xcvr_info_dict["specification_compliance"] == "passive_copper_media_interface":
                 return False
-        else:
-            spec_compliance_dict = ast.literal_eval(xcvr_info_dict["specification_compliance"])
             if xcvr_info_dict["type_abbrv_name"] == "SFP":
                 compliance_code = spec_compliance_dict.get("SFP+CableTechnology")
                 if compliance_code == "Passive Cable":
                     return False
-            else:
-                compliance_code = spec_compliance_dict.get("10/40G Ethernet Compliance Code", " ")
-                if "CR" in compliance_code:
-                    return False
-                extended_code = spec_compliance_dict.get("Extended Specification Compliance", " ")
-                if "CR" in extended_code:
-                    return False
+        else:
+            compliance_code = spec_compliance_dict.get("10/40G Ethernet Compliance Code", " ")
+            if "CR" in compliance_code:
+                return False
+            extended_code = spec_compliance_dict.get("Extended Specification Compliance", " ")
+            if "CR" in extended_code:
+                return False
         return True
 
     def is_xcvr_resettable(self, request, xcvr_info_dict):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
https://github.com/sonic-net/sonic-mgmt/pull/23956
This PR added SFP into the if block, but didn't move the compliance code check for SFP from the else block
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
platform_tests/api/test_sfp.py::TestSfpApi::test_tx_disable_channel has been failing on devices with SFP xcvrs and "Passive Cable" compliance code since merge of #23956 

#### How did you do it?
Move the compliance code check for SFP from else block to if block

#### How did you verify/test it?
The test now passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
