### PR TITLE
[dhcp_relay] add multivlan variant for DHCPv4 relay test

### DIFF
--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -576,10 +576,11 @@ def enable_sonic_dhcpv4_relay_agent(rand_selected_dut, request):
 
     duthost = rand_selected_dut
 
-    if "dut_dhcp_relay_data" in request.fixturenames:
-        dut_dhcp_relay_data = request.getfixturevalue("dut_dhcp_relay_data")
-    else:
-        dut_dhcp_relay_data = None
+    dut_dhcp_relay_data = None
+    for _name in ("dut_dhcp_relay_data_multivlan", "dut_dhcp_relay_data"):
+        if _name in request.fixturenames:
+            dut_dhcp_relay_data = request.getfixturevalue(_name)
+            break
 
     try:
         if request.getfixturevalue("relay_agent") == "sonic-relay-agent":

--- a/tests/dhcp_relay/conftest.py
+++ b/tests/dhcp_relay/conftest.py
@@ -5,6 +5,7 @@ import logging
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert as py_assert
 from tests.common.dhcp_relay_utils import check_routes_to_dhcp_server
+from tests.common.fixtures.vlan_config_swap import load_topo_vlan_configs
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +54,185 @@ def check_dhcp_feature_status(duthost):
             pytest.skip("dhcp_relay is not enabled")
 
 
