### PR TITLE
qos: use unfiltered port pool for qosParams in updateTestPortIdIp

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -706,6 +706,13 @@ class QosSaiBase(QosBase):
         dst_asic_index = get_src_dst_asic_and_duts['dst_asic_index']
         src_testPortIds = dutConfig["testPortIds"][src_dut_index][src_asic_index]
         dst_testPortIds = dutConfig["testPortIds"][dst_dut_index][dst_asic_index]
+
+        # Save unfiltered port pools for qosParams replacement later.
+        # Speed filtering should only constrain dutConfig["testPorts"] replacements,
+        # not qosParams ports which are already selected by qos_param_generator.
+        src_testPortIds_unfiltered = list(src_testPortIds)
+        dst_testPortIds_unfiltered = list(dst_testPortIds)
+
         # Keep src and dest ports separate so we can pick a valid replacement from the correct asic
         src_portIdNames = []
         src_portIds = []
@@ -804,6 +811,17 @@ class QosSaiBase(QosBase):
         logger.debug('updateTestPortIdIp dutConfig["testPorts"]: {}'.format(dutConfig["testPorts"]))
 
         if qosParams is not None:
+            # Use unfiltered port pools for qosParams replacement.
+            # qosParams ports (e.g., hdrm_pool_size.src_port_ids) are selected by
+            # qos_param_generator for the specific test and typically already exist
+            # in the test port map. Speed filtering should not exclude them.
+            src_qosPortIds = list(src_testPortIds_unfiltered)
+            dst_qosPortIds = list(dst_testPortIds_unfiltered)
+            # Remove ports already consumed by dutConfig["testPorts"] to avoid conflicts
+            if sameSrcDestDutAndAsic:
+                src_qosPortIds = list(set(src_qosPortIds) - set(src_portIds))
+                dst_qosPortIds = list(set(dst_qosPortIds) - set(dst_portIds) - set(src_portIds))
+
             for idName in list(qosParams.keys()):
                 if re.match(r'src_port\S+ids?', idName):
                     port_list = qosParams[idName]
@@ -811,30 +829,30 @@ class QosSaiBase(QosBase):
                     if not isinstance(port_list, list):
                         port_list = [port_list]
                         isList = False
