### PR TITLE
drop_counters: ignore transient syncd flex counter ERR during config_reload

### DIFF
--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -62,12 +62,19 @@ def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loga
     CopperCableIgnoreRegex = [
         ".* ERR pmon#xcvrd.*no suitable app for the port appl.*host_lane_count.*host_speed.*"
     ]
+    # Ignore transient syncd error during config_reload when FlexCounter polls a port VID that was
+    # briefly removed/re-created (e.g. after port split). syncd self-heals by removing the stale entry.
+    FlexCounterPortNotFoundRegex = [
+        r".* ERR syncd\d*#syncd: :- processFlexCounterEvent: port VID .* was not found "
+        r"\(probably port was removed/splitted\) and will remove from counters now"
+    ]
     duthost = duthosts[rand_one_dut_hostname]
     if loganalyzer:  # Skip if loganalyzer is disabled
         if duthost.facts["asic_type"] == "vs":
             loganalyzer[duthost.hostname].ignore_regex.extend(KVMIgnoreRegex)
         loganalyzer[duthost.hostname].ignore_regex.extend(SAISwitchIgnoreRegex)
         loganalyzer[duthost.hostname].ignore_regex.extend(CopperCableIgnoreRegex)
+        loganalyzer[duthost.hostname].ignore_regex.extend(FlexCounterPortNotFoundRegex)
         if duthost.sonichost.facts['platform_asic'] == 'broadcom':
             ignore_regex = r".* ERR swss#orchagent:\s*.*\s*queryAattributeEnumValuesCapability:\s*returned value " \
                 r"\d+ is not allowed on SAI_SWITCH_ATTR_(?:ECMP|LAG)_DEFAULT_HASH_ALGORITHM.*"


### PR DESCRIPTION
### Description of PR
Summary:
`test_drop_counters.py::test_ip_pkt_with_expired_ttl` fails because loganalyzer catches a transient `ERR` from syncd during test teardown.

**Root cause:**
The `configure_copp_drop_for_ttl_error` fixture (`drop_packets.py` line 271) calls `config_reload(duthost, safe_reload=True)` in its teardown after modifying the COPP trap configuration. During reload, orchagent restarts and immediately sends `FLEX_COUNTER_TABLE` SET commands via the ASIC channel carrying the newly allocated port VIDs. At this point syncd may not yet have finished creating all port SAI objects and populating its VID→RID translation map. For each unresolved VID, `Syncd.cpp processFlexCounterEvent` logs:
```
ERR syncd#syncd: :- processFlexCounterEvent: port VID <oid> was not found (probably port was removed/splitted) and will remove from counters now
```
syncd then self-heals by issuing a DEL for the stale counter entry. The race resolves once orchagent finishes re-programming all ports.

**Fix:**
Add the pattern to the `ignore_expected_loganalyzer_exceptions` autouse fixture so loganalyzer does not fail the test on this benign transient noise.

### Type of change
- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
`test_ip_pkt_with_expired_ttl` was failing on Arista-7060X6-64PE-P32O64 due to a loganalyzer false positive.

#### How did you do it?
Added `FlexCounterPortNotFoundRegex` to the `ignore_expected_loganalyzer_exceptions` autouse fixture in `test_drop_counters.py`. The regex matches exactly the transient syncd message that fires during `config_reload` port re-initialization.

#### How did you verify/test it?
- Traced the error to `config_reload` in `configure_copp_drop_for_ttl_error` teardown (drop_packets.py line 271).
- Confirmed in syncd source (`Syncd.cpp processFlexCounterEvent`) that this is a known race: when `fromAsicChannel=true` and VID lookup fails, the code logs ERR and cleans up by issuing DEL for the stale counter. No functional impact.

#### Any platform specific information?
Observed on Arista-7060X6-64PE-P32O64 (broadcom ASIC). The error is not platform-specific — it can occur on any platform after `config_reload` when port flex counters are enabled.

#### Supported testbed topology if it's a new test case?
N/A — bug fix only.

### Documentation