### PR TITLE
Fix Ansible playbook and Jinja2 template compatibility for ansible-core 2.20 (Ansible 13.6)

### DIFF
--- a/ansible/roles/eos/tasks/ceos.yml
+++ b/ansible/roles/eos/tasks/ceos.yml
@@ -6,7 +6,8 @@
   become: yes
 
 - name: set force_restart=yes for ceos container
-  set_fact: force_restart=yes
+  set_fact:
+    force_restart: yes
 
 - name: Check if ceos container responses to snmp
   when: ctninfo.exists
@@ -17,7 +18,8 @@
     ignore_errors: true
 
   - name: set force_restart=no for ceos container
-    set_fact: force_restart=no
+    set_fact:
+      force_restart: no
     when: snmp_data.ansible_facts.ansible_sysname is defined
 
 - include_vars: group_vars/vm_host/ceos.yml
@@ -98,7 +100,8 @@
   delegate_to: "{{ VM_host[0] }}"
 
 - name: set container_reachable=False for ceos container
-  set_fact: container_reachable=False
+  set_fact:
+    container_reachable: false
 
 # loop four times, if all containers are reachable in any iteration, the rest loop will be skipped
 - name: make sure container's mgmt-ip is reachable

--- a/ansible/roles/eos/templates/m0-mx.j2
+++ b/ansible/roles/eos/templates/m0-mx.j2
@@ -1,4 +1,4 @@
-{% set converged = topo_is_multi_vrf|default(false) %}
+{% set converged = topo_is_multi_vrf|default(false)|bool %}
 {% set host = configuration[hostname] %}
 {% if converged %}
     {% set conv_config = convergence_data["converged_peers"][hostname] %}

--- a/ansible/roles/eos/templates/t0-isolated-d2u254s1-tor.j2
+++ b/ansible/roles/eos/templates/t0-isolated-d2u254s1-tor.j2
@@ -1,4 +1,4 @@
-{% set converged = topo_is_multi_vrf|default(false) %}
+{% set converged = topo_is_multi_vrf|default(false)|bool %}
 {% set host = configuration[hostname] %}
 {% if converged %}
     {% set conv_config = convergence_data["converged_peers"][hostname] %}

--- a/ansible/roles/eos/templates/t0-leaf.j2
+++ b/ansible/roles/eos/templates/t0-leaf.j2
@@ -1,4 +1,4 @@
-{% set converged = topo_is_multi_vrf|default(false) %}
+{% set converged = topo_is_multi_vrf|default(false)|bool %}
 {% set host = configuration[hostname] %}
 {% if converged %}
     {% set conv_config = convergence_data["converged_peers"][hostname] %}

--- a/ansible/roles/eos/templates/t0-v6-leaf.j2
+++ b/ansible/roles/eos/templates/t0-v6-leaf.j2
@@ -1,4 +1,4 @@
-{% set converged = topo_is_multi_vrf|default(false) %}
+{% set converged = topo_is_multi_vrf|default(false)|bool %}
 {% set host = configuration[hostname] %}
 {% if converged %}
     {% set conv_config = convergence_data["converged_peers"][hostname] %}

--- a/ansible/roles/eos/templates/t1-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-lag-spine.j2
@@ -1,5 +1,5 @@
 {% set host = configuration[hostname] %}
-{% set converged = topo_is_multi_vrf|default(false) %}
+{% set converged = topo_is_multi_vrf|default(false)|bool %}
 {% if converged %}
     {% set conv_config = convergence_data["converged_peers"][hostname] %}
     {% set conv_mapping = convergence_data["convergence_mapping"][hostname] %}

--- a/ansible/roles/eos/templates/t1-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-lag-tor.j2
@@ -1,5 +1,5 @@
 {% set host = configuration[hostname] %}
-{% set converged = topo_is_multi_vrf|default(false) %}
+{% set converged = topo_is_multi_vrf|default(false)|bool %}
 {% if converged %}
     {% set conv_config = convergence_data["converged_peers"][hostname] %}
     {% set conv_mapping = convergence_data["convergence_mapping"][hostname] %}

--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -175,7 +175,8 @@
           include_vars: "vars/topo_{{ topo }}.yml"
 
         - name: Set default value for topo_is_multi_vrf
-          set_fact: topo_is_multi_vrf=False
+          set_fact:
+            topo_is_multi_vrf: false
           when: topo_is_multi_vrf is not defined
 
         - name: Find current server group

--- a/ansible/testbed_announce_routes.yml
+++ b/ansible/testbed_announce_routes.yml
@@ -43,7 +43,8 @@
     include_vars: "vars/topo_{{ topo }}.yml"
 
   - name: Set default value for topo_is_multi_vrf
-    set_fact: topo_is_multi_vrf=False
+    set_fact:
+      topo_is_multi_vrf: false
     when: topo_is_multi_vrf is not defined
 
   tasks:

--- a/tests/common/devices/base.py
+++ b/tests/common/devices/base.py
@@ -59,12 +59,6 @@ def suppress_signal_registration_for_non_main_thread():
             def _thread_safe_signal(signum, handler):
                 if threading.current_thread() is threading.main_thread():
                     return _original_signal(signum, handler)
-                logger.warning(
-                    "Skipping signal.signal(%s, %s) from non-main thread %s; "
-                    "ansible-core 2.19+ restricts signal handling to main thread. "
-                    "Returning default handler instead.",
-                    signum, handler, threading.current_thread().name
-                )
                 return signal.getsignal(signum)
 
             signal.signal = _thread_safe_signal


### PR DESCRIPTION
### Description of PR

Summary:
Fix Ansible playbook and Jinja2 template compatibility for ansible-core 2.20 (Ansible 13.6) while maintaining backward compatibility with ansible-core 2.18 (Ansible 11.10).

In ansible-core 2.20, the inline `set_fact: key=value` syntax treats `False`/`True`/`yes`/`no` as **strings** instead of booleans. The string `"False"` is truthy in Jinja2, which caused the `add-topo` flow to fail: the `topo_is_multi_vrf` variable evaluated as truthy and errored on all cEOS VM creation/startup. Also, `container_reachable=False` (string `"False"`, truthy) caused the `when: not container_reachable` reachability check loop to be skipped.

In addition, remove logger warning for signal registration as it prints too many warnings causing clutter during test execution.

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Upgrading from Ansible 11.10 (ansible-core 2.18.6) to Ansible 13.6 (ansible-core 2.20.5) broke the `add-topo` testbed provisioning. 

#### How did you do it?

Converted inline `set_fact: key=value` to YAML mapping syntax so boolean values are preserved across Ansible versions:

#### How did you verify/test it?

Ran `./testbed-cli.sh -m veos_vtb -t vtestbed.yaml add-topo vms-kvm-t0 ./password.txt` with Ansible 13.6 (ansible-core 2.20.5). Changes are backward compatible with Ansible 11.10 (ansible-core 2.18.6).

#### Any platform specific information?

N/A — affects testbed provisioning infrastructure only.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A