### PR TITLE
chore: ignore omrelp 'could not connect to remote server' in test_syslog

### DIFF
--- a/tests/generic_config_updater/test_syslog.py
+++ b/tests/generic_config_updater/test_syslog.py
@@ -306,6 +306,7 @@ def test_syslog_server_tc1_suite(rand_selected_dut, cfg_facts, loganalyzer):
     if loganalyzer:
         ignoreRegex = [
             r".*omrelp\[.*\]: error 'error opening connection to remote peer'.*",
+            r".*omrelp: could not connect to remote server, librelp error \d+.*",
         ]
         loganalyzer[rand_selected_dut.hostname].ignore_regex.extend(ignoreRegex)
 

--- a/tests/syslog/test_syslog.py
+++ b/tests/syslog/test_syslog.py
@@ -24,6 +24,7 @@ def test_syslog(rand_selected_dut, dummy_syslog_server_ip_a, dummy_syslog_server
     if loganalyzer:
         ignoreRegex = [
             r".*omrelp\[.*\]: error 'error opening connection to remote peer'.*",
+            r".*omrelp: could not connect to remote server, librelp error \d+.*",
         ]
         loganalyzer[rand_selected_dut.hostname].ignore_regex.extend(ignoreRegex)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Ignore omrelp 'could not connect to remote server' in test_syslog
Fixes # (issue) 37879332

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
 What is the motivation for this PR?

  The signature was first observed on 2026-04-07 and is now responsible for 47 LogAnalyzer false-positive failures across 42 test plans in the last 14 days, with the latest hit at 2026-05-13 01:20 UTC (testplan 6a03c0c1686444e666af82fc). The errors come from 18 different containers (pmon, swss, snmp, bgp, lldp, database, gnmi, bmp, teamd, macsec, syncd, gbsyncd, eventd, mgmt-framework, radv, …) — all of them dutifully attempting to ship logs to the test-configured fake destination.

 A Kusto check confirms the signature appears only in syslog.test_syslog / generic_config_updater.test_syslog and has zero occurrences in any other test module in the same period — so it is exclusively a test-induced side-effect and cannot mask real issues in unrelated tests.



#### How did you do it?
Added one regex to the existing per-test ignoreRegex list in each of the two test_syslog files:

   r".*omrelp: could not connect to remote server, librelp error \d+.*",

The \d+ keeps the pattern resilient across librelp error codes (10014 today, others possible).


#### How did you verify/test it?
 - Confirmed via Kusto that the signature only occurs inside syslog.test_syslog and
generic_config_updater.test_syslog (47 hits, 0 elsewhere).
 - Reviewed the test body in both files — config-application is the assertion; log delivery is not.
 - Verified the regex matches all observed Summary samples in Kusto (from containers bgp3, pmon, swss*, snmp, database,
lldp3, gnmi, mgmt-framework, bmp0/1, teamd0, macsec0, gbsyncd0/1, syncd0/1/2, eventd, radv, swss0).

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
