### PR TITLE
[fanout] Fix FEC logic in arista_7060_deploy.j2 to enable RS-FEC by default on 100G ports

### DIFF
--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -47,7 +47,7 @@ interface {{ intf }}
 {%   else %}
    switchport mode dot1q-tunnel
    switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
-{%     if device_conn[inventory_hostname][intf]['speed'] == "100000" and device_conn[inventory_hostname][intf].get('autoneg', '')|lower == "off" %}
+{%     if device_conn[inventory_hostname][intf]['speed'] == "100000" and device_conn[inventory_hostname][intf].get('autoneg', '')|lower != "on" %}
    error-correction encoding reed-solomon
 {%     else %}
    no error-correction encoding


### PR DESCRIPTION
### Description of PR
Summary:

The EOS deploy template for Arista-7060CX-32S fanouts (`arista_7060_deploy.j2`) only enabled RS-FEC on 100G access ports when `AutoNeg` was explicitly set to `off` in the links CSV:

```jinja2
{% if speed == "100000" and autoneg|lower == "off" %}
   error-correction encoding reed-solomon
{% else %}
   no error-correction encoding   {# FEC disabled when AutoNeg is empty #}
```

This is inconsistent with:
1. **SONiC fanout templates** (`sonic_deploy_202*.j2`): unconditionally set `fec: rs` for all 100G/200G/400G/800G ports.
2. **`arista_7260cx3_deploy.j2`**: enables RS-FEC by default and only disables it when `autoneg=on`.

Since the `AutoNeg` field is typically empty for 100G DAC cable links, the old condition always evaluated to false, leaving FEC disabled on all 100G access ports of Arista-7060CX-32S fanouts.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

FEC was always disabled on Arista-7060CX-32S leaf fanouts for 100G access ports connected via DAC cables, causing link issues with DUTs that require RS-FEC.

#### How did you do it?

Changed the FEC condition from `autoneg == "off"` to `autoneg != "on"`, so RS-FEC is enabled by default for all 100G access ports unless autoneg is explicitly `on` (in which case FEC is negotiated between link partners). This aligns with the behavior of `arista_7260cx3_deploy.j2` and all SONiC fanout deploy templates.

#### How did you verify/test it?

Compared against `arista_7260cx3_deploy.j2` which has the correct logic and confirmed FEC is enabled on Arista-7260CX3 fanouts with the same (empty) AutoNeg setting.

#### Any platform specific information?

Affects Arista-7060CX-32S fanout switches running EOS.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation