### PR TITLE
[BMC] Skip bmp / frr_bmp / swss / syncd FEATURE in golden_config_db for BMC devices

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -1112,12 +1112,6 @@ class GenerateGoldenConfigDBModule(object):
                 config = self.overwrite_feature_golden_config_db_singleasic(config, "bmp")
 
         # Disable swss and syncd features on BMC devices.
-        # BMC platforms (e.g. Aspeed Komodo) have no front-side ASIC; the swss/syncd containers
-        # have nothing to manage. Leaving the features as 'enabled' creates a mismatch
-        # (feature_status enabled vs systemd unit inactive) that breaks tests/tools using
-        # feature_status or swss.service ActiveState as a readiness gate -- e.g.
-        # config_system_checks_passed() in platform_tests/test_reload_config.py waits up to 360s
-        # for swss.service to become active and never succeeds on a BMC.
         if self.is_bmc_device():
             if multi_asic.is_multi_asic():
                 config = self.overwrite_feature_golden_config_db_multiasic(config, "swss", "disabled", "disabled")

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -219,11 +219,7 @@ class GenerateGoldenConfigDBModule(object):
         return False
 
     def is_bmc_device(self):
-        # BMC devices (e.g. Aspeed-based management controllers) do not host BGP sessions,
-        # so BGP-monitoring features (bmp, frr_bmp) are not applicable and their containers
-        # are not built/shipped for BMC images. Presence of /etc/sonic/bmc_config.json is
-        # the canonical indicator that the running SONiC image is a BMC build.
-        return device_info.get_bmc_build_config() is not None
+        return device_info.get_bmc_data() is not None
 
     def has_otel_image(self):
         rc, out, _ = self.module.run_command("docker images --format '{{.Repository}}'")

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -218,6 +218,13 @@ class GenerateGoldenConfigDBModule(object):
         # disable bmp feature table first
         return False
 
+    def is_bmc_device(self):
+        # BMC devices (e.g. Aspeed-based management controllers) do not host BGP sessions,
+        # so BGP-monitoring features (bmp, frr_bmp) are not applicable and their containers
+        # are not built/shipped for BMC images. Presence of /etc/sonic/bmc_config.json is
+        # the canonical indicator that the running SONiC image is a BMC build.
+        return device_info.get_bmc_build_config() is not None
+
     def has_otel_image(self):
         rc, out, _ = self.module.run_command("docker images --format '{{.Repository}}'")
         if rc != 0:
@@ -1097,13 +1104,31 @@ class GenerateGoldenConfigDBModule(object):
 
         # To enable bmp feature when the image version is >= 202411 and the device is not supervisor
         # Note: the Chassis supervisor is not holding any BGP sessions so the BMP feature is not needed
-        if self.check_version_for_bmp() is True and device_info.is_supervisor() is False:
+        # Note: BMC devices also do not host BGP sessions, so the BMP feature is not applicable
+        if (self.check_version_for_bmp() is True
+                and device_info.is_supervisor() is False
+                and not self.is_bmc_device()):
             if multi_asic.is_multi_asic():
                 config = self.overwrite_feature_golden_config_db_multiasic(config, "frr_bmp", "disabled", "enabled")
                 config = self.overwrite_feature_golden_config_db_multiasic(config, "bmp")
             else:
                 config = self.overwrite_feature_golden_config_db_singleasic(config, "frr_bmp", "disabled", "enabled")
                 config = self.overwrite_feature_golden_config_db_singleasic(config, "bmp")
+
+        # Disable swss and syncd features on BMC devices.
+        # BMC platforms (e.g. Aspeed Komodo) have no front-side ASIC; the swss/syncd containers
+        # have nothing to manage. Leaving the features as 'enabled' creates a mismatch
+        # (feature_status enabled vs systemd unit inactive) that breaks tests/tools using
+        # feature_status or swss.service ActiveState as a readiness gate -- e.g.
+        # config_system_checks_passed() in platform_tests/test_reload_config.py waits up to 360s
+        # for swss.service to become active and never succeeds on a BMC.
+        if self.is_bmc_device():
+            if multi_asic.is_multi_asic():
+                config = self.overwrite_feature_golden_config_db_multiasic(config, "swss", "disabled", "disabled")
+                config = self.overwrite_feature_golden_config_db_multiasic(config, "syncd", "disabled", "disabled")
+            else:
+                config = self.overwrite_feature_golden_config_db_singleasic(config, "swss", "disabled", "disabled")
+                config = self.overwrite_feature_golden_config_db_singleasic(config, "syncd", "disabled", "disabled")
 
         # Enable otel feature when docker-sonic-otel image exists
         if self.has_otel_image():


### PR DESCRIPTION
### Description of PR

