### PR TITLE
[system_health] Verify Fan is Supported Before Running Fan Check

### DIFF
--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -341,20 +341,21 @@ def test_external_checker(duthosts, enum_rand_one_per_hwsku_hostname):
 @pytest.mark.parametrize('ignore_log_analyzer_by_vendor', [['mellanox']], indirect=True)
 def test_system_health_config(duthosts, enum_rand_one_per_hwsku_hostname,
                               device_mocker_factory, ignore_log_analyzer_by_vendor,  # noqa F811
-                              is_support_mock_asic, is_support_psu):    # noqa F811
+                              is_support_mock_asic, is_support_psu, is_support_fan):    # noqa F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     device_mocker = device_mocker_factory(duthost)
     wait_system_health_boot_up(duthost)
-    logger.info(
-        'Ignore fan check, verify there is no error information about fan')
-    with ConfigFileContext(duthost, os.path.join(FILES_DIR, IGNORE_FAN_CHECK_CONFIG_FILE)):
-        time.sleep(DEFAULT_INTERVAL)
-        mock_result, fan_name = device_mocker.mock_fan_presence(False)
-        expect_value = EXPECT_FAN_MISSING.format(fan_name)
-        if mock_result:
-            assert wait_until(THERMAL_CHECK_INTERVAL, 10, 2,
-                              check_health_field_not_equal, duthost, fan_name, expect_value), \
-                'Fan check is still performed after it is configured to be ignored'
+    if is_support_fan:
+        logger.info(
+            'Ignore fan check, verify there is no error information about fan')
+        with ConfigFileContext(duthost, os.path.join(FILES_DIR, IGNORE_FAN_CHECK_CONFIG_FILE)):
+            time.sleep(DEFAULT_INTERVAL)
+            mock_result, fan_name = device_mocker.mock_fan_presence(False)
+            expect_value = EXPECT_FAN_MISSING.format(fan_name)
+            if mock_result:
+                assert wait_until(THERMAL_CHECK_INTERVAL, 10, 2,
+                                  check_health_field_not_equal, duthost, fan_name, expect_value), \
+                    'Fan check is still performed after it is configured to be ignored'
 
     logger.info(
         'Ignore ASIC check, verify there is no error information about ASIC')


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add s step to verify that fan us supported by system before checking fans as part of test_system_health_config.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
test failed on system without fans (LD)

#### How did you do it?
fixed it by verifying fans existence on system 

#### How did you verify/test it?
Internal regression

#### Any platform specific information?
non-mellanox data will return True for is_support_fan - existing design of fixture 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
