### PR TITLE
[fib] Enable test_ipinip_hash, test_nvgre_hash, test_vxlan_hash on so…

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -258,7 +258,7 @@ everflow:
 #   - libsaivs: opt the default + non-default VRFs (both AF_INET and
 #     AF_INET6) into the new VPP_IP_API_FLOW_HASH_PEEK_INNER bit
 #     (sonic-sairedis #1896, vslib/vpp/SwitchVppRif.cpp).
-#   - sonic-mgmt: test_nvgre_hash limited to inner 5-tuple keys for vpp
+#   - sonic-mgmt: test_nvgre_hash limited to inner keys['src-ip', 'dst-ip', 'src-port', 'dst-port'] for vpp
 #     (no MAC-aware hash, same as marvell-teralynx limitation).
 
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -251,29 +251,15 @@ everflow:
 #######################################
 #####           FIB               #####
 #######################################
-fib/test_fib.py::test_ipinip_hash:
-  skip:
-    reason: >
-            Unsupported
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-fib/test_fib.py::test_nvgre_hash:
-  skip:
-    reason: >
-            Unsupported
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-fib/test_fib.py::test_vxlan_hash:
-  skip:
-    reason: >
-            Unsupported
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
+# test_ipinip_hash, test_nvgre_hash, test_vxlan_hash now PASS on sonic-vpp
+# (issue #25762). Required:
+#   - VPP: inner-aware ECMP and LAG flow hash for IPinIP and GRE/NVGRE
+#     (sonic-platform-vpp #234 / patch 0010-sonic-inner-aware-flow-hash).
+#   - libsaivs: opt the default + non-default VRFs (both AF_INET and
+#     AF_INET6) into the new VPP_IP_API_FLOW_HASH_PEEK_INNER bit
+#     (sonic-sairedis #1896, vslib/vpp/SwitchVppRif.cpp).
+#   - sonic-mgmt: test_nvgre_hash limited to inner 5-tuple keys for vpp
+#     (no MAC-aware hash, same as marvell-teralynx limitation).
 
 #######################################
 #####    Generic Config Updater   #####

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -782,7 +782,7 @@ def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                
         logging.info("Marvell-Teralynx: hash-key is src-ip, dst-ip")
         hash_keys = ['src-ip', 'dst-ip']
     if duthost.facts['asic_type'] in ["vpp"]:
-        logging.info("VPP: hash-keys are inner 5-tuple (no Ethernet MAC)")
+        logging.info("VPP: hash-keys are src-ip, dst-ip, src-port, dst-port")
         hash_keys = ['src-ip', 'dst-ip', 'src-port', 'dst-port']
 
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -781,6 +781,9 @@ def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                
     if duthost.facts['asic_type'] in ["marvell-teralynx"]:
         logging.info("Marvell-Teralynx: hash-key is src-ip, dst-ip")
         hash_keys = ['src-ip', 'dst-ip']
