### PR TITLE
Fix cEOS converged neighbor support and LT2-O128/O256 route announcement

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -1533,6 +1533,10 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes={}):
     BASE_ADDR_V4 = "192.128.0.0/9"
     BASE_ADDR_V6 = "20c0:a800::0:0/108"
     ROUTE_NUMBER_T1 = 16000 * 2  # x2 for unique route
+    BASE_ADDR_V4_T0 = "192.0.0.0/9"
+    BASE_ADDR_V6_T0 = "20c0:a900::0:0/108"
+    T0_ROUTES_PER_VM = 128  # 128 unique IPv4 + 128 unique IPv6 routes per T0 VM
+    T0_ASN_OFFSET = 200  # Offset to avoid collision with T1/UT2 ASN range
 
     common_config = topo['configuration_properties'].get('common', {})
     nhipv4 = common_config.get('nhipv4', NHIPV4)
@@ -1541,9 +1545,14 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes={}):
     leaf_asn_start = common_config.get("leaf_asn_start", LEAF_ASN_START)
     tor_asn_start = common_config.get("tor_asn_start", TOR_ASN_START)
 
-    vms = sorted(topo['topology']['VMs'])
-    t1_vms = list(filter(lambda vm: "T1" in vm, vms))
-    ut2_vms = list(filter(lambda vm: "UT2" in vm, vms))
+    multi_vrf_data = topo.get('convergence_data', {})
+    if multi_vrf_data:
+        all_vms = sorted([vrf for vrfs in multi_vrf_data['convergence_mapping'].values() for vrf in vrfs])
+    else:
+        all_vms = sorted(topo['topology']['VMs'])
+    t1_vms = list(filter(lambda vm: "T1" in vm, all_vms))
+    ut2_vms = list(filter(lambda vm: "UT2" in vm, all_vms))
+    t0_vms = list(filter(lambda vm: vm.endswith("T0"), all_vms))
 
     default_route_as_path = get_uplink_router_as_path("upperspine", None)
 
@@ -1606,6 +1615,30 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes={}):
 
         ipv4_routes.append((topo['configuration'][vm_name]['interfaces']['Loopback0']['ipv4'], nhipv4, as_path))
         ipv6_routes.append((topo['configuration'][vm_name]['interfaces']['Loopback0']['ipv6'], nhipv6, as_path))
+
+        if vm_name not in topo_routes:
+            topo_routes[vm_name] = {}
+        topo_routes[vm_name][IPV4] = ipv4_routes
+        topo_routes[vm_name][IPV6] = ipv6_routes
+        if action != GENERATE_WITHOUT_APPLY:
+            change_routes(action, ptf_ip, port, ipv4_routes)
+            change_routes(action, ptf_ip, port6, ipv6_routes)
+
+    # T0 routes: each T0 VM advertises T0_ROUTES_PER_VM unique IPv4 + IPv6 routes
+    all_subnetv4_t0 = list(ipaddress.ip_network(UNICODE_TYPE(BASE_ADDR_V4_T0)).subnets(new_prefix=24))
+    all_subnetv6_t0 = list(ipaddress.ip_network(UNICODE_TYPE(BASE_ADDR_V6_T0)).subnets(new_prefix=124))
+
+    for t0_group, vm_name in enumerate(t0_vms):
+        selected_v4 = all_subnetv4_t0[t0_group * T0_ROUTES_PER_VM:
+                                       t0_group * T0_ROUTES_PER_VM + T0_ROUTES_PER_VM]
+        selected_v6 = all_subnetv6_t0[t0_group * T0_ROUTES_PER_VM:
+                                       t0_group * T0_ROUTES_PER_VM + T0_ROUTES_PER_VM]
+        as_path = "{} {}".format(leaf_asn_start + T0_ASN_OFFSET + t0_group,
+                                  tor_asn_start + T0_ASN_OFFSET + t0_group)
+        port, port6 = get_change_routes_ports(vm_name, topo)
+
+        ipv4_routes = [(str(s), nhipv4, as_path) for s in selected_v4]
+        ipv6_routes = [(str(s), nhipv6, as_path) for s in selected_v6]
 
         if vm_name not in topo_routes:
             topo_routes[vm_name] = {}

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -1529,17 +1529,13 @@ def fib_t0_mclag(topo, ptf_ip, action="announce", topo_routes={}):
 
 
 def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes=None):
+    if topo_routes is None:
+        topo_routes = {}
     T1_GROUP_SIZE = 2
     BASE_ADDR_V4 = "192.128.0.0/9"
     BASE_ADDR_V6 = "20c0:a800::0:0/108"
     ROUTE_NUMBER_T1 = 16000 * 2  # x2 for unique route
-    BASE_ADDR_V4_T0 = "192.0.0.0/9"
-    BASE_ADDR_V6_T0 = "20c0:a900::0:0/108"
-    T0_ROUTES_PER_VM = 128  # 128 unique IPv4 + 128 unique IPv6 routes per T0 VM
-    T0_ASN_OFFSET = 200  # Offset to avoid collision with T1/UT2 ASN range
 
-    if topo_routes is None:
-        topo_routes = {}
     common_config = topo['configuration_properties'].get('common', {})
     nhipv4 = common_config.get('nhipv4', NHIPV4)
     nhipv6 = common_config.get('nhipv6', NHIPV6)
@@ -1549,12 +1545,13 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes=None):
 
     multi_vrf_data = topo.get('convergence_data', {})
     if multi_vrf_data:
-        all_vms = sorted([vrf for vrfs in multi_vrf_data['convergence_mapping'].values() for vrf in vrfs])
+        vms = sorted([vm for vrfs in multi_vrf_data['convergence_mapping'].values() for vm in vrfs])
     else:
-        all_vms = sorted(topo['topology']['VMs'])
-    t1_vms = list(filter(lambda vm: "T1" in vm, all_vms))
-    ut2_vms = list(filter(lambda vm: "UT2" in vm, all_vms))
-    t0_vms = list(filter(lambda vm: vm.endswith("T0"), all_vms))
+        vms = sorted(topo['topology']['VMs'])
+    t1_vms = list(filter(lambda vm: "T1" in vm, vms))
+    ut2_vms = list(filter(lambda vm: "UT2" in vm, vms))
+
+    ptf_bp_addrs = multi_vrf_data.get('ptf_backplane_addrs', {})
 
     default_route_as_path = get_uplink_router_as_path("upperspine", None)
 
@@ -1564,12 +1561,16 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes=None):
     group_nums = int(math.ceil(float(len(t1_vms)) / T1_GROUP_SIZE))
     t1_route_per_group = int(math.ceil(ROUTE_NUMBER_T1 / T1_GROUP_SIZE / group_nums))
 
-    # 32 route each x 4 to match 110 T1
+    # 32 routes each x 8 to support up to 256 T1 VMs
     extra_ipv4_t1 = itertools.chain(
         ipaddress.ip_network("192.168.0.0/27"),
         ipaddress.ip_network("192.169.0.0/27"),
         ipaddress.ip_network("192.170.0.0/27"),
         ipaddress.ip_network("192.171.0.0/27"),
+        ipaddress.ip_network("192.172.0.0/27"),
+        ipaddress.ip_network("192.173.0.0/27"),
+        ipaddress.ip_network("192.174.0.0/27"),
+        ipaddress.ip_network("192.175.0.0/27"),
     )
 
     for group in range(group_nums):
@@ -1584,14 +1585,24 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes=None):
             vm_name = t1_vms[group * T1_GROUP_SIZE + vm_index]
             port, port6 = get_change_routes_ports(vm_name, topo)
 
+            # For converged topo, use per-VRF PTF backplane IP as nexthop.
+            # The global nhipv4 may equal a VRF's own cEOS IP (e.g. ARISTA78T1),
+            # causing cEOS to reject routes where next-hop == self.
+            if vm_name in ptf_bp_addrs:
+                vm_nhipv4 = ptf_bp_addrs[vm_name]['ipv4'].split('/')[0]
+                vm_nhipv6 = ptf_bp_addrs[vm_name]['ipv6'].split('/')[0]
+            else:
+                vm_nhipv4 = nhipv4
+                vm_nhipv6 = nhipv6
+
             ipv4_routes = []
             ipv6_routes = []
 
             for subnetv4, subnetv6 in zip(selected_v4_subnets, selected_v6_subnets):
-                ipv4_routes.append((str(subnetv4), nhipv4, as_path))
-                ipv6_routes.append((str(subnetv6), nhipv6, as_path))
+                ipv4_routes.append((str(subnetv4), vm_nhipv4, as_path))
+                ipv6_routes.append((str(subnetv6), vm_nhipv6, as_path))
 
-            ipv4_routes.append((str(next(extra_ipv4_t1)), nhipv4, as_path))
+            ipv4_routes.append((str(next(extra_ipv4_t1)), vm_nhipv4, as_path))
 
             topo_routes[vm_name] = {}
             topo_routes[vm_name][IPV4] = ipv4_routes
@@ -1601,46 +1612,29 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes=None):
                 change_routes(action, ptf_ip, port6, ipv6_routes)
 
     for device in range(len(ut2_vms)):
-        ipv4_routes = [
-            ("0.0.0.0/0", nhipv4, default_route_as_path),
-        ]
-
-        ipv6_routes = [
-            ("::/0", nhipv6, default_route_as_path),
-        ]
-
         group += 1
         as_path = "{} {}".format(leaf_asn_start + group, tor_asn_start + group)
 
         vm_name = ut2_vms[device]
         port, port6 = get_change_routes_ports(vm_name, topo)
 
-        ipv4_routes.append((topo['configuration'][vm_name]['interfaces']['Loopback0']['ipv4'], nhipv4, as_path))
-        ipv6_routes.append((topo['configuration'][vm_name]['interfaces']['Loopback0']['ipv6'], nhipv6, as_path))
+        if vm_name in ptf_bp_addrs:
+            vm_nhipv4 = ptf_bp_addrs[vm_name]['ipv4'].split('/')[0]
+            vm_nhipv6 = ptf_bp_addrs[vm_name]['ipv6'].split('/')[0]
+        else:
+            vm_nhipv4 = nhipv4
+            vm_nhipv6 = nhipv6
 
-        if vm_name not in topo_routes:
-            topo_routes[vm_name] = {}
-        topo_routes[vm_name][IPV4] = ipv4_routes
-        topo_routes[vm_name][IPV6] = ipv6_routes
-        if action != GENERATE_WITHOUT_APPLY:
-            change_routes(action, ptf_ip, port, ipv4_routes)
-            change_routes(action, ptf_ip, port6, ipv6_routes)
+        ipv4_routes = [
+            ("0.0.0.0/0", vm_nhipv4, default_route_as_path),
+        ]
 
