### PR TITLE
Validate Spectrum-6 egress ACL mirroring behavior

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -479,9 +479,6 @@ r, ".*ERR systemd\[1\]: Failed to listen on systemd-networkd.socket - Network Se
 # Ignore syncd error when switching global packet trimming mode
 r, ".*ERR .* SAI_API_SWITCH:brcm_sai_switch_pkt_trim_qos_tc_egr_entries_create:.* Egress qos map with idx .* entries are already present.*"
 
-# Ignore SPC6 Egress mirroring not supported failures on SPC6 mellanox platform
-r, ".*ERR syncd#SDK: \[SAI_PORT.ERR\] .*mlnx_sai_port.c\[.*\]- mlnx_port_samplepacket_session_get: Egress mirroring is not supported on SPC6.*"
-
 # Ignore the error when the sysfs was accessed too soon, before sys creation has been completed.
 r, ".*ERR sfputil: Failed to read from file /sys/module/sx_core/asic\d+/module\d+/present - FileNotFoundError.*"
 

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -24,6 +24,7 @@ from tests.common.utilities import wait_until, check_msg_in_syslog, get_plt_wait
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.utilities import find_duthost_on_role
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
+from tests.common.mellanox_data import get_chip_type
 from tests.common.macsec.macsec_helper import MACSEC_INFO
 from tests.common.dualtor.dual_tor_common import mux_config              # noqa: F401
 from tests.common.helpers.sonic_db import AsicDbCli
@@ -856,7 +857,6 @@ class BaseEverflowTest(object):
         duthost_set = BaseEverflowTest.get_duthost_set(setup_info)
 
         session_info = None
-
         for duthost in duthost_set:
             if not session_info:
                 session_info = BaseEverflowTest.mirror_session_info("test_session_1", duthost.facts["asic_type"])
@@ -870,7 +870,7 @@ class BaseEverflowTest(object):
             # Default to "false" when keys are absent — this matches the CLI behavior in
             # sonic-utilities (config/main.py is_port_mirror_capability_supported) which
             # reads STATE_DB directly and rejects when keys are missing.
-            if config_method == CONFIG_MODE_CLI:
+            if config_method == CONFIG_MODE_CLI and not self.egress_mirror_payload_unchanged(duthost):
                 switch_caps = everflow_capabilities.get(duthost.hostname, {})
                 ingress_capable = switch_caps.get("PORT_INGRESS_MIRROR_CAPABLE", "false")
                 egress_capable = switch_caps.get("PORT_EGRESS_MIRROR_CAPABLE", "false")
@@ -884,7 +884,8 @@ class BaseEverflowTest(object):
 
             BaseEverflowTest.apply_mirror_config(
                 duthost, session_info, config_method,
-                erspan_ip_ver=erspan_ip_ver, direction=self.mirror_type())
+                erspan_ip_ver=erspan_ip_ver, direction=self.mirror_type(),
+                prefer_directional_cli=self.egress_mirror_payload_unchanged(duthost))
 
         yield session_info
 
@@ -947,7 +948,8 @@ class BaseEverflowTest(object):
         Args:
             session_info: Mirror session parameters dict.
             queue_num: Optional queue number.
-            direction: Optional mirror direction (ingress/egress/both).
+            direction: Optional Everflow mirror direction (ingress/egress)
+                or CLI direction (rx/tx/both).
             policer: Optional policer name.
             use_erspan_subcmd: If True, use 'config mirror_session erspan add'
                 (supports direction as positional arg). If False, use the
@@ -965,6 +967,9 @@ class BaseEverflowTest(object):
         if use_erspan_subcmd:
             # New syntax: config mirror_session erspan add <name> <src> <dst>
             #     <dscp> <ttl> [gre_type] [queue] [src_port] [direction]
+            # CLI direction values are rx/tx/both; Everflow uses ingress/egress
+            # to describe the mirror action under test.
+            cli_direction = {"ingress": "rx", "egress": "tx"}.get(direction, direction)
             command = (
                 f"config mirror_session erspan add"
                 f" {session_info['session_name']}"
@@ -973,14 +978,16 @@ class BaseEverflowTest(object):
                 f" {session_info['session_ttl']}"
                 f" {session_info['session_gre']}"
             )
-            if queue_num:
+            if queue_num is not None:
                 command += f" {queue_num}"
