### PR TITLE
[TH6-128] Fix PTF backplane netmask for lt2-o256-u32d224 topology

### DIFF
--- a/ansible/generate_topo.py
+++ b/ansible/generate_topo.py
@@ -7,6 +7,8 @@ from ipaddress import IPv4Network, IPv6Network, IPv4Address
 import click
 import jinja2
 
+# PTF backplane pool is 10.10.244.0/22 (see bounds below). Large topologies that wrap
+# within this pool must use /22 on bp_interface, not /24.
 PTF_BACKPLANE_IPV4 = "10.10.246.254"
 # current PTF subnet is  10.10.246.0/22
 PTF_BACKPLANE_IPV4_LOWER_BOUND = "10.10.244.1"

--- a/ansible/templates/topo_lt2-o256-u32d224.j2
+++ b/ansible/templates/topo_lt2-o256-u32d224.j2
@@ -60,6 +60,6 @@ configuration:
         ipv6: {{vm.pc_intf_ipv6}}/126
       {%- endif %}
     bp_interface:
-      ipv4: {{vm.bp_ipv4}}/24
+      ipv4: {{vm.bp_ipv4}}/22
       ipv6: {{vm.bp_ipv6}}/64
 {%- endfor %}

--- a/ansible/vars/topo_lt2-o256-u32d224.yml
+++ b/ansible/vars/topo_lt2-o256-u32d224.yml
@@ -1008,6 +1008,22 @@ topology:
       vlans:
       - 251
       vm_offset: 251
+    ARISTA221T1:
+      vlans:
+      - 252
+      vm_offset: 252
+    ARISTA222T1:
+      vlans:
+      - 253
+      vm_offset: 253
+    ARISTA223T1:
+      vlans:
+      - 254
+      vm_offset: 254
+    ARISTA224T1:
+      vlans:
+      - 255
+      vm_offset: 255
 configuration_properties:
   common:
     dut_asn: 4200100000
@@ -1015,10 +1031,10 @@ configuration_properties:
     nhipv4: 10.10.246.254
     nhipv6: FC0A::FF
     podset_number: 200
-    tor_number: 220
+    tor_number: 224
     tor_subnet_number: 2
-    max_tor_subnet_number: 220
-    tor_subnet_size: 220
+    max_tor_subnet_number: 224
+    tor_subnet_size: 224
   spine:
     swrole: spine
   leaf:
@@ -1045,7 +1061,7 @@ configuration:
         ipv4: 10.0.0.1/31
         ipv6: fc00::2/126
     bp_interface:
-      ipv4: 10.10.246.2/24
+      ipv4: 10.10.246.2/22
       ipv6: fc0a::2/64
   ARISTA02T1:
     properties:
@@ -1068,7 +1084,7 @@ configuration:
         ipv4: 10.0.0.3/31
         ipv6: fc00::6/126
     bp_interface:
-      ipv4: 10.10.246.3/24
+      ipv4: 10.10.246.3/22
       ipv6: fc0a::3/64
   ARISTA03T1:
     properties:
@@ -1091,7 +1107,7 @@ configuration:
         ipv4: 10.0.0.5/31
         ipv6: fc00::a/126
     bp_interface:
-      ipv4: 10.10.246.4/24
+      ipv4: 10.10.246.4/22
       ipv6: fc0a::4/64
   ARISTA04T1:
     properties:
@@ -1114,7 +1130,7 @@ configuration:
         ipv4: 10.0.0.7/31
         ipv6: fc00::e/126
     bp_interface:
-      ipv4: 10.10.246.5/24
+      ipv4: 10.10.246.5/22
       ipv6: fc0a::5/64
   ARISTA05T1:
     properties:
@@ -1137,7 +1153,7 @@ configuration:
         ipv4: 10.0.0.9/31
         ipv6: fc00::12/126
     bp_interface:
-      ipv4: 10.10.246.6/24
+      ipv4: 10.10.246.6/22
       ipv6: fc0a::6/64
   ARISTA06T1:
     properties:
@@ -1160,7 +1176,7 @@ configuration:
         ipv4: 10.0.0.11/31
         ipv6: fc00::16/126
     bp_interface:
-      ipv4: 10.10.246.7/24
+      ipv4: 10.10.246.7/22
       ipv6: fc0a::7/64
   ARISTA07T1:
     properties:
@@ -1183,7 +1199,7 @@ configuration:
         ipv4: 10.0.0.13/31
         ipv6: fc00::1a/126
     bp_interface:
-      ipv4: 10.10.246.8/24
+      ipv4: 10.10.246.8/22
       ipv6: fc0a::8/64
   ARISTA08T1:
     properties:
@@ -1206,7 +1222,7 @@ configuration:
         ipv4: 10.0.0.15/31
         ipv6: fc00::1e/126
     bp_interface:
-      ipv4: 10.10.246.9/24
+      ipv4: 10.10.246.9/22
       ipv6: fc0a::9/64
   ARISTA09T1:
     properties:
@@ -1229,7 +1245,7 @@ configuration:
         ipv4: 10.0.0.17/31
         ipv6: fc00::22/126
     bp_interface:
-      ipv4: 10.10.246.10/24
+      ipv4: 10.10.246.10/22
       ipv6: fc0a::a/64
   ARISTA10T1:
     properties:
@@ -1252,7 +1268,7 @@ configuration:
         ipv4: 10.0.0.19/31
         ipv6: fc00::26/126
     bp_interface:
-      ipv4: 10.10.246.11/24
+      ipv4: 10.10.246.11/22
       ipv6: fc0a::b/64
   ARISTA11T1:
     properties:
@@ -1275,7 +1291,7 @@ configuration:
         ipv4: 10.0.0.21/31
         ipv6: fc00::2a/126
     bp_interface:
-      ipv4: 10.10.246.12/24
+      ipv4: 10.10.246.12/22
       ipv6: fc0a::c/64
   ARISTA12T1:
     properties:
@@ -1298,7 +1314,7 @@ configuration:
         ipv4: 10.0.0.23/31
         ipv6: fc00::2e/126
     bp_interface:
-      ipv4: 10.10.246.13/24
+      ipv4: 10.10.246.13/22
       ipv6: fc0a::d/64
   ARISTA13T1:
     properties:
@@ -1321,7 +1337,7 @@ configuration:
         ipv4: 10.0.0.25/31
         ipv6: fc00::32/126
     bp_interface:
-      ipv4: 10.10.246.14/24
+      ipv4: 10.10.246.14/22
       ipv6: fc0a::e/64
   ARISTA14T1:
     properties:
@@ -1344,7 +1360,7 @@ configuration:
         ipv4: 10.0.0.27/31
         ipv6: fc00::36/126
     bp_interface:
-      ipv4: 10.10.246.15/24
+      ipv4: 10.10.246.15/22
       ipv6: fc0a::f/64
   ARISTA15T1:
     properties:
@@ -1367,7 +1383,7 @@ configuration:
         ipv4: 10.0.0.29/31
         ipv6: fc00::3a/126
     bp_interface:
-      ipv4: 10.10.246.16/24
+      ipv4: 10.10.246.16/22
       ipv6: fc0a::10/64
   ARISTA16T1:
     properties:
@@ -1390,7 +1406,7 @@ configuration:
         ipv4: 10.0.0.31/31
         ipv6: fc00::3e/126
     bp_interface:
-      ipv4: 10.10.246.17/24
+      ipv4: 10.10.246.17/22
       ipv6: fc0a::11/64
   ARISTA17T1:
     properties:
@@ -1413,7 +1429,7 @@ configuration:
         ipv4: 10.0.0.33/31
         ipv6: fc00::42/126
     bp_interface:
-      ipv4: 10.10.246.18/24
+      ipv4: 10.10.246.18/22
       ipv6: fc0a::12/64
   ARISTA18T1:
     properties:
@@ -1436,7 +1452,7 @@ configuration:
         ipv4: 10.0.0.35/31
         ipv6: fc00::46/126
     bp_interface:
-      ipv4: 10.10.246.19/24
+      ipv4: 10.10.246.19/22
       ipv6: fc0a::13/64
   ARISTA19T1:
     properties:
@@ -1459,7 +1475,7 @@ configuration:
         ipv4: 10.0.0.37/31
         ipv6: fc00::4a/126
     bp_interface:
-      ipv4: 10.10.246.20/24
+      ipv4: 10.10.246.20/22
       ipv6: fc0a::14/64
   ARISTA20T1:
     properties:
@@ -1482,7 +1498,7 @@ configuration:
         ipv4: 10.0.0.39/31
         ipv6: fc00::4e/126
     bp_interface:
-      ipv4: 10.10.246.21/24
+      ipv4: 10.10.246.21/22
       ipv6: fc0a::15/64
   ARISTA21T1:
     properties:
@@ -1505,7 +1521,7 @@ configuration:
         ipv4: 10.0.0.41/31
         ipv6: fc00::52/126
     bp_interface:
-      ipv4: 10.10.246.22/24
+      ipv4: 10.10.246.22/22
       ipv6: fc0a::16/64
   ARISTA22T1:
     properties:
@@ -1528,7 +1544,7 @@ configuration:
         ipv4: 10.0.0.43/31
         ipv6: fc00::56/126
     bp_interface:
-      ipv4: 10.10.246.23/24
+      ipv4: 10.10.246.23/22
       ipv6: fc0a::17/64
   ARISTA23T1:
     properties:
@@ -1551,7 +1567,7 @@ configuration:
         ipv4: 10.0.0.45/31
         ipv6: fc00::5a/126
     bp_interface:
-      ipv4: 10.10.246.24/24
+      ipv4: 10.10.246.24/22
       ipv6: fc0a::18/64
   ARISTA24T1:
     properties:
@@ -1574,7 +1590,7 @@ configuration:
         ipv4: 10.0.0.47/31
         ipv6: fc00::5e/126
     bp_interface:
-      ipv4: 10.10.246.25/24
+      ipv4: 10.10.246.25/22
       ipv6: fc0a::19/64
   ARISTA25T1:
     properties:
@@ -1597,7 +1613,7 @@ configuration:
         ipv4: 10.0.0.49/31
         ipv6: fc00::62/126
     bp_interface:
-      ipv4: 10.10.246.26/24
+      ipv4: 10.10.246.26/22
       ipv6: fc0a::1a/64
   ARISTA26T1:
     properties:
@@ -1620,7 +1636,7 @@ configuration:
         ipv4: 10.0.0.51/31
         ipv6: fc00::66/126
     bp_interface:
-      ipv4: 10.10.246.27/24
+      ipv4: 10.10.246.27/22
       ipv6: fc0a::1b/64
   ARISTA27T1:
     properties:
@@ -1643,7 +1659,7 @@ configuration:
         ipv4: 10.0.0.53/31
         ipv6: fc00::6a/126
     bp_interface:
-      ipv4: 10.10.246.28/24
+      ipv4: 10.10.246.28/22
       ipv6: fc0a::1c/64
   ARISTA28T1:
     properties:
@@ -1666,7 +1682,7 @@ configuration:
         ipv4: 10.0.0.55/31
         ipv6: fc00::6e/126
     bp_interface:
-      ipv4: 10.10.246.29/24
+      ipv4: 10.10.246.29/22
       ipv6: fc0a::1d/64
   ARISTA29T1:
     properties:
