### PR TITLE
Sanity: retry DB check to avoid xcvrd race

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -354,6 +354,16 @@ def check_interfaces_and_transceivers(duthost, request):
     interfaces = conn_graph_facts["device_conn"][duthost.hostname]
     if duthost.facts['hwsku'] in MGFX_HWSKU:
         interfaces = MGFX_XCVR_INTF
+
+    retry_deadline = time.time() + 120
+    while not all(intf in parsed_xcvr_info for intf in interfaces) and time.time() < retry_deadline:
+        time.sleep(5)
+        parsed_xcvr_info = []
+        for asichost in duthost.asics:
+            docker_cmd = asichost.get_docker_cmd("redis-cli -n 6 keys TRANSCEIVER_INFO*", "database")
+            xcvr_info = duthost.command(docker_cmd)
+            parsed_xcvr_info.extend(parse_transceiver_info(xcvr_info["stdout_lines"]))
+
     for intf in interfaces:
         if intf not in parsed_xcvr_info:
             raise RebootHealthError(

--- a/tests/common/platform/transceiver_utils.py
+++ b/tests/common/platform/transceiver_utils.py
@@ -7,6 +7,8 @@ import logging
 import re
 from copy import deepcopy
 
+from tests.common.utilities import wait_until
+
 I2C_WAIT_TIME_AFTER_SFP_RESET = 5  # in seconds
 
 
@@ -68,6 +70,10 @@ def check_transceiver_basic(dut, asic_index, interfaces, xcvr_skip_list):
     docker_cmd = asichost.get_docker_cmd(cmd, "database")
     xcvr_info = dut.command(docker_cmd)
     parsed_xcvr_info = parse_transceiver_info(xcvr_info["stdout_lines"])
+    if not all_transceivers_detected(dut, asic_index, interfaces, xcvr_skip_list):
+        if wait_until(120, 5, 0, all_transceivers_detected, dut, asic_index, interfaces, xcvr_skip_list):
+            xcvr_info = dut.command(docker_cmd)
+            parsed_xcvr_info = parse_transceiver_info(xcvr_info["stdout_lines"])
     for intf in interfaces:
         if intf not in xcvr_skip_list[dut.hostname]:
             assert intf in parsed_xcvr_info, "TRANSCEIVER INFO of %s is not found in DB" % intf

--- a/tests/common/platform/transceiver_utils.py
+++ b/tests/common/platform/transceiver_utils.py
@@ -5,9 +5,8 @@ This script contains re-usable functions for checking status of transceivers.
 """
 import logging
 import re
+import time
 from copy import deepcopy
-
-from tests.common.utilities import wait_until
 
 I2C_WAIT_TIME_AFTER_SFP_RESET = 5  # in seconds
 
@@ -68,12 +67,14 @@ def check_transceiver_basic(dut, asic_index, interfaces, xcvr_skip_list):
     cmd = "redis-cli -n 6 keys TRANSCEIVER_INFO*"
     asichost = dut.asic_instance(asic_index)
     docker_cmd = asichost.get_docker_cmd(cmd, "database")
+    retry_deadline = time.time() + 120
+    while not all_transceivers_detected(dut, asic_index, interfaces, xcvr_skip_list):
+        if time.time() >= retry_deadline:
+            break
+        time.sleep(5)
+
     xcvr_info = dut.command(docker_cmd)
     parsed_xcvr_info = parse_transceiver_info(xcvr_info["stdout_lines"])
-    if not all_transceivers_detected(dut, asic_index, interfaces, xcvr_skip_list):
-        if wait_until(120, 5, 0, all_transceivers_detected, dut, asic_index, interfaces, xcvr_skip_list):
-            xcvr_info = dut.command(docker_cmd)
-            parsed_xcvr_info = parse_transceiver_info(xcvr_info["stdout_lines"])
     for intf in interfaces:
         if intf not in xcvr_skip_list[dut.hostname]:
             assert intf in parsed_xcvr_info, "TRANSCEIVER INFO of %s is not found in DB" % intf


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Nightly sanity check reads `TRANSCEIVER_INFO | EthernetN` from STATE_DB once and fails the test setup with `RebootHealthError: TRANSCEIVER INFO of EthernetN is not found in DB` when `xcvrd` hasn't finished populating every
 entry yet. As per recent logs, xcvrd can take ~30–60 s to finish that work, so the single-shot read loses the race and
 the whole test set is aborted at setup time.

 This PR wraps the membership check in a 120 s / 5 s poll. The original read stays as the fast path; only when at least one expected port is missing on the first look do we re-read until either xcvrd catches up or the deadline
 expires. 


### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Pulled out the logs for the last ~90 days where 3 distinct test plans across 2 testbeds all
fail at the same sanity check with the same signature. 

#### How did you do it?

Two files in `tests/common/platform/`:

 1. **`device_utils.py` :: `check_interfaces_and_transceivers`** — keep the
    existing single-shot read intact; if any expected interface is missing,
    enter a `time.time() + 120` poll loop that re-reads the DB every 5 s.
   
 2. **`transceiver_utils.py` :: `check_transceiver_basic`** — same idea: keep
    the original read, and on first-look miss, call
    `wait_until(120, 5, 0, all_transceivers_detected, ...)` (helper) 


#### How did you verify/test it?
Logs confirm the same testbed passes the platform recovery check in the next attempt, bending the issue towards a race condition which will be addressed by the changes. 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
N/A — bug fix in shared sanity-check infrastructure
### Documentation
N/A

