### PR TITLE
[cacl] Add dhcp_server_syslog iptables rule to expected rules

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -534,6 +534,13 @@ def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expecte
                                    .format(v['IPv6Address'],
                                            docker_network['bridge']['IPv6Address']))
 
+        # dhcp_server uses bridge networking; its startup script adds an iptables
+        # rule to allow syslog (UDP 514) past caclmgrd's catch-all DROP.
+        if "dhcp_server" in docker_network['container']:
+            iptables_rules.append(
+                "-A INPUT -i docker0 -p udp -m udp --dport 514"
+                " -m comment --comment dhcp_server_syslog -j ACCEPT")
+
     else:
         iptables_rules.append("-A INPUT -s {}/32 -d {}/32 -j ACCEPT".format(docker_network['container']['database'
                                                                             + str(asic_index)]['IPv4Address'],

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -687,12 +687,6 @@ bmp/:
 #######################################
 #####            cacl             #####
 #######################################
-cacl/test_cacl_application.py:
-  skip:
-    reason: "skip test_cacl_application in PR test temporarily"
-    conditions:
-      - "asic_type in ['vs']"
-
 cacl/test_cacl_application.py::test_cacl_acl_loader_commands_internal:
   skip:
     reason: "test_cacl_acl_loader_commands_internal is only supported on t0/t1 testbed"


### PR DESCRIPTION
### Description of PR

Summary:
Add the `dhcp_server_syslog` iptables rule to the expected rules in `test_cacl_application`. This rule was introduced in sonic-buildimage PR https://github.com/sonic-net/sonic-buildimage/pull/27255 — the `dhcp_server` container (bridge networking mode) adds an iptables ACCEPT rule for UDP port 514 on docker0 to allow syslog past caclmgrd's catch-all DROP.

Also remove the temporary skip for `cacl/test_cacl_application.py` on VS platform in `tests_mark_conditions.yaml` since the test can now handle this rule properly.

Fixes https://msazure.visualstudio.com/One/_workitems/edit/37977688

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The `dhcp_server` container uses bridge networking (`docker0`). When CACL rules are configured, `caclmgrd` adds a catch-all `iptables -A INPUT -j DROP`. To allow syslog (UDP 514) from the container to host rsyslog, sonic-buildimage PR #27255 added an iptables ACCEPT rule during container startup. The `test_cacl_application` test was not aware of this new rule and flagged it as "unexpected".

#### How did you do it?
1. In `generate_expected_rules()`, when `dhcp_server` is present in `docker_network['container']`, append the expected iptables rule: `-A INPUT -i docker0 -p udp -m udp --dport 514 -m comment --comment dhcp_server_syslog -j ACCEPT`
2. Removed the blanket VS skip for the test module from `tests_mark_conditions.yaml`

#### How did you verify/test it?
Verified the rule string matches the actual iptables output from the failing test log on MX topology
```
Results (130.16s (0:02:10)):
       1 passed
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_cacl_application_nondualtor[bjw2-can-7215-3-None]>
```

#### Any platform specific information?
Affects platforms running `dhcp_server` container in bridge mode (M0/MX topology with Nokia-7215 and similar).

#### Supported testbed topology if it's a new test case?
N/A (bug fix for existing test)

### Documentation
N/A