### PR TITLE
[ARP][test_arp_update] Add IPv6 support to test_dut_arping_learns_mac and test_dut_ping_learns_mac

### DIFF
--- a/tests/arp/arp_utils.py
+++ b/tests/arp/arp_utils.py
@@ -2,7 +2,7 @@ import re
 import logging
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
-from ipaddress import ip_address, ip_interface, ip_network, IPv4Network
+from ipaddress import ip_address, ip_interface, ip_network, IPv4Network, IPv6Network
 
 
 logger = logging.getLogger(__name__)
@@ -131,3 +131,19 @@ def get_vlan_ipv4_for_subnet(config_facts, target_ip):
             except ValueError:
                 continue
     return None, None, None
+
+
+def get_vlan_ipv6(config_facts):
+    """
+    Return (vlan_intf_name, ipv6_addr) for the first VLAN_INTERFACE with IPv6.
+    """
+    vlan_intfs = config_facts.get("VLAN_INTERFACE", {})
+    for intf, addrs in vlan_intfs.items():
+        for addr in addrs:
+            try:
+                if type(ip_network(addr, strict=False)) is IPv6Network:
+                    iface = ip_interface(addr)
+                    return intf, iface.ip
+            except ValueError:
+                continue
+    return None, None

--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -40,19 +40,21 @@ def pause_arp_update(rand_selected_dut):
 @pytest.fixture
 def ptf_interface_info(ip_and_intf_info, ptfadapter):
     """
-    Get PTF interface information
+    Get PTF interface information (IPv4 and, when available, IPv6).
     """
-    ptf_intf_ipv4_addr, _, _, _, ptf_intf_index = ip_and_intf_info
+    ptf_intf_ipv4_addr, _, ptf_intf_ipv6_addr, _, ptf_intf_index = ip_and_intf_info
     ptf_intf_mac = ptfadapter.dataplane.get_mac(0, ptf_intf_index)
     if isinstance(ptf_intf_mac, (bytes, bytearray)):
         ptf_intf_mac = ptf_intf_mac.decode()
 
     ptf_iface = f"eth{ptf_intf_index}"
