### PR TITLE
Fix the names of the qos-capable topologies to prevent skipping tests

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -30,8 +30,9 @@ MARK_CONDITIONS_CONSTANTS = {
                      't1-backend', 't1-isolated-d128', 't1-isolated-d32',
                      't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic',
                      'lt2-p32o64', 'lt2-o128', 'ft2-64', 'ft2-16', 't2_one_hwsku_min', 't2_one_hwsku_max',
-                     't2-single-node-min', 't2_single_node_max', 't2_single_node_max_64p', 't2-single-node-max-64p',
-                     'topo_t2_single_node_max_64p_v2', 'urh_min', 'lrh_min']
+                     't2-single-node-min', 't2_single_node_min', 't2_single_node_max',
+                     't2_single_node_max_64p', 't2-single-node-max-64p',
+                     't2_single_node_max_64p_v2', 'urh_min', 'lrh_min']
 }
 
 


### PR DESCRIPTION
- Add t2_single_node_min
- topo_t2_single_node_max_64p_v2  -> t2_single_node_max_64p_v2

Fix qos tests being skipped on t2_single_node_min and t2_single_node_max_64p_v2 topologies.

### NEEDED IN 202511 TOO

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach

#### How did you verify/test it?
Saw the `qos/test_qos_sai.py::TestQosSai` tests were not being run, 
Then fixed the topo names, reran the tests to see them pass.

Introduced in:
[master] https://github.com/sonic-net/sonic-mgmt/pull/23325
[202511] https://github.com/sonic-net/sonic-mgmt/pull/23884

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
