### PR TITLE
feat: Improve BGP topology setup in Snappi/Ixia

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -205,7 +205,7 @@ def get_addrs_in_subnet(subnet, number_of_ip, exclude_ips=None):
     return results
 
 
-def get_peer_snappi_chassis(conn_data, dut_hostname):
+def get_peer_snappi_chassis(conn_data, dut_hostname, tbinfo=None):
     """
     Get the Snappi chassis connected to the DUT
     Note that a DUT can only be connected to a Snappi chassis
@@ -249,21 +249,81 @@ def get_peer_snappi_chassis(conn_data, dut_hostname):
         u'device_vlan_map_list': {u'sonic-s6100-dut': {u'19': 2}},
         u'device_vlan_range': {u'sonic-s6100-dut': [u'2']}}
         dut_hostname (str): hostname of the DUT
+        tbinfo (dict): optional testbed information containing 'tgs' list (traffic generators)
     Returns:
         The name of the peer Snappi chassis or None
     """
-
-    device_conn = conn_data['device_conn']
+    import logging
+    logger = logging.getLogger(__name__)
+    
+    device_conn = conn_data.get('device_conn', {})
+    device_info = conn_data.get('device_info', {})
+    
+    logger.debug(f"DEBUG get_peer_snappi_chassis: dut_hostname={dut_hostname}")
+    logger.debug(f"DEBUG: device_conn keys: {list(device_conn.keys())}")
+    
     if dut_hostname not in device_conn:
+        logger.debug(f"DEBUG: {dut_hostname} not found in device_conn, returning None")
         return None
 
     dut_device_conn = device_conn[dut_hostname]
-    peer_devices = [dut_device_conn[port]['peerdevice'] for port in dut_device_conn]
-    peer_devices = list(set(peer_devices))
+    logger.debug(f"DEBUG: dut_device_conn type={type(dut_device_conn)}, content={dut_device_conn}")
+
+    def _is_snappi_peer(peer_name, peer_port):
+        if not peer_name:
+            return False
+            
+        peer_name_l = str(peer_name).lower()
+        if 'snappi' in peer_name_l or 'ixia' in peer_name_l:
+            logger.debug(f"DEBUG: {peer_name} matched Tier 1 (hostname has snappi/ixia)")
+            return True
+
+        peer_info = device_info.get(peer_name, {})
+        peer_type_l = str(peer_info.get('Type', '')).lower()
+        peer_hwsku_l = str(peer_info.get('HwSku', '')).lower()
+        if any(token in peer_type_l for token in ('snappi', 'ixia', 'devsnappi', 'devixia')):
+            logger.debug(f"DEBUG: {peer_name} matched Tier 2 (Type={peer_type_l})")
+            return True
+        if peer_hwsku_l in ('snappi-tester', 'ixia-tester') or 'ixia' in peer_hwsku_l:
+            logger.debug(f"DEBUG: {peer_name} matched Tier 3 (HwSku={peer_hwsku_l})")
+            return True
+
+        # Some labs use generic hostnames for Ixia/Snappi fanouts, but their peer port
+        # format is still card/port style (e.g. Card1/Port4 or Port1.1).
+        if peer_port:
+            peer_port_l = str(peer_port).lower()
+            if peer_port_l.startswith('card') or peer_port_l.startswith('port'):
+                logger.debug(f"DEBUG: {peer_name} matched Tier 4 (port format={peer_port_l})")
+                return True
+
+        logger.debug(f"DEBUG: {peer_name} did not match any tier (port={peer_port})")
+        return False
+
     peer_snappi_devices = []
