### PR TITLE
Update qos params for topo-t0-isolated-d96u32s2

### DIFF
--- a/tests/qos/files/qos_params.th5.yaml
+++ b/tests/qos/files/qos_params.th5.yaml
@@ -1096,66 +1096,26 @@ qos_params:
         topo-t0-isolated-d96u32s2:
             400000_5m:
                 hdrm_pool_size:
-                    dscps:
-                    - 3
-                    - 4
+                    dscps: [3, 4]
                     dst_port_id: 32
                     ecn: 1
-                    margin: 2
-                    pgs:
-                    - 3
-                    - 4
+                    margin: 4
+                    pgs: [3, 4]
                     pgs_num: 26
                     pkts_num_hdrm_full: 1548
                     pkts_num_hdrm_partial: 1028
-                    pkts_num_trig_pfc: 134690
-                    pkts_num_trig_pfc_multi:
-                    - 134690
-                    - 67382
-                    - 33728
-                    - 16901
-                    - 8488
-                    - 4281
-                    - 2177
-                    - 1126
-                    - 600
-                    - 337
-                    - 205
-                    - 140
-                    - 107
-                    - 90
-                    - 82
-                    - 78
-                    - 76
-                    - 75
-                    - 75
-                    - 74
-                    - 74
-                    - 74
-                    - 74
-                    - 74
-                    - 74
-                    - 74
-                    src_port_ids:
-                    - 33
-                    - 34
-                    - 35
-                    - 36
-                    - 37
-                    - 38
-                    - 39
-                    - 40
-                    - 41
-                    - 42
-                    - 43
-                    - 56
-                    - 57
+                    pkts_num_trig_pfc: 134725
+                    pkts_num_trig_pfc_multi: [134725, 67400, 33737, 16905, 8490, 4282,
+                        2178, 1126, 600, 337, 205, 140, 107, 90, 82, 78, 76, 75, 75,
+                        74, 74, 74, 74, 74, 74, 74]
+                    src_port_ids: [33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 56,
+                        57]
                 lossy_queue_1:
-                    dscp: 8
+                    dscp: 0
                     ecn: 1
                     pg: 0
-                    pkts_num_margin: 2
-                    pkts_num_trig_egr_drp: 134624
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 134659
                 pkts_num_egr_mem: 376
                 pkts_num_leak_out: 0
                 wm_pg_headroom:
@@ -1163,9 +1123,9 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_margin: 2
-                    pkts_num_trig_ingr_drp: 136239
-                    pkts_num_trig_pfc: 134690
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 136274
+                    pkts_num_trig_pfc: 134725
                 wm_pg_shared_lossless:
                     cell_size: 254
                     dscp: 3
@@ -1173,191 +1133,61 @@ qos_params:
                     packet_size: 64
                     pg: 3
                     pkts_num_fill_min: 74
-                    pkts_num_margin: 2
-                    pkts_num_trig_pfc: 134690
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 134725
                 wm_pg_shared_lossy:
                     cell_size: 254
-                    dscp: 8
+                    dscp: 0
                     ecn: 1
                     packet_size: 64
                     pg: 0
                     pkts_num_fill_min: 7
-                    pkts_num_margin: 2
-                    pkts_num_trig_egr_drp: 134624
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 134659
                 wm_q_shared_lossless:
                     cell_size: 254
                     dscp: 3
                     ecn: 1
                     pkts_num_fill_min: 0
-                    pkts_num_margin: 2
-                    pkts_num_trig_ingr_drp: 136239
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 136274
                     queue: 3
                 wm_q_shared_lossy:
                     cell_size: 254
-                    dscp: 8
+                    dscp: 0
                     ecn: 1
                     pkts_num_fill_min: 7
-                    pkts_num_margin: 2
-                    pkts_num_trig_egr_drp: 134624
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 134659
                     queue: 0
                 xoff_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_margin: 2
-                    pkts_num_trig_ingr_drp: 136239
-                    pkts_num_trig_pfc: 134690
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 136274
+                    pkts_num_trig_pfc: 134725
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_margin: 2
-                    pkts_num_trig_ingr_drp: 136239
-                    pkts_num_trig_pfc: 134690
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 136274
+                    pkts_num_trig_pfc: 134725
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
                     pkts_num_dismiss_pfc: 14
-                    pkts_num_margin: 2
-                    pkts_num_trig_pfc: 134690
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 134725
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
                     pkts_num_dismiss_pfc: 14