+def _resolve_plan_to_vlan_list(tbinfo, mg_facts, vlan_plan):
+    topo_name = tbinfo['topo']['name']
+    vlan_configs = load_topo_vlan_configs(topo_name)
+    py_assert(
+        vlan_configs is not None,
+        "Topo {} does not define DUT.vlan_configs".format(topo_name),
+    )
+
+    resolved_plan_name = vlan_plan
+    if resolved_plan_name is None:
+        resolved_plan_name = vlan_configs.get('default_vlan_config')
+
+    py_assert(
+        resolved_plan_name in vlan_configs,
+        "VLAN plan {!r} not defined in topo {}; available plans: {}".format(
+            resolved_plan_name,
+            topo_name,
+            [k for k in vlan_configs.keys() if k != 'default_vlan_config'],
+        ),
+    )
+
+    ptf_idx_to_dut_port = {v: k for k, v in mg_facts['minigraph_ptf_indices'].items()}
+    vlan_list = []
+    for vlan_iface_name, vlan_params in list(vlan_configs[resolved_plan_name].items()):
+        prefix = vlan_params.get('prefix')
+        if not prefix:
+            # DHCPv4 relay data only includes IPv4-capable VLAN interfaces.
+            # Skip v6-only VLANs (e.g. topo_t0-isolated-v6-*) whose variant
+            # defines prefix_v6 but no v4 prefix, so we never propagate a
+            # None addr/mask into the PTF DHCPv4 runner.
+            continue
+        vlan_iface = ipaddress.IPv4Interface(prefix)
+        vlan_addr = str(vlan_iface.ip)
+        vlan_mask = str(vlan_iface.netmask)
+
+        vlan_members = []
+        for ptf_idx in vlan_params.get('intfs', []) or []:
+            dut_port = ptf_idx_to_dut_port.get(ptf_idx)
+            if dut_port is None:
+                logger.warning(
+                    "vlan %s: ptf_idx %s from vlan_config %r has no dut port in "
+                    "minigraph_ptf_indices; skipping (topo/minigraph gap)",
+                    vlan_iface_name, ptf_idx, resolved_plan_name,
+                )
+                continue
+            if 'PortChannel' in dut_port:
+                continue
+            vlan_members.append(dut_port)
+
+        vlan_list.append((vlan_iface_name, vlan_members, vlan_addr, vlan_mask))
+
+    return resolved_plan_name, vlan_list
+
+
+def _build_dhcp_relay_entry_for_vlan(duthost, duthosts, rand_one_dut_hostname, ptfhost, tbinfo,
+                                     mg_facts, vlan_iface_name, vlan_members, vlan_addr,
+                                     vlan_mask, vlan_plan):
+    switch_loopback_ip = mg_facts['minigraph_lo_interfaces'][0]['addr']
+
+    downlink_vlan_iface = {}
+    downlink_vlan_iface['name'] = vlan_iface_name
+    downlink_vlan_iface['addr'] = vlan_addr
+    downlink_vlan_iface['mask'] = vlan_mask
+    if vlan_addr and vlan_mask:
+        subnet = ipaddress.IPv4Interface("{}/{}".format(vlan_addr, vlan_mask)).network
+        downlink_vlan_iface['link_selection_ip'] = str(subnet.network_address)
+
+    res = duthost.shell('cat /sys/class/net/{}/address'.format(vlan_iface_name))
+    downlink_vlan_iface['mac'] = res['stdout']
+    downlink_vlan_iface['dhcp_server_addrs'] = mg_facts['dhcp_servers']
+
+    client_iface = {}
+    for port in vlan_members:
+        if port in mg_facts['minigraph_port_name_to_alias_map']:
+            break
+    else:
+        return None
+    client_iface['name'] = port
+    client_iface['alias'] = mg_facts['minigraph_port_name_to_alias_map'][client_iface['name']]
+    client_iface['port_idx'] = mg_facts['minigraph_ptf_indices'][client_iface['name']]
+
+    uplink_interfaces, uplink_port_indices = calculate_uplink_interfaces_and_port_indices(mg_facts)
+    other_client_ports_indices = []
+    for iface_name in vlan_members:
+        if mg_facts['minigraph_ptf_indices'][iface_name] == client_iface['port_idx']:
+            pass
+        else:
+            other_client_ports_indices.append(mg_facts['minigraph_ptf_indices'][iface_name])
+
+    dhcp_relay_data = {}
+    dhcp_relay_data['downlink_vlan_iface'] = downlink_vlan_iface
+    dhcp_relay_data['client_iface'] = client_iface
+    dhcp_relay_data['other_client_ports'] = other_client_ports_indices
+    dhcp_relay_data['uplink_interfaces'] = uplink_interfaces
+    dhcp_relay_data['uplink_port_indices'] = uplink_port_indices
+    dhcp_relay_data['switch_loopback_ip'] = str(switch_loopback_ip)
+    dhcp_relay_data['portchannels'] = mg_facts['minigraph_portchannels']
+    dhcp_relay_data['vlan_members'] = vlan_members
+    dhcp_relay_data['vlan_plan'] = vlan_plan
+
+    loopback_iface = mg_facts['minigraph_lo_interfaces'][0]['name']
+    dhcp_relay_data['loopback_iface'] = loopback_iface
+    portchannels_with_ips = {}
+    portchannels_ip_list = []
+
+    for portchannel_name, portchannel_info in mg_facts['minigraph_portchannels'].items():
+        for pc_interface in mg_facts['minigraph_portchannel_interfaces']:
+            if pc_interface['attachto'] == portchannel_name:
+                ip_with_mask = f"{pc_interface['addr']}/{pc_interface['mask']}"
+                ip_obj = ipaddress.ip_interface(ip_with_mask)
+                if ip_obj.version != 4:
+                    continue
+                host_iter = ip_obj.network.hosts()
+                first_host = next(host_iter, None)
+                second_host = next(host_iter, None)
+                if first_host is None or second_host is None:
+                    logger.warning(f"Not enough hosts for nexthop in {ip_with_mask}")
+                    continue
+
+                nexthop = str(second_host) if str(ip_obj.ip) == str(first_host) else str(first_host)
+                portchannels_with_ips[portchannel_name] = {
+                    "ip": str(ip_obj),
+                    "nexthop": nexthop
+                }
+                portchannels_ip_list.append(str(ip_obj))
+
+    dhcp_relay_data['portchannels_with_ips'] = portchannels_with_ips
+    dhcp_relay_data['portchannels_ip_list'] = portchannels_ip_list
+
+    res = duthost.shell('cat /sys/class/net/{}/address'.format(uplink_interfaces[0]))
+    dhcp_relay_data['uplink_mac'] = res['stdout']
+    if 'dualtor' in tbinfo['topo']['name']:
+        standby_duthost = [duthost for duthost in duthosts if duthost != duthosts[rand_one_dut_hostname]][0]
+        res = standby_duthost.shell('cat /sys/class/net/{}/address'.format(uplink_interfaces[0]))
+        dhcp_relay_data['standby_uplink_mac'] = res['stdout']
+        dhcp_relay_data['standby_dut_lo_addr'] = \
+            mg_facts["minigraph_devices"][standby_duthost.sonichost.hostname]['lo_addr']
+        standby_mg_facts = standby_duthost.get_extended_minigraph_facts(tbinfo)
+        standby_uplink_interfaces, standby_uplink_port_indices = \
+            calculate_uplink_interfaces_and_port_indices(standby_mg_facts)
+        dhcp_relay_data['standby_uplink_port_indices'] = standby_uplink_port_indices
+    dhcp_relay_data['default_gw_ip'] = mg_facts['minigraph_mgmt_interface']['gwaddr']
+
+    return dhcp_relay_data
+
+
+def _build_dhcp_relay_data_list(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, vlan_plan=None):
+    duthost = duthosts[rand_one_dut_hostname]
+    dhcp_relay_data_list = []
+
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    resolved_plan_name, vlan_list = _resolve_plan_to_vlan_list(tbinfo, mg_facts, vlan_plan)
+
+    for vlan_iface_name, vlan_members, vlan_addr, vlan_mask in vlan_list:
+        dhcp_relay_data = _build_dhcp_relay_entry_for_vlan(
+            duthost, duthosts, rand_one_dut_hostname, ptfhost, tbinfo,
+            mg_facts, vlan_iface_name, vlan_members, vlan_addr, vlan_mask,
+            resolved_plan_name,
+        )
+        if dhcp_relay_data is not None:
+            dhcp_relay_data_list.append(dhcp_relay_data)
+
+    return dhcp_relay_data_list
+
+
+@pytest.fixture(scope="module")
+def dut_dhcp_relay_data_multivlan(duthosts, rand_one_dut_hostname, ptfhost, tbinfo,
+                                  parametrize_vlan_config_from_topo):
+    """Same shape as `dut_dhcp_relay_data`, but for whichever vlan_config
+    variant is currently active. The variant is supplied by
+    `parametrize_vlan_config_from_topo` (which also applies the config
+    patch). We read its `vlan_plan` and build the matching dhcp_relay_data
+    entries."""
+    vlan_plan = parametrize_vlan_config_from_topo[0]["vlan_plan"]
+    return _build_dhcp_relay_data_list(
+        duthosts, rand_one_dut_hostname, ptfhost, tbinfo, vlan_plan,
+    )
+
+
 @pytest.fixture(scope="module")
 def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
     """ Fixture which returns a list of dictionaries where each dictionary contains
@@ -60,124 +240,7 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
         This fixture is scoped to the module, as the data it gathers can be used by
         all tests in this module. It does not need to be run before each test.
     """
