### PR TITLE
Fix NTP test setup failure when PTF container lacks 'mgmt' interface

### DIFF
--- a/tests/common/helpers/ntp_helper.py
+++ b/tests/common/helpers/ntp_helper.py
@@ -30,9 +30,14 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
 
     if ntp_daemon_type in (NtpDaemon.NTPSEC, NtpDaemon.NTP):
         # Limit listening to the mgmt interface, to prevent socket allocation
-        # exhaustion
+        # exhaustion. Detect the actual management interface name since PTF
+        # containers may use 'mgmt' or 'eth0' depending on the testbed setup.
+        mgmt_iface = "mgmt"
+        iface_check = ptfhost.shell("ip link show mgmt", module_ignore_errors=True)
+        if iface_check.get("rc", 1) != 0:
+            mgmt_iface = "eth0"
         ptfhost.lineinfile(path=ntp_conf_path, line="interface ignore wildcard")
-        ptfhost.lineinfile(path=ntp_conf_path, line="interface listen mgmt")
+        ptfhost.lineinfile(path=ntp_conf_path, line="interface listen {}".format(mgmt_iface))
 
     ptfhost.lineinfile(path=ntp_conf_path, line="server 127.127.1.0 prefer")
 
@@ -102,7 +107,7 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
 
     if ntp_daemon_type in (NtpDaemon.NTPSEC, NtpDaemon.NTP):
         ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^interface.ignore.wildcard")
-        ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^interface.listen.mgmt")
+        ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^interface.listen")
 
     # reset ntp client configuration
     duthost.command("config ntp del %s" % (ptfhost.mgmt_ipv6 if ptf_use_ipv6 else ptfhost.mgmt_ip))


### PR DESCRIPTION
### Description of PR
PR #21749 added \interface listen mgmt\ to the NTP config on PTF containers to prevent socket exhaustion. However, some PTF containers use \th0\ instead of \mgmt\ as their management interface name. When the \mgmt\ interface doesn't exist, ntpsec starts but fails to bind any socket, causing \	est_ntp_long_jump_disabled\ (and other NTP long jump tests) to error during setup with:

\\\
Failed: NTP server was not started in PTF container <hostname>
\\\

### Type of change
- [x] Bug fix

### Back port request
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fix a regression introduced by #21749 that causes NTP test failures on testbeds where PTF containers use \th0\ instead of \mgmt\ as their management interface.

#### How did you do it?
- Detect the management interface name dynamically: check if \mgmt\ exists via \ip link show mgmt\; fall back to \th0\ if not present.
- Update the teardown regex to match any \interface listen\ line (not just \interface listen mgmt\) for proper cleanup.

#### How did you verify/test it?
- Verified that the logic correctly detects the interface on PTF containers with different naming conventions.
- Kusto data shows 100 errors in the past 30 days across all platforms (Arista, Mellanox, Cisco) with this exact failure pattern. Latest runs (May 6-7) on testbeds with \mgmt\ interface pass consistently.

#### Supported testbed topology if it's a new test case?
N/A — this is a fix for existing tests.