### PR TITLE
Force port-alias in <AttachTo>/<StartPort>/<InterfaceName> for HWSKUs whose alias and port-name namespaces overlap

### DIFF
--- a/ansible/templates/minigraph_device.j2
+++ b/ansible/templates/minigraph_device.j2
@@ -1,3 +1,8 @@
+{# HWSKUs whose port-alias namespace overlaps the SONiC port-name namespace.
+   Patterns in this list are matched as SUBSTRINGS against the DUT hwsku.
+   See ansible/templates/minigraph_dpg.j2 for the full rationale. #}
+{% set alias_name_collision_hwsku_patterns = ['Arista-7050CX3'] %}
+{% set hwsku_has_alias_name_collision = (alias_name_collision_hwsku_patterns | select('in', hwsku) | list | length > 0) %}
   <DeviceInfos>
     <DeviceInfo>
       <EthernetInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
@@ -10,7 +15,7 @@
           <AlternateSpeeds i:nil="true"/>
           <EnableFlowControl>true</EnableFlowControl>
           <Index>1</Index>
-          {% if num_asics > 1 %}
+          {% if num_asics > 1 or hwsku_has_alias_name_collision %}
           <InterfaceName>{{ port_alias[index] }}</InterfaceName>
           {% else %}
           <InterfaceName>{{ port_alias_map[port_alias[index]] }}</InterfaceName>

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -1,3 +1,13 @@
+{# HWSKUs whose port-alias namespace overlaps the SONiC port-name namespace.
+   Patterns in this list are matched as SUBSTRINGS against the DUT hwsku,
+   so e.g. "Arista-7050CX3" matches "Arista-7050CX3-32C", "Arista-7050CX3-32S",
+   and any other Arista-7050CX3 variant.
+   For these, <AttachTo> must carry the alias verbatim, because the SONiC
+   minigraph parser will perform its own alias->name lookup; pre-converting
+   here would cause a second lookup on a string that is also a valid alias
+   for a *different* port (see PR #24516 / regression from PR #22166). #}
+{% set alias_name_collision_hwsku_patterns = ['Arista-7050CX3'] %}
+{% set hwsku_has_alias_name_collision = (alias_name_collision_hwsku_patterns | select('in', hwsku) | list | length > 0) %}
   <DpgDec>
     <DeviceDataPlaneInfo>
       <IPSecTunnels/>
@@ -200,8 +210,8 @@
   <AttachTo>PortChannel{{ (100 + index + 1)|string }}</AttachTo>
 {% else %}
   {% set intf_alias = port_alias[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] %}
-  {% if num_asics > 1 %}
-    {# Chassis: use alias directly #}
+  {% if num_asics > 1 or hwsku_has_alias_name_collision %}
+    {# Chassis, or HWSKU whose alias namespace overlaps port-name namespace: use alias directly #}
     <AttachTo>{{ intf_alias }}</AttachTo>
   {% else %}
     {# TOR: use port_alias_map #}
@@ -218,7 +228,7 @@
           <AttachTo>PortChannel{{ (100 + index + 1)|string }}</AttachTo>
 {% else %}
           {% set intf_alias = port_alias[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] %}
-          {% if num_asics > 1 %}
+          {% if num_asics > 1 or hwsku_has_alias_name_collision %}
             <AttachTo>{{ intf_alias }}</AttachTo>
           {% else %}
             <AttachTo>{{ port_alias_map[intf_alias] }}</AttachTo>
@@ -319,7 +329,7 @@
 {% if 'port-channel' not in vm_topo_config['vm'][vms[index]]['ip_intf']|lower %}
 {% if vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|length %}
 {% set intf_alias = port_alias[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] %}
-{% if num_asics > 1 %}
+{% if num_asics > 1 or hwsku_has_alias_name_collision %}
   {% set a_intf = intf_alias %}
 {% else %}
   {% set a_intf = port_alias_map[intf_alias] %}

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -1,3 +1,8 @@
+{# HWSKUs whose port-alias namespace overlaps the SONiC port-name namespace.
+   Patterns in this list are matched as SUBSTRINGS against the DUT hwsku.
+   See ansible/templates/minigraph_dpg.j2 for the full rationale. #}
+{% set alias_name_collision_hwsku_patterns = ['Arista-7050CX3'] %}
+{% set hwsku_has_alias_name_collision = (alias_name_collision_hwsku_patterns | select('in', hwsku) | list | length > 0) %}
   <PngDec>
     <DeviceInterfaceLinks>
 {% if card_type is not defined or card_type != 'supervisor' %}
@@ -10,7 +15,7 @@
         <EndDevice>{{ vms[index] }}</EndDevice>
         <EndPort>{{ vm_intfs[if_index] }}</EndPort>
         <StartDevice>{{ inventory_hostname }}</StartDevice>
-        {% if num_asics > 1 %}
+        {% if num_asics > 1 or hwsku_has_alias_name_collision %}
         <StartPort>{{ port_alias[dut_intfs[if_index]] }}</StartPort>
         {% else %}
         <StartPort>{{ port_alias_map[port_alias[dut_intfs[if_index]]] }}</StartPort>
@@ -111,7 +116,7 @@
         <EndPort>{{ front_panel_asic_ifnames[if_index] }}</EndPort>
         <FlowControl>true</FlowControl>
         <StartDevice>{{ inventory_hostname }}</StartDevice>
-        {% if num_asics > 1 %}
+        {% if num_asics > 1 or hwsku_has_alias_name_collision %}
         <StartPort>{{ port_alias[loop.index - 1] }}</StartPort>
         {% else %}
         <StartPort>{{ port_alias_map[port_alias[loop.index - 1]] }}</StartPort>


### PR DESCRIPTION
### Description of PR

PR #22166 wrapped `port_alias[i]` with `port_alias_map[...]` in the minigraph templates so that, on single-ASIC (TOR) DUTs, `<AttachTo>` / `<StartPort>` / `<InterfaceName>` are emitted as the SONiC port name instead of the port alias. This breaks HWSKUs whose port-alias namespace overlaps the port-name namespace (for example, the **Arista-7050CX3** family, where `Ethernet33` is both a port alias and the name of a different physical port).

The SONiC minigraph parser (`sonic-buildimage/src/sonic-config-engine/minigraph.py`) treats `<AttachTo>` / `<StartPort>` / `<InterfaceName>` as port **aliases** and performs its own alias→name lookup via `port_alias_map`. When the template pre-converts alias to name, the parser performs a second lookup on a string that happens to also be a valid alias for a *different* port, attaching the IP/link to the wrong port and leaving the intended port unconfigured (admin-down).

**This PR does NOT revert PR #22166.** It keeps the alias→name conversion as the default behavior for single-ASIC TORs (preserving the original PR's intent) and only forces the alias-only path for HWSKUs that match a known-collision pattern.

The collision list lives in each affected template as a top-level Jinja variable, `alias_name_collision_hwsku_patterns`, and patterns are matched as **substrings** against the DUT `hwsku`, so e.g. `Arista-7050CX3` also matches `Arista-7050CX3-32C`, `Arista-7050CX3-32S`, and any other Arista-7050CX3 variant. Add new patterns to the list as collisions are discovered.

Affected sites (5 total):

- `ansible/templates/minigraph_dpg.j2`
  - `<IPInterfaces>` IPv4 `<AttachTo>`
  - `<IPInterfaces>` IPv6 `<AttachTo>`
  - `acl_intfs` set used in `<AclInterface><AttachTo>`
- `ansible/templates/minigraph_device.j2`
  - `<EthernetInterface><InterfaceName>`
- `ansible/templates/minigraph_png.j2`
  - `<DeviceInterfaceLink><StartPort>` (front panel)
  - `<DeviceInterfaceLink><StartPort>` (chassis-internal)

Initial collision pattern list: `['Arista-7050CX3']`.

Summary:
Fixes regression introduced by #22166 for HWSKUs whose port-alias and port-name namespaces overlap.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
After PR #22166 was merged, `deploy-mg` produced a `minigraph.xml` in which `<AttachTo>` / `<StartPort>` / `<InterfaceName>` carried SONiC port names instead of port aliases for single-ASIC TORs. On Arista-7050CX3 the alias `Ethernet33` is the alias of one port and also the name of a different port, so the SONiC parser's own alias→name lookup remapped the value a second time and configured the wrong port; the originally targeted port ended up unconfigured/admin-down.

#### How did you do it?
Kept PR #22166's logic intact and added a small allow-list of HWSKU substring patterns (currently `['Arista-7050CX3']`) that need the legacy alias-only emission. The condition guarding the alias→name conversion was changed from `num_asics > 1` to `num_asics > 1 or hwsku_has_alias_name_collision` in all 5 sites across the three templates. The patterns and the precomputed boolean are declared once at the top of each template (using `alias_name_collision_hwsku_patterns | select('in', hwsku) | list | length > 0`) so the gates stay readable and so adding a new pattern is a one-line change.

#### How did you verify/test it?
- Ran `./testbed-cli.sh -t testbed.yaml deploy-mg` against an Arista-7050CX3 TOR (single-ASIC) and confirmed the generated `minigraph.xml` now carries port aliases in `<AttachTo>` / `<StartPort>` / `<InterfaceName>`, matching the format produced before #22166.
- Confirmed that an Arista-7050CX3 deploy-mg no longer leaves port `Ethernet33` admin-down and that the IP interface attaches to the intended port.
- Verified that other single-ASIC TOR HWSKUs (not matching the pattern list) still get the new PR #22166 behavior, so the original fix for those platforms is preserved.
- Validated the substring-match semantics of `select('in', hwsku)` in a small Jinja2 sanity test: `Arista-7050CX3` matches `Arista-7050CX3-32C` and `Arista-7050CX3-32S`, and does not match unrelated SKUs such as `Arista-7060CX-32S`.

#### Any platform specific information?
The visible regression was on the Arista-7050CX3 family. Other HWSKUs whose alias schema produces strings that also exist in their port-name set on the same `port_config.ini` should be added to `alias_name_collision_hwsku_patterns` as they are identified.

#### Supported testbed topology if it's a new test case?
N/A — this is a bug fix; no new test case.

### Documentation
N/A