-    duthost = duthosts[rand_one_dut_hostname]
-    dhcp_relay_data_list = []
-
-    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-
-    switch_loopback_ip = mg_facts['minigraph_lo_interfaces'][0]['addr']
-
-    # SONiC spawns one DHCP relay agent per VLAN interface configured on the DUT
-    vlan_dict = mg_facts['minigraph_vlans']
-    for vlan_iface_name, vlan_info_dict in list(vlan_dict.items()):
-        # Filter(remove) PortChannel interfaces from VLAN members list
-        vlan_members = [port for port in vlan_info_dict['members'] if 'PortChannel' not in port]
-        # Gather information about the downlink VLAN interface this relay agent is listening on
-        downlink_vlan_iface = {}
-        downlink_vlan_iface['name'] = vlan_iface_name
-
-        for vlan_interface_info_dict in mg_facts['minigraph_vlan_interfaces']:
-            if vlan_interface_info_dict['attachto'] == vlan_iface_name:
-                downlink_vlan_iface['addr'] = vlan_interface_info_dict['addr']
-                downlink_vlan_iface['mask'] = vlan_interface_info_dict['mask']
-                subnet = ipaddress.IPv4Interface("{}/{}".format(vlan_interface_info_dict['addr'],
-                                                 vlan_interface_info_dict['mask'])).network
-                downlink_vlan_iface['link_selection_ip'] = str(subnet.network_address)
-                break
-
-        # Obtain MAC address of the VLAN interface
-        res = duthost.shell('cat /sys/class/net/{}/address'.format(vlan_iface_name))
-        downlink_vlan_iface['mac'] = res['stdout']
-
-        downlink_vlan_iface['dhcp_server_addrs'] = mg_facts['dhcp_servers']
-
-        # We choose the physical interface where our DHCP client resides to be index of first interface
-        # with alias (ignore PortChannel) in the VLAN
-        client_iface = {}
-        for port in vlan_members:
-            if port in mg_facts['minigraph_port_name_to_alias_map']:
-                break
-        else:
-            continue
-        client_iface['name'] = port
-        client_iface['alias'] = mg_facts['minigraph_port_name_to_alias_map'][client_iface['name']]
-        client_iface['port_idx'] = mg_facts['minigraph_ptf_indices'][client_iface['name']]
-
-        # Obtain uplink port indices for this DHCP relay agent
-
-        uplink_interfaces, uplink_port_indices = calculate_uplink_interfaces_and_port_indices(mg_facts)
-        other_client_ports_indices = []
-        for iface_name in vlan_members:
-            if mg_facts['minigraph_ptf_indices'][iface_name] == client_iface['port_idx']:
-                pass
-            else:
-                other_client_ports_indices.append(mg_facts['minigraph_ptf_indices'][iface_name])
-
-        dhcp_relay_data = {}
-        dhcp_relay_data['downlink_vlan_iface'] = downlink_vlan_iface
-        dhcp_relay_data['client_iface'] = client_iface
-        dhcp_relay_data['other_client_ports'] = other_client_ports_indices
-        dhcp_relay_data['uplink_interfaces'] = uplink_interfaces
-        dhcp_relay_data['uplink_port_indices'] = uplink_port_indices
-        dhcp_relay_data['switch_loopback_ip'] = str(switch_loopback_ip)
-        dhcp_relay_data['portchannels'] = mg_facts['minigraph_portchannels']
-        dhcp_relay_data['vlan_members'] = vlan_members
-
-        # Add loopback interface name (needed for source_interface)
-        loopback_iface = mg_facts['minigraph_lo_interfaces'][0]['name']
-        dhcp_relay_data['loopback_iface'] = loopback_iface
-        portchannels_with_ips = {}
-        portchannels_ip_list = []
-
-        for portchannel_name, portchannel_info in mg_facts['minigraph_portchannels'].items():
-            for pc_interface in mg_facts['minigraph_portchannel_interfaces']:
-                if pc_interface['attachto'] == portchannel_name:
-                    ip_with_mask = f"{pc_interface['addr']}/{pc_interface['mask']}"
-
-                    # Optional: format to standard CIDR
-                    # formatted_ip = str(ipaddress.ip_interface(ip_with_mask))
-                    ip_obj = ipaddress.ip_interface(ip_with_mask)
-                    # Skip IPv6 if needed
-                    if ip_obj.version != 4:
-                        continue
-                    hosts = list(ip_obj.network.hosts())
-                    if len(hosts) < 2:
-                        logger.warning(f"Not enough hosts for nexthop in {ip_with_mask}")
-                        continue
-
-                    nexthop = str(hosts[1]) if str(ip_obj.ip) == str(hosts[0]) else str(hosts[0])
-                    if portchannel_name not in portchannels_with_ips:
-                        portchannels_with_ips[portchannel_name] = []
-                    # Save as flat dictionary
-                    portchannels_with_ips[portchannel_name] = {
-                        "ip": str(ip_obj),
-                        "nexthop": nexthop
-                    }
-                    # Append the IP to the list
-                    portchannels_ip_list.append(str(ip_obj))
-
-        dhcp_relay_data['portchannels_with_ips'] = portchannels_with_ips
-        dhcp_relay_data['portchannels_ip_list'] = portchannels_ip_list
-
-        # Obtain MAC address of an uplink interface because vlan mac may be different than that of physical interfaces
-        res = duthost.shell('cat /sys/class/net/{}/address'.format(uplink_interfaces[0]))
-        dhcp_relay_data['uplink_mac'] = res['stdout']
-        # get standby duthost if dualtor
-        if 'dualtor' in tbinfo['topo']['name']:
-            standby_duthost = [duthost for duthost in duthosts if duthost != duthosts[rand_one_dut_hostname]][0]
-            res = standby_duthost.shell('cat /sys/class/net/{}/address'.format(uplink_interfaces[0]))
-            dhcp_relay_data['standby_uplink_mac'] = res['stdout']
-            dhcp_relay_data['standby_dut_lo_addr'] = \
-                mg_facts["minigraph_devices"][standby_duthost.sonichost.hostname]['lo_addr']
-            standby_mg_facts = standby_duthost.get_extended_minigraph_facts(tbinfo)
-            standby_uplink_interfaces, standby_uplink_port_indices = \
-                calculate_uplink_interfaces_and_port_indices(standby_mg_facts)
-            dhcp_relay_data['standby_uplink_port_indices'] = standby_uplink_port_indices
-        dhcp_relay_data['default_gw_ip'] = mg_facts['minigraph_mgmt_interface']['gwaddr']
-
-        dhcp_relay_data_list.append(dhcp_relay_data)
-
-    return dhcp_relay_data_list
+    return _build_dhcp_relay_data_list(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, vlan_plan=None)
 
 
 def calculate_uplink_interfaces_and_port_indices(mg_facts):

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -29,11 +29,6 @@ pytestmark = [
     pytest.mark.parametrize("relay_agent", ["isc-relay-agent", "sonic-relay-agent"]),
 ]
 
