### PR TITLE
Skip COPP test cases due to issue #26925

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -787,6 +787,12 @@ copp/test_copp.py:
     conditions:
       - "'-v6-' in topo_name"
 
+copp/test_copp.py::TestCOPP:
+  xfail:
+    reason: "PTF docker image does not support ptf_nn_agent with pynng: https://github.com/sonic-net/sonic-buildimage/issues/26925"
+    conditions:
+      - "https://github.com/sonic-net/sonic-buildimage/issues/26925 and asic_type in ['mellanox', 'nvidia']"
+
 copp/test_copp.py::TestCOPP::test_add_new_trap:
   skip:
     reason: "Copp test_add_new_trap is not yet supported on these testbeds"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:Skip COPP test cases due to issue #26925
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Skip known COPP failures caused by ptf_nn_agent requiring missing pynng in the affected image: https://github.com/sonic-net/sonic-buildimage/issues/26925.

#### How did you do it?
Added a conditional skip for copp/test_copp.py::TestCOPP, scoped to the issue and asic_type in ['mellanox', 'nvidia'].

#### How did you verify/test it?
Confirmed ptf_nn_agent was FATAL, logs showed missing pynng, and git diff --check passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
