### PR TITLE
[202511][cpu_shaper] Fix test for TH5 platforms by capturing pps values befor…

### DIFF
--- a/tests/cpu_shaper/test_cpu_shaper.py
+++ b/tests/cpu_shaper/test_cpu_shaper.py
@@ -24,14 +24,20 @@ logger = logging.getLogger(__name__)
 BCM_CINT_FILENAME = "get_shaper.c"
 DEST_DIR = "/tmp"
 CMD_GET_SHAPER = "bcmcmd 'cint {}'".format(BCM_CINT_FILENAME)
+EXPECTED_COS_QUEUES = {0, 7}
+EXPECTED_PPS = 600
+PPS_TOLERANCE = 0.05  # Allow 5% tolerance in PPS values
 
 
-def verify_cpu_queue_shaper(dut):
+def get_cpu_queue_shaper(dut):
     """
-    Verify cpu queue shaper configuration is as expected
+    Read cpu queue shaper PPS configuration from the ASIC.
 
     Args:
         dut (SonicHost): The target device
+
+    Returns:
+        dict: Mapping of cos queue index to PPS max value, e.g. {0: 600, 7: 600}
     """
     # Copy cint script to /tmp on the device
     dut.copy(src="cpu_shaper/scripts/{}".format(BCM_CINT_FILENAME), dest=DEST_DIR)
@@ -42,35 +48,53 @@ def verify_cpu_queue_shaper(dut):
     # Execute the cint script and parse the output
     res = dut.shell(CMD_GET_SHAPER)['stdout']
 
-    # Expected shaper PPS configuration for CPU queues 0, and 7
-    expected_pps = {0: 600, 7: 600}
     pattern = r'cos=(\d+) pps_max=(\d+)'
     matches = re.findall(pattern, res)
-    actual_pps = {int(cos): int(pps) for cos, pps in matches}
-    assert (expected_pps == actual_pps)
+    return {int(cos): int(pps) for cos, pps in matches}
 
 
 @pytest.mark.disable_loganalyzer
 def test_cpu_queue_shaper(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname, request):
     """
-    Validates the cpu queue shaper configuration after reboot(reboot, warm-reboot)
-
+    Validates the cpu queue shaper configuration survives reboot by comparing
+    shaper values before and after reboot.
     """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     try:
-        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         reboot_type = request.config.getoption("--cpu_shaper_reboot_type")
+        # Read shaper config before reboot
+        before_pps = get_cpu_queue_shaper(duthost)
+        logger.info("CPU queue shaper before reboot: {}".format(before_pps))
 
-        # Perform reboot as specified via the reboot_type parameter
+        # Validate all expected queues are present with non-zero shaper values
+        missing = EXPECTED_COS_QUEUES - set(before_pps.keys())
+        assert not missing, \
+            "CPU queue shaper missing for cos queues {} before reboot. Got: {}".format(missing, before_pps)
+        assert all(before_pps[cos] > 0 for cos in EXPECTED_COS_QUEUES), \
+            "CPU queue shaper has zero PPS before reboot: {}".format(before_pps)
+        # Validate shaper values are close to original 600 PPS (allowing 5% tolerance)
+        pps_low, pps_high = int(EXPECTED_PPS * (1 - PPS_TOLERANCE)), int(EXPECTED_PPS * (1 + PPS_TOLERANCE))
+        for cos in EXPECTED_COS_QUEUES:
+            assert pps_low <= before_pps[cos] <= pps_high, \
+                "CPU queue {} shaper PPS {} is outside {}% tolerance of {} PPS".format(
+                    cos, before_pps[cos], int(PPS_TOLERANCE * 100), EXPECTED_PPS)
+
+        # Perform reboot
         logger.info("Do {} reboot".format(reboot_type))
         reboot(duthost, localhost, reboot_type=reboot_type, reboot_helper=None, reboot_kwargs=None)
 
         # Wait for critical processes to be up
         wait_critical_processes(duthost)
-        logger.info("Verify cpu queue shaper config after {} reboot".format(reboot_type))
 
-        # Verify cpu queue shaper configuration
-        verify_cpu_queue_shaper(duthost)
+        # Read shaper config after reboot
+        after_pps = get_cpu_queue_shaper(duthost)
+        logger.info("CPU queue shaper after {} reboot: {}".format(reboot_type, after_pps))
+
+        # Verify shaper config survived reboot unchanged
+        assert before_pps == after_pps, \
+            "CPU queue shaper changed after {} reboot: before={}, after={}".format(
+                reboot_type, before_pps, after_pps)
 
     finally:
-        duthost.shell("rm {}/{}".format(DEST_DIR, BCM_CINT_FILENAME))
+        duthost.shell("rm -f {}/{}".format(DEST_DIR, BCM_CINT_FILENAME))
         config_reload(duthost)


### PR DESCRIPTION
…e and after reboot (#24153)

### Description of PR

Summary:

The `cpu_shaper` test hardcodes expected PPS values (`{0: 600, 7: 600}`) which don't account for hardware rate quantization on different Broadcom ASIC generations. After putting out a fix for TH5+ testbed in PR https://github.com/sonic-net/sonic-mgmt/pull/24065, the tests failed on TH5 where it reports 608 PPS for a configured 600 PPS shaper due to platform dependent CPU values. This causes a false test failure.

This PR replaces the hardcoded expected values with a before/after reboot comparison reads shaper config before reboot, reboots, reads again, and asserts they match. This correctly tests the stated intent ("shaper survives reboot") without being affected by per-platform hardware quantization differences.

We also make sure the PPS reported before and after reboot is in a safe range.

Edge-case bugs in the original test are also fixed:
- Missing COS queues were silently accepted
- `rm` in cleanup failed if the temp file didn't exist

### Type of change

- [x] Bug fix
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

After the gport API fix in `get_shaper.c`, the test still fails on TH5 platforms:
actual_pps = {0: 608, 7: 600}
expected_pps = {0: 600, 7: 600}

TH5 hardware quantizes 600 PPS to 608 due to internal register granularity. Hardcoding either value is fragile, different chips may quantize differently.

#### How did you do it?

- Replaced `verify_cpu_queue_shaper` (hardcoded assertion) with `get_cpu_queue_shaper` (returns parsed dict).
- Capture shaper values **before** reboot as the baseline.
- Sanity-check the baseline: all expected COS queues (0, 7) must be present with non-zero PPS values.
- After reboot, read shaper values again and assert they match the baseline exactly (same hardware = same quantization, so exact match is valid).
- Moved all DUT operations inside `try` so `finally` cleanup always runs.
- Changed `rm` to `rm -f` in cleanup to avoid failure if the file doesn't exist.

#### How did you verify/test it?

- **TH5 platform (Arista 7060X6):** returns `{0: 608, 7: 600}` before reboot. After cold reboot, returns the same values. Test passes.
- **XGS platforms:** returns `{0: 600, 7: 600}` before and after reboot. Test passes.
- Verified all failure output formats from `get_shaper.c` do not false-match the Python regex `r'cos=(\d+) pps_max=(\d+)'`.

#### Any platform specific information?

The before/after comparison approach is platform-agnostic, same hardware produces the same quantized value before and after reboot, so exact match works regardless of the underlying ASIC generation.

#### Supported testbed topology if it's a new test case?

N/A 

### Documentation

N/A

---------

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
