### PR TITLE
[smartswitch]: Skip admin-down DPUs in sanity check and health_checker

### DIFF
--- a/ansible/health_checker.py
+++ b/ansible/health_checker.py
@@ -40,6 +40,58 @@ def get_testbeds_dict():
     return testbeds_dict
 
 
+def _get_admin_down_dpu_hostnames(tbinfo):
+    """Return the set of DPU hostnames administratively down for a testbed.
+
+    Mirrors ``tests.common.helpers.dut_utils.get_admin_down_dpu_hostnames`` but
+    kept self-contained so this ansible-side script has no dependency on the
+    pytest tree.
+
+    A DPU hostname has the form ``<npu_hostname>-dpu-<index>``. The testbed.yaml
+    ``enabled_dpus`` mapping lists the DPU indices that should be admin-up for
+    each NPU; any DPU index missing from that list is treated as admin-down.
+
+    If ``enabled_dpus`` is absent for the testbed, returns an empty set
+    (legacy behavior).
+    """
+    admin_down = set()
+    if not tbinfo:
+        return admin_down
+
+    enabled_dpus = tbinfo.get('enabled_dpus')
+    if not enabled_dpus:
+        return admin_down
+
+    duts = tbinfo.get('duts', []) or []
+    for npu_host, dpu_entries in enabled_dpus.items():
+        enabled_indices = set()
+        for entry in (dpu_entries or []):
+            if isinstance(entry, dict) and 'dpu_index' in entry:
+                try:
+                    enabled_indices.add(int(entry['dpu_index']))
+                except (TypeError, ValueError):
+                    continue
+            else:
+                try:
+                    enabled_indices.add(int(entry))
+                except (TypeError, ValueError):
+                    continue
+
+        prefix = "{}-dpu-".format(npu_host)
+        for dut in duts:
+            if not dut.startswith(prefix):
+                continue
+            suffix = dut[len(prefix):]
+            try:
+                idx = int(suffix)
+            except ValueError:
+                continue
+            if idx not in enabled_indices:
+                admin_down.add(dut)
+
+    return admin_down
+
+
 def get_server_host(inventory_files, server):
     if not has_ansible:
         raise Exception("Ansible is needed for this module")
