### PR TITLE
xfail test_trimming_with_srv6 on 202412 isolated topology

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3862,6 +3862,12 @@ packet_trimming/test_packet_trimming_asymmetric.py::TestPacketTrimmingAsymmetric
     conditions:
       - "asic_gen in ['th5']"
 
+packet_trimming/test_packet_trimming_asymmetric.py::TestPacketTrimmingAsymmetric::test_trimming_with_srv6:
+  xfail:
+    reason: "vlan decap is disabled in 202412 image"
+    conditions:
+      - "'isolated' in topo_name and release in ['202412']"
+
 packet_trimming/test_packet_trimming_symmetric.py::TestPacketTrimmingSymmetric::test_trimming_counters_with_feature_toggle:
   skip:
     reason: "TH5 clears trim counters when packet trimming is turned off, skipping until trim counter persistance is supported."


### PR DESCRIPTION
### Description of PR

Adds an `xfail` rule for `TestPacketTrimmingAsymmetric::test_trimming_with_srv6` on 202412 isolated topologies, where `vlan decap` is disabled in the image. 

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

- **Motivation:** `vlan decap` is disabled in the 202412 image on isolated topologies, causing `test_trimming_with_srv6` (asymmetric) to fail in a non-actionable way.
- **Change:** Added an `xfail` entry in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`.
- **Verification:** Running on internal 202412 isolated testbeds; the test is xfailed as expected.
