### PR TITLE
[QoS] Add DSCP pipe mode preservation test

### DIFF
--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -90,10 +90,13 @@ def dscp_config(dscp_mode, rand_selected_dut, loganalyzer):
     asic_type = duthost.facts['asic_type']
 
     # global DSCP_TO_TC_MAP update is not supported on Broadcom platforms
+    # Broadcom ASICs do not support inner DSCP-based queue remapping for IPIP pipe mode.
+    # Pipe mode decap works correctly (inner DSCP preserved in packet header) but queue
+    # selection always uses outer DSCP. Pipe mode DSCP preservation (without queue mapping)
+    # is covered by test_pipe_mode_dscp_preservation below.
     if asic_type == 'broadcom':
-        hwsku = duthost.facts.get("hwsku", "")
-        if dscp_mode == "pipe" and hwsku.startswith("Arista-7060CX"):
-            pytest.skip("Broadcom TH (Tomahawk 1) does not support IPIP pipe mode"
+        if dscp_mode == "pipe":
+            pytest.skip("Broadcom does not support IPIP pipe mode egress queue remapping"
                         " -- hardware always uses outer DSCP for egress queue selection")
         apply_dscp_cfg_setup(duthost, dscp_mode, loganalyzer)
         yield
@@ -117,6 +120,32 @@ def dscp_config(dscp_mode, rand_selected_dut, loganalyzer):
         duthost.shell(f'redis-cli -n 4 -c HSET "PORT_QOS_MAP|global" "dscp_to_tc_map" "{origin_dscp_to_tc_map}"')
     else:
         duthost.shell('redis-cli -n 4 -c DEL "PORT_QOS_MAP|global"')
+
+
+@pytest.fixture(scope='function')
+def dscp_config_pipe(rand_selected_dut, loganalyzer):
+    """
+    Test setup and teardown for pipe mode DSCP preservation test.
+
+    Sets up pipe mode on the switch (Broadcom ASICs only for now). This fixture is for tests that validate DSCP
+    preservation in the decapsulated packet header, not egress queue placement.
+
+    Args:
+        rand_selected_dut (AnsibleHost): The randomly selected DUT host
+        loganalyzer: Log analyzer fixture
+    """
+    duthost = rand_selected_dut
+    asic_type = duthost.facts['asic_type']
+
+    if asic_type != 'broadcom':
+        # TODO: Remove this skip for other vendors/platforms that want to validate
+        # pipe mode DSCP preservation without queue mapping verification.
+        pytest.skip(f"{asic_type} pipe mode DSCP-only check not needed:"
+                    " covered by test_dscp_to_queue_mapping[pipe]")
+
+    apply_dscp_cfg_setup(duthost, "pipe", loganalyzer)
+    yield
+    apply_dscp_cfg_teardown(duthost, loganalyzer)
 
 
 def create_ipip_packet(outer_src_mac,
@@ -535,3 +564,112 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
             with allure.step("Run test after warm-reboot"):
                 self._run_test(ptfadapter, duthost, tbinfo, test_params, inner_dst_ip_list, dut_qos_maps_module,
                                dscp_mode)
+
+    @pytest.mark.disable_loganalyzer
+    def test_pipe_mode_dscp_preservation(self, ptfadapter, rand_selected_dut, localhost, dscp_config_pipe,
+                                         toggle_all_simulator_ports_to_rand_selected_tor,  # noqa F811
+                                         setup_standby_ports_on_rand_unselected_tor, route_config,
+                                         tbinfo, downstream_links, upstream_links, loganalyzer, rotate_syslog):  # noqa F811
+        """
+        Test that pipe mode decap preserves the inner DSCP value in the decapsulated packet header.
+
+        This test validates the packet-level DSCP preservation guarantee and is designed to run on any platform
+        that supports pipe mode decap without full queue remapping support.
+        """
+        if "backend" in tbinfo["topo"]["type"]:
+            pytest.skip("Dscp-queue mapping is not supported on {}".format(tbinfo["topo"]["type"]))
+
+        duthost = rand_selected_dut
+        asic_type = duthost.facts['asic_type']
+
+        if asic_type == 'vs':
+            pytest.skip("Skipping DSCP preservation check for VS platform")
+
+        inner_dst_ip_list = route_config
+        step = len(inner_dst_ip_list)
+
+        with allure.step("Prepare test parameters"):
+            test_params = self._setup_test_params(duthost, tbinfo, downstream_links, upstream_links)
+
+        dst_mac = test_params['dst_mac']
+        ptf_src_port_id = test_params['ptf_src_port_id']
+        ptf_dst_port_ids = test_params['ptf_dst_port_ids']
+        outer_dst_pkt_ip = test_params['outer_dst_ip']
+        outer_src_pkt_ip = DUMMY_OUTER_SRC_IP
+        inner_src_pkt_ip = DUMMY_INNER_SRC_IP
+        ptf_src_mac = ptfadapter.dataplane.get_mac(0, ptf_src_port_id)
+
+        failed_once = False
+        global output_table, packet_egressed_success
+        output_table = []
+        packet_egressed_success = []
+
+        def check_tunnel_dscp_mode(duthost, dscp_mode):
+            real_dscp_mode = duthost.shell('redis-cli hget "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" "dscp_mode"')["stdout"]
+            pytest_assert(dscp_mode == real_dscp_mode, "Wrong DSCP mode configured")
+
+        def check_ip_route(duthost, step):
+            ip_route_list = [INNER_DST_IP_PREFIX + str(i + 1) + '/32' for i in range(step)]
+            for i in range(step):
+                route = duthost.shell(f"show ip route {ip_route_list[i]}")["stdout"]
+                if ip_route_list[i] not in route:
+                    return False
+            return True
+
+        logger.info("Checking pipe mode is active on tunnel")
+        check_tunnel_dscp_mode(duthost, "pipe")
+        logger.info("Checking ip routes")
+        pytest_assert(wait_until(30, 10, 0, check_ip_route, duthost, step), "IP routes are not configured")
+
+        with allure.step("Run DSCP preservation test"):
+            for rotating_dscp in range(0, 64, step):
+                pkt_list = []
+                exp_pkt_list = []
+                inner_dst_pkt_ip_list = inner_dst_ip_list
+
+                for i in range(step):
+                    inner_dscp = rotating_dscp + i
+                    logger.info(f"pipe mode: outer_dscp={DEFAULT_DSCP}, inner_dscp={inner_dscp}")
+                    pkt, exp_pkt = create_ipip_packet(
+                        outer_src_mac=ptf_src_mac,
+                        outer_dst_mac=dst_mac,
+                        outer_src_pkt_ip=outer_src_pkt_ip,
+                        outer_dst_pkt_ip=outer_dst_pkt_ip,
+                        outer_dscp=DEFAULT_DSCP,
+                        inner_src_pkt_ip=inner_src_pkt_ip,
+                        inner_dst_pkt_ip=inner_dst_pkt_ip_list[i],
+                        inner_dscp=inner_dscp,
+                        decap_mode="pipe"
+                    )
+                    pkt_list.append(pkt)
+                    exp_pkt_list.append(exp_pkt)
+
+                try:
+                    send_and_verify_traffic(ptfadapter=ptfadapter,
+                                            pkt_list=pkt_list,
+                                            exp_pkt_list=exp_pkt_list,
+                                            ptf_src_port_id=ptf_src_port_id,
+                                            ptf_dst_port_ids=ptf_dst_port_ids)
+                except ConnectionError as e:
+                    logger.error("{}: Try reducing DEFAULT_PKT_COUNT value".format(str(e)))
+                    failed_once = True
+
+                for i in range(step):
+                    cur_dscp = rotating_dscp + i
+                    if packet_egressed_success[i]:
+                        logger.info(f"SUCCESS: Inner DSCP {cur_dscp} preserved in decapsulated packet")
+                        output_table.append([cur_dscp, "SUCCESS - DSCP PRESERVED"])
+                    else:
+                        logger.info(f"FAILURE: Inner DSCP {cur_dscp} not found in decapsulated packet")
+                        output_table.append([cur_dscp, "FAILURE - DSCP NOT PRESERVED"])
+                        failed_once = True
+
+                packet_egressed_success = []
+
+        logger.info("Pipe mode DSCP preservation test results:\n{}"
+                    .format(tabulate(output_table,
+                                     headers=["Inner Packet DSCP Value", "Result"])))
+        output_table = []
+
+        pytest_assert(not failed_once, "FAIL: One or more inner DSCP values were not preserved after decap."
+                                       " Please check the table above for details.")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add a new test (`test_pipe_mode_dscp_preservation`) that validates inner DSCP values are preserved in decapsulated packet headers during IPIP pipe mode on Broadcom ASICs. Also refines the existing pipe mode skip logic to skip all Broadcom platforms (not just Arista-7060CX) for queue remapping tests, since Broadcom hardware doesn't support global level port qos mapping.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
Broadcom ASICs support pipe mode decap (preserving inner DSCP in the packet header) but do not support egress queue remapping based on inner DSCP. The existing test was only skipping Arista-7060CX (TH1) for pipe mode, but the limitation applies to all Broadcom platforms. A dedicated test is needed to validate DSCP preservation without requiring queue mapping.

#### How did you do it?
Added a `dscp_config_pipe` fixture scoped to Broadcom platforms and a new `test_pipe_mode_dscp_preservation` test method that sends IPIP packets with varying inner DSCP values (0–63) and verifies the decapsulated packet retains the inner DSCP. Updated the existing `dscp_config` fixture to skip all Broadcom platforms for pipe mode queue remapping tests with a clarifying comment.

#### How did you verify/test it?
Validated on a Broadcom-based testbed by running the new test and confirming inner DSCP values 0–63 are preserved in decapsulated packets.

#### Any platform specific information?
Broadcom ASICs: pipe mode decap preserves inner DSCP in the packet header, but egress queue selection always uses outer DSCP. Non-Broadcom platforms are skipped by the new test since they are already covered by `test_dscp_to_queue_mapping[pipe]`.

#### Supported testbed topology if it's a new test case?
t0, t1, dualtor (same topologies as existing DSCP queue mapping tests)

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

Test output:
```
  Inner Packet DSCP Value  Result                                                                                                                                                                         
-------------------------  ------------------------                                                                                                                                                       
                        0  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                        1  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                        2  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                        3  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                        4  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                        5  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                        6  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                        7  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                        8  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                        9  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                       10  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                       11  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                       12  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                       13  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                       14  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                       15  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                       16  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                       17  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                       18  SUCCESS - DSCP PRESERVED
                       19  SUCCESS - DSCP PRESERVED
                       20  SUCCESS - DSCP PRESERVED
                       21  SUCCESS - DSCP PRESERVED
                       22  SUCCESS - DSCP PRESERVED
                       23  SUCCESS - DSCP PRESERVED
                       24  SUCCESS - DSCP PRESERVED
                       25  SUCCESS - DSCP PRESERVED
                       26  SUCCESS - DSCP PRESERVED
                       27  SUCCESS - DSCP PRESERVED
                       28  SUCCESS - DSCP PRESERVED
                       29  SUCCESS - DSCP PRESERVED
                       30  SUCCESS - DSCP PRESERVED
                       31  SUCCESS - DSCP PRESERVED
                       32  SUCCESS - DSCP PRESERVED
                       33  SUCCESS - DSCP PRESERVED
                       34  SUCCESS - DSCP PRESERVED
                       35  SUCCESS - DSCP PRESERVED
                       36  SUCCESS - DSCP PRESERVED
                       37  SUCCESS - DSCP PRESERVED
                       38  SUCCESS - DSCP PRESERVED
                       39  SUCCESS - DSCP PRESERVED
                       40  SUCCESS - DSCP PRESERVED
                       41  SUCCESS - DSCP PRESERVED
                       42  SUCCESS - DSCP PRESERVED
                       43  SUCCESS - DSCP PRESERVED
                       44  SUCCESS - DSCP PRESERVED
                       45  SUCCESS - DSCP PRESERVED
                       46  SUCCESS - DSCP PRESERVED
                       47  SUCCESS - DSCP PRESERVED
                       48  SUCCESS - DSCP PRESERVED
                       49  SUCCESS - DSCP PRESERVED
                       50  SUCCESS - DSCP PRESERVED
                       51  SUCCESS - DSCP PRESERVED                                                                                                                
                       52  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                       53  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                       54  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                       55  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                       56  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                       57  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                       58  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                       59  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                       60  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                       61  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                       62  SUCCESS - DSCP PRESERVED                                                                                                                                                       
                       63  SUCCESS - DSCP PRESERVED                                                                                                                                                       
PASSED                                                           
...
------------------------------------------------ live log sessionfinish -----------------------------------------------------------------------------------------
08/05/2026 11:14:50 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
============================================================================== 1 passed, 321 warnings in 867.24s (0:14:27) ========================
```

