### PR TITLE
[202511] Add utility to upgrade DPU images for smartswitch testbeds

### DIFF
--- a/.azure-pipelines/upgrade_image.py
+++ b/.azure-pipelines/upgrade_image.py
@@ -32,6 +32,7 @@ if ansible_path not in sys.path:
 from devutil.devices.factory import init_localhost, init_testbed_sonichosts, init_sonichosts  # noqa: E402
 from devutil.devices.sonic import upgrade_image             # noqa: E402
 from devutil.devices.dpu_utils import enable_nat_for_dpuhosts  # noqa: E402
+from devutil.devices.ansible_hosts import RunAnsibleModuleFailed, HostsUnreachable    # noqa: E402
 
 
 logger = logging.getLogger(__name__)
@@ -44,6 +45,8 @@ RC_ENABLE_FIPS_FAILED = 4
 RC_SET_DOCKER_FOLDER_SIZE_FAILED = 5
 RC_SHUTDOWN_FAILED = 6
 RC_HOSTS_UNREACHABLE = 7
+RC_DPU_UPGRADE_PREV_FAILED = 8
+RC_DPU_UPGRADE_FAILED = 9
 
 
 def validate_args(args):
@@ -60,23 +63,98 @@ def validate_args(args):
         format="%(asctime)s %(filename)s#%(lineno)d %(levelname)s - %(message)s"
     )
 
-    args.skip_prev_image = False
-    if not args.prev_image_url:
-        args.prev_image_url = "{}.PREV.1".format(args.image_url)
-    logger.info("PREV_IMAGE_URL={}".format(args.prev_image_url))
+    if not args.image_url and not args.dpu_image_url:
+        logger.error("At least one of --url or --dpu-url must be provided")
+        sys.exit(RC_INIT_FAILED)
 
