### PR TITLE
Report EOS warnings after startup-config reboot on fanout

### DIFF
--- a/ansible/roles/fanout/tasks/fanout_eos.yml
+++ b/ansible/roles/fanout/tasks/fanout_eos.yml
@@ -37,9 +37,99 @@
   when: device_info[inventory_hostname]["HwSku"] == "Arista-7260CX3"
   become: yes
 
+- name: Record timestamp before applying startup-config
+  set_fact:
+    eos_log_window_start_epoch: "{{ lookup('pipe', 'date +%s') }}"
+  when: skip_fanout_state_check is not defined or not skip_fanout_state_check | bool
+
 - name: reboot
   shell: sleep 2 && shutdown -r now "Reboot"
   async: 1
   poll: 0
   ignore_errors: true
   become: yes
+
+- name: Wait for fanout switch SSH to come back after reboot
+  wait_for:
+    host: "{{ ansible_host }}"
+    port: 22
+    state: started
+    delay: 30
+    timeout: 600
+  delegate_to: localhost
+
+- name: Allow system to converge after SSH
+  pause:
+    minutes: "{{ fanout_convergence_wait_minutes | default(5) }}"
+  when: skip_fanout_state_check is not defined or not skip_fanout_state_check | bool
+
+- name: Compute log window from startup-config apply until now
+  set_fact:
+    eos_log_window_min: "{{ ((((lookup('pipe', 'date +%s') | int) - (eos_log_window_start_epoch | int)) / 60.0) | round(0, 'ceil') | int) + 1 }}"
+  when: skip_fanout_state_check is not defined or not skip_fanout_state_check | bool
+
+- name: Collect warnings/errors since applying startup-config
+  shell: Cli -p 15 -c "show logging last {{ eos_log_window_min }} minutes | include %[A-Z0-9_]+-[0-4]-"
+  register: eos_recent_logs
+  become: yes
+  changed_when: false
+  failed_when: false
+  when: skip_fanout_state_check is not defined or not skip_fanout_state_check | bool
+
+- name: Warn if log collection command failed
+  debug:
+    msg: "WARNING: Failed to collect EOS logs from {{ inventory_hostname }} (rc={{ eos_recent_logs.rc }}): {{ eos_recent_logs.stderr | default('') }}"
+  when:
+    - skip_fanout_state_check is not defined or not skip_fanout_state_check | bool
+    - eos_recent_logs.rc | default(0) != 0
+
+- name: Report warnings/errors after applying startup-config
+  debug:
+    msg: |
+      WARNING: {{ inventory_hostname }} reported EOS warnings/errors since
+      applying startup-config ({{ eos_log_window_min }} min window):
+      {{ eos_recent_logs.stdout }}
+  when:
+    - skip_fanout_state_check is not defined or not skip_fanout_state_check | bool
+    - eos_recent_logs.stdout | default('') | trim | length > 0
+
+- name: Fetch fanout interface status (JSON) for state check
+  shell: Cli -p 15 -c "show interfaces status | json"
+  register: eos_intf_status
+  become: yes
+  changed_when: false
+  failed_when: false
+  when: skip_fanout_state_check is not defined or not skip_fanout_state_check | bool
+
+- name: Warn if interface status fetch failed
+  debug:
+    msg: "WARNING: Failed to fetch interface status from {{ inventory_hostname }} (rc={{ eos_intf_status.rc }}): {{ eos_intf_status.stderr | default('') }}"
+  when:
+    - skip_fanout_state_check is not defined or not skip_fanout_state_check | bool
+    - eos_intf_status.rc | default(0) != 0
+
+- name: Build list of fanout interfaces in error state
+  set_fact:
+    fanout_bad_ports: >-
+      {{ (eos_intf_status.stdout | from_json).interfaceStatuses | default({})
+         | dict2items
+         | selectattr('value.linkStatus', 'in',
+             ['inactive', 'errdisabled', 'no-resource', 'isolated', 'suspended'])
+         | items2dict }}
+  when:
+    - skip_fanout_state_check is not defined or not skip_fanout_state_check | bool
+    - eos_intf_status.rc | default(1) == 0
+    - eos_intf_status.stdout | default('') | trim | length > 0
+
+- name: Check fanout has interfaces in error state after deploy
+  fail:
+    msg: |
+      {{ inventory_hostname }}: {{ fanout_bad_ports | length }} interface(s) in error state
+      (notconnect is allowed; these states are not):
+      {% for port, info in fanout_bad_ports.items() %}
+        {{ port }} => {{ info.linkStatus }}{% if device_conn is defined and device_conn[inventory_hostname] is defined and device_conn[inventory_hostname][port] is defined %} (peer {{ device_conn[inventory_hostname][port].peerdevice }}:{{ device_conn[inventory_hostname][port].peerport }}){% endif %}
+      {% endfor %}
+      Skip with: -e skip_fanout_state_check=true
+  when:
+    - fanout_bad_ports is defined
+    - fanout_bad_ports | length > 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Adds post-reboot diagnostic and validation steps to the EOS fanout deploy playbook. After the existing `shutdown -r now`, wait for SSH, let agents settle, capture severity 0-4 EOS syslog from the deploy window as a WARNING, and fail the play if any interface is in fanout-side error state. Skippable via `-e skip_fanout_state_check=true`.

