### PR TITLE
[snappi] tgen_port_info support for PFC port_congestion and no_port_congestion test scripts.

### DIFF
--- a/tests/snappi_tests/pfc/files/pfc_congestion_helper.py
+++ b/tests/snappi_tests/pfc/files/pfc_congestion_helper.py
@@ -1,13 +1,14 @@
 import logging
 import time
+import os
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
     fanout_graph_facts  # noqa: F401
-from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector,\
-    get_lossless_buffer_size, get_pg_dropped_packets,\
-    stop_pfcwd, disable_packet_aging, sec_to_nanosec,\
-    get_pfc_frame_count, packet_capture, config_capture_pkt,\
+from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector, \
+    get_lossless_buffer_size, get_pg_dropped_packets, \
+    stop_pfcwd, disable_packet_aging, sec_to_nanosec, \
+    get_pfc_frame_count, packet_capture, config_capture_pkt, \
     start_pfcwd, enable_packet_aging, \
     traffic_flow_mode, calc_pfc_pause_flow_rate      # noqa: F401
 from tests.common.snappi_tests.port import select_ports, select_tx_port  # noqa: F401
@@ -31,6 +32,104 @@ CONTINUOUS_MODE = -5
 ANSIBLE_POLL_DELAY_SEC = 4
 global DATA_FLOW_DURATION_SEC
 global data_flow_delay_sec
