### PR TITLE
[vm_set]: rebind DUT mgmt port to mgmt bridge during renumber

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -2570,6 +2570,13 @@ def main():
             ptf_bp_ip_addr = module.params['ptf_bp_ip_addr']
             ptf_bp_ipv6_addr = module.params['ptf_bp_ipv6_addr']
 
+            if module.params['duts_mgmt_port']:
+                for dut_mgmt_port in module.params['duts_mgmt_port']:
+                    if dut_mgmt_port != "":
+                        # For VS setup: rebind the DUT mgmt tap that the prior
+                        # unbind step detached from the mgmt bridge.
+                        net.bind_mgmt_port(mgmt_bridge, dut_mgmt_port)
+
             if net.netns:
                 net.unbind_mgmt_port(NETNS_MGMT_IF_TEMPLATE % net.vm_set_name)
                 net.delete_network_namespace()


### PR DESCRIPTION
### Description of PR
Summary:
`testbed-cli.sh restart-ptf` leaves the DUT mgmt tap (e.g. `vlab-01-0`) detached from the mgmt bridge `br1`. After restart-ptf, the DUT loses management connectivity to the sonic-mgmt container and the PTF mgmt network, breaking subsequent test runs.

Fixes # (issue) — N/A

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`testbed-cli.sh restart-ptf` runs `testbed_renumber_vm_topology.yml`, which invokes `vm_topology` twice: first with `cmd: unbind`, then with `cmd: renumber`.

The `unbind` handler iterates `duts_mgmt_port` and calls `unbind_mgmt_port(dut_mgmt_port)`, which executes `brctl delif br1 vlab-01-0` on a VS testbed.

The `renumber` handler unbinds and rebinds the front-panel ports (`unbind_fp_ports` / `bind_fp_ports`) and the VS chassis ports, but does **not** rebind the DUT mgmt ports. The `bind` handler (used at initial `add-topo`) does perform this binding via `net.bind_mgmt_port(mgmt_bridge, dut_mgmt_port)`.

The result is asymmetric: `unbind` detaches the DUT mgmt tap, `renumber` never reattaches it, so after every `restart-ptf` the tap is dangling.

#### How did you do it?
Added the `bind_mgmt_port` loop to the `renumber` handler in `ansible/roles/vm_set/library/vm_topology.py`, mirroring the existing logic in the `bind` handler. The new loop is gated on `module.params['duts_mgmt_port']` and skips empty entries (same guards the `bind` handler uses).

#### How did you verify/test it?
Verified on a `vms-kvm-t0` VS testbed on Ubuntu 22.04:

1. Reproduced: pre-fix, after `restart-ptf`, `bridge link show dev vlab-01-0` shows no `master br1`; `brctl show br1` does not list the DUT tap.
2. Manually reattached `vlab-01-0` to `br1` to establish a known-good baseline.
3. Applied the fix and ran `testbed-cli.sh restart-ptf vms-kvm-t0` — `failed=0`, `vlab-01-0` remains attached to `br1`, `ptf_vms6-1` can ping the DUT mgmt IP through `br1`.
4. Ran `restart-ptf` a second time back-to-back — same result, confirming idempotency.

#### Any platform specific information?
The change only affects VS (KVM) testbeds where `duts_mgmt_port` is populated. On physical testbeds where `duts_mgmt_port` is empty, the new loop is a no-op (same as the existing `bind` handler).

#### Supported testbed topology if it's a new test case?
N/A — not a test case.

### Documentation
N/A
