### PR TITLE
ci: enable impacted area for t1-lag-vpp

### DIFF
--- a/.azure-pipelines/impacted_area_testing/constant.py
+++ b/.azure-pipelines/impacted_area_testing/constant.py
@@ -5,9 +5,11 @@
 # - t0
 # - t0-2vlans
 # - t0-sonic
-# - t1- lag
+# - t1-lag
+# - t1-lag-vpp
 PR_TOPOLOGY_TYPE = ["t0_checker", "t0-2vlans_checker", "t0-sonic_checker", "t1_checker",
-                    "t1-multi-asic_checker", "dpu_checker", "dualtor_checker", "t2_checker"]
+                    "t1-multi-asic_checker", "t1-lag-vpp_checker", "dpu_checker",
+                    "dualtor_checker", "t2_checker"]
 
 EXCLUDE_TEST_SCRIPTS = [
     "test_posttest.py",
@@ -21,6 +23,7 @@ PR_CHECKER_TOPOLOGY_NAME = {
     "t0-sonic": ["t0-64-32", "kvmtest-t0-sonic_"],
     "t1": ["t1-lag", "kvmtest-t1-lag_"],
     "t1-multi-asic": ["t1-8-lag", "kvmtest-multi-asic-t1-lag_"],
+    "t1-lag-vpp": ["t1-lag-vpp", "kvmtest-t1-lag-vpp_"],
     "dpu": ["dpu", "kvmtest-dpu_"],
     "dualtor": ["dualtor", "kvmtest-dualtor-t0_"],
     "t2": ["t2", "kvmtest-t2_"]

--- a/.azure-pipelines/impacted_area_testing/get_test_scripts.py
+++ b/.azure-pipelines/impacted_area_testing/get_test_scripts.py
@@ -16,6 +16,9 @@ import functools
 from natsort import natsorted
 from constant import PR_TOPOLOGY_TYPE, EXCLUDE_TEST_SCRIPTS, CONTROL_PLANE_DEDUP_RULES
 
+VPP_TOPOLOGY = "t1-lag-vpp"
+VPP_CHECKER = "t1-lag-vpp_checker"
+
 
 def topo_name_to_topo_checker(topo_name):
     pattern = re.compile(r'^(ciscovs-7nodes|ciscovs-5nodes|wan|wan-pub-isis|wan-com|wan-pub|wan-pub-cisco|wan-3link-tg|'
@@ -56,6 +59,55 @@ def distribute_scripts_to_PR_checkers(match, script_name, test_scripts_per_topol
                 test_scripts_per_topology_checker[topology_checker].append(script_name)
 
 
+def load_vpp_test_scripts_allowlist():
+    pr_test_scripts_path = os.path.abspath(os.path.join(
+        os.path.dirname(os.path.dirname(__file__)),
+        "pr_test_scripts.yaml"
+    ))
+    try:
+        import yaml
+    except ImportError as e:
+        raise Exception(
+            "PyYAML is required to load {}".format(pr_test_scripts_path)
+        ) from e
+
+    try:
+        with open(pr_test_scripts_path, "r") as f:
+            pr_test_scripts = yaml.safe_load(f)
+    except Exception as e:
+        raise Exception(
+            "Exception occurred while trying to load {}, error {}".format(
+                pr_test_scripts_path, e
+            )
+        )
+
+    if not isinstance(pr_test_scripts, dict) or VPP_TOPOLOGY not in pr_test_scripts:
+        raise Exception(
+            "Missing {} allowlist in {}".format(
+                VPP_TOPOLOGY, pr_test_scripts_path
+            )
+        )
+
+    vpp_scripts = pr_test_scripts[VPP_TOPOLOGY]
+    if not isinstance(vpp_scripts, list):
+        raise Exception(
+            "{} allowlist in {} must be a list".format(
+                VPP_TOPOLOGY, pr_test_scripts_path
+            )
+        )
+
+    return vpp_scripts
+
+
+def build_vpp_impacted_scripts(raw_impacted_scripts, vpp_allowlist):
+    raw_impacted_scripts = set(raw_impacted_scripts)
+    return [
+        script
+        for script in vpp_allowlist
+        if script in raw_impacted_scripts
+    ]
+
+
 def collect_scripts_by_topology_type(features: str, location: str) -> dict:
     """
     This function collects all test scripts under the impacted area and category them by topology type.
@@ -87,11 +139,15 @@ def collect_scripts_by_topology_type(features: str, location: str) -> dict:
     for topology_type in PR_TOPOLOGY_TYPE:
         test_scripts_per_topology_checker[topology_type] = []
 
+    raw_impacted_scripts = []
+
     for s in scripts:
         # Remove prefix from file name:
         script_name = s[len(location) + 1:]
         if script_name in EXCLUDE_TEST_SCRIPTS:
             continue
+
+        raw_impacted_scripts.append(script_name)
 
         try:
             with open(s, 'r') as script:
@@ -103,6 +159,13 @@ def collect_scripts_by_topology_type(features: str, location: str) -> dict:
                         break
         except Exception as e:
             raise Exception('Exception occurred while trying to get topology in {}, error {}'.format(s, e))
+
+    vpp_scripts = build_vpp_impacted_scripts(
+        raw_impacted_scripts,
+        load_vpp_test_scripts_allowlist()
+    )
+    if vpp_scripts:
+        test_scripts_per_topology_checker[VPP_CHECKER] = vpp_scripts
 
     return {k: v for k, v in test_scripts_per_topology_checker.items() if v}
 

--- a/.azure-pipelines/impacted_area_testing/test_get_test_scripts.py
+++ b/.azure-pipelines/impacted_area_testing/test_get_test_scripts.py
@@ -5,13 +5,19 @@ import os
 import sys
 import tempfile
 import shutil
+import builtins
 
 # Ensure the module under test is importable
 sys.path.insert(0, os.path.dirname(__file__))
 
 import pytest  # noqa: E402
 from get_test_scripts import (  # noqa: E402
+    VPP_CHECKER,
+    VPP_TOPOLOGY,
+    build_vpp_impacted_scripts,
+    collect_scripts_by_topology_type,
     dedup_control_plane_tests,
+    load_vpp_test_scripts_allowlist,
     _collect_conftest_files,
     _detect_data_plane_tests,
     _has_traffic_pattern,
@@ -36,6 +42,211 @@ def _write_file(directory, relpath, content=""):
     with open(full, "w") as f:
         f.write(content)
     return full
+
+
+# ── t1-lag-vpp allowlist intersection ─────────────────────
+
+class TestVppImpactedArea:
+
+    def test_vpp_allowlist_intersection_includes_raw_script(
+        self, test_dir, monkeypatch
+    ):
+        tests_dir = os.path.join(test_dir, "tests")
+        _write_file(tests_dir, "bgp/test_allowed.py", "import pytest\n")
+        _write_file(tests_dir, "bgp/test_not_allowed.py", "import pytest\n")
+        monkeypatch.setattr(
+            "get_test_scripts.load_vpp_test_scripts_allowlist",
+            lambda: ["bgp/test_allowed.py"],
+        )
+
+        result = collect_scripts_by_topology_type("bgp", tests_dir)
+
+        assert result[VPP_CHECKER] == ["bgp/test_allowed.py"]
+        assert "bgp/test_not_allowed.py" not in result[VPP_CHECKER]
+
+    def test_vpp_checker_omitted_when_no_allowlisted_impacted_scripts(
+        self, test_dir, monkeypatch
+    ):
+        tests_dir = os.path.join(test_dir, "tests")
+        _write_file(tests_dir, "bgp/test_not_allowed.py", "import pytest\n")
+        monkeypatch.setattr(
+            "get_test_scripts.load_vpp_test_scripts_allowlist",
+            lambda: ["route/test_default_route.py"],
+        )
+
+        result = collect_scripts_by_topology_type("bgp", tests_dir)
+
+        assert VPP_CHECKER not in result
+
+    def test_vpp_output_order_follows_allowlist(
+        self, test_dir, monkeypatch
+    ):
+        tests_dir = os.path.join(test_dir, "tests")
+        _write_file(tests_dir, "bgp/test_first.py", "import pytest\n")
+        _write_file(tests_dir, "bgp/test_second.py", "import pytest\n")
+        monkeypatch.setattr(
+            "get_test_scripts.load_vpp_test_scripts_allowlist",
+            lambda: ["bgp/test_second.py", "bgp/test_first.py"],
+        )
+
+        result = collect_scripts_by_topology_type("bgp", tests_dir)
+
+        assert result[VPP_CHECKER] == [
+            "bgp/test_second.py",
+            "bgp/test_first.py",
+        ]
+
+    def test_vpp_broad_impact_filters_by_allowlist(
+        self, test_dir, monkeypatch
+    ):
+        tests_dir = os.path.join(test_dir, "tests")
+        _write_file(tests_dir, "bgp/test_allowed.py", "import pytest\n")
+        _write_file(tests_dir, "bgp/test_not_allowed.py", "import pytest\n")
+        _write_file(tests_dir, "route/test_allowed.py", "import pytest\n")
+        monkeypatch.setattr(
+            "get_test_scripts.load_vpp_test_scripts_allowlist",
+            lambda: [
+                "route/test_allowed.py",
+                "bgp/test_allowed.py",
+                "missing/test_missing.py",
+            ],
+        )
+
+        result = collect_scripts_by_topology_type("", tests_dir)
+
+        assert result[VPP_CHECKER] == [
+            "route/test_allowed.py",
+            "bgp/test_allowed.py",
+        ]
+
+    def test_vpp_includes_allowlisted_scripts_for_any_marker_shape(
+        self, test_dir, monkeypatch
+    ):
+        tests_dir = os.path.join(test_dir, "tests")
+        scripts = [
+            "bgp/test_t0.py",
+            "bgp/test_t2.py",
+            "bgp/test_any.py",
+            "bgp/test_missing_marker.py",
+        ]
+        _write_file(
+            tests_dir,
+            scripts[0],
+            "pytestmark = [pytest.mark.topology('t0')]\n",
+        )
+        _write_file(
+            tests_dir,
+            scripts[1],
+            "pytestmark = [pytest.mark.topology('t2')]\n",
+        )
+        _write_file(
+            tests_dir,
+            scripts[2],
+            "pytestmark = [pytest.mark.topology('any')]\n",
+        )
+        _write_file(tests_dir, scripts[3], "import pytest\n")
+        monkeypatch.setattr(
+            "get_test_scripts.load_vpp_test_scripts_allowlist",
+            lambda: scripts,
+        )
+
+        result = collect_scripts_by_topology_type("bgp", tests_dir)
+
+        assert result[VPP_CHECKER] == scripts
+
+    def test_build_vpp_impacted_scripts_preserves_allowlist_order(self):
+        result = build_vpp_impacted_scripts(
+            ["bgp/test_first.py", "bgp/test_second.py"],
+            ["bgp/test_second.py", "bgp/test_first.py"],
+        )
+
+        assert result == ["bgp/test_second.py", "bgp/test_first.py"]
+
+    def test_load_vpp_allowlist_requires_yaml_key(
+        self, test_dir, monkeypatch
+    ):
+        pipeline_dir = os.path.join(test_dir, ".azure-pipelines")
+        _write_file(pipeline_dir, "pr_test_scripts.yaml", "t0: []\n")
+        monkeypatch.setattr(
+            "get_test_scripts.__file__",
+            os.path.join(
+                pipeline_dir,
+                "impacted_area_testing",
+                "get_test_scripts.py",
+            ),
+        )
+
+        with pytest.raises(
+            Exception,
+            match="Missing {} allowlist".format(VPP_TOPOLOGY)
+        ):
+            load_vpp_test_scripts_allowlist()
+
+    def test_load_vpp_allowlist_requires_list(
+        self, test_dir, monkeypatch
+    ):
+        pipeline_dir = os.path.join(test_dir, ".azure-pipelines")
+        _write_file(
+            pipeline_dir,
+            "pr_test_scripts.yaml",
+            "{}: invalid\n".format(VPP_TOPOLOGY),
+        )
+        monkeypatch.setattr(
+            "get_test_scripts.__file__",
+            os.path.join(
+                pipeline_dir,
+                "impacted_area_testing",
+                "get_test_scripts.py",
+            ),
+        )
+
+        with pytest.raises(Exception, match="must be a list"):
+            load_vpp_test_scripts_allowlist()
+
+    def test_load_vpp_allowlist_reports_load_error(
+        self, test_dir, monkeypatch
+    ):
+        pipeline_dir = os.path.join(test_dir, ".azure-pipelines")
+        monkeypatch.setattr(
+            "get_test_scripts.__file__",
+            os.path.join(
+                pipeline_dir,
+                "impacted_area_testing",
+                "get_test_scripts.py",
+            ),
+        )
+
+        with pytest.raises(Exception, match="trying to load"):
+            load_vpp_test_scripts_allowlist()
+
+    def test_load_vpp_allowlist_reports_missing_pyyaml(
+        self, test_dir, monkeypatch
+    ):
+        pipeline_dir = os.path.join(test_dir, ".azure-pipelines")
+        _write_file(
+            pipeline_dir,
+            "pr_test_scripts.yaml",
+            "{}: []\n".format(VPP_TOPOLOGY),
+        )
+        monkeypatch.setattr(
+            "get_test_scripts.__file__",
+            os.path.join(
+                pipeline_dir,
+                "impacted_area_testing",
+                "get_test_scripts.py",
+            ),
+        )
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "yaml":
+                raise ImportError("No module named yaml")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        with pytest.raises(Exception, match="PyYAML is required"):
+            load_vpp_test_scripts_allowlist()
 
 
 # ── dedup_control_plane_tests ──────────────────────────────

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -53,7 +53,7 @@ parameters:
   type: string
   default: "sonic-mgmt"
 
-# Keys: "dpu_checker","dualtor_checker","t0-2vlans_checker","t0-sonic_checker","t0_checker","t1-multi-asic_checker","t1_checker","t2_checker"
+# Keys: "dpu_checker","dualtor_checker","t0-2vlans_checker","t0-sonic_checker","t0_checker","t1-lag-vpp_checker","t1-multi-asic_checker","t1_checker","t2_checker"
 # Example: {"t0_checker": ["bgp/test_bgp_command.py", "bgp/test_ping_bgp_neighbor.py"], "t1_checker": ["bgp/test_bgp_fact.py"]}
 - name: IMPACT_AREA_INFO
   type: object
@@ -454,32 +454,46 @@ jobs:
             ${{ param.key }}: ${{ param.value }}
 
   - job: t1_lag_vpp_elastictest
-    displayName: "kvmtest-t1-lag-vpp by Elastictest"
+    displayName: "impacted-area-kvmtest-t1-lag-vpp by Elastictest"
     dependsOn:
     - get_impacted_area
     - cancel_previous_test_plan_for_same_pr
     variables:
+      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       RUN_BY_INCLUDE_JOBS: ${{ or(eq(parameters.INCLUDE_JOBS, 'all'), contains(parameters.INCLUDE_JOBS, 't1_lag_vpp_job')) }}
-    condition: and(not(canceled()), eq(variables['RUN_BY_INCLUDE_JOBS'], 'True'))
+    condition: and(not(canceled()), succeeded(), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't1-lag-vpp_checker'), eq(variables['RUN_BY_INCLUDE_JOBS'], 'True'))
     timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     pool: ${{ parameters.RUN_TEST_AGENT_POOL }}
     steps:
+      - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
+        - checkout: ${{ parameters.SONIC_MGMT_NAME }}
+          displayName: "Checkout sonic-mgmt repository"
+
+      - template: impacted_area_testing/calculate-instance-numbers.yml
+        parameters:
+          TOPOLOGY: t1-lag-vpp
+          BUILD_BRANCH: $(BUILD_BRANCH)
+
       - template: run-test-elastictest-template.yml
         parameters:
           BUILD_REASON: ${{ parameters.BUILD_REASON }}
           RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
+          STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
           TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
           MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
           MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
           PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
           EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
           TOPOLOGY: t1-lag-vpp
-          MIN_WORKER: $(T1_LAG_VPP_INSTANCE_NUM)
-          MAX_WORKER: $(T1_LAG_VPP_INSTANCE_NUM)
+          SCRIPTS: $(SCRIPTS)
+          MIN_WORKER: $(INSTANCE_NUMBER)
+          MAX_WORKER: $(INSTANCE_NUMBER)
           KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
           KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
           MGMT_BRANCH: $(BUILD_BRANCH)
           ASIC_TYPE: "vpp"
           KVM_IMAGE_BUILD_PIPELINE_ID: "2818"
           COMMON_EXTRA_PARAMS: "--disable_sai_validation --disable_loganalyzer"
+          ${{ each param in parameters.OVERRIDE_PARAMS }}:
+            ${{ param.key }}: ${{ param.value }}

--- a/.azure-pipelines/pre_defined_pr_test.yml
+++ b/.azure-pipelines/pre_defined_pr_test.yml
@@ -28,7 +28,7 @@ parameters:
   type: string
   default: " "
 
-# Keys: "dpu_checker","dualtor_checker","t0-2vlans_checker","t0-sonic_checker","t0_checker","t1-multi-asic_checker","t1_checker","t2_checker"
+# Keys: "dpu_checker","dualtor_checker","t0-2vlans_checker","t0-sonic_checker","t0_checker","t1-lag-vpp_checker","t1-multi-asic_checker","t1_checker","t2_checker"
 # Example: {"t0_checker": ["bgp/test_bgp_command.py", "bgp/test_ping_bgp_neighbor.py"], "t1_checker": ["bgp/test_bgp_fact.py"]}
 - name: IMPACT_AREA_INFO
   type: object


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enable impacted-area filtering for the `t1-lag-vpp` PR checker. 

Fixes # (issue) Microsoft ADO 37938318

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

`t1-lag-vpp` currently runs as a standalone PR checker and does not consume impacted-area output. This means it cannot be narrowed by impacted test scripts the same way existing impacted-area PR checkers can.

#### How did you do it?
Added `t1-lag-vpp_checker` to the impacted-area flow without requiring `pytest.mark.topology('t1-lag-vpp')` markers on test files. Instead, VPP impacted scripts are computed as:

 ```text
 raw impacted feature-folder test scripts ∩ .azure-pipelines/pr_test_scripts.yaml["t1-lag-vpp"]
```

This keeps the current t1-lag-vpp allowlist as the source of truth and avoids adding VPP-specific topology marker.

#### How did you verify/test it?
Added unit tests covering different scenarios like VPP allowlist intersection, missing/malformed allowlist error handling, and missing PyYAML error handling etc. Also verified with some debug changes in https://github.com/sonic-net/sonic-mgmt/pull/24593

**Why does this PR #24590 run (almost) all PR checker jobs?**

This PR modifies `.azure-pipelines/*` files only. The existing impacted-area logic treats non-tests/ changes as broad
impact:
```python
 else
   FINAL_FEATURES=""
   break
 fi
```

`FINAL_FEATURES=""` causes `get_test_scripts.py` to scan all test features, so it emits all applicable checker keys. With
the default `INCLUDE_JOBS`, this means all default impacted-area PR checker jobs are expected to run, including the newly
added `t1_lag_vpp_elastictest`.

>dualtor_checker may be generated by impacted-area discovery, especially for broad-impact changes, but the dualtor PR job does not run by default. The job has a second gate on `INCLUDE_JOBS`, and we intentionally exclude `dualtor_job` due to prior PR test capacity/resource concerns

**Why does debug PR #24593 only run a few checker jobs?**

PR #24593 is a temporary debug-only PR. It intentionally changes get-impacted-area.yml so non-tests/ changes are **ignored**. It also adds dummy test changes under selected test feature folders.

Because impacted-area discovery works at feature-folder granularity, not individual file granularity, the dummy test
changes resolve to: `FINAL_FEATURES=generic_config_updater,srv6`. Then only tests under those feature folders are scanned. In that debug PR, the generated checker keys were limited to:
```text
t0_checker,t1-lag-vpp_checker,t1_checker,t2_checker
```

Therefore #24593 only ran the checker jobs matching those keys and default `INCLUDE_JOBS`. This was intentional to
validate the VPP impacted-area path with lower CI cost. The debug-only change is not part of this production PR.

#### Any platform specific information?
t1-lag-vpp

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
