### PR TITLE
chore: skip route flow counter for VPP

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4766,11 +4766,12 @@ route/test_route_flap.py:
 
 route/test_route_flow_counter.py:
   skip:
-    reason: "Test not supported for cisco-8122 platform / Route flow counter is not supported on vs platform."
+    reason: "Test not supported for cisco-8122 platform / Route flow counter is not supported on vs platform / VPP platform is skipped while route flow counter issues are active."
     conditions_logical_operator: or
     conditions:
       - "platform in ['x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
       - "asic_type in ['vs']"
+      - "asic_type in ['vpp'] and (https://github.com/sonic-net/sonic-mgmt/issues/24467 or https://github.com/sonic-net/sonic-platform-vpp/issues/229)"
   xfail:
     reason: "xfail for IPv6-only topologies, didn't use IPv6 when should"
     conditions:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add a VPP-specific conditional skip for `route/test_route_flow_counter.py` while either of the following issues is active:
- https://github.com/sonic-net/sonic-mgmt/issues/24467
- https://github.com/sonic-net/sonic-platform-vpp/issues/229

Fixes # (issue) N/A

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`route/test_route_flow_counter.py` is currently not expected to run on VPP while the linked `sonic-mgmt` and `sonic-platform-vpp` issues are active.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
