### PR TITLE
[202511] Adjust Q200 buffer pool watermark margin (#24608)

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -523,6 +523,8 @@ class QosParamCisco(object):
             if self.dutAsic == "gr2":
                 lossless_params["pkts_num_margin"] = 8
                 lossless_params["extra_cap_margin"] = 20
+            if self.dutAsic == "gb":
+                lossless_params["pkts_num_margin"] = 6
             self.write_params("wm_buf_pool_lossless", lossless_params)
         if self.should_autogen(["wm_buf_pool_lossy"]):
             lossy_params = {"dscp": self.dscp_queue0,
@@ -536,6 +538,8 @@ class QosParamCisco(object):
             if self.dutAsic == "gr2":
                 lossy_params["pkts_num_margin"] = 8
                 lossy_params["extra_cap_margin"] = 25
+            if self.dutAsic == "gb":
+                lossy_params["pkts_num_margin"] = 6
             self.write_params("wm_buf_pool_lossy", lossy_params)
 
     def __define_q_shared_watermark(self):


### PR DESCRIPTION
Cherry-pick of #24608 to 202511.

Original PR: https://github.com/sonic-net/sonic-mgmt/pull/24608

### Description of PR
Summary:
Fix failure on qos/test_qos_sai.py:testQosSaiBufferPoolWatermark on Q200 (Cisco-8102-C64).
The SMS usage is changing without any traffic; initial watermark fluctuation caused failures. Adjusts margin to 6 pkts for `gb` ASIC.

Note: A minor merge conflict on `tests/qos/files/cisco/qos_param_generator.py` was resolved by preserving 202511's existing `extra_cap_margin = 20` for lossless (the change in master from 20 -> 25 is unrelated to this PR) and adding the new `gb` blocks from #24608.

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Cherry-pick of #24608 into 202511.

#### How did you do it?
Cherry-picked commit 667279bef0682e1152ff08052df1d1d2eaaf535a from #24608. Resolved conflict in `tests/qos/files/cisco/qos_param_generator.py`.

#### How did you verify/test it?
Verified on m64 Cisco-8102-C64 in original PR #24608.

#### Any platform specific information?
Q200.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
