### PR TITLE
Fix KeyError in analyzer_logrotate error handler

### DIFF
--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -35,7 +35,9 @@ def analyzer_logrotate(node=None, results=None):
             logging.warning("logrotate is failed. Command returned:\n"
                             "Stdout: {}\n"
                             "Stderr: {}\n"
-                            "Return code: {}".format(e.results["stdout"], e.results["stderr"], e.results["rc"]))
+                            "Return code: {}".format(e.results.get("stdout", ""),
+                                                     e.results.get("stderr", ""),
+                                                     e.results.get("rc", "")))
 
 
 @reset_ansible_local_tmp


### PR DESCRIPTION
### Description of PR

Summary:
Fix `KeyError('stdout')` in `analyzer_logrotate` error handler that crashes the parallel worker process when `logrotate` fails on DUT.

Fixes https://msazure.visualstudio.com/One/_workitems/edit/37977676

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

When `logrotate -f /etc/logrotate.conf` fails on a DUT, the `analyzer_logrotate` function is supposed to catch the `RunAnsibleModuleFail` exception and log a warning. However, the error handler accesses `e.results["stdout"]` directly. In some failure scenarios (e.g., Ansible connection issues, module-level failures), the result dictionary does not contain `stdout`/`stderr`/`rc` keys, causing an unhandled `KeyError('stdout')`.

This `KeyError` crashes the `parallel_run` worker process (exit code 1), which then blocks **all** tests using the `loganalyzer` fixture (`autouse=True`) with a setup error:
```
Failed: Processes "['analyzer_logrotate--<MultiAsicSonicHost ...>']" failed with exit code "1"
Exception: 'stdout'
```

KQL analysis shows this pattern affected 63 tests across multiple testbeds/SKUs in the last 14 days.

#### How did you do it?

Changed `e.results["stdout"]` to `e.results.get("stdout", "")` (and same for `stderr` and `rc`) so the error handler gracefully handles missing keys and logs a warning instead of crashing.

#### How did you verify/test it?

- Code review: the fix is a one-line defensive change using `dict.get()` with defaults
- Verified the `RunAnsibleModuleFail.results` attribute is dict-like (inherits from Ansible result objects) and supports `.get()`
- KQL confirmed the test passes on retry (Attempt #1 PASSED), so the underlying logrotate failure is transient — the fix ensures the framework handles it gracefully

#### Any platform specific information?

No — this affects all platforms. The `loganalyzer` fixture is `autouse=True` and runs on every DUT.

#### Supported testbed topology if it's a new test case?

N/A — bug fix only.

### Documentation

N/A — no new features.