+            elif direction:
+                command += " 0"
             else:
                 command += " ''"
             # src_port placeholder (not used for ERSPAN without SPAN src)
             command += " ''"
-            if direction:
-                command += f" {direction}"
+            if cli_direction:
+                command += f" {cli_direction}"
             if policer:
                 command += f" --policer {policer}"
         else:
@@ -1002,10 +1009,56 @@ class BaseEverflowTest(object):
         return command
 
     @staticmethod
+    def _build_mirror_db_command(session_info, policer=None, erspan_ip_ver=4):
+        """Build a sonic-db-cli command to write mirror session directly to CONFIG_DB.
+
+        CLI commands (both legacy and erspan cmd) do not support IPv6
+        addresses, so we bypass the CLI and write to the database directly.
+        """
+        src_ip = session_info['session_src_ip'] if erspan_ip_ver == 4 \
+            else session_info['session_src_ipv6']
+        dst_ip = session_info['session_dst_ip'] if erspan_ip_ver == 4 \
+            else session_info['session_dst_ipv6']
+
+        command = (
+            f"sonic-db-cli CONFIG_DB HSET"
+            f" 'MIRROR_SESSION|{session_info['session_name']}'"
+            f" 'dscp' '{session_info['session_dscp']}'"
+            f" 'dst_ip' '{dst_ip}'"
+            f" 'gre_type' '{session_info['session_gre']}'"
+            f" 'src_ip' '{src_ip}'"
+            f" 'ttl' '{session_info['session_ttl']}'"
+        )
+        if policer:
+            command += f" 'policer' '{policer}'"
+        return command
+
+    @staticmethod
     def apply_mirror_config(duthost, session_info, config_method=CONFIG_MODE_CLI, policer=None,
-                            erspan_ip_ver=4, queue_num=None, direction=None):
+                            erspan_ip_ver=4, queue_num=None, direction=None, prefer_directional_cli=False):
         if config_method == CONFIG_MODE_CLI:
-            if direction:
+            if erspan_ip_ver == 6:
+                command = BaseEverflowTest._build_mirror_db_command(
+                    session_info, policer=policer, erspan_ip_ver=erspan_ip_ver
+                )
+                duthost.command(command)
+            elif direction:
+                if prefer_directional_cli:
+                    erspan_cmd = BaseEverflowTest._build_erspan_cli_command(
+                        session_info, queue_num=queue_num,
+                        direction=direction, policer=policer,
+                        use_erspan_subcmd=True,
+                        erspan_ip_ver=erspan_ip_ver
+                    )
+                    result2 = duthost.command(erspan_cmd, module_ignore_errors=True)
+                    if result2["rc"] == 0:
+                        return
+                    pytest.skip(
+                        "Cannot create mirror session with direction. "
+                        "ERSPAN error: {}. Legacy CLI does not configure "
+                        "mirror direction.".format(result2.get("stderr", "").strip())
+                    )
+
                 # Try legacy command first (without direction since it
                 # does not support it), then fall back to erspan subcmd.
                 # sonic-utilities PR #4089 added capability checks but
@@ -1332,6 +1385,86 @@ class BaseEverflowTest(object):
         }
         self.apply_non_openconfig_acl_rule(duthost, extra_vars, rule_file, table_name)
 
