### PR TITLE
Extend backup_and_restore_config_db to also preserve golden_config_db.json

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -26,14 +26,22 @@ logger = logging.getLogger(__name__)
 
 
 def _backup_and_restore_config_db(duts, scope='function'):
-    """Back up the existing config_db.json file and restore it once the test ends.
+    """Back up config_db.json and golden_config_db.json, restore after test.
 
-    Some cases will update the running config during the test and save the config
-    to be recovered aftet reboot. In such a case we need to backup config_db.json before
-    the test starts and then restore it after the test ends.
+    Some cases will update the running config during the test and save the
+    config to be recovered after reboot. Upgrade tests also delete
+    golden_config_db.json which contains lab-specific settings (DNS, NTP,
+    syslog) not present in minigraph. Without golden_config, the DUT falls
+    back to image-default DNS from dns.j2, which may be unreachable from
+    the lab network.
+
+    This backs up both files before the test and restores them afterward.
     """
     CONFIG_DB = "/etc/sonic/config_db.json"
     CONFIG_DB_BAK = "/host/config_db.json.before_test_{}".format(scope)
+    GOLDEN_CONFIG = "/etc/sonic/golden_config_db.json"
+    GOLDEN_CONFIG_BAK = "/host/golden_config_db.json.before_test_{}".format(
+        scope)
 
     if type(duts) is not list:
         duthosts = [duts]
@@ -41,14 +49,35 @@ def _backup_and_restore_config_db(duts, scope='function'):
         duthosts = duts
 
     for duthost in duthosts:
-        logger.info("Backup {} to {} on {}".format(CONFIG_DB, CONFIG_DB_BAK, duthost.hostname))
+        logger.info("Backup {} to {} on {}".format(
+            CONFIG_DB, CONFIG_DB_BAK, duthost.hostname))
         duthost.shell("cp {} {}".format(CONFIG_DB, CONFIG_DB_BAK))
+
+        # Backup golden_config if it exists
+        if duthost.shell("test -f {}".format(GOLDEN_CONFIG),
+                         module_ignore_errors=True)['rc'] == 0:
+            logger.info("Backup {} to {} on {}".format(
+                GOLDEN_CONFIG, GOLDEN_CONFIG_BAK, duthost.hostname))
+            duthost.shell("cp {} {}".format(GOLDEN_CONFIG, GOLDEN_CONFIG_BAK))
 
     yield
 
     for duthost in duthosts:
-        logger.info("Restore {} with {} on {}".format(CONFIG_DB, CONFIG_DB_BAK, duthost.hostname))
+        logger.info("Restore {} with {} on {}".format(
+            CONFIG_DB, CONFIG_DB_BAK, duthost.hostname))
         duthost.shell("mv {} {}".format(CONFIG_DB_BAK, CONFIG_DB))
+
+        # Restore golden_config if backup exists
+        if duthost.shell("test -f {}".format(GOLDEN_CONFIG_BAK),
+                         module_ignore_errors=True)['rc'] == 0:
+            logger.info("Restore {} from {} on {}".format(
+                GOLDEN_CONFIG, GOLDEN_CONFIG_BAK, duthost.hostname))
+            duthost.shell("cp {} {}".format(GOLDEN_CONFIG_BAK, GOLDEN_CONFIG))
+            duthost.shell(
+                "cp {} /host/old_config/golden_config_db.json".format(
+                    GOLDEN_CONFIG_BAK),
+                module_ignore_errors=True)
+            duthost.shell("rm -f {}".format(GOLDEN_CONFIG_BAK))
 
 
 @pytest.fixture(scope="module")

--- a/tests/upgrade_path/conftest.py
+++ b/tests/upgrade_path/conftest.py
@@ -1,5 +1,17 @@
 import pytest
 
+from tests.common.fixtures.duthost_utils import _backup_and_restore_config_db
+
+
+@pytest.fixture(autouse=True, scope="session")
+def backup_and_restore_config_db_for_upgrade(duthosts):
+    """Session-scoped autouse fixture to backup/restore config_db and golden_config.
+
+    Applies to all tests in upgrade_path/ automatically.
+    """
+    for func in _backup_and_restore_config_db(duthosts, "session"):
+        yield func
+
 
 def pytest_runtest_setup(item):
     from_list = item.config.getoption('base_image_list')


### PR DESCRIPTION
### Description of PR

Summary:
Extend `_backup_and_restore_config_db()` to also backup and restore `golden_config_db.json` during upgrade/downgrade tests, and apply it directory-wide for all upgrade_path tests via conftest.py.

Fixes https://msazure.visualstudio.com/One/_workitems/edit/37926440

### Type of change

- [x] Testbed and Framework(new/improvement)
- [ ] Bug fix
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

PR #20420 added deletion of `golden_config_db.json` during image upgrades. While this fixes upgrade/downgrade flow, it permanently destroys lab-specific settings:

1. `golden_config_db.json` deleted during upgrade (3 code paths in `reduce_and_add_sonic_images.py`, `utilities.py`, `advanced_reboot.py`)
2. After reboot, SONiC generates config from minigraph only
3. Minigraph XML has **no DNS entries** (not in the schema)
4. `dns.j2` template fills image-default DNS (e.g. `10.64.5.5` for MSIT builds)
5. Lab-correct DNS (e.g. `10.50.50.50` for BJW) is permanently lost

#### How did you do it?

Two changes:

1. **`tests/common/fixtures/duthost_utils.py`**: Extended `_backup_and_restore_config_db()` to also handle `golden_config_db.json`:
   - Before test: backs up golden_config alongside config_db (with existence check)
   - After test: restores golden_config to `/etc/sonic/` AND copies to `/host/old_config/` so it survives reboots

2. **`tests/upgrade_path/conftest.py`**: Added `backup_and_restore_config_db_session` as a directory-wide fixture via `pytestmark = [pytest.mark.usefixtures(...)]`. This covers ALL upgrade path tests:
   - `test_upgrade_path.py` (already had fixture individually)
   - `test_multi_hop_upgrade_path.py` (already had fixture individually)
   - `test_warmboot_data_consistency.py` (was NOT protected before)
   - `test_upgrade_gnoi.py` (was NOT protected before)

Tests in `platform_tests/test_advanced_reboot.py` already use `backup_and_restore_config_db` in their function signature and are also automatically protected.

#### How did you verify/test it?

- Traced the full config generation chain: `deploy-mg` -> `generate_golden_config_db.py` -> `golden_config_db.json` -> `config load_minigraph`
- Verified via ElasticTest logs that DNS changes from correct to wrong during upgrade tests (plans 6a013820, 69e6f85a for `test_warmboot_data_consistency`)
- Audited 11 BJW 7260 testbeds: 6 had wrong/missing DNS after running upgrade tests

#### Any platform specific information?
Any lab using internal SONiC images where `dns.j2` defaults differ from lab DNS is affected.

#### Supported testbed topology if it's a new test case?
N/A — framework change, not a new test case.

### Documentation
N/A