### PR TITLE
[tests/console]: source link-wiring lines from *_serial_links.csv

### DIFF
--- a/tests/console/test_console_link_wiring.py
+++ b/tests/console/test_console_link_wiring.py
@@ -1,4 +1,7 @@
+import logging
+
 import pytest
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts  # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.console_helper import (
     assert_expect_text,
@@ -8,31 +11,23 @@ from tests.common.helpers.console_helper import (
     disconnect_console_client,
     ensure_console_session_up,
     generate_random_string,
+    get_dut_console_lines,
     get_host_ip_and_creds,
 )
+
+logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('c0')
 ]
 
 
-console_lines = list(map(str, range(1, 49)))
+def _verify_one_line(duthost, console_fanout, creds, target_line, same_host):
+    """Configure, exercise via reverse-SSH, and clean up a single console line.
 
-
-@pytest.mark.parametrize("target_line", console_lines)
-def test_console_link_wiring(setup_c0, creds, target_line):
+    Raises if either the data path or the post-test cleanup fails for this
+    line. Always restores the line to IDLE before returning.
     """
-    Test data transfer is working as expect between dut and fanout.
-    Verify data can go out through the dut console port and go in through the fanout console port
-    """
-    duthost, console_fanout = setup_c0
-    # In the c0-lo topology, setup_c0 returns the same object for both
-    # `duthost` and `console_fanout` (the DUT loops its own console lines).
-    # Treat that case specially so we don't duplicate config, don't try to
-    # open a second reverse-SSH session to the same line (which would
-    # collide with the first one), and don't duplicate cleanup.
-    same_host = duthost is console_fanout
-
     baud_rate = 9600  # The default baud rate for console lines, we will set it explicitly just in case
     configure_console_line(duthost, target_line, baud_rate, "disable")
     if not same_host:
@@ -74,9 +69,6 @@ def test_console_link_wiring(setup_c0, creds, target_line):
         text = generate_random_string(packet_size)
         dut_client.sendline(text)
         assert_expect_text(fanout_client, text, target_line, timeout_sec)
-
-    except Exception as e:
-        pytest.fail("Not able to communicate DUT via reverse SSH: {}".format(e))
     finally:
         disconnect_console_client(dut_client)
         if not same_host:
@@ -88,3 +80,51 @@ def test_console_link_wiring(setup_c0, creds, target_line):
             pytest_assert(
                 check_target_line_status(console_fanout, target_line, "IDLE"),
                 "Target line {} of fanout is busy after exited reverse SSH session".format(target_line))
+
+
+def test_console_link_wiring(setup_c0, creds, conn_graph_facts):  # noqa: F811
+    """
+    Test data transfer is working as expect between dut and fanout for every
+    console line wired in the lab's ``*_serial_links.csv``.
+
+    The list of console lines is sourced from
+    ``conn_graph_facts['device_serial_link']`` via ``get_dut_console_lines``
+    instead of a hardcoded port range, so the test adapts to whatever wiring
+    is recorded for the DUT under test.
+
+    Each line is configured, exercised, and cleaned up independently. Per-line
+    failures are collected and reported together so that one bad line does not
+    mask failures on the rest.
+    """
+    duthost, console_fanout = setup_c0
+    # In the c0-lo topology, setup_c0 returns the same object for both
+    # `duthost` and `console_fanout` (the DUT loops its own console lines).
+    # Treat that case specially so we don't duplicate config, don't try to
+    # open a second reverse-SSH session to the same line (which would
+    # collide with the first one), and don't duplicate cleanup.
+    same_host = duthost is console_fanout
+
+    target_lines = get_dut_console_lines(conn_graph_facts, duthost)
+    pytest_assert(
+        target_lines,
+        "No console lines wired to DUT '{}' in serial_links.csv; "
+        "cannot verify link wiring.".format(duthost.hostname),
+    )
+    logger.info("Verifying %d console line(s) for DUT %s: %s",
+                len(target_lines), duthost.hostname, target_lines)
+
+    failures = []
+    for target_line in target_lines:
+        try:
+            _verify_one_line(duthost, console_fanout, creds, target_line, same_host)
+            logger.info("Line %s: OK", target_line)
+        except Exception as e:
+            failures.append((target_line, str(e)))
+
+    pytest_assert(
+        not failures,
+        "Console wiring verification failed for {} of {} lines: {}".format(
+            len(failures), len(target_lines),
+            "; ".join("line {} -> {}".format(ln, msg) for ln, msg in failures),
+        ),
+    )


### PR DESCRIPTION
## Description

`tests/console/test_console_link_wiring.py` used to parametrize the wiring check over `range(1, 49)`, baking in the assumption that every `c0` testbed exposes exactly 48 console lines. That's brittle: it tests ports that may not be wired in the lab and silently misses lines beyond port 48 on newer chassis.

This refactor sources the line list from `conn_graph_facts['device_serial_link']` via the existing `get_dut_console_lines` helper (which itself reads `ansible/files/sonic_<inv_name>_serial_links.csv`). The test now adapts to whatever wiring is actually recorded for the DUT under test.

Because the line list is only known at runtime (it depends on fixtures), the `@pytest.mark.parametrize` decorator is replaced with an inner loop. Per-line failures are collected and reported together so one bad line doesn't mask problems on the rest, and each line is still cleaned up independently via the same `try/finally` the previous implementation used.

When no console lines are wired to the DUT in the CSV, the test fails fast with an explanatory message instead of running with bogus line numbers.

## Summary of changes

- Drop hardcoded `console_lines = list(map(str, range(1, 49)))` and the `@pytest.mark.parametrize("target_line", console_lines)` decorator.
- Add `conn_graph_facts` fixture import and call `get_dut_console_lines(conn_graph_facts, duthost)` to discover the lines at runtime.
- Extract the per-line config / verify / cleanup logic into a private `_verify_one_line` helper so the outer test loop stays small.
- Collect per-line failures and surface them together in a single assertion message.

## Type of change

- [x] Test

## Approach

#### What is the motivation for this PR?

Make the wiring test follow the lab's actual serial-link inventory instead of a hardcoded port range so it works on any `c0` DUT without per-platform edits.

#### How did you do it?

Reused `get_dut_console_lines`, which already reads the `*_serial_links.csv` files via `conn_graph_facts`, instead of inventing a new code path.

#### How did you verify/test it?

Verified on a physical `c0-lo` testbed:

- `pytest --collect-only` works and the test runs once per DUT.
- The inner loop iterates every console line recorded for the DUT in `*_serial_links.csv` (48 lines on the testbed used).
- Per-line cleanup runs after each iteration; all lines except one (which had a known testbed-side issue) passed.

#### Any platform specific information?

Per-platform `delay_factor` handling for `arm64-c8220tg_48a` is preserved unchanged.

#### Supported testbed topology if it's a new test case?

`c0` (unchanged from the original test).

## co-authorship
Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;