@@ -1689,7 +1705,7 @@ configuration:
         ipv4: 10.0.0.57/31
         ipv6: fc00::72/126
     bp_interface:
-      ipv4: 10.10.246.30/24
+      ipv4: 10.10.246.30/22
       ipv6: fc0a::1e/64
   ARISTA30T1:
     properties:
@@ -1712,7 +1728,7 @@ configuration:
         ipv4: 10.0.0.59/31
         ipv6: fc00::76/126
     bp_interface:
-      ipv4: 10.10.246.31/24
+      ipv4: 10.10.246.31/22
       ipv6: fc0a::1f/64
   ARISTA31T1:
     properties:
@@ -1735,7 +1751,7 @@ configuration:
         ipv4: 10.0.0.61/31
         ipv6: fc00::7a/126
     bp_interface:
-      ipv4: 10.10.246.32/24
+      ipv4: 10.10.246.32/22
       ipv6: fc0a::20/64
   ARISTA32T1:
     properties:
@@ -1758,7 +1774,7 @@ configuration:
         ipv4: 10.0.0.63/31
         ipv6: fc00::7e/126
     bp_interface:
-      ipv4: 10.10.246.33/24
+      ipv4: 10.10.246.33/22
       ipv6: fc0a::21/64
   ARISTA33T1:
     properties:
@@ -1781,7 +1797,7 @@ configuration:
         ipv4: 10.0.0.65/31
         ipv6: fc00::82/126
     bp_interface:
-      ipv4: 10.10.246.34/24
+      ipv4: 10.10.246.34/22
       ipv6: fc0a::22/64
   ARISTA34T1:
     properties:
@@ -1804,7 +1820,7 @@ configuration:
         ipv4: 10.0.0.67/31
         ipv6: fc00::86/126
     bp_interface:
-      ipv4: 10.10.246.35/24
+      ipv4: 10.10.246.35/22
       ipv6: fc0a::23/64
   ARISTA35T1:
     properties:
@@ -1827,7 +1843,7 @@ configuration:
         ipv4: 10.0.0.69/31
         ipv6: fc00::8a/126
     bp_interface:
-      ipv4: 10.10.246.36/24
+      ipv4: 10.10.246.36/22
       ipv6: fc0a::24/64
   ARISTA36T1:
     properties:
@@ -1850,7 +1866,7 @@ configuration:
         ipv4: 10.0.0.71/31
         ipv6: fc00::8e/126
     bp_interface:
-      ipv4: 10.10.246.37/24
+      ipv4: 10.10.246.37/22
       ipv6: fc0a::25/64
   ARISTA37T1:
     properties:
@@ -1873,7 +1889,7 @@ configuration:
         ipv4: 10.0.0.73/31
         ipv6: fc00::92/126
     bp_interface:
-      ipv4: 10.10.246.38/24
+      ipv4: 10.10.246.38/22
       ipv6: fc0a::26/64
   ARISTA38T1:
     properties:
@@ -1896,7 +1912,7 @@ configuration:
         ipv4: 10.0.0.75/31
         ipv6: fc00::96/126
     bp_interface:
-      ipv4: 10.10.246.39/24
+      ipv4: 10.10.246.39/22
       ipv6: fc0a::27/64
   ARISTA39T1:
     properties:
@@ -1919,7 +1935,7 @@ configuration:
         ipv4: 10.0.0.77/31
         ipv6: fc00::9a/126
     bp_interface:
-      ipv4: 10.10.246.40/24
+      ipv4: 10.10.246.40/22
       ipv6: fc0a::28/64
   ARISTA40T1:
     properties:
@@ -1942,7 +1958,7 @@ configuration:
         ipv4: 10.0.0.79/31
         ipv6: fc00::9e/126
     bp_interface:
-      ipv4: 10.10.246.41/24
+      ipv4: 10.10.246.41/22
       ipv6: fc0a::29/64
   ARISTA41T1:
     properties:
@@ -1965,7 +1981,7 @@ configuration:
         ipv4: 10.0.0.81/31
         ipv6: fc00::a2/126
     bp_interface:
-      ipv4: 10.10.246.42/24
+      ipv4: 10.10.246.42/22
       ipv6: fc0a::2a/64
   ARISTA42T1:
     properties:
@@ -1988,7 +2004,7 @@ configuration:
         ipv4: 10.0.0.83/31
         ipv6: fc00::a6/126
     bp_interface:
-      ipv4: 10.10.246.43/24
+      ipv4: 10.10.246.43/22
       ipv6: fc0a::2b/64
   ARISTA43T1:
     properties:
@@ -2011,7 +2027,7 @@ configuration:
         ipv4: 10.0.0.85/31
         ipv6: fc00::aa/126
     bp_interface:
-      ipv4: 10.10.246.44/24
+      ipv4: 10.10.246.44/22
       ipv6: fc0a::2c/64
   ARISTA44T1:
     properties:
@@ -2034,7 +2050,7 @@ configuration:
         ipv4: 10.0.0.87/31
         ipv6: fc00::ae/126
     bp_interface:
-      ipv4: 10.10.246.45/24
+      ipv4: 10.10.246.45/22
       ipv6: fc0a::2d/64
   ARISTA45T1:
     properties:
@@ -2057,7 +2073,7 @@ configuration:
         ipv4: 10.0.0.89/31
         ipv6: fc00::b2/126
     bp_interface:
-      ipv4: 10.10.246.46/24
+      ipv4: 10.10.246.46/22
       ipv6: fc0a::2e/64
   ARISTA46T1:
     properties:
@@ -2080,7 +2096,7 @@ configuration:
         ipv4: 10.0.0.91/31
         ipv6: fc00::b6/126
     bp_interface:
-      ipv4: 10.10.246.47/24
+      ipv4: 10.10.246.47/22
       ipv6: fc0a::2f/64
   ARISTA47T1:
     properties:
@@ -2103,7 +2119,7 @@ configuration:
         ipv4: 10.0.0.93/31
         ipv6: fc00::ba/126
     bp_interface:
-      ipv4: 10.10.246.48/24
+      ipv4: 10.10.246.48/22
       ipv6: fc0a::30/64
   ARISTA48T1:
     properties:
@@ -2126,7 +2142,7 @@ configuration:
         ipv4: 10.0.0.95/31
         ipv6: fc00::be/126
     bp_interface:
-      ipv4: 10.10.246.49/24
+      ipv4: 10.10.246.49/22
       ipv6: fc0a::31/64
   ARISTA49T1:
     properties:
@@ -2149,7 +2165,7 @@ configuration:
         ipv4: 10.0.0.97/31
         ipv6: fc00::c2/126
     bp_interface:
-      ipv4: 10.10.246.50/24
+      ipv4: 10.10.246.50/22
       ipv6: fc0a::32/64
   ARISTA50T1:
     properties:
@@ -2172,7 +2188,7 @@ configuration:
         ipv4: 10.0.0.99/31
         ipv6: fc00::c6/126
     bp_interface:
-      ipv4: 10.10.246.51/24
+      ipv4: 10.10.246.51/22
       ipv6: fc0a::33/64
   ARISTA51T1:
     properties:
@@ -2195,7 +2211,7 @@ configuration:
         ipv4: 10.0.0.101/31
         ipv6: fc00::ca/126
     bp_interface:
-      ipv4: 10.10.246.52/24
+      ipv4: 10.10.246.52/22
       ipv6: fc0a::34/64
   ARISTA52T1:
     properties:
@@ -2218,7 +2234,7 @@ configuration:
         ipv4: 10.0.0.103/31
         ipv6: fc00::ce/126
     bp_interface:
-      ipv4: 10.10.246.53/24
+      ipv4: 10.10.246.53/22
       ipv6: fc0a::35/64
   ARISTA53T1:
     properties:
@@ -2241,7 +2257,7 @@ configuration:
         ipv4: 10.0.0.105/31
         ipv6: fc00::d2/126
     bp_interface:
-      ipv4: 10.10.246.54/24
+      ipv4: 10.10.246.54/22
       ipv6: fc0a::36/64
   ARISTA54T1:
     properties:
@@ -2264,7 +2280,7 @@ configuration:
         ipv4: 10.0.0.107/31
         ipv6: fc00::d6/126
     bp_interface:
-      ipv4: 10.10.246.55/24
+      ipv4: 10.10.246.55/22
       ipv6: fc0a::37/64
   ARISTA55T1:
     properties:
@@ -2287,7 +2303,7 @@ configuration:
         ipv4: 10.0.0.109/31
         ipv6: fc00::da/126
     bp_interface:
-      ipv4: 10.10.246.56/24
+      ipv4: 10.10.246.56/22
       ipv6: fc0a::38/64
   ARISTA56T1:
     properties:
@@ -2310,7 +2326,7 @@ configuration:
         ipv4: 10.0.0.111/31
         ipv6: fc00::de/126
     bp_interface:
-      ipv4: 10.10.246.57/24
+      ipv4: 10.10.246.57/22
       ipv6: fc0a::39/64
   ARISTA57T1:
     properties:
@@ -2333,7 +2349,7 @@ configuration:
         ipv4: 10.0.0.113/31
         ipv6: fc00::e2/126
     bp_interface:
-      ipv4: 10.10.246.58/24
+      ipv4: 10.10.246.58/22
       ipv6: fc0a::3a/64
   ARISTA58T1:
     properties:
@@ -2356,7 +2372,7 @@ configuration:
         ipv4: 10.0.0.115/31
         ipv6: fc00::e6/126
     bp_interface:
-      ipv4: 10.10.246.59/24
+      ipv4: 10.10.246.59/22
       ipv6: fc0a::3b/64
   ARISTA59T1:
     properties:
@@ -2379,7 +2395,7 @@ configuration:
         ipv4: 10.0.0.117/31
         ipv6: fc00::ea/126
     bp_interface:
-      ipv4: 10.10.246.60/24
+      ipv4: 10.10.246.60/22
       ipv6: fc0a::3c/64
   ARISTA60T1:
     properties:
@@ -2402,7 +2418,7 @@ configuration:
         ipv4: 10.0.0.119/31
         ipv6: fc00::ee/126
     bp_interface:
-      ipv4: 10.10.246.61/24
+      ipv4: 10.10.246.61/22
       ipv6: fc0a::3d/64
   ARISTA61T1:
     properties:
@@ -2425,7 +2441,7 @@ configuration:
         ipv4: 10.0.0.121/31
         ipv6: fc00::f2/126
     bp_interface:
-      ipv4: 10.10.246.62/24
+      ipv4: 10.10.246.62/22
       ipv6: fc0a::3e/64
   ARISTA62T1:
     properties:
@@ -2448,7 +2464,7 @@ configuration:
         ipv4: 10.0.0.123/31
         ipv6: fc00::f6/126
     bp_interface:
-      ipv4: 10.10.246.63/24
+      ipv4: 10.10.246.63/22
       ipv6: fc0a::3f/64
   ARISTA63T1:
     properties:
@@ -2471,7 +2487,7 @@ configuration:
         ipv4: 10.0.0.125/31
         ipv6: fc00::fa/126
     bp_interface:
-      ipv4: 10.10.246.64/24
+      ipv4: 10.10.246.64/22
       ipv6: fc0a::40/64
   ARISTA64T1:
     properties:
