### PR TITLE
sanity_check: avoid pretest flakiness by waiting for bgp_facts to be …

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -219,6 +219,15 @@ def check_bgp(duthosts, tbinfo):
 
         def _check_bgp_status_helper():
             asic_check_results = []
+
+            def _bgp_facts_ready():
+                try:
+                    return len(dut.bgp_facts(asic_index='all')) > 0
+                except Exception:
+                    return False
+
+            wait_until(120, 10, 0, _bgp_facts_ready)
+
             try:
                 bgp_facts = dut.bgp_facts(asic_index='all')
             except Exception as e:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Fixes the P0 flake on the PR pipeline: test_pretest::test_features_state failing at fixture setup with KeyError('bgp') from tests/common/plugins/sanity_check/recover.py:223 oncold-booted DUTs.

Root cause: on a freshly-booted DUT (especially KVM in PR runs), SSH/Ansible is reachable before bgpcfgd/bgpd are ready to serve facts. 

Fix: add a 120s / 10s - interval wait_until warm-up at the top of status check helper that silently absorbs the cold-boot window before the existing BGP polling loop runs.

Summary:
Fixes (P0 flake — 1017 hits / 122 PRs / 30d)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

test_pretest::test_features_state is the first test of every PR plan and is currently the top P0 flake — 1017 hits across 122 PRs over the last 30 days (5pp of all failed PR plans). One occurrence causes the testbed to be marked unhealthy, cancelling all downstream modules in the plan. 

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
