### PR TITLE
Update potential places `show int stat` can run to skip for supervisor

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -4,6 +4,7 @@ import ipaddress
 import json
 import logging
 
+from pytest_ansible.results import ModuleResult
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.devices.sonic import SonicHost
 from tests.common.devices.sonic_asic import SonicAsic
@@ -171,6 +172,21 @@ class MultiAsicSonicHost(object):
                 return [getattr(asic, multi_asic_attr)(*module_args, **asic_complex_args) for asic in self.asics]
             else:
                 raise ValueError("Argument 'asic_index' must be an int or string 'all'.")
+
+    def show_interface(self, *module_args, **complex_args):
+        """Wrapper that short-circuits on supervisor nodes.
+
+        On supervisor, 'show interface status' triggers 'rexec -c ... all' which
+        prompts for LC passwords and hangs. Return empty ModuleResult instead.
+        """
+        if self.sonichost.is_supervisor_node():
+            logger.debug("Skipping show_interface on supervisor node %s", self.hostname)
+            return ModuleResult(ansible_facts={
+                "int_status": {},
+                "int_counter": {},
+                "ansible_interface_link_down_ports": [],
+            }, changed=False)
+        return self._run_on_asics("show_interface", *module_args, **complex_args)
 
     def get_dut_iface_mac(self, iface_name):
         """

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -8,6 +8,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.cache_utils import sonic_asic_zone_getter
 from tests.common.helpers.constants import DEFAULT_NAMESPACE, NAMESPACE_PREFIX
 from tests.common.errors import RunAnsibleModuleFail
+from pytest_ansible.results import ModuleResult
 from tests.common.platform.ssh_utils import ssh_authorize_local_user
 
 logger = logging.getLogger(__name__)
@@ -143,6 +144,13 @@ class SonicAsic(object):
         Returns:
             [dict]: [the output of show interface status command]
         """
+        if self.sonichost.is_supervisor_node():
+            logger.debug("Skipping show_interface on supervisor node %s asic %s", self.sonichost.hostname, self.namespace)
+            return ModuleResult(ansible_facts={
+                "int_status": {},
+                "int_counter": {},
+                "ansible_interface_link_down_ports": [],
+            }, changed=False)
         complex_args['namespace'] = self.namespace
         return self.sonichost.show_interface(*module_args, **complex_args)
 

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -145,7 +145,8 @@ class SonicAsic(object):
             [dict]: [the output of show interface status command]
         """
         if self.sonichost.is_supervisor_node():
-            logger.debug("Skipping show_interface on supervisor node %s asic %s", self.sonichost.hostname, self.namespace)
+            logger.debug("Skipping show_interface on supervisor node %s asic %s",
+                         self.sonichost.hostname, self.namespace)
             return ModuleResult(ansible_facts={
                 "int_status": {},
                 "int_counter": {},

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -88,6 +88,11 @@ def print_logs(duthosts, ptfhost, print_dual_tor_logs=False, check_ptf_mgmt=True
 
         cmds = list(constants.PRINT_LOGS.values())
 
+        # Skip commands that trigger rexec on supervisor (e.g. show interface status, show ip bgp summary)
+        if dut.is_supervisor_node():
+            cmds = [cmd for cmd in cmds
+                    if not any(p.search(cmd) for p in constants.SUPERVISOR_REXEC_COMMAND_PATTERNS)]
+
         if is_dual_tor is False:
             cmds.remove(constants.PRINT_LOGS['mux_status'])
             cmds.remove(constants.PRINT_LOGS['mux_config'])

--- a/tests/common/plugins/sanity_check/constants.py
+++ b/tests/common/plugins/sanity_check/constants.py
@@ -1,3 +1,4 @@
+import re
 
 PRINT_LOGS = {
     "version": "show version",
@@ -12,6 +13,13 @@ PRINT_LOGS = {
     "mux_status": "show mux status",
     "mux_config": "show mux config",
 }
+
+# Regex patterns matching CLI commands that trigger rexec on supervisor.
+# Use these to filter out commands that would hang on supervisor nodes.
+SUPERVISOR_REXEC_COMMAND_PATTERNS = [
+    re.compile(r"show int(erface)? stat(us)?"),
+    re.compile(r"show ip bgp sum(mary)?"),
+]
 
 # Check items for testbed infrastructure that are not
 # controlled by the DUT

--- a/tests/gnmi/test_gnmi_configdb.py
+++ b/tests/gnmi/test_gnmi_configdb.py
@@ -25,6 +25,8 @@ pytestmark = [
 
 
 def get_first_interface(duthost):
+    if duthost.is_supervisor_node():
+        return None
     cmds = "show interface status"
     output = duthost.shell(cmds)
     assert (not output['rc']), "No output"

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -184,7 +184,6 @@ def test_authorization_tacacs_only(
         "portstat -c",
         "show interfaces portchannel",
         "show platform summary",
-        "show interfaces status",
         "show version",
         "show lldp table",
         "show reboot-cause",
@@ -198,6 +197,7 @@ def test_authorization_tacacs_only(
         "show ip bgp summary",
         "show ipv6 bgp summary",
         "show muxcable firmware",
+        "show interfaces status"
     ]
 
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]

--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -4,6 +4,7 @@ import shlex
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import check_output
 from tests.common.helpers.tacacs.tacacs_helper import ssh_remote_run, ssh_remote_run_retry, check_tacacs  # noqa: F401
+from tests.common.plugins.sanity_check.constants import SUPERVISOR_REXEC_COMMAND_PATTERNS
 
 import logging
 
@@ -143,6 +144,11 @@ def test_ro_user_allowed_command(localhost, duthosts, enum_rand_one_per_hwsku_ho
         if does_command_exist(localhost, dutip, tacacs_creds['tacacs_ro_user'],
                               tacacs_creds['tacacs_ro_user_passwd'], command):
             for subcommand in commands[command]:
+                # Skip commands that trigger rexec on supervisor
+                if duthost.is_supervisor_node() and any(p.search(subcommand)
+                                                        for p in SUPERVISOR_REXEC_COMMAND_PATTERNS):
+                    logger.info("Skipping '{}' on supervisor node — triggers rexec".format(subcommand))
+                    continue
                 allowed = ssh_remote_allow_run(localhost, dutip, tacacs_creds['tacacs_ro_user'],
                                                tacacs_creds['tacacs_ro_user_passwd'], subcommand)
                 pytest_assert(allowed, "command '{}' not authorized".format(subcommand))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #24709

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Prevent failures / support changes at https://github.com/sonic-net/sonic-utilities/pull/4529
#### How did you do it?
Scan codebase for potential places `show int stat` could run on supervisor and skip
#### How did you verify/test it?
Test pretest was a failing test due to this change, ensure it passed on physical testbed
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A