### PR TITLE
[snappi][bgp] Consistent ordering of duts in duthosts list in bgp_outbound_helper

### DIFF
--- a/tests/snappi_tests/bgp/files/bgp_outbound_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_outbound_helper.py
@@ -88,6 +88,19 @@ def get_as_numbers_for_topology():
     }
 
 
+def build_ordered_multi_duthosts(*duts):
+    """
+    Stable DUT list in the same order as arguments (typically duthost1 uplink LC,
+    duthost2 downlink LC, optional duthost3 supervisor). Skips None; drops
+    duplicates without reordering earlier entries.
+    """
+    duthosts = []
+    for dut in duts:
+        if dut is not None and dut not in duthosts:
+            duthosts.append(dut)
+    return duthosts
+
+
 def run_bgp_outbound_uplink_blackout_test(api,
                                           snappi_extra_params,
                                           creds, record_property):
@@ -109,7 +122,7 @@ def run_bgp_outbound_uplink_blackout_test(api,
     duthost1 = snappi_extra_params.multi_dut_params.duthost1
     duthost2 = snappi_extra_params.multi_dut_params.duthost2
     # Build unique duthosts list, filtering None values
-    duthosts = list({dut for dut in [duthost1, duthost2] if dut is not None})
+    duthosts = build_ordered_multi_duthosts(duthost1, duthost2)
     t1_hostname = snappi_extra_params.multi_dut_params.t1_hostname
     route_ranges = snappi_extra_params.ROUTE_RANGES
     snappi_ports = snappi_extra_params.multi_dut_params.multi_dut_ports
@@ -166,7 +179,7 @@ def run_bgp_outbound_tsa_tsb_test(api,
     duthost2 = snappi_extra_params.multi_dut_params.duthost2
     duthost3 = snappi_extra_params.multi_dut_params.duthost3
     # Build unique duthosts list, filtering None values
-    duthosts = list({dut for dut in [duthost1, duthost2, duthost3] if dut is not None})
+    duthosts = build_ordered_multi_duthosts(duthost1, duthost2, duthost3)
     t1_hostname = snappi_extra_params.multi_dut_params.t1_hostname
     route_ranges = snappi_extra_params.ROUTE_RANGES
     snappi_ports = snappi_extra_params.multi_dut_params.multi_dut_ports
@@ -224,7 +237,7 @@ def run_bgp_outbound_ungraceful_restart(api,
     duthost2 = snappi_extra_params.multi_dut_params.duthost2
     duthost3 = snappi_extra_params.multi_dut_params.duthost3
     # Build unique duthosts list, filtering None values
-    duthosts = list({dut for dut in [duthost1, duthost2, duthost3] if dut is not None})
+    duthosts = build_ordered_multi_duthosts(duthost1, duthost2, duthost3)
     t1_hostname = snappi_extra_params.multi_dut_params.t1_hostname
     route_ranges = snappi_extra_params.ROUTE_RANGES
     snappi_ports = snappi_extra_params.multi_dut_params.multi_dut_ports
@@ -283,7 +296,7 @@ def run_bgp_outbound_process_restart_test(api,
     duthost1 = snappi_extra_params.multi_dut_params.duthost1
     duthost2 = snappi_extra_params.multi_dut_params.duthost2
     # Build unique duthosts list, filtering None values
-    duthosts = list({dut for dut in [duthost1, duthost2] if dut is not None})
+    duthosts = build_ordered_multi_duthosts(duthost1, duthost2)
     t1_hostname = snappi_extra_params.multi_dut_params.t1_hostname
     route_ranges = snappi_extra_params.ROUTE_RANGES
     snappi_ports = snappi_extra_params.multi_dut_params.multi_dut_ports
@@ -342,7 +355,7 @@ def run_bgp_outbound_link_flap_test(api,
     duthost1 = snappi_extra_params.multi_dut_params.duthost1
     duthost2 = snappi_extra_params.multi_dut_params.duthost2
     # Build unique duthosts list, filtering None values
-    duthosts = list({dut for dut in [duthost1, duthost2] if dut is not None})
+    duthosts = build_ordered_multi_duthosts(duthost1, duthost2)
     t1_hostname = snappi_extra_params.multi_dut_params.t1_hostname
     route_ranges = snappi_extra_params.ROUTE_RANGES
     snappi_ports = snappi_extra_params.multi_dut_params.multi_dut_ports


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #24442 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
Several helpers built duthosts with list({duthost1, duthost2, ...}). A set does not define iteration order, so duthosts[0] / duthosts[1] are not guaranteed to be uplink LC (duthost1) then downlink LC (duthost2). Anything that assumed index 0 = upper/uplink and index 1 = lower/downlink could behave inconsistently across runs or environments.

```
duthost1 = snappi_extra_params.multi_dut_params.duthost1
duthost2 = snappi_extra_params.multi_dut_params.duthost2
# Build unique duthosts list, filtering None values
duthosts = list({dut for dut in [duthost1, duthost2] if dut is not None})

# Same anti-pattern with three hosts:
# duthosts = list({dut for dut in [duthost1, duthost2, duthost3] if dut is not None})
```

#### How did you do it?
Introduce build_ordered_multi_duthosts(*duts) to walk arguments in a fixed order, skip None, and dedupe without reordering earlier entries. Call sites use build_ordered_multi_duthosts(duthost1, duthost2) or (..., duthost3) so duthosts[0] is always uplink when present, then downlink, then supervisor when the test wired duthost1 / duthost2 / duthost3 that way.

```
def build_ordered_multi_duthosts(*duts):
    """
    Stable DUT list in the same order as arguments (typically duthost1 uplink LC,
    duthost2 downlink LC, optional duthost3 supervisor). Skips None; drops
    duplicates without reordering earlier entries.
    """
    duthosts = []
    for dut in duts:
        if dut is not None and dut not in duthosts:
            duthosts.append(dut)
    return duthosts
```
This function is called wherever the duthosts list is created.

Note - Stable indices still depend on tests assigning duthost1 = uplink and duthost2 = downlink correctly in snappi_extra_params (for example from device_hostnames[1] / [2]); this fix only makes the derived list match that assignment order every time. However, most of the testcases has the info correctly set.

#### How did you verify/test it?
Ran the test on the local branch.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
