### PR TITLE
Use cryptography library to add buffer for notBefore field to gnmi/telemetry certs

### DIFF
--- a/tests/common/cert_utils.py
+++ b/tests/common/cert_utils.py
@@ -163,6 +163,13 @@ class TlsCertificateGenerator:
                 ),
                 critical=True,
             )
+            # SubjectKeyIdentifier matches what `openssl req -x509` adds by
+            # default. Required so the CRL flow (which sets
+            # authorityKeyIdentifier=keyid:always) can resolve.
+            .add_extension(
+                x509.SubjectKeyIdentifier.from_public_key(key.public_key()),
+                critical=False,
+            )
             .sign(key, hashes.SHA256())
         )
 

--- a/tests/common/gnmi_setup.py
+++ b/tests/common/gnmi_setup.py
@@ -15,6 +15,7 @@ import time
 
 import tests.common.gu_utils as gu_utils
 
+from tests.common.cert_utils import TlsCertificateGenerator
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
 from tests.common.utilities import wait_until
 from tests.common.helpers.ntp_helper import NtpDaemon, get_ntp_daemon_in_use   # noqa: F401
@@ -175,9 +176,17 @@ def recover_cert_config(duthost):
 
 def create_certificates(localhost, duthost_mgmt_ip, cert_path: Path):
     """
-    Create GNMI CA, server and client certificates
-    :param localhost: localhost fixture
-    :param duthost_mgmt_ip: DUT management IP
+    Create GNMI CA, server and client certificates.
+
+    Builds the test PKI in-process via cryptography (not openssl shell) so
+    that notBefore can be backdated by 7 days. This absorbs clock skew
+    between the sonic-mgmt runner, the DUT, and the PTF docker; otherwise
+    the TLS handshake fails with "certificate is not yet valid". The
+    openssl 3.0.x runtime on Ubuntu 24.04 has no CLI flag to set
+    notBefore on `req -x509` or `x509 -req` (added only in 3.5).
+
+    :param localhost: localhost fixture (unused; kept for backward compat)
+    :param duthost_mgmt_ip: DUT management IP (included in server cert SAN)
     :param cert_path: Path to store the certificates
     :return: True if successful, False otherwise
     """
@@ -200,105 +209,24 @@ def create_certificates(localhost, duthost_mgmt_ip, cert_path: Path):
         logger.error(f"Failed to create directory {dest_dir}: {e}")
         raise Exception(f"Failed to create directory {dest_dir}: {e}")
 
