### PR TITLE
[dhcp_relay] use parametrize_vlan_config_from_topo for DHCPv6 multivlan test

### DIFF
--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -8,7 +8,6 @@ import logging
 from tests.common.dhcp_relay_utils import restart_dhcp_service, wait_dhcp_relay_ready
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
-from tests.common.fixtures.split_vlan import setup_multiple_vlans_and_teardown  # noqa F401
 from tests.ptf_runner import ptf_runner
 from tests.common import config_reload
 from tests.common.platform.processes_utils import wait_critical_processes
@@ -551,15 +550,14 @@ class TestDhcpv6RelayWithMultipleVlan:
         yield
         restart_dhcp_service(duthost, ['v6'])
 
-    @pytest.mark.parametrize("setup_multiple_vlans_and_teardown", [3], indirect=True)
     def test_dhcp_relay_default(self, ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
                                                 toggle_all_simulator_ports_to_rand_selected_tor_m, # noqa F811
                                                 setup_active_active_as_active_standby,             # noqa F811
-                                                setup_multiple_vlans_and_teardown):                # noqa F811
+                                                parametrize_vlan_config_from_topo):                # noqa F811
         '''
             Test DHCP relay should set correct link address when relay packet to DHCP server
         '''
-        vlans_info = setup_multiple_vlans_and_teardown
+        vlans_info = parametrize_vlan_config_from_topo
         _, duthost = testing_config
         # Please note: relay interface always means vlan interface
         pytest_assert(len(dut_dhcp_relay_data) > 0, "No VLAN data")
@@ -568,8 +566,12 @@ class TestDhcpv6RelayWithMultipleVlan:
         restart_dhcp_service(duthost, ['v6'])  # restart dhcp_relay to make new vlans config take into effect
         for vlan_info in vlans_info:
             vlan_name = vlan_info['vlan_name']
+            members_with_ptf_idx = vlan_info['members_with_ptf_idx']
+            if not members_with_ptf_idx:
+                logger.info("Vlan %s has no PTF-mapped members (PortChannel-only); skipping", vlan_name)
+                continue
             exp_link_addr = vlan_info['interface_ipv6'].split('/')[0]
-            _, ptf_port_index = random.choice(vlan_info['members_with_ptf_idx'])
+            _, ptf_port_index = random.choice(members_with_ptf_idx)
             logger.info("Randomly selected PTF port index: {}".format(ptf_port_index))
             ensure_client_reachability(duthost, vlan_name)
             command = "ip addr show {} | grep inet6 | grep 'scope link' | awk '{{print $2}}' | cut -d '/' -f1" \


### PR DESCRIPTION
### Description of PR

Summary: Refactor the multivlan path in `tests/dhcp_relay/test_dhcpv6_relay.py`
to use the unified `parametrize_vlan_config_from_topo` fixture (#24669),
replacing the previous bespoke multivlan mechanism.

Fixes # N/A

##### Work item tracking
- Microsoft ADO: 38915797 (https://msazure.visualstudio.com/One/_workitems/edit/38915797)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Not requested (not backporting).

### Tested branch (Please provide the tested image version)

- [x] master

### Test result

The per-variant config is applied through `parametrize_vlan_config_from_topo`,
whose equivalence to `deploy-mg` was validated on dualtor-aa hardware
(`testbed-bjw2-can-dual-t0-8101c1-1`): `config_db_check` showed no
`inconsistent_config` diffs across `VLAN`, `VLAN_INTERFACE`, `VLAN_MEMBER`,
**`DHCP_RELAY`**, `MUX_CABLE`. The DHCPv6 relay test body runs in CI
(t0 / KVM dhcp_relay lanes).

### Approach

#### What is the motivation for this PR?

Replace the bespoke multivlan mechanism in the DHCPv6 relay test with the
unified `parametrize_vlan_config_from_topo` fixture, so it uses the same
CONFIG_DB apply-patch path as the other multivlan consumer tests.

#### How did you do it?

Switched the DHCPv6 multivlan test to consume `parametrize_vlan_config_from_topo`
instead of the previous bespoke setup.

#### How did you verify/test it?

Fixture equivalence (including the `DHCP_RELAY` table) validated on dualtor-aa
hardware (see Test result); the test body runs in CI.

#### Any platform specific information?

Applicable to topologies that define `DUT.vlan_configs`.

### Documentation

N/A

