### PR TITLE
Adding support for copying socat to the DUTs.

### DIFF
--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -99,7 +99,7 @@ def cleanup_modules(setup_c0):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def prepare_hosts(duthost, fanouthosts, tbinfo):
+def install_socat_on_c0_hosts(duthost, fanouthosts, tbinfo):
     if tbinfo["topo"]["name"] not in ["c0", "c0-lo"]:
         pytest.skip(
             'These tests are not applicable for '

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts  # noqa: F401
+from tests.common.helpers.assertions import pytest_assert
 
 
 console_lines = list(map(str, range(1, 49)))
@@ -60,11 +61,6 @@ def get_console_fanout(duthost, fanouthosts, tbinfo):
         console_fanout = duthost
     else:
         pytest.fail("Test requires c0 or c0-lo topology")
-    if console_fanout is None:
-        pytest.fail(
-            f"Couldnot find the console fanout for the DUT:{duthost}. "
-            "Pls fix the ansible files, there should be atleast one "
-            "console fanout.")
     return console_fanout
 
 
@@ -108,7 +104,8 @@ def install_socat_on_c0_hosts(duthost, fanouthosts, tbinfo):
     required_hosts = set([duthost, console_fanout])
     for host in required_hosts:
         host.copy(src="./console/socat", dest="/usr/local/bin/socat", mode='0755')
-        assert host.shell("socat -V", module_ignore_errors=True)["rc"] == 0, \
-            f"socat installation failed on DUT host:{host}"
+        pytest_assert(
+            host.shell("socat -V", module_ignore_errors=True)["rc"] == 0,
+            f"socat installation failed on DUT host:{host}")
 
     yield

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -38,9 +38,19 @@ def setup_c0(request, duthost, tbinfo):
             pytest.fail("Flow control mismatch for line {}: expect {}, got {}".format(line_number,
                                                                                       bool(int(flow_control)),
                                                                                       dut_line_config["flow_control"]))
+    fanouthosts = request.getfixturevalue("fanouthosts")
+    console_fanout = get_console_fanout(duthost, fanouthosts, tbinfo)
+    console_facts = duthost.console_facts()['ansible_facts']['console_facts']
+    if len(console_facts["lines"]) != len(console_lines):
+        pytest.fail("C0 topo test requires DUT with 48 console lines configured, got {}"
+                    .format(len(console_facts["lines"])))
 
+    return duthost, console_fanout
+
+
+def get_console_fanout(duthost, fanouthosts, tbinfo):
+    console_fanouts = None
     if tbinfo["topo"]["name"] == "c0":
-        fanouthosts = request.getfixturevalue("fanouthosts")
         console_fanouts = list(filter(lambda fh: fh.get_fanout_os() == 'sonic' and fh.is_console_switch(),
                                       fanouthosts.values()))
         if len(console_fanouts) != 1:
@@ -50,13 +60,12 @@ def setup_c0(request, duthost, tbinfo):
         console_fanout = duthost
     else:
         pytest.fail("Test requires c0 or c0-lo topology")
-
-    console_facts = duthost.console_facts()['ansible_facts']['console_facts']
-    if len(console_facts["lines"]) != len(console_lines):
-        pytest.fail("C0 topo test requires DUT with 48 console lines configured, got {}"
-                    .format(len(console_facts["lines"])))
-
-    return duthost, console_fanout
+    if console_fanout is None:
+        pytest.fail(
+            f"Couldnot find the console fanout for the DUT:{duthost}. "
+            "Pls fix the ansible files, there should be atleast one "
+            "console fanout.")
+    return console_fanout
 
 
 @pytest.fixture(scope='module')
@@ -87,3 +96,19 @@ def cleanup_modules(setup_c0):
         console_fanout.shell("sudo killall socat", module_ignore_errors=True)
         console_fanout.shell("rmmod nim_async_lite; rmmod tty_async; modprobe nim_async_lite ",
                              module_ignore_errors=True)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def prepare_hosts(duthost, fanouthosts, tbinfo):
+    if tbinfo["topo"]["name"] not in ["c0", "c0-lo"]:
+        pytest.skip(
+            'These tests are not applicable for '
+            f'this topology:{tbinfo["topo"]["name"]}')
+    console_fanout = get_console_fanout(duthost, fanouthosts, tbinfo)
+    required_hosts = set([duthost, console_fanout])
+    for host in required_hosts:
+        host.copy(src="./console/socat", dest="/usr/local/bin/socat", mode='0755')
+        assert host.shell("socat -V", module_ignore_errors=True)["rc"] == 0, \
+            f"socat installation failed on DUT host:{host}"
+
+    yield

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -49,7 +49,7 @@ def setup_c0(request, duthost, tbinfo):
 
 
 def get_console_fanout(duthost, fanouthosts, tbinfo):
-    console_fanouts = None
+    console_fanout = None
     if tbinfo["topo"]["name"] == "c0":
         console_fanouts = list(filter(lambda fh: fh.get_fanout_os() == 'sonic' and fh.is_console_switch(),
                                       fanouthosts.values()))


### PR DESCRIPTION
Copy of https://github.com/sonic-net/sonic-mgmt/pull/23595 since it is messed up.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Sometimes the console script execute the "socat" command in dut or console-fanout. But the socat executable is not copied to the hosts. This fixture is to copy the socat from tests/console/socat to the DUTs and console-fanouts.

Summary:
Fixes issues where socat is needed, but not yet available in the fanouts.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
The tests execute socat without copyting the required executable.

#### How did you do it?
Added a new fixture to the console/conftest.py folder.

#### How did you verify/test it?
Ran a couple of tests:
```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================================================================================== PASSES =======================================================================================================================
________________________________________________________________________________________________________ test_console_link_wiring[115200-40] ________________________________________________________________________________________________________
----------------------------------------- generated xml file: /run_logs/tb3/copy-socat/2026-04-03-02-41-42/console/test_console_link_wiring.py::test_console_link_wiring[115200-40]_2026-04-03-02-41-42.xml -----------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
============================================================================================================== short test summary info ==============================================================================================================
PASSED console/test_console_link_wiring.py::test_console_link_wiring[115200-40]
===================================================================================================== 1 passed, 1 warning in 215.98s (0:03:35) ======================================================================================================
sonic@arctos_cicd_TB3_double_console_202511:/data/tests$ 
```