### PR TITLE
save pfcwd_timer_accuracy test result to file

### DIFF
--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -34,6 +34,8 @@ def pytest_addoption(parser):
                      help='Fake storm for most ports instead of using pfc gen')
     parser.addoption('--two-queues', action='store_true', default=True,
                      help='Run test with sending traffic to both queues [3, 4]')
+    parser.addoption('--save-timer-results', action='store_true', default=False,
+                     help='Save results of pfc timer accuracy test to file')
 
 
 @pytest.fixture(scope="module")
@@ -79,6 +81,20 @@ def fake_storm(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
                      is_cisco_device(duthost) or
                      "7060X6" in duthost.facts['hwsku'].upper()) \
         else request.config.getoption('--fake-storm')
+
+
+@pytest.fixture(scope="module")
+def save_timer_results(request):
+    """
+    Save timer results to file
+
+    Args:
+        request: pytest request object
+
+    Returns:
+        save_timer_results: True/False
+    """
+    return request.config.getoption('--save-timer-results')
 
 
 @pytest.fixture(scope="module")

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import time
 import re
+import json
 
 from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts      # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
@@ -164,6 +165,29 @@ def set_storm_params(dut, fanout_info, fanout, peer_params):
     return storm_handle
 
 
+def save_test_results_to_file(test_func_name, test_data):
+    """
+    Save test results to JSON file.
+
+    Args:
+        test_func_name (str): test function name
+        test_data (dict): metrics to persist
+    """
+    try:
+        formatted_data = {}
+        for key, value in test_data.items():
+            if isinstance(value, float):
+                formatted_data[key] = round(value, 2)
+            else:
+                formatted_data[key] = value
+        report_filename = f'/tmp/test_pfcwd_timer_accuracy_{test_func_name}.json'
+        with open(report_filename, 'w') as f:
+            json.dump(formatted_data, f, indent=2)
+        logger.info("Saved test results to: %s", report_filename)
+    except Exception as err:
+        logger.error("Failed to save test results to file. Error: %s", err)
+
+
 @pytest.mark.usefixtures('pfcwd_timer_setup_restore', 'start_background_traffic')
 class TestPfcwdAllTimer(object):
     """ PFCwd timer test class """
@@ -291,6 +315,20 @@ class TestPfcwdAllTimer(object):
                     restore_count, ITERATION_NUM, restore_failures,
                     required_samples))
 
+        if self.save_timer_results:
+            data = {
+                'detect_time_min': self.all_detect_time[0],
+                'detect_time_max': self.all_detect_time[-1],
+                'detect_time_check': self.all_detect_time[check_point],
+                'restore_time_min': self.all_restore_time[0],
+                'restore_time_max': self.all_restore_time[-1],
+                'restore_time_check': self.all_restore_time[check_point],
+            }
+            logger.info("Saving timer results to file")
+            save_test_results_to_file('test_pfcwd_timer_accuracy', data)
+        else:
+            logger.info("Timer results will not be saved to file due to --save-timer-results not set")
+
         err_msg = ("Real detection time is greater than configured: Real detect time: {} "
                    "Expected: {} (wd_detect_time + wd_poll_time)".format(self.all_detect_time[check_point],
                                                                          config_detect_time))
@@ -369,7 +407,7 @@ class TestPfcwdAllTimer(object):
             return int(0)
 
     def test_pfcwd_timer_accuracy(self, duthosts, ptfhost, enum_rand_one_per_hwsku_frontend_hostname,
-                                  pfcwd_timer_setup_restore, fanouthosts, set_pfc_time_cisco_8000):
+                                  pfcwd_timer_setup_restore, fanouthosts, set_pfc_time_cisco_8000, save_timer_results):
         """
         Tests PFCwd timer accuracy
 
@@ -384,6 +422,7 @@ class TestPfcwdAllTimer(object):
         self.dut = duthost
         self.ptf = ptfhost
         self.fanout = fanouthosts
+        self.save_timer_results = save_timer_results
         self.all_detect_time = list()
         self.all_restore_time = list()
         self.all_dut_detect_restore_time = list()


### PR DESCRIPTION
### Description of PR

Summary:

Save the pfcwd_timer_accuracy test result to a file for later data analyzing, help design team to know the difference between max/min detect/restore time in single test and trend during several times of test.

Usage:

By default, there won't be any test result files generated after the test_pfcwd_timer_accuracy. 

To enable it:
1. users need to add the option '--save-timer-results' to the test command and run the test
2. when the test finishes, a json file will generated under /tmp/ directory
3. users can open the file to check the test checkpoints data during times of iterations
4. the files will be overwrote each time, so it is recommended to transport it to somewhere else for future use

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
To get trackable record for further analyzing about detect/restore time in pfcwd_timer_accuracy test

#### How did you do it?
Save needed date to a file for later use

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
N/A
