### PR TITLE
fix(pc): ignore transient teamsyncd error in test_retry_count

### DIFF
--- a/tests/pc/test_retry_count.py
+++ b/tests/pc/test_retry_count.py
@@ -19,6 +19,28 @@ pytestmark = [
 ]
 
 
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
+    """Ignore transient teamsyncd errors caused by killing teamd in this module.
+
+    Tests like ``test_kill_team_lag_up`` and ``test_kill_team_peer_lag_up``
+    deliberately stop teamd (via SIGUSR1 / pkill) and then run ``config reload``
+    in the cleanup fixture. While the PortChannels are being re-created during
+    that recovery, teamsyncd may briefly fail to bind a team socket with
+    ``Cannot assign requested address`` before the next ``RTM_NEWLINK`` arrives.
+    The condition is transient and not a real failure, but loganalyzer otherwise
+    matches it on teardown and fails the test.
+    """
+    ignore_errors = [
+        r".* ERR teamd#teamsyncd: .*addLag: addLag: Failed to initialize team handler for LAG "
+        r".* Unable to initialize team socket: Cannot assign requested address\. "
+        r"Waiting for next RTM_NEWLINK\..*",
+    ]
+    if loganalyzer:
+        for duthost in duthosts:
+            loganalyzer[duthost.hostname].ignore_regex.extend(ignore_errors)
+
+
 class LACPRetryCount(Packet):
     name = "LACPRetryCount"
     fields_desc = [


### PR DESCRIPTION
### Description of PR

Summary:
Fix flakiness in `pc/test_retry_count.py::TestNeighborRetryCount::test_kill_team_lag_up` and `pc/test_retry_count.py::TestDutRetryCount::test_kill_team_peer_lag_up`, both of which fail on teardown with a loganalyzer match against a transient teamsyncd error.

Both tests deliberately stop `teamd` (via `pkill -USR1`/`docker exec teamd pkill -USR1 -x teamd`) and then run `config reload` in the `config_reload_on_cleanup` fixture. While the PortChannels are being re-created during recovery, teamsyncd briefly logs:

```
ERR teamd#teamsyncd: :- addLag: addLag: Failed to initialize team handler for LAG PortChannelXXX (ifindex N): 99:Unable to initialize team socket: Cannot assign requested address. Waiting for next RTM_NEWLINK.
```

This is transient — teamsyncd recovers on the next `RTM_NEWLINK` notification — but loganalyzer matches the ERR during the teardown phase and fails the test.

Across the last 30 days these two tests account for roughly 650 failed PR occurrences across ~360 distinct PRs (top entries in the PR flaky-episode leaderboard), all sharing the same teamsyncd signature.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

The two `test_kill_team_*` tests are at the top of the PR flaky-test list, failing on teardown because of a benign, expected teamsyncd error emitted while PortChannels are re-created by `config reload`. This causes hundreds of unnecessary PR failures per month and forces developers to rerun unrelated PRs.

#### How did you do it?

Added an `autouse=True` fixture `ignore_expected_loganalyzer_exception` in `tests/pc/test_retry_count.py` that appends a single targeted regex to `loganalyzer.ignore_regex` for each DUT:

```
.* ERR teamd#teamsyncd: .*addLag: addLag: Failed to initialize team handler for LAG .* Unable to initialize team socket: Cannot assign requested address. Waiting for next RTM_NEWLINK..*
```

The regex is intentionally scoped to the exact teamsyncd `addLag` "Cannot assign requested address / Waiting for next RTM_NEWLINK" wording so we do not mask any other real teamd/teamsyncd errors. The same pattern (module-local autouse loganalyzer ignore fixture) is already used in `tests/pc/test_lag_member_forwarding.py`.

No test logic or assertions changed.

#### How did you verify/test it?

- Confirmed via Kusto (`V2TestCases` over the last 7-30 days) that the only teardown failure signature for these two tests is the teamsyncd "Cannot assign requested address" message.
- Reviewed the test source: the only DUT-affecting state is the teamd stop + `config reload` in the existing `config_reload_on_cleanup` fixture, which is exactly where this transient ERR is produced.
- Python syntax / compile check on the modified file (`python3 -m py_compile`) and `flake8 --max-line-length=120` on the file — both pass.
- The change is additive and only extends `loganalyzer.ignore_regex`; it cannot change pass/fail behavior for any other test.

#### Any platform specific information?

None. The error pattern is generic to teamd/teamsyncd and applies on any topology where this module already runs (`t0`, `t1`, `t0-sonic`).

#### Supported testbed topology if it's a new test case?

N/A — not a new test case.

### Documentation

N/A — no documentation changes required.