-    # T0 routes: each T0 VM advertises T0_ROUTES_PER_VM unique IPv4 + IPv6 routes
-    all_subnetv4_t0 = list(ipaddress.ip_network(UNICODE_TYPE(BASE_ADDR_V4_T0)).subnets(new_prefix=24))
-    all_subnetv6_t0 = list(ipaddress.ip_network(UNICODE_TYPE(BASE_ADDR_V6_T0)).subnets(new_prefix=124))
+        ipv6_routes = [
+            ("::/0", vm_nhipv6, default_route_as_path),
+        ]
 
-    for t0_group, vm_name in enumerate(t0_vms):
-        selected_v4 = all_subnetv4_t0[
-            t0_group * T0_ROUTES_PER_VM:t0_group * T0_ROUTES_PER_VM + T0_ROUTES_PER_VM]
-        selected_v6 = all_subnetv6_t0[
-            t0_group * T0_ROUTES_PER_VM:t0_group * T0_ROUTES_PER_VM + T0_ROUTES_PER_VM]
-        as_path = "{} {}".format(leaf_asn_start + T0_ASN_OFFSET + t0_group,
-                                 tor_asn_start + T0_ASN_OFFSET + t0_group)
-        port, port6 = get_change_routes_ports(vm_name, topo)
-
-        ipv4_routes = [(str(s), nhipv4, as_path) for s in selected_v4]
-        ipv6_routes = [(str(s), nhipv6, as_path) for s in selected_v6]
+        ipv4_routes.append((topo['configuration'][vm_name]['interfaces']['Loopback0']['ipv4'], vm_nhipv4, as_path))
+        ipv6_routes.append((topo['configuration'][vm_name]['interfaces']['Loopback0']['ipv6'], vm_nhipv6, as_path))
 
         if vm_name not in topo_routes:
             topo_routes[vm_name] = {}

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -1533,30 +1533,26 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes={}):
     BASE_ADDR_V4 = "192.128.0.0/9"
     BASE_ADDR_V6 = "20c0:a800::0:0/108"
     ROUTE_NUMBER_T1 = 16000 * 2  # x2 for unique route
-    T0_ASN_OFFSET = 200  # Must be > len(t1_vms) + len(ut2_vms); asserted below
+    BASE_ADDR_V4_T0 = "192.0.0.0/9"
+    BASE_ADDR_V6_T0 = "20c0:a900::0:0/108"
+    T0_ROUTES_PER_VM = 128  # 128 unique IPv4 + 128 unique IPv6 routes per T0 VM
+    T0_ASN_OFFSET = 200  # Offset to avoid collision with T1/UT2 ASN range
 
     common_config = topo['configuration_properties'].get('common', {})
     nhipv4 = common_config.get('nhipv4', NHIPV4)
     nhipv6 = common_config.get('nhipv6', NHIPV6)
-
-    BASE_ADDR_V4_T0 = common_config.get("base_addr_v4_t0", "192.0.0.0/9")
-    BASE_ADDR_V6_T0 = common_config.get("base_addr_v6_t0", "20c0:a900::0:0/108")
-    T0_ROUTES_PER_VM = common_config.get("route_number_t0", 128)
 
     leaf_asn_start = common_config.get("leaf_asn_start", LEAF_ASN_START)
     tor_asn_start = common_config.get("tor_asn_start", TOR_ASN_START)
 
     multi_vrf_data = topo.get('convergence_data', {})
     if multi_vrf_data:
-        conv_mapping = multi_vrf_data.get('convergence_mapping', {})
-        all_vms = sorted([vrf for vrfs in conv_mapping.values() for vrf in vrfs])
+        all_vms = sorted([vrf for vrfs in multi_vrf_data['convergence_mapping'].values() for vrf in vrfs])
     else:
         all_vms = sorted(topo['topology']['VMs'])
     t1_vms = list(filter(lambda vm: "T1" in vm, all_vms))
     ut2_vms = list(filter(lambda vm: "UT2" in vm, all_vms))
-    t0_vms = list(filter(lambda vm: "T0" in vm, all_vms))
-    assert len(t1_vms) + len(ut2_vms) < T0_ASN_OFFSET, \
-        "T0_ASN_OFFSET {} too small for {} T1 + {} UT2 VMs".format(T0_ASN_OFFSET, len(t1_vms), len(ut2_vms))
+    t0_vms = list(filter(lambda vm: vm.endswith("T0"), all_vms))
 
     default_route_as_path = get_uplink_router_as_path("upperspine", None)
 

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -1631,12 +1631,12 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes=None):
     all_subnetv6_t0 = list(ipaddress.ip_network(UNICODE_TYPE(BASE_ADDR_V6_T0)).subnets(new_prefix=124))
 
     for t0_group, vm_name in enumerate(t0_vms):
-        selected_v4 = all_subnetv4_t0[t0_group * T0_ROUTES_PER_VM:
-                                       t0_group * T0_ROUTES_PER_VM + T0_ROUTES_PER_VM]
-        selected_v6 = all_subnetv6_t0[t0_group * T0_ROUTES_PER_VM:
-                                       t0_group * T0_ROUTES_PER_VM + T0_ROUTES_PER_VM]
+        selected_v4 = all_subnetv4_t0[
+            t0_group * T0_ROUTES_PER_VM:t0_group * T0_ROUTES_PER_VM + T0_ROUTES_PER_VM]
+        selected_v6 = all_subnetv6_t0[
+            t0_group * T0_ROUTES_PER_VM:t0_group * T0_ROUTES_PER_VM + T0_ROUTES_PER_VM]
         as_path = "{} {}".format(leaf_asn_start + T0_ASN_OFFSET + t0_group,
-                                  tor_asn_start + T0_ASN_OFFSET + t0_group)
+                                 tor_asn_start + T0_ASN_OFFSET + t0_group)
         port, port6 = get_change_routes_ports(vm_name, topo)
 
         ipv4_routes = [(str(s), nhipv4, as_path) for s in selected_v4]

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -1550,6 +1550,7 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes=None):
         vms = sorted(topo['topology']['VMs'])
     t1_vms = list(filter(lambda vm: "T1" in vm, vms))
     ut2_vms = list(filter(lambda vm: "UT2" in vm, vms))
+    t0_vms = list(filter(lambda vm: vm.endswith("T0"), vms))
 
     ptf_bp_addrs = multi_vrf_data.get('ptf_backplane_addrs', {})
 
@@ -1638,6 +1639,41 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes=None):
 
         if vm_name not in topo_routes:
             topo_routes[vm_name] = {}
+        topo_routes[vm_name][IPV4] = ipv4_routes
+        topo_routes[vm_name][IPV6] = ipv6_routes
+        if action != GENERATE_WITHOUT_APPLY:
+            change_routes(action, ptf_ip, port, ipv4_routes)
+            change_routes(action, ptf_ip, port6, ipv6_routes)
+
+    BASE_ADDR_V4_T0 = "192.0.0.0/9"
+    BASE_ADDR_V6_T0 = "20c0:a900::0:0/108"
+    T0_ROUTES_PER_VM = 128  # 128 unique IPv4 + 128 unique IPv6 routes per T0 VM
+    T0_ASN_OFFSET = 200  # Offset to avoid collision with T1/UT2 ASN range
+
+    all_subnetv4_t0 = list(ipaddress.ip_network(UNICODE_TYPE(BASE_ADDR_V4_T0)).subnets(new_prefix=24))
+    all_subnetv6_t0 = list(ipaddress.ip_network(UNICODE_TYPE(BASE_ADDR_V6_T0)).subnets(new_prefix=124))
+
+    for t0_group, vm_name in enumerate(t0_vms):
+        port, port6 = get_change_routes_ports(vm_name, topo)
+
+        if vm_name in ptf_bp_addrs:
+            vm_nhipv4 = ptf_bp_addrs[vm_name]['ipv4'].split('/')[0]
+            vm_nhipv6 = ptf_bp_addrs[vm_name]['ipv6'].split('/')[0]
+        else:
+            vm_nhipv4 = nhipv4
+            vm_nhipv6 = nhipv6
+
+        selected_v4 = all_subnetv4_t0[
+            t0_group * T0_ROUTES_PER_VM:t0_group * T0_ROUTES_PER_VM + T0_ROUTES_PER_VM]
+        selected_v6 = all_subnetv6_t0[
+            t0_group * T0_ROUTES_PER_VM:t0_group * T0_ROUTES_PER_VM + T0_ROUTES_PER_VM]
+        as_path = "{} {}".format(leaf_asn_start + T0_ASN_OFFSET + t0_group,
+                                 tor_asn_start + T0_ASN_OFFSET + t0_group)
+
+        ipv4_routes = [(str(s), vm_nhipv4, as_path) for s in selected_v4]
+        ipv6_routes = [(str(s), vm_nhipv6, as_path) for s in selected_v6]
+
+        topo_routes[vm_name] = {}
         topo_routes[vm_name][IPV4] = ipv4_routes
         topo_routes[vm_name][IPV6] = ipv6_routes
         if action != GENERATE_WITHOUT_APPLY:

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -1533,26 +1533,30 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes={}):
     BASE_ADDR_V4 = "192.128.0.0/9"
     BASE_ADDR_V6 = "20c0:a800::0:0/108"
     ROUTE_NUMBER_T1 = 16000 * 2  # x2 for unique route
-    BASE_ADDR_V4_T0 = "192.0.0.0/9"
-    BASE_ADDR_V6_T0 = "20c0:a900::0:0/108"
-    T0_ROUTES_PER_VM = 128  # 128 unique IPv4 + 128 unique IPv6 routes per T0 VM
-    T0_ASN_OFFSET = 200  # Offset to avoid collision with T1/UT2 ASN range
+    T0_ASN_OFFSET = 200  # Must be > len(t1_vms) + len(ut2_vms); asserted below
 
     common_config = topo['configuration_properties'].get('common', {})
     nhipv4 = common_config.get('nhipv4', NHIPV4)
     nhipv6 = common_config.get('nhipv6', NHIPV6)
+
+    BASE_ADDR_V4_T0 = common_config.get("base_addr_v4_t0", "192.0.0.0/9")
+    BASE_ADDR_V6_T0 = common_config.get("base_addr_v6_t0", "20c0:a900::0:0/108")
+    T0_ROUTES_PER_VM = common_config.get("route_number_t0", 128)
 
     leaf_asn_start = common_config.get("leaf_asn_start", LEAF_ASN_START)
     tor_asn_start = common_config.get("tor_asn_start", TOR_ASN_START)
 
     multi_vrf_data = topo.get('convergence_data', {})
     if multi_vrf_data:
