### PR TITLE
Update trimming with srv6 case to avoid loop packet

### DIFF
--- a/tests/packet_trimming/conftest.py
+++ b/tests/packet_trimming/conftest.py
@@ -15,7 +15,8 @@ from tests.packet_trimming.packet_trimming_helper import (
     delete_blocking_scheduler, check_trimming_capability, prepare_service_port, get_interface_peer_addresses,
     configure_tc_to_dscp_map, set_buffer_profile_for_block_queue, set_buffer_profile_for_trim_queue,
     create_blocking_scheduler, configure_trimming_action, cleanup_trimming_acl, get_queue_id_by_dscp,
-    get_test_ports, create_trim_queue_test_buffer_profile, delete_trim_queue_test_buffer_profile,
+    get_test_ports, configure_srv6_loop_break_acl, cleanup_srv6_loop_break_acl,
+    create_trim_queue_test_buffer_profile, delete_trim_queue_test_buffer_profile,
     is_queue_level_trim_sent_drop_supported)
 
 
@@ -302,9 +303,14 @@ def setup_srv6(duthost, request, rand_selected_dut, upstream_links, peer_links, 
     )
     logger.info(f"Added static route {SRV6_ROUTE_PREFIX} -> {nexthop} via {egress_intf}")
 
+    # Install ingress ACL on the egress logical interface (PortChannel or physical Ethernet)
+    # to drop decap SRv6 packets coming back from the neighbor.
+    configure_srv6_loop_break_acl(rand_selected_dut, test_params['egress_ports'][0]['name'])
+
     yield dscp_mode
 
-    # Cleanup: Remove static route
+    # Cleanup: remove ingress ACL first, then the static route
+    cleanup_srv6_loop_break_acl(rand_selected_dut)
     rand_selected_dut.command(f'sonic-db-cli CONFIG_DB DEL "STATIC_ROUTE|default|{SRV6_ROUTE_PREFIX}"')
     logger.info(f"Removed static route {SRV6_ROUTE_PREFIX}")
 

--- a/tests/packet_trimming/constants.py
+++ b/tests/packet_trimming/constants.py
@@ -153,6 +153,12 @@ SRV6_MY_SID_LIST = [
 # Static route prefix for SRv6 packets
 SRV6_ROUTE_PREFIX = '2001::/16'
 
+# Ingress ACL on the SRv6 egress interface to drop packets bounced back from the neighbor
+SRV6_LOOP_BREAK_ACL_TABLE_TYPE_NAME = "SRV6_LOOP_BREAK_TYPE"
+SRV6_LOOP_BREAK_ACL_TABLE_NAME = "SRV6_LOOP_BREAK"
+SRV6_LOOP_BREAK_ACL_RULE_NAME = "DROP_BOUNCED_SRV6"
+SRV6_LOOP_BREAK_ACL_RULE_PRIORITY = "999"
+
 # Drop counter
 # The polling interval should be no less than 2 seconds to avoid BGP routes large convergence time.
 TRIMMING_COUNTER_INTERVAL = 2000

--- a/tests/packet_trimming/packet_trimming_helper.py
+++ b/tests/packet_trimming/packet_trimming_helper.py
@@ -23,6 +23,9 @@ from tests.packet_trimming.constants import (DEFAULT_SRC_PORT, DEFAULT_DST_PORT,
                                              TRIM_QUEUE_PROFILE, TRIM_QUEUE_PROFILE_CONFIG, TRIMMING_CAPABILITY,
                                              ACL_TABLE_NAME,
                                              ACL_RULE_PRIORITY, ACL_TABLE_TYPE_NAME, ACL_RULE_NAME, SRV6_MY_SID_LIST,
+                                             SRV6_ROUTE_PREFIX, SRV6_LOOP_BREAK_ACL_TABLE_TYPE_NAME,
+                                             SRV6_LOOP_BREAK_ACL_TABLE_NAME, SRV6_LOOP_BREAK_ACL_RULE_NAME,
+                                             SRV6_LOOP_BREAK_ACL_RULE_PRIORITY,
                                              SRV6_INNER_SRC_IP, SRV6_INNER_DST_IP, DEFAULT_QUEUE_SCHEDULER_CONFIG,
                                              SRV6_UNIFORM_MODE, SRV6_OUTER_SRC_IPV6, SRV6_INNER_SRC_IPV6, ECN,
                                              SRV6_INNER_DST_IPV6, SRV6_UN, ASYM_PORT_1_DSCP, ASYM_PORT_2_DSCP,
@@ -846,6 +849,9 @@ def fill_egress_buffer(duthost, ptfadapter, port_id, buffer_size, target_queue, 
                 ptfadapter.dataplane.flush()
 
     logger.info(f"Buffer filling completed, sent {total_sent_packets} packets")
+    sleep_time = TRIMMING_COUNTER_INTERVAL / 1000 + 1
+    logger.info(f"Waiting {sleep_time} seconds for the counter to be updated")
+    time.sleep(sleep_time)
 
     # Fail fast when nothing was sent so the buffer never gets filled
     if total_sent_packets == 0:
@@ -1572,6 +1578,115 @@ def cleanup_trimming_acl(duthost):
     duthost.shell("show acl rule")
 
     logger.info("ACL rules cleanup completed successfully")
+
+
+def configure_srv6_loop_break_acl(duthost, egress_ports):
+    """
+    Add an ingress ACL on the SRv6 egress interface(s) to drop packets bounced
+    back from the neighbor whose destination falls in SRV6_ROUTE_PREFIX. Without this
+    filter, the DUT keeps re-forwarding bounced packets out the same interface, forming a
+    DUT<->neighbor L3 ping-pong loop until hlim hits zero (~32 bounces per packet).
+
+    Matching only on DST_IPV6 is sufficient: SRV6_ROUTE_PREFIX is exclusive to this
+    test, and on this port's ingress side no legitimate traffic should carry such a
+    destination (the legitimate flow is PTF -> DUT -> neighbor, not the reverse).
+
+    The ACL is bound to the logical egress interface(s), i.e. the PortChannel or the
+    physical Ethernet.
+
+    Args:
+        duthost: DUT host object
+        egress_ports (list[str] or str): Logical egress interface name(s) to bind the ACL
+            to as ingress. Accepts a single name or a list. For a PortChannel egress, pass
+            the PortChannel name (e.g. test_params['egress_ports'][0]['name']), not its
+            members.
+    """
+    if isinstance(egress_ports, str):
+        ports_list = [egress_ports]
+    else:
+        ports_list = list(egress_ports)
+
+    logger.info(f"Configuring SRv6 loop-break ACL on {ports_list}, drop dst={SRV6_ROUTE_PREFIX}")
+
+    acl_config = {
+        "ACL_RULE": {
+            f"{SRV6_LOOP_BREAK_ACL_TABLE_NAME}|{SRV6_LOOP_BREAK_ACL_RULE_NAME}": {
+                "PACKET_ACTION": "DROP",
+                "PRIORITY": SRV6_LOOP_BREAK_ACL_RULE_PRIORITY,
+                "DST_IPV6": SRV6_ROUTE_PREFIX
+            }
+        },
+        "ACL_TABLE": {
+            SRV6_LOOP_BREAK_ACL_TABLE_NAME: {
+                "policy_desc": "Drop SRv6 bounced packets to break DUT<->neighbor L3 loop",
+                "ports": ports_list,
+                "stage": "INGRESS",
+                "type": SRV6_LOOP_BREAK_ACL_TABLE_TYPE_NAME
+            }
+        },
+        "ACL_TABLE_TYPE": {
+            SRV6_LOOP_BREAK_ACL_TABLE_TYPE_NAME: {
+                "ACTIONS": [
+                    "PACKET_ACTION",
+                    "COUNTER"
+                ],
+                "BIND_POINTS": [
+                    "PORT",
+                    "PORTCHANNEL"
+                ],
+                "MATCHES": [
+                    "DST_IPV6"
+                ]
+            }
+        }
+    }
+
+    with tempfile.NamedTemporaryFile(mode='w+', suffix='.json', delete=False) as temp_file:
+        temp_file_path = temp_file.name
+        json.dump(acl_config, temp_file, indent=4)
+
+    dut_json_path = f"/tmp/acl_config_{SRV6_LOOP_BREAK_ACL_TABLE_NAME}.json"
+    duthost.copy(src=temp_file_path, dest=dut_json_path)
+    os.unlink(temp_file_path)
+
+    duthost.shell(f"sonic-cfggen -w -j {dut_json_path}")
+
+    # Remove the DUT-side JSON; sonic-cfggen has already loaded it into CONFIG_DB.
+    duthost.shell(f"rm -f {dut_json_path}")
+
+    # Verify the ACL table and rule were actually installed - silent apply failures
+    # would let the bounce loop run unchecked and inflate egress queue counters.
+    table_output = duthost.shell("show acl table")["stdout"]
+    rule_output = duthost.shell("show acl rule")["stdout"]
+    logger.info(f"ACL tables after apply:\n{table_output}")
+    logger.info(f"ACL rules after apply:\n{rule_output}")
+
+    if SRV6_LOOP_BREAK_ACL_TABLE_NAME not in table_output:
+        raise RuntimeError(
+            f"SRv6 loop-break ACL table {SRV6_LOOP_BREAK_ACL_TABLE_NAME} was not installed. "
+            f"show acl table output:\n{table_output}"
+        )
+    if SRV6_LOOP_BREAK_ACL_RULE_NAME not in rule_output:
+        raise RuntimeError(
+            f"SRv6 loop-break ACL rule {SRV6_LOOP_BREAK_ACL_RULE_NAME} was not installed. "
+            f"show acl rule output:\n{rule_output}"
+        )
+
+    logger.info("SRv6 loop-break ACL applied and verified")
+
+
+def cleanup_srv6_loop_break_acl(duthost):
+    """
+    Remove the SRv6 loop-break ACL configuration installed by configure_srv6_loop_break_acl.
+    """
+    logger.info(f"Cleaning up SRv6 loop-break ACL, table: {SRV6_LOOP_BREAK_ACL_TABLE_NAME}")
+    duthost.shell(
+        f"sonic-db-cli CONFIG_DB DEL "
+        f"'ACL_RULE|{SRV6_LOOP_BREAK_ACL_TABLE_NAME}|{SRV6_LOOP_BREAK_ACL_RULE_NAME}'"
+    )
+    duthost.shell(f"sonic-db-cli CONFIG_DB DEL 'ACL_TABLE|{SRV6_LOOP_BREAK_ACL_TABLE_NAME}'")
+    duthost.shell(f"sonic-db-cli CONFIG_DB DEL 'ACL_TABLE_TYPE|{SRV6_LOOP_BREAK_ACL_TABLE_TYPE_NAME}'")
+    logger.info("SRv6 loop-break ACL cleanup completed")
 
 
 def set_buffer_profile_for_block_queue(duthost, interfaces, block_queue_id, block_queue_profile):


### PR DESCRIPTION
Summary: Update trimming with srv6 case to avoid loop packet
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The SRv6 packet trimming fixture forwards uN-shifted packets out a neighbor port via a static `2001::/16` route. Because the neighbor falls back to its default route (`::/0` via the DUT) for any `2001::` destination it does not have a more specific route for, every uN-shifted packet bounces between DUT and neighbor until hlim reaches zero - amplifying each test packet by ~32x and inflating egress queue counters (e.g. UC0=62000 for 2000 SRv6 packets).
The issue might lead to error `nnpy.errors.NNError: Connection timed out`

- before fix 
```
admin@router:~$ show queue counters Ethernet432
For namespace :
       Port    TxQ    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
-----------  -----  --------------  ---------------  -----------  ------------
Ethernet432    UC0           62000         16120000            0           N/A    <<< Loop packets
Ethernet432    UC1             524           788096         3084           N/A
Ethernet432    UC2               0                0            0           N/A
Ethernet432    UC3               0                0            0           N/A
Ethernet432    UC4               0                0            0           N/A
Ethernet432    UC5               0                0            0           N/A
Ethernet432    UC6            3084           801840            0           N/A
Ethernet432    UC7             981           530903            0           N/A
```

#### How did you do it?
Add a new ingress ACL helper pair configure_srv6_loop_break_acl / cleanup_srv6_loop_break_acl. The ACL is bound ingress to the egress interface and drops packets whose dst falls in SRV6_ROUTE_PREFIX, so any packet bounced back from the neighbor is filtered at the second hop and the loop is broken.


- after fix
```
admin@router:~$ show queue counter Ethernet176
For namespace :
       Port    TxQ    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
-----------  -----  --------------  ---------------  -----------  ------------
Ethernet176    UC0               0                0            0           N/A    <<< No loop packets
Ethernet176    UC1               0                0         3077           N/A
Ethernet176    UC2               0                0            0           N/A
Ethernet176    UC3               0                0            0           N/A
Ethernet176    UC4               0                0            0           N/A
Ethernet176    UC5               0                0            0           N/A
Ethernet176    UC6            3077           800020            0           N/A
Ethernet176    UC7             338           461967            0           N/A
```

#### How did you verify/test it?
Regression pass

#### Any platform specific information?
All

#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A
