### PR TITLE
[202511] Enable test_qos_sai on topo-t2-single-node-max-64p

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -29,7 +29,8 @@ MARK_CONDITIONS_CONSTANTS = {
                      't1-backend', 't1-isolated-d128', 't1-isolated-d32',
                      't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic',
                      'lt2-p32o64', 'lt2-o128', 'ft2-64', 't2-single-node-min',
-                     't2_single_node_max', 't2_single_node_max_64p', 'topo_t2_single_node_max_64p_v2']
+                     't2_single_node_max', 't2_single_node_max_64p', 't2-single-node-max-64p',
+                     'topo_t2_single_node_max_64p_v2']
 }
 
 

--- a/tests/qos/files/qos_params.q3d.yaml
+++ b/tests/qos/files/qos_params.q3d.yaml
@@ -1,6 +1,6 @@
 qos_params:
     q3d:
-        topo-t2-single-node-min:
+        topo-t2_single_node_min: &topo-t2_single_node_min
             400000_2000m:
                 hdrm_pool_size:
                     dscps:
@@ -359,5 +359,8 @@ qos_params:
                 lossy_weight: 8
                 q_list: [0, 1, 3, 4, 5, 6]
                 q_pkt_cnt: [80, 100, 300, 100, 100, 700]
+        topo-t2-single-node-min: *topo-t2_single_node_min
+        topo-t2-single-node-max-64p: *topo-t2_single_node_min
+        topo-t2_single_node_max_64p: *topo-t2_single_node_min
         topo-any:
             cell_size: 4096


### PR DESCRIPTION
Enable tests on the t2-single-node-max-64p topology. 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Run test_qos_sai on t2-single-node-max-64p.

#### How did you do it?
Added t2-single-node-max-64p to QOS_SAI_TOPO and aliased it to the existing topo-t2_single_node_min profile in qos_params.q3d.yaml.

#### How did you verify/test it?
Ran test_qos_sai on a t2-single-node-max-64p testbed.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
