### PR TITLE
Fix skip condition for testQosSaiBufferPoolWatermark on DNX

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4371,7 +4371,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark:
     reason: "sai_thrift_read_buffer_pool_watermark are not supported on DNX / Unsupported testbed type."
     conditions_logical_operator: or
     conditions:
-      - "platform in ['x86_64-nokia_ixr7250e_36x400g-r0', 'x86_64-arista_7800r3_48cq2_lc', 'x86_64-arista_7800r3_48cqm2_lc', 'x86_64-arista_7800r3a_36d2_lc', 'x86_64-arista_7800r3a_36dm2_lc','x86_64-arista_7800r3ak_36dm2_lc']"
+      - "asic_subtype in ['broadcom-dnx']"
       - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in (constants['QOS_SAI_TOPO'] + ['t2_single_node_max', 't2_single_node_min']) and asic_type not in ['mellanox']"
       - "topo_type not in ['t0'] and asic_type in ['marvell-teralynx']"


### PR DESCRIPTION
T2 Topos were recently added to constants['QOS_SAI_TOPO'] so the skip condition was not working as expected. This change replaces the current platform skip condition with a more strict asic based skip condition.

This test is invalid on DNX platforms as they do not support sai_thrift_read_buffer_pool_watermark.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511: Opened manually https://github.com/sonic-net/sonic-mgmt/pull/24754
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
T2 Topos were recently added to constants['QOS_SAI_TOPO'] so the skip condition was not working as expected. This change replaces the current platform skip condition with a more strict asic based skip condition.

This test is invalid on DNX platforms as they do not support sai_thrift_read_buffer_pool_watermark.

#### How did you do it?
Changed the "platform in [" condition to "asic_subtype in" condition.

#### How did you verify/test it?
Ran on a DNX SKU to see the test is skipping.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
