### PR TITLE
[loganalyzer] Ignore FEC alignment lock ERR on Mellanox non-SPC4+ platforms

### DIFF
--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -4,7 +4,10 @@ import pytest
 from .loganalyzer import LogAnalyzer, DisableLogrotateCronContext
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.helpers.parallel import parallel_run, reset_ansible_local_tmp
+from tests.common.mellanox_data import SPC4_HWSKUS, SPC5_HWSKUS, SPC6_HWSKUS
 from .bug_handler_helper import get_bughandler_instance
+
+SPC4_PLUS_HWSKUS = SPC4_HWSKUS + SPC5_HWSKUS + SPC6_HWSKUS
 
 
 def pytest_addoption(parser):
@@ -152,5 +155,37 @@ def ignore_port_phy_attr_errors_on_vs(duthosts, loganalyzer):
                     [
                         r".*ERR swss#orchagent.*verifyPortSupportsAllPhyAttr.*PORT_PHY_ATTR.*"
                         r"does not support.*attribute.*"
+                    ]
+                )
+
+
+@pytest.fixture(autouse=True)
+def ignore_mlnx_fec_alignment_lock_errors(duthosts, loganalyzer):
+    """Ignore FEC alignment lock ERR on Mellanox non-SPC4+ platforms.
+
+    Mellanox SAI on SPC1/SPC2/SPC3 logs ERR when syncd queries the
+    FEC_ALIGNMENT_LOCK port attribute, which is only supported on SPC4+.
+    These are harmless hardware limitation logs, not functional errors.
+    Only applied when the HWSKU is NOT in the SPC4+/SPC5/SPC6 lists so that
+    any real FEC issues on newer platforms are not masked.
+    """
+    SPC4_PLUS = SPC4_PLUS_HWSKUS
+    if loganalyzer:
+        for duthost in duthosts:
+            hwsku = duthost.facts.get("hwsku", "")
+            if duthost.facts.get("asic_type") == "mellanox" and hwsku not in SPC4_PLUS:
+                loganalyzer[duthost.hostname].ignore_regex.extend(
+                    [
+                        r".*ERR syncd#SDK: \[SAI_PORT\.ERR\].*mlnx_sai_port\.c.*"
+                        r"FEC alignment lock only supported on SPC4\+",
+                        r".*ERR syncd#SDK: \[SAI_UTILS\.ERR\].*get_dispatch_attribs_handler:.*"
+                        r"FEC_ALIGNMENT_LOCK.*",
+                        # This pattern is broader than ideal — matches any SAI utils
+                        # attribute-get failure, not just FEC. Narrowing isn't feasible
+                        # because the generic error lacks "FEC" context. Scoped to
+                        # non-SPC4+ Mellanox only, limiting blast radius.
+                        # See ADO #37689505 for context.
+                        r".*ERR syncd#SDK: \[SAI_UTILS\.ERR\].*mlnx_sai_utils\.c.*"
+                        r"sai_get_attributes: Failed to get attribute",
                     ]
                 )


### PR DESCRIPTION
### Description of PR

Summary:
Add loganalyzer ignore patterns for Mellanox SAI FEC alignment lock errors on non-SPC4+ platforms (SPC1/SPC2/SPC3). These are harmless hardware-limitation logs that cause loganalyzer false positives on teardown.

Fixes ADO #37689505

### Type of change

- [x] Testbed and Framework(new/improvement)

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Nightly test `test_incremental_qos_config_updates` failed once (1/108 over 60 days) on Mellanox SN4700 (SPC3) testbed `vms66-t0-4700-1`. The test passed functionally but loganalyzer caught 168 ERR syslog messages from Mellanox SDK during teardown:

```
ERR syncd#SDK: [SAI_PORT.ERR] mlnx_sai_port.c - mlnx_port_state_get: FEC alignment lock only supported on SPC4+
ERR syncd#SDK: [SAI_UTILS.ERR] mlnx_sai_utils.c - get_dispatch_attribs_handler: Failed Get #0, FEC_ALIGNMENT_LOCK
ERR syncd#SDK: [SAI_UTILS.ERR] mlnx_sai_utils.c - sai_get_attributes: Failed to get attribute
```

These errors occur when syncd queries the `FEC_ALIGNMENT_LOCK` port attribute on SPC1/SPC2/SPC3 hardware where this feature is not available. They are benign — the port works fine, the query simply returns "not supported".

#### How did you do it?

Added an `autouse` pytest fixture `ignore_mlnx_fec_alignment_lock_errors` in `tests/common/plugins/loganalyzer/__init__.py` that extends `loganalyzer.ignore_regex` with three patterns matching the FEC alignment lock error triplet. The fixture is scoped to Mellanox platforms whose HWSKU is NOT in the SPC4+/SPC5/SPC6 lists (from `mellanox_data.py`), so any real FEC issues on newer platforms are not masked.

This follows the same pattern as existing fixtures `ignore_pkt_trim_errors` (Broadcom) and `ignore_port_phy_attr_errors_on_vs` (VS/KVM).

#### How did you verify/test it?

- Regex patterns verified against actual error messages from the failing testplan (`69e849bff94ae1409b8d3b16`)
- All 3 patterns correctly match the real syslog errors (56 + 56 + 56 = 168 matches)
- False positive check: patterns do NOT match unrelated SAI errors
- HWSKU coverage verified: `Mellanox-SN4700-O8V48` (the failing SKU) is not in any `mellanox_data.py` HWSKU list, validating the NOT-IN-SPC4+ approach over a whitelist
- `py_compile` + `flake8 --max-line-length=120` pass clean

#### Any platform specific information?

Applies to Mellanox/NVIDIA SPC1/SPC2/SPC3 platforms only. SPC4+ natively supports FEC_ALIGNMENT_LOCK so these errors do not occur on those platforms.

#### Supported testbed topology if it is a new test case?

N/A — not a new test case.

### Documentation

N/A