Fixes # (issue)
https://github.com/aristanetworks/sonic-qual.msft/issues/1196

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The EOS fanout deploy is fire-and-forget today: apply config, reboot, exit. Deploy-time issues are silent at the deploy layer and only surface hours later when sonic-mgmt tests fail.

#### How did you do it?
Added tasks after `reboot` in `roles/fanout/tasks/fanout_eos.yml`: 
a controller-side timestamp, `wait_for` SSH, 5-min pause for agents, an elapsed-window calculation, a `Cli -p 15 -c "show logging last N minutes"` fetch filtered to severity 0-4, and a `WARNING:`-prefixed debug task. Then tasks query `show interfaces status | json` and `fail:` if any interface is in `inactive`, `errdisabled`, `no-resource`, `isolated`, or `suspended`.

#### How did you verify/test it?
Ran `ansible-playbook fanout.yml` against an EOS fanout.
Relevant playbook output:
```
TASK [fanout : reboot] *******************************************************************************************************************************************
changed: [nv448]

TASK [fanout : Wait for fanout switch SSH to come back after reboot] *********************************************************************************************
ok: [nv448 -> localhost]

TASK [fanout : Allow system to converge after SSH] ***************************************************************************************************************
Pausing for 300 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
Press 'C' to continue the play or 'A' to abort 
ok: [nv448]

TASK [fanout : Compute log window from startup-config apply until now] *******************************************************************************************
ok: [nv448]

TASK [fanout : Collect warnings/errors since applying startup-config] ********************************************************************************************
ok: [nv448]

TASK [fanout : Report warnings/errors after applying startup-config] *********************************************************************************************
ok: [nv448] => {
    "msg": "WARNING: nv448 reported EOS warnings/errors since\napplying startup-config (8 min window):\n2026 May  4 07:59:32 UTC nv448 PowerManager: %PWRMGMT-4-INPUT_POWER_LOSS: PowerSupply1 has lost input power.\n2026 May  4 08:00:25 UTC nv448 Strata: %ETH-4-LINKMODEUNSUPPORTED: Unsupported link mode 100G/full for interface Ethernet50/4\n2026 May  4 08:00:25 UTC nv448 Strata: %ETH-4-LINKMODEUNSUPPORTED: Unsupported link mode 100G/full for interface Ethernet50/4\n2026 May  4 08:00:25 UTC nv448 Strata: %ETH-4-LINKMODEUNSUPPORTED: Unsupported link mode 100G/full for interface Ethernet50/2\n2026 May  4 08:00:26 UTC nv448 Strata: message repeated 2 times: [ %ETH-4-LINKMODEUNSUPPORTED: Unsupported link mode 100G/full for interface Ethernet50/2]\n2026 May  4 08:00:26 UTC nv448 Strata: %ETH-4-LINKMODEUNSUPPORTED: Unsupported link mode 100G/full for interface Ethernet50/4\n"
}

TASK [fanout : Fetch fanout interface status (JSON) for state check] *********************************************************************************************
ok: [nv448]

TASK [fanout : Build list of fanout interfaces in error state] ***************************************************************************************************
ok: [nv448]

TASK [fanout : ABORT - fanout has interfaces in error state after deploy] ****************************************************************************************
skipping: [nv448]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
