### PR TITLE
Optimize the execution time of everflow ipv6 test cases on dualtor setup

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -46,12 +46,14 @@ from tests.ptf_runner import ptf_runner
 
 __all__ = ['tor_mux_intf', 'tor_mux_intfs', 'ptf_server_intf', 't1_upper_tor_intfs', 't1_lower_tor_intfs',
            'upper_tor_host', 'lower_tor_host', 'force_active_tor', 'force_standby_tor',
-           'config_active_active_dualtor_active_standby', 'validate_active_active_dualtor_setup',
+           'config_active_active_dualtor_active_standby', 'config_active_active_dualtor_active_standby_module',
+           'validate_active_active_dualtor_setup',
            'setup_standby_ports_on_rand_selected_tor',
            'setup_standby_ports_on_rand_unselected_tor',
            'setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m',
            'setup_standby_ports_on_non_enum_rand_one_per_hwsku_host_m',
            'setup_standby_ports_on_rand_unselected_tor_unconditionally',
+           'setup_standby_ports_on_rand_unselected_tor_unconditionally_module',
            'setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally',
            ]
 
@@ -1782,22 +1784,32 @@ def config_active_active_dualtor(active_tor, standby_tor, ports, unconditionally
     time.sleep(90)
 
 
-@pytest.fixture
-def config_active_active_dualtor_active_standby(duthosts, active_active_ports, tbinfo):     # noqa: F811
-    """Config the active-active dualtor that one ToR as active and the other as standby."""
-    if not ('dualtor' in tbinfo['topo']['name'] and active_active_ports):
-        yield
+def _check_docker_status(duthost):
+    """Check if all containers on the DUT are fully started."""
+    containers = duthost.get_all_containers()
+    for container in containers:
+        if not duthost.is_service_fully_started(container):
+            return False
+    return True
+
+
+def _restore_mux_ports(duthosts, ports_to_restore):
+    """Restore mux ports to auto mode."""
+    if not ports_to_restore:
         return
 
-    def check_docker_status(duthost):
-        containers = duthost.get_all_containers()
-        for container in containers:
-            if not duthost.is_service_fully_started(container):
-                return False
-        return True
+    restore_cmds = []
+    for port in ports_to_restore:
+        restore_cmds.append("config mux mode auto {}".format(port))
 
+    for duthost in duthosts:
+        duthost.shell_cmds(cmds=restore_cmds)
+
+
+def _create_config_active_active_dualtor_handler(active_active_ports, ports_to_restore):  # noqa: F811
+    """Create a handler function for configuring active-active dualtor."""
     def _config_active_active_dualtor_active_standby(active_tor, standby_tor, ports, unconditionally=False):
-        wait_until(300, 10, 0, check_docker_status, standby_tor)
+        wait_until(300, 10, 0, _check_docker_status, standby_tor)
         for port in ports:
             if port not in active_active_ports:
                 raise ValueError("Port {} is not in the active-active ports".format(port))
@@ -1806,20 +1818,48 @@ def config_active_active_dualtor_active_standby(duthosts, active_active_ports, t
 
         ports_to_restore.extend(ports)
 
+    return _config_active_active_dualtor_active_standby
+
+
+@pytest.fixture(scope="module")
+def config_active_active_dualtor_active_standby_module(duthosts, active_active_ports, tbinfo):  # noqa: F811
+    """Module-level fixture: Config the active-active dualtor that one ToR as active and the other as standby."""
+    if not ('dualtor' in tbinfo['topo']['name'] and active_active_ports):
+        yield None
+        return
+
     ports_to_restore = []
+    handler = _create_config_active_active_dualtor_handler(active_active_ports, ports_to_restore)
 
     warnings.warn("Deprecated mux port setup fixture, please use setup_dualtor_mux_ports "
                   "(docs/tests/setup.dualtor.mux.ports.md).", DeprecationWarning)
 
-    yield _config_active_active_dualtor_active_standby
+    yield handler
 
-    if ports_to_restore:
-        restore_cmds = []
-        for port in ports_to_restore:
-            restore_cmds.append("config mux mode auto {}".format(port))
+    _restore_mux_ports(duthosts, ports_to_restore)
 
-        for duthost in duthosts:
-            duthost.shell_cmds(cmds=restore_cmds)
+
+@pytest.fixture
+def config_active_active_dualtor_active_standby(duthosts, active_active_ports, tbinfo):     # noqa: F811
+    """Config the active-active dualtor that one ToR as active and the other as standby.
+
+    This fixture is kept for backward compatibility. It defaults to function scope.
+    For explicit scope control, use config_active_active_dualtor_active_standby_module or
+    config_active_active_dualtor_active_standby instead.
+    """
+    if not ('dualtor' in tbinfo['topo']['name'] and active_active_ports):
+        yield None
+        return
+
+    ports_to_restore = []
+    handler = _create_config_active_active_dualtor_handler(active_active_ports, ports_to_restore)
+
+    warnings.warn("Deprecated mux port setup fixture, please use setup_dualtor_mux_ports "
+                  "(docs/tests/setup.dualtor.mux.ports.md).", DeprecationWarning)
+
+    yield handler
+
+    _restore_mux_ports(duthosts, ports_to_restore)
 
 
 @pytest.fixture
@@ -2002,6 +2042,19 @@ def setup_standby_ports_on_rand_unselected_tor_unconditionally(
 ):
     if active_active_ports:
         config_active_active_dualtor_active_standby(rand_selected_dut, rand_unselected_dut, active_active_ports, True)
+    return
+
+
+@pytest.fixture(scope='module')
+def setup_standby_ports_on_rand_unselected_tor_unconditionally_module(
+    active_active_ports,                                                   # noqa: F811
+    rand_selected_dut,
+    rand_unselected_dut,
+    config_active_active_dualtor_active_standby_module
+):
+    if active_active_ports:
+        config_active_active_dualtor_active_standby_module(rand_selected_dut, rand_unselected_dut,
+                                                           active_active_ports, True)
     return
 
 

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -117,7 +117,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     @pytest.fixture(scope='function', autouse=True)
     def background_traffic(self, ptfadapter, everflow_direction, setup_info, everflow_dut,  # noqa F811
-                           setup_standby_ports_on_rand_unselected_tor_unconditionally,      # noqa F811
+                           setup_standby_ports_on_rand_unselected_tor_unconditionally_module,      # noqa F811
                            toggle_all_simulator_ports_to_rand_selected_tor):                # noqa F811
         stop_thread = threading.Event()
         src_port = EverflowIPv6Tests.rx_port_ptf_id


### PR DESCRIPTION

### Description of PR
The port toggle fixture is function scope, so it would be executed 100 times across the script running
4 hours would be used for the port toggle in total Change the fixture to module scope
After the enhancement, it would only use around 40 mins to run the test.



Summary:
Fixes # (issue)

### Type of change


- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- 202605: test pass

### Approach
#### What is the motivation for this PR?
The tests/everflow/test_everflow_ipv6.py run time would take 4 hours

#### How did you do it?
Change the functional port toggle fixture to module scope. It would save hours during IPv6 everflow test run.
#### How did you verify/test it?
Run it at local setup
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

