### PR TITLE
[TH6-128] Console test support: BMC->CPU switch

### DIFF
--- a/tests/common/connections/base_console_conn.py
+++ b/tests/common/connections/base_console_conn.py
@@ -4,6 +4,7 @@ Base class for console connection of SONiC devices
 
 import logging
 import paramiko
+import re
 import time
 
 from netmiko.cisco_base_connection import CiscoBaseConnection
@@ -124,6 +125,17 @@ class BaseConsoleConn(CiscoBaseConnection):
         self.write_channel(command + self.RETURN)
         self.read_until_pattern(pattern=pattern)
 
+    def prepare_bmc_first_console(self):
+        """
+        On BMC-first UART mux platforms, switch to CPU console before SONiC login.
+        Shared by telnet and SSH console connection paths.
+        """
+        if not self.bmc_first_console_switch:
+            return
+        time.sleep(0.3)
+        self.read_channel()
+        self.switch_bmc_to_cpu_console()
+
     def switch_bmc_to_cpu_console(self):
         """
         Some platforms mux BMC UART before CPU; send Ctrl+U, digit 2, then Enter so SONiC login appears.
@@ -133,7 +145,32 @@ class BaseConsoleConn(CiscoBaseConnection):
         self.write_channel("\x15")
         time.sleep(0.5)
         self.write_channel("2" + newline)
-        time.sleep(1.5)
+        time.sleep(0.5)
+        self.write_channel(newline)
+        output = ""
+        deadline = time.time() + 10
+        # Match telnet_login() prompt patterns plus SONiC boot banner text.
+        cpu_console_pattern = re.compile(
+            r"(?:user:|username|login|user name|assword|SONiC Software|Open Networking)",
+            re.IGNORECASE,
+        )
+        while time.time() < deadline:
+            chunk = self.read_channel()
+            if chunk:
+                output += chunk
+                if cpu_console_pattern.search(chunk):
+                    break
+            else:
+                time.sleep(0.2)
+        if output:
+            self.logger.info(
+                "Console mux response (first 500 chars): %r",
+                output[:500],
+            )
+        else:
+            self.logger.warning(
+                "Console mux: no UART output within 10s after CPU switch"
+            )
 
     def disable_paging(self, command="", delay_factor=1):
         # not supported

--- a/tests/common/connections/base_console_conn.py
+++ b/tests/common/connections/base_console_conn.py
@@ -4,6 +4,7 @@ Base class for console connection of SONiC devices
 
 import logging
 import paramiko
+import time
 
 from netmiko.cisco_base_connection import CiscoBaseConnection
 
@@ -42,6 +43,7 @@ class BaseConsoleConn(CiscoBaseConnection):
 
     def __init__(self, **kwargs):
         self.logger = logging.getLogger(__name__)
+        self.bmc_first_console_switch = bool(kwargs.pop('bmc_first_console_switch', False))
         # Clear additional args before passing to BaseConsoleConn
         all_passwords = kwargs['console_password']
         key_to_rm = ['console_username', 'console_password',
@@ -121,6 +123,17 @@ class BaseConsoleConn(CiscoBaseConnection):
         """
         self.write_channel(command + self.RETURN)
         self.read_until_pattern(pattern=pattern)
+
+    def switch_bmc_to_cpu_console(self):
+        """
+        Some platforms mux BMC UART before CPU; send Ctrl+U, digit 2, then Enter so SONiC login appears.
+        """
+        self.logger.info("Console mux: Ctrl+U, 2, Enter for CPU console")
+        newline = getattr(self, "TELNET_RETURN", self.RETURN)
+        self.write_channel("\x15")
+        time.sleep(0.5)
+        self.write_channel("2" + newline)
+        time.sleep(1.5)
 
     def disable_paging(self, command="", delay_factor=1):
         # not supported

--- a/tests/common/connections/console_host.py
+++ b/tests/common/connections/console_host.py
@@ -38,7 +38,8 @@ def ConsoleHost(console_type,
                 supervisor_ip=None,
                 linecard_number=None,
                 slot_num=None,
-                hwsku=None):
+                hwsku=None,
+                bmc_first_console_switch=False):
     if console_type not in ConsoleTypeMapper:
         raise ValueError("console type {} is not supported yet".format(console_type))
     params = {
@@ -50,7 +51,8 @@ def ConsoleHost(console_type,
         "console_username": console_username,
         "console_password": console_password,
         "console_device": console_device,
-        "timeout": timeout_s
+        "timeout": timeout_s,
+        "bmc_first_console_switch": bmc_first_console_switch
     }
 
     # Add linecard-specific parameters if provided

--- a/tests/common/connections/ssh_console_conn.py
+++ b/tests/common/connections/ssh_console_conn.py
@@ -69,6 +69,10 @@ class SSHConsoleConn(BaseConsoleConn):
         # re-synchronise the terminal back to a fresh "login:" prompt between
         # attempts (the failed attempt leaves a "Login incorrect" banner in the
         # buffer that would otherwise desync the next login).
+
+        # After the console server hands off to DUT serial (direct SSH port or menu port).
+        self.prepare_bmc_first_console()
+
         for i in range(0, len(self.sonic_password)):
             password = self.sonic_password[i]
             try:

--- a/tests/common/connections/telnet_console_conn.py
+++ b/tests/common/connections/telnet_console_conn.py
@@ -37,6 +37,13 @@ class TelnetConsoleConn(BaseConsoleConn):
         delay_factor = self.select_delay_factor(delay_factor)
         time.sleep(1 * delay_factor)
 
+        # Netmiko opens telnet then calls telnet_login() directly — session_preparation() is not
+        # invoked first, so BMC→CPU mux must run here before SONiC login probes.
+        if self.bmc_first_console_switch:
+            time.sleep(0.3)
+            self.read_channel()
+            self.switch_bmc_to_cpu_console()
+
         output = ""
         return_msg = ""
         login_failure_prompt = r".*incorrect"

--- a/tests/common/connections/telnet_console_conn.py
+++ b/tests/common/connections/telnet_console_conn.py
@@ -39,10 +39,7 @@ class TelnetConsoleConn(BaseConsoleConn):
 
         # Netmiko opens telnet then calls telnet_login() directly — session_preparation() is not
         # invoked first, so BMC→CPU mux must run here before SONiC login probes.
-        if self.bmc_first_console_switch:
-            time.sleep(0.3)
-            self.read_channel()
-            self.switch_bmc_to_cpu_console()
+        self.prepare_bmc_first_console()
 
         output = ""
         return_msg = ""

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -13,6 +13,7 @@ from tests.common.errors import RunAnsibleModuleFail
 from collections import defaultdict
 from tests.common.connections.console_host import ConsoleHost, CONSOLE_LINECARD
 from tests.common.connections.linecard_console_conn import UnsupportedPlatformError
+from tests.common.nokia_data import needs_bmc_to_cpu_console_switch
 from tests.common.utilities import get_dut_current_passwd, update_console_creds
 from tests.common.connections.base_console_conn import (
     CONSOLE_SSH_CISCO_CONFIG,
@@ -644,19 +645,30 @@ def create_duthost_console(duthost, localhost, conn_graph_facts, creds):  # noqa
     except Exception as e:
         logger.warning(f"Issue trying to clear console port: {e}")
 
+    graph_hwsku = conn_graph_facts.get("device_info", {}).get(dut_hostname, {}).get("HwSku")
+    bmc_mux = needs_bmc_to_cpu_console_switch(duthost, hwsku_hint=graph_hwsku)
+    _facts = getattr(duthost, "facts", None) or getattr(getattr(duthost, "sonichost", None), "facts", None) or {}
+    logger.info(
+        "create_duthost_console %s: bmc_first_console_switch=%s (graph HwSku=%r, facts platform=%r)",
+        dut_hostname,
+        bmc_mux,
+        graph_hwsku,
+        _facts.get("platform"),
+    )
+
     # Set up console host
     for attempt in range(1, 4):
         try:
-            return ConsoleHost(
-                console_type=console_type,
-                console_host=console_host,
-                console_port=console_port,
-                sonic_username=creds["sonicadmin_user"],
-                sonic_password=sonic_password,
-                console_username=console_username,
-                console_password=creds["console_password"][console_type],
-                console_device=console_device,
-            )
+            host = ConsoleHost(console_type=console_type,
+                               console_host=console_host,
+                               console_port=console_port,
+                               sonic_username=creds['sonicadmin_user'],
+                               sonic_password=sonic_password,
+                               console_username=console_username,
+                               console_password=creds['console_password'][console_type],
+                               console_device=console_device,
+                               bmc_first_console_switch=bmc_mux)
+            break
         except Exception as e:
             logger.warning(f"Attempt {attempt}/3 failed: {e}")
             # Back off so rapid retries do not trip the DUT serial-getty start limit.
@@ -665,6 +677,8 @@ def create_duthost_console(duthost, localhost, conn_graph_facts, creds):  # noqa
             continue
     else:
         raise Exception("Failed to set up connection to console port. See warning logs for details.")
+
+    return host
 
 
 def creds_on_dut(duthost):

--- a/tests/common/nokia_data.py
+++ b/tests/common/nokia_data.py
@@ -3,3 +3,33 @@ def is_nokia_device(dut):
 
 
 NO_QOS_HWSKUS = ['Nokia-7215-C1']
+
+# Platforms where the console mux lands on BMC first; use Ctrl+U then "2" for CPU SONiC console.
+# Add other nokia platforms when needed
+BMC_FIRST_CONSOLE_PLATFORMS = (
+    "x86_64-nokia_ixr7220_h6_128-r0",
+)
+
+
+def _nokia_ixr7220_h6_hwsku(hwsku):
+    if not hwsku:
+        return False
+    h = hwsku.lower()
+    return "nokia" in h and "ixr7220" in h and "-h6-" in h
+
+
+def needs_bmc_to_cpu_console_switch(dut, hwsku_hint=None):
+    """
+    True when serial mux lands on BMC first (Ctrl+U, 2, Enter for CPU console).
+    Uses dut facts when present; optional hwsku_hint (e.g. from conn_graph device_info)
+    """
+    if hwsku_hint and _nokia_ixr7220_h6_hwsku(hwsku_hint):
+        return True
+    facts = getattr(dut, "facts", None)
+    if facts is None and hasattr(dut, "sonichost"):
+        facts = getattr(dut.sonichost, "facts", None)
+    facts = facts or {}
+    plat = facts.get("platform") or ""
+    if plat in BMC_FIRST_CONSOLE_PLATFORMS:
+        return True
+    return _nokia_ixr7220_h6_hwsku(facts.get("hwsku"))

--- a/tests/common/nokia_data.py
+++ b/tests/common/nokia_data.py
@@ -4,18 +4,21 @@ def is_nokia_device(dut):
 
 NO_QOS_HWSKUS = ['Nokia-7215-C1']
 
-# Platforms where the console mux lands on BMC first; use Ctrl+U then "2" for CPU SONiC console.
-# Add other nokia platforms when needed
+# Platforms/HwSKUs where the console mux lands on BMC first; use Ctrl+U then "2" for CPU SONiC console.
+# Add entries only after BMC-first mux is confirmed on hardware.
 BMC_FIRST_CONSOLE_PLATFORMS = (
     "x86_64-nokia_ixr7220_h6_128-r0",
 )
 
+BMC_FIRST_CONSOLE_HWSKUS = (
+    "Nokia-IXR7220-H6-O256",
+)
 
-def _nokia_ixr7220_h6_hwsku(hwsku):
+
+def _bmc_first_console_hwsku(hwsku):
     if not hwsku:
         return False
-    h = hwsku.lower()
-    return "nokia" in h and "ixr7220" in h and "-h6-" in h
+    return hwsku in BMC_FIRST_CONSOLE_HWSKUS
 
 
 def needs_bmc_to_cpu_console_switch(dut, hwsku_hint=None):
@@ -23,7 +26,7 @@ def needs_bmc_to_cpu_console_switch(dut, hwsku_hint=None):
     True when serial mux lands on BMC first (Ctrl+U, 2, Enter for CPU console).
     Uses dut facts when present; optional hwsku_hint (e.g. from conn_graph device_info)
     """
-    if hwsku_hint and _nokia_ixr7220_h6_hwsku(hwsku_hint):
+    if hwsku_hint and _bmc_first_console_hwsku(hwsku_hint):
         return True
     facts = getattr(dut, "facts", None)
     if facts is None and hasattr(dut, "sonichost"):
@@ -32,4 +35,4 @@ def needs_bmc_to_cpu_console_switch(dut, hwsku_hint=None):
     plat = facts.get("platform") or ""
     if plat in BMC_FIRST_CONSOLE_PLATFORMS:
         return True
-    return _nokia_ixr7220_h6_hwsku(facts.get("hwsku"))
+    return _bmc_first_console_hwsku(facts.get("hwsku"))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- This PR adds support for platforms where the console mux lands on BMC first and switches to CPU SONiC console.
- These fixes needed for _dut_console_ test cases.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
For platforms, where the console mux lands on BMC first and switches to CPU, support needed in sonic-mgmt to handle this behavior. For example, _x86_64-nokia_ixr7220_h6_128-r0_ platform.

#### How did you do it?

- Implement "_switch_bmc_to_cpu_console_" to switch from BMC to CPU by entering  Ctrl+U , 2/
- Made changes so that it will not affect the existing platforms.

#### How did you verify/test it?

- Ran all the _dutconsole_ tests and made sure they are working as expected.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
[test_idle_timeout.html](https://github.com/user-attachments/files/27806339/test_idle_timeout.html)
[test_non_ascii_output.html](https://github.com/user-attachments/files/27806341/test_non_ascii_output.html)
[test_escape_character.html](https://github.com/user-attachments/files/27806342/test_escape_character.html)