+    def egress_mirror_payload_unchanged(self, duthost):
+        if self.acl_stage() != "egress" or self.mirror_type() != "egress":
+            return False
+        if duthost.facts["asic_type"] != "mellanox":
+            return False
+        try:
+            return get_chip_type(duthost) == "spectrum6"
+        except KeyError:
+            return False
+
+    @staticmethod
+    def _get_interface_mtu(duthost, interface):
+        interface_status = duthost.show_and_parse(f"show interface status {interface}")
+        pytest_assert(interface_status, f"Failed to read MTU for interface {interface}")
+        return int(interface_status[0]["mtu"])
+
+    def _set_interface_mtu(self, duthost, interface, mtu):
+        duthost.command(f"config interface mtu {interface} {mtu}")
+        pytest_assert(
+            wait_until(30, 5, 0, lambda: self._get_interface_mtu(duthost, interface) == mtu),
+            f"Failed to update MTU {mtu} on interface {interface}"
+        )
+
+    @staticmethod
+    def _get_acl_packets_count(duthost, table_name, rule_name):
+        acl_counters = duthost.show_and_parse("aclshow -a")
+        pytest_assert(acl_counters, f"Failed to read ACL counters for {table_name}|{rule_name}")
+
+        for rule in acl_counters:
+            if rule["table name"] == table_name and rule["rule name"] == rule_name:
+                packets_count = rule["packets count"]
+                pytest_assert(
+                    packets_count != "N/A",
+                    f"ACL counter is not ready for {table_name}|{rule_name}"
+                )
+                return int(packets_count)
+
+        pytest.fail(f"ACL counter entry not found for {table_name}|{rule_name}")
+
+    @staticmethod
+    def _select_tx_port_not_in(port_info, excluded_ptf_ids, purpose):
+        for port, ptf_id in zip(port_info["dest_port"], port_info["dest_port_ptf_id"]):
+            ptf_ids = BaseEverflowTest._get_tx_port_id_list([ptf_id])
+            if not set(ptf_ids).intersection(excluded_ptf_ids):
+                return port, ptf_ids
+        pytest.skip(f"Skip test as there is no available {purpose} port.")
+
+    @staticmethod
+    def _select_route_ready_tx_port(remote_dut, port_info, tbinfo, session_prefix, namespace, ip_version,
+                                    route_timeout=60, route_interval=10):
+        attempts = []
+
+        for port, ptf_id in zip(port_info["dest_port"], port_info["dest_port_ptf_id"]):
+            peer_ip = get_neighbor_info(remote_dut, port, tbinfo, ip_version=ip_version)
+            attempts.append(f"{port}->{peer_ip}")
+            logging.info(
+                "Probe mirror session route candidate: prefix=%s port=%s peer_ip=%s namespace=%s",
+                session_prefix,
+                port,
+                peer_ip,
+                namespace
+            )
+
+            add_route(remote_dut, session_prefix, peer_ip, namespace)
+            if wait_until(route_timeout, route_interval, 0, validate_asic_route, remote_dut, session_prefix):
+                return port, BaseEverflowTest._get_tx_port_id_list([ptf_id]), peer_ip
+
+            logging.info(
+                "Mirror session route candidate did not reach ASIC: prefix=%s port=%s peer_ip=%s",
+                session_prefix,
+                port,
+                peer_ip
+            )
+            remove_route(remote_dut, session_prefix, peer_ip, namespace)
+
+        pytest.fail(
+            f"Failed to install mirror session route {session_prefix} into ASIC for all candidates: "
+            f"{', '.join(attempts)}"
+        )
+
     def send_and_check_mirror_packets(self,
                                       setup,
                                       mirror_session,
@@ -1425,7 +1558,9 @@ class BaseEverflowTest(object):
 
                 inner_packet = Mask(inner_packet)
 
-                # For egress mirroring, we expect the DUT to have modified the packet
+                # Spectrum-6 mirrors the original eACL egress payload without rewriting it.
+                #
+                # For egress mirroring, we expect older platforms to have modified the packet
                 # before forwarding it. Specifically:
                 #
                 # - In L2 the SMAC and DMAC will change.
@@ -1434,7 +1569,7 @@ class BaseEverflowTest(object):
                 # We know what the TTL and SMAC should be after going through the pipeline,
                 # but DMAC and checksum are trickier. For now, update the TTL and SMAC, and
                 # mask off the DMAC and IP Checksum to verify the packet contents.
-                if self.mirror_type() == "egress":
+                if self.mirror_type() == "egress" and not self.egress_mirror_payload_unchanged(duthost):
                     inner_packet.set_do_not_care_scapy(packet.Ether, "dst")
 
                     if self.acl_ip_version() == 4:

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -1,4 +1,5 @@
 """Test cases to support the Everflow IPv6 Mirroring feature in SONiC."""
+import logging
 import threading
 import time
 import pytest
@@ -8,6 +9,8 @@ from ptf.mask import Mask
 import ptf.packet as scapy
 from . import everflow_test_utilities as everflow_utils
 from .everflow_test_utilities import BaseEverflowTest, DOWN_STREAM, UP_STREAM, erspan_ip_ver              # noqa: F401
+from tests.common.utilities import wait_until
+from common.helpers.assertions import pytest_assert
 import random
 # Module-level fixtures
 from .everflow_test_utilities import setup_info, skip_ipv6_everflow_tests                                 # noqa: F401
@@ -53,19 +56,26 @@ class EverflowIPv6Tests(BaseEverflowTest):
         ip = "ipv4" if erspan_ip_ver == 4 else "ipv6"
         # On T0 testbed, the collector IP is routed to T1
         namespace = setup_info[dest_port_type]['remote_namespace']
-        tx_port = setup_info[dest_port_type]["dest_port"][0]
-        dest_port_ptf_id_list = [setup_info[dest_port_type]["dest_port_ptf_id"][0]]
         remote_dut = setup_info[dest_port_type]['remote_dut']
         rx_port_id = setup_info[dest_port_type]["src_port_ptf_id"]
         remote_dut.shell(remote_dut.get_vtysh_cmd_for_namespace(
             f"vtysh -c \"config\" -c \"router bgp\" -c \"address-family {ip}\" -c \"redistribute static\"", namespace))
-        peer_ip = everflow_utils.get_neighbor_info(remote_dut, tx_port, tbinfo, ip_version=erspan_ip_ver)
         session_prefixes = setup_mirror_session["session_prefixes"] if erspan_ip_ver == 4 \
             else setup_mirror_session["session_prefixes_ipv6"]
-        everflow_utils.add_route(remote_dut, session_prefixes[0], peer_ip, namespace)
-        EverflowIPv6Tests.tx_port_ids = BaseEverflowTest._get_tx_port_id_list(dest_port_ptf_id_list)
+        _, dest_port_ptf_id_list, peer_ip = self._select_route_ready_tx_port(
+            remote_dut,
+            setup_info[dest_port_type],
+            tbinfo,
+            session_prefixes[0],
+            namespace,
+            erspan_ip_ver,
+            route_timeout=60,
+            route_interval=10
+        )
+        pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_mirror_session_up,
+                                 remote_dut, setup_mirror_session["session_name"]))
+        EverflowIPv6Tests.tx_port_ids = dest_port_ptf_id_list
         EverflowIPv6Tests.rx_port_ptf_id = rx_port_id
