### PR TITLE
[macsec]: Fix wait_mka_establish racing before macsec_setup + honest check_appl_db

### DIFF
--- a/tests/common/macsec/__init__.py
+++ b/tests/common/macsec/__init__.py
@@ -132,18 +132,17 @@ class MacsecPlugin(object):
         """
 
         if get_macsec_enable_status(macsec_duthost) and get_macsec_profile(macsec_duthost):
-            # Ensure MKA sessions are established (SC/SA present in DB) if the
-            # test environment provides the wait_mka_establish fixture
-            # (defined in tests/macsec/conftest.py). For environments that do
-            # not define it, fall back to the original behaviour.
-            try:
-                request.getfixturevalue('wait_mka_establish')
-            except pytest.FixtureLookupError:
-                # Some environments do not define wait_mka_establish; fall back
-                # to the original behaviour when the fixture is missing.
-                pass
-
             if is_macsec_configured(macsec_duthost, macsec_profile, ctrl_links):
+                # MACsec is already configured (e.g., carried over from a
+                # previous module). Wait for MKA sessions to be established
+                # (SC/SA present in DB, including SAK) before loading info, so
+                # we don't race wpa_supplicant writing the egress SA row.
+                # If the wait_mka_establish fixture isn't registered in this
+                # environment, fall back to loading directly.
+                try:
+                    request.getfixturevalue('wait_mka_establish')
+                except pytest.FixtureLookupError:
+                    pass
                 load_all_macsec_info(macsec_duthost, ctrl_links, tbinfo)
             else:
                 request.getfixturevalue('macsec_setup')

--- a/tests/common/macsec/macsec_helper.py
+++ b/tests/common/macsec/macsec_helper.py
@@ -44,6 +44,7 @@ def submit_async_task(target, args):
     proc = Process(target=target, args=args)
     process_queue.append(proc)
     proc.start()
+    return proc
 
 
 def wait_all_complete(timeout=300):
@@ -194,13 +195,19 @@ def __check_appl_db(duthost, dut_ctrl_port_name, nbrhost, nbr_ctrl_port_name, po
 
 def check_appl_db(duthost, ctrl_links, policy, cipher_suite, send_sci):
     logger.info("Check appl_db start")
+    procs = []
     for port_name, nbr in list(ctrl_links.items()):
         if isinstance(nbr["host"], EosHost):
             continue
-        submit_async_task(
+        proc = submit_async_task(
             __check_appl_db,
             (duthost, port_name, nbr["host"], nbr["port"], policy, cipher_suite, send_sci))
+        procs.append(proc)
     wait_all_complete(timeout=180)
+    failed = [p.exitcode for p in procs if p.exitcode != 0]
+    if failed:
+        logger.info("Check appl_db: %d/%d port pair(s) not yet ready", len(failed), len(procs))
+        return False
     logger.info("Check appl_db finished")
     return True
 


### PR DESCRIPTION
### Description of PR

Summary:
Fixes intermittent `KeyError: 'enable_encrypt'` (and similar) at module setup of `macsec/test_*.py`, raised from `load_all_macsec_info` → `get_macsec_attr` while reading `APPL_DB:MACSEC_*` rows, and the related symptom where every macsec test errors at `wait_mka_establish` with `AssertionError` and no setup ever runs.

Root cause has **two** stacked bugs:

**Bug 1 — `check_appl_db` silently returns `True` on subprocess failure.**
`check_appl_db` (the predicate `wait_mka_establish` polls via `wait_until`) fans out per-port checks into child `multiprocessing.Process`es via `submit_async_task`, then calls `wait_all_complete` to join them. `wait_all_complete` only checks `proc.is_alive()` after `join(timeout)` — it does not inspect `proc.exitcode`. If a child `__check_appl_db` raises an `AssertionError`/`KeyError` because the port's APPL_DB rows aren't populated yet, the child exits non-zero but `check_appl_db` returned `True` anyway. `wait_until` exits on the first poll, `wait_mka_establish` reports "established" while some links are still un-MKA'd, the test body then races wpa_supplicant, and `get_macsec_attr` KeyErrors out.

**Bug 2 — `load_macsec_info` waits for MKA *before* running `macsec_setup`.**
The autouse fixture in `tests/common/macsec/__init__.py` invokes `request.getfixturevalue('wait_mka_establish')` *before* checking `is_macsec_configured(...)` and dispatching to `macsec_setup`. On a fresh testbed MACsec is unconfigured, so the wait can never succeed; the `try/except` only catches `pytest.FixtureLookupError`, so the `AssertionError` from the wait propagates out of the fixture and the test errors at setup — `macsec_setup` is **unreachable**.

Bug 2 was previously masked by Bug 1: with the old silent-True predicate, `wait_mka_establish` always returned immediately, control fell through to the `if is_macsec_configured: ... else: macsec_setup` branch, and setup ran (sometimes followed by KeyError-flakes from Bug 1). Fixing Bug 1 alone surfaces Bug 2 as a hard failure for every macsec test on fresh testbeds, which is exactly what was observed in the PR test run for this PR (see "How did you verify/test it?" below for the log excerpt).

Tracking: ADO 38022753

### Type of change

 - [x] Bug fix
 - [ ] Testbed and Framework(new/improvement)
 - [ ] New Test case
     - [ ] Skipped for non-supported platforms
 - [ ] Test case improvement

### Back port request
 - [ ] 202311
 - [ ] 202405
 - [ ] 202411
 - [x] 202505
 - [x] 202511
 - [x] 202512
 - [x] 202605

### Approach
#### What is the motivation for this PR?

`macsec/test_dataplane.py` (mostly the `[128_SCI]` and `[256_XPN_SCI]` parametrizations on T2/SN5640) flakes at module setup with `KeyError` from `get_macsec_attr`, despite the test having a dedicated `wait_mka_establish` fixture whose entire purpose is to gate the test on APPL_DB readiness. Investigating that flakiness uncovered a second, more severe issue: on KVM/master, every macsec test errors at fixture setup because `wait_mka_establish` is being asked to wait before MACsec is even configured.

#### How did you do it?

Two surgical fixes:

1. **`tests/common/macsec/macsec_helper.py` — make `check_appl_db` honest.**
   - Snapshot the submitted children, then after `wait_all_complete` inspect each `proc.exitcode` and return `False` if any child failed. `wait_until` now correctly keeps polling until APPL_DB is genuinely populated on every ctrl_link.
   - Log which port(s) weren't ready so future flakes are diagnosable.
   - The fan-out and 180 s join timeout are unchanged. `wait_all_complete` itself is intentionally left alone for this PR — its other callers (`set_macsec_profile`, `enable_macsec_port`, `delete_macsec_profile`, `disable_macsec_port`) include teardown paths that may rely on the current silent-swallow behavior. A broader audit there is filed as a follow-up.

2. **`tests/common/macsec/__init__.py` — fix fixture ordering in `load_macsec_info`.**
   - Move `request.getfixturevalue('wait_mka_establish')` *inside* the `if is_macsec_configured(...)` branch, where the original docstring intent applies (avoid racing wpa_supplicant when MACsec is already configured carried over from a previous module).
   - Fresh testbeds now take the `else: request.getfixturevalue('macsec_setup')` branch, run setup, and test functions that need to wait for MKA do so via their own `wait_mka_establish` fixture parameter (they all already declare it).

#### How did you verify/test it?

- **Log evidence from the failing PR test run** (`testplan 6a0e44b5823c68ee324ddeac`, `macsec/test_deployment.py|||2`, OS `SONiC.master.1118527-e0977c2d8`, topology `t0-64-32 kvm`) before fix (2):
   ```
   00:36:50  load_macsec_info  → getfixturevalue('wait_mka_establish')
   00:36:50  wait_until        → poll check_appl_db, timeout 300s
   00:37:02  check_appl_db     → APPL_DB:MACSEC_PORT_TABLE:Ethernet* = "{}"   (empty — never configured)
   00:37:18  check_appl_db     → 4/4 port pair(s) not yet ready
   …(15 iterations, ~20 s each)…
   00:41:55  wait_until        → 300 s elapsed
   conftest.py:62               → AssertionError
   ERROR at setup of TestDeployment.test_config_reload[128_SCI]
   ```
   No `Setup macsec configuration step1: set macsec profile` log line anywhere — `macsec_setup` was never called.
- **Local Python harness** mirroring `submit_async_task` / `wait_all_complete` confirms for fix (1):
   - all children pass → predicate returns `True`
   - one child raises `AssertionError` → predicate returns `False` and names the offending port
   - empty target list (all-EosHost) → predicate returns `True`
- **flake8** clean on touched files (pre-existing F824 warnings on unrelated `global` statements remain).
- **CI**: Azure Pipelines triggered via `/azp run`.

#### Any platform specific information?

No. Both changes are in shared test-helper / plugin code. The original `KeyError` flakes were most common on Cisco-8000 and SN5640 (XPN cipher suites) where MKA establishment is slower, but both fixes apply to every macsec topology that uses `wait_mka_establish` — including KVM where fix (2) is mandatory because the fresh testbed always takes the unconfigured branch.

#### Supported testbed topology if it's a new test case?

N/A — bug fix to existing helper / plugin.

### Documentation
N/A.
