### PR TITLE
fix: fix mkdirat var/run: file exists

### DIFF
--- a/setup-container.sh
+++ b/setup-container.sh
@@ -266,9 +266,19 @@ chmod 0600 /home/${USER}/.ssh/authorized_keys
 chown -R ${HOST_UID}:${HOST_GID} /home/${USER}/.ssh
 SETUP_EOF
 
-    docker cp "${TMP_SETUP}" "${CONTAINER_NAME}:/tmp/setup_user.sh"
-    docker cp "${PRIVKEY_FILE}" "${CONTAINER_NAME}:/tmp/id_ed25519"
-    docker cp "${PUBKEY_FILE}" "${CONTAINER_NAME}:/tmp/id_ed25519.pub"
+    # Use `docker exec -i ... tee` instead of `docker cp` to inject these files.
+    # `docker cp` into a running container goes through the daemon's tar-extract
+    # path, which trips a moby/runc mkdirat bug on the current docker-sonic-mgmt
+    # image ("Error response from daemon: mkdirat var/run: file exists"). The
+    # daemon prints the error but `docker cp` still exits 0, so `set -e` cannot
+    # catch the failure; setup_user.sh later fails with
+    # "/tmp/setup_user.sh: No such file or directory". `docker exec ... tee` does
+    # not use the tar-extract path, propagates the real exit code, and is
+    # already proven on the next line (ssh_pubkey_to_add).
+    docker exec -i --user root "${CONTAINER_NAME}" tee /tmp/setup_user.sh < "${TMP_SETUP}" > /dev/null
+    docker exec -i --user root "${CONTAINER_NAME}" tee /tmp/id_ed25519 < "${PRIVKEY_FILE}" > /dev/null
+    docker exec --user root "${CONTAINER_NAME}" chmod 0600 /tmp/id_ed25519
+    docker exec -i --user root "${CONTAINER_NAME}" tee /tmp/id_ed25519.pub < "${PUBKEY_FILE}" > /dev/null
     echo "${SSH_PUBKEY}" | docker exec -i --user root "${CONTAINER_NAME}" tee /tmp/ssh_pubkey_to_add > /dev/null
     rm -f "${TMP_SETUP}"
     trap - RETURN


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix setup container issue

```
+ docker rm -f sonic-mgmt
sonic-mgmt
+ ./setup-container.sh -n sonic-mgmt -e SONIC_AUTOMATION_PROXY_GITHUB_ISSUES_URL=https://sonic-elastictest-prod-proxy-webapp.azurewebsites.net/get_github_issues -e ELASTICTEST_TEST_PLAN_ID=6a0bd957672c47a2a90223dd -v
NOTICE: using default bind mount directory: /var/src
INFO: pulling docker image from a registry ...
latest: Pulling from docker-sonic-mgmt
Digest: sha256:95de00dc1a418aaaf8e7d338b5848f8478063bf236f986f3e48a4e4ad3b19800
Status: Image is up to date for sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest
sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest
NOTICE: using default docker image: sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest
INFO: read SSH public key: /home/AzDevOps/.ssh/id_ed25519_docker_sonic_mgmt.pub
INFO: creating a container: sonic-mgmt ...
e642301f9eb73883a8ff5c3c954685e611a785a575231a0810ae9b8579b4012d
INFO: configuring user AzDevOps inside container ...
Error response from daemon: mkdirat var/run: file exists
Error response from daemon: mkdirat var/run: file exists
Error response from daemon: mkdirat var/run: file exists
bash: /tmp/setup_user.sh: No such file or directory

ERROR: failed to configure user in container

+ sudo rm -f /var/run/elastictest-prepare.lock
```

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Root cause is from docker 29.5.1 itself

Commit: [64a22d8](https://github.com/moby/moby/commit/64a22d80b93ddc1416b501b5145df02947312249) in moby/moby — "daemon/copy: Fix symlink escape in mount destination creation"
Author: Paweł Gronowski (Docker Inc), 2026-03-26
Shipped in: v29.5.1 (2026-05-18) as the patch for CVE-2026-41568 / GHSA-vp62-88p7-qqf5

Before the fix (v29.5.0 and earlier) — daemon/containerfs_linux.go:
```
 func createIfNotExists(dest string, isDir bool) error {
     if _, err := os.Stat(dest); err != nil {   // ← stat first
         if os.IsNotExist(err) {
             if isDir {
                 return os.MkdirAll(dest, 0o755)
             }
             ...
         }
     }
     return nil   // ← if it exists, NO-OP, no error
 }
```

After the fix (v29.5.1) — this is the regression:
```
 func createIfNotExists(root *os.Root, unsafePath string, isDir bool) error {
     if isDir {
         return root.MkdirAll(unsafePath, 0o755)
     }
     parent := filepath.Dir(unsafePath)
     if parent != "." && parent != "/" {
         if err := root.MkdirAll(parent, 0o755); err != nil {  // ← errors on EEXIST
             return err
         }
     }
     f, err := root.OpenFile(unsafePath, os.O_CREATE|os.O_WRONLY, 0o755)
     ...
 }
```

For docker cp foo sonic-mgmt:/var/run/id_ed25519:

 1. isDir=false, unsafePath="var/run/id_ed25519"
 2. parent = "var/run"
 3. root.MkdirAll("var/run", 0o755) is called
 4. Container has /var/run/docker.sock bind-mounted — so var/run exists as a mount-point dir
 5. Go's os.Root.MkdirAll issues mkdirat(rootFd, "var/run", 0o755), gets EEXIST, and returns the error instead of silently treating it assuccess (which the old os.Stat+os.MkdirAll codepath did)
 6. Daemon returns Error response from daemon: mkdirat var/run: file exists — the exact error in your prepare log

The old code's os.Stat check made existence a no-op. The new code's root.MkdirAll is not equivalent to os.MkdirAll when the path alreadyexists as a bind-mount target — it surfaces the EEXIST instead of swallowing it.

#### How did you do it?
```
azure@sonic-ela000TPF:~$ docker --version
Docker version 29.5.1, build 2518b52
```

CI of this PR should pass

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
