### PR TITLE
temporary fix for test_gnmi.py longer time and larger test log

### DIFF
--- a/tests/gnmi/test_gnmi.py
+++ b/tests/gnmi/test_gnmi.py
@@ -215,6 +215,37 @@ def setup_crl_server_on_ptf(ptfhost, duthosts, rand_one_dut_hostname):
     ptfhost.shell("pkill -9 -f '/root/env-python3/bin/python /root/crl_server.py'", module_ignore_errors=True)
 
 
+def test_gnmi_authorize_failed_with_revoked_cert(duthosts,
+                                                 rand_one_dut_hostname,
+                                                 ptfhost,
+                                                 setup_crl_server_on_ptf):
+    '''
+    Verify GNMI native write, incremental config for configDB
+    GNMI set request with invalid path
+    '''
+    duthost = duthosts[rand_one_dut_hostname]
+
+    retry = 3
+    msg = ""
+    gnmi_log = ""
+    while retry > 0:
+        retry -= 1
+        msg, gnmi_log = gnmi_create_vnet(duthost, ptfhost, "gnmiclient.revoked")
+        # retry when download crl failed, ptf device network not stable
+        if "desc = Peer certificate revoked" in gnmi_log:
+            break
+
+    assert "Unauthenticated" in msg, (
+        "'Unauthenticated' error message not found in GNMI response. "
+        "- Actual message: '{}'"
+    ).format(msg)
+
+    assert "desc = Peer certificate revoked" in gnmi_log, (
+        "'desc = Peer certificate revoked' message not found in GNMI log. "
+        "- Actual GNMI log: '{}'"
+    ).format(gnmi_log)
+
+
 def test_gnmi_subscribe_sample(duthosts, rand_one_dut_hostname, ptfhost):
     '''
     Verify GNMI subscribe sample request
@@ -261,34 +292,3 @@ def test_gnmi_subscribe_sample(duthosts, rand_one_dut_hostname, ptfhost):
         )
         logger.debug("gNMI subscribe response: %s", stdout_msg)
         validates_subscribe_sample(stdout_msg)
-
-
-def test_gnmi_authorize_failed_with_revoked_cert(duthosts,
-                                                 rand_one_dut_hostname,
-                                                 ptfhost,
-                                                 setup_crl_server_on_ptf):
-    '''
-    Verify GNMI native write, incremental config for configDB
-    GNMI set request with invalid path
-    '''
-    duthost = duthosts[rand_one_dut_hostname]
-
-    retry = 3
-    msg = ""
-    gnmi_log = ""
-    while retry > 0:
-        retry -= 1
-        msg, gnmi_log = gnmi_create_vnet(duthost, ptfhost, "gnmiclient.revoked")
-        # retry when download crl failed, ptf device network not stable
-        if "desc = Peer certificate revoked" in gnmi_log:
-            break
-
-    assert "Unauthenticated" in msg, (
-        "'Unauthenticated' error message not found in GNMI response. "
-        "- Actual message: '{}'"
-    ).format(msg)
-
-    assert "desc = Peer certificate revoked" in gnmi_log, (
-        "'desc = Peer certificate revoked' message not found in GNMI log. "
-        "- Actual GNMI log: '{}'"
-    ).format(gnmi_log)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In PR https://github.com/sonic-net/sonic-mgmt/pull/21739, the new added test case will continuously write content to gnmi.log, while in later test case test_gnmi_authorize_failed_with_revoked_cert, it will call dump_gnmi_log() several times and cat the content of gnmi.log to test log, causing the test log 100 times larger(~600mb in mellanox scenario). This fix is a temporary fix for it.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Fix side effect of previous merged code

#### How did you do it?
change the order of the test case, so that the before the test_gnmi_authorize_failed_with_revoked_cert(), there will not be much content in gnmi.log

#### How did you verify/test it?
locally test, the time and log size return to previous level

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
