### PR TITLE
[BMC] Skip test_orchagent_heartbeat on BMC (no orchagent)

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4118,12 +4118,13 @@ process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical
 
 process_monitoring/test_critical_process_monitoring.py::test_orchagent_heartbeat:
   skip:
-    reason: This test is intended for Orchagent freeze scenario during warm-reboot. It is not required for T1 devices, and not supported on 202412 release.
+    reason: "This test is intended for Orchagent freeze scenario during warm-reboot. It is not required for T1 devices, and not supported on 202412 release. Also not applicable on BMC platforms which have no orchagent."
     conditions_logical_operator: or
     conditions:
       - "'t1' in topo_name"
       - "release in ['202412']"
       - "is_smartswitch==True" # t0 and t1 should all be skipped on smartswitch
+      - "'bmc' in topo_type"
 
 #######################################
 #####     ptftests      #####


### PR DESCRIPTION
### Description of PR

Summary: extend the existing skip block for `test_orchagent_heartbeat` with a BMC condition.

BMC platforms (e.g. Aspeed Komodo NH-B27) have no orchagent container — no swss/syncd, no front-side ASIC. The warm-reboot orchagent-freeze scenario this test exercises is not applicable on BMC.

```yaml
process_monitoring/test_critical_process_monitoring.py::test_orchagent_heartbeat:
  skip:
    reason: "This test is intended for Orchagent freeze scenario during warm-reboot. It is not required for T1 devices, and not supported on 202412 release. Also not applicable on BMC platforms which have no orchagent."
    conditions_logical_operator: or
    conditions:
      - "'t1' in topo_name"
      - "release in ['202412']"
      - "is_smartswitch==True"
      - "'bmc' in topo_type"           # ← new
```

**Scope is intentionally limited to `test_orchagent_heartbeat`.** The other test in the same module (`test_monitoring_critical_processes`) is kept running on BMC because it may surface real BMC-specific process-monitoring issues — the existing xfail entry tied to [issue #10336](https://github.com/sonic-net/sonic-buildimage/issues/10336) already handles its expected behavior on platforms where the global heuristic fails.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

`test_orchagent_heartbeat` errors on every Komodo BMC run (R1 2026-04-15 and R2 2026-05-08, same outcome) with a teardown `BaseExceptionGroup`. The test body even has an early `return` for "no swss container", but the module-scoped autouse fixture `config_reload_after_tests` still fires its destructive teardown. Since BMC has no orchagent at all, the right answer is to skip this case at collection time.

#### How did you do it?

Added `"'bmc' in topo_type"` to the existing skip's `conditions` list. The list already had `conditions_logical_operator: or`, so any one of t1 / 202412 / smartswitch / bmc triggers the skip.

#### How did you verify/test it?

- YAML lint clean (`python3 -c "import yaml; yaml.safe_load(...)"`)
- No behavioral change for non-BMC platforms (existing 3 conditions still trigger as before)
- `test_monitoring_critical_processes` unaffected — keeps running on BMC (intentional)

#### Any platform specific information?

Only BMC topologies (`'bmc' in topo_type`). No effect on switching platforms.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.
