### PR TITLE
Update platform list having combined L2/L3 drop counters

### DIFF
--- a/tests/drop_packets/combined_drop_counters.yml
+++ b/tests/drop_packets/combined_drop_counters.yml
@@ -31,6 +31,7 @@ l2_l3:
     - "x86_64-wistron_6512_32r-r0"
     - "x86_64-marvell_dbmvtx9180-r0"
     - "x86_64-nokia.*"
+    - "x86_64-nexthop.*"
 
 acl_l2:
     - "x86_64-mlnx"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fixes test failures on nexthop platform in drop_packets when discard group is L3

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Fixes test failures on nexthop platform in drop_packets when discard group is L3. Without this change, the test looks for the drops in RX_ERR, but the packet drops increment RX_DRP

#### How did you do it?
Add all broadcom platforms to combined l2/l3 platform list

#### How did you verify/test it?
Ran drop_packets tests with discard group as L3

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
