### PR TITLE
[Mellanox] Add SN6600 SKUs to port_utils

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -637,17 +637,27 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
                         port_alias_to_name_map[alias] = eth_name
             port_alias_to_name_map['etp65'] = "Ethernet512"
             port_alias_to_name_map['etp66'] = "Ethernet520"
-        elif hwsku in ["ACS-SN6600"]:
-            split_alias_list = ["a", "b"]
+        elif hwsku in ["ACS-SN6600", "Mellanox-SN6600-C512S4",
+                       "Mellanox-SN6600_LD-P128C2", "Mellanox-SN6600_LD-P64O128C2"]:
+            if hwsku in ["ACS-SN6600", "Mellanox-SN6600_LD-P128C2"]:
+                split_alias_list = ["a", "b"]
+                lane_offsets = [0, 4]
+            elif hwsku == "Mellanox-SN6600_LD-P64O128C2":
+                split_alias_list = ["a", "b", "c"]
+                lane_offsets = [0, 2, 4]
+            else:
+                split_alias_list = ["a", "b", "c", "d", "e", "f", "g", "h"]
+                lane_offsets = [0, 1, 2, 3, 4, 5, 6, 7]
             for i in range(1, 65):
                 for idx, split_alias in enumerate(split_alias_list):
                     alias = "etp{}{}".format(i, split_alias)
-                    eth_name = "Ethernet{}".format((i - 1) * 8 + idx * 4)
+                    eth_name = "Ethernet{}".format((i - 1) * 8 + lane_offsets[idx])
                     port_alias_to_name_map[alias] = eth_name
             port_alias_to_name_map['etp65a'] = "Ethernet512"
             port_alias_to_name_map['etp65b'] = "Ethernet513"
-            port_alias_to_name_map['etp67'] = "Ethernet520"
-            port_alias_to_name_map['etp68'] = "Ethernet528"
+            if hwsku not in ["Mellanox-SN6600_LD-P128C2", "Mellanox-SN6600_LD-P64O128C2"]:
+                port_alias_to_name_map['etp66'] = "Ethernet520"
+                port_alias_to_name_map['etp67'] = "Ethernet528"
         elif hwsku in ["Mellanox-SN6600_LD-V512C2", "Mellanox-SN6600_LD-V448P16C2"]:
             split_alias_list = ["a", "b", "c", "d", "e", "f", "g", "h"]
             for i in range(1, 65):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add port-alias mappings for `Mellanox-SN6600-C512S4`, `Mellanox-SN6600_LD-P128C2`, and `Mellanox-SN6600_LD-P64O128C2` (64 × 8/2/3-lane splits).
Without this, conn_graph_facts fails on these SKUs with `Did not find port for 'EthernetN'`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Missing port mappings break conn_graph_facts on these SKUs

#### How did you do it?
Added the SKUs to the SN6600 mapping.

#### How did you verify/test it?
testbed-cli.sh add-topo now passes

#### Any platform specific information?
SN6600


