### PR TITLE
Fix critical process status check: race condition and insufficient retry timeout

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -613,7 +613,33 @@ class SonicHost(AnsibleHostBase):
                 'exited_critical_process': [],
                 'running_critical_process': []
             }
-            if service not in group_process_results or service not in service_results:
+            if service not in group_process_results:
+                # Container may have started between the critical_processes
+                # file read and the supervisorctl status batch. Retry reading
+                # the critical_processes file for this specific service.
+                if (service in service_results
+                        and service_results[service].get('stdout_lines')):
+                    logging.info(
+                        "Service '%s' was not available during initial "
+                        "critical_processes batch read, retrying.", service
+                    )
+                    critical_group_list, critical_process_list, succeeded = \
+                        self.get_critical_group_and_process_lists(service)
+                    if succeeded:
+                        group_process_results[service] = {
+                            'groups': critical_group_list,
+                            'processes': critical_process_list
+                        }
+                    else:
+                        service_critical_process['status'] = False
+                        all_critical_process[service] = service_critical_process
+                        continue
+                else:
+                    service_critical_process['status'] = False
+                    all_critical_process[service] = service_critical_process
+                    continue
+
+            if service not in service_results:
                 service_critical_process['status'] = False
                 all_critical_process[service] = service_critical_process
                 continue

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -22,6 +22,7 @@ from tests.common.errors import RunAnsibleModuleFail
 
 logger = logging.getLogger(__name__)
 SYSTEM_STABILIZE_MAX_TIME = 300
+MIN_PROCESS_CHECK_TIMEOUT = 180
 MONIT_STABILIZE_MAX_TIME = 500
 OMEM_THRESHOLD_BYTES = 10485760     # 10MB
 cache = FactsCache()
@@ -114,7 +115,7 @@ def check_interfaces(duthosts, tbinfo):
         logger.info("Checking interfaces status on %s..." % dut.hostname)
 
         networking_uptime = dut.get_networking_uptime().seconds
-        timeout = max((SYSTEM_STABILIZE_MAX_TIME - networking_uptime), 0)
+        timeout = max((SYSTEM_STABILIZE_MAX_TIME - networking_uptime), MIN_PROCESS_CHECK_TIMEOUT)
         if dut.get_facts().get("modular_chassis"):
             timeout = max(timeout, 600)
         interval = 20
@@ -914,7 +915,7 @@ def check_processes(duthosts):
         logger.info("Checking process status on %s..." % dut.hostname)
 
         networking_uptime = dut.get_networking_uptime().seconds
-        timeout = max((SYSTEM_STABILIZE_MAX_TIME - networking_uptime), 0)
+        timeout = max((SYSTEM_STABILIZE_MAX_TIME - networking_uptime), MIN_PROCESS_CHECK_TIMEOUT)
         interval = 20
         logger.info("networking_uptime=%d seconds, timeout=%d seconds, interval=%d seconds" %
                     (networking_uptime, timeout, interval))


### PR DESCRIPTION
### Description of PR

Summary:
Fix two issues causing false post-test sanity check failures for critical process status checks, especially on platforms with slow-starting containers (e.g. Nokia-7215).

**Fix 1 — Race condition in `all_critical_process_status()`** (`sonic.py`):
When a container starts between the `critical_processes` file read batch and the `supervisorctl status` batch, the code short-circuits to `status=False` without parsing the supervisorctl output. Fix: retry reading the `critical_processes` file for that specific service.

**Fix 2 — Insufficient retry timeout** (`checks.py`):
Add `MIN_PROCESS_CHECK_TIMEOUT = 180s` as a floor for the process check retry window. Currently `timeout = 300 - networking_uptime`, which can leave as little as ~100s of retries. Each `all_critical_process_status()` call takes ~60s for the full batch, leaving only 1-2 retry attempts. The 180s floor ensures at least 3 retry attempts regardless of uptime.

