### PR TITLE
[ansible/vm_set]: Refactor host setup and Python environment management

### DIFF
--- a/ansible/roles/vm_set/defaults/main.yml
+++ b/ansible/roles/vm_set/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Path to the managed Python virtual environment on the testbed host.
+sonic_testbed_venv: "/opt/sonic-testbed/venv"

--- a/ansible/roles/vm_set/tasks/control_mux_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_mux_simulator.yml
@@ -17,11 +17,11 @@
       werkzeug_version: "2.3.7"
       python_command: "/opt/sonic-testbed/venv/bin/python3"
 
-  - name: Install Flask, Werkzeug, and blinker in venv
+  - name: Install Flask and Werkzeug in venv
     command: >-
-      /usr/local/bin/uv pip install
+      uv pip install
       --python /opt/sonic-testbed/venv/bin/python
-      blinker flask=={{ flask_version }} werkzeug=={{ werkzeug_version }}
+      flask=={{ flask_version }} werkzeug=={{ werkzeug_version }}
     become: yes
     environment: "{{ proxy_env | default({}) }}"
 

--- a/ansible/roles/vm_set/tasks/control_mux_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_mux_simulator.yml
@@ -15,7 +15,6 @@
     set_fact:
       flask_version: "2.3.3"
       werkzeug_version: "2.3.7"
-      python_command: "{{ sonic_testbed_venv }}/bin/python3"
 
   - name: Install Flask and Werkzeug in venv
     command: >-

--- a/ansible/roles/vm_set/tasks/control_mux_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_mux_simulator.yml
@@ -16,6 +16,14 @@
       flask_version: "2.3.3"
       werkzeug_version: "2.3.7"
 
+  - name: Check installed Flask and Werkzeug versions
+    command: >-
+      {{ sonic_testbed_venv }}/bin/python -c
+      "import flask, werkzeug; print(flask.__version__); print(werkzeug.__version__)"
+    register: flask_versions
+    changed_when: false
+    failed_when: false
+
   - name: Install Flask and Werkzeug in venv
     command: >-
       uv pip install
@@ -23,6 +31,8 @@
       flask=={{ flask_version }} werkzeug=={{ werkzeug_version }}
     become: yes
     environment: "{{ proxy_env | default({}) }}"
+    when: flask_versions.rc != 0
+          or flask_versions.stdout_lines != [flask_version, werkzeug_version]
 
   - name: Copy the mux simulator to test server
     copy:

--- a/ansible/roles/vm_set/tasks/control_mux_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_mux_simulator.yml
@@ -11,54 +11,19 @@
 - name: Start mux simulator
   block:
 
-  - name: Set default Flask version
-    set_fact:
-      flask_version: "1.1.2"
-      werkzeug_version: "1.0.1"
-      python_command: "python"
-
-  - name: Use newer Flask and Werkzeug version for pip3
+  - name: Set Flask and Werkzeug versions
     set_fact:
       flask_version: "2.3.3"
       werkzeug_version: "2.3.7"
-      python_command: "python3"
-    when: pip_executable == "pip3"
+      python_command: "/opt/sonic-testbed/venv/bin/python3"
 
-  - name: Run python3 in a virtualenv
-    set_fact:
-      python_command: "/tmp/sonic-mgmt-virtualenv/bin/python3"
-    when: host_distribution_version.stdout >= "24.04"
-
-  - name: Install Flask and Werkzeug
-    block:
-    - name: Install blinker
-      pip: name=blinker executable={{ pip_executable }} extra_args="--ignore-installed"
-      become: yes
-      environment: "{{ proxy_env | default({}) }}"
-
-    - name: Install flask
-      pip: name=flask version={{ flask_version }} executable={{ pip_executable }}
-      become: yes
-      environment: "{{ proxy_env | default({}) }}"
-
-    - name: Install werkzeug
-      pip: name=werkzeug version={{ werkzeug_version }} state=forcereinstall executable={{ pip_executable }}
-      become: yes
-      environment: "{{ proxy_env | default({}) }}"
-    when: host_distribution_version.stdout < "24.04"
-
-  - name: Install Flask and Werkzeug
-    block:
-    - name: Install flask
-      pip: name=flask version={{ flask_version }} state=forcereinstall virtualenv=/tmp/sonic-mgmt-virtualenv virtualenv_site_packages=true
-      become: yes
-      environment: "{{ proxy_env | default({}) }}"
-
-    - name: Install werkzeug
-      pip: name=werkzeug version={{ werkzeug_version }} state=forcereinstall virtualenv=/tmp/sonic-mgmt-virtualenv virtualenv_site_packages=true
-      become: yes
-      environment: "{{ proxy_env | default({}) }}"
-    when: host_distribution_version.stdout >= "24.04"
+  - name: Install Flask, Werkzeug, and blinker in venv
+    command: >-
+      /usr/local/bin/uv pip install
+      --python /opt/sonic-testbed/venv/bin/python
+      blinker flask=={{ flask_version }} werkzeug=={{ werkzeug_version }}
+    become: yes
+    environment: "{{ proxy_env | default({}) }}"
 
   - name: Copy the mux simulator to test server
     copy:

--- a/ansible/roles/vm_set/tasks/control_mux_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_mux_simulator.yml
@@ -15,12 +15,12 @@
     set_fact:
       flask_version: "2.3.3"
       werkzeug_version: "2.3.7"
-      python_command: "/opt/sonic-testbed/venv/bin/python3"
+      python_command: "{{ sonic_testbed_venv }}/bin/python3"
 
   - name: Install Flask and Werkzeug in venv
     command: >-
       uv pip install
-      --python /opt/sonic-testbed/venv/bin/python
+      --python {{ sonic_testbed_venv }}/bin/python
       flask=={{ flask_version }} werkzeug=={{ werkzeug_version }}
     become: yes
     environment: "{{ proxy_env | default({}) }}"

--- a/ansible/roles/vm_set/tasks/control_nic_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_nic_simulator.yml
@@ -25,12 +25,12 @@
     - name: Set ip command absolute path
       set_fact:
         ip_command_path: "{{ which_ip_output.stdout }}"
-        python_command: "/opt/sonic-testbed/venv/bin/python3"
+        python_command: "{{ sonic_testbed_venv }}/bin/python3"
 
     - name: Install gRPC library in venv
       command: >-
         uv pip install
-        --python /opt/sonic-testbed/venv/bin/python
+        --python {{ sonic_testbed_venv }}/bin/python
         grpcio grpcio-tools
       become: yes
       environment: "{{ proxy_env | default({}) }}"
@@ -48,7 +48,7 @@
 
     - name: Generate gRPC dependencies from the protocol buffer definitions
       shell:
-        cmd: /opt/sonic-testbed/venv/bin/python3 -m grpc.tools.protoc -I. --python_out=. --grpc_python_out=. {{ item }}
+        cmd: "{{ sonic_testbed_venv }}/bin/python3 -m grpc.tools.protoc -I. --python_out=. --grpc_python_out=. {{ item }}"
         chdir: "{{ remote_nic_simulator_dir }}"
       loop:
        - nic_simulator_grpc_service.proto

--- a/ansible/roles/vm_set/tasks/control_nic_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_nic_simulator.yml
@@ -25,7 +25,6 @@
     - name: Set ip command absolute path
       set_fact:
         ip_command_path: "{{ which_ip_output.stdout }}"
-        python_command: "{{ sonic_testbed_venv }}/bin/python3"
 
     - name: Install gRPC library in venv
       command: >-

--- a/ansible/roles/vm_set/tasks/control_nic_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_nic_simulator.yml
@@ -26,6 +26,12 @@
       set_fact:
         ip_command_path: "{{ which_ip_output.stdout }}"
 
+    - name: Check installed gRPC library
+      command: "{{ sonic_testbed_venv }}/bin/python -c 'import grpc, grpc_tools'"
+      register: grpc_check
+      changed_when: false
+      failed_when: false
+
     - name: Install gRPC library in venv
       command: >-
         uv pip install
@@ -33,6 +39,7 @@
         grpcio grpcio-tools
       become: yes
       environment: "{{ proxy_env | default({}) }}"
+      when: grpc_check.rc != 0
 
     - name: Set nic simulator source directory
       set_fact:

--- a/ansible/roles/vm_set/tasks/control_nic_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_nic_simulator.yml
@@ -25,25 +25,13 @@
     - name: Set ip command absolute path
       set_fact:
         ip_command_path: "{{ which_ip_output.stdout }}"
+        python_command: "/opt/sonic-testbed/venv/bin/python3"
 
-    - name: Install pip3
-      apt:
-        name: python3-pip
-        state: present
-      become: yes
-      when: host_distribution_version.stdout == "18.04"
-
-    - name: Set Python version
-      set_fact:
-        python_command: "python3"
-        pip_command: "pip3"
-
-    - name: Install gRPC library
-      pip:
-        name:
-          - grpcio
-          - grpcio-tools
-        executable: "{{ pip_command }}"
+    - name: Install gRPC library in venv
+      command: >-
+        /usr/local/bin/uv pip install
+        --python /opt/sonic-testbed/venv/bin/python
+        grpcio grpcio-tools
       become: yes
       environment: "{{ proxy_env | default({}) }}"
 
@@ -60,7 +48,7 @@
 
     - name: Generate gRPC dependencies from the protocol buffer definitions
       shell:
-        cmd: python3 -m grpc.tools.protoc -I. --python_out=. --grpc_python_out=. {{ item }}
+        cmd: /opt/sonic-testbed/venv/bin/python3 -m grpc.tools.protoc -I. --python_out=. --grpc_python_out=. {{ item }}
         chdir: "{{ remote_nic_simulator_dir }}"
       loop:
        - nic_simulator_grpc_service.proto

--- a/ansible/roles/vm_set/tasks/control_nic_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_nic_simulator.yml
@@ -29,7 +29,7 @@
 
     - name: Install gRPC library in venv
       command: >-
-        /usr/local/bin/uv pip install
+        uv pip install
         --python /opt/sonic-testbed/venv/bin/python
         grpcio grpcio-tools
       become: yes

--- a/ansible/roles/vm_set/tasks/docker.yml
+++ b/ansible/roles/vm_set/tasks/docker.yml
@@ -20,34 +20,6 @@
   environment: "{{ proxy_env | default({}) }}"
   when: docker_repo.matched == 0
 
-- name: Add docker repository for 16.04
-  apt_repository:
-    repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
-    state: present
-  become: yes
-  when: host_distribution_version.stdout == "16.04" and docker_repo.matched == 0
-
-- name: Add docker repository for 17.04
-  apt_repository:
-    repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu zesty stable
-    state: present
-  become: yes
-  when: host_distribution_version == "17.04" and docker_repo.matched == 0
-
-- name: Add docker repository for 18.04
-  apt_repository:
-    repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable
-    state: present
-  become: yes
-  when: host_distribution_version.stdout == "18.04" and docker_repo.matched == 0
-
-- name: Add docker repository for 20.04
-  apt_repository:
-    repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable
-    state: present
-  become: yes
-  when: host_distribution_version.stdout == "20.04" and docker_repo.matched == 0
-
 - name: Add docker repository for 22.04
   apt_repository:
     repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu jammy stable
@@ -62,7 +34,8 @@
   become: yes
   when: host_distribution_version.stdout == "24.04" and docker_repo.matched == 0
 
-# In ansible 2.8, there isn't update_cache_retries option in apt module, we can manually run update as a seperate and retryable step
+# In ansible 2.8, there isn't update_cache_retries option in apt module,
+# we can manually run update as a separate and retryable step.
 - name: Run the "apt-get update" as a separate and retryable step
   apt:
     update_cache: yes
@@ -77,52 +50,3 @@
   apt: pkg=docker-ce
   become: yes
   environment: "{{ proxy_env | default({}) }}"
-
-- name: Update python2 packages
-  block:
-  - name: remove old python packages
-    pip: name=docker-py state=absent executable={{ pip_executable }}
-    become: yes
-    environment: "{{ proxy_env | default({}) }}"
-    ignore_errors: yes
-  - name: Install python packages
-    pip: name=docker version=4.1.0 state=forcereinstall executable={{ pip_executable }}
-    become: yes
-    environment: "{{ proxy_env | default({}) }}"
-  when: pip_executable=="pip"
-
-- name: Update python3 packages
-  block:
-  - name: remove old python packages
-    pip: name=docker-py state=absent executable={{ pip_executable }}
-    become: yes
-    environment: "{{ proxy_env | default({}) }}"
-    ignore_errors: yes
-  - name: Install python packages requests=2.32.5
-    pip: name=requests version=2.32.5 executable={{ pip_executable }} extra_args="--force-reinstall --no-deps"
-    become: yes
-    environment: "{{ proxy_env | default({}) }}"
-  - name: Install python packages docker==7.1.0
-    pip: name=docker version=7.1.0 state=forcereinstall executable={{ pip_executable }}
-    become: yes
-    environment: "{{ proxy_env | default({}) }}"
-  when: pip_executable=="pip3" and host_distribution_version.stdout < "24.04"
-
-- name: Update python3 packages
-  block:
-  - name: Ensure python3-venv is installed
-    apt:
-      name: python3-venv
-      state: present
-      update_cache: yes
-    become: yes
-  - name: Install python packages
-    pip: name=docker version=7.1.0 state=forcereinstall virtualenv=/tmp/sonic-mgmt-virtualenv virtualenv_site_packages=true virtualenv_command="python3 -m venv"
-    become: yes
-    environment: "{{ proxy_env | default({}) }}"
-  when: host_distribution_version.stdout >= "24.04"
-
-- name: Use virtualenv for all Python scripts on Ubuntu 24.04 and newer
-  set_fact:
-    ansible_python_interpreter: "/tmp/sonic-mgmt-virtualenv/bin/python"
-  when: host_distribution_version.stdout >= "24.04"

--- a/ansible/roles/vm_set/tasks/ensure_python_env.yml
+++ b/ansible/roles/vm_set/tasks/ensure_python_env.yml
@@ -1,6 +1,6 @@
 # Ensure uv is installed, venv exists at {{ sonic_testbed_venv }},
-# and required Python packages are present. This file is idempotent
-# and always runs (not gated by the host_setup flag).
+# and required Python packages are present. Idempotent: tasks here
+# detect existing state and skip work that is not needed.
 
 - name: Check if uv is installed
   command: uv --version
@@ -9,9 +9,7 @@
   changed_when: false
 
 - name: Install uv
-  shell: >-
-    curl -LsSf https://astral.sh/uv/0.7.2/install.sh |
-    env UV_INSTALL_DIR=/usr/local/bin INSTALLER_NO_MODIFY_PATH=1 sh
+  shell: curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin INSTALLER_NO_MODIFY_PATH=1 sh
   become: yes
   environment: "{{ proxy_env | default({}) }}"
   when: uv_check.rc != 0
@@ -33,6 +31,14 @@
   become: yes
   when: not venv_stat.stat.exists
 
+- name: Check installed versions of pinned Python packages
+  command: >-
+    {{ sonic_testbed_venv }}/bin/python -c
+    "import requests, docker; print(requests.__version__); print(docker.__version__)"
+  register: pkg_versions
+  changed_when: false
+  failed_when: false
+
 - name: Install Python packages in venv
   command: >-
     uv pip install
@@ -40,3 +46,5 @@
     requests==2.33.1 docker==7.1.0
   become: yes
   environment: "{{ proxy_env | default({}) }}"
+  when: pkg_versions.rc != 0
+        or pkg_versions.stdout_lines != ['2.33.1', '7.1.0']

--- a/ansible/roles/vm_set/tasks/ensure_python_env.yml
+++ b/ansible/roles/vm_set/tasks/ensure_python_env.yml
@@ -3,7 +3,7 @@
 # and always runs (not gated by the host_setup flag).
 
 - name: Check if uv is installed
-  command: /usr/local/bin/uv --version
+  command: uv --version
   register: uv_check
   ignore_errors: yes
   changed_when: false
@@ -29,13 +29,13 @@
   register: venv_stat
 
 - name: Create Python venv with system site-packages
-  command: /usr/local/bin/uv venv --python /usr/bin/python3 --system-site-packages /opt/sonic-testbed/venv
+  command: uv venv --python /usr/bin/python3 --system-site-packages /opt/sonic-testbed/venv
   become: yes
   when: not venv_stat.stat.exists
 
 - name: Install Python packages in venv
   command: >-
-    /usr/local/bin/uv pip install
+    uv pip install
     --python /opt/sonic-testbed/venv/bin/python
     requests==2.32.3 docker==7.1.0
   become: yes

--- a/ansible/roles/vm_set/tasks/ensure_python_env.yml
+++ b/ansible/roles/vm_set/tasks/ensure_python_env.yml
@@ -1,4 +1,4 @@
-# Ensure uv is installed, venv exists at /opt/sonic-testbed/venv,
+# Ensure uv is installed, venv exists at {{ sonic_testbed_venv }},
 # and required Python packages are present. This file is idempotent
 # and always runs (not gated by the host_setup flag).
 
@@ -16,27 +16,27 @@
   environment: "{{ proxy_env | default({}) }}"
   when: uv_check.rc != 0
 
-- name: Ensure /opt/sonic-testbed directory exists
+- name: Ensure sonic-testbed directory exists
   file:
-    path: /opt/sonic-testbed
+    path: "{{ sonic_testbed_venv | dirname }}"
     state: directory
     mode: '0755'
   become: yes
 
 - name: Check if venv exists
   stat:
-    path: /opt/sonic-testbed/venv/bin/python
+    path: "{{ sonic_testbed_venv }}/bin/python"
   register: venv_stat
 
 - name: Create Python venv with system site-packages
-  command: uv venv --python /usr/bin/python3 --system-site-packages /opt/sonic-testbed/venv
+  command: uv venv --python /usr/bin/python3 --system-site-packages {{ sonic_testbed_venv }}
   become: yes
   when: not venv_stat.stat.exists
 
 - name: Install Python packages in venv
   command: >-
     uv pip install
-    --python /opt/sonic-testbed/venv/bin/python
-    requests==2.32.3 docker==7.1.0
+    --python {{ sonic_testbed_venv }}/bin/python
+    requests==2.33.1 docker==7.1.0
   become: yes
   environment: "{{ proxy_env | default({}) }}"

--- a/ansible/roles/vm_set/tasks/ensure_python_env.yml
+++ b/ansible/roles/vm_set/tasks/ensure_python_env.yml
@@ -1,0 +1,42 @@
+# Ensure uv is installed, venv exists at /opt/sonic-testbed/venv,
+# and required Python packages are present. This file is idempotent
+# and always runs (not gated by the host_setup flag).
+
+- name: Check if uv is installed
+  command: /usr/local/bin/uv --version
+  register: uv_check
+  ignore_errors: yes
+  changed_when: false
+
+- name: Install uv
+  shell: >-
+    curl -LsSf https://astral.sh/uv/0.7.2/install.sh |
+    env UV_INSTALL_DIR=/usr/local/bin INSTALLER_NO_MODIFY_PATH=1 sh
+  become: yes
+  environment: "{{ proxy_env | default({}) }}"
+  when: uv_check.rc != 0
+
+- name: Ensure /opt/sonic-testbed directory exists
+  file:
+    path: /opt/sonic-testbed
+    state: directory
+    mode: '0755'
+  become: yes
+
+- name: Check if venv exists
+  stat:
+    path: /opt/sonic-testbed/venv/bin/python
+  register: venv_stat
+
+- name: Create Python venv with system site-packages
+  command: /usr/local/bin/uv venv --python /usr/bin/python3 --system-site-packages /opt/sonic-testbed/venv
+  become: yes
+  when: not venv_stat.stat.exists
+
+- name: Install Python packages in venv
+  command: >-
+    /usr/local/bin/uv pip install
+    --python /opt/sonic-testbed/venv/bin/python
+    requests==2.32.3 docker==7.1.0
+  become: yes
+  environment: "{{ proxy_env | default({}) }}"

