### PR TITLE
fix(conftest): always regenerate pre-test config snapshot from live CONFIG_DB

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3115,23 +3115,25 @@ def core_dump_and_config_check(duthosts, tbinfo, parallel_run_context, request,
 
                 logger.info("Collecting running config before test on {}".format(dut.hostname))
                 duts_data[dut.hostname]["pre_running_config"] = {}
-                if not dut.stat(path="/etc/sonic/running_golden_config.json")['stat']['exists']:
-                    logger.info("Collecting running golden config before test on {}".format(dut.hostname))
-                    dut.shell("sonic-cfggen -d --print-data > /etc/sonic/running_golden_config.json")
+                # Always regenerate the pre-test snapshot from live CONFIG_DB.
+                # A cached running_golden_config.json may be stale — daemon-written
+                # fields (e.g. BGP_NEIGHBOR admin_status from bgpcfgd, DEVICE_METADATA
+                # zebra_nexthop) may have been added after the cached file was created,
+                # causing spurious config_db_check diffs.
+                logger.info("Collecting running golden config before test on {}".format(dut.hostname))
+                dut.shell("sonic-cfggen -d --print-data > /etc/sonic/running_golden_config.json")
                 duts_data[dut.hostname]["pre_running_config"][None] = \
                     json.loads(dut.shell("cat /etc/sonic/running_golden_config.json", verbose=False)['stdout'])
 
                 if dut.is_multi_asic:
                     for asic_index in range(0, dut.facts.get('num_asic')):
                         asic_ns = "asic{}".format(asic_index)
-                        if not dut.stat(
-                                path="/etc/sonic/running_golden_config{}.json".format(asic_index))['stat']['exists']:
-                            dut.shell(
-                                "sonic-cfggen -n {} -d --print-data > /etc/sonic/running_golden_config{}.json".format(
-                                    asic_ns,
-                                    asic_index,
-                                )
+                        dut.shell(
+                            "sonic-cfggen -n {} -d --print-data > /etc/sonic/running_golden_config{}.json".format(
+                                asic_ns,
+                                asic_index,
                             )
+                        )
                         duts_data[dut.hostname]['pre_running_config'][asic_ns] = \
                             json.loads(dut.shell("cat /etc/sonic/running_golden_config{}.json".format(asic_index),
                                                  verbose=False)['stdout'])


### PR DESCRIPTION
### Description

The `config_db_check` sanity checker in `conftest.py` uses `running_golden_config.json` as the pre-test CONFIG_DB baseline. Previously, this file was only generated if it didn't already exist on the DUT (created once during `test_pretest`), which meant it could become **stale** across test runs.

Daemon-written fields get added to CONFIG_DB at runtime after `config reload` / `load_minigraph`:
- `BGP_NEIGHBOR|*/admin_status: up` — written by **bgpcfgd** when `default_bgp_status: down` is set in DEVICE_METADATA
- `DEVICE_METADATA|localhost/zebra_nexthop: disabled` — written by **zebra** config logic

When the cached pre-test snapshot was created before these daemons finished writing, the post-test snapshot includes these fields but the pre-test snapshot does not, causing a spurious `config_db_check_failed: True`.

### Fix

Always regenerate `running_golden_config.json` from live CONFIG_DB (`sonic-cfggen -d --print-data`) before each test. This ensures the pre-test baseline reflects the fully-converged state including all daemon-injected fields.

### Affected tests

Fixes flaky `config_db_check` failures observed in:
- `override_config_table/test_override_config_table.py::test_load_minigraph_with_golden_config`
- Potentially other tests that trigger `config reload` with daemon-injected CONFIG_DB fields

### Risk

Low — this only changes when the snapshot file is regenerated (always vs. only-if-missing). The snapshot content is identical when daemons have converged. This also benefits the recovery system (`recover.py`) which uses the same file for `config_reload(config_source="running_golden_config")`, ensuring recovery uses an up-to-date baseline.