### PR TITLE
Fix the Broadcom supported cmds list in techsupport

### DIFF
--- a/tests/show_techsupport/tech_support_cmds.py
+++ b/tests/show_techsupport/tech_support_cmds.py
@@ -250,31 +250,48 @@ copy_config_cmds_no_qos = [
 ]
 
 broadcom_cmd_bcmcmd_xgs = [
-    'bcmcmd{} -t5 version',
-    'bcmcmd{} -t5 soc',
-    'bcmcmd{} -t5 ps',
-    'bcmcmd{} "l3 nat_ingress show"',
-    'bcmcmd{} "l3 nat_egress show"',
+    'bcmcmd{} -t 5 version',
+    'bcmcmd{} -t 5 ps',
     'bcmcmd{} "ipmc table show"',
     'bcmcmd{} "multicast show"',
-    'bcmcmd{} "conf show"',
     'bcmcmd{} "fp show"',
     'bcmcmd{} "pvlan show"',
     'bcmcmd{} "l2 show"',
     'bcmcmd{} "l3 intf show"',
-    'bcmcmd{} "l3 defip show"',
-    'bcmcmd{} "l3 l3table show"',
     'bcmcmd{} "l3 egress show"',
-    'bcmcmd{} "l3 ecmp egress show"',
-    'bcmcmd{} "l3 multipath show"',
-    'bcmcmd{} "l3 ip6host show"',
-    'bcmcmd{} "l3 ip6route show"',
     'bcmcmd{} "mc show"',
     'bcmcmd{} "cstat *"',
     'bcmcmd{} "mirror show"',
     'bcmcmd{} "mirror dest show"',
     'bcmcmd{} "port *"',
+]
+
+broadcom_cmd_bcmcmd_xgs_soc = [
+    'bcmcmd{} -t 5 soc',
+    'bcmcmd{} "conf show"',
+    'bcmcmd{} "l3 defip show"',
+    'bcmcmd{} "l3 l3table show"',
+    'bcmcmd{} "l3 ecmp egress show"',
+    'bcmcmd{} "l3 multipath show"',
+    'bcmcmd{} "l3 ip6host show"',
+    'bcmcmd{} "l3 ip6route show"',
     'bcmcmd{} "d chg my_station_tcam"',
+]
+
+broadcom_cmd_bcmcmd_xgs_th5 = [
+    'bcmcmd{} "show config lt raw"',
+    'bcmcmd{} "l3 route show v6=0"',
+    'bcmcmd{} "l3 host show v6=0"',
+    'bcmcmd{} "l3 ecmp show"',
+    'bcmcmd{} "l3 host show v6=1"',
+    'bcmcmd{} "l3 route show v6=1"',
+    'bcmcmd{} "l2 station show"',
+    'bcmcmd{} "bcmltshell -c \'pt dump -d my_station_tcam\'"',
+]
+
+broadcom_cmd_bcmcmd_xgs_nat = [
+    'bcmcmd{} "l3 nat_ingress show"',
+    'bcmcmd{} "l3 nat_egress show"',
 ]
 
 broadcom_cmd_bcmcmd_dnx = [

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -534,6 +534,30 @@ def commands_to_check(duthosts, enum_rand_one_per_hwsku_hostname):
             asic_cmds = cmds.broadcom_cmd_bcmcmd_dnx
         else:
             asic_cmds = cmds.broadcom_cmd_bcmcmd_xgs
+
+            # Check if soc commands should be supported
+            soc_supported = None
+            try:
+                soc_supported = duthost.shell(r'bcmcmd bsh -c SOC')
+            except Exception:
+                pass
+            else:
+                if (soc_supported and soc_supported['rc'] == 0
+                        and 'Unknown command: SOC' not in ' '.join(soc_supported["stdout_lines"])):
+                    asic_cmds += cmds.broadcom_cmd_bcmcmd_xgs_soc
+                else:
+                    asic_cmds += cmds.broadcom_cmd_bcmcmd_xgs_th5
+
+            # Check if nat commands should be supported
+            nat_supported = None
+            try:
+                nat_supported = duthost.shell(r'bcmcmd "show feature" | grep -i nat')
+            except Exception:
+                pass
+            else:
+                if (nat_supported and nat_supported['rc'] == 0):
+                    asic_cmds += cmds.broadcom_cmd_bcmcmd_xgs_nat
+
         cmds_to_check.update(
             {
                 "broadcom_cmd_bcmcmd":


### PR DESCRIPTION
Due to the changes in [PR#4542](https://github.com/sonic-net/sonic-utilities/pull/4542), the show_techsupport test needs to check Broadcom commands based on the chip module. 

The fix separates non-TH5 and TH5 commands into different lists (broadcom_cmd_bcmcmd_xgs_soc and broadcom_cmd_bcmcmd_xgs_th5) and combines with the common commands list (broadcom_cmd_bcmcmd_xgs) before checking.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
To address show_techsupport test failure after [PR#4542](https://github.com/sonic-net/sonic-utilities/pull/4542) is merged.

#### How did you do it?

#### How did you verify/test it?
Run show_techsupport test on the DUTs with Broadcom non-TH5 and TH5 chipsets, and verify no failed cases.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
