### PR TITLE
[mmu probing] pr15.fix: Fix LAG dst port mismatch in stream_manager get_packet

### DIFF
--- a/tests/saitests/mock/it/test_ingress_drop_probing.py
+++ b/tests/saitests/mock/it/test_ingress_drop_probing.py
@@ -10,13 +10,14 @@ Ingress Drop Characteristics:
 - Uses same 3/4-phase algorithm as PFC XOFF
 - Typically higher threshold than PFC XOFF (Ingress Drop > PFC XOFF)
 
-Test Coverage (23 tests):
+Test Coverage (24 tests):
 A. Basic Hardware (4 tests)
 B. Point Probing (3 tests)
 C. Precision Ratio (4 tests)
 D. Noise + Verification Attempts (4 tests)
 E. Boundary Conditions (5 tests)
 F. Failure Scenarios (3 tests)
+G. Bug Fix Validation (incl. LAG dual-key regression)
 """
 
 import pytest
@@ -555,7 +556,7 @@ class TestIngressDropProbing:
             print("[PASS] Inconsistent: Extreme inconsistency handled")
 
     # ========================================================================
-    # G. Bug Fix Validation (3 tests)
+    # G. Bug Fix Validation (4 tests + LAG regression)
     # ========================================================================
 
     def test_ingress_drop_threshold_at_one(self):
@@ -701,9 +702,45 @@ class TestIngressDropProbing:
         else:
             print("[PASS] Completed (bad spots caused failure)")
 
+    def test_ingress_drop_lag_port_remapping(self):
+        """
+        G5: LAG port remapping - rx_port_resolver returns different member
+
+        Regression test for LAG dual-key bug (commit 921dfb7f09):
+        - add_flow() creates key with original dst port (28)
+        - generate_packets() resolves actual via get_rx_port → 29 (different member)
+        - get_packet(src, actual_dst=29) must succeed via dual-key alias
+        - Without fix: ValueError in get_packet() → probe crash
+        """
+        actual_threshold = 700
+
+        probe = create_ingress_drop_probe_instance(
+            actual_threshold=actual_threshold,
+            scenario=None,
+            enable_precise_detection=False,
+            precision_target_ratio=0.05
+        )
+
+        # Override get_rx_port to simulate LAG member remapping:
+        # dst port 28 → actual member 29
+        def lag_get_rx_port(src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip, dst_port_id, src_vlan):
+            if dst_port_id == 28:
+                return 29  # LAG hashing selects different member
+            return dst_port_id
+        probe.get_rx_port = lag_get_rx_port
+
+        probe.runTest()
+        result = probe.probe_result
+
+        assert result is not None, "Probe must not crash with LAG port remapping"
+        if result.success:
+            assert result.lower_bound <= actual_threshold <= result.upper_bound, \
+                f"Result [{result.lower_bound}, {result.upper_bound}] should bracket {actual_threshold}"
+        print(f"[PASS] LAG remapping: result=[{result.lower_bound}, {result.upper_bound}]")
+
     def test_ingress_drop_small_threshold_precision(self):
         """
