### PR TITLE
[memory_utilization] Add --monit_polling_interval=N option to shrink stale-cache window

### DIFF
--- a/tests/common/plugins/memory_utilization/__init__.py
+++ b/tests/common/plugins/memory_utilization/__init__.py
@@ -41,7 +41,6 @@ def store_fixture_values(request, duthosts, memory_utilization):
     request.config.store_memory_utilization = memory_utilization
 
 
-
 # ---------------------------------------------------------------------------
 # --monit_polling_interval support
 #

--- a/tests/common/plugins/memory_utilization/__init__.py
+++ b/tests/common/plugins/memory_utilization/__init__.py
@@ -16,6 +16,19 @@ def pytest_addoption(parser):
         default=False,
         help="Disable memory utilization analysis for the 'memory_utilization' fixture"
     )
+    parser.addoption(
+        "--monit_polling_interval",
+        type=int,
+        default=None,
+        help="Override the monit daemon polling interval (seconds) on the DUT "
+             "for the duration of the pytest session. When set, the fixture "
+             "reads the current `set daemon N` value from /etc/monit/monitrc on "
+             "each DUT, replaces it with the provided value, reloads monit, and "
+             "restores the original value at session teardown. A smaller value "
+             "(e.g. 10) shrinks the stale-cache window and reduces the chance "
+             "of false memory alarms. When not set (default), monit's polling "
+             "interval is left unchanged."
+    )
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -26,6 +39,150 @@ def store_fixture_values(request, duthosts, memory_utilization):
     logger.debug("store memory_utilization {}".format(request.node.name))
     request.config.store_duthosts = duthosts
     request.config.store_memory_utilization = memory_utilization
