### PR TITLE
Update BMC API and fwutil tests to support different BMC flavors and fix merge-induced inconsistencies in the BMC workflow.

### DIFF
--- a/tests/common/helpers/firmware_helper.py
+++ b/tests/common/helpers/firmware_helper.py
@@ -1,21 +1,178 @@
 import re
+import os
+import json
+import logging
+import tarfile
+import paramiko
+import yaml
 
+logger = logging.getLogger(__name__)
+
+_BMC_SECRETS_PATH = os.path.normpath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                 '../../../ansible/group_vars/lab/secrets.yml'))
+
+
+def load_bmc_creds():
+    """Load BMC credentials from ansible/group_vars/lab/secrets.yml."""
+    with open(_BMC_SECRETS_PATH) as f:
+        secrets = yaml.safe_load(f)
+    return secrets['sonic_bmc_root_user'], secrets['sonic_bmc_root_password']
 
 PLATFORM_COMP_PATH_TEMPLATE = '/usr/share/sonic/device/{}/platform_components.json'
 FW_TYPE_INSTALL = 'install'
 FW_TYPE_UPDATE = 'update'
 
 
-def show_firmware(duthost):
-    out = duthost.command("fwutil show status")
+def extract_fw_data(fw_pkg_path):
+    """Extract firmware data dict from a tar.gz or plain json file."""
+    if tarfile.is_tarfile(fw_pkg_path):
+        path = "/tmp/firmware"
+        if not os.path.exists(path):
+            os.mkdir(path)
+        with tarfile.open(fw_pkg_path, "r:gz") as f:
+            f.extractall(path)
+            json_file = os.path.join(path, "firmware.json")
+            with open(json_file, 'r') as fw:
+                fw_data = json.load(fw)
+    else:
+        with open(fw_pkg_path, 'r') as fw:
+            fw_data = json.load(fw)
+
+    return fw_data
+
+
+def get_bmc_ip(duthost):
+    """Read BMC IP from the DUT's bmc.json config file. Returns None if unavailable."""
+    platform = duthost.shell(
+        "sudo show platform summary | grep Platform | awk '{print $2}'"
+    )["stdout"]
+    bmc_config_file = f"/usr/share/sonic/device/{platform}/bmc.json"
+    duthost.fetch(src=bmc_config_file, dest="/tmp")
+    with open(f"/tmp/{duthost.hostname}/{bmc_config_file}") as f:
+        return json.load(f)["bmc_addr"]
+
+
+def _ssh_bmc_cmd(duthost, bmc_ip, bmc_user, bmc_password, cmd):
+    """
+    Run *cmd* on the BMC via SSH through the DUT. No sshpass needed.
+
+    """
+    if hasattr(duthost, 'engine'):
+        transport = duthost.engine.remote_conn.get_transport()
+        channel = transport.open_channel("direct-tcpip", (bmc_ip, 22), ("127.0.0.1", 0))
+        bmc_client = paramiko.SSHClient()
+        bmc_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        try:
+            bmc_client.connect(bmc_ip, username=bmc_user, password=bmc_password,
+                               sock=channel, timeout=30)
+            _, stdout, _ = bmc_client.exec_command(cmd)
+            return stdout.read().decode().strip()
+        finally:
+            bmc_client.close()
+
+    return duthost.command(
+        f"python3 -c 'import paramiko;"
+        f"c=paramiko.SSHClient();"
+        f"c.set_missing_host_key_policy(paramiko.AutoAddPolicy());"
+        f"c.connect(\"{bmc_ip}\",username=\"{bmc_user}\",password=\"{bmc_password}\",timeout=30);"
+        f"_,o,_=c.exec_command(\"{cmd}\");"
+        f"print(o.read().decode().strip());"
+        f"c.close()'"
+    )["stdout"]
+
+
+def get_bmc_flavor(duthost, bmc_ip, bmc_user, bmc_password):
+    """
+    Detect BMC flavor from ``/proc/device-tree/model``
+    (e.g. ``AST2700-A1 Spc6 CPU BMC`` -> ``AST2700-A1``).
+    """
+    model_output = _ssh_bmc_cmd(duthost, bmc_ip, bmc_user, bmc_password,
+                                "cat /proc/device-tree/model")
+
+    if not model_output:
+        raise ValueError("Empty output from BMC /proc/device-tree/model")
+
+    flavor = model_output.split()[0]
+    logger.info("Detected BMC flavor: %s (model: %s)", flavor, model_output)
+    return flavor
+
+
+def get_bmc_firmware_list(fw_pkg, chassis, duthost, bmc_ip,
+                          bmc_user, bmc_password):
+    """Resolve BMC flavor and return the firmware entry list for *chassis*."""
+    bmc_entry = fw_pkg["chassis"][chassis]["component"]["BMC"]
+    if isinstance(bmc_entry, list):
+        logger.info("No flavor defined in firmware.json for chassis=%s, using flat BMC entry", chassis)
+        return bmc_entry
+    flavor = resolve_bmc_flavor(fw_pkg, chassis, duthost, bmc_ip,
+                                bmc_user, bmc_password)
+    return bmc_entry[flavor]
+
+
+def resolve_bmc_flavor(fw_pkg, chassis, duthost, bmc_ip,
+                       bmc_user, bmc_password):
+    """Return the BMC flavor for *chassis*. Returns None when the old flat-list format is used."""
+    bmc_entry = fw_pkg.get("chassis", {}).get(chassis, {}).get("component", {}).get("BMC")
+
+    if isinstance(bmc_entry, list):
+        logger.debug("BMC entry is a flat list (no flavor layer)")
+        return None
+
+    if not isinstance(bmc_entry, dict) or not bmc_entry:
+        raise KeyError(f"No BMC flavors defined for chassis={chassis}")
+
+    flavors = list(bmc_entry.keys())
+    if len(flavors) == 1:
+        logger.info("Single BMC flavor available: %s", flavors[0])
+        return flavors[0]
+
+    if not bmc_ip:
+        raise ValueError(
+            f"Multiple BMC flavors {flavors} for chassis={chassis}, but bmc_ip is not available"
+        )
+
+    return get_bmc_flavor(duthost, bmc_ip, bmc_user, bmc_password)
+
+
+def get_bmc_info_from_firmware_data(fw_data, chassis_name, flavor):
+    """Return ``(expected_version, firmware_path)`` or ``(None, None)``."""
+    bmc_info = fw_data.get('chassis', {}).get(chassis_name, {}).get('component', {}).get('BMC')
+    if not bmc_info:
+        return None, None
+
+    if isinstance(bmc_info, list):
+        fw_list = bmc_info
+    elif isinstance(bmc_info, dict):
+        fw_list = bmc_info.get(flavor)
+    else:
+        return None, None
+
+    if not fw_list:
+        return None, None
+
+    return fw_list[0].get('version'), fw_list[0].get('firmware')
+
+
+def parse_firmware_status(status_output):
+    """Parse ``fwutil show status`` output into ``{"chassis": {name: {"component": {...}}}}``."""
+    output_data = {"chassis": {}}
+
+    if not status_output:
+        return output_data
+
+    lines = status_output.splitlines()
+    if len(lines) < 3:
+        return output_data
+
     num_spaces = 2
     curr_chassis = ""
-    output_data = {"chassis": {}}
-    status_output = out['stdout']
-    separators = re.split(r'\s{2,}', status_output.splitlines()[1])  # get separators
-    output_lines = status_output.splitlines()[2:]
+    separators = re.split(r'\s{2,}', lines[1])
 
-    for line in output_lines:
+    for line in lines[2:]:
+        if not line.strip():
+            continue
+
         data = []
         start = 0
 
@@ -24,10 +181,34 @@ def show_firmware(duthost):
             data.append(line[start:start+curr_len].strip())
             start += curr_len + num_spaces
 
-        if data[0].strip() != "":
+        if len(data) < 4:
+            continue
+
+        if data[0].strip():
             curr_chassis = data[0].strip()
             output_data["chassis"][curr_chassis] = {"component": {}}
 
-        output_data["chassis"][curr_chassis]["component"][data[2]] = data[3]
+        if curr_chassis and curr_chassis in output_data["chassis"]:
+            output_data["chassis"][curr_chassis]["component"][data[2]] = data[3]
 
     return output_data
+
+
+def show_firmware(duthost):
+    """Run ``fwutil show status`` on the DUT and return parsed dict."""
+    out = duthost.command("sudo fwutil show status")["stdout"]
+    return parse_firmware_status(out)
+
+
+def get_bmc_version_from_firmware_data(fw_data):
+    """Return ``(bmc_version, chassis_name)`` or ``(None, None)``."""
+    chassis_dict = fw_data.get("chassis", {})
+    if not chassis_dict:
+        return None, None
+
+    # Get first chassis name (typically only one)
+    chassis_name = list(chassis_dict.keys())[0]
+    components = chassis_dict[chassis_name].get("component", {})
+
+    bmc_version = components.get("BMC")
+    return bmc_version, chassis_name

--- a/tests/common/helpers/firmware_helper.py
+++ b/tests/common/helpers/firmware_helper.py
@@ -3,8 +3,9 @@ import os
 import json
 import logging
 import tarfile
-import paramiko
 import yaml
+
+from tests.common.helpers.platform_api import bmc
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +20,7 @@ def load_bmc_creds():
         secrets = yaml.safe_load(f)
     return secrets['sonic_bmc_root_user'], secrets['sonic_bmc_root_password']
 
+
 PLATFORM_COMP_PATH_TEMPLATE = '/usr/share/sonic/device/{}/platform_components.json'
 FW_TYPE_INSTALL = 'install'
 FW_TYPE_UPDATE = 'update'
@@ -27,13 +29,16 @@ FW_TYPE_UPDATE = 'update'
 def extract_fw_data(fw_pkg_path):
     """Extract firmware data dict from a tar.gz or plain json file."""
     if tarfile.is_tarfile(fw_pkg_path):
-        path = "/tmp/firmware"
-        if not os.path.exists(path):
-            os.mkdir(path)
-        with tarfile.open(fw_pkg_path, "r:gz") as f:
-            f.extractall(path)
-            json_file = os.path.join(path, "firmware.json")
-            with open(json_file, 'r') as fw:
+        with tarfile.open(fw_pkg_path, "r:gz") as fw_tar:
+            member = fw_tar.getmember("firmware.json")
+            if not member.isfile():
+                raise ValueError("firmware.json in {} is not a regular file".format(fw_pkg_path))
+
+            fw = fw_tar.extractfile(member)
+            if fw is None:
+                raise ValueError("Failed to read firmware.json from {}".format(fw_pkg_path))
+
+            with fw:
                 fw_data = json.load(fw)
     else:
         with open(fw_pkg_path, 'r') as fw:
@@ -53,47 +58,17 @@ def get_bmc_ip(duthost):
         return json.load(f)["bmc_addr"]
 
 
-def _ssh_bmc_cmd(duthost, bmc_ip, bmc_user, bmc_password, cmd):
-    """
-    Run *cmd* on the BMC via SSH through the DUT. No sshpass needed.
-
-    """
-    if hasattr(duthost, 'engine'):
-        transport = duthost.engine.remote_conn.get_transport()
-        channel = transport.open_channel("direct-tcpip", (bmc_ip, 22), ("127.0.0.1", 0))
-        bmc_client = paramiko.SSHClient()
-        bmc_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        try:
-            bmc_client.connect(bmc_ip, username=bmc_user, password=bmc_password,
-                               sock=channel, timeout=30)
-            _, stdout, _ = bmc_client.exec_command(cmd)
-            return stdout.read().decode().strip()
-        finally:
-            bmc_client.close()
-
-    return duthost.command(
-        f"python3 -c 'import paramiko;"
-        f"c=paramiko.SSHClient();"
-        f"c.set_missing_host_key_policy(paramiko.AutoAddPolicy());"
-        f"c.connect(\"{bmc_ip}\",username=\"{bmc_user}\",password=\"{bmc_password}\",timeout=30);"
-        f"_,o,_=c.exec_command(\"{cmd}\");"
-        f"print(o.read().decode().strip());"
-        f"c.close()'"
-    )["stdout"]
-
-
 def get_bmc_flavor(duthost, bmc_ip, bmc_user, bmc_password):
     """
-    Detect BMC flavor from ``/proc/device-tree/model``
+    Detect BMC flavor from BMC platform API model output
     (e.g. ``AST2700-A1 Spc6 CPU BMC`` -> ``AST2700-A1``).
     """
-    model_output = _ssh_bmc_cmd(duthost, bmc_ip, bmc_user, bmc_password,
-                                "cat /proc/device-tree/model")
+    model_output = bmc.get_model(duthost)
 
     if not model_output:
-        raise ValueError("Empty output from BMC /proc/device-tree/model")
+        raise ValueError("Empty BMC model output from platform API")
 
-    flavor = model_output.split()[0]
+    flavor = str(model_output).split()[0]
     logger.info("Detected BMC flavor: %s (model: %s)", flavor, model_output)
     return flavor
 

--- a/tests/common/helpers/firmware_helper.py
+++ b/tests/common/helpers/firmware_helper.py
@@ -3,9 +3,8 @@ import os
 import json
 import logging
 import tarfile
+import paramiko
 import yaml
-
-from tests.common.helpers.platform_api import bmc
 
 logger = logging.getLogger(__name__)
 