-    # Create CA key and certificate
-    logger.info("Creating CA key and certificate.")
-    key_file = str(dest_dir / 'gnmiCA.key')
-    out_file = str(dest_dir / 'gnmiCA.pem')
-    logger.debug(f"CA key file: {key_file}, CA certificate file: {out_file}")
-    local_command = f"openssl genrsa -out {key_file} 2048"
-    localhost.shell(local_command)
-    local_command = (
-        f"openssl req -x509 -new -nodes -key {key_file} "
-        f"-sha256 -days 1825 -subj '/CN=test.gnmi.sonic' "
-        f"-out {out_file}"
-    )
-    out = localhost.shell(local_command)
-    if out['rc'] != 0:
-        logger.error(f"Failed to create CA certificate {out['stderr']}")
-        return False
-
-    # Create server key
-    logger.info("Creating server key.")
-    key_file = str(dest_dir / 'gnmiserver.key')
-    logger.debug(f"Server key file: {key_file}")
-    local_command = f"openssl genrsa -out {key_file} 2048"
-    out = localhost.shell(local_command)
-    if out['rc'] != 0:
-        logger.error(f"Failed to create server key {out['stderr']}")
-        return False
-
-    # Create server CSR
-    logger.info("Creating server CSR.")
-    out_file = str(dest_dir / 'gnmiserver.csr')
-    logger.debug(f"Server CSR file: {out_file}")
-    local_command = (
-        f"openssl req -new -key {key_file} "
-        f"-subj '/CN=test.server.gnmi.sonic' -out {out_file}"
-    )
-    localhost.shell(local_command)
-    if out['rc'] != 0:
-        logger.error(f"Failed to create server CSR {out['stderr']}")
-        return False
-
-    # Sign server certificate
-    logger.info("Signing server certificate.")
-    extfile_path = str(dest_dir / 'extfile.cnf')
-    logger.debug(f"Extension file path: {extfile_path}")
-    create_ext_conf(duthost_mgmt_ip, extfile_path)
-    ca_key = str(dest_dir / 'gnmiCA.key')
-    ca_pem = str(dest_dir / 'gnmiCA.pem')
-    in_file = str(dest_dir / 'gnmiserver.csr')
-    out_file = str(dest_dir / 'gnmiserver.crt')
-    logger.debug(f"CA key: {ca_key}, CA PEM: {ca_pem}, Input CSR: {in_file}, Output CRT: {out_file}")
-    local_command = (
-        f"openssl x509 -req -in {in_file} "
-        f"-CA {ca_pem} -CAkey {ca_key} -CAcreateserial "
-        f"-out {out_file} -days 825 -sha256 "
-        f"-extensions req_ext -extfile {extfile_path}"
-    )
-    out = localhost.shell(local_command)
-    if out['rc'] != 0:
-        logger.error(f"Failed to sign server certificate {out['stderr']}")
-        return False
-
-    # Create client key
-    logger.info("Creating client key.")
-    key_file = str(dest_dir / 'gnmiclient.key')
-    logger.debug(f"Client key file: {key_file}")
-    local_command = f"openssl genrsa -out {key_file} 2048"
-    out = localhost.shell(local_command)
-    if out['rc'] != 0:
-        logger.error(f"Failed to create client key {out['stderr']}")
-        return False
-
-    # Create client CSR
-    logger.info("Creating client CSR.")
-    out_file = str(dest_dir / 'gnmiclient.csr')
-    logger.debug(f"Client CSR file: {out_file}")
-    local_command = (
-        f"openssl req -new -key {key_file} "
-        f"-subj '/CN=test.client.gnmi.sonic' -out {out_file}"
-    )
-    out = localhost.shell(local_command)
-    if out['rc'] != 0:
-        logger.error(f"Failed to create client CSR {out['stderr']}")
-        return False
-
-    # Sign client certificate
-    logger.info("Signing client certificate.")
-    in_file = str(dest_dir / 'gnmiclient.csr')
-    ca_pem = str(dest_dir / 'gnmiCA.pem')
-    ca_key = str(dest_dir / 'gnmiCA.key')
-    out_file = str(dest_dir / 'gnmiclient.crt')
-    logger.debug(f"CA key: {ca_key}, CA PEM: {ca_pem}, Input CSR: {in_file}, Output CRT: {out_file}")
-    local_command = (
-        f"openssl x509 -req -in {in_file} "
-        f"-CA {ca_pem} -CAkey {ca_key} "
-        f"-CAcreateserial -out {out_file} -days 825 -sha256"
-    )
-    out = localhost.shell(local_command)
-    if out['rc'] != 0:
-        logger.error(f"Failed to sign client certificate {out['stderr']}")
+    try:
+        generator = TlsCertificateGenerator(
+            server_ip=duthost_mgmt_ip,
+            backdate_days=7,
+            dns_names=["hostname.com"],
+            ca_cn="test.gnmi.sonic",
+            server_cn="test.server.gnmi.sonic",
+            client_cn="test.client.gnmi.sonic",
+            ca_cert_name="gnmiCA.pem",
+            ca_key_name="gnmiCA.key",
+            server_cert_name="gnmiserver.crt",
+            server_key_name="gnmiserver.key",
+            client_cert_name="gnmiclient.crt",
+            client_key_name="gnmiclient.key",
+        )
+        generator.write_all(str(dest_dir))
+    except Exception as e:
+        logger.error(f"Failed to generate GNMI certificates: {e}")
         return False
 
     logger.info("Certificate creation process completed successfully.")

