### PR TITLE
[decap] Remove orphaned --ttl_uniform / --dscp_uniform options

### DIFF
--- a/tests/decap/__init__.py
+++ b/tests/decap/__init__.py
@@ -26,28 +26,3 @@ def pytest_addoption(parser):
         default=True,
         help="Specify whether inner layer IPv6 testing will be covered",
     )
-
-    decap_group.addoption(
-        "--ttl_uniform",
-        action="store_true",
-        default=False,
-        help="indicates TTL uniform is supported"
-    )
-    decap_group.addoption(
-        "--dscp_uniform",
-        action="store_true",
-        default=True,
-        help="indicates DSCP uniform is supported"
-    )
-    decap_group.addoption(
-        "--no_ttl_uniform",
-        dest='ttl_uniform',
-        action="store_false",
-        help="indicates TTL uniform is not supported"
-    )
-    decap_group.addoption(
-        "--no_dscp_uniform",
-        dest='dscp_uniform',
-        action="store_false",
-        help="indicates DSCP uniform is not supported"
-    )


### PR DESCRIPTION
## Description of PR

Remove the four orphaned pytest CLI options registered in `tests/decap/__init__.py`:

- `--ttl_uniform`
- `--dscp_uniform`
- `--no_ttl_uniform`
- `--no_dscp_uniform`

## Why

PR #20304 refactored `tests/decap/conftest.py`. It removed `pytest_generate_tests` and `build_ttl_dscp_params`, and replaced them with the `supported_ttl_dscp_params` fixture, which returns a single `{ttl, dscp, vxlan}` dict at runtime based on the DUT's APP_DB / ASIC heuristics. That refactor left the four `--*_uniform` options registered with no consumer.

The companion conditional_mark cleanup PR (#24626) removes the parametrize-keyed entries these options used to drive. A grep across `origin/master` and `origin/202511` confirms that no file in the public sonic-mgmt repo references `--ttl_uniform`, `--dscp_uniform`, `--no_ttl_uniform`, or `--no_dscp_uniform` outside the `addoption` block itself.

Removing the dead options keeps the test surface honest. The `--outer_ipv4` / `--outer_ipv6` / `--inner_ipv4` / `--inner_ipv6` options are still in use and remain.

## Approach

Pure deletion in `tests/decap/__init__.py` — −25 lines, no additions.

## How to verify it

`pytest --collect-only tests/decap/test_decap.py` still collects exactly **one** item (`decap/test_decap.py::test_decap`), identical to before. After this change, passing `--no_dscp_uniform` will be rejected by pytest as `unrecognized arguments`, surfacing dead invocations rather than silently doing nothing.

## Related

- Refactor that orphaned the flags: **#20304**
- Companion conditional_mark cleanup (skip on Arista-720DT + remove stale parametrize entries): **#24626**
- Tracking issue: **aristanetworks/sonic-qual.msft#1176**

## Backports

Backports handled by automation after master merges.
