### PR TITLE
[qos]: Skip warm reboot on TH5 devices in DSCP queue mapping test

### DIFF
--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -517,10 +517,14 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
             self._run_test(ptfadapter, duthost, tbinfo, test_params, inner_dst_ip_list, dut_qos_maps_module, dscp_mode)
 
         is_smartswitch = duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_smartswitch", False)
+        # TH5 devices don't support warm reboot; only cold reboot supported during upgrades.
+        # Remove this check if TH5 warm reboot support is added in the future.
+        is_th5_device = duthost.get_asic_name() == 'th5'
         topo_name = tbinfo["topo"]["name"]
         if (
             completeness_level != "basic"
             and not is_smartswitch
+            and not is_th5_device
             and "dualtor" not in topo_name
             and "t1" not in topo_name
         ):


### PR DESCRIPTION
### Description of PR

Summary:
Skip warm reboot on Broadcom TH5 devices in `test_qos_dscp_mapping`, as TH5 only supports cold reboot for upgrades. Uses `duthost.get_asic_name()` for th5 device check.

### Type of change

- [ x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ x ] 202511

### Approach
#### What is the motivation for this PR?
TH5 devices (e.g., Arista-7060X6-16PE-384C-B-O128S2) don't support warm reboot, they use cold reboot for upgrades. The DSCP queue mapping test currently attempts warm reboot on all non-smartswitch, non-dualtor t0 topologies, which causes failures on TH5 platforms.

#### How did you do it?
Added a TH5 check using `duthost.get_asic_name() == 'th5'` before the warm reboot block in `test_dscp_to_queue_mapping`. 

#### How did you verify/test it?
- Verified `duthost.get_asic_name()` returns `'th5'` on Arista-7060X6-16PE-384C-B-O128S2 from test logs.
- Confirmed the warm reboot step is skipped on TH5 and the test passes with DSCP queue mapping validation in both uniform and pipe modes.

#### Any platform specific information?
Affects Broadcom TH5 platforms (Arista-7060X6 variants). No impact on other platforms, warm reboot continues to run on all other supported devices.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A