### PR TITLE
[cherry-pick][acl] Replace time.sleep with wait_until in test_acl_outer_vlan (#22978)

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -296,12 +296,20 @@ def get_acl_counter(duthost, table_name, rule_name, timeout=ACL_COUNTERS_UPDATE_
     Returns:
         Acl counter value for packets
     """
-    # Wait for orchagent to update the ACL counters
-    time.sleep(timeout)
-    result = duthost.show_and_parse('aclshow -a')
+    def _check_acl_counter():
+        result = duthost.show_and_parse('aclshow -a')
+        if len(result) == 0:
+            return False
+        for rule in result:
+            if table_name == rule['table name'] and rule_name == rule['rule name']:
+                return True
+        return False
 
-    if len(result) == 0:
+    # Wait for orchagent to update the ACL counters
+    if not wait_until(timeout, 2, 0, _check_acl_counter):
         pytest.fail("Failed to retrieve acl counter for {}|{}".format(table_name, rule_name))
+
+    result = duthost.show_and_parse('aclshow -a')
     for rule in result:
         if table_name == rule['table name'] and rule_name == rule['rule name']:
             return int(rule['packets count'])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Cherry-pick of https://github.com/sonic-net/sonic-mgmt/pull/22801
check original PR for details
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #  https://github.com/aristanetworks/sonic-qual.msft/issues/1266

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
