### PR TITLE
Running `test_vnet_decap.py` on T0 topologies

### DIFF
--- a/tests/vxlan/test_vnet_decap.py
+++ b/tests/vxlan/test_vnet_decap.py
@@ -10,7 +10,7 @@ from ptf.mask import Mask
 
 
 pytestmark = [
-    pytest.mark.topology("t1", "t1-64-lag", "t1-56-lag", "t1-lag"),
+    pytest.mark.topology("t0", "t1", "t1-64-lag", "t1-56-lag", "t1-lag"),
     pytest.mark.disable_loganalyzer
 ]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
`test_vnet_decap.py` should run on T0 topologies.

Summary:
This PR ensures that `test_vnet_decap.py` is run on T0 topologies as well as T1.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Ensuring that this test passes on both T0 and T1 topologies.

#### How did you do it?
Changed pytest marker.

#### How did you verify/test it?
Run the test on Mellanox or Cisco T0 switches.

#### Any platform specific information?
This test only runs on Mellanox (except MSN2700) and Cisco.

#### Supported testbed topology if it's a new test case?
T0 and T1

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A