### PR TITLE
feat: enable vxlan VPP tests (part 1)

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -718,6 +718,9 @@ t1-lag-vpp:
   - vxlan/test_vxlan_route_advertisement.py
   - vxlan/test_vnet_route_leak.py
   - vxlan/test_vxlan_crm.py
+  - vxlan/test_vnet_bgp_route_precedence.py
+  - vxlan/test_vxlan_multi_tunnel.py
+  - vxlan/test_vxlan_route_advertisement.py
 
 
 multi-asic-t1-lag:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5697,10 +5697,10 @@ vrf/test_vrf_attr.py::TestVrfAttrSrcMac::test_vrf1_neigh_with_default_router_mac
 #######################################
 vxlan/test_vnet_bgp_route_precedence.py:
   skip:
-    reason: "test_vnet_bgp_route_precedence can only run on cisco and mnlx platforms. Also skip in 202411"
+    reason: "test_vnet_bgp_route_precedence can only run on cisco, mnlx and VPP platforms. Also skip in 202411"
     conditions_logical_operator: or
     conditions:
-      - "asic_type not in ['cisco-8000', 'mellanox']"
+      - "asic_type not in ['cisco-8000', 'mellanox', 'vpp']"
       - "release in ['202411']"
   xfail:
     reason: "Testcase ignored due to github issue: https://github.com/sonic-net/sonic-buildimage/issues/23824"
@@ -5929,7 +5929,7 @@ vxlan/test_vxlan_route_advertisement.py:
   skip:
     reason: "VxLAN route advertisement can only run on cisco , mnlx and marvell-teralynx platforms. "
     conditions:
-      - "asic_type not in ['cisco-8000', 'mellanox' , 'marvell-teralynx' , 'vs']"
+      - "asic_type not in ['cisco-8000', 'mellanox' , 'marvell-teralynx' , 'vs', 'vpp']"
 
 vxlan/test_vxlan_route_advertisement.py::Test_VxLAN_route_Advertisement::test_basic_route_advertisement[v4_in_v4]:
   xfail:

--- a/tests/vxlan/test_vnet_bgp_route_precedence.py
+++ b/tests/vxlan/test_vnet_bgp_route_precedence.py
@@ -219,8 +219,9 @@ def fixture_setUp(duthosts,
         data['loopback_v4'] = data['minigraph_facts']['minigraph_lo_interfaces'][1]['addr']
         data['loopback_v6'] = data['minigraph_facts']['minigraph_lo_interfaces'][0]['addr']
     asic_type = duthosts[rand_one_dut_hostname].facts["asic_type"]
-    if asic_type not in ["cisco-8000", "mellanox"]:
-        pytest.skip(f"{asic_type} is not a supported platform for this test. Only support MNLX and CISCO platforms.")
+    if asic_type not in ["cisco-8000", "mellanox", "vpp"]:
+        pytest.skip(f"{asic_type} is not a supported platform for this test. "
+                    f"Only support MNLX, CISCO and VPP platforms.")
 
     # Should I keep the temporary files copied to DUT?
     ecmp_utils.Constants['KEEP_TEMP_FILES'] = \

--- a/tests/vxlan/test_vxlan_route_advertisement.py
+++ b/tests/vxlan/test_vxlan_route_advertisement.py
@@ -86,7 +86,7 @@ def fixture_setUp(duthosts,
             data['t2'].append(nbrhosts[name])
 
     asic_type = duthosts[rand_one_dut_hostname].facts["asic_type"]
-    if asic_type not in ["cisco-8000", "mellanox", "marvell-teralynx", "vs"]:
+    if asic_type not in ["cisco-8000", "mellanox", "marvell-teralynx", "vs", "vpp"]:
         pytest.skip(f"{asic_type} is not a supported platform for this test. \
                 Only support MNLX, CISCO and marvell-teralynx platforms.")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR enables the first batch of VXLAN tests for the VPP platform.

SONiC-VPP currently supports L3 VXLAN. Based on the test logic, this PR enables the test modules that
validate L3 VXLAN control-plane and route-to-tunnel behavior only:

| Test module | Scope |
| --- | --- |
| `test_vnet_bgp_route_precedence.py` | VNET route precedence over BGP route with VXLAN tunnel route forwarding |
| `test_vxlan_multi_tunnel.py` | VXLAN tunnel, VNET, and VNET route programming smoke test |
| `test_vxlan_route_advertisement.py` | VNET tunnel route advertisement and BGP community handling |

The remaining VXLAN tests are intentionally not enabled yet. ECMP related tests (e.g. `vxlan/test_vxlan_ecmp.py::Test_VxLAN_ecmp_random_hash`) will be enabled after https://github.com/sonic-net/sonic-buildimage/issues/25762, and IP-in-IP related tests (e.g. `vxlan/test_vnet_decap.py` & ` test_vxlan_multiple_tunnels.py`) will be enabled after https://github.com/sonic-net/sonic-buildimage/issues/25779

Fixes # (issue) https://github.com/sonic-net/sonic-buildimage/issues/25777

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
We want to enable as many vxlan tests for VPP platform as possible

#### How did you do it?

#### How did you verify/test it?

Ran each test module twice and confirmed they are passed: https://elastictest.org/scheduler/testplan/6a029d19686444e666af80ea

<img width="525" height="545" alt="image" src="https://github.com/user-attachments/assets/96f52fc4-b30e-4a8b-823d-288bb9285a0f" />


#### Any platform specific information?
VPP

#### Supported testbed topology if it's a new test case?
t1-lag-vpp

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
