### PR TITLE
fix fixture scope in custom acl test case

### DIFF
--- a/tests/acl/custom_acl_table/acl_rules_ipv6.json
+++ b/tests/acl/custom_acl_table/acl_rules_ipv6.json
@@ -41,6 +41,8 @@
             "PRIORITY": "9994"
         },
         "CUSTOM_IPV6_TABLE|DEFAULT_DROP_RULE": {
+            "SRC_IPV6": "2001:db8:200::1/128",
+            "DST_IPV6": "2001:db8:201::1/128",
             "IP_TYPE": "IPV6ANY",
             "PACKET_ACTION": "DROP",
             "PRIORITY": "1"

--- a/tests/acl/custom_acl_table/test_custom_acl_table.py
+++ b/tests/acl/custom_acl_table/test_custom_acl_table.py
@@ -165,7 +165,7 @@ def setup_and_cleanup_custom_acl_table(rand_selected_dut, rand_unselected_dut, t
         rand_unselected_dut.shell("sonic-db-cli CONFIG_DB del \'ACL_TABLE_TYPE|{}\'".format(table_type_name))
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def setup_custom_acl_table(rand_selected_dut, rand_unselected_dut, tbinfo):
     """Setup CUSTOM_TABLE with CUSTOM_TYPE for IPv4/IPv6 mix testing"""
     yield from setup_and_cleanup_custom_acl_table(
@@ -175,7 +175,7 @@ def setup_custom_acl_table(rand_selected_dut, rand_unselected_dut, tbinfo):
     )
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def setup_custom_acl_table_ipv6(rand_selected_dut, rand_unselected_dut, tbinfo):
     """Setup CUSTOM_IPV6_TABLE with CUSTOM_TYPE_IPV6 for IPv6-specific field testing"""
     yield from setup_and_cleanup_custom_acl_table(
@@ -224,7 +224,7 @@ def setup_and_cleanup_acl_rules(rand_selected_dut, rand_unselected_dut, tbinfo,
         rand_unselected_dut.shell(cmd_rm_rules)
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def setup_acl_rules(rand_selected_dut, rand_unselected_dut, tbinfo, setup_custom_acl_table):
     """Load ACL rules for CUSTOM_TABLE"""
     yield from setup_and_cleanup_acl_rules(
@@ -233,7 +233,7 @@ def setup_acl_rules(rand_selected_dut, rand_unselected_dut, tbinfo, setup_custom
     )
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def setup_acl_rules_ipv6(rand_selected_dut, rand_unselected_dut, tbinfo, setup_custom_acl_table_ipv6):
     """Load ACL rules for CUSTOM_IPV6_TABLE"""
     yield from setup_and_cleanup_acl_rules(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix two test failure introduced in [encountered in tests/acl/custome_acl_table](https://github.com/sonic-net/sonic-mgmt/pull/24108). 

1. The acl table and acl rules are not cleaned up after the first test case test_custom_acl_table.py::test_custom_acl, which apply another custom acl table on same vlan. The matching rules configured in acl_rules_ipv6.json get invalid and fail the test.

2. When verifying the ACL counter of rule DEFAULT_DROP_RULE, sometimes the ACL counter number is more than 1, we think it comes from the unrelated BGP packets from ptf, and the DEFAULT_DROP_RULE should be narrowed down to exclude this. This issues can happen from time to time in our environment.
```    
             logger.info("ACL counter for rule {} is {}".format(rule, acl_counter))
>           pytest_assert(acl_counter == 1, "ACL counter for {} didn't increase as expected".format(rule))
E           Failed: ACL counter for DEFAULT_DROP_RULE didn't increase as expected

_          = 'PortChannel108'
acl_counter = 97
asic_type  = 'mellanox'
dst_port_indices = [12, 13, 14, 15, 40, 41, ...]
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
To fix the test failure in test_custom_acl_table_ipv6

#### How did you do it?
Update the fixture scope of from module to function, and narrow down the DEFAULT_DROP_RULE for ipv6, to exactly match the packet built to test this rule and exclude BGP packets inference.

#### How did you verify/test it?
After applying the update, both test cases passed, and the acl counter increased as expected, which is exactly 1 packet.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
