### PR TITLE
[fanout]: Add buffer config for Arista-7060CX-32S-C32 in SONiC 202205 deploy template

### DIFF
--- a/ansible/roles/fanout/templates/sonic_deploy_202205.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202205.j2
@@ -213,6 +213,78 @@
 
 {% endif %}
 
+{% if fanout_hwsku in ("Arista-7060CX-32S-C32") %}
+    "BUFFER_QUEUE": {
+    {% for alias in fanout_port_config %}
+        "{{ fanout_port_config[alias]['name'] }}|0-2": {
+            "profile": "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "{{ fanout_port_config[alias]['name'] }}|3-4": {
+            "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "{{ fanout_port_config[alias]['name'] }}|5-6": {
+            "profile": "[BUFFER_PROFILE|egress_lossy_profile]"
+        }{% if not loop.last %},{% endif %}
+    {% endfor %}
+    },
+
+    "BUFFER_PG": {
+    {% for alias in fanout_port_config %}
+        "{{ fanout_port_config[alias]['name'] }}|0": {
+            "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "{{ fanout_port_config[alias]['name'] }}|3-4": {
+            "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+        }{% if not loop.last %},{% endif %}
+    {% endfor %}
+    },
+
+    "BUFFER_POOL": {
+        "egress_lossless_pool": {
+            "type": "egress",
+            "mode": "static",
+            "size": "15982720"
+        },
+        "egress_lossy_pool": {
+            "type": "egress",
+            "mode": "dynamic",
+            "size": "9243812"
+        },
+        "ingress_lossless_pool": {
+            "xoff": "4194112",
+            "type": "ingress",
+            "mode": "dynamic",
+            "size": "10875072"
+        }
+    },
+
+    "BUFFER_PROFILE": {
+        "egress_lossless_profile": {
+            "static_th": "15982720",
+            "pool": "[BUFFER_POOL|egress_lossless_pool]",
+            "size": "1518"
+        },
+        "egress_lossy_profile": {
+            "dynamic_th": "3",
+            "pool": "[BUFFER_POOL|egress_lossy_pool]",
+            "size": "1518"
+        },
+        "ingress_lossy_profile": {
+            "dynamic_th": "3",
+            "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+            "size": "0"
+        },
+        "pg_lossless_100000_300m_profile": {
+            "xon_offset": "2288",
+            "dynamic_th": "0",
+            "xon": "2288",
+            "xoff": "268736",
+            "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+            "size": "1248"
+        }
+    },
+{% endif %}
+
     "FEATURE": {
         "acms": {
             "auto_restart": "disabled",


### PR DESCRIPTION
### Description of PR
Summary:
Add buffer configuration (BUFFER_QUEUE, BUFFER_PG, BUFFER_POOL, BUFFER_PROFILE) for Arista-7060CX-32S-C32 HWSKU in the SONiC 202205 fanout deploy template.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The Arista-7060CX-32S-C32 fanout switch running SONiC 202205 is missing buffer configuration, which can cause traffic issues. This adds the necessary BUFFER_QUEUE, BUFFER_PG, BUFFER_POOL, and BUFFER_PROFILE entries to the `sonic_deploy_202205.j2` template.

#### How did you do it?
Added a Jinja2 conditional block for `fanout_hwsku == "Arista-7060CX-32S-C32"` in `ansible/roles/fanout/templates/sonic_deploy_202205.j2` with:
- **BUFFER_QUEUE**: 3 queues per port (queues 0-2 lossy, 3-4 lossless, 5-6 lossy)
- **BUFFER_PG**: 2 PG entries per port (PG 0 lossy, PG 3-4 lossless)
- **BUFFER_POOL**: 3 pools (egress_lossless=15982720, egress_lossy=9243812, ingress_lossless=10875072 with xoff=4194112)
- **BUFFER_PROFILE**: 4 profiles matching the pools above

#### How did you verify/test it?
Deployed on Arista-7060CX-32S-C32 fanout running SONiC 202205 and confirmed buffer configuration is applied correctly.

#### Any platform specific information?
Specific to Arista-7060CX-32S-C32 HWSKU running SONiC 202205 fanout image.

#### Supported testbed topology if it's a new test case?
N/A — fanout switch configuration change

### Documentation
N/A