### PR TITLE
[ssw] fix PORT lanes validation

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -506,6 +506,16 @@ class GenerateGoldenConfigDBModule(object):
         if "PORT" not in ori_config_db or "INTERFACE" not in ori_config_db:
             return "{}"
 
+        # Filter PORT entries: YANG validation requires the 'lanes' leaf for
+        # every PORT_LIST entry.  sonic-cfggen may emit PORT entries (e.g. from
+        # init_cfg.json or internal ports) that lack 'lanes', which causes
+        # 'config load_minigraph --override_config' to abort.  Exclude them so
+        # the golden config remains YANG-valid; those ports will keep their
+        # minigraph-generated values.
+        ori_config_db["PORT"] = {
+            k: v for k, v in ori_config_db["PORT"].items() if "lanes" in v
+        }
+
         if hwsku not in smartswitch_hwsku_config:
             return "{}"
 


### PR DESCRIPTION
### Description of PR

Summary:
`config load_minigraph --override_config -y` was failing on SmartSwitch testbeds with:

```
libyang[0]: Missing required element "lanes" in "PORT_LIST". (path: /sonic-port:sonic-port/PORT/PORT_LIST[name='etp1'])
Aborted!
/etc/sonic/golden_config_db.json fails YANG validation! Error: Data Loading Failed
Missing required element "lanes" in "PORT_LIST".
```

`sonic-cfggen` can emit PORT entries (e.g. `etp1`) without the `lanes` field. Since `--override_config` validates `golden_config_db.json` against YANG before applying it, any PORT entry missing `lanes` causes an abort.

Fix: filter out PORT entries without `lanes` before writing the golden config. Those ports retain their minigraph-generated values.

### Type of change

- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`deploy-mg` was failing on SmartSwitch testbeds (Cisco-8102-28FH-DPU-O) due to YANG validation rejecting PORT entries without `lanes` in `golden_config_db.json`.

#### How did you do it?
In `generate_smartswitch_golden_config_db()`, filter `ori_config_db["PORT"]` to only include entries that have a `lanes` field before writing them into the golden config.

#### How did you verify/test it?
- Ran `deploy-mg` on testbed `vms25-t1-smartswitch-ha-8102-01` (str2-8102-smartswitch-03, str2-8102-smartswitch-04): both DUTs completed with `failed=0`.
- Ran `config load_minigraph --override_config -y` a second time directly on both DUTs: `rc=0`, no YANG errors.
- Confirmed all 36 PORT entries in the resulting `golden_config_db.json` have `lanes`.

#### Any platform specific information?
Cisco-8102-28FH-DPU-O SmartSwitch. May affect any SmartSwitch hwsku where `sonic-cfggen` emits PORT entries without `lanes`.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation