### PR TITLE
Fixing pfcwd_all_port_storm failure for Cisco devices, for T0 topologies

### DIFF
--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -1,3 +1,4 @@
+import ipaddress
 import logging
 import os
 import pytest
@@ -181,23 +182,103 @@ def set_storm_params(duthost, fanout_graph, fanouthosts, peer_params):
 
 def resolve_arp(duthost, ptfhost, test_ports_info, vlan, ip_version):
     """
-    Populate ARP info for the DUT vlan port
+    Populate ARP info for DUT vlan ports.
+
+    For Cisco-8000: assigns a unique IP to each PTF port within the vlan subnet
+    so that background traffic creates independent egress flows on each server port.
+
+    For other platforms: uses the single test_neighbor_addr from the first VLAN port
+
+    Args:
+        duthost: DUT host instance
+        ptfhost: ptf host instance
+        test_ports_info: test ports information (modified in place for Cisco)
+        vlan: vlan info dict with 'addr' and 'prefix'
+        ip_version: "IPv4" or "IPv6"
+    """
+    # In T1, T2 topology there are no VLANs - nothing to resolve
+    if vlan is None:
+        return
+
+    if duthost.facts['asic_type'] == 'cisco-8000':
+        # Assign unique IPs to each VLAN port starting from gateway + 1
+        vlan_addr = vlan['addr']
+        prefix = vlan['prefix']
+        if ip_version == "IPv4":
+            base_ip = ipaddress.IPv4Address(vlan_addr) + 1
+            # Set arp_ignore=1 so each PTF interface only responds to ARP for its own IP.
+            # Without this, Linux's weak host model causes all interfaces to respond to
+            # ARP requests for any local IP, polluting the DUT's ARP table.
+            ptfhost.command("sysctl -w net.ipv4.conf.all.arp_ignore=1")
+            ptfhost.command("sysctl -w net.ipv4.conf.all.arp_announce=2")
+        else:
+            base_ip = ipaddress.IPv6Address(vlan_addr) + 1
+
+        idx = 0
+        for port, port_info in test_ports_info.items():
+            if port_info['test_port_type'] == 'vlan':
+                unique_ip = str(base_ip + idx)
+                port_info['test_neighbor_addr'] = unique_ip
+                ptf_port = f"eth{port_info['test_port_id']}"
+                if ip_version == "IPv4":
+                    ptfhost.command(f"ifconfig {ptf_port} {unique_ip} netmask "
+                                    f"{ipaddress.IPv4Network(f'0.0.0.0/{prefix}').netmask}")
+                else:
+                    ptfhost.command(f"ip -6 addr add {unique_ip}/{prefix} dev {ptf_port}")
+                idx += 1
+
+        # Resolve ARP/NDP after all IPs are configured so each arping gets a single response
+        if ip_version == "IPv4":
+            for port, port_info in test_ports_info.items():
+                if port_info['test_port_type'] == 'vlan':
+                    duthost.command(f"docker exec -i swss arping {port_info['test_neighbor_addr']} -c 3")
+        else:
+            for port, port_info in test_ports_info.items():
+                if port_info['test_port_type'] == 'vlan':
+                    duthost.command(f"docker exec -i swss ping -6 -c 3 {port_info['test_neighbor_addr']}")
+    else:
+        # Original behavior: resolve ARP for the first VLAN port only
+        for port, port_info in test_ports_info.items():
+            if port_info['test_port_type'] == 'vlan':
+                neighbor_ip = port_info['test_neighbor_addr']
+                ptf_port = f"eth{port_info['test_port_id']}"
+                if ip_version == "IPv4":
+                    ptfhost.command(f"ifconfig {ptf_port} {neighbor_ip}")
+                    duthost.command(f"docker exec -i swss arping {neighbor_ip} -c 5")
+                else:
+                    ptfhost.command(f"ip -6 addr add {neighbor_ip}/{vlan['prefix']} dev {ptf_port}")
+                    duthost.command(f"docker exec -i swss ping -6 -c 5 {neighbor_ip}")
+                break
+
+
+def cleanup_ptf_ips(ptfhost, test_ports_info, vlan, ip_version):
+    """
+    Remove IPs configured on PTF ports by resolve_arp.
 
     Args:
         ptfhost: ptf host instance
         test_ports_info: test ports information
+        vlan: vlan info dict with 'addr' and 'prefix'
+        ip_version: "IPv4" or "IPv6"
     """
+    if vlan is None:
+        return
+
+    prefix = vlan['prefix']
     for port, port_info in test_ports_info.items():
         if port_info['test_port_type'] == 'vlan':
-            neighbor_ip = port_info['test_neighbor_addr']
             ptf_port = f"eth{port_info['test_port_id']}"
