### PR TITLE
[loganalyzer] Add syncd collectData Port Counter failure to common ignore list

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -373,6 +373,8 @@ r, ".* ERR kernel:.*sxd_kernel: \[error\] Health-Check: device=1, cause=10 \['SD
 
 # Ignore gbsynd error for 720DT
 r, ".*ERR gbsyncd#syncd: :- collectData: Failed to get stats of Port Counter.*"
+# Ignore syncd Port Counter stats collection transient failure on Memory ASIC platforms (e.g. 7060X6)
+r, ".*ERR syncd\d*#syncd: :- collectData: Failed to get stats of Port Counter.*"
 r, ".*ERR gbsyncd#syncd: :- diagShellThreadProc: Failed to enable switch shell: SAI_STATUS_NOT_SUPPORTED.*"
 r, ".* ERR gbsyncd#syncd: /arsonic/packages/broncos-sai/build/PAI_\d+\.\d+/src/brcm_pai_port\.c:\d+ brcm_pai_get_port_stats.*\s*.*"
 r, ".* ERR gbsyncd#syncd: /arsonic/packages/broncos-sai/build/PAI_\d+\.\d+/src/brcm_pai_adapter\.c:\d+ sai_api_query: :- Invalid sai_api_t \d+ passed#\d+"


### PR DESCRIPTION
### Description of PR
Summary:
Add `syncd#syncd` variant of the `collectData: Failed to get stats of Port Counter` pattern to the global LogAnalyzer common ignore list.

The existing line 375 already ignores this pattern for `gbsyncd#syncd` (gearbox syncd on 720DT), but the regex only matches `gbsyncd`, missing `syncd` on non-gearbox platforms like Arista 7060X6.

The FlexCounter periodic `collectData` poll occasionally fails to get port counter stats with SAI error `-2`. This is a transient error that self-recovers on the next polling cycle and does not affect functionality.

**Impact**: Kusto data from the last 30 days shows **5 testbeds** (all Arista 7060X6 variants) with **48 teardown failures** across 10+ test cases.

Affected testbeds:
| Testbed | HwSKU | Failures |
|---------|-------|----------|
| vms92-t0-7060x6-moby-512-2 | Arista-7060X6-16PE-384C-B-O128S2 | 22 |
| vms91-t0-7060x6-moby-512-3 | Arista-7060X6-16PE-384C-B-O128S2 | 14 |
| vms93-t1-7060x6-512-4 | Arista-7060X6-64PE-B-O128 | 6 |
| vms75-t1-7060x6-512-7 | Arista-7060X6-64PE-B-C448O16 | 5 |
| vms91-t0-7060x6-512-3 | Arista-7060X6-64PE-B-C512S2 | 1 |

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Reduce false-positive teardown failures on Arista 7060X6 platforms caused by transient syncd Port Counter collection errors.

#### How did you do it?
Added one regex line to `loganalyzer_common_ignore.txt`, placed right after the existing `gbsyncd` variant (line 375) for consistency.

#### How did you verify/test it?
- Verified the regex `r, ".*ERR syncd\d*#syncd: :- collectData: Failed to get stats of Port Counter.*"` matches the actual syslog: `ERR syncd#syncd: :- collectData: Failed to get stats of Port Counter 0x1000000f1: -2`
- Cross-checked with the existing `gbsyncd` pattern on line 375 which uses the identical format
- Kusto analysis confirms all 48 failures across 5 testbeds match this pattern

#### Any platform specific information?
Observed on Arista 7060X6 (Memory ASIC / Memory-Memory) platforms only. The `gbsyncd` variant (720DT) is already covered.

#### Supported testbed topology if it's a new test case?
N/A — this is a LogAnalyzer ignore pattern change, not a new test case.

### Documentation
N/A