### PR TITLE
[202511]Reapply PR23348 diff. broadcom-dnx check needs to support single asic

### DIFF
--- a/tests/snmp/test_snmp_queue_counters.py
+++ b/tests/snmp/test_snmp_queue_counters.py
@@ -342,7 +342,7 @@ def test_snmp_queue_counters(duthosts,
     # cannot be modified dynamically. Hence, make sure the queue counters
     # before deletion and after deletion are same for broadcom-dnx voq chassis
     platform_asic = duthost.facts.get("platform_asic")
-    if platform_asic == "broadcom-dnx" and duthost.sonichost.is_multi_asic:
+    if platform_asic == "broadcom-dnx":
         pytest_assert(
             (queue_counters_cnt_pre == queue_counters_cnt_post),
             "Queue counters actual count {} differs from expected values {}"


### PR DESCRIPTION
Reapply PR23348 diff. broadcom-dnx check needs to support single asic
https://github.com/sonic-net/sonic-mgmt/pull/23851 seems to have reverted the fix from https://github.com/sonic-net/sonic-mgmt/pull/23348

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