+
+
+
+# ---------------------------------------------------------------------------
+# --monit_polling_interval support
+#
+# Optionally override monit's daemon polling interval at session scope by
+# rewriting `set daemon N` in /etc/monit/monitrc and reloading monit, with a
+# full-file backup so the original config can be restored even if the session
+# crashes mid-run.
+# ---------------------------------------------------------------------------
+
+MONIT_RC_PATH = "/etc/monit/monitrc"
+MONIT_RC_BACKUP_PATH = "/etc/monit/monitrc.copilot_memory_utilization.bak"
+
+
+def _monit_rc_backup_exists(duthost):
+    """Return True iff the monit_rc backup file already exists on the DUT."""
+    res = duthost.shell("test -f {}".format(MONIT_RC_BACKUP_PATH), module_ignore_errors=True)
+    return res.get("rc", 1) == 0
+
+
+def _backup_monit_rc(duthost):
+    """Copy /etc/monit/monitrc to the well-known backup path (preserving perms)."""
+    duthost.shell("sudo cp -p {} {}".format(MONIT_RC_PATH, MONIT_RC_BACKUP_PATH))
+
+
+def _restore_monit_rc(duthost):
+    """Restore /etc/monit/monitrc from backup (if present) and reload monit."""
+    if not _monit_rc_backup_exists(duthost):
+        logger.warning(
+            "No monit_rc backup found on %s at %s; skipping restore",
+            duthost.hostname, MONIT_RC_BACKUP_PATH)
+        return
+    duthost.shell("sudo cp -p {} {}".format(MONIT_RC_BACKUP_PATH, MONIT_RC_PATH))
+    duthost.shell("sudo rm -f {}".format(MONIT_RC_BACKUP_PATH))
+    duthost.shell("sudo monit reload", module_ignore_errors=True)
+
+
+def _read_monit_daemon_interval(duthost):
+    """
+    Read the current `set daemon N` value from /etc/monit/monitrc.
+
+    Tolerates leading whitespace (sonic-buildimage indents the directive by two
+    spaces) and any trailing inline comment. Returns the integer N on success
+    or None if the directive cannot be located.
+    """
+    cmd = r"grep -m1 -oP '^\s*set daemon \K[0-9]+' " + MONIT_RC_PATH
+    res = duthost.shell(cmd, module_ignore_errors=True)
+    out = (res.get("stdout") or "").strip()
+    if not out.isdigit():
+        return None
+    return int(out)
+
+
+def _write_monit_daemon_interval(duthost, value):
+    """
+    Rewrite the integer in the `set daemon N` directive to `value` and reload monit.
+
+    The sed regex captures the leading whitespace + literal text via group \1 so
+    any indentation and any trailing inline comment on the line are preserved.
+    """
+    sed_expr = r"s/(^[[:space:]]*set daemon )[0-9]+/\1{}/".format(int(value))
+    duthost.shell("sudo sed -i -E '{}' {}".format(sed_expr, MONIT_RC_PATH))
+    duthost.shell("sudo monit reload", module_ignore_errors=True)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def override_monit_polling_interval(request, duthosts):
+    """
+    Temporarily override monit's daemon polling interval on each non-t2 DUT for
+    the lifetime of the pytest session, restoring the original value at session
+    teardown. No-op when --monit_polling_interval is not provided.
+    """
+    new_interval = request.config.getoption("--monit_polling_interval")
+    if new_interval is None:
+        yield
+        return
+
+    original_intervals = {}
+    for duthost in duthosts:
+        if duthost.topo_type == "t2":
+            continue
+
+        # Recover from a previous crashed session that left a backup behind.
+        if _monit_rc_backup_exists(duthost):
+            logger.warning(
+                "Found leftover %s on %s from a previous session; restoring "
+                "from backup before modifying monitrc",
+                MONIT_RC_BACKUP_PATH, duthost.hostname)
+            _restore_monit_rc(duthost)
+
+        current = _read_monit_daemon_interval(duthost)
+        if current is None:
+            logger.warning(
+                "Could not locate `set daemon N` in %s on %s; skipping override",
+                MONIT_RC_PATH, duthost.hostname)
+            continue
+
+        # Create a fresh backup of the (original) live config, then verify it
+        # exists before modifying. If the backup did not get created, skip the
+        # modification on this DUT rather than leaving it in an inconsistent state.
+        _backup_monit_rc(duthost)
+        if not _monit_rc_backup_exists(duthost):
+            logger.error(
+                "Failed to create monit_rc backup at %s on %s; skipping override",
+                MONIT_RC_BACKUP_PATH, duthost.hostname)
+            continue
+
+        logger.info(
+            "[MemoryUtilization] overriding monit daemon polling interval on %s: %ss -> %ss",
+            duthost.hostname, current, new_interval)
+        _write_monit_daemon_interval(duthost, new_interval)
+        original_intervals[duthost.hostname] = current
+
+    yield
+
+    for duthost in duthosts:
+        if duthost.hostname not in original_intervals:
+            continue
+        logger.info(
+            "[MemoryUtilization] restoring monit daemon polling interval on %s from backup",
+            duthost.hostname)
+        _restore_monit_rc(duthost)
+
+
+def _compute_monit_retry_wait(config):
+    """
+    Pair the freshness-retry sleep with the monit daemon polling interval.
+
+    - If --monit_polling_interval is NOT set: return None and let the freshness
+      retry use the module-level MONIT_STATUS_FRESHNESS_WAIT_SECONDS default (60s).
+    - If --monit_polling_interval is set: return polling_interval exactly.
+      `sudo monit validate` is invoked immediately before reading status, so we
+      are phase-aligned with the daemon and the next cycle is at most one
+      polling_interval away.
+
+    The fixture itself is session-scoped, so monit is reconfigured once at
+    session start and restored once at session end, not per test.
+    """
+    polling = config.getoption("--monit_polling_interval")
+    if polling is None:
+        return None
+    return polling
 
 
 @pytest.hookimpl(trylast=True)
@@ -57,11 +214,21 @@ def pytest_runtest_setup(item):
         validate_output = memory_monitors[duthost.hostname].execute_command("sudo monit validate")
         memory_monitors[duthost.hostname].record_monit_baseline_from_validate_output(validate_output)
 
+        # Compute polling-aligned retry_wait (None falls back to module default)
+        retry_wait = _compute_monit_retry_wait(item.config)
+        if retry_wait is not None:
+            logger.info(
+                "[MemoryUtilization] [setup] DUT={} polling-aligned freshness-retry wait={}s "
+                "(polling_interval={})".format(
+                    duthost.hostname, retry_wait,
+                    item.config.getoption('--monit_polling_interval')))
+
         # Initial memory check for all registered commands
         for name, cmd, memory_params, memory_check in memory_monitors[duthost.hostname].commands:
             try:
                 if name == "monit":
-                    output = memory_monitors[duthost.hostname].read_monit_status_with_freshness_retry(cmd)
+                    output = memory_monitors[duthost.hostname].read_monit_status_with_freshness_retry(
+                        cmd, retry_wait=retry_wait)
                 else:
                     output = memory_monitors[duthost.hostname].execute_command(cmd)
                 memory_values["before_test"][duthost.hostname][name] = memory_check(output, memory_params)
@@ -104,11 +271,21 @@ def pytest_runtest_teardown(item, nextitem):
         validate_output = memory_monitors[duthost.hostname].execute_command("sudo monit validate")
         memory_monitors[duthost.hostname].record_monit_baseline_from_validate_output(validate_output)
 
