### PR TITLE
Improve reboot-cause check failure messages with expected vs actual details

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -571,13 +571,26 @@ def get_reboot_cause(dut):
 
 def check_reboot_cause(dut, reboot_cause_expected):
     """
-    @summary: Check the reboot cause on DUT. Can be used with wailt_until
+    @summary: Check the reboot cause on DUT. Can be used with wait_until
     @param dut: The AnsibleHost object of DUT.
     @param reboot_cause_expected: The expected reboot cause.
     """
     reboot_cause_got = get_reboot_cause(dut)
-    logger.debug("dut {} last reboot-cause {}".format(dut.hostname, reboot_cause_got))
-    return reboot_cause_got == reboot_cause_expected
+    logger.info("dut %s last reboot-cause: got '%s', expected '%s'",
+                dut.hostname, reboot_cause_got, reboot_cause_expected)
+    if reboot_cause_got != reboot_cause_expected:
+        cause_output = dut.shell('show reboot-cause')['stdout']
+        expected_pattern = reboot_ctrl_dict.get(
+            reboot_cause_expected, {}
+        ).get('cause', reboot_cause_expected)
+        logger.warning(
+            "dut %s reboot-cause mismatch: expected type='%s' "
+            "(pattern='%s'), got type='%s', raw output='%s'",
+            dut.hostname, reboot_cause_expected, expected_pattern,
+            reboot_cause_got, cause_output
+        )
+        return False
+    return True
 
 
 def sync_reboot_history_queue_with_dut(dut):

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -13,7 +13,7 @@ import pytest
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts     # noqa: F401
 from tests.common.fixtures.grpc_fixtures import gnmi_tls  # noqa: F401
 from tests.common.utilities import wait_until, get_plt_reboot_ctrl
-from tests.common.reboot import check_reboot_cause,\
+from tests.common.reboot import check_reboot_cause, get_reboot_cause,\
     check_reboot_cause_history, check_determine_reboot_cause_service, reboot_ctrl_dict,\
     wait_for_startup, REBOOT_TYPE_HISTOYR_QUEUE, REBOOT_TYPE_COLD,\
     REBOOT_TYPE_SOFT, REBOOT_TYPE_FAST, REBOOT_TYPE_WARM, REBOOT_TYPE_WATCHDOG
@@ -159,8 +159,20 @@ def check_interfaces_and_services(dut, interfaces, xcvr_skip_list,
             check_determine_reboot_cause_service(dut)
 
         logging.info("Check reboot cause")
-        assert wait_until(MAX_WAIT_TIME_FOR_REBOOT_CAUSE, 20, 30, check_reboot_cause, dut, reboot_type), \
-            "got reboot-cause failed after rebooted by %s" % reboot_type
+        if not wait_until(MAX_WAIT_TIME_FOR_REBOOT_CAUSE, 20, 30,
+                          check_reboot_cause, dut, reboot_type):
+            actual_type = get_reboot_cause(dut)
+            raw_output = dut.shell('show reboot-cause')['stdout']
+            expected_pattern = reboot_ctrl_dict.get(
+                reboot_type, {}
+            ).get('cause', 'N/A')
+            pytest.fail(
+                "Reboot cause mismatch after '{}' reboot. "
+                "Expected pattern: '{}', actual type: '{}', "
+                "raw 'show reboot-cause' output: '{}'"
+                .format(reboot_type, expected_pattern,
+                        actual_type, raw_output)
+            )
 
         if "201811" in dut.os_version or "201911" in dut.os_version:
             logging.info(


### PR DESCRIPTION
### Description of PR

Summary:
Improve the reboot-cause check failure messages to include expected vs actual reboot cause details. Currently when `check_reboot_cause` fails, the assertion only says `"got reboot-cause failed after rebooted by power off"` without showing what the DUT actually reported or what pattern was expected. This makes nightly test triage difficult because engineers cannot tell from the test summary alone whether the issue is a platform bug, a timing issue, or a test gap.

**Example of current vague message:**
`AssertionError: got reboot-cause failed after rebooted by power off`

**Example of improved message:**
`Reboot cause mismatch after 'power off' reboot. Expected pattern: 'Power Loss', actual type: 'Unknown', raw 'show reboot-cause' output: '<actual DUT output>'`

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
When investigating nightly test failures for `test_power_off_reboot`, the failure summary `"got reboot-cause failed after rebooted by power off"` provides no actionable information. Engineers must dig through the full test log to find what `show reboot-cause` actually returned on the DUT and compare it against the expected pattern. This wastes significant triage time.

Real failure example: [ElasticTest plan 69f86e2026d9738095cf8ff2](https://elastictest.org/scheduler/testplan/69f86e2026d9738095cf8ff2?testcase=platform_tests%2Ftest_power_off_reboot.py&type=console) (ADO BuildId 37158186)

#### How did you do it?
Two targeted changes:

1. **`tests/common/reboot.py` - `check_reboot_cause()`**: Changed the debug log to INFO level showing both expected and actual types. Added a WARNING log on mismatch that includes the expected type, expected regex pattern (from `reboot_ctrl_dict`), actual mapped type, and raw `show reboot-cause` output.

2. **`tests/platform_tests/test_reboot.py` - `check_interfaces_and_services()`**: Replaced the one-liner assert with an explicit check that, on failure, fetches the actual reboot cause one more time and calls `pytest.fail()` with a detailed message including expected pattern, actual type, and raw DUT output.

#### How did you verify/test it?
- Code review of the change logic
- Verified the assertion message format matches what triage engineers need
- Confirmed no CRLF issues in the diff
- Pre-commit checks pass (trailing whitespace, line length, blank lines)

#### Any platform specific information?
N/A - this improves error reporting for all platforms and reboot types.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A