### PR TITLE
[202511] [conditional_mark] Skip decap/test_decap.py on Arista-720DT and remove stale parametrize-keyed entries

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -867,77 +867,17 @@ db_migrator/test_migrate_dns.py::test_migrate_dns_03:
 #######################################
 decap/test_decap.py:
   skip:
-    reason: 'Skip on t1-isolated-d32/128 topos'
+    reason: 'Skip on t1-isolated-d32/128 topos. Skip on Arista-720DT (TD3-X2 chip does not honor DSCP uniform decap; concession in aristanetworks/sonic-qual.msft#1176).'
+    conditions_logical_operator: or
     conditions:
       - "topo_name in ['t1-isolated-d128', 't1-isolated-d32']"
+      - "'Arista-720DT' in hwsku"
   xfail:
     reason: "Xfail due to github issue 20982. Or decap is not supported on x86_64-nvidia_sn5640-r0."
     conditions_logical_operator: or
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/20982 and asic_type in ['mellanox', 'nvidia']"
       - "platform in ['x86_64-nvidia_sn5640-r0']"
-
-decap/test_decap.py::test_decap[ttl=pipe, dscp=pipe, vxlan=disable]:
-  skip:
-    reason: "Not supported on broadcom after 201911 release, cisco-8000 all releases. Skip on t1-isolated-d32/128 topos"
-    conditions_logical_operator: or
-    conditions:
-      - "(asic_type in ['broadcom'] and release not in ['201811', '201911']) or (asic_type in ['cisco-8000'])"
-      - "topo_name in ['t1-isolated-d128', 't1-isolated-d32']"
-  xfail:
-    reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
-    conditions:
-      - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
-
-decap/test_decap.py::test_decap[ttl=pipe, dscp=pipe, vxlan=set_unset]:
-  skip:
-    reason: "Not supported on broadcom after 201911 release, cisco-8000 all releases and marvell-prestera asics. Skip on t1-isolated-d32/128 topos"
-    conditions_logical_operator: or
-    conditions:
-      - "(asic_type in ['broadcom'] and release not in ['201811', '201911']) or (asic_type in ['cisco-8000']) or (asic_type in ['marvell-prestera', 'marvell'])"
-      - "topo_name in ['t1-isolated-d128', 't1-isolated-d32']"
-  xfail:
-    reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
-    conditions:
-      - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
-
-decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=disable]:
-  skip:
-    conditions_logical_operator: or
-    reason: "Not supported on backend, broadcom before 202012 release. Skip 7260CX3 T1 topo in 202305 release. Skip on t1-isolated-d32/128 topos"
-    conditions:
-      - "(topo_name in ['t1-backend', 't0-backend']) or (asic_type in ['broadcom'] and release in ['201811', '201911'])"
-      - "'7260CX3' in hwsku and release in ['202305'] and 't1' in topo_type"
-      - "topo_name in ['t1-isolated-d128', 't1-isolated-d32']"
-  xfail:
-    reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
-    conditions:
-      - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
-
-decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=set_unset]:
-  skip:
-    reason: "Not supported on backend, T2 topologies , broadcom platforms before 202012 release, x86_64-8111_32eh_o-r0 platform. Skip on mellanox all releases. Skip on 7260CX3 T1 topo in 202305 release. Not required on isolated topologies d256u256s2, d96u32s2, d448u15-lag, and d128, as well as their minimzed and -v6 variants."
-    conditions_logical_operator: or
-    conditions:
-      - "('t2' in topo_name) or (topo_name in ['t1-backend', 't0-backend']) or (asic_type in ['broadcom'] and release in ['201811', '201911']) or platform in ['x86_64-8111_32eh_o-r0'] or asic_type in ['mellanox']"
-      - "'7260CX3' in hwsku and release in ['202305'] and 't1' in topo_type"
-      - *noVxlanTopos
-
-decap/test_decap.py::test_decap[ttl=uniform, dscp=pipe, vxlan=disable]:
-  skip:
-    reason: "Not supported uniform ttl mode"
-
-decap/test_decap.py::test_decap[ttl=uniform, dscp=pipe, vxlan=set_unset]:
-  skip:
-    reason: "Not supported uniform ttl mode"
-
-decap/test_decap.py::test_decap[ttl=uniform, dscp=uniform, vxlan=disable]:
-  skip:
-    reason: "Not supported uniform ttl mode"
-
-decap/test_decap.py::test_decap[ttl=uniform, dscp=uniform, vxlan=set_unset]:
-  skip:
-    reason: "Not supported uniform ttl mode"
 
 decap/test_subnet_decap.py::test_vlan_subnet_decap:
   skip:


### PR DESCRIPTION
Manual cherry-pick of #24626 to 202511 (auto-cherry-pick blocked by `Cherry Pick Conflict_202511` -- surrounding `decap/test_subnet_decap.py` entries diverge between master and 202511; this PR replays only the `decap/test_decap.py`-scoped portion, which is the entire content of #24626).

Same diff as master commit `19fdea04` (+3 / -63).

## What this changes

1. Adds `'Arista-720DT' in hwsku` to the top-level `decap/test_decap.py:` skip block. Arista-720DT (TD3-X2 / BCM56873) does not honor `SAI_TUNNEL_DSCP_MODE_UNIFORM_MODEL`; platform-level concession in `aristanetworks/sonic-qual.msft#1176`.
2. Removes 8 stale `decap/test_decap.py::test_decap[ttl=*, dscp=*, vxlan=*]:` entries that have matched zero collected items since PR #20304 (2025-08-28) refactored `tests/decap/conftest.py` to a single non-parametrized collection.

## Verification

Empirically verified on `testbed-bjw2-can-720dt-6` (m0, internal-202511):

- Baseline: `1 error in 8.56s` (`test_decap` proceeds past conditional_mark, errors at `duthosts` fixture)
- With this patch: `1 skipped, 9 warnings in 2.98s` -- SKIPPED before any fixture fires

## Related

- Master PR: #24626
- Tracking: `aristanetworks/sonic-qual.msft#1176`
- Refactor that orphaned the parametrize entries: #20304