### PR TITLE
Fix test issue in testNeighborMacAgingAfterIntfDown

### DIFF
--- a/tests/arp/test_neighbor_mac_aging.py
+++ b/tests/arp/test_neighbor_mac_aging.py
@@ -62,8 +62,9 @@ class TestNeighborMacAging:
         def check_neighbor_aged_out():
             arp_lines = duthost.command("{} neigh show {}".format(
                 asichost.ip_cmd, neighbor_ip))['stdout_lines']
-            redis_lines = duthost.command("{} ASIC_DB KEYS \"ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY*{}*\"".format(
-                asichost.sonic_db_cli, neighbor_ip))['stdout_lines']
+            redis_lines = duthost.command(
+                "{} ASIC_DB KEYS \"ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY*\\\"{}\\\"*\"".format(
+                    asichost.sonic_db_cli, neighbor_ip))['stdout_lines']
             return len(arp_lines) == 0 and len(redis_lines) == 0
 
         # Verify that the MAC address is aged out from the ARP table and ASIC_DB


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix the command to get the asic neighbor entry.
With the original command, the IP like "10.0.0.13" will be matched by pattern "10.0.0.1*", which is intended to match only "10.0.0.1"

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Fix test issue in testNeighborMacAgingAfterIntfDown
#### How did you do it?
Add quotes in the pattern.
#### How did you verify/test it?
Run the test testNeighborMacAgingAfterIntfDown, passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
