### PR TITLE
[dhcp_relay] fix: kill tcpdump in finally block to prevent memory leak on test failure

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1342,6 +1342,7 @@ def capture_and_check_packet_on_dut(
             duthost.fetch(src=pcap_save_path, dest=temp_pcap.name, flat=True)
             pkts_validator(scapy_sniff(offline=temp_pcap.name), *pkts_validator_args, **pkts_validator_kwargs)
     finally:
+        duthost.shell("kill -9 %s || true" % tcpdump_pid, module_ignore_errors=True)
         duthost.file(path=pcap_save_path, state="absent")
 
 


### PR DESCRIPTION
Fix memory leak in `capture_and_check_packet_on_dut()`: ensure tcpdump is always killed even when the test raises an exception.

### Description of PR

Summary:
When `capture_and_check_packet_on_dut()` is used as a context manager and the test raises an exception (e.g., a 600s `wait_until` timeout in `test_dhcp_counter_stress`), the `kill -s 2 <pid>` call was inside the `try:` block after `yield`.  On exception, Python skips the rest of `try:` and jumps directly to `finally:`, which only deleted the pcap file — leaving tcpdump running indefinitely.

On the `internal-202511` branch this caused ~2 GB physical memory commits because `BUFFER_SIZE = 1024 * 1024` was passed to `tcpdump --buffer-size` (which takes **KiB**), allocating a 1 GiB ring buffer per process.

This PR adds `kill -9 $pid || true` to the `finally:` block so tcpdump is always cleaned up regardless of test outcome.

ADO work item: https://dev.azure.com/msazure/One/_workitems/edit/37864761

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?
`capture_and_check_packet_on_dut()` in `tests/common/utilities.py` is a context manager that starts a tcpdump process on the DUT.  When a test failure causes an exception during the `with` block, the tcpdump kill command (previously in `try:` after `yield`) was never executed.  On the internal-202511 branch this left a process with a 1 GiB ring buffer alive, triggering nightly memory alarms.

#### How did you do it?
Added one line to the `finally:` block:
```python
duthost.shell("kill -9 %s || true" % tcpdump_pid, module_ignore_errors=True)
```
This uses SIGKILL (|| true to suppress error if tcpdump already exited) and `module_ignore_errors=True` to avoid masking the original test exception.

#### How did you verify/test it?
Root cause confirmed by log analysis comparing passing build (2026-04-23, no alarm) vs failing build (2026-05-01, +2255 MB memory spike).  The kill-in-try pattern was verified against the master branch source.

#### Any platform specific information?
None — affects any platform that uses `capture_and_check_packet_on_dut()`.

#### Supported testbed topology if it's a new test case?
N/A (bug fix)

### Documentation

N/A