### PR TITLE
[bgp]: Migrate test_bgp_dual_asn.py to use common2 BGP route controller

### DIFF
--- a/tests/bgp/test_bgp_dual_asn.py
+++ b/tests/bgp/test_bgp_dual_asn.py
@@ -11,7 +11,7 @@ from tests.common.utilities import skip_release
 from tests.common.utilities import wait_tcp_connection
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
-from bgp_helpers import update_routes
+from tests.common2.routing.bgp.bgp_route_control import update_routes
 from tests.common.gu_utils import get_bgp_speaker_runningconfig
 from tests.common.gu_utils import apply_patch, expect_op_success
 from tests.common.gu_utils import generate_tmpfile, delete_tmpfile


### PR DESCRIPTION
### Description of PR
Summary:
Migrate `tests/bgp/test_bgp_dual_asn.py` to use the common2 BGP route controller helper.
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Migrate this test module to use the new common2 BGP route controller as part of the gradual tests/common to tests/common2 migration that enforces stricter code-quality checks.

#### How did you do it?
Swapped `from bgp_helpers import update_routes` to `from tests.common2.routing.bgp.bgp_route_control import update_routes`. 

#### How did you verify/test it?
Manual test run

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A