### PR TITLE
[platform_tests] Re-enable DAC skip for SFP in test_tx_disable_channel

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -309,24 +309,30 @@ class TestSfpApi(PlatformApiTestBase):
     #
     def is_xcvr_optical(self, xcvr_info_dict):
         """Returns True if transceiver is optical, False if copper (DAC)"""
-        # For QSFP-DD specification compliance will return type as passive or active
-        if xcvr_info_dict["type_abbrv_name"] in ["QSFP-DD", "OSFP-8X", "QSFP+C", "BP", "SFP"]:
-            if xcvr_info_dict["specification_compliance"] == "Passive Copper Cable" or \
-                    xcvr_info_dict["specification_compliance"] == "passive_copper_media_interface":
+        type_name = xcvr_info_dict["type_abbrv_name"]
+        spec = xcvr_info_dict["specification_compliance"]
+
+        # QSFP-DD/OSFP-8X/QSFP+C/BP report specification_compliance as a plain string.
+        if type_name in ["QSFP-DD", "OSFP-8X", "QSFP+C", "BP"]:
+            return spec not in ("Passive Copper Cable", "passive_copper_media_interface")
+
+        # SFP may report specification_compliance either as a plain string
+        # (e.g. Cisco-console SFP) or as a dict-formatted string (standard SFP/SFP+ DAC).
+        if type_name == "SFP":
+            if spec in ("Passive Copper Cable", "passive_copper_media_interface"):
                 return False
-        else:
-            spec_compliance_dict = ast.literal_eval(xcvr_info_dict["specification_compliance"])
-            if xcvr_info_dict["type_abbrv_name"] == "SFP":
-                compliance_code = spec_compliance_dict.get("SFP+CableTechnology")
-                if compliance_code == "Passive Cable":
-                    return False
-            else:
-                compliance_code = spec_compliance_dict.get("10/40G Ethernet Compliance Code", " ")
-                if "CR" in compliance_code:
-                    return False
-                extended_code = spec_compliance_dict.get("Extended Specification Compliance", " ")
-                if "CR" in extended_code:
-                    return False
+            try:
+                spec_compliance_dict = ast.literal_eval(spec)
+            except (ValueError, SyntaxError):
+                return True
+            return spec_compliance_dict.get("SFP+CableTechnology") != "Passive Cable"
+
+        # All other types use the dict-based copper check.
+        spec_compliance_dict = ast.literal_eval(spec)
+        if "CR" in spec_compliance_dict.get("10/40G Ethernet Compliance Code", " "):
+            return False
+        if "CR" in spec_compliance_dict.get("Extended Specification Compliance", " "):
+            return False
         return True
 
     def is_xcvr_resettable(self, request, xcvr_info_dict):


### PR DESCRIPTION
### Description of PR

`platform_tests.api.test_sfp.TestSfpApi::test_tx_disable_channel` is supposed to skip ports whose transceiver doesn't support per-channel TX disable (e.g. DAC cables). On platforms with SFP+ DAC uplinks (e.g. Nokia 7215) the skip stopped taking effect and the test fails on every SFP+ DAC port.

**Root cause:** PR #23972 added `"SFP"` to the plain-string compliance check list inside `is_xcvr_optical()`:

```diff
- if xcvr_info_dict["type_abbrv_name"] in ["QSFP-DD", "OSFP-8X", "QSFP+C", "BP"]:
+ if xcvr_info_dict["type_abbrv_name"] in ["QSFP-DD", "OSFP-8X", "QSFP+C", "BP", "SFP"]:
```

That change was needed for Cisco-console SFP whose `specification_compliance` is a plain string, but it broke the existing SFP DAC detection path: a standard SFP/SFP+ DAC reports `specification_compliance` as a **dict-formatted string** (e.g. `{'SFP+CableTechnology': 'Passive Cable', ...}`). Because `"SFP"` is now matched in the first branch, the dict-string never matches the two literal copper strings, the function returns `True`, and `test_tx_disable_channel` runs on the DAC port and fails.

**Fix:** keep the new plain-string fast-path (still handles QSFP-DD/OSFP-8X/QSFP+C/BP and Cisco-console SFP), but for `SFP` fall through to the existing `ast.literal_eval()`-based dict parsing when the spec is not one of the known plain-string copper values. `ast.literal_eval` is wrapped in `try/except (ValueError, SyntaxError)` so a non-dict, non-copper spec is treated as optical instead of raising.

Summary:
Fixes the regression introduced by #23972 for SFP DAC transceivers.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
`test_tx_disable_channel` started failing on platforms with SFP+ DAC uplinks (e.g. Nokia 7215) after PR #23972. The DAC skip in `is_xcvr_optical()` no longer triggers for `type_abbrv_name == "SFP"` whose `specification_compliance` is a dict-formatted string.

#### How did you do it?
In `tests/platform_tests/api/test_sfp.py::is_xcvr_optical`:
- Keep the plain-string check for `QSFP-DD`, `OSFP-8X`, `QSFP+C`, `BP`, and `SFP` (returns False on `"Passive Copper Cable"` / `"passive_copper_media_interface"`).
- For `SFP`, if the spec didn't match those plain strings, fall through to `ast.literal_eval(spec)` and the existing `SFP+CableTechnology == "Passive Cable"` check.
- For all other types, keep the existing dict-based `10/40G Ethernet Compliance Code` / `Extended Specification Compliance` "CR" check.
- Wrap `ast.literal_eval` in `try/except (ValueError, SyntaxError)` so a non-dict, non-copper plain-string spec is treated as optical (preserves the Cisco-console SFP behavior added by #23972).

#### How did you verify/test it?
Ran the testcase on a Nokia 7215 testbed (m0 topology, 4× SFP+ DAC uplinks) with the fix:

```
platform_tests/api/test_sfp.py::TestSfpApi::test_tx_disable_channel
WARNING tests.platform_tests.api.test_sfp:test_sfp.py:862 test_tx_disable_channel: Skipping transceiver 49 (not applicable for this transceiver type)
WARNING tests.platform_tests.api.test_sfp:test_sfp.py:862 test_tx_disable_channel: Skipping transceiver 50 (not applicable for this transceiver type)
WARNING tests.platform_tests.api.test_sfp:test_sfp.py:862 test_tx_disable_channel: Skipping transceiver 51 (not applicable for this transceiver type)
WARNING tests.platform_tests.api.test_sfp:test_sfp.py:862 test_tx_disable_channel: Skipping transceiver 52 (not applicable for this transceiver type)
PASSED
================= 1 passed, 154 warnings in 287.91s (0:04:47) ==================
```

All four SFP+ uplinks (49–52) are now correctly identified as DAC and skipped.

#### Any platform specific information?
First reported on Nokia 7215 (4× SFP+ DAC uplinks), but the regression affects any platform where an SFP/SFP+ DAC's `specification_compliance` is reported as a dict-formatted string (which is the standard / default representation for SFP DAC).

#### Supported testbed topology if it's a new test case?
N/A — fix to an existing test case.

### Documentation
N/A
