### PR TITLE
Update trimming case to support queue-level TrimSent and TrimDrop counters

### DIFF
--- a/tests/packet_trimming/base_packet_trimming.py
+++ b/tests/packet_trimming/base_packet_trimming.py
@@ -344,7 +344,8 @@ class BasePacketTrimming:
                                   f"port level trim counters are zero for {port}")
                     verify_queue_and_port_trim_counter_consistency(duthost, port)
 
-    def test_trimming_counters(self, duthost, ptfadapter, test_params, trim_counter_params):
+    def test_trimming_counters(self, duthost, ptfadapter, test_params, trim_counter_params,
+                               queue_level_trim_supported):
         """
         Test Case: Verify PacketTrimming Counters
         """
@@ -384,7 +385,8 @@ class BasePacketTrimming:
                     port_trim_tx_value = get_port_trim_counters_json(duthost, port)['TRIM_TX_PKTS']
                     ports_trim_sent_counters.append(port_trim_tx_value)
                     # Verify queue-level TrimSent matches port-level TrimSent
-                    verify_queue_and_port_trim_sent_counter_consistency(duthost, port, port_trim_tx_value)
+                    verify_queue_and_port_trim_sent_counter_consistency(duthost, port, port_trim_tx_value,
+                                                                        supported=queue_level_trim_supported)
 
             pytest_assert(sum(ports_trim_sent_counters) == switch_trim_sent_value and switch_trim_sent_value != 0,
                           "Trim sent counter on switch level is not equal to the sum of trim sent counter on port "
@@ -444,7 +446,8 @@ class BasePacketTrimming:
                         pytest_assert(port_trim_drop_value > 0,
                                       f"Trim drop counter on port {port} is not greater than 0")
                         # Verify queue-level TrimDrop matches port-level TrimDrop
-                        verify_queue_and_port_trim_drop_counter_consistency(duthost, port, port_trim_drop_value)
+                        verify_queue_and_port_trim_drop_counter_consistency(duthost, port, port_trim_drop_value,
+                                                                            supported=queue_level_trim_supported)
 
             finally:
                 # Enable the trimmed queue with original scheduler

--- a/tests/packet_trimming/base_packet_trimming.py
+++ b/tests/packet_trimming/base_packet_trimming.py
@@ -15,7 +15,8 @@ from tests.packet_trimming.packet_trimming_helper import (
     get_port_trim_counters_json, disable_egress_data_plane, enable_egress_data_plane,
     verify_queue_and_port_trim_counter_consistency, get_queue_trim_counters_json, compare_counters,
     has_non_zero_trim_counters, configure_port_mirror_session, remove_port_mirror_session,
-    check_trim_drop_counter_zero)
+    verify_queue_and_port_trim_sent_counter_consistency, verify_queue_and_port_trim_drop_counter_consistency,
+    compute_buffer_threshold, fill_egress_buffer)
 
 logger = logging.getLogger(__name__)
 
@@ -382,9 +383,9 @@ class BasePacketTrimming:
                 for port in egress_port['dut_members']:
                     port_trim_tx_value = get_port_trim_counters_json(duthost, port)['TRIM_TX_PKTS']
                     ports_trim_sent_counters.append(port_trim_tx_value)
+                    # Verify queue-level TrimSent matches port-level TrimSent
+                    verify_queue_and_port_trim_sent_counter_consistency(duthost, port, port_trim_tx_value)
 
-            # Verify the trim sent counter on the switch level is equal to the sum of the trim sent counter on the
-            # port level
             pytest_assert(sum(ports_trim_sent_counters) == switch_trim_sent_value and switch_trim_sent_value != 0,
                           "Trim sent counter on switch level is not equal to the sum of trim sent counter on port "
                           "level")
@@ -400,7 +401,32 @@ class BasePacketTrimming:
                         original_scheduler = disable_egress_data_plane(duthost, dut_member, trim_queue)
                         original_schedulers[dut_member] = original_scheduler
 