-        time.sleep(5)
 
         yield
 
@@ -852,8 +862,10 @@ class EverflowIPv6Tests(BaseEverflowTest):
                            dscp=None,
                            sport=2020,
                            dport=8080,
-                           flags=0x10):
+                           flags=0x10,
+                           pktlen=100):
         pkt = testutils.simple_tcpv6_packet(
+            pktlen=pktlen,
             eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
             eth_dst=setup[direction]["ingress_router_mac"],
             ipv6_src=src_ip,
@@ -908,8 +920,187 @@ class TestIngressEverflowIPv6(EverflowIPv6Tests):
 
 class TestEgressEverflowIPv6(EverflowIPv6Tests):
     """Parameters for Egress Everflow IPv6 testing. (Egress ACLs/Egress Mirror)"""
+    MTU_DROP_PACKET_LEN = 1600
+    MTU_DROP_CONTROL_PACKET_LEN = 256
+    MTU_DROP_DEFAULT_DST_IP = "2002:0225:7c6b:a982:d48b:230e:f271:0011"
+    MTU_DROP_PACKET_QUALIFIERS = [
+        ("src_ipv6", {"src_ip": "2002:0225:7c6b:a982:d48b:230e:f271:0002"}),
+        ("dst_ipv6", {"dst_ip": "2002:0225:7c6b:a982:d48b:230e:f271:0003"}),
+        ("next_header", {"next_header": 0x7E}),
+        ("l4_src_port", {"sport": 9000}),
+        ("l4_dst_port", {"dport": 9001}),
+        ("l4_src_port_range", {"sport": 10200}),
+        ("l4_dst_port_range", {"dport": 10700}),
+        ("tcp_flags", {"flags": 0x1B}),
+        ("dscp", {"dscp": 37}),
+    ]
+    MTU_DROP_RULES_BY_QUALIFIER = {
+        "src_ipv6": "RULE_1",
+        "dst_ipv6": "RULE_2",
+        "next_header": "RULE_3",
+        "l4_src_port": "RULE_4",
+        "l4_dst_port": "RULE_5",
+        "l4_src_port_range": "RULE_6",
+        "l4_dst_port_range": "RULE_7",
+        "tcp_flags": "RULE_8",
+        "dscp": "RULE_9",
+    }
+
     def acl_stage(self):
         return "egress"
 
     def mirror_type(self):
         return "egress"
+
+    def test_everflow_egress_mirror_mtu_drop_ipv6(
+        self,
+        setup_info,
+        setup_mirror_session,
+        ptfadapter,
+        everflow_dut,
+        tbinfo,
+        everflow_direction,
+        erspan_ip_ver
+    ):
+        """Verify IPv6 egress mirroring still occurs when original packet is dropped by MTU."""
+        if not self.egress_mirror_payload_unchanged(everflow_dut):
+            pytest.skip("MTU-drop mirror validation only applies to platforms with unchanged egress mirror payload.")
+        if erspan_ip_ver != 4:
+            pytest.skip("IPv6 MTU-drop mirror validation only runs with IPv4 ERSPAN.")
+
+        if len(setup_info[everflow_direction]["dest_port"]) <= 1:
+            pytest.skip("Skip test as there are not enough ports to separate mirror and default traffic.")
+
+        remote_dut = setup_info[everflow_direction]["remote_dut"]
+        default_traffic_port_type = DOWN_STREAM if everflow_direction == UP_STREAM else UP_STREAM
+        excluded_ptf_ids = set(EverflowIPv6Tests.tx_port_ids)
+        excluded_ptf_ids.update(self._get_tx_port_id_list([EverflowIPv6Tests.rx_port_ptf_id]))
+        default_traffic_tx_port, default_traffic_tx_port_ptf_id = self._select_tx_port_not_in(
+            setup_info[default_traffic_port_type],
+            excluded_ptf_ids,
+            "default traffic"
+        )
+        default_traffic_peer_ip = everflow_utils.get_neighbor_info(
+            everflow_dut, default_traffic_tx_port, tbinfo, ip_version=6)
+        default_traffic_namespace = setup_info[default_traffic_port_type]["remote_namespace"]
+        original_mtu = self._get_interface_mtu(everflow_dut, default_traffic_tx_port)
+        default_traffic_routes = set()
+        session_prefixes = setup_mirror_session["session_prefixes"] if erspan_ip_ver == 4 \
+            else setup_mirror_session["session_prefixes_ipv6"]
+
+        try:
+            pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_asic_route, remote_dut, session_prefixes[0]))
+            pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_mirror_session_up,
+                                     remote_dut, setup_mirror_session["session_name"]))
+            pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_acl_rules_in_asic_db, everflow_dut))
+            self._set_interface_mtu(everflow_dut, default_traffic_tx_port, 1500)
+
+            for packet_qualifier, packet_kwargs in self.MTU_DROP_PACKET_QUALIFIERS:
+                logging.info("Verify IPv6 MTU-drop egress mirroring for %s packet qualifier", packet_qualifier)
+                rule_name = self.MTU_DROP_RULES_BY_QUALIFIER[packet_qualifier]
+                packet_kwargs_with_default_dst = {"dst_ip": self.MTU_DROP_DEFAULT_DST_IP}
+                packet_kwargs_with_default_dst.update(packet_kwargs)
+                control_pkt = self._base_tcpv6_packet(
+                    everflow_direction,
+                    ptfadapter,
+                    setup_info,
+                    pktlen=self.MTU_DROP_CONTROL_PACKET_LEN,
+                    **packet_kwargs_with_default_dst
+                )
+                oversized_pkt = self._base_tcpv6_packet(
+                    everflow_direction,
+                    ptfadapter,
+                    setup_info,
+                    pktlen=self.MTU_DROP_PACKET_LEN,
+                    **packet_kwargs_with_default_dst
+                )
+                default_traffic_route = oversized_pkt[packet.IPv6].dst + "/128"
+                if default_traffic_route not in default_traffic_routes:
+                    everflow_utils.add_route(
+                        everflow_dut,
+                        default_traffic_route,
+                        default_traffic_peer_ip,
+                        default_traffic_namespace
+                    )
+                    default_traffic_routes.add(default_traffic_route)
+                    pytest_assert(wait_until(30, 5, 0, everflow_utils.validate_asic_route,
+                                             everflow_dut, default_traffic_route))
+
+                control_counter_before = self._get_acl_packets_count(
+                    everflow_dut, "EVERFLOW_EGRESSV6", rule_name
+                )
+                logging.info(
+                    "IPv6 MTU-drop control probe for %s uses %s, counter_before=%s",
+                    packet_qualifier,
+                    rule_name,
+                    control_counter_before
+                )
+
+                self.send_and_check_mirror_packets(
+                    setup_info,
+                    setup_mirror_session,
+                    ptfadapter,
+                    everflow_dut,
+                    control_pkt,
+                    everflow_direction,
+                    src_port=EverflowIPv6Tests.rx_port_ptf_id,
+                    dest_ports=EverflowIPv6Tests.tx_port_ids,
+                    erspan_ip_ver=erspan_ip_ver
+                )
+
+                control_counter_updated = wait_until(
+                    10,
+                    1,
+                    0,
+                    lambda: self._get_acl_packets_count(everflow_dut, "EVERFLOW_EGRESSV6", rule_name) >
+                    control_counter_before
+                )
+                if not control_counter_updated:
+                    pytest.fail(
+                        f"IPv6 control probe for {packet_qualifier} did not increment {rule_name}. "
+                        "The normal packet path did not hit EVERFLOW_EGRESSV6, so the MTU-drop result "
+                        "is not conclusive."
+                    )
+
+                control_counter_after = self._get_acl_packets_count(
+                    everflow_dut, "EVERFLOW_EGRESSV6", rule_name
+                )
+                logging.info(
+                    "IPv6 MTU-drop control probe for %s incremented %s from %s to %s",
+                    packet_qualifier,
+                    rule_name,
+                    control_counter_before,
+                    control_counter_after
+                )
+
+                self.send_and_check_mirror_packets(
+                    setup_info,
+                    setup_mirror_session,
+                    ptfadapter,
+                    everflow_dut,
+                    oversized_pkt,
+                    everflow_direction,
+                    src_port=EverflowIPv6Tests.rx_port_ptf_id,
+                    dest_ports=EverflowIPv6Tests.tx_port_ids,
+                    erspan_ip_ver=erspan_ip_ver
+                )
+
+                expected_packet = Mask(oversized_pkt.copy())
+                expected_packet.set_do_not_care_scapy(packet.Ether, "dst")
+                expected_packet.set_do_not_care_scapy(packet.Ether, "src")
+                expected_packet.set_do_not_care_scapy(packet.IPv6, "hlim")
+
+                testutils.verify_no_packet_any(
+                    ptfadapter,
+                    expected_packet,
+                    ports=default_traffic_tx_port_ptf_id
+                )
+        finally:
+            self._set_interface_mtu(everflow_dut, default_traffic_tx_port, original_mtu)
+            for default_traffic_route in default_traffic_routes:
+                everflow_utils.remove_route(
+                    everflow_dut,
+                    default_traffic_route,
+                    default_traffic_peer_ip,
+                    default_traffic_namespace
+                )

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -1233,9 +1233,12 @@ class EverflowIPv4Tests(BaseEverflowTest):
         dscp=None,
         sport=0x1234,
         dport=0x50,
