### PR TITLE
[memory_utilization] Add --enable_monit_refresh option to opt into monit cache refresh

### DIFF
--- a/tests/common/plugins/memory_utilization/__init__.py
+++ b/tests/common/plugins/memory_utilization/__init__.py
@@ -16,6 +16,17 @@ def pytest_addoption(parser):
         default=False,
         help="Disable memory utilization analysis for the 'memory_utilization' fixture"
     )
+    parser.addoption(
+        "--skip_monit_refresh",
+        action="store_true",
+        default=False,
+        help="Skip the monit cache refresh in the memory_utilization fixture. "
+             "When set, the fixture does NOT issue `sudo monit validate` before "
+             "collection and does NOT retry the `sudo monit status` read for "
+             "freshness. Saves up to ~MONIT_STATUS_FRESHNESS_WAIT_SECONDS * "
+             "MONIT_STATUS_FRESHNESS_MAX_RETRIES seconds per setup/teardown, in "
+             "exchange for possibly reading stale monit cache data."
+    )
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -48,20 +59,29 @@ def pytest_runtest_setup(item):
     logger.debug("Memory monitors ready: {}".format(list(memory_monitors.keys()) if memory_monitors else "None"))
     logger.debug("memory_values {} ".format(memory_values))
 
+    skip_monit_refresh = item.config.getoption("--skip_monit_refresh") or \
+        "skip_monit_refresh" in item.keywords
+
     for duthost in duthosts:
         if duthost.topo_type == 't2':
             continue
 
-        # Trigger monit to refresh its cache so subsequent collection reads fresh data
-        logger.info("Triggering monit refresh on {} before collecting memory data".format(duthost.hostname))
-        validate_output = memory_monitors[duthost.hostname].execute_command("sudo monit validate")
-        memory_monitors[duthost.hostname].record_monit_baseline_from_validate_output(validate_output)
+        if not skip_monit_refresh:
+            # Trigger monit to refresh its cache so subsequent collection reads fresh data
+            logger.info("Triggering monit refresh on {} before collecting memory data".format(duthost.hostname))
+            validate_output = memory_monitors[duthost.hostname].execute_command("sudo monit validate")
+            memory_monitors[duthost.hostname].record_monit_baseline_from_validate_output(validate_output)
+        else:
+            logger.info(
+                "skip_monit_refresh=True; bypassing 'sudo monit validate' pre-trigger on {}".format(
+                    duthost.hostname))
 
         # Initial memory check for all registered commands
         for name, cmd, memory_params, memory_check in memory_monitors[duthost.hostname].commands:
             try:
                 if name == "monit":
-                    output = memory_monitors[duthost.hostname].read_monit_status_with_freshness_retry(cmd)
+                    output = memory_monitors[duthost.hostname].read_monit_status_with_freshness_retry(
+                        cmd, skip_retry=skip_monit_refresh)
                 else:
                     output = memory_monitors[duthost.hostname].execute_command(cmd)
                 memory_values["before_test"][duthost.hostname][name] = memory_check(output, memory_params)
@@ -95,20 +115,29 @@ def pytest_runtest_teardown(item, nextitem):
     memory_monitors, memory_values = memory_utilization
     memory_errors = []
 
+    skip_monit_refresh = item.config.getoption("--skip_monit_refresh") or \
+        "skip_monit_refresh" in item.keywords
+
     for duthost in duthosts:
         if duthost.topo_type == 't2':
             continue
 
-        # Trigger monit to refresh its cache so subsequent collection reads fresh data
-        logger.info("Triggering monit refresh on {} before collecting memory data".format(duthost.hostname))
-        validate_output = memory_monitors[duthost.hostname].execute_command("sudo monit validate")
-        memory_monitors[duthost.hostname].record_monit_baseline_from_validate_output(validate_output)
+        if not skip_monit_refresh:
+            # Trigger monit to refresh its cache so subsequent collection reads fresh data
+            logger.info("Triggering monit refresh on {} before collecting memory data".format(duthost.hostname))
+            validate_output = memory_monitors[duthost.hostname].execute_command("sudo monit validate")
+            memory_monitors[duthost.hostname].record_monit_baseline_from_validate_output(validate_output)
+        else:
+            logger.info(
+                "skip_monit_refresh=True; bypassing 'sudo monit validate' pre-trigger on {}".format(
+                    duthost.hostname))
 
         # memory check for all registered commands
         for name, cmd, memory_params, memory_check in memory_monitors[duthost.hostname].commands:
             try:
                 if name == "monit":
-                    output = memory_monitors[duthost.hostname].read_monit_status_with_freshness_retry(cmd)
+                    output = memory_monitors[duthost.hostname].read_monit_status_with_freshness_retry(
+                        cmd, skip_retry=skip_monit_refresh)
                 else:
                     output = memory_monitors[duthost.hostname].execute_command(cmd)
                 memory_values["after_test"][duthost.hostname][name] = memory_check(output, memory_params)

--- a/tests/common/plugins/memory_utilization/__init__.py
+++ b/tests/common/plugins/memory_utilization/__init__.py
@@ -17,15 +17,20 @@ def pytest_addoption(parser):
         help="Disable memory utilization analysis for the 'memory_utilization' fixture"
     )
     parser.addoption(
-        "--skip_monit_refresh",
+        "--enable_monit_refresh",
         action="store_true",
         default=False,
-        help="Skip the monit cache refresh in the memory_utilization fixture. "
-             "When set, the fixture does NOT issue `sudo monit validate` before "
-             "collection and does NOT retry the `sudo monit status` read for "
-             "freshness. Saves up to ~MONIT_STATUS_FRESHNESS_WAIT_SECONDS * "
-             "MONIT_STATUS_FRESHNESS_MAX_RETRIES seconds per setup/teardown, in "
-             "exchange for possibly reading stale monit cache data."
+        help="Enable the monit cache refresh in the memory_utilization fixture. "
+             "When NOT set (default), the fixture does NOT issue `sudo monit "
+             "validate` before collection and does NOT retry the `sudo monit "
+             "status` read for freshness; the first read is returned as-is "
+             "(faster, may contain stale monit cache data). When set, the fixture "
+             "issues `sudo monit validate` to refresh the cache and retries the "
+             "`sudo monit status` read for freshness, costing up to "
+             "~MONIT_STATUS_FRESHNESS_WAIT_SECONDS * "
+             "MONIT_STATUS_FRESHNESS_MAX_RETRIES seconds per setup/teardown when "
+             "the cache is stale. Refresh can also be enabled per-test via "
+             "`@pytest.mark.enable_monit_refresh`."
     )
 
 
@@ -59,21 +64,21 @@ def pytest_runtest_setup(item):
     logger.debug("Memory monitors ready: {}".format(list(memory_monitors.keys()) if memory_monitors else "None"))
     logger.debug("memory_values {} ".format(memory_values))
 
-    skip_monit_refresh = item.config.getoption("--skip_monit_refresh") or \
-        "skip_monit_refresh" in item.keywords
+    enable_monit_refresh = item.config.getoption("--enable_monit_refresh") or \
+        "enable_monit_refresh" in item.keywords
 
     for duthost in duthosts:
         if duthost.topo_type == 't2':
             continue
 
-        if not skip_monit_refresh:
+        if enable_monit_refresh:
             # Trigger monit to refresh its cache so subsequent collection reads fresh data
             logger.info("Triggering monit refresh on {} before collecting memory data".format(duthost.hostname))
             validate_output = memory_monitors[duthost.hostname].execute_command("sudo monit validate")
             memory_monitors[duthost.hostname].record_monit_baseline_from_validate_output(validate_output)
         else:
             logger.info(
-                "skip_monit_refresh=True; bypassing 'sudo monit validate' pre-trigger on {}".format(
+                "enable_monit_refresh=False; bypassing 'sudo monit validate' pre-trigger on {}".format(
                     duthost.hostname))
 
         # Initial memory check for all registered commands
@@ -81,7 +86,7 @@ def pytest_runtest_setup(item):
             try:
                 if name == "monit":
                     output = memory_monitors[duthost.hostname].read_monit_status_with_freshness_retry(
-                        cmd, skip_retry=skip_monit_refresh)
+                        cmd, enable_retry=enable_monit_refresh)
                 else:
                     output = memory_monitors[duthost.hostname].execute_command(cmd)
                 memory_values["before_test"][duthost.hostname][name] = memory_check(output, memory_params)
@@ -115,21 +120,21 @@ def pytest_runtest_teardown(item, nextitem):
     memory_monitors, memory_values = memory_utilization
     memory_errors = []
 
-    skip_monit_refresh = item.config.getoption("--skip_monit_refresh") or \
-        "skip_monit_refresh" in item.keywords
+    enable_monit_refresh = item.config.getoption("--enable_monit_refresh") or \
+        "enable_monit_refresh" in item.keywords
 
     for duthost in duthosts:
         if duthost.topo_type == 't2':
             continue
 
-        if not skip_monit_refresh:
+        if enable_monit_refresh:
             # Trigger monit to refresh its cache so subsequent collection reads fresh data
             logger.info("Triggering monit refresh on {} before collecting memory data".format(duthost.hostname))
             validate_output = memory_monitors[duthost.hostname].execute_command("sudo monit validate")
             memory_monitors[duthost.hostname].record_monit_baseline_from_validate_output(validate_output)
         else:
             logger.info(
-                "skip_monit_refresh=True; bypassing 'sudo monit validate' pre-trigger on {}".format(
+                "enable_monit_refresh=False; bypassing 'sudo monit validate' pre-trigger on {}".format(
                     duthost.hostname))
 
         # memory check for all registered commands
@@ -137,7 +142,7 @@ def pytest_runtest_teardown(item, nextitem):
             try:
                 if name == "monit":
                     output = memory_monitors[duthost.hostname].read_monit_status_with_freshness_retry(
-                        cmd, skip_retry=skip_monit_refresh)
+                        cmd, enable_retry=enable_monit_refresh)
                 else:
                     output = memory_monitors[duthost.hostname].execute_command(cmd)
                 memory_values["after_test"][duthost.hostname][name] = memory_check(output, memory_params)

--- a/tests/common/plugins/memory_utilization/memory_utilization.py
+++ b/tests/common/plugins/memory_utilization/memory_utilization.py
@@ -89,7 +89,7 @@ class MemoryMonitor:
             "[MemoryUtilization] recorded validate baseline System-block 'data collected': {}".format(
                 self._monit_memory_baseline_timestamp or "<none>"))
 
-    def read_monit_status_with_freshness_retry(self, cmd, skip_retry=False):
+    def read_monit_status_with_freshness_retry(self, cmd, enable_retry=False):
         """
         Execute `sudo monit status` and verify its System-block 'data collected' timestamp
         differs from the validate-output baseline. If it still matches, sleep
@@ -97,19 +97,19 @@ class MemoryMonitor:
         MONIT_STATUS_FRESHNESS_MAX_RETRIES times. Never re-issues `monit validate`.
         Returns the final output even when freshness cannot be confirmed.
 
-        When `skip_retry` is True, the freshness-check retry loop is bypassed
-        entirely: the first `sudo monit status` output is returned as-is regardless
-        of whether its System-block timestamp matches the validate baseline. This
-        is useful for tests that tolerate potentially stale monit cache data in
-        exchange for avoiding up to MONIT_STATUS_FRESHNESS_WAIT_SECONDS *
-        MONIT_STATUS_FRESHNESS_MAX_RETRIES seconds of sleep per setup/teardown
-        when the cache is stale.
+        When `enable_retry` is False (the default), the freshness-check retry
+        loop is bypassed entirely: the first `sudo monit status` output is returned
+        as-is regardless of whether its System-block timestamp matches the validate
+        baseline. This is the cheaper path for tests that tolerate potentially
+        stale monit cache data. When `enable_retry` is True, the retry loop runs
+        and may sleep up to MONIT_STATUS_FRESHNESS_WAIT_SECONDS *
+        MONIT_STATUS_FRESHNESS_MAX_RETRIES seconds per call.
         """
         output = self.execute_command(cmd)
 
-        if skip_retry:
+        if not enable_retry:
             logger.info(
-                "[MemoryUtilization] skip_retry=True; returning monit status output "
+                "[MemoryUtilization] enable_retry=False; returning monit status output "
                 "without freshness retry for '{}'".format(cmd))
             return output
 

--- a/tests/common/plugins/memory_utilization/memory_utilization.py
+++ b/tests/common/plugins/memory_utilization/memory_utilization.py
@@ -89,15 +89,29 @@ class MemoryMonitor:
             "[MemoryUtilization] recorded validate baseline System-block 'data collected': {}".format(
                 self._monit_memory_baseline_timestamp or "<none>"))
 
