### PR TITLE
[decap] Remove orphaned --ttl_uniform / --dscp_uniform options

### DIFF
--- a/tests/decap/__init__.py
+++ b/tests/decap/__init__.py
@@ -26,28 +26,3 @@ def pytest_addoption(parser):
         default=True,
         help="Specify whether inner layer IPv6 testing will be covered",
     )
-
-    decap_group.addoption(
-        "--ttl_uniform",
-        action="store_true",
-        default=False,
-        help="indicates TTL uniform is supported"
-    )
-    decap_group.addoption(
-        "--dscp_uniform",
-        action="store_true",
-        default=True,
-        help="indicates DSCP uniform is supported"
-    )
-    decap_group.addoption(
-        "--no_ttl_uniform",
-        dest='ttl_uniform',
-        action="store_false",
-        help="indicates TTL uniform is not supported"
-    )
-    decap_group.addoption(
-        "--no_dscp_uniform",
-        dest='dscp_uniform',
-        action="store_false",
-        help="indicates DSCP uniform is not supported"
-    )


### PR DESCRIPTION
## Description of PR

Remove the four orphaned pytest CLI options registered in `tests/decap/__init__.py`:

- `--ttl_uniform`
- `--dscp_uniform`
- `--no_ttl_uniform`
- `--no_dscp_uniform`

## Why

PR #20304 refactored `tests/decap/conftest.py`. It removed `pytest_generate_tests` and `build_ttl_dscp_params`, and replaced them with the `supported_ttl_dscp_params` fixture, which reads the DUT `APP_DB` `TUNNEL_DECAP_TABLE` `dscp_mode` directly via `_should_use_pipe_for_dscp()`. That refactor left the four `--*_uniform` options registered with no consumer.

Since #20304 these flags have been **silent no-ops** wherever they were still passed: jobs that historically relied on `--no_dscp_uniform` to suppress unsupported parametrized cases stopped suppressing them and started failing on platforms that don't honor DSCP uniform decap (notably Arista-720DT — see issue **aristanetworks/sonic-qual.msft#1176**).

The platform-specific behavior is now expressed via `conditional_mark` (see #24619). With that in place, the public sonic-mgmt repo has no remaining consumer of these CLI options, so we can remove them.

## Approach

Pure deletion in `tests/decap/__init__.py`. The `--outer_ipv4` / `--outer_ipv6` / `--inner_ipv4` / `--inner_ipv6` options are still consumed and remain.

A grep across `origin/master` and `origin/202511` confirms that no other file in the public repo references `--ttl_uniform`, `--dscp_uniform`, `--no_ttl_uniform`, or `--no_dscp_uniform`.

## How to verify it

`pytest --collect-only tests/decap/test_decap.py` should still collect identically. After this change, passing `--no_dscp_uniform` will be rejected by pytest as `unrecognized arguments`, surfacing the dead invocations rather than silently doing nothing.

## Related

- Refactor that orphaned the flags: #20304
- Conditional-mark Arista-720DT skip: #24619
- Tracking issue: aristanetworks/sonic-qual.msft#1176
