### PR TITLE
[bgp]: Migrate test_bgp_suppress_fib.py to use common2 BGP route controller

### DIFF
--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -1,4 +1,3 @@
-import requests
 import json
 import logging
 import random
@@ -27,6 +26,7 @@ from tests.bgp.bgp_helpers import restart_bgp_session, get_eth_port, get_exabgp_
     get_bgp_neighbor_ip, check_route_install_status, validate_route_propagate_status, operate_orchagent, \
     get_upstream_ptf_intfs, get_eth_name_from_ptf_port, check_bgp_neighbor, check_fib_route
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_ALL_NEIGHBOR_MAP
+from tests.common2.routing.bgp.bgp_route_control import install_route_from_exabgp
 
 pytestmark = [
     pytest.mark.topology('t1', 't2'),
@@ -456,28 +456,6 @@ def setup_vrf(duthost, nbrhosts, tbinfo, loganalyzer):
 
     cfg_t1 = get_cfg_facts(duthost)
     setup_vrf_cfg(duthost, cfg_t1, nbrhosts, tbinfo, loganalyzer)
-
-
-def install_route_from_exabgp(operation, ptfip, route_list, port):
-    """
-    Install or withdraw ipv4 or ipv6 route by exabgp
-    """
-    route_data = []
-    url = "http://{}:{}".format(ptfip, port)
-    for route in route_list:
-        route_data.append(route)
-    command = "{} attributes next-hop self nlri {}".format(operation, ' '.join(route_data))
-    data = {"command": command}
-    logger.info("url: {}".format(url))
-    logger.info("command: {}".format(data))
-    r = requests.post(url, data=data, timeout=90, proxies={"http": None, "https": None})
-    assert r.status_code == 200, (
-        "HTTP request to ExaBGP API failed with status code {}. URL: {}. Data: {}"
-    ).format(
-        r.status_code,
-        url,
-        data
-    )
 
 
 def announce_route(ptfip, route_list, port, action=ANNOUNCE):


### PR DESCRIPTION
### Description of PR
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Migrate this test module to use the new common2 BGP route controller as part of the gradual tests/common → tests/common2 migration that enforces stricter code-quality checks (pylint, mypy, black, unit tests).

#### How did you do it?

Removed the locally defined install_route_from_exabgp helper. Imported the identical-signature implementation from tests.common2.routing.bgp.bgp_route_control. The local announce_route wrapper (which only adds logging) is kept and now delegates to the imported helper.

#### How did you verify/test it?

Confirmed the module parses, all call sites of announce_route (~lines 760, 762, 1671, 1716) still match the unchanged wrapper signature, and the common2 command-string build is byte-equivalent to the previous local code.

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

t1, t2 (existing markers; not a new test case)

### Documentation