### PR TITLE
Adding port status check in drop packets UT config reload

### DIFF
--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -268,7 +268,7 @@ EOF
     yield
 
     duthost.command("rm {} {}".format(copp_trap_group_json, copp_trap_rule_json))
-    config_reload(duthost, safe_reload=True, ignore_loganalyzer=loganalyzer)
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, ignore_loganalyzer=loganalyzer)
     if duthost.facts["asic_type"] == "vpp":
         # monit refreshes on a ~60s cycle, so wait one full cycle to let usage
         # settle and ensure monit's next refresh captures the steady-state


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [x] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
The fixture 'configure_copp_drop_for_ttl_error' is called when the test_ip_pkt_with_expired_ttl testcase is run - this fixture updates copp configuration to dropp packets with TTL=0 before the actual testcase is run, as part of setup, and then clears this configuration once the execution of the test case is completed, doing a 'config_reload' after removing to the drop rule from the configs, to reflect this change.

When the next test case is run (as part of the drop_packets/test_drop_counters.py suite), which is the test_broken_ip_header test case, the state of the ports in the DUT have not yet stabilized after the config reload from the previous test case, and several ports are still oper/admin down, therefore when the testcase attempts to send packets with broken IP headers, expecting to see the corresponding interface drop counters incremented, we do not see this since the interfaces are not up and ready to process packets yet.

#### How did you do it?
This PR changes the config_reload function call, to set the check_intf_up_ports parameter to "True", such that config reload ensures all interfaces are up and ready, before we proceed to the next test case.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
