### PR TITLE
[BMC] Skip GCU test_ntp/test_monitor_config cases that need Loopback0 / switch ports

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2744,9 +2744,11 @@ generic_config_updater/test_mmu_dynamic_threshold_config_update.py::test_dynamic
 
 generic_config_updater/test_monitor_config.py::test_monitor_config_tc1_suite:
   skip:
-    reason: "This test is not run on this asic type or version currently / ERSPAN meter is not supported for Cisco Platform"
+    reason: "Not applicable: ERSPAN meter is not supported on Cisco-8000; no switch ports for ACL_TABLE on BMC."
+    conditions_logical_operator: or
     conditions:
       - "asic_type in ['cisco-8000']"
+      - "'bmc' in topo_type"
 
 generic_config_updater/test_multiasic_addcluster.py:
   skip:
@@ -2769,6 +2771,12 @@ generic_config_updater/test_multiasic_linkcrc.py:
     conditions_logical_operator: or
     conditions:
       - "(is_multi_asic is False)"
+      - "'bmc' in topo_type"
+
+generic_config_updater/test_ntp.py::test_ntp_server_change_source_intf:
+  skip:
+    reason: "Loopback0 is not present on BMC platforms (no routing data plane); sonic-ntp YANG validation rejects src_intf=Loopback0."
+    conditions:
       - "'bmc' in topo_type"
 
 generic_config_updater/test_packet_trimming_config_asymmetric.py:


### PR DESCRIPTION
### Description of PR

Summary: Skip two `generic_config_updater` test cases on BMC platforms where the patches they apply reference data-plane resources that do not exist on a BMC (no `Loopback0`, no front-panel switch ports).

- `tests/generic_config_updater/test_ntp.py::test_ntp_server_change_source_intf` hard-codes `src_intf=Loopback0`. BMC builds do not have Loopback0, so `sonic-ntp` YANG validation rejects the patch with `Invalid value "Loopback0" in "src_intf" element` and `config apply-patch` returns non-zero. The test then fails on `expect_op_success` with the generic message `Failed: Command is not running successfully`.

- `tests/generic_config_updater/test_monitor_config.py::test_monitor_config_tc1_suite` creates an `ACL_TABLE EVERFLOW_DSCP` bound to switch ports plus a `MIRROR_SESSION mirror_session_dscp`. BMC has no front-panel ports, so `sonic-acl` YANG validation rejects the patch with `Invalid JSON data (unexpected value)` on `ACL_TABLE/.../ports`. Same generic failure surface.

Both were verified live on `host1-komodo-bmc` (`arm64-nexthop_b27-r0`, image `internal.163077873-4e9636d05b`): with the actual test patches, `config apply-patch` fails at libyang validation, before any change reaches CONFIG_DB.

The skip pattern `"'bmc' in topo_type"` is already used dozens of times in this file, including for three other `generic_config_updater` entries (`test_ecn_config_update`, `test_multiasic_idf`, `test_multiasic_linkcrc`), so this PR is on-pattern.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

Two `generic_config_updater` cases fail on BMC platforms (Aspeed Komodo, `arm64-nexthop_b27-r0`) every run, with `Failed: Command is not running successfully`. The underlying cause is platform applicability, not a GCU bug: the JSON patches reference resources that BMC builds intentionally do not have. Skipping via the existing `conditional_mark` plugin matches the project convention for BMC topology applicability.

#### How did you do it?

In `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`:

```yaml
generic_config_updater/test_monitor_config.py::test_monitor_config_tc1_suite:
  skip:
    reason: "Not applicable: ERSPAN meter is not supported on Cisco-8000; no switch ports for ACL_TABLE on BMC."
    conditions_logical_operator: or
    conditions:
      - "asic_type in ['cisco-8000']"
      - "'bmc' in topo_type"

generic_config_updater/test_ntp.py::test_ntp_server_change_source_intf:
  skip:
    reason: "Loopback0 is not present on BMC platforms (no routing data plane); sonic-ntp YANG validation rejects src_intf=Loopback0."
    conditions:
      - "'bmc' in topo_type"
```

For `test_monitor_config_tc1_suite`, the existing Cisco-8000 skip is extended with an OR-ed BMC condition rather than a separate entry, and `conditions_logical_operator: or` is set explicitly (the file uses both AND and OR styles; default is AND, so this needed to be made explicit when adding a second independent reason).

#### How did you verify/test it?

Live repro on `host1-komodo-bmc` (Aspeed Komodo BMC):

```
admin@host1-komodo-bmc:~$ cat ntp_patch.json
[{"op":"add","path":"/NTP","value":{"global":{"src_intf":"Loopback0"}}}]
admin@host1-komodo-bmc:~$ sudo config apply-patch ntp_patch.json
libyang[0]: Invalid value "Loopback0" in "src_intf" element.
            (path: /sonic-ntp:sonic-ntp/NTP/global/src_intf[.='Loopback0'])
Failed to apply patch due to: Validate json patch ... Data Loading Failed
rc=1

admin@host1-komodo-bmc:~$ cat monitor_patch.json
[{"op":"add","path":"/ACL_TABLE/EVERFLOW_DSCP","value":{...ports:[]...}}, ...]
admin@host1-komodo-bmc:~$ sudo config apply-patch monitor_patch.json
libyang[0]: Invalid JSON data (unexpected value).
            (path: /sonic-acl:sonic-acl/ACL_TABLE/.../EVERFLOW_DSCP/ports)
Failed to apply patch due to: Validate json patch ... Data Loading Failed
rc=1
```

Also confirmed that on the same DUT, an NTP patch with `src_intf=eth0` succeeds with `rc=0`, so `config apply-patch` itself is healthy — only the Loopback0/ports references trip YANG.

YAML lint: `python3 -c "import yaml; yaml.safe_load(open(...))"` parses clean.

#### Any platform specific information?

Affects all platforms whose `topo_type` contains `bmc` (Komodo and any future BMC topology). No effect on switching platforms.

#### Supported testbed topology if it's a new test case?

N/A (skip update, not a new test).

### Documentation

N/A.
