### PR TITLE
Fix withdraw_and_announce_existing_routes fixture to wait until routess withdrawn

### DIFF
--- a/tests/stress/conftest.py
+++ b/tests/stress/conftest.py
@@ -57,10 +57,28 @@ def withdraw_and_announce_existing_routes(duthosts, localhost, tbinfo, enum_rand
     logger.info("withdraw existing ipv4 and ipv6 routes")
     localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw", path="../ansible/")
 
-    wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") is True)
-    sleep_to_wait(CRM_POLLING_INTERVAL * 100)
+    result = wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") is True)
+    if not result:
+        logger.warning("Failed to process all withdraw requests in {} seconds".format(MAX_WAIT_TIME))
+
     ipv4_route_used_before = get_crm_resource_status(duthost, "ipv4_route", "used", namespace)
     ipv6_route_used_before = get_crm_resource_status(duthost, "ipv6_route", "used", namespace)
+
+    def routes_stable():
+        nonlocal ipv4_route_used_before, ipv6_route_used_before
+        ipv4_route_used_now = get_crm_resource_status(duthost, "ipv4_route", "used", namespace)
+        ipv6_route_used_now = get_crm_resource_status(duthost, "ipv6_route", "used", namespace)
+        ipv4_stable = ipv4_route_used_now == ipv4_route_used_before
+        ipv6_stable = ipv6_route_used_now == ipv6_route_used_before
+        ipv4_route_used_before = ipv4_route_used_now
+        ipv6_route_used_before = ipv6_route_used_now
+        return ipv4_stable and ipv6_stable
+
+    full_wait_time = MAX_WAIT_TIME + CRM_POLLING_INTERVAL * 100
+    result = wait_until(full_wait_time, CRM_POLLING_INTERVAL, CRM_POLLING_INTERVAL, routes_stable)
+    if not result:
+        pytest.fail("Routes failed to withdraw in {} seconds".format(full_wait_time))
+
     logger.info("ipv4 route used {}".format(ipv4_route_used_before))
     logger.info("ipv6 route used {}".format(ipv6_route_used_before))
 


### PR DESCRIPTION
Previously the fixture could yield a base number of withdrawn routes much too early. I replaced the generic sleep with a wait_until that does not progress until the number of routes is stable after withdrawing them.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Fix stress/test_stress_routes.py on large T2 Topos.

#### How did you do it?
I replaced the generic sleep with a wait_until that does not progress until the number of routes is stable after withdrawing them.

#### How did you verify/test it?
I reran the test multiple times, before it was flaky but now It passes every time.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