@@ -2494,7 +2510,7 @@ configuration:
         ipv4: 10.0.0.127/31
         ipv6: fc00::fe/126
     bp_interface:
-      ipv4: 10.10.246.65/24
+      ipv4: 10.10.246.65/22
       ipv6: fc0a::41/64
   ARISTA65T1:
     properties:
@@ -2517,7 +2533,7 @@ configuration:
         ipv4: 10.0.0.129/31
         ipv6: fc00::102/126
     bp_interface:
-      ipv4: 10.10.246.66/24
+      ipv4: 10.10.246.66/22
       ipv6: fc0a::42/64
   ARISTA66T1:
     properties:
@@ -2540,7 +2556,7 @@ configuration:
         ipv4: 10.0.0.131/31
         ipv6: fc00::106/126
     bp_interface:
-      ipv4: 10.10.246.67/24
+      ipv4: 10.10.246.67/22
       ipv6: fc0a::43/64
   ARISTA67T1:
     properties:
@@ -2563,7 +2579,7 @@ configuration:
         ipv4: 10.0.0.133/31
         ipv6: fc00::10a/126
     bp_interface:
-      ipv4: 10.10.246.68/24
+      ipv4: 10.10.246.68/22
       ipv6: fc0a::44/64
   ARISTA68T1:
     properties:
@@ -2586,7 +2602,7 @@ configuration:
         ipv4: 10.0.0.135/31
         ipv6: fc00::10e/126
     bp_interface:
-      ipv4: 10.10.246.69/24
+      ipv4: 10.10.246.69/22
       ipv6: fc0a::45/64
   ARISTA69T1:
     properties:
@@ -2609,7 +2625,7 @@ configuration:
         ipv4: 10.0.0.137/31
         ipv6: fc00::112/126
     bp_interface:
-      ipv4: 10.10.246.70/24
+      ipv4: 10.10.246.70/22
       ipv6: fc0a::46/64
   ARISTA70T1:
     properties:
@@ -2632,7 +2648,7 @@ configuration:
         ipv4: 10.0.0.139/31
         ipv6: fc00::116/126
     bp_interface:
-      ipv4: 10.10.246.71/24
+      ipv4: 10.10.246.71/22
       ipv6: fc0a::47/64
   ARISTA71T1:
     properties:
@@ -2655,7 +2671,7 @@ configuration:
         ipv4: 10.0.0.141/31
         ipv6: fc00::11a/126
     bp_interface:
-      ipv4: 10.10.246.72/24
+      ipv4: 10.10.246.72/22
       ipv6: fc0a::48/64
   ARISTA72T1:
     properties:
@@ -2678,7 +2694,7 @@ configuration:
         ipv4: 10.0.0.143/31
         ipv6: fc00::11e/126
     bp_interface:
-      ipv4: 10.10.246.73/24
+      ipv4: 10.10.246.73/22
       ipv6: fc0a::49/64
   ARISTA73T1:
     properties:
@@ -2701,7 +2717,7 @@ configuration:
         ipv4: 10.0.0.145/31
         ipv6: fc00::122/126
     bp_interface:
-      ipv4: 10.10.246.74/24
+      ipv4: 10.10.246.74/22
       ipv6: fc0a::4a/64
   ARISTA74T1:
     properties:
@@ -2724,7 +2740,7 @@ configuration:
         ipv4: 10.0.0.147/31
         ipv6: fc00::126/126
     bp_interface:
-      ipv4: 10.10.246.75/24
+      ipv4: 10.10.246.75/22
       ipv6: fc0a::4b/64
   ARISTA75T1:
     properties:
@@ -2747,7 +2763,7 @@ configuration:
         ipv4: 10.0.0.149/31
         ipv6: fc00::12a/126
     bp_interface:
-      ipv4: 10.10.246.76/24
+      ipv4: 10.10.246.76/22
       ipv6: fc0a::4c/64
   ARISTA76T1:
     properties:
@@ -2770,7 +2786,7 @@ configuration:
         ipv4: 10.0.0.151/31
         ipv6: fc00::12e/126
     bp_interface:
-      ipv4: 10.10.246.77/24
+      ipv4: 10.10.246.77/22
       ipv6: fc0a::4d/64
   ARISTA77T1:
     properties:
@@ -2793,7 +2809,7 @@ configuration:
         ipv4: 10.0.0.153/31
         ipv6: fc00::132/126
     bp_interface:
-      ipv4: 10.10.246.78/24
+      ipv4: 10.10.246.78/22
       ipv6: fc0a::4e/64
   ARISTA78T1:
     properties:
@@ -2816,7 +2832,7 @@ configuration:
         ipv4: 10.0.0.155/31
         ipv6: fc00::136/126
     bp_interface:
-      ipv4: 10.10.246.79/24
+      ipv4: 10.10.246.79/22
       ipv6: fc0a::4f/64
   ARISTA79T1:
     properties:
@@ -2839,7 +2855,7 @@ configuration:
         ipv4: 10.0.0.157/31
         ipv6: fc00::13a/126
     bp_interface:
-      ipv4: 10.10.246.80/24
+      ipv4: 10.10.246.80/22
       ipv6: fc0a::50/64
   ARISTA80T1:
     properties:
@@ -2862,7 +2878,7 @@ configuration:
         ipv4: 10.0.0.159/31
         ipv6: fc00::13e/126
     bp_interface:
-      ipv4: 10.10.246.81/24
+      ipv4: 10.10.246.81/22
       ipv6: fc0a::51/64
   ARISTA81T1:
     properties:
@@ -2885,7 +2901,7 @@ configuration:
         ipv4: 10.0.0.161/31
         ipv6: fc00::142/126
     bp_interface:
-      ipv4: 10.10.246.82/24
+      ipv4: 10.10.246.82/22
       ipv6: fc0a::52/64
   ARISTA82T1:
     properties:
@@ -2908,7 +2924,7 @@ configuration:
         ipv4: 10.0.0.163/31
         ipv6: fc00::146/126
     bp_interface:
-      ipv4: 10.10.246.83/24
+      ipv4: 10.10.246.83/22
       ipv6: fc0a::53/64
   ARISTA83T1:
     properties:
@@ -2931,7 +2947,7 @@ configuration:
         ipv4: 10.0.0.165/31
         ipv6: fc00::14a/126
     bp_interface:
-      ipv4: 10.10.246.84/24
+      ipv4: 10.10.246.84/22
       ipv6: fc0a::54/64
   ARISTA84T1:
     properties:
@@ -2954,7 +2970,7 @@ configuration:
         ipv4: 10.0.0.167/31
         ipv6: fc00::14e/126
     bp_interface:
-      ipv4: 10.10.246.85/24
+      ipv4: 10.10.246.85/22
       ipv6: fc0a::55/64
   ARISTA85T1:
     properties:
@@ -2977,7 +2993,7 @@ configuration:
         ipv4: 10.0.0.169/31
         ipv6: fc00::152/126
     bp_interface:
-      ipv4: 10.10.246.86/24
+      ipv4: 10.10.246.86/22
       ipv6: fc0a::56/64
   ARISTA86T1:
     properties:
@@ -3000,7 +3016,7 @@ configuration:
         ipv4: 10.0.0.171/31
         ipv6: fc00::156/126
     bp_interface:
-      ipv4: 10.10.246.87/24
+      ipv4: 10.10.246.87/22
       ipv6: fc0a::57/64
   ARISTA87T1:
     properties:
@@ -3023,7 +3039,7 @@ configuration:
         ipv4: 10.0.0.173/31
         ipv6: fc00::15a/126
     bp_interface:
-      ipv4: 10.10.246.88/24
+      ipv4: 10.10.246.88/22
       ipv6: fc0a::58/64
   ARISTA88T1:
     properties:
@@ -3046,7 +3062,7 @@ configuration:
         ipv4: 10.0.0.175/31
         ipv6: fc00::15e/126
     bp_interface:
-      ipv4: 10.10.246.89/24
+      ipv4: 10.10.246.89/22
       ipv6: fc0a::59/64
   ARISTA89T1:
     properties:
@@ -3069,7 +3085,7 @@ configuration:
         ipv4: 10.0.0.177/31
         ipv6: fc00::162/126
     bp_interface:
-      ipv4: 10.10.246.90/24
+      ipv4: 10.10.246.90/22
       ipv6: fc0a::5a/64
   ARISTA90T1:
     properties:
@@ -3092,7 +3108,7 @@ configuration:
         ipv4: 10.0.0.179/31
         ipv6: fc00::166/126
     bp_interface:
-      ipv4: 10.10.246.91/24
+      ipv4: 10.10.246.91/22
       ipv6: fc0a::5b/64
   ARISTA01UT2:
     properties:
@@ -3112,7 +3128,7 @@ configuration:
         ipv4: 10.0.0.181/31
         ipv6: fc00::16a/126
     bp_interface:
-      ipv4: 10.10.246.92/24
+      ipv4: 10.10.246.92/22
       ipv6: fc0a::5c/64
   ARISTA02UT2:
     properties:
@@ -3132,7 +3148,7 @@ configuration:
         ipv4: 10.0.0.183/31
         ipv6: fc00::16e/126
     bp_interface:
-      ipv4: 10.10.246.93/24
+      ipv4: 10.10.246.93/22
       ipv6: fc0a::5d/64
   ARISTA03UT2:
     properties:
@@ -3152,7 +3168,7 @@ configuration:
         ipv4: 10.0.0.185/31
         ipv6: fc00::172/126
     bp_interface:
-      ipv4: 10.10.246.94/24
+      ipv4: 10.10.246.94/22
       ipv6: fc0a::5e/64
   ARISTA04UT2:
     properties:
@@ -3172,7 +3188,7 @@ configuration:
         ipv4: 10.0.0.187/31
         ipv6: fc00::176/126
     bp_interface:
-      ipv4: 10.10.246.95/24
+      ipv4: 10.10.246.95/22
       ipv6: fc0a::5f/64
   ARISTA05UT2:
     properties:
@@ -3192,7 +3208,7 @@ configuration:
         ipv4: 10.0.0.189/31
         ipv6: fc00::17a/126
     bp_interface:
-      ipv4: 10.10.246.96/24
+      ipv4: 10.10.246.96/22
       ipv6: fc0a::60/64
   ARISTA06UT2:
     properties:
@@ -3212,7 +3228,7 @@ configuration:
         ipv4: 10.0.0.191/31
         ipv6: fc00::17e/126
     bp_interface:
-      ipv4: 10.10.246.97/24
+      ipv4: 10.10.246.97/22
       ipv6: fc0a::61/64
   ARISTA07UT2:
     properties:
@@ -3232,7 +3248,7 @@ configuration:
         ipv4: 10.0.0.193/31
         ipv6: fc00::182/126
     bp_interface:
-      ipv4: 10.10.246.98/24
+      ipv4: 10.10.246.98/22
       ipv6: fc0a::62/64
   ARISTA08UT2:
     properties:
@@ -3252,7 +3268,7 @@ configuration:
         ipv4: 10.0.0.195/31
         ipv6: fc00::186/126
     bp_interface:
-      ipv4: 10.10.246.99/24
+      ipv4: 10.10.246.99/22
       ipv6: fc0a::63/64
   ARISTA09UT2:
     properties:
