### PR TITLE
[loganalyzer] Add routeCheck monit failure to common ignore list

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -7,6 +7,7 @@ r, ".* ERR .*initializeGlobalConfig: SonicDBConfig Global config is already init
 r, ".* NOTICE kernel:.*profile=""/usr/sbin/ntpd"" name=""sbin"" pid=.* comm=""ntpd"" requested_mask=.*"
 r, ".* ERR snmp#snmp-subagent.*"
 r, ".* ERR route_check.py.*"
+r, ".*ERR monit\[\d+\]: 'routeCheck' status failed.*"
 r, ".* INFO mgmt-framework#supervisord: rest-server.*"
 r, ".* ERR radv#radvd.* Exiting, privsep_read_loop.*"
 r, ".* ERR ntpd.*bind.*AF_INET6.*"


### PR DESCRIPTION
### Description of PR
Summary:
Add monit `routeCheck` failure pattern to the global LogAnalyzer common ignore list.

The monit `routeCheck` program periodically runs `route_check.py` to verify route consistency between FRR, APPL_DB, and ASIC_DB. During tests that cause interface flaps or route programming changes, FRR routes may transiently enter a "failed" state while APPL_DB and ASIC_DB remain in sync. The `routeCheck` script catches this transient window and logs an ERR syslog, which the LogAnalyzer then flags as a test failure on teardown.

This pattern is already individually ignored by 6+ tests:
- `tests/arp/test_stress_arp.py`
- `tests/pc/test_lag_2.py`
- `tests/route/test_route_perf.py`
- `tests/stress/test_stress_routes.py`
- `tests/generic_config_updater/conftest.py`
- `tests/lldp/test_lldp_syncd.py`

Adding it to the common ignore list eliminates false-positive teardown failures across all tests.

**Impact**: Kusto data from the last 30 days shows **74 testbeds** across 5 ASIC vendors (Broadcom, Marvell-Prestera, Cisco-8000, Mellanox, Nvidia-Bluefield) hit this routeCheck teardown failure.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Reduce false-positive teardown failures caused by transient `routeCheck` monit errors. 74 testbeds across all major ASIC vendors are affected in the last 30 days.

#### How did you do it?
Added one regex line to `loganalyzer_common_ignore.txt`, placed next to the existing `route_check.py` ignore pattern (line 9).

#### How did you verify/test it?
- Verified the regex matches the syslog format: `ERR monit[1283]: 'routeCheck' status failed (255) -- ...`
- Cross-checked with 6 existing per-test ignore patterns that use the same regex
- Kusto analysis confirms all 74 testbed failures match this pattern

#### Any platform specific information?
Affects all platforms — Broadcom, Marvell-Prestera, Cisco-8000, Mellanox, Nvidia-Bluefield.

#### Supported testbed topology if it's a new test case?
N/A — this is a LogAnalyzer ignore pattern change, not a new test case.

### Documentation
N/A