### PR TITLE
[C1]Added Xfail condition for console availability for Nokia-7215-C1 platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -761,9 +761,6 @@ console/test_console_availability.py:
     reason: "This test is applicable to virtual setup only."
     conditions:
       - "asic_type in ['vpp'] and platform.startswith('arm64-c8220tg_48a_o')"
-  xfail:
-    reason: "xfail for arm64-nokia_ixs7215_c1xa-r0  as current test is catered towards virtual testbeds"
-    conditions:
       - "platform in ['arm64-nokia_ixs7215_c1xa-r0']"
 
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -761,6 +761,10 @@ console/test_console_availability.py:
     reason: "This test is applicable to virtual setup only."
     conditions:
       - "asic_type in ['vpp'] and platform.startswith('arm64-c8220tg_48a_o')"
+  xfail:
+    reason: "xfail for arm64-nokia_ixs7215_c1xa-r0  as current test is catered towards virtual testbeds"
+    conditions:
+      - "platform in ['arm64-nokia_ixs7215_c1xa-r0']"
 
 #######################################
 #####    container_hardening      #####


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
`test_console_availability.py` is catered towards virtual testbeds. Adding xfail condition until its enhanced for hardware testbeds as well.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Xfail condition for console_availability for Nokia-7215-C1 platform, as testcase is for virtual testbeds only
#### How did you do it?
Added xfail condition for Nokia-7215-C1 for console_availability testcase
#### How did you verify/test it?
Run console_availability on physical setup of Nokia-7215-C1 platform
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
