### PR TITLE
[HA][dash] Add Flow comparison support using Flow API

### DIFF
--- a/tests/ha/ha_dash_flow_utils.py
+++ b/tests/ha/ha_dash_flow_utils.py
@@ -1,5 +1,7 @@
 import re
 import logging
+import json
+from pprint import pformat
 
 logger = logging.getLogger(__name__)
 
@@ -46,11 +48,100 @@ def parse_pdsctl_show_flow_output(output):
     return sorted_flow_array
 
 
-def compare_flow_tables_pdsctl(dpuhost1, dpuhost2):
-    if 'pensando' not in dpuhost1.facts['asic_type'] or 'pensando' not in dpuhost2.facts['asic_type']:
-        logger.warning("Only Pensando is supported - return true")
-        return True
+FLOW_KEY_FIELDS = (
+    "ENI_MAC", "VNET_ID", "SRC_IP", "SRC_PORT", "DST_IP", "DST_PORT", "IP_PROTO"
+)
+IGNORE_FIELDS = {
+    "EPOCH",
+    "SAI_FLOW_ENTRY_ATTR_UNDERLAY0_SMAC",
+    "SAI_FLOW_ENTRY_ATTR_UNDERLAY0_DMAC",
+    # TODO: currently ignore version because it has bug waiting for fix
+    "SAI_FLOW_ENTRY_ATTR_VERSION",
+}
 
+
+def flow_key(flow):
+    return tuple(flow[field] for field in FLOW_KEY_FIELDS)
+
+
+def format_flow_key(key):
+    return dict(zip(FLOW_KEY_FIELDS, key))
+
+
+def comparable_flow(flow):
+    return {
+        k: v
+        for k, v in flow.items()
+        if k not in IGNORE_FIELDS
+    }
+
+
+def parse_sonic_dpu_flow_dump_output(output):
+    """
+    Return dict of flows, None if failed to parse
+    """
+    result = {}
+    if not output:
+        return result
+    try:
+        flows = json.loads(output)
+    except json.JSONDecodeError:
+        logger.error(f"Failed to parse sonic-dpu-flow-dump output: {output}")
+        return None
+
+    for flow in flows:
+        key = flow_key(flow)
+        result[key] = comparable_flow(flow)
+    return result
+
+
+def log_flow_map_diff(flow_map1, flow_map2, host1, host2):
+    only_on_1 = [format_flow_key(k) for k in flow_map1.keys() - flow_map2.keys()]
+    only_on_2 = [format_flow_key(k) for k in flow_map2.keys() - flow_map1.keys()]
+    attr_diffs = []
+    for k in flow_map1.keys() & flow_map2.keys():
+        if flow_map1[k] == flow_map2[k]:
+            continue
+        differing_fields = {
+            field: (flow_map1[k].get(field), flow_map2[k].get(field))
+            for field in flow_map1[k].keys() | flow_map2[k].keys()
+            if flow_map1[k].get(field) != flow_map2[k].get(field)
+        }
+        attr_diffs.append({
+            "flow": format_flow_key(k),
+            "differing_fields": differing_fields,
+        })
+    logger.warning(f" flows only on {host1}:\n{pformat(only_on_1, sort_dicts=False, width=120)}")
+    logger.warning(f" flows only on {host2}:\n{pformat(only_on_2, sort_dicts=False, width=120)}")
+    logger.warning(f" flows with attribute differences:\n{pformat(attr_diffs, sort_dicts=False, width=120)}")
+
+
+def compare_flow_tables_sonic_dpu_flow_dump(dpuhost1, dpuhost2):
+    output1 = dpuhost1.shell("sudo sonic-dpu-flow-dump.py")["stdout"]
+    output2 = dpuhost2.shell("sudo sonic-dpu-flow-dump.py")["stdout"]
+
+    logger.debug(f"dump on {dpuhost1.hostname}:\n{output1}")
+    logger.debug(f"dump on {dpuhost2.hostname}:\n{output2}")
+
+    flow_map1 = parse_sonic_dpu_flow_dump_output(output1)
+    if flow_map1 is None:
+        logger.warning(f" flows table for {dpuhost1.hostname} is None")
+        return False
+    flow_map2 = parse_sonic_dpu_flow_dump_output(output2)
+    if flow_map2 is None:
+        logger.warning(f" flows table for {dpuhost2.hostname} is None")
+        return False
+
+    if flow_map1 == flow_map2:
+        logger.info(f" flows for {dpuhost1.hostname} and {dpuhost2.hostname} are identical")
+        return True
+    else:
+        logger.warning(f" flows for {dpuhost1.hostname} and {dpuhost2.hostname} are different")
+        log_flow_map_diff(flow_map1, flow_map2, dpuhost1.hostname, dpuhost2.hostname)
+        return False
+
+
+def compare_flow_tables_pdsctl(dpuhost1, dpuhost2):
     output1 = dpuhost1.shell("pdsctl show flow")["stdout"]
     output2 = dpuhost2.shell("pdsctl show flow")["stdout"]
     flow_table1 = parse_pdsctl_show_flow_output(output1)
