### PR TITLE
allow '-' as topology variant separator in add-topo

### DIFF
--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -95,6 +95,9 @@
 
   - set_fact:
       base_topo: "{{ topo.split('_') | first }}"
+  - set_fact:
+      base_topo: "{{ base_topo.split('-') | first }}"
+    when: base_topo not in topologies
 
   - name: Check that topo is a known topology
     fail: msg="Unknown topology {{ topo }}"
@@ -151,6 +154,9 @@
 
         - set_fact:
             base_topo: "{{ topo.split('_') | first }}"
+        - set_fact:
+            base_topo: "{{ base_topo.split('-') | first }}"
+          when: base_topo not in topologies
 
         - name: Require VMs as CEOS by default
           set_fact:

--- a/ansible/testbed_announce_routes.yml
+++ b/ansible/testbed_announce_routes.yml
@@ -27,6 +27,9 @@
 
   - set_fact:
       base_topo: "{{ topo.split('_') | first }}"
+  - set_fact:
+      base_topo: "{{ base_topo.split('-') | first }}"
+    when: base_topo not in topologies
 
   - name: Check that topo is a known topology
     fail: msg="Unknown topology {{ topo }}"

--- a/ansible/testbed_config_vchassis.yml
+++ b/ansible/testbed_config_vchassis.yml
@@ -16,6 +16,9 @@
 
   - set_fact:
       base_topo: "{{ topo.split('_') | first }}"
+  - set_fact:
+      base_topo: "{{ base_topo.split('-') | first }}"
+    when: base_topo not in topologies
 
   - debug: msg="base_topo = {{ base_topo }}"
 

--- a/ansible/testbed_config_vchassis.yml
+++ b/ansible/testbed_config_vchassis.yml
@@ -16,9 +16,6 @@
 
   - set_fact:
       base_topo: "{{ topo.split('_') | first }}"
-  - set_fact:
-      base_topo: "{{ base_topo.split('-') | first }}"
-    when: base_topo not in topologies
 
   - debug: msg="base_topo = {{ base_topo }}"
 

--- a/ansible/testbed_connect_topo.yml
+++ b/ansible/testbed_connect_topo.yml
@@ -33,6 +33,9 @@
 
   - set_fact:
       base_topo: "{{ topo.split('_') | first }}"
+  - set_fact:
+      base_topo: "{{ base_topo.split('-') | first }}"
+    when: base_topo not in topologies
 
   - name: Check if it is a known topology
     fail: msg="Unknown topology {{ topo }}"

--- a/ansible/testbed_disconnect_vms.yml
+++ b/ansible/testbed_disconnect_vms.yml
@@ -40,6 +40,9 @@
 
   - set_fact:
       base_topo: "{{ topo.split('_') | first }}"
+  - set_fact:
+      base_topo: "{{ base_topo.split('-') | first }}"
+    when: base_topo not in topologies
 
   - name: Check that variable topo is defined
     fail: msg="Define topo variable with -e topo=something"

--- a/ansible/testbed_renumber_vm_topology.yml
+++ b/ansible/testbed_renumber_vm_topology.yml
@@ -67,6 +67,9 @@
 
   - set_fact:
       base_topo: "{{ topo.split('_') | first }}"
+  - set_fact:
+      base_topo: "{{ base_topo.split('-') | first }}"
+    when: base_topo not in topologies
 
   - name: Check that variable topo is defined
     fail: msg="Define topo variable with -e topo=something"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
`add-topo` fails when topology names contain `-`. Root cause is that `base_topo: "{{ topo.split('_') | first }}"` only treats `_` as a variant separator; a name like `t2-foo` lands as `t2-foo` in the allowlist check and fails with "Unknown topology"

Fix - add a fallback `set_fact` that further splits on `-` only when the result of the underscore split isn't already in the `topologies` allowlist

Summary:
Fixes #24426

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
When we use topo names with a '-' in them, add-topo (or deploy-mg?) fails. Instead, we need to use '_'. If the infra can be fixed to accommodate this, then the topo names can use '-'es.

#### How did you do it?
Added a fallback `set_fact` that further splits on `-` only when the result of the underscore split isn't already in the `topologies` allowlist.

#### How did you verify/test it?
Ran add-topo with a topo name that has a `-` in it

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