-    try:
-        res_prev_image = requests.head(args.prev_image_url, timeout=20)
-        if res_prev_image.status_code != 200:
-            logger.info("Not able to get prev_image at {}, skip upgrading to prev_image.".format(args.prev_image_url))
-            args.skip_prev_image = True
-    except Exception as e:
-        logger.info(
-            "Downloading prev image {} failed with {}, skip upgrading to prev image".format(
-                args.prev_image_url, repr(e)
+    args.skip_prev_image = False
+    if args.image_url:
+        if not args.prev_image_url:
+            args.prev_image_url = "{}.PREV.1".format(args.image_url)
+        logger.info("PREV_IMAGE_URL={}".format(args.prev_image_url))
+
+        try:
+            res_prev_image = requests.head(args.prev_image_url, timeout=20)
+            if res_prev_image.status_code != 200:
+                logger.info("Not able to get prev_image at {}, skip upgrading to prev_image.".format(
+                    args.prev_image_url))
+                args.skip_prev_image = True
+        except Exception as e:
+            logger.info(
+                "Downloading prev image {} failed with {}, skip upgrading to prev image".format(
+                    args.prev_image_url, repr(e)
+                )
             )
-        )
+            args.skip_prev_image = True
+    else:
+        logger.info("No NPU image URL provided, skipping NPU image upgrade")
         args.skip_prev_image = True
+
+    # DPU prev image validation
+    args.skip_dpu_prev_image = False
+    if args.dpu_image_url:
+        if not args.dpu_prev_image_url:
+            args.dpu_prev_image_url = "{}.PREV.1".format(args.dpu_image_url)
+        logger.info("DPU_PREV_IMAGE_URL={}".format(args.dpu_prev_image_url))
+        try:
+            res_dpu_prev = requests.head(args.dpu_prev_image_url, timeout=20)
+            if res_dpu_prev.status_code != 200:
+                logger.info(
+                    "Not able to get dpu prev_image at {}, skip upgrading DPU to prev_image.".format(
+                        args.dpu_prev_image_url))
+                args.skip_dpu_prev_image = True
+        except Exception as e:
+            logger.info(
+                "Downloading DPU prev image {} failed with {}, skip upgrading DPU to prev image".format(
+                    args.dpu_prev_image_url, repr(e)
+                )
+            )
+            args.skip_dpu_prev_image = True
+    else:
+        args.dpu_prev_image_url = None
+        args.skip_dpu_prev_image = True
+
+
+def upgrade_dpu_images(sonichosts, dpu_image_url):
+    """Upgrade DPU images on all NPU hosts using the upgrade_dpu_sonic_image Ansible module.
+
+    Args:
+        sonichosts: SonicHosts instance containing NPU hosts.
+        dpu_image_url: URL of the SONiC image to install on DPUs.
+
+    Returns:
+        bool: True if all DPU upgrades succeeded, False otherwise.
+    """
+    try:
+        for hostname in sonichosts.hostnames:
+            cfg_facts = sonichosts.config_facts(host=hostname, source='running')[hostname]
+            hwsku = cfg_facts.get('ansible_facts', {}) \
+                .get('DEVICE_METADATA', {}) \
+                .get('localhost', {}) \
+                .get('hwsku', 'unknown')
+            logger.info("Upgrading DPU images on host %s (hwsku=%s)", hostname, hwsku)
+
+            host_username = sonichosts.get_host_visible_var(hostname, 'sonic_login') or 'admin'
+            host_passwords = sonichosts.get_host_visible_var(hostname, 'sonic_default_passwords') or ['password']
+
+            sonichosts.upgrade_dpu_sonic_image(
+                hwsku=hwsku,
+                hostname=hostname,
+                host_username=host_username,
+                host_passwords=host_passwords,
+                new_image_url=dpu_image_url,
+                target_hosts=[hostname],
+                module_attrs={"become": True, "async": 7200, "poll": 60}
+            )
+            logger.info("DPU image upgrade complete on host %s", hostname)
+
+        return True
+    except RunAnsibleModuleFailed as e:
+        logger.error("DPU image upgrade failed: %s", repr(e))
+        return False
+    except HostsUnreachable as e:
+        logger.error("DPU image upgrade failed, host unreachable: %s", repr(e))
+        return False
 
 
 def main(args):
@@ -158,99 +236,136 @@ def main(args):
         logger.error("Some hosts are still unreachable, abort image upgrading: {}".format(hosts_reachability))
         sys.exit(RC_HOSTS_UNREACHABLE)
 
-    # Upgrade to prev image
-    if not args.skip_prev_image:
-        logger.info("upgrade to prev image at {}".format(args.prev_image_url))
+    # Upgrade NPU image (skip if only --dpu-url was provided)
+    if args.image_url:
+        # Upgrade to prev image
+        if not args.skip_prev_image:
+            logger.info("upgrade to prev image at {}".format(args.prev_image_url))
+            upgrade_success = upgrade_image(
+                sonichosts,
+                localhost,
+                args.prev_image_url,
+                upgrade_type=args.upgrade_type,
+                onie_pause_time=args.onie_pause_time
+            )
+
+            if not upgrade_success:
+                logger.error("Upgrade prev_image {} failed".format(args.prev_image_url))
+                sys.exit(RC_UPGRADE_PREV_FAILED)
+            else:
+                logger.info("Upgraded to prev_image {}.".format(args.prev_image_url))
+
+            # Re-enable NAT after reboot so DPU SSH proxy ports are reachable
+            if dpu_hostnames:
+                logger.info("Re-enabling NAT for DPU hosts after prev-image upgrade")
+                enable_nat_for_dpuhosts(sonichosts, args.inventory, dpu_hostnames)
+
+            for hostname, version in sonichosts.sonic_version.items():
+                logger.info("SONiC host {} current version {}".format(hostname, version.get("build_version")))
+        else:
+            logger.info("Skipping upgrade to prev image")
+
+        # Upgrade to target image
+        logger.info("upgrade to target image at {}".format(args.image_url))
         upgrade_success = upgrade_image(
             sonichosts,
             localhost,
-            args.prev_image_url,
+            args.image_url,
             upgrade_type=args.upgrade_type,
             onie_pause_time=args.onie_pause_time
         )
-
         if not upgrade_success:
-            logger.error("Upgrade prev_image {} failed".format(args.prev_image_url))
-            sys.exit(RC_UPGRADE_PREV_FAILED)
+            logger.error("Upgrade to target image {} failed".format(args.image_url))
+            sys.exit(RC_UPGRADE_FAILED)
         else:
-            logger.info("Upgraded to prev_image {}.".format(args.prev_image_url))
+            logger.info("Upgraded to target image {} done".format(args.image_url))
 
         # Re-enable NAT after reboot so DPU SSH proxy ports are reachable
         if dpu_hostnames:
-            logger.info("Re-enabling NAT for DPU hosts after prev-image upgrade")
+            logger.info("Re-enabling NAT for DPU hosts after target-image upgrade")
             enable_nat_for_dpuhosts(sonichosts, args.inventory, dpu_hostnames)
-
-        for hostname, version in sonichosts.sonic_version.items():
-            logger.info("SONiC host {} current version {}".format(hostname, version.get("build_version")))
     else:
-        logger.info("Skipping upgrade to prev image")
+        logger.info("No NPU image URL provided, skipping NPU image upgrade")
 
-    # Upgrade to target image
-    logger.info("upgrade to target image at {}".format(args.image_url))
-    upgrade_success = upgrade_image(
-        sonichosts,
-        localhost,
-        args.image_url,
-        upgrade_type=args.upgrade_type,
-        onie_pause_time=args.onie_pause_time
-    )
-    if not upgrade_success:
-        logger.error("Upgrade to target image {} failed".format(args.image_url))
-        sys.exit(RC_UPGRADE_FAILED)
-    else:
-        logger.info("Upgrad to target image {} done".format(args.image_url))
+    # Upgrade DPU images (if --dpu-url was provided and SmartSwitch detected)
+    if args.dpu_image_url and dpu_hostnames:
+        # Upgrade DPUs to prev image first
+        if not args.skip_dpu_prev_image:
+            logger.info("Upgrading DPU images to prev image at %s", args.dpu_prev_image_url)
+            dpu_upgrade_success = upgrade_dpu_images(sonichosts, args.dpu_prev_image_url)
+            if not dpu_upgrade_success:
+                logger.error("DPU upgrade to prev_image %s failed", args.dpu_prev_image_url)
+                sys.exit(RC_DPU_UPGRADE_PREV_FAILED)
+            else:
+                logger.info("DPU upgraded to prev_image %s", args.dpu_prev_image_url)
 
-    # Re-enable NAT after reboot so DPU SSH proxy ports are reachable
-    if dpu_hostnames:
-        logger.info("Re-enabling NAT for DPU hosts after target-image upgrade")
+            # Re-enable NAT after DPU reboot
+            logger.info("Re-enabling NAT for DPU hosts after DPU prev-image upgrade")
+            enable_nat_for_dpuhosts(sonichosts, args.inventory, dpu_hostnames)
+        else:
+            logger.info("Skipping DPU upgrade to prev image")
+
+        # Upgrade DPUs to target image
+        logger.info("Upgrading DPU images to target image at %s", args.dpu_image_url)
+        dpu_upgrade_success = upgrade_dpu_images(sonichosts, args.dpu_image_url)
+        if not dpu_upgrade_success:
+            logger.error("DPU upgrade to target image %s failed", args.dpu_image_url)
+            sys.exit(RC_DPU_UPGRADE_FAILED)
+        else:
+            logger.info("DPU upgraded to target image %s", args.dpu_image_url)
+
+        # Re-enable NAT after DPU reboot
+        logger.info("Re-enabling NAT for DPU hosts after DPU target-image upgrade")
         enable_nat_for_dpuhosts(sonichosts, args.inventory, dpu_hostnames)
 
-    current_build_version = None
-    for hostname, version in sonichosts.sonic_version.items():
-        logger.info("SONiC host {} current version {}".format(hostname, version.get("build_version")))
-        if not current_build_version:
-            current_build_version = version.get("build_version")
+    # NPU post-upgrade steps (FIPS, docker folder size, force reboot)
+    if args.image_url:
+        current_build_version = None
+        for hostname, version in sonichosts.sonic_version.items():
+            logger.info("SONiC host {} current version {}".format(hostname, version.get("build_version")))
+            if not current_build_version:
+                current_build_version = version.get("build_version")
 
-    # Enable FIPS
-    need_shutdown = False
-    if args.enable_fips:
-        logger.info("Need to enable FIPS")
-        try:
-            sonichosts.command("sonic-installer set-fips", module_attrs={"become": True})
-            need_shutdown = True
-        except Exception as e:
-            logger.error("Failed to enable FIPS mode: {}".repr(e))
-            sys.exit(RC_ENABLE_FIPS_FAILED)
-    else:
-        logger.info("Skip enabling FIPS")
+        # Enable FIPS
+        need_shutdown = False
+        if args.enable_fips:
+            logger.info("Need to enable FIPS")
+            try:
+                sonichosts.command("sonic-installer set-fips", module_attrs={"become": True})
+                need_shutdown = True
+            except Exception as e:
+                logger.error("Failed to enable FIPS mode: {}".repr(e))
+                sys.exit(RC_ENABLE_FIPS_FAILED)
+        else:
+            logger.info("Skip enabling FIPS")
 
-    # Set docker folder size, required for platforms with small disk
-    if args.docker_folder_size:
-        logger.info("Need to set docker folder size to '{}'".format(args.docker_folder_size))
-        try:
-            sonichosts.lineinfile(
-                line="docker_inram_size={}".format(args.docker_folder_size),
-                path="/host/image-{}/kernel-cmdline-append".format(current_build_version),
-                state="present",
-                create=True,
-                module_attrs={"become": True}
-            )
-            need_shutdown = True
-        except Exception as e:
-            logger.error("Failed to set docker folder size: {}".repr(e))
-            sys.exit(RC_SET_DOCKER_FOLDER_SIZE_FAILED)
-    else:
-        logger.info("Use default docker folder size")
+        # Set docker folder size, required for platforms with small disk
+        if args.docker_folder_size:
+            logger.info("Need to set docker folder size to '{}'".format(args.docker_folder_size))
+            try:
+                sonichosts.lineinfile(
+                    line="docker_inram_size={}".format(args.docker_folder_size),
+                    path="/host/image-{}/kernel-cmdline-append".format(current_build_version),
+                    state="present",
+                    create=True,
+                    module_attrs={"become": True}
+                )
+                need_shutdown = True
+            except Exception as e:
+                logger.error("Failed to set docker folder size: {}".repr(e))
+                sys.exit(RC_SET_DOCKER_FOLDER_SIZE_FAILED)
+        else:
+            logger.info("Use default docker folder size")
 
-    # Force reboot the device to apply changes
-    if need_shutdown:
-        logger.info("Need to force reboot")
-        try:
-            sonichosts.command("shutdown -r now", module_attrs={"become": True, "async": 300, "poll": 0})
-            localhost.pause(seconds=180, prompt="Pause after force reboot")
-        except Exception as e:
-            logger.error("Failed to shutdown: {}".repr(e))
-            sys.exit(RC_SHUTDOWN_FAILED)
+        # Force reboot the device to apply changes
+        if need_shutdown:
+            logger.info("Need to force reboot")
+            try:
+                sonichosts.command("shutdown -r now", module_attrs={"become": True, "async": 300, "poll": 0})
+                localhost.pause(seconds=180, prompt="Pause after force reboot")
+            except Exception as e:
+                logger.error("Failed to shutdown: {}".repr(e))
+                sys.exit(RC_SHUTDOWN_FAILED)
 
     logger.info("===== UPGRADE IMAGE DONE =====")
 
@@ -279,8 +394,9 @@ if __name__ == "__main__":
         "-u", "--url",
         type=str,
         dest="image_url",
-        required=True,
-        help="SONiC image url."
+        required=False,
+        default=None,
+        help="SONiC image url. Required unless only --dpu-url is provided."
     )
 
     parser.add_argument(
@@ -289,6 +405,22 @@ if __name__ == "__main__":
         dest="prev_image_url",
         default=None,
         help="SONiC image url."
+    )
+
+    parser.add_argument(
+        "--dpu-url",
+        type=str,
+        dest="dpu_image_url",
+        default=None,
+        help="SONiC image url for DPU upgrade on SmartSwitch testbeds."
+    )
+
+    parser.add_argument(
+        "--dpu-prev-url",
+        type=str,
+        dest="dpu_prev_image_url",
+        default=None,
+        help="Previous SONiC image url for DPU. If not set, derived from --dpu-url."
     )
 
     parser.add_argument(

--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -324,19 +324,32 @@ def install_new_sonic_image(module, new_image_url, save_as=None, required_space=
 
     # If sonic device is configured with minigraph, remove config_db.json
     # to force next image to load minigraph.
+    # Skip this for SmartSwitch devices — they need config_db.json and
+    # golden_config_db.json for DPU configuration.
     if path.exists("/host/old_config/minigraph.xml"):
-        log("Remove /host/old_config/config_db.json when /etc/old_config/minigraph.xml exists")
-        exec_command(
-            module,
-            cmd="rm -f /host/old_config/config_db.json",
-            msg="Remove config_db.json in preference of minigraph.xml"
-        )
-        log("Remove /host/old_config/golden_config_db.json when /etc/old_config/minigraph.xml exists")
-        exec_command(
-            module,
-            cmd="rm -f /host/old_config/golden_config_db.json",
-            msg="Remove golden_config_db.json in preference of minigraph.xml"
-        )
+        is_smartswitch = False
+        try:
+            from sonic_py_common import device_info
+            if hasattr(device_info, 'is_smartswitch'):
+                is_smartswitch = device_info.is_smartswitch()
+        except Exception:
+            log("Failed to determine if device is SmartSwitch")
+
+        if is_smartswitch:
+            log("SmartSwitch detected, keeping config_db.json and golden_config_db.json")
+        else:
+            log("Remove /host/old_config/config_db.json when /etc/old_config/minigraph.xml exists")
+            exec_command(
+                module,
+                cmd="rm -f /host/old_config/config_db.json",
+                msg="Remove config_db.json in preference of minigraph.xml"
+            )
+            log("Remove /host/old_config/golden_config_db.json when /etc/old_config/minigraph.xml exists")
+            exec_command(
+                module,
+                cmd="rm -f /host/old_config/golden_config_db.json",
+                msg="Remove golden_config_db.json in preference of minigraph.xml"
+            )
 
     try:
         get_sonic_image_size(module)

--- a/ansible/library/upgrade_dpu_sonic_image.py
+++ b/ansible/library/upgrade_dpu_sonic_image.py
@@ -1,0 +1,571 @@
+#!/usr/bin/python
+
+import logging
+import os
+import time
+import paramiko
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.smartswitch_utils import smartswitch_hwsku_config
+from ansible.module_utils.debug_utils import config_module_logging
+
+DOCUMENTATION = '''
+module:  upgrade_dpu_sonic_image
+version_added:  "1.0"
+
+short_description: Install a new SONiC image on one or all DPUs of a SmartSwitch
+
+description:
+    - Downloads the image on the NPU (which has lab network access), then transfers
+      it to each DPU via SCP over the midplane network (169.254.200.x).
+    - Cleans up old images, installs using sonic-installer, reboots the DPU.
+    - Follows the same installation logic as reduce_and_add_sonic_images but executed
+      remotely on DPUs via paramiko SSH (modeled after load_extra_dpu_config).
+
+Options:
+    - option-name: hwsku
+      description: Hardware SKU of the SmartSwitch (determines DPU count)
+      required: True
+    - option-name: hostname
+      description: NPU hostname (used for logging)
+      required: True
+    - option-name: host_username
+      description: SSH username for the DPU
+      required: True
+    - option-name: host_passwords
+      description: List of SSH passwords to try for the DPU
+      required: True
+    - option-name: new_image_url
+      description: URL pointing to the new SONiC image to install on DPUs
+      required: True
+    - option-name: target_dpu_index
+      description: Index of a specific DPU to upgrade (-1 for all DPUs)
+      required: False
+      Default: -1
+    - option-name: disk_used_pcent
+      description: Maximum disk used percentage threshold for cleanup
+      required: False
+      Default: 50
+'''
+
+config_module_logging("upgrade_dpu_sonic_image")
+
+DPU_HOST_IP_BASE = "169.254.200.{}"
+NPU_DOWNLOAD_PATH = "/tmp/dpu-sonic-image"
+DPU_IMAGE_PATH = "/tmp/downloaded-sonic-image"
+
+MAX_RETRIES = 5
+RETRY_DELAY = 60
+SUCCESS_THRESHOLD = 1.0
+
+# Longer timeout for SCP transfer and install operations (20 minutes)
+LONG_CMD_TIMEOUT = 1200
+# Standard timeout for quick commands
+SHORT_CMD_TIMEOUT = 120
+# How long to wait for DPU to come back after startup
+REBOOT_TIMEOUT = 600
+# Poll interval while waiting for DPU reboot
+REBOOT_POLL_INTERVAL = 30
+
+
+class UpgradeDpuSonicImageModule(object):
+    def __init__(self):
+        self.module = AnsibleModule(
+            argument_spec=dict(
+                hwsku=dict(type='str', required=True),
+                hostname=dict(type='str', required=True),
+                host_username=dict(type='str', required=True),
+                host_passwords=dict(type='list', elements='str', required=True, no_log=True),
+                new_image_url=dict(type='str', required=True),
+                target_dpu_index=dict(type='int', required=False, default=-1),
+                disk_used_pcent=dict(type='int', required=False, default=50),
+            ),
+            supports_check_mode=False
+        )
+
+        self.messages = []
+
+        self.hwsku = self.module.params['hwsku']
+        self.hostname = self.module.params['hostname']
+        self.host_username = self.module.params['host_username']
+        self.host_passwords = self.module.params['host_passwords']
+        self.new_image_url = self.module.params['new_image_url']
+        self.target_dpu_index = self.module.params['target_dpu_index']
+        self.disk_used_pcent = self.module.params['disk_used_pcent']
+
+        self.log("Initializing: hostname={}, hwsku={}, image_url={}, target_dpu_index={}".format(
+            self.hostname, self.hwsku, self.new_image_url, self.target_dpu_index))
+
+        try:
+            self.hwsku_config = smartswitch_hwsku_config[self.hwsku]
+            self.dpu_num = self.hwsku_config.get('dpu_num', 0)
+            self.log("HWSKU config: dpu_num={}".format(self.dpu_num))
+            if self.dpu_num == 0:
+                self.module.fail_json(msg="No DPUs defined for hwsku: {}".format(self.hwsku))
+        except KeyError:
+            self.module.fail_json(msg="No DPU configuration found for hwsku: {}".format(self.hwsku))
+
+    def log(self, msg):
+        """Log a timestamped message to both the messages list and the logging framework."""
+        timestamp = time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime())
+        self.messages.append("{} {}".format(timestamp, msg))
+        logging.debug(msg)
+
+    def connect_to_dpu(self, dpu_ip):
+        """Establish an SSH connection to the DPU with retry."""
+        retry_count = 0
+        last_exception = None
+
+        self.log("Connecting to DPU {} (max {} retries, {}s delay)".format(
+            dpu_ip, MAX_RETRIES, RETRY_DELAY))
+
+        while retry_count < MAX_RETRIES:
+            for password in self.host_passwords:
+                try:
+                    ssh = paramiko.SSHClient()
+                    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+                    ssh.connect(dpu_ip, username=self.host_username, password=password, timeout=30)
+                    self.log("SSH connected to DPU {} on attempt {}".format(
+                        dpu_ip, retry_count + 1))
+                    return ssh
+                except Exception as e:
+                    last_exception = e
+                    continue
+
+            retry_count += 1
+            if retry_count < MAX_RETRIES:
+                self.log("SSH to DPU {} failed (attempt {}/{}), retrying in {}s: {}".format(
+                    dpu_ip, retry_count, MAX_RETRIES, RETRY_DELAY, str(last_exception)))
+                time.sleep(RETRY_DELAY)
+
+        self.log("WARNING: Failed to connect to DPU {} after {} retries: {}".format(
+            dpu_ip, MAX_RETRIES, str(last_exception)))
+        return None
+
+    def execute_command(self, ssh, dpu_ip, command, timeout=SHORT_CMD_TIMEOUT, get_pty=False):
+        """Execute a command on the DPU via SSH and return (success, stdout, stderr)."""
+        try:
+            self.log("[DPU {}] Running: {} (timeout={}s)".format(dpu_ip, command, timeout))
+            start_time = time.time()
+            _, stdout, stderr = ssh.exec_command(command, timeout=timeout, get_pty=get_pty)
+            exit_code = stdout.channel.recv_exit_status()
+            out = stdout.read().decode('utf-8', errors='replace')
+            err = stderr.read().decode('utf-8', errors='replace')
+            elapsed = time.time() - start_time
+            if exit_code != 0:
+                self.log("WARNING: [DPU {}] Command failed (rc={}, {:.1f}s): {} | stderr: {}".format(
+                    dpu_ip, exit_code, elapsed, command, err.strip()))
+                return False, out, err
+            self.log("[DPU {}] Command succeeded ({:.1f}s): {}".format(
+                dpu_ip, elapsed, command))
+            return True, out, err
+        except Exception as e:
+            self.log("WARNING: [DPU {}] Exception running '{}': {}".format(dpu_ip, command, str(e)))
+            return False, "", str(e)
+
+    def reduce_installed_images(self, ssh, dpu_ip):
+        """Clean up old SONiC images on the DPU, keeping only the current image."""
+        self.log("[DPU {}] Step: Reducing installed images".format(dpu_ip))
+
+        ok = False
+        out = ""
+        for attempt in range(3):
+            ok, out, _ = self.execute_command(ssh, dpu_ip, "sudo sonic-installer list")
+            if ok:
+                break
+            self.log("[DPU {}] sonic-installer list failed (attempt {}/3), retrying in 20s".format(
+                dpu_ip, attempt + 1))
+            time.sleep(20)
+
+        if not ok:
+            self.log("WARNING: [DPU {}] Failed to list images after 3 attempts. Continuing anyway.".format(dpu_ip))
+            return
+
+        curr_image = ""
+        next_image = ""
+        for line in out.split('\n'):
+            if 'Current:' in line:
+                curr_image = line.split(':')[1].strip()
+            elif 'Next:' in line:
+                next_image = line.split(':')[1].strip()
+
+        self.log("[DPU {}] Current image: '{}', Next image: '{}'".format(
+            dpu_ip, curr_image, next_image))
+
+        if not curr_image:
+            self.log("WARNING: [DPU {}] Could not determine current image".format(dpu_ip))
+            return
+
+        if curr_image != next_image and next_image:
+            self.log("[DPU {}] Setting next-boot to current image".format(dpu_ip))
+            self.execute_command(ssh, dpu_ip,
+                                 "sudo sonic-installer set-next-boot {}".format(curr_image))
+
+        self.execute_command(ssh, dpu_ip, "sudo sonic-installer cleanup -y")
+        self.log("[DPU {}] Done reducing images".format(dpu_ip))
+
+    def free_up_disk_space(self, ssh, dpu_ip):
+        """Remove old logs, core dumps, and other expendable files on the DPU."""
+        self.log("[DPU {}] Step: Checking disk space".format(dpu_ip))
+
+        should_cleanup = True
+        ok, out, _ = self.execute_command(ssh, dpu_ip, "df -BM --output=pcent /host")
+        if ok:
+            try:
+                used_pcent = int(out.splitlines()[-1].strip().rstrip('%'))
+                if used_pcent <= self.disk_used_pcent:
+                    self.log("[DPU {}] Disk usage {}% <= threshold {}%, no cleanup needed".format(
+                        dpu_ip, used_pcent, self.disk_used_pcent))
+                    should_cleanup = False
+                else:
+                    self.log("[DPU {}] Disk usage {}% > threshold {}%, cleaning up".format(
+                        dpu_ip, used_pcent, self.disk_used_pcent))
+            except (ValueError, IndexError):
+                self.log("[DPU {}] Could not parse disk usage, performing cleanup as precaution".format(dpu_ip))
+        else:
+            self.log("[DPU {}] Could not check disk usage, performing cleanup as precaution".format(dpu_ip))
+
+        if not should_cleanup:
+            return
+
+        cleanup_cmds = [
+            "sudo rm -f /var/log/*.gz",
+            "sudo rm -f /var/core/*",
+            "sudo rm -rf /var/dump/*",
+            "sudo rm -rf /home/admin/*",
+            "sudo rm -rf /host/logs_before_reboot/*",
+        ]
+        for cmd in cleanup_cmds:
+            self.execute_command(ssh, dpu_ip, cmd)
+
+        self.log("[DPU {}] Done freeing disk space".format(dpu_ip))
+
+    def download_image_on_npu(self):
+        """Download the SONiC image on the NPU using curl."""
+        self.log("Downloading DPU image on NPU from {}".format(self.new_image_url))
+        start_time = time.time()
+        rc, out, err = self.module.run_command(
+            "curl -fLo {} {}".format(NPU_DOWNLOAD_PATH, self.new_image_url),
+            use_unsafe_shell=True
+        )
+        elapsed = time.time() - start_time
+        if rc != 0:
+            self.module.fail_json(
+                msg="Failed to download image on NPU ({:.1f}s): rc={}, err={}".format(elapsed, rc, err))
+        if not os.path.exists(NPU_DOWNLOAD_PATH):
+            self.module.fail_json(msg="Downloaded image not found at {}".format(NPU_DOWNLOAD_PATH))
+        size = os.path.getsize(NPU_DOWNLOAD_PATH)
+        self.log("Image downloaded on NPU: {} bytes in {:.1f}s ({:.1f} MB/s)".format(
+            size, elapsed, size / 1024 / 1024 / max(elapsed, 0.1)))
+
+    def cleanup_npu_image(self):
+        """Remove the downloaded image from the NPU."""
+        self.module.run_command("rm -f {}".format(NPU_DOWNLOAD_PATH))
+
+    def scp_image_to_dpu(self, dpu_ip):
+        """Transfer the image from NPU to DPU using paramiko SFTP over the midplane."""
+        src_size = os.path.getsize(NPU_DOWNLOAD_PATH)
+        self.log("[DPU {}] Step: SCP transfer ({:.1f} MB) to {}".format(
+            dpu_ip, src_size / 1024 / 1024, DPU_IMAGE_PATH))
+        ssh = self.connect_to_dpu(dpu_ip)
+        if not ssh:
+            return False
+        try:
+            start_time = time.time()
+            with ssh.open_sftp() as sftp:
+                sftp.put(NPU_DOWNLOAD_PATH, DPU_IMAGE_PATH)
+            elapsed = time.time() - start_time
+            self.log("[DPU {}] SCP transfer succeeded in {:.1f}s ({:.1f} MB/s)".format(
+                dpu_ip, elapsed, src_size / 1024 / 1024 / max(elapsed, 0.1)))
+            return True
+        except Exception as e:
+            self.log("WARNING: [DPU {}] SCP transfer failed: {}".format(dpu_ip, str(e)))
+            return False
+        finally:
+            ssh.close()
+
+    def install_image_on_dpu(self, ssh, dpu_ip):
+        """Transfer the image from NPU to DPU via SCP and install it."""
+        self.log("[DPU {}] Step: Install image".format(dpu_ip))
+
+        # Clean up any previous download
+        self.execute_command(ssh, dpu_ip, "sudo rm -f {}".format(DPU_IMAGE_PATH))
+
+        # Transfer image from NPU to DPU
+        if not self.scp_image_to_dpu(dpu_ip):
+            return False
+
+        # Check for --skip-package-migration support
+        skip_param = ""
+        ok, help_out, _ = self.execute_command(ssh, dpu_ip, "sudo sonic-installer install --help")
+        if "skip-package-migration" in help_out:
+            skip_param = "--skip-package-migration"
+            self.log("[DPU {}] Using --skip-package-migration".format(dpu_ip))
+
+        # Install the image
+        self.log("[DPU {}] Running sonic-installer install (timeout={}s)".format(
+            dpu_ip, LONG_CMD_TIMEOUT))
+        ok, out, err = self.execute_command(
+            ssh, dpu_ip,
+            "sudo sonic-installer install {} {} -y".format(DPU_IMAGE_PATH, skip_param),
+            timeout=LONG_CMD_TIMEOUT,
+            get_pty=True
+        )
+
+        # Clean up downloaded image
+        self.execute_command(ssh, dpu_ip, "sudo rm -f {}".format(DPU_IMAGE_PATH))
+
+        if not ok:
+            self.log("WARNING: [DPU {}] Image installation FAILED: {}".format(dpu_ip, err.strip()))
+            return False
+
+        self.log("[DPU {}] Image installed successfully".format(dpu_ip))
+        return True
+
+    def verify_installed_image(self, ssh, dpu_ip, dpu_index):
+        """Log the current and next boot image versions after upgrade."""
+        ok, out, _ = self.execute_command(ssh, dpu_ip, "sudo sonic-installer list")
+        if not ok:
+            self.log("WARNING: [DPU{}] Could not verify installed image version".format(dpu_index))
+            return
+
+        for line in out.split('\n'):
+            line = line.strip()
+            if line.startswith("Current:") or line.startswith("Next:"):
+                self.log("[DPU{}] {}".format(dpu_index, line))
+
+    def reboot_dpu(self, dpu_index):
+        """Reboot DPU by shutting down and starting it via NPU chassis module commands."""
+        dpu_name = "DPU{}".format(dpu_index)
+        self.log("[DPU{}] Step: Rebooting via chassis module shutdown/startup".format(dpu_index))
+
+        rc, out, err = self.module.run_command("config chassis modules shutdown {}".format(dpu_name))
+        if rc != 0:
+            self.log("WARNING: [DPU{}] shutdown failed (rc={}): stdout={} stderr={}".format(
+                dpu_index, rc, out.strip(), err.strip()))
+            return False
+
+        self.log("[DPU{}] Shutdown issued, waiting 60s before startup".format(dpu_index))
+        time.sleep(60)
+
+        rc, out, err = self.module.run_command("config chassis modules startup {}".format(dpu_name))
+        if rc != 0:
+            self.log("WARNING: [DPU{}] startup failed (rc={}): stdout={} stderr={}".format(
+                dpu_index, rc, out.strip(), err.strip()))
+            return False
+
+        self.log("[DPU{}] Startup issued successfully".format(dpu_index))
+        return True
+
+    def remove_known_host(self, dpu_ip):
+        """Remove DPU entry from SSH known_hosts on the NPU after reboot."""
+        self.log("Removing {} from SSH known_hosts for root and admin".format(dpu_ip))
+        self.module.run_command("ssh-keygen -R {}".format(dpu_ip))
+        self.module.run_command(
+            "sudo -u admin ssh-keygen -R {} -f /home/admin/.ssh/known_hosts".format(dpu_ip)
+        )
+
+    def wait_for_dpu_reboot(self, dpu_ip):
+        """Wait for a DPU to become reachable again after reboot."""
+        self.log("[DPU {}] Step: Waiting up to {}s for DPU to come back".format(
+            dpu_ip, REBOOT_TIMEOUT))
+
+        elapsed = 0
+        while elapsed < REBOOT_TIMEOUT:
+            ssh = None
+            try:
+                ssh = paramiko.SSHClient()
+                ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+                for password in self.host_passwords:
+                    try:
+                        ssh.connect(dpu_ip, username=self.host_username,
+                                    password=password, timeout=15)
+                        self.log("[DPU {}] Back online after {}s".format(dpu_ip, elapsed))
+                        ssh.close()
+                        return True
+                    except Exception as e:
+                        self.log("SSH connection to DPU {} failed during reboot wait: {}".format(dpu_ip, str(e)))
+                        continue
+            except Exception as e:
+                self.log("Exception while waiting for DPU {} to reboot: {}".format(dpu_ip, str(e)))
+            finally:
+                if ssh:
+                    try:
+                        ssh.close()
+                    except Exception as e:
+                        self.log("Exception while closing SSH connection to DPU {}: {}".format(dpu_ip, str(e)))
+
+            time.sleep(REBOOT_POLL_INTERVAL)
+            elapsed += REBOOT_POLL_INTERVAL
+            if elapsed % 120 == 0:
+                self.log("[DPU {}] Still waiting... {}s/{}s elapsed".format(
+                    dpu_ip, elapsed, REBOOT_TIMEOUT))
+
+        self.log("WARNING: [DPU {}] Did NOT come back within {}s".format(dpu_ip, REBOOT_TIMEOUT))
+        return False
+
+    def get_dpu_online_mid_plane_up_counts(self):
+        """Return (online_count, midplane_up_count) from NPU system health."""
+        cmd = "show system-health dpu all"
+        rc, out, err = self.module.run_command(cmd)
+        if rc != 0:
+            self.log("WARNING: Failed to get DPU health (rc={}): {}".format(rc, err))
+            return 0, 0
+
+        online_count = 0
+        midplane_up_count = 0
+        for line in out.split("\n"):
+            if "up" in line and "dpu_midplane_link_state" in line:
+                midplane_up_count += 1
+            if line.startswith("DPU") and "Online" in line:
+                online_count += 1
+
+        self.log("DPU health: {} online, {} midplane up".format(online_count, midplane_up_count))
+        return online_count, midplane_up_count
+
+    def wait_for_dpu_count_fully_online(self, required_count):
+        """Wait until at least required_count DPUs report 'Online' status."""
+        retry_count = 0
+        while retry_count < MAX_RETRIES:
+            online, _ = self.get_dpu_online_mid_plane_up_counts()
+            if online >= required_count:
+                return True
+            self.log("Waiting for {} DPUs online (currently {})".format(
+                required_count, online))
+            time.sleep(RETRY_DELAY)
+            retry_count += 1
+        return False
+
+    def upgrade_single_dpu(self, dpu_index):
+        """Upgrade a single DPU. Returns True on success."""
+        dpu_ip = DPU_HOST_IP_BASE.format(dpu_index + 1)
+        start_time = time.time()
+        self.log("========== Starting upgrade of DPU{} at {} ==========".format(dpu_index, dpu_ip))
+
+        ssh = self.connect_to_dpu(dpu_ip)
+        if not ssh:
+            self.log("WARNING: [DPU{}] FAILED: Could not establish SSH connection".format(dpu_index))
+            return False
+
+        try:
+            self.reduce_installed_images(ssh, dpu_ip)
+            self.free_up_disk_space(ssh, dpu_ip)
+
+            if not self.install_image_on_dpu(ssh, dpu_ip):
+                self.log("WARNING: [DPU{}] FAILED: Image installation failed".format(dpu_index))
+                return False
+        except Exception as e:
+            self.log("WARNING: [DPU{}] FAILED: Exception during upgrade: {}".format(dpu_index, str(e)))
+            return False
+        finally:
+            try:
+                ssh.close()
+            except Exception as e:
+                self.log("WARNING: [DPU{}] Exception while closing SSH connection: {}".format(dpu_index, str(e)))
+
+        if not self.reboot_dpu(dpu_index):
+            self.log("WARNING: [DPU{}] FAILED: Reboot command failed".format(dpu_index))
+            return False
+
+        self.remove_known_host(dpu_ip)
+
+        if not self.wait_for_dpu_reboot(dpu_ip):
+            self.log("WARNING: [DPU{}] FAILED: Did not come back after reboot".format(dpu_index))
+            return False
+
+        # Clean up old images after reboot and verify the new version
+        ssh = self.connect_to_dpu(dpu_ip)
+        if ssh:
+            try:
+                self.reduce_installed_images(ssh, dpu_ip)
+                self.verify_installed_image(ssh, dpu_ip, dpu_index)
+            finally:
+                try:
+                    ssh.close()
+                except Exception as e:
+                    self.log("WARNING: [DPU{}] Exception while closing SSH connection: {}".format(dpu_index, str(e)))
+        else:
+            self.log("WARNING: [DPU{}] Could not connect for post-reboot image cleanup".format(dpu_index))
+
+        elapsed = time.time() - start_time
+        self.log("========== DPU{} upgrade SUCCEEDED ({:.0f}s) ==========".format(
+            dpu_index, elapsed))
+        return True
+
+    def upgrade_dpus(self):
+        """Upgrade all targeted DPUs and return (success_count, failure_count)."""
+        if self.target_dpu_index >= 0:
+            if self.target_dpu_index >= self.dpu_num:
+                self.module.fail_json(
+                    msg="target_dpu_index {} out of range (dpu_num={})".format(
+                        self.target_dpu_index, self.dpu_num))
+            dpu_indices = [self.target_dpu_index]
+        else:
+            dpu_indices = list(range(self.dpu_num))
+
+        total = len(dpu_indices)
+        required = max(1, int(total * SUCCESS_THRESHOLD))
+        success_count = 0
+        failure_count = 0
+        results_per_dpu = {}
+
+        self.download_image_on_npu()
+
+        self.log("===== DPU upgrade: {} DPU(s) to upgrade, {} required for success =====".format(
+            total, required))
+
+        try:
+            for idx in dpu_indices:
+                if self.upgrade_single_dpu(idx):
+                    success_count += 1
+                    results_per_dpu[idx] = "SUCCESS"
+                else:
+                    failure_count += 1
+                    results_per_dpu[idx] = "FAILED"
+                self.log("Progress: {}/{} complete ({} succeeded, {} failed)".format(
+                    success_count + failure_count, total, success_count, failure_count))
+        finally:
+            self.cleanup_npu_image()
+
+        self.log("DPU upgrade results: {}".format(results_per_dpu))
+
+        self.log("Verifying DPU online status after upgrades")
+        if not self.wait_for_dpu_count_fully_online(success_count):
+            self.log("WARNING: Not all upgraded DPUs came fully online")
+
+        if success_count < required:
+            self.module.fail_json(
+                msg="DPU upgrade failed: {}/{} succeeded (required {})".format(
+                    success_count, total, required),
+                success_count=success_count,
+                failure_count=failure_count,
+                total_dpus=total,
+                messages=self.messages)
+
+        return success_count, failure_count
+
+    def run(self):
+        success_count, failure_count = self.upgrade_dpus()
+        total = success_count + failure_count
+
+        if failure_count == 0:
+            msg = "Successfully upgraded all {} DPU(s)".format(success_count)
+        else:
+            msg = ("Upgraded {} of {} DPU(s) ({} failures, "
+                   "met success threshold)").format(success_count, total, failure_count)
+
+        self.module.exit_json(
+            changed=True,
+            msg=msg,
+            success_count=success_count,
+            failure_count=failure_count,
+            total_dpus=total,
+            messages=self.messages)
+
+
+def main():
+    module = UpgradeDpuSonicImageModule()
+    module.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -32,6 +32,7 @@ function usage
   echo "    $0 [options] restart-ptf <testbed-name> <vault-password-file>"
   echo "    $0 [options] set-l2 <testbed-name> <vault-password-file>"
   echo "    $0 [options] install-image <testbed-name> <inventory> <image-url>"
+  echo "    $0 [options] install-dpu-image <testbed-name> <inventory> <image-url> [<dpu-index>]"
   echo "    $0 [options] collect-show-tech <testbed-name> <inventory> <vault-password-file>"
   echo
   echo "Options:"
@@ -88,6 +89,9 @@ function usage
   echo "To restart ptf of specified testbed: $0 restart-ptf 'testbed-name' ~/.password"
   echo "To set DUT of specified testbed to l2 switch mode: $0 set-l2 'testbed-name' ~/.password"
   echo "To install an image on all DUTs in a testbed: $0 install-image 'testbed-name' 'inventory' 'image-url'"
+  echo "To install an image on DPUs of a testbed: $0 install-dpu-image 'testbed-name' 'inventory' 'image-url' [dpu-index]"
+  echo "    Optional argument for install-dpu-image:"
+  echo "        <dpu-index>              # Upgrade only the DPU at this index (default: all DPUs)"
   echo "To collect show techsupport result of a testbed: $0 collect-show-tech 'testbed-name' 'inventory' ~/.password"
   echo "    collect-show-tech supports specify output path for dumped files"
   echo "        -e output_path=<user-specified-path>"
@@ -885,6 +889,28 @@ function install_image
   echo Done
 }
 
