### PR TITLE
Fix gnmi_tls fixture race against slow-binding gNMI server

### DIFF
--- a/tests/common/fixtures/grpc_fixtures.py
+++ b/tests/common/fixtures/grpc_fixtures.py
@@ -18,7 +18,6 @@ import shutil
 import subprocess
 import tarfile
 import tempfile
-import time
 import pytest
 import logging
 from dataclasses import dataclass
@@ -33,6 +32,7 @@ from tests.common.ptf_gnoi import PtfGnoi
 from tests.common.ptf_gnmic import PtfGnmic
 from tests.common.dut_grpc import DutGrpc
 from tests.common.dut_gnoi import DutGnoi
+from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
@@ -492,44 +492,85 @@ def _restart_gnoi_server(duthost):
     if result['rc'] != 0:
         raise Exception(f"Failed to restart gnmi-native: {result['stderr']}")
 
-    # Verify process is running
-    time.sleep(3)  # Give process time to start
+    # Wait for supervisor to report RUNNING. This is a fast guard against
+    # immediate crash loops; it does NOT prove that telemetry has actually
+    # bound its TLS listener (supervisor flips RUNNING after startsecs=1,
+    # but on slow armhf platforms the gnmi-native wrapper + Go telemetry
+    # startup can take longer than that to call listen()). The end-to-end
+    # readiness check lives in _verify_gnoi_tls_connectivity, which retries
+    # bounded grpcurl calls from PTF.
+    def _supervisor_running():
+        status = duthost.shell("docker exec gnmi supervisorctl status gnmi-native",
+                               module_ignore_errors=True)
+        return "RUNNING" in status.get('stdout', '')
 
-    status_result = duthost.shell("docker exec gnmi supervisorctl status gnmi-native", module_ignore_errors=True)
-    if "RUNNING" not in status_result['stdout']:
-        raise Exception(f"gnmi-native failed to start: {status_result['stdout']}")
+    if not wait_until(30, 1, 0, _supervisor_running):
+        status = duthost.shell("docker exec gnmi supervisorctl status gnmi-native",
+                               module_ignore_errors=True)
+        raise Exception(
+            f"gnmi-native failed to reach RUNNING within 30s: {status.get('stdout', '')}"
+        )
 
-    logger.info("gNOI server restart completed")
+    logger.info("gNOI server restart completed (supervisor reports RUNNING)")
 
 
 def _verify_gnoi_tls_connectivity(duthost, ptfhost):
-    """Verify TLS connectivity to gNOI server."""
+    """Verify TLS connectivity to gNOI server with retry on transient errors.
+
+    Retries each grpcurl call with a bounded per-attempt timeout. This absorbs
+    the brief window between supervisor reporting gnmi-native RUNNING and the
+    telemetry process actually accepting connections on the TLS port. On slow
+    armhf platforms (e.g. marvell-prestera) that window can be several
+    seconds, manifesting as `connect: connection refused` errors from PTF.
+    """
     logger.info("Verifying gNOI TLS connectivity")
 
-    # Test basic gRPC service listing with TLS
     cacert_arg, cert_arg, key_arg = grpc_config.get_grpcurl_cert_args()
-    test_cmd = f"""grpcurl {cacert_arg} {cert_arg} {key_arg} \
-                         {duthost.mgmt_ip}:{grpc_config.DEFAULT_TLS_PORT} list"""
+    target = f"{duthost.mgmt_ip}:{grpc_config.DEFAULT_TLS_PORT}"
 
-    result = ptfhost.shell(test_cmd, module_ignore_errors=True)
+    # -connect-timeout bounds the TCP/TLS handshake portion; -max-time bounds
+    # the whole call. Both keep a single retry attempt from hanging if packets
+    # are blackholed instead of refused.
+    grpcurl_timeouts = "-connect-timeout 5 -max-time 10"
 
-    if result['rc'] != 0:
-        raise Exception(f"TLS connectivity test failed: {result['stderr']}")
+    list_cmd = (
+        f"grpcurl {grpcurl_timeouts} {cacert_arg} {cert_arg} {key_arg} "
+        f"{target} list"
+    )
+    time_cmd = (
+        f"grpcurl {grpcurl_timeouts} {cacert_arg} {cert_arg} {key_arg} "
+        f"{target} gnoi.system.System.Time"
+    )
 
-    if "gnoi.system.System" not in result['stdout']:
-        raise Exception(f"gNOI services not found in response: {result['stdout']}")
+    list_last = {}
 
-    # Test basic gNOI call
-    time_cmd = f"""grpcurl {cacert_arg} {cert_arg} {key_arg} \
-                         {duthost.mgmt_ip}:{grpc_config.DEFAULT_TLS_PORT} gnoi.system.System.Time"""
+    def _list_ok():
+        res = ptfhost.shell(list_cmd, module_ignore_errors=True)
+        list_last.clear()
+        list_last.update(res)
+        return res.get('rc', 1) == 0 and "gnoi.system.System" in res.get('stdout', '')
 