--- a/ansible/roles/vm_set/tasks/host_setup.yml
+++ b/ansible/roles/vm_set/tasks/host_setup.yml
@@ -67,6 +67,7 @@
       name: libvirtd
       state: restarted
     become: yes
+  when: host_distribution_version.stdout is version("24.04", ">=") or force_qemu_root | default(false) | bool
 
 - name: Install br_netfilter kernel module
   become: yes

--- a/ansible/roles/vm_set/tasks/host_setup.yml
+++ b/ansible/roles/vm_set/tasks/host_setup.yml
@@ -45,14 +45,6 @@
     reload: true
     sysctl_file: /etc/sysctl.d/99-pty.conf
 
-# On Ubuntu the default home-directory mode shipped by adduser has been
-# tightened from 0755 to 0750 in newer releases, which prevents the
-# libvirt-qemu user from traversing /home/<user> to read VM disk images
-# stored under {{ home_path }}/sonic-vm/.  Granting libvirt-qemu the
-# execute bit via a POSIX ACL on home_path is targeted, idempotent, and
-# keeps QEMU running as the unprivileged libvirt-qemu user.  This task
-# is in main.yml (not host_setup.yml) because home_path is only known
-# after the getent passwd lookup below.
 - name: Install br_netfilter kernel module
   become: yes
   modprobe: name=br_netfilter state=present

--- a/ansible/roles/vm_set/tasks/host_setup.yml
+++ b/ansible/roles/vm_set/tasks/host_setup.yml
@@ -1,0 +1,164 @@
+# Host setup tasks -- run once, skipped via version-stamped flag file.
+# To force re-run: export FORCE_HOST_SETUP=true
+# To trigger re-run after changes: bump host_setup_version in main.yml
+
+# ---- System packages ----
+- name: Install necessary system packages
+  apt:
+    update_cache: yes
+    cache_valid_time: 86400
+    pkg:
+      - ifupdown
+      - openvswitch-switch
+      - net-tools
+      - bridge-utils
+      - util-linux
+      - iproute2
+      - vlan
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - software-properties-common
+      - libvirt-clients
+      - python3-libvirt
+      - python3-lxml
+      - libvirt-daemon-system
+      - qemu-system-x86
+  register: apt_res
+  retries: 2
+  delay: 30
+  until: apt_res is success
+  become: yes
+
+# ---- Docker ----
+- include_tasks: docker.yml
+
+# ---- Kernel tuning ----
+- name: Set kernel.pty.max to 8192
+  become: true
+  sysctl:
+    name: kernel.pty.max
+    value: 8192
+    state: present
+    sysctl_set: true
+    reload: true
+    sysctl_file: /etc/sysctl.d/99-pty.conf
+
+- name: Update libvirt qemu configuration
+  block:
+  - name: Set user to root in qemu.conf
+    lineinfile:
+      path: /etc/libvirt/qemu.conf
+      regexp: '^#?user\s*=.*'
+      line: 'user = "root"'
+      state: present
+      backrefs: yes
+    become: yes
+  - name: Set group to root in qemu.conf
+    lineinfile:
+      path: /etc/libvirt/qemu.conf
+      regexp: '^#?group\s*=.*'
+      line: 'group = "root"'
+      state: present
+      backrefs: yes
+    become: yes
+  - name: Restart libvirtd to apply qemu.conf changes
+    service:
+      name: libvirtd
+      state: restarted
+    become: yes
+
+- name: Install br_netfilter kernel module
+  become: yes
+  modprobe: name=br_netfilter state=present
+
+- name: Set sysctl bridge parameters for testbed
+  sysctl:
+    name: "{{ item }}"
+    value: "0"
+    sysctl_set: yes
+  become: yes
+  with_items:
+   - net.bridge.bridge-nf-call-arptables
+   - net.bridge.bridge-nf-call-ip6tables
+   - net.bridge.bridge-nf-call-iptables
+
+- name: Set sysctl RCVBUF max parameter for testbed
+  sysctl:
+    name: "net.core.rmem_max"
+    value: "509430500"
+    sysctl_set: yes
+  become: yes
+
+- name: Set sysctl RCVBUF default parameter for testbed
+  sysctl:
+    name: "net.core.rmem_default"
+    value: "31457280"
+    sysctl_set: yes
+  become: yes
+
+- name: Increase IPv6 route cache size
+  sysctl:
+    name: "net.ipv6.route.max_size"
+    value: "16384"
+    sysctl_set: yes
+  become: yes
+
+- name: Increase neighbor gc_thresh1
+  sysctl:
+    sysctl_set: yes
+    name: "{{ item }}"
+    value: "8192"
+  become: yes
+  with_items:
+    - net.ipv4.neigh.default.gc_thresh1
+    - net.ipv6.neigh.default.gc_thresh1
+
+- name: Increase neighbor gc_thresh2
+  sysctl:
+    sysctl_set: yes
+    name: "{{ item }}"
+    value: "16384"
+  become: yes
+  with_items:
+    - net.ipv4.neigh.default.gc_thresh2
+    - net.ipv6.neigh.default.gc_thresh2
+
+- name: Increase neighbor gc_thresh3
+  sysctl:
+    sysctl_set: yes
+    name: "{{ item }}"
+    value: "32768"
+  become: yes
+  with_items:
+    - net.ipv4.neigh.default.gc_thresh3
+    - net.ipv6.neigh.default.gc_thresh3
+
+- name: increase kernel pid max
+  sysctl:
+    name: "kernel.pid_max"
+    value: "4194304"
+    sysctl_set: yes
+  become: yes
+
+- name: Increase fs limitation
+  sysctl:
+    name: "fs.inotify.max_user_instances"
+    value: "62800"
+    sysctl_set: yes
+  become: yes
+
+# ---- Write flag file ----
+- name: Ensure /opt/sonic-testbed directory exists
+  file:
+    path: /opt/sonic-testbed
+    state: directory
+    mode: '0755'
+  become: yes
+
+- name: Write host setup done flag with version
+  copy:
+    content: "{{ host_setup_version }}"
+    dest: /opt/sonic-testbed/.host_setup_done
+    mode: '0644'
+  become: yes

--- a/ansible/roles/vm_set/tasks/host_setup.yml
+++ b/ansible/roles/vm_set/tasks/host_setup.yml
@@ -44,6 +44,12 @@
     reload: true
     sysctl_file: /etc/sysctl.d/99-pty.conf
 
