### PR TITLE
[bgp/agg]: Fix ImportError in test_bgp_aggregate_address_scale_stress on older base branches

### DIFF
--- a/tests/bgp/test_bgp_aggregate_address_scale_stress.py
+++ b/tests/bgp/test_bgp_aggregate_address_scale_stress.py
@@ -35,7 +35,6 @@ from bgp_aggregate_helpers import (
     verify_route_on_m2,
     withdraw_contributing_routes,
 )
-from tests.bgp.bgp_helpers import get_upstream_ptf_intfs
 from tests.common.gcu_utils import (
     create_checkpoint,
     rollback,
@@ -643,7 +642,16 @@ class TestGroup7CapacityStress:
         # Resolve PTF port mappings
         mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
         router_mac = duthost.facts["router_mac"]
-        upstream_ptf_ports = get_upstream_ptf_intfs(mg_facts, tbinfo)
+
+        # Compute upstream (M2) ethernets and their PTF port indices.
+        upstream_type = UPSTREAM_NEIGHBOR_MAP[tbinfo["topo"]["type"]].upper()
+        upstream_ethernets = [
+            k for k, v in mg_facts["minigraph_neighbors"].items()
+            if v["name"].endswith(upstream_type)
+        ]
+        upstream_ptf_ports = [
+            mg_facts["minigraph_ptf_indices"][port] for port in upstream_ethernets
+        ]
         pytest_assert(
             upstream_ptf_ports,
             "No upstream PTF ports found for data-plane testing",
@@ -670,11 +678,6 @@ class TestGroup7CapacityStress:
         # Discover destination IPs routable via upstream (M2) neighbors.
         # These are routes the DUT learned from M2 with upstream nexthops.
         # We use M2 neighbor BGP peer IPs — always routable via upstream links.
-        upstream_type = UPSTREAM_NEIGHBOR_MAP[tbinfo["topo"]["type"]].upper()
-        upstream_ethernets = [
-            k for k, v in mg_facts["minigraph_neighbors"].items()
-            if v["name"].endswith(upstream_type)
-        ]
         # Collect the M2-side peer IPs from the DUT's interface addresses
         upstream_dst_ips = []
         for intf in upstream_ethernets:


### PR DESCRIPTION
### Description of PR
Summary:
Fixes test collection ImportError for `test_bgp_aggregate_address_scale_stress.py` on
branches/testbeds whose `tests/bgp/bgp_helpers.py` does not yet contain
`get_upstream_ptf_intfs` (introduced in #22619, commit `0e3b0e883b`).

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Test collection failed on the CI testbed with:

```
ImportError: cannot import name 'get_upstream_ptf_intfs' from 'tests.bgp.bgp_helpers'
```

`get_upstream_ptf_intfs` is only present in `bgp_helpers.py` on branches that include
PR #22619. Importing it from this new scale/stress test file therefore breaks pytest
collection on any branch/testbed without that commit, blocking the entire bgp test
module from running.

#### How did you do it?
- Removed the `from tests.bgp.bgp_helpers import get_upstream_ptf_intfs` import in
  [tests/bgp/test_bgp_aggregate_address_scale_stress.py](tests/bgp/test_bgp_aggregate_address_scale_stress.py).
- Inlined the equivalent logic inside `test_7_2_data_plane_under_scale` using
  `UPSTREAM_NEIGHBOR_MAP` (already imported):
  - Compute `upstream_ethernets` once from `mg_facts["minigraph_neighbors"]`.
  - Derive `upstream_ptf_ports` via `mg_facts["minigraph_ptf_indices"]`.
  - Reuse the same `upstream_ethernets` list for the existing M2 peer-IP discovery
    (de-duplicates what was previously computed twice).
- No functional change — behavior matches the original helper exactly.

#### How did you verify/test it?
- Confirmed pytest can now collect `tests/bgp/test_bgp_aggregate_address_scale_stress.py`
  without the ImportError.
- Verified the file passes lint/static analysis (no new errors introduced).
- The inlined logic mirrors `get_upstream_ptf_intfs` in `bgp_helpers.py`:
  same `UPSTREAM_NEIGHBOR_MAP` lookup, same `minigraph_neighbors` filter, same
  `minigraph_ptf_indices` mapping.
-test all case in this file on DUT
<img width="1596" height="20" alt="image" src="https://github.com/user-attachments/assets/e613c6b0-c358-4f9a-952e-cda830cbf598" />
<img width="1597" height="18" alt="image" src="https://github.com/user-attachments/assets/c429b1df-04aa-41fe-bd46-22b339f3b264" />
<img width="1618" height="17" alt="image" src="https://github.com/user-attachments/assets/ceff4976-4fce-4d91-bf6e-b7b83401f18f" />


#### Any platform specific information?
None. Change is purely test-side and topology-agnostic within the M1 topology
this test targets.

#### Supported testbed topology if it's a new test case?
N/A — this is a bug fix for an existing test. The test remains marked
`@pytest.mark.topology("m1")`.

### Documentation
N/A