### PR TITLE
Fix test issues in test_gnoi_system_reboot.py

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -188,7 +188,7 @@ def check_warmboot_finalizer_inactive(duthost):
     return 'inactive' == stdout.strip()
 
 
-def wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res):
+def wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res=None):
     hostname = duthost.hostname
     dut_ip = duthost.mgmt_ip
     logger.info('waiting for ssh to drop on {}'.format(hostname))
@@ -201,7 +201,7 @@ def wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res):
                              module_ignore_errors=True)
 
     if res.is_failed or ('msg' in res and 'Timeout' in res['msg']):
-        if reboot_res.ready():
+        if reboot_res and reboot_res.ready():
             logger.error('reboot result: {} on {}'.format(reboot_res.get(), hostname))
         raise Exception('DUT {} did not shutdown'.format(hostname))
 

--- a/tests/gnmi/test_gnoi_system_reboot.py
+++ b/tests/gnmi/test_gnoi_system_reboot.py
@@ -5,7 +5,7 @@ import pytest
 import logging
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.reboot import wait_for_startup
+from tests.common.reboot import wait_for_startup, wait_for_shutdown
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.utilities import wait_until
 
@@ -86,6 +86,10 @@ def test_gnoi_system_reboot_cold(duthosts, rand_one_dut_hostname, localhost, gnm
         expected_method="COLD"
     )
 
+    # Wait until the system is down
+    wait_for_shutdown(duthost, localhost, delay=10, timeout=180, reboot_res=None)
+    logging.info("System is down after reboot")
+
     # Wait until the system is back up
     wait_for_startup(duthost, localhost, delay=20, timeout=600)
     logging.info("System is back up after reboot")
@@ -113,6 +117,8 @@ def test_gnoi_system_reboot_warm(duthosts, rand_one_dut_hostname, localhost, gnm
     and the system recovers with all critical processes running.
     """
     duthost = duthosts[rand_one_dut_hostname]
+    if duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_smartswitch"):
+        pytest.skip("Warm reboot is not supported on smartswitch")
 
     # Trigger reboot via gNOI using gnmi_tls fixture
     reboot_response = gnmi_tls.gnoi.system_reboot(
@@ -127,6 +133,10 @@ def test_gnoi_system_reboot_warm(duthosts, rand_one_dut_hostname, localhost, gnm
         expected_reason=REBOOT_MESSAGE,
         expected_method="WARM"
     )
+
+    # Wait until the system is down
+    wait_for_shutdown(duthost, localhost, delay=10, timeout=180, reboot_res=None)
+    logging.info("System is down after reboot")
 
     # Wait until the system is back up
     wait_for_startup(duthost, localhost, delay=20, timeout=600)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. The test doesn't wait for the switch to shutdown after the reboot command is issued. The validations after the reboot step may pass even before the switch is rebooted.

Timeline in a test log:
| Time (DUT clock) | Elapsed | Event |
|---|---|---|
| **10:53:09.232** | T+0s | gNOI `System.Reboot(WARM)` grpcurl executed, returned `{}` (rc=0) in 0.16s |
| **10:53:09.396** | T+0s | RebootStatus confirms: `active=True, method=WARM, reason="gnoi test reboot"` |
| **10:53:09** | T+0s | `wait_for_startup(delay=20, timeout=600)` begins waiting for SSH |
| **10:53:29** | T+20s | SSH check passes (elapsed=20s, SSH never went down or recovered instantly) |
| **10:53:29** | T+20s | `"System is back up after reboot"` logged |

So, we need wait for dut shutdown before checking dut is up

2. The warm reboot test case should be skipped on smartswitch. Smartswitch doesn't support warm-reboot.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Fix test issues in test_gnoi_system_reboot.py
#### How did you do it?
1. Fix test issues in test_gnoi_system_reboot.py
2. Skip the warm reboot test case on smartswitch
#### How did you verify/test it?
Run the test on all Nvidia platforms.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
