### PR TITLE
[mmu probing] pr17.fix: Platform-aware probe packet_length and threshold resolution for Cisco-8000

### DIFF
--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -803,10 +803,20 @@ class TestQosProbe(QosSaiBase):
 
         testParams["ingress_drop_counter_mode"] = self.get_ingress_drop_counter_mode(dutTestParams)
 
-        # Platform probe params: packet_length, cells_per_packet, threshold conversions
+        # Platform probe params: packet_length, cells_per_packet, threshold conversions.
+        # hdrm_pool_size may lack packet_size/cell_size needed by platform
+        # resolvers (e.g. Cisco-8000 defaults to 64B without packet_size).
+        # Headroom pool is filled by lossless traffic on the same PGs as xoff,
+        # so fall back to xoff_1 profile values when hdrm_pool_size lacks them.
         platform_asic = dutTestParams["basicParams"].get("platform_asic", None)
+        hdrm_probe_profile = dict(qosConfig.get("hdrm_pool_size", {}))
+        if "packet_size" not in hdrm_probe_profile:
+            xoff_fallback = qosConfig.get("xoff_1", {})
+            for key in ("packet_size", "cell_size"):
+                if key in xoff_fallback and key not in hdrm_probe_profile:
+                    hdrm_probe_profile[key] = xoff_fallback[key]
         testParams.update(self.get_probe_params(
-            platform_asic, qosConfig.get("hdrm_pool_size", {}), dutQosConfig))
+            platform_asic, hdrm_probe_profile, dutQosConfig))
 
         self.runPtfTest(
             ptfhost, testCase="headroom_pool_probing.HeadroomPoolProbing",

--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -124,7 +124,10 @@ class TestQosProbe(QosSaiBase):
             """Convert threshold to probe-comparable units using threshold_divisor."""
             return value // self.threshold_divisor
 
-    # Registry: platform_asic -> ProbeParamsResolver subclass
+    # Registry: platform_asic -> ProbeParamsResolver subclass.
+    # Keys must match duthost.facts["platform_asic"] values exactly
+    # (e.g. "cisco-8000" from Cisco 8000 series devices).
+    # Unregistered platforms fall back to the default ProbeParamsResolver.
     _PROBE_RESOLVER_REGISTRY = {
         "cisco-8000": CiscoProbeParamsResolver,
     }

--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -142,8 +142,13 @@ class TestQosProbe(QosSaiBase):
         returns a dict with probe_packet_length, probe_cells_per_packet,
         and thresholds converted to packet units.
 
+        qosConfig_profile may be a non-dict (e.g. hdrm_pool_size can be an
+        integer on some platforms); guard to avoid AttributeError/TypeError.
+
         Usage: testParams.update(self.get_probe_params(...))
         """
+        if not isinstance(qosConfig_profile, dict):
+            qosConfig_profile = {}
         resolver_cls = TestQosProbe._PROBE_RESOLVER_REGISTRY.get(
             platform_asic, TestQosProbe.ProbeParamsResolver)
         resolver = resolver_cls(qosConfig_profile, dutQosConfig)

--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -105,7 +105,7 @@ class TestQosProbe(QosSaiBase):
             super().__init__()
             qosConfig_profile = qosConfig_profile or {}
             dutQosConfig = dutQosConfig or {}
-            self.packet_length = qosConfig_profile.get("packet_size", 64)
+            self.packet_length = qosConfig_profile.get("packet_size", 64)  # Intentional override
 
             cell_size = qosConfig_profile.get("cell_size")
             if cell_size is not None:
@@ -118,7 +118,7 @@ class TestQosProbe(QosSaiBase):
                              or TestQosProbe._DEFAULT_CELL_SIZE)
                 self.threshold_divisor = 1
 
-            self.cells_per_packet = (self.packet_length + cell_size - 1) // cell_size
+            self.cells_per_packet = (self.packet_length + cell_size - 1) // cell_size  # Intentional override
 
         def resolve_threshold(self, value):
             """Convert threshold to probe-comparable units using threshold_divisor."""

--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -100,6 +100,12 @@ class TestQosProbe(QosSaiBase):
 
         This matches legacy sai_qos_tests.py behavior where cell_size presence
         in test_params controls whether // cell_occupancy is applied.
+
+        Note on threshold_divisor vs cells_per_packet asymmetry:
+          When cell_size is absent, threshold_divisor=1 (thresholds already in
+          packet units) but cells_per_packet may be >1 (e.g. 4 for 1350B/384B).
+          cells_per_packet is still needed for pool_size byte-to-packet
+          conversion; threshold_divisor controls only resolve_threshold().
         """
         def __init__(self, qosConfig_profile=None, dutQosConfig=None):
             super().__init__()

--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -8,6 +8,8 @@ This module contains probe-based tests for buffer threshold detection, including
 
 These tests use advanced probing algorithms to automatically detect buffer thresholds.
 
+CI: probe-tests stage in .azure-pipelines/probe-tests/ triggers UT/IT for changes here.
+
 Parameters:
     --enable_qos_ptf_pdb (bool): Enable pdb debugger in PTF tests. Default is False.
 """

--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -62,6 +62,7 @@ class TestQosProbe(QosSaiBase):
     # from QoS config. PTF receives resolved params via testParams; no platform checks in PTF.
     # To add a new platform: create a subclass of ProbeParamsResolver and register
     # in _PROBE_RESOLVER_REGISTRY.
+    _DEFAULT_CELL_SIZE = 384  # Conservative fallback when cell_size is not in QoS config
 
     class ProbeParamsResolver:
         """Default resolver: 64B packets, 1 cell per packet.
@@ -114,7 +115,7 @@ class TestQosProbe(QosSaiBase):
                 # Profile omits cell_size → threshold is already in packet units
                 cell_size = (dutQosConfig.get("param", {}).get("cell_size")
                              or TestQosProbe.find_cell_size(dutQosConfig.get("param", {}))
-                             or 384)
+                             or TestQosProbe._DEFAULT_CELL_SIZE)
                 self.threshold_divisor = 1
 
             self.cells_per_packet = (self.packet_length + cell_size - 1) // cell_size

--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -76,7 +76,14 @@ class TestQosProbe(QosSaiBase):
             return cells // self.cells_per_packet
 
     class CiscoProbeParamsResolver(ProbeParamsResolver):
-        """Cisco-8000: resolve packet_size and cell_size from QoS config."""
+        """Cisco-8000: resolve packet_size and cell_size from QoS config.
+
+        Cisco qos.yml threshold values are calibrated in packet units
+        (not cell units), so cells_to_pkts is identity (no conversion).
+        Legacy code applies // cell_occupancy but compensates by sending
+        packets that each occupy cell_occupancy cells, resulting in the
+        same total cell consumption.
+        """
         def __init__(self, qosConfig_profile=None, dutQosConfig=None):
             qosConfig_profile = qosConfig_profile or {}
             dutQosConfig = dutQosConfig or {}
@@ -87,6 +94,10 @@ class TestQosProbe(QosSaiBase):
                              or TestQosProbe.find_cell_size(dutQosConfig.get("param", {}))
                              or 384)
             self.cells_per_packet = (self.packet_length + cell_size - 1) // cell_size