+        # Compute polling-aligned retry_wait (None falls back to module default)
+        retry_wait = _compute_monit_retry_wait(item.config)
+        if retry_wait is not None:
+            logger.info(
+                "[MemoryUtilization] [teardown] DUT={} polling-aligned freshness-retry wait={}s "
+                "(polling_interval={})".format(
+                    duthost.hostname, retry_wait,
+                    item.config.getoption('--monit_polling_interval')))
+
         # memory check for all registered commands
         for name, cmd, memory_params, memory_check in memory_monitors[duthost.hostname].commands:
             try:
                 if name == "monit":
-                    output = memory_monitors[duthost.hostname].read_monit_status_with_freshness_retry(cmd)
+                    output = memory_monitors[duthost.hostname].read_monit_status_with_freshness_retry(
+                        cmd, retry_wait=retry_wait)
                 else:
                     output = memory_monitors[duthost.hostname].execute_command(cmd)
                 memory_values["after_test"][duthost.hostname][name] = memory_check(output, memory_params)

--- a/tests/common/plugins/memory_utilization/__init__.py
+++ b/tests/common/plugins/memory_utilization/__init__.py
@@ -118,51 +118,89 @@ def override_monit_polling_interval(request, duthosts):
         yield
         return
 
+    # --monit_polling_interval must be a positive integer. type=int already rejects
+    # non-integers; reject 0 and negatives explicitly to avoid writing an invalid
+    # `set daemon 0` / `set daemon -1` into /etc/monit/monitrc.
+    if new_interval <= 0:
+        pytest.fail(
+            "--monit_polling_interval must be a positive integer, got: {}".format(new_interval))
+
     original_intervals = {}
     for duthost in duthosts:
         if duthost.topo_type == "t2":
             continue
 
-        # Recover from a previous crashed session that left a backup behind.
-        if _monit_rc_backup_exists(duthost):
-            logger.warning(
-                "Found leftover %s on %s from a previous session; restoring "
-                "from backup before modifying monitrc",
-                MONIT_RC_BACKUP_PATH, duthost.hostname)
-            _restore_monit_rc(duthost)
+        # Per-DUT setup is wrapped so an SSH/sudo/grep failure on one DUT does
+        # NOT abort the loop and leave other DUTs unconfigured.
+        try:
+            # Recover from a previous crashed session that left a backup behind.
+            if _monit_rc_backup_exists(duthost):
+                logger.warning(
+                    "Found leftover %s on %s from a previous session; restoring "
+                    "from backup before modifying monitrc",
+                    MONIT_RC_BACKUP_PATH, duthost.hostname)
+                _restore_monit_rc(duthost)
 
-        current = _read_monit_daemon_interval(duthost)
-        if current is None:
-            logger.warning(
-                "Could not locate `set daemon N` in %s on %s; skipping override",
-                MONIT_RC_PATH, duthost.hostname)
-            continue
+            current = _read_monit_daemon_interval(duthost)
+            if current is None:
+                logger.warning(
+                    "Could not locate `set daemon N` in %s on %s; skipping override",
+                    MONIT_RC_PATH, duthost.hostname)
+                continue
 
-        # Create a fresh backup of the (original) live config, then verify it
-        # exists before modifying. If the backup did not get created, skip the
-        # modification on this DUT rather than leaving it in an inconsistent state.
-        _backup_monit_rc(duthost)
-        if not _monit_rc_backup_exists(duthost):
+            # Per-DUT bound: the new interval must be strictly less than the
+            # DUT's current value. Setting it equal is a no-op; setting it larger
+            # would defeat the purpose of the flag (shrinking the stale-cache
+            # window). Skip this DUT with a warning rather than failing the whole
+            # session, so multi-DUT testbeds with one mis-configured DUT can still
+            # run the other DUTs.
+            if new_interval >= current:
+                logger.warning(
+                    "[MemoryUtilization] --monit_polling_interval=%s is not strictly "
+                    "less than the current monit polling interval on %s (%ss); "
+                    "skipping override on this DUT",
+                    new_interval, duthost.hostname, current)
+                continue
+
+            # Create a fresh backup of the (original) live config, then verify it
+            # exists before modifying. If the backup did not get created, skip the
+            # modification on this DUT rather than leaving it in an inconsistent state.
+            _backup_monit_rc(duthost)
+            if not _monit_rc_backup_exists(duthost):
+                logger.error(
+                    "Failed to create monit_rc backup at %s on %s; skipping override",
+                    MONIT_RC_BACKUP_PATH, duthost.hostname)
+                continue
+
+            logger.info(
+                "[MemoryUtilization] overriding monit daemon polling interval on %s: %ss -> %ss",
+                duthost.hostname, current, new_interval)
+            _write_monit_daemon_interval(duthost, new_interval)
+            original_intervals[duthost.hostname] = current
+        except Exception as e:
             logger.error(
-                "Failed to create monit_rc backup at %s on %s; skipping override",
-                MONIT_RC_BACKUP_PATH, duthost.hostname)
-            continue
-
-        logger.info(
-            "[MemoryUtilization] overriding monit daemon polling interval on %s: %ss -> %ss",
-            duthost.hostname, current, new_interval)
-        _write_monit_daemon_interval(duthost, new_interval)
-        original_intervals[duthost.hostname] = current
+                "[MemoryUtilization] failed to override monit polling interval on %s: %s; "
+                "skipping this DUT - manual cleanup of %s may be required if a "
+                "backup was created",
+                duthost.hostname, e, MONIT_RC_BACKUP_PATH)
 
     yield
 
