### PR TITLE
Fix cleanup between reboot testcases.

### DIFF
--- a/tests/ha/test_ha_npu_reboot.py
+++ b/tests/ha/test_ha_npu_reboot.py
@@ -8,22 +8,33 @@ import pytest
 import time
 import threading
 from constants import (
+    LOCAL_DUT_INTF,
     LOCAL_PTF_INTF,
+    REMOTE_DUT_INTF,
     REMOTE_PTF_RECV_INTF
 )
-from gnmi_utils import apply_messages
+from gnmi_utils import (
+    apply_messages,
+    apply_gnmi_cert,
+    generate_gnmi_cert,
+    recover_gnmi_cert
+)
 from packets import outbound_pl_packets
 from tests.common.utilities import wait_until
 from tests.common.config_reload import config_reload
-from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.assertions import pytest_assert, pytest_require as pt_require
+from tests.common.platform.processes_utils import wait_critical_processes
 from ha_dash_flow_utils import compare_flow_tables_pdsctl
 from tests.common.reboot import reboot_smartswitch, wait_for_startup
+from tests.ha.conftest import get_interface_ip
 from tests.ha.ha_dpu_utils import CHECK_DPU_STATE_TIMEOUT, CHECK_DPU_STATE_TIME_INT, check_dpu_up_state
+
 
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t1-smartswitch-ha')
+    pytest.mark.topology('t1-smartswitch-ha'),
+    pytest.mark.skip_check_dut_health
 ]
 
 
@@ -35,6 +46,65 @@ INITIAL_SEND_COUNT = 100
 def reload_config_for_host(dpuhost):
     logger.info(f"config reload on {dpuhost.hostname}")
     config_reload(dpuhost, safe_reload=True, yang_validate=False)
+
+
+@pytest.fixture(scope="function")
+def setup_gnmi_server(duthosts, localhost, ptfhost, skip_cert_cleanup):
+    for duthost in duthosts:
+        wait_for_startup(duthost, localhost, delay=10, timeout=600)
+        wait_critical_processes(duthost)
+        generate_gnmi_cert(localhost, duthost)
+        apply_gnmi_cert(duthost, ptfhost)
+    yield
+    for duthost in duthosts:
+        wait_for_startup(duthost, localhost, delay=10, timeout=600)
+        wait_critical_processes(duthost)
+        recover_gnmi_cert(localhost, duthost, skip_cert_cleanup)
+
+
+@pytest.fixture(scope="function")
+def add_npu_static_routes(
+    duthosts, localhost, dash_pl_config, skip_config, skip_cleanup, dpu_index
+):
+    if not skip_config:
+        for i in range(len(duthosts)):
+            duthost = duthosts[i]
+            wait_for_startup(duthost, localhost, delay=10, timeout=600)
+            wait_critical_processes(duthost)
+
+            cmds = []
+            vm_nexthop_ip = get_interface_ip(duthost, dash_pl_config[i][LOCAL_DUT_INTF]).ip + 1
+            pe_nexthop_ip = get_interface_ip(duthost, dash_pl_config[i][REMOTE_DUT_INTF]).ip + 1
+
+            pt_require(vm_nexthop_ip, "VM nexthop interface does not have an IP address")
+            pt_require(pe_nexthop_ip, "PE nexthop interface does not have an IP address")
+
+            cmds.append(f"ip route replace {pl.VM1_PA}/32 via {vm_nexthop_ip}")
+            cmds.append(f"ip route replace {pl.PE_PA}/32 via {pe_nexthop_ip}")
+            logger.info(f"Adding function-scoped static routes: {cmds} on {duthost}")
+            duthost.shell_cmds(cmds=cmds)
+
+    yield
+
+    if not skip_config and not skip_cleanup:
+        for i in range(len(duthosts)):
+            duthost = duthosts[i]
+            wait_for_startup(duthost, localhost, delay=10, timeout=600)
+            wait_critical_processes(duthost)
+
+            cmds = []
+            vm_nexthop_ip = get_interface_ip(duthost, dash_pl_config[i][LOCAL_DUT_INTF]).ip + 1
+            pe_nexthop_ip = get_interface_ip(duthost, dash_pl_config[i][REMOTE_DUT_INTF]).ip + 1
+
+            cmds.append(f"ip route del {pl.VM1_PA}/32 via {vm_nexthop_ip}")
+            cmds.append(f"ip route del {pl.PE_PA}/32 via {pe_nexthop_ip}")
+            logger.info(f"Removing function-scoped static routes: {cmds} from {duthost}")
+            duthost.shell_cmds(cmds=cmds, continue_on_fail=True, module_ignore_errors=True)
+
+
+@pytest.fixture(scope="function")
+def setup_npu_dpu(dpu_setup, setup_gnmi_server, add_npu_static_routes):
+    yield
 
 
 @pytest.fixture(autouse=True, scope="function")

