### PR TITLE
chore: skip critical process monitoring on VS

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4114,7 +4114,11 @@ process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical
   xfail:
     reason: "Testcase ignored due to issue: https://github.com/sonic-net/sonic-buildimage/issues/10336"
     conditions:
-    - "https://github.com/sonic-net/sonic-buildimage/issues/10336"
+      - "https://github.com/sonic-net/sonic-buildimage/issues/10336"
+  skip:
+    reason: "Skip test on VS due to issue: https://github.com/sonic-net/sonic-buildimage/issues/10336"
+    conditions:
+      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-buildimage/issues/10336"
 
 process_monitoring/test_critical_process_monitoring.py::test_orchagent_heartbeat:
   skip:


### PR DESCRIPTION
### Description of PR
Summary:
Add a VS-specific conditional skip for `process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical_processes` when sonic-buildimage issue 10336 is active.

The test was already marked `xfail` while the issue is active. This PR keeps that behavior for all platforms, and adds a narrower `skip` mark for VS so VS runs do not execute the known failing test while the issue remains open.

Fixes # (issue): N/A
Related issue: https://github.com/sonic-net/sonic-buildimage/issues/10336

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`test_monitoring_critical_processes` is affected by sonic-buildimage issue 10336, causing this test case to hang until timeout in the PR checker sometimes. The existing conditional mark xfails the test for all platforms while the issue is active. VS needs to skip the test entirely for the same active issue.

#### How did you do it?
Added a `skip` mark to the existing conditional mark entry for `test_monitoring_critical_processes` with condition: "asic_type in ['vs'] and https://github.com/sonic-net/sonic-buildimage/issues/10336"

The existing issue-gated `xfail` remains unchanged for non-VS platforms.

#### How did you verify/test it?
Verified that the `process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical_processes` is skipped on VS platform
<img width="2859" height="647" alt="image" src="https://github.com/user-attachments/assets/0a9fb531-2c9e-4c6e-83a8-671a5b2bb422" />

and remains `XFAIL` on physical testbed:
<img width="2898" height="875" alt="image" src="https://github.com/user-attachments/assets/3ed6ee47-af19-468a-a50b-becee0f1f450" />


#### Any platform specific information?
The new skip applies only to VS ASIC type. Non-VS platforms continue to use the existing conditional xfail while issue 10336 is active.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