-        all_vms = sorted([vrf for vrfs in multi_vrf_data['convergence_mapping'].values() for vrf in vrfs])
+        conv_mapping = multi_vrf_data.get('convergence_mapping', {})
+        all_vms = sorted([vrf for vrfs in conv_mapping.values() for vrf in vrfs])
     else:
         all_vms = sorted(topo['topology']['VMs'])
     t1_vms = list(filter(lambda vm: "T1" in vm, all_vms))
     ut2_vms = list(filter(lambda vm: "UT2" in vm, all_vms))
-    t0_vms = list(filter(lambda vm: vm.endswith("T0"), all_vms))
+    t0_vms = list(filter(lambda vm: "T0" in vm, all_vms))
+    assert len(t1_vms) + len(ut2_vms) < T0_ASN_OFFSET, \
+        "T0_ASN_OFFSET {} too small for {} T1 + {} UT2 VMs".format(T0_ASN_OFFSET, len(t1_vms), len(ut2_vms))
 
     default_route_as_path = get_uplink_router_as_path("upperspine", None)
 

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -1528,7 +1528,7 @@ def fib_t0_mclag(topo, ptf_ip, action="announce", topo_routes={}):
                 change_routes(action, ptf_ip, port6, routes_v6)
 
 
-def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes={}):
+def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes=None):
     T1_GROUP_SIZE = 2
     BASE_ADDR_V4 = "192.128.0.0/9"
     BASE_ADDR_V6 = "20c0:a800::0:0/108"
@@ -1538,6 +1538,8 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes={}):
     T0_ROUTES_PER_VM = 128  # 128 unique IPv4 + 128 unique IPv6 routes per T0 VM
     T0_ASN_OFFSET = 200  # Offset to avoid collision with T1/UT2 ASN range
 
+    if topo_routes is None:
+        topo_routes = {}
     common_config = topo['configuration_properties'].get('common', {})
     nhipv4 = common_config.get('nhipv4', NHIPV4)
     nhipv6 = common_config.get('nhipv6', NHIPV6)

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -977,7 +977,8 @@ class GenerateGoldenConfigDBModule(object):
         """
         Generate golden_config for FT2 to enable FEC and set BGP confed.
         """
-        SUPPORTED_TOPO = ["ft2-64", "ft2-16", "lt2-p32o64", "lt2-o128", "ft2-o128"]
+        SUPPORTED_TOPO = ["ft2-64", "ft2-16", "lt2-p32o64", "lt2-o128", "lt2-o128-d110u14",
+                          "ft2-o128", "lt2-o256-u32d224"]
         if self.topo_name not in SUPPORTED_TOPO:
             return "{}"
         SUPPORTED_PORT_SPEED = ["200000", "400000", "800000"]

--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -721,6 +721,12 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
             for i in range(28, 36):
                 port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % idx
                 idx += 8
+        elif hwsku == "Nokia-IXR7220-H6-O256":
+            for i in range(1, 129):
+                port_alias_to_name_map["etp%da" % i] = "Ethernet%d" % ((i - 1) * 8)
+                port_alias_to_name_map["etp%db" % i] = "Ethernet%d" % ((i - 1) * 8 + 4)
+            port_alias_to_name_map["etp129"] = "Ethernet1024"
+            port_alias_to_name_map["etp130"] = "Ethernet1025"
         elif hwsku == "Nokia-IXR7220-D4-36D":
             for i in range(1, 9):
                 port_alias_to_name_map["Ethernet{}/{}".format(i, 1)] = "Ethernet%d" % ((i - 1) * 2)

--- a/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
+++ b/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
@@ -20,7 +20,7 @@
       timeout: "{{ timeout_threshold }}"
     register: ceos_reachability
     ignore_errors: yes
-    delegate_to: "{{ VM_host[0] }}"
+    delegate_to: "localhost"
 
   - name: restart cEOS container
     become: yes

--- a/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
+++ b/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
@@ -20,7 +20,7 @@
       timeout: "{{ timeout_threshold }}"
     register: ceos_reachability
     ignore_errors: yes
-    delegate_to: "localhost"
+    delegate_to: "{{ VM_host[0] }}"
 
   - name: restart cEOS container
     become: yes

--- a/ansible/roles/eos/templates/lt2-o128-tor.j2
+++ b/ansible/roles/eos/templates/lt2-o128-tor.j2
@@ -1,4 +1,10 @@
 {% set host = configuration[hostname] %}
+{% set converged = topo_is_multi_vrf|default(false) %}
+{% if converged %}
+{% set conv_config = convergence_data["converged_peers"][hostname] %}
+{% set conv_mapping = convergence_data["convergence_mapping"][hostname] %}
+{% set ptf_bp_addrs = convergence_data["ptf_backplane_addrs"] %}
+{% endif %}
 {% set mgmt_ip = ansible_host %}
 {% set tornum = host['tornum'] %}
 {% if vm_type is defined and vm_type == "ceos" %}
@@ -20,9 +26,17 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+{% if converged %}
+vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
 !
+{% endif %}
+vrf instance MGMT
+{% if converged %}
+{% for vrf_name in conv_config['vrf'] %}
+vrf instance {{vrf_name}}
+{% endfor %}
+!
+{% endif %}
 spanning-tree mode mstp
 !
 aaa root secret 0 123456
@@ -40,7 +54,17 @@ snmp-server vrf MGMT
 !
 ip routing
 ip routing vrf MGMT
+{% if converged %}
+{% for vrf_name in conv_config['vrf'] %}
+ip routing vrf {{vrf_name}}
+{% endfor %}
+{% endif %}
 ipv6 unicast-routing
+{% if converged %}
+{% for vrf_name in conv_config['vrf'] %}
+ipv6 unicast-routing vrf {{vrf_name}}
+{% endfor %}
+{% endif %}
 !
 {% if disable_ceos_mgmt_gateway is defined and disable_ceos_mgmt_gateway == 'yes'%}
 {% elif vm_mgmt_gw is defined %}
@@ -51,14 +75,61 @@ ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
 !
 interface Management {{ mgmt_if_index }}
  description TO LAB MGMT SWITCH
- {% if vm_type is defined and vm_type == "ceos" %}
+{% if vm_type is defined and vm_type == "ceos" %}
  vrf MGMT
 {% else %}
  vrf forwarding MGMT
- {% endif %}
+{% endif %}
  ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
  no shutdown
 !
+{% if converged %}
+interface {{ bp_ifname }}
+!
+ description backplane
+ mtu 9214
+ switchport trunk allowed vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
+ switchport mode trunk
+ no shutdown
+!
+{% for vrf in conv_mapping %}
+{% for if_name, if_data in conv_config['vrf'][vrf].items() %}
+interface {{ if_name }}
+{% if if_name.startswith('Vlan') %}
+ description {{ vrf }} backplane
+{% endif %}
+{% if if_name.startswith('Loopback') %}
+ description {{ vrf }} LOOPBACK
+{% endif %}
+{% if if_name.startswith('Port-Channel') %}
+ port-channel min-links 1
+ mtu 9214
+ no switchport
+{% endif %}
+{% if if_name.startswith('Ethernet') %}
+ mtu 9214
+ no switchport
+{% endif %}
+ vrf {{ vrf }}
+{% if if_data['lacp'] is defined %}
+ channel-group {{ if_data['lacp'] }} mode active
+ lacp rate normal
+{% endif %}
+{% if if_data['ipv4'] is defined %}
+ ip address {{ if_data['ipv4'] }}
+{% endif %}
+{% if if_data['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ if_data['ipv6'] }}
+ ipv6 nd ra suppress
+ ipv6 nd dad disabled
+{% endif %}
+ no shutdown
+!
+{% endfor %}
+{% endfor %}
+!
+{% else %}
 {% for name, iface in host['interfaces'].items() %}
 interface {{ name }}
 {% if name.startswith('Loopback') %}
@@ -101,6 +172,63 @@ interface {{ bp_ifname }}
 {% endif %}
  no shutdown
 !
+{% endif %}
+{% if converged %}
+router bgp {{ conv_config['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
+{% for vrf in conv_config['vrf'] %}
+ vrf {{ vrf }}
+{% set vrf_bgp = configuration[vrf]['bgp'] %}
+{% set vrf_intfs = conv_config['vrf'][vrf] %}
+{% set lo_config = vrf_intfs|get_first_loopback %}
+  graceful-restart restart-time {{ bgp_gr_timer }}
+  graceful-restart
+{% if vrf_bgp['router-id'] is defined %}
+  router-id {{ vrf_bgp['router-id'] }}
+{% else %}
+{% if lo_config['ipv4'] is defined %}
+  router-id {{ lo_config['ipv4']|ansible.utils.ipaddr('address') }}
+{% endif %}
+{% endif %}
+  local-as {{ vrf_bgp['asn'] }}
+{% for asn, remote_ips in vrf_bgp['peers'].items() %}
+{% for remote_ip in remote_ips %}
+  neighbor {{ remote_ip }} remote-as {{ asn }}
+  neighbor {{ remote_ip }} description {{ asn }}
+  neighbor {{ remote_ip }} next-hop-self
+{% if remote_ip|ipv6 %}
+  address-family ipv6
+   neighbor {{ remote_ip }} activate
+  exit
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} remote-as {{ vrf_bgp['asn'] }}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} next-hop-peer
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} description exabgp_v4
+{% endif %}
+{% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} remote-as {{ vrf_bgp['asn'] }}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} next-hop-peer
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} description exabgp_v6
+{% endif %}
+  address-family ipv4
+{% if lo_config['ipv4'] is defined %}
+   network {{ lo_config['ipv4'] }}
+{% endif %}
+  exit
+  address-family ipv6
+   neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} activate
+{% if lo_config['ipv6'] is defined %}
+   network {{ lo_config['ipv6'] }}
+{% endif %}
+  exit
+ exit
+{% endfor %}
+{% else %}
 router bgp {{ host['bgp']['asn'] }}
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
@@ -140,6 +268,7 @@ router bgp {{ host['bgp']['asn'] }}
  network {{ iface['ipv6'] }}
 {% endif %}
 {% endfor %}
+{% endif %}
 !
 management api http-commands
  no protocol https

--- a/ansible/roles/eos/templates/lt2-o128-tor.j2
+++ b/ansible/roles/eos/templates/lt2-o128-tor.j2
@@ -30,11 +30,15 @@ hostname {{ hostname }}
 vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
 !
 {% endif %}
