### PR TITLE
[202511][conditional_mark] Skip decap test_decap dscp=uniform on Arista-720DT

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -904,11 +904,12 @@ decap/test_decap.py::test_decap[ttl=pipe, dscp=pipe, vxlan=set_unset]:
 decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=disable]:
   skip:
     conditions_logical_operator: or
-    reason: "Not supported on backend, broadcom before 202012 release. Skip 7260CX3 T1 topo in 202305 release. Skip on t1-isolated-d32/128 topos"
+    reason: "Not supported on backend, broadcom before 202012 release. Skip 7260CX3 T1 topo in 202305 release. Skip on t1-isolated-d32/128 topos. Skip on Arista-720DT (TD3-X2 chip does not honor DSCP uniform decap; concession in aristanetworks/sonic-qual.msft#1176)."
     conditions:
       - "(topo_name in ['t1-backend', 't0-backend']) or (asic_type in ['broadcom'] and release in ['201811', '201911'])"
       - "'7260CX3' in hwsku and release in ['202305'] and 't1' in topo_type"
       - "topo_name in ['t1-isolated-d128', 't1-isolated-d32']"
+      - "'Arista-720DT' in hwsku"
   xfail:
     reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
     conditions:
@@ -916,12 +917,13 @@ decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=disable]:
 
 decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=set_unset]:
   skip:
-    reason: "Not supported on backend, T2 topologies , broadcom platforms before 202012 release, x86_64-8111_32eh_o-r0 platform. Skip on mellanox all releases. Skip on 7260CX3 T1 topo in 202305 release. Not required on isolated topologies d256u256s2, d96u32s2, d448u15-lag, and d128, as well as their minimzed and -v6 variants."
+    reason: "Not supported on backend, T2 topologies , broadcom platforms before 202012 release, x86_64-8111_32eh_o-r0 platform. Skip on mellanox all releases. Skip on 7260CX3 T1 topo in 202305 release. Not required on isolated topologies d256u256s2, d96u32s2, d448u15-lag, and d128, as well as their minimzed and -v6 variants. Skip on Arista-720DT (TD3-X2 chip does not honor DSCP uniform decap; concession in aristanetworks/sonic-qual.msft#1176)."
     conditions_logical_operator: or
     conditions:
       - "('t2' in topo_name) or (topo_name in ['t1-backend', 't0-backend']) or (asic_type in ['broadcom'] and release in ['201811', '201911']) or platform in ['x86_64-8111_32eh_o-r0'] or asic_type in ['mellanox']"
       - "'7260CX3' in hwsku and release in ['202305'] and 't1' in topo_type"
       - *noVxlanTopos
+      - "'Arista-720DT' in hwsku"
 
 decap/test_decap.py::test_decap[ttl=uniform, dscp=pipe, vxlan=disable]:
   skip:


### PR DESCRIPTION
## Description of PR

202511 backport of #24619.

Skip the failing `dscp=uniform` parametrized variants of `decap/test_decap.py::test_decap` on **Arista-720DT** (TD3-X2 / BCM56873).

## Why

Arista-720DT does not honor `SAI_TUNNEL_DSCP_MODE_UNIFORM_MODEL`. SONiC programs the entire stack correctly (CONFIG_DB → APPL_DB → ASIC_DB → sairedis.rec all show `dscp_mode=uniform`), but the chip clears the inner DSCP regardless of mode. Arista has acknowledged this as a platform-level limitation and granted a concession in **aristanetworks/sonic-qual.msft#1176**.

The fix has been validated against the 720dt nightly failures on internal-202511 (`SONiC.20251110.26`).

## Approach

Same as master PR: append `'Arista-720DT' in hwsku` to the existing skip blocks for the two failing parametrized cases. Both blocks already use `conditions_logical_operator: or`, so the addition is purely additive.

## Related

- Master: #24619
- Concession: aristanetworks/sonic-qual.msft#1176
