### PR TITLE
Console: Skip test_console_availability.py for hardware based testbeds.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -749,12 +749,24 @@ configlet/test_add_rack.py:
     conditions:
       - "is_multi_asic==True"
 
+#######################################
+#####            console          #####
+#######################################
 console/:
   skip:
     reason: 'Console tests under tests/console/ are designed for c0 topology, not compatible with BMC'
     conditions:
       - "'bmc' in topo_type"
 
+console/test_console_availability.py:
+  skip:
+    reason: "This test is applicable to virtual setup only."
+    conditions:
+      - "asic_type in ['vpp'] and platform.startswith('arm64-c8220tg_48a_o')"
+
+#######################################
+#####    container_hardening      #####
+#######################################
 container_hardening/test_container_hardening.py::test_container_privileged:
   skip:
     reason: "Not supported on 202305 and older releases"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The script console/test_console_availability.py was developed for virtual testbeds, not for physical devices. Adding a skip to do the same.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
Script not applicable to hardware testbeds.

#### How did you do it?
Added a skip in marker file.

#### How did you verify/test it?
Ran it in our testbeds:
```
================================================================================================ warnings summary ================================================================================================
../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------------------------ generated xml file: /run_logs/sir-c0/skip_availability/2026-05-07-19-09-45/console/test_console_availability.xml ------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
============================================================================================ short test summary info =============================================================================================
SKIPPED [4] console/test_console_availability.py:136: This test is applicable to virtual setup only.
========================================================================================= 4 skipped, 1 warning in 9.23s ==========================================================================================
sonic@arctos_cicd_all_202603:/data/tests$ 
```