-vrf instance MGMT
 {% if converged %}
+vrf instance MGMT
 {% for vrf_name in conv_config['vrf'] %}
-vrf instance {{vrf_name}}
+vrf instance {{ vrf_name }}
 {% endfor %}
+!
+{% else %}
+vrf definition MGMT
+ rd 1:1
 !
 {% endif %}
 spanning-tree mode mstp
@@ -56,13 +60,13 @@ ip routing
 ip routing vrf MGMT
 {% if converged %}
 {% for vrf_name in conv_config['vrf'] %}
-ip routing vrf {{vrf_name}}
+ip routing vrf {{ vrf_name }}
 {% endfor %}
 {% endif %}
 ipv6 unicast-routing
 {% if converged %}
 {% for vrf_name in conv_config['vrf'] %}
-ipv6 unicast-routing vrf {{vrf_name}}
+ipv6 unicast-routing vrf {{ vrf_name }}
 {% endfor %}
 {% endif %}
 !
@@ -178,6 +182,25 @@ router bgp {{ conv_config['bgp']['asn'] }}
  vrf MGMT
   rd 1:1
  exit
+{% set ns = namespace(confed_asn='', confed_peers=[]) %}
+{% for vrf in conv_config['vrf'] %}
+{% set vrf_bgp_tmp = configuration[vrf]['bgp'] %}
+{% if 'confed_asn' in vrf_bgp_tmp and vrf_bgp_tmp['confed_asn'] and not ns.confed_asn %}
+{% set ns.confed_asn = vrf_bgp_tmp['confed_asn'] %}
+{% endif %}
+{% if 'confed_peers' in vrf_bgp_tmp and vrf_bgp_tmp['confed_peers'] %}
+{% for peer in vrf_bgp_tmp['confed_peers'].split(',') %}
+{% if peer.strip() not in ns.confed_peers %}
+{% set _ = ns.confed_peers.append(peer.strip()) %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% if ns.confed_asn %}
+ bgp confederation identifier {{ ns.confed_asn }}
+ bgp confederation peers {{ ns.confed_peers | join(' ') }}
+!
+{% endif %}
 {% for vrf in conv_config['vrf'] %}
  vrf {{ vrf }}
 {% set vrf_bgp = configuration[vrf]['bgp'] %}
@@ -193,6 +216,10 @@ router bgp {{ conv_config['bgp']['asn'] }}
 {% endif %}
 {% endif %}
   local-as {{ vrf_bgp['asn'] }}
+{% if vrf_bgp['confed_asn'] is defined and vrf_bgp['confed_asn'] %}
+  bgp confederation identifier {{ vrf_bgp['confed_asn'] }}
+  bgp confederation peers {{ vrf_bgp['confed_peers'] | replace(',', ' ') }}
+{% endif %}
 {% for asn, remote_ips in vrf_bgp['peers'].items() %}
 {% for remote_ip in remote_ips %}
   neighbor {{ remote_ip }} remote-as {{ asn }}

--- a/ansible/roles/eos/templates/t1-64-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-64-lag-tor.j2
@@ -1,12 +1,11 @@
 {% set host = configuration[hostname] %}
-{% set converged = topo_is_multi_vrf|default(false) %}
+{% set converged = topo_is_multi_vrf|default(false)|bool %}
 {% if converged %}
 {% set conv_config = convergence_data["converged_peers"][hostname] %}
 {% set conv_mapping = convergence_data["convergence_mapping"][hostname] %}
 {% set ptf_bp_addrs = convergence_data["ptf_backplane_addrs"] %}
 {% endif %}
 {% set mgmt_ip = ansible_host %}
-{% set tornum = host['tornum'] %}
 {% if vm_type is defined and vm_type == "ceos" %}
 {% set mgmt_if_index = 0 %}
 {% else %}

--- a/ansible/roles/eos/templates/t1-64-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-64-lag-tor.j2
@@ -1,4 +1,10 @@
 {% set host = configuration[hostname] %}
+{% set converged = topo_is_multi_vrf|default(false) %}
+{% if converged %}
+{% set conv_config = convergence_data["converged_peers"][hostname] %}
+{% set conv_mapping = convergence_data["convergence_mapping"][hostname] %}
+{% set ptf_bp_addrs = convergence_data["ptf_backplane_addrs"] %}
+{% endif %}
 {% set mgmt_ip = ansible_host %}
 {% set tornum = host['tornum'] %}
 {% if vm_type is defined and vm_type == "ceos" %}
@@ -20,9 +26,17 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+{% if converged %}
+vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
 !
+{% endif %}
+vrf instance MGMT
+{% if converged %}
+{% for vrf_name in conv_config['vrf'] %}
+vrf instance {{vrf_name}}
+{% endfor %}
+!
+{% endif %}
 spanning-tree mode mstp
 !
 aaa root secret 0 123456
@@ -40,7 +54,17 @@ snmp-server vrf MGMT
 !
 ip routing
 ip routing vrf MGMT
+{% if converged %}
+{% for vrf_name in conv_config['vrf'] %}
+ip routing vrf {{vrf_name}}
+{% endfor %}
+{% endif %}
 ipv6 unicast-routing
+{% if converged %}
+{% for vrf_name in conv_config['vrf'] %}
+ipv6 unicast-routing vrf {{vrf_name}}
+{% endfor %}
+{% endif %}
 !
 {% if disable_ceos_mgmt_gateway is defined and disable_ceos_mgmt_gateway == 'yes'%}
 {% elif vm_mgmt_gw is defined %}
@@ -51,14 +75,61 @@ ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
 !
 interface Management {{ mgmt_if_index }}
  description TO LAB MGMT SWITCH
- {% if vm_type is defined and vm_type == "ceos" %}
+{% if vm_type is defined and vm_type == "ceos" %}
  vrf MGMT
 {% else %}
  vrf forwarding MGMT
- {% endif %}
+{% endif %}
  ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
  no shutdown
 !
+{% if converged %}
+interface {{ bp_ifname }}
+!
+ description backplane
+ mtu 9214
+ switchport trunk allowed vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
+ switchport mode trunk
+ no shutdown
+!
+{% for vrf in conv_mapping %}
+{% for if_name, if_data in conv_config['vrf'][vrf].items() %}
+interface {{ if_name }}
+{% if if_name.startswith('Vlan') %}
+ description {{ vrf }} backplane
+{% endif %}
+{% if if_name.startswith('Loopback') %}
+ description {{ vrf }} LOOPBACK
+{% endif %}
+{% if if_name.startswith('Port-Channel') %}
+ port-channel min-links 1
+ mtu 9214
+ no switchport
+{% endif %}
+{% if if_name.startswith('Ethernet') %}
+ mtu 9214
+ no switchport
+{% endif %}
+ vrf {{ vrf }}
+{% if if_data['lacp'] is defined %}
+ channel-group {{ if_data['lacp'] }} mode active
+ lacp rate normal
+{% endif %}
+{% if if_data['ipv4'] is defined %}
+ ip address {{ if_data['ipv4'] }}
+{% endif %}
+{% if if_data['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ if_data['ipv6'] }}
+ ipv6 nd ra suppress
+ ipv6 nd dad disabled
+{% endif %}
+ no shutdown
+!
+{% endfor %}
+{% endfor %}
+!
+{% else %}
 {% for name, iface in host['interfaces'].items() %}
 interface {{ name }}
 {% if name.startswith('Loopback') %}
@@ -101,6 +172,86 @@ interface {{ bp_ifname }}
 {% endif %}
  no shutdown
 !
+{% endif %}
+{% if converged %}
+router bgp {{ conv_config['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
+{% set ns = namespace(confed_asn='', confed_peers=[]) %}
+{% for vrf in conv_config['vrf'] %}
+{% set vrf_bgp_tmp = configuration[vrf]['bgp'] %}
+{% if 'confed_asn' in vrf_bgp_tmp and vrf_bgp_tmp['confed_asn'] and not ns.confed_asn %}
+{% set ns.confed_asn = vrf_bgp_tmp['confed_asn'] %}
+{% endif %}
+{% if 'confed_peers' in vrf_bgp_tmp and vrf_bgp_tmp['confed_peers'] %}
+{% for peer in vrf_bgp_tmp['confed_peers'].split(',') %}
+{% if peer.strip() not in ns.confed_peers %}
+{% set _ = ns.confed_peers.append(peer.strip()) %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% if ns.confed_asn %}
+ bgp confederation identifier {{ ns.confed_asn }}
+ bgp confederation peers {{ ns.confed_peers | join(' ') }}
+!
+{% endif %}
+{% for vrf in conv_config['vrf'] %}
+ vrf {{ vrf }}
+{% set vrf_bgp = configuration[vrf]['bgp'] %}
+{% set vrf_intfs = conv_config['vrf'][vrf] %}
+{% set lo_config = vrf_intfs|get_first_loopback %}
+  graceful-restart restart-time {{ bgp_gr_timer }}
+  graceful-restart
+{% if vrf_bgp['router-id'] is defined %}
+  router-id {{ vrf_bgp['router-id'] }}
+{% else %}
+{% if lo_config['ipv4'] is defined %}
+  router-id {{ lo_config['ipv4']|ansible.utils.ipaddr('address') }}
+{% endif %}
+{% endif %}
+  local-as {{ vrf_bgp['asn'] }}
+{% if vrf_bgp['confed_asn'] is defined and vrf_bgp['confed_asn'] %}
+  bgp confederation identifier {{ vrf_bgp['confed_asn'] }}
+  bgp confederation peers {{ vrf_bgp['confed_peers'] | replace(',', ' ') }}
+{% endif %}
+{% for asn, remote_ips in vrf_bgp['peers'].items() %}
+{% for remote_ip in remote_ips %}
+  neighbor {{ remote_ip }} remote-as {{ asn }}
+  neighbor {{ remote_ip }} description {{ asn }}
+  neighbor {{ remote_ip }} next-hop-self
+{% if remote_ip|ipv6 %}
+  address-family ipv6
+   neighbor {{ remote_ip }} activate
+  exit
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} remote-as {{ vrf_bgp['asn'] }}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} next-hop-peer
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} description exabgp_v4
+{% endif %}
+{% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} remote-as {{ vrf_bgp['asn'] }}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} next-hop-peer
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} description exabgp_v6
+{% endif %}
+  address-family ipv4
+{% if lo_config['ipv4'] is defined %}
+   network {{ lo_config['ipv4'] }}
+{% endif %}
+  exit
+  address-family ipv6
+   neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} activate
+{% if lo_config['ipv6'] is defined %}
+   network {{ lo_config['ipv6'] }}
+{% endif %}
+  exit
+ exit
+{% endfor %}
+{% else %}
 router bgp {{ host['bgp']['asn'] }}
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
@@ -140,6 +291,7 @@ router bgp {{ host['bgp']['asn'] }}
  network {{ iface['ipv6'] }}
 {% endif %}
 {% endfor %}
+{% endif %}
 !
 management api http-commands
  no protocol https

--- a/ansible/roles/eos/templates/t1-64-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-64-lag-tor.j2
@@ -30,11 +30,15 @@ hostname {{ hostname }}
 vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
 !
 {% endif %}
-vrf instance MGMT
 {% if converged %}
+vrf instance MGMT
 {% for vrf_name in conv_config['vrf'] %}
-vrf instance {{vrf_name}}
+vrf instance {{ vrf_name }}
 {% endfor %}
+!
+{% else %}
+vrf definition MGMT
+ rd 1:1
 !
 {% endif %}
 spanning-tree mode mstp
@@ -56,13 +60,13 @@ ip routing
 ip routing vrf MGMT
 {% if converged %}
 {% for vrf_name in conv_config['vrf'] %}
-ip routing vrf {{vrf_name}}
+ip routing vrf {{ vrf_name }}
 {% endfor %}
 {% endif %}
 ipv6 unicast-routing
 {% if converged %}
 {% for vrf_name in conv_config['vrf'] %}
-ipv6 unicast-routing vrf {{vrf_name}}
+ipv6 unicast-routing vrf {{ vrf_name }}
 {% endfor %}
 {% endif %}
 !

--- a/ansible/roles/eos/templates/t1-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-lag-spine.j2
@@ -1,15 +1,15 @@
 {% set host = configuration[hostname] %}
 {% set converged = topo_is_multi_vrf|default(false)|bool %}
 {% if converged %}
-    {% set conv_config = convergence_data["converged_peers"][hostname] %}
-    {% set conv_mapping = convergence_data["convergence_mapping"][hostname] %}
-    {% set ptf_bp_addrs = convergence_data["ptf_backplane_addrs"] %}
+{% set conv_config = convergence_data["converged_peers"][hostname] %}
+{% set conv_mapping = convergence_data["convergence_mapping"][hostname] %}
+{% set ptf_bp_addrs = convergence_data["ptf_backplane_addrs"] %}
 {% endif %}
 {% set mgmt_ip = ansible_host %}
 {% if vm_type is defined and vm_type == "ceos" %}
-    {% set mgmt_if_index = 0 %}
+{% set mgmt_if_index = 0 %}
 {% else %}
-    {% set mgmt_if_index = 1 %}
+{% set mgmt_if_index = 1 %}
 {% endif %}
 no schedule tech-support
 !
@@ -31,9 +31,9 @@ vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
 {% endif %}
 vrf instance MGMT
 {% if converged %}
-    {% for vrf_name in conv_config['vrf'] %}
+{% for vrf_name in conv_config['vrf'] %}
 vrf instance {{vrf_name}}
-    {% endfor %}
+{% endfor %}
 !
 {% endif %}
 spanning-tree mode mstp
@@ -54,15 +54,15 @@ snmp-server vrf MGMT
 ip routing
 ip routing vrf MGMT
 {% if converged %}
-    {% for vrf_name in conv_config['vrf'] %}
+{% for vrf_name in conv_config['vrf'] %}
 ip routing vrf {{vrf_name}}
-    {% endfor %}
+{% endfor %}
 {% endif %}
 ipv6 unicast-routing
 {% if converged %}
-    {% for vrf_name in conv_config['vrf'] %}
+{% for vrf_name in conv_config['vrf'] %}
 ipv6 unicast-routing vrf {{vrf_name}}
-    {% endfor %}
+{% endfor %}
 {% endif %}
 !
 {% if disable_ceos_mgmt_gateway is defined and disable_ceos_mgmt_gateway == 'yes'%}
@@ -91,84 +91,84 @@ interface {{ bp_ifname }}
  switchport mode trunk
  no shutdown
 !
-    {% for vrf in conv_mapping %}
-        {% for if_name, if_data in conv_config['vrf'][vrf].items() %}
+{% for vrf in conv_mapping %}
+{% for if_name, if_data in conv_config['vrf'][vrf].items() %}
 interface {{ if_name }}
-            {% if if_name.startswith('Vlan') %}
+{% if if_name.startswith('Vlan') %}
  description {{ vrf }} backplane
-            {% endif %}
-            {% if if_name.startswith('Loopback') %}
+{% endif %}
+{% if if_name.startswith('Loopback') %}
  description {{ vrf }} LOOPBACK
-            {% endif %}
-            {% if if_name.startswith('Port-Channel') %}
+{% endif %}
+{% if if_name.startswith('Port-Channel') %}
  port-channel min-links 1
  mtu 9214
  no switchport
-            {% endif %}
-            {% if if_name.startswith('Ethernet') %}
+{% endif %}
+{% if if_name.startswith('Ethernet') %}
  mtu 9214
  no switchport
-            {% endif %}
+{% endif %}
  vrf {{ vrf }}
-            {% if if_data['lacp'] is defined %}
+{% if if_data['lacp'] is defined %}
  channel-group {{ if_data['lacp'] }} mode active
  lacp rate normal
-            {% endif %}
-            {% if if_data['ipv4'] is defined %}
+{% endif %}
+{% if if_data['ipv4'] is defined %}
  ip address {{ if_data['ipv4'] }}
-            {% endif %}
-            {% if if_data['ipv6'] is defined %}
+{% endif %}
+{% if if_data['ipv6'] is defined %}
  ipv6 enable
  ipv6 address {{ if_data['ipv6'] }}
  ipv6 nd ra suppress
  ipv6 nd dad disabled
-            {% endif %}
+{% endif %}
  no shutdown
 !
-        {% endfor %}
-    {% endfor %}
+{% endfor %}
+{% endfor %}
 !
 {% else %}
-    {% for name, iface in host['interfaces'].items() %}
+{% for name, iface in host['interfaces'].items() %}
 interface {{ name }}
-        {% if name.startswith('Loopback') %}
+{% if name.startswith('Loopback') %}
  description LOOPBACK
-        {% else %}
+{% else %}
  mtu 9214
  no switchport
  no shutdown
-        {% endif %}
-        {% if name.startswith('Port-Channel') %}
+{% endif %}
+{% if name.startswith('Port-Channel') %}
  port-channel min-links 2
-        {% endif %}
-        {% if iface['lacp'] is defined %}
+{% endif %}
+{% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
  lacp rate normal
-        {% endif %}
-        {% if iface['ipv4'] is defined %}
+{% endif %}
+{% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}
-        {% endif %}
-        {% if iface['ipv6'] is defined %}
+{% endif %}
+{% if iface['ipv6'] is defined %}
  ipv6 enable
  ipv6 address {{ iface['ipv6'] }}
  ipv6 nd ra suppress
-        {% endif %}
+{% endif %}
  no shutdown
 !
-    {% endfor %}
+{% endfor %}
 !
 interface {{ bp_ifname }}
  description backplane
  no switchport
  no shutdown
-    {% if host['bp_interface']['ipv4'] is defined %}
+{% if host['bp_interface']['ipv4'] is defined %}
  ip address {{ host['bp_interface']['ipv4'] }}
-    {% endif %}
-    {% if host['bp_interface']['ipv6'] is defined %}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
  ipv6 enable
  ipv6 address {{ host['bp_interface']['ipv6'] }}
  ipv6 nd ra suppress
-    {% endif %}
+{% endif %}
  no shutdown
 !
 {% endif %}
@@ -177,54 +177,58 @@ router bgp {{ conv_config['bgp']['asn'] }}
  vrf MGMT
   rd 1:1
  exit
-    {% for vrf in conv_config['vrf'] %}
+{% for vrf in conv_config['vrf'] %}
  vrf {{ vrf }}
-        {% set vrf_bgp = configuration[vrf]['bgp'] %}
-        {% set vrf_intfs = conv_config['vrf'][vrf] %}
-        {% set lo_config = vrf_intfs|get_first_loopback %}
-        {% if vrf_bgp['router-id'] is defined %}
+{% set vrf_bgp = configuration[vrf]['bgp'] %}
+{% set vrf_intfs = conv_config['vrf'][vrf] %}
+{% set lo_config = vrf_intfs|get_first_loopback %}
+{% if vrf_bgp['router-id'] is defined %}
   router-id {{ vrf_bgp['router-id'] }}
-        {% else %}
-            {% if lo_config['ipv4'] is defined %}
+{% else %}
+{% if lo_config['ipv4'] is defined %}
   router-id {{ lo_config['ipv4']|ansible.utils.ipaddr('address') }}
-            {% endif %}
-        {% endif %}
+{% endif %}
+{% endif %}
   local-as {{ vrf_bgp['asn'] }}
-        {% for asn, remote_ips in vrf_bgp['peers'].items() %}
-            {% for remote_ip in remote_ips %}
+{% if vrf_bgp['confed_asn'] is defined and vrf_bgp['confed_asn'] %}
+  bgp confederation identifier {{ vrf_bgp['confed_asn'] }}
+  bgp confederation peers {{ vrf_bgp['confed_peers'] | replace(',', ' ') }}
+{% endif %}
+{% for asn, remote_ips in vrf_bgp['peers'].items() %}
+{% for remote_ip in remote_ips %}
   neighbor {{ remote_ip }} remote-as {{ asn }}
   neighbor {{ remote_ip }} description {{ asn }}
   neighbor {{ remote_ip }} next-hop-self
-                {% if remote_ip|ipv6 %}
+{% if remote_ip|ipv6 %}
   address-family ipv6
    neighbor {{ remote_ip }} activate
   exit
-                {% endif %}
-            {% endfor %}
-        {% endfor %}
-        {% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
   neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} remote-as {{ vrf_bgp['asn'] }}
   neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} next-hop-peer
   neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} description exabgp_v4
-        {% endif %}
-        {% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
+{% endif %}
+{% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
   neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} remote-as {{ vrf_bgp['asn'] }}
   neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} next-hop-peer
   neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} description exabgp_v6
-        {% endif %}
+{% endif %}
   address-family ipv4
-        {% if lo_config['ipv4'] is defined %}
+{% if lo_config['ipv4'] is defined %}
    network {{ lo_config['ipv4'] }}
-        {% endif %}
+{% endif %}
   exit
   address-family ipv6
    neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} activate
-        {% if lo_config['ipv6'] is defined %}
+{% if lo_config['ipv6'] is defined %}
    network {{ lo_config['ipv6'] }}
-        {% endif %}
+{% endif %}
   exit
  exit
-    {% endfor %}
+{% endfor %}
 {% else %}
 router bgp {{ host['bgp']['asn'] }}
  vrf MGMT
@@ -238,37 +242,37 @@ router bgp {{ host['bgp']['asn'] }}
 !
 {% endif %}
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
-    {% for remote_ip in remote_ips %}
+{% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-            {% if remote_ip | ansible.utils.ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit
-            {% endif %}
-        {% endfor %}
-    {% endfor %}
-    {% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
  neighbor {{ props.nhipv4 }} remote-as {{ host['bgp']['asn'] }}
  neighbor {{ props.nhipv4 }} description exabgp_v4
-    {% endif %}
-    {% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
+{% endif %}
+{% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
  neighbor {{ props.nhipv6 }} remote-as {{ host['bgp']['asn'] }}
  neighbor {{ props.nhipv6 }} description exabgp_v6
  address-family ipv6
   neighbor {{ props.nhipv6 }} activate
  exit
-    {% endif %}
+{% endif %}
  !
-    {% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
-        {% if iface['ipv4'] is defined %}
+{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+{% if iface['ipv4'] is defined %}
  network {{ iface['ipv4'] }}
-        {% endif %}
-        {% if iface['ipv6'] is defined %}
+{% endif %}
+{% if iface['ipv6'] is defined %}
  network {{ iface['ipv6'] }}
-        {% endif %}
-    {% endfor %}
+{% endif %}
+{% endfor %}
 {% endif %}
 !
 management api http-commands

--- a/ansible/roles/eos/templates/t1-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-lag-spine.j2
@@ -1,15 +1,15 @@
 {% set host = configuration[hostname] %}
 {% set converged = topo_is_multi_vrf|default(false)|bool %}
 {% if converged %}
-{% set conv_config = convergence_data["converged_peers"][hostname] %}
-{% set conv_mapping = convergence_data["convergence_mapping"][hostname] %}
-{% set ptf_bp_addrs = convergence_data["ptf_backplane_addrs"] %}
+    {% set conv_config = convergence_data["converged_peers"][hostname] %}
+    {% set conv_mapping = convergence_data["convergence_mapping"][hostname] %}
+    {% set ptf_bp_addrs = convergence_data["ptf_backplane_addrs"] %}
 {% endif %}
 {% set mgmt_ip = ansible_host %}
 {% if vm_type is defined and vm_type == "ceos" %}
-{% set mgmt_if_index = 0 %}
+    {% set mgmt_if_index = 0 %}
 {% else %}
-{% set mgmt_if_index = 1 %}
+    {% set mgmt_if_index = 1 %}
 {% endif %}
 no schedule tech-support
 !
@@ -31,9 +31,9 @@ vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
 {% endif %}
 vrf instance MGMT
 {% if converged %}
-{% for vrf_name in conv_config['vrf'] %}
+    {% for vrf_name in conv_config['vrf'] %}
 vrf instance {{vrf_name}}
-{% endfor %}
+    {% endfor %}
 !
 {% endif %}
 spanning-tree mode mstp
@@ -54,15 +54,15 @@ snmp-server vrf MGMT
 ip routing
 ip routing vrf MGMT
 {% if converged %}
-{% for vrf_name in conv_config['vrf'] %}
+    {% for vrf_name in conv_config['vrf'] %}
 ip routing vrf {{vrf_name}}
-{% endfor %}
+    {% endfor %}
 {% endif %}
 ipv6 unicast-routing
 {% if converged %}
-{% for vrf_name in conv_config['vrf'] %}
+    {% for vrf_name in conv_config['vrf'] %}
 ipv6 unicast-routing vrf {{vrf_name}}
-{% endfor %}
+    {% endfor %}
 {% endif %}
 !
 {% if disable_ceos_mgmt_gateway is defined and disable_ceos_mgmt_gateway == 'yes'%}
@@ -91,84 +91,84 @@ interface {{ bp_ifname }}
  switchport mode trunk
  no shutdown
 !
-{% for vrf in conv_mapping %}
-{% for if_name, if_data in conv_config['vrf'][vrf].items() %}
+    {% for vrf in conv_mapping %}
+        {% for if_name, if_data in conv_config['vrf'][vrf].items() %}
 interface {{ if_name }}
-{% if if_name.startswith('Vlan') %}
+            {% if if_name.startswith('Vlan') %}
  description {{ vrf }} backplane
-{% endif %}
-{% if if_name.startswith('Loopback') %}
+            {% endif %}
+            {% if if_name.startswith('Loopback') %}
  description {{ vrf }} LOOPBACK
-{% endif %}
-{% if if_name.startswith('Port-Channel') %}
+            {% endif %}
+            {% if if_name.startswith('Port-Channel') %}
  port-channel min-links 1
  mtu 9214
  no switchport
-{% endif %}
-{% if if_name.startswith('Ethernet') %}
+            {% endif %}
+            {% if if_name.startswith('Ethernet') %}
  mtu 9214
  no switchport
-{% endif %}
+            {% endif %}
  vrf {{ vrf }}
-{% if if_data['lacp'] is defined %}
+            {% if if_data['lacp'] is defined %}
  channel-group {{ if_data['lacp'] }} mode active
  lacp rate normal
-{% endif %}
-{% if if_data['ipv4'] is defined %}
+            {% endif %}
+            {% if if_data['ipv4'] is defined %}
  ip address {{ if_data['ipv4'] }}
-{% endif %}
-{% if if_data['ipv6'] is defined %}
+            {% endif %}
+            {% if if_data['ipv6'] is defined %}
  ipv6 enable
  ipv6 address {{ if_data['ipv6'] }}
  ipv6 nd ra suppress
  ipv6 nd dad disabled
-{% endif %}
+            {% endif %}
  no shutdown
 !
-{% endfor %}
-{% endfor %}
+        {% endfor %}
+    {% endfor %}
 !
 {% else %}
-{% for name, iface in host['interfaces'].items() %}
+    {% for name, iface in host['interfaces'].items() %}
 interface {{ name }}
-{% if name.startswith('Loopback') %}
+        {% if name.startswith('Loopback') %}
  description LOOPBACK
-{% else %}
+        {% else %}
  mtu 9214
  no switchport
  no shutdown
-{% endif %}
-{% if name.startswith('Port-Channel') %}
+        {% endif %}
+        {% if name.startswith('Port-Channel') %}
  port-channel min-links 2
-{% endif %}
-{% if iface['lacp'] is defined %}
+        {% endif %}
+        {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
  lacp rate normal
-{% endif %}
-{% if iface['ipv4'] is defined %}
+        {% endif %}
+        {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}
-{% endif %}
-{% if iface['ipv6'] is defined %}
+        {% endif %}
+        {% if iface['ipv6'] is defined %}
  ipv6 enable
  ipv6 address {{ iface['ipv6'] }}
  ipv6 nd ra suppress
-{% endif %}
+        {% endif %}
  no shutdown
 !
-{% endfor %}
+    {% endfor %}
 !
 interface {{ bp_ifname }}
  description backplane
  no switchport
  no shutdown
-{% if host['bp_interface']['ipv4'] is defined %}
+    {% if host['bp_interface']['ipv4'] is defined %}
  ip address {{ host['bp_interface']['ipv4'] }}
-{% endif %}
-{% if host['bp_interface']['ipv6'] is defined %}
+    {% endif %}
+    {% if host['bp_interface']['ipv6'] is defined %}
  ipv6 enable
  ipv6 address {{ host['bp_interface']['ipv6'] }}
  ipv6 nd ra suppress
-{% endif %}
+    {% endif %}
  no shutdown
 !
 {% endif %}
@@ -177,58 +177,58 @@ router bgp {{ conv_config['bgp']['asn'] }}
  vrf MGMT
   rd 1:1
  exit
-{% for vrf in conv_config['vrf'] %}
+    {% for vrf in conv_config['vrf'] %}
  vrf {{ vrf }}
-{% set vrf_bgp = configuration[vrf]['bgp'] %}
-{% set vrf_intfs = conv_config['vrf'][vrf] %}
-{% set lo_config = vrf_intfs|get_first_loopback %}
-{% if vrf_bgp['router-id'] is defined %}
+        {% set vrf_bgp = configuration[vrf]['bgp'] %}
+        {% set vrf_intfs = conv_config['vrf'][vrf] %}
+        {% set lo_config = vrf_intfs|get_first_loopback %}
+        {% if vrf_bgp['router-id'] is defined %}
   router-id {{ vrf_bgp['router-id'] }}
-{% else %}
-{% if lo_config['ipv4'] is defined %}
+        {% else %}
+            {% if lo_config['ipv4'] is defined %}
   router-id {{ lo_config['ipv4']|ansible.utils.ipaddr('address') }}
-{% endif %}
-{% endif %}
+            {% endif %}
+        {% endif %}
   local-as {{ vrf_bgp['asn'] }}
 {% if vrf_bgp['confed_asn'] is defined and vrf_bgp['confed_asn'] %}
   bgp confederation identifier {{ vrf_bgp['confed_asn'] }}
   bgp confederation peers {{ vrf_bgp['confed_peers'] | replace(',', ' ') }}
 {% endif %}
-{% for asn, remote_ips in vrf_bgp['peers'].items() %}
-{% for remote_ip in remote_ips %}
+        {% for asn, remote_ips in vrf_bgp['peers'].items() %}
+            {% for remote_ip in remote_ips %}
   neighbor {{ remote_ip }} remote-as {{ asn }}
   neighbor {{ remote_ip }} description {{ asn }}
   neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip|ipv6 %}
+                {% if remote_ip|ipv6 %}
   address-family ipv6
    neighbor {{ remote_ip }} activate
   exit
-{% endif %}
-{% endfor %}
-{% endfor %}
-{% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
+        {% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
   neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} remote-as {{ vrf_bgp['asn'] }}
   neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} next-hop-peer
   neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} description exabgp_v4
-{% endif %}
-{% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
+        {% endif %}
+        {% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
   neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} remote-as {{ vrf_bgp['asn'] }}
   neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} next-hop-peer
   neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} description exabgp_v6
-{% endif %}
+        {% endif %}
   address-family ipv4
-{% if lo_config['ipv4'] is defined %}
+        {% if lo_config['ipv4'] is defined %}
    network {{ lo_config['ipv4'] }}
-{% endif %}
+        {% endif %}
   exit
   address-family ipv6
    neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} activate
-{% if lo_config['ipv6'] is defined %}
+        {% if lo_config['ipv6'] is defined %}
    network {{ lo_config['ipv6'] }}
-{% endif %}
+        {% endif %}
   exit
  exit
-{% endfor %}
+    {% endfor %}
 {% else %}
 router bgp {{ host['bgp']['asn'] }}
  vrf MGMT
@@ -242,37 +242,37 @@ router bgp {{ host['bgp']['asn'] }}
 !
 {% endif %}
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
-{% for remote_ip in remote_ips %}
+    {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ansible.utils.ipv6 %}
+            {% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit
-{% endif %}
-{% endfor %}
-{% endfor %}
-{% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
+            {% endif %}
+        {% endfor %}
+    {% endfor %}
+    {% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
  neighbor {{ props.nhipv4 }} remote-as {{ host['bgp']['asn'] }}
  neighbor {{ props.nhipv4 }} description exabgp_v4
-{% endif %}
-{% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
+    {% endif %}
+    {% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
  neighbor {{ props.nhipv6 }} remote-as {{ host['bgp']['asn'] }}
  neighbor {{ props.nhipv6 }} description exabgp_v6
  address-family ipv6
   neighbor {{ props.nhipv6 }} activate
  exit
-{% endif %}
+    {% endif %}
  !
-{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
-{% if iface['ipv4'] is defined %}
+    {% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+        {% if iface['ipv4'] is defined %}
  network {{ iface['ipv4'] }}
-{% endif %}
-{% if iface['ipv6'] is defined %}
+        {% endif %}
+        {% if iface['ipv6'] is defined %}
  network {{ iface['ipv6'] }}
-{% endif %}
-{% endfor %}
+        {% endif %}
+    {% endfor %}
 {% endif %}
 !
 management api http-commands

--- a/ansible/roles/fanout/templates/sonic_deploy_202511.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202511.j2
@@ -1,0 +1,495 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "default_pfcwd_status": "disable",
+            "hwsku": "{{ fanout_hwsku }}",
+{% if 'marvell-teralynx' in fanout_sonic_version["asic_type"] %}
+            "type": "LeafRouter",
+{% endif %}
+            "hostname": "{{ inventory_hostname }}"
+        }
+    },
+
+    "PORT": {
+    {% for port_name in fanout_port_config %}
+        "{{ port_name }}": {
+            "alias": "{{ fanout_port_config[port_name]['alias'] }}",
+            "speed" : "{{ fanout_port_config[port_name]['speed'] | default('100000') }}",
+            "index": "{{ fanout_port_config[port_name]['index'] }}",
+            "lanes": "{{ fanout_port_config[port_name]['lanes'] }}",
+            "pfc_asym": "off",
+            "mtu": "9100",
+    {% if fanout_hwsku == "Arista-720DT-G48S4" and (fanout_port_config[port_name]['lanes'] | int) <= 24 %}
+            "autoneg": "on",
+    {% endif %}
+    {% if fanout_port_config[port_name]['speed'] | default('100000') in ["100000", "400000"] %}
+            "fec" : "rs",
+    {% endif %}
+    {% if port_name in device_conn[inventory_hostname] %}
+        {% if 'autoneg' in device_conn[inventory_hostname][port_name] %}
+                {% if 'on' in device_conn[inventory_hostname][port_name]['autoneg'] %}
+                    "autoneg": "on",
+                    {% if msft_an_enabled is defined %}
+                        "fec": "none",
+                    {% endif %}
+                {% elif 'off' in device_conn[inventory_hostname][port_name]['autoneg'] %}
+                    "autoneg": "off",
+                {% endif %}
+        {% endif %}
+    {% endif %}
+    {% if 'broadcom' in fanout_sonic_version["asic_type"] or 'marvell' in fanout_sonic_version["asic_type"] or 'marvell-teralynx' in fanout_sonic_version["asic_type"] or 'mellanox' in fanout_sonic_version["asic_type"] %}
+        {% if port_name in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][port_name]["mode"].lower() == "access" %}
+            "tpid": "0x9100",
+        {% endif %}
+    {% endif %}
+    {% if 'peerdevice' in fanout_port_config[port_name] %}
+            "admin_status": "up"
+    {% else %}
+            "admin_status": "down"
+    {% endif %}
+        }{% if not loop.last %},{% endif %}
+    {% endfor %}
+    },
+
+    "VLAN": {
+    {% for vlanid in device_vlan_list[inventory_hostname] | unique %}
+        "Vlan{{ vlanid }}": {
+            "vlanid": "{{ vlanid }}"
+        }{% if not loop.last %},{% endif %}
+    {% endfor %}
+    },
+
+    {% set ns = {'firstPrinted': False} %}
+    "VLAN_MEMBER": {
+    {% if device_info[inventory_hostname]['PortConfigIni'] is defined %}
+      {% set port_config = fanout_port_config %}
+    {% else %}
+      {% set port_config = device_port_vlans[inventory_hostname] %}
+    {% endif %}
+    {% for port_name in port_config %}
+    {% if port_name in device_port_vlans[inventory_hostname] %}
+    {% if device_port_vlans[inventory_hostname][port_name]['mode'].lower() == 'access' %}
+    {% if device_port_vlans[inventory_hostname][port_name]['vlanids'] != '' %}
+    {% if ns.firstPrinted %},{% endif %}
+        "Vlan{{ device_port_vlans[inventory_hostname][port_name]['vlanids'] }}|{{ fanout_port_config[port_name]['name'] }}": {
+            "tagging_mode" : "untagged"
+        }
+    {% if ns.update({'firstPrinted': True}) %} {% endif %}
+    {% endif %}
+    {% elif device_port_vlans[inventory_hostname][port_name]['mode'].lower() == 'trunk' %}
+    {% for vlanid in device_port_vlans[inventory_hostname][port_name]['vlanlist'] %}
+    {% if ns.firstPrinted %},{% endif %}
+        "Vlan{{ vlanid }}|{{ fanout_port_config[port_name]['name'] }}": {
+            "tagging_mode" : "tagged"
+        }
+    {% if ns.update({'firstPrinted': True}) %} {% endif %}
+    {% endfor %}
+    {% endif %}
+    {% endif %}
+    {% endfor %}
+    },
+
+    "MGMT_INTERFACE": {
+        "eth0|{{ device_info[inventory_hostname]["ManagementIp"] }}": {
+            "gwaddr": "{{ device_info[inventory_hostname]["ManagementGw"] }}"
+        }
+    },
+    "MGMT_PORT": {
+        "eth0": {
+            "admin_status": "up",
+            "alias": "eth0"
+        }
+    },
+
+    "VERSIONS": {
+        "DATABASE": {
+            "VERSION": "version_1_0_1"
+        }
+    },
+{% if 'mellanox' in fanout_sonic_version["asic_type"] %}
+    "BUFFER_POOL": {
+        "egress_lossless_pool": {
+            "mode": "dynamic",
+            "size": "60817392",
+            "type": "egress"
+        },
+        "egress_lossy_pool": {
+            "mode": "dynamic",
+            "size": "49946624",
+            "type": "egress"
+        },
+        "ingress_lossless_pool": {
+            "mode": "dynamic",
+            "size": "49946624",
+            "type": "ingress",
+            "xoff": "4063232"
+        },
+        "ingress_zero_pool": {
+            "mode": "static",
+            "size": "0",
+            "type": "ingress"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "egress_lossless_profile": {
+            "dynamic_th": "7",
+            "pool": "egress_lossless_pool",
+            "size": "0"
+        },
+        "egress_lossless_zero_profile": {
+            "dynamic_th": "-8",
+            "pool": "egress_lossless_pool",
+            "size": "0"
+        },
+        "egress_lossy_profile": {
+            "dynamic_th": "7",
+            "pool": "egress_lossy_pool",
+            "size": "9216"
+        },
+        "egress_lossy_zero_profile": {
+            "dynamic_th": "-8",
+            "pool": "egress_lossy_pool",
+            "size": "0"
+        },
+        "ingress_lossless_profile": {
+            "dynamic_th": "7",
+            "pool": "ingress_lossless_pool",
+            "size": "0"
+        },
+        "ingress_lossless_zero_profile": {
+            "dynamic_th": "-8",
+            "pool": "ingress_lossless_pool",
+            "size": "0"
+        },
+        "ingress_lossy_pg_zero_profile": {
+            "pool": "ingress_zero_pool",
+            "size": "0",
+            "static_th": "0"
+        },
+        "ingress_lossy_profile": {
+            "dynamic_th": "3",
+            "pool": "ingress_lossless_pool",
+            "size": "0"
+        },
+        "pg_lossless_200000_5m_profile": {
+            "dynamic_th": "0",
+            "pool": "ingress_lossless_pool",
+            "size": "19456",
+            "xoff": "66560",
+            "xon": "19456"
+        },
+        "pg_lossless_400000_5m_profile": {
+            "dynamic_th": "0",
+            "pool": "ingress_lossless_pool",
+            "size": "38912",
+            "xoff": "115712",
+            "xon": "38912"
+        },
+        "q_lossy_profile": {
+            "dynamic_th": "3",
+            "pool": "egress_lossy_pool",
+            "size": "0"
+        }
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
+    {% for port_name in fanout_port_config %}
+         "{{ port_name }}": {
+            "profile_list": "egress_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+    {% endfor %}
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
+    {% for port_name in fanout_port_config %}
+         "{{ port_name }}": {
+            "profile_list": "ingress_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+    {% endfor %}
+    },
+{% endif %}
+{% set no_buffer_hwsku = (
+    "Nokia-7215", "Nokia-7215-A1", "Nokia-7215-A1-G48S4", "Nokia-7215-A1-MGX-G48S4",
+    "NH-5010-F-O64", "Arista-720DT-G48S4",
+    "Arista-7050CX3-32S-S128", "Arista-7050CX3-32S-C6S104", "Arista-7050CX3-32S-C28S16"
+) %}
+{% if 'marvell-teralynx' not in fanout_sonic_version["asic_type"] and not (fanout_hwsku in no_buffer_hwsku or "Arista-7060X6" in fanout_hwsku) %}
+    "BUFFER_QUEUE": {
+    {% for port_name in fanout_port_config %}
+         "{{ port_name }}|0-7": {
+            "profile": "q_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+    {% endfor %}
+    },
+    "BUFFER_PG": {
+    {% for port_name in fanout_port_config %}
+         "{{ port_name }}|0-7": {
+            "profile": "ingress_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+    {% endfor %}
+    },
+{% endif %}
+{% if 'marvell-teralynx' in fanout_sonic_version["asic_type"] or fanout_hwsku == "Arista-720DT-G48S4" or "Nokia-7215" in fanout_hwsku or fanout_hwsku == "NH-5010-F-O64" %}
+
+    "FLEX_COUNTER_TABLE": {
+        "ACL": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "BUFFER_POOL_WATERMARK": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "PFCWD": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "PG_DROP": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "PG_WATERMARK": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "PORT": {
+            "FLEX_COUNTER_STATUS": "enable"
+        },
+        "PORT_BUFFER_DROP": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "QUEUE": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "QUEUE_WATERMARK": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "RIF": {
+            "FLEX_COUNTER_STATUS": "disable"
+        }
+    },
+
+{% else %}
+
+    "FLEX_COUNTER_TABLE": {
+        "PFCWD": {
+            "FLEX_COUNTER_STATUS": "enable"
+        },
+        "PORT": {
+            "FLEX_COUNTER_STATUS": "enable"
+        },
+        "QUEUE": {
+            "FLEX_COUNTER_STATUS": "enable"
+        }
+    },
+
+    "QUEUE": {
+    {% for port_name in fanout_port_config %}
+        "{{ port_name }}|0-7": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        }{% if not loop.last %},{% endif %}
+    {% endfor %}
+    },
+
+    "CABLE_LENGTH": {
+        "AZURE": {
+    {% for port_name in fanout_port_config %}
+        "{{ port_name }}": "300m"{% if not loop.last %},{% endif %}
+    {% endfor %}
+        }
+    },
+
+    "PFC_WD": {
+        "GLOBAL": {
+            "POLL_INTERVAL": "200"
+        }
+    },
+
+    "SCHEDULER": {
+        "scheduler.0": {
+            "type": "DWRR",
+            "weight": "14"
+        },
+        "scheduler.1": {
+            "type": "DWRR",
+            "weight": "15"
+        }
+    },
+
+    "WRED_PROFILE": {
+        "AZURE_LOSSLESS": {
+            "red_max_threshold": "2097152",
+            "red_drop_probability": "5",
+            "wred_green_enable": "true",
+            "ecn": "ecn_all",
+            "green_min_threshold": "250000",
+            "red_min_threshold": "1048576",
+            "wred_yellow_enable": "true",
+            "yellow_min_threshold": "1048576",
+            "green_max_threshold": "2097152",
+            "green_drop_probability": "5",
+            "yellow_max_threshold": "2097152",
+            "yellow_drop_probability": "5",
+            "wred_red_enable": "true"
+        }
+    },
+
+    "SCHEDULER": {
+        "scheduler.0": {
+            "type": "DWRR",
+            "weight": "14"
+        },
+        "scheduler.1": {
+            "type": "DWRR",
+            "weight": "15"
+        }
+    },
+
+{% endif %}
+
+    "FEATURE": {
+        "acms": {
+            "auto_restart": "disabled",
+            "has_global_scope": "True",
+            "has_per_asic_scope": "False",
+            "has_timer": "False",
+            "high_mem_alert": "disabled",
+            "set_owner": "local",
+            "state": "disabled"
+        },
+        "mux": {
+            "auto_restart": "disabled",
+            "has_global_scope": "True",
+            "has_per_asic_scope": "False",
+            "has_timer": "False",
+            "high_mem_alert": "disabled",
+            "set_owner": "local",
+            "state": "disabled"
+        },
+        "bgp": {
+            "state": "disabled",
+            "has_timer": false,
+            "has_global_scope": false,
+            "has_per_asic_scope": true,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "database": {
+            "state": "always_enabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": true,
+            "auto_restart": "always_enabled",
+            "high_mem_alert": "disabled"
+        },
+        "dhcp_relay": {
+            "state": "disabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+    {% if 'marvell-teralynx' in fanout_sonic_version["asic_type"] %}
+            "lldp": {
+            "state": "enabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": true,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+    {% else %}
+        "lldp": {
+            "state": "disabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": true,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+    {% endif %}
+        "pmon": {
+            "state": "enabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "radv": {
+            "state": "disabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "snmp": {
+            "state": "enabled",
+            "has_timer": true,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "swss": {
+            "state": "enabled",
+            "has_timer": false,
+            "has_global_scope": false,
+            "has_per_asic_scope": true,
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "syncd": {
+            "state": "enabled",
+            "has_timer": false,
+            "has_global_scope": false,
+            "has_per_asic_scope": true,
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "teamd": {
+            "state": "disabled",
+            "has_timer": false,
+            "has_global_scope": false,
+            "has_per_asic_scope": true,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "mgmt-framework": {
+            "state": "disabled",
+            "has_timer": true,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "nat": {
+            "state": "disabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "sflow": {
+            "state": "disabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "telemetry": {
+            "state": "disabled",
+            "has_timer": true,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "restapi": {
+            "auto_restart": "disabled",
+            "has_global_scope": "True",
+            "has_per_asic_scope": "False",
+            "has_timer": "False",
+            "high_mem_alert": "disabled",
+            "set_owner": "local",
+            "state": "disabled"
+        }
+    }
+}

--- a/ansible/roles/fanout/templates/sonic_deploy_202511.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202511.j2
@@ -42,6 +42,9 @@
             "tpid": "0x9100",
         {% endif %}
     {% endif %}
+    {% if 'subport' in fanout_port_config[port_name] %}
+            "subport": "{{ fanout_port_config[port_name]['subport'] }}",
+    {% endif %}
     {% if 'peerdevice' in fanout_port_config[port_name] %}
             "admin_status": "up"
     {% else %}

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -300,8 +300,8 @@ class VMTopology(object):
                 vm_bridge_regx = OVS_FP_BRIDGE_REGEX % vmname
                 num_intfs = len([intf for intf in intf_names if re.search(vm_bridge_regx, intf)])
                 if len(attrs['vlans']) > num_intfs:
-                    raise Exception("Wrong vlans parameter for hostname %s, vm %s. Too many vlans. Maximum is %d %s"
-                                    % (hostname, vmname, num_intfs, str(attrs['vlans'])))
+                    raise Exception("Wrong vlans parameter for hostname %s, vm %s. Too many vlans. Maximum is %d"
+                                    % (hostname, vmname, num_intfs))
 
         self.VM_LINKs = {}
         if 'VM_LINKs' in self.topo:

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -300,8 +300,8 @@ class VMTopology(object):
                 vm_bridge_regx = OVS_FP_BRIDGE_REGEX % vmname
                 num_intfs = len([intf for intf in intf_names if re.search(vm_bridge_regx, intf)])
                 if len(attrs['vlans']) > num_intfs:
-                    raise Exception("Wrong vlans parameter for hostname %s, vm %s. Too many vlans. Maximum is %d"
-                                    % (hostname, vmname, num_intfs))
+                    raise Exception("Wrong vlans parameter for hostname %s, vm %s. Too many vlans. Maximum is %d %s"
+                                    % (hostname, vmname, num_intfs, str(attrs['vlans'])))
 
         self.VM_LINKs = {}
         if 'VM_LINKs' in self.topo:
@@ -649,7 +649,8 @@ class VMTopology(object):
             vlan_id = data.get("vlan")
             if vlan_id:
                 vlan_intf_name = "%s.%d" % (BP_PORT_NAME, vlan_id)
-                VMTopology.cmd("nsenter -t %s -n ip link del %s" % (self.pid, vlan_intf_name))
+                if VMTopology.intf_exists(vlan_intf_name, pid=self.pid):
+                    VMTopology.cmd("nsenter -t %s -n ip link del %s" % (self.pid, vlan_intf_name))
 
     def add_br_if_to_docker(self, bridge, ext_if, int_if):
         # add unique suffix to int_if to support multiple tasks run concurrently


### PR DESCRIPTION
### Description of PR

Summary:
Add converged neighbor (multi-VRF cEOS) support to EOS templates and fix route
announcement for LT2-O128 topology with converged neighbors.

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach

#### What is the motivation for this PR?

When deploying LT2-O128 topology with converged cEOS neighbors (multi-VRF prime containers), several issues prevented BGP sessions and routes from working:

1. EOS templates (`lt2-o128-tor.j2`, `t1-64-lag-tor.j2`) lacked converged peer support - missing VRF instances, backplane interfaces, and per-VRF BGP config.
2. `t1-lag-spine.j2` had Jinja2 indentation issues in existing converged blocks, causing incorrect config generation.
3. `announce_routes.py` `fib_lt2_routes` only read `topology.VMs` which in converged mode only has 4 prime containers instead of all 128 VMs, causing T1/T0 route announcement to be skipped for most neighbors.
4. `ceos_ensure_reachable.yml` used `VM_host[0]` as delegate which fails when reachability checks must run from the management host.
5. `vm_topology.py` could fail with "No such device" when a VLAN interface was already removed before the cleanup task ran.

#### How did you do it?

- `lt2-o128-tor.j2` / `t1-64-lag-tor.j2`: Added `{% if converged %}` blocks to configure VLAN trunks, per-VRF routing, backplane interfaces, and per-VRF BGP sessions with optional confederation support.
- `t1-lag-spine.j2`: Fixed Jinja2 indentation (removed leading whitespace in `{% for %}` blocks inside `{% if converged %}`) so config renders correctly.
- `announce_routes.py`: When `convergence_data` is present, enumerate all VRFs from `convergence_data["convergence_mapping"]` instead of `topology["VMs"]`. Also added T0 route announcement: 128 unique IPv4 + 128 unique IPv6 routes per T0 VM using `192.0.0.0/9` and `20c0:a900::/108` address spaces.
- `ceos_ensure_reachable.yml`: Changed `delegate_to` from `VM_host[0]` to `localhost` so ping reachability check runs from the correct host.
- `vm_topology.py`: Added `intf_exists()` guard before deleting VLAN sub-interface to avoid errors during teardown; improved vlans error message to include the actual vlan list for easier debugging.

#### How did you verify/test it?

Deployed LT2-O128 converged testbed with 128 cEOS VMs (4 prime containers x 32 VRFs each). Verified:
- All 256 BGP sessions established (128 IPv4 + 128 IPv6)
- T1 neighbors (48 VMs): 668 IPv4 + 667-668 IPv6 routes each
- T0 neighbors (16 VMs): 128 IPv4 + 128 IPv6 routes each
- FT2 neighbors (56 VMs): 1 route each
- UT2 neighbors (8 VMs): 2 routes each (default route via confederation)

#### Any platform specific information?

Changes apply to cEOS-based testbeds using converged neighbor (multi-VRF) mode. The template changes are backward compatible - non-converged deployments (`topo_is_multi_vrf=false`) are unaffected.

#### Supported testbed topology if its a new test case?

N/A

### Documentation