--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -1,4 +1,11 @@
+import ipaddress
 import logging
+import re
+from datetime import datetime, timedelta, timezone
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.x509.oid import NameOID
 
 logger = logging.getLogger(__name__)
 
@@ -6,6 +13,50 @@ logger = logging.getLogger(__name__)
 GNMI_CERT_NAME = "test.client.gnmi.sonic"
 REVOKED_GNMICERT_NAME = "test.client.revoked.gnmi.sonic"
 TELEMETRY_CONTAINER = "telemetry"
+
+# Backdate notBefore on test certs to absorb clock skew between the
+# sonic-mgmt runner, the DUT, and the PTF docker. Without this, even a
+# few minutes of drift produces TLS handshake failures with
+# "certificate is not yet valid". We do the signing in-process via
+# cryptography because the openssl 3.0.x CLI on the runner has no flag
+# to set notBefore on `req -x509` / `x509 -req` (added only in 3.5).
+_CERT_BACKDATE_DAYS = 7
+
+
+def _cert_validity_period(days):
+    """notBefore is backdated by _CERT_BACKDATE_DAYS; notAfter is `days` from now."""
+    now = datetime.now(timezone.utc)
+    not_before = now - timedelta(days=_CERT_BACKDATE_DAYS)
+    not_after = now + timedelta(days=int(days))
+    return not_before, not_after
+
+
+def _load_pem_private_key(path):
+    with open(path, "rb") as f:
+        return serialization.load_pem_private_key(f.read(), password=None)
+
+
+def _load_pem_certificate(path):
+    with open(path, "rb") as f:
+        return x509.load_pem_x509_certificate(f.read())
+
+
+def _load_pem_csr(path):
+    with open(path, "rb") as f:
+        return x509.load_pem_x509_csr(f.read())
+
+
+def _write_pem_certificate(path, cert):
+    with open(path, "wb") as f:
+        f.write(cert.public_bytes(serialization.Encoding.PEM))
+
+
+def _parse_crl_dp_uri(extension_file):
+    """Extract the CRL distribution point URI written by create_ca_conf."""
+    with open(extension_file, "r") as f:
+        text = f.read()
+    match = re.search(r"crlDistributionPoints\s*=\s*URI:(\S+)", text)
+    return match.group(1) if match else None
 
 
 class GNMIEnvironment(object):
@@ -267,16 +318,37 @@ def create_root_key(localhost):
 
 
 def create_root_cert(localhost, days):
-    local_command = "openssl req \
-                            -x509 \
-                            -new \
-                            -nodes \
-                            -key gnmiCA.key \
-                            -sha256 \
-                            -days {} \
-                            -subj '/CN=test.gnmi.sonic' \
-                            -out gnmiCA.pem".format(days)
-    localhost.shell(local_command)
+    """Self-signed CA cert, backdated by _CERT_BACKDATE_DAYS.
+
+    Includes SubjectKeyIdentifier to match what `openssl req -x509`
+    used to add for free via the system openssl.cnf [v3_ca] section.
+    The CRL flow in create_revoked_cert_and_crl needs SKI here so its
+    `authorityKeyIdentifier=keyid:always` extension can resolve.
+    """
+    ca_key = _load_pem_private_key("gnmiCA.key")
+    subject = issuer = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, "test.gnmi.sonic"),
+    ])
+    not_before, not_after = _cert_validity_period(days)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=None),
+            critical=True,
+        )
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(ca_key.public_key()),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+    _write_pem_certificate("gnmiCA.pem", cert)
 
 
 def prepare_server_cert(duthost, localhost, days="825"):
@@ -300,19 +372,30 @@ def create_server_csr(localhost):
 
 
 def sign_server_certificate(duthost, localhost, days):