+    # Per-DUT teardown is wrapped so a restore failure on one DUT does NOT
+    # abort the loop and leave subsequent DUTs with a modified /etc/monit/monitrc.
     for duthost in duthosts:
         if duthost.hostname not in original_intervals:
             continue
-        logger.info(
-            "[MemoryUtilization] restoring monit daemon polling interval on %s from backup",
-            duthost.hostname)
-        _restore_monit_rc(duthost)
+        try:
+            logger.info(
+                "[MemoryUtilization] restoring monit daemon polling interval on %s from backup",
+                duthost.hostname)
+            _restore_monit_rc(duthost)
+        except Exception as e:
+            logger.error(
+                "[MemoryUtilization] failed to restore monit_rc on %s: %s; DUT may "
+                "still have %ss polling interval in /etc/monit/monitrc - backup at %s",
+                duthost.hostname, e, new_interval, MONIT_RC_BACKUP_PATH)
 
 
 def _compute_monit_retry_wait(config):

--- a/tests/common/plugins/memory_utilization/memory_utilization.py
+++ b/tests/common/plugins/memory_utilization/memory_utilization.py
@@ -89,14 +89,23 @@ class MemoryMonitor:
             "[MemoryUtilization] recorded validate baseline System-block 'data collected': {}".format(
                 self._monit_memory_baseline_timestamp or "<none>"))
 
-    def read_monit_status_with_freshness_retry(self, cmd):
+    def read_monit_status_with_freshness_retry(self, cmd, retry_wait=None):
         """
         Execute `sudo monit status` and verify its System-block 'data collected' timestamp
         differs from the validate-output baseline. If it still matches, sleep
         MONIT_STATUS_FRESHNESS_WAIT_SECONDS and retry the status read, up to
         MONIT_STATUS_FRESHNESS_MAX_RETRIES times. Never re-issues `monit validate`.
         Returns the final output even when freshness cannot be confirmed.
+
+        When `retry_wait` is provided (int seconds), it overrides the module-level
+        MONIT_STATUS_FRESHNESS_WAIT_SECONDS default for the sleep between retries.
+        Intended to be paired with the monit daemon polling interval so the retry
+        sleep does not exceed the actual cache-refresh period.
         """
+        effective_wait = retry_wait if retry_wait is not None else MONIT_STATUS_FRESHNESS_WAIT_SECONDS
+        logger.debug(
+            "[MemoryUtilization] freshness-retry config for '{}': wait={}s (override={}), max_retries={}".format(
+                cmd, effective_wait, retry_wait is not None, MONIT_STATUS_FRESHNESS_MAX_RETRIES))
         output = self.execute_command(cmd)
 
         if not self._monit_memory_baseline_timestamp:
@@ -116,9 +125,9 @@ class MemoryMonitor:
                 "[MemoryUtilization] status System-block ts still matches validate baseline ({}); "
                 "sleeping {}s before retry {}/{} of status read".format(
                     self._monit_memory_baseline_timestamp,
-                    MONIT_STATUS_FRESHNESS_WAIT_SECONDS,
+                    effective_wait,
                     attempt, MONIT_STATUS_FRESHNESS_MAX_RETRIES))
-            time.sleep(MONIT_STATUS_FRESHNESS_WAIT_SECONDS)
+            time.sleep(effective_wait)
 
             output = self.execute_command(cmd)
             current_ts = self._parse_monit_memory_data_collected_timestamp(output)


### PR DESCRIPTION
### Description of PR