-    def read_monit_status_with_freshness_retry(self, cmd):
+    def read_monit_status_with_freshness_retry(self, cmd, skip_retry=False):
         """
         Execute `sudo monit status` and verify its System-block 'data collected' timestamp
         differs from the validate-output baseline. If it still matches, sleep
         MONIT_STATUS_FRESHNESS_WAIT_SECONDS and retry the status read, up to
         MONIT_STATUS_FRESHNESS_MAX_RETRIES times. Never re-issues `monit validate`.
         Returns the final output even when freshness cannot be confirmed.
+
+        When `skip_retry` is True, the freshness-check retry loop is bypassed
+        entirely: the first `sudo monit status` output is returned as-is regardless
+        of whether its System-block timestamp matches the validate baseline. This
+        is useful for tests that tolerate potentially stale monit cache data in
+        exchange for avoiding up to MONIT_STATUS_FRESHNESS_WAIT_SECONDS *
+        MONIT_STATUS_FRESHNESS_MAX_RETRIES seconds of sleep per setup/teardown
+        when the cache is stale.
         """
         output = self.execute_command(cmd)
+
+        if skip_retry:
+            logger.info(
+                "[MemoryUtilization] skip_retry=True; returning monit status output "
+                "without freshness retry for '{}'".format(cmd))
+            return output
 
         if not self._monit_memory_baseline_timestamp:
             logger.warning(


### PR DESCRIPTION
### Description of PR

Summary:
Make the monit cache refresh sequence in the memory_utilization fixture opt-in.

The memory_utilization fixture (PR #24122 / PR #24552) invokes a two-step monit cache refresh on each test setup and teardown to defeat stale-cache false alarms:

1. `sudo monit validate` — trigger fresh collection
2. `read_monit_status_with_freshness_retry()` — read `sudo monit status`, retry up to `MONIT_STATUS_FRESHNESS_MAX_RETRIES` = 3 times with `MONIT_STATUS_FRESHNESS_WAIT_SECONDS` = 60s sleep each when the timestamp still matches the validate baseline.

This guarantees fresh monit data but adds up to ~180s of sleep per hook when the cache is stale (worst case ~360s per test, plus ~0.5s per `sudo monit validate`). Per review feedback, the refresh path is now **opt-in** — only tests that explicitly request it pay the cost; all other tests fall back to the pre-PR #24122 fast read path.

> Updated 2026-05-21 (commit `dfd455`): flipped the default per review feedback — was `--skip_monit_refresh` (opt-out); now `--enable_monit_refresh` (opt-in).

Fixes # (issue)

ADO: 
https://github.com/sonic-net/sonic-mgmt/issues/24785

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The memory_utilization fixture's monit cache refresh added by PR #24122 / PR #24552 can add up to ~360s of wall-clock time per test in the worst case when the monit cache is stale on first read. Only tests that actually depend on a freshly-revalidated monit cache should pay that cost; every other test should keep the pre-PR #24122 fast read path.

#### How did you do it?
Added an opt-in mechanism that runs the `sudo monit validate` pre-trigger AND the freshness retry loop only when explicitly requested:

- New CLI flag: `--enable_monit_refresh` (applies to the whole pytest run)
- Per-test marker: `@pytest.mark.enable_monit_refresh` (applies to individual tests)

When set:
- `sudo monit validate` is invoked before reading status.
- `read_monit_status_with_freshness_retry()` receives `enable_retry=True` and runs the freshness check + retry loop.

When NOT set (default):
- `sudo monit validate` is skipped.
- `read_monit_status_with_freshness_retry()` returns the first `sudo monit status` output as-is, without entering the retry loop.

`sudo monit status` is still executed in both cases (production parity preserved).

Default behavior matches the pre-PR #24122 fast path, so no existing test regresses on wall-clock time. Tests that need fresh data must opt in.

#### How did you verify/test it?
- Syntax checked with `py_compile` and `pyflakes` (no new warnings).
- Verified the new default (no flag, no marker) bypasses `sudo monit validate` and the retry loop.
- Verified that with `--enable_monit_refresh` set, the `sudo monit validate` step and the retry loop both run as before.

#### Any platform specific information?
None. Behaves identically across platforms. T2 topologies were already excluded by the existing code; no change there.

#### Supported testbed topology if it's a new test case?
N/A — testbed/framework improvement, not a new test case.

### Documentation
N/A — internal pytest plugin option.