-        G5: Precision check max(1,...) guard for small threshold
+        G6: Precision check max(1,...) guard for small threshold
         """
         import io
         import sys

--- a/tests/saitests/mock/ut/test_stream_manager.py
+++ b/tests/saitests/mock/ut/test_stream_manager.py
@@ -529,6 +529,86 @@ class TestStreamManagerGetPacket(unittest.TestCase):
         assert mgr.get_packet(11, 24, pg=3) == b"pkt_pg3"
         assert mgr.get_packet(11, 24, pg=4) == b"pkt_pg4"
 
+    @pytest.mark.order(3745)
+    def test_get_packet_with_lag_resolved_port(self):
+        """Test get_packet works with both original and LAG-resolved dst port.
+
+        Regression test for LAG dual-key bug (commit 921dfb7f09):
+        - add_flow() freezes key with original dst port (e.g., 16)
+        - generate_packets() resolves actual dst port via rx_port_resolver (e.g., 17)
+        - get_packet(src, actual_dst=17) must find the flow via dual-key alias
+        - get_packet(src, original_dst=16) must also still work
+        """
+        pkt_constructor = MagicMock(return_value=b"lag_packet")
+        # LAG hashing selects different member: original=24, actual=26
+        rx_resolver = MagicMock(return_value=26)
+
+        mgr = self.StreamManager(
+            packet_constructor=pkt_constructor,
+            rx_port_resolver=rx_resolver
+        )
+
+        src = self.PortInfo(port_id=11, mac="00:11:22:33:44:55", ip="10.0.0.1")
+        dst = self.PortInfo(port_id=24, mac="aa:bb:cc:dd:ee:ff", ip="10.0.0.2")
+        flow = self.FlowConfig(src, dst, dmac="aa:bb:cc:dd:ee:ff")
+
+        mgr.add_flow(flow)
+        mgr.generate_packets()
+
+        # Both original and resolved port must work
+        assert mgr.get_packet(11, 26) == b"lag_packet", \
+            "get_packet must find flow via actual (LAG-resolved) dst port"
+        assert mgr.get_packet(11, 24) == b"lag_packet", \
+            "get_packet must still find flow via original dst port"
+
+    @pytest.mark.order(3746)
+    def test_get_packet_with_lag_resolved_port_and_traffic_keys(self):
+        """Test LAG dual-key lookup works with PG-based traffic keys."""
+        pkt_constructor = MagicMock(return_value=b"lag_pg3_pkt")
+        rx_resolver = MagicMock(return_value=17)  # original=16, actual=17
+
+        mgr = self.StreamManager(
+            packet_constructor=pkt_constructor,
+            rx_port_resolver=rx_resolver
+        )
+
+        src = self.PortInfo(port_id=11, mac="00:11:22:33:44:55", ip="10.0.0.1")
+        dst = self.PortInfo(port_id=16, mac="aa:bb:cc:dd:ee:ff", ip="10.0.0.2")
+        flow = self.FlowConfig(src, dst, dmac="aa:bb:cc:dd:ee:ff")
+
+        mgr.add_flow(flow, pg=3)
+        mgr.generate_packets()
+
+        # Dual-key works with traffic keys too
+        assert mgr.get_packet(11, 17, pg=3) == b"lag_pg3_pkt", \
+            "get_packet must find flow via actual port + traffic key"
+        assert mgr.get_packet(11, 16, pg=3) == b"lag_pg3_pkt", \
+            "get_packet must still find flow via original port + traffic key"
+        # Wrong traffic key should still miss
+        assert mgr.get_packet(11, 17, pg=4) is None
+
+    @pytest.mark.order(3747)
+    def test_get_packet_no_alias_when_ports_match(self):
+        """Test no extra alias created when resolved port == original port."""
+        pkt_constructor = MagicMock(return_value=b"same_port_pkt")
+        rx_resolver = MagicMock(return_value=24)  # same as original
+
+        mgr = self.StreamManager(
+            packet_constructor=pkt_constructor,
+            rx_port_resolver=rx_resolver
+        )
+
+        src = self.PortInfo(port_id=11, mac="00:11:22:33:44:55", ip="10.0.0.1")
+        dst = self.PortInfo(port_id=24, mac="aa:bb:cc:dd:ee:ff", ip="10.0.0.2")
+        flow = self.FlowConfig(src, dst, dmac="aa:bb:cc:dd:ee:ff")
+
+        mgr.add_flow(flow)
+        mgr.generate_packets()
+
+        # Only 1 entry in flows dict (no duplicate alias needed)
+        assert len(mgr.flows) == 1
+        assert mgr.get_packet(11, 24) == b"same_port_pkt"
+
 
 @pytest.mark.order(3750)
 class TestDetermineTrafficDmac(unittest.TestCase):

--- a/tests/saitests/probe/stream_manager.py
+++ b/tests/saitests/probe/stream_manager.py
@@ -120,6 +120,7 @@ class StreamManager:
 
     def generate_packets(self):
         """Generate packets for all flows and resolve actual dst ports"""
+        import logging
         for flow_config in self.flows.values():
             spi = flow_config.src_port
             dpi = flow_config.dst_port
@@ -132,6 +133,28 @@ class StreamManager:
                 spi.port_id, flow_config.dmac, dpi.ip, spi.ip, dpi.port_id, spi.vlan
             )
             flow_config.dst_port.actual_port_id = actual_rx_port
+
+        # Add resolved-port keys alongside original keys
+        # so get_packet() works with both original and actual dst port IDs.
+        # Bug context: add_flow() freezes key with original_port_id (before resolve).
+        # After resolve, port_id property returns actual_port_id which may differ
+        # (e.g., LAG member selection: original=16 but actual=17).
+        # Without this, get_packet(src, actual_dst) misses the flow.
+        extra = {}
+        for (src_id, dst_id, frozen_keys), flow_config in self.flows.items():
+            actual_dst = flow_config.dst_port.port_id  # returns actual if resolved
+            if actual_dst != dst_id:
+                extra[(src_id, actual_dst, frozen_keys)] = flow_config
+                logging.info(
+                    "[StreamManager] dst port resolved: original=%d -> actual=%d "
+                    "(src=%d, keys=%s). Added dual-key lookup." % (
+                        dst_id, actual_dst, src_id, dict(frozen_keys)))
+        if extra:
+            self.flows.update(extra)
+            logging.info("[StreamManager] flows dict: %d entries (including %d resolved-port aliases)" % (
+                len(self.flows), len(extra)))
+        else:
+            logging.info("[StreamManager] all dst ports match original (no LAG remapping needed)")
 
     def get_port_ids(self, type="all"):
         """Get port IDs from all flows