-        flags=0x10
+        flags=0x10,
+        pktlen=100,
+        ip_flags=0
     ):
         pkt = testutils.simple_tcp_packet(
+            pktlen=pktlen,
             eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
             eth_dst=router_mac,
             ip_src=src_ip,
@@ -1246,6 +1249,9 @@ class EverflowIPv4Tests(BaseEverflowTest):
             tcp_dport=dport,
             tcp_flags=flags
         )
+
+        if ip_flags:
+            pkt["IP"].flags = ip_flags
 
         if ip_protocol:
             pkt["IP"].proto = ip_protocol
@@ -1281,8 +1287,187 @@ class TestEverflowV4EgressAclIngressMirror(EverflowIPv4Tests):
 
 
 class TestEverflowV4EgressAclEgressMirror(EverflowIPv4Tests):
+    MTU_DROP_PACKET_LEN = 1600
+    MTU_DROP_CONTROL_PACKET_LEN = 256
+    MTU_DROP_PACKET_QUALIFIERS = [
+        ("src_ip", {"src_ip": "20.0.0.10"}),
+        ("dst_ip", {"dst_ip": "30.0.0.10"}),
+        ("ip_protocol", {"ip_protocol": 0x7E}),
+        ("l4_src_port", {"sport": 9000}),
+        ("l4_dst_port", {"dport": 9001}),
+        ("l4_src_port_range", {"sport": 10200}),
+        ("l4_dst_port_range", {"dport": 10700}),
+        ("tcp_flags", {"flags": 0x1B}),
+        ("dscp", {"dscp": 37}),
+    ]
+    MTU_DROP_RULES_BY_QUALIFIER = {
+        "src_ip": "RULE_1",
+        "dst_ip": "RULE_2",
+        "ip_protocol": "RULE_3",
+        "l4_src_port": "RULE_4",
+        "l4_dst_port": "RULE_5",
+        "l4_src_port_range": "RULE_6",
+        "l4_dst_port_range": "RULE_7",
+        "tcp_flags": "RULE_8",
+        "dscp": "RULE_9",
+    }
+
     def acl_stage(self):
         return "egress"
 
     def mirror_type(self):
         return "egress"