-                    pkts_num_margin: 2
-                    pkts_num_trig_pfc: 134690
-            400000_40m:
-                hdrm_pool_size:
-                    dscps:
-                    - 3
-                    - 4
-                    dst_port_id: 2
-                    ecn: 1
-                    margin: 2
-                    pgs:
-                    - 3
-                    - 4
-                    pgs_num: 23
-                    pkts_num_hdrm_full: 1755
-                    pkts_num_hdrm_partial: 1118
-                    pkts_num_trig_pfc: 134690
-                    pkts_num_trig_pfc_multi:
-                    - 134690
-                    - 67382
-                    - 33728
-                    - 16901
-                    - 8488
-                    - 4281
-                    - 2177
-                    - 1126
-                    - 600
-                    - 337
-                    - 205
-                    - 140
-                    - 107
-                    - 90
-                    - 82
-                    - 78
-                    - 76
-                    - 75
-                    - 75
-                    - 74
-                    - 74
-                    - 74
-                    - 74
-                    src_port_ids:
-                    - 3
-                    - 4
-                    - 5
-                    - 6
-                    - 7
-                    - 16
-                    - 17
-                    - 18
-                    - 19
-                    - 24
-                    - 25
-                    - 26
-                lossy_queue_1:
-                    dscp: 8
-                    ecn: 1
-                    pg: 0
-                    pkts_num_margin: 2
-                    pkts_num_trig_egr_drp: 134624
-                pkts_num_egr_mem: 376
-                pkts_num_leak_out: 0
-                wm_pg_headroom:
-                    cell_size: 254
-                    dscp: 3
-                    ecn: 1
-                    pg: 3
-                    pkts_num_margin: 2
-                    pkts_num_trig_ingr_drp: 136446
-                    pkts_num_trig_pfc: 134690
-                wm_pg_shared_lossless:
-                    cell_size: 254
-                    dscp: 3
-                    ecn: 1
-                    packet_size: 64
-                    pg: 3
-                    pkts_num_fill_min: 74
-                    pkts_num_margin: 2
-                    pkts_num_trig_pfc: 134690
-                wm_pg_shared_lossy:
-                    cell_size: 254
-                    dscp: 8
-                    ecn: 1
-                    packet_size: 64
-                    pg: 0
-                    pkts_num_fill_min: 7
-                    pkts_num_margin: 2
-                    pkts_num_trig_egr_drp: 134624
-                wm_q_shared_lossless:
-                    cell_size: 254
-                    dscp: 3
-                    ecn: 1
-                    pkts_num_fill_min: 0
-                    pkts_num_margin: 2
-                    pkts_num_trig_ingr_drp: 136446
-                    queue: 3
-                wm_q_shared_lossy:
-                    cell_size: 254
-                    dscp: 8
-                    ecn: 1
-                    pkts_num_fill_min: 7
-                    pkts_num_margin: 2
-                    pkts_num_trig_egr_drp: 134624
-                    queue: 0
-                xoff_1:
-                    dscp: 3
-                    ecn: 1
-                    pg: 3
-                    pkts_num_margin: 2
-                    pkts_num_trig_ingr_drp: 136446
-                    pkts_num_trig_pfc: 134690
-                xoff_2:
-                    dscp: 4
-                    ecn: 1
-                    pg: 4
-                    pkts_num_margin: 2
-                    pkts_num_trig_ingr_drp: 136446
-                    pkts_num_trig_pfc: 134690
-                xon_1:
-                    dscp: 3
-                    ecn: 1
-                    pg: 3
-                    pkts_num_dismiss_pfc: 14
-                    pkts_num_margin: 2
-                    pkts_num_trig_pfc: 134690
-                xon_2:
-                    dscp: 4
-                    ecn: 1
-                    pg: 4
-                    pkts_num_dismiss_pfc: 14
-                    pkts_num_margin: 2
-                    pkts_num_trig_pfc: 134690
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 134725
             cell_size: 254
             hdrm_pool_wm_multiplier: 2
             wrr:
@@ -1365,7 +1195,7 @@ qos_params:
                 ecn: 1
                 limit: 80
                 q_list: [0, 1, 3, 4, 5, 6]
-                q_pkt_cnt: [50, 50, 100, 50, 50, 350]
+                q_pkt_cnt: [100, 100, 200, 100, 100, 700]
             wrr_chg:
                 dscp_list: [0, 47, 3, 4, 46, 44]
                 ecn: 1
