### PR TITLE
fix: fix timeout waiting for PTF ssh restart-ptf

### DIFF
--- a/ansible/roles/vm_set/tasks/ptf_change_mac.yml
+++ b/ansible/roles/vm_set/tasks/ptf_change_mac.yml
@@ -15,6 +15,13 @@
   become: yes
   ignore_errors: yes
 
+# If container is restarted, the upstream ARP entry may become stale. Send ARP request to flush the stale entry.
+- name: Send ARP request to mgmt gateway to flush stale upstream ARP
+  command: docker exec -i ptf_{{ vm_set_name }} arping -c 2 {{ mgmt_gw }}
+  become: yes
+  ignore_errors: yes
+  when: mgmt_gw is defined
+
 - name: wait until ptf is reachable
   wait_for:
     port: 22


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix PTF ssh timeout during restart-ptf

```
TASK [vm_set : pattern_b — re-raise original SSH timeout] **********************
task path: /var/src/sonic-mgmt_XXXX-1/ansible/roles/vm_set/tasks/ptf_change_mac.yml:111
fatal: [XXX]: FAILED! => {"changed": false, "msg": "PTF SSH not reachable (Timeout when waiting for PTF_IP:22). Diagnostics in /tmp/pattern_b/ on XXX"}
```
Fixes # (issue) 37877313

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
When do restart-ptf, if the ptf container get tear down and relaunch it will get assigned a new MAC address. By default linux does not send gratuitous ARP when we plumb an IP onto an interface (by default arp_notify=0), in a multi-server setup, gateway will still have the stale arp and break restart-ptf

#### How did you do it?
Send a arpping to router to refresh the cache before attempt to check for ssh connection

#### How did you verify/test it?
Physical testbed and verified that this change will fix this issue

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
