### PR TITLE
[202511][cherry-pick] (#23271)

### DIFF
--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -46,13 +46,25 @@ def ignore_errors_for_non_selected_dualtor_hosts(
         # There is a known issue which causes redundant route entry delete and reports an ERR log.
         # FYI, https://github.com/sonic-net/sonic-swss/issues/2579
         # This error can be safely ignored on standby
-        error_patterns = [
+        standby_error_patterns = [
             ".*ERR swss#orchagent: :- meta_sai_validate_route_entry: object key SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\".*\",\"switch_id\":\"oid:.*\",\"vr\":\"oid:.*\"} doesn't exist",  # noqa: E501
         ]
         for duthost in duthosts:
             if duthost.hostname != enum_rand_one_per_hwsku_frontend_hostname:
                 if loganalyzer and duthost.hostname in loganalyzer:
-                    loganalyzer[duthost.hostname].ignore_regex.extend(error_patterns)
+                    loganalyzer[duthost.hostname].ignore_regex.extend(standby_error_patterns)
+
+        # The stress ARP flood overwhelms orchagent/muxorch on dualtor testbeds, causing transient
+        # monit check failures while orchagent processes the neighbor/route churn (~18 min recovery).
+        # These are expected during stress testing and not indicative of a real problem.
+        # Tracked: ADO 37245786
+        monit_error_patterns = [
+            r".*ERR monit\[\d+\]: 'dualtorNeighborCheck' status failed.*",
+            r".*ERR monit\[\d+\]: 'routeCheck' status failed.*",
+        ]
+        for duthost in duthosts:
+            if loganalyzer and duthost.hostname in loganalyzer:
+                loganalyzer[duthost.hostname].ignore_regex.extend(monit_error_patterns)
     yield
 
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR is a cherry-pick of #23271.

Summary:

The stress ARP flood overwhelms orchagent/muxorch on dualtor testbeds, causing transient dualtorNeighborCheck and routeCheck monit failures while orchagent processes the neighbor/route churn (~18 min recovery).

Add loganalyzer ignore patterns for these expected monit errors on all dualtor hosts during stress_arp tests.

Fixes: [qual-issue](https://github.com/aristanetworks/sonic-qual.msft/issues/1244)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