Summary: Skip the `bmp` / `frr_bmp` / `swss` / `syncd` FEATURE injection in `generate_golden_config_db` when the DUT is a BMC build.

A `NetworkBmc` device (e.g. Aspeed Komodo NH-B27) has **neither BGP sessions nor a front-side ASIC**. The `docker-sonic-bmp`, `frr_bmp`, `swss` and `syncd` containers are either not shipped on BMC images at all (bmp/frr_bmp) or have nothing to manage (swss/syncd — the front ASIC sits on the separate switch CPU). Leaving any of these features as `enabled` in golden_config_db produces a mismatch between the feature manifest and the actual systemd state and causes downstream test breakage:

- **bmp/frr_bmp**: hostcfgd repeatedly tries to start non-existent containers, pollutes systemd / system-health with `bmp` errors, and causes `system_health/test_external_checker` to time out waiting for the BMC bucket to become healthy.

- **swss/syncd**: `feature_status` reports `enabled` but `swss.service` / `syncd.service` stay `inactive`. `config_system_checks_passed()` in `platform_tests/test_reload_config.py` waits up to 360s for `swss.service` to become `active` and fails 100% of the time on Komodo BMC.

The original plan was to fix swss/syncd at build time in `init_cfg.json.j2` ([sonic-buildimage#27302](https://github.com/sonic-net/sonic-buildimage/pull/27302)) but `init_cfg.json` is protected against platform-specific gating; the gate belongs in deploy-mg (sonic-mgmt) where `golden_config_db` is generated. This PR moves the swss/syncd disable into the same `is_bmc_device()` block as the bmp/frr_bmp disable.

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

On Aspeed BMC devices (`host1-komodo-bmc`), every `deploy-mg` leaves `FEATURE.bmp`, `FEATURE.frr_bmp`, `FEATURE.swss`, `FEATURE.syncd` enabled in CONFIG_DB even though none of those containers run on BMC. The resulting hostcfgd / systemd / system-health errors and feature-vs-systemd mismatch break:

- `system_health/test_external_checker.py` (bmp errors)
- `platform_tests/test_reload_config.py::test_reload_configuration*` (waits forever for `swss.service` to become active)

#### How did you do it?

Added a new helper `is_bmc_device()` to `GenerateGoldenConfigDBModule` that returns True when `/etc/sonic/bmc.json` is present (created only on platforms that actually have a BMC, via `sonic_py_common.device_info.get_bmc_data()`). This matches how the Mellanox platform API (`mlnx-platform-api/sonic_platform/bmc.py::_get_bmc_values`) gates BMC presence. Then two BMC gates in `generate_default_golden_config_db()`:

1. **bmp/frr_bmp**: extend the existing version + `is_supervisor()` gate so BMC devices are also excluded.

```python
if (self.check_version_for_bmp() is True
        and device_info.is_supervisor() is False
        and not self.is_bmc_device()):
    ...overwrite FEATURE.bmp / FEATURE.frr_bmp...
```

2. **swss/syncd**: new block that overwrites those features as `disabled` on BMC.

```python
if self.is_bmc_device():
    config = self.overwrite_feature_golden_config_db_singleasic(config, "swss",  "disabled", "disabled")
    config = self.overwrite_feature_golden_config_db_singleasic(config, "syncd", "disabled", "disabled")
```

Both paths handle multi-asic correctly via the existing `overwrite_feature_golden_config_db_multiasic` helper.

#### How did you verify/test it?

- Confirmed `/etc/sonic/bmc.json` exists on `host1-komodo-bmc` (Aspeed BMC) → `is_bmc_device()` returns True.
- Confirmed `/etc/sonic/bmc.json` is NOT created on non-BMC images (including KVM/vlab) → `is_bmc_device()` returns False, so the new swss/syncd block is a no-op there. (An earlier version of this PR keyed off `/etc/sonic/bmc_config.json`, which is rendered unconditionally by `build_debian.sh` ([sonic-buildimage#24345](https://github.com/sonic-net/sonic-buildimage/pull/24345)) and is present on every image — that incorrectly disabled swss/syncd on KVM and broke vlab sanity checks. Switched to `bmc.json` to fix.)
- Will validate end-to-end on the live BMC testbed after merge by re-running `deploy-mg` and verifying:
  ```
  show feature status | grep -E 'bmp|frr_bmp|swss|syncd'
  # ↳ swss / syncd → disabled, bmp / frr_bmp → not listed
  ```

#### Any platform specific information?

Affects only DUTs that ship with `/etc/sonic/bmc.json` (real BMC platforms). Master branch only — no back-port requested.

#### Supported testbed topology if it's a new test case?

N/A (bug fix in testbed framework).

### Documentation

N/A.