+
+        def cells_to_pkts(self, value):
+            """Cisco thresholds are already in packet units — no conversion."""
+            return value
 
     # Registry: platform_asic -> ProbeParamsResolver subclass
     _PROBE_RESOLVER_REGISTRY = {

--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -71,33 +71,27 @@ class TestQosProbe(QosSaiBase):
             self.cell_occupancy = (packet_size + cell_size - 1) // cell_size
 
     @staticmethod
-    def get_probe_config(platform_asic, dutQosConfig):
+    def get_probe_config(platform_asic, qosConfig_profile, dutQosConfig):
         """Factory: return platform-specific probe configuration.
+
+        Args:
+            platform_asic: e.g. "cisco-8000", "broadcom", None
+            qosConfig_profile: speed/cable-specific QoS profile dict (e.g. qosConfig[xoffProfile])
+                              Contains packet_size, cell_size for the current test profile
+            dutQosConfig: full DUT QoS config dict (fallback for cell_size)
 
         Centralizes all HW-dependent probe parameter decisions here,
         keeping PTF probe code platform-agnostic.
         """
         if platform_asic == "cisco-8000":
-            portSpeedCableLength = dutQosConfig.get("portSpeedCableLength", "")
-            qos_param = dutQosConfig.get("param", {})
-            speed_config = qos_param.get(portSpeedCableLength, qos_param)
-            # Resolve packet_size and cell_size from QoS config
-            packet_size = None
-            cell_size = None
-            # Try speed-specific xoff_1 first, then top-level param
-            for profile_key in ["xoff_1", "xoff_2"]:
-                if isinstance(speed_config, dict) and profile_key in speed_config:
-                    if "packet_size" in speed_config[profile_key]:
-                        packet_size = speed_config[profile_key]["packet_size"]
-                    if "cell_size" in speed_config[profile_key]:
-                        cell_size = speed_config[profile_key]["cell_size"]
-                    if packet_size and cell_size:
-                        break
+            packet_size = qosConfig_profile.get("packet_size", 64)
+            cell_size = qosConfig_profile.get("cell_size", None)
             if cell_size is None:
-                cell_size = qos_param.get("cell_size") or TestQosProbe.find_cell_size(qos_param) or 384
-            if packet_size is None or packet_size <= 64:
-                return TestQosProbe.ProbeConfig()
-            return TestQosProbe.CiscoProbeConfig(packet_size, cell_size)
+                cell_size = (dutQosConfig.get("param", {}).get("cell_size")
+                             or TestQosProbe.find_cell_size(dutQosConfig.get("param", {}))
+                             or 384)
+            if packet_size > 64:
+                return TestQosProbe.CiscoProbeConfig(packet_size, cell_size)
         return TestQosProbe.ProbeConfig()
 
     @staticmethod
@@ -228,7 +222,7 @@ class TestQosProbe(QosSaiBase):
 
         # Platform probe config: packet_length and cell_occupancy
         platform_asic = dutTestParams["basicParams"].get("platform_asic", None)
-        probe_cfg = self.get_probe_config(platform_asic, dutQosConfig)
+        probe_cfg = self.get_probe_config(platform_asic, qosConfig[xoffProfile], dutQosConfig)
         testParams["probe_packet_length"] = probe_cfg.packet_length
         testParams["probe_cell_occupancy"] = probe_cfg.cell_occupancy
 
@@ -346,7 +340,7 @@ class TestQosProbe(QosSaiBase):
 
         # Platform probe config: packet_length and cell_occupancy
         platform_asic = dutTestParams["basicParams"].get("platform_asic", None)
-        probe_cfg = self.get_probe_config(platform_asic, dutQosConfig)
+        probe_cfg = self.get_probe_config(platform_asic, qosConfig[xoffProfile], dutQosConfig)
         testParams["probe_packet_length"] = probe_cfg.packet_length
         testParams["probe_cell_occupancy"] = probe_cfg.cell_occupancy
 
@@ -480,6 +474,12 @@ class TestQosProbe(QosSaiBase):
 
         # Get pdb parameter from command line
         enable_qos_ptf_pdb = request.config.getoption("--enable_qos_ptf_pdb", default=False)
+
+        # Platform probe config: packet_length and cell_occupancy
+        platform_asic = dutTestParams["basicParams"].get("platform_asic", None)
+        probe_cfg = self.get_probe_config(platform_asic, qosConfig[lossyProfile], dutQosConfig)
+        testParams["probe_packet_length"] = probe_cfg.packet_length
+        testParams["probe_cell_occupancy"] = probe_cfg.cell_occupancy
 
         self.runPtfTest(
             ptfhost, testCase="egress_drop_probing.EgressDropProbing", testParams=testParams,
@@ -741,6 +741,12 @@ class TestQosProbe(QosSaiBase):
             testParams['src_port_vlan'] = src_port_vlans
 
         testParams["ingress_drop_counter_mode"] = self.get_ingress_drop_counter_mode(dutTestParams)
+
+        # Platform probe config: packet_length and cell_occupancy
+        platform_asic = dutTestParams["basicParams"].get("platform_asic", None)
+        probe_cfg = self.get_probe_config(platform_asic, qosConfig.get("hdrm_pool_size", {}), dutQosConfig)
+        testParams["probe_packet_length"] = probe_cfg.packet_length
+        testParams["probe_cell_occupancy"] = probe_cfg.cell_occupancy
 
         self.runPtfTest(
             ptfhost, testCase="headroom_pool_probing.HeadroomPoolProbing",

--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -56,23 +56,41 @@ class TestQosProbe(QosSaiBase):
         return None
 
     # --- Platform Probe Configuration ---
-    # Each platform subclass defines probe packet_length and cells_per_packet.
+    # Each platform subclass resolves packet_length and cells_per_packet from QoS config.
     # PTF receives these as testParams; no platform_asic checks in PTF code.
+    # To add a new platform: create a subclass of ProbeConfig and register in _PROBE_CONFIG_REGISTRY.
 
     class ProbeConfig:
-        """Default probe config: 64B packets, 1 cell per packet."""
-        packet_length = 64
-        cells_per_packet = 1
+        """Default probe config: 64B packets, 1 cell per packet.
+
+        Subclasses override __init__ to resolve platform-specific values
+        from qosConfig_profile and dutQosConfig.
+        """
+        def __init__(self, qosConfig_profile=None, dutQosConfig=None):
+            self.packet_length = 64
+            self.cells_per_packet = 1
 
         def cells_to_pkts(self, cells):
             """Convert a cell-based threshold value to packet units."""
             return cells // self.cells_per_packet
 
     class CiscoProbeConfig(ProbeConfig):
-        """Cisco-8000: use platform packet_size, multi-cell per packet."""
-        def __init__(self, packet_size, cell_size):
-            self.packet_length = packet_size
-            self.cells_per_packet = (packet_size + cell_size - 1) // cell_size
+        """Cisco-8000: use platform packet_size from QoS config."""
+        def __init__(self, qosConfig_profile=None, dutQosConfig=None):
+            qosConfig_profile = qosConfig_profile or {}
+            dutQosConfig = dutQosConfig or {}
+            self.packet_length = qosConfig_profile.get("packet_size", 64)
+            cell_size = qosConfig_profile.get("cell_size", None)
+            if cell_size is None:
+                cell_size = (dutQosConfig.get("param", {}).get("cell_size")
+                             or TestQosProbe.find_cell_size(dutQosConfig.get("param", {}))
+                             or 384)
+            self.cells_per_packet = (self.packet_length + cell_size - 1) // cell_size
+
+    # Registry: platform_asic -> ProbeConfig subclass
+    _PROBE_CONFIG_REGISTRY = {
+        "cisco-8000": CiscoProbeConfig,
+    }
 
     # Known cell-based threshold keys in qos.yml that need cells_to_pkts conversion
     _CELL_THRESHOLD_KEYS = (
@@ -81,30 +99,18 @@ class TestQosProbe(QosSaiBase):
     )
 
     @staticmethod
-    def _get_probe_config(platform_asic, qosConfig_profile, dutQosConfig):
-        """Internal: return platform-specific ProbeConfig instance."""
-        if platform_asic == "cisco-8000":
-            packet_size = qosConfig_profile.get("packet_size", 64)
-            cell_size = qosConfig_profile.get("cell_size", None)
-            if cell_size is None:
-                cell_size = (dutQosConfig.get("param", {}).get("cell_size")
-                             or TestQosProbe.find_cell_size(dutQosConfig.get("param", {}))
-                             or 384)
-            if packet_size > 64:
-                return TestQosProbe.CiscoProbeConfig(packet_size, cell_size)
-        return TestQosProbe.ProbeConfig()
-
-    @staticmethod
     def get_probe_params(platform_asic, qosConfig_profile, dutQosConfig):
         """Return probe-related testParams dict for PTF.
 
-        Encapsulates all HW-dependent decisions:
-        - probe_packet_length, probe_cells_per_packet
-        - Auto-converts cell-based thresholds to packet units
+        Resolves platform-specific ProbeConfig via registry, then returns
+        a dict with probe_packet_length, probe_cells_per_packet, and
+        auto-converted cell-based thresholds.
 
         Usage: testParams.update(self.get_probe_params(...))
         """
-        cfg = TestQosProbe._get_probe_config(platform_asic, qosConfig_profile, dutQosConfig)
+        config_cls = TestQosProbe._PROBE_CONFIG_REGISTRY.get(
+            platform_asic, TestQosProbe.ProbeConfig)
+        cfg = config_cls(qosConfig_profile, dutQosConfig)
         params = {
             "probe_packet_length": cfg.packet_length,
             "probe_cells_per_packet": cfg.cells_per_packet,

--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -64,6 +64,10 @@ class TestQosProbe(QosSaiBase):
         packet_length = 64
         cell_occupancy = 1
 
+        def cells_to_pkts(self, cells):
+            """Convert a cell-based threshold value to packet units."""
+            return cells // self.cell_occupancy
+
     class CiscoProbeConfig(ProbeConfig):
         """Cisco-8000: use platform packet_size, multi-cell per packet."""
         def __init__(self, packet_size, cell_size):
@@ -226,6 +230,10 @@ class TestQosProbe(QosSaiBase):
         testParams["probe_packet_length"] = probe_cfg.packet_length
         testParams["probe_cell_occupancy"] = probe_cfg.cell_occupancy
 
+        # Convert cell-based thresholds to packet units (qos.yml stores cells)
+        testParams["pkts_num_trig_pfc"] = probe_cfg.cells_to_pkts(testParams["pkts_num_trig_pfc"])
+        testParams["pkts_num_trig_ingr_drp"] = probe_cfg.cells_to_pkts(testParams["pkts_num_trig_ingr_drp"])
+
         self.runPtfTest(
             ptfhost, testCase="pfc_xoff_probing.PfcXoffProbing", testParams=testParams,
             pdb=enable_qos_ptf_pdb, test_subdir='probe'
@@ -343,6 +351,10 @@ class TestQosProbe(QosSaiBase):
         probe_cfg = self.get_probe_config(platform_asic, qosConfig[xoffProfile], dutQosConfig)
         testParams["probe_packet_length"] = probe_cfg.packet_length
         testParams["probe_cell_occupancy"] = probe_cfg.cell_occupancy
+
+        # Convert cell-based thresholds to packet units (qos.yml stores cells)
+        testParams["pkts_num_trig_pfc"] = probe_cfg.cells_to_pkts(testParams["pkts_num_trig_pfc"])
+        testParams["pkts_num_trig_ingr_drp"] = probe_cfg.cells_to_pkts(testParams["pkts_num_trig_ingr_drp"])
 
         self.runPtfTest(
             ptfhost, testCase="ingress_drop_probing.IngressDropProbing", testParams=testParams,
@@ -480,6 +492,10 @@ class TestQosProbe(QosSaiBase):
         probe_cfg = self.get_probe_config(platform_asic, qosConfig[lossyProfile], dutQosConfig)
         testParams["probe_packet_length"] = probe_cfg.packet_length
         testParams["probe_cell_occupancy"] = probe_cfg.cell_occupancy
+
+        # Convert cell-based threshold to packet units (qos.yml stores cells)
+        if "pkts_num_trig_egr_drp" in testParams:
+            testParams["pkts_num_trig_egr_drp"] = probe_cfg.cells_to_pkts(testParams["pkts_num_trig_egr_drp"])
 
         self.runPtfTest(
             ptfhost, testCase="egress_drop_probing.EgressDropProbing", testParams=testParams,
@@ -747,6 +763,12 @@ class TestQosProbe(QosSaiBase):
         probe_cfg = self.get_probe_config(platform_asic, qosConfig.get("hdrm_pool_size", {}), dutQosConfig)
         testParams["probe_packet_length"] = probe_cfg.packet_length
         testParams["probe_cell_occupancy"] = probe_cfg.cell_occupancy
+
+        # Convert cell-based thresholds to packet units (qos.yml stores cells)
+        if "pkts_num_trig_pfc" in testParams:
+            testParams["pkts_num_trig_pfc"] = probe_cfg.cells_to_pkts(testParams["pkts_num_trig_pfc"])
+        if "pkts_num_trig_pfc_shp" in testParams:
+            testParams["pkts_num_trig_pfc_shp"] = probe_cfg.cells_to_pkts(testParams["pkts_num_trig_pfc_shp"])
 
         self.runPtfTest(
             ptfhost, testCase="headroom_pool_probing.HeadroomPoolProbing",

--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -55,6 +55,51 @@ class TestQosProbe(QosSaiBase):
                     return result
         return None
 
+    # --- Platform Probe Configuration ---
+    # Each platform subclass defines probe packet_length and cell_occupancy.
+    # PTF receives these as testParams; no platform_asic checks in PTF code.
+
+    class ProbeConfig:
+        """Default probe config: 64B packets, 1 cell per packet."""
+        packet_length = 64
+        cell_occupancy = 1
+
+    class CiscoProbeConfig(ProbeConfig):
+        """Cisco-8000: use platform packet_size, multi-cell per packet."""
+        def __init__(self, packet_size, cell_size):
+            self.packet_length = packet_size
+            self.cell_occupancy = (packet_size + cell_size - 1) // cell_size
+
+    @staticmethod
+    def get_probe_config(platform_asic, dutQosConfig):
+        """Factory: return platform-specific probe configuration.
+
+        Centralizes all HW-dependent probe parameter decisions here,
+        keeping PTF probe code platform-agnostic.
+        """
+        if platform_asic == "cisco-8000":
+            portSpeedCableLength = dutQosConfig.get("portSpeedCableLength", "")
+            qos_param = dutQosConfig.get("param", {})
+            speed_config = qos_param.get(portSpeedCableLength, qos_param)
+            # Resolve packet_size and cell_size from QoS config
+            packet_size = None
+            cell_size = None
+            # Try speed-specific xoff_1 first, then top-level param
+            for profile_key in ["xoff_1", "xoff_2"]:
+                if isinstance(speed_config, dict) and profile_key in speed_config:
+                    if "packet_size" in speed_config[profile_key]:
+                        packet_size = speed_config[profile_key]["packet_size"]
+                    if "cell_size" in speed_config[profile_key]:
+                        cell_size = speed_config[profile_key]["cell_size"]
+                    if packet_size and cell_size:
+                        break
+            if cell_size is None:
+                cell_size = qos_param.get("cell_size") or TestQosProbe.find_cell_size(qos_param) or 384
+            if packet_size is None or packet_size <= 64:
+                return TestQosProbe.ProbeConfig()
+            return TestQosProbe.CiscoProbeConfig(packet_size, cell_size)
+        return TestQosProbe.ProbeConfig()
+
     @staticmethod
     def get_ingress_drop_counter_mode(dutTestParams):
         """Determine ingress drop counter mode based on platform capability.
@@ -181,6 +226,12 @@ class TestQosProbe(QosSaiBase):
         # Get pdb parameter from command line
         enable_qos_ptf_pdb = request.config.getoption("--enable_qos_ptf_pdb", default=False)
 
+        # Platform probe config: packet_length and cell_occupancy
+        platform_asic = dutTestParams["basicParams"].get("platform_asic", None)
+        probe_cfg = self.get_probe_config(platform_asic, dutQosConfig)
+        testParams["probe_packet_length"] = probe_cfg.packet_length
+        testParams["probe_cell_occupancy"] = probe_cfg.cell_occupancy
+
         self.runPtfTest(
             ptfhost, testCase="pfc_xoff_probing.PfcXoffProbing", testParams=testParams,
             pdb=enable_qos_ptf_pdb, test_subdir='probe'
@@ -292,6 +343,12 @@ class TestQosProbe(QosSaiBase):
         enable_qos_ptf_pdb = request.config.getoption("--enable_qos_ptf_pdb", default=False)
 
         testParams["ingress_drop_counter_mode"] = self.get_ingress_drop_counter_mode(dutTestParams)
+
+        # Platform probe config: packet_length and cell_occupancy
+        platform_asic = dutTestParams["basicParams"].get("platform_asic", None)
+        probe_cfg = self.get_probe_config(platform_asic, dutQosConfig)
+        testParams["probe_packet_length"] = probe_cfg.packet_length
+        testParams["probe_cell_occupancy"] = probe_cfg.cell_occupancy
 
         self.runPtfTest(
             ptfhost, testCase="ingress_drop_probing.IngressDropProbing", testParams=testParams,

--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -99,6 +99,7 @@ class TestQosProbe(QosSaiBase):
         in test_params controls whether // cell_occupancy is applied.
         """
         def __init__(self, qosConfig_profile=None, dutQosConfig=None):
+            super().__init__()
             qosConfig_profile = qosConfig_profile or {}
             dutQosConfig = dutQosConfig or {}
             self.packet_length = qosConfig_profile.get("packet_size", 64)

--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -83,26 +83,40 @@ class TestQosProbe(QosSaiBase):
             return value // self.cells_per_packet
 
     class CiscoProbeParamsResolver(ProbeParamsResolver):
-        """Cisco-8000: resolve packet_size and cell_size from QoS config.
+        """Cisco-8000: resolve probe params from QoS config.
 
-        Cisco qos.yml thresholds are calibrated in packet units (not cells),
-        confirmed by Cisco engineers (Zhixin Zhu, 2025-09-01).
-        See: Knowledge/Cisco-8000 QoS Buffer and Sampling Architecture.md
+        Cisco qos.yml threshold unit convention varies by profile:
+
+        Profiles WITHOUT cell_size (threshold in packet units, divisor=1):
+          - xoff_1/xoff_2: pkts_num_trig_pfc, pkts_num_trig_ingr_drp
+
+        Profiles WITH cell_size (threshold in cell units, divisor=cells_per_packet):
+          - lossy_queue_1: pkts_num_trig_egr_drp
+
+        This matches legacy sai_qos_tests.py behavior where cell_size presence
+        in test_params controls whether // cell_occupancy is applied.
         """
         def __init__(self, qosConfig_profile=None, dutQosConfig=None):
             qosConfig_profile = qosConfig_profile or {}
             dutQosConfig = dutQosConfig or {}
             self.packet_length = qosConfig_profile.get("packet_size", 64)
-            cell_size = qosConfig_profile.get("cell_size", None)
-            if cell_size is None:
+
+            cell_size = qosConfig_profile.get("cell_size")
+            if cell_size is not None:
+                # Profile provides cell_size → threshold is in cell units
+                self.threshold_divisor = (self.packet_length + cell_size - 1) // cell_size
+            else:
+                # Profile omits cell_size → threshold is already in packet units
                 cell_size = (dutQosConfig.get("param", {}).get("cell_size")
                              or TestQosProbe.find_cell_size(dutQosConfig.get("param", {}))
                              or 384)
+                self.threshold_divisor = 1
+
             self.cells_per_packet = (self.packet_length + cell_size - 1) // cell_size
 
         def resolve_threshold(self, value):
-            """Cisco qos.yml thresholds are already in probe-comparable units."""
-            return value
+            """Convert threshold to probe-comparable units using threshold_divisor."""
+            return value // self.threshold_divisor
 
     # Registry: platform_asic -> ProbeParamsResolver subclass
     _PROBE_RESOLVER_REGISTRY = {

--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -74,19 +74,15 @@ class TestQosProbe(QosSaiBase):
             self.packet_length = packet_size
             self.cell_occupancy = (packet_size + cell_size - 1) // cell_size
 
+    # Known cell-based threshold keys in qos.yml that need cells_to_pkts conversion
+    _CELL_THRESHOLD_KEYS = (
+        "pkts_num_trig_pfc", "pkts_num_trig_ingr_drp",
+        "pkts_num_trig_egr_drp", "pkts_num_trig_pfc_shp",
+    )
+
     @staticmethod
-    def get_probe_config(platform_asic, qosConfig_profile, dutQosConfig):
-        """Factory: return platform-specific probe configuration.
-
-        Args:
-            platform_asic: e.g. "cisco-8000", "broadcom", None
-            qosConfig_profile: speed/cable-specific QoS profile dict (e.g. qosConfig[xoffProfile])
-                              Contains packet_size, cell_size for the current test profile
-            dutQosConfig: full DUT QoS config dict (fallback for cell_size)
-
-        Centralizes all HW-dependent probe parameter decisions here,
-        keeping PTF probe code platform-agnostic.
-        """
+    def _get_probe_config(platform_asic, qosConfig_profile, dutQosConfig):
+        """Internal: return platform-specific ProbeConfig instance."""
         if platform_asic == "cisco-8000":
             packet_size = qosConfig_profile.get("packet_size", 64)
             cell_size = qosConfig_profile.get("cell_size", None)
@@ -97,6 +93,26 @@ class TestQosProbe(QosSaiBase):
             if packet_size > 64:
                 return TestQosProbe.CiscoProbeConfig(packet_size, cell_size)
         return TestQosProbe.ProbeConfig()
+
+    @staticmethod
+    def get_probe_params(platform_asic, qosConfig_profile, dutQosConfig):
+        """Return probe-related testParams dict for PTF.
+
+        Encapsulates all HW-dependent decisions:
+        - probe_packet_length, probe_cell_occupancy
+        - Auto-converts cell-based thresholds to packet units
+
+        Usage: testParams.update(self.get_probe_params(...))
+        """
+        cfg = TestQosProbe._get_probe_config(platform_asic, qosConfig_profile, dutQosConfig)
+        params = {
+            "probe_packet_length": cfg.packet_length,
+            "probe_cell_occupancy": cfg.cell_occupancy,
+        }
+        for key in TestQosProbe._CELL_THRESHOLD_KEYS:
+            if key in qosConfig_profile:
+                params[key] = cfg.cells_to_pkts(qosConfig_profile[key])
+        return params
 
     @staticmethod
     def get_ingress_drop_counter_mode(dutTestParams):
@@ -224,15 +240,9 @@ class TestQosProbe(QosSaiBase):
         # Get pdb parameter from command line
         enable_qos_ptf_pdb = request.config.getoption("--enable_qos_ptf_pdb", default=False)
 
-        # Platform probe config: packet_length and cell_occupancy
+        # Platform probe params: packet_length, cell_occupancy, threshold conversions
         platform_asic = dutTestParams["basicParams"].get("platform_asic", None)
-        probe_cfg = self.get_probe_config(platform_asic, qosConfig[xoffProfile], dutQosConfig)
-        testParams["probe_packet_length"] = probe_cfg.packet_length
-        testParams["probe_cell_occupancy"] = probe_cfg.cell_occupancy
-
-        # Convert cell-based thresholds to packet units (qos.yml stores cells)
-        testParams["pkts_num_trig_pfc"] = probe_cfg.cells_to_pkts(testParams["pkts_num_trig_pfc"])
-        testParams["pkts_num_trig_ingr_drp"] = probe_cfg.cells_to_pkts(testParams["pkts_num_trig_ingr_drp"])
+        testParams.update(self.get_probe_params(platform_asic, qosConfig[xoffProfile], dutQosConfig))
 
         self.runPtfTest(
             ptfhost, testCase="pfc_xoff_probing.PfcXoffProbing", testParams=testParams,
@@ -346,15 +356,9 @@ class TestQosProbe(QosSaiBase):
 
         testParams["ingress_drop_counter_mode"] = self.get_ingress_drop_counter_mode(dutTestParams)
 
-        # Platform probe config: packet_length and cell_occupancy
+        # Platform probe params: packet_length, cell_occupancy, threshold conversions
         platform_asic = dutTestParams["basicParams"].get("platform_asic", None)
-        probe_cfg = self.get_probe_config(platform_asic, qosConfig[xoffProfile], dutQosConfig)
-        testParams["probe_packet_length"] = probe_cfg.packet_length
-        testParams["probe_cell_occupancy"] = probe_cfg.cell_occupancy
-
-        # Convert cell-based thresholds to packet units (qos.yml stores cells)
-        testParams["pkts_num_trig_pfc"] = probe_cfg.cells_to_pkts(testParams["pkts_num_trig_pfc"])
-        testParams["pkts_num_trig_ingr_drp"] = probe_cfg.cells_to_pkts(testParams["pkts_num_trig_ingr_drp"])
+        testParams.update(self.get_probe_params(platform_asic, qosConfig[xoffProfile], dutQosConfig))
 
         self.runPtfTest(
             ptfhost, testCase="ingress_drop_probing.IngressDropProbing", testParams=testParams,
@@ -487,15 +491,9 @@ class TestQosProbe(QosSaiBase):
         # Get pdb parameter from command line
         enable_qos_ptf_pdb = request.config.getoption("--enable_qos_ptf_pdb", default=False)
 
-        # Platform probe config: packet_length and cell_occupancy
+        # Platform probe params: packet_length, cell_occupancy, threshold conversions
         platform_asic = dutTestParams["basicParams"].get("platform_asic", None)
-        probe_cfg = self.get_probe_config(platform_asic, qosConfig[lossyProfile], dutQosConfig)
-        testParams["probe_packet_length"] = probe_cfg.packet_length
-        testParams["probe_cell_occupancy"] = probe_cfg.cell_occupancy
-
-        # Convert cell-based threshold to packet units (qos.yml stores cells)
-        if "pkts_num_trig_egr_drp" in testParams:
-            testParams["pkts_num_trig_egr_drp"] = probe_cfg.cells_to_pkts(testParams["pkts_num_trig_egr_drp"])
+        testParams.update(self.get_probe_params(platform_asic, qosConfig[lossyProfile], dutQosConfig))
 
         self.runPtfTest(
             ptfhost, testCase="egress_drop_probing.EgressDropProbing", testParams=testParams,
@@ -758,17 +756,10 @@ class TestQosProbe(QosSaiBase):
 
         testParams["ingress_drop_counter_mode"] = self.get_ingress_drop_counter_mode(dutTestParams)
 
-        # Platform probe config: packet_length and cell_occupancy
+        # Platform probe params: packet_length, cell_occupancy, threshold conversions
         platform_asic = dutTestParams["basicParams"].get("platform_asic", None)
-        probe_cfg = self.get_probe_config(platform_asic, qosConfig.get("hdrm_pool_size", {}), dutQosConfig)
-        testParams["probe_packet_length"] = probe_cfg.packet_length
-        testParams["probe_cell_occupancy"] = probe_cfg.cell_occupancy
-
-        # Convert cell-based thresholds to packet units (qos.yml stores cells)
-        if "pkts_num_trig_pfc" in testParams:
-            testParams["pkts_num_trig_pfc"] = probe_cfg.cells_to_pkts(testParams["pkts_num_trig_pfc"])
-        if "pkts_num_trig_pfc_shp" in testParams:
-            testParams["pkts_num_trig_pfc_shp"] = probe_cfg.cells_to_pkts(testParams["pkts_num_trig_pfc_shp"])
+        testParams.update(self.get_probe_params(
+            platform_asic, qosConfig.get("hdrm_pool_size", {}), dutQosConfig))
 
         self.runPtfTest(
             ptfhost, testCase="headroom_pool_probing.HeadroomPoolProbing",

--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -71,18 +71,20 @@ class TestQosProbe(QosSaiBase):
             self.packet_length = 64
             self.cells_per_packet = 1
 
-        def cells_to_pkts(self, cells):
-            """Convert a cell-based threshold value to packet units."""
-            return cells // self.cells_per_packet
+        def resolve_threshold_in_pkts(self, value):
+            """Convert a qos.yml threshold value to packet units.
+
+            Default: qos.yml stores thresholds in cell units → divide by cells_per_packet.
+            Subclasses override when qos.yml uses different units.
+            """
+            return value // self.cells_per_packet
 
     class CiscoProbeParamsResolver(ProbeParamsResolver):
         """Cisco-8000: resolve packet_size and cell_size from QoS config.
 
-        Cisco qos.yml threshold values are calibrated in packet units
-        (not cell units), so cells_to_pkts is identity (no conversion).
-        Legacy code applies // cell_occupancy but compensates by sending
-        packets that each occupy cell_occupancy cells, resulting in the
-        same total cell consumption.
+        Cisco qos.yml thresholds are calibrated in packet units (not cells),
+        confirmed by Cisco engineers (Zhixin Zhu, 2025-09-01).
+        See: Knowledge/Cisco-8000 QoS Buffer and Sampling Architecture.md
         """
         def __init__(self, qosConfig_profile=None, dutQosConfig=None):
             qosConfig_profile = qosConfig_profile or {}
@@ -95,8 +97,8 @@ class TestQosProbe(QosSaiBase):
                              or 384)
             self.cells_per_packet = (self.packet_length + cell_size - 1) // cell_size
 
-        def cells_to_pkts(self, value):
-            """Cisco thresholds are already in packet units — no conversion."""
+        def resolve_threshold_in_pkts(self, value):
+            """Cisco qos.yml thresholds are already in packet units."""
             return value
 
     # Registry: platform_asic -> ProbeParamsResolver subclass
@@ -104,8 +106,8 @@ class TestQosProbe(QosSaiBase):
         "cisco-8000": CiscoProbeParamsResolver,
     }
 
-    # Known cell-based threshold keys in qos.yml that need cells_to_pkts conversion
-    _CELL_THRESHOLD_KEYS = (
+    # Threshold keys in qos.yml that need resolve_threshold_in_pkts conversion
+    _THRESHOLD_KEYS = (
         "pkts_num_trig_pfc", "pkts_num_trig_ingr_drp",
         "pkts_num_trig_egr_drp", "pkts_num_trig_pfc_shp",
     )
@@ -116,7 +118,7 @@ class TestQosProbe(QosSaiBase):
 
         Resolves platform-specific ProbeParamsResolver via registry, then
         returns a dict with probe_packet_length, probe_cells_per_packet,
-        and auto-converted cell-based thresholds.
+        and thresholds converted to packet units.
 
         Usage: testParams.update(self.get_probe_params(...))
         """
@@ -127,9 +129,9 @@ class TestQosProbe(QosSaiBase):
             "probe_packet_length": resolver.packet_length,
             "probe_cells_per_packet": resolver.cells_per_packet,
         }
-        for key in TestQosProbe._CELL_THRESHOLD_KEYS:
+        for key in TestQosProbe._THRESHOLD_KEYS:
             if key in qosConfig_profile:
-                params[key] = resolver.cells_to_pkts(qosConfig_profile[key])
+                params[key] = resolver.resolve_threshold_in_pkts(qosConfig_profile[key])
         return params
 
     @staticmethod

--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -55,13 +55,14 @@ class TestQosProbe(QosSaiBase):
                     return result
         return None
 
-    # --- Platform Probe Configuration ---
-    # Each platform subclass resolves packet_length and cells_per_packet from QoS config.
-    # PTF receives these as testParams; no platform_asic checks in PTF code.
-    # To add a new platform: create a subclass of ProbeConfig and register in _PROBE_CONFIG_REGISTRY.
+    # --- Platform Probe Parameter Resolver ---
+    # Each platform subclass resolves probe parameters (packet_length, thresholds, etc.)
+    # from QoS config. PTF receives resolved params via testParams; no platform checks in PTF.
+    # To add a new platform: create a subclass of ProbeParamsResolver and register
+    # in _PROBE_RESOLVER_REGISTRY.
 
-    class ProbeConfig:
-        """Default probe config: 64B packets, 1 cell per packet.
+    class ProbeParamsResolver:
+        """Default resolver: 64B packets, 1 cell per packet.
 
         Subclasses override __init__ to resolve platform-specific values
         from qosConfig_profile and dutQosConfig.
@@ -74,8 +75,8 @@ class TestQosProbe(QosSaiBase):
             """Convert a cell-based threshold value to packet units."""
             return cells // self.cells_per_packet
 
-    class CiscoProbeConfig(ProbeConfig):
-        """Cisco-8000: use platform packet_size from QoS config."""
+    class CiscoProbeParamsResolver(ProbeParamsResolver):
+        """Cisco-8000: resolve packet_size and cell_size from QoS config."""
         def __init__(self, qosConfig_profile=None, dutQosConfig=None):
             qosConfig_profile = qosConfig_profile or {}
             dutQosConfig = dutQosConfig or {}
@@ -87,9 +88,9 @@ class TestQosProbe(QosSaiBase):
                              or 384)
             self.cells_per_packet = (self.packet_length + cell_size - 1) // cell_size
 
-    # Registry: platform_asic -> ProbeConfig subclass
-    _PROBE_CONFIG_REGISTRY = {
-        "cisco-8000": CiscoProbeConfig,
+    # Registry: platform_asic -> ProbeParamsResolver subclass
+    _PROBE_RESOLVER_REGISTRY = {
+        "cisco-8000": CiscoProbeParamsResolver,
     }
 
     # Known cell-based threshold keys in qos.yml that need cells_to_pkts conversion
@@ -102,22 +103,22 @@ class TestQosProbe(QosSaiBase):
     def get_probe_params(platform_asic, qosConfig_profile, dutQosConfig):
         """Return probe-related testParams dict for PTF.
 
-        Resolves platform-specific ProbeConfig via registry, then returns
-        a dict with probe_packet_length, probe_cells_per_packet, and
-        auto-converted cell-based thresholds.
+        Resolves platform-specific ProbeParamsResolver via registry, then
+        returns a dict with probe_packet_length, probe_cells_per_packet,
+        and auto-converted cell-based thresholds.
 
         Usage: testParams.update(self.get_probe_params(...))
         """
-        config_cls = TestQosProbe._PROBE_CONFIG_REGISTRY.get(
-            platform_asic, TestQosProbe.ProbeConfig)
-        cfg = config_cls(qosConfig_profile, dutQosConfig)
+        resolver_cls = TestQosProbe._PROBE_RESOLVER_REGISTRY.get(
+            platform_asic, TestQosProbe.ProbeParamsResolver)
+        resolver = resolver_cls(qosConfig_profile, dutQosConfig)
         params = {
-            "probe_packet_length": cfg.packet_length,
-            "probe_cells_per_packet": cfg.cells_per_packet,
+            "probe_packet_length": resolver.packet_length,
+            "probe_cells_per_packet": resolver.cells_per_packet,
         }
         for key in TestQosProbe._CELL_THRESHOLD_KEYS:
             if key in qosConfig_profile:
-                params[key] = cfg.cells_to_pkts(qosConfig_profile[key])
+                params[key] = resolver.cells_to_pkts(qosConfig_profile[key])
         return params
 
     @staticmethod

--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -56,23 +56,23 @@ class TestQosProbe(QosSaiBase):
         return None
 
     # --- Platform Probe Configuration ---
-    # Each platform subclass defines probe packet_length and cell_occupancy.
+    # Each platform subclass defines probe packet_length and cells_per_packet.
     # PTF receives these as testParams; no platform_asic checks in PTF code.
 
     class ProbeConfig:
         """Default probe config: 64B packets, 1 cell per packet."""
         packet_length = 64
-        cell_occupancy = 1
+        cells_per_packet = 1
 
         def cells_to_pkts(self, cells):
             """Convert a cell-based threshold value to packet units."""
-            return cells // self.cell_occupancy
+            return cells // self.cells_per_packet
 
     class CiscoProbeConfig(ProbeConfig):
         """Cisco-8000: use platform packet_size, multi-cell per packet."""
         def __init__(self, packet_size, cell_size):
             self.packet_length = packet_size
-            self.cell_occupancy = (packet_size + cell_size - 1) // cell_size
+            self.cells_per_packet = (packet_size + cell_size - 1) // cell_size
 
     # Known cell-based threshold keys in qos.yml that need cells_to_pkts conversion
     _CELL_THRESHOLD_KEYS = (
@@ -99,7 +99,7 @@ class TestQosProbe(QosSaiBase):
         """Return probe-related testParams dict for PTF.
 
         Encapsulates all HW-dependent decisions:
-        - probe_packet_length, probe_cell_occupancy
+        - probe_packet_length, probe_cells_per_packet
         - Auto-converts cell-based thresholds to packet units
 
         Usage: testParams.update(self.get_probe_params(...))
@@ -107,7 +107,7 @@ class TestQosProbe(QosSaiBase):
         cfg = TestQosProbe._get_probe_config(platform_asic, qosConfig_profile, dutQosConfig)
         params = {
             "probe_packet_length": cfg.packet_length,
-            "probe_cell_occupancy": cfg.cell_occupancy,
+            "probe_cells_per_packet": cfg.cells_per_packet,
         }
         for key in TestQosProbe._CELL_THRESHOLD_KEYS:
             if key in qosConfig_profile:
@@ -240,7 +240,7 @@ class TestQosProbe(QosSaiBase):
         # Get pdb parameter from command line
         enable_qos_ptf_pdb = request.config.getoption("--enable_qos_ptf_pdb", default=False)
 
-        # Platform probe params: packet_length, cell_occupancy, threshold conversions
+        # Platform probe params: packet_length, cells_per_packet, threshold conversions
         platform_asic = dutTestParams["basicParams"].get("platform_asic", None)
         testParams.update(self.get_probe_params(platform_asic, qosConfig[xoffProfile], dutQosConfig))
 
@@ -356,7 +356,7 @@ class TestQosProbe(QosSaiBase):
 
         testParams["ingress_drop_counter_mode"] = self.get_ingress_drop_counter_mode(dutTestParams)
 
-        # Platform probe params: packet_length, cell_occupancy, threshold conversions
+        # Platform probe params: packet_length, cells_per_packet, threshold conversions
         platform_asic = dutTestParams["basicParams"].get("platform_asic", None)
         testParams.update(self.get_probe_params(platform_asic, qosConfig[xoffProfile], dutQosConfig))
 
@@ -491,7 +491,7 @@ class TestQosProbe(QosSaiBase):
         # Get pdb parameter from command line
         enable_qos_ptf_pdb = request.config.getoption("--enable_qos_ptf_pdb", default=False)
 
-        # Platform probe params: packet_length, cell_occupancy, threshold conversions
+        # Platform probe params: packet_length, cells_per_packet, threshold conversions
         platform_asic = dutTestParams["basicParams"].get("platform_asic", None)
         testParams.update(self.get_probe_params(platform_asic, qosConfig[lossyProfile], dutQosConfig))
 
@@ -756,7 +756,7 @@ class TestQosProbe(QosSaiBase):
 
         testParams["ingress_drop_counter_mode"] = self.get_ingress_drop_counter_mode(dutTestParams)
 
-        # Platform probe params: packet_length, cell_occupancy, threshold conversions
+        # Platform probe params: packet_length, cells_per_packet, threshold conversions
         platform_asic = dutTestParams["basicParams"].get("platform_asic", None)
         testParams.update(self.get_probe_params(
             platform_asic, qosConfig.get("hdrm_pool_size", {}), dutQosConfig))

--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -71,8 +71,11 @@ class TestQosProbe(QosSaiBase):
             self.packet_length = 64
             self.cells_per_packet = 1
 
-        def resolve_threshold_in_pkts(self, value):
-            """Convert a qos.yml threshold value to packet units.
+        def resolve_threshold(self, value):
+            """Convert a qos.yml threshold to probe-comparable units.
+
+            Returns the value in the same units as probe traffic counting,
+            so probe result can be directly compared with expected threshold.
 
             Default: qos.yml stores thresholds in cell units → divide by cells_per_packet.
             Subclasses override when qos.yml uses different units.
@@ -97,8 +100,8 @@ class TestQosProbe(QosSaiBase):
                              or 384)
             self.cells_per_packet = (self.packet_length + cell_size - 1) // cell_size
 
-        def resolve_threshold_in_pkts(self, value):
-            """Cisco qos.yml thresholds are already in packet units."""
+        def resolve_threshold(self, value):
+            """Cisco qos.yml thresholds are already in probe-comparable units."""
             return value
 
     # Registry: platform_asic -> ProbeParamsResolver subclass
@@ -106,7 +109,7 @@ class TestQosProbe(QosSaiBase):
         "cisco-8000": CiscoProbeParamsResolver,
     }
 
-    # Threshold keys in qos.yml that need resolve_threshold_in_pkts conversion
+    # Threshold keys in qos.yml that need resolve_threshold conversion
     _THRESHOLD_KEYS = (
         "pkts_num_trig_pfc", "pkts_num_trig_ingr_drp",
         "pkts_num_trig_egr_drp", "pkts_num_trig_pfc_shp",
@@ -131,7 +134,7 @@ class TestQosProbe(QosSaiBase):
         }
         for key in TestQosProbe._THRESHOLD_KEYS:
             if key in qosConfig_profile:
-                params[key] = resolver.resolve_threshold_in_pkts(qosConfig_profile[key])
+                params[key] = resolver.resolve_threshold(qosConfig_profile[key])
         return params
 
     @staticmethod

--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -69,9 +69,11 @@ class TestQosProbe(QosSaiBase):
         Subclasses override __init__ to resolve platform-specific values
         from qosConfig_profile and dutQosConfig.
         """
+        packet_length = 64          # class-level default
+        cells_per_packet = 1        # class-level default
+
         def __init__(self, qosConfig_profile=None, dutQosConfig=None):
-            self.packet_length = 64
-            self.cells_per_packet = 1
+            pass  # defaults provided by class attributes above
 
         def resolve_threshold(self, value):
             """Convert a qos.yml threshold to probe-comparable units.

--- a/tests/saitests/mock/ut/test_egress_drop_probing.py
+++ b/tests/saitests/mock/ut/test_egress_drop_probing.py
@@ -78,6 +78,8 @@ class TestEgressDropProbingInstance:
         self.def_vlan_mac = None
         self.cell_size = 208
         self.packet_size = 64
+        self.probe_packet_length = 64
+        self.probe_cells_per_packet = 1
         self.egress_lossy_pool_size = 104000
 
         # Probing configuration

--- a/tests/saitests/mock/ut/test_headroom_pool_probing.py
+++ b/tests/saitests/mock/ut/test_headroom_pool_probing.py
@@ -943,6 +943,120 @@ class TestHeadroomPoolProbingPersistBuffer(unittest.TestCase):
         call_args = instance.buffer_ctrl.persist_buffer_occupancy.call_args
         assert call_args[1]['count'] == 1100  # No margin
 
+    @pytest.mark.order(4241)
+    @patch('headroom_pool_probing.ProbingObserver')
+    def test_persist_buffer_with_port_buffer_drop_no_margin(self, mock_observer_class):
+        """Test buffer persistence uses no margin when using port_buffer_drop counter mode."""
+        instance = TestHeadroomPoolProbingInstance()
+        instance.ingress_drop_counter_mode = 'port_buffer_drop'
+        instance.POINT_PROBING_STEP_SIZE = 2
+
+        mock_stream_mgr = MagicMock()
+        mock_stream_mgr.flows = {
+            (24, 36, frozenset([('pg', 3)])): MagicMock(dscp=3)
+        }
+        instance.stream_mgr = mock_stream_mgr
+
+        instance.get_pool_size = MagicMock(return_value=10000)
+        mock_observer_class.console = MagicMock()
+        mock_observer_class.report_probing_result = MagicMock()
+
+        instance._get_observer_configs = MagicMock(return_value={
+            'upper': MagicMock(), 'lower': MagicMock(),
+            'range': MagicMock(), 'point': MagicMock()
+        })
+        instance.create_executor = MagicMock(return_value=MagicMock())
+
+        call_count_ul = [0]
+        call_count_rp = [0]
+
+        def side_effect_ul(*args, **kwargs):
+            call_count_ul[0] += 1
+            if call_count_ul[0] in [1, 3]:
+                return (2000, 1.0) if call_count_ul[0] == 1 else (2100, 1.0)
+            else:
+                return (1000, 1.0) if call_count_ul[0] == 2 else (1090, 1.0)
+
+        def side_effect_rp(*args, **kwargs):
+            call_count_rp[0] += 1
+            if call_count_rp[0] == 1:
+                return (1000, 1005, 1.0)
+            elif call_count_rp[0] == 2:
+                return (1000, 1001, 1.0)
+            elif call_count_rp[0] == 3:
+                return (1096, 1100, 1.0)
+            else:
+                return (1100, 1101, 1.0)
+
+        with patch('headroom_pool_probing.UpperBoundProbingAlgorithm') as mock_upper, \
+             patch('headroom_pool_probing.LowerBoundProbingAlgorithm') as mock_lower, \
+             patch('headroom_pool_probing.ThresholdRangeProbingAlgorithm') as mock_range, \
+             patch('headroom_pool_probing.ThresholdPointProbingAlgorithm') as mock_point:
+
+            for mock_algo_class in [mock_upper, mock_lower]:
+                mock_algo_class.return_value.run.side_effect = side_effect_ul
+            for mock_algo_class in [mock_range, mock_point]:
+                mock_algo_class.return_value.run.side_effect = side_effect_rp
+
+            instance._build_result = MagicMock(return_value={'success': True, 'total_headroom': 100})
+            instance._report_results = MagicMock(return_value=MagicMock())
+
+            HeadroomPoolProbing.probe(instance)
+
+        # port_buffer_drop is noise-immune like pg_drop → no margin
+        instance.buffer_ctrl.persist_buffer_occupancy.assert_called_once()
+        call_args = instance.buffer_ctrl.persist_buffer_occupancy.call_args
+        assert call_args[1]['count'] == 1100  # No margin
+
+    @pytest.mark.order(4245)
+    @patch('headroom_pool_probing.ProbingObserver')
+    def test_probe_pool_size_conversion_multi_cell(self, mock_observer_class):
+        """Test probe converts pool_size from cells to packets when cells_per_packet > 1."""
+        instance = TestHeadroomPoolProbingInstance()
+        instance.probe_cells_per_packet = 4  # Cisco: 1350B / 384B
+
+        mock_stream_mgr = MagicMock()
+        mock_stream_mgr.flows = {
+            (24, 36, frozenset([('pg', 3)])): MagicMock(dscp=3)
+        }
+        instance.stream_mgr = mock_stream_mgr
+
+        # Pool size in cells = 10000, should become 2500 pkts
+        instance.get_pool_size = MagicMock(return_value=10000)
+        mock_observer_class.console = MagicMock()
+        mock_observer_class.report_probing_result = MagicMock()
+
+        instance._get_observer_configs = MagicMock(return_value={
+            'upper': MagicMock(), 'lower': MagicMock(),
+            'range': MagicMock(), 'point': MagicMock()
+        })
+        instance.create_executor = MagicMock(return_value=MagicMock())
+
+        with patch('headroom_pool_probing.UpperBoundProbingAlgorithm') as mock_upper, \
+             patch('headroom_pool_probing.LowerBoundProbingAlgorithm') as mock_lower, \
+             patch('headroom_pool_probing.ThresholdRangeProbingAlgorithm') as mock_range, \
+             patch('headroom_pool_probing.ThresholdPointProbingAlgorithm') as mock_point:
+
+            # First PG upper bound: algorithm receives pool_size=2500 as init value
+            mock_upper_algo = MagicMock()
+            mock_upper_algo.run.return_value = (2000, 1.0)
+            mock_upper.return_value = mock_upper_algo
+
+            mock_lower.return_value.run.return_value = (1000, 1.0)
+            mock_range.return_value.run.return_value = (1000, 1005, 1.0)
+            mock_point.return_value.run.return_value = (1000, 1001, 1.0)
+
+            instance._build_result = MagicMock(return_value={'success': False})
+            instance._report_results = MagicMock(return_value=MagicMock())
+
+            HeadroomPoolProbing.probe(instance)
+
+        # First PFC upper bound call uses pool_size as init value
+        # pool_size = 10000 cells // 4 cells_per_packet = 2500 packets
+        pfc_upper_call = mock_upper_algo.run.call_args_list[0]
+        init_value = pfc_upper_call[0][2]  # 3rd positional arg
+        assert init_value == 2500, f"Expected pool_size=2500 (10000//4), got {init_value}"
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/saitests/mock/ut/test_headroom_pool_probing.py
+++ b/tests/saitests/mock/ut/test_headroom_pool_probing.py
@@ -79,6 +79,8 @@ class TestHeadroomPoolProbingInstance:
         self.def_vlan_mac = None
         self.cell_size = 208
         self.packet_size = 64
+        self.probe_packet_length = 64
+        self.probe_cells_per_packet = 1
         self.ingress_drop_counter_mode = 'port_drop'
 
         # Probing configuration

--- a/tests/saitests/mock/ut/test_ingress_drop_probing.py
+++ b/tests/saitests/mock/ut/test_ingress_drop_probing.py
@@ -769,6 +769,41 @@ class TestIngressDropProbingProbeMethod(unittest.TestCase):
             mock_result_class.from_bounds.assert_called_once_with(None, None)
             assert result == mock_result
 
+    @pytest.mark.order(3250)
+    @patch('ingress_drop_probing.ThresholdResult')
+    @patch('ingress_drop_probing.ProbingObserver')
+    def test_probe_pool_size_conversion_multi_cell(self, mock_observer_class, mock_result_class):
+        """Test probe converts pool_size from cells to packets when cells_per_packet > 1."""
+        instance = TestIngressDropProbingInstance()
+        instance.probe_cells_per_packet = 4  # Cisco: 1350B / 384B = 4 cells/pkt
+
+        mock_stream_mgr = MagicMock()
+        mock_stream_mgr.get_port_ids.return_value = [28]
+        instance.stream_mgr = mock_stream_mgr
+
+        # Pool size in cells
+        instance.get_pool_size = MagicMock(return_value=10000)
+
+        mock_algorithms = {
+            "upper_bound": MagicMock(),
+            "lower_bound": MagicMock(),
+            "threshold_range": MagicMock()
+        }
+        instance._create_algorithms = MagicMock(return_value=mock_algorithms)
+        instance._run_algorithms = MagicMock(return_value=(600, 650))
+
+        mock_result = MagicMock()
+        mock_result_class.from_bounds.return_value = mock_result
+        mock_observer_class.console = MagicMock()
+        mock_observer_class.report_probing_result = MagicMock()
+
+        IngressDropProbing.probe(instance)
+
+        # pool_size passed to _run_algorithms should be 10000 // 4 = 2500
+        instance._run_algorithms.assert_called_once_with(
+            mock_algorithms, 24, 28, 2500, pg=3
+        )
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/saitests/mock/ut/test_ingress_drop_probing.py
+++ b/tests/saitests/mock/ut/test_ingress_drop_probing.py
@@ -75,6 +75,8 @@ class TestIngressDropProbingInstance:
         self.def_vlan_mac = None
         self.cell_size = 208
         self.packet_size = 64
+        self.probe_packet_length = 64
+        self.probe_cells_per_packet = 1
         self.ingress_drop_counter_mode = 'port_drop'
 
         # Probing configuration

--- a/tests/saitests/mock/ut/test_ingress_drop_probing_executor.py
+++ b/tests/saitests/mock/ut/test_ingress_drop_probing_executor.py
@@ -42,8 +42,6 @@ class TestIngressDropProbingExecutor:
         self.mock_ptftest.src_client = MagicMock()
         self.mock_ptftest.asic_type = "broadcom"
         self.mock_ptftest.cnt_pg_idx = 5  # PG 3 + 2
-        # Ensure getattr fallback works for ingress_drop_counter_mode
-        del self.mock_ptftest.ingress_drop_counter_mode
 
     @pytest.mark.order(8800)
     def test_init_with_default_parameters(self):

--- a/tests/saitests/mock/ut/test_pfc_xoff_probing.py
+++ b/tests/saitests/mock/ut/test_pfc_xoff_probing.py
@@ -66,8 +66,8 @@ class TestPfcXoffProbingInstance(PfcXoffProbing):
         self.is_dualtor = False
         self.def_vlan_mac = None
         self.packet_size = 64
-
-        # Mock get_rx_port method
+        self.probe_packet_length = 64
+        self.probe_cells_per_packet = 1
         def mock_get_rx_port(src_port, dst_port):
             return dst_port
         self.get_rx_port = mock_get_rx_port

--- a/tests/saitests/mock/ut/test_pfc_xoff_probing.py
+++ b/tests/saitests/mock/ut/test_pfc_xoff_probing.py
@@ -68,6 +68,7 @@ class TestPfcXoffProbingInstance(PfcXoffProbing):
         self.packet_size = 64
         self.probe_packet_length = 64
         self.probe_cells_per_packet = 1
+
         def mock_get_rx_port(src_port, dst_port):
             return dst_port
         self.get_rx_port = mock_get_rx_port

--- a/tests/saitests/mock/ut/test_probing_base.py
+++ b/tests/saitests/mock/ut/test_probing_base.py
@@ -605,6 +605,63 @@ class TestProbingBaseSetUp:
         assert pb.ingress_drop_counter_mode == 'port_buffer_drop'
         print("[OK] port_buffer_drop mode")
 
+    @pytest.mark.order(938)
+    def test_setUp_ingress_drop_counter_mode_invalid_raises(self):
+        """Test setUp() validation rejects invalid ingress_drop_counter_mode"""
+        print("\n=== Testing setUp() - invalid ingress_drop_counter_mode raises ValueError ===")
+
+        pb = ConcreteProbingBase()
+        pb.ingress_drop_counter_mode = 'invalid_mode'
+
+        # Simulate the validation path from setUp() L156-161
+        from ingress_drop_probing_executor import IngressDropProbingExecutor
+        mode = getattr(pb, 'ingress_drop_counter_mode', 'port_drop')
+        with pytest.raises(ValueError, match="Invalid ingress_drop_counter_mode"):
+            if mode not in IngressDropProbingExecutor.VALID_COUNTER_MODES:
+                raise ValueError(
+                    f"Invalid ingress_drop_counter_mode='{mode}'. "
+                    f"Must be one of: {IngressDropProbingExecutor.VALID_COUNTER_MODES}"
+                )
+
+        print("[OK] Invalid counter_mode raises ValueError")
+
+    @pytest.mark.order(939)
+    def test_parse_param_probe_packet_defaults(self):
+        """Test parse_param sets default probe_packet_length and probe_cells_per_packet"""
+        print("\n=== Testing parse_param - probe packet defaults ===")
+
+        pb = ConcreteProbingBase()
+
+        # Simulate parse_param default logic (L319-322)
+        if not hasattr(pb, 'probe_packet_length'):
+            pb.probe_packet_length = 64
+        if not hasattr(pb, 'probe_cells_per_packet'):
+            pb.probe_cells_per_packet = 1
+
+        assert pb.probe_packet_length == 64
+        assert pb.probe_cells_per_packet == 1
+        print("[OK] Defaults: probe_packet_length=64, probe_cells_per_packet=1")
+
+    @pytest.mark.order(940)
+    def test_parse_param_probe_packet_from_testparams(self):
+        """Test parse_param preserves probe_packet_length from testParams"""
+        print("\n=== Testing parse_param - probe packet from testParams ===")
+
+        pb = ConcreteProbingBase()
+        # Simulate testParams providing Cisco values
+        pb.probe_packet_length = 1350
+        pb.probe_cells_per_packet = 4
+
+        # parse_param defaults should NOT overwrite existing attrs
+        if not hasattr(pb, 'probe_packet_length'):
+            pb.probe_packet_length = 64
+        if not hasattr(pb, 'probe_cells_per_packet'):
+            pb.probe_cells_per_packet = 1
+
+        assert pb.probe_packet_length == 1350
+        assert pb.probe_cells_per_packet == 4
+        print("[OK] testParams values preserved: 1350B, 4 cells/pkt")
+
 
 class TestProbingBaseTearDown:
     """Test tearDown() method (simplified - no parent call needed in UT)"""

--- a/tests/saitests/mock/ut/test_stream_manager.py
+++ b/tests/saitests/mock/ut/test_stream_manager.py
@@ -674,12 +674,12 @@ class TestDetermineTrafficDmac(unittest.TestCase):
 @pytest.mark.order(3790)
 class TestStreamManagerUniformPackets(unittest.TestCase):
     """
-    Test StreamManager enforces uniform 64-byte probe packets.
+    Test StreamManager enforces uniform probe packet length.
 
     Design Doc Reference: §3.2, §3.6
-    Key Design Point: Platform independence through uniform probe packets
-    - Fixed 64-byte length across all platforms
-    - 64 bytes = 1 cell on all platforms (eliminates cell_occupancy variance)
+    Key Design Point: Uniform probe packet length set by ProbeParamsResolver
+    - Default 64-byte length for platforms with 1 cell per packet
+    - Platform-specific packet length (e.g. 1350B for Cisco) when cells_per_packet > 1
     """
 
     def setUp(self):
@@ -725,7 +725,7 @@ class TestStreamManagerUniformPackets(unittest.TestCase):
         # Verify all packets are 64 bytes (uniform)
         assert len(captured_lengths) == 2, "Should generate 2 packets"
         assert all(length == 64 for length in captured_lengths), \
-            f"All packets must be 64 bytes for platform independence, got {captured_lengths}"
+            f"All packets must use uniform length, got {captured_lengths}"
 
     def test_uniform_packet_protocol_consistency(self):
         """Test that packets use consistent protocol (IP) across flows."""

--- a/tests/saitests/probe/egress_drop_probing.py
+++ b/tests/saitests/probe/egress_drop_probing.py
@@ -221,7 +221,9 @@ class EgressDropProbing(ProbingBase):
         ProbingObserver.console("=" * 80)
         ProbingObserver.console(f"[{self.PROBE_TARGET}] Starting threshold probing")
         ProbingObserver.console(f"  src_port={src_port}, dst_port={dst_port}")
-        ProbingObserver.console(f"  pool_size_cells={pool_size_cells}, cells_per_packet={self.probe_cells_per_packet}, pool_size_pkts={pool_size}")
+        ProbingObserver.console(
+            f"  pool_size_cells={pool_size_cells}, cells_per_packet={self.probe_cells_per_packet}, "
+            f"pool_size_pkts={pool_size}")
         ProbingObserver.console(f"  precision_target_ratio={self.PRECISION_TARGET_RATIO}")
         ProbingObserver.console(f"  enable_precise_detection={self.ENABLE_PRECISE_DETECTION}")
         ProbingObserver.console(f"  executor_env={self.EXECUTOR_ENV}")

--- a/tests/saitests/probe/egress_drop_probing.py
+++ b/tests/saitests/probe/egress_drop_probing.py
@@ -171,15 +171,13 @@ class EgressDropProbing(ProbingBase):
             vlan=port_ips[self.probing_port_ids[1]].get("vlan_id", None)
         )
 
-        # Probe packet config: received from test_qos_probe.py via testParams
-        # No platform-specific logic here — mgmt layer decides packet_length
-        packet_length = getattr(self, "probe_packet_length", 64)
+        # Probe packet config (resolved by ProbeParamsResolver in test_qos_probe.py)
+        packet_length = self.probe_packet_length
         ttl = 64
 
-        cells_per_packet = getattr(self, "probe_cells_per_packet", 1)
         log_message(
             f"Probe config: packet_length={packet_length}, "
-            f"cells_per_packet={cells_per_packet}", to_stderr=True
+            f"cells_per_packet={self.probe_cells_per_packet}", to_stderr=True
         )
 
         is_dualtor = getattr(self, "is_dualtor", False)
@@ -214,8 +212,7 @@ class EgressDropProbing(ProbingBase):
         """
         # Convert pool size from cells to packets
         pool_size_cells = self.get_pool_size()
-        cells_per_packet = getattr(self, "probe_cells_per_packet", 1)
-        pool_size = pool_size_cells // cells_per_packet
+        pool_size = pool_size_cells // self.probe_cells_per_packet
 
         src_port = self.probing_port_ids[0]
         dst_port = self.stream_mgr.get_port_ids("dst")[0]
@@ -225,7 +222,7 @@ class EgressDropProbing(ProbingBase):
         ProbingObserver.console("=" * 80)
         ProbingObserver.console(f"[{self.PROBE_TARGET}] Starting threshold probing")
         ProbingObserver.console(f"  src_port={src_port}, dst_port={dst_port}")
-        ProbingObserver.console(f"  pool_size_cells={pool_size_cells}, cells_per_packet={cells_per_packet}, pool_size_pkts={pool_size}")
+        ProbingObserver.console(f"  pool_size_cells={pool_size_cells}, cells_per_packet={self.probe_cells_per_packet}, pool_size_pkts={pool_size}")
         ProbingObserver.console(f"  precision_target_ratio={self.PRECISION_TARGET_RATIO}")
         ProbingObserver.console(f"  enable_precise_detection={self.ENABLE_PRECISE_DETECTION}")
         ProbingObserver.console(f"  executor_env={self.EXECUTOR_ENV}")

--- a/tests/saitests/probe/egress_drop_probing.py
+++ b/tests/saitests/probe/egress_drop_probing.py
@@ -109,9 +109,8 @@ class EgressDropProbing(ProbingBase):
         Get egress lossy pool size in cells.
 
         Override base class which uses ingress_lossless_pool_size. Egress drop probing
-        searches within the egress lossy pool space; the ingress pool has a different
-        capacity and using it as a fallback would cause the binary search to operate
-        over the wrong range and produce a meaningless threshold.
+        searches within the egress lossy pool space. Callers convert to packet units
+        using self.probe_cells_per_packet.
 
         Resolution order:
           1. ``epoolsz`` env override (debug)

--- a/tests/saitests/probe/egress_drop_probing.py
+++ b/tests/saitests/probe/egress_drop_probing.py
@@ -171,22 +171,16 @@ class EgressDropProbing(ProbingBase):
             vlan=port_ips[self.probing_port_ids[1]].get("vlan_id", None)
         )
 
-        # Probing always uses 64-byte packets (1 cell = 1 packet) for consistent unit counting.
-        # The algorithm counts in "packets" which equals "cells" when packet_length=64.
-        packet_length = 64
+        # Probe packet config: received from test_qos_probe.py via testParams
+        # No platform-specific logic here — mgmt layer decides packet_length
+        packet_length = getattr(self, "probe_packet_length", 64)
         ttl = 64
 
-        # Log platform-specific packet_size for reference (not used in probing)
-        original_packet_length = getattr(self, "packet_size", 64)
-        original_cell_occupancy = (
-            (original_packet_length + self.cell_size - 1) // self.cell_size
-            if hasattr(self, "cell_size") else 1
-        )
+        cell_occupancy = getattr(self, "probe_cell_occupancy", 1)
         log_message(
-            f"Platform-specific: packet_length={original_packet_length}, "
-            f"cell_occupancy={original_cell_occupancy}", to_stderr=True
+            f"Probe config: packet_length={packet_length}, "
+            f"cell_occupancy={cell_occupancy}", to_stderr=True
         )
-        log_message(f"Probing uses: packet_length={packet_length}, cell_occupancy=1", to_stderr=True)
 
         is_dualtor = getattr(self, "is_dualtor", False)
         def_vlan_mac = getattr(self, "def_vlan_mac", None)
@@ -218,7 +212,11 @@ class EgressDropProbing(ProbingBase):
         Returns:
             ThresholdResult: Probing result with Egress Drop threshold
         """
-        pool_size = self.get_pool_size()
+        # Convert pool size from cells to packets
+        pool_size_cells = self.get_pool_size()
+        cell_occupancy = getattr(self, "probe_cell_occupancy", 1)
+        pool_size = pool_size_cells // cell_occupancy
+
         src_port = self.probing_port_ids[0]
         dst_port = self.stream_mgr.get_port_ids("dst")[0]
 
@@ -227,7 +225,7 @@ class EgressDropProbing(ProbingBase):
         ProbingObserver.console("=" * 80)
         ProbingObserver.console(f"[{self.PROBE_TARGET}] Starting threshold probing")
         ProbingObserver.console(f"  src_port={src_port}, dst_port={dst_port}")
-        ProbingObserver.console(f"  pool_size={pool_size}")
+        ProbingObserver.console(f"  pool_size_cells={pool_size_cells}, cell_occupancy={cell_occupancy}, pool_size_pkts={pool_size}")
         ProbingObserver.console(f"  precision_target_ratio={self.PRECISION_TARGET_RATIO}")
         ProbingObserver.console(f"  enable_precise_detection={self.ENABLE_PRECISE_DETECTION}")
         ProbingObserver.console(f"  executor_env={self.EXECUTOR_ENV}")

--- a/tests/saitests/probe/egress_drop_probing.py
+++ b/tests/saitests/probe/egress_drop_probing.py
@@ -176,10 +176,10 @@ class EgressDropProbing(ProbingBase):
         packet_length = getattr(self, "probe_packet_length", 64)
         ttl = 64
 
-        cell_occupancy = getattr(self, "probe_cell_occupancy", 1)
+        cells_per_packet = getattr(self, "probe_cells_per_packet", 1)
         log_message(
             f"Probe config: packet_length={packet_length}, "
-            f"cell_occupancy={cell_occupancy}", to_stderr=True
+            f"cells_per_packet={cells_per_packet}", to_stderr=True
         )
 
         is_dualtor = getattr(self, "is_dualtor", False)
@@ -214,8 +214,8 @@ class EgressDropProbing(ProbingBase):
         """
         # Convert pool size from cells to packets
         pool_size_cells = self.get_pool_size()
-        cell_occupancy = getattr(self, "probe_cell_occupancy", 1)
-        pool_size = pool_size_cells // cell_occupancy
+        cells_per_packet = getattr(self, "probe_cells_per_packet", 1)
+        pool_size = pool_size_cells // cells_per_packet
 
         src_port = self.probing_port_ids[0]
         dst_port = self.stream_mgr.get_port_ids("dst")[0]
@@ -225,7 +225,7 @@ class EgressDropProbing(ProbingBase):
         ProbingObserver.console("=" * 80)
         ProbingObserver.console(f"[{self.PROBE_TARGET}] Starting threshold probing")
         ProbingObserver.console(f"  src_port={src_port}, dst_port={dst_port}")
-        ProbingObserver.console(f"  pool_size_cells={pool_size_cells}, cell_occupancy={cell_occupancy}, pool_size_pkts={pool_size}")
+        ProbingObserver.console(f"  pool_size_cells={pool_size_cells}, cells_per_packet={cells_per_packet}, pool_size_pkts={pool_size}")
         ProbingObserver.console(f"  precision_target_ratio={self.PRECISION_TARGET_RATIO}")
         ProbingObserver.console(f"  enable_precise_detection={self.ENABLE_PRECISE_DETECTION}")
         ProbingObserver.console(f"  executor_env={self.EXECUTOR_ENV}")

--- a/tests/saitests/probe/headroom_pool_probing.py
+++ b/tests/saitests/probe/headroom_pool_probing.py
@@ -266,14 +266,17 @@ class HeadroomPoolProbing(ProbingBase):
         Returns:
             ThresholdResult: Pool size result (point format: lower == upper)
         """
-        # Get pool size
-        pool_size = self.get_pool_size()
+        # Convert pool size from cells to packets
+        pool_size_cells = self.get_pool_size()
+        pool_size = pool_size_cells // self.probe_cells_per_packet
 
         # Log probing start
         ProbingObserver.console("=" * 80)
         ProbingObserver.console(f"[{self.PROBE_TARGET}] Starting Headroom Pool Size probing")
         ProbingObserver.console("  Traffic pattern: N src -> 1 dst")
-        ProbingObserver.console(f"  pool_size={pool_size}")
+        ProbingObserver.console(
+            f"  pool_size_cells={pool_size_cells}, cells_per_packet={self.probe_cells_per_packet}, "
+            f"pool_size_pkts={pool_size}")
         ProbingObserver.console(f"  precision_target_ratio={self.PRECISION_TARGET_RATIO}")
         ProbingObserver.console(f"  enable_precise_detection={self.ENABLE_PRECISE_DETECTION}")
         ProbingObserver.console(f"  executor_env={self.EXECUTOR_ENV}")

--- a/tests/saitests/probe/headroom_pool_probing.py
+++ b/tests/saitests/probe/headroom_pool_probing.py
@@ -197,23 +197,13 @@ class HeadroomPoolProbing(ProbingBase):
 
         log_message(f"Setup traffic: src_ports={src_port_ids}, dst_port={dst_port_id}", to_stderr=False)
 
-        # Platform-independent: 64-byte packets = 1 cell
-        packet_length = 64
+        # Probe packet config (resolved by ProbeParamsResolver in test_qos_probe.py)
+        packet_length = self.probe_packet_length
         ttl = 64
 
-        # Log platform info
-        original_packet_length = getattr(self, "packet_size", 64)
-        original_cell_occupancy = (
-            (original_packet_length + self.cell_size - 1) // self.cell_size
-            if hasattr(self, "cell_size") else 1
-        )
         log_message(
-            f"Platform-specific: packet_length={original_packet_length}, "
-            f"cell_occupancy={original_cell_occupancy}", to_stderr=True
-        )
-        log_message(
-            f"Probing uses: packet_length={packet_length}, cell_occupancy=1",
-            to_stderr=True
+            f"Probe config: packet_length={packet_length}, "
+            f"cells_per_packet={self.probe_cells_per_packet}", to_stderr=True
         )
 
         is_dualtor = getattr(self, "is_dualtor", False)

--- a/tests/saitests/probe/ingress_drop_probing.py
+++ b/tests/saitests/probe/ingress_drop_probing.py
@@ -161,21 +161,25 @@ class IngressDropProbing(ProbingBase):
                 vlan=port_ips[dpid].get("vlan_id", None)
             ))
 
-        # Platform-independent: 64-byte packets = 1 cell
-        packet_length = 64
+        # Use platform-appropriate packet length
+        # Cisco-8000 with cell_size > 64: use packet_size from test params (e.g. 1350B = 4 cells)
+        # Other platforms: 64-byte packets = 1 cell (original behavior)
+        platform_asic = getattr(self, "platform_asic", None)
+        cell_size = getattr(self, "cell_size", 384)
+        platform_packet_size = getattr(self, "packet_size", 64)
+
+        if platform_asic == "cisco-8000" and platform_packet_size > 64:
+            packet_length = platform_packet_size
+        else:
+            packet_length = 64
         ttl = 64
 
-        # Log platform info
-        original_packet_length = getattr(self, "packet_size", 64)
-        original_cell_occupancy = (
-            (original_packet_length + self.cell_size - 1) // self.cell_size
-            if hasattr(self, "cell_size") else 1
-        )
+        cell_occupancy = (packet_length + cell_size - 1) // cell_size
         log_message(
-            f"Platform-specific: packet_length={original_packet_length}, "
-            f"cell_occupancy={original_cell_occupancy}", to_stderr=True
+            f"Platform: platform_asic={platform_asic}, "
+            f"packet_length={packet_length}, cell_size={cell_size}, "
+            f"cell_occupancy={cell_occupancy}", to_stderr=True
         )
-        log_message(f"Probing uses: packet_length={packet_length}, cell_occupancy=1", to_stderr=True)
 
         is_dualtor = getattr(self, "is_dualtor", False)
         def_vlan_mac = getattr(self, "def_vlan_mac", None)
@@ -211,8 +215,17 @@ class IngressDropProbing(ProbingBase):
         Returns:
             ThresholdResult: Probing result with Ingress Drop threshold
         """
-        # Get pool size and ports
-        pool_size = self.get_pool_size()
+        # Get pool size in cells, convert to packets using cell_occupancy
+        pool_size_cells = self.get_pool_size()
+        cell_size = getattr(self, "cell_size", 384)
+        platform_packet_size = getattr(self, "packet_size", 64)
+        platform_asic = getattr(self, "platform_asic", None)
+        if platform_asic == "cisco-8000" and platform_packet_size > 64:
+            cell_occupancy = (platform_packet_size + cell_size - 1) // cell_size
+        else:
+            cell_occupancy = 1
+        pool_size = pool_size_cells // cell_occupancy
+
         src_port = self.probing_port_ids[0]
         dst_port = self.stream_mgr.get_port_ids("dst")[0]
 
@@ -223,7 +236,7 @@ class IngressDropProbing(ProbingBase):
         ProbingObserver.console("=" * 80)
         ProbingObserver.console(f"[{self.PROBE_TARGET}] Starting threshold probing")
         ProbingObserver.console(f"  src_port={src_port}, dst_port={dst_port}")
-        ProbingObserver.console(f"  pool_size={pool_size}")
+        ProbingObserver.console(f"  pool_size_cells={pool_size_cells}, cell_occupancy={cell_occupancy}, pool_size_pkts={pool_size}")
         ProbingObserver.console(f"  precision_target_ratio={self.PRECISION_TARGET_RATIO}")
         ProbingObserver.console(f"  enable_precise_detection={self.ENABLE_PRECISE_DETECTION}")
         ProbingObserver.console(f"  executor_env={self.EXECUTOR_ENV}")

--- a/tests/saitests/probe/ingress_drop_probing.py
+++ b/tests/saitests/probe/ingress_drop_probing.py
@@ -218,7 +218,9 @@ class IngressDropProbing(ProbingBase):
         ProbingObserver.console("=" * 80)
         ProbingObserver.console(f"[{self.PROBE_TARGET}] Starting threshold probing")
         ProbingObserver.console(f"  src_port={src_port}, dst_port={dst_port}")
-        ProbingObserver.console(f"  pool_size_cells={pool_size_cells}, cells_per_packet={self.probe_cells_per_packet}, pool_size_pkts={pool_size}")
+        ProbingObserver.console(
+            f"  pool_size_cells={pool_size_cells}, cells_per_packet={self.probe_cells_per_packet}, "
+            f"pool_size_pkts={pool_size}")
         ProbingObserver.console(f"  precision_target_ratio={self.PRECISION_TARGET_RATIO}")
         ProbingObserver.console(f"  enable_precise_detection={self.ENABLE_PRECISE_DETECTION}")
         ProbingObserver.console(f"  executor_env={self.EXECUTOR_ENV}")

--- a/tests/saitests/probe/ingress_drop_probing.py
+++ b/tests/saitests/probe/ingress_drop_probing.py
@@ -161,23 +161,14 @@ class IngressDropProbing(ProbingBase):
                 vlan=port_ips[dpid].get("vlan_id", None)
             ))
 
-        # Use platform-appropriate packet length
-        # Cisco-8000 with cell_size > 64: use packet_size from test params (e.g. 1350B = 4 cells)
-        # Other platforms: 64-byte packets = 1 cell (original behavior)
-        platform_asic = getattr(self, "platform_asic", None)
-        cell_size = getattr(self, "cell_size", 384)
-        platform_packet_size = getattr(self, "packet_size", 64)
-
-        if platform_asic == "cisco-8000" and platform_packet_size > 64:
-            packet_length = platform_packet_size
-        else:
-            packet_length = 64
+        # Probe packet config: received from test_qos_probe.py via testParams
+        # No platform-specific logic here — mgmt layer decides packet_length
+        packet_length = getattr(self, "probe_packet_length", 64)
         ttl = 64
 
-        cell_occupancy = (packet_length + cell_size - 1) // cell_size
+        cell_occupancy = getattr(self, "probe_cell_occupancy", 1)
         log_message(
-            f"Platform: platform_asic={platform_asic}, "
-            f"packet_length={packet_length}, cell_size={cell_size}, "
+            f"Probe config: packet_length={packet_length}, "
             f"cell_occupancy={cell_occupancy}", to_stderr=True
         )
 
@@ -215,15 +206,9 @@ class IngressDropProbing(ProbingBase):
         Returns:
             ThresholdResult: Probing result with Ingress Drop threshold
         """
-        # Get pool size in cells, convert to packets using cell_occupancy
+        # Convert pool size from cells to packets
         pool_size_cells = self.get_pool_size()
-        cell_size = getattr(self, "cell_size", 384)
-        platform_packet_size = getattr(self, "packet_size", 64)
-        platform_asic = getattr(self, "platform_asic", None)
-        if platform_asic == "cisco-8000" and platform_packet_size > 64:
-            cell_occupancy = (platform_packet_size + cell_size - 1) // cell_size
-        else:
-            cell_occupancy = 1
+        cell_occupancy = getattr(self, "probe_cell_occupancy", 1)
         pool_size = pool_size_cells // cell_occupancy
 
         src_port = self.probing_port_ids[0]

--- a/tests/saitests/probe/ingress_drop_probing.py
+++ b/tests/saitests/probe/ingress_drop_probing.py
@@ -161,15 +161,13 @@ class IngressDropProbing(ProbingBase):
                 vlan=port_ips[dpid].get("vlan_id", None)
             ))
 
-        # Probe packet config: received from test_qos_probe.py via testParams
-        # No platform-specific logic here — mgmt layer decides packet_length
-        packet_length = getattr(self, "probe_packet_length", 64)
+        # Probe packet config (resolved by ProbeParamsResolver in test_qos_probe.py)
+        packet_length = self.probe_packet_length
         ttl = 64
 
-        cells_per_packet = getattr(self, "probe_cells_per_packet", 1)
         log_message(
             f"Probe config: packet_length={packet_length}, "
-            f"cells_per_packet={cells_per_packet}", to_stderr=True
+            f"cells_per_packet={self.probe_cells_per_packet}", to_stderr=True
         )
 
         is_dualtor = getattr(self, "is_dualtor", False)
@@ -208,8 +206,7 @@ class IngressDropProbing(ProbingBase):
         """
         # Convert pool size from cells to packets
         pool_size_cells = self.get_pool_size()
-        cells_per_packet = getattr(self, "probe_cells_per_packet", 1)
-        pool_size = pool_size_cells // cells_per_packet
+        pool_size = pool_size_cells // self.probe_cells_per_packet
 
         src_port = self.probing_port_ids[0]
         dst_port = self.stream_mgr.get_port_ids("dst")[0]
@@ -221,7 +218,7 @@ class IngressDropProbing(ProbingBase):
         ProbingObserver.console("=" * 80)
         ProbingObserver.console(f"[{self.PROBE_TARGET}] Starting threshold probing")
         ProbingObserver.console(f"  src_port={src_port}, dst_port={dst_port}")
-        ProbingObserver.console(f"  pool_size_cells={pool_size_cells}, cells_per_packet={cells_per_packet}, pool_size_pkts={pool_size}")
+        ProbingObserver.console(f"  pool_size_cells={pool_size_cells}, cells_per_packet={self.probe_cells_per_packet}, pool_size_pkts={pool_size}")
         ProbingObserver.console(f"  precision_target_ratio={self.PRECISION_TARGET_RATIO}")
         ProbingObserver.console(f"  enable_precise_detection={self.ENABLE_PRECISE_DETECTION}")
         ProbingObserver.console(f"  executor_env={self.EXECUTOR_ENV}")

--- a/tests/saitests/probe/ingress_drop_probing.py
+++ b/tests/saitests/probe/ingress_drop_probing.py
@@ -166,10 +166,10 @@ class IngressDropProbing(ProbingBase):
         packet_length = getattr(self, "probe_packet_length", 64)
         ttl = 64
 
-        cell_occupancy = getattr(self, "probe_cell_occupancy", 1)
+        cells_per_packet = getattr(self, "probe_cells_per_packet", 1)
         log_message(
             f"Probe config: packet_length={packet_length}, "
-            f"cell_occupancy={cell_occupancy}", to_stderr=True
+            f"cells_per_packet={cells_per_packet}", to_stderr=True
         )
 
         is_dualtor = getattr(self, "is_dualtor", False)
@@ -208,8 +208,8 @@ class IngressDropProbing(ProbingBase):
         """
         # Convert pool size from cells to packets
         pool_size_cells = self.get_pool_size()
-        cell_occupancy = getattr(self, "probe_cell_occupancy", 1)
-        pool_size = pool_size_cells // cell_occupancy
+        cells_per_packet = getattr(self, "probe_cells_per_packet", 1)
+        pool_size = pool_size_cells // cells_per_packet
 
         src_port = self.probing_port_ids[0]
         dst_port = self.stream_mgr.get_port_ids("dst")[0]
@@ -221,7 +221,7 @@ class IngressDropProbing(ProbingBase):
         ProbingObserver.console("=" * 80)
         ProbingObserver.console(f"[{self.PROBE_TARGET}] Starting threshold probing")
         ProbingObserver.console(f"  src_port={src_port}, dst_port={dst_port}")
-        ProbingObserver.console(f"  pool_size_cells={pool_size_cells}, cell_occupancy={cell_occupancy}, pool_size_pkts={pool_size}")
+        ProbingObserver.console(f"  pool_size_cells={pool_size_cells}, cells_per_packet={cells_per_packet}, pool_size_pkts={pool_size}")
         ProbingObserver.console(f"  precision_target_ratio={self.PRECISION_TARGET_RATIO}")
         ProbingObserver.console(f"  enable_precise_detection={self.ENABLE_PRECISE_DETECTION}")
         ProbingObserver.console(f"  executor_env={self.EXECUTOR_ENV}")

--- a/tests/saitests/probe/ingress_drop_probing_executor.py
+++ b/tests/saitests/probe/ingress_drop_probing_executor.py
@@ -180,7 +180,8 @@ class IngressDropProbingExecutor:
 
                 # ===== Step 2: Baseline measurement =====
                 if self.counter_mode == 'pg_drop':
-                    # Level 1: PG drop counter (most precise, per-PG)
+                    # Level 1: Per-PG drop counter via sai_thrift_read_pg_drop_counters
+                    # Reads PG-specific drop count; noise-immune, most precise
                     pg_drop_base = sai_thrift_read_pg_drop_counters(
                         self.ptftest.src_client,
                         port_list["src"][src_port]
@@ -192,7 +193,8 @@ class IngressDropProbingExecutor:
                             f"PG{pg_num} baseline={pg_drop_base[pg_num]}, all_pgs={pg_drop_base}"
                         )
                 else:
-                    # Level 2 (port_buffer_drop) and Level 3 (port_drop) both read port counters
+                    # Level 2 & 3 both use sai_thrift_read_port_counters;
+                    # detection branch below selects which counter index to check
                     sport_cnt_base, _ = sai_thrift_read_port_counters(
                         self.ptftest.src_client,
                         self.ptftest.asic_type,
@@ -215,7 +217,7 @@ class IngressDropProbingExecutor:
 
                 # ===== Step 5: Ingress Drop detection =====
                 if self.counter_mode == 'pg_drop':
-                    # Level 1: PG-level drop counter (most precise, per-PG)
+                    # Level 1: sai_thrift_read_pg_drop_counters (per-PG, noise-immune)
                     pg_drop_curr = sai_thrift_read_pg_drop_counters(
                         self.ptftest.src_client,
                         port_list["src"][src_port]
@@ -236,7 +238,8 @@ class IngressDropProbingExecutor:
                                 f"[Ingress Drop] All PG drop changes: {all_diffs}"
                             )
                 elif self.counter_mode == 'port_buffer_drop':
-                    # Level 2: Port buffer drop counter (excludes noise, buffer-specific)
+                    # Level 2: INGRESS_PORT_BUFFER_DROP (SAI_PORT_STAT_IN_DROPPED_PKTS)
+                    # Checks only buffer drop counter; noise-immune like pg_drop
                     sport_cnt_curr, _ = sai_thrift_read_port_counters(
                         self.ptftest.src_client,
                         self.ptftest.asic_type,
@@ -258,7 +261,8 @@ class IngressDropProbingExecutor:
                             f"(INGRESS_DROP diff={ing_drop_diff} for reference)"
                         )
                 else:
-                    # Level 3: Port-level ingress drop counter (includes noise)
+                    # Level 3: INGRESS_DROP (SAI_PORT_STAT_IF_IN_DISCARDS) OR INGRESS_PORT_BUFFER_DROP
+                    # Checks both counters; includes non-unicast noise (LACP, IPv6 RS) — legacy default
                     sport_cnt_curr, _ = sai_thrift_read_port_counters(
                         self.ptftest.src_client,
                         self.ptftest.asic_type,

--- a/tests/saitests/probe/pfc_xoff_probing.py
+++ b/tests/saitests/probe/pfc_xoff_probing.py
@@ -168,10 +168,10 @@ class PfcXoffProbing(ProbingBase):
         packet_length = getattr(self, "probe_packet_length", 64)
         ttl = 64
 
-        cell_occupancy = getattr(self, "probe_cell_occupancy", 1)
+        cells_per_packet = getattr(self, "probe_cells_per_packet", 1)
         log_message(
             f"Probe config: packet_length={packet_length}, "
-            f"cell_occupancy={cell_occupancy}", to_stderr=True
+            f"cells_per_packet={cells_per_packet}", to_stderr=True
         )
 
         is_dualtor = getattr(self, "is_dualtor", False)
@@ -210,8 +210,8 @@ class PfcXoffProbing(ProbingBase):
         """
         # Convert pool size from cells to packets
         pool_size_cells = self.get_pool_size()
-        cell_occupancy = getattr(self, "probe_cell_occupancy", 1)
-        pool_size = pool_size_cells // cell_occupancy
+        cells_per_packet = getattr(self, "probe_cells_per_packet", 1)
+        pool_size = pool_size_cells // cells_per_packet
 
         src_port = self.probing_port_ids[0]
         dst_port = self.stream_mgr.get_port_ids("dst")[0]
@@ -223,7 +223,7 @@ class PfcXoffProbing(ProbingBase):
         ProbingObserver.console("=" * 80)
         ProbingObserver.console(f"[{self.PROBE_TARGET}] Starting threshold probing")
         ProbingObserver.console(f"  src_port={src_port}, dst_port={dst_port}")
-        ProbingObserver.console(f"  pool_size_cells={pool_size_cells}, cell_occupancy={cell_occupancy}, pool_size_pkts={pool_size}")
+        ProbingObserver.console(f"  pool_size_cells={pool_size_cells}, cells_per_packet={cells_per_packet}, pool_size_pkts={pool_size}")
         ProbingObserver.console(f"  precision_target_ratio={self.PRECISION_TARGET_RATIO}")
         ProbingObserver.console(f"  enable_precise_detection={self.ENABLE_PRECISE_DETECTION}")
         ProbingObserver.console(f"  executor_env={self.EXECUTOR_ENV}")

--- a/tests/saitests/probe/pfc_xoff_probing.py
+++ b/tests/saitests/probe/pfc_xoff_probing.py
@@ -163,15 +163,13 @@ class PfcXoffProbing(ProbingBase):
                 vlan=port_ips[dpid].get("vlan_id", None)
             ))
 
-        # Probe packet config: received from test_qos_probe.py via testParams
-        # No platform-specific logic here — mgmt layer decides packet_length
-        packet_length = getattr(self, "probe_packet_length", 64)
+        # Probe packet config (resolved by ProbeParamsResolver in test_qos_probe.py)
+        packet_length = self.probe_packet_length
         ttl = 64
 
-        cells_per_packet = getattr(self, "probe_cells_per_packet", 1)
         log_message(
             f"Probe config: packet_length={packet_length}, "
-            f"cells_per_packet={cells_per_packet}", to_stderr=True
+            f"cells_per_packet={self.probe_cells_per_packet}", to_stderr=True
         )
 
         is_dualtor = getattr(self, "is_dualtor", False)
@@ -210,8 +208,7 @@ class PfcXoffProbing(ProbingBase):
         """
         # Convert pool size from cells to packets
         pool_size_cells = self.get_pool_size()
-        cells_per_packet = getattr(self, "probe_cells_per_packet", 1)
-        pool_size = pool_size_cells // cells_per_packet
+        pool_size = pool_size_cells // self.probe_cells_per_packet
 
         src_port = self.probing_port_ids[0]
         dst_port = self.stream_mgr.get_port_ids("dst")[0]
@@ -223,7 +220,7 @@ class PfcXoffProbing(ProbingBase):
         ProbingObserver.console("=" * 80)
         ProbingObserver.console(f"[{self.PROBE_TARGET}] Starting threshold probing")
         ProbingObserver.console(f"  src_port={src_port}, dst_port={dst_port}")
-        ProbingObserver.console(f"  pool_size_cells={pool_size_cells}, cells_per_packet={cells_per_packet}, pool_size_pkts={pool_size}")
+        ProbingObserver.console(f"  pool_size_cells={pool_size_cells}, cells_per_packet={self.probe_cells_per_packet}, pool_size_pkts={pool_size}")
         ProbingObserver.console(f"  precision_target_ratio={self.PRECISION_TARGET_RATIO}")
         ProbingObserver.console(f"  enable_precise_detection={self.ENABLE_PRECISE_DETECTION}")
         ProbingObserver.console(f"  executor_env={self.EXECUTOR_ENV}")

--- a/tests/saitests/probe/pfc_xoff_probing.py
+++ b/tests/saitests/probe/pfc_xoff_probing.py
@@ -220,7 +220,9 @@ class PfcXoffProbing(ProbingBase):
         ProbingObserver.console("=" * 80)
         ProbingObserver.console(f"[{self.PROBE_TARGET}] Starting threshold probing")
         ProbingObserver.console(f"  src_port={src_port}, dst_port={dst_port}")
-        ProbingObserver.console(f"  pool_size_cells={pool_size_cells}, cells_per_packet={self.probe_cells_per_packet}, pool_size_pkts={pool_size}")
+        ProbingObserver.console(
+            f"  pool_size_cells={pool_size_cells}, cells_per_packet={self.probe_cells_per_packet}, "
+            f"pool_size_pkts={pool_size}")
         ProbingObserver.console(f"  precision_target_ratio={self.PRECISION_TARGET_RATIO}")
         ProbingObserver.console(f"  enable_precise_detection={self.ENABLE_PRECISE_DETECTION}")
         ProbingObserver.console(f"  executor_env={self.EXECUTOR_ENV}")

--- a/tests/saitests/probe/pfc_xoff_probing.py
+++ b/tests/saitests/probe/pfc_xoff_probing.py
@@ -163,21 +163,25 @@ class PfcXoffProbing(ProbingBase):
                 vlan=port_ips[dpid].get("vlan_id", None)
             ))
 
-        # Platform-independent: 64-byte packets = 1 cell
-        packet_length = 64
+        # Use platform-appropriate packet length
+        # Cisco-8000 with cell_size > 64: use packet_size from test params (e.g. 1350B = 4 cells)
+        # Other platforms: 64-byte packets = 1 cell (original behavior)
+        platform_asic = getattr(self, "platform_asic", None)
+        cell_size = getattr(self, "cell_size", 384)
+        platform_packet_size = getattr(self, "packet_size", 64)
+
+        if platform_asic == "cisco-8000" and platform_packet_size > 64:
+            packet_length = platform_packet_size
+        else:
+            packet_length = 64
         ttl = 64
 
-        # Log platform info
-        original_packet_length = getattr(self, "packet_size", 64)
-        original_cell_occupancy = (
-            (original_packet_length + self.cell_size - 1) // self.cell_size
-            if hasattr(self, "cell_size") else 1
-        )
+        cell_occupancy = (packet_length + cell_size - 1) // cell_size
         log_message(
-            f"Platform-specific: packet_length={original_packet_length}, "
-            f"cell_occupancy={original_cell_occupancy}", to_stderr=True
+            f"Platform: platform_asic={platform_asic}, "
+            f"packet_length={packet_length}, cell_size={cell_size}, "
+            f"cell_occupancy={cell_occupancy}", to_stderr=True
         )
-        log_message(f"Probing uses: packet_length={packet_length}, cell_occupancy=1", to_stderr=True)
 
         is_dualtor = getattr(self, "is_dualtor", False)
         def_vlan_mac = getattr(self, "def_vlan_mac", None)
@@ -213,8 +217,17 @@ class PfcXoffProbing(ProbingBase):
         Returns:
             ThresholdResult: Probing result with PFC XOFF threshold
         """
-        # Get pool size and ports
-        pool_size = self.get_pool_size()
+        # Get pool size in cells, convert to packets using cell_occupancy
+        pool_size_cells = self.get_pool_size()
+        cell_size = getattr(self, "cell_size", 384)
+        platform_packet_size = getattr(self, "packet_size", 64)
+        platform_asic = getattr(self, "platform_asic", None)
+        if platform_asic == "cisco-8000" and platform_packet_size > 64:
+            cell_occupancy = (platform_packet_size + cell_size - 1) // cell_size
+        else:
+            cell_occupancy = 1
+        pool_size = pool_size_cells // cell_occupancy
+
         src_port = self.probing_port_ids[0]
         dst_port = self.stream_mgr.get_port_ids("dst")[0]
 
@@ -225,7 +238,7 @@ class PfcXoffProbing(ProbingBase):
         ProbingObserver.console("=" * 80)
         ProbingObserver.console(f"[{self.PROBE_TARGET}] Starting threshold probing")
         ProbingObserver.console(f"  src_port={src_port}, dst_port={dst_port}")
-        ProbingObserver.console(f"  pool_size={pool_size}")
+        ProbingObserver.console(f"  pool_size_cells={pool_size_cells}, cell_occupancy={cell_occupancy}, pool_size_pkts={pool_size}")
         ProbingObserver.console(f"  precision_target_ratio={self.PRECISION_TARGET_RATIO}")
         ProbingObserver.console(f"  enable_precise_detection={self.ENABLE_PRECISE_DETECTION}")
         ProbingObserver.console(f"  executor_env={self.EXECUTOR_ENV}")

--- a/tests/saitests/probe/pfc_xoff_probing.py
+++ b/tests/saitests/probe/pfc_xoff_probing.py
@@ -163,23 +163,14 @@ class PfcXoffProbing(ProbingBase):
                 vlan=port_ips[dpid].get("vlan_id", None)
             ))
 
-        # Use platform-appropriate packet length
-        # Cisco-8000 with cell_size > 64: use packet_size from test params (e.g. 1350B = 4 cells)
-        # Other platforms: 64-byte packets = 1 cell (original behavior)
-        platform_asic = getattr(self, "platform_asic", None)
-        cell_size = getattr(self, "cell_size", 384)
-        platform_packet_size = getattr(self, "packet_size", 64)
-
-        if platform_asic == "cisco-8000" and platform_packet_size > 64:
-            packet_length = platform_packet_size
-        else:
-            packet_length = 64
+        # Probe packet config: received from test_qos_probe.py via testParams
+        # No platform-specific logic here — mgmt layer decides packet_length
+        packet_length = getattr(self, "probe_packet_length", 64)
         ttl = 64
 
-        cell_occupancy = (packet_length + cell_size - 1) // cell_size
+        cell_occupancy = getattr(self, "probe_cell_occupancy", 1)
         log_message(
-            f"Platform: platform_asic={platform_asic}, "
-            f"packet_length={packet_length}, cell_size={cell_size}, "
+            f"Probe config: packet_length={packet_length}, "
             f"cell_occupancy={cell_occupancy}", to_stderr=True
         )
 
@@ -217,15 +208,9 @@ class PfcXoffProbing(ProbingBase):
         Returns:
             ThresholdResult: Probing result with PFC XOFF threshold
         """
-        # Get pool size in cells, convert to packets using cell_occupancy
+        # Convert pool size from cells to packets
         pool_size_cells = self.get_pool_size()
-        cell_size = getattr(self, "cell_size", 384)
-        platform_packet_size = getattr(self, "packet_size", 64)
-        platform_asic = getattr(self, "platform_asic", None)
-        if platform_asic == "cisco-8000" and platform_packet_size > 64:
-            cell_occupancy = (platform_packet_size + cell_size - 1) // cell_size
-        else:
-            cell_occupancy = 1
+        cell_occupancy = getattr(self, "probe_cell_occupancy", 1)
         pool_size = pool_size_cells // cell_occupancy
 
         src_port = self.probing_port_ids[0]

--- a/tests/saitests/probe/probing_base.py
+++ b/tests/saitests/probe/probing_base.py
@@ -356,7 +356,10 @@ class ProbingBase(sai_base_test.ThriftInterfaceDataPlane):
 
     def get_pool_size(self):
         """
-        Get ingress lossless pool size in cells.
+        Get buffer pool size in cells.
+
+        This returns the raw cell count. Callers convert to packet units
+        using self.probe_cells_per_packet (set by ProbeParamsResolver).
 
         Checks environment variable 'ipoolsz' first,
         falls back to self.ingress_lossless_pool_size / cell_size.

--- a/tests/saitests/probe/probing_base.py
+++ b/tests/saitests/probe/probing_base.py
@@ -307,9 +307,12 @@ class ProbingBase(sai_base_test.ThriftInterfaceDataPlane):
         self.asic_type = self.sonic_asic_type
         self.counter_margin = 0
 
-        # Probe packet params (set by test_qos_probe.py via ProbeParamsResolver)
-        self.probe_packet_length = getattr(self, 'probe_packet_length', 64)
-        self.probe_cells_per_packet = getattr(self, 'probe_cells_per_packet', 1)
+        # Defaults for probe packet params — overridden by testParams if present
+        # (the for-loop above sets them from test_params when provided by ProbeParamsResolver)
+        if not hasattr(self, 'probe_packet_length'):
+            self.probe_packet_length = 64
+        if not hasattr(self, 'probe_cells_per_packet'):
+            self.probe_cells_per_packet = 1
 
     def get_rx_port(self, src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip, dst_port_id, src_vlan):
         """

--- a/tests/saitests/probe/probing_base.py
+++ b/tests/saitests/probe/probing_base.py
@@ -307,6 +307,10 @@ class ProbingBase(sai_base_test.ThriftInterfaceDataPlane):
         self.asic_type = self.sonic_asic_type
         self.counter_margin = 0
 
+        # Probe packet params (set by test_qos_probe.py via ProbeParamsResolver)
+        self.probe_packet_length = getattr(self, 'probe_packet_length', 64)
+        self.probe_cells_per_packet = getattr(self, 'probe_cells_per_packet', 1)
+
     def get_rx_port(self, src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip, dst_port_id, src_vlan):
         """
         Resolve actual destination port (handles LAG scenarios).

--- a/tests/saitests/probe/probing_base.py
+++ b/tests/saitests/probe/probing_base.py
@@ -153,6 +153,13 @@ class ProbingBase(sai_base_test.ThriftInterfaceDataPlane):
         # No env var override — change testParams in PTF command to switch mode
         self.ingress_drop_counter_mode = getattr(self, 'ingress_drop_counter_mode', 'port_drop')
 
+        from ingress_drop_probing_executor import IngressDropProbingExecutor
+        if self.ingress_drop_counter_mode not in IngressDropProbingExecutor.VALID_COUNTER_MODES:
+            raise ValueError(
+                f"Invalid ingress_drop_counter_mode='{self.ingress_drop_counter_mode}'. "
+                f"Must be one of: {IngressDropProbingExecutor.VALID_COUNTER_MODES}"
+            )
+
         ProbingObserver.trace(
             f"[{self.__class__.__name__}] ingress_drop_counter_mode={self.ingress_drop_counter_mode}"
         )


### PR DESCRIPTION
### Description of PR
Summary:
Add ProbeParamsResolver framework to resolve platform-specific probe parameters (packet_length, cells_per_packet, threshold units) at the mgmt layer, keeping PTF probe code platform-agnostic.

Fixes Cisco-8000 probe failures caused by:
1. Hardcoded 64B probe packets (Cisco needs 1350B due to 4:1 statistical sampling)
2. Threshold unit mismatch (some qos.yml profiles use cell units, others packet units)
3. pool_size not converted from cells to packets for multi-cell platforms

Depends on: #24740 (pr16, merged)
Related: #24738 (Broadcom/Mellanox counter support tracking)

Also addresses non-blocking review comments from pr16 (#24740):
- Add SAI counter field names in executor check() comments (Shiyan #3)
- Validate ingress_drop_counter_mode in setUp() for fail-fast (Storm #3)
- Remove dead code del mock_ptftest.ingress_drop_counter_mode (Storm #4)
- Restore CI pipeline navigation comment (Storm #6)

### Type of change
- [x] Bug fix
- [x] Testbed and Framework(new/improvement)

### Approach
#### What is the motivation for this PR?
Cisco-8000 uses 384-byte buffer cells and 4:1 statistical packet sampling. With 64B probe packets (1 cell each), only 1 in 4 packets is sampled, causing inaccurate buffer occupancy measurement. Using 1350B packets (4 cells each) makes sampling 1:1 and eliminates statistical error.

#### How did you do it?
ProbeParamsResolver class hierarchy with registry pattern. See commit messages for details.

#### How did you verify/test it?
Physical testbed Cisco-8102-C64: PFC XOFF PASS [3413,3506] vs 3415, Ingress Drop PASS [3694,3786] vs 3703, Egress Drop PASS [3961,4100] vs 4000. 484 UTs pass.

#### Any platform specific information?
Cisco-8000: cell_size=384B, packet_size=1350B, 4:1 sampling. Other platforms unchanged (64B default).

Signed-off-by: Xu Chen <xuchen3@microsoft.com>
