### PR TITLE
Fix power-off reboot cause check for Arista-7260CX3 GPI-2

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -568,7 +568,7 @@ def get_reboot_cause(dut):
 
     # On Arista-7260CX3 platforms, power-loss detection hardware occasionally
     # reports "Hardware - Other (gpi-2, ...)" instead of "Power Loss".
-    # This is a confirmed hardware limitation (aristanetworks/sonic-qual.msft#1181).
+    # This is a confirmed hardware limitation. See https://github.com/sonic-net/sonic-mgmt/issues/24475
     if "7260CX3" in dut.facts.get("platform", "") and re.search(r"Hardware - Other.*gpi", cause):
         return REBOOT_TYPE_POWEROFF
 

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -566,6 +566,12 @@ def get_reboot_cause(dut):
             if re.search(ctrl['cause'], cause):
                 return type
 
+    # On Arista-7260CX3 platforms, power-loss detection hardware occasionally
+    # reports "Hardware - Other (gpi-2, ...)" instead of "Power Loss".
+    # This is a confirmed hardware limitation (aristanetworks/sonic-qual.msft#1181).
+    if "7260CX3" in dut.facts.get("platform", "") and re.search(r"Hardware - Other.*gpi", cause):
+        return REBOOT_TYPE_POWEROFF
+
     return REBOOT_TYPE_UNKNOWN
 
 


### PR DESCRIPTION
### Description of PR

Summary:
Fix `test_power_off_reboot` flaky failure on Arista-7260CX3 platforms where the DUT intermittently reports reboot cause as `Hardware - Other (gpi-2, description: gpi 2 detailed fault)` instead of `Power Loss` after PDU power cycling.

This is a confirmed hardware limitation on 7260CX3 platforms where the power-loss detection mechanism occasionally fails to classify the event correctly (10-20% failure rate).

Fixes #24475

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

On Arista-7260CX3-D108C8 and 7260CX3-C64 platforms, the hardware power-loss detection mechanism uses GPI (General Purpose Input) signals. Due to a known hardware design limitation, the platform intermittently reports `Hardware - Other (gpi-2, description: gpi 2 detailed fault)` instead of `Power Loss` after PDU power cycling. Arista has confirmed this cannot be fixed in platform code.

This causes `test_power_off_reboot` to fail with cause mismatch ~10-20% of the time on these platforms.

#### How did you do it?

Added platform-specific handling in `get_reboot_cause()` that checks:
1. The DUT platform contains "7260CX3" (restricts to affected Arista hardware only)
2. The reported cause matches `Hardware - Other.*gpi` pattern

If both conditions are met, returns `REBOOT_TYPE_POWEROFF`. The generic `"Power Loss"` regex in `reboot_ctrl_dict` is unchanged — no impact on other platforms.

#### How did you verify/test it?

- The regex `Hardware - Other.*gpi` matches the observed output: `Hardware - Other (gpi-2, description: gpi 2 detailed fault, time: ...)`
- The platform check `"7260CX3" in dut.facts.get("platform", "")` ensures this only applies to Arista-7260CX3-D108C8 and 7260CX3-C64
- No impact on other platforms since the check is guarded by platform name
- Confirmed with Arista that GPI-2 reporting is exclusively a power-loss detection artifact on 7260CX3

#### Any platform specific information?

Affected platforms: Arista-7260CX3-D108C8, Arista-7260CX3-C64

#### Supported testbed topology if it's a new test case?

N/A (existing test fix)

### Documentation

N/A