-SUPPORTED_DHCPV4_TYPE = [
-    "Unknown", "Discover", "Offer", "Request", "Decline", "Ack", "Nak", "Release", "Inform", "Bootp"
-]
-SUPPORTED_DIR = ["TX", "RX"]
-
 
 BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
 DEFAULT_DHCP_CLIENT_PORT = 68
@@ -768,3 +763,70 @@ def test_dhcp_broadcast_not_flooded(ptfhost, dut_dhcp_relay_data, validate_dut_r
                    log_file=("/tmp/dhcp_relay_test.DHCPBroadcastNotFloodedTest.{}.log"
                              .format(dhcp_relay["downlink_vlan_iface"]["name"])),
                    is_python3=True)
+
+
+class TestDhcpv4RelayWithMultipleVlan:
+    """V4 sibling of TestDhcpv6RelayWithMultipleVlan, driven by
+    parametrize_vlan_config_from_topo. Auto-parametrized across every
+    vlan_config variant defined in the topo file (one_vlan_a, two_vlan_a,
+    four_vlan_a, ...). Variants that put secondary_subnet on a Vlan in a
+    multi-Vlan config trigger the dhcrelay duplicate `-iu` rendering path,
+    and `check_relayed_pkts_on_server_side` (in the PTF runner) asserts
+    strict equality `captured_count == num_dhcp_servers`, so any
+    duplication on the wire fails the test.
+    """
+
+    @pytest.fixture(scope="function", autouse=True)
+    def restart_dhcp_relay_after_test(self, duthost, relay_agent):
+        yield
+        restart_dhcp_service(duthost, ['sonic' if relay_agent == 'sonic-relay-agent' else 'isc'])
+
+    def test_dhcp_relay_no_double_forward(
+        self, ptfhost, duthost, dut_dhcp_relay_data_multivlan, validate_dut_routes_exist,
+        testing_config, toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
+        setup_standby_ports_on_rand_unselected_tor,  # noqa F811
+        relay_agent,
+    ):
+        """Verify DHCPv4 relay does not double-forward on any topo VLAN plan."""
+        testing_mode, duthost = testing_config
+        pytest_assert(
+            len(dut_dhcp_relay_data_multivlan) > 0,
+            "Need at least one DHCP relay entry for VLAN plan",
+        )
+
+        # The relay config is identical across the VLAN entries, so restart the
+        # relay service once before iterating rather than once per VLAN.
+        relay_types = ['sonic' if relay_agent == 'sonic-relay-agent' else 'isc']
+        restart_dhcp_service(duthost, relay_types)
+        for dhcp_relay in dut_dhcp_relay_data_multivlan:
+            if not dhcp_relay.get('downlink_vlan_iface', {}).get('addr'):
+                continue
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "dhcp_relay_test.DHCPTest",
+                platform_dir="ptftests",
+                params={
+                    "hostname": duthost.hostname,
+                    "client_port_index": dhcp_relay['client_iface']['port_idx'],
+                    "client_iface_alias": str(dhcp_relay['client_iface']['alias']),
+                    "leaf_port_indices": repr(dhcp_relay['uplink_port_indices']),
+                    "num_dhcp_servers": len(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs']),
+                    "server_ip": dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'],
+                    "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
+                    "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
+                    "relay_iface_netmask": str(dhcp_relay['downlink_vlan_iface']['mask']),
+                    "dest_mac_address": BROADCAST_MAC,
+                    "client_udp_src_port": DEFAULT_DHCP_CLIENT_PORT,
+                    "switch_loopback_ip": str(dhcp_relay['switch_loopback_ip']),
+                    "uplink_mac": str(dhcp_relay['uplink_mac']),
+                    "testing_mode": testing_mode,
+                    "kvm_support": True,
+                    "relay_agent": relay_agent,
+                    "downlink_vlan_iface_name": str(dhcp_relay['downlink_vlan_iface']['name']),
+                },
+                log_file="/tmp/dhcp_relay_test.DHCPTest.multi_vlan.{}.log".format(
+                    dhcp_relay['downlink_vlan_iface']['name'],
+                ),
+                is_python3=True,
+            )