+    if duthost.facts['asic_type'] in ["vpp"]:
+        logging.info("VPP: hash-keys are inner 5-tuple (no Ethernet MAC)")
+        hash_keys = ['src-ip', 'dst-ip', 'src-port', 'dst-port']
 
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
     log_file = "/tmp/hash_test.NvgreHashTest.{}.{}.log".format(


### PR DESCRIPTION
### Description of PR

Summary: Re-enable the three previously skipped tunnel-hashing tests for the `vpp` `asic_type` now that VPP has **opt-in** inner-aware ECMP / LAG flow hashing.

The two prerequisite changes that make these tests actually pass on `vms-kvm-vpp-t1-lag`:

- [sonic-net/sonic-platform-vpp#234](https://github.com/sonic-net/sonic-platform-vpp/pull/234) — vendors VPP patch `0010-sonic-inner-aware-flow-hash.patch`, which registers the **new** opt-in `hash-eth-l34-inner` bond load-balance function, the new `BOND_API_LB_ALGO_L34_INNER = 6` bond algorithm, and the new `FLOW_HASH_PEEK_INNER` ECMP FIB bit.  Stock `hash-eth-l34` and the legacy `BOND_API_LB_ALGO_L34 = 1` are byte-for-byte unchanged.
- [sonic-net/sonic-sairedis#1896](https://github.com/sonic-net/sonic-sairedis/pull/1896) — opts the `vslib/vpp` adapter into the new path: selects `BOND_API_LB_ALGO_L34_INNER` in `vpp_create_lag` and OR's `VPP_IP_API_FLOW_HASH_PEEK_INNER` into `vpp_add_ip_vrf` for both `AF_INET` and `AF_INET6` (default + non-default VRFs).
- `sonic-net/sonic-buildimage` submodule bump for sonic-sairedis is a separate routine PR once #1896 lands.

Fixes [#25762](https://github.com/sonic-net/sonic-mgmt/issues/25762)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

`fib/test_fib.py::test_ipinip_hash`, `test_nvgre_hash`, and `test_vxlan_hash` were unconditionally skipped on `asic_type == 'vpp'` because the underlying VPP runtime hashed every transit tunnel (IPinIP / 6in4 / 4in6 / 6in6 / GRE / NVGRE) on its **outer** 5-tuple only.  When many distinct inner flows share an outer 5-tuple — the common case for SONiC T1-LAG topologies — they collapse onto a single LAG member and a single ECMP next-hop, and these three tests deviate by more than the 5% balance threshold.

With the upstream VPP fix (`hash-eth-l34-inner` + `PEEK_INNER` bit) and the libsaivs opt-in landed, the three tests now pass on `vms-kvm-vpp-t1-lag` and there is no reason to keep them on the skip list.

#### How did you do it?

Two small changes (total **2 files, +12 / −23**):

| File | Change |
|---|---|
| `tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml` | Remove the three unconditional `skip` entries for `test_ipinip_hash`, `test_nvgre_hash`, and `test_vxlan_hash` on `asic_type == 'vpp'`.  Replace with a comment block that points to issue #25762 and lists the three prerequisites (VPP patch + vslib/vpp opt-in + the `test_nvgre_hash` hash-key override below). |
| `tests/fib/test_fib.py` | In `test_nvgre_hash`, add a `vpp` `asic_type` branch that sets `hash_keys = ['src-ip', 'dst-ip', 'src-port', 'dst-port']`.  VPP's new opt-in `hash-eth-l34-inner` bond LB peeks into the inner IP/L4 of NVGRE encap but does **not** mix in the inner Ethernet src/dst MAC — identical to the `marvell-teralynx` and `mellanox` behavioural carve-outs already in this test.  Without this override, `NvgreHashTest` treats inner MAC variations as additional hash keys and incorrectly flags the run as deviating > 5 %. |

#### How did you verify/test it?

End-to-end on `vms-kvm-vpp-t1-lag` (`vlab-vpp-01`) with both prerequisite PRs (#234, #1896) applied:

```
cd sonic-mgmt/tests
pytest fib/test_fib.py --topology=t1-lag-vpp --testbed=vms-kvm-vpp-t1-lag
```

Result: full `tests/fib/test_fib.py` is **16 / 16 PASS** in 2:01:36 — `test_basic_fib`, `test_hash[ipv4/ipv6]`, `test_ipinip_hash[ipv4/ipv6]`, `test_ipinip_hash_negative[ipv4/ipv6]`, `test_vxlan_hash × 4`, `test_nvgre_hash × 4`, `test_ecmp_group_member_flap`.

Re-validated after the `0011 → 0010` VPP patch squash on 2026-05-19.

#### Any platform specific information?

This PR only affects `asic_type == 'vpp'`:

- The `tests_mark_conditions_sonic_vpp.yaml` change is scoped to the `sonic-vpp` conditional-mark file.
- The `test_fib.py` change is a new `if duthost.facts['asic_type'] in ["vpp"]:` branch inside `test_nvgre_hash`, parallel to the existing `marvell-teralynx` carve-out.  Other `asic_type`s are unaffected.

If a sonic-vpp image **without** the two prerequisite changes (PR #234, PR #1896) is used, the three re-enabled tests will deviate > 5 % and fail.  This is the expected hard prerequisite — see the comment block in the `tests_mark_conditions_sonic_vpp.yaml` change for details.

#### Supported testbed topology if it's a new test case?

N/A — this PR re-enables existing tests on an existing topology (`t1-lag-vpp` / `vms-kvm-vpp-t1-lag`).  No new test case, no new topology.

### Documentation

HLD: [sonic-net/SONiC#1860](https://github.com/sonic-net/SONiC/pull/1860) — *Inner-aware flow hash for VPP-based platforms* (v0.3, opt-in design).