### PR TITLE
Add testbed-specific delay for acl and everflow

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -25,7 +25,7 @@ from tests.common.fixtures.ptfhost_utils import \
     copy_arp_responder_py, run_garp_service, change_mac_addresses   # noqa: F401
 from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr     # noqa: F401
 from tests.common.helpers.constants import ARP_RESPONDER_DEFAULT_CONFIG, DEFAULT_NAMESPACE
-from tests.common.utilities import get_plt_reboot_ctrl, wait_until, check_msg_in_syslog
+from tests.common.utilities import get_plt_wait_time, wait_until, check_msg_in_syslog
 from tests.common.utilities import get_all_upstream_neigh_type, get_all_downstream_neigh_type
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts         # noqa: F401
 from tests.common.platform.processes_utils import wait_critical_processes
@@ -1092,8 +1092,8 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
             logger.info('Skip checking rule counters for vs platform')
             return True
 
-        reboot_dict = get_plt_reboot_ctrl(duthost, "acl/test_acl.py", None)
-        wait = reboot_dict.get("wait", 300)
+        plt_wait_dict = get_plt_wait_time(duthost, "acl/test_acl.py")
+        wait = plt_wait_dict.get("wait", 300)
         logger.info('Wait for {} to ensure all rule counters are ready'.format(wait))
         return wait_until(wait, 2, 0, self.check_rule_counters_internal, duthost)
 

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -1092,9 +1092,9 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
             logger.info('Skip checking rule counters for vs platform')
             return True
 
-        reboot_dict = get_plt_reboot_ctrl(duthost, "acl/test_acl.py", None)        
+        reboot_dict = get_plt_reboot_ctrl(duthost, "acl/test_acl.py", None)
         wait = reboot_dict.get("wait", 300)
-        logger.info('Wait for {} to ensure all rule counters are ready'.format(wait))  
+        logger.info('Wait for {} to ensure all rule counters are ready'.format(wait))
         return wait_until(wait, 2, 0, self.check_rule_counters_internal, duthost)
 
     def check_rule_counters_internal(self, duthost):

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -25,7 +25,7 @@ from tests.common.fixtures.ptfhost_utils import \
     copy_arp_responder_py, run_garp_service, change_mac_addresses   # noqa: F401
 from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr     # noqa: F401
 from tests.common.helpers.constants import ARP_RESPONDER_DEFAULT_CONFIG, DEFAULT_NAMESPACE
-from tests.common.utilities import wait_until, check_msg_in_syslog
+from tests.common.utilities import get_plt_reboot_ctrl, wait_until, check_msg_in_syslog
 from tests.common.utilities import get_all_upstream_neigh_type, get_all_downstream_neigh_type
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts         # noqa: F401
 from tests.common.platform.processes_utils import wait_critical_processes
@@ -1092,8 +1092,10 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
             logger.info('Skip checking rule counters for vs platform')
             return True
 
-        logger.info('Wait all rule counters are ready')
-        return wait_until(300, 2, 0, self.check_rule_counters_internal, duthost)
+        reboot_dict = get_plt_reboot_ctrl(duthost, "acl/test_acl.py", None)        
+        wait = reboot_dict.get("wait", 300)
+        logger.info('Wait for {} to ensure all rule counters are ready'.format(wait))  
+        return wait_until(wait, 2, 0, self.check_rule_counters_internal, duthost)
 
     def check_rule_counters_internal(self, duthost):
         for asic_id in duthost.get_frontend_asic_ids():

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -873,6 +873,33 @@ def get_plt_reboot_ctrl(duthost, tc_name, reboot_type):
 
     return reboot_dict
 
