### PR TITLE
marvell-teralynx fanout: remove type from DEVICE_METADATA

### DIFF
--- a/ansible/roles/fanout/templates/sonic_deploy_202505.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202505.j2
@@ -3,9 +3,7 @@
         "localhost": {
             "default_pfcwd_status": "disable",
             "hwsku": "{{ fanout_hwsku }}",
-{% if 'marvell-teralynx' in fanout_sonic_version["asic_type"] %}
-            "type": "LeafRouter",
-{% endif %}
+
             "hostname": "{{ inventory_hostname }}"
         }
     },


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Remove conditional that added "type": "LeafRouter" for marvell-teralynx.

This field is no longer needed and interferes with new qos/buffer jinja templates.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
By running PTF on marvell-teralynx switches

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
