### PR TITLE
Patch Ansible WorkerProcess and signal processing for ansible-core 2.19+ compatibility

### DIFF
--- a/tests/common/devices/base.py
+++ b/tests/common/devices/base.py
@@ -30,7 +30,7 @@ _avm.load_extra_vars = _safe_load_extra_vars
 logger = logging.getLogger(__name__)
 
 
-def ansible_tqm_registers_signals():
+def ansible_tqm_has_signal_registration():
     version = getattr(ansible, "__version__", "0.0.0")
     try:
         major, minor = version.split(".")[:2]
@@ -47,7 +47,7 @@ _original_signal = None
 @contextmanager
 def suppress_signal_registration_for_non_main_thread():
     """Temporarily bypass signal registration from worker threads for ansible-core 2.19+."""
-    if not ansible_tqm_registers_signals() or threading.current_thread() is threading.main_thread():
+    if not ansible_tqm_has_signal_registration() or threading.current_thread() is threading.main_thread():
         yield
         return
 

--- a/tests/common/devices/base.py
+++ b/tests/common/devices/base.py
@@ -2,7 +2,11 @@ import inspect
 import json
 import logging
 import collections
+import signal
+import threading
+from contextlib import contextmanager
 from multiprocessing.pool import ThreadPool
+import ansible
 from pytest_ansible.results import AdHocResult, ModuleResult
 
 from tests.common.errors import RunAnsibleModuleFail
@@ -24,6 +28,56 @@ _avm.load_extra_vars = _safe_load_extra_vars
 
 
 logger = logging.getLogger(__name__)
+
+
+def ansible_tqm_registers_signals():
+    version = getattr(ansible, "__version__", "0.0.0")
+    try:
+        major, minor = version.split(".")[:2]
+        return (int(major), int(minor)) >= (2, 19)
+    except (TypeError, ValueError):
+        return False
+
+
+_signal_patch_lock = threading.RLock()
+_signal_patch_ref_count = 0
+_original_signal = None
+
+
+@contextmanager
+def suppress_signal_registration_for_non_main_thread():
+    """Temporarily bypass signal registration from worker threads for ansible-core 2.19+."""
+    if not ansible_tqm_registers_signals() or threading.current_thread() is threading.main_thread():
+        yield
+        return
+
+    global _signal_patch_ref_count, _original_signal
+    with _signal_patch_lock:
+        if _signal_patch_ref_count == 0:
+            _original_signal = signal.signal
+
+            def _thread_safe_signal(signum, handler):
+                if threading.current_thread() is threading.main_thread():
+                    return _original_signal(signum, handler)
+                logger.warning(
+                    "Skipping signal.signal(%s, %s) from non-main thread %s; "
+                    "ansible-core 2.19+ restricts signal handling to main thread. "
+                    "Returning default handler instead.",
+                    signum, handler, threading.current_thread().name
+                )
+                return signal.getsignal(signum)
+
+            signal.signal = _thread_safe_signal
+        _signal_patch_ref_count += 1
+
+    try:
+        yield
+    finally:
+        with _signal_patch_lock:
+            _signal_patch_ref_count -= 1
+            if _signal_patch_ref_count == 0 and _original_signal is not None:
+                signal.signal = _original_signal
+                _original_signal = None
 
 
 # HACK: This is a hack for issue https://github.com/sonic-net/sonic-mgmt/issues/1941 and issue
@@ -153,7 +207,8 @@ class AnsibleHostBase(object):
 
         if module_async:
             def run_module(module_args, complex_args):
-                return module(*module_args, **complex_args)[self.hostname]
+                with suppress_signal_registration_for_non_main_thread():
+                    return module(*module_args, **complex_args)[self.hostname]
             pool = ThreadPool()
             result = pool.apply_async(run_module, (module_args, complex_args))
             return pool, result
@@ -161,7 +216,8 @@ class AnsibleHostBase(object):
         module_args = json.loads(json.dumps(module_args, cls=AnsibleHostBase.CustomEncoder))
         complex_args = json.loads(json.dumps(complex_args, cls=AnsibleHostBase.CustomEncoder))
 
-        adhoc_res: AdHocResult = module(*module_args, **complex_args)
+        with suppress_signal_registration_for_non_main_thread():
+            adhoc_res: AdHocResult = module(*module_args, **complex_args)
 
         if module_name == "meta":
             # The meta module is special in Ansible - it doesn't execute on remote hosts, it controls Ansible's behavior

--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -21,14 +21,25 @@ logger = logging.getLogger(__name__)
 
 
 def patch_ansible_worker_process():
-    """Patch AnsibleWorkerProcess to avoid logging deadlock after fork."""
+    """
+    Patch AnsibleWorkerProcess to avoid logging deadlock after fork.
+
+    ansible-core <= 2.18 also called self._save_stdin() to dup stdin
+    across the fork; that helper (and self._new_stdin) was removed in
+    ansible-core 2.19, so we only invoke it when present.
+    """
+
+    has_save_stdin = hasattr(WorkerProcess, "_save_stdin")
 
     def start(self):
-        self._save_stdin()
-        try:
+        if has_save_stdin:
+            self._save_stdin()
+            try:
+                return super(WorkerProcess, self).start()
+            finally:
+                self._new_stdin.close()
+        else:
             return super(WorkerProcess, self).start()
-        finally:
-            self._new_stdin.close()
 
     WorkerProcess.start = start
 


### PR DESCRIPTION
### Description of PR

Upgrading ansible from 11.10.0 to 12.2.0 or above upgrades ansible-core from 2.18.16 to 2.19.x or above. This introduces two compatibility issues:

**1. WorkerProcess._save_stdin removed**

ansible-core 2.18 invokes the WorkerProcess `_save_stdin()` method to duplicate stdin across fork:
https://github.com/ansible/ansible/blob/stable-2.18/lib/ansible/executor/process/worker.py#L102

ansible-core 2.19 removed this method and no longer dups stdin. The patch in parallel.py maintains backward compatibility by checking for the method's existence before invoking it. This can be reverted after ansible-core 2.19+ is confirmed stable across all CI and container environments.

**2. Signal registration restricted to main thread in ansible-core 2.19**

ansible-core 2.19 introduced a fix for signal propagation:
https://github.com/ansible/ansible/pull/85907

This fix registers signal handlers in `TaskQueueManager.__init__`. Since sonic-mgmt invokes DutHosts fixtures from within thread pools, tests crash with:
```
ValueError: signal only works in main thread of the main interpreter
```

The patch in base.py adds `_suppress_signal_registration_for_non_main_thread()` context manager that:
- Detects ansible-core 2.19+
- Temporarily patches `signal.signal()` to bypass registration from worker threads
- Returns the default handler instead to avoid the ValueError
- Includes warning logs when signal registration is bypassed, for visibility into edge cases

All threadpools remain active (not globally serialized), preserving performance.

---

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Upgrading from ansible 11.10.0 to 12.2.0 requires these changes.

#### How did you do it?

See description above

#### How did you verify/test it?

Local vs tests

#### Any platform specific information?

NA

#### Supported testbed topology if it's a new test case?

NA


### Documentation

NA