### PR TITLE
[BMC] Skip disk/test_disk_exhaustion on BMC topology

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1227,6 +1227,10 @@ dhcp_server:
 #####             disk            #####
 #######################################
 disk/test_disk_exhaustion.py:
+  skip:
+    reason: "Not applicable on BMC: test validates data-plane packet forwarding under disk pressure; BMC has no front-panel ports or PortChannel data plane (peer_ip_ifaces_pair[0] -> IndexError)."
+    conditions:
+      - "'bmc' in topo_type"
   xfail:
     reason: "xfail for IPv6-only topologies, issue https://github.com/sonic-net/sonic-mgmt/issues/20759"
     conditions:


### PR DESCRIPTION
### Description of PR

Summary: skip `disk/test_disk_exhaustion.py` on BMC topologies.

The test validates that with `/var` (root disk) deliberately exhausted, the SONiC **data plane** still forwards packets end-to-end. It requires a PortChannel with a peer IP from the minigraph (`construct_packet_and_get_params`, lines 72-76 in `tests/disk/test_disk_exhaustion.py`) and uses `ptfadapter` to inject/verify packets through that PortChannel.

BMC platforms have no front-panel ports and no PortChannels in the minigraph. So:

- `mg_facts["minigraph_portchannel_interfaces"]` is empty
- `peer_ip_pc_pair = []`
- `peer_ip_ifaces_pair = []`
- Line 100: `peer_ip_ifaces_pair[0][1][0]` → **`IndexError: list index out of range`**

Even if we got past that line, the rest of the test cannot do anything meaningful — there is no data plane on BMC to validate under disk pressure.

```yaml
disk/test_disk_exhaustion.py:
  skip:
    reason: "Not applicable on BMC: test validates data-plane packet forwarding under disk pressure; BMC has no front-panel ports or PortChannel data plane (peer_ip_ifaces_pair[0] -> IndexError)."
    conditions:
      - "'bmc' in topo_type"
  xfail:
    reason: "xfail for IPv6-only topologies, ..."
    ...
```

The new `skip` is added alongside the existing IPv6 `xfail`, matching the dozens of similar BMC-specific skips elsewhere in this file.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

`test_disk_exhaustion` fails with `IndexError: list index out of range` at line 100 on Komodo BMC (`arm64-nexthop_b27-r0`) in every baseline run (R1, R2, R3). The test is fundamentally a data-plane test; BMC has no data plane.

#### How did you do it?

Added a `skip` block to the existing `disk/test_disk_exhaustion.py` entry in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`, gated on `"'bmc' in topo_type"`.

#### How did you verify/test it?

- `python3 -c "import yaml; yaml.safe_load(open(...))"` confirms the YAML parses clean.
- Manually traced the failure to line 100 of `tests/disk/test_disk_exhaustion.py` indexing an empty list.

#### Any platform specific information?

Only BMC topologies (`'bmc' in topo_type`). No effect on switching platforms.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.