-                # Trigger trimmed packets on queue6
+                # Fill the trim queue buffer so TRIM_DRP_PKTS is triggered on platforms
+                trim_size = PacketTrimmingConfig.get_trim_size(duthost)
+                counter_dscp = PacketTrimmingConfig.get_counter_dscp(duthost)
+                for egress_port in trim_counter_params['egress_ports']:
+                    port_for_compute = egress_port['dut_members'][0]
+                    trim_queue_buffer_size = compute_buffer_threshold(duthost, port_for_compute, trim_queue)
+                    dst_addr = egress_port['ipv4'] or egress_port['ipv6']
+                    fill_egress_buffer(
+                        duthost,
+                        ptfadapter,
+                        trim_counter_params['ingress_port']['ptf_id'],
+                        trim_queue_buffer_size,
+                        trim_queue,
+                        dst_addr,
+                        counter_dscp,
+                        egress_port['dut_members'],
+                        packet_size_in_queue=trim_size,
+                    )
+
+                # Show port/queue level trim counters
+                for egress_port in trim_counter_params['egress_ports']:
+                    for port in egress_port['dut_members']:
+                        get_port_trim_counters_json(duthost, port)
+                        get_queue_trim_counters_json(duthost, port)
+
+                # Send packets that get trimmed and verify they are dropped at the blocked trim queue
                 counter_kwargs = self.get_verify_trimmed_counter_packet_kwargs(duthost, ptfadapter,
                                                                                {**trim_counter_params})
                 # TH5 cannot completely block egress queues, so trimmed packets will leak out of the trim queues.
@@ -417,6 +443,8 @@ class BasePacketTrimming:
                         logger.info(f"port: {port}, port_trim_drop_value: {port_trim_drop_value}")
                         pytest_assert(port_trim_drop_value > 0,
                                       f"Trim drop counter on port {port} is not greater than 0")
+                        # Verify queue-level TrimDrop matches port-level TrimDrop
+                        verify_queue_and_port_trim_drop_counter_consistency(duthost, port, port_trim_drop_value)
 
             finally:
                 # Enable the trimmed queue with original scheduler
@@ -424,14 +452,6 @@ class BasePacketTrimming:
                     for dut_member in port['dut_members']:
                         original_scheduler = original_schedulers.get(dut_member)
                         enable_egress_data_plane(duthost, dut_member, trim_queue, original_scheduler)
-                        # Known limitation: TRIM_DRP_PKTS is a calculated counter (TRIM_PKTS - TRIM_TX_PKTS)
-                        # rather than a real hardware counter. After restoring the blocked trim queue,
-                        # queued packets drain out and TRIM_DRP_PKTS gradually decreases to 0.
-                        # Wait for it to stabilize before reading baseline counters for the next step.
-                        pytest_assert(
-                            wait_until(30, 2, 0, check_trim_drop_counter_zero, duthost, dut_member),
-                            f"TRIM_DRP_PKTS on port {dut_member} did not stabilize to 0"
-                        )
 
     def test_trimming_counters_with_feature_toggle(self, duthost, ptfadapter, test_params, trim_counter_params):
         """

--- a/tests/packet_trimming/conftest.py
+++ b/tests/packet_trimming/conftest.py
@@ -15,7 +15,8 @@ from tests.packet_trimming.packet_trimming_helper import (
     delete_blocking_scheduler, check_trimming_capability, prepare_service_port, get_interface_peer_addresses,
     configure_tc_to_dscp_map, set_buffer_profile_for_block_queue, set_buffer_profile_for_trim_queue,
     create_blocking_scheduler, configure_trimming_action, cleanup_trimming_acl, get_queue_id_by_dscp,
-    get_test_ports, create_trim_queue_test_buffer_profile)
+    get_test_ports, create_trim_queue_test_buffer_profile, delete_trim_queue_test_buffer_profile,
+    is_queue_level_trim_sent_drop_supported)
 
 
 logger = logging.getLogger(__name__)
@@ -151,6 +152,19 @@ def trim_counter_params(duthost, test_params, dut_qos_maps_module):
     return counter_param
 
 
+@pytest.fixture(scope="module")
+def queue_level_trim_supported(duthost):
+    """
+    Whether the platform supports queue-level TrimSent / TrimDrop counters.
+
+    Computed once per module (lazy init) so the per-port consistency checks do not repeat the
+    same platform lookup on every call.
+    """
+    supported = is_queue_level_trim_sent_drop_supported(duthost)
+    logger.info(f"Queue-level TrimSent/TrimDrop counters supported on this platform: {supported}")
+    return supported
+
+
 @pytest.fixture(scope="module", autouse=True)
 def setup_trimming(duthost, test_params, trim_counter_params):
     """
