### PR TITLE
[BMC] Skip test_logrotate_small_size and test_logrotate_full_partition_no_archives_cleanup

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5227,6 +5227,18 @@ sub_port_interfaces/test_sub_port_l2_forwarding.py::test_sub_port_l2_forwarding[
 #######################################
 #####             syslog          #####
 #######################################
+syslog/test_logrotate.py::test_logrotate_small_size:
+  skip:
+    reason: "Not applicable on BMC: the simulate_small_var_log_partition fixture calls config_reload(check_intf_up_ports=True, wait_for_bgp=True), which never succeeds on BMC (no front-panel ports, no BGP)."
+    conditions:
+      - "'bmc' in topo_type"
+
+syslog/test_logrotate.py::test_logrotate_full_partition_no_archives_cleanup:
+  skip:
+    reason: "Not applicable on BMC: the simulate_small_var_log_partition fixture calls config_reload(check_intf_up_ports=True, wait_for_bgp=True), which never succeeds on BMC (no front-panel ports, no BGP)."
+    conditions:
+      - "'bmc' in topo_type"
+
 syslog/test_logrotate.py::test_orchagent_logrotate:
   xfail:
     reason: "Test case has issue on the t0-isolated-d256u256s2 topo."


### PR DESCRIPTION
### Description of PR

Summary: skip two cases in `tests/syslog/test_logrotate.py` on BMC platforms. Both depend on the `simulate_small_var_log_partition` fixture (defined in the same file), which calls `config_reload(check_intf_up_ports=True, wait_for_bgp=True)` in setup and teardown. BMC has no front-panel ports and no BGP, so both calls wait forever and the fixture errors out.

- `test_logrotate_small_size`
- `test_logrotate_full_partition_no_archives_cleanup`

```yaml
syslog/test_logrotate.py::test_logrotate_small_size:
  skip:
    reason: "Not applicable on BMC: the simulate_small_var_log_partition fixture calls config_reload(check_intf_up_ports=True, wait_for_bgp=True), which never succeeds on BMC (no front-panel ports, no BGP)."
    conditions:
      - "'bmc' in topo_type"

syslog/test_logrotate.py::test_logrotate_full_partition_no_archives_cleanup:
  skip:
    reason: "Not applicable on BMC: the simulate_small_var_log_partition fixture calls config_reload(check_intf_up_ports=True, wait_for_bgp=True), which never succeeds on BMC (no front-panel ports, no BGP)."
    conditions:
      - "'bmc' in topo_type"
```

`test_logrotate_normal_size` does not use the fixture and continues to run on BMC (currently PASSING).

`test_orchagent_logrotate` is separately covered by [#24514](https://github.com/sonic-net/sonic-mgmt/pull/24514) (BMC has no orchagent).

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

Both cases fail at fixture setup on Komodo BMC (`arm64-nexthop_b27-r0`) — once the recent snmp fix from PR #24084 landed, the residual failure mode became `Failed: Not all ports that are admin up on are operationally up` (no front-panel ports on BMC). Earlier R1 runs sometimes hit `losetup: Device or resource busy` from a stale `/dev/loop2` left by an interrupted prior run, but even with a clean loop device the test cannot get past the fixture's `config_reload(check_intf_up_ports=True, wait_for_bgp=True)`.

The tests validate generic SONiC logrotate behavior on a real-disk `/var/log`. BMC has `/var/log` as `tmpfs` (sized ~365 MB) by default, so this is not BMC-specific coverage anyway.

#### How did you do it?

Two new entries in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`, gated on `"'bmc' in topo_type"` — same convention as the other ~30 BMC skips already in this file.

#### How did you verify/test it?

- Verified live on `host1-komodo-bmc` (Aspeed BMC) that `/var/log` is `tmpfs` and that no front-panel ports / no BGP sessions exist, so `check_intf_up_ports=True` / `wait_for_bgp=True` cannot succeed.
- `python3 -c "import yaml; yaml.safe_load(open(...))"` confirms YAML parses clean.
- `test_logrotate_normal_size` is not affected — it doesn't use the fixture and still runs on BMC.

#### Any platform specific information?

Only BMC topologies (`'bmc' in topo_type`). No effect on switching platforms.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.
