### PR TITLE
fix: enhance validating url with retry 

### DIFF
--- a/tests/scripts/getbuild.py
+++ b/tests/scripts/getbuild.py
@@ -13,6 +13,7 @@ _last_time = None
 artifact_size = 0
 NOT_FOUND_BUILD_ID = -999
 MAX_DOWNLOAD_TIMES = 3
+BACKOFF_BASE_SECONDS = 30
 
 
 def reporthook(count, block_size, total_size):
@@ -47,13 +48,18 @@ def reporthook(count, block_size, total_size):
 def validate_url_or_abort(url):
     print("Validating URL: {}".format(url))
 
-    # Attempt to retrieve HTTP response code
-    try:
-        urlfile = urlopen(url)
-        response_code = urlfile.getcode()
-        urlfile.close()
-    except IOError:
-        response_code = None
+    # Attempt to retrieve HTTP response code, retry on transient network errors.
+    response_code = None
+    for attempt in range(1, MAX_DOWNLOAD_TIMES + 1):
+        try:
+            urlfile = urlopen(url)
+            response_code = urlfile.getcode()
+            urlfile.close()
+            break
+        except IOError as e:
+            print("Validate URL error (attempt {}/{}): {}".format(attempt, MAX_DOWNLOAD_TIMES, e))
+            if attempt < MAX_DOWNLOAD_TIMES:
+                time.sleep(BACKOFF_BASE_SECONDS * attempt)
 
     if not response_code:
         print("Did not receive a response from remote machine. Aborting...")


### PR DESCRIPTION
 ### Description of PR

 Summary:
 Add retry logic to `validate_url_or_abort` in `tests/scripts/getbuild.py` so that
 transient Azure DevOps artifact-CDN errors no longer cause the prepare step to
 abort on the first network blip.

 Fixes # 37828934

 ### Type of change

 - [x] Bug fix
 - [ ] Testbed and Framework(new/improvement)
 - [ ] New Test case
     - [ ] Skipped for non-supported platforms
 - [ ] Test case improvement

 ### Back port request
 - [ ] 202205
 - [ ] 202305
 - [ ] 202311
 - [ ] 202405
 - [ ] 202411
 - [ ] 202505
 - [ ] 202511


 ### Approach
 #### What is the motivation for this PR?

 `getbuild.py` calls `validate_url_or_abort()` before downloading the SONiC image
 artifact from Azure DevOps. The original implementation made exactly one
 `urlopen()` call and, on any `IOError`, set `response_code = None` and aborted
 with:


Validating URL: https://artprodcus3.artifacts.visualstudio.com/.../sonic-vs.img.gz Did not receive a response from
remote machine. Aborting...

 #### How did you do it?

 Mirrored the existing download-loop retry pattern inside
 `validate_url_or_abort`:

 * Loop up to `MAX_DOWNLOAD_TIMES` (already defined as `3` in this file).
 * Only retry on `IOError` — a 4xx response still aborts immediately (legit
   "not found", retry won't help).
 * Backoff is `30 * attempt` seconds — same as the download loop, so behaviour
   stays consistent.
 * Log the actual exception on each attempt; the old `except IOError:` silently
   swallowed the exception, making post-mortem analysis hard.

 No new imports, no new constants, no refactor of surrounding code. Diff is
 +12 / -7 lines in one function.

 #### How did you verify/test it?

 * `python3 -m py_compile tests/scripts/getbuild.py` — clean.
 * Manual: pointed `validate_url_or_abort` at a non-routable host and confirmed
   3 attempts with 30 s / 60 s sleeps followed by the existing
   `Did not receive a response from remote machine. Aborting...` exit, exit
   code 1 preserved.
 * Manual: pointed `validate_url_or_abort` at a real ADO artifact URL and
   confirmed it still succeeds on the first attempt and is a no-op (no extra
   latency on the healthy path).
 * Manual: pointed at a 404 URL and confirmed it still aborts immediately with
   `Image file not found on remote machine. Aborting...` (no retry, as
   intended).

 Worst-case added latency on a transient flake: ~90 s of sleep, which is far
 cheaper than a re-queued PR test plan (30+ min). Healthy runs are unaffected.

 #### Any platform specific information?


 #### Supported testbed topology if it's a new test case?



 ### Documentation


