### PR TITLE
[conditional_mark] Skip decap/test_decap.py on Arista-720DT and remove stale parametrize-keyed entries

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -951,77 +951,17 @@ decap/:
 
 decap/test_decap.py:
   skip:
-    reason: 'Skip on t1-isolated-d32/128 topos'
+    reason: 'Skip on t1-isolated-d32/128 topos. Skip on Arista-720DT (TD3-X2 chip does not honor DSCP uniform decap; concession in aristanetworks/sonic-qual.msft#1176).'
+    conditions_logical_operator: or
     conditions:
       - "topo_name in ['t1-isolated-d128', 't1-isolated-d32']"
+      - "'Arista-720DT' in hwsku"
   xfail:
     reason: "Xfail due to github issue 20982. Or decap is not supported on x86_64-nvidia_sn5640-r0."
     conditions_logical_operator: or
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/20982 and asic_type in ['mellanox', 'nvidia']"
       - "platform in ['x86_64-nvidia_sn5640-r0']"
-
-decap/test_decap.py::test_decap[ttl=pipe, dscp=pipe, vxlan=disable]:
-  skip:
-    reason: "Not supported on broadcom after 201911 release, cisco-8000 all releases. Skip on t1-isolated-d32/128 topos"
-    conditions_logical_operator: or
-    conditions:
-      - "(asic_type in ['broadcom'] and release not in ['201811', '201911']) or (asic_type in ['cisco-8000'])"
-      - "topo_name in ['t1-isolated-d128', 't1-isolated-d32']"
-  xfail:
-    reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
-    conditions:
-      - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
-
-decap/test_decap.py::test_decap[ttl=pipe, dscp=pipe, vxlan=set_unset]:
-  skip:
-    reason: "Not supported on broadcom after 201911 release, cisco-8000 all releases and marvell-prestera asics. Skip on t1-isolated-d32/128 topos"
-    conditions_logical_operator: or
-    conditions:
-      - "(asic_type in ['broadcom'] and release not in ['201811', '201911']) or (asic_type in ['cisco-8000']) or (asic_type in ['marvell-prestera', 'marvell'])"
-      - "topo_name in ['t1-isolated-d128', 't1-isolated-d32']"
-  xfail:
-    reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
-    conditions:
-      - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
-
-decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=disable]:
-  skip:
-    conditions_logical_operator: or
-    reason: "Not supported on backend, broadcom before 202012 release. Skip 7260CX3 T1 topo in 202305 release. Skip on t1-isolated-d32/128 topos"
-    conditions:
-      - "(topo_name in ['t1-backend', 't0-backend']) or (asic_type in ['broadcom'] and release in ['201811', '201911'])"
-      - "'7260CX3' in hwsku and release in ['202305'] and 't1' in topo_type"
-      - "topo_name in ['t1-isolated-d128', 't1-isolated-d32']"
-  xfail:
-    reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
-    conditions:
-      - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
-
-decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=set_unset]:
-  skip:
-    reason: "Not supported on backend, T2 topologies , broadcom platforms before 202012 release, x86_64-8111_32eh_o-r0 platform. Skip on mellanox all releases. Skip on 7260CX3 T1 topo in 202305 release. Not required on isolated topologies d256u256s2, d96u32s2, d448u15-lag, and d128, as well as their minimzed and -v6 variants."
-    conditions_logical_operator: or
-    conditions:
-      - "('t2' in topo_name) or (topo_name in ['t1-backend', 't0-backend']) or (asic_type in ['broadcom'] and release in ['201811', '201911']) or platform in ['x86_64-8111_32eh_o-r0'] or asic_type in ['mellanox']"
-      - "'7260CX3' in hwsku and release in ['202305'] and 't1' in topo_type"
-      - *noVxlanTopos
-
-decap/test_decap.py::test_decap[ttl=uniform, dscp=pipe, vxlan=disable]:
-  skip:
-    reason: "Not supported uniform ttl mode"
-
-decap/test_decap.py::test_decap[ttl=uniform, dscp=pipe, vxlan=set_unset]:
-  skip:
-    reason: "Not supported uniform ttl mode"
-
-decap/test_decap.py::test_decap[ttl=uniform, dscp=uniform, vxlan=disable]:
-  skip:
-    reason: "Not supported uniform ttl mode"
-
-decap/test_decap.py::test_decap[ttl=uniform, dscp=uniform, vxlan=set_unset]:
-  skip:
-    reason: "Not supported uniform ttl mode"
 
 decap/test_subnet_decap.py::test_vip_packet_decap:
   skip:


### PR DESCRIPTION
## Description of PR

Two related changes to `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` for `decap/test_decap.py`:

1. **Add `'Arista-720DT' in hwsku` to the top-level `decap/test_decap.py:` skip block.**
2. **Remove eight stale parametrize-keyed entries** that have been dead since PR #20304 — `decap/test_decap.py::test_decap[ttl=*, dscp=*, vxlan=*]:`.

Result: **+3 / -63 lines**, no behavioural changes for any platform other than `Arista-720DT` (which gets skipped).

## Why (1) — skip on Arista-720DT

Arista-720DT (TD3-X2 / BCM56873) does **not** honor `SAI_TUNNEL_DSCP_MODE_UNIFORM_MODEL`. SONiC programs the entire stack correctly (CONFIG_DB → APPL_DB → ASIC_DB → sairedis.rec all show `dscp_mode=uniform`), but the chip clears the inner DSCP regardless of the configured mode. Arista has acknowledged this as a platform-level limitation and granted a concession in **aristanetworks/sonic-qual.msft#1176**.

## Why (2) — remove stale entries

PR #20304 (2025-08-28) refactored `tests/decap/conftest.py`: it removed `pytest_generate_tests` + `build_ttl_dscp_params` and replaced them with the `supported_ttl_dscp_params` fixture, which returns a single `{ttl, dscp, vxlan}` dict per session based on the DUT's APP_DB / ASIC heuristics.

Since that refactor, `pytest --collect-only decap/test_decap.py` collects exactly **one** item: `decap/test_decap.py::test_decap` — no parametrize suffix. The eight `[ttl=*, dscp=*, vxlan=*]` entries in `tests_mark_conditions.yaml` have therefore been matching zero items for the last ~9 months. Removing them is a pure cleanup; git history preserves them.

The only rule that pytest's conditional_mark plugin can match against the single collected `test_decap` item is the top-level `decap/test_decap.py:` rule, which is why the new skip belongs there.

## How to verify it

Empirically verified on `testbed-bjw2-can-720dt-6` (m0, internal-202511 mgmt + `SONiC.20251110.26`):

| Run | yaml state | pytest result |
|---|---|---|
| baseline | unchanged | `1 error in 8.56s` (`test_decap` proceeds past conditional_mark and errors at `duthosts` fixture — nothing matched) |
| this PR | top-level skip + stale entries removed | **`1 skipped, 9 warnings in 2.98s`** — `test_decap` is marked SKIPPED before any fixture fires |
| skip-only sub-patch | top-level skip only, stale entries still present | same `1 skipped, 9 warnings in 2.98s` — confirms removing the stale entries has zero behavioural effect |

## Related

- Tracking issue / concession: **aristanetworks/sonic-qual.msft#1176**
- Refactor that orphaned the parametrize-keyed entries: **#20304**

## Backports

Backports handled by automation after master merges.
