### PR TITLE
[ENHANCEMENT] Adding extra waiting margin for armhf devices

### DIFF
--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -665,7 +665,12 @@ def test_memory_checker_recover(memory_checker_dut_and_container, test_setup_and
     loganalyzer.expect_regex = container.get_restart_expected_logre()
     marker = loganalyzer.init()
 
-    timeout_status_change = 30  # monit has a 5s cycle interval per test parameters
+    platform = duthost.facts["platform"]
+
+    if platform in ["armhf-nokia_ixs7215_52x-r0"]:
+        timeout_status_change = 60  # these platforms have longer time to change status
+    else:
+        timeout_status_change = 30  # monit has a 5s cycle interval per test parameters
 
     container.start_consume_memory()
     container.wait_monit_mem_last_failed(timeout_status_change)

--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -187,7 +187,7 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
 
     config_reload_timeout = 120
     if hwsku in ["Nokia-M0-7215", "Nokia-7215"]:
-        config_reload_timeout = 180
+        config_reload_timeout = 240
 
     if not config_force_option_supported(duthost):
         return

--- a/tests/show_techsupport/test_auto_techsupport.py
+++ b/tests/show_techsupport/test_auto_techsupport.py
@@ -945,7 +945,17 @@ def validate_techsupport_generation(duthost, dut_cli, is_techsupport_expected, e
     if expected_techsupport_files:
         # ensure that creation of tar.gz file is complete by checking if the intermediate tar
         # file generated is removed
-        assert wait_until(600, 10, 0, is_new_techsupport_file_generated, duthost, available_tech_support_files), \
+
+        platform = duthost.facts["platform"]
+
+        if platform in ["armhf-nokia_ixs7215_52x-r0"]:
+            # For this platform, techsupport takes more time, so increase waiting time
+            wait = 900
+        else:
+            # For other platforms, fall back to default 600 seconds
+            wait = 600
+
+        assert wait_until(wait, 10, 0, is_new_techsupport_file_generated, duthost, available_tech_support_files), \
             'New expected techsupport file was not generated'
 
     # Do validation for history


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Summary: Armhf devices are resource restricted and timer exceptions written for more powerful devices do not accurately apply to them. PR targets Nokia-M0-7215 and Nokia-7215 devices.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Increase timers to reflect resource restrictions of armhf devices

#### How did you verify/test it?
Run entire test suite and individual testcases modified on our devices


signed:
Michail Karatzidis
NOKIA
michail-nektarios.karatzidis@nokia.com
