### PR TITLE
[testbed-health-check]: Add IPv6 management address support to testbed health checker 

### DIFF
--- a/.azure-pipelines/testbed_health_check.py
+++ b/.azure-pipelines/testbed_health_check.py
@@ -16,7 +16,7 @@ import sys
 import json
 import yaml
 from datetime import datetime
-from netaddr import valid_ipv4
+from netaddr import valid_ipv4, valid_ipv6
 
 _self_dir = os.path.dirname(os.path.abspath(__file__))
 base_path = os.path.realpath(os.path.join(_self_dir, ".."))
@@ -317,49 +317,51 @@ class TestbedHealthChecker:
         if not hosts_reachable:
             raise HostsUnreachable(self.check_result.errmsg)
 
-        # Verify mgmt-ipv4 address exists
+        # Verify management IP address exists (IPv4 or IPv6)
         config_db_file = "/etc/sonic/config_db.json"
-        ipv4_not_exists_hosts = []
+        mgmt_ip_not_exists_hosts = []
 
         for sonichost in self.sonichosts:
-
             # Skip MGMT_INTERFACE check for DPU hosts - they use midplane IPs, not mgmt interface
             if "dpu" in sonichost.hostname.lower():
-                logger.info("Skipping MGMT_INTERFACE check for DPU host: {}".format(sonichost.hostname))
+                logger.info(
+                    "Skipping MGMT_INTERFACE check for DPU host: {}".format(sonichost.hostname)
+                )
                 continue
 
-            rst = sonichost.shell(f"jq '.MGMT_INTERFACE' {config_db_file}", module_ignore_errors=True).get("stdout",
-                                                                                                           None)
-
-            device_hostname = sonichost.shell(f"jq '.DEVICE_METADATA.localhost.hostname' {config_db_file}")\
-                .get("stdout", None)
+            rst = sonichost.shell(
+                f"jq '.MGMT_INTERFACE' {config_db_file}",
+                module_ignore_errors=True,
+            ).get("stdout", None)
+            device_hostname = sonichost.shell(
+                f"jq '.DEVICE_METADATA.localhost.hostname' {config_db_file}"
+            ).get("stdout", None)
 
             if not device_hostname or device_hostname == '"sonic"':
                 raise RuntimeError(f"Device {sonichost.hostname} is not properly configured, "
                                    f"hostname is still: {device_hostname}")
             # If valid stdout (also check for "null" which jq returns when key doesn't exist)
             if rst is not None and rst.strip() != "" and rst.strip() != "null":
-
                 mgmt_interface = json.loads(rst)
-
-                ipv4_exists = False
-
+                mgmt_ip_exists = False
                 # Use list() to make a copy of mgmt_interface.keys() to avoid
                 for key in list(mgmt_interface):
-                    ip_addr = key.split("|")[1]
-                    ip_addr_without_mask = ip_addr.split('/')[0]
-                    if ip_addr:
-                        is_ipv4 = valid_ipv4(ip_addr_without_mask)
-                        if is_ipv4:
-                            ipv4_exists = True
-                            break
+                    key_parts = key.split("|", 1)
+                    if len(key_parts) < 2:
+                        continue
+                    ip_addr = key_parts[1]
+                    ip_addr_without_mask = ip_addr.split('/', 1)[0]
+                    if ip_addr_without_mask and (valid_ipv4(ip_addr_without_mask) or valid_ipv6(ip_addr_without_mask)):
+                        mgmt_ip_exists = True
+                        break
+                if not mgmt_ip_exists:
+                    mgmt_ip_not_exists_hosts.append(sonichost.hostname)
+                    logger.info("{} does not have mgmt IPv4/IPv6 address.".format(sonichost.hostname))
+                    self.check_result.errmsg.append(
+                        "{} does not have mgmt IPv4/IPv6 address.".format(sonichost.hostname)
+                    )
 
-                if not ipv4_exists:
-                    ipv4_not_exists_hosts.append(sonichost.hostname)
-                    logger.info("{} does not have mgmt-ipv4 address.".format(sonichost.hostname))
-                    self.check_result.errmsg.append("{} does not have mgmt-ipv4 address.".format(sonichost.hostname))
-
-        if len(ipv4_not_exists_hosts) > 0:
+        if len(mgmt_ip_not_exists_hosts) > 0:
             raise HostsUnreachable(self.check_result.errmsg)
 
         logger.info("======================= pre_check ends =======================")


### PR DESCRIPTION
### Description of PR
Summary:
Allow testbed health pre-check to treat either IPv4 or IPv6 management addresses as valid in MGMT_INTERFACE validation.
Fixes # N/A

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The health check currently requires mgmt-ipv4 to exist, which incorrectly fails hosts configured with IPv6-only management addresses.

#### How did you do it?
- Updated testbed health check logic to accept both IPv4 and IPv6 management addresses from MGMT_INTERFACE.
- Added valid_ipv6 import and validation alongside valid_ipv4.

#### How did you verify/test it?

Ran checks on local IPv4 and IPv6 only testbeds.

#### Any platform specific information?

No platform-specific behavior changes intended. This affects pipeline-side health check validation logic.

#### Supported testbed topology if it's a new test case?
N/A (not a new test case)

### Documentation
No documentation update required.