### PR TITLE
pfcwd: ignore benign cisco-8000 SAI/orchagent errors during teardown of test_pfcwd_cli

### DIFF
--- a/tests/pfcwd/test_pfcwd_cli.py
+++ b/tests/pfcwd/test_pfcwd_cli.py
@@ -40,11 +40,27 @@ def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loga
         r".*tac_connect_single: .*",
         r".*nss_tacplus: .*",
     ]
+    # On cisco-8000 platforms (e.g. Cisco-8101), the test teardown path that restores
+    # LAG / port-channel members re-binds cached QoS TC->Queue map and PFC settings
+    # on the affected ports. The underlying SAI objects can be recreated during the
+    # test, leaving orchagent with stale OIDs. The re-bind then fails in syncd with
+    # SAI_STATUS_ITEM_NOT_FOUND and orchagent logs ERR for handlePortQosMapTable /
+    # setPortPfc. The test itself passes; only loganalyzer flags these as failures.
+    Cisco8000IgnoreRegex = [
+        r".*sendApiResponse: api SAI_COMMON_API_SET failed in syncd mode: SAI_STATUS_ITEM_NOT_FOUND.*",
+        r".*processQuadEvent: VID: oid:0x[0-9a-f]+ RID: oid:0x[0-9a-f]+.*",
+        r".*processQuadEvent: attr: SAI_PORT_ATTR_QOS_TC_TO_QUEUE_MAP: oid:0x[0-9a-f]+.*",
+        r".*processQuadEvent: attr: SAI_PORT_ATTR_PRIORITY_FLOW_CONTROL: \d+.*",
+        r".*handlePortQosMapTable: Failed to apply \S+ to port Ethernet\d+, rv:-7.*",
+        r".*setPortPfc: Failed to set PFC 0x[0-9a-f]+ to port id 0x[0-9a-f]+ \(rc:-7\).*",
+    ]
     duthost = duthosts[rand_one_dut_hostname]
     if loganalyzer:  # Skip if loganalyzer is disabled
         loganalyzer[duthost.hostname].ignore_regex.extend(TacacsIgnoreRegex)
         if duthost.facts["asic_type"] == "vs":
             loganalyzer[duthost.hostname].ignore_regex.extend(KVMIgnoreRegex)
+        if duthost.facts["asic_type"] == "cisco-8000":
+            loganalyzer[duthost.hostname].ignore_regex.extend(Cisco8000IgnoreRegex)
 
 
 @pytest.fixture(scope='function', autouse=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md
-->
### Description of PR

Summary:
On `cisco-8000` platforms (observed on `Cisco-8101-O8V48`), `tests/pfcwd/test_pfcwd_cli.py::TestPfcwdFunc::test_pfcwd_show_stat` consistently reports `ERROR at teardown` even though the test body itself passes. The `loganalyzer` autouse fixture matches hundreds of ERR-level syslog lines emitted from `syncd` and `orchagent` while the test teardown (LAG / port-channel member restore in `manage_lag_config` → `_restore_original_config`) re-binds cached QoS TC→Queue map and PFC settings to the affected ports.

Representative syslog (664 matches in a single run):

```
syncd#syncd:  sendApiResponse: api SAI_COMMON_API_SET failed in syncd mode: SAI_STATUS_ITEM_NOT_FOUND
syncd#syncd:  processQuadEvent: VID: oid:0x100000000000a RID: oid:0x80000000000015
syncd#syncd:  processQuadEvent: attr: SAI_PORT_ATTR_QOS_TC_TO_QUEUE_MAP: oid:0x1400000000089a
swss#orchagent: handlePortQosMapTable: Failed to apply AZURE to port Ethernet0, rv:-7
syncd#syncd:  processQuadEvent: attr: SAI_PORT_ATTR_PRIORITY_FLOW_CONTROL: 24
swss#orchagent: setPortPfc: Failed to set PFC 0x18 to port id 0x100000000000a (rc:-7)
```

The same QoS TC→Queue map OID is re-applied to every restored LAG-member port but no longer exists in SAI, so syncd returns `SAI_STATUS_ITEM_NOT_FOUND` and orchagent logs ERR. The behavior is specific to cisco-8000 and is not observed on other platforms.

This PR extends the existing `ignore_expected_loganalyzer_exceptions` fixture in `test_pfcwd_cli.py` to suppress these benign teardown-time errors only on `asic_type == "cisco-8000"`, mirroring the existing pattern used for `vs` / KVM. A proper fix for the stale-OID rebind belongs in orchagent / cisco-sai and will be tracked separately.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

`test_pfcwd_cli.py::test_pfcwd_show_stat[IPv4-*]` fails on cisco-8000 nightly runs (e.g. testplan `8101.t1.202511.O8V48_NightlyTest_20260515.1`) as `ERROR at teardown` because the loganalyzer autouse fixture matches a large burst of syncd/orchagent ERR syslog while the test teardown restores LAG / port-channel members. The test logic itself passes; only the post-test log scan fails.

#### How did you do it?

Extended the existing `ignore_expected_loganalyzer_exceptions` fixture in `tests/pfcwd/test_pfcwd_cli.py` with a new `Cisco8000IgnoreRegex` list and applied it only when `duthost.facts["asic_type"] == "cisco-8000"`, following the same conditional pattern already used for `vs` (KVM). The regexes are narrow and target only the specific signatures observed during teardown of this test:

- `sendApiResponse: api SAI_COMMON_API_SET failed in syncd mode: SAI_STATUS_ITEM_NOT_FOUND`
- `processQuadEvent: VID: oid:0x... RID: oid:0x...`
- `processQuadEvent: attr: SAI_PORT_ATTR_QOS_TC_TO_QUEUE_MAP: oid:0x...`
- `processQuadEvent: attr: SAI_PORT_ATTR_PRIORITY_FLOW_CONTROL: <num>`
- `handlePortQosMapTable: Failed to apply <profile> to port Ethernet<N>, rv:-7`
- `setPortPfc: Failed to set PFC 0x<mask> to port id 0x... (rc:-7)`

#### How did you verify/test it?

- Reviewed the failing run logs from testplan `6a06ce85ea3a02a739d03d63` (`8101.t1.202511.O8V48_NightlyTest_20260515.1`) to enumerate every ERR signature emitted during teardown and to confirm they all match the new regexes.
- Verified the change is syntactically valid (`python -m py_compile tests/pfcwd/test_pfcwd_cli.py`).
- Change is scoped to a `cisco-8000`-only branch, so other platforms (mellanox, broadcom, marvell-teralynx, vs/KVM, …) are not affected.

#### Any platform specific information?

Yes — the new ignore list is applied **only** when `duthost.facts["asic_type"] == "cisco-8000"`. No behavior change on any other platform.

#### Supported testbed topology if it's a new test case?

N/A — this is a bug fix for an existing test.

### Documentation
N/A
