### PR TITLE
Update PR template: remove EOL branches 202205/202305, add 202512/202605

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,13 +30,13 @@ Fixes # (issue)
 
 
 ### Back port request
-- [ ] 202205
-- [ ] 202305
 - [ ] 202311
 - [ ] 202405
 - [ ] 202411
 - [ ] 202505
 - [ ] 202511
+- [ ] 202512
+- [ ] 202605
 
 ### Approach
 #### What is the motivation for this PR?


### PR DESCRIPTION
### Description of PR

Summary:
Update the back port request section of the PR template:
- Remove EOL branches: 202205, 202305
- Add new branches: 202512, 202605

### Type of change
- [x] Testbed and Framework(new/improvement)

### Back port request
N/A

### Approach
#### What is the motivation for this PR?
Keep the PR template up to date with active SONiC release branches.

#### How did you do it?
Removed end-of-life branches (202205, 202305) and added new branches (202512, 202605) to the back port request checklist.

#### How did you verify/test it?
Manual review of the updated template.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A