+# On Ubuntu 24.04+, AppArmor's libvirt profile denies the default
+# libvirt-qemu user access to VM disk images stored outside
+# /var/lib/libvirt/images (e.g. under ~/sonic-vm/).  Running QEMU as
+# root is a pragmatic workaround; a proper AppArmor local override is
+# preferable long-term.  On 22.04 this is not needed unless the user
+# opts in via force_qemu_root=true.
 - name: Update libvirt qemu configuration
   block:
   - name: Set user to root in qemu.conf

--- a/ansible/roles/vm_set/tasks/host_setup.yml
+++ b/ansible/roles/vm_set/tasks/host_setup.yml
@@ -24,6 +24,7 @@
       - python3-lxml
       - libvirt-daemon-system
       - qemu-system-x86
+      - acl
   register: apt_res
   retries: 2
   delay: 30
@@ -44,37 +45,14 @@
     reload: true
     sysctl_file: /etc/sysctl.d/99-pty.conf
 
-# On Ubuntu 24.04+, AppArmor's libvirt profile denies the default
-# libvirt-qemu user access to VM disk images stored outside
-# /var/lib/libvirt/images (e.g. under ~/sonic-vm/).  Running QEMU as
-# root is a pragmatic workaround; a proper AppArmor local override is
-# preferable long-term.  On 22.04 this is not needed unless the user
-# opts in via force_qemu_root=true.
-- name: Update libvirt qemu configuration
-  block:
-  - name: Set user to root in qemu.conf
-    lineinfile:
-      path: /etc/libvirt/qemu.conf
-      regexp: '^#?user\s*=.*'
-      line: 'user = "root"'
-      state: present
-      backrefs: yes
-    become: yes
-  - name: Set group to root in qemu.conf
-    lineinfile:
-      path: /etc/libvirt/qemu.conf
-      regexp: '^#?group\s*=.*'
-      line: 'group = "root"'
-      state: present
-      backrefs: yes
-    become: yes
-  - name: Restart libvirtd to apply qemu.conf changes
-    service:
-      name: libvirtd
-      state: restarted
-    become: yes
-  when: host_distribution_version.stdout is version("24.04", ">=") or force_qemu_root | default(false) | bool
-
+# On Ubuntu the default home-directory mode shipped by adduser has been
+# tightened from 0755 to 0750 in newer releases, which prevents the
+# libvirt-qemu user from traversing /home/<user> to read VM disk images
+# stored under {{ home_path }}/sonic-vm/.  Granting libvirt-qemu the
+# execute bit via a POSIX ACL on home_path is targeted, idempotent, and
+# keeps QEMU running as the unprivileged libvirt-qemu user.  This task
+# is in main.yml (not host_setup.yml) because home_path is only known
+# after the getent passwd lookup below.
 - name: Install br_netfilter kernel module
   become: yes
   modprobe: name=br_netfilter state=present

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -62,7 +62,7 @@
 # Bump this version string whenever host_setup.yml tasks change materially.
 - name: Define host setup version
   set_fact:
-    host_setup_version: "2"
+    host_setup_version: "1"
 
 - name: Check if host setup flag file exists
   stat:
@@ -155,6 +155,11 @@
     # libvirt-qemu the execute (traverse) bit on home_path via a POSIX
     # ACL.  This is targeted (only libvirt-qemu, not "other"), survives
     # subsequent chmod operations, and avoids running QEMU as root.
+    #
+    # Gated on package_installation because the acl package and the
+    # libvirt-qemu user are both installed by host_setup.yml; with
+    # package_installation=false the caller is responsible for ensuring
+    # those exist out-of-band.
     - name: Allow libvirt-qemu to traverse home directory
       acl:
         path: "{{ home_path }}"
@@ -163,6 +168,7 @@
         permissions: x
         state: present
       become: yes
+      when: package_installation | bool
 
 # ---- VM setup ----
 - name: Require veos or SONiC or cisco VMs by default

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -15,21 +15,7 @@
 # downloaded from the URLs defined in the variables. Please update the URLs to the actual URLs of the image files in
 # your environment.
 
-# Need latest ubuntu 4.10 kernel to fix a openvswitch bug
-# https://bugs.launchpad.net/ubuntu/+source/kernel-package/+bug/1685742
-- name: Pick package_installation from env
-  set_fact:
-    package_installation: "{{ lookup('env', 'PACKAGE_INSTALLATION') | default(omit) }}"
-
-- name: Set the default variable package_installation
-  set_fact:
-    package_installation: true
-  when: package_installation is not defined or package_installation == ''
-
-- name: Initialize async flag
-  set_fact:
-    enable_async: "{{ enable_async | default(false) | bool }}"
-
+# ---- Distribution detection ----
 - name: get host distribution
   shell: grep ^NAME /etc/os-release | awk -F '=' '{print $2}' | tr -d '"'
   register: host_distribution
@@ -40,116 +26,83 @@
   register: host_distribution_version
   changed_when: False
 
-- name: get host kernel version
-  shell: uname -r
-  register: host_kernel
-  changed_when: False
+# ---- Fail if Ubuntu < 22.04 ----
+- name: Fail if distribution is not Ubuntu
+  fail:
+    msg: >-
+      Distribution '{{ host_distribution.stdout }}' is not supported.
+      Only Ubuntu 22.04 and 24.04 are supported.
+  when:
+    - host_distribution.stdout != "Ubuntu"
 
-- name: Check if kernel upgrade needed
-  set_fact:
-    kernel_upgrade_needed: true
+- name: Fail if Ubuntu version is not supported
+  fail:
+    msg: >-
+      Ubuntu {{ host_distribution_version.stdout }} is not supported.
+      Minimum required version is 22.04.
   when:
     - host_distribution.stdout == "Ubuntu"
-    - host_distribution_version.stdout == "17.04"
-    - host_kernel.stdout.find('4.10.0') != -1
-    - "{{ host_kernel.stdout | regex_replace('4.10.0-([0-9]+)-.*', '\\1') | int < 25 }}"
+    - host_distribution_version.stdout is version("22.04", "<")
 
