### PR TITLE
Fix test_crm_neighbor for broadcom-dnx VOQ platforms

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -1003,7 +1003,11 @@ def test_crm_neighbor(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     crm_stats_neighbor_used, crm_stats_neighbor_available = get_crm_stats(get_neighbor_stats, duthost)
 
     # Add reachability to the neighbor
-    if is_cisco_device(duthost):
+    # Cisco and broadcom-dnx VOQ platforms need the host IP on the interface
+    # so the neighbor address is in-subnet and gets programmed by orchagent.
+    needs_host_ip = is_cisco_device(duthost) or \
+        duthost.facts.get("platform_asic") == "broadcom-dnx"
+    if needs_host_ip:
         asichost.config_ip_intf(crm_interface[0], host, "add")
     # Add neighbor
     asichost.shell(neighbor_add_cmd)
@@ -1018,7 +1022,7 @@ def test_crm_neighbor(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                   "\"crm_stats_ipv4_neighbor_available\" counter was not decremented")
 
     # Remove reachability to the neighbor
-    if is_cisco_device(duthost):
+    if needs_host_ip:
         asichost.config_ip_intf(crm_interface[0], host, "remove")
     # Remove neighbor
     asichost.shell(neighbor_del_cmd)


### PR DESCRIPTION
**Description of PR**

**Summary:**
On broadcom-dnx VOQ platforms (e.g. Q3D), `test_crm_neighbor` fails for IPv4 because the CRM counter does not increment when the neighbor address (2.2.2.2) is outside the interface's configured subnet (10.0.0.0/31).

Investigation shows that the kernel accepts the neighbor entry and orchagent programs it into SAI (`addNeighbor: Created neighbor` in syslog, `SAI_OBJECT_TYPE_NEIGHBOR_ENTRY` create in sairedis). However, on some vendor SAI implementations, CRM accounting does not count out-of-subnet neighbor entries, so `crm_stats_ipv4_neighbor_used` never increments and the test assertion fails.

The test already handles this for Cisco devices by adding the host IP (2.2.2.1/8 or 2001::2/64) to the interface before adding the neighbor, making the neighbor address in-subnet. This PR extends that logic to broadcom-dnx platforms so CRM correctly tracks the entry.

Fixes persistent `test_crm_neighbor[IPv4]` failure on single-asic broadcom-dnx VOQ switches.

**Type of change**
- Bug fix

**Approach**

*What is the motivation for this PR?*

`test_crm_neighbor` has been failing on single-asic broadcom-dnx VOQ platforms with:
```
Failed: "crm_stats_ipv4_neighbor_used" counter was not incremented or 
"crm_stats_ipv4_neighbor_available" counter was not decremented
```

Root cause: The test adds neighbor 2.2.2.2 on PortChannel101 which has IP 10.0.0.0/31. Since 2.2.2.2 is outside the /31 subnet, the neighbor gets programmed into SAI but the CRM counter does not account for it on some vendor SAI implementations — the counter stays unchanged even though the neighbor entry exists in hardware.

Note: This behavior is vendor-SAI-specific. Some broadcom-dnx SAI implementations do correctly update CRM for out-of-subnet neighbors, while others do not. Adding the host IP to make the neighbor in-subnet ensures consistent CRM behavior across all broadcom-dnx vendor SAI implementations.

*How did you do it?*

Extended the existing Cisco host-IP-add logic to also apply to broadcom-dnx platforms:
```python
# Before (only Cisco):
if is_cisco_device(duthost):
    asichost.config_ip_intf(crm_interface[0], host, "add")

# After (Cisco + broadcom-dnx):
needs_host_ip = is_cisco_device(duthost) or \
    duthost.facts.get("platform_asic") == "broadcom-dnx"
if needs_host_ip:
    asichost.config_ip_intf(crm_interface[0], host, "add")
```
Same change for the cleanup (remove) path. No other platforms are affected.

*How did you verify/test it?*

Tested on a broadcom-dnx Q3D single-ASIC VOQ platform (`switch_type: voq`):

| Test | Without fix | With fix |
|------|-------------|----------|
| test_crm_neighbor[IPv4] | FAILED — CRM counter not incremented | PASSED |
| test_crm_neighbor[IPv6] | PASSED | PASSED |

Manual verification on the DUT confirmed:
- `ip neigh replace 2.2.2.2 ... dev PortChannel101` — neighbor appears in kernel AND orchagent programs it into SAI
- CRM counter does NOT increment for the out-of-subnet neighbor
- After adding host IP (2.2.2.1/8), CRM counter correctly increments

*Any platform specific information?*

Affects broadcom-dnx platforms where vendor SAI does not update CRM counters for out-of-subnet neighbors. Safe for all platforms — on SAI implementations where CRM already works without the host IP, adding it is a no-op since the neighbor was already being counted.

*Supported testbed topology if it's a new test case?*

N/A — bug fix for existing test supporting `any` and `t1-multi-asic` topologies.