@@ -16,9 +15,25 @@ _BMC_SECRETS_PATH = os.path.normpath(
 
 def load_bmc_creds():
     """Load BMC credentials from ansible/group_vars/lab/secrets.yml."""
-    with open(_BMC_SECRETS_PATH) as f:
-        secrets = yaml.safe_load(f)
-    return secrets['sonic_bmc_root_user'], secrets['sonic_bmc_root_password']
+    try:
+        with open(_BMC_SECRETS_PATH) as f:
+            secrets = yaml.safe_load(f)
+    except FileNotFoundError as e:
+        raise FileNotFoundError(
+            "BMC secrets file not found at {}".format(_BMC_SECRETS_PATH)
+        ) from e
+
+    if not isinstance(secrets, dict):
+        raise ValueError(
+            "Invalid BMC secrets file {}: expected a mapping".format(_BMC_SECRETS_PATH)
+        )
+
+    try:
+        return secrets['sonic_bmc_root_user'], secrets['sonic_bmc_root_password']
+    except KeyError as e:
+        raise KeyError(
+            "Missing BMC credential key {} in {}".format(e, _BMC_SECRETS_PATH)
+        ) from e
 
 
 PLATFORM_COMP_PATH_TEMPLATE = '/usr/share/sonic/device/{}/platform_components.json'
@@ -49,26 +64,64 @@ def extract_fw_data(fw_pkg_path):
 
 def get_bmc_ip(duthost):
     """Read BMC IP from the DUT's bmc.json config file. Returns None if unavailable."""
-    platform = duthost.shell(
-        "sudo show platform summary | grep Platform | awk '{print $2}'"
+    try:
+        platform = duthost.shell(
+            "sudo show platform summary | grep Platform | awk '{print $2}'"
+        )["stdout"]
+        if not platform:
+            logger.warning("Failed to get platform name from %s", duthost.hostname)
+            return None
+
+        bmc_config_file = f"/usr/share/sonic/device/{platform}/bmc.json"
+        duthost.fetch(src=bmc_config_file, dest="/tmp")
+        with open(f"/tmp/{duthost.hostname}/{bmc_config_file}") as f:
+            return json.load(f).get("bmc_addr")
+    except Exception as e:
+        logger.warning("Failed to read BMC IP from %s: %s", duthost.hostname, e)
+        return None
+
+
+def _ssh_bmc_cmd(duthost, bmc_ip, bmc_user, bmc_password, cmd):
+    """
+    Run *cmd* on the BMC via SSH through the DUT. No sshpass needed.
+
+    """
+    if hasattr(duthost, 'engine'):
+        transport = duthost.engine.remote_conn.get_transport()
+        channel = transport.open_channel("direct-tcpip", (bmc_ip, 22), ("127.0.0.1", 0))
+        bmc_client = paramiko.SSHClient()
+        bmc_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        try:
+            bmc_client.connect(bmc_ip, username=bmc_user, password=bmc_password,
+                               sock=channel, timeout=30)
+            _, stdout, _ = bmc_client.exec_command(cmd)
+            return stdout.read().decode().strip()
+        finally:
+            bmc_client.close()
+
+    return duthost.command(
+        f"python3 -c 'import paramiko;"
+        f"c=paramiko.SSHClient();"
+        f"c.set_missing_host_key_policy(paramiko.AutoAddPolicy());"
+        f"c.connect(\"{bmc_ip}\",username=\"{bmc_user}\",password=\"{bmc_password}\",timeout=30);"
+        f"_,o,_=c.exec_command(\"{cmd}\");"
+        f"print(o.read().decode().strip());"
+        f"c.close()'"
     )["stdout"]
-    bmc_config_file = f"/usr/share/sonic/device/{platform}/bmc.json"
-    duthost.fetch(src=bmc_config_file, dest="/tmp")
-    with open(f"/tmp/{duthost.hostname}/{bmc_config_file}") as f:
-        return json.load(f)["bmc_addr"]
 
 
 def get_bmc_flavor(duthost, bmc_ip, bmc_user, bmc_password):
     """
-    Detect BMC flavor from BMC platform API model output
+    Detect BMC flavor from ``/proc/device-tree/model``
     (e.g. ``AST2700-A1 Spc6 CPU BMC`` -> ``AST2700-A1``).
     """
-    model_output = bmc.get_model(duthost)
+    model_output = _ssh_bmc_cmd(duthost, bmc_ip, bmc_user, bmc_password,
+                                "cat /proc/device-tree/model")
 
     if not model_output:
-        raise ValueError("Empty BMC model output from platform API")
+        raise ValueError("Empty output from BMC /proc/device-tree/model")
 
-    flavor = str(model_output).split()[0]
+    flavor = model_output.split()[0]
     logger.info("Detected BMC flavor: %s (model: %s)", flavor, model_output)
     return flavor
 
@@ -108,25 +161,6 @@ def resolve_bmc_flavor(fw_pkg, chassis, duthost, bmc_ip,
         )
 
     return get_bmc_flavor(duthost, bmc_ip, bmc_user, bmc_password)
-
-
-def get_bmc_info_from_firmware_data(fw_data, chassis_name, flavor):
-    """Return ``(expected_version, firmware_path)`` or ``(None, None)``."""
-    bmc_info = fw_data.get('chassis', {}).get(chassis_name, {}).get('component', {}).get('BMC')
-    if not bmc_info:
-        return None, None
-
-    if isinstance(bmc_info, list):
-        fw_list = bmc_info
-    elif isinstance(bmc_info, dict):
-        fw_list = bmc_info.get(flavor)
-    else:
-        return None, None
-
-    if not fw_list:
-        return None, None
-
-    return fw_list[0].get('version'), fw_list[0].get('firmware')
 
 
 def parse_firmware_status(status_output):

--- a/tests/common/helpers/firmware_helper.py
+++ b/tests/common/helpers/firmware_helper.py
@@ -2,6 +2,7 @@ import re
 import os
 import json
 import logging
+import shlex
 import tarfile
 import paramiko
 import yaml
@@ -99,15 +100,17 @@ def _ssh_bmc_cmd(duthost, bmc_ip, bmc_user, bmc_password, cmd):
         finally:
             bmc_client.close()
 
-    return duthost.command(
-        f"python3 -c 'import paramiko;"
-        f"c=paramiko.SSHClient();"
-        f"c.set_missing_host_key_policy(paramiko.AutoAddPolicy());"
-        f"c.connect(\"{bmc_ip}\",username=\"{bmc_user}\",password=\"{bmc_password}\",timeout=30);"
-        f"_,o,_=c.exec_command(\"{cmd}\");"
-        f"print(o.read().decode().strip());"
-        f"c.close()'"
-    )["stdout"]
+    python_code = (
+        "import paramiko\n"
+        "client = paramiko.SSHClient()\n"
+        "client.set_missing_host_key_policy(paramiko.AutoAddPolicy())\n"
+        f"client.connect({bmc_ip!r}, username={bmc_user!r}, "
+        f"password={bmc_password!r}, timeout=30)\n"
+        f"_, stdout, _ = client.exec_command({cmd!r})\n"
+        "print(stdout.read().decode().strip())\n"
+        "client.close()"
+    )
+    return duthost.command(f"python3 -c {shlex.quote(python_code)}")["stdout"]
 
 
 def get_bmc_flavor(duthost, bmc_ip, bmc_user, bmc_password):

--- a/tests/platform_tests/api/test_bmc.py
+++ b/tests/platform_tests/api/test_bmc.py
@@ -15,8 +15,10 @@ from tests.common.platform.device_utils import platform_api_conn, start_platform
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
 from .platform_api_test_base import PlatformApiTestBase
 from tests.platform_tests.conftest import extract_fw_data
-from tests.common.helpers.firmware_helper import show_firmware, FW_TYPE_UPDATE, PLATFORM_COMP_PATH_TEMPLATE
-
+from tests.common.helpers.firmware_helper import (
+    show_firmware, FW_TYPE_UPDATE, PLATFORM_COMP_PATH_TEMPLATE,
+    get_bmc_firmware_list, get_bmc_ip
+)
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +35,7 @@ LATEST_BMC_VERSION_IDX = 0
 OLD_BMC_VERSION_IDX = 1
 EROT_BUSY_MSG = "ERoT is busy"
 EROT_STABLE_TIMEOUT = 600
-WAIT_TIME = 30
+WAIT_TIME_INTERVAL_BETWEEN_ATTEMPTS = 30
 BMC_COMPONENT_NAME = 'BMC'
 BMC_UPDATE_COMMAND = "sudo config platform firmware {} chassis component BMC fw -y"
 BMC_INSTALL_COMMAND = "sudo config platform firmware {} chassis component BMC fw -y {}"
@@ -52,13 +54,133 @@ REDFISH_EVENT_SUBSCRIPTIONS_ENDPOINT = "/redfish/v1/EventService/Subscriptions"
 # Curl command templates (for session tests)
 CURL_TOKEN_AUTH_GET = "curl -k -H \"X-Auth-Token: {}\" -X GET https://{}{}"
 CURL_TOKEN_AUTH_GET_WITH_HEADERS = "curl -k -i -H \"X-Auth-Token: {}\" -X GET https://{}{}"
-CURL_TOKEN_AUTH_POST = ("curl -k -i -H \"X-Auth-Token: {}\" -H \"Content-Type: application/json\""
-                        " -X POST https://{}{} -d '{}'")
+CURL_TOKEN_AUTH_POST = "curl -k -i -H \"X-Auth-Token: {}\" -H \"Content-Type: application/json\" -X POST https://{}{} -d '{}'"
 CURL_TOKEN_AUTH_DELETE = "curl -i -k -H \"X-Auth-Token: {}\" -X DELETE https://{}{}"
 CURL_BASIC_AUTH_GET = "curl -k -u {}:{} -X GET https://{}{}"
 CURL_BASIC_AUTH_GET_WITH_HEADERS = "curl -k -i -u {}:{} -X GET https://{}{}"
 CURL_BASIC_AUTH_PATCH = "curl -k -i -u {}:{} -H \"Content-Type: application/json\" -X PATCH https://{}{} -d '{}'"
 CURL_BASIC_AUTH_DELETE = "curl -k -u {}:{} -X DELETE https://{}{}"
+
+
+def _get_bmc_version(duthost, timeout=120):
+    """Get BMC firmware version from 'show platform firmware status' output."""
+    start_time = time.time()
+    while True:
+        if time.time() - start_time > timeout:
+            logger.warning(f"Timeout after {timeout}s while getting BMC version")
+            return None
+        res = duthost.show_and_parse('sudo show platform firmware status')
+        for entry in res:
+            if entry['component'] == 'BMC' and entry['version'] != 'N/A':
+                return entry['version']
+        time.sleep(5)
+
+
+def _is_bmc_busy(duthost, bmc_ip, bmc_root_user, bmc_root_password):
+    """
+    Check if BMC is busy by querying BackgroundCopyStatus from Redfish API
+
+    Args:
+        duthost: DUT host object
+        bmc_ip: BMC IP address
+        bmc_root_user: BMC root username
+        bmc_root_password: BMC root password
+    Returns:
+        bool: True if BMC is busy (BackgroundCopyStatus != "Completed"), False otherwise
+    """
+    res = duthost.command(BMC_GET_STATUS_COMMAND.format(bmc_root_user, bmc_root_password, bmc_ip))["stdout"]
+    pytest_assert(res is not None, "Failed to query BMC status")
+
+    try:
+        response_json = json.loads(res)
+        background_copy_status = response_json.get("Oem", {}).get("Nvidia", {}).get("BackgroundCopyStatus", "")
+        logger.info(f"BMC BackgroundCopyStatus: {background_copy_status}")
+        return background_copy_status != BMC_COMPLETE_STATUS
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        logger.warning(f"Failed to parse BMC status response: {e}, response: {res}")
+        return True
+
+
+def _update_bmc_firmware(duthost, fw_image, bmc_ip, method='api',
+                         cli_type=None, timeout=EROT_STABLE_TIMEOUT,
+                         bmc_root_user=None, bmc_root_password=None):
+    """
+    Update BMC firmware with retry mechanism for ERoT busy scenarios
+
+    Args:
+        duthost: DUT host object
+        fw_image: Path to firmware image file
+        bmc_ip: BMC IP address
+        method: Update method - 'api' or 'cli' (default: 'api')
+        cli_type: CLI command type when method='cli' - FW_TYPE_INSTALL or FW_TYPE_UPDATE
+        timeout: Maximum time to wait for update (default: EROT_STABLE_TIMEOUT)
+        bmc_root_user: BMC root username (required for cli method)
+        bmc_root_password: BMC root password (required for cli method)
+
+    Returns:
+        bool: True if update successful, False otherwise
+    """
+    start_time = time.time()
+
+    logger.info(f"Starting BMC firmware update via {method.upper()}" +
+               (f" ({cli_type})" if method == 'cli' and cli_type else ""))
+
+    while True:
+        if time.time() - start_time > timeout:
+            logger.warning(f"Timeout after {timeout} seconds while updating BMC firmware")
+            return False
+        time.sleep(WAIT_TIME_INTERVAL_BETWEEN_ATTEMPTS)
+
+        if method == 'api':
+            ret_code, (message, _) = bmc.update_firmware(duthost, fw_image)
+
+            if EROT_BUSY_MSG in message:
+                logger.info(f"{EROT_BUSY_MSG}, waiting for {WAIT_TIME_INTERVAL_BETWEEN_ATTEMPTS} seconds")
+                continue
+            elif ret_code != 0:
+                logger.warning(f"Failed to update BMC firmware: return code: {ret_code}, message: {message}")
+                return False
+            else:
+                logger.info("BMC firmware updated successfully via API!")
+                break
+
+        elif method == 'cli':
+            if cli_type is None:
+                logger.error("cli_type must be specified when method='cli'")
+                return False
+
+            if _is_bmc_busy(duthost, bmc_ip, bmc_root_user, bmc_root_password):
+                logger.info(f"BMC is busy, waiting for {WAIT_TIME_INTERVAL_BETWEEN_ATTEMPTS} seconds")
+                continue
+
+            if cli_type == FW_TYPE_UPDATE:
+                res = duthost.command(BMC_UPDATE_COMMAND.format(cli_type))
+            else:
+                res = duthost.command(BMC_INSTALL_COMMAND.format(cli_type, fw_image))
+
+            if res['rc'] == 0:
+                logger.info(f"BMC firmware updated successfully via CLI ({cli_type})!")
+            else:
+                logger.info(f"Failed to update BMC firmware: {res['stdout']}")
+            break
+        else:
+            logger.error(f"Unknown update method: {method}")
+            return False
+
+    if method == 'api':
+        logger.info("Requesting BMC reset after successful update by platform api")
+        bmc.request_bmc_reset(duthost)
+
+    return True
+
+
+@pytest.fixture(scope="module")
+def bmc_ip(duthosts, enum_rand_one_per_hwsku_hostname):
+    """Module-scoped fixture to get BMC IP address. Returns None if BMC is not present."""
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    if not bmc.is_bmc_exists(duthost):
+        return None
+    return get_bmc_ip(duthost)
 
 
 def pytest_generate_tests(metafunc):
@@ -103,112 +225,57 @@ class TestBMCApi(PlatformApiTestBase):
         yield extract_fw_data(fw_pkg_name)
 
     @pytest.fixture(scope="class")
-    def bmc_ip(self, duthosts, enum_rand_one_per_hwsku_hostname, skip_if_no_bmc):
+    def recover_bmc_firmware(self, duthosts, enum_rand_one_per_hwsku_hostname,
+                             bmc_fw_pkg, bmc_ip, creds):
+        """Recover BMC firmware to the latest version after all parametrized runs."""
+        yield
+
+        if bmc_ip is None:
+            logger.info("Recovery: BMC is not present, skipping recovery")
+            return
+
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        platform = duthost.shell("sudo show platform summary | grep Platform | awk '{print $2}'")["stdout"]
-        bmc_config_file = f"/usr/share/sonic/device/{platform}/bmc.json"
-        duthost.fetch(src=bmc_config_file, dest='/tmp')
-        with open(f'/tmp/{duthost.hostname}/{bmc_config_file}', "r") as f:
-            bmc_config = json.load(f)
-        yield bmc_config["bmc_addr"]
+
+        bmc_version_current = _get_bmc_version(duthost)
+        if bmc_version_current is None:
+            logger.warning("Recovery: could not determine current BMC version, skipping recovery")
+            return
+
+        chassis = list(show_firmware(duthost)["chassis"].keys())[0]
+        bmc_fw_list = get_bmc_firmware_list(
+            bmc_fw_pkg, chassis, duthost, bmc_ip,
+            creds['sonic_bmc_root_user'], creds['sonic_bmc_root_password']
+        )
+        fw_version_latest = bmc_fw_list[LATEST_BMC_VERSION_IDX]["version"]
+
+        if bmc_version_current == fw_version_latest:
+            logger.info("Recovery: already on latest BMC version, skipping recovery")
+            return
+
+        fw_pkg_path = bmc_fw_list[LATEST_BMC_VERSION_IDX]["firmware"]
+        fw_pkg_clean_path = urlparse(fw_pkg_path).path
+        fw_pkt_name = os.path.basename(fw_pkg_path)
+
+        logger.info(f"Recovery: copying BMC firmware {fw_pkt_name} to DUT")
+        duthost.copy(src=fw_pkg_clean_path, dest=f"/tmp/{fw_pkt_name}")
+
+        logger.info(f"Recovery: updating BMC firmware to latest version {fw_version_latest} via API")
+        success = _update_bmc_firmware(
+            duthost, f"/tmp/{fw_pkt_name}", bmc_ip=None, method='api'
+        )
+        if not success:
+            logger.error("Recovery: failed to update BMC firmware to latest version")
+            return
+
+        bmc_version_after = _get_bmc_version(duthost)
+        logger.info(f"Recovery: BMC version after recovery: {bmc_version_after}")
+        if bmc_version_after != fw_version_latest:
+            logger.error(f"Recovery: expected {fw_version_latest}, got {bmc_version_after}")
 
     @pytest.fixture(autouse=True)
     def prepare_param(self, creds):
         self.bmc_root_user = creds['sonic_bmc_root_user']
         self.bmc_root_password = creds['sonic_bmc_root_password']
-
-    def _is_bmc_busy(self, duthost, bmc_ip):
-        """
-        Check if BMC is busy by querying BackgroundCopyStatus from Redfish API
-
-        Args:
-            duthost: DUT host object
-            bmc_ip: BMC IP address
-        Returns:
-            bool: True if BMC is busy (BackgroundCopyStatus != "Completed"), False otherwise
-        """
-        res = duthost.command(
-            BMC_GET_STATUS_COMMAND.format(self.bmc_root_user, self.bmc_root_password, bmc_ip))["stdout"]
-        pytest_assert(res is not None, "Failed to query BMC status")
-
-        try:
-            response_json = json.loads(res)
-            background_copy_status = response_json.get("Oem", {}).get("Nvidia", {}).get("BackgroundCopyStatus", "")
-            logger.info(f"BMC BackgroundCopyStatus: {background_copy_status}")
-
-            return background_copy_status != BMC_COMPLETE_STATUS
-        except (json.JSONDecodeError, KeyError, TypeError) as e:
-            logger.warning(f"Failed to parse BMC status response: {e}, response: {res}")
-            return True
-
-    def _update_bmc_firmware(self, duthost, fw_image, bmc_ip, method='api',
-                             cli_type=None, timeout=EROT_STABLE_TIMEOUT):
-        """
-        Update BMC firmware with retry mechanism for ERoT busy scenarios
-
-        Args:
-            duthost: DUT host object
-            fw_image: Path to firmware image file
-            bmc_ip: BMC IP address
-            method: Update method - 'api' or 'cli' (default: 'api')
-            cli_type: CLI command type when method='cli' - FW_TYPE_INSTALL or FW_TYPE_UPDATE
-            timeout: Maximum time to wait for update (default: EROT_STABLE_TIMEOUT)
-
-        Returns:
-            bool: True if update successful, False otherwise
-        """
-        start_time = time.time()
-        cli_suffix = f" ({cli_type})" if method == 'cli' and cli_type else ""
-        logger.info(f"Starting BMC firmware update via {method.upper()}{cli_suffix}")
-
-        while True:
-            if time.time() - start_time > timeout:
-                logger.warning(f"Timeout after {timeout} seconds while updating BMC firmware")
-                return False
-            time.sleep(WAIT_TIME)
-
-            if method == 'api':
-                ret_code, (message, _) = bmc.update_firmware(duthost, fw_image)
-
-                if EROT_BUSY_MSG in message:
-                    logger.info(f"{EROT_BUSY_MSG}, waiting for {WAIT_TIME} seconds")
-                    continue
-                elif ret_code != 0:
-                    logger.warning(f"Failed to update BMC firmware: return code: {ret_code}, message: {message}")
-                    return False
-                else:
-                    logger.info("BMC firmware updated successfully via API!")
-                    break
-
-            elif method == 'cli':
-                if cli_type is None:
-                    logger.error("cli_type must be specified when method='cli'")
-                    return False
-
-                is_bmc_busy = self._is_bmc_busy(duthost, bmc_ip)
-                if is_bmc_busy:
-                    logger.info(f"BMC is busy, waiting for {WAIT_TIME} seconds")
-                    continue
-
-                if cli_type == FW_TYPE_UPDATE:
-                    res = duthost.command(BMC_UPDATE_COMMAND.format(cli_type))
-                else:
-                    res = duthost.command(BMC_INSTALL_COMMAND.format(cli_type, fw_image))
-
-                if res['rc'] == 0:
-                    logger.info(f"BMC firmware updated successfully via CLI ({cli_type})!")
-                else:
-                    logger.info(f"Failed to update BMC firmware: {res['stdout']}")
-                break
-            else:
-                logger.error(f"Unknown update method: {method}")
-                return False
-
-        if method == 'api':
-            logger.info("Requesting BMC reset after successful update by platform api")
-            bmc.request_bmc_reset(duthost)
-
-        return True
 
     def _generate_password(self):
         password_length = random.choice(range(BMC_SHORTEST_PASSWD_LEN, BMC_LONGEST_PASSWD_LEN))
@@ -290,26 +357,9 @@ class TestBMCApi(PlatformApiTestBase):
                     logger.info(f"Deleted {len(existing_subs)} existing subscriptions")
                     return len(existing_subs)
             except (json.JSONDecodeError, KeyError, TypeError) as e:
-                logger.warning(
-                    f"Failed to parse subscription list response: {e}, "
-                    f"response: {get_subs_result['stdout']}")
+                logger.warning(f"Failed to parse subscription list response: {e}, response: {get_subs_result['stdout']}")
                 return 0
         return 0
-
-    def _get_bmc_version(self, duthost, timeout=120):
-        start_time = time.time()
-
-        while True:
-            if time.time() - start_time > timeout:
-                logger.warning(f"Timeout after {timeout} seconds while getting BMC version")
-                return
-
-            res = duthost.show_and_parse('sudo show platform firmware status')
-            for entry in res:
-                if entry['component'] == 'BMC':
-                    if entry['version'] == 'N/A':
-                        continue
-                    return entry['version']
 
     def _generate_platform_file(self, duthost, chassis_name, fw_path, fw_version):
         """
@@ -435,12 +485,14 @@ class TestBMCApi(PlatformApiTestBase):
         """
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
-        bmc.reset_root_password(duthost)
+        res = bmc.reset_root_password(duthost)
+        pytest_assert(res[0] == 0, f"Failed to reset BMC root password {res[1]}")
         self._validate_bmc_login(duthost, bmc_ip, self.bmc_root_password)
         temp_password = self._generate_password()
         self._change_bmc_root_password(duthost, bmc_ip, temp_password)
         self._validate_bmc_login(duthost, bmc_ip, temp_password)
-        bmc.reset_root_password(duthost)
+        res = bmc.reset_root_password(duthost)
+        pytest_assert(res[0] == 0, f"Failed to reset BMC root password {res[1]}")
         self._validate_bmc_login(duthost, bmc_ip, self.bmc_root_password)
 
     def test_reset_root_password_cli(self, duthosts, enum_rand_one_per_hwsku_hostname, bmc_ip):
@@ -468,9 +520,8 @@ class TestBMCApi(PlatformApiTestBase):
             with allure.step("Step 1: Reset password to default state"):
                 reset_result = duthost.command(BMC_RESET_ROOT_PASSWORD_COMMAND)
                 pytest_assert(reset_result["rc"] == 0, f"Failed to reset BMC root password: {reset_result['stderr']}")
-                pytest_assert(
-                    "BMC root password reset successful" in reset_result["stdout"],
-                    f"Unexpected output: {reset_result['stdout']}")
+                pytest_assert("BMC root password reset successful" in reset_result["stdout"],
+                            f"Unexpected output: {reset_result['stdout']}")
                 logger.info("BMC root password reset to default state successfully")
 
             with allure.step("Step 2: Change password from default to new password"):
@@ -480,56 +531,47 @@ class TestBMCApi(PlatformApiTestBase):
                     self.bmc_root_user, self.bmc_root_password, bmc_ip,
                     "/redfish/v1/AccountService/Accounts/root", password_data)
                 change_result = duthost.command(change_pwd_cmd)
-                pytest_assert(
-                    re.match(r"^HTTP/\S+\s+20\d", change_result["stdout"]),
-                    f"Failed to change password: {change_result['stdout']}")
+                pytest_assert(re.match(r"^HTTP/\S+\s+20\d", change_result["stdout"]),
+                            f"Failed to change password: {change_result['stdout']}")
                 logger.info("BMC root password changed to new password successfully")
 
             with allure.step("Step 3: Verify new password works"):
                 verify_new_pwd_cmd = CURL_BASIC_AUTH_GET_WITH_HEADERS.format(
                     self.bmc_root_user, temp_password, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
                 verify_result = duthost.command(verify_new_pwd_cmd)
-                pytest_assert(
-                    re.match(r"^HTTP/\S+\s+20\d", verify_result["stdout"]),
-                    f"New password should work, got: {verify_result['stdout']}")
+                pytest_assert(re.match(r"^HTTP/\S+\s+20\d", verify_result["stdout"]),
+                            f"New password should work, got: {verify_result['stdout']}")
                 logger.info("New password verified successfully")
 
             with allure.step("Step 4: Verify old default password is denied"):
                 verify_old_pwd_cmd = CURL_BASIC_AUTH_GET_WITH_HEADERS.format(
                     self.bmc_root_user, self.bmc_root_password, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
                 verify_old_result = duthost.command(verify_old_pwd_cmd, module_ignore_errors=True)
-                pytest_assert(
-                    re.match(r"^HTTP/\S+\s+401", verify_old_result["stdout"]),
-                    "Old default password should be denied with HTTP 401, "
-                    f"got: {verify_old_result['stdout']}")
+                pytest_assert(re.match(r"^HTTP/\S+\s+401", verify_old_result["stdout"]),
+                            f"Old default password should be denied with HTTP 401, got: {verify_old_result['stdout']}")
                 logger.info("Old default password is correctly denied")
 
             with allure.step("Step 5: Reset password back to default"):
                 reset_result = duthost.command(BMC_RESET_ROOT_PASSWORD_COMMAND)
                 pytest_assert(reset_result["rc"] == 0, f"Failed to reset BMC root password: {reset_result['stderr']}")
-                pytest_assert(
-                    "BMC root password reset successful" in reset_result["stdout"],
-                    f"Unexpected output: {reset_result['stdout']}")
+                pytest_assert("BMC root password reset successful" in reset_result["stdout"],
+                            f"Unexpected output: {reset_result['stdout']}")
                 logger.info("BMC root password reset back to default successfully")
 
             with allure.step("Step 6: Verify default password works again"):
                 verify_default_cmd = CURL_BASIC_AUTH_GET_WITH_HEADERS.format(
                     self.bmc_root_user, self.bmc_root_password, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
                 verify_default_result = duthost.command(verify_default_cmd)
-                pytest_assert(
-                    re.match(r"^HTTP/\S+\s+20\d", verify_default_result["stdout"]),
-                    "Default password should work after reset, "
-                    f"got: {verify_default_result['stdout']}")
+                pytest_assert(re.match(r"^HTTP/\S+\s+20\d", verify_default_result["stdout"]),
+                            f"Default password should work after reset, got: {verify_default_result['stdout']}")
                 logger.info("Default password verified successfully after reset")
 
             with allure.step("Step 7: Verify previous new password is denied"):
                 verify_temp_pwd_cmd = CURL_BASIC_AUTH_GET_WITH_HEADERS.format(
                     self.bmc_root_user, temp_password, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
                 verify_temp_result = duthost.command(verify_temp_pwd_cmd, module_ignore_errors=True)
-                pytest_assert(
-                    re.match(r"^HTTP/\S+\s+401", verify_temp_result["stdout"]),
-                    "Previous new password should be denied with HTTP 401, "
-                    f"got: {verify_temp_result['stdout']}")
+                pytest_assert(re.match(r"^HTTP/\S+\s+401", verify_temp_result["stdout"]),
+                            f"Previous new password should be denied with HTTP 401, got: {verify_temp_result['stdout']}")
                 logger.info("Previous new password is correctly denied after reset")
         finally:
             duthost.command(BMC_RESET_ROOT_PASSWORD_COMMAND)
@@ -553,72 +595,76 @@ class TestBMCApi(PlatformApiTestBase):
         pytest_assert(duthost.command(
             f"ls -l {bmc_dump_path}")["rc"] == 0, f"BMC dump file not found: {bmc_dump_path}")
 
-    def test_bmc_firmware_update(self, duthosts, enum_rand_one_per_hwsku_hostname, bmc_fw_pkg,
-                                 bmc_firmware_command_type, backup_platform_file, bmc_ip, request):
+    def test_bmc_firmware_update(self, duthosts, enum_rand_one_per_hwsku_hostname,
+                                 bmc_fw_pkg, bmc_firmware_command_type, backup_platform_file,
+                                 bmc_ip, recover_bmc_firmware, request, creds):
         """
         Test BMC firmware update with platform API and CLI
 
         Steps:
         1. Check and record the original BMC firmware version
-        2. Update the BMC firmware version by command
+        2. Pick the target firmware: if DUT is on old version, target is latest;
+           if DUT is on latest, target is old. This ensures the CLI command always
+           performs an actual firmware change regardless of the starting state.
+        3. Update the BMC firmware version by command
             'config platform firmware install chassis component BMC fw -y xxx' or
             'config platform firmware update chassis component BMC fw -y xxx'
             depending on completeness_level:
                 if the completeness_level is basic, only test one command type randomly
                 if the completeness_level is others, test both command types
                 in this case,the test test_bmc_firmware_update will be executed twice times
-        3. Wait after the installation done
-        4. Validate the BMC firmware had been updated to the destination version by command
+        4. Wait after the installation done
+        5. Validate the BMC firmware had been updated to the destination version by command
             'show platform firmware status'
-        5. Recover the BMC firmware version to the original one by BMC platform api update_firmware(fw_image)
-        6. Wait after the installation done
-        7. Validate the BMC firmware had been restored to the original version by command
-            'show platform firmware status'
+
+        Note: Recovery to latest BMC firmware is handled by the class-scoped
+        recover_bmc_firmware fixture, which runs once after all parametrized
+        runs (install/update) complete.
         """
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         fw_pkg = bmc_fw_pkg
-        bmc_version_origin = self._get_bmc_version(duthost)
+        bmc_version_origin = _get_bmc_version(duthost)
         logger.info(f"BMC version origin: {bmc_version_origin}")
         logger.info(f"Testing with command type: {bmc_firmware_command_type}")
 
         chassis = list(show_firmware(duthost)["chassis"].keys())[0]
         logger.info(f"Chassis: {chassis}")
-        fw_pkg_path_new = fw_pkg["chassis"][chassis]["component"]["BMC"][LATEST_BMC_VERSION_IDX]["firmware"]
-        fw_version_new = fw_pkg["chassis"][chassis]["component"]["BMC"][LATEST_BMC_VERSION_IDX]["version"]
-        fw_pkg_clean_path_new = urlparse(fw_pkg_path_new).path
-        fw_pkt_name_new = os.path.basename(fw_pkg_path_new)
+        bmc_fw_list = get_bmc_firmware_list(fw_pkg, chassis, duthost, bmc_ip,
+                                            creds['sonic_bmc_root_user'],
+                                            creds['sonic_bmc_root_password'])
+        fw_version_old = bmc_fw_list[OLD_BMC_VERSION_IDX]["version"]
+
+        # Pick the other version so we always test an actual firmware change.
+        # If already on old -> install latest; if already on latest -> install old.
+        if bmc_version_origin == fw_version_old:
+            target_idx = LATEST_BMC_VERSION_IDX
+        else:
+            target_idx = OLD_BMC_VERSION_IDX
+
+        fw_pkg_path_target = bmc_fw_list[target_idx]["firmware"]
+        fw_version_target = bmc_fw_list[target_idx]["version"]
+        fw_pkg_clean_path_target = urlparse(fw_pkg_path_target).path
+        fw_pkt_name_target = os.path.basename(fw_pkg_path_target)
+
         if bmc_firmware_command_type == FW_TYPE_UPDATE:
-            logger.info(f"Generate 'platform_components.json' for BMC firmware: {fw_version_new}")
-            self._generate_platform_file(duthost, chassis, f"/tmp/{fw_pkt_name_new}", fw_version_new)
+            logger.info(f"Generate 'platform_components.json' for BMC firmware: {fw_version_target}")
+            self._generate_platform_file(duthost, chassis, f"/tmp/{fw_pkt_name_target}", fw_version_target)
 
-        logger.info(f"BMC firmware path: {fw_pkg_clean_path_new}")
-        logger.info(f"Copy BMC firmware to localhost: /tmp/{fw_pkt_name_new}")
-        duthost.copy(src=fw_pkg_clean_path_new, dest=f"/tmp/{fw_pkt_name_new}")
+        logger.info(f"BMC firmware path: {fw_pkg_clean_path_target}")
+        logger.info(f"Copy BMC firmware to localhost: /tmp/{fw_pkt_name_target}")
+        duthost.copy(src=fw_pkg_clean_path_target, dest=f"/tmp/{fw_pkt_name_target}")
 
-        logger.info(f"Execute BMC firmware {bmc_firmware_command_type} to {fw_pkt_name_new} and "
+        logger.info(f"Execute BMC firmware {bmc_firmware_command_type} to {fw_pkt_name_target} and "
                     f"Wait for BMC firmware update to complete")
-        res = self._update_bmc_firmware(duthost, f"/tmp/{fw_pkt_name_new}", bmc_ip,
-                                        method='cli', cli_type=bmc_firmware_command_type)
+        res = _update_bmc_firmware(duthost, f"/tmp/{fw_pkt_name_target}", bmc_ip,
+                                   method='cli', cli_type=bmc_firmware_command_type,
+                                   bmc_root_user=self.bmc_root_user,
+                                   bmc_root_password=self.bmc_root_password)
         pytest_assert(res, f"Failed to execute BMC firmware {bmc_firmware_command_type} by CLI!")
 
-        bmc_version_latest = self._get_bmc_version(duthost)
-        logger.info(f"BMC version after {bmc_firmware_command_type}: {bmc_version_latest}")
-        pytest_assert(bmc_version_latest != bmc_version_origin, f"BMC firmware {bmc_firmware_command_type} failed")
-
-        fw_pkg_path_old = fw_pkg["chassis"][chassis]["component"]["BMC"][OLD_BMC_VERSION_IDX]["firmware"]
-        fw_pkg_clean_path_old = urlparse(fw_pkg_path_old).path
-        fw_pkt_name_old = os.path.basename(fw_pkg_path_old)
-        logger.info(f"BMC firmware path: {fw_pkg_clean_path_old}")
-        logger.info(f"Copy BMC firmware to localhost: /tmp/{fw_pkt_name_old}")
-        duthost.copy(src=fw_pkg_clean_path_old, dest=f"/tmp/{fw_pkt_name_old}")
-
-        logger.info(f"Execute BMC firmware update to {fw_pkt_name_old} and Wait for BMC firmware update to complete")
-        res = self._update_bmc_firmware(duthost, f"/tmp/{fw_pkt_name_old}", bmc_ip, method='api')
-        pytest_assert(res, "Failed to execute BMC firmware update by API!")
-
-        bmc_version_current = self._get_bmc_version(duthost)
-        logger.info(f"BMC version after recovery: {bmc_version_current}")
-        pytest_assert(bmc_version_latest != bmc_version_current, "BMC firmware recovery failed")
+        bmc_version_after_cli = _get_bmc_version(duthost)
+        logger.info(f"BMC version after {bmc_firmware_command_type}: {bmc_version_after_cli}")
+        pytest_assert(bmc_version_after_cli != bmc_version_origin, f"BMC firmware {bmc_firmware_command_type} failed")
 
     def _parse_bmc_session(self, output):
         """Parse BMC session output to extract session ID and token"""
@@ -645,8 +691,7 @@ class TestBMCApi(PlatformApiTestBase):
                     ids.add(id_segment)
         return ids
 
-    def test_bmc_session_open_close(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                                    bmc_ip, cleanup_bmc_subscriptions):
+    def test_bmc_session_open_close(self, duthosts, enum_rand_one_per_hwsku_hostname, bmc_ip, cleanup_bmc_subscriptions):
         """
         Test CLIs commands for open and close BMC session
 
@@ -663,9 +708,7 @@ class TestBMCApi(PlatformApiTestBase):
         try:
             with allure.step("Open BMC session"):
                 open_session_result = duthost.command(BMC_OPEN_SESSION_COMMAND)
-                pytest_assert(
-                    open_session_result["rc"] == 0,
-                    f"Failed to open session: {open_session_result['stderr']}")
+                pytest_assert(open_session_result["rc"] == 0, f"Failed to open session: {open_session_result['stderr']}")
                 session_id, token = self._parse_bmc_session(open_session_result["stdout"])
                 logger.info(f"Session opened: {session_id}")
                 pytest_assert(session_id and token, "Session ID or token not returned")
@@ -676,10 +719,7 @@ class TestBMCApi(PlatformApiTestBase):
                 try:
                     sessions_data = json.loads(sessions_result["stdout"])
                 except json.JSONDecodeError as e:
-                    pytest_assert(
-                        False,
-                        f"Failed to parse sessions response as JSON: {e}, "
-                        f"response: {sessions_result['stdout']}")
+                    pytest_assert(False, f"Failed to parse sessions response as JSON: {e}, response: {sessions_result['stdout']}")
                 member_session_ids = self._extract_ids_from_members(sessions_data)
                 pytest_assert(session_id in member_session_ids,
                               "Session {} not present in Members: {}".format(session_id, member_session_ids))
@@ -693,7 +733,7 @@ class TestBMCApi(PlatformApiTestBase):
                 # Extract subscription ID from Location header
                 location_match = re.search(r'Location:\s*.+/([^/\s]+)', subscription_result["stdout"], re.IGNORECASE)
                 subscription_id = location_match.group(1) if location_match else None
-                pytest_assert(subscription_id, "Failed to extract subscription ID")
+                pytest_assert(subscription_id, f"Failed to extract subscription ID")
                 logger.info(f"Subscription created: {subscription_id}")
 
             with allure.step("Close session and verify token becomes invalid"):
@@ -702,50 +742,38 @@ class TestBMCApi(PlatformApiTestBase):
                 logger.info(f"Session {session_id} closed")
                 session_id = None  # Mark as closed
 
-                invalid_get_cmd = CURL_TOKEN_AUTH_GET_WITH_HEADERS.format(
-                    token, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
-                invalid_get_result = duthost.command(
-                    invalid_get_cmd, module_ignore_errors=True)
-                pytest_assert(
-                    re.match(r"^HTTP/\S+\s+401", invalid_get_result["stdout"]),
-                    "GET with invalid token should return HTTP 401, "
-                    f"got: {invalid_get_result['stdout']}")
+                invalid_get_cmd = CURL_TOKEN_AUTH_GET_WITH_HEADERS.format(token, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
+                invalid_get_result = duthost.command(invalid_get_cmd, module_ignore_errors=True)
+                pytest_assert(re.match(r"^HTTP/\S+\s+401", invalid_get_result["stdout"]),
+                             f"GET with invalid token should return HTTP 401, got: {invalid_get_result['stdout']}")
 
                 invalid_post_result = duthost.command(create_subscription_cmd, module_ignore_errors=True)
                 pytest_assert(
-                    invalid_post_result["stdout"].startswith("HTTP/1.1 401 Unauthorized"),
-                    f"POST with invalid token should return HTTP 401 Unauthorized, "
+                    re.match(r"^HTTP/\S+\s+401", invalid_post_result["stdout"]),
+                    f"POST with invalid token should return HTTP 401, "
                     f"got: {invalid_post_result['stdout']}")
 
             with allure.step("Open new session and cleanup subscription"):
                 new_session_result = duthost.command(BMC_OPEN_SESSION_COMMAND)
-                pytest_assert(
-                    new_session_result["rc"] == 0,
-                    f"Failed to open new session: {new_session_result['stderr']}")
+                pytest_assert(new_session_result["rc"] == 0, f"Failed to open new session: {new_session_result['stderr']}")
                 new_session_id, new_token = self._parse_bmc_session(new_session_result["stdout"])
                 pytest_assert(new_session_id and new_token, "New session ID or token not returned")
                 logger.info(f"New session opened: {new_session_id}")
 
                 # Delete subscription
-                delete_sub_endpoint = (
-                    f"{REDFISH_EVENT_SUBSCRIPTIONS_ENDPOINT}/{subscription_id}")
                 delete_result = duthost.command(
-                    CURL_TOKEN_AUTH_DELETE.format(
-                        new_token, bmc_ip, delete_sub_endpoint),
+                    CURL_TOKEN_AUTH_DELETE.format(new_token, bmc_ip, f"{REDFISH_EVENT_SUBSCRIPTIONS_ENDPOINT}/{subscription_id}"),
                     module_ignore_errors=True)
-                pytest_assert(delete_result["stdout"].startswith("HTTP/1.1 200 OK") or
-                              delete_result["stdout"].startswith("HTTP/1.1 204 No Content"),
-                              f"DELETE should return HTTP 200 OK or 204 No Content, got: {delete_result['stdout']}")
+                pytest_assert(
+                    re.match(r"^HTTP/\S+\s+20\d", delete_result["stdout"]),
+                    f"DELETE should return HTTP 2xx, got: {delete_result['stdout']}")
 
                 # Verify subscription is deleted by checking the specific subscription returns 404
                 verify_deleted_cmd = CURL_TOKEN_AUTH_GET_WITH_HEADERS.format(
-                    new_token, bmc_ip, delete_sub_endpoint)
-                verify_deleted_result = duthost.command(
-                    verify_deleted_cmd, module_ignore_errors=True)
-                pytest_assert(
-                    re.match(r"^HTTP/\S+\s+404", verify_deleted_result["stdout"]),
-                    "GET deleted subscription should return HTTP 404, "
-                    f"got: {verify_deleted_result['stdout']}")
+                    new_token, bmc_ip, f"{REDFISH_EVENT_SUBSCRIPTIONS_ENDPOINT}/{subscription_id}")
+                verify_deleted_result = duthost.command(verify_deleted_cmd, module_ignore_errors=True)
+                pytest_assert(re.match(r"^HTTP/\S+\s+404", verify_deleted_result["stdout"]),
+                              f"GET deleted subscription should return HTTP 404, got: {verify_deleted_result['stdout']}")
                 logger.info(f"Subscription {subscription_id} deleted and verified (404 status)")
 
         finally:

--- a/tests/platform_tests/api/test_bmc.py
+++ b/tests/platform_tests/api/test_bmc.py
@@ -753,7 +753,7 @@ class TestBMCApi(PlatformApiTestBase):
                     )
                 member_session_ids = self._extract_ids_from_members(sessions_data)
                 pytest_assert(session_id in member_session_ids,
-                              "Session {} not present in Members: {}".format(session_id, member_session_ids))
+                              "Session {} is absent from Members: {}".format(session_id, member_session_ids))
 
             with allure.step("Create event subscription"):
                 subscription_data = json.dumps({

--- a/tests/platform_tests/api/test_bmc.py
+++ b/tests/platform_tests/api/test_bmc.py
@@ -54,11 +54,17 @@ REDFISH_EVENT_SUBSCRIPTIONS_ENDPOINT = "/redfish/v1/EventService/Subscriptions"
 # Curl command templates (for session tests)
 CURL_TOKEN_AUTH_GET = "curl -k -H \"X-Auth-Token: {}\" -X GET https://{}{}"
 CURL_TOKEN_AUTH_GET_WITH_HEADERS = "curl -k -i -H \"X-Auth-Token: {}\" -X GET https://{}{}"
-CURL_TOKEN_AUTH_POST = "curl -k -i -H \"X-Auth-Token: {}\" -H \"Content-Type: application/json\" -X POST https://{}{} -d '{}'"
+CURL_TOKEN_AUTH_POST = (
+    "curl -k -i -H \"X-Auth-Token: {}\" -H \"Content-Type: application/json\" "
+    "-X POST https://{}{} -d '{}'"
+)
 CURL_TOKEN_AUTH_DELETE = "curl -i -k -H \"X-Auth-Token: {}\" -X DELETE https://{}{}"
 CURL_BASIC_AUTH_GET = "curl -k -u {}:{} -X GET https://{}{}"
 CURL_BASIC_AUTH_GET_WITH_HEADERS = "curl -k -i -u {}:{} -X GET https://{}{}"
-CURL_BASIC_AUTH_PATCH = "curl -k -i -u {}:{} -H \"Content-Type: application/json\" -X PATCH https://{}{} -d '{}'"
+CURL_BASIC_AUTH_PATCH = (
+    "curl -k -i -u {}:{} -H \"Content-Type: application/json\" "
+    "-X PATCH https://{}{} -d '{}'"
+)
 CURL_BASIC_AUTH_DELETE = "curl -k -u {}:{} -X DELETE https://{}{}"
 
 
@@ -122,8 +128,10 @@ def _update_bmc_firmware(duthost, fw_image, bmc_ip, method='api',
     """
     start_time = time.time()
 
-    logger.info(f"Starting BMC firmware update via {method.upper()}" +
-               (f" ({cli_type})" if method == 'cli' and cli_type else ""))
+    logger.info(
+        f"Starting BMC firmware update via {method.upper()}" +
+        (f" ({cli_type})" if method == 'cli' and cli_type else "")
+    )
 
     while True:
         if time.time() - start_time > timeout:
@@ -357,7 +365,9 @@ class TestBMCApi(PlatformApiTestBase):
                     logger.info(f"Deleted {len(existing_subs)} existing subscriptions")
                     return len(existing_subs)
             except (json.JSONDecodeError, KeyError, TypeError) as e:
-                logger.warning(f"Failed to parse subscription list response: {e}, response: {get_subs_result['stdout']}")
+                logger.warning(
+                    f"Failed to parse subscription list response: {e}, response: {get_subs_result['stdout']}"
+                )
                 return 0
         return 0
 
@@ -520,8 +530,10 @@ class TestBMCApi(PlatformApiTestBase):
             with allure.step("Step 1: Reset password to default state"):
                 reset_result = duthost.command(BMC_RESET_ROOT_PASSWORD_COMMAND)
                 pytest_assert(reset_result["rc"] == 0, f"Failed to reset BMC root password: {reset_result['stderr']}")
-                pytest_assert("BMC root password reset successful" in reset_result["stdout"],
-                            f"Unexpected output: {reset_result['stdout']}")
+                pytest_assert(
+                    "BMC root password reset successful" in reset_result["stdout"],
+                    f"Unexpected output: {reset_result['stdout']}"
+                )
                 logger.info("BMC root password reset to default state successfully")
 
             with allure.step("Step 2: Change password from default to new password"):
@@ -531,47 +543,59 @@ class TestBMCApi(PlatformApiTestBase):
                     self.bmc_root_user, self.bmc_root_password, bmc_ip,
                     "/redfish/v1/AccountService/Accounts/root", password_data)
                 change_result = duthost.command(change_pwd_cmd)
-                pytest_assert(re.match(r"^HTTP/\S+\s+20\d", change_result["stdout"]),
-                            f"Failed to change password: {change_result['stdout']}")
+                pytest_assert(
+                    re.match(r"^HTTP/\S+\s+20\d", change_result["stdout"]),
+                    f"Failed to change password: {change_result['stdout']}"
+                )
                 logger.info("BMC root password changed to new password successfully")
 
             with allure.step("Step 3: Verify new password works"):
                 verify_new_pwd_cmd = CURL_BASIC_AUTH_GET_WITH_HEADERS.format(
                     self.bmc_root_user, temp_password, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
                 verify_result = duthost.command(verify_new_pwd_cmd)
-                pytest_assert(re.match(r"^HTTP/\S+\s+20\d", verify_result["stdout"]),
-                            f"New password should work, got: {verify_result['stdout']}")
+                pytest_assert(
+                    re.match(r"^HTTP/\S+\s+20\d", verify_result["stdout"]),
+                    f"New password should work, got: {verify_result['stdout']}"
+                )
                 logger.info("New password verified successfully")
 
             with allure.step("Step 4: Verify old default password is denied"):
                 verify_old_pwd_cmd = CURL_BASIC_AUTH_GET_WITH_HEADERS.format(
                     self.bmc_root_user, self.bmc_root_password, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
                 verify_old_result = duthost.command(verify_old_pwd_cmd, module_ignore_errors=True)
-                pytest_assert(re.match(r"^HTTP/\S+\s+401", verify_old_result["stdout"]),
-                            f"Old default password should be denied with HTTP 401, got: {verify_old_result['stdout']}")
+                pytest_assert(
+                    re.match(r"^HTTP/\S+\s+401", verify_old_result["stdout"]),
+                    f"Old default password should be denied with HTTP 401, got: {verify_old_result['stdout']}"
+                )
                 logger.info("Old default password is correctly denied")
 
             with allure.step("Step 5: Reset password back to default"):
                 reset_result = duthost.command(BMC_RESET_ROOT_PASSWORD_COMMAND)
                 pytest_assert(reset_result["rc"] == 0, f"Failed to reset BMC root password: {reset_result['stderr']}")
-                pytest_assert("BMC root password reset successful" in reset_result["stdout"],
-                            f"Unexpected output: {reset_result['stdout']}")
+                pytest_assert(
+                    "BMC root password reset successful" in reset_result["stdout"],
+                    f"Unexpected output: {reset_result['stdout']}"
+                )
                 logger.info("BMC root password reset back to default successfully")
 
             with allure.step("Step 6: Verify default password works again"):
                 verify_default_cmd = CURL_BASIC_AUTH_GET_WITH_HEADERS.format(
                     self.bmc_root_user, self.bmc_root_password, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
                 verify_default_result = duthost.command(verify_default_cmd)
-                pytest_assert(re.match(r"^HTTP/\S+\s+20\d", verify_default_result["stdout"]),
-                            f"Default password should work after reset, got: {verify_default_result['stdout']}")
+                pytest_assert(
+                    re.match(r"^HTTP/\S+\s+20\d", verify_default_result["stdout"]),
+                    f"Default password should work after reset, got: {verify_default_result['stdout']}"
+                )
                 logger.info("Default password verified successfully after reset")
 
             with allure.step("Step 7: Verify previous new password is denied"):
                 verify_temp_pwd_cmd = CURL_BASIC_AUTH_GET_WITH_HEADERS.format(
                     self.bmc_root_user, temp_password, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
                 verify_temp_result = duthost.command(verify_temp_pwd_cmd, module_ignore_errors=True)
-                pytest_assert(re.match(r"^HTTP/\S+\s+401", verify_temp_result["stdout"]),
-                            f"Previous new password should be denied with HTTP 401, got: {verify_temp_result['stdout']}")
+                pytest_assert(
+                    re.match(r"^HTTP/\S+\s+401", verify_temp_result["stdout"]),
+                    f"Previous new password should be denied with HTTP 401, got: {verify_temp_result['stdout']}"
+                )
                 logger.info("Previous new password is correctly denied after reset")
         finally:
             duthost.command(BMC_RESET_ROOT_PASSWORD_COMMAND)
@@ -691,7 +715,8 @@ class TestBMCApi(PlatformApiTestBase):
                     ids.add(id_segment)
         return ids
 
-    def test_bmc_session_open_close(self, duthosts, enum_rand_one_per_hwsku_hostname, bmc_ip, cleanup_bmc_subscriptions):
+    def test_bmc_session_open_close(self, duthosts, enum_rand_one_per_hwsku_hostname,
+                                    bmc_ip, cleanup_bmc_subscriptions):
         """
         Test CLIs commands for open and close BMC session
 
@@ -708,7 +733,10 @@ class TestBMCApi(PlatformApiTestBase):
         try:
             with allure.step("Open BMC session"):
                 open_session_result = duthost.command(BMC_OPEN_SESSION_COMMAND)
-                pytest_assert(open_session_result["rc"] == 0, f"Failed to open session: {open_session_result['stderr']}")
+                pytest_assert(
+                    open_session_result["rc"] == 0,
+                    f"Failed to open session: {open_session_result['stderr']}"
+                )
                 session_id, token = self._parse_bmc_session(open_session_result["stdout"])
                 logger.info(f"Session opened: {session_id}")
                 pytest_assert(session_id and token, "Session ID or token not returned")
@@ -719,13 +747,19 @@ class TestBMCApi(PlatformApiTestBase):
                 try:
                     sessions_data = json.loads(sessions_result["stdout"])
                 except json.JSONDecodeError as e:
-                    pytest_assert(False, f"Failed to parse sessions response as JSON: {e}, response: {sessions_result['stdout']}")
+                    pytest_assert(
+                        False,
+                        f"Failed to parse sessions response as JSON: {e}, response: {sessions_result['stdout']}"
+                    )
                 member_session_ids = self._extract_ids_from_members(sessions_data)
                 pytest_assert(session_id in member_session_ids,
                               "Session {} not present in Members: {}".format(session_id, member_session_ids))
 
             with allure.step("Create event subscription"):
-                subscription_data = json.dumps({"Destination": "https://example.com/events", "Protocol": "Redfish"})
+                subscription_data = json.dumps({
+                    "Destination": "https://example.com/events",
+                    "Protocol": "Redfish"
+                })
                 create_subscription_cmd = CURL_TOKEN_AUTH_POST.format(
                     token, bmc_ip, REDFISH_EVENT_SUBSCRIPTIONS_ENDPOINT, subscription_data)
                 subscription_result = duthost.command(create_subscription_cmd)
@@ -733,7 +767,7 @@ class TestBMCApi(PlatformApiTestBase):
                 # Extract subscription ID from Location header
                 location_match = re.search(r'Location:\s*.+/([^/\s]+)', subscription_result["stdout"], re.IGNORECASE)
                 subscription_id = location_match.group(1) if location_match else None
-                pytest_assert(subscription_id, f"Failed to extract subscription ID")
+                pytest_assert(subscription_id, "Failed to extract subscription ID")
                 logger.info(f"Subscription created: {subscription_id}")
 
             with allure.step("Close session and verify token becomes invalid"):
@@ -742,38 +776,50 @@ class TestBMCApi(PlatformApiTestBase):
                 logger.info(f"Session {session_id} closed")
                 session_id = None  # Mark as closed
 
-                invalid_get_cmd = CURL_TOKEN_AUTH_GET_WITH_HEADERS.format(token, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
+                invalid_get_cmd = CURL_TOKEN_AUTH_GET_WITH_HEADERS.format(
+                    token, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
                 invalid_get_result = duthost.command(invalid_get_cmd, module_ignore_errors=True)
-                pytest_assert(re.match(r"^HTTP/\S+\s+401", invalid_get_result["stdout"]),
-                             f"GET with invalid token should return HTTP 401, got: {invalid_get_result['stdout']}")
+                pytest_assert(
+                    re.match(r"^HTTP/\S+\s+401", invalid_get_result["stdout"]),
+                    f"GET with invalid token should return HTTP 401, got: {invalid_get_result['stdout']}"
+                )
 
                 invalid_post_result = duthost.command(create_subscription_cmd, module_ignore_errors=True)
                 pytest_assert(
                     re.match(r"^HTTP/\S+\s+401", invalid_post_result["stdout"]),
                     f"POST with invalid token should return HTTP 401, "
-                    f"got: {invalid_post_result['stdout']}")
+                    f"got: {invalid_post_result['stdout']}"
+                )
 
             with allure.step("Open new session and cleanup subscription"):
                 new_session_result = duthost.command(BMC_OPEN_SESSION_COMMAND)
-                pytest_assert(new_session_result["rc"] == 0, f"Failed to open new session: {new_session_result['stderr']}")
+                pytest_assert(
+                    new_session_result["rc"] == 0,
+                    f"Failed to open new session: {new_session_result['stderr']}"
+                )
                 new_session_id, new_token = self._parse_bmc_session(new_session_result["stdout"])
                 pytest_assert(new_session_id and new_token, "New session ID or token not returned")
                 logger.info(f"New session opened: {new_session_id}")
 
                 # Delete subscription
+                subscription_endpoint = f"{REDFISH_EVENT_SUBSCRIPTIONS_ENDPOINT}/{subscription_id}"
+                delete_cmd = CURL_TOKEN_AUTH_DELETE.format(
+                    new_token, bmc_ip, subscription_endpoint)
                 delete_result = duthost.command(
-                    CURL_TOKEN_AUTH_DELETE.format(new_token, bmc_ip, f"{REDFISH_EVENT_SUBSCRIPTIONS_ENDPOINT}/{subscription_id}"),
-                    module_ignore_errors=True)
+                    delete_cmd, module_ignore_errors=True)
                 pytest_assert(
                     re.match(r"^HTTP/\S+\s+20\d", delete_result["stdout"]),
-                    f"DELETE should return HTTP 2xx, got: {delete_result['stdout']}")
+                    f"DELETE should return HTTP 2xx, got: {delete_result['stdout']}"
+                )
 
                 # Verify subscription is deleted by checking the specific subscription returns 404
                 verify_deleted_cmd = CURL_TOKEN_AUTH_GET_WITH_HEADERS.format(
-                    new_token, bmc_ip, f"{REDFISH_EVENT_SUBSCRIPTIONS_ENDPOINT}/{subscription_id}")
+                    new_token, bmc_ip, subscription_endpoint)
                 verify_deleted_result = duthost.command(verify_deleted_cmd, module_ignore_errors=True)
-                pytest_assert(re.match(r"^HTTP/\S+\s+404", verify_deleted_result["stdout"]),
-                              f"GET deleted subscription should return HTTP 404, got: {verify_deleted_result['stdout']}")
+                pytest_assert(
+                    re.match(r"^HTTP/\S+\s+404", verify_deleted_result["stdout"]),
+                    f"GET deleted subscription should return HTTP 404, got: {verify_deleted_result['stdout']}"
+                )
                 logger.info(f"Subscription {subscription_id} deleted and verified (404 status)")
 
         finally:

--- a/tests/platform_tests/api/test_bmc.py
+++ b/tests/platform_tests/api/test_bmc.py
@@ -36,11 +36,17 @@ OLD_BMC_VERSION_IDX = 1
 EROT_BUSY_MSG = "ERoT is busy"
 EROT_STABLE_TIMEOUT = 600
 WAIT_TIME_INTERVAL_BETWEEN_ATTEMPTS = 30
+BMC_DISABLE_BACKGROUND_COPY_TIMEOUT = 30
+BMC_DISABLE_BACKGROUND_COPY_INTERVAL = 5
 BMC_COMPONENT_NAME = 'BMC'
 BMC_UPDATE_COMMAND = "sudo config platform firmware {} chassis component BMC fw -y"
 BMC_INSTALL_COMMAND = "sudo config platform firmware {} chassis component BMC fw -y {}"
-BMC_GET_STATUS_COMMAND = "curl -k -u {}:{} -X GET https://{}/redfish/v1/Chassis/MGX_ERoT_BMC_0"
-BMC_COMPLETE_STATUS = "Completed"
+BMC_GET_STATUS_COMMAND = "curl -k -u {}:{} --request GET --location https://{}/redfish/v1/Chassis/MGX_ERoT_BMC_0"
+BMC_DISABLE_BACKGROUND_COPY_COMMAND = (
+    "curl -k -u {}:{} -H \"Content-Type: application/json\" -X PATCH "
+    "https://{}/redfish/v1/Chassis/MGX_ERoT_BMC_0 "
+    "-d '{{\"Oem\": {{\"Nvidia\": {{\"AutomaticBackgroundCopyEnabled\": false}}}}}}'"
+)
 
 # BMC session test commands
 BMC_OPEN_SESSION_COMMAND = "sudo config bmc open-session"
@@ -82,9 +88,9 @@ def _get_bmc_version(duthost, timeout=120):
         time.sleep(5)
 
 
-def _is_bmc_busy(duthost, bmc_ip, bmc_root_user, bmc_root_password):
+def _get_bmc_background_copy_enabled(duthost, bmc_ip, bmc_root_user, bmc_root_password):
     """
-    Check if BMC is busy by querying BackgroundCopyStatus from Redfish API
+    Query the ERoT-BMC Chassis endpoint and return Oem.Nvidia.AutomaticBackgroundCopyEnabled.
 
     Args:
         duthost: DUT host object
@@ -92,19 +98,90 @@ def _is_bmc_busy(duthost, bmc_ip, bmc_root_user, bmc_root_password):
         bmc_root_user: BMC root username
         bmc_root_password: BMC root password
     Returns:
-        bool: True if BMC is busy (BackgroundCopyStatus != "Completed"), False otherwise
+        bool: value of AutomaticBackgroundCopyEnabled (defaults to True if missing/unparsable)
     """
     res = duthost.command(BMC_GET_STATUS_COMMAND.format(bmc_root_user, bmc_root_password, bmc_ip))["stdout"]
     pytest_assert(res is not None, "Failed to query BMC status")
 
     try:
         response_json = json.loads(res)
-        background_copy_status = response_json.get("Oem", {}).get("Nvidia", {}).get("BackgroundCopyStatus", "")
-        logger.info(f"BMC BackgroundCopyStatus: {background_copy_status}")
-        return background_copy_status != BMC_COMPLETE_STATUS
+        background_copy_enabled = response_json.get("Oem", {}).get("Nvidia", {}).get(
+            "AutomaticBackgroundCopyEnabled", True)
     except (json.JSONDecodeError, KeyError, TypeError) as e:
         logger.warning(f"Failed to parse BMC status response: {e}, response: {res}")
         return True
+
+    logger.info(f"BMC AutomaticBackgroundCopyEnabled: {background_copy_enabled}")
+    return background_copy_enabled
+
+
+def _disable_bmc_background_copy(duthost, bmc_ip, bmc_root_user, bmc_root_password):
+    """
+    Disable automatic background copy on the ERoT-BMC via Redfish PATCH.
+
+    Sends:
+        PATCH /redfish/v1/Chassis/MGX_ERoT_BMC_0
+        -d '{"Oem": {"Nvidia": {"AutomaticBackgroundCopyEnabled": false}}}'
+
+    Args:
+        duthost: DUT host object
+        bmc_ip: BMC IP address
+        bmc_root_user: BMC root username
+        bmc_root_password: BMC root password
+    Returns:
+        str: raw response body from the PATCH request
+    """
+    logger.info("Disabling BMC AutomaticBackgroundCopyEnabled via Redfish PATCH")
+    res = duthost.command(
+        BMC_DISABLE_BACKGROUND_COPY_COMMAND.format(bmc_root_user, bmc_root_password, bmc_ip))["stdout"]
+    logger.info(f"BMC disable background copy response: {res}")
+    return res
+
+
+def _is_bmc_busy(duthost, bmc_ip, bmc_root_user, bmc_root_password):
+    """
+    Check if BMC/ERoT is busy.
+
+    Logic:
+        1. Query the Chassis Redfish endpoint for Oem.Nvidia.AutomaticBackgroundCopyEnabled.
+           - If False -> automatic background copy is disabled -> BMC is NOT busy.
+           - If True  -> PATCH the Chassis endpoint to disable AutomaticBackgroundCopyEnabled,
+                         then poll (re-query) for up to BMC_DISABLE_BACKGROUND_COPY_TIMEOUT
+                         seconds until it becomes False. If it becomes False, BMC is NOT busy;
+                         otherwise (timeout) it is still busy.
+
+    Args:
+        duthost: DUT host object
+        bmc_ip: BMC IP address
+        bmc_root_user: BMC root username
+        bmc_root_password: BMC root password
+    Returns:
+        bool: True if BMC is busy, False otherwise
+    """
+    background_copy_enabled = _get_bmc_background_copy_enabled(
+        duthost, bmc_ip, bmc_root_user, bmc_root_password)
+
+    if not background_copy_enabled:
+        # AutomaticBackgroundCopyEnabled is False -> BMC is not busy
+        return False
+
+    # AutomaticBackgroundCopyEnabled is True -> disable it via PATCH
+    _disable_bmc_background_copy(duthost, bmc_ip, bmc_root_user, bmc_root_password)
+
+    # Poll until AutomaticBackgroundCopyEnabled becomes False (up to timeout).
+    start_time = time.time()
+    while True:
+        background_copy_enabled = _get_bmc_background_copy_enabled(
+            duthost, bmc_ip, bmc_root_user, bmc_root_password)
+        if not background_copy_enabled:
+            # Confirmed disabled -> BMC is not busy
+            return False
+        if time.time() - start_time > BMC_DISABLE_BACKGROUND_COPY_TIMEOUT:
+            logger.warning(
+                f"AutomaticBackgroundCopyEnabled still True after "
+                f"{BMC_DISABLE_BACKGROUND_COPY_TIMEOUT}s -> BMC is still busy")
+            return True
+        time.sleep(BMC_DISABLE_BACKGROUND_COPY_INTERVAL)
 
 
 def _update_bmc_firmware(duthost, fw_image, bmc_ip, method='api',

--- a/tests/platform_tests/api/test_bmc.py
+++ b/tests/platform_tests/api/test_bmc.py
@@ -15,8 +15,10 @@ from tests.common.platform.device_utils import platform_api_conn, start_platform
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
 from .platform_api_test_base import PlatformApiTestBase
 from tests.platform_tests.conftest import extract_fw_data
-from tests.common.helpers.firmware_helper import show_firmware, FW_TYPE_UPDATE, PLATFORM_COMP_PATH_TEMPLATE
-
+from tests.common.helpers.firmware_helper import (
+    show_firmware, FW_TYPE_UPDATE, PLATFORM_COMP_PATH_TEMPLATE,
+    get_bmc_firmware_list, get_bmc_ip
+)
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +35,7 @@ LATEST_BMC_VERSION_IDX = 0
 OLD_BMC_VERSION_IDX = 1
 EROT_BUSY_MSG = "ERoT is busy"
 EROT_STABLE_TIMEOUT = 600
-WAIT_TIME = 30
+WAIT_TIME_INTERVAL_BETWEEN_ATTEMPTS = 30
 BMC_COMPONENT_NAME = 'BMC'
 BMC_UPDATE_COMMAND = "sudo config platform firmware {} chassis component BMC fw -y"
 BMC_INSTALL_COMMAND = "sudo config platform firmware {} chassis component BMC fw -y {}"
@@ -52,13 +54,133 @@ REDFISH_EVENT_SUBSCRIPTIONS_ENDPOINT = "/redfish/v1/EventService/Subscriptions"
 # Curl command templates (for session tests)
 CURL_TOKEN_AUTH_GET = "curl -k -H \"X-Auth-Token: {}\" -X GET https://{}{}"
 CURL_TOKEN_AUTH_GET_WITH_HEADERS = "curl -k -i -H \"X-Auth-Token: {}\" -X GET https://{}{}"
-CURL_TOKEN_AUTH_POST = ("curl -k -i -H \"X-Auth-Token: {}\" -H \"Content-Type: application/json\""
-                        " -X POST https://{}{} -d '{}'")
+CURL_TOKEN_AUTH_POST = "curl -k -i -H \"X-Auth-Token: {}\" -H \"Content-Type: application/json\" -X POST https://{}{} -d '{}'"
 CURL_TOKEN_AUTH_DELETE = "curl -i -k -H \"X-Auth-Token: {}\" -X DELETE https://{}{}"
 CURL_BASIC_AUTH_GET = "curl -k -u {}:{} -X GET https://{}{}"
 CURL_BASIC_AUTH_GET_WITH_HEADERS = "curl -k -i -u {}:{} -X GET https://{}{}"
 CURL_BASIC_AUTH_PATCH = "curl -k -i -u {}:{} -H \"Content-Type: application/json\" -X PATCH https://{}{} -d '{}'"
 CURL_BASIC_AUTH_DELETE = "curl -k -u {}:{} -X DELETE https://{}{}"
+
+
+def _get_bmc_version(duthost, timeout=120):
+    """Get BMC firmware version from 'show platform firmware status' output."""
+    start_time = time.time()
+    while True:
+        if time.time() - start_time > timeout:
+            logger.warning(f"Timeout after {timeout}s while getting BMC version")
+            return None
+        res = duthost.show_and_parse('sudo show platform firmware status')
+        for entry in res:
+            if entry['component'] == 'BMC' and entry['version'] != 'N/A':
+                return entry['version']
+        time.sleep(5)
+
+
+def _is_bmc_busy(duthost, bmc_ip, bmc_root_user, bmc_root_password):
+    """
+    Check if BMC is busy by querying BackgroundCopyStatus from Redfish API
+
+    Args:
+        duthost: DUT host object
+        bmc_ip: BMC IP address
+        bmc_root_user: BMC root username
+        bmc_root_password: BMC root password
+    Returns:
+        bool: True if BMC is busy (BackgroundCopyStatus != "Completed"), False otherwise
+    """
+    res = duthost.command(BMC_GET_STATUS_COMMAND.format(bmc_root_user, bmc_root_password, bmc_ip))["stdout"]
+    pytest_assert(res is not None, "Failed to query BMC status")
+
+    try:
+        response_json = json.loads(res)
+        background_copy_status = response_json.get("Oem", {}).get("Nvidia", {}).get("BackgroundCopyStatus", "")
+        logger.info(f"BMC BackgroundCopyStatus: {background_copy_status}")
+        return background_copy_status != BMC_COMPLETE_STATUS
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        logger.warning(f"Failed to parse BMC status response: {e}, response: {res}")
+        return True
+
+
+def _update_bmc_firmware(duthost, fw_image, bmc_ip, method='api',
+                         cli_type=None, timeout=EROT_STABLE_TIMEOUT,
+                         bmc_root_user=None, bmc_root_password=None):
+    """
+    Update BMC firmware with retry mechanism for ERoT busy scenarios
+
+    Args:
+        duthost: DUT host object
+        fw_image: Path to firmware image file
+        bmc_ip: BMC IP address
+        method: Update method - 'api' or 'cli' (default: 'api')
+        cli_type: CLI command type when method='cli' - FW_TYPE_INSTALL or FW_TYPE_UPDATE
+        timeout: Maximum time to wait for update (default: EROT_STABLE_TIMEOUT)
+        bmc_root_user: BMC root username (required for cli method)
+        bmc_root_password: BMC root password (required for cli method)
+
+    Returns:
+        bool: True if update successful, False otherwise
+    """
+    start_time = time.time()
+
+    logger.info(f"Starting BMC firmware update via {method.upper()}" +
+               (f" ({cli_type})" if method == 'cli' and cli_type else ""))
+
+    while True:
+        if time.time() - start_time > timeout:
+            logger.warning(f"Timeout after {timeout} seconds while updating BMC firmware")
+            return False
+        time.sleep(WAIT_TIME_INTERVAL_BETWEEN_ATTEMPTS)
+
+        if method == 'api':
+            ret_code, (message, _) = bmc.update_firmware(duthost, fw_image)
+
+            if EROT_BUSY_MSG in message:
+                logger.info(f"{EROT_BUSY_MSG}, waiting for {WAIT_TIME_INTERVAL_BETWEEN_ATTEMPTS} seconds")
+                continue
+            elif ret_code != 0:
+                logger.warning(f"Failed to update BMC firmware: return code: {ret_code}, message: {message}")
+                return False
+            else:
+                logger.info("BMC firmware updated successfully via API!")
+                break
+
+        elif method == 'cli':
+            if cli_type is None:
+                logger.error("cli_type must be specified when method='cli'")
+                return False
+
+            if _is_bmc_busy(duthost, bmc_ip, bmc_root_user, bmc_root_password):
+                logger.info(f"BMC is busy, waiting for {WAIT_TIME_INTERVAL_BETWEEN_ATTEMPTS} seconds")
+                continue
+
+            if cli_type == FW_TYPE_UPDATE:
+                res = duthost.command(BMC_UPDATE_COMMAND.format(cli_type))
+            else:
+                res = duthost.command(BMC_INSTALL_COMMAND.format(cli_type, fw_image))
+
+            if res['rc'] == 0:
+                logger.info(f"BMC firmware updated successfully via CLI ({cli_type})!")
+            else:
+                logger.info(f"Failed to update BMC firmware: {res['stdout']}")
+            break
+        else:
+            logger.error(f"Unknown update method: {method}")
+            return False
+
+    if method == 'api':
+        logger.info("Requesting BMC reset after successful update by platform api")
+        bmc.request_bmc_reset(duthost)
+
+    return True
+
+
+@pytest.fixture(scope="module")
+def bmc_ip(duthosts, enum_rand_one_per_hwsku_hostname):
+    """Module-scoped fixture to get BMC IP address. Returns None if BMC is not present."""
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    if not bmc.is_bmc_exists(duthost):
+        return None
+    return get_bmc_ip(duthost)
 
 
 def pytest_generate_tests(metafunc):
@@ -99,112 +221,57 @@ class TestBMCApi(PlatformApiTestBase):
         yield extract_fw_data(fw_pkg_name)
 
     @pytest.fixture(scope="class")
-    def bmc_ip(self, duthosts, enum_rand_one_per_hwsku_hostname, skip_if_no_bmc):
+    def recover_bmc_firmware(self, duthosts, enum_rand_one_per_hwsku_hostname,
+                             bmc_fw_pkg, bmc_ip, creds):
+        """Recover BMC firmware to the latest version after all parametrized runs."""
+        yield
+
+        if bmc_ip is None:
+            logger.info("Recovery: BMC is not present, skipping recovery")
+            return
+
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        platform = duthost.shell("sudo show platform summary | grep Platform | awk '{print $2}'")["stdout"]
-        bmc_config_file = f"/usr/share/sonic/device/{platform}/bmc.json"
-        duthost.fetch(src=bmc_config_file, dest='/tmp')
-        with open(f'/tmp/{duthost.hostname}/{bmc_config_file}', "r") as f:
-            bmc_config = json.load(f)
-        yield bmc_config["bmc_addr"]
+
+        bmc_version_current = _get_bmc_version(duthost)
+        if bmc_version_current is None:
+            logger.warning("Recovery: could not determine current BMC version, skipping recovery")
+            return
+
+        chassis = list(show_firmware(duthost)["chassis"].keys())[0]
+        bmc_fw_list = get_bmc_firmware_list(
+            bmc_fw_pkg, chassis, duthost, bmc_ip,
+            creds['sonic_bmc_root_user'], creds['sonic_bmc_root_password']
+        )
+        fw_version_latest = bmc_fw_list[LATEST_BMC_VERSION_IDX]["version"]
+
+        if bmc_version_current == fw_version_latest:
+            logger.info("Recovery: already on latest BMC version, skipping recovery")
+            return
+
+        fw_pkg_path = bmc_fw_list[LATEST_BMC_VERSION_IDX]["firmware"]
+        fw_pkg_clean_path = urlparse(fw_pkg_path).path
+        fw_pkt_name = os.path.basename(fw_pkg_path)
+
+        logger.info(f"Recovery: copying BMC firmware {fw_pkt_name} to DUT")
+        duthost.copy(src=fw_pkg_clean_path, dest=f"/tmp/{fw_pkt_name}")
+
+        logger.info(f"Recovery: updating BMC firmware to latest version {fw_version_latest} via API")
+        success = _update_bmc_firmware(
+            duthost, f"/tmp/{fw_pkt_name}", bmc_ip=None, method='api'
+        )
+        if not success:
+            logger.error("Recovery: failed to update BMC firmware to latest version")
+            return
+
+        bmc_version_after = _get_bmc_version(duthost)
+        logger.info(f"Recovery: BMC version after recovery: {bmc_version_after}")
+        if bmc_version_after != fw_version_latest:
+            logger.error(f"Recovery: expected {fw_version_latest}, got {bmc_version_after}")
 
     @pytest.fixture(autouse=True)
     def prepare_param(self, creds):
         self.bmc_root_user = creds['sonic_bmc_root_user']
         self.bmc_root_password = creds['sonic_bmc_root_password']
-
-    def _is_bmc_busy(self, duthost, bmc_ip):
-        """
-        Check if BMC is busy by querying BackgroundCopyStatus from Redfish API
-
-        Args:
-            duthost: DUT host object
-            bmc_ip: BMC IP address
-        Returns:
-            bool: True if BMC is busy (BackgroundCopyStatus != "Completed"), False otherwise
-        """
-        res = duthost.command(
-            BMC_GET_STATUS_COMMAND.format(self.bmc_root_user, self.bmc_root_password, bmc_ip))["stdout"]
-        pytest_assert(res is not None, "Failed to query BMC status")
-
-        try:
-            response_json = json.loads(res)
-            background_copy_status = response_json.get("Oem", {}).get("Nvidia", {}).get("BackgroundCopyStatus", "")
-            logger.info(f"BMC BackgroundCopyStatus: {background_copy_status}")
-
-            return background_copy_status != BMC_COMPLETE_STATUS
-        except (json.JSONDecodeError, KeyError, TypeError) as e:
-            logger.warning(f"Failed to parse BMC status response: {e}, response: {res}")
-            return True
-
-    def _update_bmc_firmware(self, duthost, fw_image, bmc_ip, method='api',
-                             cli_type=None, timeout=EROT_STABLE_TIMEOUT):
-        """
-        Update BMC firmware with retry mechanism for ERoT busy scenarios
-
-        Args:
-            duthost: DUT host object
-            fw_image: Path to firmware image file
-            bmc_ip: BMC IP address
-            method: Update method - 'api' or 'cli' (default: 'api')
-            cli_type: CLI command type when method='cli' - FW_TYPE_INSTALL or FW_TYPE_UPDATE
-            timeout: Maximum time to wait for update (default: EROT_STABLE_TIMEOUT)
-
-        Returns:
-            bool: True if update successful, False otherwise
-        """
-        start_time = time.time()
-        cli_suffix = f" ({cli_type})" if method == 'cli' and cli_type else ""
-        logger.info(f"Starting BMC firmware update via {method.upper()}{cli_suffix}")
-
-        while True:
-            if time.time() - start_time > timeout:
-                logger.warning(f"Timeout after {timeout} seconds while updating BMC firmware")
-                return False
-            time.sleep(WAIT_TIME)
-
-            if method == 'api':
-                ret_code, (message, _) = bmc.update_firmware(duthost, fw_image)
-
-                if EROT_BUSY_MSG in message:
-                    logger.info(f"{EROT_BUSY_MSG}, waiting for {WAIT_TIME} seconds")
-                    continue
-                elif ret_code != 0:
-                    logger.warning(f"Failed to update BMC firmware: return code: {ret_code}, message: {message}")
-                    return False
-                else:
-                    logger.info("BMC firmware updated successfully via API!")
-                    break
-
-            elif method == 'cli':
-                if cli_type is None:
-                    logger.error("cli_type must be specified when method='cli'")
-                    return False
-
-                is_bmc_busy = self._is_bmc_busy(duthost, bmc_ip)
-                if is_bmc_busy:
-                    logger.info(f"BMC is busy, waiting for {WAIT_TIME} seconds")
-                    continue
-
-                if cli_type == FW_TYPE_UPDATE:
-                    res = duthost.command(BMC_UPDATE_COMMAND.format(cli_type))
-                else:
-                    res = duthost.command(BMC_INSTALL_COMMAND.format(cli_type, fw_image))
-
-                if res['rc'] == 0:
-                    logger.info(f"BMC firmware updated successfully via CLI ({cli_type})!")
-                else:
-                    logger.info(f"Failed to update BMC firmware: {res['stdout']}")
-                break
-            else:
-                logger.error(f"Unknown update method: {method}")
-                return False
-
-        if method == 'api':
-            logger.info("Requesting BMC reset after successful update by platform api")
-            bmc.request_bmc_reset(duthost)
-
-        return True
 
     def _generate_password(self):
         password_length = random.choice(range(BMC_SHORTEST_PASSWD_LEN, BMC_LONGEST_PASSWD_LEN))
@@ -286,26 +353,9 @@ class TestBMCApi(PlatformApiTestBase):
                     logger.info(f"Deleted {len(existing_subs)} existing subscriptions")
                     return len(existing_subs)
             except (json.JSONDecodeError, KeyError, TypeError) as e:
-                logger.warning(
-                    f"Failed to parse subscription list response: {e}, "
-                    f"response: {get_subs_result['stdout']}")
+                logger.warning(f"Failed to parse subscription list response: {e}, response: {get_subs_result['stdout']}")
                 return 0
         return 0
-
-    def _get_bmc_version(self, duthost, timeout=120):
-        start_time = time.time()
-
-        while True:
-            if time.time() - start_time > timeout:
-                logger.warning(f"Timeout after {timeout} seconds while getting BMC version")
-                return
-
-            res = duthost.show_and_parse('sudo show platform firmware status')
-            for entry in res:
-                if entry['component'] == 'BMC':
-                    if entry['version'] == 'N/A':
-                        continue
-                    return entry['version']
 
     def _generate_platform_file(self, duthost, chassis_name, fw_path, fw_version):
         """
@@ -431,12 +481,14 @@ class TestBMCApi(PlatformApiTestBase):
         """
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
-        bmc.reset_root_password(duthost)
+        res = bmc.reset_root_password(duthost)
+        pytest_assert(res[0] == 0, f"Failed to reset BMC root password {res[1]}")
         self._validate_bmc_login(duthost, bmc_ip, self.bmc_root_password)
         temp_password = self._generate_password()
         self._change_bmc_root_password(duthost, bmc_ip, temp_password)
         self._validate_bmc_login(duthost, bmc_ip, temp_password)
-        bmc.reset_root_password(duthost)
+        res = bmc.reset_root_password(duthost)
+        pytest_assert(res[0] == 0, f"Failed to reset BMC root password {res[1]}")
         self._validate_bmc_login(duthost, bmc_ip, self.bmc_root_password)
 
     def test_reset_root_password_cli(self, duthosts, enum_rand_one_per_hwsku_hostname, bmc_ip):
@@ -464,9 +516,8 @@ class TestBMCApi(PlatformApiTestBase):
             with allure.step("Step 1: Reset password to default state"):
                 reset_result = duthost.command(BMC_RESET_ROOT_PASSWORD_COMMAND)
                 pytest_assert(reset_result["rc"] == 0, f"Failed to reset BMC root password: {reset_result['stderr']}")
-                pytest_assert(
-                    "BMC root password reset successful" in reset_result["stdout"],
-                    f"Unexpected output: {reset_result['stdout']}")
+                pytest_assert("BMC root password reset successful" in reset_result["stdout"],
+                            f"Unexpected output: {reset_result['stdout']}")
                 logger.info("BMC root password reset to default state successfully")
 
             with allure.step("Step 2: Change password from default to new password"):
@@ -476,56 +527,47 @@ class TestBMCApi(PlatformApiTestBase):
                     self.bmc_root_user, self.bmc_root_password, bmc_ip,
                     "/redfish/v1/AccountService/Accounts/root", password_data)
                 change_result = duthost.command(change_pwd_cmd)
-                pytest_assert(
-                    re.match(r"^HTTP/\S+\s+20\d", change_result["stdout"]),
-                    f"Failed to change password: {change_result['stdout']}")
+                pytest_assert(re.match(r"^HTTP/\S+\s+20\d", change_result["stdout"]),
+                            f"Failed to change password: {change_result['stdout']}")
                 logger.info("BMC root password changed to new password successfully")
 
             with allure.step("Step 3: Verify new password works"):
                 verify_new_pwd_cmd = CURL_BASIC_AUTH_GET_WITH_HEADERS.format(
                     self.bmc_root_user, temp_password, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
                 verify_result = duthost.command(verify_new_pwd_cmd)
-                pytest_assert(
-                    re.match(r"^HTTP/\S+\s+20\d", verify_result["stdout"]),
-                    f"New password should work, got: {verify_result['stdout']}")
+                pytest_assert(re.match(r"^HTTP/\S+\s+20\d", verify_result["stdout"]),
+                            f"New password should work, got: {verify_result['stdout']}")
                 logger.info("New password verified successfully")
 
             with allure.step("Step 4: Verify old default password is denied"):
                 verify_old_pwd_cmd = CURL_BASIC_AUTH_GET_WITH_HEADERS.format(
                     self.bmc_root_user, self.bmc_root_password, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
                 verify_old_result = duthost.command(verify_old_pwd_cmd, module_ignore_errors=True)
-                pytest_assert(
-                    re.match(r"^HTTP/\S+\s+401", verify_old_result["stdout"]),
-                    "Old default password should be denied with HTTP 401, "
-                    f"got: {verify_old_result['stdout']}")
+                pytest_assert(re.match(r"^HTTP/\S+\s+401", verify_old_result["stdout"]),
+                            f"Old default password should be denied with HTTP 401, got: {verify_old_result['stdout']}")
                 logger.info("Old default password is correctly denied")
 
             with allure.step("Step 5: Reset password back to default"):
                 reset_result = duthost.command(BMC_RESET_ROOT_PASSWORD_COMMAND)
                 pytest_assert(reset_result["rc"] == 0, f"Failed to reset BMC root password: {reset_result['stderr']}")
-                pytest_assert(
-                    "BMC root password reset successful" in reset_result["stdout"],
-                    f"Unexpected output: {reset_result['stdout']}")
+                pytest_assert("BMC root password reset successful" in reset_result["stdout"],
+                            f"Unexpected output: {reset_result['stdout']}")
                 logger.info("BMC root password reset back to default successfully")
 
             with allure.step("Step 6: Verify default password works again"):
                 verify_default_cmd = CURL_BASIC_AUTH_GET_WITH_HEADERS.format(
                     self.bmc_root_user, self.bmc_root_password, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
                 verify_default_result = duthost.command(verify_default_cmd)
-                pytest_assert(
-                    re.match(r"^HTTP/\S+\s+20\d", verify_default_result["stdout"]),
-                    "Default password should work after reset, "
-                    f"got: {verify_default_result['stdout']}")
+                pytest_assert(re.match(r"^HTTP/\S+\s+20\d", verify_default_result["stdout"]),
+                            f"Default password should work after reset, got: {verify_default_result['stdout']}")
                 logger.info("Default password verified successfully after reset")
 
             with allure.step("Step 7: Verify previous new password is denied"):
                 verify_temp_pwd_cmd = CURL_BASIC_AUTH_GET_WITH_HEADERS.format(
                     self.bmc_root_user, temp_password, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
                 verify_temp_result = duthost.command(verify_temp_pwd_cmd, module_ignore_errors=True)
-                pytest_assert(
-                    re.match(r"^HTTP/\S+\s+401", verify_temp_result["stdout"]),
-                    "Previous new password should be denied with HTTP 401, "
-                    f"got: {verify_temp_result['stdout']}")
+                pytest_assert(re.match(r"^HTTP/\S+\s+401", verify_temp_result["stdout"]),
+                            f"Previous new password should be denied with HTTP 401, got: {verify_temp_result['stdout']}")
                 logger.info("Previous new password is correctly denied after reset")
         finally:
             duthost.command(BMC_RESET_ROOT_PASSWORD_COMMAND)
@@ -549,72 +591,76 @@ class TestBMCApi(PlatformApiTestBase):
         pytest_assert(duthost.command(
             f"ls -l {bmc_dump_path}")["rc"] == 0, f"BMC dump file not found: {bmc_dump_path}")
 
-    def test_bmc_firmware_update(self, duthosts, enum_rand_one_per_hwsku_hostname, bmc_fw_pkg,
-                                 bmc_firmware_command_type, backup_platform_file, bmc_ip, request):
+    def test_bmc_firmware_update(self, duthosts, enum_rand_one_per_hwsku_hostname,
+                                 bmc_fw_pkg, bmc_firmware_command_type, backup_platform_file,
+                                 bmc_ip, recover_bmc_firmware, request, creds):
         """
         Test BMC firmware update with platform API and CLI
 
         Steps:
         1. Check and record the original BMC firmware version
-        2. Update the BMC firmware version by command
+        2. Pick the target firmware: if DUT is on old version, target is latest;
+           if DUT is on latest, target is old. This ensures the CLI command always
+           performs an actual firmware change regardless of the starting state.
+        3. Update the BMC firmware version by command
             'config platform firmware install chassis component BMC fw -y xxx' or
             'config platform firmware update chassis component BMC fw -y xxx'
             depending on completeness_level:
                 if the completeness_level is basic, only test one command type randomly
                 if the completeness_level is others, test both command types
                 in this case,the test test_bmc_firmware_update will be executed twice times
-        3. Wait after the installation done
-        4. Validate the BMC firmware had been updated to the destination version by command
+        4. Wait after the installation done
+        5. Validate the BMC firmware had been updated to the destination version by command
             'show platform firmware status'
-        5. Recover the BMC firmware version to the original one by BMC platform api update_firmware(fw_image)
-        6. Wait after the installation done
-        7. Validate the BMC firmware had been restored to the original version by command
-            'show platform firmware status'
+
+        Note: Recovery to latest BMC firmware is handled by the class-scoped
+        recover_bmc_firmware fixture, which runs once after all parametrized
+        runs (install/update) complete.
         """
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         fw_pkg = bmc_fw_pkg
-        bmc_version_origin = self._get_bmc_version(duthost)
+        bmc_version_origin = _get_bmc_version(duthost)
         logger.info(f"BMC version origin: {bmc_version_origin}")
         logger.info(f"Testing with command type: {bmc_firmware_command_type}")
 
         chassis = list(show_firmware(duthost)["chassis"].keys())[0]
         logger.info(f"Chassis: {chassis}")
-        fw_pkg_path_new = fw_pkg["chassis"][chassis]["component"]["BMC"][LATEST_BMC_VERSION_IDX]["firmware"]
-        fw_version_new = fw_pkg["chassis"][chassis]["component"]["BMC"][LATEST_BMC_VERSION_IDX]["version"]
-        fw_pkg_clean_path_new = urlparse(fw_pkg_path_new).path
-        fw_pkt_name_new = os.path.basename(fw_pkg_path_new)
+        bmc_fw_list = get_bmc_firmware_list(fw_pkg, chassis, duthost, bmc_ip,
+                                            creds['sonic_bmc_root_user'],
+                                            creds['sonic_bmc_root_password'])
+        fw_version_old = bmc_fw_list[OLD_BMC_VERSION_IDX]["version"]
+
+        # Pick the other version so we always test an actual firmware change.
+        # If already on old -> install latest; if already on latest -> install old.
+        if bmc_version_origin == fw_version_old:
+            target_idx = LATEST_BMC_VERSION_IDX
+        else:
+            target_idx = OLD_BMC_VERSION_IDX
+
+        fw_pkg_path_target = bmc_fw_list[target_idx]["firmware"]
+        fw_version_target = bmc_fw_list[target_idx]["version"]
+        fw_pkg_clean_path_target = urlparse(fw_pkg_path_target).path
+        fw_pkt_name_target = os.path.basename(fw_pkg_path_target)
+
         if bmc_firmware_command_type == FW_TYPE_UPDATE:
-            logger.info(f"Generate 'platform_components.json' for BMC firmware: {fw_version_new}")
-            self._generate_platform_file(duthost, chassis, f"/tmp/{fw_pkt_name_new}", fw_version_new)
+            logger.info(f"Generate 'platform_components.json' for BMC firmware: {fw_version_target}")
+            self._generate_platform_file(duthost, chassis, f"/tmp/{fw_pkt_name_target}", fw_version_target)
 
-        logger.info(f"BMC firmware path: {fw_pkg_clean_path_new}")
-        logger.info(f"Copy BMC firmware to localhost: /tmp/{fw_pkt_name_new}")
-        duthost.copy(src=fw_pkg_clean_path_new, dest=f"/tmp/{fw_pkt_name_new}")
+        logger.info(f"BMC firmware path: {fw_pkg_clean_path_target}")
+        logger.info(f"Copy BMC firmware to localhost: /tmp/{fw_pkt_name_target}")
+        duthost.copy(src=fw_pkg_clean_path_target, dest=f"/tmp/{fw_pkt_name_target}")
 
-        logger.info(f"Execute BMC firmware {bmc_firmware_command_type} to {fw_pkt_name_new} and "
+        logger.info(f"Execute BMC firmware {bmc_firmware_command_type} to {fw_pkt_name_target} and "
                     f"Wait for BMC firmware update to complete")
-        res = self._update_bmc_firmware(duthost, f"/tmp/{fw_pkt_name_new}", bmc_ip,
-                                        method='cli', cli_type=bmc_firmware_command_type)
+        res = _update_bmc_firmware(duthost, f"/tmp/{fw_pkt_name_target}", bmc_ip,
+                                   method='cli', cli_type=bmc_firmware_command_type,
+                                   bmc_root_user=self.bmc_root_user,
+                                   bmc_root_password=self.bmc_root_password)
         pytest_assert(res, f"Failed to execute BMC firmware {bmc_firmware_command_type} by CLI!")
 
-        bmc_version_latest = self._get_bmc_version(duthost)
-        logger.info(f"BMC version after {bmc_firmware_command_type}: {bmc_version_latest}")
-        pytest_assert(bmc_version_latest != bmc_version_origin, f"BMC firmware {bmc_firmware_command_type} failed")
-
-        fw_pkg_path_old = fw_pkg["chassis"][chassis]["component"]["BMC"][OLD_BMC_VERSION_IDX]["firmware"]
-        fw_pkg_clean_path_old = urlparse(fw_pkg_path_old).path
-        fw_pkt_name_old = os.path.basename(fw_pkg_path_old)
-        logger.info(f"BMC firmware path: {fw_pkg_clean_path_old}")
-        logger.info(f"Copy BMC firmware to localhost: /tmp/{fw_pkt_name_old}")
-        duthost.copy(src=fw_pkg_clean_path_old, dest=f"/tmp/{fw_pkt_name_old}")
-
-        logger.info(f"Execute BMC firmware update to {fw_pkt_name_old} and Wait for BMC firmware update to complete")
-        res = self._update_bmc_firmware(duthost, f"/tmp/{fw_pkt_name_old}", bmc_ip, method='api')
-        pytest_assert(res, "Failed to execute BMC firmware update by API!")
-
-        bmc_version_current = self._get_bmc_version(duthost)
-        logger.info(f"BMC version after recovery: {bmc_version_current}")
-        pytest_assert(bmc_version_latest != bmc_version_current, "BMC firmware recovery failed")
+        bmc_version_after_cli = _get_bmc_version(duthost)
+        logger.info(f"BMC version after {bmc_firmware_command_type}: {bmc_version_after_cli}")
+        pytest_assert(bmc_version_after_cli != bmc_version_origin, f"BMC firmware {bmc_firmware_command_type} failed")
 
     def _parse_bmc_session(self, output):
         """Parse BMC session output to extract session ID and token"""
@@ -641,8 +687,7 @@ class TestBMCApi(PlatformApiTestBase):
                     ids.add(id_segment)
         return ids
 
-    def test_bmc_session_open_close(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                                    bmc_ip, cleanup_bmc_subscriptions):
+    def test_bmc_session_open_close(self, duthosts, enum_rand_one_per_hwsku_hostname, bmc_ip, cleanup_bmc_subscriptions):
         """
         Test CLIs commands for open and close BMC session
 
@@ -659,9 +704,7 @@ class TestBMCApi(PlatformApiTestBase):
         try:
             with allure.step("Open BMC session"):
                 open_session_result = duthost.command(BMC_OPEN_SESSION_COMMAND)
-                pytest_assert(
-                    open_session_result["rc"] == 0,
-                    f"Failed to open session: {open_session_result['stderr']}")
+                pytest_assert(open_session_result["rc"] == 0, f"Failed to open session: {open_session_result['stderr']}")
                 session_id, token = self._parse_bmc_session(open_session_result["stdout"])
                 logger.info(f"Session opened: {session_id}")
                 pytest_assert(session_id and token, "Session ID or token not returned")
@@ -672,10 +715,7 @@ class TestBMCApi(PlatformApiTestBase):
                 try:
                     sessions_data = json.loads(sessions_result["stdout"])
                 except json.JSONDecodeError as e:
-                    pytest_assert(
-                        False,
-                        f"Failed to parse sessions response as JSON: {e}, "
-                        f"response: {sessions_result['stdout']}")
+                    pytest_assert(False, f"Failed to parse sessions response as JSON: {e}, response: {sessions_result['stdout']}")
                 member_session_ids = self._extract_ids_from_members(sessions_data)
                 pytest_assert(session_id in member_session_ids,
                               "Session {} not present in Members: {}".format(session_id, member_session_ids))
@@ -689,7 +729,7 @@ class TestBMCApi(PlatformApiTestBase):
                 # Extract subscription ID from Location header
                 location_match = re.search(r'Location:\s*.+/([^/\s]+)', subscription_result["stdout"], re.IGNORECASE)
                 subscription_id = location_match.group(1) if location_match else None
-                pytest_assert(subscription_id, "Failed to extract subscription ID")
+                pytest_assert(subscription_id, f"Failed to extract subscription ID")
                 logger.info(f"Subscription created: {subscription_id}")
 
             with allure.step("Close session and verify token becomes invalid"):
@@ -698,50 +738,38 @@ class TestBMCApi(PlatformApiTestBase):
                 logger.info(f"Session {session_id} closed")
                 session_id = None  # Mark as closed
 
-                invalid_get_cmd = CURL_TOKEN_AUTH_GET_WITH_HEADERS.format(
-                    token, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
-                invalid_get_result = duthost.command(
-                    invalid_get_cmd, module_ignore_errors=True)
-                pytest_assert(
-                    re.match(r"^HTTP/\S+\s+401", invalid_get_result["stdout"]),
-                    "GET with invalid token should return HTTP 401, "
-                    f"got: {invalid_get_result['stdout']}")
+                invalid_get_cmd = CURL_TOKEN_AUTH_GET_WITH_HEADERS.format(token, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
+                invalid_get_result = duthost.command(invalid_get_cmd, module_ignore_errors=True)
+                pytest_assert(re.match(r"^HTTP/\S+\s+401", invalid_get_result["stdout"]),
+                             f"GET with invalid token should return HTTP 401, got: {invalid_get_result['stdout']}")
 
                 invalid_post_result = duthost.command(create_subscription_cmd, module_ignore_errors=True)
                 pytest_assert(
-                    invalid_post_result["stdout"].startswith("HTTP/1.1 401 Unauthorized"),
-                    f"POST with invalid token should return HTTP 401 Unauthorized, "
+                    re.match(r"^HTTP/\S+\s+401", invalid_post_result["stdout"]),
+                    f"POST with invalid token should return HTTP 401, "
                     f"got: {invalid_post_result['stdout']}")
 
             with allure.step("Open new session and cleanup subscription"):
                 new_session_result = duthost.command(BMC_OPEN_SESSION_COMMAND)
-                pytest_assert(
-                    new_session_result["rc"] == 0,
-                    f"Failed to open new session: {new_session_result['stderr']}")
+                pytest_assert(new_session_result["rc"] == 0, f"Failed to open new session: {new_session_result['stderr']}")
                 new_session_id, new_token = self._parse_bmc_session(new_session_result["stdout"])
                 pytest_assert(new_session_id and new_token, "New session ID or token not returned")
                 logger.info(f"New session opened: {new_session_id}")
 
                 # Delete subscription
-                delete_sub_endpoint = (
-                    f"{REDFISH_EVENT_SUBSCRIPTIONS_ENDPOINT}/{subscription_id}")
                 delete_result = duthost.command(
-                    CURL_TOKEN_AUTH_DELETE.format(
-                        new_token, bmc_ip, delete_sub_endpoint),
+                    CURL_TOKEN_AUTH_DELETE.format(new_token, bmc_ip, f"{REDFISH_EVENT_SUBSCRIPTIONS_ENDPOINT}/{subscription_id}"),
                     module_ignore_errors=True)
-                pytest_assert(delete_result["stdout"].startswith("HTTP/1.1 200 OK") or
-                              delete_result["stdout"].startswith("HTTP/1.1 204 No Content"),
-                              f"DELETE should return HTTP 200 OK or 204 No Content, got: {delete_result['stdout']}")
+                pytest_assert(
+                    re.match(r"^HTTP/\S+\s+20\d", delete_result["stdout"]),
+                    f"DELETE should return HTTP 2xx, got: {delete_result['stdout']}")
 
                 # Verify subscription is deleted by checking the specific subscription returns 404
                 verify_deleted_cmd = CURL_TOKEN_AUTH_GET_WITH_HEADERS.format(
-                    new_token, bmc_ip, delete_sub_endpoint)
-                verify_deleted_result = duthost.command(
-                    verify_deleted_cmd, module_ignore_errors=True)
-                pytest_assert(
-                    re.match(r"^HTTP/\S+\s+404", verify_deleted_result["stdout"]),
-                    "GET deleted subscription should return HTTP 404, "
-                    f"got: {verify_deleted_result['stdout']}")
+                    new_token, bmc_ip, f"{REDFISH_EVENT_SUBSCRIPTIONS_ENDPOINT}/{subscription_id}")
+                verify_deleted_result = duthost.command(verify_deleted_cmd, module_ignore_errors=True)
+                pytest_assert(re.match(r"^HTTP/\S+\s+404", verify_deleted_result["stdout"]),
+                              f"GET deleted subscription should return HTTP 404, got: {verify_deleted_result['stdout']}")
                 logger.info(f"Subscription {subscription_id} deleted and verified (404 status)")
 
         finally:

--- a/tests/platform_tests/api/test_bmc.py
+++ b/tests/platform_tests/api/test_bmc.py
@@ -54,11 +54,17 @@ REDFISH_EVENT_SUBSCRIPTIONS_ENDPOINT = "/redfish/v1/EventService/Subscriptions"
 # Curl command templates (for session tests)
 CURL_TOKEN_AUTH_GET = "curl -k -H \"X-Auth-Token: {}\" -X GET https://{}{}"
 CURL_TOKEN_AUTH_GET_WITH_HEADERS = "curl -k -i -H \"X-Auth-Token: {}\" -X GET https://{}{}"
-CURL_TOKEN_AUTH_POST = "curl -k -i -H \"X-Auth-Token: {}\" -H \"Content-Type: application/json\" -X POST https://{}{} -d '{}'"
+CURL_TOKEN_AUTH_POST = (
+    "curl -k -i -H \"X-Auth-Token: {}\" -H \"Content-Type: application/json\" "
+    "-X POST https://{}{} -d '{}'"
+)
 CURL_TOKEN_AUTH_DELETE = "curl -i -k -H \"X-Auth-Token: {}\" -X DELETE https://{}{}"
 CURL_BASIC_AUTH_GET = "curl -k -u {}:{} -X GET https://{}{}"
 CURL_BASIC_AUTH_GET_WITH_HEADERS = "curl -k -i -u {}:{} -X GET https://{}{}"
-CURL_BASIC_AUTH_PATCH = "curl -k -i -u {}:{} -H \"Content-Type: application/json\" -X PATCH https://{}{} -d '{}'"
+CURL_BASIC_AUTH_PATCH = (
+    "curl -k -i -u {}:{} -H \"Content-Type: application/json\" "
+    "-X PATCH https://{}{} -d '{}'"
+)
 CURL_BASIC_AUTH_DELETE = "curl -k -u {}:{} -X DELETE https://{}{}"
 
 
@@ -122,8 +128,10 @@ def _update_bmc_firmware(duthost, fw_image, bmc_ip, method='api',
     """
     start_time = time.time()
 
-    logger.info(f"Starting BMC firmware update via {method.upper()}" +
-               (f" ({cli_type})" if method == 'cli' and cli_type else ""))
+    logger.info(
+        f"Starting BMC firmware update via {method.upper()}" +
+        (f" ({cli_type})" if method == 'cli' and cli_type else "")
+    )
 
     while True:
         if time.time() - start_time > timeout:
@@ -353,7 +361,9 @@ class TestBMCApi(PlatformApiTestBase):
                     logger.info(f"Deleted {len(existing_subs)} existing subscriptions")
                     return len(existing_subs)
             except (json.JSONDecodeError, KeyError, TypeError) as e:
-                logger.warning(f"Failed to parse subscription list response: {e}, response: {get_subs_result['stdout']}")
+                logger.warning(
+                    f"Failed to parse subscription list response: {e}, response: {get_subs_result['stdout']}"
+                )
                 return 0
         return 0
 
@@ -516,8 +526,10 @@ class TestBMCApi(PlatformApiTestBase):
             with allure.step("Step 1: Reset password to default state"):
                 reset_result = duthost.command(BMC_RESET_ROOT_PASSWORD_COMMAND)
                 pytest_assert(reset_result["rc"] == 0, f"Failed to reset BMC root password: {reset_result['stderr']}")
-                pytest_assert("BMC root password reset successful" in reset_result["stdout"],
-                            f"Unexpected output: {reset_result['stdout']}")
+                pytest_assert(
+                    "BMC root password reset successful" in reset_result["stdout"],
+                    f"Unexpected output: {reset_result['stdout']}"
+                )
                 logger.info("BMC root password reset to default state successfully")
 
             with allure.step("Step 2: Change password from default to new password"):
@@ -527,47 +539,59 @@ class TestBMCApi(PlatformApiTestBase):
                     self.bmc_root_user, self.bmc_root_password, bmc_ip,
                     "/redfish/v1/AccountService/Accounts/root", password_data)
                 change_result = duthost.command(change_pwd_cmd)
-                pytest_assert(re.match(r"^HTTP/\S+\s+20\d", change_result["stdout"]),
-                            f"Failed to change password: {change_result['stdout']}")
+                pytest_assert(
+                    re.match(r"^HTTP/\S+\s+20\d", change_result["stdout"]),
+                    f"Failed to change password: {change_result['stdout']}"
+                )
                 logger.info("BMC root password changed to new password successfully")
 
             with allure.step("Step 3: Verify new password works"):
                 verify_new_pwd_cmd = CURL_BASIC_AUTH_GET_WITH_HEADERS.format(
                     self.bmc_root_user, temp_password, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
                 verify_result = duthost.command(verify_new_pwd_cmd)
-                pytest_assert(re.match(r"^HTTP/\S+\s+20\d", verify_result["stdout"]),
-                            f"New password should work, got: {verify_result['stdout']}")
+                pytest_assert(
+                    re.match(r"^HTTP/\S+\s+20\d", verify_result["stdout"]),
+                    f"New password should work, got: {verify_result['stdout']}"
+                )
                 logger.info("New password verified successfully")
 
             with allure.step("Step 4: Verify old default password is denied"):
                 verify_old_pwd_cmd = CURL_BASIC_AUTH_GET_WITH_HEADERS.format(
                     self.bmc_root_user, self.bmc_root_password, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
                 verify_old_result = duthost.command(verify_old_pwd_cmd, module_ignore_errors=True)
-                pytest_assert(re.match(r"^HTTP/\S+\s+401", verify_old_result["stdout"]),
-                            f"Old default password should be denied with HTTP 401, got: {verify_old_result['stdout']}")
+                pytest_assert(
+                    re.match(r"^HTTP/\S+\s+401", verify_old_result["stdout"]),
+                    f"Old default password should be denied with HTTP 401, got: {verify_old_result['stdout']}"
+                )
                 logger.info("Old default password is correctly denied")
 
             with allure.step("Step 5: Reset password back to default"):
                 reset_result = duthost.command(BMC_RESET_ROOT_PASSWORD_COMMAND)
                 pytest_assert(reset_result["rc"] == 0, f"Failed to reset BMC root password: {reset_result['stderr']}")
-                pytest_assert("BMC root password reset successful" in reset_result["stdout"],
-                            f"Unexpected output: {reset_result['stdout']}")
+                pytest_assert(
+                    "BMC root password reset successful" in reset_result["stdout"],
+                    f"Unexpected output: {reset_result['stdout']}"
+                )
                 logger.info("BMC root password reset back to default successfully")
 
             with allure.step("Step 6: Verify default password works again"):
                 verify_default_cmd = CURL_BASIC_AUTH_GET_WITH_HEADERS.format(
                     self.bmc_root_user, self.bmc_root_password, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
                 verify_default_result = duthost.command(verify_default_cmd)
-                pytest_assert(re.match(r"^HTTP/\S+\s+20\d", verify_default_result["stdout"]),
-                            f"Default password should work after reset, got: {verify_default_result['stdout']}")
+                pytest_assert(
+                    re.match(r"^HTTP/\S+\s+20\d", verify_default_result["stdout"]),
+                    f"Default password should work after reset, got: {verify_default_result['stdout']}"
+                )
                 logger.info("Default password verified successfully after reset")
 
             with allure.step("Step 7: Verify previous new password is denied"):
                 verify_temp_pwd_cmd = CURL_BASIC_AUTH_GET_WITH_HEADERS.format(
                     self.bmc_root_user, temp_password, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
                 verify_temp_result = duthost.command(verify_temp_pwd_cmd, module_ignore_errors=True)
-                pytest_assert(re.match(r"^HTTP/\S+\s+401", verify_temp_result["stdout"]),
-                            f"Previous new password should be denied with HTTP 401, got: {verify_temp_result['stdout']}")
+                pytest_assert(
+                    re.match(r"^HTTP/\S+\s+401", verify_temp_result["stdout"]),
+                    f"Previous new password should be denied with HTTP 401, got: {verify_temp_result['stdout']}"
+                )
                 logger.info("Previous new password is correctly denied after reset")
         finally:
             duthost.command(BMC_RESET_ROOT_PASSWORD_COMMAND)
@@ -687,7 +711,8 @@ class TestBMCApi(PlatformApiTestBase):
                     ids.add(id_segment)
         return ids
 
-    def test_bmc_session_open_close(self, duthosts, enum_rand_one_per_hwsku_hostname, bmc_ip, cleanup_bmc_subscriptions):
+    def test_bmc_session_open_close(self, duthosts, enum_rand_one_per_hwsku_hostname,
+                                    bmc_ip, cleanup_bmc_subscriptions):
         """
         Test CLIs commands for open and close BMC session
 
@@ -704,7 +729,10 @@ class TestBMCApi(PlatformApiTestBase):
         try:
             with allure.step("Open BMC session"):
                 open_session_result = duthost.command(BMC_OPEN_SESSION_COMMAND)
-                pytest_assert(open_session_result["rc"] == 0, f"Failed to open session: {open_session_result['stderr']}")
+                pytest_assert(
+                    open_session_result["rc"] == 0,
+                    f"Failed to open session: {open_session_result['stderr']}"
+                )
                 session_id, token = self._parse_bmc_session(open_session_result["stdout"])
                 logger.info(f"Session opened: {session_id}")
                 pytest_assert(session_id and token, "Session ID or token not returned")
@@ -715,13 +743,19 @@ class TestBMCApi(PlatformApiTestBase):
                 try:
                     sessions_data = json.loads(sessions_result["stdout"])
                 except json.JSONDecodeError as e:
-                    pytest_assert(False, f"Failed to parse sessions response as JSON: {e}, response: {sessions_result['stdout']}")
+                    pytest_assert(
+                        False,
+                        f"Failed to parse sessions response as JSON: {e}, response: {sessions_result['stdout']}"
+                    )
                 member_session_ids = self._extract_ids_from_members(sessions_data)
                 pytest_assert(session_id in member_session_ids,
                               "Session {} not present in Members: {}".format(session_id, member_session_ids))
 
             with allure.step("Create event subscription"):
-                subscription_data = json.dumps({"Destination": "https://example.com/events", "Protocol": "Redfish"})
+                subscription_data = json.dumps({
+                    "Destination": "https://example.com/events",
+                    "Protocol": "Redfish"
+                })
                 create_subscription_cmd = CURL_TOKEN_AUTH_POST.format(
                     token, bmc_ip, REDFISH_EVENT_SUBSCRIPTIONS_ENDPOINT, subscription_data)
                 subscription_result = duthost.command(create_subscription_cmd)
@@ -729,7 +763,7 @@ class TestBMCApi(PlatformApiTestBase):
                 # Extract subscription ID from Location header
                 location_match = re.search(r'Location:\s*.+/([^/\s]+)', subscription_result["stdout"], re.IGNORECASE)
                 subscription_id = location_match.group(1) if location_match else None
-                pytest_assert(subscription_id, f"Failed to extract subscription ID")
+                pytest_assert(subscription_id, "Failed to extract subscription ID")
                 logger.info(f"Subscription created: {subscription_id}")
 
             with allure.step("Close session and verify token becomes invalid"):
@@ -738,38 +772,50 @@ class TestBMCApi(PlatformApiTestBase):
                 logger.info(f"Session {session_id} closed")
                 session_id = None  # Mark as closed
 
-                invalid_get_cmd = CURL_TOKEN_AUTH_GET_WITH_HEADERS.format(token, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
+                invalid_get_cmd = CURL_TOKEN_AUTH_GET_WITH_HEADERS.format(
+                    token, bmc_ip, REDFISH_SESSION_SERVICE_ENDPOINT)
                 invalid_get_result = duthost.command(invalid_get_cmd, module_ignore_errors=True)
-                pytest_assert(re.match(r"^HTTP/\S+\s+401", invalid_get_result["stdout"]),
-                             f"GET with invalid token should return HTTP 401, got: {invalid_get_result['stdout']}")
+                pytest_assert(
+                    re.match(r"^HTTP/\S+\s+401", invalid_get_result["stdout"]),
+                    f"GET with invalid token should return HTTP 401, got: {invalid_get_result['stdout']}"
+                )
 
                 invalid_post_result = duthost.command(create_subscription_cmd, module_ignore_errors=True)
                 pytest_assert(
                     re.match(r"^HTTP/\S+\s+401", invalid_post_result["stdout"]),
                     f"POST with invalid token should return HTTP 401, "
-                    f"got: {invalid_post_result['stdout']}")
+                    f"got: {invalid_post_result['stdout']}"
+                )
 
             with allure.step("Open new session and cleanup subscription"):
                 new_session_result = duthost.command(BMC_OPEN_SESSION_COMMAND)
-                pytest_assert(new_session_result["rc"] == 0, f"Failed to open new session: {new_session_result['stderr']}")
+                pytest_assert(
+                    new_session_result["rc"] == 0,
+                    f"Failed to open new session: {new_session_result['stderr']}"
+                )
                 new_session_id, new_token = self._parse_bmc_session(new_session_result["stdout"])
                 pytest_assert(new_session_id and new_token, "New session ID or token not returned")
                 logger.info(f"New session opened: {new_session_id}")
 
                 # Delete subscription
+                subscription_endpoint = f"{REDFISH_EVENT_SUBSCRIPTIONS_ENDPOINT}/{subscription_id}"
+                delete_cmd = CURL_TOKEN_AUTH_DELETE.format(
+                    new_token, bmc_ip, subscription_endpoint)
                 delete_result = duthost.command(
-                    CURL_TOKEN_AUTH_DELETE.format(new_token, bmc_ip, f"{REDFISH_EVENT_SUBSCRIPTIONS_ENDPOINT}/{subscription_id}"),
-                    module_ignore_errors=True)
+                    delete_cmd, module_ignore_errors=True)
                 pytest_assert(
                     re.match(r"^HTTP/\S+\s+20\d", delete_result["stdout"]),
-                    f"DELETE should return HTTP 2xx, got: {delete_result['stdout']}")
+                    f"DELETE should return HTTP 2xx, got: {delete_result['stdout']}"
+                )
 
                 # Verify subscription is deleted by checking the specific subscription returns 404
                 verify_deleted_cmd = CURL_TOKEN_AUTH_GET_WITH_HEADERS.format(
-                    new_token, bmc_ip, f"{REDFISH_EVENT_SUBSCRIPTIONS_ENDPOINT}/{subscription_id}")
+                    new_token, bmc_ip, subscription_endpoint)
                 verify_deleted_result = duthost.command(verify_deleted_cmd, module_ignore_errors=True)
-                pytest_assert(re.match(r"^HTTP/\S+\s+404", verify_deleted_result["stdout"]),
-                              f"GET deleted subscription should return HTTP 404, got: {verify_deleted_result['stdout']}")
+                pytest_assert(
+                    re.match(r"^HTTP/\S+\s+404", verify_deleted_result["stdout"]),
+                    f"GET deleted subscription should return HTTP 404, got: {verify_deleted_result['stdout']}"
+                )
                 logger.info(f"Subscription {subscription_id} deleted and verified (404 status)")
 
         finally:

--- a/tests/platform_tests/api/test_bmc.py
+++ b/tests/platform_tests/api/test_bmc.py
@@ -749,7 +749,7 @@ class TestBMCApi(PlatformApiTestBase):
                     )
                 member_session_ids = self._extract_ids_from_members(sessions_data)
                 pytest_assert(session_id in member_session_ids,
-                              "Session {} not present in Members: {}".format(session_id, member_session_ids))
+                              "Session {} is absent from Members: {}".format(session_id, member_session_ids))
 
             with allure.step("Create event subscription"):
                 subscription_data = json.dumps({

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -1,4 +1,3 @@
-import tarfile
 import json
 import pytest
 import os
@@ -10,7 +9,7 @@ from .args.counterpoll_cpu_usage_args import add_counterpoll_cpu_usage_args
 from tests.common.helpers.mellanox_thermal_control_test_helper import suspend_hw_tc_service, resume_hw_tc_service
 from tests.common.platform.device_utils import MGFX_HWSKU, MGFX_XCVR_INTF
 from tests.common.platform.transceiver_utils import get_passive_cable_port_list, get_cmis_cable_ports_and_ver
-from tests.common.helpers.firmware_helper import PLATFORM_COMP_PATH_TEMPLATE
+from tests.common.helpers.firmware_helper import PLATFORM_COMP_PATH_TEMPLATE, extract_fw_data
 from tests.common.platform.interface_utils import get_ports_with_flat_memory
 
 logger = logging.getLogger(__name__)
@@ -312,28 +311,3 @@ def backup_platform_file(duthost):
     logger.info("Remove 'platform_components.json' backup from localhost: path={}".format(backup_path))
     os.remove(current_backup_path)
     os.rmdir(backup_path)
-
-
-def extract_fw_data(fw_pkg_path):
-    """
-    Extract fw data from updated-fw.tar.gz file or firmware.json file
-    :param fw_pkg_path: the path to tar.gz file or firmware.json file
-    :return: fw_data in dictionary
-    """
-    if tarfile.is_tarfile(fw_pkg_path):
-        with tarfile.open(fw_pkg_path, "r:gz") as fw_tar:
-            member = fw_tar.getmember("firmware.json")
-            if not member.isfile():
-                raise ValueError("firmware.json in {} is not a regular file".format(fw_pkg_path))
-
-            fw = fw_tar.extractfile(member)
-            if fw is None:
-                raise ValueError("Failed to read firmware.json from {}".format(fw_pkg_path))
-
-            with fw:
-                fw_data = json.load(fw)
-    else:
-        with open(fw_pkg_path, 'r') as fw:
-            fw_data = json.load(fw)
-
-    return fw_data

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -321,14 +321,16 @@ def extract_fw_data(fw_pkg_path):
     :return: fw_data in dictionary
     """
     if tarfile.is_tarfile(fw_pkg_path):
-        path = "/tmp/firmware"
-        isExist = os.path.exists(path)
-        if not isExist:
-            os.mkdir(path)
-        with tarfile.open(fw_pkg_path, "r:gz") as f:
-            f.extractall(path)
-            json_file = os.path.join(path, "firmware.json")
-            with open(json_file, 'r') as fw:
+        with tarfile.open(fw_pkg_path, "r:gz") as fw_tar:
+            member = fw_tar.getmember("firmware.json")
+            if not member.isfile():
+                raise ValueError("firmware.json in {} is not a regular file".format(fw_pkg_path))
+
+            fw = fw_tar.extractfile(member)
+            if fw is None:
+                raise ValueError("Failed to read firmware.json from {}".format(fw_pkg_path))
+
+            with fw:
                 fw_data = json.load(fw)
     else:
         with open(fw_pkg_path, 'r') as fw:

--- a/tests/platform_tests/fwutil/fwutil_common.py
+++ b/tests/platform_tests/fwutil/fwutil_common.py
@@ -9,8 +9,7 @@ from copy import deepcopy
 
 from tests.common.utilities import wait_until
 from tests.common.reboot import SONIC_SSH_REGEX
-from tests.common.helpers.assertions import pytest_assert
-from tests.common.helpers.firmware_helper import show_firmware
+from tests.common.helpers.firmware_helper import show_firmware, resolve_bmc_flavor, load_bmc_creds, get_bmc_ip
 
 logger = logging.getLogger(__name__)
 
@@ -96,29 +95,37 @@ def complete_install(duthost, localhost, boot_type, res, pdu_ctrl, component, au
         else:
             # For auto reboot scenario, it takes some time in ONIE to update the firmware
             logger.info("Waiting on switch to shutdown after auto reboot...")
-            if 'CPLD' in component or 'FPGA' in component:
-                # For CPLD/FPGA update, most time is spend before the reboot
-                pre_reboot_timeout = timeout
-                post_reboot_timeout = COMMON_REBOOT_TIMEOUT
+            if 'FPGA' in component:
+                # For FPGA update, no reboot is needed.
+                logger.info("Waiting for switch update result...")
+                res.get(timeout)
+                if res._value['failed']:
+                    pytest.fail(f"The component installation is not successful: {res._value}")
+                logger.info("FPGA update is successful")
             else:
-                # For BIOS/ONIE, most time is spend after the reboot in ONIE
-                pre_reboot_timeout = 120
-                if duthost.facts["platform"] == "x86_64-nvidia_sn4280-r0":
-                    pre_reboot_timeout += 240
-                post_reboot_timeout = timeout
-            localhost.wait_for(host=hn, port=22, state='stopped', delay=1, timeout=pre_reboot_timeout)
-            # Wait for 30s in case there is ssh flap
-            time.sleep(30)
-            logger.info("Waiting on switch to come up in SONiC....")
-            localhost.wait_for(
-                host=hn, port=22, state='started', search_regex=SONIC_SSH_REGEX, delay=10, timeout=post_reboot_timeout)
+                if 'CPLD' in component:
+                    # For CPLD update, most time is spend before the reboot
+                    pre_reboot_timeout = timeout
+                    post_reboot_timeout = COMMON_REBOOT_TIMEOUT
+                else:
+                    # For BIOS/ONIE, most time is spend after the reboot in ONIE
+                    pre_reboot_timeout = 120
+                    if duthost.facts["platform"] == "x86_64-nvidia_sn4280-r0":
+                        pre_reboot_timeout += 240
+                    post_reboot_timeout = timeout
+                localhost.wait_for(host=hn, port=22, state='stopped', delay=1, timeout=pre_reboot_timeout)
+                # Wait for 30s in case there is ssh flap
+                time.sleep(30)
+                logger.info("Waiting on switch to come up in SONiC....")
+                localhost.wait_for(
+                    host=hn, port=22, state='started', search_regex=SONIC_SSH_REGEX, delay=10,
+                  timeout=post_reboot_timeout)
 
-        logger.info("Waiting for docker service to start")
-        pytest_assert(wait_until(300, 10, 0, duthost.is_host_service_running, "docker"),
-                      "Docker service failed to start")
-        logger.info("Waiting on critical systems to come online...")
-        wait_until(300, 30, 0, duthost.critical_services_fully_started)
-        time.sleep(60)
+        # Only wait for critical systems when a reboot actually occurred (FPGA update does not reboot).
+        if (not auto_reboot) or ('FPGA' not in component):
+            logger.info("Waiting on critical systems to come online...")
+            wait_until(300, 30, 0, duthost.critical_services_fully_started)
+            time.sleep(60)
 
         # Reboot back into original image if neccesary
         if next_image and auto_reboot:
@@ -167,6 +174,18 @@ def get_install_paths(request, duthost, defined_fw, versions, chassis, target_co
     return paths
 
 
+def _resolve_flavor_components(component, defined_fw, chassis, duthost):
+    """Resolve any flavor-dict entries (e.g. BMC) into revision lists."""
+    for comp, revs in list(component.items()):
+        if comp == "BMC" and isinstance(revs, dict):
+            bmc_ip = get_bmc_ip(duthost)
+            bmc_user, bmc_password = load_bmc_creds()
+            flavor = resolve_bmc_flavor(defined_fw, chassis, duthost, bmc_ip,
+                                        bmc_user, bmc_password)
+            component[comp] = revs.get(flavor, [])
+    return component
+
+
 def get_defined_components(duthost, defined_fw, chassis):
     """
     Update the component content, in case there is a pre-definition for a specific host.
@@ -177,7 +196,7 @@ def get_defined_components(duthost, defined_fw, chassis):
     if "host" in defined_fw and duthost.hostname in defined_fw["host"]:
         for component_type in list(defined_fw["host"][duthost.hostname]["component"].keys()):
             component[component_type] = defined_fw["host"][duthost.hostname]["component"][component_type]
-    return component
+    return _resolve_flavor_components(component, defined_fw, chassis, duthost)
 
 
 def generate_config(duthost, cfg, versions):

--- a/tests/platform_tests/fwutil/fwutil_common.py
+++ b/tests/platform_tests/fwutil/fwutil_common.py
@@ -179,8 +179,10 @@ def _resolve_flavor_components(component, defined_fw, chassis, duthost):
     """Resolve any flavor-dict entries (e.g. BMC) into revision lists."""
     for comp, revs in list(component.items()):
         if comp == "BMC" and isinstance(revs, dict):
-            bmc_ip = get_bmc_ip(duthost)
-            bmc_user, bmc_password = load_bmc_creds()
+            bmc_ip = bmc_user = bmc_password = None
+            if len(revs) > 1:
+                bmc_ip = get_bmc_ip(duthost)
+                bmc_user, bmc_password = load_bmc_creds()
             flavor = resolve_bmc_flavor(defined_fw, chassis, duthost, bmc_ip,
                                         bmc_user, bmc_password)
             component[comp] = revs.get(flavor, [])

--- a/tests/platform_tests/fwutil/fwutil_common.py
+++ b/tests/platform_tests/fwutil/fwutil_common.py
@@ -74,6 +74,7 @@ def reboot(duthost, pdu_ctrl, reboot_type, pdu_delay=60):
 def complete_install(duthost, localhost, boot_type, res, pdu_ctrl, component, auto_reboot=False, current=None,
                      next_image=None, timeout=TIMEOUT, pdu_delay=60):
     hn = duthost.mgmt_ip
+    component_name = component if isinstance(component, str) else ""
 
     if boot_type != "none":
         if not auto_reboot:
@@ -95,7 +96,7 @@ def complete_install(duthost, localhost, boot_type, res, pdu_ctrl, component, au
         else:
             # For auto reboot scenario, it takes some time in ONIE to update the firmware
             logger.info("Waiting on switch to shutdown after auto reboot...")
-            if 'FPGA' in component:
+            if 'FPGA' in component_name:
                 # For FPGA update, no reboot is needed.
                 logger.info("Waiting for switch update result...")
                 res.get(timeout)
@@ -103,7 +104,7 @@ def complete_install(duthost, localhost, boot_type, res, pdu_ctrl, component, au
                     pytest.fail(f"The component installation is not successful: {res._value}")
                 logger.info("FPGA update is successful")
             else:
-                if 'CPLD' in component:
+                if 'CPLD' in component_name:
                     # For CPLD update, most time is spend before the reboot
                     pre_reboot_timeout = timeout
                     post_reboot_timeout = COMMON_REBOOT_TIMEOUT
@@ -119,10 +120,10 @@ def complete_install(duthost, localhost, boot_type, res, pdu_ctrl, component, au
                 logger.info("Waiting on switch to come up in SONiC....")
                 localhost.wait_for(
                     host=hn, port=22, state='started', search_regex=SONIC_SSH_REGEX, delay=10,
-                  timeout=post_reboot_timeout)
+                    timeout=post_reboot_timeout)
 
         # Only wait for critical systems when a reboot actually occurred (FPGA update does not reboot).
-        if (not auto_reboot) or ('FPGA' not in component):
+        if (not auto_reboot) or ('FPGA' not in component_name):
             logger.info("Waiting on critical systems to come online...")
             wait_until(300, 30, 0, duthost.critical_services_fully_started)
             time.sleep(60)


### PR DESCRIPTION
### Description of PR

Summary:
Update BMC API and fwutil tests to support different BMC flavors and fix merge-induced inconsistencies in the BMC workflow.

Fixes #27753

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #27753
Failure type: other - test framework compatibility gap

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- 202605: `test_bmc_firmware_update` and the fwutil firmware update tests passed.

### Approach

#### What is the motivation for this PR?

BMC firmware metadata may be represented either as the existing flat BMC firmware list or as a flavor-keyed BMC dictionary. The BMC API and fwutil tests need to resolve both formats consistently on the 202605 platforms that run these tests.

#### How did you do it?

Added shared firmware parsing and BMC flavor resolution, retained the flat-list behavior, resolved single-flavor packages without unnecessary credential access, and resolved multi-flavor packages from the active BMC model. Also removed duplicate and unused helpers and improved unavailable-BMC error handling.

#### How did you verify/test it?

`test_bmc_firmware_update` and the fwutil firmware update tests passed on 202605.

#### Any platform specific information?

Applies to platforms with supported BMC implementations.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

No separate documentation change is required.