-- block:
-    - debug: msg="{{ host_kernel.stdout }}"
-
-    - name: Upgrade kernel package
-      apt: pkg={{ item }} state=latest
-      become: yes
-      with_items:
-        - linux-image-generic
-        - linux-image-extra-virtual
-
-    - name: Prompt for rebooting
-      fail:
-        msg: "Kernel upgraded, need to reboot!"
-  when:
-    - kernel_upgrade_needed is defined
-    - package_installation|bool
-
-- block:
-    - name: Install necessary packages
-      apt:
-        update_cache: yes
-        cache_valid_time: 86400
-        pkg:
-          - ifupdown
-          - openvswitch-switch
-          - net-tools
-          - bridge-utils
-          - util-linux
-          - iproute2
-          - vlan
-          - apt-transport-https
-          - ca-certificates
-          - curl
-          - software-properties-common
-          - libvirt-clients
-      register: apt_res
-      retries: 2
-      delay: 30
-      until: apt_res is success
-      become: yes
-
-    - name: Install necessary packages
-      register: apt_res
-      retries: 2
-      delay: 30
-      until: apt_res is success
-      apt:
-        pkg:
-        - python
-        - libvirt-bin
-        - python-libvirt
-        - python-pip
-      become: yes
-      when: host_distribution_version.stdout == "18.04"
-
-    - name: Install necessary packages
-      register: apt_res
-      retries: 2
-      delay: 30
-      until: apt_res is success
-      apt:
-        pkg:
-        - python3-libvirt
-        - python3-pip
-        - python3-lxml
-        - libvirt-daemon-system
-        - qemu-system-x86
-      become: yes
-      when: host_distribution_version.stdout >= "20.04"
-  when: package_installation|bool
-
-- name: Get default pip_executable
+# ---- Host setup gating ----
+- name: Pick package_installation from env
   set_fact:
-    pip_executable: pip
-  when: pip_executable is not defined and host_distribution_version.stdout < "20.04"
+    package_installation: "{{ lookup('env', 'PACKAGE_INSTALLATION') }}"
+  when: package_installation is not defined and lookup('env', 'PACKAGE_INSTALLATION') | length > 0
 
-- name: Get default pip_executable
+- name: Set the default variable package_installation
   set_fact:
-    pip_executable: pip3
-  when: pip_executable is not defined and (host_distribution_version.stdout >= "20.04")
+    package_installation: true
+  when: package_installation is not defined
 
-- include_tasks: docker.yml
-  when: package_installation|bool
+- name: Pick FORCE_HOST_SETUP from env
+  set_fact:
+    force_host_setup: "{{ lookup('env', 'FORCE_HOST_SETUP') | default('false') | bool }}"
 
-- name: Install requests package
-  pip: name=requests version=2.32.3 state=present executable={{ pip_executable }}
-  become: yes
-  environment: "{{ proxy_env | default({}) }}"
-  when: pip_executable=="pip3" and host_distribution_version.stdout < "24.04"
+# Bump this version string whenever host_setup.yml tasks change materially.
+- name: Define host setup version
+  set_fact:
+    host_setup_version: "1"
 
-- name: Install requests package
-  pip: name=requests version=2.32.3 state=present virtualenv=/tmp/sonic-mgmt-virtualenv virtualenv_site_packages=true virtualenv_command="python3 -m venv"
-  become: yes
-  environment: "{{ proxy_env | default({}) }}"
-  when: host_distribution_version.stdout >= "24.04"
+- name: Check if host setup flag file exists
+  stat:
+    path: /opt/sonic-testbed/.host_setup_done
+  register: host_setup_flag
 
+- name: Read host setup version from flag
+  slurp:
+    src: /opt/sonic-testbed/.host_setup_done
+  register: host_setup_flag_content
+  when: host_setup_flag.stat.exists
+  ignore_errors: yes
+
+- name: Determine if host setup should run
+  set_fact:
+    run_host_setup: >-
+      {{ force_host_setup
+         or not host_setup_flag.stat.exists
+         or (host_setup_flag_content.content | default('') | b64decode | trim) != host_setup_version }}
+
+- name: Include host setup tasks
+  include_tasks: host_setup.yml
+  when: run_host_setup | bool and package_installation | bool
+
+# ---- Python environment (idempotent) ----
+- name: Ensure Python environment
+  include_tasks: ensure_python_env.yml
+  when: package_installation | bool
+
+- name: Check if venv python exists
+  stat:
+    path: /opt/sonic-testbed/venv/bin/python
+  register: venv_python_stat
+
+- name: Set ansible python interpreter to venv
+  set_fact:
+    ansible_python_interpreter: "/opt/sonic-testbed/venv/bin/python"
+  when: venv_python_stat.stat.exists
+
+# ---- User groups (always run, per-user) ----
 - name: Ensure {{ ansible_user }} in docker,sudo group
   user:
     name: "{{ ansible_user }}"
@@ -163,123 +116,13 @@
     append: yes
     groups: libvirt
   become: yes
-  when: host_distribution_version.stdout >= "20.04"
 
-- name: Set kernel.pty.max to 8192
-  become: true
-  sysctl:
-    name: kernel.pty.max
-    value: 8192
-    state: present
-    sysctl_set: true
-    reload: true
-    sysctl_file: /etc/sysctl.d/99-pty.conf
+# ---- Async flag ----
+- name: Initialize async flag
+  set_fact:
+    enable_async: "{{ enable_async | default(false) | bool }}"
 
-- name: Update libvirt qemu configuration
-  block:
-  - name: Set user to root in qemu.conf
-    lineinfile:
-      path: /etc/libvirt/qemu.conf
-      regexp: '^#?user\s*=.*'
-      line: 'user = "root"'
-      state: present
-      backrefs: yes
-    become: yes
-  - name: Set group to root in qemu.conf
-    lineinfile:
-      path: /etc/libvirt/qemu.conf
-      regexp: '^#?group\s*=.*'
-      line: 'group = "root"'
-      state: present
-      backrefs: yes
-    become: yes
-  - name: Restart libvirtd to apply qemu.conf changes
-    service:
-      name: libvirtd
-      state: restarted
-    become: yes
-  when: host_distribution_version.stdout >= "24.04"
-
-- name: Install br_netfilter kernel module
-  become: yes
-  modprobe: name=br_netfilter state=present
-
-- name: Set sysctl bridge parameters for testbed
-  sysctl:
-    name: "{{ item }}"
-    value: "0"
-    sysctl_set: yes
-  become: yes
-  with_items:
-   - net.bridge.bridge-nf-call-arptables
-   - net.bridge.bridge-nf-call-ip6tables
-   - net.bridge.bridge-nf-call-iptables
-
-- name: Set sysctl RCVBUF max parameter for testbed
-  sysctl:
-    name: "net.core.rmem_max"
-    value: "509430500"
-    sysctl_set: yes
-  become: yes
-
-- name: Set sysctl RCVBUF default parameter for testbed
-  sysctl:
-    name: "net.core.rmem_default"
-    value: "31457280"
-    sysctl_set: yes
-  become: yes
-
-- name: Increase IPv6 route cache size
-  sysctl:
-    name: "net.ipv6.route.max_size"
-    value: "16384"
-    sysctl_set: yes
-  become: yes
-
-- name: Increase neighbor gc_thresh1
-  sysctl:
-    sysctl_set: yes
-    name: "{{ item }}"
-    value: "8192"
-  become: yes
-  with_items:
-    - net.ipv4.neigh.default.gc_thresh1
-    - net.ipv6.neigh.default.gc_thresh1
-
-- name: Increase neighbor gc_thresh2
-  sysctl:
-    sysctl_set: yes
-    name: "{{ item }}"
-    value: "16384"
-  become: yes
-  with_items:
-    - net.ipv4.neigh.default.gc_thresh2
-    - net.ipv6.neigh.default.gc_thresh2
-
-- name: Increase neighbor gc_thresh3
-  sysctl:
-    sysctl_set: yes
-    name: "{{ item }}"
-    value: "32768"
-  become: yes
-  with_items:
-    - net.ipv4.neigh.default.gc_thresh3
-    - net.ipv6.neigh.default.gc_thresh3
-
-- name: increase kernel pid max
-  sysctl:
-    name: "kernel.pid_max"
-    value: "4194304"
-    sysctl_set: yes
-  become: yes
-
-- name: Increase fs limitation
-  sysctl:
-    name: "fs.inotify.max_user_instances"
-    value: "62800"
-    sysctl_set: yes
-  become: yes
-
+# ---- External/internal network setup ----
 - name: Setup external front port
   include_tasks: external_port.yml
   when: external_port is defined and "bmc" not in topo
