### PR TITLE
Skipping tests in `test_pfc_pause_lossless_warm_reboot.py`

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5003,8 +5003,6 @@ snappi_tests/pfc/test_global_pause_with_snappi.py:
 snappi_tests/pfc/warm_reboot/test_pfc_pause_lossless_warm_reboot.py:
   skip:
     reason: "Warm and fast reboots will be aborted if there is a queue in stormed state. https://github.com/sonic-net/sonic-utilities/pull/3969"
-    conditions:
-      - "True"
 
 snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_frwd_90_10:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5003,6 +5003,8 @@ snappi_tests/pfc/test_global_pause_with_snappi.py:
 snappi_tests/pfc/warm_reboot/test_pfc_pause_lossless_warm_reboot.py:
   skip:
     reason: "Warm and fast reboots will be aborted if there is a queue in stormed state. https://github.com/sonic-net/sonic-utilities/pull/3969"
+    conditions:
+      - "True"
 
 snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_frwd_90_10:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5000,6 +5000,12 @@ snappi_tests/pfc/test_global_pause_with_snappi.py:
       - "asic_type in ['cisco-8000', 'vs']"
       - "topo_type in ['t2', 'multidut-tgen']"
 
+snappi_tests/pfc/warm_reboot/test_pfc_pause_lossless_warm_reboot.py:
+  skip:
+    reason: "Warm and fast reboots will be aborted if there is a queue in stormed state. https://github.com/sonic-net/sonic-utilities/pull/3969"
+    conditions:
+      - "True"
+
 snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_frwd_90_10:
   skip:
     reason: "Forward action is not supported in cisco-8000."


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Skipping tests in `test_pfc_pause_lossless_warm_reboot.py` since the following PR prevents warm and fast reboots when there is at least one queue in stormed state:
https://github.com/sonic-net/sonic-utilities/pull/3969
Currently, these tests fail because `warm-reboot` and `fast-reboot` commands fail with the following message:
```
PFC storm detected. Aborting warm-reboot to prevent failure in recovery path...
```

Summary:
Microsoft ADO ID: 37501704 and 37337773
Skipping tests in `test_pfc_pause_lossless_warm_reboot.py`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
This PR skips tests in `test_pfc_pause_lossless_warm_reboot.py` so that they don't fail.

#### How did you do it?
Added an entry in `test_mark_conditions.yaml` to skip the tests.

#### How did you verify/test it?
The tests are skipped on all testbeds.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A