+def get_plt_wait_time(duthost, tc_name):
+    """
+    @summary: utility function returns platform specific wait dict for each
+    test case that contains tc_name in it
+    @return a dict containing wait time and timeout for each test case
+
+        plt_wait_time:
+          acl/test_acl.py:
+            timeout: 300
+            wait: 300
+          everflow:
+            timeout: 300
+            wait: 60
+    """
+
+    wait_dict= dict()
+    im = duthost.sonichost.host.options['inventory_manager']
+    inv_files = im._sources
+    dut_vars = get_host_visible_vars(inv_files, duthost.hostname)
+
+    if 'plt_wait_time' in dut_vars:
+        for key in list(dut_vars['plt_wait_time'].keys()):
+            if key in tc_name:
+                for mod_id in list(dut_vars['plt_wait_time'][key].keys()):
+                    wait_dict[mod_id] = dut_vars['plt_wait_time'][key][mod_id]
+
+    return wait_dict
 
 def pdu_reboot(pdu_controller):
     """Power-cycle the DUT by turning off and on the PDU outlets.

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -873,6 +873,7 @@ def get_plt_reboot_ctrl(duthost, tc_name, reboot_type):
 
     return reboot_dict
 
+
 def get_plt_wait_time(duthost, tc_name):
     """
     @summary: utility function returns platform specific wait dict for each
@@ -888,7 +889,7 @@ def get_plt_wait_time(duthost, tc_name):
             wait: 60
     """
 
-    wait_dict= dict()
+    wait_dict = dict()
     im = duthost.sonichost.host.options['inventory_manager']
     inv_files = im._sources
     dut_vars = get_host_visible_vars(inv_files, duthost.hostname)
@@ -900,6 +901,7 @@ def get_plt_wait_time(duthost, tc_name):
                     wait_dict[mod_id] = dut_vars['plt_wait_time'][key][mod_id]
 
     return wait_dict
+
 
 def pdu_reboot(pdu_controller):
     """Power-cycle the DUT by turning off and on the PDU outlets.

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -20,7 +20,7 @@ from scapy.packet import Raw
 from abc import abstractmethod
 from ptf.mask import Mask
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import wait_until, check_msg_in_syslog
+from tests.common.utilities import wait_until, check_msg_in_syslog, get_plt_reboot_ctrl
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.utilities import find_duthost_on_role
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
@@ -627,6 +627,23 @@ def validate_acl_rules_in_asic_db(duthost):
 
     # Validate ACL rule RIDs across all ASICs
     return validate_acl_rule_rids(duthost)
+
+
+def wait_for_acl_rules_in_asic_db(duthost):
+    """
+    Wait until the ACL rules in ASIC DB match CONFIG DB and RIDs are valid.
+
+    Uses the platform-specific wait time from get_plt_reboot_ctrl (key "everflow"),
+    defaulting to 120 seconds if not configured.
+
+    Args:
+        duthost: DUT host object
+    """
+    acl_rule_wait_time = get_plt_reboot_ctrl(duthost, "everflow", None).get("wait", 120)
+    pytest_assert(
+        wait_until(acl_rule_wait_time, 10, 0, validate_acl_rules_in_asic_db, duthost),
+        "ACL rules in ASIC DB did not match CONFIG DB within {} seconds".format(acl_rule_wait_time)
+    )
 
 
 # TODO: This should be refactored to some common area of sonic-mgmt.

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -20,7 +20,7 @@ from scapy.packet import Raw
 from abc import abstractmethod
 from ptf.mask import Mask
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import wait_until, check_msg_in_syslog, get_plt_reboot_ctrl
+from tests.common.utilities import wait_until, check_msg_in_syslog, get_plt_wait_time
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.utilities import find_duthost_on_role
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
@@ -633,13 +633,13 @@ def wait_for_acl_rules_in_asic_db(duthost):
     """
     Wait until the ACL rules in ASIC DB match CONFIG DB and RIDs are valid.
 
-    Uses the platform-specific wait time from get_plt_reboot_ctrl (key "everflow"),
+    Uses the platform-specific wait time from get_plt_wait_time (key "everflow"),
     defaulting to 120 seconds if not configured.
 
     Args:
         duthost: DUT host object
     """