-                    pytest_assert(self.replaceNonExistentPortId(src_testPortIds, port_list),
+                    pytest_assert(self.replaceNonExistentPortId(src_qosPortIds, port_list),
                                   f"Not enough src test ports in qosParams for {idName}")
 
                     # update qosParams for this param and remove from available src ports
                     qosParams[idName] = port_list if isList else port_list[0]
-                    src_testPortIds = list(set(src_testPortIds) - set(port_list))
+                    src_qosPortIds = list(set(src_qosPortIds) - set(port_list))
                     # if same dut and same asic, then also remove from the dest ports
                     if sameSrcDestDutAndAsic:
-                        dst_testPortIds = list(set(dst_testPortIds) - set(port_list))
+                        dst_qosPortIds = list(set(dst_qosPortIds) - set(port_list))
                 elif re.match(r'dst_port\S+ids?', idName):
                     port_list = qosParams[idName]
                     isList = True
                     if not isinstance(port_list, list):
                         port_list = [port_list]
                         isList = False
-                    pytest_assert(self.replaceNonExistentPortId(dst_testPortIds, port_list),
+                    pytest_assert(self.replaceNonExistentPortId(dst_qosPortIds, port_list),
                                   f"Not enough dst test ports in qosParams for {idName}")
 
                     # update qosParams for this param and remove from available dest ports
                     qosParams[idName] = port_list if isList else port_list[0]
-                    dst_testPortIds = list(set(dst_testPortIds) - set(port_list))
+                    dst_qosPortIds = list(set(dst_qosPortIds) - set(port_list))
                     # if same dut and same asic, then also remove from the src ports
                     if sameSrcDestDutAndAsic:
-                        src_testPortIds = list(set(src_testPortIds) - set(port_list))
+                        src_qosPortIds = list(set(src_qosPortIds) - set(port_list))
 
             logger.debug(f'updateTestPortIdIp qosParams: {qosParams}')
 


### PR DESCRIPTION
### Description of PR
Summary:
PR#23962 added `portSpeedCableLength` filtering to `updateTestPortIdIp()` to ensure
replaced `dutConfig["testPorts"]` use the same speed/cable profile. This correctly prevents
flakiness on multi-asic/disagg chassis where cross-speed port substitution caused headroom
value mismatches.

However, the speed-filtered port pool was also used for `qosParams` port replacement
(e.g., `hdrm_pool_size.src_port_ids`). On DUTs with mixed-speed port configs (e.g.,
10×100G + 108×50G in t0-118 topology), the filtering reduces the available pool to only
2 ports, but `qosParams` needs 10 — causing failure:

```
qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark[single_asic] FAILED
E   Failed: Not enough src test ports in qosParams for src_port_ids
```

The root cause is that `qosParams` ports (selected by `qos_param_generator` from YAML
config) already exist in the test port map and don't need speed-based replacement. Speed
filtering should only constrain `dutConfig["testPorts"]` replacement, not `qosParams` ports.

This fix saves the unfiltered port pool before speed filtering and uses it for `qosParams`
port replacement, while preserving speed filtering for `dutConfig["testPorts"]` replacement.

Nightly results on the same Broadcom TH2 testbed (t0-118):

| Date | OS Version | sonic-mgmt | Result |
|------|------------|------------|--------|
| 2026-03-29 | .18 | pre-PR#23962 | ✅ pass |
| 2026-04-12 | .19 | pre-PR#23962 | ✅ pass |
| 2026-04-26 | .22 | pre-PR#23962 | ✅ pass |
| 2026-05-10 | .25 | post-PR#23962 | ❌ fail |
| 2026-05-22 | .29 | with this fix | ✅ pass (verified on testbed-bjw2-can-t0-7260-10) |

Fixes #24001

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
PR#23962 introduced a regression on single-ASIC DUTs with mixed-speed port configs.
`updateTestPortIdIp()` uses a single port pool (`src_testPortIds`) for two different
purposes:

1. **`dutConfig["testPorts"]`** replacement — the generic src/dst port pair randomly
   selected by the fixture. These **do** need speed filtering (PR#23962's original goal).
2. **`qosParams`** replacement — test-specific multi-port parameters (e.g.,
   `hdrm_pool_size.src_port_ids=[31,...,40]`) selected by `qos_param_generator` from YAML
   config. These ports **already exist** in the test port map and **don't need** speed
   filtering.

PR#23962 applied speed filtering to the shared pool, which correctly constrains
`dutConfig["testPorts"]` but incorrectly reduces the pool for `qosParams` replacement.

#### How did you do it?
Saved the unfiltered port pool before speed filtering:

```python
src_testPortIds_unfiltered = list(src_testPortIds)
dst_testPortIds_unfiltered = list(dst_testPortIds)
```

Then in the `qosParams` section, used the unfiltered pool (`src_qosPortIds`) instead
of the speed-filtered pool (`src_testPortIds`):

```python
if qosParams is not None:
    src_qosPortIds = list(src_testPortIds_unfiltered)
    dst_qosPortIds = list(dst_testPortIds_unfiltered)
    # Remove ports already consumed by dutConfig["testPorts"]
    if sameSrcDestDutAndAsic:
        src_qosPortIds = list(set(src_qosPortIds) - set(src_portIds))
        dst_qosPortIds = list(set(dst_qosPortIds) - set(dst_portIds) - set(src_portIds))
```

This preserves PR#23962's speed filtering for `dutConfig["testPorts"]` while avoiding
the regression on `qosParams` ports.

#### How did you verify/test it?
1. **Reproduced failure** on `testbed-bjw2-can-t0-7260-10` (t0-118, Broadcom TH2,
   `SONiC.20251110.29`) without fix — confirmed `FAILED: Not enough src test ports`
2. **Applied fix** and reran — `testQosSaiHeadroomPoolWatermark[single_asic]` **PASSED**
3. `py_compile` + `flake8` clean
4. Code path analysis: all 14 callers of `updateTestPortIdIp` reviewed — the unfiltered
   pool only affects the `qosParams` replacement path

#### Any platform specific information?
Regression observed on Broadcom TH2 platforms with mixed-speed port configs (100G + 50G)
in t0-118 topology. Fix applies to any platform where the test port map has fewer ports
of the target speed than `qosParams` requires.

#### Supported testbed topology if it's a new test case?
N/A — bug fix.

### Documentation
N/A