### PR TITLE
Disable PR testing for 202411 branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,17 +7,7 @@
 # continueOnError: false means it's a required test job and will block merge if it fails
 # continueOnError: true means it's an optional test job and will not block merge even though it fails(unless a required test job depends on its result)
 
-pr:
-   branches:
-     include:
-       - 202411
-   paths:
-     exclude:
-       - .github
-       - docs
-       - LICENSE
-       - README.md
-       - SECURITY.md
+pr: none
 trigger: none
 
 name: $(TeamProject)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)


### PR DESCRIPTION
### Description of PR

Summary:
Support for release 202411 has ended. This PR disables PR pipeline triggers for the 202411 branch.

### Type of change

- [x] Testbed and Framework(new/improvement)

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Release 202411 has reached end of support. Continued PR pipeline runs against this branch consume CI capacity without providing release value.

#### How did you do it?

Replaced the `pr:` trigger block (which previously included `branches: [202411]` with a `paths: exclude:` list) with `pr: none`, matching the convention used by previously-retired branches (202205, 202305, 202311, 202405 — see for example #19447 for 202405).

#### How did you verify/test it?

Diff-checked against the 202405 retirement (#19447). The change is a one-block replacement of identical shape.

#### Any platform specific information?

N/A

#### Supported testbed topology if it''s a new test case?

N/A

### Documentation

N/A