+function install_dpu_image
+{
+  testbed_name=$1
+  inventory=$2
+  image_url=$3
+  dpu_index=${4:--1}
+  shift
+  shift
+  shift
+  if [ $# -gt 0 ]; then shift; fi
+
+  echo "Upgrading DPU image on '$testbed_name' (dpu_index=$dpu_index)"
+
+  ansible-playbook upgrade_dpu_sonic.yml -i "$inventory" \
+    -e testbed_name="$testbed_name" \
+    -e testbed_file=$tbfile \
+    -e image_url="$image_url" \
+    -e target_dpu_index="$dpu_index"
+
+  echo Done
+}
+
 function collect_show_tech
 {
   testbed_name=$1
@@ -1115,6 +1141,8 @@ case "${subcmd}" in
   restart-ptf) restart_ptf $@
                ;;
   install-image) install_image $@
+               ;;
+  install-dpu-image) install_dpu_image $@
                ;;
   collect-show-tech) collect_show_tech $@
                ;;

--- a/ansible/upgrade_dpu_sonic.yml
+++ b/ansible/upgrade_dpu_sonic.yml
@@ -1,0 +1,86 @@
+---
+# Playbook to install a new SONiC image on DPU(s) of a SmartSwitch.
+# The module runs on the NPU host and SSHes into DPUs via the midplane network.
+#
+# Usage:
+#   Upgrade all DPUs on a specific host:
+#     ansible-playbook upgrade_dpu_sonic.yml -i <inventory> -l <host> \
+#       -e "image_url=<url>" -vvv
+#
+#   Upgrade a single DPU by index:
+#     ansible-playbook upgrade_dpu_sonic.yml -i <inventory> -l <host> \
+#       -e "image_url=<url>" -e "target_dpu_index=0" -vvv
+#
+#   Upgrade all DPUs on DUTs in a testbed:
+#     ansible-playbook upgrade_dpu_sonic.yml -i <inventory> \
+#       -e "testbed_name=<name>" -e "image_url=<url>" -vvv
+#
+- hosts: all
+  gather_facts: no
+  tasks:
+    - name: Add NPU hosts from testbed (exclude DPU hosts)
+      block:
+        - name: Set default testbed file
+          set_fact:
+            testbed_file: testbed.yaml
+          when: testbed_file is not defined
+
+        - name: Gather testbed information
+          test_facts:
+            testbed_name: "{{ testbed_name }}"
+            testbed_file: "{{ testbed_file }}"
+
+        - name: Create upgrade targets group (NPU hosts only)
+          add_host:
+            name: "{{ item }}"
+            groups: dpu_upgrade_targets
+          loop: "{{ testbed_facts['duts'] | reject('search', '-dpu-') | list }}"
+      delegate_to: localhost
+      run_once: true
+      when: testbed_name is defined
+
+    - name: Add hosts directly when no testbed specified (exclude DPU hosts)
+      add_host:
+        name: "{{ item }}"
+        groups: dpu_upgrade_targets
+      loop: "{{ ansible_play_hosts | reject('search', '-dpu-') | list }}"
+      delegate_to: localhost
+      run_once: true
+      when: testbed_name is not defined
+
+- hosts: dpu_upgrade_targets
+  gather_facts: no
+  tasks:
+    - name: Fail if image_url is not defined
+      fail:
+        msg: "image_url must be provided"
+      when: image_url is not defined
+
+    - name: Set default disk_used_pcent
+      set_fact:
+        disk_used_pcent: 50
+      when: disk_used_pcent is not defined
+
+    - name: Set default target_dpu_index
+      set_fact:
+        target_dpu_index: -1
+      when: target_dpu_index is not defined
+
+    - name: Install new SONiC image on DPU(s)
+      upgrade_dpu_sonic_image:
+        hwsku: "{{ hwsku }}"
+        hostname: "{{ inventory_hostname }}"
+        host_username: "{{ sonic_login }}"
+        host_passwords: "{{ sonic_default_passwords }}"
+        new_image_url: "{{ image_url }}"
+        target_dpu_index: "{{ target_dpu_index | int }}"
+        disk_used_pcent: "{{ disk_used_pcent | int }}"
+      become: true
+      register: upgrade_result
+      retries: 3
+      delay: 30
+      until: upgrade_result is not failed
+
+    - name: Display upgrade results
+      debug:
+        msg: "{{ upgrade_result.msg }}"


### PR DESCRIPTION
### Description of PR

Summary: Cherry-pick of #23915 to the 202511 branch. Adds infrastructure to upgrade SONiC images on DPUs during nightly tests on SmartSwitch testbeds. Includes a new Ansible module, playbook, testbed-cli subcommand, and integration into the existing upgrade_image.py pipeline script. Also fixes config file deletion on SmartSwitch during NPU image upgrade.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

Cherry-pick of commit 42717f87722f83494e3094e0743f4e69cdaf0513 (#23915) from master to 202511.

SmartSwitch testbeds have DPUs that run independent SONiC instances. Currently, the nightly upgrade pipeline only upgrades the NPU (switch) image. DPU images must also be upgraded to keep the testbed in a consistent state. Additionally, reduce_and_add_sonic_images was deleting config_db.json and golden_config_db.json on SmartSwitch devices when minigraph.xml was present, breaking DPU configuration (DPUS table) on next boot.

#### How did you do it?

Cherry-picked the commit, resolving a conflict in `ansible/library/load_extra_dpu_config.py` by keeping the 202511 version (the cherry-picked commit added a line before `CONFIG_SETUP_FACTORY_CMD` which does not exist on 202511).

#### How did you verify/test it?

Verified on master via #23915.

#### Any platform specific information?

SmartSwitch platforms only.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation