### PR TITLE
tests/common: support graph group match for trimmed inventory names

### DIFF
--- a/tests/common/fixtures/conn_graph_facts.py
+++ b/tests/common/fixtures/conn_graph_facts.py
@@ -84,8 +84,13 @@ def get_graph_facts(duthost, localhost, hostnames):
         graph_groups = yaml.safe_load(open(graph_groups_file))
         for inv_file in inv_files:
             inv_name = os.path.basename(inv_file)
-            if inv_name in graph_groups:
-                group = inv_name
+            # Try exact match first, then prefix match for trimmed inventory names
+            for graph_group in graph_groups:
+                if (inv_name == graph_group or
+                        (inv_name.startswith("{}_".format(graph_group)) and
+                         inv_name.endswith("_trim_tmp"))):
+                    group = graph_group
+                    break
 
     kargs = {"filepath": lab_conn_graph_path}
     if group:

--- a/tests/common/unit_tests/README.md
+++ b/tests/common/unit_tests/README.md
@@ -1,0 +1,35 @@
+# Unit Tests for tests/common/unit_tests
+
+This directory contains unit tests for modules under `tests/common`.
+
+## Running Unit Tests
+
+### Run all unit tests in this directory
+```bash
+# From repository root
+python3 -m pytest --noconftest tests/common/unit_tests/ -v
+```
+
+### Run a specific test file
+```bash
+python3 -m pytest --noconftest tests/common/unit_tests/fixtures/unit_test_conn_graph_facts.py -v
+```
+
+### Run a specific test case
+```bash
+python3 -m pytest --noconftest \
+  tests/common/unit_tests/fixtures/unit_test_conn_graph_facts.py::test_get_graph_facts_matches_graph_group_for_trim_and_non_trim_inventory \
+  -v
+```
+
+## Why `--noconftest`
+
+`tests/conftest.py` pulls in integration-test dependencies (for example, `paramiko`) that are not needed for these isolated unit tests. Using `--noconftest` keeps the run lightweight and avoids unrelated import failures.
+
+If your environment has the full sonic-mgmt test dependencies installed and you intentionally want global fixtures, you can remove `--noconftest`.
+
+## Requirements
+
+- Python 3
+- `pytest`
+- `unittest.mock` (built into Python standard library)

