### PR TITLE
fix(configlet): include admin_status=down in removal patch for decommissioned ports

### DIFF
--- a/tests/configlet/util/generic_patch.py
+++ b/tests/configlet/util/generic_patch.py
@@ -86,6 +86,36 @@ def create_patch(src_dir, dst_dir, patch_dir, hack_apply=False):
                 (not re.search(rm_pattern, e["path"]))):
             jpatch.append(e)
 
+    # For ports being decommissioned (T0 removal), explicitly include
+    # admin_status=down in the patch. Without this, GCU's patch sorter
+    # injects a temporary admin_status=down (for YANG dependency ordering
+    # when removing buffers) followed by a restore to admin_status=up,
+    # leaving the port up in CONFIG_DB. The patch should specify the
+    # desired final state — GCU should not need to invent operations.
+    decommissioned_ports = set()
+    for link in tor_data.get("links", []):
+        port_name = link.get("local", {}).get("sonic_name", "")
+        if port_name:
+            decommissioned_ports.add(port_name)
+
+    if decommissioned_ports:
+        admin_status_paths = set()
+        for e in jpatch:
+            if re.match(r"^/PORT/Ethernet[0-9]+/admin_status$", e["path"]):
+                admin_status_paths.add(e["path"])
+
+        for port_name in decommissioned_ports:
+            path = "/PORT/{}/admin_status".format(port_name)
+            if path not in admin_status_paths:
+                # Only add if the port exists in source config with admin_status != down
+                src_port = src_json.get("PORT", {}).get(port_name, {})
+                if src_port.get("admin_status", "up") != "down":
+                    jpatch.append({
+                        "op": "replace",
+                        "path": path,
+                        "value": "down"
+                    })
+
     if not hack_apply:
         patch_file = os.path.join(patch_dir, "patch_0_all.json")
         with open(patch_file, "w") as s:
@@ -220,13 +250,6 @@ def generic_patch_rm_t0(duthost, skip_load=False, hack_apply=False):
         # The above error is possible, if some control plane component is making an update.
         # We can ignore rc, as DB comp is the final check. So skip it.
         # assert res["rc"] == 0, "Failed to apply patch"
-
-    # Manual shutdown needed because the removal of admin_status won't operate shutdown. It will
-    # by default keep the previous admin_status state. Thus making app-db comparison fail.
-    for link in tor_data["links"]:
-        tor_ifname = link["local"]["sonic_name"]
-        duthost.shell("config interface shutdown {}".format(tor_ifname))
-        do_pause(PAUSE_INTF_DOWN, "pause upon i/f {} shutdown before add patch".format(tor_ifname))
 
     assert wait_until(DB_COMP_WAIT_TIME, 20, 0, db_comp, duthost, patch_rm_t0_dir,
                       no_t0_db_dir, "generic_patch_rm_t0"), \

--- a/tests/configlet/util/generic_patch.py
+++ b/tests/configlet/util/generic_patch.py
@@ -107,9 +107,12 @@ def create_patch(src_dir, dst_dir, patch_dir, hack_apply=False):
         for port_name in decommissioned_ports:
             path = "/PORT/{}/admin_status".format(port_name)
             if path not in admin_status_paths:
-                # Only add if the port exists in source config with admin_status != down
+                # Only inject admin_status=down for removal patches (port
+                # exists in source but is being removed in destination).
+                # Skip for add patches where the port is being restored.
                 src_port = src_json.get("PORT", {}).get(port_name, {})
-                if src_port.get("admin_status", "up") != "down":
+                dst_port = dst_json.get("PORT", {}).get(port_name, {})
+                if src_port and not dst_port and src_port.get("admin_status", "up") != "down":
                     jpatch.append({
                         "op": "replace",
                         "path": path,


### PR DESCRIPTION
## Problem Statement

The `configlet.test_add_rack.test_add_rack` test has been flaky on Cisco-8102-C64 and Mellanox SN4600C/SN4700 platforms, while consistently passing on Arista. The failure manifests as `PORT|Ethernet136` retaining `admin_status: up` in CONFIG_DB and APP_DB after the T0 removal patch, causing the DB comparison to fail across all 8 retry cycles.

## Root Cause Analysis

When the test generates a removal patch (removing a T0 neighbor's config — BGP, buffers, queues, PFC, etc.), the patch does **not** include an explicit `admin_status=down` for the decommissioned port. The patch only contains `remove` operations for BGP_NEIGHBOR, BUFFER_PG, BUFFER_QUEUE, PORT_QOS_MAP, etc.

GCU's patch sorter then does the following:
1. **Injects** `admin_status=down` as an intermediate step to satisfy YANG dependency ordering (YANG requires the port to be down before removing buffer/queue config)
2. **Restores** `admin_status=up` as the **last** sorted change, because the target config still has the port with `admin_status=up`

This means GCU is inventing operations the caller never requested. The principle is: **GCU should be a faithful executor — it should sort and apply exactly what the patch specifies, nothing more.** If the patch cannot be applied without injecting phantom operations, then the patch is incomplete.

After the patch completes with `admin_status=up` in CONFIG_DB, a manual `config interface shutdown` workaround runs. However, on Cisco and Mellanox platforms with dynamic buffer management, `buffermgrd` races with the manual shutdown — it re-initializes buffer config after GCU removed it, which triggers port re-processing and can reset `admin_status` back to the CONFIG_DB value (`up`).

**Why Arista passes:** Arista platforms use a static buffer model where `buffermgrd` does not race with the manual shutdown.

## Fix

1. **Include `admin_status=down` in the removal patch** for ports being decommissioned. This ensures the GCU target config has `admin_status=down`, so the sorter will not inject a phantom restore-to-up operation.

2. **Remove the manual `config interface shutdown` workaround** after the patch, since the patch now correctly specifies the desired final state.

This approach follows the principle that the patch should contain the complete desired state — GCU should not need to invent operations that the caller did not request.