### PR TITLE
Save NTP config in gNMI fixture to survive DUT reboot

### DIFF
--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -34,7 +34,11 @@ def setup_gnmi_ntp_client_server(duthosts, rand_one_dut_hostname, ptfhost):
     duthost_mgmt_info = duthost.get_mgmt_ip()
     use_v6 = duthost_mgmt_info["version"] == "v6"
     with setup_ntp_context(ptfhost, duthost, use_v6):
+        # Persist NTP config so it survives DUT reboot (gNOI reboot tests)
+        duthost.shell("config save -y", module_ignore_errors=True)
         yield
+    # After teardown restores original NTP servers, save again
+    duthost.shell("config save -y", module_ignore_errors=True)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
### Description of PR

Summary:
When the original NTP server is unreachable, `setup_gnmi_ntp_client_server` configures PTF as a fallback NTP server via `setup_ntp_context`. However, this config change is only in the running config — it is never saved to disk. During gNOI reboot tests, the DUT reboots and loads config from disk, reverting to the original (broken) NTP server. Chrony cannot sync (Reach=0), and `apply_cert_config()` fails at the NTP sync assertion in `reconfigure_after_reboot()`.

Fix the failures:
```
    assert is_time_synced, "Failed to synchronize DUT system time with NTP Server"
           ^^^^^^^^^^^^^^
AssertionError: Failed to synchronize DUT system time with NTP Server
```
### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
`test_gnoi_system_reboot_cold` and `test_gnoi_system_reboot_warm` fail on testbeds where the lab NTP server is unreachable. The module-scoped fixture `setup_gnmi_ntp_client_server` detects NTP is not synced and correctly uses `setup_ntp_context` to configure PTF as a fallback NTP server. This works for the initial `apply_cert_config()` call. However, after the gNOI System.Reboot triggers a DUT reboot, the running config is lost and the DUT reverts to the original (broken) NTP server. The post-reboot `apply_cert_config()` then fails because chrony cannot sync with the unreachable server.

#### How did you do it?
Added `config save -y` in two places in `setup_gnmi_ntp_client_server` fixture (`tests/gnmi/conftest.py`):
1. **After setup**: After `setup_ntp_context` configures PTF as NTP server, call `config save -y` so the fallback NTP config persists through DUT reboot.
2. **After teardown**: After `setup_ntp_context` restores the original NTP servers, call `config save -y` to leave the saved config clean.

#### How did you verify/test it?
Tested on testbed (SONiC 20251110.25, Arista-7260CX3-D108C8) where NTP server  s unreachable (chronyc sources shows Reach=0):
- **Before fix:** `test_gnoi_system_reboot_cold` FAILED at `assert is_time_synced` — after reboot, DUT reverts to broken NTP server, chrony cannot sync within 180s timeout.
- **After fix:** `2 passed, 1 skipped in 1068.67s (17m48s)` — after reboot, DUT keeps PTF as NTP server from saved config, chrony syncs successfully, `apply_cert_config()` passes.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A