### PR DESCRIPTION
### Description of PR

Summary: Add a multivlan variant for the DHCPv4 relay test
(`TestDhcpv4RelayWithMultipleVlan` in `tests/dhcp_relay/test_dhcp_relay.py`)
driven by the unified `parametrize_vlan_config_from_topo` fixture (#24669). Adds
the supporting `dut_dhcp_relay_data_multivlan` fixture in
`tests/dhcp_relay/conftest.py`, and makes `enable_sonic_dhcpv4_relay_agent` (in
`tests/common/dhcp_relay_utils.py`) prefer the multivlan relay data when present.

Fixes # N/A

##### Work item tracking
- Microsoft ADO: 38915796 (https://msazure.visualstudio.com/One/_workitems/edit/38915796)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Not requested (not backporting).

### Tested branch (Please provide the tested image version)

- [x] master

### Test result

The per-variant config is applied through `parametrize_vlan_config_from_topo`,
whose equivalence to `deploy-mg` was validated on dualtor-aa hardware
(`testbed-bjw2-can-dual-t0-8101c1-1`): `config_db_check` showed no
`inconsistent_config` diffs across `VLAN`, `VLAN_INTERFACE`, `VLAN_MEMBER`,
**`DHCP_RELAY`**, `MUX_CABLE` — i.e. the per-variant `DHCP_RELAY` config matches
`deploy-mg`. The new `TestDhcpv4RelayWithMultipleVlan` test body runs in CI
(t0 / KVM dhcp_relay lanes).

### Approach

#### What is the motivation for this PR?

Extend DHCPv4 relay coverage to multi-VLAN topologies using the unified fixture,
so relay behavior is verified across every `vlan_config` variant the topo
defines.

#### How did you do it?

Added `TestDhcpv4RelayWithMultipleVlan`, which consumes
`dut_dhcp_relay_data_multivlan` — per-variant relay data built on top of
`parametrize_vlan_config_from_topo`. Updated `enable_sonic_dhcpv4_relay_agent`
to prefer `dut_dhcp_relay_data_multivlan` when present, falling back to
`dut_dhcp_relay_data`.

#### How did you verify/test it?

Fixture equivalence (including the `DHCP_RELAY` table) validated on dualtor-aa
hardware (see Test result); the new test body runs in CI.

#### Any platform specific information?

Applicable to topologies that define `DUT.vlan_configs`.

### Documentation

N/A

