### PR TITLE
Fix snmp queue counter test for single-ASIC VOQ switches

### DIFF
--- a/tests/snmp/test_snmp_queue_counters.py
+++ b/tests/snmp/test_snmp_queue_counters.py
@@ -326,11 +326,12 @@ def test_snmp_queue_counters(duthosts,
             queue_counters_cnt_post, expected_snmp_cnt_post,
             queue_counts_post['unicast'], queue_counts_post['multicast']))
 
-    # For broadcom-dnx voq chassis, number of voq are fixed (static), which
-    # cannot be modified dynamically. Hence, make sure the queue counters
-    # before deletion and after deletion are same for broadcom-dnx voq chassis
+    # For voq chassis and voq switches, number of queues are fixed (static),
+    # which cannot be modified dynamically. Hence, make sure the queue counters
+    # before deletion and after deletion are same for these platforms.
     platform_asic = duthost.facts.get("platform_asic")
-    if platform_asic == "broadcom-dnx":
+    switch_type = duthost.facts.get("switch_type", "")
+    if platform_asic == "broadcom-dnx" or switch_type == "voq":
         pytest_assert(
             (queue_counters_cnt_pre == queue_counters_cnt_post),
             "Queue counters actual count {} differs from expected values {}"


### PR DESCRIPTION
PR #23264 added 'and is_multi_asic' to the broadcom-dnx guard condition, which excluded single-ASIC VOQ platforms from the static-queue path. These platforms have fixed/static queues that cannot be modified dynamically, so removing BUFFER_QUEUE entries does not reduce the SNMP queue counter count.

Add switch_type == 'voq' as an alternative condition to correctly handle all VOQ platforms regardless of single/multi-ASIC configuration.

Tested on q3d (broadcom-dnx, single-ASIC, VOQ):
- Without fix: FAILED (expected reduction but got 0)
- With fix: PASSED (correctly expects static queues)

Fixes regression introduced by PR #23264.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