-    create_ext_conf(duthost.mgmt_ip, "extfile.cnf")
-    local_command = "openssl x509 \
-                            -req \
-                            -in gnmiserver.csr \
-                            -CA gnmiCA.pem \
-                            -CAkey gnmiCA.key \
-                            -CAcreateserial \
-                            -out gnmiserver.crt \
-                            -days {} \
-                            -sha256 \
-                            -extensions req_ext \
-                            -extfile extfile.cnf".format(days)
-    localhost.shell(local_command)
+    """Sign gnmiserver.csr with the CA, backdated, with SAN (hostname.com + DUT mgmt IP)."""
+    ca_cert = _load_pem_certificate("gnmiCA.pem")
+    ca_key = _load_pem_private_key("gnmiCA.key")
+    csr = _load_pem_csr("gnmiserver.csr")
+    not_before, not_after = _cert_validity_period(days)
+    san_entries = [
+        x509.DNSName("hostname.com"),
+        x509.IPAddress(ipaddress.ip_address(duthost.mgmt_ip)),
+    ]
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(csr.subject)
+        .issuer_name(ca_cert.subject)
+        .public_key(csr.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .add_extension(
+            x509.SubjectAlternativeName(san_entries),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+    _write_pem_certificate("gnmiserver.crt", cert)
 
 
 def prepare_client_cert(localhost, days="825"):
@@ -339,18 +422,44 @@ def create_client_csr(localhost, revoke=False):
 
 
 def sign_client_certificate(localhost, days="825", revoke=False, extension_file=None):
+    """Sign a (regular or revoked) client CSR with the CA, backdated.
+
+    `extension_file` is the cnf written by create_ca_conf when caller wants
+    a CRL Distribution Points extension on the cert; we parse the URI out
+    of it and add the extension via cryptography (we no longer hand the
+    file to openssl).
+    """
     revoke_suffix = "revoked." if revoke else ""
-    extensions = "-extensions req_ext -extfile {}".format(extension_file) if extension_file else ""
-    local_command = "openssl x509 \
-                            -req \
-                            -in gnmiclient.{}csr \
-                            -CA gnmiCA.pem \
-                            -CAkey gnmiCA.key \
-                            -CAcreateserial \
-                            -out gnmiclient.{}crt \
-                            -days {} \
-                            -sha256 {}".format(revoke_suffix, revoke_suffix, days, extensions)
-    localhost.shell(local_command)
+    csr_path = "gnmiclient.{}csr".format(revoke_suffix)
+    out_path = "gnmiclient.{}crt".format(revoke_suffix)
+    ca_cert = _load_pem_certificate("gnmiCA.pem")
+    ca_key = _load_pem_private_key("gnmiCA.key")
+    csr = _load_pem_csr(csr_path)
+    not_before, not_after = _cert_validity_period(days)
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(csr.subject)
+        .issuer_name(ca_cert.subject)
+        .public_key(csr.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+    )
+    if extension_file:
+        crl_uri = _parse_crl_dp_uri(extension_file)
+        if crl_uri:
+            dp = x509.DistributionPoint(
+                full_name=[x509.UniformResourceIdentifier(crl_uri)],
+                relative_name=None,
+                reasons=None,
+                crl_issuer=None,
+            )
+            builder = builder.add_extension(
+                x509.CRLDistributionPoints([dp]),
+                critical=False,
+            )
+    cert = builder.sign(ca_key, hashes.SHA256())
+    _write_pem_certificate(out_path, cert)
 
 
 def copy_certificate_to_dut(duthost):
@@ -373,7 +482,9 @@ def delete_gnmi_certs(localhost):
     '''
     Delete GNMI client certificates
     '''
-    local_command = "rm \
+    # -f because extfile.cnf is no longer always created on disk
+    # (sign_server_certificate now sets SAN in-process).
+    local_command = "rm -f \
                         extfile.cnf \
                         gnmiCA.* \
                         gnmiserver.* \

--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -2,12 +2,25 @@ import logging
 import pytest
 import json
 import re
+from datetime import datetime, timedelta, timezone
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
 
 from pkg_resources import parse_version
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
 
 logger = logging.getLogger(__name__)
+
+# Backdate rotated telemetry cert notBefore so it survives clock skew
+# between the sonic-mgmt runner and the DUT. Cryptography lib here
+# instead of openssl shell because openssl 3.0.x has no CLI flag to
+# set notBefore on `req -x509` (added only in 3.5).
+_TELEMETRY_CERT_BACKDATE_DAYS = 7
+_TELEMETRY_CERT_VALIDITY_DAYS = 365
 
 METHOD_GET = "get"
 METHOD_SUBSCRIBE = "subscribe"
@@ -174,29 +187,43 @@ def archive_telemetry_certs(duthost):
             duthost.shell(cmd)
 
 
+def _mint_self_signed_telemetry_cert(common_name, cert_path, key_path):
+    """Generate a backdated self-signed leaf cert + key on the sonic-mgmt runner."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    now = datetime.now(timezone.utc)
+    not_before = now - timedelta(days=_TELEMETRY_CERT_BACKDATE_DAYS)
+    not_after = now + timedelta(days=_TELEMETRY_CERT_VALIDITY_DAYS)
+    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .sign(key, hashes.SHA256())
+    )
+    with open(key_path, "wb") as f:
+        f.write(key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        ))
+    with open(cert_path, "wb") as f:
+        f.write(cert.public_bytes(serialization.Encoding.PEM))
+
+
 def rotate_telemetry_certs(duthost, localhost):
     path = "/etc/sonic/telemetry/"
-    # Create new certs to rotate
-    cmd = "openssl req \
-              -x509 \
-              -sha256 \
-              -nodes \
-              -days 365 \
-              -newkey rsa:2048 \
-              -keyout streamingtelemetryserver.key \
-              -subj '/CN=ndastreamingservertest' \
-              -out streamingtelemetryserver.cer"
-    localhost.shell(cmd)
-    cmd = "openssl req \
-              -x509 \
-              -sha256 \
-              -nodes \
-              -days 365 \
-              -newkey rsa:2048 \
-              -keyout dsmsroot.key \
-              -subj '/CN=ndastreamingclienttest' \
-              -out dsmsroot.cer"
-    localhost.shell(cmd)
+    # Mint fresh self-signed certs locally with a backdate so the rotated
+    # PKI survives clock skew between the sonic-mgmt runner and the DUT.
+    _mint_self_signed_telemetry_cert(
+        "ndastreamingservertest", "streamingtelemetryserver.cer", "streamingtelemetryserver.key",
+    )
+    _mint_self_signed_telemetry_cert(
+        "ndastreamingclienttest", "dsmsroot.cer", "dsmsroot.key",
+    )
 
     # Rotate certs
     duthost.copy(src="streamingtelemetryserver.cer", dest=path)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)8147607, 38147626, 38147616, 38023433, 37940586, 37924369, 38330763, 36656668

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

Ensures NTP out of sync with localhost and DUT do not affect telemetry/gnmi tests.

#### How did you do it?

Replaces the four shell-out openssl cert flows (tests/common/gnmi_setup.py, tests/common/helpers/gnmi_utils.py::create_root_cert / sign_server_certificate / sign_client_certificate, tests/telemetry/telemetry_utils.py::rotate_telemetry_certs) with cryptography-library generation, so we can set notBefore = now - 7d. The openssl 3.0.x CLI on Ubuntu 24.04 has no flag to set notBefore on req -x509 / x509 -req; that only landed in 3.5. The 7-day backdate absorbs clock skew between the sonic-mgmt runner, the DUT, and the PTF docker — which is the actual root cause of the recurring CERTIFICATE_VERIFY_FAILED: certificate is not yet valid family of nightly failures.

Adds SubjectKeyIdentifier to the gnoi CA generator in cert_utils.py so the CRL flow's authorityKeyIdentifier=keyid:always extension can resolve, matching what openssl req -x509 adds for free.

Preserves CRL distribution-point handling by parsing the URI out of the existing create_ca_conf-written cnf file and adding it as a CRLDistributionPoints extension via cryptography.

Keeps function signatures and names intact for backward compat with callers; localhost params are now unused but documented.


#### How did you verify/test it?

CI pipeline

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
