### PR TITLE
Optimize the execution time of everflow testbed test cases on dualtor testbed

### DIFF
--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -257,7 +257,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         pytest_assert(wait_until(30, 10, 0, everflow_utils.validate_mirror_session_up,
                                  remote_dut, setup_mirror_session["session_name"]))
 
-        request.getfixturevalue('setup_standby_ports_on_rand_unselected_tor_unconditionally')
+        request.getfixturevalue('setup_standby_ports_on_rand_unselected_tor_unconditionally_module')
         # Verify that mirrored traffic is sent along the route we installed
         random_upstream_intf = random.choice(list(upstream_links_for_unselected_dut.keys()))
         rx_port_ptf_id = upstream_links_for_unselected_dut[random_upstream_intf]["ptf_port_id"]
@@ -295,7 +295,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
     def test_everflow_basic_forwarding(self, setup_info, setup_mirror_session,              # noqa F811
                                        dest_port_type, ptfadapter, tbinfo, mux_config,      # noqa F811
                                        toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
-                                       setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
+                                       setup_standby_ports_on_rand_unselected_tor_unconditionally_module,  # noqa F811
                                        erspan_ip_ver):                                              # noqa F811
         """
         Verify basic forwarding scenarios for the Everflow feature.
@@ -419,7 +419,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
     def test_everflow_neighbor_mac_change(self, setup_info, setup_mirror_session,               # noqa F811
                                           dest_port_type, ptfadapter, tbinfo, mux_config,       # noqa F811
                                           toggle_all_simulator_ports_to_rand_selected_tor,      # noqa F811
-                                          setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
+                                          setup_standby_ports_on_rand_unselected_tor_unconditionally_module,  # noqa F811
                                           erspan_ip_ver):                                              # noqa F811
         """Verify that session destination MAC address is changed after neighbor MAC address update."""
 
@@ -501,7 +501,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
     def test_everflow_remove_unused_ecmp_next_hop(self, setup_info, setup_mirror_session,               # noqa F811
                                                   dest_port_type, ptfadapter, tbinfo, mux_config,       # noqa F811
                                                   toggle_all_simulator_ports_to_rand_selected_tor,      # noqa F811
-                                                  setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
+                                                  setup_standby_ports_on_rand_unselected_tor_unconditionally_module,  # noqa F811
                                                   erspan_ip_ver):                                              # noqa F811
         """Verify that session is still active after removal of next hop from ECMP route that was not in use."""
 
@@ -613,7 +613,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
     def test_everflow_remove_used_ecmp_next_hop(self, setup_info, setup_mirror_session,                 # noqa F811
                                                 dest_port_type, ptfadapter, tbinfo, mux_config,         # noqa F811
                                                 toggle_all_simulator_ports_to_rand_selected_tor,        # noqa F811
-                                                setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
+                                                setup_standby_ports_on_rand_unselected_tor_unconditionally_module,  # noqa F811
                                                 erspan_ip_ver):                                              # noqa F811
         """Verify that session is still active after removal of next hop from ECMP route that was in use."""
 
@@ -740,7 +740,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             config_method,
             tbinfo,
             toggle_all_simulator_ports_to_rand_selected_tor,    # noqa F811
-            setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
+            setup_standby_ports_on_rand_unselected_tor_unconditionally_module,  # noqa F811
             erspan_ip_ver                                                # noqa F811
     ):
         """Verify that we can rate-limit mirrored traffic from the MIRROR_DSCP table.
@@ -873,7 +873,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
                                         setup_mirror_session,
                                         dest_port_type, ptfadapter, tbinfo, mux_config,  # noqa F811
                                         erspan_ip_ver, toggle_all_simulator_ports_to_rand_selected_tor,  # noqa F811
-                                        setup_standby_ports_on_rand_unselected_tor_unconditionally):  # noqa F811
+                                        setup_standby_ports_on_rand_unselected_tor_unconditionally_module):  # noqa F811
         """
         Verify basic forwarding scenarios for the Everflow feature with background traffic.
         Background Traffic PKT1 IP in IP with same ports & macs but with dummy ips
@@ -1061,7 +1061,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
     def test_everflow_fwd_recircle_port_queue_check(self, setup_info, setup_mirror_session, # noqa F811
                                                     dest_port_type, ptfadapter, tbinfo,
                                        erspan_ip_ver, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
-                                       setup_standby_ports_on_rand_unselected_tor_unconditionally):    # noqa F811
+                                       setup_standby_ports_on_rand_unselected_tor_unconditionally_module):    # noqa F811
         """
         Verify basic forwarding scenario with mirror session config having specific queue for the Everflow feature.
         Make sure the mirrored packets are sent via the specific queue on recircle port


### PR DESCRIPTION
### Description of PR

Summary:
The everflow testbed test use the fixture setup_standby_ports_on_rand_unselected_tor_unconditionally to toggle dualtor muxcable status. 
This is a function scope fixture, it takes a few minutes in each test case and wastes 2 hours in the whole tests.
Use a module level fixture setup_standby_ports_on_rand_unselected_tor_unconditionally_module to reduce the run time.
This is a similar improvement as https://github.com/sonic-net/sonic-mgmt/pull/24504, and depends on the fixture added in #24504.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

### Approach
#### What is the motivation for this PR?
Optimize the execution time of everflow testbed test cases on dualtor testbed
#### How did you do it?
Use a module level fixture setup_standby_ports_on_rand_unselected_tor_unconditionally_module to reduce the run time.
#### How did you verify/test it?
Run the tests/everflow/test_everflow_testbed.py on SN4700 dualtor-aa testbed, passed and run time is greatly decreased by about 75%
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A
