### PR TITLE
tests: wait for BGP after config_reload in module teardowns

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -62,7 +62,7 @@ def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname, tb
     # Config reload should set the auto restart back to state before test started
     for hostname in selected_rand_one_per_hwsku_hostname:
         duthost = duthosts[hostname]
-        config_reload(duthost, config_source='config_db', safe_reload=True)
+        config_reload(duthost, config_source='config_db', safe_reload=True, wait_for_bgp=True)
         if hostname in dhcp_server_hosts:
             duthost.shell("docker rm %s" % DHCP_SERVER, module_ignore_errors=True)
 

--- a/tests/bgp/test_bgp_link_local.py
+++ b/tests/bgp/test_bgp_link_local.py
@@ -462,7 +462,7 @@ def configure_unnumbered_bgp(setup_info):
         eos_cleanup_failed = False
 
     # Config reload on DUT to restore everything
-    config_reload(duthost, wait=120)
+    config_reload(duthost, wait=120, wait_for_bgp=True)
 
     # Wait for all original BGP sessions to re-establish
     original_neighbors = [neigh_ipv4]

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2409,6 +2409,7 @@ class QosSaiBase(QosBase):
                 executor.submit(
                     config_reload,
                     duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True,
+                    wait_for_bgp=True,
                 )
 
     @pytest.fixture(scope='module', autouse=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Three module-scope test teardowns call `config_reload` without `wait_for_bgp=True`, so they return while BGP is still re-establishing. The next plan picks up the testbed and fails sanity with "Not all bgp sessions are established after config reload", which rolls up to SANITY_CHECK_FAILED and blames the wrong test in the plan Message.

Summary:
Fixes issues from the April 2026 nightly analysis. 

 Files changed (all 1-line edits):
 - `tests/autorestart/test_container_autorestart.py` — fixes plan `69ddbd672e61bab317c4487c`
 - `tests/bgp/test_bgp_link_local.py` — fixes plans `69e97d200aae266263d650b8` and `69fc2b42c2a648710f7b30c2`
 - `tests/qos/qos_sai_base.py` — attribution fix: qos_sai now fails its own teardown instead of the next test eating the failure

### Type of change
- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Dominant pattern in the April 2026 nightly SANITY_CHECK_FAILED analysis: teardowns release the testbed lock while BGP is still down, the next plan inherits a broken DUT, and the next test gets misblamed.

#### How did you do it?
 Added `wait_for_bgp=True` to the `config_reload` call in each of the
 three teardowns. With this kwarg, `config_reload` waits for all DUT BGP
 peers to be Established (via `check_bgp_session_state_all_asics`,
 `wait+120s` budget) before returning.

#### How did you verify/test it?
All 3 files parse under `python3 -m py_compile`

#### Any platform specific information?
None
#### Supported testbed topology if it's a new test case?
N/A — not a new test case.
### Documentation
 N/A — no behavior change beyond waiting for BGP
