### PR TITLE
[202511] Increase default GCU timeout from 600s to 900s

### DIFF
--- a/tests/common/gu_utils.py
+++ b/tests/common/gu_utils.py
@@ -649,4 +649,9 @@ def get_bgp_speaker_runningconfig(duthost):
 
 
 def get_gcu_timeout(duthost):
-    return GCUTIMEOUT_MAP.get(duthost.facts['platform'], 600)
+    """Return the GCU apply-patch timeout (in seconds) for this platform.
+
+    Platforms listed in GCUTIMEOUT_MAP get a custom value; everything
+    else defaults to 900 s.
+    """
+    return GCUTIMEOUT_MAP.get(duthost.facts['platform'], 900)


### PR DESCRIPTION
#### Why I did it

Cherry-pick of #24427 into 202511 (auto cherry-pick had conflicts).

The default GCU (Generic Config Updater) apply-patch timeout of 600 seconds is insufficient for some platforms, causing test failures. This increases the default to 900 seconds.

#### How I did it

Applied the same change from #24427 to the 202511 branch version of `tests/common/gu_utils.py`:
- Added docstring to `get_gcu_timeout()`
- Changed default timeout from 600s to 900s

#### How to verify it

Run any GCU test on a platform not listed in `GCUTIMEOUT_MAP` and verify the timeout is 900s.

#### Conflict resolution

On master, `get_gcu_timeout()` already had a multi-line docstring added by a prior PR. On 202511, the function was a one-liner without a docstring. Resolved by applying both the docstring addition and the timeout value change to the 202511 version.
