### PR TITLE
Fix TypeError masking real AssertionError when config reload command time out

### DIFF
--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -61,7 +61,7 @@ def test_reload_configuration(duthosts, enum_rand_one_per_hwsku_hostname,
 
     if config_force_option_supported(duthost):
         assert wait_until(360, 20, 0, config_system_checks_passed, duthost), (
-            "System checks did not pass within the allotted time after config reload. "
+            "System checks did not pass within the allotted time before config reload. "
         )
 
     logging.info("Reload configuration")
@@ -209,13 +209,12 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
 
         time.sleep(1)
 
+    stdout = out['stdout'] if out else "None (command timed out or failed)"
     # config reload command shouldn't work immediately after system reboot
-    assert result and "Retry later" in out['stdout'], (
+    assert result and "Retry later" in stdout, (
         "The config reload command did not return the expected 'Retry later' message. "
         "Output: '{}'\n"
-    ).format(
-        out['stdout']
-    )
+    ).format(stdout)
 
     assert wait_until(360, 20, 0, config_system_checks_passed, duthost, delayed_services), (
         "System checks did not pass within the allotted time after config reload on  Delayed services: {}"
@@ -232,24 +231,22 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
 
     # After the system checks succeed the config reload command should not throw error
     result, out = execute_config_reload_cmd(duthost, config_reload_timeout)
-    assert result and "Retry later" not in out['stdout'], (
+    stdout = out['stdout'] if out else "None (command timed out or failed)"
+    assert result and "Retry later" not in stdout, (
         "The config reload command returned an unexpected 'Retry later' message or failed to execute successfully. "
         "Output: '{}'\n"
-    ).format(
-        out['stdout']
-    )
+    ).format(stdout)
 
     # Immediately after one config reload command, another shouldn't execute and wait for system checks
     logging.info("Checking config reload after system is up")
     # Check if all database containers have started
     wait_until(60, 1, 0, check_database_status, duthost)
     result, out = execute_config_reload_cmd(duthost, config_reload_timeout)
-    assert result and "Retry later" in out['stdout'], (
+    stdout = out['stdout'] if out else "None (command timed out or failed)"
+    assert result and "Retry later" in stdout, (
         "The config reload command did not return the expected 'Retry later' message. "
         "Output: '{}'\n"
-    ).format(
-        out['stdout']
-    )
+    ).format(stdout)
 
     assert wait_until(360, 20, 0, config_system_checks_passed, duthost, delayed_services), (
         "System checks did not pass within the allotted time after config reload on Delayed services: {}"
@@ -266,12 +263,11 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
 
     # Without swss running config reload option should not proceed
     result, out = execute_config_reload_cmd(duthost, config_reload_timeout)
-    assert result and "Retry later" in out['stdout'], (
+    stdout = out['stdout'] if out else "None (command timed out or failed)"
+    assert result and "Retry later" in stdout, (
         "The config reload command did not return the expected 'Retry later' message. "
         "Output: '{}'\n"
-    ).format(
-        out['stdout']
-    )
+    ).format(stdout)
 
     # However with force option config reload should proceed
     logging.info("Performing force config reload")


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
In the `execute_config_reload_cmd` function, when the `sudo config reload -y` times out, it returns (False, None). The assertions always evaluate `.format(out['stdout'])` causing a misleading `TypeError` instead of the intended assertion failure message.

Also, addressing a typo in the log statement, where the check is being performed before any config reload command is executed.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Fixes the `TypeError: 'NoneType' object is not subscriptable` in test_reload_config.py file

The `execute_config_reload_cmd` function returns (False, None) when the `sudo config reload -y` command times out or fails. There are four assertion statements which access `out['stdout']` unconditionally which causes a `TypeError` that masks the actual failure reason. 

#### How did you do it?
Parsing the `out` variable into a guarded variable before each assertion


#### How did you verify/test it?
Verified the changes by running the test locally on the testbed.

Before changes :
```bash
 9385 DEBUG    root:test_reload_config.py:158 Waiting for config reload command to complete. Elapsed time: 155.04140853881836 seconds.
 9386 DEBUG    root:test_reload_config.py:158 Waiting for config reload command to complete. Elapsed time: 160.0419261455536 seconds.
 9387 DEBUG    root:test_reload_config.py:158 Waiting for config reload command to complete. Elapsed time: 165.042720079422 seconds.
 9388 DEBUG    root:test_reload_config.py:158 Waiting for config reload command to complete. Elapsed time: 170.04325461387634 seconds.
 9389 DEBUG    root:test_reload_config.py:158 Waiting for config reload command to complete. Elapsed time: 175.04371523857117 seconds.
 9390 INFO     root:test_reload_config.py:155 Config reload command did not complete within 180 seconds
 9391 ERROR    root:__init__.py:40 Traceback (most recent call last):
 ...
 ...
 9408   File "/var/src/sonic-mgmt/tests/platform_tests/test_reload_config.py", line 239, in test_reload_configuration_checks
 9409     out['stdout']
 9410     ~~~^^^^^^^^^^                                                                                                                                                        
 9411 TypeError: 'NoneType' object is not subscriptable
```

After changes :
```bash
8515 DEBUG    root:test_reload_config.py:158 Waiting for config reload command to complete. Elapsed time: 150.04236817359924 seconds.
8516 DEBUG    root:test_reload_config.py:158 Waiting for config reload command to complete. Elapsed time: 155.04289031028748 seconds.
8517 DEBUG    root:test_reload_config.py:158 Waiting for config reload command to complete. Elapsed time: 160.04343461990356 seconds.
8518 DEBUG    root:test_reload_config.py:158 Waiting for config reload command to complete. Elapsed time: 165.04393410682678 seconds.
8519 DEBUG    root:test_reload_config.py:158 Waiting for config reload command to complete. Elapsed time: 170.0444314479828 seconds.
8520 DEBUG    root:test_reload_config.py:158 Waiting for config reload command to complete. Elapsed time: 175.0449435710907 seconds.
8521 INFO     root:test_reload_config.py:155 Config reload command did not complete within 180 seconds
8522 ERROR    root:__init__.py:40 Traceback (most recent call last):
 ...
 ...
8539   File "/var/src/sonic-mgmt/tests/platform_tests/test_reload_config.py", line 235, in test_reload_configuration_checks
8540     assert result and "Retry later" not in stdout, (
8541            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
8542 AssertionError: The config reload command returned an unexpected 'Retry later' message or failed to execute successfully. Output: 'None (command timed out or failed)'
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