@@ -235,6 +249,9 @@ def setup_trimming(duthost, test_params, trim_counter_params):
             configure_trimming_action(duthost, test_params['trim_buffer_profiles'][buffer_profile], "off")
         for buffer_profile in trim_counter_params['trim_buffer_profiles']:
             configure_trimming_action(duthost, trim_counter_params['trim_buffer_profiles'][buffer_profile], "off")
+
+    with allure.step("Delete trim queue test buffer profile"):
+        delete_trim_queue_test_buffer_profile(duthost)
 
     with allure.step("Delete the blocking scheduler"):
         delete_blocking_scheduler(duthost)

--- a/tests/packet_trimming/conftest.py
+++ b/tests/packet_trimming/conftest.py
@@ -15,7 +15,7 @@ from tests.packet_trimming.packet_trimming_helper import (
     delete_blocking_scheduler, check_trimming_capability, prepare_service_port, get_interface_peer_addresses,
     configure_tc_to_dscp_map, set_buffer_profile_for_block_queue, set_buffer_profile_for_trim_queue,
     create_blocking_scheduler, configure_trimming_action, cleanup_trimming_acl, get_queue_id_by_dscp,
-    get_test_ports)
+    get_test_ports, create_trim_queue_test_buffer_profile)
 
 
 logger = logging.getLogger(__name__)
@@ -193,6 +193,7 @@ def setup_trimming(duthost, test_params, trim_counter_params):
                                            test_params['trim_buffer_profiles']['uplink'])
         set_buffer_profile_for_block_queue(duthost, counter_block_interface, trim_counter_params['block_queue'],
                                            trim_counter_params['trim_buffer_profiles']['uplink'])
+        create_trim_queue_test_buffer_profile(duthost)
         set_buffer_profile_for_trim_queue(duthost, block_interface)
 
         # The second interface is downlink interface. If the second interface exists, use downlink buffer profile
@@ -202,6 +203,7 @@ def setup_trimming(duthost, test_params, trim_counter_params):
             logger.info(f"Apply downlink buffer profile to {block_interface}:{test_params['block_queue']}")
             set_buffer_profile_for_block_queue(duthost, block_interface, test_params['block_queue'],
                                                test_params['trim_buffer_profiles']['downlink'])
+            set_buffer_profile_for_trim_queue(duthost, block_interface)
 
         # Also set the downlink buffer profile for the block queue used in counter tests, if applicable.
         if len(trim_counter_params['egress_ports']) > 1:

--- a/tests/packet_trimming/constants.py
+++ b/tests/packet_trimming/constants.py
@@ -32,7 +32,13 @@ ECN = 2   # ECN Capable Transport(0), ECT(0)
 PACKET_SIZE_MARGIN = 4
 
 # Buffer configuration constants
-TRIM_QUEUE_PROFILE = "egress_lossy_profile"
+# Dedicated buffer profile for the trim queue
+TRIM_QUEUE_PROFILE = "trim_queue_test_profile"
+TRIM_QUEUE_PROFILE_CONFIG = {
+    "pool": "egress_lossy_pool",
+    "dynamic_th": "-7",
+    "size": "0",
+}
 DYNAMIC_TH = "3"
 TRIMMING_CAPABILITY = "SAI_ADAPTIVE_ROUTING_CIRCULATION_PORT=257"
 STATIC_THRESHOLD_MULTIPLIER = 1.5   # Multiplier to ensure the buffer can be fully exhausted
@@ -155,6 +161,11 @@ COUNTER_TYPE = [
     ("switch", "SWITCH_STAT", TRIMMING_COUNTER_INTERVAL),
     ("port", "PORT_STAT", TRIMMING_COUNTER_INTERVAL),
     ("queue", "QUEUE_STAT", TRIMMING_COUNTER_INTERVAL),
+]
+
+# Platforms that support queue-level TrimSent / TrimDrop counters.
+QUEUE_LEVEL_TRIM_SENT_DROP_SUPPORTED_PLATFORMS = [
+    "nvidia_sn6",
 ]
 
 # Mirror session configuration

--- a/tests/packet_trimming/packet_trimming_config.py
+++ b/tests/packet_trimming/packet_trimming_config.py
@@ -1,6 +1,7 @@
 class PacketTrimmingConfig:
     DSCP = 48
     COUNTER_DSCP = 3   # Map to queue2
+    TRIM_QUEUE = 6
 
     @staticmethod
     def get_trim_size(duthost):
