### PR TITLE
Fix get_port_indexes_with_flat_memory crash when xcvr_api is None

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -398,10 +398,17 @@ def get_port_indexes_with_flat_memory(dut):
     cmd = """
 cat << EOF > get_port_indexes_with_flat_memory.py
 import sonic_platform.platform as P
-num_sfps = P.Platform().get_chassis().get_num_sfps()
+chassis = P.Platform().get_chassis()
+num_sfps = chassis.get_num_sfps()
 port_indexes_with_flat_memory = []
 for i in range(1, num_sfps + 1):
-    is_flat_memory = P.Platform().get_chassis().get_sfp(i).get_xcvr_api().is_flat_memory()
+    sfp = chassis.get_sfp(i)
+    if sfp is None:
+        continue
+    xcvr_api = sfp.get_xcvr_api()
+    if xcvr_api is None:
+        continue
+    is_flat_memory = xcvr_api.is_flat_memory()
     if is_flat_memory:
         port_indexes_with_flat_memory.append(i)
 print(port_indexes_with_flat_memory)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The on-DUT script crashes with AttributeError when get_sfp() or
get_xcvr_api() returns None for empty SFP slots or unsupported
transceivers (e.g., passive DAC cables). This causes the
port_list_with_flat_memory fixture to fail at setup, blocking all
dependent tests.

Add None guards to skip ports without a valid xcvr API instead of
crashing. Ports that cannot be queried are simply not added to the
flat_memory list, allowing the actual tests to handle them gracefully.

Fixes test_sfp, test_check_sfp_eeprom, and test_xcvr_info_in_db
failures on Mellanox SN4700.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The get_port_indexes_with_flat_memory() helper (added in PR: https://github.com/sonic-net/sonic-mgmt/pull/22561) assumes every SFP slot has a valid
transceiver API. On empty/unpopulated ports, get_xcvr_api() returns None, crashing the fixture and blocking 3 tests (test_sfp, test_check_sfp_eeprom, test_xcvr_info_in_db).

#### How did you do it?
Added None checks for both get_sfp() and get_xcvr_api() return values before calling is_flat_memory(), gracefully skipping
empty/unpopulated SFP slots instead of crashing.

#### How did you verify/test it?
Manual Testing

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
