### PR TITLE
[crm] Fix missing function call for is_ipv6_only_topology in test_crm_route

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -670,7 +670,7 @@ def test_crm_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
     asic_type = duthost.facts['asic_type']
     skip_stats_check = True if asic_type == "vs" else False
     RESTORE_CMDS["crm_threshold_name"] = "ipv{ip_ver}_route".format(ip_ver=ip_ver)
-    if is_ipv6_only_topology and ip_ver == "4":
+    if is_ipv6_only_topology(tbinfo) and ip_ver == "4":
         pytest.skip("Skipping IPv4 test on IPv6-only topology")
 
     # Template used to speedup execution of many similar commands on DUT


### PR DESCRIPTION
### Description of PR

Summary:
Fix a bug in `test_crm_route` where `is_ipv6_only_topology` is referenced as a bare function object (always truthy) instead of being called with `tbinfo`. This caused IPv4 CRM route tests to be unconditionally skipped on ALL topologies, not just IPv6-only ones.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

In `tests/crm/test_crm.py`, line 673 has:
`python
if is_ipv6_only_topology and ip_ver == "4":
    pytest.skip("Skipping IPv4 test on IPv6-only topology")
`

`is_ipv6_only_topology` is an imported function. When used without calling it (missing `(tbinfo)`), it evaluates to the function object which is always truthy. This means `test_crm_route` with `ip_ver="4"` is ALWAYS skipped, regardless of the actual topology.

The other two usages in the same file (lines 871, 976) correctly call `is_ipv6_only_topology(tbinfo)`.

#### How did you do it?

Changed line 673 from:
`python
if is_ipv6_only_topology and ip_ver == "4":
`
to:
`python
if is_ipv6_only_topology(tbinfo) and ip_ver == "4":
`

#### How did you verify/test it?

- Confirmed the bug exists in upstream master (line 673)
- Confirmed other usages in the same file correctly call the function with `tbinfo`
- The fix is a minimal one-character change (adding function call parentheses)

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A