@@ -288,6 +131,7 @@
   include_tasks: internal_mgmt_network.yml
   when: internal_mgmt_network is defined and internal_mgmt_network == True
 
+# ---- Home/root path ----
 - block:
     - getent:
         database: passwd
@@ -304,6 +148,7 @@
 
     - debug: msg="home_path = {{ home_path }} root_path = {{ root_path }}"
 
+# ---- VM setup ----
 - name: Require veos or SONiC or cisco VMs by default
   set_fact:
     vm_required: true
@@ -469,8 +314,3 @@
   loop_control:
     loop_var: dut_name
   when: duts_name is defined
-
-- name: Use virtualenv for all Python scripts on Ubuntu 24.04 and newer
-  set_fact:
-    ansible_python_interpreter: "/tmp/sonic-mgmt-virtualenv/bin/python"
-  when: host_distribution_version.stdout >= "24.04"

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -94,12 +94,12 @@
 
 - name: Check if venv python exists
   stat:
-    path: /opt/sonic-testbed/venv/bin/python
+    path: "{{ sonic_testbed_venv }}/bin/python"
   register: venv_python_stat
 
 - name: Set ansible python interpreter to venv
   set_fact:
-    ansible_python_interpreter: "/opt/sonic-testbed/venv/bin/python"
+    ansible_python_interpreter: "{{ sonic_testbed_venv }}/bin/python"
   when: venv_python_stat.stat.exists
 
 # ---- User groups (always run, per-user) ----

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -62,7 +62,7 @@
 # Bump this version string whenever host_setup.yml tasks change materially.
 - name: Define host setup version
   set_fact:
-    host_setup_version: "1"
+    host_setup_version: "2"
 
 - name: Check if host setup flag file exists
   stat:
@@ -147,6 +147,22 @@
       when: "not root_path.startswith('/')"
 
     - debug: msg="home_path = {{ home_path }} root_path = {{ root_path }}"
+
+    # Newer Ubuntu releases default new home directories to mode 0750
+    # (see DIR_MODE in /etc/adduser.conf), which blocks the unprivileged
+    # libvirt-qemu user from traversing /home/<user> to open VM disk
+    # images stored under {{ home_path }}/sonic-vm/disks/.  Grant
+    # libvirt-qemu the execute (traverse) bit on home_path via a POSIX
+    # ACL.  This is targeted (only libvirt-qemu, not "other"), survives
+    # subsequent chmod operations, and avoids running QEMU as root.
+    - name: Allow libvirt-qemu to traverse home directory
+      acl:
+        path: "{{ home_path }}"
+        entity: libvirt-qemu
+        etype: user
+        permissions: x
+        state: present
+      become: yes
 
 # ---- VM setup ----
 - name: Require veos or SONiC or cisco VMs by default

--- a/ansible/roles/vm_set/templates/mux-simulator.service.j2
+++ b/ansible/roles/vm_set/templates/mux-simulator.service.j2
@@ -3,4 +3,4 @@ Description=mux simulator
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/env {{python_command}} {{ abs_root_path }}/mux_simulator_{{ mux_simulator_port }}.py {{ mux_simulator_port }} {{ vm_set_name }} -v
+ExecStart=/usr/bin/env {{ sonic_testbed_venv }}/bin/python3 {{ abs_root_path }}/mux_simulator_{{ mux_simulator_port }}.py {{ mux_simulator_port }} {{ vm_set_name }} -v

--- a/ansible/roles/vm_set/templates/nic-simulator.service.j2
+++ b/ansible/roles/vm_set/templates/nic-simulator.service.j2
@@ -3,4 +3,4 @@ Description=nic simulator
 After=network.target
 
 [Service]
-ExecStart={{ ip_command_path }} netns exec {{ netns_name }} /usr/bin/env {{ python_command }} {{ abs_root_path }}/nic_simulator/nic_simulator.py -p {{ nic_simulator_port }} -v {{ vm_set_name }} -l debug
+ExecStart={{ ip_command_path }} netns exec {{ netns_name }} /usr/bin/env {{ sonic_testbed_venv }}/bin/python3 {{ abs_root_path }}/nic_simulator/nic_simulator.py -p {{ nic_simulator_port }} -v {{ vm_set_name }} -l debug


### PR DESCRIPTION
### Description of PR

Summary:
Refactor the `ansible/roles/vm_set` role to address two problems:
1. Heavy host-setup tasks (apt installs, Docker setup, sysctl tuning) run redundantly every time any of ~10 playbooks invoke the vm_set role.
2. Python packages are installed globally via `python3-pip`, which on Ubuntu 24.04 pulls in `python3-wheel` with a known CVE vulnerability.

This PR extracts host setup into a flag-gated include, replaces `pip` with `uv` + a persistent venv, drops support for Ubuntu < 22.04, and fixes a libvirt-qemu home-traversal issue on hosts with the modern `DIR_MODE=0750` adduser default via a targeted POSIX ACL.

### Type of change

- [x] Testbed and Framework(new/improvement)

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

