### PR TITLE
[BMC] Exclude BMC from is_frontend_node()

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -291,7 +291,7 @@ class SonicHost(AnsibleHostBase):
             True if it is not any other type of node. Currently, the only other type of node supported is 'supervisor'
             node. If we add more types of nodes, then we need to exclude them from this method as well.
         """
-        return not self.is_supervisor_node()
+        return not self.is_supervisor_node() and not self.is_bmc()
 
     def is_console_switch(self):
         """


### PR DESCRIPTION
### Description of PR

`SonicHost.is_frontend_node()` returns `True` for everything that is not a supervisor card. The docstring already calls out that this is incomplete and should be extended when new node types are introduced:

> Currently, the only other type of node supported is 'supervisor' node. If we add more types of nodes, then we need to exclude them from this method as well.

BMC (`router_type == "NetworkBmc"`) is exactly such a "another type of node" — it has no front-side ASIC, no BGP, no ports. Tests that gate frontend-only commands behind `is_frontend_node()` therefore run them on BMC and fail. Concrete example surfaced on a BMC testbed today:

```
tests/tacacs/test_authorization.py::test_authorization_tacacs_only
    if duthost.sonichost.is_frontend_node():
        commands.extend(frontend_commands)   # show ip bgp neighbor / show muxcable firmware ...

  -> Failed: Command 'show ip bgp neighbor' failed with exit code: 2,
     stderr: ['Error: No such command \'bgp\'.']
```

Use the existing `is_bmc()` helper (defined a few lines above in the same file) to also exclude BMC nodes.

Summary:
Fixes a long-standing TODO in the docstring; unblocks the `tacacs.test_authorization` case on BMC.

Microsoft ADO 37908237

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

(BMC support is master-only — no backport requested.)

### Approach
#### What is the motivation for this PR?

`is_frontend_node()` is used to gate frontend-only operations (BGP / muxcable show commands, macsec setup, frontend_nodes iteration). On BMC, all of these are nonsensical and currently break tests.

#### How did you do it?

One-line change in `tests/common/devices/sonic.py`:

```python
def is_frontend_node(self):
    return not self.is_supervisor_node() and not self.is_bmc()
```

#### How did you verify/test it?

Static survey of the 9 references to `is_frontend_node` in `tests/`, all are semantically improved by this change:

| File | Use | Effect on BMC |
|---|---|---|
| `common/devices/duthosts.py` (×3) | builds `duthosts.frontend_nodes` collection | BMC excluded from frontend iterations - correct |
| `conftest.py` (×2) | gates macsec setup | BMC has no macsec - correct |
| `tacacs/test_authorization.py` | extends command list with BGP/muxcable | BMC skips BGP commands - test now passes |
| `common/helpers/dut_utils.py` | different inventory-based function, untouched |  |

Will verify on a BMC testbed once the change is consumed downstream:
- `tacacs.test_authorization.test_authorization_tacacs_only` passes end-to-end.
- No regression on a non-BMC testbed: `frontend_nodes` and macsec gating unchanged for non-BMC, non-supervisor devices (`is_bmc()` returns False).

#### Any platform specific information?

Only affects nodes whose `router_type == "NetworkBmc"`. Non-BMC devices unchanged.

#### Supported testbed topology if it's a new test case?

N/A (bug fix to existing helper).

### Documentation
N/A