### PR TITLE
[syslog] Use pytest_assert for wait_rsyslogd_restart checks

### DIFF
--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -144,7 +144,12 @@ def verify_container_rate_limit(rand_selected_dut, ignore_containers=[]):
         rsyslog_pid = get_rsyslogd_pid(rand_selected_dut, container_name)
         rand_selected_dut.command('config syslog rate-limit-container {} -b {} -i {}'.format(
             service_name, RATE_LIMIT_BURST, RATE_LIMIT_INTERVAL))
-        assert wait_rsyslogd_restart(rand_selected_dut, container_name, rsyslog_pid)
+        pytest_assert(
+            wait_rsyslogd_restart(rand_selected_dut, container_name, rsyslog_pid),
+            'rsyslogd in container {} did not restart or become ready within 30s '
+            'after `config syslog rate-limit-container {} -b {} -i {}` (old pid={!r})'.format(
+                container_name, service_name, RATE_LIMIT_BURST, RATE_LIMIT_INTERVAL,
+                rsyslog_pid))
         rate_limit_data = rand_selected_dut.show_and_parse('show syslog rate-limit-container {}'.format(service_name))
         pytest_assert(rate_limit_data[0]['interval'] == str(RATE_LIMIT_INTERVAL),
                       'Expect rate limit interval {}, actual {}'.format(RATE_LIMIT_INTERVAL,
@@ -186,7 +191,11 @@ def verify_container_rate_limit(rand_selected_dut, ignore_containers=[]):
 
         rsyslog_pid = get_rsyslogd_pid(rand_selected_dut, container_name)
         rand_selected_dut.command('config syslog rate-limit-container {} -b {} -i {}'.format(service_name, 0, 0))
-        assert wait_rsyslogd_restart(rand_selected_dut, container_name, rsyslog_pid)
+        pytest_assert(
+            wait_rsyslogd_restart(rand_selected_dut, container_name, rsyslog_pid),
+            'rsyslogd in container {} did not restart or become ready within 30s '
+            'after `config syslog rate-limit-container {} -b 0 -i 0` (old pid={!r})'.format(
+                container_name, service_name, rsyslog_pid))
         rate_limit_data = rand_selected_dut.show_and_parse('show syslog rate-limit-container {}'.format(service_name))
         pytest_assert(rate_limit_data[0]['interval'] == '0',
                       'Expect rate limit interval {}, actual {}'.format(0, rate_limit_data[0]['interval']))


### PR DESCRIPTION
### Description of PR

Summary: replace the two bare `assert wait_rsyslogd_restart(...)` calls in `verify_container_rate_limit` with `pytest_assert` carrying context. No behavioral change.

**Before:**

```python
assert wait_rsyslogd_restart(rand_selected_dut, container_name, rsyslog_pid)
```

On failure, pytest reports literally just:

```
AssertionError
```

— with no info about which container, which step, what the previous PID was, or what command was being applied. Triaging required reading raw `*.log` files line-by-line.

**After:**

```python
pytest_assert(
    wait_rsyslogd_restart(rand_selected_dut, container_name, rsyslog_pid),
    'rsyslogd in container {} did not restart or become ready within 30s '
    'after `config syslog rate-limit-container {} -b {} -i {}` (old pid={!r})'.format(
        container_name, service_name, RATE_LIMIT_BURST, RATE_LIMIT_INTERVAL,
        rsyslog_pid))
```

Failure now reports:

```
Failed: rsyslogd in container <name> did not restart or become ready within 30s
        after `config syslog rate-limit-container <svc> -b 100 -i 10` (old pid=<pid>)
```

Both call sites updated symmetrically (enable + disable paths).

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

`test_syslog_rate_limit` has failed on BMC (and intermittently on other platforms) with only `AssertionError` in the report — no clue which container, which step, or what state. After this PR the failure message points directly at the problem.

#### How did you do it?

Two call sites in `tests/syslog/test_syslog_rate_limit.py::verify_container_rate_limit` changed from bare `assert` to `pytest_assert(..., "context message")`.

#### How did you verify/test it?

- Python syntax check (`ast.parse`) — clean.
- No behavioral change on healthy DUTs: `pytest_assert` evaluates the same boolean as the prior bare assert.

#### Any platform specific information?

No platform-specific code. Benefits any platform when this test fails.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.