+            ip_addr = port_info['test_neighbor_addr']
             if ip_version == "IPv4":
-                ptfhost.command(f"ifconfig {ptf_port} {neighbor_ip}")
-                duthost.command(f"docker exec -i swss arping {neighbor_ip} -c 5")
+                ptfhost.command(f"ifconfig {ptf_port} 0.0.0.0", module_ignore_errors=True)
             else:
-                ptfhost.command(f"ip -6 addr add {neighbor_ip}/{vlan['prefix']} dev {ptf_port}")
-                duthost.command(f"docker exec -i swss ping -6 -c 5 {neighbor_ip}")
-            break
+                ptfhost.command(f"ip -6 addr del {ip_addr}/{prefix} dev {ptf_port}",
+                                module_ignore_errors=True)
+
+    if ip_version == "IPv4":
+        # Restore default arp_ignore/arp_announce settings
+        ptfhost.command("sysctl -w net.ipv4.conf.all.arp_ignore=0", module_ignore_errors=True)
+        ptfhost.command("sysctl -w net.ipv4.conf.all.arp_announce=0", module_ignore_errors=True)
 
 
 @pytest.mark.usefixtures('degrade_pfcwd_detection', 'stop_pfcwd', 'storm_test_setup_restore', 'start_background_traffic')  # noqa: E501
@@ -316,3 +397,7 @@ class TestPfcwdAllPortStorm(object):
                       stormed_ports_list=stormed_ports_list,
                       selected_test_ports=selected_test_ports,
                       tbinfo=tbinfo)
+
+        if duthost.facts['asic_type'] == 'cisco-8000':
+            cleanup_ptf_ips(ptfhost, setup_pfc_test['test_ports'],
+                            setup_pfc_test["vlan"], setup_pfc_test["ip_version"])