--- a/tests/ha/test_ha_npu_reboot.py
+++ b/tests/ha/test_ha_npu_reboot.py
@@ -79,8 +79,8 @@ def add_npu_static_routes(
             pt_require(vm_nexthop_ip, "VM nexthop interface does not have an IP address")
             pt_require(pe_nexthop_ip, "PE nexthop interface does not have an IP address")
 
-            cmds.append(f"ip route replace {pl.VM1_PA}/32 via {vm_nexthop_ip}")
-            cmds.append(f"ip route replace {pl.PE_PA}/32 via {pe_nexthop_ip}")
+            cmds.append(f"config route add prefix {pl.VM1_PA}/32 nexthop {vm_nexthop_ip}")
+            cmds.append(f"config route add prefix {pl.PE_PA}/32 nexthop {pe_nexthop_ip}")
             logger.info(f"Adding function-scoped static routes: {cmds} on {duthost}")
             duthost.shell_cmds(cmds=cmds)
 
@@ -96,8 +96,8 @@ def add_npu_static_routes(
             vm_nexthop_ip = get_interface_ip(duthost, dash_pl_config[i][LOCAL_DUT_INTF]).ip + 1
             pe_nexthop_ip = get_interface_ip(duthost, dash_pl_config[i][REMOTE_DUT_INTF]).ip + 1
 
-            cmds.append(f"ip route del {pl.VM1_PA}/32 via {vm_nexthop_ip}")
-            cmds.append(f"ip route del {pl.PE_PA}/32 via {pe_nexthop_ip}")
+            cmds.append(f"config route del prefix {pl.VM1_PA}/32 nexthop {vm_nexthop_ip}")
+            cmds.append(f"config route del prefix {pl.PE_PA}/32 nexthop {pe_nexthop_ip}")
             logger.info(f"Removing function-scoped static routes: {cmds} from {duthost}")
             duthost.shell_cmds(cmds=cmds, continue_on_fail=True, module_ignore_errors=True)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The HA npu reboot testcases were passing when run individually but not when the module was run altogether. The cleanup and reconfiguration was partially function scoped and partially module scoped, so some cleanup was missing between the cases. These changes move the needed cleanup from module scope to function scope so that they are run as expected between the npu reboots.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Fixing testcase errors.

#### How did you do it?
Move the gnmi and static route config from module scope to function scope so it is run between reboot test cases.

#### How did you verify/test it?
Ran the module on local HA setup:
```
-- generated xml file: /data/sonic-mgmt/tests/logs/ha/test_ha_npu_reboot.xml ---
---------------------------- live log sessionfinish ----------------------------
INFO     root:__init__.py:67 Can not get Allure report URL. Please check logs
INFO:root:[Parallel Fixture] Terminating parallel fixture manager
INFO:root:Can not get Allure report URL. Please check logs
================ 4 passed, 1551 warnings in 3998.59s (1:06:38) =================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
