### PR TITLE
[utilities] Raise tcpdump_buffer_size default in capture_and_check_packet_on_dut

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1312,7 +1312,7 @@ def capture_and_check_packet_on_dut(
     pkts_validator_args=[],
     pkts_validator_kwargs={},
     wait_time=1,
-    tcpdump_buffer_size=4096
+    tcpdump_buffer_size=131072
 ):
     """
     Capture packets on DUT and check if the packet is expected


### PR DESCRIPTION
**Why**

PR #22876 cut the default `tcpdump_buffer_size` in `capture_and_check_packet_on_dut` from 102400 KiB (100 MiB) to 4096 KiB (4 MiB) to address the 1 GiB explicit override in `test_dhcp_counter_stress` causing a ~2 GiB memory spike. The 4 MiB default, however, is too small for normal stress-test workloads with bursty packet rates on lower-perf platforms (720dt, 7215).

**Note: PR #22876 was not actually validated.**

The `How did you verify/test it?` section of #22876 only states:

> - Code passes flake8 with max-line-length=120
> - Fix matches the exact unit interpretation from tcpdump documentation

No test execution. The 4 MiB value was a unit-correction choice based on tcpdump docs, not an empirically-tested minimum. As shown by the data below, 4 MiB drops 7.2% of relayed DHCP packets on real hardware — i.e. the new default was never validated against the stress-test workload that motivated the change.

Empirical measurements on `testbed-bjw2-can-720dt-6` (Arista-720DT-G48S4, SONiC.20251110.26) running `test_dhcp_counter_stress[discover]` (25 pps × 48 servers × 120 s):

| Buffer | tcpdump drop rate vs dhcpmon counter | test result |
|---:|---:|---|
| 1 MiB | 13.0% | FAIL |
| **4 MiB (current default, set by #22876)** | **7.2%** | **FAIL** |
| 16 MiB | 1.47% | FAIL |
| 64 MiB | <0.01% | PASS |

**How**

Bump default from `4096` (4 MiB) to `131072` (128 MiB). Gives comfortable headroom for stress tests on slow platforms while remaining 8× smaller than the historical 1 GiB explicit override that caused memory spikes.

**Back port request**
- [x] 202511

Refs: PR #22876 (commit 58a6f0b), PR #20580, PR #24592 (companion 202511-only cleanup).