### PR TITLE
[202511][BGP] Fix rollback failure in test_bgp_dual_asn by cleaning up test p…

### DIFF
--- a/tests/bgp/test_bgp_dual_asn.py
+++ b/tests/bgp/test_bgp_dual_asn.py
@@ -284,6 +284,18 @@ class BgpDualAsn:
             ptfhost.exabgp(name="bgps%d" % i, state="absent")
         logger.info("exabgp stopped")
 
+        # Delete test-specific BGP_PEER_RANGE entries so rollback can
+        # restore BGPVac without listen-range overlap
+        test_peer_ranges = [BGPSLB, BGPSLB_2, BGPSLB_V6, BGPSLB_V6_2]
+        del_keys = " ".join('"BGP_PEER_RANGE|{}"'.format(n) for n in test_peer_ranges)
+        ns_list = duthost.get_frontend_asic_namespace_list() or [None]
+        for ns in ns_list:
+            ns_flag = "-n {} ".format(ns) if ns else ""
+            duthost.shell(
+                "sonic-db-cli {}CONFIG_DB del {}".format(ns_flag, del_keys),
+                module_ignore_errors=True
+            )
+
         for port in self.ptf_ports:
             ptfhost.shell("ip addr flush dev {} scope global".format(port))
         duthost.command("sonic-clear arp")


### PR DESCRIPTION
…eer ranges before teardown (#24040)

What: Added explicit deletion of test-specific BGP_PEER_RANGE entries (BGPSLBPassive, BGPSLBPassive2, BGPSLBPassiveV6, BGPSLBPassiveV62) in dual_asn_teardown() before rollback, with multi-ASIC support.
Why: test_bgp_dual_asn_v4 splits the VLAN subnet (192.168.0.0/21) into two /22 halves. At teardown, rollback_or_reload() tries to restore BGPVac (/21) but FRR rejects it with "Listen range overlaps" because the test's /22 ranges are still active — a race condition with async bgpcfgd processing.
How: Delete all test peer ranges with module_ignore_errors=True before the setup_env fixture runs rollback, preventing the overlap conflict.
Testing: Ran test_bgp_dual_asn_v4 on Broadcom 7060x6 (202511). No bgpcfgd overlap errors. BGPVac correctly restored. All CI checks passed.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
