### PR TITLE
[202511][cpu_shaper] Add gport API support for Broadcom TH5+ platforms (#24065)

### DIFF
--- a/tests/cpu_shaper/scripts/get_shaper.c
+++ b/tests/cpu_shaper/scripts/get_shaper.c
@@ -1,13 +1,35 @@
 int get_cosq_shaper(bcm_port_t port, bcm_cos_queue_t cosq, uint32 kbits_sec_min, uint32 kbits_sec_max, uint32 flags)
 {
     int rv=0;
-    rv = bcm_cosq_port_bandwidth_get(0,port,cosq, &kbits_sec_min, &kbits_sec_max, &flags);
-    if (rv < 0) {
-        printf("bcm_cosq_port_bandwidth_get failed for port=%d, cos=%d, pps_max=%d, rv=%d\n", port, cosq, kbits_sec_max,rv);
-        return rv;
+    int rv_gport=0;
+    bcm_gport_t gport=0;
+
+    /* Try the gport-based API first: it is preferred and required on TH5+
+     * and is supported on many platforms, but it may not be available on
+     * every platform/SDK combination.
+     */
+    BCM_GPORT_LOCAL_SET(gport, port);
+    rv_gport = bcm_cosq_gport_bandwidth_get(0, gport, cosq, &kbits_sec_min, &kbits_sec_max, &flags);
+    if (rv_gport == 0) {
+        printf("bcm_cosq_gport_bandwidth_get for port=%d, cos=%d pps_max=%d\n", port, cosq, kbits_sec_max);
+        return 0;
     }
-    printf("bcm_cosq_port_bandwidth_get for port=%d, cos=%d pps_max=%d\n", port, cosq, kbits_sec_max);
-    return 0;
+    if (rv_gport != BCM_E_UNAVAIL) {
+        printf("bcm_cosq_gport_bandwidth_get failed for port=%d, cos=%d, rv=%d\n", port, cosq, rv_gport);
+        return rv_gport;
+    }
+    /* Fall back to port-based API (works on XGS only) */
+    kbits_sec_min = 0;
+    kbits_sec_max = 0;
+    flags = 0;
+    rv = bcm_cosq_port_bandwidth_get(0, port, cosq, &kbits_sec_min, &kbits_sec_max, &flags);
+    if (rv == 0) {
+        printf("bcm_cosq_port_bandwidth_get for port=%d, cos=%d pps_max=%d\n", port, cosq, kbits_sec_max);
+        return 0;
+    }
+    /* Both APIs failed, log both return codes for debugging */
+    printf("All cosq bandwidth APIs failed for port=%d, cos=%d, gport_rv=%d, legacy_rv=%d\n", port, cosq, rv_gport, rv);
+    return rv;
 }
 
 print get_cosq_shaper(0, 0, 0, 0, 0);


### PR DESCRIPTION
Cherry-pick of : https://github.com/sonic-net/sonic-mgmt/pull/24065

### Description of PR

Summary:
The `cpu_shaper` test uses a BCM cint script (`get_shaper.c`) that calls `bcm_cosq_port_bandwidth_get` to read CPU queue shaper PPS values. This is not supported on TH5+ devices, causing the test to fail on platforms like Arista 7060X6.

This change updates the cint script to try the modern gport-based API (`bcm_cosq_gport_bandwidth_get`) first, which works on TH5+ and previous platforms, and falls back to the legacy port-based API for platforms where the gport API may not be available.

The success output format is preserved (`cos=N pps_max=M`) so no changes are needed in `test_cpu_shaper.py`.

### Type of change

- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

The test `cpu_shaper/test_cpu_shaper.py` fails on TH5+ devices because `bcm_cosq_port_bandwidth_get`. The BCM SDK returns rv=-16 (`BCM_E_UNAVAIL`), the cint script prints an error line, the Python regex finds no matches, and the assertion fails with `actual_pps = {}`.

#### How did you do it?

Updated `tests/cpu_shaper/scripts/get_shaper.c` to:
1. Try `bcm_cosq_gport_bandwidth_get` (modern gport-based API) first, works on all platforms
2. If it fails, fall back to `bcm_cosq_port_bandwidth_get` (legacy API) for older platforms.
3. If both fail, print a single error line with both return codes for debugging.
4. Reset output parameters (`flags`) between API calls to prevent stale values from affecting the fallback call.

No changes to `test_cpu_shaper.py`, the success output format (`cos=%d pps_max=%d`) is identical for both API paths and matches the existing regex `r'cos=(\d+) pps_max=(\d+)'`.

#### How did you verify/test it?

- **DNX platform (7060X6 / J2C+):** gport API succeeds on first attempt, test passes.
- **XGS platform:** gport API succeeds (modern XGS), or falls back to legacy API
  (older XGS). Existing behavior preserved.
- Verified that error output format does not false-match the Python regex.

#### Any platform specific information?

- TH5+ devices, e.g., Arista 7060X6: require the gport-based API. The legacy `bcm_cosq_port_bandwidth_get` returns `BCM_E_UNAVAIL`.

#### Supported testbed topology if it's a new test case?

N/A — existing test, topology unchanged (t0, t1).

### Documentation

N/A — no new features or test cases.

---------

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