--- a/tests/common/unit_tests/fixtures/unit_test_conn_graph_facts.py
+++ b/tests/common/unit_tests/fixtures/unit_test_conn_graph_facts.py
@@ -1,0 +1,92 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+
+MODULE_PATH = (Path(__file__).resolve().parents[3] /
+               "common/fixtures/conn_graph_facts.py")
+
+
+def _load_target_module():
+    """Load the target module with pytest fixture stub."""
+    if "pytest" not in sys.modules:
+        pytest_stub = types.ModuleType("pytest")
+        fixture_decorator = (lambda *a, **k: a[0] if a and callable(a[0])
+                             else lambda f: f)
+        pytest_stub.fixture = fixture_decorator
+        sys.modules["pytest"] = pytest_stub
+
+    spec = importlib.util.spec_from_file_location(
+        "unit_target_conn_graph_facts", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def conn_graph_facts_module():
+    """Load and return the conn_graph_facts target module."""
+    return _load_target_module()
+
+
+def _make_dut(conn_graph_facts_module, sources):
+    """Create a mock DUT host with inventory sources."""
+    dut = MagicMock()
+    inventory_manager = MagicMock()
+    inventory_manager._sources = sources
+    dut.host.options = {"inventory_manager": inventory_manager}
+    return dut
+
+
+def _expected_filepath(conn_graph_facts_module):
+    """Get the expected ansible/files path."""
+    module_dir = conn_graph_facts_module.os.path.dirname(
+        conn_graph_facts_module.os.path.realpath(
+            conn_graph_facts_module.__file__))
+    return conn_graph_facts_module.os.path.join(
+        module_dir, "../../../ansible/files/")
+
+
+@pytest.mark.parametrize(
+    "sources, expected_group",
+    [
+        (["/tmp/snappi_mytestbed_trim_tmp"], "snappi"),
+        (["/tmp/snappi"], "snappi"),
+        (["/tmp/snappi_mytestbed"], None),
+    ],
+)
+def test_get_graph_facts_matches_graph_group_for_trim_and_non_trim_inventory(
+        conn_graph_facts_module, sources, expected_group):
+    """Test that trim_inv and non-trim inventory names match graph groups."""
+    dut = _make_dut(conn_graph_facts_module, sources)
+    sonic_mgmt_host = MagicMock()
+    sonic_mgmt_host.conn_graph_facts.return_value = {
+        "ansible_facts": {"device_conn": {2: {"peerdevice": "fanout-2"}}}
+    }
+
+    graph_groups_yaml = "---\n- veos\n- snappi\n"
+    with patch.object(conn_graph_facts_module.os.path, "isfile",
+                      return_value=True), \
+            patch("builtins.open", mock_open(read_data=graph_groups_yaml)):
+        result = conn_graph_facts_module.get_graph_facts(
+            dut, sonic_mgmt_host, ["dut-a", "dut-b"])
+
+    # Verify conn_graph_facts was called exactly once with the correct args
+    assert sonic_mgmt_host.conn_graph_facts.call_count == 1
+    call_kwargs = sonic_mgmt_host.conn_graph_facts.call_args.kwargs
+    expected_filepath = _expected_filepath(conn_graph_facts_module)
+    expected_call_kwargs = {
+        "filepath": expected_filepath,
+        "hosts": ["dut-a", "dut-b"],
+    }
+    if expected_group:
+        expected_call_kwargs["group"] = expected_group
+
+    assert call_kwargs == expected_call_kwargs
+
+    # Verify the result device_conn keys were converted to strings
+    assert result["device_conn"] == {"2": {"peerdevice": "fanout-2"}}


### PR DESCRIPTION
### Description of PR

Fix: https://github.com/sonic-net/sonic-mgmt/issues/24509

Summary:
This PR updates graph group detection for inventory files so an inventory is treated as part of a graph group when either condition is true:

- exact match: inv_name == graph_group
- trimmed/prefixed match: inv_name.startswith("{graph_group}_") and inv_name.endswith("_trim_tmp"), which covers inventory names generated by --trim_inv in pretest runs.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms (for new test case)
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
When tests run with --trim_inv, generated inventory names may not exactly match keys in graph_groups.yml. The previous exact-match-only logic could fail to select the correct graph group, which impacts conn_graph_facts resolution in pretest workflows.

It means “treat this inventory file as belonging to graph_group if either condition matches”:

1. `inv_name == graph_group`  
Exact match, for normal inventory files.  
Example: `inv_name = "snappi"`, `graph_group = "snappi"`.

2. `inv_name.startswith(f"{graph_group}_")`  
Prefix match for generated/trimmed inventory names.  
Example: `inv_name = "snappi_mytestbed_trim_tmp"` starts with `snappi_`, `graph_group = "snappi"`.

So this line lets the code recognize both raw inventory names and temporary names created by `--trim_inv`, then set the correct `group` for `conn_graph_facts`.

#### How did you do it?
Updated graph group matching logic in tests/common/fixtures/conn_graph_facts.py to:
- keep exact-match behavior for normal inventory names
- additionally accept prefixed/trimmed inventory names that start with graph_group_

#### How did you verify/test it?
- Ran unit tests:
```
cd ~/workspace/sonic-mgmt

python3 -m pytest --noconftest tests/common/unit_tests/fixtures/unit_test_conn_graph_facts.py -v
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: ~/workspace/sonic-mgmt/tests
configfile: pytest.ini
collected 3 items                                                              

tests/common/unit_tests/fixtures/unit_test_conn_graph_facts.py::test_get_graph_facts_matches_graph_group_for_trim_and_non_trim_inventory[sources0-snappi] PASSED [ 33%]
tests/common/unit_tests/fixtures/unit_test_conn_graph_facts.py::test_get_graph_facts_matches_graph_group_for_trim_and_non_trim_inventory[sources1-snappi] PASSED [ 66%]
tests/common/unit_tests/fixtures/unit_test_conn_graph_facts.py::test_get_graph_facts_matches_graph_group_for_trim_and_non_trim_inventory[sources2-None] PASSED [100%]

============================== 3 passed in 0.05s ===============================
```

- Confirmed the new matching logic supports both:
  - inv_name == graph_group
  - inv_name.startswith("{graph_group}_") and inv_name.endswith("_trim_tmp")

#### Any platform specific information?
No platform-specific behavior changes. This is framework-side matching logic and is topology/platform agnostic.

#### Supported testbed topology if it's a new test case?
N/A (not a new test case).

### Documentation
No documentation update required. This is a framework logic fix with no user-facing feature change.