### PR TITLE
chore: add loganalyser for server closed relp

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -322,6 +322,8 @@ r, ".* ERR syncd\d*#syncd:.* SAI_API_SWITCH:brcm_sai_get_switch_attribute.* Get 
 # Ignore rsyslog librelp error if rsyslogd on host or container is down or going down
 r, ".* ERR .*#rsyslogd: librelp error 10008 forwarding to server .* - suspending.*"
 r, ".* ERR rsyslogd: imrelp.*error 'error when receiving data, session broken', object .* - input may not work as intended.*"
+# Ignore related rsyslog librelp error, which is caused by the session closed by peer when receiving data, and it will cause the input not work as intended, but it is safe to ignore the error for now to unblock the test, and we will address the root cause later. (PBI https://msazure.visualstudio.com/One/_workitems/edit/37879332)
+r, ".* ERR rsyslogd: imrelp.*error 'server closed relp session, session broken', object .* - input may not work as intended.*"
 
 # Errors for config reload/reboot on mellanox platform
 r, ".* ERR syncd#SDK:.*\[SX_API_INTERNAL.ERR\].*Failed command read at communication channel: Connection reset by peer.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Adding 'server closed relp session, session broken' log analyzer ignore

Fixes # (issue) 37879328


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

This issue has been caused a lot of test cases failure. The pattern is 

>               pt_assert(False, failure_message)
E               Failed: Got matched syslog in processes "analyze_logs--<MultiAsicSonicHost vlab-01>" exit code:"1"
E               match: 1
E               expected_match: 0
E               expected_missing_match: 0
E               
E               Match Messages:
E               2026 May 12 22:51:15.873799 vlab-01 ERR rsyslogd: imrelp[2514]: error 'server closed relp session, session broken', object  'lstn 2514: conn to clt 127.0.0.1/127.0.0.1' - input may not work as intended [v8.2504.0 try https://www.rsyslog.com/e/2353 ]

Example testplan: https://elastictest.org/scheduler/testplan/6a039588eb4c0d0f5d30be2a?searchTestCase=bgp&testcase=bgp%2Ftest_bgp_router_id.py&type=console

 In SONiC, this happens when an internal RELP-using component restarts (a service in a docker container, a  swss/orchagent restart, log-rotate, etc.). The session is briefly torn down and reopened; rsyslog logs an ERR even though everything recovers within milliseconds. No actual log loss in practice — the protocol re-establishes — but  rsyslog v8.2504.0 emits it at ERR, which LogAnalyzer treats as a test failure unless the message is in the ignore list.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
