### PR TITLE
[202511][Backport #23939] Remove BUFFER_SIZE override in test_dhcp_counter_stress

### DIFF
--- a/tests/dhcp_relay/test_dhcp_counter_stress.py
+++ b/tests/dhcp_relay/test_dhcp_counter_stress.py
@@ -21,7 +21,6 @@ BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
 DEFAULT_DHCP_CLIENT_PORT = 68
 DEFAULT_DHCP_SERVER_PORT = 67
 DUAL_TOR_MODE = 'dual'
-BUFFER_SIZE = 1024  # 1 MiB (tcpdump --buffer-size is in KiB)
 logger = logging.getLogger(__name__)
 PACKET_RATE_PER_SEC_MAP = {
     "Mellanox-SN2700": 20
@@ -125,7 +124,6 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
             pkts_filter="udp dst port %s or udp dst port %s" % (DEFAULT_DHCP_SERVER_PORT,
                                                                 DEFAULT_DHCP_CLIENT_PORT),
             pkts_validator=_verify_packets,
-            tcpdump_buffer_size=BUFFER_SIZE
         ):
             ptf_runner(ptfhost, "ptftests", "dhcp_relay_stress_test.DHCPStress{}Test".format(dhcp_type.capitalize()),
                        platform_dir="ptftests", params=params,


### PR DESCRIPTION
Partial back-port of #23939 — only the buffer-size removal part.

The other changes in #23939 (adding `relay_agent`/`downlink_vlan_iface_name` ptf_runner params, dropping `.json` from `count_file` path) depend on PR #19198 which was reverted from 202511 by #23714, so they don't apply here.

**Why**

After PR #22876 was back-ported to 202511, the framework default for `tcpdump_buffer_size` (in `capture_and_check_packet_on_dut`) dropped from 100 MiB to 4 MiB. The explicit `BUFFER_SIZE = 1024` (1 MiB) override in this test is now smaller than the framework default. Removing the override lets the test use the (larger) framework default and matches master.

**Note**

The 4 MiB default is still too small to fully pass on 720dt-class hardware under this test's stress load. A follow-up PR will raise the default in `capture_and_check_packet_on_dut`. This PR is pure cleanup to bring 202511 in line with master.

**Tested**

Applied locally on `internal-202511` @ `da7363c`, `testbed-bjw2-can-720dt-6` (Arista-720DT-G48S4, SONiC.20251110.26):
- Before (1 MiB): tcpdump drops ~13% of relayed packets, FAIL
- After (4 MiB framework default): drops reduced to ~7%, still over the 0.01% margin (follow-up PR will fix)
- For reference, 64 MiB passes cleanly.

Refs: #23939, #22876, #20580.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>