### PR TITLE
[C1] Skip route_flow_counter tests on Nokia-7215-C1 platforms

### DIFF
--- a/tests/common/flow_counter/flow_counter_utils.py
+++ b/tests/common/flow_counter/flow_counter_utils.py
@@ -122,7 +122,7 @@ def is_route_flow_counter_supported(duthosts, tbinfo, enum_rand_one_per_hwsku_ho
     rand_selected_dut = duthosts[enum_rand_one_per_hwsku_hostname]
     if "t2" in tbinfo["topo"]["type"] or rand_selected_dut.is_multi_asic:
         pytest.skip("Skip test for T2 and multi-asic")
-    if rand_selected_dut.facts['asic_type'] == 'vs':
+    if rand_selected_dut.facts['asic_type'] in ['vs', 'nokia-vs']:
         # vs platform always set SAI capability to enabled, however, it does not really support all SAI atrributes.
         # Currently, vs platform does not support route flow counter.
         logger.info('Route flow counter is not supported on vs platform')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip route_flow_counter testcases on Nokia-7215-C1 platforms as it is not supported
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
route_flow_counters not supported on Nokia-7215-C1 platforms
#### How did you do it?
Add platform asic_type to skip condition
#### How did you verify/test it?
Run route_flow_counter tests on Nokia-7215-C1 platforms
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