-    result = ptfhost.shell(time_cmd, module_ignore_errors=True)
+    if not wait_until(60, 2, 0, _list_ok):
+        raise Exception(
+            "TLS connectivity test failed after retries: "
+            f"rc={list_last.get('rc')} stderr={list_last.get('stderr', '')} "
+            f"stdout={list_last.get('stdout', '')}"
+        )
 
-    if result['rc'] != 0:
-        raise Exception(f"gNOI System.Time test failed: {result['stderr']}")
+    time_last = {}
 
-    if "time" not in result['stdout']:
-        raise Exception(f"Invalid System.Time response: {result['stdout']}")
+    def _time_ok():
+        res = ptfhost.shell(time_cmd, module_ignore_errors=True)
+        time_last.clear()
+        time_last.update(res)
+        return res.get('rc', 1) == 0 and "time" in res.get('stdout', '')
+
+    if not wait_until(30, 2, 0, _time_ok):
+        raise Exception(
+            "gNOI System.Time test failed after retries: "
+            f"rc={time_last.get('rc')} stderr={time_last.get('stderr', '')} "
+            f"stdout={time_last.get('stdout', '')}"
+        )
 
     logger.info("TLS connectivity verification completed successfully")
 


### PR DESCRIPTION
> **Status: Draft — pending validation.** Keep as draft until the Nokia-M0-7215 Elastictest run linked below comes back green. Marking ready-for-review afterwards.

### Description

The `gnmi_tls` fixture in `tests/common/fixtures/grpc_fixtures.py` restarts `gnmi-native` via `supervisorctl restart`, sleeps a fixed 3 seconds, and then issues a single `grpcurl` probe from the PTF docker to verify the server is up. On slower platforms — concretely Nokia-7215 / Nokia-M0-7215 (marvell-prestera, armhf) — the gnmi-native wrapper takes longer than 3 s to call `listen(:50052)`, supervisor flips `RUNNING` after `startsecs=1` regardless, and the single grpcurl probe gets `connect: connection refused`. The fixture fails on setup and every test that depends on it (currently `tests/gnmi/test_gnoi_file.py` and `tests/gnmi/test_gnoi_system.py`; formerly under `tests/gnxi/`, consolidated into `tests/gnmi/`) errors out.

Master nightlies don't exercise Nokia-7215, so the race is latent here, but it has been chronic on `internal-202511` (134 occurrences in the last 30 days, 92% on Nokia-7215 marvell-prestera). The fixture file is byte-for-byte identical between master and internal-202511 in the regions this PR touches, so cherry-pick to 202511 after merge is a clean port.

### Changes

- `_restart_gnoi_server`: replaced the fixed `time.sleep(3)` + single supervisor status check with `wait_until(30, 1, 0, ...)` polling `supervisorctl status` until `RUNNING`. This is now a crash-loop guard, not the readiness contract.
- `_verify_gnoi_tls_connectivity`: bounded each `grpcurl` invocation with `-connect-timeout 5 -max-time 10`, wrapped the `list` probe in `wait_until(60, 2, 0, ...)`, and wrapped the `gnoi.system.System.Time` probe in `wait_until(30, 2, 0, ...)`. The end-to-end TLS handshake + RPC is the real readiness check; if it succeeds, the server is reachable.
- Removed unused `import time`.

### Why retry from PTF instead of probing inside the gnmi container

A `ss -lnt 'sport = :50052'` probe inside the container would tell us the socket is listening, but `ss` availability across the master / 202511 / 202603 base images isn't guaranteed; making it a hard dependency would turn a flake into a deterministic failure. The PTF grpcurl path covers the same readiness signal end-to-end and uses tools already required by the fixture.

### Validation

Static checks (already green in presubmit):
- `py_compile` clean
- `flake8 tests/common/fixtures/grpc_fixtures.py` clean
- DCO, Markers, Static Analysis, Semgrep, CodeQL all passing

End-to-end validation (in progress — PR stays draft until this is green):
- Manual Elastictest run pinning this PR onto a Nokia-M0-7215 (marvell-prestera, armhf) testbed, internal-202511 base image, scoped to `tests/gnmi/test_gnoi_file.py` + `tests/gnmi/test_gnoi_system.py` (the two consumers of `gnmi_tls` that fail on this SKU today).
- Spec: see `quick-fix/7215-gnoi-restart-race/testplan-spec-pr24631.md` / `testplan-pr24631.json` in the triage workspace.
- Testplan URL: _to be filled in once scheduled_
- Pass criterion: both modules move from `FAILED (TLS connectivity test failed: ... connection refused)` to `PASSED` on the same SKU + image.

After this PR merges, cherry-pick to `internal-202511` (label `Request for 202511 branch` already applied).

### Related

- Failing testplan (Nokia-M0-7215 marvell-prestera, internal-202511): https://elastictest.org/scheduler/testplan/6a01b818ea3a02a739d03559?testcase=gnxi
- ADO PBI: https://msazure.visualstudio.com/One/_workitems/edit/37940586
- Duplicate PBI: https://msazure.visualstudio.com/One/_workitems/edit/37731940