-    acl_rule_wait_time = get_plt_reboot_ctrl(duthost, "everflow", None).get("wait", 120)
+    acl_rule_wait_time = get_plt_wait_time(duthost, "everflow").get("wait", 120)
     pytest_assert(
         wait_until(acl_rule_wait_time, 10, 0, validate_acl_rules_in_asic_db, duthost),
         "ACL rules in ASIC DB did not match CONFIG DB within {} seconds".format(acl_rule_wait_time)

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -226,6 +226,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                        config_method, rules=EVERFLOW_V6_RULES)
             self.apply_ip_type_rule(duthost, 6)
 
+        everflow_utils.wait_for_acl_rules_in_asic_db(everflow_dut)
+
         yield
 
         for duthost in duthost_set:

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -318,7 +318,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         pytest_assert(
             wait_until(120, 10, 0, everflow_utils.validate_asic_route, remote_dut, session_prefixes[0])
         )
-        pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_acl_rules_in_asic_db, everflow_dut))
+        everflow_utils.wait_for_acl_rules_in_asic_db(everflow_dut)
 
         # Verify that mirrored traffic is sent along the route we installed
         rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
@@ -431,7 +431,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         pytest_assert(
             wait_until(120, 10, 0, everflow_utils.validate_asic_route, remote_dut, session_prefixes[0])
         )
-        pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_acl_rules_in_asic_db, everflow_dut))
+        everflow_utils.wait_for_acl_rules_in_asic_db(everflow_dut)
 
         # Verify that mirrored traffic is sent along the route we installed
         rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
@@ -519,7 +519,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         pytest_assert(
             wait_until(120, 10, 0, everflow_utils.validate_asic_route, remote_dut, session_prefixes[0])
         )
-        pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_acl_rules_in_asic_db, everflow_dut))
+        everflow_utils.wait_for_acl_rules_in_asic_db(everflow_dut)
 
         tx_port = setup_info[dest_port_type]["dest_port"][1]
         peer_ip_1 = everflow_utils.get_neighbor_info(remote_dut, tx_port, tbinfo, ip_version=erspan_ip_ver)
@@ -633,7 +633,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         pytest_assert(
             wait_until(120, 10, 0, everflow_utils.validate_asic_route, remote_dut, session_prefixes[0])
         )
-        pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_acl_rules_in_asic_db, everflow_dut))
+        everflow_utils.wait_for_acl_rules_in_asic_db(everflow_dut)
 
         # Verify that mirrored traffic is sent along the route we installed
         rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
@@ -827,7 +827,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
                                        config_method,
                                        rules=EVERFLOW_DSCP_RULES)
 
-            pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_acl_rules_in_asic_db, everflow_dut))
+            everflow_utils.wait_for_acl_rules_in_asic_db(everflow_dut)
             # Clear counters before test
             clear_interface_counters(everflow_dut)
             clear_queue_counters(everflow_dut, None)
@@ -892,7 +892,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         pytest_assert(
             wait_until(120, 10, 0, everflow_utils.validate_asic_route, remote_dut, session_prefixes[0])
         )
-        pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_acl_rules_in_asic_db, everflow_dut))
+        everflow_utils.wait_for_acl_rules_in_asic_db(everflow_dut)
 
         # Verify that mirrored traffic is sent along the route we installed
         rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
@@ -1139,7 +1139,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
                 everflow_utils.validate_asic_route, remote_dut, session_prefixes[0]
             )
         )
-        pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_acl_rules_in_asic_db, remote_dut))
+        everflow_utils.wait_for_acl_rules_in_asic_db(remote_dut)
 
         # Verify that mirrored traffic is sent along the route we installed
         rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Add testbed specific delays for ACL and Everflow to allow higher wait for platforms which are slower

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Some platforms need longer time for acl programming leading to test failures. Instead of increasing delay for all platform, move this to the inventory file, where platform specific delays can be specified. If no additional delay is specified, it defaults to the current value

#### How did you do it?
Use wait time specified in inventory if available 

#### How did you verify/test it?
Run acl and everfow test suite

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
