### PR TITLE
Fix flaky test_syslog_rate_limit: wait for rsyslogd rate-limit notification before LogAnalyzer end marker

### DIFF
--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -287,6 +287,10 @@ def verify_rate_limit_with_log_generator(duthost, service_name, log_marker, expe
 
     with loganalyzer:
         duthost.command(run_generator_cmd)
+        # Wait for rsyslogd to forward the rate-limiting notification from the container
+        # to the host syslog. Without this, the notification may arrive after the
+        # LogAnalyzer end marker, causing intermittent test failures.
+        time.sleep(5)
 
 
 def get_loganalyzer_additional_files(service_name):


### PR DESCRIPTION
### Description of PR
Summary:
Fix intermittent failure in `test_syslog_rate_limit` where the LogAnalyzer reports `expected_missing_match: 1` because the rsyslogd rate-limiting notification is not captured.

### Type of change
- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
`test_syslog_rate_limit` is flaky. It intermittently fails with:
```
LogAnalyzerError: match: 0
expected_match: 100
expected_missing_match: 1
```
This means 100 test log messages were captured but the rsyslogd rate-limiting notification (`.*rate-limit-test>: begin to drop messages due to rate-limiting.*`) was not found.

#### How did you do it?
When a container hits the syslog rate limit, rsyslogd in the container emits a "begin to drop messages due to rate-limiting" notification that must be forwarded through the container→host syslog pipeline before being written to `/var/log/syslog`. The `log_generator.py` already sleeps 2 seconds at the end, but under load or on slower platforms this forwarding can take longer, causing the notification to arrive in `/var/log/syslog` **after** the LogAnalyzer end marker is written — so it is not captured.

Added a 5-second sleep inside the `with loganalyzer:` block after the log generator command completes, giving rsyslogd 7 total seconds (2s in the generator + 5s after) to deliver the notification before the end marker is set.

#### How did you verify/test it?
Ran `test_syslog_rate_limit` 3 consecutive times on an Arista-7060X6 platform — all 3 passed.

#### Any platform specific information?
Observed on Arista-7060X6 platform, but the race condition is generic and can affect any platform.

#### Supported testbed topology if it's a new test case?
N/A — existing test case fix.

### Documentation