### PR TITLE
[202511] Fix MACsec test reliability and configuration issues (#21372)

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -751,7 +751,7 @@
           macsec_profile: "{{ macsec_profile }}"
           num_asics: "{{ num_asics }}"
         become: true
-        when: "('t2' in topo) and (enable_macsec is defined)"
+        when: "('t2' in topo) and (macsec_profile is defined)"
 
       - name: Use minigraph case
         block:

--- a/ansible/templates/golden_config_db_t2.j2
+++ b/ansible/templates/golden_config_db_t2.j2
@@ -23,8 +23,7 @@
 {% endif %}
 {%- endfor -%}
 {% else %}
-  {
-    "MACSEC_PROFILE": {
+  "MACSEC_PROFILE": {
       "{{macsec_profile}}": {
         "priority": "{{priority}}",
         "cipher_suite": "{{cipher_suite}}",
@@ -34,6 +33,5 @@
         "send_sci": "{{send_sci}}"
       }
     }
-  },
 {%- endif -%}
 }

--- a/tests/macsec/test_docker_restart.py
+++ b/tests/macsec/test_docker_restart.py
@@ -3,6 +3,8 @@ import logging
 
 from tests.common.utilities import wait_until
 from tests.common.macsec.macsec_helper import check_appl_db
+from tests.common.helpers.dut_utils import restart_service_with_startlimit_guard
+
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +19,6 @@ def test_restart_macsec_docker(duthosts, ctrl_links, policy, cipher_suite, send_
     duthost = duthosts[enum_rand_one_per_hwsku_macsec_frontend_hostname]
 
     logger.info(duthost.shell(cmd="docker ps", module_ignore_errors=True)['stdout'])
-    duthost.restart_service("macsec")
+    restart_service_with_startlimit_guard(duthost, "macsec", backoff_seconds=35, verify_timeout=180)
     logger.info(duthost.shell(cmd="docker ps", module_ignore_errors=True)['stdout'])
     assert wait_until(300, 6, 12, check_appl_db, duthost, ctrl_links, policy, cipher_suite, send_sci)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This PR addresses three issues related to MACsec testing and configuration in sonic-mgmt:

1. **Fix JSON syntax error in T2 golden config template** - Corrects malformed JSON in `golden_config_db_t2.j2` that caused parsing errors when MACsec was enabled
2. **Avoid redundant MACsec profile configuration** - Prevents generating MACsec golden config when no profile is defined in the prepare phase
3. **Improve MACsec docker restart test reliability** - Adds systemd StartLimitHit protection to prevent test flakiness during rapid restart cycles
4. **Fix MACsec test race and clean-up sync**- Ensure MKA establishment before pre-loading MACsec session info for tests and provide a helper to wait for MACsec DB cleanup after disabling MACsec

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
These changes improve MACsec test stability and fix configuration generation issues that occur when MACsec is enabled on T2 testbeds.

### Type of change


<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
 - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
**Issue 1 - JSON Syntax Error:**
- When preparing DUT with MACsec enabled, the golden config template generated invalid JSON causing: `json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes`

**Issue 2 - Redundant Configuration:**
- MACsec profile configuration was being generated during PREPARE phase even when no profile was defined, leading to redundant override configs
- The actual MACsec profile should only be set during RUN phase via `set_macsec_profile()` using direct `sonic-db-cli` commands

**Issue 3 - Test Flakiness:**
- MACsec docker restart tests intermittently failed when systemd enforced StartLimitHit due to rapid restart attempts during teardown/restart cycles
- No mechanism existed to handle systemd rate limiting gracefully

**Issue 4 - Test Race:**
- Tests fail with exceptions like KeyError('sak') when the MACsec egress SA row does not yet exist, even though MACSEC_PORT_TABLE already shows enable_encrypt="true". 
- There are also cleanup races where tests check for removal of MACsec DB entries before the background cleanup logic has finished

#### How did you do it?
**Fix 1 - JSON Template:**
- Corrected JSON syntax in `ansible/templates/golden_config_db_t2.j2` to ensure valid JSON output

**Fix 2 - Conditional Config Generation:**
- Modified `ansible/config_sonic_basedon_testbed.yml` to only generate MACsec golden config when `macsec_profile` is actually defined
- This aligns with the two-phase approach:
 - **PREPARE phase:** Uses `generate_t2_golden_config_db()` → template rendering → file-based config
 - **RUN phase:** Uses `set_macsec_profile()` → direct sonic-db-cli commands → immediate CONFIG_DB update

**Fix 3 - StartLimitHit Guard:**
- Added new helper `restart_service_with_startlimit_guard()` in `tests/common/helpers/dut_utils.py` that:
 - Proactively clears systemd failure counters (`systemctl reset-failed`)
 - Detects systemd rate limiting (StartLimitHit)
 - Applies bounded backoff (default 35s) when rate-limited
 - Executes `systemctl start` after backoff
 - Verifies the target container becomes running within timeout
- Updated `tests/macsec/test_docker_restart.py` to use the new helper instead of direct `duthost.restart_service("macsec")`

**Fix 4 -Wait for MKA and Cleanup:**
- By tying load_macsec_info to wait_mka_establish where available, we ensure those pre-loads happen only after the expected MACsec state has been fully written to Redis
- Similarly, when disabling MACsec, asynchronous background cleanup can lag behind the test’s expectations. Having a dedicated, reusable wait_for_macsec_cleanup helper lets future tests explicitly wait for cleanup completion instead of guessing with sleeps

#### How did you verify/test it?
**Fix 1 & 2:**
- Verified T2 testbed preparation with MACsec enabled completes without JSON parsing errors
- Confirmed no redundant MACsec profile configuration is generated when profile is undefined
- Validated that MACsec profile is correctly applied during RUN phase via `set_macsec_profile()`

**Fix 3:**
- Executed `tests/macsec/test_docker_restart.py::test_restart_macsec_docker` with MACsec enabled in lab environment
- Repeated restart sequences to emulate systemd rate limiting scenarios
- Verified the helper reliably recovers from StartLimitHit and container reaches running state within timeout
- Confirmed reduced test flakiness in repeated test runs

**Fix 4:**
Manually exercised MACsec configuration and teardown flows in a MACsec-enabled testbed to confirm:
- MACsec sessions establish successfully and APP/STATE DB contain expected MACsec entries before load_all_macsec_info is invoked.
- Disabling MACsec followed by wait_for_macsec_cleanup results in all MACSEC_* keys being removed from APPL/STATE DB within the timeout window.

#### Any platform specific information?
These fixes apply to all platforms that support MACsec, particularly affecting T2 topology testbeds.

#### Supported testbed topology if it's a new test case?
N/A - These are improvements to existing test infrastructure and configuration templates.

### Documentation
No documentation updates required as these are bug fixes and internal test improvements that don't change user-facing behavior or add new features.
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->





