### PR TITLE
[conditional_mark] xfail test_reload_configuration on Cisco-8102 due to timemaster.service

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1490,6 +1490,10 @@ platform_tests/test_reload_config.py::test_reload_configuration:
     conditions:
       - "asic_type in ['barefoot'] and hwsku in ['newport']"
       - "https://github.com/sonic-net/sonic-buildimage/issues/19879 and asic_type in ['vs']"
+  xfail:
+    reason: "timemaster.service fails benignly on Cisco-8102 lab DUTs (no reachable NTP/PTP source), causing 'systemctl is-system-running' to report 'degraded' and trip config_system_checks_passed. Data plane is unaffected."
+    conditions:
+      - "platform in ['x86_64-8102_64h_o-r0']"
 
 platform_tests/test_reload_config.py::test_reload_configuration_checks:
   skip:


### PR DESCRIPTION
### Description of PR

Summary:
On Cisco-8102 lab DUTs running recent SONiC images, `timemaster.service` fails benignly (no reachable NTP/PTP source in the lab management network). This causes `systemctl is-system-running` to report `degraded`, which trips `config_system_checks_passed` in `test_reload_configuration`. The pre-reload system-state gate at `platform_tests/test_reload_config.py:63` then polls for 360s and asserts:

```
$ systemctl is-system-running
degraded                 (rc=1)

$ systemctl list-units --state=failed
* timemaster.service loaded failed failed  Synchronize system clock to NTP and PTP time sources
1 loaded units listed.
```

The failure is unrelated to the data plane and unrelated to `config reload` itself - the assertion fires before the test ever invokes `config reload`. Reproduced on multiple Cisco-8102 testbeds in the same nightly plan.

This PR adds an `xfail` clause scoped strictly to `platform == 'x86_64-8102_64h_o-r0'` while the underlying `timemaster.service` issue is tracked separately on the platform/image side. The test still runs (so XPASS will surface once the platform issue is fixed); only the assertion is allowed to fail without breaking the plan.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Unblock the Cisco-8102 nightly pipeline while the platform-side `timemaster.service` issue is tracked separately. The current assertion provides no actionable signal - it only reports that a non-data-plane systemd unit is in a failed state, which is already known.

#### How did you do it?
YAML-only change in `conditional_mark`. Added an `xfail` block next to the existing `skip` block on `platform_tests/test_reload_config.py::test_reload_configuration`, with a single condition matching the 8102 platform string.

```yaml
  xfail:
    reason: "timemaster.service fails benignly on Cisco-8102 lab DUTs ..."
    conditions:
      - "platform in ['x86_64-8102_64h_o-r0']"
```

#### How did you verify/test it?
- Inspected pytest log from a failing nightly run: assertion at `test_reload_config.py:63` with `timemaster.service` as the sole failed unit on str2-8102-01.
- Confirmed `conditional_mark` supports concurrent `skip` + `xfail` blocks on the same test - precedent at `platform_tests/test_reboot.py::test_watchdog_reboot` in the same YAML file.
- Confirmed the platform string `x86_64-8102_64h_o-r0` is already used in this YAML (see `test_watchdog_reboot`).
- Other Cisco-8000 SKUs (8101, 8111, 8800-LC) and all non-Cisco platforms are unaffected because the condition matches the exact 8102 platform string only.

#### Any platform specific information?
Cisco-8102 only (`x86_64-8102_64h_o-r0`).

#### Supported testbed topology if it's a new test case?
N/A - existing test, no topology change.

### Documentation
N/A - no user-facing behavior or feature changes.