--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -184,7 +184,7 @@ def resolve_arp(duthost, ptfhost, test_ports_info, vlan, ip_version):
     """
     Populate ARP info for DUT vlan ports.
 
-    For Cisco-8000: assigns a unique IP to each PTF port within the vlan subnet
+    For Cisco-8000: assign a unique IP to each PTF port within the vlan subnet
     so that background traffic creates independent egress flows on each server port.
 
     For other platforms: uses the single test_neighbor_addr from the first VLAN port
@@ -375,29 +375,30 @@ class TestPfcwdAllPortStorm(object):
                     selected_test_ports.append(test_port)
         resolve_arp(duthost, ptfhost, setup_pfc_test['test_ports'],
                     setup_pfc_test["vlan"], setup_pfc_test["ip_version"])
-        with send_background_traffic(duthost, ptfhost, queues, selected_test_ports, setup_pfc_test['test_ports'],
-                                     pkt_count=500):
-            self.run_test(duthost,
-                          storm_hndle,
-                          expect_regex=[EXPECT_PFC_WD_DETECT_RE + fetch_vendor_specific_diagnosis_re(duthost)],
-                          syslog_marker="all_port_storm",
-                          action="storm",
+        try:
+            with send_background_traffic(duthost, ptfhost, queues, selected_test_ports,
+                                         setup_pfc_test['test_ports'],
+                                         pkt_count=500):
+                self.run_test(duthost,
+                              storm_hndle,
+                              expect_regex=[EXPECT_PFC_WD_DETECT_RE +
+                                            fetch_vendor_specific_diagnosis_re(duthost)],
+                              syslog_marker="all_port_storm",
+                              action="storm",
+                              stormed_ports_list=stormed_ports_list,
+                              selected_test_ports=selected_test_ports,
+                              tbinfo=tbinfo)
+
+            logger.info(f"--- {len(stormed_ports_list)} ports entered storm state ---")
+            logger.info("--- Testing if PFC storm is restored on stormed ports ---")
+            # test_ports_info is intentionally not passed during restore: the duplicate-neighbor
+            # adjustment in verify_all_ports_pfc_storm_in_expected_state only applies to the storm
+            # phase, so it has no effect here.
+            self.run_test(duthost, storm_hndle, expect_regex=[EXPECT_PFC_WD_RESTORE_RE],
+                          syslog_marker="all_port_storm_restore", action="restore",
                           stormed_ports_list=stormed_ports_list,
                           selected_test_ports=selected_test_ports,
-                          test_ports_info=setup_pfc_test['test_ports'],
                           tbinfo=tbinfo)
-
-        logger.info(f"--- {len(stormed_ports_list)} ports entered storm state ---")
-        logger.info("--- Testing if PFC storm is restored on stormed ports ---")
-        # test_ports_info is intentionally not passed during restore: the duplicate-neighbor
-        # adjustment in verify_all_ports_pfc_storm_in_expected_state only applies to the storm
-        # phase, so it has no effect here.
-        self.run_test(duthost, storm_hndle, expect_regex=[EXPECT_PFC_WD_RESTORE_RE],
-                      syslog_marker="all_port_storm_restore", action="restore",
-                      stormed_ports_list=stormed_ports_list,
-                      selected_test_ports=selected_test_ports,
-                      tbinfo=tbinfo)
-
-        if duthost.facts['asic_type'] == 'cisco-8000':
+        finally:
             cleanup_ptf_ips(ptfhost, setup_pfc_test['test_ports'],
                             setup_pfc_test["vlan"], setup_pfc_test["ip_version"])

--- a/tests/pfcwd/test_pfcwd_cli.py
+++ b/tests/pfcwd/test_pfcwd_cli.py
@@ -548,3 +548,6 @@ class TestPfcwdFunc(SetupPfcwdFunc):
                     self.storm_hndle.stop_storm()
                 logger.info("--- Stop PFC WD ---")
                 self.dut.command("pfcwd stop")
+                # Reset global ARP settings modified by resolve_arp
+                self.ptf.command("sysctl -w net.ipv4.conf.all.arp_ignore=0",
+                                 module_ignore_errors=True)


### PR DESCRIPTION
Summary:
Fixes # (issue)
The test pfcwd_all_port_storm failed because PFC watchdog storm detection requires both
- PFC frames received on a queue and
- Egress traffic queued on that queue.
Regression caused after this PR in Feb 2026 (its a good strict change - checking 75% ports instead of  just >0 )
https://github.com/sonic-net/sonic-mgmt/pull/21229
In T0 topology, only 5 out of 27 ports saw egress UC3 traffic, resulting in only 18.5% storm detection vs. the required 75% threshold. 

### Type of change

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Passing pfcwd_all_port_storm test

#### How did you do it?
Updated test code
Prior to fix the dest_IP for background traffic to servers was using 1 dest IP for all the streams. Thus, egress traffic was going on just 1 port instead of 22 other ports.

Added unique dest IP per port and egress traffic distributes properly and storm is detected on all the ports.

#### How did you verify/test it?
After running the test with the fix (unique per-port IPs in resolve_arp()), show queue watermark unicast confirms egress traffic is now flowing on ALL ports, not just 5:

In the problem case, egress traffic was on just 5 ports - 4 upstream towards T1 and 1 towards server
```
admin@cisco-dut:~$ show queue watermark unicast
Egress shared pool occupancy per unicast queue:
       Port    UC0    UC1    UC2    UC3    UC4    UC5    UC6    UC7
-----------  -----  -----  -----  -----  -----  -----  -----  -----
  Ethernet0      0      0      0      0      0      0      0      0
  Ethernet8      0  19200      0  19200      0      0      0  19200
 Ethernet16      0  19200      0  19200      0      0      0  19200
 Ethernet24      0  19200      0  19200      0      0      0  19200
 Ethernet32      0  19200      0  19200      0      0      0  19200
 Ethernet40      0  19200      0  19200      0      0      0  19200
 Ethernet48      0  19200      0  19200      0      0      0  19200
 Ethernet56      0  19200      0  19200      0      0      0  19200
 Ethernet64      0  19200      0  19200      0      0      0  19200
 Ethernet72      0  19200      0  19200      0      0      0  19200
 Ethernet80      0  19200      0  19200      0      0      0  19200
 Ethernet88      0  19200      0  19200      0      0      0  19200
 Ethernet96      0  19200      0  19200      0      0      0  19200
Ethernet104      0  19200      0  19200      0      0      0  19200
Ethernet112      0  19200      0  19200      0      0      0  19200
Ethernet120      0  19200      0  19200      0      0      0  19200
Ethernet128      0  19200      0  19200      0      0      0  19200
Ethernet136      0  19200      0  19200      0      0      0  19200
Ethernet144      0  19200      0  19200      0      0      0  19200
Ethernet152      0  19200      0  19200      0      0      0  19200
Ethernet160      0  19200      0  19200      0      0      0  19200
Ethernet168      0  19200      0  19200      0      0      0  19200
Ethernet176      0  19200      0  19200      0      0      0  19200
Ethernet184      0  19200      0  19200      0      0      0  19200
Ethernet192      0      0      0  19200      0      0      0  19200
Ethernet200      0      0      0  19200      0      0      0  19200
Ethernet208      0      0      0  19200      0      0      0  19200
Ethernet216      0      0      0  19200      0      0      0  19200

```

#### Any platform specific information?
Limiting the scope of change to Cisco devices only

#### Supported testbed topology if it's a new test case?

### Documentation