### PR TITLE
[BMC][Conditional Mark] Skip 14 gnmi/telemetry/syslog tests on BMC via conditional_mark

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2850,6 +2850,12 @@ gnmi/test_gnmi.py:
       - "is_mgmt_ipv6_only==True"
       - "https://github.com/sonic-net/sonic-mgmt/issues/20395"
 
+gnmi/test_gnmi.py::test_gnmi_subscribe_sample:
+  skip:
+    reason: "Test relies on Ethernet0 frontpanel port and COUNTERS_DB; not applicable on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
 gnmi/test_gnmi_appldb.py::test_gnmi_appldb_01:
   skip:
     reason: "dut ipv6 mgmt ip not supported"
@@ -2868,10 +2874,11 @@ gnmi/test_gnmi_configdb.py:
 
 gnmi/test_gnmi_configdb.py::test_gnmi_configdb_full_replace_01:
   skip:
-    reason: "dut ipv6 mgmt ip not supported"
+    reason: "dut ipv6 mgmt ip not supported / not applicable on BMC (no front-panel ports)"
+    conditions_logical_operator: or
     conditions:
-      - "is_mgmt_ipv6_only==True"
-      - "https://github.com/sonic-net/sonic-mgmt/issues/20395"
+      - "is_mgmt_ipv6_only==True and https://github.com/sonic-net/sonic-mgmt/issues/20395"
+      - "'bmc' in topo_type"
 
 gnmi/test_gnmi_configdb.py::test_gnmi_configdb_get_authenticate:
   skip:
@@ -2882,10 +2889,11 @@ gnmi/test_gnmi_configdb.py::test_gnmi_configdb_get_authenticate:
 
 gnmi/test_gnmi_configdb.py::test_gnmi_configdb_incremental_01:
   skip:
-    reason: "dut ipv6 mgmt ip not supported"
+    reason: "dut ipv6 mgmt ip not supported / not applicable on BMC (no front-panel ports)"
+    conditions_logical_operator: or
     conditions:
-      - "is_mgmt_ipv6_only==True"
-      - "https://github.com/sonic-net/sonic-mgmt/issues/20395"
+      - "is_mgmt_ipv6_only==True and https://github.com/sonic-net/sonic-mgmt/issues/20395"
+      - "'bmc' in topo_type"
 
 gnmi/test_gnmi_configdb.py::test_gnmi_configdb_incremental_02:
   skip:
@@ -2893,6 +2901,12 @@ gnmi/test_gnmi_configdb.py::test_gnmi_configdb_incremental_02:
     conditions:
       - "is_mgmt_ipv6_only==True"
       - "https://github.com/sonic-net/sonic-mgmt/issues/20395"
+
+gnmi/test_gnmi_configdb.py::test_gnmi_configdb_polling_01:
+  skip:
+    reason: "Test relies on DEVICE_METADATA bgp_asn; not configured on BMC"
+    conditions:
+      - "'bmc' in topo_type"
 
 gnmi/test_gnmi_configdb.py::test_gnmi_configdb_streaming_onchange_01:
   skip:
@@ -2910,10 +2924,11 @@ gnmi/test_gnmi_configdb.py::test_gnmi_configdb_streaming_onchange_02:
 
 gnmi/test_gnmi_configdb.py::test_gnmi_configdb_streaming_sample_01:
   skip:
-    reason: "dut ipv6 mgmt ip not supported"
+    reason: "dut ipv6 mgmt ip not supported / not applicable on BMC (no DEVICE_METADATA bgp_asn)"
+    conditions_logical_operator: or
     conditions:
-      - "is_mgmt_ipv6_only==True"
-      - "https://github.com/sonic-net/sonic-mgmt/issues/20395"
+      - "is_mgmt_ipv6_only==True and https://github.com/sonic-net/sonic-mgmt/issues/20395"
+      - "'bmc' in topo_type"
 
 gnmi/test_gnmi_configdb.py::test_gnmi_configdb_subscribe_authenticate:
   skip:
@@ -2928,26 +2943,41 @@ gnmi/test_gnmi_countersdb.py:
     conditions:
       - "is_multi_asic==True"
 
+gnmi/test_gnmi_countersdb.py::test_gnmi_counterdb_polling_01:
+  skip:
+    reason: "Test relies on COUNTERS_PORT_NAME_MAP populated by syncd; not applicable on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
+gnmi/test_gnmi_countersdb.py::test_gnmi_counterdb_polling_02:
+  skip:
+    reason: "Test relies on COUNTERS_PORT_NAME_MAP populated by syncd; not applicable on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
 gnmi/test_gnmi_countersdb.py::test_gnmi_counterdb_streaming_sample_01:
   skip:
-    reason: "dut ipv6 mgmt ip not supported"
+    reason: "dut ipv6 mgmt ip not supported / not applicable on BMC (no COUNTERS_PORT_NAME_MAP)"
+    conditions_logical_operator: or
     conditions:
-      - "is_mgmt_ipv6_only==True"
-      - "https://github.com/sonic-net/sonic-mgmt/issues/20395"
+      - "is_mgmt_ipv6_only==True and https://github.com/sonic-net/sonic-mgmt/issues/20395"
+      - "'bmc' in topo_type"
 
 gnmi/test_gnmi_countersdb.py::test_gnmi_counterdb_streaming_sample_02:
   skip:
-    reason: "dut ipv6 mgmt ip not supported"
+    reason: "dut ipv6 mgmt ip not supported / not applicable on BMC (no COUNTERS_PORT_NAME_MAP)"
+    conditions_logical_operator: or
     conditions:
-      - "is_mgmt_ipv6_only==True"
-      - "https://github.com/sonic-net/sonic-mgmt/issues/20395"
+      - "is_mgmt_ipv6_only==True and https://github.com/sonic-net/sonic-mgmt/issues/20395"
+      - "'bmc' in topo_type"
 
 gnmi/test_gnmi_countersdb.py::test_gnmi_output:
   skip:
-    reason: "dut ipv6 mgmt ip not supported"
+    reason: "dut ipv6 mgmt ip not supported / not applicable on BMC (no COUNTERS_PORT_NAME_MAP)"
+    conditions_logical_operator: or
     conditions:
-      - "is_mgmt_ipv6_only==True"
-      - "https://github.com/sonic-net/sonic-mgmt/issues/20395"
+      - "is_mgmt_ipv6_only==True and https://github.com/sonic-net/sonic-mgmt/issues/20395"
+      - "'bmc' in topo_type"
 
 gnmi/test_gnmi_countersdb.py::test_gnmi_queue_buffer_cnt:
   skip:
@@ -2959,6 +2989,12 @@ gnmi/test_gnmi_countersdb.py::test_gnmi_queue_buffer_cnt:
 gnmi/test_gnmi_smartswitch.py:
   skip:
     reason: 'SmartSwitch gNMI tests require SmartSwitch platform, not applicable to BMC'
+    conditions:
+      - "'bmc' in topo_type"
+
+gnmi/test_gnmi_stress.py::test_gnmi_latency_01:
+  skip:
+    reason: "Test relies on PORT table in CONFIG_DB; not configured on BMC"
     conditions:
       - "'bmc' in topo_type"
 
@@ -5263,6 +5299,10 @@ sub_port_interfaces/test_sub_port_l2_forwarding.py::test_sub_port_l2_forwarding[
 #####             syslog          #####
 #######################################
 syslog/test_logrotate.py::test_orchagent_logrotate:
+  skip:
+    reason: "BMC has no orchagent service; not applicable"
+    conditions:
+      - "'bmc' in topo_type"
   xfail:
     reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
     conditions:
@@ -5362,6 +5402,12 @@ telemetry/test_telemetry.py:
     conditions:
       - "(is_multi_asic==True) and (release in ['201811', '201911'])"
 
+telemetry/test_telemetry.py::test_on_change_updates:
+  skip:
+    reason: "Test relies on BGP neighbors; none configured on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
 telemetry/test_telemetry.py::test_osbuild_version:
   skip:
     reason: "dut ipv6 mgmt ip not supported"
@@ -5378,10 +5424,11 @@ telemetry/test_telemetry.py::test_sysuptime:
 
 telemetry/test_telemetry.py::test_telemetry_ouput:
   skip:
-    reason: "dut ipv6 mgmt ip not supported"
+    reason: "dut ipv6 mgmt ip not supported / not applicable on BMC (no Ethernet0/COUNTERS_DB)"
+    conditions_logical_operator: or
     conditions:
-      - "is_mgmt_ipv6_only==True"
-      - "https://github.com/sonic-net/sonic-mgmt/issues/20395"
+      - "is_mgmt_ipv6_only==True and https://github.com/sonic-net/sonic-mgmt/issues/20395"
+      - "'bmc' in topo_type"
 
 telemetry/test_telemetry.py::test_telemetry_queue_buffer_cnt:
   skip:


### PR DESCRIPTION
### Description of PR

These tests fail on BMC platforms because they depend on services or data that BMC does not have:

- `gnmi/test_gnmi.py::test_gnmi_subscribe_sample`, `gnmi/test_gnmi_configdb.py::test_gnmi_configdb_polling_01` `gnmi/test_gnmi_configdb.py::test_gnmi_configdb_streaming_sample_01` `gnmi/test_gnmi_configdb.py::test_gnmi_configdb_full_replace_01`, `gnmi/test_gnmi_configdb.py::test_gnmi_configdb_incremental_01` and `gnmi/test_gnmi_stress.py::test_gnmi_latency_01`: rely on the `PORT` table or `DEVICE_METADATA.bgp_asn` in CONFIG_DB which are not configured on BMC (no front-panel ports / no BGP).
- `gnmi/test_gnmi_countersdb.py::test_gnmi_counterdb_polling_01`, `test_gnmi_counterdb_polling_02`, `test_gnmi_counterdb_streaming_sample_01`, `test_gnmi_counterdb_streaming_sample_02` and `test_gnmi_output`: rely on `COUNTERS_PORT_NAME_MAP` populated by `syncd`; BMC does not run `syncd`.
- `telemetry/test_telemetry.py::test_on_change_updates` and `telemetry/test_telemetry.py::test_telemetry_ouput`: pick a random BGP neighbor (`random.choice(bgp_nbrs)`) — BMC has no BGP neighbors so the test errors with `IndexError: Cannot choose from an empty sequence`.
- `syslog/test_logrotate.py::test_orchagent_logrotate`: BMC does not run `orchagent`, so there is no orchagent log to rotate.

Skip them via `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` using `'bmc' in topo_type` to match the dominant convention used elsewhere in the file. For tests that already had an ipv6-only skip entry, the new BMC condition is OR-merged.

#### Summary:
Fixes # (issue)

##### Approach
###### What is the motivation for this PR?
Avoid spurious failures on BMC nightly/PR runs for tests that fundamentally cannot apply on a BMC platform.

###### How did you do it?
Added/extended entries in `tests_mark_conditions.yaml` so the conditional_mark plugin marks them as `skip` when `'bmc' in topo_type`.

###### How did you verify/test it?
Verified failure modes on the BMC testbed (`bmc-dual-mgmt` topo) and confirmed each listed test fails for the listed reason on BMC.

##### Documentation
N/A.

#### co-authorized by: jingwen<jingwenxie@microsoft.com>