### PR TITLE
Remove acl table during cleanup.

### DIFF
--- a/tests/ha/test_ha_split_brain.py
+++ b/tests/ha/test_ha_split_brain.py
@@ -9,13 +9,13 @@ from constants import (
 from tests.common.helpers.assertions import pytest_assert
 from gnmi_utils import apply_messages
 from ha_utils import (
-    set_dead_dash_ha_scope,
+    set_dash_ha_scope,
     activate_secondary_dash_ha,
     verify_ha_state,
     wait_for_pending_operation_id,
     _apply_ha_scope_gnmi
 )
-from ha_link_utils import add_acl_link_drop, remove_acl_link_drop
+from ha_link_utils import add_acl_link_drop, remove_acl_link_drop_table
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +26,7 @@ pytestmark = [
 
 
 def restore_ha_state(localhost, ptfhost, duthost, standby_vdpu_key="vdpu1_0:haset0_0"):
-    set_dead_dash_ha_scope(localhost, duthost, ptfhost, standby_vdpu_key)
+    set_dash_ha_scope(localhost, duthost, ptfhost, standby_vdpu_key, "dead", "dpu", disabled=True)
     pending_id = wait_for_pending_operation_id(duthost, standby_vdpu_key, "brainsplit_recover", timeout=60)
     if pending_id is not None:
         _apply_ha_scope_gnmi(localhost, duthost, ptfhost, standby_vdpu_key,
@@ -123,9 +123,11 @@ def test_ha_split_brain(
 
     if standby_link_fail:
         logger.info("HA: Simulate standby link failure")
+        remove_acl_link_drop_table(duthosts[1])
         add_acl_link_drop(duthosts[1], dash_pl_config[1][NPU_DATAPLANE_PORT])
     else:
         logger.info("HA: Simulate primary link failure")
+        remove_acl_link_drop_table(duthosts[0])
         add_acl_link_drop(duthosts[0], dash_pl_config[0][NPU_DATAPLANE_PORT])
     logger.info("HA: After link failure")
     pytest_assert(verify_ha_state(duthosts[0], primary_vdpu_key, "standalone"),
@@ -134,9 +136,9 @@ def test_ha_split_brain(
                   "Standby HA state is not standalone")
 
     if standby_link_fail:
-        remove_acl_link_drop(duthosts[1], dash_pl_config[1][NPU_DATAPLANE_PORT])
+        remove_acl_link_drop_table(duthosts[1])
     else:
-        remove_acl_link_drop(duthosts[0], dash_pl_config[0][NPU_DATAPLANE_PORT])
+        remove_acl_link_drop_table(duthosts[0])
     time.sleep(20)
     # take system out of split-brain
     restore_ha_state(localhost, ptfhost, duthosts[1], standby_vdpu_key=standby_vdpu_key)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
During cleanup in test_ha_split_brain.py, the link failure ACL was not being completely removed between tests. SONiC can expand a VLAN ACL binding, for example Vlan100, into the member Ethernet ports in CONFIG_DB and previously it was being removed per interface (Vlan100) but leaving it attached to the member interfaces. This PR fixes this by removing the ACL table after it is no longer needed instead.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Fix test_ha_split_brain.py test cleanup.

#### How did you do it?
Remove the link failure ACL table completely instead of unbinding from specific interfaces, and also clear it before re-adding it between test cases.

#### How did you verify/test it?
Ran test_ha_split_brain.py in HA topology:
PASS ha/test_ha_split_brain.xml: total=2 passed=2 failures=0 errors=0 skipped=0

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