#### Benefits
- **Eliminates false sanity check failures**: Prevents spurious `ERROR at teardown` caused by containers that are actually healthy but started slowly after `config_reload`.
- **Reduces wasted triage time**: Engineers no longer need to dig through logs to rule out phantom container failures that are really just timing artifacts.
- **Zero overhead in the normal case**: The retry (Fix 1) only triggers when the race condition occurs. The minimum timeout (Fix 2) doesn't slow fast platforms since the check exits immediately when all processes are healthy.
- **Improves nightly test signal quality**: Fewer false failures means higher confidence in real failure reports and less noise in nightly dashboards.

ADO:37501698

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

`all_critical_process_status()` runs two sequential batch commands against all service containers:
1. **Batch 1**: `docker exec <service> bash -c "cat /etc/supervisor/critical_processes"` — reads which processes are critical
2. **Batch 2**: `docker exec <service> supervisorctl status` — reads actual process status

**Problem 1 — Race condition (`sonic.py`):** If a container starts between batch 1 and batch 2, the critical_processes read fails but supervisorctl succeeds. The code short-circuits without parsing the supervisorctl output.

**Problem 2 — Timeout too short (`checks.py`):** `timeout = max(SYSTEM_STABILIZE_MAX_TIME - networking_uptime, 0)` with `SYSTEM_STABILIZE_MAX_TIME=300`. When `networking_uptime` exceeds 300s, timeout becomes 0 — no retries at all.

**Real failure examples:**
- [ElasticTest plan 69e608988e4392427922930b](https://elastictest.org/scheduler/testplan/69e608988e4392427922930b?testcase=gnmi_e2e%2Ftest_telemetry_auth.py%7C%7C%7C2&type=log) — Race condition: SNMP `critical_processes` read failed at 05:56:08, supervisorctl showed RUNNING at 05:56:59
- [ElasticTest plan 69e8ab9831dfe8467068332b](https://elastictest.org/scheduler/testplan/69e8ab9831dfe8467068332b?testcase=override_config_table%2Ftest_override_config_table.py%7C%7C%7C2&type=log) — Timeout: `networking_uptime=195s`, only 105s retry window, pmon+snmp not ready in time

#### How did you do it?

**Fix 1** (`tests/common/devices/sonic.py`): When a service is missing from `group_process_results` but present in `service_results` with actual output, retry reading `critical_processes` via `get_critical_group_and_process_lists()`.

**Fix 2** (`tests/common/plugins/sanity_check/checks.py`): Add `MIN_PROCESS_CHECK_TIMEOUT = 180` and change timeout calculation to: `timeout = max(SYSTEM_STABILIZE_MAX_TIME - networking_uptime, MIN_PROCESS_CHECK_TIMEOUT)`

#### How did you verify/test it?

**Test 1: `gnmi_e2e/test_telemetry_auth.py`
- Applied Fix 1 patch
- Result: Post-test sanity check **PASSED**, SNMP reported healthy:
  `snmp: {'status': True, 'running_critical_process': ['snmp-subagent', 'snmpd']}`
- Console: `No post-test sanity check item failed, post-test sanity check passed.`

**Test 2: `override_config_table/test_override_config_table.py`
- Applied both Fix 1 + Fix 2 patches
- Result: **1 passed in 3180s (53 min)**, post-test sanity check **PASSED**
- The `MIN_PROCESS_CHECK_TIMEOUT` was critical — log shows:
  `
  networking_uptime=324 seconds, timeout=180 seconds
  `
  Without the fix: `timeout = max(300-324, 0) = 0` → zero retries → guaranteed failure
  With the fix: `timeout = max(300-324, 180) = 180` → 180s of retries → processes started in time → **PASSED**
- Full sanity check log:
  `
  Start post-test sanity check
  networking_uptime=324 seconds, timeout=180 seconds, interval=20 seconds
  networking_uptime=389 seconds, timeout=180 seconds, interval=20 seconds
  No post-test sanity check item failed, post-test sanity check passed.
  `

#### Any platform specific information?

Both issues observed on Nokia-7215 , but can affect any platform where containers start slowly after `config_reload`.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A