@@ -28,7 +29,7 @@ class PacketTrimmingConfig:
             # not support being modified
             return th5_queue.get(duthost.facts['hwsku'], 9)
         else:
-            return 6
+            return PacketTrimmingConfig.TRIM_QUEUE
 
     @staticmethod
     def get_valid_trim_configs(duthost, asymmetric=False):

--- a/tests/packet_trimming/packet_trimming_helper.py
+++ b/tests/packet_trimming/packet_trimming_helper.py
@@ -724,7 +724,8 @@ def fill_egress_buffer(duthost, ptfadapter, port_id, buffer_size, target_queue, 
     fill_packet_count = buffer_size // effective_size * 3
 
     logger.info(f"Buffer size for queue {target_queue} is approximately {buffer_size} bytes")
-    logger.info(f"Sending {fill_packet_count} packets of size {fill_packet_size} bytes to fill the buffer")
+    logger.info(f"Sending {fill_packet_count} packets of wire size {fill_packet_size} bytes "
+                f"(effective in-queue size {effective_size} bytes) to fill the buffer")
 
     # Validate destination address
     if not dst_addr:
@@ -1609,6 +1610,19 @@ def create_trim_queue_test_buffer_profile(duthost):
     cmd = f"redis-cli -n 4 hset 'BUFFER_PROFILE|{TRIM_QUEUE_PROFILE}' {fields}"
     duthost.shell(cmd)
     logger.info(f"Created trim queue test buffer profile '{TRIM_QUEUE_PROFILE}': {TRIM_QUEUE_PROFILE_CONFIG}")
+
+
+def delete_trim_queue_test_buffer_profile(duthost):
+    """
+    Delete the dedicated trim queue buffer profile created for packet trimming tests.
+
+    The profile is written directly to CONFIG_DB after the configuration backup is taken, so a plain
+    "config load" of the backup does not remove it. Delete it explicitly during teardown to keep
+    CONFIG_DB clean and preserve test isolation.
+    """
+    cmd = f"redis-cli -n 4 del 'BUFFER_PROFILE|{TRIM_QUEUE_PROFILE}'"
+    duthost.shell(cmd)
+    logger.info(f"Deleted trim queue test buffer profile '{TRIM_QUEUE_PROFILE}'")
 
 
 def set_buffer_profile_for_trim_queue(duthost, interfaces, trim_queue_id=None, trim_queue_profile=TRIM_QUEUE_PROFILE):
@@ -3008,7 +3022,7 @@ def is_queue_level_trim_sent_drop_supported(duthost):
     return False
 
 
-def verify_queue_and_port_trim_sent_counter_consistency(duthost, port, port_trim_sent_packets=None):
+def verify_queue_and_port_trim_sent_counter_consistency(duthost, port, port_trim_sent_packets=None, supported=None):
     """
     Verify the consistency of the trim sent counter on the queue and the port level.
 
@@ -3022,11 +3036,16 @@ def verify_queue_and_port_trim_sent_counter_consistency(duthost, port, port_trim
         port_trim_sent_packets (int): Optional pre-fetched port-level TRIM_TX_PKTS value. If not
             provided, the function fetches it itself. Pass it when the caller already has it to
             avoid an extra "show interfaces counters trim" call.
+        supported (bool): Optional pre-computed platform-support flag (e.g. the
+            queue_level_trim_supported fixture value). If not provided, the function computes it
+            itself; pass it to avoid repeating the platform lookup on every per-port call.
 
     Raises:
         AssertionError: If the queue-level sum does not equal the port-level value, or either is zero.
     """
-    if not is_queue_level_trim_sent_drop_supported(duthost):
+    if supported is None:
+        supported = is_queue_level_trim_sent_drop_supported(duthost)
+    if not supported:
         logger.info(f"Skipping queue-level TrimSent consistency check on port {port} - platform not supported")
         return
 
@@ -3036,14 +3055,24 @@ def verify_queue_and_port_trim_sent_counter_consistency(duthost, port, port_trim
     logger.info(f"Waiting {sleep_time} seconds for the trim sent counter to be updated")
     time.sleep(sleep_time)
 
-    queue_counters = get_queue_trim_counters_json(duthost, port)
-
+    # The counter DB can lag behind the data plane; retry a few times if the queue-level counters
+    # are still all zero to avoid a false negative caused purely by counter polling delay.
+    max_retries = 5
     queue_trim_sent_details = {}
-    for queue_id, queue_data in queue_counters.items():
-        trim_sent_packets = queue_data['trimsentpacket']
-        queue_trim_sent_details[queue_id] = trim_sent_packets
-        logger.debug(f"Queue {queue_id} trim sent packets: {trim_sent_packets}")
-    total_queue_trim_sent_packets = sum(queue_trim_sent_details.values())
+    total_queue_trim_sent_packets = 0
+    for attempt in range(1, max_retries + 1):
+        queue_counters = get_queue_trim_counters_json(duthost, port)
+        queue_trim_sent_details = {}
+        for queue_id, queue_data in queue_counters.items():
+            trim_sent_packets = queue_data['trimsentpacket']
+            queue_trim_sent_details[queue_id] = trim_sent_packets
+            logger.debug(f"Queue {queue_id} trim sent packets: {trim_sent_packets}")
+        total_queue_trim_sent_packets = sum(queue_trim_sent_details.values())
+        if total_queue_trim_sent_packets > 0:
+            break
+        logger.info(f"Queue trim sent counters still zero on port {port}, "
+                    f"retry {attempt}/{max_retries} after waiting {sleep_time} seconds")
+        time.sleep(sleep_time)
     logger.info(f"Queue trim sent details: {queue_trim_sent_details}")
     logger.info(f"Total trim sent packets on all queues for port {port}: {total_queue_trim_sent_packets}")
 
@@ -3055,7 +3084,7 @@ def verify_queue_and_port_trim_sent_counter_consistency(duthost, port, port_trim
                   f"Total trim sent packets on all queues for port {port} is not equal to the port level")
 
 
-def verify_queue_and_port_trim_drop_counter_consistency(duthost, port, port_trim_drop_packets=None):
+def verify_queue_and_port_trim_drop_counter_consistency(duthost, port, port_trim_drop_packets=None, supported=None):
     """
     Verify the consistency of the trim drop counter on the queue and the port level.
 
@@ -3068,11 +3097,16 @@ def verify_queue_and_port_trim_drop_counter_consistency(duthost, port, port_trim
         port (str): port name, e.g. "Ethernet96"
         port_trim_drop_packets (int): Optional pre-fetched port-level TRIM_DRP_PKTS value. If not
             provided, the function fetches it itself.
+        supported (bool): Optional pre-computed platform-support flag (e.g. the
+            queue_level_trim_supported fixture value). If not provided, the function computes it
+            itself; pass it to avoid repeating the platform lookup on every per-port call.
 
     Raises:
         AssertionError: If the queue-level sum does not equal the port-level value, or either is zero.
     """
-    if not is_queue_level_trim_sent_drop_supported(duthost):
+    if supported is None:
+        supported = is_queue_level_trim_sent_drop_supported(duthost)
+    if not supported:
         logger.info(f"Skipping queue-level TrimDrop consistency check on port {port} - platform not supported")
         return
 
@@ -3082,14 +3116,24 @@ def verify_queue_and_port_trim_drop_counter_consistency(duthost, port, port_trim
     logger.info(f"Waiting {sleep_time} seconds for the trim drop counter to be updated")
     time.sleep(sleep_time)
 
-    queue_counters = get_queue_trim_counters_json(duthost, port)
-
+    # The counter DB can lag behind the data plane; retry a few times if the queue-level counters
+    # are still all zero to avoid a false negative caused purely by counter polling delay.
+    max_retries = 5
     queue_trim_drop_details = {}
-    for queue_id, queue_data in queue_counters.items():
-        trim_drop_packets = queue_data['trimdroppacket']
-        queue_trim_drop_details[queue_id] = trim_drop_packets
-        logger.debug(f"Queue {queue_id} trim drop packets: {trim_drop_packets}")
-    total_queue_trim_drop_packets = sum(queue_trim_drop_details.values())
+    total_queue_trim_drop_packets = 0
+    for attempt in range(1, max_retries + 1):
+        queue_counters = get_queue_trim_counters_json(duthost, port)
+        queue_trim_drop_details = {}
+        for queue_id, queue_data in queue_counters.items():
+            trim_drop_packets = queue_data['trimdroppacket']
+            queue_trim_drop_details[queue_id] = trim_drop_packets
+            logger.debug(f"Queue {queue_id} trim drop packets: {trim_drop_packets}")
+        total_queue_trim_drop_packets = sum(queue_trim_drop_details.values())
+        if total_queue_trim_drop_packets > 0:
+            break
+        logger.info(f"Queue trim drop counters still zero on port {port}, "
+                    f"retry {attempt}/{max_retries} after waiting {sleep_time} seconds")
+        time.sleep(sleep_time)
     logger.info(f"Queue trim drop details: {queue_trim_drop_details}")
     logger.info(f"Total trim drop packets on all queues for port {port}: {total_queue_trim_drop_packets}")
 

--- a/tests/packet_trimming/packet_trimming_helper.py
+++ b/tests/packet_trimming/packet_trimming_helper.py
@@ -20,7 +20,8 @@ from tests.packet_trimming.constants import (DEFAULT_SRC_PORT, DEFAULT_DST_PORT,
                                              DUMMY_FILL_IPV6, DUMMY_IP, DUMMY_FILL_IP, BATCH_PACKET_COUNT,
                                              PACKET_COUNT, SEND_MAX_RETRIES, STATIC_THRESHOLD_MULTIPLIER,
                                              BLOCK_DATA_PLANE_SCHEDULER_NAME, PACKET_TYPE, SRV6_PACKETS,
-                                             TRIM_QUEUE_PROFILE, TRIMMING_CAPABILITY, ACL_TABLE_NAME,
+                                             TRIM_QUEUE_PROFILE, TRIM_QUEUE_PROFILE_CONFIG, TRIMMING_CAPABILITY,
+                                             ACL_TABLE_NAME,
                                              ACL_RULE_PRIORITY, ACL_TABLE_TYPE_NAME, ACL_RULE_NAME, SRV6_MY_SID_LIST,
                                              SRV6_INNER_SRC_IP, SRV6_INNER_DST_IP, DEFAULT_QUEUE_SCHEDULER_CONFIG,
                                              SRV6_UNIFORM_MODE, SRV6_OUTER_SRC_IPV6, SRV6_INNER_SRC_IPV6, ECN,
@@ -29,7 +30,8 @@ from tests.packet_trimming.constants import (DEFAULT_SRC_PORT, DEFAULT_DST_PORT,
                                              MIRROR_SESSION_SRC_IP, MIRROR_SESSION_DST_IP, MIRROR_SESSION_DSCP,
                                              MIRROR_SESSION_TTL, MIRROR_SESSION_GRE, MIRROR_SESSION_QUEUE,
                                              SCHEDULER_CIR, SCHEDULER_METER_TYPE, PACKET_SIZE_MARGIN,
-                                             TRIMMING_COUNTER_INTERVAL)
+                                             TRIMMING_COUNTER_INTERVAL,
+                                             QUEUE_LEVEL_TRIM_SENT_DROP_SUPPORTED_PLATFORMS)
 from tests.packet_trimming.packet_trimming_config import PacketTrimmingConfig
 
 logger = logging.getLogger(__name__)
@@ -681,7 +683,8 @@ def get_buffer_profile_trimming_status(duthost, buffer_profile_name):
     return action
 
 
-def fill_egress_buffer(duthost, ptfadapter, port_id, buffer_size, target_queue, dst_addr, dscp_value, interfaces):
+def fill_egress_buffer(duthost, ptfadapter, port_id, buffer_size, target_queue, dst_addr, dscp_value, interfaces,
+                       packet_size_in_queue=None):
     """
     Fill the specified port queue's buffer to trigger packet trimming.
     If multiple interfaces are provided, fill with the buffers of all interfaces.
@@ -695,6 +698,9 @@ def fill_egress_buffer(duthost, ptfadapter, port_id, buffer_size, target_queue, 
         dst_addr: Destination address (IPv4 or IPv6)
         dscp_value: DSCP value used for classification to target queue
         interfaces: Single interface or list of interfaces to fill
+        packet_size_in_queue: Packet size (bytes) as it lands on target_queue. Defaults to wire size
+            (1500). When filling the trim queue, pass the trim size (e.g. 256) so the packet count is
+            calculated correctly since trimmed packets are smaller than the original packets.
 
     Returns:
         int: Actual number of packets sent
@@ -713,7 +719,9 @@ def fill_egress_buffer(duthost, ptfadapter, port_id, buffer_size, target_queue, 
 
     # Create a large packet to efficiently fill the buffer
     fill_packet_size = 1500  # Standard Ethernet MTU
-    fill_packet_count = buffer_size // fill_packet_size * 2
+    # Size as the packet lands on target_queue (e.g. trim_size when filling trim queue)
+    effective_size = packet_size_in_queue or fill_packet_size
+    fill_packet_count = buffer_size // effective_size * 3
 
     logger.info(f"Buffer size for queue {target_queue} is approximately {buffer_size} bytes")
     logger.info(f"Sending {fill_packet_count} packets of size {fill_packet_size} bytes to fill the buffer")
@@ -1591,6 +1599,16 @@ def set_buffer_profile_for_block_queue(duthost, interfaces, block_queue_id, bloc
             if not isinstance(e, RuntimeError):
                 raise RuntimeError(f"Exception while configuring interface {interface} blocking queue: {str(e)}") from e
             raise
+
+
+def create_trim_queue_test_buffer_profile(duthost):
+    """
+    Create the dedicated buffer profile used by the trim queue during packet trimming tests.
+    """
+    fields = " ".join(f"{k} {v}" for k, v in TRIM_QUEUE_PROFILE_CONFIG.items())
+    cmd = f"redis-cli -n 4 hset 'BUFFER_PROFILE|{TRIM_QUEUE_PROFILE}' {fields}"
+    duthost.shell(cmd)
+    logger.info(f"Created trim queue test buffer profile '{TRIM_QUEUE_PROFILE}': {TRIM_QUEUE_PROFILE_CONFIG}")
 
 
 def set_buffer_profile_for_trim_queue(duthost, interfaces, trim_queue_id=None, trim_queue_profile=TRIM_QUEUE_PROFILE):
@@ -2923,22 +2941,6 @@ def compare_counters(counter1, counter2, keys_to_compare):
     logger.info("All specified counters match")
 
 
-def check_trim_drop_counter_zero(duthost, port):
-    """
-    Check if TRIM_DRP_PKTS counter on the specified port is 0.
-
-    Args:
-        duthost: DUT host object
-        port (str): port name, e.g. "Ethernet96"
-
-    Returns:
-        bool: True if TRIM_DRP_PKTS is 0, False otherwise
-    """
-    trim_drop = get_port_trim_counters_json(duthost, port)['TRIM_DRP_PKTS']
-    logger.info(f"TRIM_DRP_PKTS on port {port}: {trim_drop}")
-    return trim_drop == 0
-
-
 def has_non_zero_trim_counters(duthost, port):
     """
     Checks if port level trim counters are non-zero.
@@ -2993,6 +2995,110 @@ def verify_queue_and_port_trim_counter_consistency(duthost, port):
     # Verify the consistency
     pytest_assert(total_queue_trim_packets == port_trim_packets and total_queue_trim_packets > 0,
                   f"Total trim packets on all queues for port {port} is not equal to the port level")
+
+
+def is_queue_level_trim_sent_drop_supported(duthost):
+    """
+    Check whether queue-level TrimSent and TrimDrop counters are supported on the current platform.
+    """
+    platform = duthost.facts["platform"].lower()
+    for supported_platform in QUEUE_LEVEL_TRIM_SENT_DROP_SUPPORTED_PLATFORMS:
+        if supported_platform.lower() in platform:
+            return True
+    return False
+
+
+def verify_queue_and_port_trim_sent_counter_consistency(duthost, port, port_trim_sent_packets=None):
+    """
+    Verify the consistency of the trim sent counter on the queue and the port level.
+
+    Compares the sum of queue-level TrimSent against the port-level TrimSent, and asserts
+    both are equal and greater than zero. Silently returns on platforms that do not support
+    queue-level trim counters.
+
+    Args:
+        duthost: DUT host object
+        port (str): port name, e.g. "Ethernet96"
+        port_trim_sent_packets (int): Optional pre-fetched port-level TRIM_TX_PKTS value. If not
+            provided, the function fetches it itself. Pass it when the caller already has it to
+            avoid an extra "show interfaces counters trim" call.
+
+    Raises:
+        AssertionError: If the queue-level sum does not equal the port-level value, or either is zero.
+    """
+    if not is_queue_level_trim_sent_drop_supported(duthost):
+        logger.info(f"Skipping queue-level TrimSent consistency check on port {port} - platform not supported")
+        return
+
+    logger.info(f"Verify the consistency of the trim sent counter on the queue and the port level for port {port}")
+
+    sleep_time = TRIMMING_COUNTER_INTERVAL / 1000 + 1
+    logger.info(f"Waiting {sleep_time} seconds for the trim sent counter to be updated")
+    time.sleep(sleep_time)
+
+    queue_counters = get_queue_trim_counters_json(duthost, port)
+
+    queue_trim_sent_details = {}
+    for queue_id, queue_data in queue_counters.items():
+        trim_sent_packets = queue_data['trimsentpacket']
+        queue_trim_sent_details[queue_id] = trim_sent_packets
+        logger.debug(f"Queue {queue_id} trim sent packets: {trim_sent_packets}")
+    total_queue_trim_sent_packets = sum(queue_trim_sent_details.values())
+    logger.info(f"Queue trim sent details: {queue_trim_sent_details}")
+    logger.info(f"Total trim sent packets on all queues for port {port}: {total_queue_trim_sent_packets}")
+
+    if port_trim_sent_packets is None:
+        port_trim_sent_packets = get_port_trim_counters_json(duthost, port)['TRIM_TX_PKTS']
+    logger.info(f"Port {port} port level trim sent packets: {port_trim_sent_packets}")
+
+    pytest_assert(total_queue_trim_sent_packets == port_trim_sent_packets and total_queue_trim_sent_packets > 0,
+                  f"Total trim sent packets on all queues for port {port} is not equal to the port level")
+
+
+def verify_queue_and_port_trim_drop_counter_consistency(duthost, port, port_trim_drop_packets=None):
+    """
+    Verify the consistency of the trim drop counter on the queue and the port level.
+
+    Compares the sum of queue-level TrimDrop against the port-level TrimDrop, and asserts
+    both are equal and greater than zero. Silently returns on platforms that do not support
+    queue-level trim counters.
+
+    Args:
+        duthost: DUT host object
+        port (str): port name, e.g. "Ethernet96"
+        port_trim_drop_packets (int): Optional pre-fetched port-level TRIM_DRP_PKTS value. If not
+            provided, the function fetches it itself.
+
+    Raises:
+        AssertionError: If the queue-level sum does not equal the port-level value, or either is zero.
+    """
+    if not is_queue_level_trim_sent_drop_supported(duthost):
+        logger.info(f"Skipping queue-level TrimDrop consistency check on port {port} - platform not supported")
+        return
+
+    logger.info(f"Verify the consistency of the trim drop counter on the queue and the port level for port {port}")
+
+    sleep_time = TRIMMING_COUNTER_INTERVAL / 1000 + 1
+    logger.info(f"Waiting {sleep_time} seconds for the trim drop counter to be updated")
+    time.sleep(sleep_time)
+
+    queue_counters = get_queue_trim_counters_json(duthost, port)
+
+    queue_trim_drop_details = {}
+    for queue_id, queue_data in queue_counters.items():
+        trim_drop_packets = queue_data['trimdroppacket']
+        queue_trim_drop_details[queue_id] = trim_drop_packets
+        logger.debug(f"Queue {queue_id} trim drop packets: {trim_drop_packets}")
+    total_queue_trim_drop_packets = sum(queue_trim_drop_details.values())
+    logger.info(f"Queue trim drop details: {queue_trim_drop_details}")
+    logger.info(f"Total trim drop packets on all queues for port {port}: {total_queue_trim_drop_packets}")
+
+    if port_trim_drop_packets is None:
+        port_trim_drop_packets = get_port_trim_counters_json(duthost, port)['TRIM_DRP_PKTS']
+    logger.info(f"Port {port} port level trim drop packets: {port_trim_drop_packets}")
+
+    pytest_assert(total_queue_trim_drop_packets == port_trim_drop_packets and total_queue_trim_drop_packets > 0,
+                  f"Total trim drop packets on all queues for port {port} is not equal to the port level")
 
 
 def configure_port_mirror_session(duthost):


### PR DESCRIPTION
Test Plan: https://github.com/sonic-net/sonic-mgmt/pull/19824

Summary: Update trimming case to support queue-level TrimSent and TrimDrop counters
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605 

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- master: case pass
- 202605: case pass

### Approach
#### What is the motivation for this PR?
Update trimming case to support queue-level TrimSent and TrimDrop counters

#### How did you do it?
1. Adds queue-level TrimSent/TrimDrop counter consistency checks for SPC6+ platforms.
2. Create the dedicated buffer profile for trim-queue.
3. Block the trim queue and fill buffer full in the trimming counter test.

#### How did you verify/test it?
Regression pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
