### PR TITLE
[ipfwd] Increase timeout for high-scale platforms

### DIFF
--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -337,6 +337,12 @@ def validate_asic_route(duthost, route, exist=True):
         return exist is False
 
 
+def is_high_scale_platform(duthost) -> bool:
+    interfaces_status = duthost.sonichost.get_interfaces_status()
+    number_of_interfaces = len(interfaces_status.keys())
+    return number_of_interfaces >= 128
+
+
 def test_nhop_group_member_count(duthost, tbinfo, loganalyzer):
     """
     Test next hop group resource count. Steps:
@@ -365,6 +371,10 @@ def test_nhop_group_member_count(duthost, tbinfo, loganalyzer):
         default_max_nhop_paths = 8
         polling_interval = 10
         sleep_time = 120
+    elif is_high_scale_platform(duthost):
+        default_max_nhop_paths = 32
+        polling_interval = 10
+        sleep_time = 380
     else:
         default_max_nhop_paths = 32
         polling_interval = 10
@@ -448,7 +458,7 @@ def test_nhop_group_member_count(duthost, tbinfo, loganalyzer):
 
     # verify the test used up all the NHOP group resources
     # skip this check on Mellanox as ASIC resources are shared
-    if is_cisco_device(duthost) or "7060X6" in duthost.sonichost.get_facts()['platform'].upper():
+    if is_cisco_device(duthost) or is_high_scale_platform(duthost):
         pytest_assert(
             crm_after["available_nhop_grp"] + nhop_group_count == crm_before["available_nhop_grp"],
             "Unused NHOP group resource:{}, used:{}, nhop_group_count:{}, Unused NHOP group resource before:{}".format(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Summary:

In test_nhop_group.py::test_nhop_group_member_count, use the same sleep time as the Cisco devices one for high-scale platforms (7060X6 and 7060XE7), since those platforms also take longer to set up the NHOP groups.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

This test fails on two specific platforms because the sleep time is not enough time to set up all the nhop groups in those large-scale platforms.

#### How did you do it?

I increased the sleep time for those platforms.

#### How did you verify/test it?

I ran the test in a test cluster with a 7060x6 DUT, with and without this change, and confirmed the change fixes it. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
