### PR TITLE
[T2-Chassis] sonic-mgmt changes for new feature-flag w.r.t reliable-tsa PR#27145

### DIFF
--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -1008,9 +1008,408 @@ def fetch_and_delete_pcap_file(bgp_pcap, log_dir, duthost, request):
 def get_tsa_chassisdb_config(duthost):
     """
     @summary: Returns the dut's CHASSIS_APP_DB value for BGP_DEVICE_GLOBAL.STATE.tsa_enabled flag
+    When the field is absent (e.g. chassis TSA not synced to CHASSIS_APP_DB), returns 'false'.
     """
-    tsa_conf = duthost.shell('sonic-db-cli CHASSIS_APP_DB HGET \'BGP_DEVICE_GLOBAL|STATE\' tsa_enabled')['stdout']
+    tsa_conf = duthost.shell(
+        'sonic-db-cli CHASSIS_APP_DB HGET \'BGP_DEVICE_GLOBAL|STATE\' tsa_enabled')['stdout'].strip()
+    if not tsa_conf:
+        return 'false'
     return tsa_conf
+
+
+def get_chassis_app_db_tsa_enabled_raw(duthost):
+    """
+    Raw CHASSIS_APP_DB HGET for tsa_enabled (no defaulting). Empty string if absent / (nil).
+    When chassis_tsa_supported is absent or false in CONFIG_DB, implementations may leave this
+    field unset or set it explicitly to false.
+    """
+    raw = duthost.shell(
+        'sonic-db-cli CHASSIS_APP_DB HGET \'BGP_DEVICE_GLOBAL|STATE\' tsa_enabled')['stdout'].strip()
+    if raw in ('', '(nil)'):
+        return ''
+    return raw
+
+
+def _ansi_strip(text):
+    if not text:
+        return ''
+    return re.sub(r'\x1b\[[0-?]*[ -/]*[@-~]', '', text)
+
+
+def _log_interactive_supervisor_ts(suphost, cmd, event, detail, buf=None, maxlen=1800):
+    tail = ''
+    if buf is not None:
+        s = _ansi_strip(buf)
+        tail = s[-maxlen:] if len(s) > maxlen else s
+    logging.info(
+        "interactive_supervisor_ts host=%s cmd=%s event=%s detail=%s session_tail=%r",
+        suphost.hostname, cmd, event, detail, tail,
+    )
+
+
+def _log_remote_sudo_ts_transcript(suphost, remote_cmd, transcript, maxlen=48000):
+    """Log captured stdout from ``sudo TSA`` / ``sudo TSB`` (ANSI stripped, tail if very long)."""
+    s = _ansi_strip(transcript or '')
+    tail = s[-maxlen:] if len(s) > maxlen else s
+    logging.info(
+        "interactive_supervisor_ts host=%s remote_cmd=%r event=remote_cmd_transcript "
+        "detail=ansi_stripped_len=%d tail_maxlen=%d session_tail=%r",
+        suphost.hostname, remote_cmd, len(s), maxlen, tail,
+    )
+
+
+def run_supervisor_traffic_shift_interactive(suphost, creds, cmd):
+    """
+    Run `TSA`/`TSB` on the supervisor from the pytest host over SSH with a pseudo-TTY.
+
+    On many chassis images both of these are normal when you run `sudo TSA`/`sudo TSB` by hand:
+
+    * 'sudo' may ask for the login user's password (to elevate to root).
+    * 'rexec' may ask for `Password for username 'admin':` (or similar) to reach linecards.
+
+    Ansible `shell` has no TTY, so those prompts always time out. This helper runs `sudo` over
+    SSH with a TTY: if *no* password prompt appears, it returns as soon as the shell prompt is
+    seen (or the command output settles). If a prompt *does* appear, it sends
+    `sonicadmin_password` / `ansible_altpasswords` as needed.
+
+    Args:
+        suphost: Supervisor SonicHost
+        creds: Dict with `sonicadmin_user`, `sonicadmin_password`, optional `ansible_altpasswords`
+        cmd: `TSA` or `TSB`
+    """
+    try:
+        import pexpect
+    except ImportError:
+        pytest.fail(
+            "pexpect is required for interactive supervisor TSA/TSB; install pexpect on the test runner."
+        )
+
+    if cmd not in ('TSA', 'TSB'):
+        raise ValueError("cmd must be 'TSA' or 'TSB', got {!r}".format(cmd))
+
+    mi = suphost.get_mgmt_ip()
+    raw_ip = mi['mgmt_ip']
+    if mi['version'] == 'v6':
+        target = '[{}]'.format(raw_ip)
+    else:
+        target = str(raw_ip)
+
+    user = creds['sonicadmin_user']
+    passwords = []
+    primary = creds.get('sonicadmin_password')
+    if primary:
+        passwords.append(primary)
+    for alt in creds.get('ansible_altpasswords') or []:
+        if alt and alt not in passwords:
+            passwords.append(alt)
+    if not passwords:
+        raise ValueError("creds must contain sonicadmin_password and/or ansible_altpasswords")
+
+    # regex for multiple shell prompts (ANSI color codes may wrap the prompt).
+    # Examples: [user@host ~]$ , [root@server ~]#, admin@sonic:~$, admin@leaf01:/etc#
+    _ansi_pre = r'(?:\x1b\[[0-9;?!]*[A-Za-z])*'
+    shell_prompts = (
+        _ansi_pre + r'admin@[^\r\n]+[\$#]\s*(?:\r|\n|\r\n|$)',
+        _ansi_pre + r'~\][^\r\n]*[\$#]\s*(?:\r|\n|\r\n|$)',
+    )
+
+    # Mid-stream status from TSA/TSB (may appear *before* rexec asks for a password).
+    if cmd == 'TSA':
+        mid_markers = (
+            r'(?i)Chassis Mode:',
+            r'(?i)Chassis is already in Maintenance',
+            r'(?i)Normal\s*->\s*Maintenance',
+            r'(?i)System Mode:.*Maintenance',
+        )
+    else:
+        mid_markers = (
+            r'(?i)Chassis Mode:',
+            r'(?i)Chassis is already in Normal',
+            r'(?i)Maintenance\s*->\s*Normal',
+            r'(?i)System Mode:.*Normal',
+        )
+    # Script tail: do not treat the session as finished until completion text appears (rexec done).
+    # Wording varies by image; keep alternatives so we do not return on a premature shell prompt.
+    tail_marker = (
+        r'(?i)(?:Please execute.*(?:config|rexec|save)'
+        r'|please\s+run.*rexec'
+        r'|rexec.*save'
+        r'|configuration\s+saved'
+        r'|config\s+save\s+complete)'
+    )
+
+    # -tt: force TTY so rexec/sudo can prompt and we can answer from pexpect.
+    ssh_cmd = (
+        'ssh -tt -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null '
+        '-o LogLevel=ERROR -o ConnectTimeout=30 {}@{}'
+    ).format(user, target)
+    logging.info("run_supervisor_traffic_shift_interactive: %s on %s (mgmt %s)", cmd, suphost.hostname, target)
+
+    remote_cmd = 'sudo {}'.format(cmd)
+
+    child = pexpect.spawn(ssh_cmd, timeout=420, encoding='utf-8', codec_errors='replace', echo=False)
+    try:
+        i = child.expect([r'(?i)password:', r'(?i)yes/no', pexpect.EOF], timeout=90)
+        _log_interactive_supervisor_ts(
+            suphost, cmd, "ssh_login", "expect index=%s" % i, (child.before or '') + (child.after or ''))
+        if i == 1:
+            child.sendline('yes')
+            child.expect(r'(?i)password:', timeout=90)
+            child.sendline(passwords[0])
+        elif i == 0:
+            child.sendline(passwords[0])
+        else:
+            raise AssertionError(
+                "SSH to supervisor {} ended before login: {}".format(suphost.hostname, child.before))
+
+        # Wait for a real shell prompt (avoid matching a bare '$' in MOTD/banner text).
+        child.expect(list(shell_prompts), timeout=120)
+        _log_interactive_supervisor_ts(
+            suphost, cmd, "login_shell", "ready for %r" % remote_cmd, (child.before or '') + (child.after or ''))
+        child.sendline(remote_cmd)
+        _log_interactive_supervisor_ts(suphost, cmd, "sent", "line=%r" % remote_cmd, None)
+        ts_transcript_pieces = []
+
+        password_prompts = (
+            r'(?i)Password for username',
+            r'(?i)\[sudo\] password for',
+            r'(?i)password for [^\r\n]+:',
+            r'(?i)password:',
+        )
+        pat_list = (
+            list(password_prompts)
+            + [r'(?i)Aborted!']
+            + list(mid_markers)
+            + [tail_marker]
+            + list(shell_prompts)
+        )
+        n_pw = len(password_prompts)
+        idx_abort = n_pw
+        idx_mid_start = n_pw + 1
+        n_mid = len(mid_markers)
+        idx_tail = idx_mid_start + n_mid
+        idx_shell_start = idx_tail + 1
+        pwd_round = 0
+        max_pw_sends = 12
+        saw_mid = False
+        saw_tail = False
+        max_events = 80
+        events = 0
+        clean_exit = False
+
+        def _expect_index_label(jj):
+            if jj < n_pw:
+                return 'password_prompt[%d]' % jj
+            if jj == idx_abort:
+                return 'Aborted'
+            if idx_mid_start <= jj <= idx_tail - 1:
+                return 'mid_marker[%d]' % (jj - idx_mid_start)
+            if jj == idx_tail:
+                return 'tail_marker'
+            if jj >= idx_shell_start:
+                return 'shell_prompt[%d]' % (jj - idx_shell_start)
+            return 'unknown[%d]' % jj
+
+        def _append_ts_transcript_fragment(text):
+            if text:
+                ts_transcript_pieces.append(text)
+
+        def _emit_remote_cmd_transcript():
+            joined = ''.join(ts_transcript_pieces)
+            if joined:
+                _log_remote_sudo_ts_transcript(suphost, remote_cmd, joined)
+
+        while events < max_events:
+            events += 1
+            try:
+                j = child.expect(pat_list, timeout=240)
+            except pexpect.TIMEOUT:
+                buf = (child.before or '') + (child.after or '')
+                try:
+                    buf += child.read_nonblocking(size=65536, timeout=4)
+                except pexpect.TIMEOUT:
+                    pass
+                except Exception:
+                    pass
+                _append_ts_transcript_fragment(buf)
+                _log_interactive_supervisor_ts(suphost, cmd, "expect_timeout", "event=%d" % events, buf)
+                if re.search(r'(?i)Aborted!', buf):
+                    _emit_remote_cmd_transcript()
+                    raise AssertionError("{} aborted: {}".format(cmd, _ansi_strip(buf)[-4000:]))
+                pw_hit = False
+                for p in password_prompts:
+                    if re.search(p, buf):
+                        child.sendline(passwords[min(pwd_round, len(passwords) - 1)])
+                        pwd_round += 1
+                        if pwd_round > max_pw_sends:
+                            _emit_remote_cmd_transcript()
+                            raise AssertionError(
+                                "{}: too many password prompts without completion".format(cmd))
+                        pw_hit = True
+                        _log_interactive_supervisor_ts(
+                            suphost, cmd, "password_from_timeout", "pwd_round=%d" % pwd_round, buf)
+                        break
+                if pw_hit:
+                    continue
+                if re.search(tail_marker, buf):
+                    saw_tail = True
+                    _log_interactive_supervisor_ts(suphost, cmd, "tail_from_timeout", "saw_tail set", buf)
+                for mm in mid_markers:
+                    if re.search(mm, buf):
+                        saw_mid = True
+                        break
+                if saw_tail:
+                    try:
+                        j2 = child.expect(list(shell_prompts) + list(password_prompts), timeout=90)
+                        if j2 < len(shell_prompts):
+                            clean_exit = True
+                            _log_interactive_supervisor_ts(
+                                suphost, cmd, "shell_after_tail", "j2=%d" % j2,
+                                (child.before or '') + (child.after or ''))
+                            _append_ts_transcript_fragment((child.before or '') + (child.after or ''))
+                            break
+                        child.sendline(passwords[min(pwd_round, len(passwords) - 1)])
+                        pwd_round += 1
+                        continue
+                    except pexpect.TIMEOUT:
+                        pass
+                _emit_remote_cmd_transcript()
+                raise AssertionError(
+                    "{}: timed out waiting for completion; saw_mid=%s saw_tail=%s pwd_round=%s tail=%r".format(
+                        cmd, saw_mid, saw_tail, pwd_round, _ansi_strip(buf)[-4000:]))
+
+            _append_ts_transcript_fragment((child.before or '') + (child.after or ''))
+            _log_interactive_supervisor_ts(
+                suphost, cmd, "expect_match",
+                "event=%d j=%d %s match=%r" % (
+                    events, j, _expect_index_label(j), (child.after or '')[:200]),
+                (child.before or '') + (child.after or ''))
+
+            if j < n_pw:
+                child.sendline(passwords[min(pwd_round, len(passwords) - 1)])
+                pwd_round += 1
+                if pwd_round > max_pw_sends:
+                    _emit_remote_cmd_transcript()
+                    raise AssertionError(
+                        "{}: too many password prompts without completion".format(cmd))
+                continue
+            if j == idx_abort:
+                acc = (child.before or '') + (child.after or '')
+                _emit_remote_cmd_transcript()
+                raise AssertionError("{} aborted: {}".format(cmd, _ansi_strip(acc)[-4000:]))
+            if idx_mid_start <= j <= idx_tail - 1:
+                saw_mid = True
+                continue
+            if j == idx_tail:
+                saw_tail = True
+                continue
+            if j >= idx_shell_start:
+                # Do not return on shell until the script tail matched — mid text + passwords can precede rexec.
+                if saw_tail:
+                    clean_exit = True
+                    break
+                logging.warning(
+                    "run_supervisor_traffic_shift_interactive: ignoring shell match "
+                    "(waiting for completion tail); saw_mid=%s saw_tail=%s pwd_round=%s",
+                    saw_mid, saw_tail, pwd_round,
+                )
+                continue
+
+        if not clean_exit:
+            _emit_remote_cmd_transcript()
+            raise AssertionError(
+                "{}: no clean shell exit (saw_mid=%s saw_tail=%s pwd_round=%s)".format(
+                    cmd, saw_mid, saw_tail, pwd_round))
+        time.sleep(3)
+        try:
+            raw_app = get_chassis_app_db_tsa_enabled_raw(suphost)
+            raw_cfg = get_configdb_tsa_enabled_raw(suphost)
+            sup_flag = get_configdb_chassis_tsa_supported(suphost)
+            logging.info(
+                "run_supervisor_traffic_shift_interactive: post-%s supervisor DB snapshot "
+                "CHASSIS_APP_DB tsa_enabled=%r CONFIG_DB tsa_enabled=%r chassis_tsa_supported=%r",
+                cmd, raw_app, raw_cfg, sup_flag,
+            )
+        except Exception as ex:
+            logging.warning("run_supervisor_traffic_shift_interactive: post-%s DB snapshot failed: %s", cmd, ex)
+        acc = (child.before or '') + (child.after or '')
+        try:
+            acc += child.read_nonblocking(size=65536, timeout=5)
+        except Exception:
+            pass
+        _append_ts_transcript_fragment(acc)
+        _log_interactive_supervisor_ts(suphost, cmd, "post_wait", "drain", acc)
+        _emit_remote_cmd_transcript()
+        if 'Aborted!' in acc or re.search(r'(?i)Aborted!\s', acc):
+            raise AssertionError("{} aborted after wait: {}".format(cmd, _ansi_strip(acc)[-4000:]))
+    finally:
+        try:
+            if child.isalive():
+                child.sendline('exit')
+        except Exception:
+            pass
+        try:
+            child.close(force=True)
+        except Exception:
+            pass
+
+
+def run_supervisor_rexec_path_traffic_shift(duthost, cmd, creds=None, **shell_kw):
+    """
+    Run supervisor ``TSA`` or ``TSB`` for the chassis_tsa_supported off (rexec-style) path.
+
+    `sudo TSA`/`sudo TSB` is not password-free on every image: sudo and/or rexec may still
+    prompt when you run them manually.
+    When `creds` is set, this uses SSH + `pexpect` from the test runner to supply inventory passwords.
+    Without `creds`, only non-interactive `shell` is used (`sudo` + command), which will fail if the DUT
+    requires a TTY for passwords.
+
+    Args:
+        duthost: Supervisor SonicHost
+        cmd: `TSA` or `TSB`
+        creds: Optional dict with `sonicadmin_user` / `sonicadmin_password`
+        **shell_kw: passed to `duthost.shell` only when `creds` is None
+    """
+    if cmd not in ('TSA', 'TSB'):
+        raise ValueError("cmd must be 'TSA' or 'TSB', got {}".format(cmd))
+    if creds is not None:
+        if shell_kw:
+            logging.warning(
+                "run_supervisor_rexec_path_traffic_shift: ignoring shell kwargs %s when creds is set",
+                shell_kw,
+            )
+        run_supervisor_traffic_shift_interactive(duthost, creds, cmd)
+        return
+    duthost.shell('sudo {}'.format(cmd), **shell_kw)
+
+
+def get_configdb_chassis_tsa_supported(duthost):
+    """CONFIG_DB BGP_DEVICE_GLOBAL|STATE chassis_tsa_supported (empty if absent)."""
+    out = duthost.shell(
+        "sonic-db-cli CONFIG_DB HGET 'BGP_DEVICE_GLOBAL|STATE' chassis_tsa_supported")['stdout']
+    return out.strip()
+
+
+def get_configdb_tsa_enabled_raw(duthost):
+    """CONFIG_DB HGET BGP_DEVICE_GLOBAL|STATE tsa_enabled (stripped)."""
+    return duthost.shell(
+        "sonic-db-cli CONFIG_DB HGET 'BGP_DEVICE_GLOBAL|STATE' tsa_enabled")['stdout'].strip()
+
+
+def set_configdb_chassis_tsa_supported(duthost, value):
+    """CONFIG_DB HMSET BGP_DEVICE_GLOBAL|STATE chassis_tsa_supported."""
+    duthost.shell(
+        "sonic-db-cli CONFIG_DB HMSET 'BGP_DEVICE_GLOBAL|STATE' chassis_tsa_supported {}".format(value))
+
+
+def restore_configdb_chassis_tsa_supported(duthost, prior_value):
+    """Restore prior chassis_tsa_supported; prior_value empty means field was absent (HDEL)."""
+    if not prior_value:
+        duthost.shell(
+            "sonic-db-cli CONFIG_DB HDEL 'BGP_DEVICE_GLOBAL|STATE' chassis_tsa_supported",
+            module_ignore_errors=True)
+    else:
+        set_configdb_chassis_tsa_supported(duthost, prior_value)
 
 
 def get_sup_cfggen_tsa_value(suphost):

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -3,6 +3,7 @@ import os
 import re
 import tempfile
 import time
