### PR TITLE
[tests/console]: expand custom-escape-char param set for reverse-SSH test

### DIFF
--- a/tests/console/test_console_reversessh.py
+++ b/tests/console/test_console_reversessh.py
@@ -156,9 +156,12 @@ def test_console_reversessh_force_interrupt(duthost, creds, conn_graph_facts):  
 #   - 'c'/'z'/'d'/'s'/'q'/'\\' (SIGINT/SIGTSTP/EOF/XOFF/XON/SIGQUIT — eaten by
 #     signal or TTY layer before reaching picocom)
 #   - 'r'/'l'/'u'/'w'/'t' (common readline / shell hotkeys)
-# Selected chars map to readline editing actions (back-char, bell,
-# next-history, prev-history, yank) that picocom sees cleanly.
-CUSTOM_ESCAPE_CHARS = ["b", "g", "n", "p", "y"]
+#   - 'h'/'i'/'j'/'m'/'v' (BS/Tab/LF/CR/lnext — rewritten or swallowed by the
+#     SSH-client PTY line discipline before reaching picocom)
+# Selected chars map to readline editing actions (back-char, end-of-line,
+# forward-char, bell, kill-line, next-history, prev-history, yank) that
+# picocom sees cleanly.
+CUSTOM_ESCAPE_CHARS = ["b", "e", "f", "g", "k", "n", "p", "y"]
 
 
 @pytest.mark.parametrize("escape_char", CUSTOM_ESCAPE_CHARS)


### PR DESCRIPTION
### Description of PR

Expand `CUSTOM_ESCAPE_CHARS` in `tests/console/test_console_reversessh.py` from `["b", "g", "n", "p", "y"]` to `["b", "e", "f", "g", "k", "n", "p", "y"]` to broaden coverage of the `default_escape_char` configurability with three additional readline editing actions:

| char | `Ctrl-<char>` | readline action |
| --- | --- | --- |
| `e` | ENQ (0x05) | end-of-line |
| `f` | ACK (0x06) | forward-char |
| `k` | VT  (0x0B) | kill-line |

Same selection rule as the existing entries: pure readline editing actions that are *not* intercepted by the SSH-client PTY line discipline, so `picocom` on the DUT sees the raw control byte cleanly.

### Char selection — additional exclusions documented

The existing comment block already calls out signal/TTY-eaten letters. This PR adds one more exclusion line covering letters that the SSH client's PTY line discipline rewrites or swallows before they ever reach `picocom`:

| char | reason |
| --- | --- |
| `h` | BS — usually rewritten by `ICRNL`/`ECHO` on the SSH client side |
| `i` | Tab — TTY processes regardless of picocom mode |
| `j` | LF — TTY converts to CR/LF |
| `m` | CR — same |
| `v` | `VLNEXT` — swallows the *next* byte, turning `Ctrl-V Ctrl-X` into a literal insert |

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework (new/improvement)
- [x] Test case(new/improvement)

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach

#### What is the motivation?
The previous parametrize set (`b, g, n, p, y`) covered five chars. Three more readline-only chars (`e, f, k`) are equally safe and add ~3 min of wall time for non-trivially better feature coverage. Test IDs read `[b]`, `[e]`, `[f]`, `[g]`, `[k]`, `[n]`, `[p]`, `[y]` — easy to grep / `-k` filter.

#### How did you do it?
- Append `e`, `f`, `k` to `CUSTOM_ESCAPE_CHARS`.
- Update the explanatory comment block above the constant: extend the "selected chars" list with the three new actions, and add a new exclusion bullet for `h/i/j/m/v` so future contributors know why those letters are off-limits.
- No changes to the fixture, test body, or any other test in the file.

#### How did you verify it?
- `flake8 --max-line-length=120` clean.
- Live verification on a physical c0-lo testbed: **8 passed, 0 errors in 7:25**, no teardown drift on `CONSOLE_SWITCH|console_mgmt.default_escape_char`.

### Documentation
N/A.
