### PR TITLE
[swap_syncd] Wait for mgmt plane recovery before docker login

### DIFF
--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -160,16 +160,18 @@ def swap_syncd(duthost, creds, namespace=DEFAULT_NAMESPACE):
     else:
         # After swss stops, the management plane (PortChannel default route) may be
         # unavailable for ~60s. Poll until the registry responds before docker login.
-        registry_host = creds.get("docker_registry_host", "soniccr1.azurecr.io")
+        registry_host = creds.get("docker_registry_host", "")
 
         def mgmt_plane_ready():
             cmd = ("curl -s -o /dev/null -w '%{http_code}' --max-time 5 "
                    "https://" + registry_host + "/v2/")
             result = duthost.command(cmd, module_ignore_errors=True)
-            return result["rc"] == 0 or result["stdout"].strip() in ("200", "401", "403")
+            return result["rc"] == 0
 
-        logger.info("Waiting for management plane to recover before docker login...")
-        wait_until(120, 5, 0, mgmt_plane_ready)
+        if registry_host:
+            logger.info("Waiting for management plane to recover before docker login...")
+            if not wait_until(120, 5, 0, mgmt_plane_ready):
+                logger.warning("Management plane did not recover within 120s — proceeding to docker login anyway")
         registry = load_docker_registry_info(duthost, creds)
         download_image(duthost, registry, docker_rpc_image, duthost.os_version)
 

--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -158,6 +158,18 @@ def swap_syncd(duthost, creds, namespace=DEFAULT_NAMESPACE):
             'latest'
         )
     else:
+        # After swss stops, the management plane (PortChannel default route) may be
+        # unavailable for ~60s. Poll until the registry responds before docker login.
+        registry_host = creds.get("docker_registry_host", "soniccr1.azurecr.io")
+
+        def mgmt_plane_ready():
+            cmd = ("curl -s -o /dev/null -w '%{http_code}' --max-time 5 "
+                   "https://" + registry_host + "/v2/")
+            result = duthost.command(cmd, module_ignore_errors=True)
+            return result["rc"] == 0 or result["stdout"].strip() in ("200", "401", "403")
+
+        logger.info("Waiting for management plane to recover before docker login...")
+        wait_until(120, 5, 0, mgmt_plane_ready)
         registry = load_docker_registry_info(duthost, creds)
         download_image(duthost, registry, docker_rpc_image, duthost.os_version)
 


### PR DESCRIPTION
### Description of PR

Summary:
After `asic.stop_service("swss")` in `swap_syncd()`, the PortChannel default kernel route is removed, causing an ~60s management plane blackout. The subsequent `docker login soniccr1.azurecr.io` fails because the registry host is unreachable during this window.

This fix adds a `mgmt_plane_ready()` polling function that checks the registry `/v2/` endpoint via curl (accepting rc=0 or HTTP 200/401/403 as "ready"), and calls `wait_until(120, 5, 0, mgmt_plane_ready)` before `load_docker_registry_info()` + `download_image()` in the `else` branch (i.e., when the RPC image is not present locally and must be downloaded).

ADO: https://msazure.visualstudio.com/One/_workitems/edit/37923598

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`swap_syncd()` calls `docker login soniccr1.azurecr.io` after stopping `swss`, but the ~60s management plane blackout caused by PortChannel route removal makes the registry unreachable, causing docker login to fail and the test to error out.

#### How did you do it?
Added inline helper function `mgmt_plane_ready()` that runs:
```
curl -s -o /dev/null -w '%{http_code}' --max-time 5 https://soniccr1.azurecr.io/v2/
```
and returns `True` when the registry is reachable (rc==0 or HTTP 200/401/403).

Then added `wait_until(120, 5, 0, mgmt_plane_ready)` with a log message before attempting docker login in `docker.py`.

#### How did you verify/test it?
Run a test that calls `swap_syncd()` with the RPC image absent locally (force a fresh pull). Verify that:
1. The test does not fail with a `docker login` timeout.
2. The log shows "Waiting for management plane to recover before docker login..."
3. The test completes successfully after the management plane recovers.

Elastic test verification jobs (qos/test_qos_sai.py, internal-202511, legacy-th):

**Run 1:**
- testbed-bjw3-can-t0-7060-3: https://elastictest.org/scheduler/testplan/6a026fabb836de58495e23bd
- testbed-bjw3-can-t0-7060-4: https://elastictest.org/scheduler/testplan/6a026facea3a02a739d0367e

**Run 2:**
- testbed-bjw3-can-t0-7060-4: https://elastictest.org/scheduler/testplan/6a03adb7eb4c0d0f5d30be52
- testbed-bjw3-can-t0-7060-3: https://elastictest.org/scheduler/testplan/6a03adb9a907302e5e8241c8

#### Any platform specific information?
N/A — applies to all platforms that use `swap_syncd()`.

#### Supported testbed topology if it's a new test case?
N/A — this is a framework bug fix, not a new test case.

### Documentation
N/A