### PR TITLE
Add loganalyzer ignore patterns for Mellanox SDK serdes/FEC errors

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -252,6 +252,18 @@ r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\].*.\/src\/mlnx_sai_utils.c.*- get_dispatc
 r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\].*.\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, BROADCAST_FLOOD_GROUP, key:BRIDGE \[OID:.*Type:.*sx_bridge_id.*"
 r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\].*get_dispatch_attribs_handler:.*(INGRESS_SAMPLE_MIRROR_SESSION|EGRESS_SAMPLE_MIRROR_SESSION).*"
 
+# https://github.com/sonic-net/sonic-buildimage/issues/27327
+# Mellanox SDK new log format (with client_pid prefix) - FEC_ALIGNMENT_LOCK polling on ports without FEC support
+# and sai_get_attributes failures in the new format
+r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] client_pid=\d+, .\/src\/mlnx_sai_utils.c\[\d+\]- get_dispatch_attribs_handler: Failed Get #\d+, FEC_ALIGNMENT_LOCK, key:PORT.*"
+r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] client_pid=\d+, .\/src\/mlnx_sai_utils.c\[\d+\]- sai_get_attributes: Failed to get attribute.*"
+
+# Mellanox SAI_PORT FEC alignment lock not supported on pre-SPC4 platforms (SN2700, SN4600C, SN4700)
+r, ".* ERR syncd#SDK: \[SAI_PORT.ERR\].*mlnx_sai_port.c\[\d+\]- mlnx_port_state_get: FEC alignment lock only supported on SPC4\+.*"
+
+# Orchagent PORT_PHY_SERDES_ATTR counter map errors for ports without serdes objects
+r, ".* ERR swss\d*#orchagent: :- clearPortPhySerdesAttrCounterMap: PORT_PHY_SERDES_ATTR: Port .* has no serdes object"
+
 # https://github.com/sonic-net/sonic-mgmt/issues/10384
 r, ".*kdump-tools\[[0-9]+\]: no crashkernel= parameter in the kernel cmdline.*"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The Mellanox SDK recently changed its log format to include 'client_pid=N, '
before the file path, causing existing ignore patterns to no longer match.
Additionally, FEC alignment lock polling generates errors on pre-SPC4
platforms (SN2700, SN4600C, SN4700) and orchagent emits errors for ports
without serdes objects. These unignored ERR-level syslogs cause loganalyzer
teardown failures across all Mellanox platforms affecting any test using
loganalyzer.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### How did you do it?
New patterns added:
  - SAI_UTILS FEC_ALIGNMENT_LOCK get_dispatch_attribs_handler (new SDK format)
  - SAI_UTILS sai_get_attributes failures (new SDK format with client_pid)
  - SAI_PORT mlnx_port_state_get FEC alignment lock on pre-SPC4 platforms
  - orchagent clearPortPhySerdesAttrCounterMap for ports without serdes objects
  
#### How did you verify/test it?
Manual testing

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