--- a/tests/saitests/probe/stream_manager.py
+++ b/tests/saitests/probe/stream_manager.py
@@ -120,7 +120,6 @@ class StreamManager:
 
     def generate_packets(self):
         """Generate packets for all flows and resolve actual dst ports"""
-        import logging
         for flow_config in self.flows.values():
             spi = flow_config.src_port
             dpi = flow_config.dst_port
@@ -134,27 +133,18 @@ class StreamManager:
             )
             flow_config.dst_port.actual_port_id = actual_rx_port
 
-        # Add resolved-port keys alongside original keys
-        # so get_packet() works with both original and actual dst port IDs.
-        # Bug context: add_flow() freezes key with original_port_id (before resolve).
-        # After resolve, port_id property returns actual_port_id which may differ
-        # (e.g., LAG member selection: original=16 but actual=17).
-        # Without this, get_packet(src, actual_dst) misses the flow.
+        # Add resolved-port aliases so get_packet() works with both original
+        # and actual dst port IDs (e.g., LAG member selection differs).
         extra = {}
         for (src_id, dst_id, frozen_keys), flow_config in self.flows.items():
-            actual_dst = flow_config.dst_port.port_id  # returns actual if resolved
+            actual_dst = flow_config.dst_port.port_id
             if actual_dst != dst_id:
                 extra[(src_id, actual_dst, frozen_keys)] = flow_config
-                logging.info(
-                    "[StreamManager] dst port resolved: original=%d -> actual=%d "
-                    "(src=%d, keys=%s). Added dual-key lookup." % (
-                        dst_id, actual_dst, src_id, dict(frozen_keys)))
         if extra:
             self.flows.update(extra)
-            logging.info("[StreamManager] flows dict: %d entries (including %d resolved-port aliases)" % (
-                len(self.flows), len(extra)))
-        else:
-            logging.info("[StreamManager] all dst ports match original (no LAG remapping needed)")
+            from probing_observer import ProbingObserver
+            ProbingObserver.trace(
+                "[StreamManager] LAG remapping: added %d dual-key alias(es)" % len(extra))
 
     def get_port_ids(self, type="all"):
         """Get port IDs from all flows


### PR DESCRIPTION
### Description of PR

Summary:
Fix LAG dst port mismatch bug in `stream_manager.get_packet()` and add regression tests.

**Bug**: `add_flow()` freezes the dict key using `original_port_id` (before resolve). After `generate_packets()` resolves the actual dst port via `rx_port_resolver` (e.g., LAG member selection: original=16, actual=17), `get_packet(src, actual_dst=17)` fails because the key still uses the original port. This causes a `ValueError` crash on LAG topologies (t1-64-lag) when ECMP/LAG hashing selects a different member port.

**Fix**: After `generate_packets()` resolves ports, add dual-key aliases so both original and actual dst port IDs map to the same flow.

### Type of change

- [x] Bug fix
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

On LAG topologies (e.g., `t1-64-lag`), `rx_port_resolver` may return a different physical port than the original configured port due to LAG/ECMP hashing. The `StreamManager.get_packet()` lookup then fails because `add_flow()` stored the key with the original port ID, but callers (via `get_port_ids("dst")`) pass the resolved actual port ID.

Existing UT and IT tests did not catch this because:
- **UT**: `get_packet()` tests used `rx_port_resolver=MagicMock()` which never returns a different port
- **IT**: `mock_get_rx_port` always returns `dst_port_id` (same as original), explicitly coded as "no LAG"

#### How did you do it?

1. **Bug fix** (`stream_manager.py`): After `generate_packets()` resolves actual dst ports, iterate flows and add dual-key aliases where `actual != original`. Both keys point to the same `FlowConfig`.

2. **Regression tests** (`test_stream_manager.py`):
   - `test_get_packet_with_lag_resolved_port`: resolver returns port 26 (≠ original 24), verifies `get_packet()` works with both ports
   - `test_get_packet_with_lag_resolved_port_and_traffic_keys`: same scenario with PG traffic keys
   - `test_get_packet_no_alias_when_ports_match`: verifies no duplicate alias when actual == original

3. **IT test** (`test_ingress_drop_probing.py`):
   - `test_ingress_drop_lag_port_remapping`: full probe cycle with `get_rx_port` returning different LAG member (28 → 29)

4. **Logging cleanup**: Replaced verbose `logging.info()` debug logs with single `ProbingObserver.trace()` for LAG remapping events, consistent with probe codebase conventions.

#### How did you verify/test it?

1. Cherry-picked only the test commit onto unfixed master → **2 UT tests failed** as expected (proving they catch the bug)
2. With fix applied → all **34 UT** + **29 IT** tests pass
3. `stream_manager.py` achieves **100% code coverage**

#### Any platform specific information?

Bug only triggers on LAG topologies where ECMP/LAG hashing selects a different member port. Non-LAG topologies are unaffected.

#### Supported testbed topology if it's a new test case?

N/A (UT/IT mock tests, no testbed required)

### Documentation
N/A