### PR TITLE
[C1]Skipped checking for /proc/dma for Nokia-7215-C1 platforms

### DIFF
--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -557,7 +557,7 @@ def commands_to_check(duthosts, enum_rand_one_per_hwsku_hostname):
                 }
             )
     # Remove /proc/dma for armh
-    elif duthost.facts["asic_type"] in ["marvell-prestera", "marvell"]:
+    elif duthost.facts["asic_type"] in ["marvell-prestera", "marvell", "nokia-vs"]:
         if 'armhf-' in duthost.facts["platform"] or 'arm64-' in duthost.facts["platform"]:
             cmds.copy_proc_files.remove("/proc/dma")
     elif duthost.facts["asic_type"] == "vpp":


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
/proc/dma file is not supported on Nokia-7215-C1 platforms. so adding asic to list that skips checking for /proc/dma in test_techsupport.py
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
/proc/dma file is not supported on Nokia-7215-C1 platforms. Need to be skipped
#### How did you do it?
Added asic to list to skip checking for /proc/dma
#### How did you verify/test it?
Run test_techsupport.py on Nokia-7215-C1 platforms
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
