### PR TITLE
conditional_mark: skip DUT fact loading when topology mismatch causes all tests to be skipped

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -645,9 +645,11 @@ def evaluate_conditions(dynamic_update_skip_reason, mark_details, conditions, ba
 
 
 def pytest_collection(session):
-    """Hook for loading conditions and basic facts.
+    """Hook for loading conditions.
 
-    The pytest session.config.cache is used for caching loaded conditions and basic facts for later use.
+    The pytest session.config.cache is used for caching loaded conditions for later use.
+    DUT facts are loaded lazily in pytest_collection_modifyitems to avoid expensive SSH
+    overhead when all tests are already going to be skipped (e.g. topology mismatch).
 
     Args:
         session (obj): Pytest session object.
@@ -664,12 +666,14 @@ def pytest_collection(session):
     if conditions:
         session.config.cache.set('TESTS_MARK_CONDITIONS', conditions)
 
-        # Only load basic facts if conditions are defined.
-        get_basic_facts(session)
 
-
+@pytest.hookimpl(trylast=True)
 def pytest_collection_modifyitems(session, config, items):
     """Hook for adding marks to test cases based on conditions defined in a centralized file.
+
+    Uses trylast=True so topology and other collection-modify hooks (e.g. custom_markers)
+    run first.  This allows skipping the expensive DUT fact loading (TestbedInfo + ansible
+    SSH, ~90 s on some testbeds) when every collected item has already been marked as skip.
 
     Args:
         session (obj): Pytest session object.
@@ -680,6 +684,20 @@ def pytest_collection_modifyitems(session, config, items):
     if not conditions:
         logger.debug('No mark condition is defined')
         return
+
+    # Skip the expensive DUT fact loading when there is nothing to process.
+    # This saves ~90 s (TestbedInfo YAML parsing + ansible SSH) on testbeds where
+    # every test is already marked as skip by an earlier hook such as the topology
+    # check in custom_markers (e.g. running a t0/t1 test against an lt2 testbed).
+    if not items:
+        logger.debug('No collected items; skipping DUT fact loading')
+        return
+    if all(item.get_closest_marker('skip') for item in items):
+        logger.debug('All collected items are already marked as skip; skipping DUT fact loading')
+        return
+
+    # Lazily load DUT facts now that we know they are actually needed.
+    get_basic_facts(session)
 
     dut_name = get_dut_name(session)
     cached_facts_name = f'BASIC_FACTS_{dut_name}'


### PR DESCRIPTION
### Description of PR
Summary:

When running a test with `--topology <X>` that does not match the test's topology marker, all collected items are immediately marked as `skip` by the `custom_markers` plugin. However, the `conditional_mark` plugin was still spending ~90 s on expensive DUT fact loading (TestbedInfo YAML parsing + ansible SSH) that was never needed.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

Tests skipped by topology mismatch (e.g. running `pc/test_retry_count.py` with `--topology lt2` when the test requires `t0/t1/t0-sonic`) wasted ~90 s before being skipped. The delay was measured at:
- `tests/pc/test_retry_count.py` with `--topology lt2` on testbed `vms13-lt2-7060x6-8` (DUT: `str4-7060x6-512-8`): **46 s before fix → 22 s after fix** (~52% reduction in collection time). The remaining ~16 s is from `pytest_generate_tests` calling `TestbedInfo` to build DUT enumerations, which is outside the scope of this fix.

#### How did you do it?

1. **Moved DUT fact loading from `pytest_collection` to `pytest_collection_modifyitems`** in `conditional_mark`: DUT facts are now loaded lazily instead of eagerly during the collection phase.

2. **Added `@pytest.hookimpl(trylast=True)`** on `conditional_mark.pytest_collection_modifyitems` so that the topology check in `custom_markers` (which marks topology-mismatched items as `skip`) runs **before** `conditional_mark` inspects the items.

3. **Added two early-exit guards** in `conditional_mark.pytest_collection_modifyitems`:
   - If `items` is empty: return immediately.
   - If **all** collected items already carry a `skip` marker (e.g. topology mismatch): return immediately, skipping the ~90 s of `TestbedInfo` YAML parsing + ansible SSH.

#### How did you verify/test it?

Ran `tests/pc/test_retry_count.py` with `--topology lt2` on testbed `vms13-lt2-7060x6-8` (DUT: Arista-7060X6-512S):

| | Collection time |
|---|---|
| Before fix | 46 s |
| After fix | 22 s |

All 8 test cases correctly skipped in both runs.

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation