### PR TITLE
Fix IPv6 address formatting in gRPC fixtures for grpcurl commands

### DIFF
--- a/tests/common/fixtures/grpc_fixtures.py
+++ b/tests/common/fixtures/grpc_fixtures.py
@@ -38,6 +38,14 @@ logger = logging.getLogger(__name__)
 
 GRPCURL_VERSION = "1.9.3"
 
+
+def _format_target(host, port):
+    """Format host:port, wrapping IPv6 addresses in square brackets."""
+    if ':' in str(host):
+        return f"[{host}]:{port}"
+    return f"{host}:{port}"
+
+
 # Architecture mapping: dpkg --print-architecture → grpcurl release suffix
 _GRPCURL_ARCH_MAP = {
     "amd64": "linux_x86_64",
@@ -231,7 +239,7 @@ def gnmi_tls(request, duthost, ptfhost):
         # Build coupled client with the exact config we just set up
         host = duthost.mgmt_ip
         port = grpc_config.DEFAULT_TLS_PORT
-        target = f"{host}:{port}"
+        target = _format_target(host, port)
 
         ptf_cert_paths = grpc_config.get_ptf_cert_paths()
         cert_paths = CertPaths(
@@ -314,7 +322,7 @@ def gnmi_plaintext(duthost, ptfhost):
     """
     host = duthost.mgmt_ip
     port = grpc_config.DEFAULT_PLAINTEXT_PORT
-    target = f"{host}:{port}"
+    target = _format_target(host, port)
 
     client = PtfGrpc(ptfhost, target, plaintext=True)
     gnoi_client = PtfGnoi(client)
@@ -526,7 +534,7 @@ def _verify_gnoi_tls_connectivity(duthost, ptfhost):
     logger.info("Verifying gNOI TLS connectivity")
 
     cacert_arg, cert_arg, key_arg = grpc_config.get_grpcurl_cert_args()
-    target = f"{duthost.mgmt_ip}:{grpc_config.DEFAULT_TLS_PORT}"
+    target = _format_target(duthost.mgmt_ip, grpc_config.DEFAULT_TLS_PORT)
 
     # -connect-timeout bounds the TCP/TLS handshake portion; -max-time bounds
     # the whole call. Both keep a single retry attempt from hanging if packets


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fix IPv6 address formatting in gRPC fixtures for grpcurl commands

Wrap IPv6 management addresses in square brackets when constructing host:port targets, preventing 'too many colons in address' errors from grpcurl/Go's net.Dial on IPv6-only management setups.
  

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Fix IPv6 address formatting in gRPC fixtures for grpcurl commands

#### How did you do it?
Wrap IPv6 management addresses in square brackets when constructing host:port targets, preventing 'too many colons in address' errors from grpcurl/Go's net.Dial on IPv6-only management setups.

#### How did you verify/test it?
Run the relevant tests on ipv6 setup

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
