### PR TITLE
Chassis: fix test_eth_interfaces GCU for modular with differing LCs

### DIFF
--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -20,17 +20,17 @@ SHOW_FEC_OPER_CMD_TEMPLATE = "show interfaces fec status {}"
 
 
 @pytest.fixture(autouse=True)
-def ensure_dut_readiness(duthosts, rand_one_dut_front_end_hostname):
+def ensure_dut_readiness(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     Setup/teardown fixture for each ethernet test
     rollback to check if it goes back to starting config
 
     Args:
         duthosts: list of DUTs
-        rand_one_dut_front_end_hostname: The fixture returns a randomly selected frontend DUT hostname
+        enum_rand_one_per_hwsku_frontend_hostname: The fixture returns a randomly selected frontend DUT hostname
     """
 
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     create_checkpoint(duthost)
 
     yield
@@ -267,9 +267,9 @@ def get_fec_oper(duthost, interface):
     return fec_status[0].get("fec oper", "N/A")
 
 
-def test_remove_lanes(duthosts, rand_one_dut_front_end_hostname,
+def test_remove_lanes(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                       ensure_dut_readiness, enum_rand_one_frontend_asic_index):
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
         'asic{}'.format(enum_rand_one_frontend_asic_index)
     port = get_test_port(duthost, namespace=asic_namespace)
@@ -294,9 +294,9 @@ def test_remove_lanes(duthosts, rand_one_dut_front_end_hostname,
 
 
 @pytest.mark.skip(reason="Bypass as it is blocking submodule update")
-def test_replace_lanes(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness,
+def test_replace_lanes(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ensure_dut_readiness,
                        enum_rand_one_frontend_asic_index):
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
         'asic{}'.format(enum_rand_one_frontend_asic_index)
     port = get_test_port(duthost, namespace=asic_namespace)
@@ -327,9 +327,9 @@ def test_replace_lanes(duthosts, rand_one_dut_front_end_hostname, ensure_dut_rea
         delete_tmpfile(duthost, tmpfile)
 
 
-def test_replace_mtu(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness,
+def test_replace_mtu(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ensure_dut_readiness,
                      enum_rand_one_frontend_asic_index):
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
         'asic{}'.format(enum_rand_one_frontend_asic_index)
 
@@ -365,9 +365,9 @@ def test_replace_mtu(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readi
 
 
 @pytest.mark.parametrize("pfc_asym", ["on", "off"])
-def test_toggle_pfc_asym(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness, pfc_asym,
+def test_toggle_pfc_asym(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ensure_dut_readiness, pfc_asym,
                          enum_rand_one_frontend_asic_index):
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
         'asic{}'.format(enum_rand_one_frontend_asic_index)
     port = get_test_port(duthost, namespace=asic_namespace)
@@ -397,9 +397,9 @@ def test_toggle_pfc_asym(duthosts, rand_one_dut_front_end_hostname, ensure_dut_r
 
 @pytest.mark.device_type('physical')
 @pytest.mark.parametrize("fec", ["rs", "fc"])
-def test_replace_fec(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness, fec,
+def test_replace_fec(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ensure_dut_readiness, fec,
                      enum_rand_one_frontend_asic_index):
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
         'asic{}'.format(enum_rand_one_frontend_asic_index)
     namespace_prefix = '' if asic_namespace is None else '-n ' + asic_namespace
@@ -443,9 +443,9 @@ def test_replace_fec(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readi
 
 
 @pytest.mark.skip(reason="Bypass as this is not a production scenario")
-def test_update_invalid_index(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness,
+def test_update_invalid_index(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ensure_dut_readiness,
                               enum_rand_one_frontend_asic_index):
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
         'asic{}'.format(enum_rand_one_frontend_asic_index)
     port = get_test_port(duthost, namespace=asic_namespace)
@@ -471,9 +471,9 @@ def test_update_invalid_index(duthosts, rand_one_dut_front_end_hostname, ensure_
 
 
 @pytest.mark.skip(reason="Bypass as this is not a production scenario")
-def test_update_valid_index(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness,
+def test_update_valid_index(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ensure_dut_readiness,
                             enum_rand_one_frontend_asic_index, cli_namespace_prefix):
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
         'asic{}'.format(enum_rand_one_frontend_asic_index)
     output = duthost.shell('sonic-db-cli {} CONFIG_DB keys "PORT|"\\*'.format(cli_namespace_prefix))["stdout"]
@@ -514,9 +514,9 @@ def test_update_valid_index(duthosts, rand_one_dut_front_end_hostname, ensure_du
         delete_tmpfile(duthost, tmpfile)
 
 
-def test_update_speed(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness,
+def test_update_speed(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ensure_dut_readiness,
                       enum_rand_one_frontend_asic_index):
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
         'asic{}'.format(enum_rand_one_frontend_asic_index)
     port = get_test_port(duthost, namespace=asic_namespace)
@@ -550,9 +550,9 @@ def test_update_speed(duthosts, rand_one_dut_front_end_hostname, ensure_dut_read
             delete_tmpfile(duthost, tmpfile)
 
 
-def test_update_description(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness,
+def test_update_description(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ensure_dut_readiness,
                             enum_rand_one_frontend_asic_index):
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
         'asic{}'.format(enum_rand_one_frontend_asic_index)
     port = get_test_port(duthost, namespace=asic_namespace)
@@ -578,9 +578,9 @@ def test_update_description(duthosts, rand_one_dut_front_end_hostname, ensure_du
 
 
 @pytest.mark.parametrize("admin_status", ["up", "down"])
-def test_eth_interface_admin_change(duthosts, rand_one_dut_front_end_hostname, admin_status,
+def test_eth_interface_admin_change(duthosts, enum_rand_one_per_hwsku_frontend_hostname, admin_status,
                                     enum_rand_one_frontend_asic_index):
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
         'asic{}'.format(enum_rand_one_frontend_asic_index)
     port = get_test_port(duthost, namespace=asic_namespace)
@@ -608,7 +608,7 @@ def test_eth_interface_admin_change(duthosts, rand_one_dut_front_end_hostname, a
         delete_tmpfile(duthost, tmpfile)
 
 
-def test_port_speed_change_oper_status(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness,
+def test_port_speed_change_oper_status(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ensure_dut_readiness,
                                        enum_rand_one_frontend_asic_index, loganalyzer):
     """
     Test that applying a GCU patch to change port speed (and lanes) also results in the expected
@@ -631,7 +631,7 @@ def test_port_speed_change_oper_status(duthosts, rand_one_dut_front_end_hostname
        occurred during the speed change.
     7. Rollback is handled automatically by the ensure_dut_readiness fixture.
     """
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
         'asic{}'.format(enum_rand_one_frontend_asic_index)
     namespace_prefix = '' if asic_namespace is None else '-n ' + asic_namespace


### PR DESCRIPTION
When LC1 and LC2 are two different HWSKUs (in particular, diff number of asics) we need to ensure that the random asic index chosen corresponds to the random dut.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #24432

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Currently a random asic is picked at collection time but the random front-end dut is not chosen until run time, the asic defaults to the first front-end node (LC1) but if the dut chosen for the test is LC2 then the test will fail when LC2 has a different number of asics from LC1


#### How did you do it?
The fix is to replace the rand_one_dut_hostname fixture with enum_rand_one_per_hwsku_frontend_hostname fixture so that the dut is picked at collection time and the asic will correspond to it instead of to a default.

enum_rand_one_per_hwsku_frontend_hostname will run the test once for each hwsku dut, meaning both LC1 and LC2 will run when differing hwskus. This commit provides an improvement to test coverage as well as fixing the issue.

#### How did you verify/test it?
I reran `generic_config_updater/test_eth_interface.py` on a modular chassis with a single asic LC1 and multi asic LC2 to see the tests now run on both linecards and all pass.

Also confirmed the tests still ran successfully on a pizza box.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