+import importlib
 import json
 import pytest
 import yaml
@@ -1077,12 +1078,14 @@ def run_supervisor_traffic_shift_interactive(suphost, creds, cmd):
         creds: Dict with `sonicadmin_user`, `sonicadmin_password`, optional `ansible_altpasswords`
         cmd: `TSA` or `TSB`
     """
+    pexpect_mod = None
     try:
-        import pexpect
+        pexpect_mod = importlib.import_module("pexpect")
     except ImportError:
         pytest.fail(
             "pexpect is required for interactive supervisor TSA/TSB; install pexpect on the test runner."
         )
+    assert pexpect_mod is not None  # import path is definite
 
     if cmd not in ('TSA', 'TSB'):
         raise ValueError("cmd must be 'TSA' or 'TSB', got {!r}".format(cmd))
@@ -1147,9 +1150,9 @@ def run_supervisor_traffic_shift_interactive(suphost, creds, cmd):
 
     remote_cmd = 'sudo {}'.format(cmd)
 
-    child = pexpect.spawn(ssh_cmd, timeout=420, encoding='utf-8', codec_errors='replace', echo=False)
+    child = pexpect_mod.spawn(ssh_cmd, timeout=420, encoding='utf-8', codec_errors='replace', echo=False)
     try:
-        i = child.expect([r'(?i)password:', r'(?i)yes/no', pexpect.EOF], timeout=90)
+        i = child.expect([r'(?i)password:', r'(?i)yes/no', pexpect_mod.EOF], timeout=90)
         _log_interactive_supervisor_ts(
             suphost, cmd, "ssh_login", "expect index=%s" % i, (child.before or '') + (child.after or ''))
         if i == 1:
@@ -1223,13 +1226,15 @@ def run_supervisor_traffic_shift_interactive(suphost, creds, cmd):
             events += 1
             try:
                 j = child.expect(pat_list, timeout=240)
-            except pexpect.TIMEOUT:
+            except pexpect_mod.TIMEOUT:
                 buf = (child.before or '') + (child.after or '')
                 try:
                     buf += child.read_nonblocking(size=65536, timeout=4)
-                except pexpect.TIMEOUT:
+                except pexpect_mod.TIMEOUT:
+                    # No extra bytes available within the short drain window; buf already has before/after.
                     pass
                 except Exception:
+                    # read_nonblocking can fail if the child is closing; partial buf is still useful.
                     pass
                 _append_ts_transcript_fragment(buf)
                 _log_interactive_supervisor_ts(suphost, cmd, "expect_timeout", "event=%d" % events, buf)
@@ -1271,11 +1276,12 @@ def run_supervisor_traffic_shift_interactive(suphost, creds, cmd):
                         child.sendline(passwords[min(pwd_round, len(passwords) - 1)])
                         pwd_round += 1
                         continue
-                    except pexpect.TIMEOUT:
+                    except pexpect_mod.TIMEOUT:
+                        # Prompt not seen in time after tail; fall through and fail with full timeout context.
                         pass
                 _emit_remote_cmd_transcript()
                 raise AssertionError(
-                    "{}: timed out waiting for completion; saw_mid=%s saw_tail=%s pwd_round=%s tail=%r".format(
+                    "{}: timed out waiting for completion; saw_mid={} saw_tail={} pwd_round={} tail={!r}".format(
                         cmd, saw_mid, saw_tail, pwd_round, _ansi_strip(buf)[-4000:]))
 
             _append_ts_transcript_fragment((child.before or '') + (child.after or ''))
@@ -1318,7 +1324,7 @@ def run_supervisor_traffic_shift_interactive(suphost, creds, cmd):
         if not clean_exit:
             _emit_remote_cmd_transcript()
             raise AssertionError(
-                "{}: no clean shell exit (saw_mid=%s saw_tail=%s pwd_round=%s)".format(
+                "{}: no clean shell exit (saw_mid={} saw_tail={} pwd_round={})".format(
                     cmd, saw_mid, saw_tail, pwd_round))
         time.sleep(3)
         try:
@@ -1336,6 +1342,7 @@ def run_supervisor_traffic_shift_interactive(suphost, creds, cmd):
         try:
             acc += child.read_nonblocking(size=65536, timeout=5)
         except Exception:
+            # Best-effort drain after TSA/TSB completes; ignore EOF/pty errors.
             pass
         _append_ts_transcript_fragment(acc)
         _log_interactive_supervisor_ts(suphost, cmd, "post_wait", "drain", acc)
@@ -1347,10 +1354,12 @@ def run_supervisor_traffic_shift_interactive(suphost, creds, cmd):
             if child.isalive():
                 child.sendline('exit')
         except Exception:
+            # Child may already be dead or the pty unusable; cleanup must not mask prior failures.
             pass
         try:
             child.close(force=True)
         except Exception:
+            # close(force=True) can still raise if the fd is invalid; ignore in teardown.
             pass
 
 

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -915,11 +915,11 @@ def check_fib_route(duthost, route_list, ip_ver=IP_VER):
 
     for route in route_list:
         if route in out:
-            logging.debug(f"Route:{route} installed into fib")
+            logging.debug("Route {} installed into fib".format(route))
         else:
-            logging.info(f"Route:{route} not found in fib")
+            logging.info("Route {} not found in fib".format(route))
             assert False
-    logging.info(f"{route_list} are installed into fib successfully")
+    logging.info("{} are installed into fib successfully".format(route_list))
 
 
 def operate_orchagent(duthost, action=ACTION_STOP):

--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -22,7 +22,8 @@ from tests.common.utilities import is_ipv6_only_topology
 from tests.common import config_reload
 from bgp_helpers import define_config, apply_default_bgp_config, DUT_TMP_DIR, TEMPLATE_DIR, BGP_PLAIN_TEMPLATE,\
     BGP_NO_EXPORT_TEMPLATE, DUMP_FILE, CUSTOM_DUMP_SCRIPT, CUSTOM_DUMP_SCRIPT_DEST,\
-    BGPMON_TEMPLATE_FILE, BGPMON_CONFIG_FILE, BGP_MONITOR_NAME, BGP_MONITOR_PORT
+    BGPMON_TEMPLATE_FILE, BGPMON_CONFIG_FILE, BGP_MONITOR_NAME, BGP_MONITOR_PORT,\
+    get_configdb_chassis_tsa_supported, restore_configdb_chassis_tsa_supported, set_configdb_chassis_tsa_supported
 from tests.common.helpers.constants import ARP_RESPONDER_DEFAULT_CONFIG, DEFAULT_NAMESPACE
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common import constants
@@ -30,6 +31,37 @@ from tests.common.devices.eos import EosHost
 from tests.common.devices.sonic import SonicHost
 
 logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def chassis_tsa_supported_pre_req(duthosts):
+    """
+    sonic-buildimage PR #27145: CHASSIS_APP_DB tsa_enabled is synced only when CONFIG_DB
+    chassis_tsa_supported is true on the supervisor. Tests using initial_tsa_check_before_and_after_test
+    expect CHASSIS_APP_DB to reflect TSA state; enable for the module, then restore prior CONFIG_DB state.
+    No-op on topologies without a supervisor.
+    """
+    saved = {}
+    for dut in duthosts:
+        if not dut.is_supervisor_node():
+            continue  # supervisor-only CONFIG_DB key
+        prior = get_configdb_chassis_tsa_supported(dut)
+        saved[dut.hostname] = prior
+        logger.info(
+            "chassis_tsa_supported_pre_req: CONFIG_DB chassis_tsa_supported=true on %s (was %r)",
+            dut.hostname, prior)
+        set_configdb_chassis_tsa_supported(dut, "true")
+
+    yield
+
+    for dut in duthosts:
+        if not dut.is_supervisor_node():
+            continue
+        prior = saved.get(dut.hostname, "")
+        logger.info(
+            "chassis_tsa_supported_pre_req: restoring CONFIG_DB chassis_tsa_supported on %s to %r",
+            dut.hostname, prior if prior else "<absent>")
+        restore_configdb_chassis_tsa_supported(dut, prior)
 
 
 def check_results(results):

--- a/tests/bgp/reliable_tsa/test_reliable_tsa_chassis_flag.py
+++ b/tests/bgp/reliable_tsa/test_reliable_tsa_chassis_flag.py
@@ -1,0 +1,248 @@
+"""
+Reliable TSA / chassis_tsa_supported (CONFIG_DB) vs CHASSIS_APP_DB tsa_enabled behavior.
+
+These tests manipulate CONFIG_DB chassis_tsa_supported explicitly.
+"""
+import logging
+
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
+from tests.common.utilities import wait_until
+from tests.bgp.constants import TS_MAINTENANCE, TS_NORMAL
+from tests.bgp.traffic_checker import get_traffic_shift_state
+from tests.bgp.bgp_helpers import (
+    get_chassis_app_db_tsa_enabled_raw,
+    get_configdb_chassis_tsa_supported,
+    get_configdb_tsa_enabled_raw,
+    get_tsa_chassisdb_config,
+    initial_tsa_check_before_and_after_test,
+    restore_configdb_chassis_tsa_supported,
+    run_supervisor_rexec_path_traffic_shift,
+    set_configdb_chassis_tsa_supported,
+)
+
+pytestmark = [
+    pytest.mark.topology('t2'),
+]
+
+logger = logging.getLogger(__name__)
+
+APP_DB_SYNC_TIMEOUT_SEC = 120
+APP_DB_SYNC_INTERVAL_SEC = 5
+TSA_TSB_TIMEOUT_SEC = 90
+TSA_TSB_INTERVAL_SEC = 5
+
+
+def verify_traffic_shift_state_all_lcs(duthosts, ts_state, state_label):
+    def _verify(lc):
+        pytest_assert(
+            wait_until(
+                TSA_TSB_TIMEOUT_SEC, TSA_TSB_INTERVAL_SEC, 0,
+                lambda: get_traffic_shift_state(lc, "TSC no-stats") == ts_state),
+            "Linecard {} is not in {} ({})".format(lc.hostname, state_label, ts_state))
+
+    with SafeThreadPoolExecutor(max_workers=8) as executor:
+        for lc in duthosts.frontend_nodes:
+            executor.submit(_verify, lc)
+
+
+def chassis_app_db_tsa_false_or_absent(raw):
+    """
+    Valid CHASSIS_APP_DB tsa_enabled value when chassis_tsa_supported is absent or false in CONFIG_DB:
+    field may be missing / empty or explicitly false.
+    """
+    return raw in ('', 'false')
+
+
+def restore_sup_flag_and_tsb(duthosts, enum_supervisor_dut_hostname, prior_flag, creds=None):
+    suphost = duthosts[enum_supervisor_dut_hostname]
+    try:
+        if creds is not None:
+            try:
+                run_supervisor_rexec_path_traffic_shift(suphost, "TSB", creds=creds)
+            except Exception as err:
+                logger.warning("interactive TSB cleanup failed, trying shell TSB: %s", err)
+                suphost.shell("TSB", module_ignore_errors=True)
+        else:
+            suphost.shell("TSB", module_ignore_errors=True)
+        suphost.shell("sudo config save -y", module_ignore_errors=True)
+    except Exception as err:
+        logger.error("cleanup TSB failed: %s", err)
+
+    restore_configdb_chassis_tsa_supported(suphost, prior_flag)
+
+
+@pytest.mark.disable_loganalyzer
+def test_chassis_tsa_supported_config_app_db_and_supervisor_tsa_tsb(
+        duthosts, enum_supervisor_dut_hostname):
+    """
+    With chassis_tsa_supported true (APP_DB path):
+      1) Baseline TSB / LCs normal.
+      2) CONFIG_DB tsa_enabled false; CHASSIS_APP_DB tsa_enabled absent or explicit false.
+      3) TSA: APP_DB true, CONFIG_DB tsa_enabled true, chassis_tsa_supported still true, LCs maintenance.
+      4) TSB: APP_DB tsa_enabled false, CONFIG_DB tsa_enabled false, LCs normal.
+      5) Set chassis_tsa_supported false; CONFIG_DB tsa_enabled false; CHASSIS_APP_DB tsa_enabled false.
+      6) Restore chassis_tsa_supported to pre-test value (finally).
+    """
+    suphost = duthosts[enum_supervisor_dut_hostname]
+    prior_flag = get_configdb_chassis_tsa_supported(suphost)
+
+    try:
+        set_configdb_chassis_tsa_supported(suphost, "true")
+        initial_tsa_check_before_and_after_test(duthosts)
+        verify_traffic_shift_state_all_lcs(duthosts, TS_NORMAL, "normal")
+
+        pytest_assert(
+            get_configdb_chassis_tsa_supported(suphost) == 'true',
+            "chassis_tsa_supported must be true for APP_DB path in this test")
+        pytest_assert(
+            get_configdb_tsa_enabled_raw(suphost) == 'false',
+            "Step 2: CONFIG_DB tsa_enabled must be false when idle")
+        pytest_assert(
+            wait_until(
+                APP_DB_SYNC_TIMEOUT_SEC, APP_DB_SYNC_INTERVAL_SEC, 0,
+                lambda: chassis_app_db_tsa_false_or_absent(get_chassis_app_db_tsa_enabled_raw(suphost))),
+            "Step 2: CHASSIS_APP_DB tsa_enabled must be absent or false when idle")
+
+        suphost.shell("TSA")
+        pytest_assert(
+            wait_until(
+                TSA_TSB_TIMEOUT_SEC, TSA_TSB_INTERVAL_SEC, 0,
+                lambda: get_chassis_app_db_tsa_enabled_raw(suphost) == 'true'),
+            "Step 3: CHASSIS_APP_DB tsa_enabled must be true after TSA")
+        pytest_assert(
+            wait_until(
+                TSA_TSB_TIMEOUT_SEC, TSA_TSB_INTERVAL_SEC, 0,
+                lambda: get_configdb_tsa_enabled_raw(suphost) == 'true'),
+            "Step 3: CONFIG_DB tsa_enabled must be true after TSA")
+        pytest_assert(
+            get_configdb_chassis_tsa_supported(suphost) == 'true',
+            "Step 3: chassis_tsa_supported must remain true after TSA")
+        verify_traffic_shift_state_all_lcs(duthosts, TS_MAINTENANCE, "maintenance")
+
+        suphost.shell("TSB")
+        pytest_assert(
+            wait_until(
+                TSA_TSB_TIMEOUT_SEC, TSA_TSB_INTERVAL_SEC, 0,
+                lambda: chassis_app_db_tsa_false_or_absent(get_chassis_app_db_tsa_enabled_raw(suphost))),
+            "Step 4: CHASSIS_APP_DB tsa_enabled must be false after TSB")
+        pytest_assert(
+            wait_until(
+                TSA_TSB_TIMEOUT_SEC, TSA_TSB_INTERVAL_SEC, 0,
+                lambda: get_configdb_tsa_enabled_raw(suphost) == 'false'),
+            "Step 4: CONFIG_DB tsa_enabled must be false after TSB")
+        verify_traffic_shift_state_all_lcs(duthosts, TS_NORMAL, "normal")
+
+        set_configdb_chassis_tsa_supported(suphost, "false")
+        pytest_assert(get_configdb_chassis_tsa_supported(suphost) == 'false')
+        pytest_assert(
+            wait_until(
+                APP_DB_SYNC_TIMEOUT_SEC, APP_DB_SYNC_INTERVAL_SEC, 0,
+                lambda: get_configdb_tsa_enabled_raw(suphost) == 'false'),
+            "Step 5: CONFIG_DB tsa_enabled is expected to be false")
+        pytest_assert(
+            wait_until(
+                APP_DB_SYNC_TIMEOUT_SEC, APP_DB_SYNC_INTERVAL_SEC, 0,
+                lambda: chassis_app_db_tsa_false_or_absent(get_chassis_app_db_tsa_enabled_raw(suphost))),
+            "Step 5: CHASSIS_APP_DB tsa_enabled must remain false with chassis_tsa_supported false")
+
+    finally:
+        restore_sup_flag_and_tsb(duthosts, enum_supervisor_dut_hostname, prior_flag)
+
+
+@pytest.mark.disable_loganalyzer
+def test_chassis_tsa_rexec_path_then_app_db_path(
+        duthosts, enum_supervisor_dut_hostname, creds_all_duts):
+    """
+    Rexec traffic-shift path when `chassis_tsa_supported` is absent, then APP_DB path via `shell`.
+
+      1) Baseline TSB / LCs normal.
+      2) `TSA` via `rexec' path. Verify LCs maintenance and make sure tsa_enabled flags are 'false' and 'true'
+          in CHASSIS_APP_DB and CONFIG_DB respectively.
+      3) TSB` via `rexec' path. Verify LCs normal and make sure tsa_enabled flags are 'false'
+         in both CHASSIS_APP_DB and CONFIG_DB.
+      4) Set `chassis_tsa_supported` true (APP_DB path); wait idle CHASSIS_APP_DB false; verify LCs normal.
+      5) `TSA` via 'shell'; CHASSIS_APP_DB true; verify LCs maintenance.
+      6) `TSB` via `shell`; CHASSIS_APP_DB false; verify LCs normal.
+      7) Restore `chassis_tsa_supported` and TSB cleanup in `finally` (`restore_sup_flag_and_tsb` with creds).
+    """
+    suphost = duthosts[enum_supervisor_dut_hostname]
+    creds = creds_all_duts[suphost.hostname]
+    prior_flag = get_configdb_chassis_tsa_supported(suphost)
+    try:
+        set_configdb_chassis_tsa_supported(suphost, "true")
+        initial_tsa_check_before_and_after_test(duthosts)
+
+        restore_configdb_chassis_tsa_supported(suphost, "")
+        pytest_assert(
+            wait_until(
+                APP_DB_SYNC_TIMEOUT_SEC, APP_DB_SYNC_INTERVAL_SEC, 0,
+                lambda: chassis_app_db_tsa_false_or_absent(get_chassis_app_db_tsa_enabled_raw(suphost))),
+            "Step 1: CHASSIS_APP_DB tsa_enabled absent or false when chassis_tsa_supported absent")
+
+        verify_traffic_shift_state_all_lcs(duthosts, TS_NORMAL, "normal")
+        # rexec TSA: CHASSIS_APP_DB tsa_enabled stays false/absent; CONFIG_DB returns to true.
+        run_supervisor_rexec_path_traffic_shift(suphost, "TSA", creds=creds)
+        pytest_assert(
+            wait_until(
+                TSA_TSB_TIMEOUT_SEC, TSA_TSB_INTERVAL_SEC, 0,
+                lambda: (
+                    (
+                        chassis_app_db_tsa_false_or_absent(get_chassis_app_db_tsa_enabled_raw(suphost))
+                        and get_configdb_tsa_enabled_raw(suphost) == 'true'
+                    )
+                    or all(
+                        get_traffic_shift_state(lc, "TSC no-stats") == TS_MAINTENANCE
+                        for lc in duthosts.frontend_nodes))),
+            "Step 2: rexec TSA: need (CHASSIS_APP_DB tsa_enabled false/absent and CONFIG_DB tsa_enabled true), "
+            "or all LCs maintenance; APP_DB={} CONFIG_DB={}".format(
+                get_chassis_app_db_tsa_enabled_raw(suphost),
+                get_configdb_tsa_enabled_raw(suphost)))
+        verify_traffic_shift_state_all_lcs(duthosts, TS_MAINTENANCE, "maintenance")
+        run_supervisor_rexec_path_traffic_shift(suphost, "TSB", creds=creds)
+        # rexec TSB: CHASSIS_APP_DB tsa_enabled stays false/absent; CONFIG_DB returns to false.
+        pytest_assert(
+            wait_until(
+                TSA_TSB_TIMEOUT_SEC, TSA_TSB_INTERVAL_SEC, 0,
+                lambda: (
+                    (
+                        chassis_app_db_tsa_false_or_absent(get_chassis_app_db_tsa_enabled_raw(suphost))
+                        and get_configdb_tsa_enabled_raw(suphost) == 'false'
+                    )
+                    or all(
+                        get_traffic_shift_state(lc, "TSC no-stats") == TS_NORMAL
+                        for lc in duthosts.frontend_nodes))),
+            "Step 3: rexec TSB: need (CHASSIS_APP_DB tsa_enabled false/absent and CONFIG_DB tsa_enabled false), "
+            "or all LCs normal; APP_DB={} CONFIG_DB={}".format(
+                get_chassis_app_db_tsa_enabled_raw(suphost),
+                get_configdb_tsa_enabled_raw(suphost)))
+        verify_traffic_shift_state_all_lcs(duthosts, TS_NORMAL, "normal")
+
+        set_configdb_chassis_tsa_supported(suphost, "true")
+        pytest_assert(
+            wait_until(
+                APP_DB_SYNC_TIMEOUT_SEC, APP_DB_SYNC_INTERVAL_SEC, 0,
+                lambda: get_chassis_app_db_tsa_enabled_raw(suphost) == 'false'),
+            "Step 4: Idle APP_DB tsa_enabled should be false when chassis_tsa_supported true")
+
+        verify_traffic_shift_state_all_lcs(duthosts, TS_NORMAL, "normal")
+        suphost.shell("TSA")
+        pytest_assert(
+            wait_until(
+                TSA_TSB_TIMEOUT_SEC, TSA_TSB_INTERVAL_SEC, 0,
+                lambda: get_tsa_chassisdb_config(suphost) == 'true'),
+            "Step 5: CHASSIS_APP_DB tsa_enabled true after TSA")
+        verify_traffic_shift_state_all_lcs(duthosts, TS_MAINTENANCE, "maintenance")
+
+        suphost.shell("TSB")
+        pytest_assert(
+            wait_until(
+                TSA_TSB_TIMEOUT_SEC, TSA_TSB_INTERVAL_SEC, 0,
+                lambda: get_tsa_chassisdb_config(suphost) == 'false'),
+            "Step 6: CHASSIS_APP_DB tsa_enabled false after TSB")
+        verify_traffic_shift_state_all_lcs(duthosts, TS_NORMAL, "normal")
+
+    finally:
+        restore_sup_flag_and_tsb(duthosts, enum_supervisor_dut_hostname, prior_flag, creds)

--- a/tests/bgp/reliable_tsa/test_reliable_tsa_flaky.py
+++ b/tests/bgp/reliable_tsa/test_reliable_tsa_flaky.py
@@ -19,7 +19,7 @@ from tests.bgp.test_startup_tsa_tsb_service import get_tsa_tsb_service_uptime, g
     get_startup_tsb_timer, enable_disable_startup_tsa_tsb_service     # noqa: F401
 
 pytestmark = [
-    pytest.mark.topology('t2', 'lrh', 'urh')
+    pytest.mark.topology('t2', 'lrh', 'urh'),
     pytest.mark.usefixtures("chassis_tsa_supported_pre_req"),
 ]
 

--- a/tests/bgp/reliable_tsa/test_reliable_tsa_flaky.py
+++ b/tests/bgp/reliable_tsa/test_reliable_tsa_flaky.py
@@ -20,6 +20,7 @@ from tests.bgp.test_startup_tsa_tsb_service import get_tsa_tsb_service_uptime, g
 
 pytestmark = [
     pytest.mark.topology('t2', 'lrh', 'urh')
+    pytest.mark.usefixtures("chassis_tsa_supported_pre_req"),
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/bgp/reliable_tsa/test_reliable_tsa_stable.py
+++ b/tests/bgp/reliable_tsa/test_reliable_tsa_stable.py
@@ -19,7 +19,7 @@ from tests.bgp.test_startup_tsa_tsb_service import get_tsa_tsb_service_uptime, g
     get_startup_tsb_timer, enable_disable_startup_tsa_tsb_service     # noqa: F401
 
 pytestmark = [
-    pytest.mark.topology('t2', 'lrh', 'urh')
+    pytest.mark.topology('t2', 'lrh', 'urh'),
     pytest.mark.usefixtures("chassis_tsa_supported_pre_req"),
 ]
 

--- a/tests/bgp/reliable_tsa/test_reliable_tsa_stable.py
+++ b/tests/bgp/reliable_tsa/test_reliable_tsa_stable.py
@@ -20,6 +20,7 @@ from tests.bgp.test_startup_tsa_tsb_service import get_tsa_tsb_service_uptime, g
 
 pytestmark = [
     pytest.mark.topology('t2', 'lrh', 'urh')
+    pytest.mark.usefixtures("chassis_tsa_supported_pre_req"),
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/bgp/test_startup_tsa_tsb_service.py
+++ b/tests/bgp/test_startup_tsa_tsb_service.py
@@ -20,6 +20,7 @@ from tests.conftest import get_hosts_per_hwsku
 
 pytestmark = [
     pytest.mark.topology('t2', 'lrh', 'urh')
+    pytest.mark.usefixtures("chassis_tsa_supported_pre_req"),
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/bgp/test_startup_tsa_tsb_service.py
+++ b/tests/bgp/test_startup_tsa_tsb_service.py
@@ -19,7 +19,7 @@ from tests.bgp.constants import TS_NORMAL, TS_MAINTENANCE
 from tests.conftest import get_hosts_per_hwsku
 
 pytestmark = [
-    pytest.mark.topology('t2', 'lrh', 'urh')
+    pytest.mark.topology('t2', 'lrh', 'urh'),
     pytest.mark.usefixtures("chassis_tsa_supported_pre_req"),
 ]
 

--- a/tests/bgp/test_traffic_shift_lc.py
+++ b/tests/bgp/test_traffic_shift_lc.py
@@ -20,7 +20,8 @@ from tests.conftest import get_hosts_per_hwsku, backup_golden_config, restore_go
     update_golden_config_tsa_enabled
 
 pytestmark = [
-    pytest.mark.topology('t2')
+    pytest.mark.topology('t2'),
+    pytest.mark.usefixtures("chassis_tsa_supported_pre_req"),
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/bgp/test_traffic_shift_sup.py
+++ b/tests/bgp/test_traffic_shift_sup.py
@@ -9,7 +9,8 @@ from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
 from tests.common.utilities import wait_until
 
 pytestmark = [
-    pytest.mark.topology('t2')
+    pytest.mark.topology('t2'),
+    pytest.mark.usefixtures("chassis_tsa_supported_pre_req"),
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -349,6 +349,12 @@ bgp/:
     conditions:
       - "'bmc' in topo_type"
 
+bgp/reliable_tsa/test_reliable_tsa_chassis_flag.py:
+  skip:
+    reason: "reliable TSA is not supported on non-chassis"
+    conditions:
+      - "is_chassis==False"
+
 bgp/reliable_tsa/test_reliable_tsa_flaky.py:
   skip:
     reason: "reliable TSA is not supported on non-chassis"
@@ -356,12 +362,6 @@ bgp/reliable_tsa/test_reliable_tsa_flaky.py:
       - "is_chassis==False"
 
 bgp/reliable_tsa/test_reliable_tsa_stable.py:
-  skip:
-    reason: "reliable TSA is not supported on non-chassis"
-    conditions:
-      - "is_chassis==False"
-
-bgp/reliable_tsa/test_reliable_tsa_chassis_flag.py:
   skip:
     reason: "reliable TSA is not supported on non-chassis"
     conditions:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -361,6 +361,12 @@ bgp/reliable_tsa/test_reliable_tsa_stable.py:
     conditions:
       - "is_chassis==False"
 
+bgp/reliable_tsa/test_reliable_tsa_chassis_flag.py:
+  skip:
+    reason: "reliable TSA is not supported on non-chassis"
+    conditions:
+      - "is_chassis==False"
+
 bgp/test_bgp_aggregate_address.py:
   skip:
     reason: "Skip for multi-ASIC testbed"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- This PR supports build image changes w.r.t PR #[27145](https://github.com/sonic-net/sonic-buildimage/pull/27145), for Reliable Chassis TSA feature.

- This PR adds the sonic-mgmt changes to support the new flag '_chassis_tsa_supported_' in _CONFIG_DB_ to decide whether chassis TSA updates the '_tsa_enabled_' flag in _CHASSIS_APP_DB_ or sends 'sudo TSA/TSB'   to Line cards with **rexec** command.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

- To support the new changes introduced as part of #[27145](https://github.com/sonic-net/sonic-buildimage/pull/27145) PR to handle the new flag '_chassis_tsa_supported_'
- Add new test cases to verify APP_DB path and rexec path w.r.t the new flag '_chassis_tsa_supported_'
- Adapt existing test suites to work with this new flag.

#### How did you do it?

- Added new test cases '_test_chassis_tsa_supported_config_app_db_and_supervisor_tsa_tsb_' and '_test_chassis_tsa_rexec_path_then_app_db_path_' under test_reliable_tsa_chassis_flag.py to verify the new functional changes introduced.
- Verified the existing _reliable_tsa_ , _startup_tsa_tsb_ and _traffic_shift_ test suites adapt to these new changes.

#### How did you verify/test it?

- Ran new test cases and made sure they are working as expected.
- Similarly, verified the existing test suites w.r.t _reliable_tsa_ , _startup_tsa_tsb_ and _traffic_shift_ are working fine as expected.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

- T2 topo for Chassis

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
<img width="1775" height="798" alt="image" src="https://github.com/user-attachments/assets/62c877b7-5255-4014-ae25-60d025ffc61f" />

<img width="886" height="599" alt="image" src="https://github.com/user-attachments/assets/41f379d6-75d0-46e9-94e9-609caf1a5572" />

<img width="603" height="460" alt="image" src="https://github.com/user-attachments/assets/f4f0b6e7-4fad-4015-8e72-cf4e94fc515f" />

