### PR TITLE
Fixing a packet trimming counter test failure seen on TH5

### DIFF
--- a/tests/packet_trimming/base_packet_trimming.py
+++ b/tests/packet_trimming/base_packet_trimming.py
@@ -403,7 +403,11 @@ class BasePacketTrimming:
                 # Trigger trimmed packets on queue6
                 counter_kwargs = self.get_verify_trimmed_counter_packet_kwargs(duthost, ptfadapter,
                                                                                {**trim_counter_params})
-                counter_kwargs.update({'expect_packets': False})
+                # TH5 cannot completely block egress queues, so trimmed packets will leak out of the trim queues.
+                if duthost.get_asic_name() == "th5":
+                    counter_kwargs.update({'expect_packets': "skip"})
+                else:
+                    counter_kwargs.update({'expect_packets': False})
                 verify_trimmed_packet(**counter_kwargs)
 
                 # Get the TrimDrop counters on port level

--- a/tests/packet_trimming/packet_trimming_helper.py
+++ b/tests/packet_trimming/packet_trimming_helper.py
@@ -948,7 +948,7 @@ def verify_packet_trimming(duthost, ptfadapter, ingress_port, egress_port, block
                     verify_ports = [egress_port['ptf_id']]
 
                 # Verify packet based on expectation
-                if expect_packets:
+                if expect_packets is True:
                     logger.info(
                         f"Expecting packets on ports {verify_ports} with size {recv_pkt_size} and DSCP {recv_pkt_dscp}")
                     _, matched = testutils.verify_packet_any_port(
@@ -961,7 +961,7 @@ def verify_packet_trimming(duthost, ptfadapter, ingress_port, egress_port, block
                     logger.info(
                         f"Successfully verified {packet_type} packet trimming with size {recv_pkt_size} "
                         f"and DSCP {recv_pkt_dscp}")
-                else:
+                elif expect_packets is False:
                     logger.info(f"Expecting NO packets on any of ports {verify_ports}")
                     testutils.verify_no_packet_any(
                         ptfadapter,
@@ -970,6 +970,8 @@ def verify_packet_trimming(duthost, ptfadapter, ingress_port, egress_port, block
                         timeout=timeout
                     )
                     logger.info(f"Successfully verified NO {packet_type} packets were received as expected")
+                else:
+                    logger.info(f"Skip capturing packets on ports {verify_ports}.")
 
         return True
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR fixes a test failure in `test_trimming_counters` seen on TH5 devices.

Summary:
Microsoft ADO ID: 37947965
Fixed a packet trimming counter test failure seen on TH5.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The last step of `test_trimming_counters` is to block the trim queue and verify trim drop counters. The test does not expect to receive any trimmed packets since the trim queue is blocked. However, TH5 switches cannot completely block egress queues. So the test fails because trimmed packets leak out from the trim queue at a very low rate.

#### How did you do it?
For TH5 switches, we skip checking that no trimmed packet is captured on the egress port.

#### How did you verify/test it?
Ran the test on a TH5 device after changes:
```
packet_trimming/test_packet_trimming_symmetric.py::TestPacketTrimmingSymmetric::test_trimming_counters PASSED                                         [100%]
```

#### Any platform specific information?
The behavior of the test is only changed for TH5.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