@@ -3272,7 +3288,7 @@ configuration:
         ipv4: 10.0.0.197/31
         ipv6: fc00::18a/126
     bp_interface:
-      ipv4: 10.10.246.100/24
+      ipv4: 10.10.246.100/22
       ipv6: fc0a::64/64
   ARISTA10UT2:
     properties:
@@ -3292,7 +3308,7 @@ configuration:
         ipv4: 10.0.0.199/31
         ipv6: fc00::18e/126
     bp_interface:
-      ipv4: 10.10.246.101/24
+      ipv4: 10.10.246.101/22
       ipv6: fc0a::65/64
   ARISTA11UT2:
     properties:
@@ -3312,7 +3328,7 @@ configuration:
         ipv4: 10.0.0.201/31
         ipv6: fc00::192/126
     bp_interface:
-      ipv4: 10.10.246.102/24
+      ipv4: 10.10.246.102/22
       ipv6: fc0a::66/64
   ARISTA12UT2:
     properties:
@@ -3332,7 +3348,7 @@ configuration:
         ipv4: 10.0.0.203/31
         ipv6: fc00::196/126
     bp_interface:
-      ipv4: 10.10.246.103/24
+      ipv4: 10.10.246.103/22
       ipv6: fc0a::67/64
   ARISTA13UT2:
     properties:
@@ -3352,7 +3368,7 @@ configuration:
         ipv4: 10.0.0.205/31
         ipv6: fc00::19a/126
     bp_interface:
-      ipv4: 10.10.246.104/24
+      ipv4: 10.10.246.104/22
       ipv6: fc0a::68/64
   ARISTA14UT2:
     properties:
@@ -3372,7 +3388,7 @@ configuration:
         ipv4: 10.0.0.207/31
         ipv6: fc00::19e/126
     bp_interface:
-      ipv4: 10.10.246.105/24
+      ipv4: 10.10.246.105/22
       ipv6: fc0a::69/64
   ARISTA15UT2:
     properties:
@@ -3392,7 +3408,7 @@ configuration:
         ipv4: 10.0.0.209/31
         ipv6: fc00::1a2/126
     bp_interface:
-      ipv4: 10.10.246.106/24
+      ipv4: 10.10.246.106/22
       ipv6: fc0a::6a/64
   ARISTA16UT2:
     properties:
@@ -3412,7 +3428,7 @@ configuration:
         ipv4: 10.0.0.211/31
         ipv6: fc00::1a6/126
     bp_interface:
-      ipv4: 10.10.246.107/24
+      ipv4: 10.10.246.107/22
       ipv6: fc0a::6b/64
   ARISTA17UT2:
     properties:
@@ -3432,7 +3448,7 @@ configuration:
         ipv4: 10.0.0.213/31
         ipv6: fc00::1aa/126
     bp_interface:
-      ipv4: 10.10.246.108/24
+      ipv4: 10.10.246.108/22
       ipv6: fc0a::6c/64
   ARISTA18UT2:
     properties:
@@ -3452,7 +3468,7 @@ configuration:
         ipv4: 10.0.0.215/31
         ipv6: fc00::1ae/126
     bp_interface:
-      ipv4: 10.10.246.109/24
+      ipv4: 10.10.246.109/22
       ipv6: fc0a::6d/64
   ARISTA19UT2:
     properties:
@@ -3472,7 +3488,7 @@ configuration:
         ipv4: 10.0.0.217/31
         ipv6: fc00::1b2/126
     bp_interface:
-      ipv4: 10.10.246.110/24
+      ipv4: 10.10.246.110/22
       ipv6: fc0a::6e/64
   ARISTA20UT2:
     properties:
@@ -3492,7 +3508,7 @@ configuration:
         ipv4: 10.0.0.219/31
         ipv6: fc00::1b6/126
     bp_interface:
-      ipv4: 10.10.246.111/24
+      ipv4: 10.10.246.111/22
       ipv6: fc0a::6f/64
   ARISTA21UT2:
     properties:
@@ -3512,7 +3528,7 @@ configuration:
         ipv4: 10.0.0.221/31
         ipv6: fc00::1ba/126
     bp_interface:
-      ipv4: 10.10.246.112/24
+      ipv4: 10.10.246.112/22
       ipv6: fc0a::70/64
   ARISTA22UT2:
     properties:
@@ -3532,7 +3548,7 @@ configuration:
         ipv4: 10.0.0.223/31
         ipv6: fc00::1be/126
     bp_interface:
-      ipv4: 10.10.246.113/24
+      ipv4: 10.10.246.113/22
       ipv6: fc0a::71/64
   ARISTA23UT2:
     properties:
@@ -3552,7 +3568,7 @@ configuration:
         ipv4: 10.0.0.225/31
         ipv6: fc00::1c2/126
     bp_interface:
-      ipv4: 10.10.246.114/24
+      ipv4: 10.10.246.114/22
       ipv6: fc0a::72/64
   ARISTA24UT2:
     properties:
@@ -3572,7 +3588,7 @@ configuration:
         ipv4: 10.0.0.227/31
         ipv6: fc00::1c6/126
     bp_interface:
-      ipv4: 10.10.246.115/24
+      ipv4: 10.10.246.115/22
       ipv6: fc0a::73/64
   ARISTA25UT2:
     properties:
@@ -3592,7 +3608,7 @@ configuration:
         ipv4: 10.0.0.229/31
         ipv6: fc00::1ca/126
     bp_interface:
-      ipv4: 10.10.246.116/24
+      ipv4: 10.10.246.116/22
       ipv6: fc0a::74/64
   ARISTA26UT2:
     properties:
@@ -3612,7 +3628,7 @@ configuration:
         ipv4: 10.0.0.231/31
         ipv6: fc00::1ce/126
     bp_interface:
-      ipv4: 10.10.246.117/24
+      ipv4: 10.10.246.117/22
       ipv6: fc0a::75/64
   ARISTA27UT2:
     properties:
@@ -3632,7 +3648,7 @@ configuration:
         ipv4: 10.0.0.233/31
         ipv6: fc00::1d2/126
     bp_interface:
-      ipv4: 10.10.246.118/24
+      ipv4: 10.10.246.118/22
       ipv6: fc0a::76/64
   ARISTA28UT2:
     properties:
@@ -3652,7 +3668,7 @@ configuration:
         ipv4: 10.0.0.235/31
         ipv6: fc00::1d6/126
     bp_interface:
-      ipv4: 10.10.246.119/24
+      ipv4: 10.10.246.119/22
       ipv6: fc0a::77/64
   ARISTA29UT2:
     properties:
@@ -3672,7 +3688,7 @@ configuration:
         ipv4: 10.0.0.237/31
         ipv6: fc00::1da/126
     bp_interface:
-      ipv4: 10.10.246.120/24
+      ipv4: 10.10.246.120/22
       ipv6: fc0a::78/64
   ARISTA30UT2:
     properties:
@@ -3692,7 +3708,7 @@ configuration:
         ipv4: 10.0.0.239/31
         ipv6: fc00::1de/126
     bp_interface:
-      ipv4: 10.10.246.121/24
+      ipv4: 10.10.246.121/22
       ipv6: fc0a::79/64
   ARISTA31UT2:
     properties:
@@ -3712,7 +3728,7 @@ configuration:
         ipv4: 10.0.0.241/31
         ipv6: fc00::1e2/126
     bp_interface:
-      ipv4: 10.10.246.122/24
+      ipv4: 10.10.246.122/22
       ipv6: fc0a::7a/64
   ARISTA32UT2:
     properties:
@@ -3732,7 +3748,7 @@ configuration:
         ipv4: 10.0.0.243/31
         ipv6: fc00::1e6/126
     bp_interface:
-      ipv4: 10.10.246.123/24
+      ipv4: 10.10.246.123/22
       ipv6: fc0a::7b/64
   ARISTA91T1:
     properties:
@@ -3755,7 +3771,7 @@ configuration:
         ipv4: 10.0.0.245/31
         ipv6: fc00::1ea/126
     bp_interface:
-      ipv4: 10.10.246.124/24
+      ipv4: 10.10.246.124/22
       ipv6: fc0a::7c/64
   ARISTA92T1:
     properties:
@@ -3778,7 +3794,7 @@ configuration:
         ipv4: 10.0.0.247/31
         ipv6: fc00::1ee/126
     bp_interface:
-      ipv4: 10.10.246.125/24
+      ipv4: 10.10.246.125/22
       ipv6: fc0a::7d/64
   ARISTA93T1:
     properties:
@@ -3801,7 +3817,7 @@ configuration:
         ipv4: 10.0.0.249/31
         ipv6: fc00::1f2/126
     bp_interface:
-      ipv4: 10.10.246.126/24
+      ipv4: 10.10.246.126/22
       ipv6: fc0a::7e/64
   ARISTA94T1:
     properties:
@@ -3824,7 +3840,7 @@ configuration:
         ipv4: 10.0.0.251/31
         ipv6: fc00::1f6/126
     bp_interface:
-      ipv4: 10.10.246.127/24
+      ipv4: 10.10.246.127/22
       ipv6: fc0a::7f/64
   ARISTA95T1:
     properties:
@@ -3847,7 +3863,7 @@ configuration:
         ipv4: 10.0.0.253/31
         ipv6: fc00::1fa/126
     bp_interface:
-      ipv4: 10.10.246.128/24
+      ipv4: 10.10.246.128/22
       ipv6: fc0a::80/64
   ARISTA96T1:
     properties:
@@ -3870,7 +3886,7 @@ configuration:
         ipv4: 10.0.0.255/31
         ipv6: fc00::1fe/126
     bp_interface:
-      ipv4: 10.10.246.129/24
+      ipv4: 10.10.246.129/22
       ipv6: fc0a::81/64
   ARISTA97T1:
     properties:
@@ -3893,7 +3909,7 @@ configuration:
         ipv4: 10.0.1.1/31
         ipv6: fc00::202/126
     bp_interface:
-      ipv4: 10.10.246.130/24
+      ipv4: 10.10.246.130/22
       ipv6: fc0a::82/64
   ARISTA98T1:
     properties:
@@ -3916,7 +3932,7 @@ configuration:
         ipv4: 10.0.1.3/31
         ipv6: fc00::206/126
     bp_interface:
-      ipv4: 10.10.246.131/24
+      ipv4: 10.10.246.131/22
       ipv6: fc0a::83/64
   ARISTA99T1:
     properties:
@@ -3939,7 +3955,7 @@ configuration:
         ipv4: 10.0.1.5/31
         ipv6: fc00::20a/126
     bp_interface:
-      ipv4: 10.10.246.132/24
+      ipv4: 10.10.246.132/22
       ipv6: fc0a::84/64
   ARISTA100T1:
     properties:
@@ -3962,7 +3978,7 @@ configuration:
         ipv4: 10.0.1.7/31
         ipv6: fc00::20e/126
     bp_interface:
-      ipv4: 10.10.246.133/24
+      ipv4: 10.10.246.133/22
       ipv6: fc0a::85/64
   ARISTA101T1:
     properties:
@@ -3985,7 +4001,7 @@ configuration:
         ipv4: 10.0.1.9/31
         ipv6: fc00::212/126
     bp_interface:
-      ipv4: 10.10.246.134/24
+      ipv4: 10.10.246.134/22
       ipv6: fc0a::86/64
   ARISTA102T1:
     properties:
@@ -4008,7 +4024,7 @@ configuration:
         ipv4: 10.0.1.11/31
         ipv6: fc00::216/126
     bp_interface:
-      ipv4: 10.10.246.135/24
+      ipv4: 10.10.246.135/22
       ipv6: fc0a::87/64
   ARISTA103T1:
     properties:
@@ -4031,7 +4047,7 @@ configuration:
         ipv4: 10.0.1.13/31
         ipv6: fc00::21a/126
     bp_interface:
-      ipv4: 10.10.246.136/24
+      ipv4: 10.10.246.136/22
       ipv6: fc0a::88/64
   ARISTA104T1:
     properties:
@@ -4054,7 +4070,7 @@ configuration:
         ipv4: 10.0.1.15/31
         ipv6: fc00::21e/126
     bp_interface:
-      ipv4: 10.10.246.137/24
+      ipv4: 10.10.246.137/22
       ipv6: fc0a::89/64
   ARISTA105T1:
     properties:
@@ -4077,7 +4093,7 @@ configuration:
         ipv4: 10.0.1.17/31
         ipv6: fc00::222/126
     bp_interface:
-      ipv4: 10.10.246.138/24
+      ipv4: 10.10.246.138/22
       ipv6: fc0a::8a/64
   ARISTA106T1:
     properties:
@@ -4100,7 +4116,7 @@ configuration:
         ipv4: 10.0.1.19/31
         ipv6: fc00::226/126
     bp_interface:
-      ipv4: 10.10.246.139/24
+      ipv4: 10.10.246.139/22
       ipv6: fc0a::8b/64
   ARISTA107T1:
     properties:
@@ -4123,7 +4139,7 @@ configuration:
         ipv4: 10.0.1.21/31
         ipv6: fc00::22a/126
     bp_interface:
-      ipv4: 10.10.246.140/24
+      ipv4: 10.10.246.140/22
       ipv6: fc0a::8c/64
   ARISTA108T1:
     properties:
@@ -4146,7 +4162,7 @@ configuration:
         ipv4: 10.0.1.23/31
         ipv6: fc00::22e/126
     bp_interface:
-      ipv4: 10.10.246.141/24
+      ipv4: 10.10.246.141/22
       ipv6: fc0a::8d/64
   ARISTA109T1:
     properties:
@@ -4169,7 +4185,7 @@ configuration:
         ipv4: 10.0.1.25/31
         ipv6: fc00::232/126
     bp_interface:
-      ipv4: 10.10.246.142/24
+      ipv4: 10.10.246.142/22
       ipv6: fc0a::8e/64
   ARISTA110T1:
     properties:
@@ -4192,7 +4208,7 @@ configuration:
         ipv4: 10.0.1.27/31
         ipv6: fc00::236/126
     bp_interface:
-      ipv4: 10.10.246.143/24
+      ipv4: 10.10.246.143/22
       ipv6: fc0a::8f/64
   ARISTA111T1:
     properties:
@@ -4215,7 +4231,7 @@ configuration:
         ipv4: 10.0.1.29/31
         ipv6: fc00::23a/126
     bp_interface:
-      ipv4: 10.10.246.144/24
+      ipv4: 10.10.246.144/22
       ipv6: fc0a::90/64
   ARISTA112T1:
     properties:
@@ -4238,7 +4254,7 @@ configuration:
         ipv4: 10.0.1.31/31
         ipv6: fc00::23e/126
     bp_interface:
-      ipv4: 10.10.246.145/24
+      ipv4: 10.10.246.145/22
       ipv6: fc0a::91/64
   ARISTA113T1:
     properties:
@@ -4261,7 +4277,7 @@ configuration:
         ipv4: 10.0.1.33/31
         ipv6: fc00::242/126
     bp_interface:
-      ipv4: 10.10.246.146/24
+      ipv4: 10.10.246.146/22
       ipv6: fc0a::92/64
   ARISTA114T1:
     properties:
@@ -4284,7 +4300,7 @@ configuration:
         ipv4: 10.0.1.35/31
         ipv6: fc00::246/126
     bp_interface:
-      ipv4: 10.10.246.147/24
+      ipv4: 10.10.246.147/22
       ipv6: fc0a::93/64
   ARISTA115T1:
     properties:
@@ -4307,7 +4323,7 @@ configuration:
         ipv4: 10.0.1.37/31
         ipv6: fc00::24a/126
     bp_interface:
-      ipv4: 10.10.246.148/24
+      ipv4: 10.10.246.148/22
       ipv6: fc0a::94/64
   ARISTA116T1:
     properties:
@@ -4330,7 +4346,7 @@ configuration:
         ipv4: 10.0.1.39/31
         ipv6: fc00::24e/126
     bp_interface:
-      ipv4: 10.10.246.149/24
+      ipv4: 10.10.246.149/22
       ipv6: fc0a::95/64
   ARISTA117T1:
     properties:
@@ -4353,7 +4369,7 @@ configuration:
         ipv4: 10.0.1.41/31
         ipv6: fc00::252/126
     bp_interface:
-      ipv4: 10.10.246.150/24
+      ipv4: 10.10.246.150/22
       ipv6: fc0a::96/64
   ARISTA118T1:
     properties:
@@ -4376,7 +4392,7 @@ configuration:
         ipv4: 10.0.1.43/31
         ipv6: fc00::256/126
     bp_interface:
-      ipv4: 10.10.246.151/24
+      ipv4: 10.10.246.151/22
       ipv6: fc0a::97/64
   ARISTA119T1:
     properties:
@@ -4399,7 +4415,7 @@ configuration:
         ipv4: 10.0.1.45/31
         ipv6: fc00::25a/126
     bp_interface:
-      ipv4: 10.10.246.152/24
+      ipv4: 10.10.246.152/22
       ipv6: fc0a::98/64
   ARISTA120T1:
     properties:
@@ -4422,7 +4438,7 @@ configuration:
         ipv4: 10.0.1.47/31
         ipv6: fc00::25e/126
     bp_interface:
-      ipv4: 10.10.246.153/24
+      ipv4: 10.10.246.153/22
       ipv6: fc0a::99/64
   ARISTA121T1:
     properties:
@@ -4445,7 +4461,7 @@ configuration:
         ipv4: 10.0.1.49/31
         ipv6: fc00::262/126
     bp_interface:
-      ipv4: 10.10.246.154/24
+      ipv4: 10.10.246.154/22
       ipv6: fc0a::9a/64
   ARISTA122T1:
     properties:
@@ -4468,7 +4484,7 @@ configuration:
         ipv4: 10.0.1.51/31
         ipv6: fc00::266/126
     bp_interface:
-      ipv4: 10.10.246.155/24
+      ipv4: 10.10.246.155/22
       ipv6: fc0a::9b/64
   ARISTA123T1:
     properties:
@@ -4491,7 +4507,7 @@ configuration:
         ipv4: 10.0.1.53/31
         ipv6: fc00::26a/126
     bp_interface:
-      ipv4: 10.10.246.156/24
+      ipv4: 10.10.246.156/22
       ipv6: fc0a::9c/64
   ARISTA124T1:
     properties:
@@ -4514,7 +4530,7 @@ configuration:
         ipv4: 10.0.1.55/31
         ipv6: fc00::26e/126
     bp_interface:
-      ipv4: 10.10.246.157/24
+      ipv4: 10.10.246.157/22
       ipv6: fc0a::9d/64
   ARISTA125T1:
     properties:
@@ -4537,7 +4553,7 @@ configuration:
         ipv4: 10.0.1.57/31
         ipv6: fc00::272/126
     bp_interface:
-      ipv4: 10.10.246.158/24
+      ipv4: 10.10.246.158/22
       ipv6: fc0a::9e/64
   ARISTA126T1:
     properties:
@@ -4560,7 +4576,7 @@ configuration:
         ipv4: 10.0.1.59/31
         ipv6: fc00::276/126
     bp_interface:
-      ipv4: 10.10.246.159/24
+      ipv4: 10.10.246.159/22
       ipv6: fc0a::9f/64
   ARISTA127T1:
     properties:
@@ -4583,7 +4599,7 @@ configuration:
         ipv4: 10.0.1.61/31
         ipv6: fc00::27a/126
     bp_interface:
-      ipv4: 10.10.246.160/24
+      ipv4: 10.10.246.160/22
       ipv6: fc0a::a0/64
   ARISTA128T1:
     properties:
@@ -4606,7 +4622,7 @@ configuration:
         ipv4: 10.0.1.63/31
         ipv6: fc00::27e/126
     bp_interface:
-      ipv4: 10.10.246.161/24
+      ipv4: 10.10.246.161/22
       ipv6: fc0a::a1/64
   ARISTA129T1:
     properties:
@@ -4629,7 +4645,7 @@ configuration:
         ipv4: 10.0.1.65/31
         ipv6: fc00::282/126
     bp_interface:
-      ipv4: 10.10.246.162/24
+      ipv4: 10.10.246.162/22
       ipv6: fc0a::a2/64
   ARISTA130T1:
     properties:
@@ -4652,7 +4668,7 @@ configuration:
         ipv4: 10.0.1.67/31
         ipv6: fc00::286/126
     bp_interface:
-      ipv4: 10.10.246.163/24
+      ipv4: 10.10.246.163/22
       ipv6: fc0a::a3/64
   ARISTA131T1:
     properties:
@@ -4675,7 +4691,7 @@ configuration:
         ipv4: 10.0.1.69/31
         ipv6: fc00::28a/126
     bp_interface:
-      ipv4: 10.10.246.164/24
+      ipv4: 10.10.246.164/22
       ipv6: fc0a::a4/64
   ARISTA132T1:
     properties:
@@ -4698,7 +4714,7 @@ configuration:
         ipv4: 10.0.1.71/31
         ipv6: fc00::28e/126
     bp_interface:
-      ipv4: 10.10.246.165/24
+      ipv4: 10.10.246.165/22
       ipv6: fc0a::a5/64
   ARISTA133T1:
     properties:
@@ -4721,7 +4737,7 @@ configuration:
         ipv4: 10.0.1.73/31
         ipv6: fc00::292/126
     bp_interface:
-      ipv4: 10.10.246.166/24
+      ipv4: 10.10.246.166/22
       ipv6: fc0a::a6/64
   ARISTA134T1:
     properties:
@@ -4744,7 +4760,7 @@ configuration:
         ipv4: 10.0.1.75/31
         ipv6: fc00::296/126
     bp_interface:
-      ipv4: 10.10.246.167/24
+      ipv4: 10.10.246.167/22
       ipv6: fc0a::a7/64
   ARISTA135T1:
     properties:
@@ -4767,7 +4783,7 @@ configuration:
         ipv4: 10.0.1.77/31
         ipv6: fc00::29a/126
     bp_interface:
-      ipv4: 10.10.246.168/24
+      ipv4: 10.10.246.168/22
       ipv6: fc0a::a8/64
   ARISTA136T1:
     properties:
@@ -4790,7 +4806,7 @@ configuration:
         ipv4: 10.0.1.79/31
         ipv6: fc00::29e/126
     bp_interface:
