### PR TITLE
Add a tolerance in the original traffic validation in test EverflowPolicerTest

### DIFF
--- a/ansible/roles/test/files/acstests/everflow_policer_test.py
+++ b/ansible/roles/test/files/acstests/everflow_policer_test.py
@@ -341,7 +341,8 @@ class EverflowPolicerTest(BaseTest):
 
         # Send traffic and verify the original traffic is not rate limited
         count = self.checkOriginalFlow()
-        assert count == self.NUM_OF_TOTAL_PACKETS
+        # Allow 1% packet loss due to ptf performance limit
+        assert count >= self.NUM_OF_TOTAL_PACKETS * 0.99
 
         # Verify packet policing is used
         assert_str = "Non packet policing is not supported"


### PR DESCRIPTION
### Description of PR

Summary:
Sometimes there are ~25 packets lost in the test due to the packets are received too late by the ptf(no real packet loss). This should be a test issue since it's only observed on the dualtor testbed.

It could be related to the ptf performance, as the test sends 10000 packets in a burst.
As this step is only to validate the packet rate is not limited, a small(1%) tolerance can be allowed to make the test more stable.


### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

### Approach
#### What is the motivation for this PR?
Stabilize the everflow policer test.
#### How did you do it?
Introduce a small(1%) tolerance in the packet validation.
#### How did you verify/test it?
Run the test on the testbed which it had failed, no more failures observed. 
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A
