### PR TITLE
[platform_tests]: Add tests for thermalctld optimizations (issue #2240)

### DIFF
--- a/tests/platform_tests/test_sfp_thermal_state_db.py
+++ b/tests/platform_tests/test_sfp_thermal_state_db.py
@@ -176,7 +176,7 @@ class TestSfpThermalStateDb:
                 try:
                     port_index_to_dom[int(match.group(1))] = round(float(val), 1)
                 except (ValueError, TypeError):
-                    pass
+                    pass  # Skip ports with non-numeric temperature values
 
         # Collect temperature values from CLI SFP rows
         cli_temperatures = {}
@@ -285,22 +285,22 @@ class TestSfpThermalStateDb:
                 try:
                     dom_high_th_values.add(round(float(th["temphighwarning"]), 1))
                 except (ValueError, TypeError):
-                    pass
+                    pass  # Skip non-numeric threshold from STATE_DB
             if th["templowwarning"]:
                 try:
                     dom_low_th_values.add(round(float(th["templowwarning"]), 1))
                 except (ValueError, TypeError):
-                    pass
+                    pass  # Skip non-numeric threshold from STATE_DB
             if th["temphighalarm"]:
                 try:
                     dom_crit_high_values.add(round(float(th["temphighalarm"]), 1))
                 except (ValueError, TypeError):
-                    pass
+                    pass  # Skip non-numeric threshold from STATE_DB
             if th["templowalarm"]:
                 try:
                     dom_crit_low_values.add(round(float(th["templowalarm"]), 1))
                 except (ValueError, TypeError):
-                    pass
+                    pass  # Skip non-numeric threshold from STATE_DB
 
         logger.info("DOM threshold value sets - High TH: %s, Low TH: %s, "
                     "Crit High: %s, Crit Low: %s",
@@ -328,7 +328,7 @@ class TestSfpThermalStateDb:
                     if val in dom_high_th_values:
                         row_matched = True
                 except (ValueError, TypeError):
-                    pass
+                    pass  # Non-numeric CLI value, skip comparison
 
             if low_th != "N/A":
                 row_has_threshold = True
@@ -337,7 +337,7 @@ class TestSfpThermalStateDb:
                     if val in dom_low_th_values:
                         row_matched = True
                 except (ValueError, TypeError):
-                    pass
+                    pass  # Non-numeric CLI value, skip comparison
 
             if crit_high != "N/A":
                 row_has_threshold = True
@@ -346,7 +346,7 @@ class TestSfpThermalStateDb:
                     if val in dom_crit_high_values:
                         row_matched = True
                 except (ValueError, TypeError):
-                    pass
+                    pass  # Non-numeric CLI value, skip comparison
 
             if crit_low != "N/A":
                 row_has_threshold = True
@@ -355,7 +355,7 @@ class TestSfpThermalStateDb:
                     if val in dom_crit_low_values:
                         row_matched = True
                 except (ValueError, TypeError):
-                    pass
+                    pass  # Non-numeric CLI value, skip comparison
 
             if row_has_threshold:
                 rows_with_thresholds += 1

--- a/tests/platform_tests/test_sfp_thermal_state_db.py
+++ b/tests/platform_tests/test_sfp_thermal_state_db.py
@@ -1,0 +1,469 @@
+"""
+Verify SFP temperature in 'show platform temperature' is sourced from
+xcvrd-managed TRANSCEIVER_DOM_TEMPERATURE / TRANSCEIVER_DOM_THRESHOLD /
+TRANSCEIVER_DOM_FLAG tables in STATE_DB.
+"""
+import json
+import logging
+
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('physical')
+]
+
+logger = logging.getLogger(__name__)
+
+
+class TestSfpThermalStateDb:
+    """
+    Validate that 'show platform temperature' SFP rows are sourced from
+    xcvrd-managed TRANSCEIVER_DOM_TEMPERATURE / TRANSCEIVER_DOM_THRESHOLD /
+    TRANSCEIVER_DOM_FLAG tables in STATE_DB.
+    """
+
+    def _get_sfp_ports_with_dom_temperature(self, duthost):
+        """Return list of port names that have TRANSCEIVER_DOM_TEMPERATURE entries."""
+        result = duthost.shell(
+            'sonic-db-cli STATE_DB KEYS "TRANSCEIVER_DOM_TEMPERATURE|*"',
+            module_ignore_errors=True
+        )
+        if result["rc"] != 0 or not result["stdout"].strip():
+            return []
+        keys = result["stdout"].strip().split("\n")
+        return [k.split("|", 1)[1] for k in keys]
+
+    def _get_dom_temperature_data(self, duthost, port):
+        """Get temperature value from TRANSCEIVER_DOM_TEMPERATURE for a port."""
+        result = duthost.shell(
+            'sonic-db-cli STATE_DB HGET "TRANSCEIVER_DOM_TEMPERATURE|{}" temperature'.format(port),
+            module_ignore_errors=True
+        )
+        if result["rc"] == 0 and result["stdout"].strip():
+            return result["stdout"].strip()
+        return None
+
+    def _get_dom_threshold_data(self, duthost, port):
+        """
+        Get threshold values from TRANSCEIVER_DOM_THRESHOLD for a port.
+        Returns dict with keys: temphighwarning, templowwarning, temphighalarm, templowalarm
+        """
+        fields = ["temphighwarning", "templowwarning", "temphighalarm", "templowalarm"]
+        thresholds = {}
+        for field in fields:
+            result = duthost.shell(
+                'sonic-db-cli STATE_DB HGET "TRANSCEIVER_DOM_THRESHOLD|{}" {}'.format(port, field),
+                module_ignore_errors=True
+            )
+            if result["rc"] == 0 and result["stdout"].strip():
+                thresholds[field] = result["stdout"].strip()
+            else:
+                thresholds[field] = None
+        return thresholds
+
+    def _get_dom_flag_data(self, duthost, port):
+        """
+        Get temperature warning flags from TRANSCEIVER_DOM_FLAG for a port.
+        Returns dict with keys: tempHWarn, tempLWarn, tempHAlarm, tempLAlarm
+        """
+        fields = ["tempHWarn", "tempLWarn", "tempHAlarm", "tempLAlarm"]
+        flags = {}
+        for field in fields:
+            result = duthost.shell(
+                'sonic-db-cli STATE_DB HGET "TRANSCEIVER_DOM_FLAG|{}" {}'.format(port, field),
+                module_ignore_errors=True
+            )
+            if result["rc"] == 0 and result["stdout"].strip():
+                flags[field] = result["stdout"].strip()
+            else:
+                flags[field] = None
+        return flags
+
+    def _is_sfp_sensor(self, sensor_name):
+        """
+        Determine if a sensor name refers to an SFP/transceiver temperature.
+        Matches patterns like 'xSFP module N Temp'.
+        """
+        sensor_lower = sensor_name.lower()
+        return ("sfp" in sensor_lower or "transceiver" in sensor_lower or
+                "optic" in sensor_lower)
+
+    def test_sfp_temperature_present_in_show_platform_temperature(
+            self, duthosts, enum_rand_one_per_hwsku_hostname):
+        """
+        Verify that SFP temperature entries appear in 'show platform temperature'
+        when TRANSCEIVER_DOM_TEMPERATURE has data for connected ports.
+        """
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+        sfp_ports = self._get_sfp_ports_with_dom_temperature(duthost)
+        if not sfp_ports:
+            pytest.skip("No TRANSCEIVER_DOM_TEMPERATURE entries found in STATE_DB "
+                        "(no transceivers with DOM support present)")
+
+        logger.info("Found %d ports with TRANSCEIVER_DOM_TEMPERATURE data", len(sfp_ports))
+
+        temp_output = duthost.show_and_parse("show platform temperature")
+        pytest_assert(len(temp_output) > 0,
+                      "'show platform temperature' returned no data")
+
+        sfp_rows = [row for row in temp_output if self._is_sfp_sensor(row.get("sensor", ""))]
+
+        logger.info("Found %d SFP sensor rows in 'show platform temperature'", len(sfp_rows))
+
+        pytest_assert(
+            len(sfp_rows) > 0,
+            "Expected SFP temperature rows in 'show platform temperature' since "
+            "{} ports have TRANSCEIVER_DOM_TEMPERATURE data, but found none. "
+            "Available sensors: {}".format(
+                len(sfp_ports),
+                [row.get("sensor", "") for row in temp_output]
+            )
+        )
+
+    def test_sfp_temperature_values_match_xcvrd_tables(
+            self, duthosts, enum_rand_one_per_hwsku_hostname):
+        """
+        Verify that SFP temperature values shown in 'show platform temperature'
+        match the values in TRANSCEIVER_DOM_TEMPERATURE table populated by xcvrd.
+        """
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+        sfp_ports = self._get_sfp_ports_with_dom_temperature(duthost)
+        if not sfp_ports:
+            pytest.skip("No TRANSCEIVER_DOM_TEMPERATURE entries found")
+
+        temp_output = duthost.show_and_parse("show platform temperature")
+        sfp_rows = [row for row in temp_output if self._is_sfp_sensor(row.get("sensor", ""))]
+
+        if not sfp_rows:
+            pytest.skip("No SFP rows in 'show platform temperature' output")
+
+        # Collect temperature values from xcvrd table
+        dom_temperatures = {}
+        for port in sfp_ports:
+            temp_val = self._get_dom_temperature_data(duthost, port)
+            if temp_val:
+                dom_temperatures[port] = temp_val
+
+        logger.info("TRANSCEIVER_DOM_TEMPERATURE values (first 5): %s",
+                    json.dumps(dict(list(dom_temperatures.items())[:5]), indent=2))
+
+        # Collect temperature values from CLI SFP rows
+        cli_temperatures = {}
+        for row in sfp_rows:
+            sensor = row.get("sensor", "")
+            temp = row.get("temperature", "N/A")
+            if temp != "N/A":
+                cli_temperatures[sensor] = temp
+
+        # Build set of DOM temperature values for comparison
+        dom_temp_values = set()
+        for val in dom_temperatures.values():
+            try:
+                dom_temp_values.add(round(float(val), 3))
+            except (ValueError, TypeError):
+                pass
+
+        mismatches = []
+        for sensor, cli_temp in cli_temperatures.items():
+            try:
+                cli_val = round(float(cli_temp), 3)
+                if cli_val not in dom_temp_values and cli_val != 0.0:
+                    # Allow small floating point differences due to timing
+                    found_close = any(
+                        abs(cli_val - dom_val) < 0.1
+                        for dom_val in dom_temp_values
+                    )
+                    if not found_close:
+                        mismatches.append(
+                            "Sensor '{}': CLI temp={} not found in "
+                            "TRANSCEIVER_DOM_TEMPERATURE values".format(sensor, cli_temp)
+                        )
+            except (ValueError, TypeError):
+                pass
+
+        if mismatches:
+            logger.warning("Temperature mismatches (may be due to timing): %s", mismatches)
+
+        matched_count = len(cli_temperatures) - len(mismatches)
+        pytest_assert(
+            matched_count > 0 or len(cli_temperatures) == 0,
+            "No SFP temperature values in CLI matched TRANSCEIVER_DOM_TEMPERATURE. "
+            "Mismatches: {}".format(mismatches)
+        )
+
+    def test_sfp_thresholds_match_xcvrd_tables(
+            self, duthosts, enum_rand_one_per_hwsku_hostname):
+        """
+        Verify SFP threshold values in 'show platform temperature' match
+        TRANSCEIVER_DOM_THRESHOLD table data populated by xcvrd.
+
+        Field mapping:
+          High TH -> temphighwarning
+          Low TH -> templowwarning
+          Crit High TH -> temphighalarm
+          Crit Low TH -> templowalarm
+        """
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+        sfp_ports = self._get_sfp_ports_with_dom_temperature(duthost)
+        if not sfp_ports:
+            pytest.skip("No TRANSCEIVER_DOM_TEMPERATURE entries found")
+
+        temp_output = duthost.show_and_parse("show platform temperature")
+        sfp_rows = [row for row in temp_output if self._is_sfp_sensor(row.get("sensor", ""))]
+
+        if not sfp_rows:
+            pytest.skip("No SFP rows in 'show platform temperature' output")
+
+        # Get threshold values from xcvrd table
+        dom_thresholds = {}
+        for port in sfp_ports:
+            thresholds = self._get_dom_threshold_data(duthost, port)
+            if any(v is not None for v in thresholds.values()):
+                dom_thresholds[port] = thresholds
+
+        if not dom_thresholds:
+            pytest.skip("No TRANSCEIVER_DOM_THRESHOLD data available")
+
+        # Collect all threshold values from the DOM table
+        dom_high_th_values = set()
+        dom_low_th_values = set()
+        dom_crit_high_values = set()
+        dom_crit_low_values = set()
+
+        for port, th in dom_thresholds.items():
+            if th["temphighwarning"]:
+                try:
+                    dom_high_th_values.add(round(float(th["temphighwarning"]), 1))
+                except (ValueError, TypeError):
+                    pass
+            if th["templowwarning"]:
+                try:
+                    dom_low_th_values.add(round(float(th["templowwarning"]), 1))
+                except (ValueError, TypeError):
+                    pass
+            if th["temphighalarm"]:
+                try:
+                    dom_crit_high_values.add(round(float(th["temphighalarm"]), 1))
+                except (ValueError, TypeError):
+                    pass
+            if th["templowalarm"]:
+                try:
+                    dom_crit_low_values.add(round(float(th["templowalarm"]), 1))
+                except (ValueError, TypeError):
+                    pass
+
+        logger.info("DOM threshold value sets - High TH: %s, Low TH: %s, "
+                    "Crit High: %s, Crit Low: %s",
+                    dom_high_th_values, dom_low_th_values,
+                    dom_crit_high_values, dom_crit_low_values)
+
+        # Verify CLI SFP rows have thresholds matching the DOM table
+        verified_count = 0
+        for row in sfp_rows:
+            high_th = row.get("high th", "N/A")
+            low_th = row.get("low th", "N/A")
+            crit_high = row.get("crit high th", "N/A")
+            crit_low = row.get("crit low th", "N/A")
+
+            if high_th != "N/A":
+                try:
+                    val = round(float(high_th), 1)
+                    if val in dom_high_th_values:
+                        verified_count += 1
+                except (ValueError, TypeError):
+                    pass
+
+            if low_th != "N/A":
+                try:
+                    val = round(float(low_th), 1)
+                    if val in dom_low_th_values:
+                        verified_count += 1
+                except (ValueError, TypeError):
+                    pass
+
+            if crit_high != "N/A":
+                try:
+                    val = round(float(crit_high), 1)
+                    if val in dom_crit_high_values:
+                        verified_count += 1
+                except (ValueError, TypeError):
+                    pass
+
+            if crit_low != "N/A":
+                try:
+                    val = round(float(crit_low), 1)
+                    if val in dom_crit_low_values:
+                        verified_count += 1
+                except (ValueError, TypeError):
+                    pass
+
+        logger.info("Verified %d threshold matches between CLI and TRANSCEIVER_DOM_THRESHOLD",
+                    verified_count)
+
+        pytest_assert(
+            verified_count > 0,
+            "No SFP threshold values in 'show platform temperature' matched "
+            "TRANSCEIVER_DOM_THRESHOLD entries. CLI SFP rows: {}, "
+            "DOM threshold ports: {}".format(len(sfp_rows), len(dom_thresholds))
+        )
+
+    def test_sfp_warning_status_from_dom_flag(
+            self, duthosts, enum_rand_one_per_hwsku_hostname):
+        """
+        Verify that the Warning column for SFP rows in 'show platform temperature'
+        reflects the temperature flag state in TRANSCEIVER_DOM_FLAG table.
+
+        Warning = True if any of tempHWarn/tempLWarn/tempHAlarm/tempLAlarm is asserted.
+        Warning = False if all four are present and de-asserted.
+        Warning = N/A if flags are not populated.
+        """
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+        sfp_ports = self._get_sfp_ports_with_dom_temperature(duthost)
+        if not sfp_ports:
+            pytest.skip("No TRANSCEIVER_DOM_TEMPERATURE entries found")
+
+        temp_output = duthost.show_and_parse("show platform temperature")
+        sfp_rows = [row for row in temp_output if self._is_sfp_sensor(row.get("sensor", ""))]
+
+        if not sfp_rows:
+            pytest.skip("No SFP rows in 'show platform temperature' output")
+
+        # Check DOM flags for a subset of ports
+        ports_with_flags = 0
+        ports_without_flags = 0
+
+        for port in sfp_ports[:10]:
+            flags = self._get_dom_flag_data(duthost, port)
+            has_any_flag = any(v is not None for v in flags.values())
+            if has_any_flag:
+                ports_with_flags += 1
+            else:
+                ports_without_flags += 1
+
+        logger.info("DOM flag status: %d ports with flags, %d without",
+                    ports_with_flags, ports_without_flags)
+
+        # Verify Warning column values are valid
+        valid_warnings = {"True", "False", "N/A", "true", "false"}
+        for row in sfp_rows:
+            warning = row.get("warning", "")
+            pytest_assert(
+                warning in valid_warnings,
+                "Invalid warning value '{}' for sensor '{}'. "
+                "Expected one of: {}".format(warning, row.get("sensor", ""), valid_warnings)
+            )
+
+        # If ports have flags, at least some SFP rows should have True/False warning
+        if ports_with_flags > 0:
+            rows_with_warning_status = [
+                row for row in sfp_rows
+                if row.get("warning", "").lower() in ("true", "false")
+            ]
+            pytest_assert(
+                len(rows_with_warning_status) > 0,
+                "Ports have TRANSCEIVER_DOM_FLAG data but no SFP rows show "
+                "True/False warning status"
+            )
+
+    def test_no_sfp_entries_in_temperature_info(
+            self, duthosts, enum_rand_one_per_hwsku_hostname):
+        """
+        After thermalctld optimization, TEMPERATURE_INFO should no longer contain
+        SFP/transceiver entries — those are exclusively in TRANSCEIVER_DOM_TEMPERATURE.
+
+        This verifies thermalctld no longer publishes duplicate SFP data.
+        """
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+        result = duthost.shell(
+            'sonic-db-cli STATE_DB KEYS "TEMPERATURE_INFO|*"',
+            module_ignore_errors=True
+        )
+        if result["rc"] != 0 or not result["stdout"].strip():
+            pytest.skip("No TEMPERATURE_INFO entries found in STATE_DB")
+
+        keys = result["stdout"].strip().split("\n")
+        sfp_keys = [
+            k for k in keys
+            if any(pattern in k.lower() for pattern in ["sfp", "transceiver", "xsfp", "optic"])
+        ]
+
+        logger.info("TEMPERATURE_INFO keys: %d total, %d SFP-related",
+                    len(keys), len(sfp_keys))
+
+        pytest_assert(
+            len(sfp_keys) == 0,
+            "TEMPERATURE_INFO should not contain SFP entries after thermalctld "
+            "optimization. Found {} SFP keys: {}".format(len(sfp_keys), sfp_keys[:10])
+        )
+
+    def test_platform_sensors_still_in_temperature_info(
+            self, duthosts, enum_rand_one_per_hwsku_hostname):
+        """
+        Verify that non-SFP platform sensors (ASIC, CPU, PSU, fan, ambient)
+        are still published to TEMPERATURE_INFO by thermalctld.
+        """
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+        result = duthost.shell(
+            'sonic-db-cli STATE_DB KEYS "TEMPERATURE_INFO|*"',
+            module_ignore_errors=True
+        )
+        if result["rc"] != 0 or not result["stdout"].strip():
+            pytest.skip("No TEMPERATURE_INFO entries found in STATE_DB")
+
+        keys = result["stdout"].strip().split("\n")
+        sensor_names = [k.split("|", 1)[1] for k in keys]
+
+        logger.info("Platform sensors in TEMPERATURE_INFO: %s", sensor_names)
+
+        pytest_assert(
+            len(sensor_names) > 0,
+            "TEMPERATURE_INFO should contain at least one platform sensor "
+            "(ASIC, CPU, PSU, etc.)"
+        )
+
+        non_sfp_sensors = [
+            name for name in sensor_names
+            if not any(p in name.lower() for p in ["sfp", "transceiver", "xsfp", "optic"])
+        ]
+
+        pytest_assert(
+            len(non_sfp_sensors) > 0,
+            "Expected non-SFP platform sensors (ASIC, CPU, etc.) in "
+            "TEMPERATURE_INFO but found none. All sensors: {}".format(sensor_names)
+        )
+
+    def test_show_platform_temperature_has_all_columns(
+            self, duthosts, enum_rand_one_per_hwsku_hostname):
+        """
+        Verify 'show platform temperature' output has the expected 8 columns
+        for both platform and SFP sensors.
+        """
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+        temp_output = duthost.show_and_parse("show platform temperature")
+        if not temp_output:
+            pytest.skip("'show platform temperature' returned no data")
+
+        expected_columns = {
+            "sensor", "temperature", "high th", "low th",
+            "crit high th", "crit low th", "warning", "timestamp"
+        }
+
+        for row in temp_output:
+            row_keys = set(k.lower() for k in row.keys())
+            missing = expected_columns - row_keys
+            pytest_assert(
+                not missing,
+                "Sensor '{}' missing columns: {}. Got: {}".format(
+                    row.get("sensor", "unknown"), missing, list(row.keys())
+                )
+            )

--- a/tests/platform_tests/test_sfp_thermal_state_db.py
+++ b/tests/platform_tests/test_sfp_thermal_state_db.py
@@ -5,6 +5,7 @@ TRANSCEIVER_DOM_FLAG tables in STATE_DB.
 """
 import json
 import logging
+import re
 
 import pytest
 
@@ -124,11 +125,26 @@ class TestSfpThermalStateDb:
             )
         )
 
+    def _extract_port_index_from_sensor(self, sensor_name):
+        """
+        Attempt to extract a numeric port/module index from a sensor name.
+        E.g., 'xSFP module 3 Temp' -> 3, 'Transceiver Ethernet4 Temp' -> 4
+        Returns the index as int, or None if not parseable.
+        """
+        # Match patterns like 'module N', 'Ethernet N', or standalone number
+        match = re.search(r'(?:module|ethernet)\s*(\d+)', sensor_name, re.IGNORECASE)
+        if match:
+            return int(match.group(1))
+        return None
+
     def test_sfp_temperature_values_match_xcvrd_tables(
             self, duthosts, enum_rand_one_per_hwsku_hostname):
         """
         Verify that SFP temperature values shown in 'show platform temperature'
         match the values in TRANSCEIVER_DOM_TEMPERATURE table populated by xcvrd.
+
+        Attempts per-port matching where possible; falls back to value proximity
+        check against the full DOM temperature set only for unresolvable sensors.
         """
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
@@ -152,6 +168,16 @@ class TestSfpThermalStateDb:
         logger.info("TRANSCEIVER_DOM_TEMPERATURE values (first 5): %s",
                     json.dumps(dict(list(dom_temperatures.items())[:5]), indent=2))
 
+        # Build port-index -> DOM temperature mapping for per-port verification
+        port_index_to_dom = {}
+        for port, val in dom_temperatures.items():
+            match = re.search(r'(\d+)$', port)
+            if match:
+                try:
+                    port_index_to_dom[int(match.group(1))] = round(float(val), 1)
+                except (ValueError, TypeError):
+                    pass
+
         # Collect temperature values from CLI SFP rows
         cli_temperatures = {}
         for row in sfp_rows:
@@ -160,40 +186,58 @@ class TestSfpThermalStateDb:
             if temp != "N/A":
                 cli_temperatures[sensor] = temp
 
-        # Build set of DOM temperature values for comparison
-        dom_temp_values = set()
-        for val in dom_temperatures.values():
-            try:
-                dom_temp_values.add(round(float(val), 3))
-            except (ValueError, TypeError):
-                pass
+        pytest_assert(
+            len(cli_temperatures) > 0,
+            "All SFP sensors report N/A temperature — cannot verify DOM sourcing"
+        )
 
         mismatches = []
+        matched_count = 0
         for sensor, cli_temp in cli_temperatures.items():
             try:
-                cli_val = round(float(cli_temp), 3)
-                if cli_val not in dom_temp_values and cli_val != 0.0:
-                    # Allow small floating point differences due to timing
-                    found_close = any(
-                        abs(cli_val - dom_val) < 0.1
-                        for dom_val in dom_temp_values
-                    )
-                    if not found_close:
-                        mismatches.append(
-                            "Sensor '{}': CLI temp={} not found in "
-                            "TRANSCEIVER_DOM_TEMPERATURE values".format(sensor, cli_temp)
-                        )
+                cli_val = round(float(cli_temp), 1)
             except (ValueError, TypeError):
-                pass
+                continue
+
+            # Try per-port match first
+            port_idx = self._extract_port_index_from_sensor(sensor)
+            if port_idx is not None and port_idx in port_index_to_dom:
+                dom_val = port_index_to_dom[port_idx]
+                if abs(cli_val - dom_val) < 0.5:
+                    matched_count += 1
+                    continue
+                else:
+                    mismatches.append(
+                        "Sensor '{}' (port idx {}): CLI temp={} vs DOM temp={}".format(
+                            sensor, port_idx, cli_val, dom_val)
+                    )
+                    continue
+
+            # Fallback: check against all DOM values with proximity tolerance
+            found_close = any(
+                abs(cli_val - round(float(dv), 1)) < 0.5
+                for dv in dom_temperatures.values()
+                if dv is not None
+            )
+            if found_close:
+                matched_count += 1
+            else:
+                mismatches.append(
+                    "Sensor '{}': CLI temp={} not found in "
+                    "TRANSCEIVER_DOM_TEMPERATURE values".format(sensor, cli_temp)
+                )
 
         if mismatches:
             logger.warning("Temperature mismatches (may be due to timing): %s", mismatches)
 
-        matched_count = len(cli_temperatures) - len(mismatches)
+        # Require that the majority of sensors match
+        total_compared = len(cli_temperatures)
+        min_required = max(1, total_compared // 2)
         pytest_assert(
-            matched_count > 0 or len(cli_temperatures) == 0,
-            "No SFP temperature values in CLI matched TRANSCEIVER_DOM_TEMPERATURE. "
-            "Mismatches: {}".format(mismatches)
+            matched_count >= min_required,
+            "Only {}/{} SFP temperature values matched TRANSCEIVER_DOM_TEMPERATURE. "
+            "At least {} required. Mismatches: {}".format(
+                matched_count, total_compared, min_required, mismatches)
         )
 
     def test_sfp_thresholds_match_xcvrd_tables(
@@ -263,54 +307,72 @@ class TestSfpThermalStateDb:
                     dom_high_th_values, dom_low_th_values,
                     dom_crit_high_values, dom_crit_low_values)
 
-        # Verify CLI SFP rows have thresholds matching the DOM table
-        verified_count = 0
+        # Verify CLI SFP rows have thresholds matching the DOM table.
+        # Track per-row: a row is "verified" if at least one of its threshold
+        # fields matches the corresponding DOM value set.
+        rows_verified = 0
+        rows_with_thresholds = 0
         for row in sfp_rows:
             high_th = row.get("high th", "N/A")
             low_th = row.get("low th", "N/A")
             crit_high = row.get("crit high th", "N/A")
             crit_low = row.get("crit low th", "N/A")
 
+            row_has_threshold = False
+            row_matched = False
+
             if high_th != "N/A":
+                row_has_threshold = True
                 try:
                     val = round(float(high_th), 1)
                     if val in dom_high_th_values:
-                        verified_count += 1
+                        row_matched = True
                 except (ValueError, TypeError):
                     pass
 
             if low_th != "N/A":
+                row_has_threshold = True
                 try:
                     val = round(float(low_th), 1)
                     if val in dom_low_th_values:
-                        verified_count += 1
+                        row_matched = True
                 except (ValueError, TypeError):
                     pass
 
             if crit_high != "N/A":
+                row_has_threshold = True
                 try:
                     val = round(float(crit_high), 1)
                     if val in dom_crit_high_values:
-                        verified_count += 1
+                        row_matched = True
                 except (ValueError, TypeError):
                     pass
 
             if crit_low != "N/A":
+                row_has_threshold = True
                 try:
                     val = round(float(crit_low), 1)
                     if val in dom_crit_low_values:
-                        verified_count += 1
+                        row_matched = True
                 except (ValueError, TypeError):
                     pass
 
-        logger.info("Verified %d threshold matches between CLI and TRANSCEIVER_DOM_THRESHOLD",
-                    verified_count)
+            if row_has_threshold:
+                rows_with_thresholds += 1
+                if row_matched:
+                    rows_verified += 1
 
+        logger.info("Verified %d/%d SFP rows with thresholds matched TRANSCEIVER_DOM_THRESHOLD",
+                    rows_verified, rows_with_thresholds)
+
+        # Require that the majority of SFP rows with thresholds match
+        min_required = max(1, rows_with_thresholds // 2)
         pytest_assert(
-            verified_count > 0,
-            "No SFP threshold values in 'show platform temperature' matched "
-            "TRANSCEIVER_DOM_THRESHOLD entries. CLI SFP rows: {}, "
-            "DOM threshold ports: {}".format(len(sfp_rows), len(dom_thresholds))
+            rows_verified >= min_required,
+            "Only {}/{} SFP rows had thresholds matching TRANSCEIVER_DOM_THRESHOLD. "
+            "At least {} required. CLI SFP rows: {}, DOM threshold ports: {}".format(
+                rows_verified, rows_with_thresholds, min_required,
+                len(sfp_rows), len(dom_thresholds))
         )
 
     def test_sfp_warning_status_from_dom_flag(
@@ -350,14 +412,16 @@ class TestSfpThermalStateDb:
         logger.info("DOM flag status: %d ports with flags, %d without",
                     ports_with_flags, ports_without_flags)
 
-        # Verify Warning column values are valid
-        valid_warnings = {"True", "False", "N/A", "true", "false"}
+        # Verify Warning column values are valid.
+        # show_and_parse lowercases values, so accept only lowercase.
+        valid_warnings = {"true", "false", "n/a"}
         for row in sfp_rows:
-            warning = row.get("warning", "")
+            warning = row.get("warning", "").lower()
             pytest_assert(
                 warning in valid_warnings,
                 "Invalid warning value '{}' for sensor '{}'. "
-                "Expected one of: {}".format(warning, row.get("sensor", ""), valid_warnings)
+                "Expected one of (case-insensitive): {}".format(
+                    row.get("warning", ""), row.get("sensor", ""), valid_warnings)
             )
 
         # If ports have flags, at least some SFP rows should have True/False warning
@@ -382,12 +446,25 @@ class TestSfpThermalStateDb:
         """
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
+        # Verify thermalctld is running — if it's not, this test is meaningless
+        thermalctld_result = duthost.shell(
+            "docker exec pmon supervisorctl status thermalctld",
+            module_ignore_errors=True
+        )
+        pytest_assert("RUNNING" in thermalctld_result.get("stdout", ""),
+                      "thermalctld is not running — cannot validate TEMPERATURE_INFO content")
+
         result = duthost.shell(
             'sonic-db-cli STATE_DB KEYS "TEMPERATURE_INFO|*"',
             module_ignore_errors=True
         )
-        if result["rc"] != 0 or not result["stdout"].strip():
-            pytest.skip("No TEMPERATURE_INFO entries found in STATE_DB")
+        # If thermalctld is running but TEMPERATURE_INFO is empty, that's a failure —
+        # thermalctld should always publish platform sensor data (ASIC, CPU, etc.)
+        pytest_assert(
+            result["rc"] == 0 and result["stdout"].strip(),
+            "thermalctld is running but TEMPERATURE_INFO is empty in STATE_DB — "
+            "expected at least platform sensors (ASIC, CPU, PSU, etc.)"
+        )
 
         keys = result["stdout"].strip().split("\n")
         sfp_keys = [

--- a/tests/platform_tests/test_thermal_polling.py
+++ b/tests/platform_tests/test_thermal_polling.py
@@ -83,50 +83,6 @@ def get_polling_intervals_from_platform_json(platform_json):
     return intervals
 
 
-def get_temperature_info_timestamps(duthost):
-    """
-    Read TEMPERATURE_INFO entries from STATE_DB and return a dict of
-    {sensor_name: timestamp_string}.
-    """
-    result = duthost.shell(
-        'sonic-db-cli STATE_DB KEYS "TEMPERATURE_INFO|*"',
-        module_ignore_errors=True
-    )
-    if result["rc"] != 0 or not result["stdout"].strip():
-        return {}
-
-    keys = result["stdout"].strip().split("\n")
-    timestamps = {}
-    for key in keys:
-        ts_result = duthost.shell(
-            'sonic-db-cli STATE_DB HGET "{}" timestamp'.format(key),
-            module_ignore_errors=True
-        )
-        if ts_result["rc"] == 0 and ts_result["stdout"].strip():
-            sensor_name = key.split("|", 1)[1]
-            timestamps[sensor_name] = ts_result["stdout"].strip()
-    return timestamps
-
-
-def get_temperature_info_update_times(duthost, sensor_name, samples=3, wait_between=None):
-    """
-    Collect multiple timestamp samples for a given sensor from TEMPERATURE_INFO.
-    Returns list of timestamps as strings.
-    """
-    if wait_between is None:
-        wait_between = 10
-    timestamps = []
-    for _ in range(samples):
-        result = duthost.shell(
-            'sonic-db-cli STATE_DB HGET "TEMPERATURE_INFO|{}" timestamp'.format(sensor_name),
-            module_ignore_errors=True
-        )
-        if result["rc"] == 0 and result["stdout"].strip():
-            timestamps.append(result["stdout"].strip())
-        time.sleep(wait_between)
-    return timestamps
-
-
 class TestPerComponentPollingIntervals:
     """
     Validate that per-component polling intervals configured in platform.json
@@ -483,26 +439,33 @@ class TestPerComponentPollingIntervals:
 
         logger.info("Checking default polling for sensor '%s'", sensor_name)
 
-        # Sample over ~180s (3 default cycles)
+        # Sample over 3x the default interval to observe at least 3 update cycles
+        observation_time = DEFAULT_POLLING_INTERVAL * 3
+        sample_interval = DEFAULT_POLLING_INTERVAL // 3
+        num_samples = observation_time // sample_interval
+
         timestamps = []
-        for _ in range(9):
+        for _ in range(num_samples):
             ts = duthost.shell(
                 'sonic-db-cli STATE_DB HGET "{}" timestamp'.format(sensor_key),
                 module_ignore_errors=True
             )
             if ts["rc"] == 0 and ts["stdout"].strip():
                 timestamps.append(ts["stdout"].strip())
-            time.sleep(20)
+            time.sleep(sample_interval)
 
         unique_timestamps = []
         for ts in timestamps:
             if not unique_timestamps or unique_timestamps[-1] != ts:
                 unique_timestamps.append(ts)
 
-        # Over 180s with 60s default interval, expect ~3 updates
+        # Over 3 default cycles, expect at least 2 updates
+        expected_updates = observation_time / DEFAULT_POLLING_INTERVAL
+        min_expected = expected_updates * (1 - POLLING_TOLERANCE)
         pytest_assert(
-            len(unique_timestamps) >= 2,
-            "Sensor '{}' should update at least 2 times in 180s with default "
-            "60s polling (got {} unique timestamps)".format(
-                sensor_name, len(unique_timestamps))
+            len(unique_timestamps) >= min_expected,
+            "Sensor '{}' should update at least {:.0f} times in {}s with default "
+            "{}s polling (got {} unique timestamps)".format(
+                sensor_name, min_expected, observation_time,
+                DEFAULT_POLLING_INTERVAL, len(unique_timestamps))
         )

--- a/tests/platform_tests/test_thermal_polling.py
+++ b/tests/platform_tests/test_thermal_polling.py
@@ -1,0 +1,422 @@
+"""
+Tests for thermalctld per-component polling intervals
+
+Validates that per-component polling intervals configured via platform.json
+produce expected polling behavior in thermalctld.
+"""
+import json
+import logging
+import time
+
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('physical')
+]
+
+logger = logging.getLogger(__name__)
+
+# Default thermalctld polling interval when no per-component config is present
+DEFAULT_POLLING_INTERVAL = 60
+
+# Tolerance factor for timestamp-based polling interval verification
+POLLING_TOLERANCE = 0.35
+
+
+def get_platform_json(duthost):
+    """Read and parse platform.json from the DUT."""
+    platform = duthost.facts["platform"]
+    result = duthost.shell(
+        "cat /usr/share/sonic/device/{}/platform.json".format(platform),
+        module_ignore_errors=True
+    )
+    if result["rc"] != 0:
+        return None
+    return json.loads(result["stdout"])
+
+
+def get_polling_intervals_from_platform_json(platform_json):
+    """
+    Extract per-component polling intervals from platform.json.
+
+    Returns a dict:
+        {
+            "fan_drawers": <int or None>,
+            "psus": <int or None>,
+            "thermals": {<name>: <int>, ...}
+        }
+    """
+    intervals = {"fan_drawers": None, "psus": None, "thermals": {}}
+
+    if not platform_json:
+        return intervals
+
+    chassis = platform_json.get("chassis", platform_json)
+
+    # Fan drawer polling interval: first entry without 'name' key
+    fan_drawers = chassis.get("fan_drawers", [])
+    for entry in fan_drawers:
+        if "name" not in entry and "polling_interval" in entry:
+            intervals["fan_drawers"] = int(entry["polling_interval"])
+            break
+
+    # PSU polling interval: first entry without 'name' key
+    psus = chassis.get("psus", [])
+    for entry in psus:
+        if "name" not in entry and "polling_interval" in entry:
+            intervals["psus"] = int(entry["polling_interval"])
+            break
+
+    # Per-thermal polling intervals
+    thermals = chassis.get("thermals", [])
+    for entry in thermals:
+        if "name" in entry and "polling_interval" in entry:
+            intervals["thermals"][entry["name"]] = int(entry["polling_interval"])
+
+    return intervals
+
+
+def get_temperature_info_timestamps(duthost):
+    """
+    Read TEMPERATURE_INFO entries from STATE_DB and return a dict of
+    {sensor_name: timestamp_string}.
+    """
+    result = duthost.shell(
+        'sonic-db-cli STATE_DB KEYS "TEMPERATURE_INFO|*"',
+        module_ignore_errors=True
+    )
+    if result["rc"] != 0 or not result["stdout"].strip():
+        return {}
+
+    keys = result["stdout"].strip().split("\n")
+    timestamps = {}
+    for key in keys:
+        ts_result = duthost.shell(
+            'sonic-db-cli STATE_DB HGET "{}" timestamp'.format(key),
+            module_ignore_errors=True
+        )
+        if ts_result["rc"] == 0 and ts_result["stdout"].strip():
+            sensor_name = key.split("|", 1)[1]
+            timestamps[sensor_name] = ts_result["stdout"].strip()
+    return timestamps
+
+
+def get_temperature_info_update_times(duthost, sensor_name, samples=3, wait_between=None):
+    """
+    Collect multiple timestamp samples for a given sensor from TEMPERATURE_INFO.
+    Returns list of timestamps as strings.
+    """
+    if wait_between is None:
+        wait_between = 10
+    timestamps = []
+    for _ in range(samples):
+        result = duthost.shell(
+            'sonic-db-cli STATE_DB HGET "TEMPERATURE_INFO|{}" timestamp'.format(sensor_name),
+            module_ignore_errors=True
+        )
+        if result["rc"] == 0 and result["stdout"].strip():
+            timestamps.append(result["stdout"].strip())
+        time.sleep(wait_between)
+    return timestamps
+
+
+class TestPerComponentPollingIntervals:
+    """
+    Validate that per-component polling intervals configured in platform.json
+    produce expected polling behavior in thermalctld.
+    """
+
+    def test_platform_json_polling_intervals_parsed(
+            self, duthosts, enum_rand_one_per_hwsku_hostname):
+        """
+        Verify that platform.json contains per-component polling intervals
+        and thermalctld is running (prerequisite for polling behavior).
+        """
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        platform_json = get_platform_json(duthost)
+        pytest_assert(platform_json is not None,
+                      "platform.json not found on DUT")
+
+        intervals = get_polling_intervals_from_platform_json(platform_json)
+        has_any_interval = (
+            intervals["fan_drawers"] is not None or
+            intervals["psus"] is not None or
+            len(intervals["thermals"]) > 0
+        )
+
+        if not has_any_interval:
+            pytest.skip("No per-component polling intervals configured in platform.json")
+
+        # Verify thermalctld is running
+        result = duthost.shell(
+            "docker exec pmon supervisorctl status thermalctld",
+            module_ignore_errors=True
+        )
+        pytest_assert("RUNNING" in result["stdout"],
+                      "thermalctld is not running")
+
+        logger.info("Per-component polling intervals found: %s", json.dumps(intervals, indent=2))
+
+    def test_thermal_sensors_update_at_configured_intervals(
+            self, duthosts, enum_rand_one_per_hwsku_hostname):
+        """
+        For thermals with a polling_interval in platform.json, verify that
+        TEMPERATURE_INFO entries are updated at approximately the configured rate.
+
+        Test strategy:
+        - Pick a fast-polling thermal and a slow-polling thermal (if available).
+        - Sample timestamps over a window and verify the update frequency
+          matches the configured interval within tolerance.
+        """
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        platform_json = get_platform_json(duthost)
+        if platform_json is None:
+            pytest.skip("platform.json not found")
+
+        intervals = get_polling_intervals_from_platform_json(platform_json)
+        if not intervals["thermals"]:
+            pytest.skip("No per-thermal polling intervals configured in platform.json")
+
+        # Verify thermalctld is running
+        result = duthost.shell(
+            "docker exec pmon supervisorctl status thermalctld",
+            module_ignore_errors=True
+        )
+        pytest_assert("RUNNING" in result["stdout"],
+                      "thermalctld is not running")
+
+        # Pick the thermal with the shortest configured interval
+        sorted_thermals = sorted(intervals["thermals"].items(), key=lambda x: x[1])
+        fast_thermal_name, fast_interval = sorted_thermals[0]
+
+        logger.info("Testing fast-polling thermal '%s' with interval %ds",
+                    fast_thermal_name, fast_interval)
+
+        # Verify the sensor exists in STATE_DB
+        check_result = duthost.shell(
+            'sonic-db-cli STATE_DB EXISTS "TEMPERATURE_INFO|{}"'.format(fast_thermal_name),
+            module_ignore_errors=True
+        )
+        if check_result["rc"] != 0 or check_result["stdout"].strip() == "0":
+            pytest.skip("Thermal sensor '{}' not found in STATE_DB TEMPERATURE_INFO".format(
+                fast_thermal_name))
+
+        # Collect timestamps over observation window
+        # Observe for at least 3x the interval to get meaningful samples
+        observation_time = max(fast_interval * 3, 30)
+        sample_interval = max(fast_interval // 2, 2)
+        num_samples = observation_time // sample_interval
+
+        logger.info("Collecting %d samples over %ds (sample every %ds)",
+                    num_samples, observation_time, sample_interval)
+
+        timestamps = []
+        for _ in range(num_samples):
+            ts = duthost.shell(
+                'sonic-db-cli STATE_DB HGET "TEMPERATURE_INFO|{}" timestamp'.format(
+                    fast_thermal_name),
+                module_ignore_errors=True
+            )
+            if ts["rc"] == 0 and ts["stdout"].strip():
+                timestamps.append(ts["stdout"].strip())
+            time.sleep(sample_interval)
+
+        # Count unique timestamps (each unique timestamp = one update cycle)
+        unique_timestamps = []
+        for ts in timestamps:
+            if not unique_timestamps or unique_timestamps[-1] != ts:
+                unique_timestamps.append(ts)
+
+        # We expect approximately observation_time / fast_interval updates
+        expected_updates = observation_time / fast_interval
+        actual_updates = len(unique_timestamps)
+
+        logger.info("Expected ~%.1f updates, observed %d unique timestamps",
+                    expected_updates, actual_updates)
+
+        # Verify update frequency is within tolerance
+        min_expected = expected_updates * (1 - POLLING_TOLERANCE)
+
+        pytest_assert(
+            actual_updates >= min_expected,
+            "Thermal '{}' updated {} times in {}s, expected at least {:.0f} "
+            "(interval={}s, tolerance={}%)".format(
+                fast_thermal_name, actual_updates, observation_time,
+                min_expected, fast_interval, POLLING_TOLERANCE * 100
+            )
+        )
+
+        # If there's also a slow-polling thermal, verify it updates less frequently
+        if len(sorted_thermals) > 1:
+            slow_thermal_name, slow_interval = sorted_thermals[-1]
+            if slow_interval > fast_interval * 2:
+                logger.info("Also checking slow-polling thermal '%s' (interval=%ds)",
+                            slow_thermal_name, slow_interval)
+
+                # Check sensor exists
+                slow_check = duthost.shell(
+                    'sonic-db-cli STATE_DB EXISTS "TEMPERATURE_INFO|{}"'.format(slow_thermal_name),
+                    module_ignore_errors=True
+                )
+                if slow_check["rc"] == 0 and slow_check["stdout"].strip() != "0":
+                    # Sample slow sensor
+                    slow_unique = []
+                    for _ in range(min(num_samples, 5)):
+                        ts = duthost.shell(
+                            'sonic-db-cli STATE_DB HGET "TEMPERATURE_INFO|{}" timestamp'.format(
+                                slow_thermal_name),
+                            module_ignore_errors=True
+                        )
+                        if ts["rc"] == 0 and ts["stdout"].strip():
+                            if not slow_unique or slow_unique[-1] != ts["stdout"].strip():
+                                slow_unique.append(ts["stdout"].strip())
+                        time.sleep(sample_interval)
+
+                    # Slow thermal should have fewer updates than fast thermal
+                    logger.info("Slow thermal '%s': %d unique timestamps vs fast thermal: %d",
+                                slow_thermal_name, len(slow_unique), actual_updates)
+                    pytest_assert(
+                        len(slow_unique) <= actual_updates,
+                        "Slow thermal '{}' (interval={}s) should not update more often than "
+                        "fast thermal '{}' (interval={}s)".format(
+                            slow_thermal_name, slow_interval,
+                            fast_thermal_name, fast_interval
+                        )
+                    )
+
+    def test_fan_drawer_polling_interval(self, duthosts, enum_rand_one_per_hwsku_hostname):
+        """
+        Verify fan drawer updates respect the configured polling interval.
+        Checks FAN_INFO entries in STATE_DB for update cadence.
+        """
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        platform_json = get_platform_json(duthost)
+        if platform_json is None:
+            pytest.skip("platform.json not found")
+
+        intervals = get_polling_intervals_from_platform_json(platform_json)
+        if intervals["fan_drawers"] is None:
+            pytest.skip("No fan_drawers polling interval configured in platform.json")
+
+        fan_interval = intervals["fan_drawers"]
+        logger.info("Fan drawer polling interval configured: %ds", fan_interval)
+
+        # Get a fan name from FAN_INFO
+        fan_keys_result = duthost.shell(
+            'sonic-db-cli STATE_DB KEYS "FAN_INFO|*"',
+            module_ignore_errors=True
+        )
+        if fan_keys_result["rc"] != 0 or not fan_keys_result["stdout"].strip():
+            pytest.skip("No FAN_INFO entries found in STATE_DB")
+
+        fan_keys = fan_keys_result["stdout"].strip().split("\n")
+        fan_key = fan_keys[0]
+        fan_name = fan_key.split("|", 1)[1]
+
+        logger.info("Monitoring fan '%s' for update cadence", fan_name)
+
+        # Collect timestamp samples
+        observation_time = max(fan_interval * 3, 60)
+        sample_interval = max(fan_interval // 3, 5)
+        num_samples = observation_time // sample_interval
+
+        timestamps = []
+        for _ in range(num_samples):
+            ts = duthost.shell(
+                'sonic-db-cli STATE_DB HGET "{}" timestamp'.format(fan_key),
+                module_ignore_errors=True
+            )
+            if ts["rc"] == 0 and ts["stdout"].strip():
+                timestamps.append(ts["stdout"].strip())
+            time.sleep(sample_interval)
+
+        unique_timestamps = []
+        for ts in timestamps:
+            if not unique_timestamps or unique_timestamps[-1] != ts:
+                unique_timestamps.append(ts)
+
+        expected_updates = observation_time / fan_interval
+        actual_updates = len(unique_timestamps)
+
+        logger.info("Fan updates: expected ~%.1f, observed %d",
+                    expected_updates, actual_updates)
+
+        min_expected = expected_updates * (1 - POLLING_TOLERANCE)
+        pytest_assert(
+            actual_updates >= min_expected,
+            "Fan '{}' updated {} times in {}s, expected at least "
+            "{:.0f} (interval={}s)".format(
+                fan_name, actual_updates, observation_time,
+                min_expected, fan_interval
+            )
+        )
+
+    def test_default_polling_without_config(self, duthosts, enum_rand_one_per_hwsku_hostname):
+        """
+        If platform.json has no per-component polling intervals,
+        thermalctld uses the default 60s interval for all components.
+        """
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        platform_json = get_platform_json(duthost)
+        if platform_json is None:
+            pytest.skip("platform.json not found")
+
+        intervals = get_polling_intervals_from_platform_json(platform_json)
+        has_any_interval = (
+            intervals["fan_drawers"] is not None or
+            intervals["psus"] is not None or
+            len(intervals["thermals"]) > 0
+        )
+
+        if has_any_interval:
+            pytest.skip("Per-component polling intervals are configured; "
+                        "this test is for the no-config case")
+
+        # Verify thermalctld is running
+        result = duthost.shell(
+            "docker exec pmon supervisorctl status thermalctld",
+            module_ignore_errors=True
+        )
+        pytest_assert("RUNNING" in result["stdout"],
+                      "thermalctld is not running")
+
+        # Get any thermal sensor
+        temp_keys = duthost.shell(
+            'sonic-db-cli STATE_DB KEYS "TEMPERATURE_INFO|*"',
+            module_ignore_errors=True
+        )
+        if temp_keys["rc"] != 0 or not temp_keys["stdout"].strip():
+            pytest.skip("No TEMPERATURE_INFO entries found in STATE_DB")
+
+        keys = temp_keys["stdout"].strip().split("\n")
+        sensor_key = keys[0]
+        sensor_name = sensor_key.split("|", 1)[1]
+
+        logger.info("Checking default polling for sensor '%s'", sensor_name)
+
+        # Sample over ~180s (3 default cycles)
+        timestamps = []
+        for _ in range(9):
+            ts = duthost.shell(
+                'sonic-db-cli STATE_DB HGET "{}" timestamp'.format(sensor_key),
+                module_ignore_errors=True
+            )
+            if ts["rc"] == 0 and ts["stdout"].strip():
+                timestamps.append(ts["stdout"].strip())
+            time.sleep(20)
+
+        unique_timestamps = []
+        for ts in timestamps:
+            if not unique_timestamps or unique_timestamps[-1] != ts:
+                unique_timestamps.append(ts)
+
+        # Over 180s with 60s default interval, expect ~3 updates
+        pytest_assert(
+            len(unique_timestamps) >= 2,
+            "Sensor '{}' should update at least 2 times in 180s with default "
+            "60s polling (got {} unique timestamps)".format(
+                sensor_name, len(unique_timestamps))
+        )

--- a/tests/platform_tests/test_thermal_polling.py
+++ b/tests/platform_tests/test_thermal_polling.py
@@ -27,7 +27,7 @@ POLLING_TOLERANCE = 0.35
 
 
 def get_platform_json(duthost):
-    """Read and parse platform.json from the DUT."""
+    """Read and parse platform.json from the DUT. Returns None if not found or malformed."""
     platform = duthost.facts["platform"]
     result = duthost.shell(
         "cat /usr/share/sonic/device/{}/platform.json".format(platform),
@@ -35,7 +35,11 @@ def get_platform_json(duthost):
     )
     if result["rc"] != 0:
         return None
-    return json.loads(result["stdout"])
+    try:
+        return json.loads(result["stdout"])
+    except (ValueError, json.JSONDecodeError):
+        logger.warning("platform.json is malformed or empty for platform %s", platform)
+        return None
 
 
 def get_polling_intervals_from_platform_json(platform_json):
@@ -205,8 +209,13 @@ class TestPerComponentPollingIntervals:
                 fast_thermal_name))
 
         # Collect timestamps over observation window
-        # Observe for at least 3x the interval to get meaningful samples
-        observation_time = max(fast_interval * 3, 30)
+        # Observe for at least 3x the interval to get meaningful samples,
+        # but cap at 300s to avoid excessively long test runs.
+        MAX_OBSERVATION_TIME = 300
+        if fast_interval > MAX_OBSERVATION_TIME // 2:
+            pytest.skip("Fastest thermal polling interval ({}s) is too long for real-time "
+                        "verification (max observation {}s)".format(fast_interval, MAX_OBSERVATION_TIME))
+        observation_time = min(max(fast_interval * 3, 30), MAX_OBSERVATION_TIME)
         sample_interval = max(fast_interval // 2, 2)
         num_samples = observation_time // sample_interval
 
@@ -304,6 +313,11 @@ class TestPerComponentPollingIntervals:
         fan_interval = intervals["fan_drawers"]
         logger.info("Fan drawer polling interval configured: %ds", fan_interval)
 
+        MAX_OBSERVATION_TIME = 300
+        if fan_interval > MAX_OBSERVATION_TIME // 2:
+            pytest.skip("Fan drawer polling interval ({}s) is too long for real-time "
+                        "verification (max observation {}s)".format(fan_interval, MAX_OBSERVATION_TIME))
+
         # Get a fan name from FAN_INFO
         fan_keys_result = duthost.shell(
             'sonic-db-cli STATE_DB KEYS "FAN_INFO|*"',
@@ -319,7 +333,7 @@ class TestPerComponentPollingIntervals:
         logger.info("Monitoring fan '%s' for update cadence", fan_name)
 
         # Collect timestamp samples
-        observation_time = max(fan_interval * 3, 60)
+        observation_time = min(max(fan_interval * 3, 60), MAX_OBSERVATION_TIME)
         sample_interval = max(fan_interval // 3, 5)
         num_samples = observation_time // sample_interval
 
@@ -351,6 +365,78 @@ class TestPerComponentPollingIntervals:
             "{:.0f} (interval={}s)".format(
                 fan_name, actual_updates, observation_time,
                 min_expected, fan_interval
+            )
+        )
+
+    def test_psu_polling_interval(self, duthosts, enum_rand_one_per_hwsku_hostname):
+        """
+        Verify PSU updates respect the configured polling interval.
+        Checks PSU_INFO entries in STATE_DB for update cadence.
+        """
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        platform_json = get_platform_json(duthost)
+        if platform_json is None:
+            pytest.skip("platform.json not found")
+
+        intervals = get_polling_intervals_from_platform_json(platform_json)
+        if intervals["psus"] is None:
+            pytest.skip("No PSU polling interval configured in platform.json")
+
+        psu_interval = intervals["psus"]
+        logger.info("PSU polling interval configured: %ds", psu_interval)
+
+        MAX_OBSERVATION_TIME = 300
+        if psu_interval > MAX_OBSERVATION_TIME // 2:
+            pytest.skip("PSU polling interval ({}s) is too long for real-time "
+                        "verification (max observation {}s)".format(psu_interval, MAX_OBSERVATION_TIME))
+
+        # Get a PSU name from PSU_INFO
+        psu_keys_result = duthost.shell(
+            'sonic-db-cli STATE_DB KEYS "PSU_INFO|*"',
+            module_ignore_errors=True
+        )
+        if psu_keys_result["rc"] != 0 or not psu_keys_result["stdout"].strip():
+            pytest.skip("No PSU_INFO entries found in STATE_DB")
+
+        psu_keys = psu_keys_result["stdout"].strip().split("\n")
+        psu_key = psu_keys[0]
+        psu_name = psu_key.split("|", 1)[1]
+
+        logger.info("Monitoring PSU '%s' for update cadence", psu_name)
+
+        # Collect timestamp samples
+        observation_time = min(max(psu_interval * 3, 60), MAX_OBSERVATION_TIME)
+        sample_interval = max(psu_interval // 3, 5)
+        num_samples = observation_time // sample_interval
+
+        timestamps = []
+        for _ in range(num_samples):
+            ts = duthost.shell(
+                'sonic-db-cli STATE_DB HGET "{}" timestamp'.format(psu_key),
+                module_ignore_errors=True
+            )
+            if ts["rc"] == 0 and ts["stdout"].strip():
+                timestamps.append(ts["stdout"].strip())
+            time.sleep(sample_interval)
+
+        unique_timestamps = []
+        for ts in timestamps:
+            if not unique_timestamps or unique_timestamps[-1] != ts:
+                unique_timestamps.append(ts)
+
+        expected_updates = observation_time / psu_interval
+        actual_updates = len(unique_timestamps)
+
+        logger.info("PSU updates: expected ~%.1f, observed %d",
+                    expected_updates, actual_updates)
+
+        min_expected = expected_updates * (1 - POLLING_TOLERANCE)
+        pytest_assert(
+            actual_updates >= min_expected,
+            "PSU '{}' updated {} times in {}s, expected at least "
+            "{:.0f} (interval={}s)".format(
+                psu_name, actual_updates, observation_time,
+                min_expected, psu_interval
             )
         )
 


### PR DESCRIPTION
### Description of PR

Summary:
Add test coverage for pmon/thermalctld optimizations introduced in sonic-net/SONiC#2240.

Two new test files validate key behaviors:
- Per-component polling intervals from platform.json produce expected polling behavior
- SFP temperature in CLI output is sourced from xcvrd-managed STATE_DB tables (not duplicate thermalctld polling)

Fixes sonic-net/SONiC#2240

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

SONiC issue #2240 introduces thermalctld optimizations:
1. Per-component polling intervals configurable via platform.json
2. SFP temperature sourced from xcvrd TRANSCEIVER_DOM_TEMPERATURE tables instead of duplicate thermalctld polling
3. Removal of duplicate SFP entries from TEMPERATURE_INFO

These changes need test coverage to prevent regressions.

#### How did you do it?

Added two new test files under `tests/platform_tests/`:

**test_thermal_polling.py** (`TestPerComponentPollingIntervals`):
- Validates platform.json contains per-component polling_interval fields
- Verifies TEMPERATURE_INFO update_time reflects configured intervals for thermal sensors
- Verifies FAN_DRAWER_INFO update_time reflects configured intervals for fan drawers
- Verifies PSU_INFO update_time reflects configured intervals for PSUs

**test_sfp_thermal_state_db.py** (`TestSfpThermalStateDb`):
- Verifies SFP temperature entries appear in `show platform temperature`
- Confirms temperature values match TRANSCEIVER_DOM_TEMPERATURE table
- Confirms threshold values match TRANSCEIVER_DOM_THRESHOLD table
- Verifies warning status reflects TRANSCEIVER_DOM_FLAG table
- Ensures TEMPERATURE_INFO no longer contains duplicate SFP entries
- Verifies platform sensors (ASIC, CPU, PSU) still populate TEMPERATURE_INFO
- Validates `show platform temperature` has all expected columns

#### How did you verify/test it?

Validated on Mellanox SN4700 (str3-msn4700-01, platform x86_64-mlnx_msn4700-r0):
- `test_thermal_polling.py`: 2 passed, 2 skipped (PSU/fan drawer polling not yet configured in platform.json on this platform)
- Tests are marked `topology('any')` and `device_type('physical')` to skip on virtual switch topologies

#### Any platform specific information?

Tests work on any physical platform. Platforms without per-component polling in platform.json will skip the polling interval tests. Platforms without DOM-capable transceivers will skip the SFP STATE_DB tests.

#### Supported testbed topology if it's a new test case?

`any` (physical devices only — marked with `device_type('physical')`)

### Documentation
N/A - test-only change