-    ptf_ip = str(ptf_intf_ipv4_addr)
+    ptf_ip = str(ptf_intf_ipv4_addr) if ptf_intf_ipv4_addr is not None else None
+    ptf_ipv6 = str(ptf_intf_ipv6_addr) if ptf_intf_ipv6_addr is not None else None
 
     return {
         'ip': ptf_ip,
         'ipv4_addr': ptf_intf_ipv4_addr,
+        'ipv6': ptf_ipv6,
         'mac': ptf_intf_mac,
         'index': ptf_intf_index,
         'interface': ptf_iface
@@ -109,20 +111,38 @@ def clean_environment(rand_selected_dut, ptfadapter):
 @pytest.fixture
 def ptf_with_ip_config(ptf_interface_info, dut_interface_info, ptfhost):
     """
-    Configure IP on PTF interface using the correct prefix length from the DUT VLAN subnet.
+    Configure an IP on the PTF interface. Uses IPv4 if the DUT VLAN has an IPv4
+    address, otherwise falls back to IPv6 (e.g. IPv6-only topologies).
     """
     ptf_info = ptf_interface_info
-    prefix_len = dut_interface_info.get('prefix_len', 24)
+    iface = ptf_info['interface']
 
-    # Configure IP on PTF interface
-    ptfhost.shell(f"ip addr add {ptf_info['ip']}/{prefix_len} dev {ptf_info['interface']}",
-                  module_ignore_errors=True)
+    if dut_interface_info.get('ipv4') is None:
+        # No IPv4 on DUT VLAN - configure IPv6 on PTF interface instead
+        prefix_len = 64
+        ptf_addr = ptf_info['ipv6']
+        pt_assert(ptf_addr is not None, "No IPv6 address available on PTF interface")
+        ptfhost.shell(f"ip -6 addr add {ptf_addr}/{prefix_len} dev {iface}",
+                      module_ignore_errors=True)
 
-    yield ptf_info
+        yield ptf_info
 
-    # Cleanup: remove IP from PTF interface
-    ptfhost.shell(f"ip addr del {ptf_info['ip']}/{prefix_len} dev {ptf_info['interface']}",
-                  module_ignore_errors=True)
+        # Cleanup: remove IPv6 from PTF interface
+        ptfhost.shell(f"ip -6 addr del {ptf_addr}/{prefix_len} dev {iface}",
+                      module_ignore_errors=True)
+    else:
+        prefix_len = dut_interface_info.get('prefix_len', 24)
+        ptf_addr = ptf_info['ip']
+
+        # Configure IP on PTF interface
+        ptfhost.shell(f"ip addr add {ptf_addr}/{prefix_len} dev {iface}",
+                      module_ignore_errors=True)
+
+        yield ptf_info
+
+        # Cleanup: remove IP from PTF interface
+        ptfhost.shell(f"ip addr del {ptf_addr}/{prefix_len} dev {iface}",
+                      module_ignore_errors=True)
 
 
 def neighbor_learned(dut, target_ip):
@@ -283,28 +303,46 @@ def test_dut_arping_learns_mac(
     setup_vlan_arp_responder  # noqa: F811
 ):
     """
-    After fdb_cleanup and clearing DUT ARP cache,
-    enable PTF to respond to arping,
-    simulate arping from DUT to PTF,
-    verify DUT learns PTF MAC in FDB
+    After fdb_cleanup and clearing DUT ARP/neighbor cache, have PTF respond to
+    ARP (IPv4) or NDP (IPv6-only), trigger neighbor resolution from the DUT,
+    and verify the DUT learns the PTF MAC in the FDB.
+
+    On IPv6-only topologies `arping` (IPv4-only) is replaced by `ndisc6`,
+    the IPv6 NDP equivalent of arping: it sends an NDP Neighbor Solicitation
+    and waits for a Neighbor Advertisement from arp_responder on PTF.
     """
     # Setup PTF and DUT info
     ptf_info = ptf_interface_info
     dut_info = dut_interface_info
 
     # Setup PTF responder info
-    vlan_name, ipv4_base, _, ip_offset = setup_vlan_arp_responder
-    ptf_responder_ip = str(ipv4_base.ip + ip_offset)
-    logger.info("PTF responder IP (setup_vlan_arp_responder): {}".format(ptf_responder_ip))
-    logger.info("DUT VLAN IPv4: {}".format(dut_info['ipv4']))
+    vlan_name, ipv4_base, ipv6_base, ip_offset = setup_vlan_arp_responder
 
-    # Simulate arping from DUT to PTF interface
-    dut_info['host'].shell(f"arping -c 1 -I {dut_info['vlan_name']} {ptf_responder_ip}")
+    if dut_info['ipv4'] is None:
+        # No IPv4 on VLAN - trigger NDP from DUT via ping6
+        pt_assert(ipv6_base is not None,
+                  "setup_vlan_arp_responder did not provide an IPv6 base address")
+        ptf_responder_ip = str(ipv6_base.ip + ip_offset)
+        logger.info("PTF responder IPv6 (setup_vlan_arp_responder): {}".format(ptf_responder_ip))
+        logger.info("DUT VLAN IPv6: {}".format(dut_info['ipv6']))
+
+        # Simulate NDP from DUT to PTF interface (IPv6 equivalent of arping)
+        dut_info['host'].shell(
+            f"ndisc6 {ptf_responder_ip} {dut_info['vlan_name']}",
+            module_ignore_errors=True
+        )
+    else:
+        ptf_responder_ip = str(ipv4_base.ip + ip_offset)
+        logger.info("PTF responder IP (setup_vlan_arp_responder): {}".format(ptf_responder_ip))
+        logger.info("DUT VLAN IPv4: {}".format(dut_info['ipv4']))
+
+        # Simulate arping from DUT to PTF interface
+        dut_info['host'].shell(f"arping -c 1 -I {dut_info['vlan_name']} {ptf_responder_ip}")
 
     # Confirm MAC is learned on DUT FDB
     pt_assert(
         wait_until(10, 1, 0, fdb_has_mac, dut_info['host'], ptf_info['mac']),
-        "FDB did not learn PTF MAC after DUT arping"
+        "FDB did not learn PTF MAC after DUT neighbor resolution"
     )
 
 
@@ -315,16 +353,27 @@ def test_dut_ping_learns_mac(
     ptfhost
 ):
     """
-    Configure IP on PTF interface,
-    ping DUT from PTF,
-    then verify both sides learned MAC address
+    Configure an IP on the PTF interface (IPv4 or IPv6 depending on DUT VLAN
+    configuration), ping the DUT from PTF, and verify both sides learn the
+    peer MAC.
     """
     # Setup PTF and DUT info
     ptf_info = ptf_with_ip_config
     dut_info = dut_interface_info
 
+    # Pick the address family that matches the DUT VLAN configuration
+    if dut_info['ipv4'] is None:
+        pt_assert(dut_info['ipv6'] is not None, "No IPv6 address on DUT VLAN interface")
+        dut_addr = str(dut_info['ipv6'])
+        ping_cmd = f"ping6 -c 3 {dut_addr}"
+        neigh_cmd = f"ip -6 neigh show {dut_addr}"
+    else:
+        dut_addr = str(dut_info['ipv4'])
+        ping_cmd = f"ping -c 3 {dut_addr}"
+        neigh_cmd = f"ip neigh show {dut_addr}"
+
     # Ping DUT from PTF (3 times)
-    ping_res = ptfhost.shell(f"ping -c 3 {dut_info['ipv4']}", module_ignore_errors=True)
+    ping_res = ptfhost.shell(ping_cmd, module_ignore_errors=True)
     pt_assert(ping_res["rc"] == 0, f"PTF ping to DUT failed: {ping_res['stdout']}")
 
     # DUT learns PTF MAC
@@ -334,6 +383,6 @@ def test_dut_ping_learns_mac(
     )
 
     # PTF learns DUT MAC
-    ptf_neigh = ptfhost.shell(f"ip neigh show {dut_info['ipv4']}")["stdout"]
+    ptf_neigh = ptfhost.shell(neigh_cmd)["stdout"]
     pt_assert(dut_info['mac'].lower() in ptf_neigh.lower(),
               f"PTF did not learn DUT MAC, ip neigh: {ptf_neigh}")

--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -17,7 +17,6 @@ from tests.common.helpers.assertions import pytest_assert as pt_assert
 from tests.common.helpers.constants import PTF_TIMEOUT
 from tests.common.utilities import wait_until
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
-from tests.common.utilities import is_ipv6_only_topology
 
 logger = logging.getLogger(__name__)
 
@@ -196,8 +195,7 @@ def test_ptf_arp_learns_mac(
     ptf_interface_info,
     dut_interface_info,
     clean_environment,
-    ptfadapter,
-    tbinfo
+    ptfadapter
 ):
     """
     After fdb_cleanup and clearing DUT ARP/neighbor cache,
@@ -207,8 +205,8 @@ def test_ptf_arp_learns_mac(
     ptf_info = ptf_interface_info
     dut_info = dut_interface_info
 
-    if is_ipv6_only_topology(tbinfo):
-        # IPv6-only: send NDP Neighbor Solicitation
+    if dut_info['ipv4'] is None:
+        # No IPv4 on VLAN — send NDP Neighbor Solicitation instead of ARP
         pt_assert(dut_info['ipv6'] is not None, "No IPv6 address on DUT VLAN interface")
 
         tgt_addr = str(dut_info['ipv6'])

--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -4,9 +4,13 @@ import logging
 import ptf.testutils as testutils
 import pytest
 import random
+import socket
 
+from scapy.all import Ether, IPv6, ICMPv6ND_NS, ICMPv6NDOptSrcLLAddr, in6_getnsmac, \
+                      in6_getnsma, inet_pton, inet_ntop
 from tests.arp.arp_utils import (clear_dut_arp_cache, fdb_cleanup, get_dut_mac,
-                                 fdb_has_mac, get_vlan_last_ipv4, get_vlan_ipv4_for_subnet)
+                                 fdb_has_mac, get_vlan_last_ipv4, get_vlan_ipv4_for_subnet,
+                                 get_vlan_ipv6)
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa: F401
 from tests.common.fixtures.ptfhost_utils import setup_vlan_arp_responder, run_icmp_responder  # noqa: F401
 from tests.common.helpers.assertions import pytest_assert as pt_assert
@@ -73,11 +77,14 @@ def dut_interface_info(rand_selected_dut, config_facts, tbinfo, ptf_interface_in
         logger.warning("No VLAN subnet match for PTF IP %s, falling back to %s/%s",
                        ptf_interface_info['ip'], dut_ipv4, prefix_len)
 
+    vlan_name_v6, dut_ipv6 = get_vlan_ipv6(config_facts)
+
     return {
         'host': duthost,
         'mac': dut_mac,
-        'vlan_name': vlan_name,
+        'vlan_name': vlan_name or vlan_name_v6,
         'ipv4': dut_ipv4,
+        'ipv6': dut_ipv6,
         'prefix_len': prefix_len
     }
 
@@ -85,13 +92,14 @@ def dut_interface_info(rand_selected_dut, config_facts, tbinfo, ptf_interface_in
 @pytest.fixture
 def clean_environment(rand_selected_dut, ptfadapter):
     """
-    Cleanup FDB and DUT ARP cache before and after test run
+    Cleanup FDB and DUT ARP/neighbor cache before and after test run
     """
     duthost = rand_selected_dut
 
-    logger.info("Setting up clean environment: clearing FDB and ARP cache")
+    logger.info("Setting up clean environment: clearing FDB and ARP/neighbor cache")
     fdb_cleanup(duthost)
     clear_dut_arp_cache(duthost)
+    clear_dut_arp_cache(duthost, is_ipv6=True)
     ptfadapter.dataplane.flush()
 
     yield
@@ -192,55 +200,82 @@ def test_ptf_arp_learns_mac(
     tbinfo
 ):
     """
-    After fdb_cleanup and clearing DUT ARP cache,
-    simulate ARP request from PTF to DUT,
+    After fdb_cleanup and clearing DUT ARP/neighbor cache,
+    simulate ARP request (IPv4) or NDP Neighbor Solicitation (IPv6) from PTF to DUT,
     verify DUT replies and learns PTF MAC in FDB
     """
-    if is_ipv6_only_topology(tbinfo):
-        pytest.skip("ARP is IPv4-only; IPv6 uses NDP. Skipping on IPv6-only topology.")
-
-    # Setup PTF and DUT info
     ptf_info = ptf_interface_info
     dut_info = dut_interface_info
 
-    logger.info("DUT VLAN IPv4: {}".format(dut_info['ipv4']))
+    if is_ipv6_only_topology(tbinfo):
+        # IPv6-only: send NDP Neighbor Solicitation
+        pt_assert(dut_info['ipv6'] is not None, "No IPv6 address on DUT VLAN interface")
 
-    # Simulate ARP request from PTF to DUT
-    arp_req = testutils.simple_arp_packet(
-        pktlen=60,
-        eth_dst='ff:ff:ff:ff:ff:ff',
-        eth_src=ptf_info['mac'],
-        vlan_pcp=0,
-        arp_op=1,
-        ip_snd=ptf_info['ip'],
-        ip_tgt=str(dut_info['ipv4']),
-        hw_snd=ptf_info['mac'],
-        hw_tgt='ff:ff:ff:ff:ff:ff'
-    )
+        tgt_addr = str(dut_info['ipv6'])
+        multicast_tgt_addr = in6_getnsma(inet_pton(socket.AF_INET6, tgt_addr))
+        multicast_tgt_mac = in6_getnsmac(multicast_tgt_addr)
 
-    # Expected ARP reply packet from DUT
-    arp_reply = testutils.simple_arp_packet(
-        eth_dst=ptf_info['mac'],
-        eth_src=dut_info['mac'],
-        arp_op=2,
-        ip_snd=str(dut_info['ipv4']),
-        ip_tgt=ptf_info['ip'],
-        hw_snd=dut_info['mac'],
-        hw_tgt=ptf_info['mac']
-    )
+        # Build EUI-64 link-local address from PTF MAC
+        mac_parts = ptf_info['mac'].split(':')
+        mac_parts[0] = "{:02x}".format(int(mac_parts[0], 16) ^ 0x02)
+        eui64 = "{}{}:{}ff:fe{}:{}{}".format(
+            mac_parts[0], mac_parts[1], mac_parts[2],
+            mac_parts[3], mac_parts[4], mac_parts[5]
+        )
+        src_ipv6 = "fe80::{}".format(eui64)
 
-    logger.info("Sending ARP request for target {} from PTF interface {}".format(
-        dut_info['ipv4'], ptf_info['index']))
+        ns_pkt = Ether(src=ptf_info['mac'], dst=multicast_tgt_mac)
+        ns_pkt /= IPv6(dst=inet_ntop(socket.AF_INET6, multicast_tgt_addr),
+                       src=src_ipv6)
+        ns_pkt /= ICMPv6ND_NS(tgt=tgt_addr)
+        ns_pkt /= ICMPv6NDOptSrcLLAddr(lladdr=ptf_info['mac'])
 
-    # Send ARP request and verify ARP reply
-    testutils.send_packet(ptfadapter, ptf_info['index'], arp_req)
-    testutils.verify_packet(ptfadapter, arp_reply, ptf_info['index'], timeout=PTF_TIMEOUT)
+        logger.info("Sending NDP NS for target {} from PTF interface {}".format(
+            tgt_addr, ptf_info['index']))
+        testutils.send_packet(ptfadapter, ptf_info['index'], ns_pkt)
 
-    # Confirm MAC is learned on DUT FDB
-    pt_assert(
-        wait_until(10, 1, 0, fdb_has_mac, dut_info['host'], ptf_info['mac']),
-        "FDB did not learn PTF MAC after ARP request"
-    )
+        # Verify DUT sends Neighbor Advertisement back (indicates it processed our NS)
+        # and learns PTF MAC in FDB
+        pt_assert(
+            wait_until(10, 1, 0, fdb_has_mac, dut_info['host'], ptf_info['mac']),
+            "FDB did not learn PTF MAC after NDP Neighbor Solicitation"
+        )
+    else:
+        # IPv4: send ARP request
+        logger.info("DUT VLAN IPv4: {}".format(dut_info['ipv4']))
+
+        arp_req = testutils.simple_arp_packet(
+            pktlen=60,
+            eth_dst='ff:ff:ff:ff:ff:ff',
+            eth_src=ptf_info['mac'],
+            vlan_pcp=0,
+            arp_op=1,
+            ip_snd=ptf_info['ip'],
+            ip_tgt=str(dut_info['ipv4']),
+            hw_snd=ptf_info['mac'],
+            hw_tgt='ff:ff:ff:ff:ff:ff'
+        )
+
+        arp_reply = testutils.simple_arp_packet(
+            eth_dst=ptf_info['mac'],
+            eth_src=dut_info['mac'],
+            arp_op=2,
+            ip_snd=str(dut_info['ipv4']),
+            ip_tgt=ptf_info['ip'],
+            hw_snd=dut_info['mac'],
+            hw_tgt=ptf_info['mac']
+        )
+
+        logger.info("Sending ARP request for target {} from PTF interface {}".format(
+            dut_info['ipv4'], ptf_info['index']))
+
+        testutils.send_packet(ptfadapter, ptf_info['index'], arp_req)
+        testutils.verify_packet(ptfadapter, arp_reply, ptf_info['index'], timeout=PTF_TIMEOUT)
+
+        pt_assert(
+            wait_until(10, 1, 0, fdb_has_mac, dut_info['host'], ptf_info['mac']),
+            "FDB did not learn PTF MAC after ARP request"
+        )
 
 
 def test_dut_arping_learns_mac(

--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -13,6 +13,7 @@ from tests.common.helpers.assertions import pytest_assert as pt_assert
 from tests.common.helpers.constants import PTF_TIMEOUT
 from tests.common.utilities import wait_until
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
+from tests.common.utilities import is_ipv6_only_topology
 
 logger = logging.getLogger(__name__)
 
@@ -195,6 +196,9 @@ def test_ptf_arp_learns_mac(
     simulate ARP request from PTF to DUT,
     verify DUT replies and learns PTF MAC in FDB
     """
+    if is_ipv6_only_topology(tbinfo):
+        pytest.skip("ARP is IPv4-only; IPv6 uses NDP. Skipping on IPv6-only topology.")
+
     # Setup PTF and DUT info
     ptf_info = ptf_interface_info
     dut_info = dut_interface_info


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: This PR add test cases coverage `test_dut_arping_learns_mac` and `test_dut_ping_learns_mac` for ipv6 only topo.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
