### PR TITLE
Support range-based QUEUE config keys in qos_sai_base.py.

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -575,10 +575,15 @@ class QosSaiBase(QosBase):
                         ]
                     )[0])
             else:
+                queue_key = self._get_queue_config_key(dut_asic, port, queue)
+
+                assert queue_key is not None, \
+                    "No QUEUE config found for {} queue {}".format(port, queue)
+
                 schedProfile = "SCHEDULER|" + six.text_type(dut_asic.run_redis_cmd(
                     argv=[
                         "redis-cli", "-n", "4", "HGET",
-                        "QUEUE|{0}|{1}".format(port, queue), "scheduler"
+                        queue_key, "scheduler"
                     ]
                 )[0])
         schedWeight = six.text_type(dut_asic.run_redis_cmd(
@@ -586,6 +591,35 @@ class QosSaiBase(QosBase):
         )[0])
 
         return {"schedProfile": schedProfile, "schedWeight": schedWeight}
+
+    def _get_queue_config_key(self, dut_asic, port, queue):
+        """
+            Resolve the correct QUEUE CONFIG_DB key for a given port and queue.
+
+            Supports:
+            - Legacy per-queue keys: QUEUE|Ethernet0|3
+            - Range-based keys:      QUEUE|Ethernet0|0-2
+        """
+        keys = dut_asic.run_redis_cmd(
+            argv=[
+                "redis-cli", "-n", "4", "KEYS",
+                "QUEUE|{}|*".format(port)
+            ]
+        )
+        for key in keys:
+            try:
+                _, _, queue_range = key.split('|')
+                if '-' in queue_range:
+                    start, end = map(int, queue_range.split('-'))
+                    if start <= queue <= end:
+                        return key
+                else:
+                    if int(queue_range) == queue:
+                        return key
+            except (ValueError, IndexError):
+                continue
+
+        return None
 
     def __assignTestPortIps(self, mgFacts, topo, lower_tor_host):  # noqa: F811
         """


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add a helper to resolve CONFIG_DB queue keys that may be stored either as single-queue entries or as queue ranges in tests/qos/qos_sai_base.py.

Summary: 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

The existing QosSaiBase code hard-codes the CONFIG_DB queue key format as QUEUE|<port>|<queue> (e.g., QUEUE|Ethernet0|3). This breaks when the CONFIG_DB uses range-based queue keys (e.g., QUEUE|Ethernet0|0-2), causing QoS SAI tests to fail on platforms that store queue configurations using ranges.

#### How did you do it?

Added a new helper method _get_queue_config_key(dut_asic, port, queue) to the QosSaiBase class in tests/qos/qos_sai_base.py that:

Queries all QUEUE|<port>|* keys from CONFIG_DB
Supports legacy per-queue keys (e.g., QUEUE|Ethernet0|3)
Supports range-based keys (e.g., QUEUE|Ethernet0|0-2) by checking if the queue index falls within the range
Returns the matching key, or None (with an assert) if no matching key is found
The existing code that fetches the scheduler field was updated to call this helper before the Redis lookup, replacing the hard-coded key format.

#### How did you verify/test it?
Validated the changes in tests with t0 topology
Ran the testcase qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange
Confirmed no regressions in existing functionality

#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