+
+
+def _get_bgp_neighbor_name_for_port(duthost, peer_port, tbinfo):
+    """
+    Get BGP neighbor name (e.g. ARISTA01T1) for a DUT port from minigraph.
+    Used to derive short_link (T1) vs long_link (T3) for traffic direction.
+    """
+    try:
+        mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+        minigraph_neighbors = mg_facts.get('minigraph_neighbors') or {}
+        # Key can be interface name; for PortChannel setups key might be PC name
+        for key, value in minigraph_neighbors.items():
+            if key == peer_port:
+                return value.get('name', '')
+        # If peer_port is a PC member, minigraph_neighbors may key by interface
+        return ''
+    except Exception:
+        return ''
+
+
+def _traffic_direction_from_neighbor_names(first_port_neighbor_name, last_port_neighbor_name):
+    """
+    Map T1 -> short, T3 -> long; build short_to_short, long_to_long, short_to_long, long_to_short.
+    """
+    def _link_type(name):
+        if not name:
+            return 'unknown'
+        if name.endswith('T1'):
+            return 'short'
+        if name.endswith('T3'):
+            return 'long'
+        return 'unknown'
+    first = _link_type(first_port_neighbor_name)
+    last = _link_type(last_port_neighbor_name)
+    if first == 'unknown' or last == 'unknown':
+        return 'unknown_to_unknown'
+    return f"{first}_to_{last}"
+
+
+def _port_type_prefix(snappi_ports):
+    """
+    ml_ if first and last port on different duthosts; else single_asic_ or multi_asic_
+    based on asic_value of first vs last port (same host).
+    """
+    first = snappi_ports[0]
+    last = snappi_ports[-1]
+    first_host = first['duthost'].hostname
+    last_host = last['duthost'].hostname
+
+    if first_host != last_host:
+        return 'ml_'   # multi-line
+    # Same host: compare asic
+    first_asic = first.get('asic_value', 'asic0')
+    last_asic = last.get('asic_value', 'asic0')
+    if first_asic == last_asic:
+        return 'single_asic_'
+    return 'multi_asic_'
+
+
+def _speed_from_port_map(port_map):
+    """
+    Derive ingress-egress category and speed category from port_map.
+    port_map = [egress_count, egress_speed_gbps, ingress_count, ingress_speed_gbps].
+    Returns:
+        tuple: (ingress_egress_str, speed_str)
+    """
+    egress_speed = port_map[1]
+    ingress_speed = port_map[3]
+
+    # Speed category
+    if egress_speed == ingress_speed:
+        if egress_speed == 100:
+            speed_cat = '100Gbps'
+        elif egress_speed == 400:
+            speed_cat = '400Gbps'
+        else:
+            speed_cat = f'{egress_speed}Gbps'
+    else:
+        speed_cat = 'multi_speed'
+    return speed_cat
+
+
+def get_test_subtype_from_ports(snappi_ports, port_map, tbinfo):
+    port_type = _port_type_prefix(snappi_ports)
+    traffic_dir = _traffic_direction_from_neighbor_names(
+        _get_bgp_neighbor_name_for_port(
+            snappi_ports[0]['duthost'],
+            snappi_ports[0]['peer_port'],
+            tbinfo
+        ),
+        _get_bgp_neighbor_name_for_port(
+            snappi_ports[-1]['duthost'],
+            snappi_ports[-1]['peer_port'],
+            tbinfo
+        )
+    )
+    speed_cat = _speed_from_port_map(port_map)
+    return f"{port_type}{traffic_dir}_{speed_cat}"
 
 
 def run_pfc_test(api,
@@ -82,6 +181,11 @@ def run_pfc_test(api,
         fname = test_def['test_type'] + '_' + test_def['line_card_choice'] + '_' + str(data_flow_pkt_size) + 'B'
     port_map = test_def['port_map']
 
+    # Ensure log directory exists
+    log_dir = os.path.dirname(fname)
+    if log_dir:
+        os.makedirs(log_dir, exist_ok=True)
+
     if snappi_extra_params is None:
         snappi_extra_params = SnappiTestParams()
 
@@ -111,11 +215,11 @@ def run_pfc_test(api,
         stop_pfcwd(ingress_duthost)
 
     if (test_def['enable_credit_wd']):
-        enable_packet_aging(egress_duthost, rx_port['asic_value'])
-        enable_packet_aging(ingress_duthost, tx_port['asic_value'])
+        enable_packet_aging(egress_duthost, int(rx_port['asic_value'].split('asic')[1]))
+        enable_packet_aging(ingress_duthost, int(tx_port['asic_value'].split('asic')[1]))
     else:
-        disable_packet_aging(egress_duthost, rx_port['asic_value'])
-        disable_packet_aging(ingress_duthost, tx_port['asic_value'])
+        disable_packet_aging(egress_duthost, int(rx_port['asic_value'].split('asic')[1]))
+        disable_packet_aging(ingress_duthost, int(tx_port['asic_value'].split('asic')[1]))
 
     # Port id of Rx port for traffic config
     # rx_port_id and tx_port_id belong to IXIA chassis.

--- a/tests/snappi_tests/pfc/files/pfc_congestion_helper.py
+++ b/tests/snappi_tests/pfc/files/pfc_congestion_helper.py
@@ -4,19 +4,18 @@ import os
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
-    fanout_graph_facts  # noqa: F401
-from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector, \
-    get_lossless_buffer_size, get_pg_dropped_packets, \
-    stop_pfcwd, disable_packet_aging, sec_to_nanosec, \
-    get_pfc_frame_count, packet_capture, config_capture_pkt, \
-    start_pfcwd, enable_packet_aging, \
-    traffic_flow_mode, calc_pfc_pause_flow_rate      # noqa: F401
-from tests.common.snappi_tests.port import select_ports, select_tx_port  # noqa: F401
-from tests.common.snappi_tests.snappi_helpers import wait_for_arp  # noqa: F401
-from tests.common.snappi_tests.traffic_generation import generate_pause_flows,  verify_pause_flow, \
-    verify_basic_test_flow, verify_background_flow, verify_pause_frame_count_dut, verify_egress_queue_frame_count, \
-    verify_in_flight_buffer_pkts, verify_unset_cev_pause_frame_count, run_traffic_and_collect_stats, \
-    multi_base_traffic_config, generate_test_flows, generate_background_flows
+    fanout_graph_facts                                                                          # noqa: F401
+from tests.common.snappi_tests.common_helpers import stop_pfcwd, disable_packet_aging, \
+    packet_capture, config_capture_pkt, start_pfcwd, enable_packet_aging, \
+    traffic_flow_mode, calc_pfc_pause_flow_rate                                                 # noqa: F401
+from tests.common.snappi_tests.port import select_ports, select_tx_port                         # noqa: F401
+from tests.common.snappi_tests.snappi_helpers import wait_for_arp                               # noqa: F401
+from tests.common.snappi_tests.traffic_generation import generate_pause_flows, \
+    verify_pause_flow, verify_basic_test_flow, verify_background_flow, \
+    verify_pause_frame_count_dut, verify_in_flight_buffer_pkts, \
+    verify_unset_cev_pause_frame_count, run_traffic_and_collect_stats, \
+    multi_base_traffic_config, generate_test_flows, generate_background_flows, \
+    verify_egress_queue_frame_count
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.read_pcap import validate_pfc_frame
 from tests.snappi_tests.files.helper import get_number_of_streams
@@ -215,11 +214,11 @@ def run_pfc_test(api,
         stop_pfcwd(ingress_duthost)
 
     if (test_def['enable_credit_wd']):
-        enable_packet_aging(egress_duthost, int(rx_port['asic_value'].split('asic')[1]))
-        enable_packet_aging(ingress_duthost, int(tx_port['asic_value'].split('asic')[1]))
+        enable_packet_aging(egress_duthost, rx_port['asic_value'])
+        enable_packet_aging(ingress_duthost, tx_port['asic_value'])
     else:
-        disable_packet_aging(egress_duthost, int(rx_port['asic_value'].split('asic')[1]))
-        disable_packet_aging(ingress_duthost, int(tx_port['asic_value'].split('asic')[1]))
+        disable_packet_aging(egress_duthost, rx_port['asic_value'])
+        disable_packet_aging(ingress_duthost, tx_port['asic_value'])
 
     # Port id of Rx port for traffic config
     # rx_port_id and tx_port_id belong to IXIA chassis.

--- a/tests/snappi_tests/pfc/files/pfc_congestion_helper.py
+++ b/tests/snappi_tests/pfc/files/pfc_congestion_helper.py
@@ -8,8 +8,6 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
 from tests.common.snappi_tests.common_helpers import stop_pfcwd, disable_packet_aging, \
     packet_capture, config_capture_pkt, start_pfcwd, enable_packet_aging, \
     traffic_flow_mode, calc_pfc_pause_flow_rate                                                 # noqa: F401
-from tests.common.snappi_tests.port import select_ports, select_tx_port                         # noqa: F401
-from tests.common.snappi_tests.snappi_helpers import wait_for_arp                               # noqa: F401
 from tests.common.snappi_tests.traffic_generation import generate_pause_flows, \
     verify_pause_flow, verify_basic_test_flow, verify_background_flow, \
     verify_pause_frame_count_dut, verify_in_flight_buffer_pkts, \

--- a/tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py
+++ b/tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py
@@ -2,44 +2,52 @@ import pytest
 import random
 from tests.common.helpers.assertions import pytest_require, pytest_assert                           # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut, \
-    fanout_graph_facts    # noqa: F401
+    fanout_graph_facts                                                                              # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
-    snappi_api, cleanup_config, get_snappi_ports_for_rdma, snappi_multi_base_config, \
-    get_snappi_ports, get_snappi_ports_multi_dut, clear_fabric_counters, check_fabric_counters, \
-    get_snappi_ports_single_dut      # noqa: F401
+    snappi_api, snappi_dut_base_config, get_snappi_ports_for_rdma, cleanup_config, \
+    snappi_testbed_config, get_snappi_ports_single_dut, snappi_port_selection, \
+    get_snappi_ports, tgen_port_info, tgen_testbed_subtype, is_snappi_multidut, \
+    get_snappi_ports_multi_dut, clear_fabric_counters, check_fabric_counters, \
+    snappi_multi_base_config                                                                        # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list, \
     lossy_prio_list, all_prio_list, disable_pfcwd                                                   # noqa: F401
-from tests.snappi_tests.pfc.files.pfc_congestion_helper import run_pfc_test
+from tests.snappi_tests.pfc.files.pfc_congestion_helper import run_pfc_test, get_test_subtype_from_ports
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
-from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
 from tests.snappi_tests.files.helper import adjust_test_flow_rate
-from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                                    # noqa: F401
 
 import logging
 logger = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.topology('multidut-tgen')]
 
-port_map = [[1, 100, 1, 100], [1, 400, 1, 400]]
+
+@pytest.fixture(autouse=True, scope='module')
+def number_of_tx_rx_ports():
+    yield (1, 1)
+
+
+def create_port_map(snappi_ports):
+    return ([1,
+            int(snappi_ports[0]['snappi_speed_type'].split('_')[1]),
+            len(snappi_ports) - 1,
+            int(snappi_ports[-1]['snappi_speed_type'].split('_')[1])])
+
 
 # Testplan: docs/testplan/PFC_Snappi_Additional_Testcases.md
 # This test-script covers testcase#01-non-congestion(normal).
 
 
-@pytest.mark.parametrize('port_map', port_map)
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
-def test_multiple_prio_diff_dist(snappi_api,                   # noqa: F811
-                                 conn_graph_facts,             # noqa: F811
-                                 fanout_graph_facts_multidut,  # noqa: F811
+def test_multiple_prio_diff_dist(snappi_api,                    # noqa: F811
+                                 conn_graph_facts,              # noqa: F811
+                                 fanout_graph_facts_multidut,   # noqa: F811
                                  duthosts,
-                                 prio_dscp_map,                # noqa: F811
-                                 lossless_prio_list,           # noqa: F811
-                                 lossy_prio_list,              # noqa: F811
+                                 prio_dscp_map,                 # noqa: F811
+                                 lossless_prio_list,            # noqa: F811
+                                 lossy_prio_list,               # noqa: F811
                                  tbinfo,
-                                 get_snappi_ports,             # noqa: F811
-                                 port_map,
-                                 multidut_port_info,
-                                 disable_pfcwd):          # noqa: F811
+                                 tgen_port_info,                # noqa: F811
+                                 disable_pfcwd):                # noqa: F811
 
     """
     Purpose of the test is to check if line-rate can be achieved.
@@ -59,52 +67,25 @@ def test_multiple_prio_diff_dist(snappi_api,                   # noqa: F811
         lossless_prio_list(list): list of lossless priorities
         lossy_prio_list(list): list of lossy priorities.
         tbinfo(key): element to identify testbed info name.
-        get_snappi_ports(pytest fixture): returns list of ports based on linecards selected.
-        port_map(list): list for port-speed combination.
-        multidut_port_info : Line card classification along with ports selected as Rx and Tx port.
+        tgen_port_info(pytest fixture): returns list of ports based on linecards selected.
+        tgen_testbed_subtype(pytest_fixture): returns test_subtype for the test.
+
     Returns:
         N/A
 
     """
 
-    # port_map is defined as port-speed combination.
-    # first two parameters are count of egress links and its speed.
-    # last two parameters are count of ingress links and its speed.
-
     # pkt_size of 1024B will be used unless imix flag is set.
     # With imix flag set, the traffic_generation.py uses IMIX profile.
     pkt_size = 1024
 
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = port_map[0]
-        rx_port_count = port_map[2]
-        tmp_snappi_port_list = get_snappi_ports
-        snappi_port_list = []
-        for item in tmp_snappi_port_list:
-            if (int(item['speed']) == (port_map[1] * 1000)):
-                snappi_port_list.append(item)
-        pytest_require(MULTIDUT_TESTBED == tbinfo['conf-name'],
-                       "The testbed name from testbed file doesn't match with MULTIDUT_TESTBED in variables.py ")
-        pytest_require(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                       "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
+    logger.info("Snappi Ports : {}".format(snappi_ports))
 
-        pytest_require(len(rdma_ports['tx_ports']) >= tx_port_count,
-                       'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                       testbed {}, subtype {} in variables.py'.
-                       format(MULTIDUT_TESTBED, testbed_subtype))
+    # port_map = [1 egress port, speed of egress port, remaining ingress ports, speed of ingress port]
+    port_map = create_port_map(snappi_ports)
 
-        pytest_require(len(rdma_ports['rx_ports']) >= rx_port_count,
-                       'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                       testbed {}, subtype {} in variables.py'.
-                       format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-
-        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-
-        testbed_config, port_config_list, snappi_ports = snappi_multi_base_config(duthosts,
-                                                                                  snappi_ports,
-                                                                                  snappi_api)
+    testbed_type = get_test_subtype_from_ports(snappi_ports, port_map, tbinfo)
 
     # Percentage drop expected for lossless and lossy traffic.
     # speed_tol is speed tolerance between egress link speed and actual speed.
@@ -117,7 +98,7 @@ def test_multiple_prio_diff_dist(snappi_api,                   # noqa: F811
                 'data_flow_delay_sec': 0,
                 'SNAPPI_POLL_DELAY_SEC': 60,
                 'test_type': 'logs/snappi_tests/pfc/Single_Ingress_Egress_diff_dist_'+str(port_map[1])+'Gbps',
-                'line_card_choice': testbed_subtype,
+                'line_card_choice': testbed_type,
                 'port_map': port_map,
                 'enable_pfcwd': True,
                 'enable_credit_wd': True,
@@ -139,6 +120,7 @@ def test_multiple_prio_diff_dist(snappi_api,                   # noqa: F811
     snappi_extra_params.multi_dut_params.duthost2 = snappi_ports[-1]['duthost']
 
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+
     if (snappi_ports[0]['peer_device'] == snappi_ports[-1]['peer_device']):
         dut_list = [snappi_ports[0]['duthost']]
     else:
@@ -164,25 +146,20 @@ def test_multiple_prio_diff_dist(snappi_api,                   # noqa: F811
 
         for dut in duthosts:
             check_fabric_counters(dut)
-
     finally:
         cleanup_config(dut_list, snappi_ports)
 
 
-@pytest.mark.parametrize('port_map', port_map)
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
-def test_multiple_prio_uni_dist(snappi_api,                   # noqa: F811
-                                conn_graph_facts,             # noqa: F811
-                                fanout_graph_facts_multidut,  # noqa: F811
+def test_multiple_prio_uni_dist(snappi_api,                     # noqa: F811
+                                conn_graph_facts,               # noqa: F811
+                                fanout_graph_facts_multidut,    # noqa: F811
                                 duthosts,
-                                prio_dscp_map,                # noqa: F811
-                                lossless_prio_list,           # noqa: F811
-                                lossy_prio_list,              # noqa: F811
+                                prio_dscp_map,                  # noqa: F811
+                                lossless_prio_list,             # noqa: F811
+                                lossy_prio_list,                # noqa: F811
                                 tbinfo,
-                                get_snappi_ports,             # noqa: F811
-                                port_map,
-                                multidut_port_info,
-                                disable_pfcwd):          # noqa: F811
+                                tgen_port_info,                 # noqa: F811
+                                disable_pfcwd):                 # noqa: F811
 
     """
     Purpose of the test is to check if line-rate can be achieved.
@@ -202,9 +179,8 @@ def test_multiple_prio_uni_dist(snappi_api,                   # noqa: F811
         lossless_prio_list(list): list of lossless priorities
         lossy_prio_list(list): list of lossy priorities.
         tbinfo(key): element to identify testbed info name.
-        get_snappi_ports(pytest fixture): returns list of ports based on linecards selected.
-        port_map(list): list for port-speed combination.
-        multidut_port_info : Line card classification along with ports selected as Rx and Tx port.
+        tgen_port_info(pytest fixture): returns list of ports based on linecards selected.
+        tgen_testbed_subtype(pytest_fixture): returns test_subtype for the test.
 
     Returns:
         N/A
@@ -218,36 +194,13 @@ def test_multiple_prio_uni_dist(snappi_api,                   # noqa: F811
     # With imix flag set, the traffic_generation.py uses IMIX profile.
     pkt_size = 1024
 
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = port_map[0]
-        rx_port_count = port_map[2]
-        tmp_snappi_port_list = get_snappi_ports
-        snappi_port_list = []
-        for item in tmp_snappi_port_list:
-            if (int(item['speed']) == (port_map[1] * 1000)):
-                snappi_port_list.append(item)
-        pytest_require(MULTIDUT_TESTBED == tbinfo['conf-name'],
-                       "The testbed name from testbed file doesn't match with MULTIDUT_TESTBED in variables.py ")
-        pytest_require(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                       "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
+    logger.info("Snappi Ports : {}".format(snappi_ports))
 
-        pytest_require(len(rdma_ports['tx_ports']) >= tx_port_count,
-                       'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                       testbed {}, subtype {} in variables.py'.
-                       format(MULTIDUT_TESTBED, testbed_subtype))
+    # port_map = [1 egress port, speed of egress port, remaining ingress ports, speed of ingress port]
+    port_map = create_port_map(snappi_ports)
 
-        pytest_require(len(rdma_ports['rx_ports']) >= rx_port_count,
-                       'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                       testbed {}, subtype {} in variables.py'.
-                       format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-
-        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-
-        testbed_config, port_config_list, snappi_ports = snappi_multi_base_config(duthosts,
-                                                                                  snappi_ports,
-                                                                                  snappi_api)
+    testbed_type = get_test_subtype_from_ports(snappi_ports, port_map, tbinfo)
 
     # Percentage drop expected for lossless and lossy traffic.
     # speed_tol is speed tolerance between egress link speed and actual speed.
@@ -261,7 +214,7 @@ def test_multiple_prio_uni_dist(snappi_api,                   # noqa: F811
                 'data_flow_delay_sec': 0,
                 'SNAPPI_POLL_DELAY_SEC': 60,
                 'test_type': 'logs/snappi_tests/pfc/Single_Ingress_Egress_uni_dist_'+str(port_map[1])+'Gbps',
-                'line_card_choice': testbed_subtype,
+                'line_card_choice': testbed_type,
                 'port_map': port_map,
                 'enable_pfcwd': True,
                 'enable_credit_wd': True,
@@ -283,6 +236,7 @@ def test_multiple_prio_uni_dist(snappi_api,                   # noqa: F811
     snappi_extra_params.multi_dut_params.duthost2 = snappi_ports[-1]['duthost']
 
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+
     if (snappi_ports[0]['peer_device'] == snappi_ports[-1]['peer_device']):
         dut_list = [snappi_ports[0]['duthost']]
     else:
@@ -308,13 +262,10 @@ def test_multiple_prio_uni_dist(snappi_api,                   # noqa: F811
 
         for dut in duthosts:
             check_fabric_counters(dut)
-
     finally:
         cleanup_config(dut_list, snappi_ports)
 
 
-@pytest.mark.parametrize('port_map', port_map)
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_single_lossless_prio(snappi_api,                   # noqa: F811
                               conn_graph_facts,             # noqa: F811
                               fanout_graph_facts_multidut,  # noqa: F811
@@ -323,10 +274,8 @@ def test_single_lossless_prio(snappi_api,                   # noqa: F811
                               lossless_prio_list,           # noqa: F811
                               lossy_prio_list,              # noqa: F811
                               tbinfo,
-                              get_snappi_ports,             # noqa: F811
-                              port_map,
-                              multidut_port_info,
-                              disable_pfcwd):          # noqa: F811
+                              tgen_port_info,               # noqa: F811
+                              disable_pfcwd):               # noqa: F811
 
     """
     Purpose of the test is to check if line-rate can be achieved with single priority traffic.
@@ -345,9 +294,8 @@ def test_single_lossless_prio(snappi_api,                   # noqa: F811
         lossless_prio_list(list): list of lossless priorities
         lossy_prio_list(list): list of lossy priorities.
         tbinfo(key): element to identify testbed info name.
-        get_snappi_ports(pytest fixture): returns list of ports based on linecards selected.
-        port_map(list): list for port-speed combination.
-        multidut_port_info : Line card classification along with ports selected as Rx and Tx port.
+        tgen_port_info(pytest fixture): returns list of ports based on linecards selected.
+        tgen_testbed_subtype(pytest_fixture): returns test_subtype for the test.
 
     Returns:
         N/A
@@ -361,36 +309,13 @@ def test_single_lossless_prio(snappi_api,                   # noqa: F811
     # With imix flag set, the traffic_generation.py uses IMIX profile.
     pkt_size = 1024
 
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = port_map[0]
-        rx_port_count = port_map[2]
-        tmp_snappi_port_list = get_snappi_ports
-        snappi_port_list = []
-        for item in tmp_snappi_port_list:
-            if (int(item['speed']) == (port_map[1] * 1000)):
-                snappi_port_list.append(item)
-        pytest_require(MULTIDUT_TESTBED == tbinfo['conf-name'],
-                       "The testbed name from testbed file doesn't match with MULTIDUT_TESTBED in variables.py ")
-        pytest_require(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                       "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
+    logger.info("Snappi Ports : {}".format(snappi_ports))
 
-        pytest_require(len(rdma_ports['tx_ports']) >= tx_port_count,
-                       'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                       testbed {}, subtype {} in variables.py'.
-                       format(MULTIDUT_TESTBED, testbed_subtype))
+    # port_map = [1 egress port, speed of egress port, remaining ingress ports, speed of ingress port]
+    port_map = create_port_map(snappi_ports)
 
-        pytest_require(len(rdma_ports['rx_ports']) >= rx_port_count,
-                       'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                       testbed {}, subtype {} in variables.py'.
-                       format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-
-        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-
-        testbed_config, port_config_list, snappi_ports = snappi_multi_base_config(duthosts,
-                                                                                  snappi_ports,
-                                                                                  snappi_api)
+    testbed_type = get_test_subtype_from_ports(snappi_ports, port_map, tbinfo)
 
     # Percentage drop expected for lossless and lossy traffic.
     # speed_tol is speed tolerance between egress link speed and actual speed.
@@ -405,7 +330,7 @@ def test_single_lossless_prio(snappi_api,                   # noqa: F811
                 'data_flow_delay_sec': 0,
                 'SNAPPI_POLL_DELAY_SEC': 60,
                 'test_type': 'logs/snappi_tests/pfc/Single_Ingress_Egress_1Prio_linerate_'+str(port_map[1])+'Gbps',
-                'line_card_choice': testbed_subtype,
+                'line_card_choice': testbed_type,
                 'port_map': port_map,
                 'enable_pfcwd': True,
                 'enable_credit_wd': True,
@@ -428,6 +353,7 @@ def test_single_lossless_prio(snappi_api,                   # noqa: F811
     snappi_extra_params.multi_dut_params.duthost2 = snappi_ports[-1]['duthost']
 
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+
     if (snappi_ports[0]['peer_device'] == snappi_ports[-1]['peer_device']):
         dut_list = [snappi_ports[0]['duthost']]
     else:
@@ -453,6 +379,5 @@ def test_single_lossless_prio(snappi_api,                   # noqa: F811
 
         for dut in duthosts:
             check_fabric_counters(dut)
-
     finally:
         cleanup_config(dut_list, snappi_ports)

--- a/tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py
+++ b/tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py
@@ -1,12 +1,11 @@
 import pytest
 import random
-from tests.common.helpers.assertions import pytest_require, pytest_assert                           # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut, \
     fanout_graph_facts                                                                              # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     snappi_api, snappi_dut_base_config, get_snappi_ports_for_rdma, cleanup_config, \
     snappi_testbed_config, get_snappi_ports_single_dut, snappi_port_selection, \
-    get_snappi_ports, tgen_port_info, tgen_testbed_subtype, is_snappi_multidut, \
+    get_snappi_ports, tgen_port_info, is_snappi_multidut, \
     get_snappi_ports_multi_dut, clear_fabric_counters, check_fabric_counters, \
     snappi_multi_base_config                                                                        # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list, \
@@ -68,7 +67,6 @@ def test_multiple_prio_diff_dist(snappi_api,                    # noqa: F811
         lossy_prio_list(list): list of lossy priorities.
         tbinfo(key): element to identify testbed info name.
         tgen_port_info(pytest fixture): returns list of ports based on linecards selected.
-        tgen_testbed_subtype(pytest_fixture): returns test_subtype for the test.
 
     Returns:
         N/A
@@ -180,7 +178,6 @@ def test_multiple_prio_uni_dist(snappi_api,                     # noqa: F811
         lossy_prio_list(list): list of lossy priorities.
         tbinfo(key): element to identify testbed info name.
         tgen_port_info(pytest fixture): returns list of ports based on linecards selected.
-        tgen_testbed_subtype(pytest_fixture): returns test_subtype for the test.
 
     Returns:
         N/A
@@ -295,7 +292,6 @@ def test_single_lossless_prio(snappi_api,                   # noqa: F811
         lossy_prio_list(list): list of lossy priorities.
         tbinfo(key): element to identify testbed info name.
         tgen_port_info(pytest fixture): returns list of ports based on linecards selected.
-        tgen_testbed_subtype(pytest_fixture): returns test_subtype for the test.
 
     Returns:
         N/A

--- a/tests/snappi_tests/pfc/test_pfc_port_congestion.py
+++ b/tests/snappi_tests/pfc/test_pfc_port_congestion.py
@@ -1,6 +1,5 @@
 import pytest
 import random
-from tests.common.helpers.assertions import pytest_require, pytest_assert                           # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut, \
     fanout_graph_facts                                                                              # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \

--- a/tests/snappi_tests/pfc/test_pfc_port_congestion.py
+++ b/tests/snappi_tests/pfc/test_pfc_port_congestion.py
@@ -1,25 +1,35 @@
 import pytest
 import random
-from tests.common.helpers.assertions import pytest_require, pytest_assert                            # noqa: F401
+from tests.common.helpers.assertions import pytest_require, pytest_assert                           # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut, \
-    fanout_graph_facts     # noqa: F401
+    fanout_graph_facts                                                                              # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
-    snappi_api, snappi_multi_base_config, cleanup_config, get_snappi_ports_for_rdma, \
-    get_snappi_ports, get_snappi_ports_multi_dut, clear_fabric_counters, check_fabric_counters, \
-    get_snappi_ports_single_dut       # noqa: F401
+    snappi_api, snappi_dut_base_config, get_snappi_ports_for_rdma, cleanup_config, \
+    snappi_testbed_config, get_snappi_ports_single_dut, snappi_port_selection, \
+    get_snappi_ports, tgen_port_info, is_snappi_multidut, get_snappi_ports_multi_dut, \
+    clear_fabric_counters, check_fabric_counters, snappi_multi_base_config                          # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list, \
-    lossy_prio_list, all_prio_list, disable_pfcwd                                                     # noqa: F401
-from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
-from tests.snappi_tests.pfc.files.pfc_congestion_helper import run_pfc_test
+    lossy_prio_list, all_prio_list, disable_pfcwd                                                   # noqa: F401
+from tests.snappi_tests.pfc.files.pfc_congestion_helper import run_pfc_test, get_test_subtype_from_ports
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
-from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                                    # noqa: F401
 
 import logging
 logger = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.topology('multidut-tgen')]
 
-port_map = [[1, 100, 2, 100], [1, 400, 2, 400]]
+
+@pytest.fixture(autouse=True, scope='module')
+def number_of_tx_rx_ports():
+    yield (1, 2)
+
+
+def create_port_map(snappi_ports):
+    return ([1,
+             int(snappi_ports[0]['snappi_speed_type'].split('_')[1]),
+             len(snappi_ports) - 1,
+             int(snappi_ports[-1]['snappi_speed_type'].split('_')[1])])
 
 # Testplan: docs/testplan/PFC_Snappi_Additional_Testcases.md
 # This test-script covers following testcases:
@@ -27,8 +37,6 @@ port_map = [[1, 100, 2, 100], [1, 400, 2, 400]]
 # testcase#05: DETECT CONGESTION WITH EQUAL DISTRIBUTION OF LOSSLESS AND LOSSY TRAFFIC
 
 
-@pytest.mark.parametrize('port_map', port_map)
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_multiple_prio_diff_dist(snappi_api,                   # noqa: F811
                                  conn_graph_facts,             # noqa: F811
                                  fanout_graph_facts_multidut,  # noqa: F811
@@ -37,9 +45,7 @@ def test_multiple_prio_diff_dist(snappi_api,                   # noqa: F811
                                  lossless_prio_list,           # noqa: F811
                                  lossy_prio_list,              # noqa: F811
                                  tbinfo,
-                                 get_snappi_ports,             # noqa: F811
-                                 port_map,
-                                 multidut_port_info,           # noqa: F811
+                                 tgen_port_info,               # noqa: F811
                                  disable_pfcwd):               # noqa: F811
 
     """
@@ -56,9 +62,8 @@ def test_multiple_prio_diff_dist(snappi_api,                   # noqa: F811
         lossless_prio_list(list): list of lossless priorities
         lossy_prio_list(list): list of lossy priorities.
         tbinfo(key): element to identify testbed info name.
-        get_snappi_ports(pytest fixture): returns list of ports based on linecards selected.
-        port_map(list): list for port-speed combination.
-        multidut_port_info : Line card classification along with ports selected as Rx and Tx port.
+        tgen_port_info(pytest fixture): returns list of ports based on linecards selected.
+        tgen_testbed_subtype(pytest_fixture): returns test_subtype for the test.
     Returns:
         N/A
 
@@ -72,36 +77,14 @@ def test_multiple_prio_diff_dist(snappi_api,                   # noqa: F811
     # With imix flag set, the traffic_generation.py uses IMIX profile.
     pkt_size = 1024
 
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        rx_port_count = port_map[0]
-        tx_port_count = port_map[2]
-        tmp_snappi_port_list = get_snappi_ports
-        snappi_port_list = []
-        for item in tmp_snappi_port_list:
-            if (int(item['speed']) == (port_map[1] * 1000)):
-                snappi_port_list.append(item)
-        pytest_require(MULTIDUT_TESTBED == tbinfo['conf-name'],
-                       "The testbed name from testbed file doesn't match with MULTIDUT_TESTBED in variables.py ")
-        pytest_require(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                       "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
+    logger.info("Snappi Ports : {}".format(snappi_ports))
 
-        pytest_require(len(rdma_ports['tx_ports']) >= tx_port_count,
-                       'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                       testbed {}, subtype {} in variables.py'.
-                       format(MULTIDUT_TESTBED, testbed_subtype))
+    # port_map = [1 egress port, speed of egress port, remaining ingress ports, speed of ingress port]
+    port_map = create_port_map(snappi_ports)
 
-        pytest_require(len(rdma_ports['rx_ports']) >= rx_port_count,
-                       'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                       testbed {}, subtype {} in variables.py'.
-                       format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
+    testbed_type = get_test_subtype_from_ports(snappi_ports, port_map, tbinfo)
 
-        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-
-        testbed_config, port_config_list, snappi_ports = snappi_multi_base_config(duthosts,
-                                                                                  snappi_ports,
-                                                                                  snappi_api)
     enable_pfcwd = True
     if duthosts[0].facts["platform_asic"] == 'cisco-8000' and duthosts[0].get_facts().get("modular_chassis"):
         enable_pfcwd = False
@@ -117,7 +100,7 @@ def test_multiple_prio_diff_dist(snappi_api,                   # noqa: F811
                 'data_flow_delay_sec': 0,
                 'SNAPPI_POLL_DELAY_SEC': 60,
                 'test_type': 'logs/snappi_tests/pfc/Two_Ingress_Single_Egress_diff_dist_'+str(port_map[1])+'Gbps',
-                'line_card_choice': testbed_subtype,
+                'line_card_choice': testbed_type,
                 'port_map': port_map,
                 'enable_pfcwd': enable_pfcwd,
                 'enable_credit_wd': True,
@@ -137,6 +120,7 @@ def test_multiple_prio_diff_dist(snappi_api,                   # noqa: F811
     snappi_extra_params.multi_dut_params.duthost2 = snappi_ports[-1]['duthost']
 
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+
     if (snappi_ports[0]['peer_device'] == snappi_ports[-1]['peer_device']):
         dut_list = [snappi_ports[0]['duthost']]
     else:
@@ -162,13 +146,10 @@ def test_multiple_prio_diff_dist(snappi_api,                   # noqa: F811
 
         for dut in duthosts:
             check_fabric_counters(dut)
-
     finally:
         cleanup_config(dut_list, snappi_ports)
 
 
-@pytest.mark.parametrize('port_map', port_map)
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_multiple_prio_uni_dist(snappi_api,                   # noqa: F811
                                 conn_graph_facts,             # noqa: F811
                                 fanout_graph_facts_multidut,  # noqa: F811
@@ -177,10 +158,8 @@ def test_multiple_prio_uni_dist(snappi_api,                   # noqa: F811
                                 lossless_prio_list,           # noqa: F811
                                 lossy_prio_list,              # noqa: F811
                                 tbinfo,
-                                get_snappi_ports,             # noqa: F811
-                                port_map,
-                                multidut_port_info,  # noqa: F811
-                                disable_pfcwd):          # noqa: F811
+                                tgen_port_info,               # noqa: F811
+                                disable_pfcwd):               # noqa: F811
     """
     Purpose of the test case is to test oversubscription with two ingresses and single ingress.
     Traffic pattern has 24% lossless priority and 36% lossy priority traffic.
@@ -195,9 +174,8 @@ def test_multiple_prio_uni_dist(snappi_api,                   # noqa: F811
         lossless_prio_list(list): list of lossless priorities
         lossy_prio_list(list): list of lossy priorities.
         tbinfo(key): element to identify testbed info name.
-        get_snappi_ports(pytest fixture): returns list of ports based on linecards selected.
-        port_map(list): list for port-speed combination.
-        multidut_port_info : Line card classification along with ports selected as Rx and Tx port.
+        tgen_port_info(pytest fixture): returns list of ports based on linecards selected.
+        tgen_testbed_subtype(pytest_fixture): returns test_subtype for the test.
 
     Returns:
         N/A
@@ -210,36 +188,14 @@ def test_multiple_prio_uni_dist(snappi_api,                   # noqa: F811
     # With imix flag set, the traffic_generation.py uses IMIX profile.
     pkt_size = 1024
 
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        rx_port_count = port_map[0]
-        tx_port_count = port_map[2]
-        tmp_snappi_port_list = get_snappi_ports
-        snappi_port_list = []
-        for item in tmp_snappi_port_list:
-            if (int(item['speed']) == (port_map[1] * 1000)):
-                snappi_port_list.append(item)
-        pytest_require(MULTIDUT_TESTBED == tbinfo['conf-name'],
-                       "The testbed name from testbed file doesn't match with MULTIDUT_TESTBED in variables.py ")
-        pytest_require(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                       "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
+    logger.info("Snappi Ports : {}".format(snappi_ports))
 
-        pytest_require(len(rdma_ports['tx_ports']) >= tx_port_count,
-                       'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                       testbed {}, subtype {} in variables.py'.
-                       format(MULTIDUT_TESTBED, testbed_subtype))
+    # port_map = [1 egress port, speed of egress port, remaining ingress ports, speed of ingress port]
+    port_map = create_port_map(snappi_ports)
 
-        pytest_require(len(rdma_ports['rx_ports']) >= rx_port_count,
-                       'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                       testbed {}, subtype {} in variables.py'.
-                       format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
+    testbed_type = get_test_subtype_from_ports(snappi_ports, port_map, tbinfo)
 
-        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-
-        testbed_config, port_config_list, snappi_ports = snappi_multi_base_config(duthosts,
-                                                                                  snappi_ports,
-                                                                                  snappi_api)
     enable_pfcwd = True
     if duthosts[0].facts["platform_asic"] == 'cisco-8000' and duthosts[0].get_facts().get("modular_chassis"):
         enable_pfcwd = False
@@ -256,7 +212,7 @@ def test_multiple_prio_uni_dist(snappi_api,                   # noqa: F811
                 'data_flow_delay_sec': 0,
                 'SNAPPI_POLL_DELAY_SEC': 60,
                 'test_type': 'logs/snappi_tests/pfc/Two_Ingress_Single_Egress_uni_dist_full'+str(port_map[1])+'Gbps',
-                'line_card_choice': testbed_subtype,
+                'line_card_choice': testbed_type,
                 'port_map': port_map,
                 'enable_pfcwd': enable_pfcwd,
                 'enable_credit_wd': True,
@@ -276,6 +232,7 @@ def test_multiple_prio_uni_dist(snappi_api,                   # noqa: F811
     snappi_extra_params.multi_dut_params.duthost2 = snappi_ports[-1]['duthost']
 
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+
     if (snappi_ports[0]['peer_device'] == snappi_ports[-1]['peer_device']):
         dut_list = [snappi_ports[0]['duthost']]
     else:
@@ -301,13 +258,10 @@ def test_multiple_prio_uni_dist(snappi_api,                   # noqa: F811
 
         for dut in duthosts:
             check_fabric_counters(dut)
-
     finally:
         cleanup_config(dut_list, snappi_ports)
 
 
-@pytest.mark.parametrize('port_map', port_map)
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_multiple_prio_equal_dist(snappi_api,                   # noqa: F811
                                   conn_graph_facts,             # noqa: F811
                                   fanout_graph_facts_multidut,  # noqa: F811
@@ -316,10 +270,8 @@ def test_multiple_prio_equal_dist(snappi_api,                   # noqa: F811
                                   lossless_prio_list,           # noqa: F811
                                   lossy_prio_list,              # noqa: F811
                                   tbinfo,
-                                  get_snappi_ports,             # noqa: F811
-                                  port_map,
-                                  multidut_port_info,  # noqa: F811
-                                  disable_pfcwd):          # noqa: F811
+                                  tgen_port_info,               # noqa: F811
+                                  disable_pfcwd):               # noqa: F811
 
     """
     Purpose of the test case is to test oversubscription with two ingresses and single ingress.
@@ -336,9 +288,8 @@ def test_multiple_prio_equal_dist(snappi_api,                   # noqa: F811
         lossless_prio_list(list): list of lossless priorities
         lossy_prio_list(list): list of lossy priorities.
         tbinfo(key): element to identify testbed info name.
-        get_snappi_ports(pytest fixture): returns list of ports based on linecards selected.
-        port_map(list): list for port-speed combination.
-        multidut_port_info : Line card classification along with ports selected as Rx and Tx port.
+        tgen_port_info(pytest fixture): returns list of ports based on linecards selected.
+        tgen_testbed_subtype(pytest_fixture): returns test_subtype for the test.
 
     Returns:
         N/A
@@ -351,36 +302,14 @@ def test_multiple_prio_equal_dist(snappi_api,                   # noqa: F811
     # With imix flag set, the traffic_generation.py uses IMIX profile.
     pkt_size = 1024
 
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        rx_port_count = port_map[0]
-        tx_port_count = port_map[2]
-        tmp_snappi_port_list = get_snappi_ports
-        snappi_port_list = []
-        for item in tmp_snappi_port_list:
-            if (int(item['speed']) == (port_map[1] * 1000)):
-                snappi_port_list.append(item)
-        pytest_require(MULTIDUT_TESTBED == tbinfo['conf-name'],
-                       "The testbed name from testbed file doesn't match with MULTIDUT_TESTBED in variables.py ")
-        pytest_require(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                       "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
+    logger.info("Snappi Ports : {}".format(snappi_ports))
 
-        pytest_require(len(rdma_ports['tx_ports']) >= tx_port_count,
-                       'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                       testbed {}, subtype {} in variables.py'.
-                       format(MULTIDUT_TESTBED, testbed_subtype))
+    # port_map = [1 egress port, speed of egress port, remaining ingress ports, speed of ingress port]
+    port_map = create_port_map(snappi_ports)
 
-        pytest_require(len(rdma_ports['rx_ports']) >= rx_port_count,
-                       'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                       testbed {}, subtype {} in variables.py'.
-                       format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
+    testbed_type = get_test_subtype_from_ports(snappi_ports, port_map, tbinfo)
 
-        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-
-        testbed_config, port_config_list, snappi_ports = snappi_multi_base_config(duthosts,
-                                                                                  snappi_ports,
-                                                                                  snappi_api)
     enable_pfcwd = True
     if duthosts[0].facts["platform_asic"] == 'cisco-8000' and duthosts[0].get_facts().get("modular_chassis"):
         enable_pfcwd = False
@@ -397,7 +326,7 @@ def test_multiple_prio_equal_dist(snappi_api,                   # noqa: F811
                 'data_flow_delay_sec': 0,
                 'SNAPPI_POLL_DELAY_SEC': 60,
                 'test_type': 'logs/snappi_tests/pfc/Two_Ingress_Single_Egress_equal_dist'+str(port_map[1])+'Gbps',
-                'line_card_choice': testbed_subtype,
+                'line_card_choice': testbed_type,
                 'port_map': port_map,
                 'enable_pfcwd': enable_pfcwd,
                 'enable_credit_wd': True,
@@ -417,6 +346,7 @@ def test_multiple_prio_equal_dist(snappi_api,                   # noqa: F811
     snappi_extra_params.multi_dut_params.duthost2 = snappi_ports[-1]['duthost']
 
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+
     if (snappi_ports[0]['peer_device'] == snappi_ports[-1]['peer_device']):
         dut_list = [snappi_ports[0]['duthost']]
     else:
@@ -442,13 +372,10 @@ def test_multiple_prio_equal_dist(snappi_api,                   # noqa: F811
 
         for dut in duthosts:
             check_fabric_counters(dut)
-
     finally:
         cleanup_config(dut_list, snappi_ports)
 
 
-@pytest.mark.parametrize('port_map', port_map)
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_multiple_prio_non_cngtn(snappi_api,                   # noqa: F811
                                  conn_graph_facts,             # noqa: F811
                                  fanout_graph_facts_multidut,  # noqa: F811
@@ -457,10 +384,8 @@ def test_multiple_prio_non_cngtn(snappi_api,                   # noqa: F811
                                  lossless_prio_list,           # noqa: F811
                                  lossy_prio_list,              # noqa: F811
                                  tbinfo,
-                                 get_snappi_ports,             # noqa: F811
-                                 port_map,
-                                 multidut_port_info,  # noqa: F811
-                                 disable_pfcwd):          # noqa: F811
+                                 tgen_port_info,               # noqa: F811
+                                 disable_pfcwd):               # noqa: F811
 
     """
     Purpose of the test case is to test oversubscription with two ingresses and single ingress.
@@ -477,9 +402,9 @@ def test_multiple_prio_non_cngtn(snappi_api,                   # noqa: F811
         lossless_prio_list(list): list of lossless priorities
         lossy_prio_list(list): list of lossy priorities.
         tbinfo(key): element to identify testbed info name.
-        get_snappi_ports(pytest fixture): returns list of ports based on linecards selected.
-        port_map(list): list for port-speed combination.
-        multidut_port_info : Line card classification along with ports selected as Rx and Tx port.
+        tgen_port_info(pytest fixture): returns list of ports based on linecards selected.
+        tgen_testbed_subtype(pytest_fixture): returns test_subtype for the test.
+
     Returns:
         N/A
 
@@ -493,36 +418,14 @@ def test_multiple_prio_non_cngtn(snappi_api,                   # noqa: F811
     # With imix flag set, the traffic_generation.py uses IMIX profile.
     pkt_size = 1024
 
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        rx_port_count = port_map[0]
-        tx_port_count = port_map[2]
-        tmp_snappi_port_list = get_snappi_ports
-        snappi_port_list = []
-        for item in tmp_snappi_port_list:
-            if (int(item['speed']) == (port_map[1] * 1000)):
-                snappi_port_list.append(item)
-        pytest_require(MULTIDUT_TESTBED == tbinfo['conf-name'],
-                       "The testbed name from testbed file doesn't match with MULTIDUT_TESTBED in variables.py ")
-        pytest_require(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                       "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
+    logger.info("Snappi Ports : {}".format(snappi_ports))
 
-        pytest_require(len(rdma_ports['tx_ports']) >= tx_port_count,
-                       'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                       testbed {}, subtype {} in variables.py'.
-                       format(MULTIDUT_TESTBED, testbed_subtype))
+    # port_map = [1 egress port, speed of egress port, remaining ingress ports, speed of ingress port]
+    port_map = create_port_map(snappi_ports)
 
-        pytest_require(len(rdma_ports['rx_ports']) >= rx_port_count,
-                       'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                       testbed {}, subtype {} in variables.py'.
-                       format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
+    testbed_type = get_test_subtype_from_ports(snappi_ports, port_map, tbinfo)
 
-        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-
-        testbed_config, port_config_list, snappi_ports = snappi_multi_base_config(duthosts,
-                                                                                  snappi_ports,
-                                                                                  snappi_api)
     enable_pfcwd = True
     if duthosts[0].facts["platform_asic"] == 'cisco-8000' and duthosts[0].get_facts().get("modular_chassis"):
         enable_pfcwd = False
@@ -539,7 +442,7 @@ def test_multiple_prio_non_cngtn(snappi_api,                   # noqa: F811
                 'data_flow_delay_sec': 0,
                 'SNAPPI_POLL_DELAY_SEC': 60,
                 'test_type': 'logs/snappi_tests/pfc/Two_Ingress_Single_Egress_non_cngstn_'+str(port_map[1])+'Gbps',
-                'line_card_choice': testbed_subtype,
+                'line_card_choice': testbed_type,
                 'port_map': port_map,
                 'enable_pfcwd': enable_pfcwd,
                 'enable_credit_wd': True,
@@ -559,6 +462,7 @@ def test_multiple_prio_non_cngtn(snappi_api,                   # noqa: F811
     snappi_extra_params.multi_dut_params.duthost2 = snappi_ports[-1]['duthost']
 
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+
     if (snappi_ports[0]['peer_device'] == snappi_ports[-1]['peer_device']):
         dut_list = [snappi_ports[0]['duthost']]
     else:
@@ -584,6 +488,5 @@ def test_multiple_prio_non_cngtn(snappi_api,                   # noqa: F811
 
         for dut in duthosts:
             check_fabric_counters(dut)
-
     finally:
         cleanup_config(dut_list, snappi_ports)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Added tgen_port_info support for following PFC testcases:
test_pfc_no_congestion_throughput.py
test_pfc_port_congestion.py

New PR will be raised to handle support for PFCWD action test script. Splitting changes into two pull-requests(one for PFC and other for PFCWD) for better tracking and review process.

Summary:
Fixes #22473 (partially)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The PFC test_pfc_no_congestion_throughput.py and test_pfc_port_congestion.py test scripts relied on snappi_tests/variables.py to read the info for the ports. It used port_map functionality to determine ingress and egress count of ports and their speed.

Switched the testcases to use the tgen_port_info functionality, which uses snappi_tests/variables.override.yml file for ports.

#### How did you do it?
- Removed the port_map and reference to MULTIDUT_PORT_INFO dictionary being read from variables.py.
- Used tgen_port_info to generate testbed_config, port_config_list and snappi_ports.
- The filename (with raw data in text and CSV format) was dependent on port_map to determine the ingress and egress ports and their speeds. Instead creating the same port_map dynamically using function - create_port_map in the test-script.
- Following changes were done in the helper file:
    - function _get_bgp_neighbor_name_for_port returns the BGP neighbor name for each port.
    - function _traffic_direction_from_neighbor_names determines if the traffic is flowing from uplink-> downlink port or vice-versa.
    - function _port_type_prefix determines if the test is single_asic, multi_asic or multi-line(ml) test.
    - function _speed_from_port_map returns the port_speed.
- All of the above info is used to return the file-name which stores the raw-data and CSV info.

#### How did you verify/test it?
- Verified the same on local repo branched off of master.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
