### PR TITLE
test: fix bugs in test_rib_route_opt_perf preventing execution

### DIFF
--- a/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
@@ -348,7 +348,7 @@ def __tgen_bgp_config(snappi_api,
         config.devices.device(name='Topology %d' % i)
 
     config.options.port_options.location_preemption = True
-    for index, port_data in enumerate(temp_tg_port):
+    for index, port_data in enumerate(temp_tg_port[:port_count]):
         layer1 = config.layer1.layer1()[-1]
         layer1.name = f"{index}_settings"
         layer1.port_names = [config.ports[index].name]

--- a/tests/snappi_tests/bgp/test_bgp_rib_route_optimztn_perf.py
+++ b/tests/snappi_tests/bgp/test_bgp_rib_route_optimztn_perf.py
@@ -1,5 +1,6 @@
 from tests.common.snappi_tests.snappi_fixtures import (                     # noqa: F401
-    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
+    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports,
+    get_snappi_ports, get_snappi_ports_single_dut, get_snappi_ports_multi_dut)
 from tests.snappi_tests.bgp.files.bgp_convergence_helper import run_rib_in_convergence_test
 from tests.common.fixtures.conn_graph_facts import (                        # noqa: F401
     conn_graph_facts, fanout_graph_facts)
@@ -219,5 +220,4 @@ def test_rib_route_opt_perf(snappi_api,                    # noqa: F811
                                 NUMBER_OF_ROUTES,
                                 route_type,
                                 timeout=RIB_TIMEOUT,
-                                skip_cleanup=True,
                                 skip_duthost_bgp_config=use_bgp_pc_config,)


### PR DESCRIPTION
### Description
Fix three bugs in PR #22727's RIB route optimization performance test that prevent it from running successfully.

### Bugs Fixed

| # | Bug | File | Impact | Fix |
|---|-----|------|--------|-----|
| 1 | Missing `get_snappi_ports` fixture imports | `test_bgp_rib_route_optimztn_perf.py` | Test fails with 'fixture not found' — `tgen_ports` depends on `get_snappi_ports` which requires `get_snappi_ports_single_dut`/`get_snappi_ports_multi_dut` in scope | Add explicit imports from `snappi_fixtures.py` |
| 2 | Layer1 loop iterates all `temp_tg_port` but only `port_count` ports created | `bgp_convergence_helper.py` line 351 | IndexError when `len(tgen_ports) > port_count` | Slice: `temp_tg_port[:port_count]` |
| 3 | `skip_cleanup=True` passed but `run_rib_in_convergence_test()` doesn't accept it | `test_bgp_rib_route_optimztn_perf.py` line 222 | TypeError on every invocation | Removed dead parameter |

### How I tested
- Ran `test_rib_route_opt_perf[300000-1-IPv4-default-default-baseline_config_db]` with IXIA/snappi traffic generator
- Test completes successfully with RIB-IN convergence measurement
- Without fixes: test fails at collection (fixture not found) or at runtime (TypeError/IndexError)
