### PR TITLE
[VLAN]: Fix sporadic failures in test_vlan_ping when adding static neighbours

### DIFF
--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -35,7 +35,7 @@ def static_neighbor_entry(duthost, dic, oper, ip_version="both"):
             if oper == "add":
                 logger.debug("adding ipv6 static arp entry for ip %s on DUT" % (member['ipv6']))
                 duthost.shell(
-                    "sudo ip -6 neigh add {0} lladdr {1} dev Vlan{2}".format(member['ipv6'], member['mac'],
+                    "sudo ip -6 neigh replace {0} lladdr {1} dev Vlan{2}".format(member['ipv6'], member['mac'],
                                                                              member['Vlanid']))
             elif oper == "del":
                 logger.debug("deleting ipv6 static arp entry for ip %s on DUT" % (member['ipv6']))


### PR DESCRIPTION
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix

### Approach
#### What is the motivation for this PR?
Test failures can occur when packets are received from a neighbour whose entry was just deleted, causing the entry to be dynamically re-added.

Subsequently, when that neighbour entry is statically added it fails with `RTNETLINK answers: File exists".
#### How did you do it?
Disabling neighbour discovery for the duration of the test prevents this race condition.
#### How did you verify/test it?
Ran test_vlan_ping 100 times.