### PR TITLE
[qos] Fix conditional mark for testPfcStormWithSharedHeadroomOccupancy to skip all non-Mellanox platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4358,9 +4358,8 @@ qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy:
     reason: "This test is only for Mellanox."
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['cisco-8000']"
+      - "asic_type not in ['mellanox']"
       - "topo_type in ['m0', 'mx', 'm1']"
-      - "topo_name not in constants['QOS_SAI_TOPO'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark:
   skip:


### PR DESCRIPTION
### Description of PR

Summary: Fix the conditional mark skip condition for `testPfcStormWithSharedHeadroomOccupancy` to correctly skip all non-Mellanox platforms at collection time.

Fixes https://msazure.visualstudio.com/One/_workitems/edit/37432198

### Type of change
- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

`testPfcStormWithSharedHeadroomOccupancy` is a **Mellanox-only** test (the test body explicitly does `pytest.skip("This Test Case is only meant for Mellanox ASIC")` for non-Mellanox platforms). However, the conditional mark in `tests_mark_conditions.yaml` had an incomplete skip condition that allowed **Broadcom platforms on QOS_SAI_TOPO topologies** (t0, t1-lag, etc.) to pass collection and proceed to the setup phase.

The previous conditions were:
```yaml
conditions:
  - "asic_type in ['cisco-8000']"          # Only skips Cisco
  - "topo_type in ['m0', 'mx', 'm1']"     # Only skips M0/MX/M1
  - "topo_name not in constants['QOS_SAI_TOPO'] and asic_type not in ['mellanox']"
    # Only skips non-Mellanox on non-QOS_SAI_TOPO topologies
```

Since `QOS_SAI_TOPO` includes `t0`, `t1-lag`, and most common topologies, Broadcom platforms (e.g. Arista-7060CX-32S on t0) were **not skipped** at collection time. The `swap_syncd` fixture then ran and attempted to download the RPC syncd image from the Docker registry, which failed with `docker login` timeout errors — producing false `error` results instead of `skipped`.

**Kusto evidence** (60 days, branch 20251110): 33 HwSKUs, **0 passes**, 9 errors (all infrastructure failures in setup phase), ~780 skipped. The test logic never executes on any platform.

#### How did you do it?

Simplified the conditions to:
```yaml
conditions:
  - "asic_type not in ['mellanox']"      # Skip ALL non-Mellanox at collection time
  - "topo_type in ['m0', 'mx', 'm1']"   # Skip unsupported topologies
```

This matches the test body intent and ensures non-Mellanox platforms are skipped before any fixture (including `swap_syncd`) runs.

#### How did you verify/test it?

- Verified the condition logic matches the test body skip at `test_qos_sai.py` line 460
- Confirmed via Kusto that all 9 error cases on 20251110 were from non-Mellanox platforms on QOS_SAI_TOPO topologies (the exact gap this fix closes)
- Cross-checked 202511 and 202505 branches on ADO — same code, same gap

#### Any platform specific information?

This change affects all non-Mellanox platforms (Broadcom, Cisco, Nokia, etc.). The test will now be correctly skipped at collection time instead of failing during fixture setup.

#### Supported testbed topology if it's a new test case?

N/A — this is a bug fix for an existing test's skip condition.

### Documentation

N/A