### PR TITLE
Fix/ansible upgrade playbook issues

### DIFF
--- a/ansible/plugins/callback/yaml.py
+++ b/ansible/plugins/callback/yaml.py
@@ -16,10 +16,14 @@ if sys.version_info.major > 2:
 else:
     represent_unicode = yaml.representer.SafeRepresenter.represent_unicode
 from ansible.parsing.yaml.dumper import AnsibleDumper
-AnsibleDumper.add_representer(
-    AnsibleUnsafeText,
-    represent_unicode,
-)
+
+# In ansible-core >= 2.20, AnsibleDumper is a factory function, not a class.
+# Only call add_representer if it's actually a class with that method.
+if isinstance(AnsibleDumper, type) and hasattr(AnsibleDumper, 'add_representer'):
+    AnsibleDumper.add_representer(
+        AnsibleUnsafeText,
+        represent_unicode,
+    )
 
 DOCUMENTATION = '''
     callback: yaml

--- a/ansible/plugins/filter/filters.py
+++ b/ansible/plugins/filter/filters.py
@@ -26,7 +26,8 @@ class FilterModule(object):
             'first_n_elements': first_n_elements,
             'expand_properties': expand_properties,
             'first_ip_of_subnet': first_ip_of_subnet,
-            'path_join': path_join
+            'path_join': path_join,
+            'network_in_usable': network_in_usable
         }
 
 
@@ -222,6 +223,26 @@ def first_ip_of_subnet(value):
 def path_join(paths):
     """Join path strings."""
     return os.path.join(*paths)
+
+
+def network_in_usable(value, test):
+    """Check if an IP address (value) is in the same network as test address.
+
+    Both value and test can be in CIDR notation (e.g., '10.0.0.1/24').
+    Returns True if both addresses are in the same subnet (based on value's prefix).
+    This is a replacement for the ansible.utils ipaddr filter 'network_in_usable'.
+    """
+    try:
+        # Parse value as an interface address (with prefix)
+        val_iface = ipaddress.ip_interface(str(value).strip())
+        val_network = val_iface.network
+
+        # Parse test as an IP address (strip prefix if present)
+        test_addr = ipaddress.ip_address(str(test).strip().split('/')[0])
+
+        return test_addr in val_network
+    except (ValueError, TypeError):
+        return False
 
 
 class MultiServersUtils:

--- a/ansible/roles/vm_set/tasks/kickstart_vm.yml
+++ b/ansible/roles/vm_set/tasks/kickstart_vm.yml
@@ -111,6 +111,12 @@
 
   when: not skip_this_vm and (vm_type | lower) == "vsonic"
 
+# Initialize cisco_vmhost before the block so that ansible-core >= 2.20 does not
+# fail when eagerly templating delegate_to on skipped tasks.
+- set_fact:
+    cisco_vmhost: ""
+  when: cisco_vmhost is not defined
+
 - block:
   - name: Wait until vm {{ vm_name }} is loaded
     cisco_kickstart: telnet_port={{ serial_port }}

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -1,12 +1,19 @@
 # This role creates a set of VM with veos or SONiC or cisco or Ubuntu for Kubernetes master
 # Input parameters for the role:
-# - action: 'start', 'stop' or 'renumber' for creating, removing, or renumbering vm set respectively
+# - vm_set_action: 'start', 'stop' or 'renumber' for creating, removing, or renumbering vm set respectively
 # - id: sequence number for vm set on the host.
 # - external_port: interface which will be used as parent for vlan interface creation
 # - vlan_base: first vlan id for the VMs
 # - VMs: a dictionary which contains hostnames of VMs as a key and a dictionary with parameters (num, memory, mgmt_ip) for every VM.
 # - topology: a dictionary which contains hostnames of VMs as a key and vlans value which define a topology (numbers of connected ports for every VM)
 # - mgmt_bridge: linux bridge which is used for management interface connections
+
+# Backward compatibility: 'action' was renamed to 'vm_set_action' because 'action' is
+# a reserved variable name in ansible-core >= 2.20. Accept both old and new names.
+- name: Map legacy 'action' variable to 'vm_set_action'
+  set_fact:
+    vm_set_action: "{{ action }}"
+  when: vm_set_action is not defined and action is defined
 
 # Variables used by the role are mostly defined in files under ansible/group_vars/vm_host directory.
 # Supported neighbor types are: veos, sonic, cisco, ubuntu, k8s
@@ -281,23 +288,23 @@
 
     - name: Stop VMs
       include_tasks: stop.yml
-      when: action == 'stop'
+      when: vm_set_action == 'stop'
 
     - name: Start VMs
       include_tasks: start.yml
-      when: action == 'start'
+      when: vm_set_action == 'start'
 
     - name: Connect VMs
       include_tasks: connect_vms.yml
-      when: action == 'connect_vms'
+      when: vm_set_action == 'connect_vms'
 
     - name: Disconnect VMs
       include_tasks: disconnect_vms.yml
-      when: action == 'disconnect_vms'
+      when: vm_set_action == 'disconnect_vms'
 
     - name: Renumber topology
       include_tasks: renumber_topo.yml
-      when: action == 'renumber_topo'
+      when: vm_set_action == 'renumber_topo'
 
   when: vm_required is defined and vm_required == True
 
@@ -316,19 +323,19 @@
 
 - name: Add topology
   include_tasks: add_topo.yml
-  when: action == 'add_topo'
+  when: vm_set_action == 'add_topo'
 
 - name: Remove topology
   include_tasks: remove_topo.yml
-  when: action == 'remove_topo'
+  when: vm_set_action == 'remove_topo'
 
 - name: Stop Kubernetes VMs
   include_tasks: stop_k8s.yml
-  when: action == 'stop_k8s'
+  when: vm_set_action == 'stop_k8s'
 
 - name: Start Kubernetes VMs
   include_tasks: start_k8s.yml
-  when: action == 'start_k8s'
+  when: vm_set_action == 'start_k8s'
 
 - name: Manage the dut state
   include_tasks: manage_duts.yml

--- a/ansible/roles/vm_set/tasks/manage_duts.yml
+++ b/ansible/roles/vm_set/tasks/manage_duts.yml
@@ -1,27 +1,27 @@
 - block:
     - name: Start SONiC VM
       include_tasks: start_sonic_vm.yml
-      when: action == 'start_sonic_vm' and hostvars[dut_name]['type'] == 'kvm'
+      when: vm_set_action == 'start_sonic_vm' and hostvars[dut_name]['type'] == 'kvm'
 
     - name: Stop SONiC VM
       include_tasks: stop_sonic_vm.yml
-      when: action == 'stop_sonic_vm' and hostvars[dut_name]['type'] == 'kvm'
+      when: vm_set_action == 'stop_sonic_vm' and hostvars[dut_name]['type'] == 'kvm'
 
     - name: Start SID
       include_tasks: start_sid.yml
-      when: action == 'start_sid' and hostvars[dut_name]['type'] == 'simx'
+      when: vm_set_action == 'start_sid' and hostvars[dut_name]['type'] == 'simx'
 
     - name: Stop SID
       include_tasks: stop_sid.yml
-      when: action == 'stop_sid' and hostvars[dut_name]['type'] == 'simx'
+      when: vm_set_action == 'stop_sid' and hostvars[dut_name]['type'] == 'simx'
 
     - name: Start 8000e-sonic sim
       include_tasks: start_8000e_sonic.yml
-      when: action == 'start_8000e_sonic' and hostvars[dut_name]['type'] == '8000e'
+      when: vm_set_action == 'start_8000e_sonic' and hostvars[dut_name]['type'] == '8000e'
 
     - name: Stop 8000e-sonic sim
       include_tasks: stop_8000e_sonic.yml
-      when: action == 'stop_8000e_sonic' and hostvars[dut_name]['type'] == '8000e'
+      when: vm_set_action == 'stop_8000e_sonic' and hostvars[dut_name]['type'] == '8000e'
 
   when:
     - hostvars[dut_name] is defined
@@ -30,13 +30,13 @@
 - block:
     - name: Start SONiC DPU VM
       include_tasks: start_dpu_vm.yml
-      when: action == 'start_sonic_vm'
+      when: vm_set_action == 'start_sonic_vm'
 
     - name: Stop SONiC VM
       include_tasks: stop_vsonic_dpu_vm.yml
       vars:
         dpu_name: "{{ item }}"
       with_items: "{{ dpu_targets }}"
-      when: action == 'stop_sonic_vm'
+      when: vm_set_action == 'stop_sonic_vm'
 
   when: dpu_targets is defined and dpu_targets | length > 0

--- a/ansible/roles/vm_set/tasks/start_sonic_vm.yml
+++ b/ansible/roles/vm_set/tasks/start_sonic_vm.yml
@@ -1,6 +1,6 @@
 - set_fact:
     sonic_vm_storage_location: "{{ home_path }}/sonic-vm"
-    when: sonic_vm_storage_location is not defined
+  when: sonic_vm_storage_location is not defined
 
 - set_fact:
     disable_updategraph: False

--- a/ansible/roles/vm_set/tasks/start_vm.yml
+++ b/ansible/roles/vm_set/tasks/start_vm.yml
@@ -65,7 +65,7 @@
 - name: Define vm {{ vm_name }}, hwsku {{ hwsku }}
   virt: name={{ vm_name }}
         command=define
-        xml="{{ lookup('template', 'templates/{{ vm_xml_template }}') }}"
+        xml="{{ lookup('template', 'templates/' ~ vm_xml_template) }}"
         uri=qemu:///system
   when: vm_name not in vm_list_defined.list_vms
   become: yes

--- a/ansible/roles/vm_set/tasks/start_vsonic_dpu_vm.yml
+++ b/ansible/roles/vm_set/tasks/start_vsonic_dpu_vm.yml
@@ -23,7 +23,7 @@
 - name: Define vm {{ vm_name }}
   virt: name={{ vm_name }}
         command=define
-        xml="{{ lookup('template', 'templates/{{ vm_xml_template }}') }}"
+        xml="{{ lookup('template', 'templates/' ~ vm_xml_template) }}"
         uri=qemu:///system
   when: vm_name not in vm_list_defined.list_vms
   become: yes

--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -137,11 +137,11 @@
     when: base_topo == "t2" and (is_vs_testbed | default(false))
 
   roles:
-    - { role: vm_set, action: 'stop_sonic_vm', when force_stop_sonic_vm is defined }
-    - { role: vm_set, action: 'start_sonic_vm' }
-    - { role: vm_set, action: 'start_sid' }
-    - { role: vm_set, action: 'start_8000e_sonic' }
-    - { role: vm_set, action: 'add_topo' }
+    - { role: vm_set, vm_set_action: 'stop_sonic_vm', when force_stop_sonic_vm is defined }
+    - { role: vm_set, vm_set_action: 'start_sonic_vm' }
+    - { role: vm_set, vm_set_action: 'start_sid' }
+    - { role: vm_set, vm_set_action: 'start_8000e_sonic' }
+    - { role: vm_set, vm_set_action: 'add_topo' }
 
 - hosts: servers:&eos
   gather_facts: no

--- a/ansible/testbed_connect_topo.yml
+++ b/ansible/testbed_connect_topo.yml
@@ -61,4 +61,4 @@
     when: duts_name.split(',')|length > 1
 
   roles:
-    - { role: vm_set, action: 'add_topo', when external_port is not defined }
+    - { role: vm_set, vm_set_action: 'add_topo', when external_port is not defined }

--- a/ansible/testbed_connect_vms.yml
+++ b/ansible/testbed_connect_vms.yml
@@ -61,4 +61,4 @@
     when: duts_name.split(',')|length > 1
 
   roles:
-    - { role: vm_set, action: 'connect_vms' }
+    - { role: vm_set, vm_set_action: 'connect_vms' }

--- a/ansible/testbed_disconnect_vms.yml
+++ b/ansible/testbed_disconnect_vms.yml
@@ -64,4 +64,4 @@
     when: duts_name.split(',')|length > 1
 
   roles:
-    - { role: vm_set, action: 'disconnect_vms' }
+    - { role: vm_set, vm_set_action: 'disconnect_vms' }

--- a/ansible/testbed_remove_vm_topology.yml
+++ b/ansible/testbed_remove_vm_topology.yml
@@ -100,7 +100,7 @@
     when: base_topo == "t2" and (is_vs_testbed | default(false))
 
   roles:
-    - { role: vm_set, action: 'remove_topo' }
-    - { role: vm_set, action: 'stop_sid' }
-    - { role: vm_set, action: 'stop_sonic_vm' }
-    - { role: vm_set, action: 'stop_8000e_sonic' }
+    - { role: vm_set, vm_set_action: 'remove_topo' }
+    - { role: vm_set, vm_set_action: 'stop_sid' }
+    - { role: vm_set, vm_set_action: 'stop_sonic_vm' }
+    - { role: vm_set, vm_set_action: 'stop_8000e_sonic' }

--- a/ansible/testbed_renumber_vm_topology.yml
+++ b/ansible/testbed_renumber_vm_topology.yml
@@ -110,4 +110,4 @@
     when: base_topo == "t2" and (is_vs_testbed | default(false))
 
   roles:
-    - { role: vm_set, action: 'renumber_topo' }
+    - { role: vm_set, vm_set_action: 'renumber_topo' }

--- a/ansible/testbed_start_VMs.yml
+++ b/ansible/testbed_start_VMs.yml
@@ -19,4 +19,4 @@
   gather_facts: no
   tasks:
   roles:
-    - { role: vm_set, action: 'start' }
+    - { role: vm_set, vm_set_action: 'start' }

--- a/ansible/testbed_start_k8s_VMs.yml
+++ b/ansible/testbed_start_k8s_VMs.yml
@@ -7,4 +7,4 @@
   vars_files:
     - group_vars/all/creds.yml
   roles:
-    - { role: vm_set, action: 'start_k8s' }
+    - { role: vm_set, vm_set_action: 'start_k8s' }

--- a/ansible/testbed_stop_VMs.yml
+++ b/ansible/testbed_stop_VMs.yml
@@ -13,4 +13,4 @@
 - hosts: servers:&vm_host
   gather_facts: no
   roles:
-  - { role: vm_set, action: 'stop' }
+  - { role: vm_set, vm_set_action: 'stop' }

--- a/ansible/testbed_stop_k8s_VMs.yml
+++ b/ansible/testbed_stop_k8s_VMs.yml
@@ -5,4 +5,4 @@
 - hosts: k8s_servers:&k8s_vm_host
   gather_facts: no
   roles:
-  - { role: vm_set, action: 'stop_k8s' }
+  - { role: vm_set, vm_set_action: 'stop_k8s' }


### PR DESCRIPTION
### Description of PR

Fix ansible testbed playbooks for compatibility with ansible-core 2.20 (ansible 13.6) while maintaining backward compatibility with ansible-core 2.18 (ansible 11.10).

ansible-core 2.20 introduced several breaking changes that cause `testbed-cli.sh` commands (`start-topo-vms`, `stop-topo-vms`.) to fail. This PR addresses all of them.

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Upgrading the sonic-mgmt docker container from ansible 11.10 to ansible 13.6 causes multiple testbed playbook failures due to breaking changes in ansible-core 2.20:

1. `action` is now a reserved variable name — all playbooks passing `action` to the `vm_set` role fail with warnings/errors.
2. `delegate_to` is now eagerly templated even when parent blocks are skipped — causes fatal undefined variable errors.
3. `AnsibleDumper` changed from a class to a factory function — breaks the custom yaml callback plugin.
4. Inline Jinja2 templates inside `lookup()` strings are deprecated — triggers warnings.
5. Indentation bugs that previously went unnoticed (e.g., `when:` inside `set_fact:`) now trigger reserved name warnings.
6. The `network_in_usable` filter (from `ansible.utils` collection) is not available — causes template rendering failures.

#### How did you do it?

- Renamed `action` to `vm_set_action` across all 10 playbooks that invoke the `vm_set` role
- start_sonic_vm.yml: Fixed `when:` mis-indented inside `set_fact:` (was being treated as a fact variable named `when`).
- `plugins/callback/yaml.py`: Added `isinstance` check before calling `AnsibleDumper.add_representer()` since `AnsibleDumper` is a factory function (not a class) in ansible-core ≥2.20.
- kickstart_vm.yml: Pre-initialized `cisco_vmhost` before the vcisco block so eager templating of `delegate_to` doesn't fail when the block is skipped.
- `plugins/filter/filters.py`: Added a local `network_in_usable` filter implementation using Python's stdlib `ipaddress` module.
- start_vm.yml, start_vsonic_dpu_vm.yml: Replaced nested `"templates/{{ var }}"` inside `lookup()` with string concatenation `"templates/" ~ var`.

#### How did you verify/test it?

Local VS environment -

- Ansible version 11.10 - `vsonic` and `ceos` build and teardown and tests
- Ansible version 13.6   - `vsonic` and `ceos` build and teardown and tests

#### Any platform specific information?

N/A — these are testbed infrastructure fixes applicable to all platforms.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A