### PR TITLE
Update the gNMI setup without authentication for liquid cooling case

### DIFF
--- a/tests/common/helpers/liquid_leakage_control_test_helper.py
+++ b/tests/common/helpers/liquid_leakage_control_test_helper.py
@@ -193,7 +193,7 @@ def startmonitor_gnmi_event(duthost, ptfhost):
     timeout = WAIT_GNMI_LD_EVENT_TIMEOUT
     gnmi_subscribe_cmd = f"python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t {dut_mgmt_ip} -p 50052 -m subscribe \
     -x all[heartbeat=2] -xt EVENTS -o ndastreamingservertest --subscribe_mode 0 --submode 1 --interval 0 \
-    --update_count 0 --create_connections 1 --filter_event_regex sonic-events-host --timeout {timeout}"
+    --update_count 0 --create_connections 1 --filter_event_regex sonic-events-host --timeout {timeout} -n"
     result = ptfhost.shell(gnmi_subscribe_cmd, module_ignore_errors=True)['stdout']
     logging.info(f"gnmi subscribe cmd: {gnmi_subscribe_cmd} \n gnmi event result: {result}")
     return result
@@ -241,7 +241,7 @@ def get_liquid_cooling_update_interval(dut):
 @pytest.fixture(scope="function")
 def setup_gnmi_server(duthosts, rand_one_dut_hostname, localhost, ptfhost):
     '''
-    Setup GNMI server with client certificates
+    Setup GNMI server with client without authentication
     '''
     duthost = duthosts[rand_one_dut_hostname]
 
@@ -250,14 +250,6 @@ def setup_gnmi_server(duthosts, rand_one_dut_hostname, localhost, ptfhost):
         check_container_state(duthost, gnmi_container(duthost), should_be_running=True),
         "Test was not supported on devices which do not support GNMI!")
     duthost.shell("sonic-db-cli CONFIG_DB hset 'GNMI|gnmi' port 50052")
-    duthost.shell("sonic-db-cli CONFIG_DB hset 'GNMI|gnmi' client_auth true")
-
-    duthost.shell(
-        "sonic-db-cli CONFIG_DB hset 'GNMI|certs' ca_crt /etc/sonic/telemetry/dsmsroot.cer")
-    duthost.shell(
-        "sonic-db-cli CONFIG_DB hset 'GNMI|certs' server_crt /etc/sonic/telemetry/streamingtelemetryserver.cer")
-    duthost.shell(
-        "sonic-db-cli CONFIG_DB hset 'GNMI|certs' server_key /etc/sonic/telemetry/streamingtelemetryserver.key")
     duthost.shell('sonic-db-cli CONFIG_DB HSET "GNMI|gnmi" "client_auth" "false"')
     duthost.shell('sudo systemctl reset-failed gnmi')
     duthost.shell('sudo service gnmi restart')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Update the gNMI setup without authentication to simplify the test logic. We do not need to validate gNMI authentication; we only need to verify that the gNMI message is triggered and received.

Previously, we used a workaround for gNMI authentication to test on chipless BU（syncd and swss will be disabled due to no asic. Later, we found that py_gnmicli.py provides a parameter to skip authentication, so we updated it. As a result, this change works for both chipless and normal setups.

Test coverage for gnmi authentication is not impacted, since there are already multiple test cases (such as test_gnmi.py)that cover gNMI authentication.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Update the gNMI setup without authentication for liquid cooling case to simplify the test logic. 

#### How did you do it?
when call py_gnmicli.py, add parameter '-n'

#### How did you verify/test it?
run the liquid cooling test 

#### Any platform specific information?
platform supporting liquid cooling

#### Supported testbed topology if it's a new test case?
Any

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
