### PR TITLE
[HA] [smartswitch] limit the DPU parameters used by HA tests to first 2

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -786,6 +786,12 @@ def fixture_dpuhosts(enhance_inventory, ansible_adhoc, tbinfo, request, enable_n
 
 
 @pytest.fixture(scope="session")
+def all_dpuhosts(dpuhosts):
+    """All DPU hosts unfiltered. Use this when a conftest overrides dpuhosts with a subset."""
+    return dpuhosts
+
+
+@pytest.fixture(scope="session")
 def dpuhost(dpuhosts, request):
     '''
     @summary: Shortcut fixture for getting DPU host. For a lengthy test case, test case module can

--- a/tests/ha/conftest.py
+++ b/tests/ha/conftest.py
@@ -38,6 +38,13 @@ from tests.ha.ha_utils import (
 ENABLE_GNMI_API = True
 logger = logging.getLogger(__name__)
 
+
+@pytest.fixture(scope="session")
+def dpuhosts(dpuhosts):
+    """Limit to the first 2 DPU hosts for all HA tests."""
+    return dpuhosts.nodes[:2]
+
+
 ha_scope_per_dut = [
     (
         "vdpu0_0:haset0_0",


### PR DESCRIPTION
Summary:
Need to limit the number of DPUs used in HA tests to first 2 so that automation to be able to run with any number of DPUs.
The repairing tests will need to access first 3 DPUs and this is why a new fixture was created for allowing this: all_dpuhosts.
### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Facilitate running automation with same parameters for DASH and HA tests

#### How did you do it?
Added 2 new fixtures.

#### How did you verify/test it?
Tested existing HA tests on smartswitch

#### Any platform specific information?
Smartswitch
#### Supported testbed topology if it's a new test case?
HA topology
### Documentation
N/A