-    for peer in peer_devices:
-        if 'snappi' in peer or 'ixia' in peer or 'stc' in peer:
-            peer_snappi_devices.append(peer)
+    for port in dut_device_conn:
+        port_data = dut_device_conn[port]
+        logger.debug(f"DEBUG: Processing port {port}, data type={type(port_data)}")
+        
+        if isinstance(port_data, dict):
+            peer_name = port_data.get('peerdevice')
+            peer_port = port_data.get('peerport')
+            logger.debug(f"DEBUG: Port {port}: peerdevice={peer_name}, peerport={peer_port}")
+            
+            if _is_snappi_peer(peer_name, peer_port) and peer_name not in peer_snappi_devices:
+                peer_snappi_devices.append(peer_name)
+                logger.debug(f"DEBUG: Added {peer_name} to peer_snappi_devices")
+        else:
+            logger.debug(f"DEBUG: Port data is not dict: {type(port_data)}")
+
+    logger.debug(f"DEBUG: Found peer_snappi_devices from conn_data: {peer_snappi_devices}")
+    
+    # Note: We do NOT use tbinfo as fallback here. The fixture requires fanouts that
+    # are DIRECT peers of the DUT (in fanout_graph_facts), so we can access their
+    # port information. When Ixia/Snappi is behind an L1 switch (not a direct peer),
+    # it cannot be used by this fixture.
+    # See: tests/common/fixtures/conn_graph_facts.py::fanout_graph_facts
+    
+    logger.debug(f"DEBUG: Final result: peer_snappi_devices={peer_snappi_devices}")
     if len(peer_snappi_devices) >= 1:
         return peer_snappi_devices
     else:

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -784,6 +784,76 @@ def _tgen_ports_from_portchannel(duthost, conn_graph_facts, fanout_graph_facts, 
     return result if result else None
 
 
+def _normalize_interface_ip_map(interface_table):
+    interface_ip_map = {}
+    for key, val in list(interface_table.items()):
+        if '|' in key:
+            intf_name, addr = key.split('|', 1)
+            interface_ip_map.setdefault(intf_name, []).append(addr)
+        else:
+            addrs = list(val.keys()) if isinstance(val, dict) else list(val)
+            interface_ip_map.setdefault(key, []).extend(addrs)
+    return interface_ip_map
+
+
+def _enrich_tgen_ports_with_l3_info(snappi_ports, config_facts):
+    interface_ip_map = _normalize_interface_ip_map(config_facts.get('INTERFACE') or {})
+    bgp_neighbors = config_facts.get('BGP_NEIGHBOR') or {}
+    local_to_neighbor = {}
+    for neighbor_ip, props in list(bgp_neighbors.items()):
+        local_addr = props.get('local_addr')
+        if local_addr:
+            local_to_neighbor[local_addr.lower()] = neighbor_ip.lower()
+
+    dut_asn_global = _normalize_sonic_config_asn(
+        ((config_facts.get('DEVICE_METADATA') or {}).get('localhost') or {}).get('bgp_asn')
+    )
+    bgp_merged = _merged_bgp_neighbor_table(config_facts)
+
+    fallback_peer_ipv4 = create_ip_list(dut_ip_start, len(snappi_ports), mask=prefix_length)
+    fallback_tgen_ipv4 = create_ip_list(snappi_ip_start, len(snappi_ports), mask=prefix_length)
+    fallback_peer_ipv6 = create_ip_list(dut_ipv6_start, len(snappi_ports), mask=v6_prefix_length)
+    fallback_tgen_ipv6 = create_ip_list(snappi_ipv6_start, len(snappi_ports), mask=v6_prefix_length)
+
+    for index, port in enumerate(snappi_ports):
+        addrs = interface_ip_map.get(port['peer_port'], [])
+        peer_ip = peer_ipv6 = prefix = ipv6_prefix = None
+        for addr in addrs:
+            if ':' in addr:
+                peer_ipv6, ipv6_prefix = addr.split('/', 1)
+            else:
+                peer_ip, prefix = addr.split('/', 1)
+
+        if peer_ip:
+            port['peer_ip'] = peer_ip
+            port['prefix'] = prefix
+            port['ip'] = local_to_neighbor.get(peer_ip.lower()) or get_addrs_in_subnet(
+                peer_ip + '/' + prefix, 1, exclude_ips=[peer_ip])[0]
+        else:
+            port['peer_ip'] = fallback_peer_ipv4[index]
+            port['prefix'] = str(prefix_length)
+            port['ip'] = fallback_tgen_ipv4[index]
+
+        if peer_ipv6:
+            port['peer_ipv6'] = peer_ipv6.lower()
+            port['ipv6_prefix'] = ipv6_prefix
+            port['ipv6'] = local_to_neighbor.get(peer_ipv6.lower()) or get_addrs_in_subnet(
+                peer_ipv6 + '/' + ipv6_prefix, 1, exclude_ips=[peer_ipv6])[0]
+        else:
+            port['peer_ipv6'] = fallback_peer_ipv6[index].lower()
+            port['ipv6_prefix'] = str(v6_prefix_length)
+            port['ipv6'] = fallback_tgen_ipv6[index].lower()
+
+        if dut_asn_global is not None:
+            port['dut_asn'] = dut_asn_global
+
+        peer_asn = _peer_asn_from_bgp_neighbor_table(bgp_merged, port.get('ip') or '')
+        if peer_asn is None:
+            peer_asn = _peer_asn_from_bgp_neighbor_table(bgp_merged, port.get('ipv6') or '')
+        if peer_asn is not None:
+            port['peer_asn'] = peer_asn
+
+
 def _peer_asn_from_bgp_neighbor_table(bgp_table, neighbor_ip):  # noqa: F811
     if not neighbor_ip:
         return None
@@ -994,7 +1064,7 @@ def _tgen_ports_from_portchannel(duthost, conn_graph_facts, fanout_graph_facts, 
 
 
 @pytest.fixture(scope="module")
-def tgen_ports(duthost, get_snappi_ports, conn_graph_facts, fanout_graph_facts, request):      # noqa: F811
+def tgen_ports(duthost, get_snappi_ports, conn_graph_facts, fanout_graph_facts, request, tbinfo):      # noqa: F811
     """
     Populate tgen ports info of T0 testbed and returns as a list
     Args:
@@ -1002,6 +1072,7 @@ def tgen_ports(duthost, get_snappi_ports, conn_graph_facts, fanout_graph_facts, 
         get_snappi_ports (pytest fixture): snappi ports
         conn_graph_facts (pytest fixture): connection graph
         fanout_graph_facts (pytest fixture): fanout graph
+        tbinfo (pytest fixture): fixture provides information about testbed
     Return:
         [{'card_id': '1',
         'ip': '22.1.1.2',
@@ -1044,62 +1115,39 @@ def tgen_ports(duthost, get_snappi_ports, conn_graph_facts, fanout_graph_facts, 
     snappi_fanouts = get_peer_snappi_chassis(conn_data=conn_graph_facts,
                                              dut_hostname=duthost.hostname)
     pytest_assert(snappi_fanouts is not None, 'Fail to get snappi_fanout')
-    dut_port_table = config_facts.get('PORT', {})
+    
+    # Filter snappi_fanouts to only include those present in fanout_graph_facts
+    # Some fanouts may be detected via tbinfo but not in the direct connection graph
+    # (e.g., when Ixia is behind an L1 switch). We only want fanouts that are
+    # direct peers of the DUT so we can get proper port information.
+    available_fanouts = [f for f in snappi_fanouts if f in fanout_graph_facts]
+    
+    pytest_assert(available_fanouts, 'No snappi fanout devices found in direct connection graph for {}'.format(duthost.hostname))
+    
     snappi_fanout_list = SnappiFanoutManager(fanout_graph_facts)
-    for snappi_fanout in snappi_fanouts:
+    snappi_ports_all = []
+    for snappi_fanout in available_fanouts:
         snappi_fanout_id = list(fanout_graph_facts.keys()).index(snappi_fanout)
         snappi_fanout_list.get_fanout_device_details(device_number=snappi_fanout_id)
         snappi_ports = snappi_fanout_list.get_ports(peer_device=duthost.hostname)
-        port_speeds = {int(p['speed']) for p in snappi_ports}
-        if len(port_speeds) != 1:
-            """ All the ports should have the same bandwidth """
-            return None
-        port_speed = port_speeds.pop()
-        dutIps = create_ip_list(dut_ip_start, len(snappi_ports), mask=prefix_length)
-        tgenIps = create_ip_list(snappi_ip_start, len(snappi_ports), mask=prefix_length)
-        dutv6Ips = create_ip_list(dut_ipv6_start, len(snappi_ports), mask=v6_prefix_length)
-        tgenv6Ips = create_ip_list(snappi_ipv6_start, len(snappi_ports), mask=v6_prefix_length)
-        for port_id, port in enumerate(snappi_ports):
-            port['port_id'] = str(port_id + 1)
-            dut_port_info = dut_port_table.get(port['peer_port'], {})
-            port['autoneg'] = dut_port_info.get('autoneg') == 'on'
-            port['fec'] = str(dut_port_info.get('fec', '')).strip().lower().startswith('rs')
-            link_training_value = str(dut_port_info.get('link_training', '')).strip().lower()
-            port['link_training'] = link_training_value in ['on', 'true', 'yes', '1']
-            port['speed'] = speed_type.get(str(port_speed), port['speed'])
-            peer_port = port['peer_port']
-            entry = bool(config_facts.get('INTERFACE', {}).get(peer_port))
-            for ipver, addr_type in (("ipv4", "IPv4"), ("ipv6", "IPv6")):
-                if ipver == "ipv4":
-                    dut_list, tgen_list, mask = dutIps, tgenIps, prefix_length
-                    peer_ip_key, prefix_key, ip_key = "peer_ip", "prefix", "ip"
-                else:
-                    dut_list, tgen_list, mask = dutv6Ips, tgenv6Ips, v6_prefix_length
-                    peer_ip_key, prefix_key, ip_key = "peer_ipv6", "ipv6_prefix", "ipv6"
-                if not entry:
-                    # Assign and configure new IPs
-                    port[peer_ip_key] = dut_list[port_id]
-                    port[prefix_key] = mask
-                    port[ip_key] = tgen_list[port_id]
-                    try:
-                        logger.info(
-                            f"Pre-configuring {addr_type}: {duthost.hostname} "
-                            f"port {peer_port} -> {dut_list[port_id]}/{mask}"
-                        )
-                        duthost.command(
-                            f"sudo config interface ip add {peer_port} {dut_list[port_id]}/{mask}"
-                        )
-                    except Exception as e:
-                        pytest.fail(
-                            f"Unable to configure {addr_type} on {peer_port}: {e}",
-                            pytrace=False,
-                        )
-                else:
-                    int_addrs = list(config_facts['INTERFACE'][peer_port].keys())
-                    entry = next((a for a in int_addrs if (":" in a) == (ipver == "ipv6")), None)
-                    port[peer_ip_key], port[prefix_key] = entry.split("/")
-                    port[ip_key] = get_addrs_in_subnet(entry, 1, exclude_ips=[entry.split("/")[0]])[0]
-    return snappi_ports
+        # Add snappi ports for each chassis connetion
+        for sp in snappi_ports:
+            snappi_ports_all.append(sp)
+
+        for port in snappi_ports_all:
+            port['intf_config_changed'] = False
+            port['api_server_ip'] = tbinfo['ptf_ip']
+            port['asic_type'] = duthost.facts["asic_type"]
+            port['duthost'] = duthost
+            port['snappi_speed_type'] = speed_type[port['speed']]
+            if duthost.facts["num_asic"] > 1:
+                port['asic_value'] = duthost.get_port_asic_instance(port['peer_port']).namespace
+            else:
+                port['asic_value'] = None
+    for index, port in enumerate(snappi_ports_all):
+        port['port_id'] = str(index + 1)
+    _enrich_tgen_ports_with_l3_info(snappi_ports_all, config_facts)
+    return snappi_ports_all
 
 
 def snappi_multi_base_config(duthost_list,
@@ -1919,12 +1967,22 @@ def get_snappi_ports_single_dut(duthosts,  # noqa: F811
 
     """ Generate L1 config """
     snappi_fanouts = get_peer_snappi_chassis(conn_data=conn_graph_facts,
-                                             dut_hostname=duthost.hostname)
+                                             dut_hostname=duthost.hostname,
+                                             tbinfo=tbinfo)
 
     pytest_assert(snappi_fanouts is not None, 'Fail to get snappi_fanout')
+    
+    # Filter snappi_fanouts to only include those present in fanout_graph_facts
+    # Some fanouts may be detected via tbinfo but not in the direct connection graph
+    # (e.g., when Ixia is behind an L1 switch). We only want fanouts that are
+    # direct peers of the DUT so we can get proper port information.
+    available_fanouts = [f for f in snappi_fanouts if f in fanout_graph_facts]
+    
+    pytest_assert(available_fanouts, 'No snappi fanout devices found in direct connection graph for {}'.format(duthost.hostname))
+    
     snappi_fanout_list = SnappiFanoutManager(fanout_graph_facts)
     snappi_ports_all = []
-    for snappi_fanout in snappi_fanouts:
+    for snappi_fanout in available_fanouts:
         snappi_fanout_id = list(fanout_graph_facts.keys()).index(snappi_fanout)
         snappi_fanout_list.get_fanout_device_details(device_number=snappi_fanout_id)
         snappi_ports = snappi_fanout_list.get_ports(peer_device=duthost.hostname)
@@ -2077,9 +2135,9 @@ def get_snappi_ports_for_rdma(snappi_port_list, rdma_ports, tx_port_count, rx_po
         f"wanted: {rx_port_count}")
     pytest_require(
         len(tx_snappi_ports) == tx_port_count,
-        f"Tx Ports for {testbed} in MULTIDUT_PORT_INFO doesn\'t match with "
-        f"ansible/files/*links.csv: tx_snappi_ports: {tx_snappi_ports}, and "
-        f"wanted: {tx_port_count}")
+        f"Tx Ports for {testbed} in MULTIDUT_PORT_INFO doesn't match with "
+        f"ansible/files/*links.csv: tx_snappi_ports:{tx_snappi_ports}, and "
+        f"wanted:{tx_port_count}")
 
     multidut_snappi_ports = rx_snappi_ports + tx_snappi_ports
     return multidut_snappi_ports

--- a/tests/common/unit_tests/snappi_tests/unit_test_common_helpers.py
+++ b/tests/common/unit_tests/snappi_tests/unit_test_common_helpers.py
@@ -1,0 +1,80 @@
+import ast
+from pathlib import Path
+
+import pytest
+
+
+def _load_get_peer_snappi_chassis():
+    module_path = Path(__file__).resolve().parents[2] / "snappi_tests" / "common_helpers.py"
+    source = module_path.read_text(encoding="utf-8")
+    parsed = ast.parse(source, filename=str(module_path))
+
+    target_fn = None
+    for node in parsed.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "get_peer_snappi_chassis":
+            target_fn = node
+            break
+
+    if target_fn is None:
+        raise RuntimeError("get_peer_snappi_chassis not found in common_helpers.py")
+
+    isolated_module = ast.Module(body=[target_fn], type_ignores=[])
+    ast.fix_missing_locations(isolated_module)
+    namespace = {}
+    exec(compile(isolated_module, filename=str(module_path), mode="exec"), namespace)
+    return namespace["get_peer_snappi_chassis"]
+
+
+get_peer_snappi_chassis = _load_get_peer_snappi_chassis()
+
+
+@pytest.mark.parametrize("tbinfo", [None, {"tgs": ["ixia-tg"]}])
+def test_get_peer_snappi_chassis_returns_none_when_no_direct_snappi_peer(tbinfo):
+    conn_data = {
+        "device_conn": {
+            "dut-01": {
+                "Ethernet0": {
+                    "peerdevice": "fanout-switch-01",
+                    "peerport": "Ethernet1",
+                    "speed": "100000",
+                }
+            }
+        },
+        "device_info": {
+            "fanout-switch-01": {
+                "Type": "FanoutLeaf",
+                "HwSku": "Arista-7060CX",
+            }
+        },
+    }
+
+    # get_peer_snappi_chassis intentionally does not fallback to tbinfo['tgs'].
+    # If there is no direct Snappi/Ixia peer in conn_data, the function must return None.
+    # Even when tbinfo has a traffic-generator list (tgs), the function should not use that as a fallback.
+    # Filter snappi_fanouts to only include those present in fanout_graph_facts
+    # Some fanouts may be detected via tbinfo but not in the direct connection graph
+    # (e.g., when Ixia is behind an L1 switch). We only want fanouts that are
+    # direct peers of the DUT so we can get proper port information.
+    assert get_peer_snappi_chassis(conn_data, "dut-01", tbinfo=tbinfo) is None
+
+
+def test_get_peer_snappi_chassis_returns_direct_peer_with_tbinfo_none():
+    conn_data = {
+        "device_conn": {
+            "dut-01": {
+                "Ethernet0": {
+                    "peerdevice": "ixia-sonic",
+                    "peerport": "Card1/Port1",
+                    "speed": "100000",
+                }
+            }
+        },
+        "device_info": {
+            "ixia-sonic": {
+                "Type": "DevIxia",
+                "HwSku": "IXIA-tester",
+            }
+        },
+    }
+
+    assert get_peer_snappi_chassis(conn_data, "dut-01", tbinfo=None) == ["ixia-sonic"]

--- a/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
@@ -15,6 +15,33 @@ NG_LIST = []
 aspaths = [65002, 65003]
 
 
+def _snappi_layer1_speed(port_entry):
+    speed = port_entry.get('snappi_speed_type') or port_entry.get('speed')
+    if isinstance(speed, str) and speed.startswith('speed_'):
+        return speed
+    return 'speed_{}_gbps'.format(int(int(speed) / 1000))
+
+
+def _snappi_rs_fec_enabled(port_entry):
+    """Infer RS-FEC behavior when fixture does not provide explicit FEC fields."""
+    if port_entry.get('fec_disable') is True:
+        return False
+    if 'fec' in port_entry:
+        return bool(port_entry.get('fec'))
+    speed = port_entry.get('snappi_speed_type') or port_entry.get('speed')
+    if isinstance(speed, str) and speed.startswith('speed_'):
+        try:
+            speed_g = int(speed.replace('speed_', '').replace('_gbps', ''))
+        except ValueError:
+            speed_g = 0
+    else:
+        try:
+            speed_g = int(int(speed) / 1000)
+        except Exception:
+            speed_g = 0
+    return speed_g >= 100
+
+
 def _asn_from_port_entry(port_entry, skip_duthost_bgp_config, fixture_keys, default):
     """
     When skip_duthost_bgp_config is True, prefer ASN from tgen_ports (dut_asn / peer_asn
@@ -27,6 +54,35 @@ def _asn_from_port_entry(port_entry, skip_duthost_bgp_config, fixture_keys, defa
         if val is not None:
             return int(val)
     return int(default)
+
+
+def _unbind_everflow_acl_from_ports(duthost, ports):
+    """Remove EVERFLOW ACL tables when they are bound to the ports used by this test."""
+    target_ports = set(ports)
+    acl_table_out = duthost.shell("show acl table", module_ignore_errors=True)
+    acl_stdout = acl_table_out.get('stdout', '')
+    if not acl_stdout:
+        logger.debug('DEBUG: show acl table returned no output; skipping EVERFLOW unbind')
+        return
+
+    for table_name in ('EVERFLOW', 'EVERFLOWV6'):
+        if table_name not in acl_stdout:
+            continue
+        bound_to_target = False
+        for line in acl_stdout.splitlines():
+            if table_name in line and any(port in line for port in target_ports):
+                bound_to_target = True
+                break
+        if not bound_to_target:
+            continue
+
+        logger.debug('DEBUG: Removing ACL table %s to unbind test ports %s', table_name, sorted(target_ports))
+        rm_result = duthost.shell('sudo config acl remove table {}'.format(table_name), module_ignore_errors=True)
+        logger.debug('DEBUG: ACL remove result for %s: %s', table_name, rm_result)
+        pytest_assert(
+            rm_result.get('rc', 1) == 0 and 'Error' not in rm_result.get('stderr', ''),
+            'Failed to remove ACL table {} before BGP PortChannel setup: {}'.format(
+                table_name, rm_result.get('stderr', '')))
 
 
 def run_bgp_local_link_failover_test(snappi_api,
@@ -227,6 +283,10 @@ def duthost_bgp_config(duthost,
     """
     global temp_tg_port
     temp_tg_port = tgen_ports
+    _unbind_everflow_acl_from_ports(
+        duthost,
+        [tgen_ports[i]['peer_port'] for i in range(0, port_count)]
+    )
     for i in range(0, port_count):
         intf_config = (
             "sudo config interface ip remove %s %s/%s \n"
@@ -238,6 +298,7 @@ def duthost_bgp_config(duthost,
                     (tgen_ports[i]['peer_port']))
         duthost.shell(intf_config)
 
+    logger.debug('DEBUG: tgen_ports content: %s', tgen_ports)
     for i in range(0, port_count):
         portchannel_config = (
             "sudo config portchannel add PortChannel%s \n"
@@ -248,9 +309,28 @@ def duthost_bgp_config(duthost,
         portchannel_config %= (i+1, i+1, tgen_ports[i]['peer_port'], i+1, tgen_ports[i]
                                ['peer_ip'], tgen_ports[i]['prefix'], i+1, tgen_ports[i]['peer_ipv6'],
                                tgen_ports[i]['ipv6_prefix'])
-        logger.info('Configuring %s to PortChannel%s with IPs %s,%s' % (
-            tgen_ports[i]['peer_port'], i+1, tgen_ports[i]['peer_ip'], tgen_ports[i]['peer_ipv6']))
-        duthost.shell(portchannel_config)
+        logger.debug('DEBUG: Configuring PortChannel%s: member=%s, IPv4=%s/%s, IPv6=%s/%s',
+                       i+1, tgen_ports[i]['peer_port'], tgen_ports[i]['peer_ip'], tgen_ports[i]['prefix'],
+                       tgen_ports[i]['peer_ipv6'], tgen_ports[i]['ipv6_prefix'])
+        logger.debug('DEBUG: Running config command:\n%s', portchannel_config)
+        result = duthost.shell(portchannel_config)
+        logger.debug('DEBUG: Command result: %s', result)
+        pytest_assert(
+            result.get('rc', 1) == 0,
+            'Failed PortChannel{} config for member {}. stderr={}'.format(
+                i+1, tgen_ports[i]['peer_port'], result.get('stderr', '')))
+        pytest_assert(
+            'Error:' not in result.get('stderr', ''),
+            'PortChannel{} member add failed for {}: {}'.format(
+                i+1, tgen_ports[i]['peer_port'], result.get('stderr', '')))
+
+    pc_status = duthost.shell('show interfaces portchannel')
+    logger.debug('DEBUG: DUT portchannel status after config:\n%s', pc_status.get('stdout', ''))
+    for i in range(0, port_count):
+        expected_member = tgen_ports[i]['peer_port']
+        pytest_assert(
+            expected_member in pc_status.get('stdout', ''),
+            'Configured member {} not present in show interfaces portchannel output'.format(expected_member))
     bgp_config = (
         "vtysh "
         "-c 'configure terminal' "
@@ -352,11 +432,11 @@ def __tgen_bgp_config(snappi_api,
         layer1 = config.layer1.layer1()[-1]
         layer1.name = f"{index}_settings"
         layer1.port_names = [config.ports[index].name]
-        layer1.speed = port_data['speed']
+        layer1.speed = _snappi_layer1_speed(port_data)
         layer1.ieee_media_defaults = False
-        layer1.auto_negotiation.rs_fec = port_data.get('fec', False)
+        layer1.auto_negotiation.rs_fec = _snappi_rs_fec_enabled(port_data)
         layer1.auto_negotiation.link_training = port_data.get('link_training', False)
-        layer1.speed = port_data['speed']
+        layer1.speed = _snappi_layer1_speed(port_data)
         layer1.auto_negotiate = port_data.get('autoneg', False)
 
     def create_v4_topo():
@@ -941,11 +1021,11 @@ def get_RIB_IN_capacity(snappi_api,
             layer1 = config.layer1.layer1()[-1]
             layer1.name = f"{index}_settings"
             layer1.port_names = [config.ports[index].name]
-            layer1.speed = port_data['speed']
+            layer1.speed = _snappi_layer1_speed(port_data)
             layer1.ieee_media_defaults = False
-            layer1.auto_negotiation.rs_fec = port_data.get('fec', False)
+            layer1.auto_negotiation.rs_fec = _snappi_rs_fec_enabled(port_data)
             layer1.auto_negotiation.link_training = port_data.get('link_training', False)
-            layer1.speed = port_data['speed']
+            layer1.speed = _snappi_layer1_speed(port_data)
             layer1.auto_negotiate = port_data.get('autoneg', False)
 
         def create_v4_topo():

--- a/tests/snappi_tests/bgp/files/bgp_test_gap_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_test_gap_helper.py
@@ -3,6 +3,7 @@ from tests.common.utilities import (wait)
 from tests.common.helpers.assertions import pytest_assert
 import logging
 import json
+import time
 logger = logging.getLogger(__name__)
 
 TGEN_AS_NUM = 65200
@@ -12,6 +13,60 @@ BGP_TYPE = 'ebgp'
 temp_tg_port = dict()
 NG_LIST = []
 aspaths = [65002, 65003]
+
+
+def _unbind_everflow_acl_from_ports(duthost, ports):
+    """Remove EVERFLOW ACL tables when they are bound to the ports used by this test."""
+    target_ports = set(ports)
+    acl_table_out = duthost.shell("show acl table", module_ignore_errors=True)
+    acl_stdout = acl_table_out.get('stdout', '')
+    if not acl_stdout:
+        logger.warning('DEBUG: show acl table returned no output; skipping EVERFLOW unbind')
+        return
+    for table_name in ('EVERFLOW', 'EVERFLOWV6'):
+        if table_name not in acl_stdout:
+            continue
+        bound_to_target = False
+        for line in acl_stdout.splitlines():
+            if table_name in line and any(port in line for port in target_ports):
+                bound_to_target = True
+                break
+        if not bound_to_target:
+            continue
+        logger.warning('DEBUG: Removing ACL table %s to unbind test ports %s', table_name, sorted(target_ports))
+        rm_result = duthost.shell('sudo config acl remove table {}'.format(table_name), module_ignore_errors=True)
+        logger.warning('DEBUG: ACL remove result for %s: %s', table_name, rm_result)
+        pytest_assert(
+            rm_result.get('rc', 1) == 0 and 'Error' not in rm_result.get('stderr', ''),
+            'Failed to remove ACL table {} before BGP PortChannel setup: {}'.format(
+                table_name, rm_result.get('stderr', '')))
+
+
+def _snappi_layer1_speed(port_entry):
+    speed = port_entry.get('snappi_speed_type') or port_entry.get('speed')
+    if isinstance(speed, str) and speed.startswith('speed_'):
+        return speed
+    return 'speed_{}_gbps'.format(int(int(speed) / 1000))
+
+
+def _snappi_rs_fec_enabled(port_entry):
+    """Infer RS-FEC behavior when fixture does not provide explicit FEC fields."""
+    if port_entry.get('fec_disable') is True:
+        return False
+    if 'fec' in port_entry:
+        return bool(port_entry.get('fec'))
+    speed = port_entry.get('snappi_speed_type') or port_entry.get('speed')
+    if isinstance(speed, str) and speed.startswith('speed_'):
+        try:
+            speed_g = int(speed.replace('speed_', '').replace('_gbps', ''))
+        except ValueError:
+            speed_g = 0
+    else:
+        try:
+            speed_g = int(int(speed) / 1000)
+        except Exception:
+            speed_g = 0
+    return speed_g >= 100
 
 
 def run_bgp_convergence_performance(snappi_api,
@@ -101,7 +156,45 @@ def run_bgp_scalability_v4_v6(snappi_api,
     """
         Run the BGP Scalability test
     """
-    get_bgp_scalability_result(snappi_api, localhost, tgen_bgp_config, limit_flag, duthost)
+    # Debug: Print TGEN config summary
+    logger.info("TGEN BGP config: %s", tgen_bgp_config)
+    for flow in getattr(tgen_bgp_config, 'flows', []):
+        logger.info("Flow %s: tx_rx=%s, packet=%s", getattr(flow, 'name', ''), getattr(flow, 'tx_rx', ''), getattr(flow, 'packet', ''))
+
+    # Debug: Print BGP session and route state before traffic
+    try:
+        logger.info("BGP summary:\n%s", duthost.shell("show ip bgp summary")['stdout'])
+        logger.info("BGP IPv4 neighbors:\n%s", duthost.shell("show ip bgp neighbors")['stdout'])
+        logger.info("BGP IPv6 summary:\n%s", duthost.shell("show ipv6 bgp summary")['stdout'])
+        logger.info("FIB routes:\n%s", duthost.shell("show ip route")['stdout'])
+    except Exception as e:
+        logger.warning("Could not fetch BGP/FIB info: %s", e)
+
+    # Debug: List core files before traffic
+    try:
+        core_files_before = duthost.shell("ls /var/core/", module_ignore_errors=True)['stdout_lines']
+        logger.info("Core files before traffic: %s", core_files_before)
+    except Exception as e:
+        logger.warning("Could not list core files before traffic: %s", e)
+
+    get_bgp_scalability_result(snappi_api,
+                               localhost,
+                               tgen_bgp_config,
+                               limit_flag,
+                               duthost,
+                               ipv4_routes,
+                               ipv6_routes)
+
+    # Debug: List core files after traffic
+    try:
+        core_files_after = duthost.shell("ls /var/core/", module_ignore_errors=True)['stdout_lines']
+        logger.info("Core files after traffic: %s", core_files_after)
+        new_cores = set(core_files_after) - set(core_files_before)
+        if new_cores:
+            logger.error("New core dumps detected after traffic: %s", new_cores)
+            logger.info("Last 100 lines of syslog:\n%s", duthost.shell("tail -n 100 /var/log/syslog")['stdout'])
+    except Exception as e:
+        logger.warning("Could not list core files after traffic: %s", e)
 
 
 def duthost_bgp_scalability_config(duthost, tgen_ports, multipath):
@@ -117,6 +210,32 @@ def duthost_bgp_scalability_config(duthost, tgen_ports, multipath):
     duthost.command('sudo crm config thresholds ipv4 route high 85')
     duthost.command('sudo crm config thresholds ipv4 route low 70')
     temp_tg_port = tgen_ports
+    _unbind_everflow_acl_from_ports(
+        duthost,
+        [tgen_ports[i]['peer_port'] for i in range(port_count)]
+    )
+
+    # Remove test ports from any existing Vlan/PortChannel membership before
+    # adding to new PortChannels (SONiC won't allow adding a Vlan member to a PC)
+    config_db_current = json.loads(duthost.shell("sonic-cfggen -d --print-data")['stdout'])
+    vlan_members = config_db_current.get("VLAN_MEMBER", {})
+    pc_members = config_db_current.get("PORTCHANNEL_MEMBER", {})
+    for i in range(port_count):
+        peer_port = tgen_ports[i]['peer_port']
+        for vlan_key in list(vlan_members.keys()):
+            vlan_name, member_port = vlan_key.split('|', 1)
+            if member_port == peer_port:
+                vlan_id = vlan_name.replace('Vlan', '')
+                logger.info(f"Removing {peer_port} from {vlan_name} before PortChannel config")
+                duthost.shell(f"sudo config vlan member del {vlan_id} {peer_port}",
+                              module_ignore_errors=True)
+        for pc_key in list(pc_members.keys()):
+            pc_name, member_port = pc_key.split('|', 1)
+            if member_port == peer_port:
+                logger.info(f"Removing {peer_port} from {pc_name} before PortChannel config")
+                duthost.shell(f"sudo config portchannel member del {pc_name} {peer_port}",
+                              module_ignore_errors=True)
+
     for i in range(port_count):
         port = tgen_ports[i]
         intf_config = (
@@ -124,19 +243,26 @@ def duthost_bgp_scalability_config(duthost, tgen_ports, multipath):
             f"sudo config interface ip remove {port['peer_port']} {port['peer_ipv6']}/{port['ipv6_prefix']}\n"
         )
         logger.info(f"Removing IPs from {port['peer_port']}")
-        duthost.shell(intf_config)
+        duthost.shell(intf_config, module_ignore_errors=True)
 
     for i in range(port_count):
         port = tgen_ports[i]
         idx = i + 1
-        portchannel_config = (
-            f"sudo config portchannel add PortChannel{idx} \n"
-            f"sudo config portchannel member add PortChannel{idx} {port['peer_port']}\n"
-            f"sudo config interface ip add PortChannel{idx} {port['peer_ip']}/{port['prefix']}\n"
-            f"sudo config interface ip add PortChannel{idx} {port['peer_ipv6']}/{port['ipv6_prefix']}\n"
-        )
         logger.info(f"Configuring {port['peer_port']} to PortChannel{idx}")
-        duthost.shell(portchannel_config)
+        duthost.shell(f"sudo config portchannel add PortChannel{idx}",
+                      module_ignore_errors=True)
+        result = duthost.shell(
+            f"sudo config portchannel member add PortChannel{idx} {port['peer_port']}")
+        pytest_assert(
+            result.get('rc', 1) == 0,
+            f"Failed to add {port['peer_port']} to PortChannel{idx}: {result.get('stderr', '')}")
+        pytest_assert(
+            'Error:' not in result.get('stderr', ''),
+            f"PortChannel{idx} member add failed for {port['peer_port']}: {result.get('stderr', '')}")
+        duthost.shell(
+            f"sudo config interface ip add PortChannel{idx} {port['peer_ip']}/{port['prefix']}")
+        duthost.shell(
+            f"sudo config interface ip add PortChannel{idx} {port['peer_ipv6']}/{port['ipv6_prefix']}")
 
     duthost.command("sudo config save -y")
     # BGP Configuration
@@ -146,6 +272,15 @@ def duthost_bgp_scalability_config(duthost, tgen_ports, multipath):
         "Loopback0|1::1/128": {},
     }
     config_db = json.loads(duthost.shell("sonic-cfggen -d --print-data")['stdout'])
+    all_test_ports = tgen_ports[:port_count]
+    bgp_ports = tgen_ports[:port_count]
+
+    # Remove stale Snappi neighbors from prior runs, then add neighbors for all test ports.
+    bgp_neighbor_table = config_db.setdefault("BGP_NEIGHBOR", {})
+    for port in all_test_ports:
+        bgp_neighbor_table.pop(port['ip'], None)
+        bgp_neighbor_table.pop(port['ipv6'], None)
+
     bgp_neighbors = {
         addr: {
             "asn": TGEN_AS_NUM,
@@ -156,29 +291,41 @@ def duthost_bgp_scalability_config(duthost, tgen_ports, multipath):
             "nhopself": "0",
             "rrclient": "0",
         }
-        for port in tgen_ports
+        for port in bgp_ports
         for addr, ip_version in [(port['ip'], port['peer_ip']), (port['ipv6'], port['peer_ipv6'])]
     }
 
-    device_neighbors = {
-        port['peer_port']: {
+    # Keep Snappi neighbor metadata only for Rx-side BGP ports used in this test.
+    device_neighbor_table = config_db.setdefault("DEVICE_NEIGHBOR", {})
+    for port in all_test_ports:
+        device_neighbor_table.pop(port['peer_port'], None)
+    for port in bgp_ports:
+        device_neighbor_table[port['peer_port']] = {
             "name": "snappi-sonic",
             "port": "Ethernet1"
         }
-        for port in tgen_ports
+
+    device_neighbor_metadata_table = config_db.setdefault("DEVICE_NEIGHBOR_METADATA", {})
+    device_neighbor_metadata_table["snappi-sonic"] = {
+        "hwsku": "snappi-sonic",
+        "mgmt_addr": "172.16.149.206",
+        "type": "LeafRouter"
     }
 
-    device_neighbor_metadatas = {
-        "snappi-sonic": {
-            "hwsku": "snappi-sonic",
-            "mgmt_addr": "172.16.149.206",
-            "type": "ToRRouter"
+    # Remove test ports from VLAN_MEMBER in the config_db so they don't get
+    # restored as Vlan members after config reload.
+    # Do NOT filter PORTCHANNEL_MEMBER — the new PortChannel memberships added
+    # above were saved by config save -y and must survive the reload.
+    test_ports = {tgen_ports[i]['peer_port'] for i in range(port_count)}
+    if "VLAN_MEMBER" in config_db:
+        config_db["VLAN_MEMBER"] = {
+            k: v for k, v in config_db["VLAN_MEMBER"].items()
+            if k.split('|', 1)[-1] not in test_ports
         }
-    }
     config_db.setdefault("LOOPBACK_INTERFACE", {}).update(loopback_interfaces)
     config_db.setdefault("BGP_NEIGHBOR", {}).update(bgp_neighbors)
-    config_db.setdefault("DEVICE_NEIGHBOR_METADATA", {}).update(device_neighbor_metadatas)
-    config_db.setdefault("DEVICE_NEIGHBOR", {}).update(device_neighbors)
+    config_db.setdefault("DEVICE_NEIGHBOR", {}).update(device_neighbor_table)
+    config_db.setdefault("DEVICE_NEIGHBOR_METADATA", {}).update(device_neighbor_metadata_table)
     with open("/tmp/temp_config.json", 'w') as fp:
         json.dump(config_db, fp, indent=4)
     duthost.copy(src="/tmp/temp_config.json", dest="/etc/sonic/config_db.json")
@@ -188,6 +335,23 @@ def duthost_bgp_scalability_config(duthost, tgen_ports, multipath):
         pytest_assert('Error' not in duthost.shell("sudo config reload -y \n")['stderr'],
                       'Error while reloading config in {} !!!!!'.format(duthost.hostname))
     wait(60, "For DUT to come back online after config reload")
+
+    # Validate that runtime BGP neighbor config contains Snappi peers for this test.
+    runtime_bgp_neighbors = duthost.shell("sonic-cfggen -d -v BGP_NEIGHBOR", module_ignore_errors=True)
+    logger.info("Runtime BGP_NEIGHBOR table:\n%s", runtime_bgp_neighbors.get('stdout', ''))
+    logger.info("Runtime IPv4 BGP summary after reload:\n%s", duthost.shell("show ip bgp summary", module_ignore_errors=True).get('stdout', ''))
+    logger.info("Runtime IPv6 BGP summary after reload:\n%s", duthost.shell("show ipv6 bgp summary", module_ignore_errors=True).get('stdout', ''))
+    expected_v4 = [p['ip'] for p in bgp_ports]
+    expected_v6 = [p['ipv6'] for p in bgp_ports]
+    missing_neighbors = [
+        n for n in (expected_v4 + expected_v6)
+        if n not in runtime_bgp_neighbors.get('stdout', '')
+    ]
+    pytest_assert(
+        not missing_neighbors,
+        "Missing Snappi BGP neighbors in runtime config after reload: {}".format(missing_neighbors)
+    )
+
     logger.info('Config Reload Successful in {} !!!'.format(duthost.hostname))
 
 
@@ -214,28 +378,37 @@ def __tgen_bgp_config(snappi_api,
         config.ports.port(name="Source", location=temp_tg_port[0]['location'])
         .port(name="Destination", location=temp_tg_port[1]['location'])
     )
+
     lag1 = config.lags.lag(name="lag1")[-1]
     lp1 = lag1.ports.port(port_name=p1.name)[-1]
-
-    lag1.protocol.lacp.actor_system_id = "00:11:03:00:00:03"
+    lag1.protocol.lacp.actor_system_id = "00:10:00:00:00:01"
+    lag1.protocol.lacp.actor_system_priority = int(1)
+    lag1.protocol.lacp.actor_key = int(1)
     lp1.ethernet.name = "lag_Ethernet 1"
-    lp1.ethernet.mac = "00:13:01:00:00:01"
+    lp1.ethernet.mac = "00:10:01:00:00:01"
+    lp1.lacp.actor_port_number = int(1)
+    lp1.lacp.actor_port_priority = int(1)
 
     lag2 = config.lags.lag(name="lag2")[-1]
     lp2 = lag2.ports.port(port_name=p2.name)[-1]
-    lag2.protocol.lacp.actor_system_id = "00:11:03:00:00:04"
+    lag2.protocol.lacp.actor_system_id = "00:10:00:00:00:02"
+    lag2.protocol.lacp.actor_system_priority = int(1)
+    lag2.protocol.lacp.actor_key = int(1)
     lp2.ethernet.name = "lag_Ethernet 2"
-    lp2.ethernet.mac = "00:13:01:00:00:02"
+    lp2.ethernet.mac = "00:10:01:00:00:02"
+    lp2.lacp.actor_port_number = int(1)
+    lp2.lacp.actor_port_priority = int(1)
 
     config.options.port_options.location_preemption = True
-    layer1 = config.layer1.layer1()[-1]
-    layer1.name = 'port settings'
-    layer1.port_names = [port.name for port in config.ports]
-    layer1.ieee_media_defaults = False
-    layer1.auto_negotiation.rs_fec = temp_tg_port[0].get('fec', False)
-    layer1.auto_negotiation.link_training = temp_tg_port[0].get('link_training', False)
-    layer1.speed = temp_tg_port[0]['speed']
-    layer1.auto_negotiate = temp_tg_port[0].get('autoneg', False)
+    for index, port_data in enumerate(temp_tg_port[:2]):
+        layer1 = config.layer1.layer1()[-1]
+        layer1.name = '{}_settings'.format(index)
+        layer1.port_names = [config.ports[index].name]
+        layer1.speed = _snappi_layer1_speed(port_data)
+        layer1.ieee_media_defaults = False
+        layer1.auto_negotiation.rs_fec = _snappi_rs_fec_enabled(port_data)
+        layer1.auto_negotiation.link_training = port_data.get('link_training', False)
+        layer1.auto_negotiate = port_data.get('autoneg', False)
 
     # Source
     config.devices.device(name='Tx')
@@ -372,7 +545,7 @@ def get_convergence_for_remote_link_failover(snappi_api,
         layer1.ieee_media_defaults = False
         layer1.auto_negotiation.rs_fec = temp_tg_port[0].get('fec', False)
         layer1.auto_negotiation.link_training = temp_tg_port[0].get('link_training', False)
-        layer1.speed = temp_tg_port[0]['speed']
+        layer1.speed = _snappi_layer1_speed(temp_tg_port[0])
         layer1.auto_negotiate = temp_tg_port[0].get('autoneg', False)
 
         def create_v4_topo():


### PR DESCRIPTION
### Description of PR

Summary:
- Improve Snappi fixture behavior by selecting direct Ixia peer from connection graph data even when it is behind L1 switch
- Improve tgen port L3 metadata handling
- Align BGP convergence helper on interface attributes such as port speed, ACL and FEC handling (including PortChannel FEC RS behavior) to improve https://github.com/sonic-net/sonic-mgmt/pull/24405 which creates L3 interfaces for BGP tests

Fixes https://github.com/sonic-net/sonic-mgmt/issues/23857

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Snappi/Ixia discovery and port metadata resolution were brittle across some topologies (especially when Ixia traffic generator is not a direct DUT peer i.e. behind L1 switch). This could lead to wrong fanout selection and unstable BGP/snappi port setup behavior.

#### How did you do it?
- Enhanced `get_peer_snappi_chassis(...)` to support robust peer detection using:
  - peer hostname patterns
  - device `Type` / `HwSku`
  - peer port naming heuristics
- Kept direct-peer-only behavior for fixture compatibility (without fallback to `tbinfo['tgs']` for peer resolution).
- Updated snappi fixture flow to:
  - normalize/collect interface IP data
  - enrich tgen ports with IPv4/IPv6 and ASN info from config facts/BGP neighbor tables
  - filter to available direct fanouts in `fanout_graph_facts`
- Updated BGP convergence helper to:
  - normalize L1 speed resolution from fixture data
  - infer RS-FEC behavior when explicit fields are not present
- Added focused unit tests for `get_peer_snappi_chassis` behavior in:
  - `tbinfo is None`
  - `tbinfo` contains `tgs`

#### How did you verify/test it?
- Ran unit tests with conftest bypass:
  - `python3 -m pytest --noconftest tests/common/unit_tests/snappi_tests/unit_test_common_helpers.py`
- Result: all tests passed.

#### Any platform specific information?
No platform-specific dependency introduced. Changes are in shared snappi framework/helper logic.

#### Supported testbed topology if it's a new test case?
Not a new test case; framework and unit-test improvement for Snappi-related paths.

### Documentation
No documentation update required (no new user-facing feature/API).