### PR TITLE
[docs]: Fix sfputil firmware download CLI command typo in transceiver…

### DIFF
--- a/docs/testplan/transceiver/test_plan.md
+++ b/docs/testplan/transceiver/test_plan.md
@@ -1455,7 +1455,7 @@ sudo sfputil show fwversion <port>
 Download firmware
 
 ```
-sudo sfputil download <port> <fwfile>
+sudo sfputil firmware download <port> <fwfile>
 ```
 
 Run firmware


### PR DESCRIPTION
### Description of PR
Summary:
Fix incorrect CLI command for firmware download in transceiver test plan.
`sudo sfputil download` should be `sudo sfputil firmware download` to match
the actual SONiC sfputil CLI command

Fixes # (N/A)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The CLI command `sudo sfputil download <port> <fwfile>` is incorrect.
The correct command is `sudo sfputil firmware download <port> <fwfile>`,

#### How did you do it?
Updated the command string in `docs/testplan/transceiver/test_plan.md`.

#### How did you verify/test it?
Cross-checked with `sfputil firmware run` / `sfputil firmware commit`
commands in the same document and the SONiC sfputil CLI subcommand structure.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A - documentation fix only

### Documentation
Updated `docs/testplan/transceiver/test_plan.md` to correct the CLI command.