1. **Redundant host setup:** The vm_set role is invoked by ~10 playbooks (`add-topo`, `remove-topo`, `restart-ptf`, `start-VMs`, `stop-VMs`, etc.). Each invocation re-runs all host-setup tasks (apt package installation, Docker setup, sysctl tuning, kernel module loading), even though these only need to run once per host. This wastes significant time on repeated testbed operations.

2. **Global pip installs and CVE vulnerability:** Python packages (`requests`, `docker`, `flask`, `grpcio`, etc.) are installed globally via `python3-pip`. On Ubuntu 24.04, installing `python3-pip` pulls in `python3-wheel` as a dependency, which has a known S360 security vulnerability. Additionally, PEP 668 on Ubuntu 24.04 marks the system Python as externally managed, making global pip installs fail without `--break-system-packages`.

3. **Dead code:** Support for Ubuntu 16.04, 17.04, 18.04, and 20.04 is no longer needed but adds complexity with version-conditional blocks and Python 2 fallbacks.

4. **libvirt-qemu home traversal:** On freshly provisioned Ubuntu hosts the default `DIR_MODE` shipped in `/etc/adduser.conf` is `0750`, which blocks the unprivileged `libvirt-qemu` user from traversing `/home/<user>` to open VM disk images stored under `~/sonic-vm/disks/`. The result is a `Permission denied (as uid:64055, gid:108)` error when starting the SONiC VM.

#### How did you do it?

**New files:**
- `defaults/main.yml` — Declares `sonic_testbed_venv: "/opt/sonic-testbed/venv"` so the venv path is defined in exactly one place.
- `host_setup.yml` — Extracted all heavy one-time setup tasks (apt packages, Docker, sysctl, br_netfilter). Gated by a version-stamped flag file at `/opt/sonic-testbed/.host_setup_done`. Subsequent invocations skip setup unless the version string is bumped or `FORCE_HOST_SETUP=true` is set. Adds `acl` to the apt package list.
- `ensure_python_env.yml` — Idempotent tasks to install `uv` and create a persistent venv at `{{ sonic_testbed_venv }}` with `--system-site-packages` (to inherit apt-provided `python3-libvirt` and `python3-lxml`). Installs `requests==2.33.1` (CVE fix in v2.33.0) and `docker==7.1.0`. Pre-checks installed versions and skips `uv pip install` when the venv already matches.

**Modified files:**
- `main.yml` — Slimmed down from ~477 to ~300 lines. Added fail-fast for non-Ubuntu or Ubuntu < 22.04. Fixed `package_installation` env var lookup to not override playbook-set values. Moved user group membership outside the flag gate (per-user, not per-host). Added an `acl` task granting `libvirt-qemu` the execute (traverse) bit on `home_path`; gated on `package_installation` since both the `acl` package and the `libvirt-qemu` user are installed via `host_setup.yml`.
- `docker.yml` — Removed Ubuntu 16.04–20.04 docker repo blocks, all pip/virtualenv Python package installs, and the trailing `ansible_python_interpreter` override.
- `control_mux_simulator.yml` / `control_nic_simulator.yml` — Replaced pip installs with `uv pip install` into the venv; pre-check installed versions to skip re-install when already present.
- `templates/mux-simulator.service.j2` / `nic-simulator.service.j2` — Use `{{ sonic_testbed_venv }}/bin/python3` directly; the redundant `python_command` set_fact is removed.

**Key design decisions:**
- `--system-site-packages` is mandatory because `python3-libvirt` and `python3-lxml` are C extensions installed via apt that must match the system's shared libraries.
- `ensure_python_env.yml` and the libvirt-qemu ACL task are both gated by `package_installation` to respect playbooks (e.g. `testbed_renumber_vm_topology.yml`) that intentionally skip first-time provisioning.
- `ansible_python_interpreter` is only set to venv python if the venv actually exists, preventing failures when `package_installation=false`.
- **libvirt-qemu disk access:** rather than rewriting `/etc/libvirt/qemu.conf` to run QEMU as root (which goes against the distro security model and broadens the attack surface), we grant the unprivileged `libvirt-qemu` user the minimum permission it needs — a POSIX ACL granting `--x` (traverse only, not read) on `home_path`. This keeps QEMU running as `libvirt-qemu`, applies uniformly to Ubuntu 22.04 and 24.04, survives subsequent `chmod` operations on the home directory, and does not require restarting `libvirtd`. See the discussion thread on PR for context.

#### How did you verify/test it?

Tested on both Ubuntu 22.04 and Ubuntu 24.04 with a VS testbed:

| Test | Result on 22.04 | Result on 24.04 |
|------|---------|---------|
| `testbed-cli.sh add-topo vms-kvm-t0` (fresh host) | ✅ `ok=302 changed=49 failed=0`, VM `vlab-01` running | ✅ `ok=283 changed=35 failed=0`, VM `vlab-01` running |
| QEMU process user | `libvirt-qemu` (unprivileged) | `libvirt-qemu` (unprivileged) |
| `/etc/libvirt/qemu.conf` user/group lines | unchanged (using libvirt defaults) | unchanged (using libvirt defaults) |
| ACL on `home_path` | `user:libvirt-qemu:--x` applied | `user:libvirt-qemu:--x` applied |
| Repeat `add-topo` (idempotence) | ✅ pip install tasks skipped (`pkg_versions.stdout_lines != ['2.33.1', '7.1.0']` false-condition), ACL re-applied after manual strip | ✅ same |
| `restart-ptf` (`package_installation=false` style path) | ✅ host_setup, python env, and ACL tasks correctly skipped | ✅ same |

#### Any platform specific information?

- Minimum Ubuntu version: 22.04
- Tested end-to-end on both Ubuntu 22.04 and Ubuntu 24.04.
- Drops support for Ubuntu 16.04, 17.04, 18.04, 20.04 and Python 2.

#### Caveat for hosts that previously ran an earlier iteration of this branch

An earlier iteration of this PR (now reverted) unconditionally rewrote `/etc/libvirt/qemu.conf` to run QEMU as root on Ubuntu 24.04. The final approach in this PR does not touch `qemu.conf` and instead uses an ACL. Any host that pulled an earlier `xiwang5/vm-set-refactor-host-setup` HEAD will still have `user = "root"` / `group = "root"` in `qemu.conf`. To revert manually after this PR lands:

```bash
sudo sed -i -e 's|^user = "root"|#user = "libvirt-qemu"|' \
            -e 's|^group = "root"|#group = "libvirt-qemu"|' /etc/libvirt/qemu.conf
sudo systemctl restart libvirtd
```

#### Supported testbed topology if it's a new test case?

N/A — this is a testbed infrastructure improvement, not a new test case.

### Documentation

N/A — internal ansible role change, no user-facing documentation impact.