@@ -79,7 +131,16 @@ def parse_ping_result(ping_dict, testbeds_dict, skip_testbeds):
     """
     final_results = []
     for testbed_name, tbinfo in testbeds_dict.items():
+        admin_down_dpus = _get_admin_down_dpu_hostnames(tbinfo)
         for duthost in tbinfo['duts']:
+            # Skip DPU hostnames that are administratively down per testbed.yaml
+            # `enabled_dpus` mapping. These DPUs are intentionally offline and
+            # should not affect testbed health reporting.
+            if duthost in admin_down_dpus:
+                logging.debug(
+                    "Skipping admin-down DPU %s in testbed %s",
+                    duthost, testbed_name)
+                continue
             device_result = {}
             # skip defined testbeds
             if skip_testbeds and skip_testbeds != '' and testbed_name in skip_testbeds:

--- a/tests/common/devices/duthosts.py
+++ b/tests/common/devices/duthosts.py
@@ -2,6 +2,7 @@ import logging
 import sys
 
 from tests.common.devices.multi_asic import MultiAsicSonicHost
+from tests.common.helpers.dut_utils import get_admin_down_dpu_hostnames
 from tests.common.helpers.parallel_utils import is_initial_checks_active
 
 logger = logging.getLogger(__name__)
@@ -63,6 +64,15 @@ class DutHosts(object):
         self.request = request
         self.duts = duts
         self.is_parallel_run = target_hostname is not None
+        # DPU hostnames that should be skipped because their parent NPU has
+        # them administratively down per testbed.yaml `enabled_dpus`. See
+        # tests/common/helpers/dut_utils.get_admin_down_dpu_hostnames.
+        self._admin_down_dpus = get_admin_down_dpu_hostnames(tbinfo)
+        if self._admin_down_dpus:
+            logger.info(
+                "Excluding admin-down DPU hostnames from duthosts: %s",
+                sorted(self._admin_down_dpus),
+            )
         # Initialize _nodes to None to avoid recursion in __getattr__
         self._nodes = None
         self._nodes_for_parallel = None
@@ -87,6 +97,7 @@ class DutHosts(object):
                     self,
                     self.tbinfo['topo']['type'],
                 ) for hostname in self.tbinfo["duts"]
+                if hostname not in self._admin_down_dpus
             ])
 
             self._nodes_for_parallel_tests = self._Nodes([
@@ -122,7 +133,8 @@ class DutHosts(object):
                 hostname,
                 self,
                 self.tbinfo['topo']['type'],
-            ) for hostname in self.tbinfo["duts"] if hostname in self.duts
+            ) for hostname in self.tbinfo["duts"]
+            if hostname in self.duts and hostname not in self._admin_down_dpus
         ])
 
         self._supervisor_nodes = self._Nodes([node for node in self._nodes if node.is_supervisor_node()])

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -71,6 +71,66 @@ def is_macsec_capable_node(inv_files, hostname):
     return False
 
 
+def get_admin_down_dpu_hostnames(tbinfo):
+    """Return the set of DPU hostnames that are administratively down per testbed.yaml.
+
+    A DPU hostname has the form ``<npu_hostname>-dpu-<index>``. The testbed.yaml
+    ``enabled_dpus`` mapping (added by PR #24573) lists the DPU indices that
+    should be admin-up for each NPU; any DPU index missing from that list is
+    treated as admin-down.
+
+    Behavior:
+        - If ``enabled_dpus`` is absent for the testbed → returns empty set
+          (legacy behavior: no DPUs are filtered out).
+        - If ``enabled_dpus`` is present but the parent NPU is not listed →
+          DPUs of that NPU are NOT filtered (legacy behavior for that NPU).
+        - If ``enabled_dpus[npu]`` is an explicit empty list → every DPU of
+          that NPU is marked admin-down.
+
+    Args:
+        tbinfo: Testbed info dict (from the ``tbinfo`` fixture).
+
+    Returns:
+        set[str]: DPU hostnames that should be skipped by sanity/health checks.
+    """
+    admin_down = set()
+    if not tbinfo:
+        return admin_down
+
+    enabled_dpus = tbinfo.get('enabled_dpus')
+    if not enabled_dpus:
+        return admin_down
+
+    duts = tbinfo.get('duts', []) or []
+    for npu_host, dpu_entries in enabled_dpus.items():
+        enabled_indices = set()
+        for entry in (dpu_entries or []):
+            if isinstance(entry, dict) and 'dpu_index' in entry:
+                try:
+                    enabled_indices.add(int(entry['dpu_index']))
+                except (TypeError, ValueError):
+                    continue
+            else:
+                try:
+                    enabled_indices.add(int(entry))
+                except (TypeError, ValueError):
+                    continue
+
+        prefix = "{}-dpu-".format(npu_host)
+        for dut in duts:
+            if not dut.startswith(prefix):
+                continue
+            suffix = dut[len(prefix):]
+            try:
+                idx = int(suffix)
+            except ValueError:
+                continue
+            if idx not in enabled_indices:
+                admin_down.add(dut)
+
+    return admin_down
+
+
 def is_container_running(duthost, container_name):
     """Decides whether the container is running or not
     @param duthost: Host DUT.


### PR DESCRIPTION
### Description of PR
Summary:
On SmartSwitch testbeds, individual DPUs can be administratively shut down via the `enabled_dpus` mapping in `testbed.yaml` (introduced by #24573). When such DPUs are still listed under `duts`, the existing pytest sanity_check loops and the `ansible/health_checker.py` ICMP report both fail on them because they are intentionally offline.

This PR makes both code paths skip DPU hostnames whose index is absent from `enabled_dpus[<npu>]`, while keeping behavior fully backward-compatible for testbeds that do not set `enabled_dpus`.

Fixes #

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
SmartSwitch deployments commonly run with only a subset of DPUs administratively up. Today every DPU listed in `duts` is exercised by sanity / health checks, which makes such testbeds appear unhealthy and aborts tests on what is in fact the intended configuration. We need an opt-in way to tell the framework which DPUs should be ignored by checks.

#### How did you do it?
- Added a helper `get_admin_down_dpu_hostnames(tbinfo)` in `tests/common/helpers/dut_utils.py` that returns the set of DPU hostnames (`<npu>-dpu-<index>`) whose index is missing from `enabled_dpus[<npu>]`.
- In `tests/common/devices/duthosts.py`, `DutHosts.__init__` uses the helper to exclude those hostnames during node init, so they disappear from `duthosts.nodes` / `frontend_nodes` / `supervisor_nodes` and all sanity_check loops skip them automatically. They are still reachable via `dpuhosts` for tests that target DPUs directly.
- In `ansible/health_checker.py`, `parse_ping_result()` skips the same hostnames before writing `testbed_ping.json`.

Backward compatibility: if `enabled_dpus` is absent the helper returns an empty set and behavior is unchanged.

#### How did you verify/test it?
- Inline unit tests of `get_admin_down_dpu_hostnames` covering 7 scenarios: `None` tbinfo, missing `enabled_dpus`, dict-form entries, empty list, plain-int form, malformed entries, partial NPU coverage — all pass.
- TODO: Run sanity_check on a SmartSwitch testbed configured with a subset of DPUs admin-up to confirm that previously failing checks on admin-down DPUs are now skipped while admin-up DPUs are still validated. (Not yet executed on hardware — pending.)

#### Any platform specific information?
SmartSwitch only. Behavior on non-SmartSwitch testbeds is unchanged because `enabled_dpus` is not set.

#### Supported testbed topology if it's a new test case?
N/A (framework improvement, not a new test case). Exercised on `t1-smartswitch-ha` and similar SmartSwitch topologies.

### Documentation
N/A