@@ -72,3 +163,11 @@ def compare_flow_tables_pdsctl(dpuhost1, dpuhost2):
     else:
         logger.warning(f" flows for {dpuhost1.hostname} and {dpuhost2.hostname} are different")
         return False
+
+
+def compare_flow_tables(dpuhost1, dpuhost2):
+    if 'pensando' not in dpuhost1.facts['asic_type'] or 'pensando' not in dpuhost2.facts['asic_type']:
+        logger.info("not pensando, using sonic-dpu-flow-dump.py")
+        return compare_flow_tables_sonic_dpu_flow_dump(dpuhost1, dpuhost2)
+    else:
+        return compare_flow_tables_pdsctl(dpuhost1, dpuhost2)

--- a/tests/ha/test_ha_steady_state_pl.py
+++ b/tests/ha/test_ha_steady_state_pl.py
@@ -9,7 +9,7 @@ from constants import LOCAL_PTF_INTF, REMOTE_PTF_RECV_INTF, REMOTE_PTF_SEND_INTF
 from gnmi_utils import apply_messages
 from packets import outbound_pl_packets, inbound_pl_packets
 from tests.common.config_reload import config_reload
-from ha_dash_flow_utils import compare_flow_tables_pdsctl
+from ha_dash_flow_utils import compare_flow_tables
 
 logger = logging.getLogger(__name__)
 
@@ -109,7 +109,7 @@ def test_privatelink_basic_transform(
     ptfadapter.dataplane.flush()
     testutils.send(ptfadapter, dash_pl_config[0][LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
     testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, dash_pl_config[0][REMOTE_PTF_RECV_INTF])
-    flow_op = compare_flow_tables_pdsctl(dpuhosts[0], dpuhosts[1])
+    flow_op = compare_flow_tables(dpuhosts[0], dpuhosts[1])
     pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
     testutils.send(ptfadapter, dash_pl_config[0][REMOTE_PTF_SEND_INTF], pe_to_dpu_pkt, 1)
     testutils.verify_packet(ptfadapter, exp_dpu_to_vm_pkt, dash_pl_config[0][LOCAL_PTF_INTF])
@@ -121,7 +121,7 @@ def test_privatelink_basic_transform(
     ptfadapter.dataplane.flush()
     testutils.send(ptfadapter, dash_pl_config[1][LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
     testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, dash_pl_config[0][REMOTE_PTF_RECV_INTF])
-    flow_op = compare_flow_tables_pdsctl(dpuhosts[0], dpuhosts[1])
+    flow_op = compare_flow_tables(dpuhosts[0], dpuhosts[1])
     pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
     testutils.send(ptfadapter, dash_pl_config[1][REMOTE_PTF_SEND_INTF], pe_to_dpu_pkt, 1)
     testutils.verify_packet(ptfadapter, exp_dpu_to_vm_pkt, dash_pl_config[0][LOCAL_PTF_INTF])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add a non-Pensando flow-table comparison path so HA steady-state tests actually verify flow parity on non-Pensando DPUs (instead of silently returning `True`).

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

`compare_flow_tables_pdsctl` returned `True` unconditionally for non-Pensando DPUs, making the flow-table assertion in `test_privatelink_basic_transform` a no-op on those platforms. As a result HA steady-state runs on non-Pensando DPUs were not actually validating that primary and standby DPUs converge to the same flow table.

#### How did you do it?

- `tests/ha/ha_dash_flow_utils.py`:
  - Added `compare_flow_tables_sonic_dpu_flow_dump` using `sonic-dpu-flow-dump.py`, with JSON parsing (`parse_sonic_dpu_flow_dump_output`) and a structured diff log (`log_flow_map_diff`) that reports flows-only-on-host-A, flows-only-on-host-B, and per-attribute differences for matching keys.
  - Introduced a stable flow key (`ENI_MAC`, `VNET_ID`, `SRC_IP`, `SRC_PORT`, `DST_IP`, `DST_PORT`, `IP_PROTO`) and an ignore list (`EPOCH`, `UNDERLAY0_SMAC`, `UNDERLAY0_DMAC`, `VERSION`) so timestamps / MACs / the known-buggy `VERSION` field don't cause false diffs.
  - Removed the Pensando guard from `compare_flow_tables_pdsctl` (it now always runs the pdsctl path when called).
  - Added a `compare_flow_tables` dispatcher that picks `pdsctl` for Pensando and `sonic-dpu-flow-dump.py` otherwise.
- `tests/ha/test_ha_steady_state_pl.py`: switched both call sites in `test_privatelink_basic_transform` from `compare_flow_tables_pdsctl` to `compare_flow_tables`.

Sample output:
```
ha_dash_flow_utils:ha_dash_flow_utils.py:134  flows for <host-a> and <host-b> are identical
```
