### PR TITLE
tests: common: Assign correct variables in get_common_supported_speeds

### DIFF
--- a/tests/common/helpers/port_utils.py
+++ b/tests/common/helpers/port_utils.py
@@ -23,12 +23,12 @@ def get_common_supported_speeds(duthost, dut_port_name, fanout, fanout_port_name
 
     fanout_supported_speeds = fanout.get_supported_speeds(fanout_port_name)
     if not fanout_supported_speeds:
-        dut_supported_speeds = [dut_current_port_speed]
+        fanout_supported_speeds = [dut_current_port_speed]
 
     # get supported speeds for the cable
     cable_supported_speeds = get_cable_supported_speeds(duthost, dut_port_name)
     if not cable_supported_speeds:
-        dut_supported_speeds = [dut_current_port_speed]
+        cable_supported_speeds = [dut_current_port_speed]
 
     supported_speeds = set(dut_supported_speeds) & set(fanout_supported_speeds) & set(cable_supported_speeds)
     if not supported_speeds:


### PR DESCRIPTION
There are guards for fanout_supported_speeds and cable_supported_speeds but the fallback code assigned dut_supported_speeds instead. Assign to the correct variables.

### Description of PR

I noticed this while setting up a local test environment. It probably came about because my fanout setup is returning None for fanout.get_supported_speeds() which is possibly why others aren't seeing it.

Summary:
Fixes # (issue)

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
