### PR TITLE
[route]: test_static_route.py failed with AssertionError: Did not receive expected packet on any of ports 

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -203,6 +203,56 @@ def ping_ip(host, dst_ip, count=4, cmd_prefix=""):
     return True
 
 
+def wait_for_arp_responder_ready(ptfhost, timeout=60):
+    """Wait until arp_responder is ready to handle ARP/NDP requests.
+
+    arp_responder writes its PID to /tmp/arp_responder.pid once all pcap L2
+    sockets are open, just before entering the scapy.sniff() loop.  We ask
+    supervisord for the current PID and poll until the file contains that PID.
+    """
+    pid = ptfhost.shell(
+        'supervisorctl pid arp_responder', module_ignore_errors=True
+    )['stdout'].strip()
+    if not pid or not pid.isdigit():
+        raise RuntimeError(
+            "Could not get arp_responder PID from supervisord (got: {!r})".format(pid)
+        )
+
+    ready_file = '/tmp/arp_responder.pid'
+
+    def _ready():
+        content = ptfhost.shell(
+            'cat {} 2>/dev/null || true'.format(ready_file),
+            module_ignore_errors=True
+        )['stdout'].strip()
+        return content == pid
+
+    if not wait_until(timeout, 1, 0, _ready):
+        raise RuntimeError(
+            "arp_responder (pid {}) did not become ready within {}s".format(pid, timeout)
+        )
+    ts = ptfhost.shell(
+        'ls --full-time {}'.format(ready_file), module_ignore_errors=True
+    )['stdout'].strip()
+    logger.info("arp_responder is ready (pid %s): %s", pid, ts)
+
+
+def restart_arp_responder(ptfhost, timeout=60):
+    """Restart arp_responder and wait until it is ready to handle ARP/NDP requests.
+
+    arp_responder reads its IP/MAC config from a JSON file and opens one pcap
+    L2 socket per interface at startup — it never reloads either dynamically.
+    A restart is therefore required whenever the test changes which IP addresses
+    PTF should respond to (e.g. after writing a new arp_responder config and
+    running 'supervisorctl reread && update').
+
+    For cases that need extra supervisord commands before the restart (e.g.
+    'reread && update'), call those first and then call this function.
+    """
+    ptfhost.shell('supervisorctl restart arp_responder')
+    wait_for_arp_responder_ready(ptfhost, timeout=timeout)
+
+
 async def async_wait_until(timeout, interval, delay, condition, *args, **kwargs):
     """
     @summary: Same as wait_until but async

--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -22,6 +22,7 @@ from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.constants import ARP_RESPONDER_DEFAULT_CONFIG, UPSTREAM_NEIGHBOR_MAP
 from tests.common import config_reload
 from tests.common.reboot import reboot
+from tests.common.utilities import restart_arp_responder
 import ptf.testutils as testutils
 import ptf.mask as mask
 import ptf.packet as packet
@@ -69,7 +70,7 @@ def add_ipaddr(ptfadapter, ptfhost, nexthop_addrs, prefix_len, nexthop_interface
         ptfhost.template(src="templates/arp_responder.conf.j2", dest="/etc/supervisor/conf.d/arp_responder.conf")
 
         ptfhost.shell('supervisorctl reread && supervisorctl update')
-        ptfhost.shell('supervisorctl restart arp_responder')
+        restart_arp_responder(ptfhost)
 
 
 def del_ipaddr(ptfhost, nexthop_addrs, prefix_len, nexthop_devs, ipv6=False):

--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -1,6 +1,7 @@
 import binascii
 import json
 import argparse
+import os
 import os.path
 from collections import defaultdict
 import logging
@@ -168,6 +169,11 @@ def main():
 
     ARPResponder.ip_sets = ip_sets
     ARPResponder.sockets = sockets
+
+    # All pcap L2 sockets are open; write PID to the pid file before
+    # entering the sniff loop so the test framework knows we are ready.
+    with open('/tmp/arp_responder.pid', 'w') as f:
+        f.write(str(os.getpid()) + '\n')
 
     scapy.sniff(prn=ARPResponder.action, opened_socket=inverse_sockets, store=False)
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix `arp_responder` readiness race in `test_static_route` that causes 11-second static route programming delays.

`arp_responder` uses Scapy with `use_pcap=True` which takes 10-15 seconds to initialize all pcap L2 sockets. The old code fired `supervisorctl restart arp_responder` and immediately proceeded with the test, so the DUT's ARP probes for nexthop neighbors arrived before `arp_responder` was ready to answer — causing repeated ARP timeouts and 11+ second delays before the route could be programmed into the ASIC.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Static route tests were taking 11+ seconds longer than expected to program a route into the ASIC. Root cause: `add_ipaddr()` restarts `arp_responder` on PTF but does not wait for it to be ready, creating a race where the DUT sends ARP probes before PTF can answer them.

#### How did you do it?

- `arp_responder.py`: once all pcap L2 sockets are open (after the slow Scapy init), write the process PID to `/tmp/arp_responder.pid` just before entering `scapy.sniff()`.
- `tests/common/utilities.py`: add `wait_for_arp_responder_ready(ptfhost)` — gets the current PID from `supervisorctl pid arp_responder` and polls until `/tmp/arp_responder.pid` contains that PID, then logs the file timestamp via `ls --full-time` for timing analysis. Add `restart_arp_responder(ptfhost)` as a convenience wrapper combining restart + wait.
- `tests/route/test_static_route.py`: replace the bare `supervisorctl restart arp_responder` in `add_ipaddr()` with `restart_arp_responder(ptfhost)`, so the function does not return until `arp_responder` is fully ready to answer ARP/NDP requests.

#### How did you verify/test it?

Ran `test_static_route` on a `t1` topology testbed. Before the fix, route programming took 11 seconds due to repeated ARP timeouts. After the fix, the route is programmed in ~1 second (single ARP round-trip).

#### Any platform specific information?

No platform-specific changes. The fix applies to all topologies that use PTF `arp_responder`.

#### Supported testbed topology if it's a new test case?

N/A — bug fix to existing test cases.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

No documentation update required.