Summary:
Add an opt-in CLI parameter `--monit_polling_interval=N` to the memory_utilization fixture that temporarily overrides monit's daemon polling interval for the duration of the pytest session, and pair the freshness-retry sleep with the same interval so retries no longer wait longer than the actual cache-refresh period.

Fixes # (issue)

ADO: N/A

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The memory_utilization fixture (PR #24122 / PR #24552) invokes a refresh-and-retry sequence on every test setup and teardown to defeat stale-cache false alarms:

1. `sudo monit validate` — trigger fresh collection
2. `read_monit_status_with_freshness_retry()` — read `sudo monit status`, retry up to `MONIT_STATUS_FRESHNESS_MAX_RETRIES` = 3 times with `MONIT_STATUS_FRESHNESS_WAIT_SECONDS` = 60s sleep between retries when the status timestamp still matches the validate baseline.

The 60s sleep was sized for the monit daemon's default polling interval (`set daemon 60` in `/etc/monit/monitrc`). When the cache happens to be stale on first read, each retry burns a full 60s waiting for the daemon's next collection cycle to commit. Worst case is 180s per hook × 2 hooks per test ≈ 360s of added wall-clock time. Stale reads are common because the daemon polls every 60s while tests run on shorter cadence.

#### How did you do it?
Two coupled changes:

**1. Session-scoped override of monit's daemon polling interval.**
New CLI option `--monit_polling_interval=N`. When set, a session-scoped autouse fixture, for each non-t2 DUT:
1. (Crash recovery) If a leftover `/etc/monit/monitrc.copilot_memory_utilization.bak` from a previously crashed session is present, restore it first so the fresh backup captures the true original config.
2. Reads the current `set daemon N` value from `/etc/monit/monitrc`.
3. Copies `/etc/monit/monitrc` to `/etc/monit/monitrc.copilot_memory_utilization.bak` (preserving perms/timestamps with `cp -p`) and verifies the backup exists.
4. Rewrites the `set daemon N` directive to the new value and runs `sudo monit reload`.
5. At session teardown, restores the file by copying the backup back over `/etc/monit/monitrc`, removes the backup, and reloads monit.

The full-file backup makes restore safe even if the modification was partial or if future config changes introduce additional directives we did not anticipate.

The fixture is session-scoped (autouse), so monit is reconfigured exactly once at session start and restored once at session end, never per test.

**2. Pair the freshness-retry sleep with the polling interval.**
New helper `_compute_monit_retry_wait(config)` selects the freshness-retry sleep:

- `--monit_polling_interval` not set → module default (60s, unchanged)
- `--monit_polling_interval` set → `polling_interval` exactly. `sudo monit validate` is invoked immediately before reading status, so we are phase-aligned with the daemon and the next cycle is at most one polling_interval away.

`read_monit_status_with_freshness_retry` gains an optional `retry_wait` kwarg that overrides `MONIT_STATUS_FRESHNESS_WAIT_SECONDS` for the sleep between retries. Both setup and teardown hooks compute the value via `_compute_monit_retry_wait` and pass it in, with an INFO-level log line emitted when the override is active so the per-test timing budget is visible.

Useful values for `--monit_polling_interval` are typically 10 to 15 seconds: small enough to keep the cache nearly fresh, large enough to keep monit's CPU cost negligible.

Notes:
- The `sed` expression preserves leading whitespace (sonic-buildimage's `monitrc` indents the directive by two spaces) and any trailing inline comment.
- The `grep` pattern uses PCRE's `\K` so only the integer is captured even with leading whitespace.

Default behavior is unchanged: without `--monit_polling_interval`, the fixture is a no-op, `/etc/monit/monitrc` is untouched, and the freshness-retry sleep stays at 60s.

#### How did you verify/test it?
- Syntax checked with `py_compile` and `pyflakes` (no new warnings introduced).
- Verified that with no `--monit_polling_interval` provided, both files behave identically to current master (default-path code unchanged, fixture is a no-op).
- Verified the `grep -m1 -oP '^\s*set daemon \K[0-9]+'` pattern against the upstream sonic-buildimage `monitrc` template (`files/image_config/monit/monitrc`) — returns `60` correctly for the actual 2-space indented `set daemon 60 # check services at 1-minute intervals` line.
- Verified the `sed` regex preserves indentation and trailing comment.

#### Any platform specific information?
None. Behaves identically across platforms. T2 topologies are excluded explicitly (matching existing fixture patterns).

#### Supported testbed topology if it's a new test case?
N/A — testbed/framework improvement, not a new test case.

### Documentation
N/A — internal pytest plugin option.
