### PR TITLE
Fix test_crm_nexthop_group: split neighbor/route into two phases

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -426,9 +426,8 @@ def generate_neighbors(amount, ip_ver):
     return ip_addr_list
 
 
-def configure_nexthop_groups(amount, interface, asichost, test_name, chunk_size):
+def configure_nexthop_groups(amount, interface, duthost, asichost, test_name):
     """ Configure bunch of nexthop groups on DUT. Bash template is used to speedup configuration """
-    # Template used to speedup execution many similar commands on DUT
     del_template = """
     %s
     for s in {{neigh_ip_list}}
@@ -442,40 +441,62 @@ def configure_nexthop_groups(amount, interface, asichost, test_name, chunk_size)
         ip {{ns_prefix}} neigh del ${s} lladdr 11:22:33:44:55:66 dev {{iface}}
     done""" % (NS_PREFIX_TEMPLATE)
 
-    add_template = """
+    neigh_template = """
     %s
-    ip -4 {{ns_prefix}} route add 2.0.0.0/8 dev {{iface}}
-    ip {{ns_prefix}} neigh replace 2.0.0.1 lladdr 11:22:33:44:55:66 dev {{iface}}
     for s in {{neigh_ip_list}}
     do
-        ip  {{ns_prefix}} neigh replace ${s} lladdr 11:22:33:44:55:66 dev {{iface}}
+        ip {{ns_prefix}} neigh replace ${s} lladdr 11:22:33:44:55:66 dev {{iface}}
+    done""" % (NS_PREFIX_TEMPLATE)
+
+    route_template = """
+    %s
+    for s in {{neigh_ip_list}}
+    do
         ip -4 {{ns_prefix}} route add ${s}/32 nexthop via ${s} nexthop via 2.0.0.1
     done""" % (NS_PREFIX_TEMPLATE)
 
+    init_template = """
+    %s
+    ip -4 {{ns_prefix}} route add 2.0.0.0/8 dev {{iface}}
+    ip {{ns_prefix}} neigh replace 2.0.0.1 lladdr 11:22:33:44:55:66 dev {{iface}}""" % (NS_PREFIX_TEMPLATE)
+
     del_template = Template(del_template)
-    add_template = Template(add_template)
+    neigh_template = Template(neigh_template)
+    route_template = Template(route_template)
+    init_template = Template(init_template)
 
     ip_addr_list = generate_neighbors(amount + 1, "4")
+    remaining_ips = ip_addr_list[1:]
+    all_ips_str = " ".join([str(item) for item in remaining_ips])
 
-    # Split up the neighbors into chunks of size chunk_size to buffer kernel neighbor messages
-    batched_ip_addr_lists = [ip_addr_list[i:i + chunk_size]
-                             for i in range(0, len(ip_addr_list), chunk_size)]
+    RESTORE_CMDS[test_name].append(del_template.render(iface=interface,
+                                                       neigh_ip_list=all_ips_str,
+                                                       namespace=asichost.namespace))
 
-    logger.info("Configuring {} total nexthop groups".format(amount))
-    for ip_batch in batched_ip_addr_lists:
-        ip_addr_list_batch = " ".join([str(item) for item in ip_batch[1:]])
-        # Store CLI command to delete all created neighbors if test case will fail
-        RESTORE_CMDS[test_name].append(del_template.render(iface=interface,
-                                                           neigh_ip_list=ip_addr_list_batch,
-                                                           namespace=asichost.namespace))
+    asichost.shell(init_template.render(iface=interface, namespace=asichost.namespace))
 
-        logger.info("Configuring {} nexthop groups".format(len(ip_batch)))
+    # Phase 1: add all neighbors, then verify via CRM counter before adding routes
+    get_neighbor_stats = "{} COUNTERS_DB HMGET CRM:STATS " \
+                         "crm_stats_ipv4_neighbor_used " \
+                         "crm_stats_ipv4_neighbor_available".format(asichost.sonic_db_cli)
+    neighbor_used_before, _ = get_crm_stats(get_neighbor_stats, duthost)
 
-        asichost.shell(add_template.render(iface=interface,
-                                           neigh_ip_list=ip_addr_list_batch,
-                                           namespace=asichost.namespace))
+    logger.info("Phase 1: Adding {} neighbors".format(amount))
+    asichost.shell(neigh_template.render(iface=interface,
+                                         neigh_ip_list=all_ips_str,
+                                         namespace=asichost.namespace))
 
-        time.sleep(1)
+    expected_neighbor_used = neighbor_used_before + amount + 1
+    logger.info("Waiting for all {} neighbors to be programmed in HW".format(amount + 1))
+    wait_for_crm_counter_update(get_neighbor_stats, duthost,
+                                expected_used=expected_neighbor_used - CRM_COUNTER_TOLERANCE,
+                                oper_used=">=", timeout=60, interval=5)
+
+    # Phase 2: add routes now that all neighbors are confirmed in HW
+    logger.info("Phase 2: Adding {} routes".format(amount))
+    asichost.shell(route_template.render(iface=interface,
+                                         neigh_ip_list=all_ips_str,
+                                         namespace=asichost.namespace))
 
 
 def increase_arp_cache(duthost, max_value, ip_ver, test_name):
@@ -1097,17 +1118,10 @@ def test_crm_nexthop_group(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
         # Increase default Linux configuration for ARP cache
         increase_arp_cache(duthost, nexthop_group_num, 4, "test_crm_nexthop_group")
 
-        # Configure neighbors in batches of size chunk_size
-        # on sn4700 devices, kernel neighbor messages were being dropped due to volume.
-        if "msn4700" in asic_type:
-            chunk_size = 200
-        else:
-            chunk_size = nexthop_group_num
-
         # Add new neighbor entries to correctly calculate used CRM resources in percentage
         configure_nexthop_groups(amount=nexthop_group_num, interface=crm_interface[0],
-                                 asichost=asichost, test_name="test_crm_nexthop_group",
-                                 chunk_size=chunk_size)
+                                 duthost=duthost, asichost=asichost,
+                                 test_name="test_crm_nexthop_group")
 
         # Wait for nexthop group resources to stabilize using polling
         expected_nhg_used = new_nexthop_group_used + nexthop_group_num - CRM_COUNTER_TOLERANCE


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Find all the details here: https://github.com/sonic-net/sonic-mgmt/pull/23129
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) This fixes the race conditions that were observed on Nvidia switches, this should also address https://github.com/sonic-net/sonic-mgmt/issues/20563

The configure_nexthop_groups() function had two problems:

Chunk batching bug: ip_batch[1:] was intended to skip only the first IP (2.0.0.1, the base neighbor), but when batching with chunk_size=200, it skipped the first element of EVERY batch, silently losing ~9 neighbors and their routes.

Race condition: neighbor and route creation were interleaved in the same for-loop, so a route could reference a nexthop before its neighbor was fully programmed in HW.

Fix by separating into two phases and removing the chunk batching mechanism (no longer needed with the two-phase approach):

Phase 1: add all neighbors in one shot, then poll CRM ipv4_neighbor counter to confirm they are programmed in HW
Phase 2: add all routes in one shot after neighbors are confirmed

cherry-pick to 2025 had conflict. so created another PR

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
test_crm_nexthop_group[group_member=False] fails intermittently on msn4600 and msn4700 platforms with:
CRM counter did not reach expected value within 60 seconds.
Expected: used >= 1891, Actual: used=1807

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?
Observed on Mellanox LSN4700 and SN4600C — platforms with large NHG resource pools (~180K+) that cause the test to create ~1800+ nexthop groups, widening the race window.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
