### PR TITLE
Serial boot log persist for KVM based testbed

### DIFF
--- a/ansible/roles/vm_set/templates/sonic.xml.j2
+++ b/ansible/roles/vm_set/templates/sonic.xml.j2
@@ -80,6 +80,7 @@
       <source host='127.0.0.1' mode='bind' service='{{ serial_port }}'/>
       <target port='0'/>
       <protocol type='telnet'/>
+      <log file='/var/log/libvirt/qemu/boot-serial-{{ dut_name }}.log' append='on'/>
     </serial>
     <interface type='ethernet'>
         <target dev='{{ dut_name }}-0' />


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Currently there is no serial boot log persist for kvm devices. If the device never boot up it's impossible for us to understand why it fails.

This PR aims to address that problem by writing serial console log to location which later on could be achieve for fetching

Fixes # (issue) 37883082

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Add serial console boot log for debugging purpose

#### How did you do it?
Modify virsh setting

#### How did you verify/test it?
Verify on virtual env

```
azure@sonic-ela000LHI:/var/log/libvirt/qemu$ sudo head boot-serial.log

                             GNU GRUB  version 2.02

 +----------------------------------------------------------------------------+
 |*SONiC-OS-master.1107799-3d7dbedfa                                          |
 | ONIE                                                                       |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 +----------------------------------------------------------------------------+

      Use the ^ and v keys to select which entry is highlighted.
      Press enter to boot the selected OS, `e' to edit the commands
      before booting or `c' for a command-line.


Loading SONiC-OS OS kernel ...
error: file `/grub/i386-pc/efi_gop.mod' not found.
Loading SONiC-OS OS initial ramdisk ...

Press any key to continue...
[    0.308864] RETBleed: WARNING: Spectre v2 mitigation leaves CPU vulnerable to RETBleed attacks, data leaks possible!

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
