### PR TITLE
drop_counters/conftest: fix loganalyzer and route_check for lt2 topology variants

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3353,9 +3353,9 @@ def temporarily_disable_route_check(request, tbinfo, duthosts):
             check_flag = True
             break
 
-    allowed_topologies = {"t2", "ut2", "lt2"}
+    allowed_topo_types = ("t2", "ut2", "lt2")
     topo_name = tbinfo['topo']['name']
-    if check_flag and topo_name not in allowed_topologies:
+    if check_flag and not any(topo_name == t or topo_name.startswith(t + "-") for t in allowed_topo_types):
         logger.info("Topology {} is not allowed for temporarily_disable_route_check fixture".format(topo_name))
         check_flag = False
 

--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -62,12 +62,19 @@ def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loga
     CopperCableIgnoreRegex = [
         ".* ERR pmon#xcvrd.*no suitable app for the port appl.*host_lane_count.*host_speed.*"
     ]
+    # Ignore transient syncd error during config_reload when FlexCounter polls a port VID that was
+    # briefly removed/re-created (e.g. after port split). syncd self-heals by removing the stale entry.
+    FlexCounterPortNotFoundRegex = [
+        r".* ERR syncd\d*#syncd: :- processFlexCounterEvent: port VID .* was not found "
+        r"\(probably port was removed/splitted\) and will remove from counters now"
+    ]
     duthost = duthosts[rand_one_dut_hostname]
     if loganalyzer:  # Skip if loganalyzer is disabled
         if duthost.facts["asic_type"] == "vs":
             loganalyzer[duthost.hostname].ignore_regex.extend(KVMIgnoreRegex)
         loganalyzer[duthost.hostname].ignore_regex.extend(SAISwitchIgnoreRegex)
         loganalyzer[duthost.hostname].ignore_regex.extend(CopperCableIgnoreRegex)
+        loganalyzer[duthost.hostname].ignore_regex.extend(FlexCounterPortNotFoundRegex)
         if duthost.sonichost.facts['platform_asic'] == 'broadcom':
             ignore_regex = r".* ERR swss#orchagent:\s*.*\s*queryAattributeEnumValuesCapability:\s*returned value " \
                 r"\d+ is not allowed on SAI_SWITCH_ATTR_(?:ECMP|LAG)_DEFAULT_HASH_ALGORITHM.*"


### PR DESCRIPTION
### Description of PR
Summary:
Fix two test reliability issues on lt2-type testbeds (e.g. Arista-7060X6-64PE-P32O64 running `lt2-p32o64` topology):

1. **`test_drop_counters.py::test_ip_pkt_with_expired_ttl` loganalyzer false positive**
   The `configure_copp_drop_for_ttl_error` fixture calls `config_reload` in teardown. During reload orchagent sends new port VIDs to syncd via the ASIC channel before syncd has finished populating its VID→RID translation map. syncd logs `ERR processFlexCounterEvent: port VID … was not found (probably port was removed/splitted) and will remove from counters now` for each unresolved VID, then self-heals by removing the stale counter entry. This is a known benign race that loganalyzer was catching and failing the test.

2. **`temporarily_disable_route_check` not effective for lt2-variant topologies**
   The fixture compared `topo_name` against an exact set `{"t2", "ut2", "lt2"}`. Topology names such as `lt2-p32o64` did not match exactly, so monit `routeCheck` was never stopped on those testbeds. During `config_reload` the monit `routeCheck` fires inside the BGP convergence window and reports BGP routes as `missed_ROUTE_TABLE_routes`, which can cause loganalyzer failures in other tests.

### Type of change
- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Two related test reliability failures on Arista-7060X6-64PE-P32O64 (lt2-p32o64 topology).

#### How did you do it?
1. Added `FlexCounterPortNotFoundRegex` to the `ignore_expected_loganalyzer_exceptions` fixture in `test_drop_counters.py` to suppress the known transient syncd error during `config_reload`.
2. Changed `temporarily_disable_route_check` in `conftest.py` from exact set membership `topo_name not in {"t2", "ut2", "lt2"}` to prefix+delimiter matching (`topo_name == t or topo_name.startswith(t + "-")`), so topology variants like `lt2-p32o64` are correctly treated as lt2-type and have routeCheck disabled during the test.

#### How did you verify/test it?
- Observed the syncd error firing during `config_reload` teardown; confirmed self-healing behavior from syncd source (Syncd.cpp `processFlexCounterEvent`).
- Verified the topo_name `lt2-p32o64` does not match the old exact set, explaining why routeCheck was never stopped. Confirmed new prefix logic covers `lt2-p32o64`, `t2-lag`, `ut2`, `lt2`, `t2`, etc. without false positives for unrelated topology names.

#### Any platform specific information?
Arista-7060X6-64PE-P32O64 (broadcom ASIC) running lt2-p32o64 topology.

#### Supported testbed topology if it's a new test case?
N/A — bug fixes only.

### Documentation