### PR TITLE
conftest: fix temporarily_disable_route_check for lt2 topology variants

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3353,10 +3353,10 @@ def temporarily_disable_route_check(request, tbinfo, duthosts):
             check_flag = True
             break
 
-    allowed_topologies = {"t2", "ut2", "lt2"}
-    topo_name = tbinfo['topo']['name']
-    if check_flag and topo_name not in allowed_topologies:
-        logger.info("Topology {} is not allowed for temporarily_disable_route_check fixture".format(topo_name))
+    allowed_topo_types = {"t2", "ut2", "lt2"}
+    topo_type = tbinfo['topo']['type']
+    if check_flag and topo_type not in allowed_topo_types:
+        logger.info("Topology type {} is not allowed for temporarily_disable_route_check fixture".format(topo_type))
         check_flag = False
 
     def wait_for_route_check_to_pass(dut):


### PR DESCRIPTION
### Description of PR
Summary:
`temporarily_disable_route_check` in `conftest.py` does not work for lt2 topology variants such as `lt2-p32o64`, causing false-positive `routeCheck` monit errors during tests that call `config_reload`.

**Root cause:**
The fixture compares `topo_name` against an exact set `{"t2", "ut2", "lt2"}`. Topology names like `lt2-p32o64` do not match exactly, so monit `routeCheck` is never stopped on those testbeds. During any test with `pytest.mark.disable_route_check` that calls `config_reload`, monit `routeCheck` fires inside the BGP convergence window and finds BGP routes already in `APPL_DB ROUTE_TABLE` but not yet programmed to `ASIC_DB` by orchagent. It reports these as `missed_ROUTE_TABLE_routes` and logs `ERR`, which loganalyzer then catches and fails the test.

**Fix:**
Replace the exact set membership check with prefix+delimiter matching so `lt2-p32o64`, `t2-lag`, etc. are correctly treated as t2-type topologies and have routeCheck disabled during the test.

### Type of change
- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Monit `routeCheck` false positives on `lt2-p32o64` testbeds were causing loganalyzer failures in tests that use `pytest.mark.disable_route_check` and perform `config_reload`.

#### How did you do it?
Changed the topology check from:
```python
allowed_topologies = {"t2", "ut2", "lt2"}
if check_flag and topo_name not in allowed_topologies:
```
to:
```python
allowed_topo_types = ("t2", "ut2", "lt2")
if check_flag and not any(topo_name == t or topo_name.startswith(t + "-") for t in allowed_topo_types):
```
This correctly covers `lt2-p32o64`, `t2-lag`, `lt2-o128`, etc. without false positives for unrelated topology names.

#### How did you verify/test it?
- Confirmed `topo_name = "lt2-p32o64"` does not match the old exact set, explaining why `routeCheck` was never stopped.
- Verified the new prefix+delimiter logic correctly matches all expected variants (`t2`, `t2-lag`, `ut2`, `lt2`, `lt2-p32o64`) and rejects unrelated names like `t0`, `t1-lag`.

#### Any platform specific information?
Arista-7060X6-64PE-P32O64 running `lt2-p32o64` topology.

#### Supported testbed topology if it's a new test case?
N/A — bug fix only.

### Documentation