-      ipv4: 10.10.246.169/24
+      ipv4: 10.10.246.169/22
       ipv6: fc0a::a9/64
   ARISTA137T1:
     properties:
@@ -4813,7 +4829,7 @@ configuration:
         ipv4: 10.0.1.81/31
         ipv6: fc00::2a2/126
     bp_interface:
-      ipv4: 10.10.246.170/24
+      ipv4: 10.10.246.170/22
       ipv6: fc0a::aa/64
   ARISTA138T1:
     properties:
@@ -4836,7 +4852,7 @@ configuration:
         ipv4: 10.0.1.83/31
         ipv6: fc00::2a6/126
     bp_interface:
-      ipv4: 10.10.246.171/24
+      ipv4: 10.10.246.171/22
       ipv6: fc0a::ab/64
   ARISTA139T1:
     properties:
@@ -4859,7 +4875,7 @@ configuration:
         ipv4: 10.0.1.85/31
         ipv6: fc00::2aa/126
     bp_interface:
-      ipv4: 10.10.246.172/24
+      ipv4: 10.10.246.172/22
       ipv6: fc0a::ac/64
   ARISTA140T1:
     properties:
@@ -4882,7 +4898,7 @@ configuration:
         ipv4: 10.0.1.87/31
         ipv6: fc00::2ae/126
     bp_interface:
-      ipv4: 10.10.246.173/24
+      ipv4: 10.10.246.173/22
       ipv6: fc0a::ad/64
   ARISTA141T1:
     properties:
@@ -4905,7 +4921,7 @@ configuration:
         ipv4: 10.0.1.89/31
         ipv6: fc00::2b2/126
     bp_interface:
-      ipv4: 10.10.246.174/24
+      ipv4: 10.10.246.174/22
       ipv6: fc0a::ae/64
   ARISTA142T1:
     properties:
@@ -4928,7 +4944,7 @@ configuration:
         ipv4: 10.0.1.91/31
         ipv6: fc00::2b6/126
     bp_interface:
-      ipv4: 10.10.246.175/24
+      ipv4: 10.10.246.175/22
       ipv6: fc0a::af/64
   ARISTA143T1:
     properties:
@@ -4951,7 +4967,7 @@ configuration:
         ipv4: 10.0.1.93/31
         ipv6: fc00::2ba/126
     bp_interface:
-      ipv4: 10.10.246.176/24
+      ipv4: 10.10.246.176/22
       ipv6: fc0a::b0/64
   ARISTA144T1:
     properties:
@@ -4974,7 +4990,7 @@ configuration:
         ipv4: 10.0.1.95/31
         ipv6: fc00::2be/126
     bp_interface:
-      ipv4: 10.10.246.177/24
+      ipv4: 10.10.246.177/22
       ipv6: fc0a::b1/64
   ARISTA145T1:
     properties:
@@ -4997,7 +5013,7 @@ configuration:
         ipv4: 10.0.1.97/31
         ipv6: fc00::2c2/126
     bp_interface:
-      ipv4: 10.10.246.178/24
+      ipv4: 10.10.246.178/22
       ipv6: fc0a::b2/64
   ARISTA146T1:
     properties:
@@ -5020,7 +5036,7 @@ configuration:
         ipv4: 10.0.1.99/31
         ipv6: fc00::2c6/126
     bp_interface:
-      ipv4: 10.10.246.179/24
+      ipv4: 10.10.246.179/22
       ipv6: fc0a::b3/64
   ARISTA147T1:
     properties:
@@ -5043,7 +5059,7 @@ configuration:
         ipv4: 10.0.1.101/31
         ipv6: fc00::2ca/126
     bp_interface:
-      ipv4: 10.10.246.180/24
+      ipv4: 10.10.246.180/22
       ipv6: fc0a::b4/64
   ARISTA148T1:
     properties:
@@ -5066,7 +5082,7 @@ configuration:
         ipv4: 10.0.1.103/31
         ipv6: fc00::2ce/126
     bp_interface:
-      ipv4: 10.10.246.181/24
+      ipv4: 10.10.246.181/22
       ipv6: fc0a::b5/64
   ARISTA149T1:
     properties:
@@ -5089,7 +5105,7 @@ configuration:
         ipv4: 10.0.1.105/31
         ipv6: fc00::2d2/126
     bp_interface:
-      ipv4: 10.10.246.182/24
+      ipv4: 10.10.246.182/22
       ipv6: fc0a::b6/64
   ARISTA150T1:
     properties:
@@ -5112,7 +5128,7 @@ configuration:
         ipv4: 10.0.1.107/31
         ipv6: fc00::2d6/126
     bp_interface:
-      ipv4: 10.10.246.183/24
+      ipv4: 10.10.246.183/22
       ipv6: fc0a::b7/64
   ARISTA151T1:
     properties:
@@ -5135,7 +5151,7 @@ configuration:
         ipv4: 10.0.1.109/31
         ipv6: fc00::2da/126
     bp_interface:
-      ipv4: 10.10.246.184/24
+      ipv4: 10.10.246.184/22
       ipv6: fc0a::b8/64
   ARISTA152T1:
     properties:
@@ -5158,7 +5174,7 @@ configuration:
         ipv4: 10.0.1.111/31
         ipv6: fc00::2de/126
     bp_interface:
-      ipv4: 10.10.246.185/24
+      ipv4: 10.10.246.185/22
       ipv6: fc0a::b9/64
   ARISTA153T1:
     properties:
@@ -5181,7 +5197,7 @@ configuration:
         ipv4: 10.0.1.113/31
         ipv6: fc00::2e2/126
     bp_interface:
-      ipv4: 10.10.246.186/24
+      ipv4: 10.10.246.186/22
       ipv6: fc0a::ba/64
   ARISTA154T1:
     properties:
@@ -5204,7 +5220,7 @@ configuration:
         ipv4: 10.0.1.115/31
         ipv6: fc00::2e6/126
     bp_interface:
-      ipv4: 10.10.246.187/24
+      ipv4: 10.10.246.187/22
       ipv6: fc0a::bb/64
   ARISTA155T1:
     properties:
@@ -5227,7 +5243,7 @@ configuration:
         ipv4: 10.0.1.117/31
         ipv6: fc00::2ea/126
     bp_interface:
-      ipv4: 10.10.246.188/24
+      ipv4: 10.10.246.188/22
       ipv6: fc0a::bc/64
   ARISTA156T1:
     properties:
@@ -5250,7 +5266,7 @@ configuration:
         ipv4: 10.0.1.119/31
         ipv6: fc00::2ee/126
     bp_interface:
-      ipv4: 10.10.246.189/24
+      ipv4: 10.10.246.189/22
       ipv6: fc0a::bd/64
   ARISTA157T1:
     properties:
@@ -5273,7 +5289,7 @@ configuration:
         ipv4: 10.0.1.121/31
         ipv6: fc00::2f2/126
     bp_interface:
-      ipv4: 10.10.246.190/24
+      ipv4: 10.10.246.190/22
       ipv6: fc0a::be/64
   ARISTA158T1:
     properties:
@@ -5296,7 +5312,7 @@ configuration:
         ipv4: 10.0.1.123/31
         ipv6: fc00::2f6/126
     bp_interface:
-      ipv4: 10.10.246.191/24
+      ipv4: 10.10.246.191/22
       ipv6: fc0a::bf/64
   ARISTA159T1:
     properties:
@@ -5319,7 +5335,7 @@ configuration:
         ipv4: 10.0.1.125/31
         ipv6: fc00::2fa/126
     bp_interface:
-      ipv4: 10.10.246.192/24
+      ipv4: 10.10.246.192/22
       ipv6: fc0a::c0/64
   ARISTA160T1:
     properties:
@@ -5342,7 +5358,7 @@ configuration:
         ipv4: 10.0.1.127/31
         ipv6: fc00::2fe/126
     bp_interface:
-      ipv4: 10.10.246.193/24
+      ipv4: 10.10.246.193/22
       ipv6: fc0a::c1/64
   ARISTA161T1:
     properties:
@@ -5365,7 +5381,7 @@ configuration:
         ipv4: 10.0.1.129/31
         ipv6: fc00::302/126
     bp_interface:
-      ipv4: 10.10.246.194/24
+      ipv4: 10.10.246.194/22
       ipv6: fc0a::c2/64
   ARISTA162T1:
     properties:
@@ -5388,7 +5404,7 @@ configuration:
         ipv4: 10.0.1.131/31
         ipv6: fc00::306/126
     bp_interface:
-      ipv4: 10.10.246.195/24
+      ipv4: 10.10.246.195/22
       ipv6: fc0a::c3/64
   ARISTA163T1:
     properties:
@@ -5411,7 +5427,7 @@ configuration:
         ipv4: 10.0.1.133/31
         ipv6: fc00::30a/126
     bp_interface:
-      ipv4: 10.10.246.196/24
+      ipv4: 10.10.246.196/22
       ipv6: fc0a::c4/64
   ARISTA164T1:
     properties:
@@ -5434,7 +5450,7 @@ configuration:
         ipv4: 10.0.1.135/31
         ipv6: fc00::30e/126
     bp_interface:
-      ipv4: 10.10.246.197/24
+      ipv4: 10.10.246.197/22
       ipv6: fc0a::c5/64
   ARISTA165T1:
     properties:
@@ -5457,7 +5473,7 @@ configuration:
         ipv4: 10.0.1.137/31
         ipv6: fc00::312/126
     bp_interface:
-      ipv4: 10.10.246.198/24
+      ipv4: 10.10.246.198/22
       ipv6: fc0a::c6/64
   ARISTA166T1:
     properties:
@@ -5480,7 +5496,7 @@ configuration:
         ipv4: 10.0.1.139/31
         ipv6: fc00::316/126
     bp_interface:
-      ipv4: 10.10.246.199/24
+      ipv4: 10.10.246.199/22
       ipv6: fc0a::c7/64
   ARISTA167T1:
     properties:
@@ -5503,7 +5519,7 @@ configuration:
         ipv4: 10.0.1.141/31
         ipv6: fc00::31a/126
     bp_interface:
-      ipv4: 10.10.246.200/24
+      ipv4: 10.10.246.200/22
       ipv6: fc0a::c8/64
   ARISTA168T1:
     properties:
@@ -5526,7 +5542,7 @@ configuration:
         ipv4: 10.0.1.143/31
         ipv6: fc00::31e/126
     bp_interface:
-      ipv4: 10.10.246.201/24
+      ipv4: 10.10.246.201/22
       ipv6: fc0a::c9/64
   ARISTA169T1:
     properties:
@@ -5549,7 +5565,7 @@ configuration:
         ipv4: 10.0.1.145/31
         ipv6: fc00::322/126
     bp_interface:
-      ipv4: 10.10.246.202/24
+      ipv4: 10.10.246.202/22
       ipv6: fc0a::ca/64
   ARISTA170T1:
     properties:
@@ -5572,7 +5588,7 @@ configuration:
         ipv4: 10.0.1.147/31
         ipv6: fc00::326/126
     bp_interface:
-      ipv4: 10.10.246.203/24
+      ipv4: 10.10.246.203/22
       ipv6: fc0a::cb/64
   ARISTA171T1:
     properties:
@@ -5595,7 +5611,7 @@ configuration:
         ipv4: 10.0.1.149/31
         ipv6: fc00::32a/126
     bp_interface:
-      ipv4: 10.10.246.204/24
+      ipv4: 10.10.246.204/22
       ipv6: fc0a::cc/64
   ARISTA172T1:
     properties:
@@ -5618,7 +5634,7 @@ configuration:
         ipv4: 10.0.1.151/31
         ipv6: fc00::32e/126
     bp_interface:
-      ipv4: 10.10.246.205/24
+      ipv4: 10.10.246.205/22
       ipv6: fc0a::cd/64
   ARISTA173T1:
     properties:
@@ -5641,7 +5657,7 @@ configuration:
         ipv4: 10.0.1.153/31
         ipv6: fc00::332/126
     bp_interface:
-      ipv4: 10.10.246.206/24
+      ipv4: 10.10.246.206/22
       ipv6: fc0a::ce/64
   ARISTA174T1:
     properties:
@@ -5664,7 +5680,7 @@ configuration:
         ipv4: 10.0.1.155/31
         ipv6: fc00::336/126
     bp_interface:
-      ipv4: 10.10.246.207/24
+      ipv4: 10.10.246.207/22
       ipv6: fc0a::cf/64
   ARISTA175T1:
     properties:
@@ -5687,7 +5703,7 @@ configuration:
         ipv4: 10.0.1.157/31
         ipv6: fc00::33a/126
     bp_interface:
-      ipv4: 10.10.246.208/24
+      ipv4: 10.10.246.208/22
       ipv6: fc0a::d0/64
   ARISTA176T1:
     properties:
@@ -5710,7 +5726,7 @@ configuration:
         ipv4: 10.0.1.159/31
         ipv6: fc00::33e/126
     bp_interface:
-      ipv4: 10.10.246.209/24
+      ipv4: 10.10.246.209/22
       ipv6: fc0a::d1/64
   ARISTA177T1:
     properties:
@@ -5733,7 +5749,7 @@ configuration:
         ipv4: 10.0.1.161/31
         ipv6: fc00::342/126
     bp_interface:
-      ipv4: 10.10.246.210/24
+      ipv4: 10.10.246.210/22
       ipv6: fc0a::d2/64
   ARISTA178T1:
     properties:
@@ -5756,7 +5772,7 @@ configuration:
         ipv4: 10.0.1.163/31
         ipv6: fc00::346/126
     bp_interface:
-      ipv4: 10.10.246.211/24
+      ipv4: 10.10.246.211/22
       ipv6: fc0a::d3/64
   ARISTA179T1:
     properties:
@@ -5779,7 +5795,7 @@ configuration:
         ipv4: 10.0.1.165/31
         ipv6: fc00::34a/126
     bp_interface:
-      ipv4: 10.10.246.212/24
+      ipv4: 10.10.246.212/22
       ipv6: fc0a::d4/64
   ARISTA180T1:
     properties:
@@ -5802,7 +5818,7 @@ configuration:
         ipv4: 10.0.1.167/31
         ipv6: fc00::34e/126
     bp_interface:
-      ipv4: 10.10.246.213/24
+      ipv4: 10.10.246.213/22
       ipv6: fc0a::d5/64
   ARISTA181T1:
     properties:
@@ -5825,7 +5841,7 @@ configuration:
         ipv4: 10.0.1.169/31
         ipv6: fc00::352/126
     bp_interface:
-      ipv4: 10.10.246.214/24
+      ipv4: 10.10.246.214/22
       ipv6: fc0a::d6/64
   ARISTA182T1:
     properties:
@@ -5848,7 +5864,7 @@ configuration:
         ipv4: 10.0.1.171/31
         ipv6: fc00::356/126
     bp_interface:
-      ipv4: 10.10.246.215/24
+      ipv4: 10.10.246.215/22
       ipv6: fc0a::d7/64
   ARISTA183T1:
     properties:
@@ -5871,7 +5887,7 @@ configuration:
         ipv4: 10.0.1.173/31
         ipv6: fc00::35a/126
     bp_interface:
-      ipv4: 10.10.246.216/24
+      ipv4: 10.10.246.216/22
       ipv6: fc0a::d8/64
   ARISTA184T1:
     properties:
@@ -5894,7 +5910,7 @@ configuration:
         ipv4: 10.0.1.175/31
         ipv6: fc00::35e/126
     bp_interface:
-      ipv4: 10.10.246.217/24
+      ipv4: 10.10.246.217/22
       ipv6: fc0a::d9/64
   ARISTA185T1:
     properties:
@@ -5917,7 +5933,7 @@ configuration:
         ipv4: 10.0.1.177/31
         ipv6: fc00::362/126
     bp_interface:
-      ipv4: 10.10.246.218/24
+      ipv4: 10.10.246.218/22
       ipv6: fc0a::da/64
   ARISTA186T1:
     properties:
@@ -5940,7 +5956,7 @@ configuration:
         ipv4: 10.0.1.179/31
         ipv6: fc00::366/126
     bp_interface:
-      ipv4: 10.10.246.219/24
+      ipv4: 10.10.246.219/22
       ipv6: fc0a::db/64
   ARISTA187T1:
     properties:
@@ -5963,7 +5979,7 @@ configuration:
         ipv4: 10.0.1.181/31
         ipv6: fc00::36a/126
     bp_interface:
-      ipv4: 10.10.246.220/24
+      ipv4: 10.10.246.220/22
       ipv6: fc0a::dc/64
   ARISTA188T1:
     properties:
@@ -5986,7 +6002,7 @@ configuration:
         ipv4: 10.0.1.183/31
         ipv6: fc00::36e/126
     bp_interface:
-      ipv4: 10.10.246.221/24
+      ipv4: 10.10.246.221/22
       ipv6: fc0a::dd/64
   ARISTA189T1:
     properties:
@@ -6009,7 +6025,7 @@ configuration:
         ipv4: 10.0.1.185/31
         ipv6: fc00::372/126
     bp_interface:
-      ipv4: 10.10.246.222/24
+      ipv4: 10.10.246.222/22
       ipv6: fc0a::de/64
   ARISTA190T1:
     properties:
@@ -6032,7 +6048,7 @@ configuration:
         ipv4: 10.0.1.187/31
         ipv6: fc00::376/126
     bp_interface:
-      ipv4: 10.10.246.223/24
+      ipv4: 10.10.246.223/22
       ipv6: fc0a::df/64
   ARISTA191T1:
     properties:
@@ -6055,7 +6071,7 @@ configuration:
         ipv4: 10.0.1.189/31
         ipv6: fc00::37a/126
     bp_interface:
-      ipv4: 10.10.246.224/24
+      ipv4: 10.10.246.224/22
       ipv6: fc0a::e0/64
   ARISTA192T1:
     properties:
@@ -6078,7 +6094,7 @@ configuration:
         ipv4: 10.0.1.191/31
         ipv6: fc00::37e/126
     bp_interface:
-      ipv4: 10.10.246.225/24
+      ipv4: 10.10.246.225/22
       ipv6: fc0a::e1/64
   ARISTA193T1:
     properties:
@@ -6101,7 +6117,7 @@ configuration:
         ipv4: 10.0.1.193/31
         ipv6: fc00::382/126
     bp_interface:
-      ipv4: 10.10.246.226/24
+      ipv4: 10.10.246.226/22
       ipv6: fc0a::e2/64
   ARISTA194T1:
     properties:
@@ -6124,7 +6140,7 @@ configuration:
         ipv4: 10.0.1.195/31
         ipv6: fc00::386/126
     bp_interface:
-      ipv4: 10.10.246.227/24
+      ipv4: 10.10.246.227/22
       ipv6: fc0a::e3/64
   ARISTA195T1:
     properties:
@@ -6147,7 +6163,7 @@ configuration:
         ipv4: 10.0.1.197/31
         ipv6: fc00::38a/126
     bp_interface:
-      ipv4: 10.10.246.228/24
+      ipv4: 10.10.246.228/22
       ipv6: fc0a::e4/64
   ARISTA196T1:
     properties:
@@ -6170,7 +6186,7 @@ configuration:
         ipv4: 10.0.1.199/31
         ipv6: fc00::38e/126
     bp_interface:
-      ipv4: 10.10.246.229/24
+      ipv4: 10.10.246.229/22
       ipv6: fc0a::e5/64
   ARISTA197T1:
     properties:
@@ -6193,7 +6209,7 @@ configuration:
         ipv4: 10.0.1.201/31
         ipv6: fc00::392/126
     bp_interface:
-      ipv4: 10.10.246.230/24
+      ipv4: 10.10.246.230/22
       ipv6: fc0a::e6/64
   ARISTA198T1:
     properties:
@@ -6216,7 +6232,7 @@ configuration:
         ipv4: 10.0.1.203/31
         ipv6: fc00::396/126
     bp_interface:
-      ipv4: 10.10.246.231/24
+      ipv4: 10.10.246.231/22
       ipv6: fc0a::e7/64
   ARISTA199T1:
     properties:
@@ -6239,7 +6255,7 @@ configuration:
         ipv4: 10.0.1.205/31
         ipv6: fc00::39a/126
     bp_interface:
-      ipv4: 10.10.246.232/24
+      ipv4: 10.10.246.232/22
       ipv6: fc0a::e8/64
   ARISTA200T1:
     properties:
@@ -6262,7 +6278,7 @@ configuration:
         ipv4: 10.0.1.207/31
         ipv6: fc00::39e/126
     bp_interface:
-      ipv4: 10.10.246.233/24
+      ipv4: 10.10.246.233/22
       ipv6: fc0a::e9/64
   ARISTA201T1:
     properties:
@@ -6285,7 +6301,7 @@ configuration:
         ipv4: 10.0.1.209/31
         ipv6: fc00::3a2/126
     bp_interface:
-      ipv4: 10.10.246.234/24
+      ipv4: 10.10.246.234/22
       ipv6: fc0a::ea/64
   ARISTA202T1:
     properties:
@@ -6308,7 +6324,7 @@ configuration:
         ipv4: 10.0.1.211/31
         ipv6: fc00::3a6/126
     bp_interface:
-      ipv4: 10.10.246.235/24
+      ipv4: 10.10.246.235/22
       ipv6: fc0a::eb/64
   ARISTA203T1:
     properties:
@@ -6331,7 +6347,7 @@ configuration:
         ipv4: 10.0.1.213/31
         ipv6: fc00::3aa/126
     bp_interface:
-      ipv4: 10.10.246.236/24
+      ipv4: 10.10.246.236/22
       ipv6: fc0a::ec/64
   ARISTA204T1:
     properties:
@@ -6354,7 +6370,7 @@ configuration:
         ipv4: 10.0.1.215/31
         ipv6: fc00::3ae/126
     bp_interface:
-      ipv4: 10.10.246.237/24
+      ipv4: 10.10.246.237/22
       ipv6: fc0a::ed/64
   ARISTA205T1:
     properties:
@@ -6377,7 +6393,7 @@ configuration:
         ipv4: 10.0.1.217/31
         ipv6: fc00::3b2/126
     bp_interface:
-      ipv4: 10.10.246.238/24
+      ipv4: 10.10.246.238/22
       ipv6: fc0a::ee/64
   ARISTA206T1:
     properties:
@@ -6400,7 +6416,7 @@ configuration:
         ipv4: 10.0.1.219/31
         ipv6: fc00::3b6/126
     bp_interface:
-      ipv4: 10.10.246.239/24
+      ipv4: 10.10.246.239/22
       ipv6: fc0a::ef/64
   ARISTA207T1:
     properties:
@@ -6423,7 +6439,7 @@ configuration:
         ipv4: 10.0.1.221/31
         ipv6: fc00::3ba/126
     bp_interface:
-      ipv4: 10.10.246.240/24
+      ipv4: 10.10.246.240/22
       ipv6: fc0a::f0/64
   ARISTA208T1:
     properties:
@@ -6446,7 +6462,7 @@ configuration:
         ipv4: 10.0.1.223/31
         ipv6: fc00::3be/126
     bp_interface:
-      ipv4: 10.10.246.241/24
+      ipv4: 10.10.246.241/22
       ipv6: fc0a::f1/64
   ARISTA209T1:
     properties:
@@ -6469,7 +6485,7 @@ configuration:
         ipv4: 10.0.1.225/31
         ipv6: fc00::3c2/126
     bp_interface:
-      ipv4: 10.10.246.242/24
+      ipv4: 10.10.246.242/22
       ipv6: fc0a::f2/64
   ARISTA210T1:
     properties:
@@ -6492,7 +6508,7 @@ configuration:
         ipv4: 10.0.1.227/31
         ipv6: fc00::3c6/126
     bp_interface:
-      ipv4: 10.10.246.243/24
+      ipv4: 10.10.246.243/22
       ipv6: fc0a::f3/64
   ARISTA211T1:
     properties:
@@ -6515,7 +6531,7 @@ configuration:
         ipv4: 10.0.1.229/31
         ipv6: fc00::3ca/126
     bp_interface:
-      ipv4: 10.10.246.244/24
+      ipv4: 10.10.246.244/22
       ipv6: fc0a::f4/64
   ARISTA212T1:
     properties:
@@ -6538,7 +6554,7 @@ configuration:
         ipv4: 10.0.1.231/31
         ipv6: fc00::3ce/126
     bp_interface:
-      ipv4: 10.10.246.245/24
+      ipv4: 10.10.246.245/22
       ipv6: fc0a::f5/64
   ARISTA213T1:
     properties:
@@ -6561,7 +6577,7 @@ configuration:
         ipv4: 10.0.1.233/31
         ipv6: fc00::3d2/126
     bp_interface:
-      ipv4: 10.10.246.246/24
+      ipv4: 10.10.246.246/22
       ipv6: fc0a::f6/64
   ARISTA214T1:
     properties:
@@ -6584,7 +6600,7 @@ configuration:
         ipv4: 10.0.1.235/31
         ipv6: fc00::3d6/126
     bp_interface:
-      ipv4: 10.10.246.247/24
+      ipv4: 10.10.246.247/22
       ipv6: fc0a::f7/64
   ARISTA215T1:
     properties:
@@ -6607,7 +6623,7 @@ configuration:
         ipv4: 10.0.1.237/31
         ipv6: fc00::3da/126
     bp_interface:
-      ipv4: 10.10.246.248/24
+      ipv4: 10.10.246.248/22
       ipv6: fc0a::f8/64
   ARISTA216T1:
     properties:
@@ -6630,7 +6646,7 @@ configuration:
         ipv4: 10.0.1.239/31
         ipv6: fc00::3de/126
     bp_interface:
-      ipv4: 10.10.246.249/24
+      ipv4: 10.10.246.249/22
       ipv6: fc0a::f9/64
   ARISTA217T1:
     properties:
@@ -6653,7 +6669,7 @@ configuration:
         ipv4: 10.0.1.241/31
         ipv6: fc00::3e2/126
     bp_interface:
-      ipv4: 10.10.246.250/24
+      ipv4: 10.10.246.250/22
       ipv6: fc0a::fa/64
   ARISTA218T1:
     properties:
@@ -6676,7 +6692,7 @@ configuration:
         ipv4: 10.0.1.243/31
         ipv6: fc00::3e6/126
     bp_interface:
-      ipv4: 10.10.246.251/24
+      ipv4: 10.10.246.251/22
       ipv6: fc0a::fb/64
   ARISTA219T1:
     properties:
@@ -6699,7 +6715,7 @@ configuration:
         ipv4: 10.0.1.245/31
         ipv6: fc00::3ea/126
     bp_interface:
-      ipv4: 10.10.246.252/24
+      ipv4: 10.10.246.252/22
       ipv6: fc0a::fc/64
   ARISTA220T1:
     properties:
@@ -6722,5 +6738,97 @@ configuration:
         ipv4: 10.0.1.247/31
         ipv6: fc00::3ee/126
     bp_interface:
-      ipv4: 10.10.246.253/24
+      ipv4: 10.10.246.253/22
       ipv6: fc0a::fd/64
+  ARISTA221T1:
+    properties:
+    - common
+    - leaf
+    tornum: 221
+    bgp:
+      asn: 4200000000
+      peers:
+        4200100000:
+        - 10.0.1.248
+        - fc00::3f1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.253/32
+        ipv6: 2064:100:0:fd::/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.1.249/31
+        ipv6: fc00::3f2/126
+    bp_interface:
+      ipv4: 10.10.246.254/22
+      ipv6: fc0a::100/64
+  ARISTA222T1:
+    properties:
+    - common
+    - leaf
+    tornum: 222
+    bgp:
+      asn: 4200000000
+      peers:
+        4200100000:
+        - 10.0.1.250
+        - fc00::3f5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.254/32
+        ipv6: 2064:100:0:fe::/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.1.251/31
+        ipv6: fc00::3f6/126
+    bp_interface:
+      ipv4: 10.10.246.255/22
+      ipv6: fc0a::101/64
+  ARISTA223T1:
+    properties:
+    - common
+    - leaf
+    tornum: 223
+    bgp:
+      asn: 4200000000
+      peers:
+        4200100000:
+        - 10.0.1.252
+        - fc00::3f9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.255/32
+        ipv6: 2064:100:0:ff::/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.1.253/31
+        ipv6: fc00::3fa/126
+    bp_interface:
+      ipv4: 10.10.247.2/22
+      ipv6: fc0a::102/64
+  ARISTA224T1:
+    properties:
+    - common
+    - leaf
+    tornum: 224
+    bgp:
+      asn: 4200000000
+      peers:
+        4200100000:
+        - 10.0.1.254
+        - fc00::3fd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.1.0/32
+        ipv6: 2064:100:0:100::/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.1.255/31
+        ipv6: fc00::3fe/126
+    bp_interface:
+      ipv4: 10.10.247.3/22
+      ipv6: fc0a::103/64

--- a/ansible/vars/topo_lt2-o256-u32d224.yml
+++ b/ansible/vars/topo_lt2-o256-u32d224.yml
@@ -1008,22 +1008,6 @@ topology:
       vlans:
       - 251
       vm_offset: 251
-    ARISTA221T1:
-      vlans:
-      - 252
-      vm_offset: 252
-    ARISTA222T1:
-      vlans:
-      - 253
-      vm_offset: 253
-    ARISTA223T1:
-      vlans:
-      - 254
-      vm_offset: 254
-    ARISTA224T1:
-      vlans:
-      - 255
-      vm_offset: 255
 configuration_properties:
   common:
     dut_asn: 4200100000
@@ -1031,10 +1015,10 @@ configuration_properties:
     nhipv4: 10.10.246.254
     nhipv6: FC0A::FF
     podset_number: 200
-    tor_number: 224
+    tor_number: 220
     tor_subnet_number: 2
-    max_tor_subnet_number: 224
-    tor_subnet_size: 224
+    max_tor_subnet_number: 220
+    tor_subnet_size: 220
   spine:
     swrole: spine
   leaf:
@@ -6740,95 +6724,3 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.253/22
       ipv6: fc0a::fd/64
-  ARISTA221T1:
-    properties:
-    - common
-    - leaf
-    tornum: 221
-    bgp:
-      asn: 4200000000
-      peers:
-        4200100000:
-        - 10.0.1.248
-        - fc00::3f1
-    interfaces:
-      Loopback0:
-        ipv4: 100.1.0.253/32
-        ipv6: 2064:100:0:fd::/128
-      Ethernet1:
-        lacp: 1
-      Port-Channel1:
-        ipv4: 10.0.1.249/31
-        ipv6: fc00::3f2/126
-    bp_interface:
-      ipv4: 10.10.246.254/22
-      ipv6: fc0a::100/64
-  ARISTA222T1:
-    properties:
-    - common
-    - leaf
-    tornum: 222
-    bgp:
-      asn: 4200000000
-      peers:
-        4200100000:
-        - 10.0.1.250
-        - fc00::3f5
-    interfaces:
-      Loopback0:
-        ipv4: 100.1.0.254/32
-        ipv6: 2064:100:0:fe::/128
-      Ethernet1:
-        lacp: 1
-      Port-Channel1:
-        ipv4: 10.0.1.251/31
-        ipv6: fc00::3f6/126
-    bp_interface:
-      ipv4: 10.10.246.255/22
-      ipv6: fc0a::101/64
-  ARISTA223T1:
-    properties:
-    - common
-    - leaf
-    tornum: 223
-    bgp:
-      asn: 4200000000
-      peers:
-        4200100000:
-        - 10.0.1.252
-        - fc00::3f9
-    interfaces:
-      Loopback0:
-        ipv4: 100.1.0.255/32
-        ipv6: 2064:100:0:ff::/128
-      Ethernet1:
-        lacp: 1
-      Port-Channel1:
-        ipv4: 10.0.1.253/31
-        ipv6: fc00::3fa/126
-    bp_interface:
-      ipv4: 10.10.247.2/22
-      ipv6: fc0a::102/64
-  ARISTA224T1:
-    properties:
-    - common
-    - leaf
-    tornum: 224
-    bgp:
-      asn: 4200000000
-      peers:
-        4200100000:
-        - 10.0.1.254
-        - fc00::3fd
-    interfaces:
-      Loopback0:
-        ipv4: 100.1.1.0/32
-        ipv6: 2064:100:0:100::/128
-      Ethernet1:
-        lacp: 1
-      Port-Channel1:
-        ipv4: 10.0.1.255/31
-        ipv6: fc00::3fe/126
-    bp_interface:
-      ipv4: 10.10.247.3/22
-      ipv6: fc0a::103/64


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

-  Fix PTF backplane netmask for `lt2-o256-u32d224` topology: set each VM _bp_interface.ipv4_ to /22 instead of /24.
- VM count remains 220 ARISTA T1 VMs (unchanged from master)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

- Fix PTF backplane netmask for `lt2-o256-u32d224` topology: set each VM _bp_interface.ipv4_ to /22 instead of /24.
- With 220 VMs, many addresses fall outside a single /24; _/24_ masks were incorrect.

#### How did you do it?

- In ansible/templates/topo_lt2-o256-u32d224.j2, changed _{{vm.bp_ipv4}}/24_ → /22

#### How did you verify/test it?

- Ran add-topo with the above topo file and made sure it worked fine.

#### Any platform specific information?

LT2- TH6

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
