### PR TITLE
fix: avoid empty-stdin flake in YANG validation helper

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -972,7 +972,13 @@ class MultiAsicSonicHost(object):
         """
         Validate yang over running config
         """
-        output = self.shell("echo '[]' | sudo config apply-patch /dev/stdin", module_ignore_errors=True)
+        # Use a tempfile rather than `echo '[]' | sudo config apply-patch /dev/stdin`
+        # to avoid intermittent empty-stdin failures from sudo+pipe handling.
+        output = self.shell(
+            'tmp=$(mktemp) && printf "[]" > "$tmp" && '
+            'sudo config apply-patch "$tmp"; rc=$?; rm -f "$tmp"; exit $rc',
+            module_ignore_errors=True
+        )
         if output['rc'] != 0:
             return False
         if strict_yang_validation:

--- a/tests/common/helpers/yang_utils.py
+++ b/tests/common/helpers/yang_utils.py
@@ -16,8 +16,14 @@ def run_yang_validation(duthost, stage="validation"):
     """
     logger.info(f"Running YANG validation on {duthost.hostname} ({stage})")
     try:
+        # Use a tempfile rather than `echo ... | sudo config apply-patch /dev/stdin`.
+        # The pipe+sudo+/dev/stdin form intermittently delivers empty stdin to the
+        # sudo'd `config` process, which then fails JSON parsing with
+        # "Expecting value: line 1 column 1 (char 0)" and is the dominant source
+        # of pre/post-test YANG validation flakes in PR runs.
         result = duthost.shell(
-            'echo "[]" | sudo config apply-patch /dev/stdin',
+            'tmp=$(mktemp) && printf "[]" > "$tmp" && '
+            'sudo config apply-patch "$tmp"; rc=$?; rm -f "$tmp"; exit $rc',
             module_ignore_errors=True
         )
 


### PR DESCRIPTION
### Description of PR
Summary: Fix the dominant pre/post-test YANG validation flake by avoiding the fragile `echo "[]" | sudo config apply-patch /dev/stdin` pattern in the `yang_validation_check` module fixture (and the sibling `MultiAsicSonicHost.yang_validate` helper).

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The module-scoped `yang_validation_check` fixture and `MultiAsicSonicHost.yang_validate` both invoke:

```
echo "[]" | sudo config apply-patch /dev/stdin
```

This pipe + sudo + `/dev/stdin` form intermittently delivers empty stdin to the sudo'd `config` process, which then fails JSON parsing with:

```
Failed: pre-test/post-test YANG validation failed:
<dut>: Failed to apply patch due to: Expecting value: line 1 column 1 (char 0)
Error: Validate json patch: [] failed due to:Data Loading Failed
```

Telemetry over the last 30 days (PR test plans only) attributes ~507 test-case failures across 77 distinct test modules and ~458 distinct PR test plans to this exact signature. Top affected modules include `test_pretest`, `lldp.test_lldp`, `bgp.test_bgp_bbr_default_state`, `srv6.test_srv6_dataplane`, `pc.test_lag_member_forwarding`, `bgp.test_frr_config_check`, `syslog.test_syslog_rate_limit`, `zmq.test_gnmi_zmq`, `tacacs.test_authorization`, `platform_tests.counterpoll.test_counterpoll_watermark`, and many more.

There is no product/test logic bug — `[]` is a valid empty patch. The flake is purely a stdin-plumbing issue in the helper.

#### How did you do it?
Write the empty-patch JSON to a tempfile on the DUT and pass that file path to `config apply-patch`, then remove the tempfile:

```
tmp=$(mktemp) && printf "[]" > "$tmp" && sudo config apply-patch "$tmp"; rc=$?; rm -f "$tmp"; exit $rc
```

Applied identically in both call sites so behavior stays consistent:

- `tests/common/helpers/yang_utils.py::run_yang_validation`
- `tests/common/devices/multi_asic.py::MultiAsicSonicHost.yang_validate`

#### How did you verify/test it?
- Verified the new shell command syntactically and semantically performs the same operation (apply empty JSON patch via `config apply-patch`), preserves the exit-code propagation through `rc=$?`, and cleans up the tempfile regardless of success/failure.
- `py_compile` on both modified files.
- The change is purely in the invocation form of the same SONiC `config apply-patch` command; no behavior change is expected on the happy path. Reduction in flake rate will be observed through PR-flakiness telemetry.

#### Any platform specific information?
None. Applies uniformly to all DUTs (VS and physical).

#### Supported testbed topology if it's a new test case?
N/A — this is a fix to a shared helper, not a new test.

### Documentation
N/A.
