### PR TITLE
Adjust Q200 buffer pool watermark margin

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -544,6 +544,8 @@ class QosParamCisco(object):
             if self.dutAsic == "gr2":
                 lossless_params["pkts_num_margin"] = 8
                 lossless_params["extra_cap_margin"] = 25
+            if self.dutAsic == "gb":
+                lossless_params["pkts_num_margin"] = 6
             self.write_params("wm_buf_pool_lossless", lossless_params)
         if self.should_autogen(["wm_buf_pool_lossy"]):
             lossy_params = {"dscp": self.dscp_queue0,
@@ -557,6 +559,8 @@ class QosParamCisco(object):
             if self.dutAsic == "gr2":
                 lossy_params["pkts_num_margin"] = 8
                 lossy_params["extra_cap_margin"] = 25
+            if self.dutAsic == "gb":
+                lossy_params["pkts_num_margin"] = 6
             self.write_params("wm_buf_pool_lossy", lossy_params)
 
     def __define_q_shared_watermark(self):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fix failure on qos/test_qos_sai.py:testQosSaiBufferPoolWatermark.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fix failure on qos/test_qos_sai.py:testQosSaiBufferPoolWatermark.
The SMS usage is changing without any traffic. The testcase failed since initial watermark is changing.
```
cisco@mth64-m5-2:~$ sudo show platform npu script -s print_sms_watermark.py
Min SMS total free buffers: 294851
SMS watermark in bytes: 23424
cisco@mth64-m5-2:~$ sudo show platform npu script -s print_sms_watermark.py
Min SMS total free buffers: 294842
SMS watermark in bytes: 26880
cisco@mth64-m5-2:~$ sudo show platform npu script -s print_sms_watermark.py
Min SMS total free buffers: 294829
SMS watermark in bytes: 31872
cisco@mth64-m5-2:~$ sudo show platform npu script -s print_sms_watermark.py
Min SMS total free buffers: 294848
SMS watermark in bytes: 24576
```

#### How did you do it?
Adjust margin to 6 pkts.

#### How did you verify/test it?
Verified on m64 Cisco-8102-C64.
```
root@ac0c4fdb8d21:~# bash BufferPoolWatermarkTest.sh 
Using packet manipulation module: ptf.packet_scapy
sai_qos_tests.BufferPoolWatermarkTest ... switch_init asic_type= cisco-8000
router_mac: 6c:4e:f6:41:67:fc
pg: 3, queue: 3, buffer pool type: ingress
buf_pool_roid: 0xc00000000000001
buf_pool_roid: 0xc00000000000001
Initial watermark: 22656
Need : 1 flows total, 1 sources, 1 packets per port
Init pkts num sent: 0, min: 0, actual watermark value to start: 9216
pkts num to send: 1, total pkts: 4, shared: 14808
fill_leakout_plus_one: Success, sent 4 packets, queue occupancy bytes rose from 0 to 1374
lower bound (-24): -7680, actual value: 9216, upper bound (+24): 10752
pkts num to send: 925, total pkts: 3704, shared: 14808
fill_leakout_plus_one: Success, sent 3 packets, queue occupancy bytes rose from 0 to 1374
lower bound (-24): 1413120, actual value: 1422336, upper bound (+24): 1431552
pkts num to send: 925, total pkts: 7404, shared: 14808
fill_leakout_plus_one: Success, sent 4 packets, queue occupancy bytes rose from 0 to 1374
lower bound (-24): 2833920, actual value: 2843136, upper bound (+24): 2852352
pkts num to send: 925, total pkts: 11104, shared: 14808
fill_leakout_plus_one: Success, sent 4 packets, queue occupancy bytes rose from 0 to 1374
lower bound (-24): 4254720, actual value: 4263936, upper bound (+24): 4273152
pkts num to send: 925, total pkts: 14804, shared: 14808
fill_leakout_plus_one: Success, sent 4 packets, queue occupancy bytes rose from 0 to 1374
lower bound (-24): 5675520, actual value: 5684736, upper bound (+24): 5693952
pkts num to send: 1, total pkts: 14808, shared: 14808
fill_leakout_plus_one: Success, sent 4 packets, queue occupancy bytes rose from 0 to 1374
lower bound (-24): 5677056, actual value: 5686272, upper bound (+24): 5695488
fill_leakout_plus_one: Success, sent 4 packets, queue occupancy bytes rose from 0 to 1374
exceeded pkts num sent: 925, expected watermark: 5686272, actual value: 5689344
ok

----------------------------------------------------------------------
Ran 1 test in 82.857s

OK
```

#### Any platform specific information?
Q200.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
