### PR TITLE
[grpc fixtures] Use square brackets around IP address

### DIFF
--- a/tests/common/fixtures/grpc_fixtures.py
+++ b/tests/common/fixtures/grpc_fixtures.py
@@ -231,7 +231,7 @@ def gnmi_tls(request, duthost, ptfhost):
         # Build coupled client with the exact config we just set up
         host = duthost.mgmt_ip
         port = grpc_config.DEFAULT_TLS_PORT
-        target = f"{host}:{port}"
+        target = f"[{host}]:{port}"
 
         ptf_cert_paths = grpc_config.get_ptf_cert_paths()
         cert_paths = CertPaths(
@@ -526,7 +526,7 @@ def _verify_gnoi_tls_connectivity(duthost, ptfhost):
     logger.info("Verifying gNOI TLS connectivity")
 
     cacert_arg, cert_arg, key_arg = grpc_config.get_grpcurl_cert_args()
-    target = f"{duthost.mgmt_ip}:{grpc_config.DEFAULT_TLS_PORT}"
+    target = f"[{duthost.mgmt_ip}]:{grpc_config.DEFAULT_TLS_PORT}"
 
     # -connect-timeout bounds the TCP/TLS handshake portion; -max-time bounds
     # the whole call. Both keep a single retry attempt from hanging if packets

--- a/tests/common/ptf_grpc.py
+++ b/tests/common/ptf_grpc.py
@@ -69,7 +69,7 @@ class PtfGrpc:
             # Auto-configuration from GNMIEnvironment
             if duthost is None:
                 raise ValueError("duthost is required when using GNMIEnvironment auto-configuration")
-            self.target = f"{duthost.mgmt_ip}:{target_or_env.gnmi_port}"
+            self.target = f"[{duthost.mgmt_ip}]:{target_or_env.gnmi_port}"
             self.plaintext = not target_or_env.use_tls if plaintext is None else plaintext
             self.env = target_or_env
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Use square brackets around the IP address when forming the host
string, in order to support IPv6 addresses.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

In `grpc_fixtures`, which is used by `gnoi` tests among others, a host string is formed by concatenating the mgmt IP address with a colon and a port number. This breaks when the IP address is IPv6.

#### How did you do it?

I escaped the IP address with [square brackets].

#### How did you verify/test it?

I ran the test in a cluster with and without `--mgmtIpv6Only` and confirmed that this change fixes the issue.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
