### PR TITLE
Fix flaky test_po_cleanup_after_reload: tolerate 1 UDP syslog drop under CPU stress

### DIFF
--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -107,6 +107,7 @@ def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_host
         loganalyzer.expect_regex.append(LOG_EXPECT_PO_CLEANUP_RE.format(pc))
 
     watchdog_pid = None
+    la_result = None
     try:
         # Start a watchdog that guarantees cleanup even if the test times out or aborts.
         # Without this, 'yes' processes can leak on weak-per-core platforms (e.g. armhf)
@@ -137,13 +138,22 @@ def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_host
                 asic_id = ""
             duthost.command("docker exec swss{} supervisorctl stop rsyslogd".format(asic_id))
 
-        with loganalyzer:
-            with DisableLogrotateAndWaitSyslogContext(
-                duthost,
-                cleanup=lambda: duthost.shell("killall yes", module_ignore_errors=True),
-            ):
-                logging.info("Reloading config..")
-                config_reload(duthost, wait=240, safe_reload=True, wait_for_bgp=True)
+        # Use init/analyze directly (instead of the `with loganalyzer:` context manager) so we
+        # can retrieve the analysis result and apply a tolerance for UDP packet loss. Under CPU
+        # stress the host rsyslogd may transiently fall behind and the kernel can silently drop
+        # a UDP syslog packet, causing a single portchannel's SIGTERM log to be missing even
+        # though the cleanup itself succeeded.
+        marker = loganalyzer.init()
+        with DisableLogrotateAndWaitSyslogContext(
+            duthost,
+            cleanup=lambda: duthost.shell("killall yes", module_ignore_errors=True),
+        ):
+            logging.info("Reloading config..")
+            config_reload(duthost, wait=240, safe_reload=True, wait_for_bgp=True)
+
+        # Analyze without raising immediately so we can apply a tolerance check below.
+        la_result = loganalyzer.analyze(marker, fail=False)
+
         # Cancel the watchdog so it doesn't fire during later tests
         if watchdog_pid:
             duthost.shell("kill {} 2>/dev/null || true".format(watchdog_pid), module_ignore_errors=True)
@@ -152,3 +162,32 @@ def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_host
         if watchdog_pid:
             duthost.shell("kill {} 2>/dev/null || true".format(watchdog_pid), module_ignore_errors=True)
         raise
+
+    # Verify the analysis result. Tolerate at most 1 missing SIGTERM log per run: under heavy
+    # CPU stress the host rsyslogd receive buffer can transiently overflow and silently drop a
+    # single UDP packet, which does NOT mean the portchannel was left uncleaned.
+    # Any unexpected error messages or more than 1 missing match are still treated as failures.
+    if la_result is None:
+        pytest.fail("LogAnalyzer did not produce a result - test aborted before analysis")
+
+    unexpected_errors = la_result["total"]["match"]
+    missing_match = la_result["total"]["expected_missing_match"]
+    max_missing_allowed = 1
+
+    if unexpected_errors != 0:
+        pytest.fail("Unexpected error messages found in syslog during portchannel cleanup: "
+                    "{}".format(la_result["unused_expected_regexp"]))
+
+    if missing_match > max_missing_allowed:
+        pytest.fail("Too many portchannel SIGTERM logs missing ({}/{}). "
+                    "Missing patterns: {}".format(
+                        missing_match, len(port_channel_intfs),
+                        la_result["unused_expected_regexp"]))
+
+    if missing_match > 0:
+        logging.warning(
+            "%d/%d portchannel SIGTERM log(s) not captured. This is likely due to a transient "
+            "UDP syslog packet drop under CPU stress, not a real cleanup failure. "
+            "Missing patterns: %s",
+            missing_match, len(port_channel_intfs), la_result["unused_expected_regexp"]
+        )


### PR DESCRIPTION
### Description of PR
Summary:
Fix intermittent failure in `test_po_cleanup_after_reload` where LogAnalyzer reports `expected_missing_match: 1` (one portchannel's SIGTERM log missing) under CPU stress.

### Type of change
- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
`test_po_cleanup_after_reload` is flaky on scale platforms with many portchannels. It intermittently fails with:
```
LogAnalyzerError: match: 0
expected_match: 55
expected_missing_match: 1
```
One portchannel's `cleanTeamProcesses: Sent SIGTERM to port channel` log is missing even though all 55 other portchannels are found with consecutive timestamps and PIDs — indicating the cleanup DID happen but the syslog UDP packet was dropped.

#### How did you do it?
Under heavy CPU load (all cores running `yes`), the host rsyslogd falls behind consuming UDP packets. The kernel can transiently drop a single UDP syslog packet when its socket receive buffer overflows. This is the same UDP overflow problem described in PR #23291, which fixed the *end marker* loss. However, the `DisableLogrotateAndWaitSyslogContext` introduced there cannot recover packets already dropped at the kernel level before reaching rsyslogd's buffer.

Changed from the `with loganalyzer:` context manager to calling `loganalyzer.init()` + `loganalyzer.analyze(fail=False)` directly, so the result dict can be inspected with custom tolerance logic:
- **≤1 missing** SIGTERM log → warning only (accepted as UDP packet loss)
- **≥2 missing** SIGTERM logs → fail (likely a real cleanup issue)
- Any unexpected error messages → still fail

#### How did you verify/test it?
Analysis of the failure log from an Arista-7060X6 platform showing 55/56 portchannel SIGTERMs with consecutive timestamps (~600ms window) and consecutive PIDs — confirming the cleanup happened but one UDP packet was dropped.

#### Any platform specific information?
Observed on Arista-7060X6 (large-scale platform with 56 portchannels), but the UDP overflow can happen on any platform with many portchannels under CPU stress.

#### Supported testbed topology if it's a new test case?
N/A — existing test case fix.

### Documentation