+
+    def test_everflow_egress_mirror_mtu_drop(self, setup_info, setup_mirror_session,        # noqa F811
+                                                  dest_port_type, ptfadapter, tbinfo, mux_config,  # noqa F811
+                                                  toggle_all_simulator_ports_to_rand_selected_tor,  # noqa F811
+                                                  setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
+                                                  erspan_ip_ver):  # noqa F811
+        """Verify egress mirroring still occurs when the original packet is dropped by MTU on Spectrum-6."""
+        everflow_dut = setup_info[dest_port_type]['everflow_dut']
+        if not self.egress_mirror_payload_unchanged(everflow_dut):
+            pytest.skip("MTU-drop mirror validation only applies to Spectrum-6 egress mirroring.")
+        if erspan_ip_ver != 4:
+            pytest.skip("IPv4 MTU-drop mirror validation only runs with IPv4 ERSPAN.")
+
+        remote_dut = setup_info[dest_port_type]['remote_dut']
+        if len(setup_info[dest_port_type]["dest_port"]) <= 1:
+            pytest.skip("Skip test as there are not enough ports to separate mirror and default traffic.")
+
+        default_traffic_port_type = DOWN_STREAM if dest_port_type == UP_STREAM else UP_STREAM
+        rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
+        session_prefixes = setup_mirror_session["session_prefixes"] if erspan_ip_ver == 4 \
+            else setup_mirror_session["session_prefixes_ipv6"]
+        _, tx_port_ptf_id, _ = self._select_route_ready_tx_port(
+            remote_dut,
+            setup_info[dest_port_type],
+            tbinfo,
+            session_prefixes[0],
+            setup_info[dest_port_type]["remote_namespace"],
+            erspan_ip_ver,
+            route_timeout=60,
+            route_interval=10
+        )
+        excluded_ptf_ids = set(self._get_tx_port_id_list([rx_port_ptf_id]))
+        excluded_ptf_ids.update(tx_port_ptf_id)
+        default_traffic_tx_port, default_traffic_tx_port_ptf_id = self._select_tx_port_not_in(
+            setup_info[default_traffic_port_type],
+            excluded_ptf_ids,
+            "default traffic"
+        )
+
+        default_traffic_peer_ip = everflow_utils.get_neighbor_info(everflow_dut, default_traffic_tx_port, tbinfo)
+        default_traffic_namespace = setup_info[default_traffic_port_type]["remote_namespace"]
+        original_mtu = self._get_interface_mtu(everflow_dut, default_traffic_tx_port)
+        default_traffic_routes = set()
+
+        try:
+            pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_asic_route, remote_dut, session_prefixes[0]))
+            pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_mirror_session_up,
+                                     remote_dut, setup_mirror_session["session_name"]))
+            pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_acl_rules_in_asic_db, everflow_dut))
+
+            self._set_interface_mtu(everflow_dut, default_traffic_tx_port, 1500)
+
+            for packet_qualifier, packet_kwargs in self.MTU_DROP_PACKET_QUALIFIERS:
+                logging.info("Verify MTU-drop egress mirroring for %s packet qualifier", packet_qualifier)
+                rule_name = self.MTU_DROP_RULES_BY_QUALIFIER[packet_qualifier]
+                control_pkt = self._base_tcp_packet(
+                    ptfadapter,
+                    setup_info[dest_port_type],
+                    setup_info[dest_port_type]["ingress_router_mac"],
+                    pktlen=self.MTU_DROP_CONTROL_PACKET_LEN,
+                    ip_flags=0x2,
+                    **packet_kwargs
+                )
+                oversized_pkt = self._base_tcp_packet(
+                    ptfadapter,
+                    setup_info[dest_port_type],
+                    setup_info[dest_port_type]["ingress_router_mac"],
+                    pktlen=self.MTU_DROP_PACKET_LEN,
+                    ip_flags=0x2,
+                    **packet_kwargs
+                )
+                default_traffic_route = oversized_pkt[packet.IP].dst + "/32"
+                if default_traffic_route not in default_traffic_routes:
+                    everflow_utils.add_route(everflow_dut, default_traffic_route, default_traffic_peer_ip,
+                                             default_traffic_namespace)
+                    default_traffic_routes.add(default_traffic_route)
+                    pytest_assert(wait_until(30, 5, 0, everflow_utils.validate_asic_route,
+                                             everflow_dut, default_traffic_route))
+
+                control_counter_before = self._get_acl_packets_count(
+                    everflow_dut, "EVERFLOW_EGRESS", rule_name
+                )
+                logging.info(
+                    "IPv4 MTU-drop control probe for %s uses %s, counter_before=%s",
+                    packet_qualifier,
+                    rule_name,
+                    control_counter_before
+                )
+
+                self.send_and_check_mirror_packets(
+                    setup_info,
+                    setup_mirror_session,
+                    ptfadapter,
+                    everflow_dut,
+                    control_pkt,
+                    dest_port_type,
+                    src_port=rx_port_ptf_id,
+                    dest_ports=tx_port_ptf_id,
+                    erspan_ip_ver=erspan_ip_ver
+                )
+
+                control_counter_updated = wait_until(
+                    10,
+                    1,
+                    0,
+                    lambda: self._get_acl_packets_count(everflow_dut, "EVERFLOW_EGRESS", rule_name) >
+                    control_counter_before
+                )
+                if not control_counter_updated:
+                    pytest.fail(
+                        f"IPv4 control probe for {packet_qualifier} did not increment {rule_name}. "
+                        "The normal packet path did not hit EVERFLOW_EGRESS, so the MTU-drop result "
+                        "is not conclusive."
+                    )
+
+                control_counter_after = self._get_acl_packets_count(
+                    everflow_dut, "EVERFLOW_EGRESS", rule_name
+                )
+                logging.info(
+                    "IPv4 MTU-drop control probe for %s incremented %s from %s to %s",
+                    packet_qualifier,
+                    rule_name,
+                    control_counter_before,
+                    control_counter_after
+                )
+
+                self.send_and_check_mirror_packets(
+                    setup_info,
+                    setup_mirror_session,
+                    ptfadapter,
+                    everflow_dut,
+                    oversized_pkt,
+                    dest_port_type,
+                    src_port=rx_port_ptf_id,
+                    dest_ports=tx_port_ptf_id,
+                    erspan_ip_ver=erspan_ip_ver
+                )
+
+                expected_packet = Mask(oversized_pkt.copy())
+                expected_packet.set_do_not_care_scapy(packet.Ether, "dst")
+                expected_packet.set_do_not_care_scapy(packet.Ether, "src")
+                expected_packet.set_do_not_care_scapy(packet.IP, "chksum")
+                expected_packet.set_do_not_care_scapy(packet.IP, "ttl")
+
+                testutils.verify_no_packet_any(
+                    ptfadapter,
+                    expected_packet,
+                    ports=default_traffic_tx_port_ptf_id
+                )
+        finally:
+            self._set_interface_mtu(everflow_dut, default_traffic_tx_port, original_mtu)
+            for default_traffic_route in default_traffic_routes:
+                everflow_utils.remove_route(everflow_dut, default_traffic_route, default_traffic_peer_ip,
+                                            default_traffic_namespace)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:Enable Spectrum-6 egress ACL mirroring coverage by removing outdated skips and stale loganalyzer ignores, and by aligning the test setup with current platform behavior. Add focused IPv4/IPv6 MTU-drop Everflow coverage while keeping existing RoCEv2 ACL counter validation working on affected platforms.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