@@ -1373,7 +1203,116 @@ qos_params:
                 lossless_weight: 30
                 lossy_weight: 8
                 q_list: [0, 1, 3, 4, 5, 6]
-                q_pkt_cnt: [40, 50, 150, 50, 50, 350]
+                q_pkt_cnt: [80, 100, 300, 100, 100, 700]
+            400000_40m:
+                hdrm_pool_size:
+                    dscps: [3, 4]
+                    dst_port_id: 2
+                    ecn: 1
+                    margin: 4
+                    pgs: [3, 4]
+                    pgs_num: 23
+                    pkts_num_hdrm_full: 1755
+                    pkts_num_hdrm_partial: 1118
+                    pkts_num_trig_pfc: 134725
+                    pkts_num_trig_pfc_multi: [134725, 67400, 33737, 16905, 8490, 4282,
+                        2178, 1126, 600, 337, 205, 140, 107, 90, 82, 78, 76, 75, 75,
+                        74, 74, 74, 74]
+                    src_port_ids: [3, 4, 5, 6, 7, 16, 17, 18, 19, 24, 25, 26]
+                lossy_queue_1:
+                    dscp: 0
+                    ecn: 1
+                    pg: 0
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 134659
+                pkts_num_egr_mem: 376
+                pkts_num_leak_out: 0
+                wm_pg_headroom:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 136481
+                    pkts_num_trig_pfc: 134725
+                wm_pg_shared_lossless:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    packet_size: 64
+                    pg: 3
+                    pkts_num_fill_min: 74
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 134725
+                wm_pg_shared_lossy:
+                    cell_size: 254
+                    dscp: 0
+                    ecn: 1
+                    packet_size: 64
+                    pg: 0
+                    pkts_num_fill_min: 7
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 134659
+                wm_q_shared_lossless:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 136481
+                    queue: 3
+                wm_q_shared_lossy:
+                    cell_size: 254
+                    dscp: 0
+                    ecn: 1
+                    pkts_num_fill_min: 7
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 134659
+                    queue: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 136481
+                    pkts_num_trig_pfc: 134725
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 136481
+                    pkts_num_trig_pfc: 134725
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 134725
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 134725
+            cell_size: 254
+            hdrm_pool_wm_multiplier: 2
+            wrr:
+                dscp_list: [0, 47, 3, 4, 46, 44]
+                ecn: 1
+                limit: 80
+                q_list: [0, 1, 3, 4, 5, 6]
+                q_pkt_cnt: [100, 100, 200, 100, 100, 700]
+            wrr_chg:
+                dscp_list: [0, 47, 3, 4, 46, 44]
+                ecn: 1
+                limit: 80
+                lossless_weight: 30
+                lossy_weight: 8
+                q_list: [0, 1, 3, 4, 5, 6]
+                q_pkt_cnt: [80, 100, 300, 100, 100, 700]
         topo-t1-isolated-d128: &topo-t1-isolated-d128
             200000_5m: &topo-t1-isolated-d128_200000_5m
                 hdrm_pool_size:

--- a/tests/qos/files/qos_params.th5.yaml
+++ b/tests/qos/files/qos_params.th5.yaml
@@ -1188,22 +1188,6 @@ qos_params:
                     pkts_num_dismiss_pfc: 14
                     pkts_num_margin: 4
                     pkts_num_trig_pfc: 134725
-            cell_size: 254
-            hdrm_pool_wm_multiplier: 2
-            wrr:
-                dscp_list: [0, 47, 3, 4, 46, 44]
-                ecn: 1
-                limit: 80
-                q_list: [0, 1, 3, 4, 5, 6]
-                q_pkt_cnt: [100, 100, 200, 100, 100, 700]
-            wrr_chg:
-                dscp_list: [0, 47, 3, 4, 46, 44]
-                ecn: 1
-                limit: 80
-                lossless_weight: 30
-                lossy_weight: 8
-                q_list: [0, 1, 3, 4, 5, 6]
-                q_pkt_cnt: [80, 100, 300, 100, 100, 700]
             400000_40m:
                 hdrm_pool_size:
                     dscps: [3, 4]


### PR DESCRIPTION
### Description of PR
Update qos params for topo-t0-isolated-d96u32s2

### Back port request
- [x] 202511

### Approach
#### What is the motivation for this PR?
Update qos params for this topo after sai 14 upgrade and buffer changes

#### How did you do it?
Script generated

#### How did you verify/test it?
Manually verified
