### PR TITLE
[smartswitch]: Add advertise_prefix to VNET in HA golden config and verify VIP BGP advertisement

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -767,7 +767,8 @@ class GenerateGoldenConfigDBModule(object):
                 "Vnet_55": {
                     "scope": "default",
                     "vni": "10000",
-                    "vxlan_tunnel": "t4"
+                    "vxlan_tunnel": "t4",
+                    "advertise_prefix": "true"
                 }
             },
             "VXLAN_TUNNEL": {

--- a/tests/ha/ha_bgp_utils.py
+++ b/tests/ha/ha_bgp_utils.py
@@ -1,7 +1,59 @@
+import json
 import logging
+
+from tests.common.helpers.assertions import pytest_assert
 
 
 logger = logging.getLogger(__name__)
+
+
+def _get_t2_peer_ips(duthost):
+    """Return DUT-side BGP peer IPs whose remote description identifies them as T2."""
+    out = duthost.shell('vtysh -c "show ip bgp summary json"')["stdout"]
+    summary = json.loads(out)
+    peers = summary.get("ipv4Unicast", {}).get("peers", {})
+    return [
+        ip for ip, p in peers.items()
+        if "T2" in (p.get("hostname") or "") or "T2" in (p.get("desc") or "")
+    ]
+
+
+def check_vip_advertised_to_t2(duthosts, vip):
+    """Verify the DUT advertises the VIP /32 prefix to every T2 BGP peer."""
+    vip_prefix = "{}/32".format(vip)
+    # DutHosts proxies any attribute name to its node list, so hasattr() lies.
+    # A real single host has a string `hostname`; DutHosts.hostname is a method.
+    if isinstance(getattr(duthosts, "hostname", None), str):
+        duts = [duthosts]
+    else:
+        duts = list(duthosts)
+
+    missing = []
+    found_any = False
+    for duthost in duts:
+        t2_peer_ips = _get_t2_peer_ips(duthost)
+        if not t2_peer_ips:
+            logger.info("%s: no T2 BGP peers found", duthost.hostname)
+            continue
+        for peer_ip in t2_peer_ips:
+            cmd = 'vtysh -c "show ip bgp neighbors {} advertised-routes json"'.format(peer_ip)
+            res = duthost.shell(cmd, module_ignore_errors=True)
+            adv = {}
+            if not res.get("failed"):
+                try:
+                    adv = json.loads(res["stdout"]).get("advertisedRoutes", {})
+                except ValueError:
+                    adv = {}
+            if vip_prefix in adv:
+                found_any = True
+                logger.info("%s -> %s: VIP %s advertised", duthost.hostname, peer_ip, vip_prefix)
+            else:
+                missing.append("{}->{}".format(duthost.hostname, peer_ip))
+
+    pytest_assert(found_any and not missing,
+                  "VIP {} not advertised to T2 peers: {}".format(vip_prefix, missing))
+    logger.info("VIP %s advertised to all T2 peers on %s",
+                vip_prefix, [d.hostname for d in duts])
 
 
 def _ha_bgp_oper(duthost, start=True):

--- a/tests/ha/test_ha_steady_state_pl.py
+++ b/tests/ha/test_ha_steady_state_pl.py
@@ -9,6 +9,7 @@ from constants import LOCAL_PTF_INTF, REMOTE_PTF_RECV_INTF, REMOTE_PTF_SEND_INTF
 from gnmi_utils import apply_messages
 from packets import outbound_pl_packets, inbound_pl_packets
 from tests.common.config_reload import config_reload
+from ha_bgp_utils import check_vip_advertised_to_t2
 from ha_dash_flow_utils import compare_flow_tables
 
 logger = logging.getLogger(__name__)
@@ -96,7 +97,9 @@ def common_setup_teardown(
 @pytest.mark.parametrize("encap_proto", ["vxlan", "gre"])
 def test_privatelink_basic_transform(
     ptfadapter,
+    duthosts,
     dpuhosts,
+    nbrhosts,
     activate_dash_ha_from_json,
     ha_owner,
     dash_pl_config,
@@ -125,3 +128,5 @@ def test_privatelink_basic_transform(
     pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
     testutils.send(ptfadapter, dash_pl_config[1][REMOTE_PTF_SEND_INTF], pe_to_dpu_pkt, 1)
     testutils.verify_packet(ptfadapter, exp_dpu_to_vm_pkt, dash_pl_config[0][LOCAL_PTF_INTF])
+
+    check_vip_advertised_to_t2(duthosts, pl.APPLIANCE_VIP)


### PR DESCRIPTION
### Description of PR
Summary:
- Add `advertise_prefix: "true"` to `Vnet_55` in the smartswitch HA golden config so the VIP `3.2.1.0/32` is redistributed into BGP.
- Add `check_vip_advertised_to_t2(duthosts, vip)` helper in `tests/ha/ha_bgp_utils.py` that queries the DUT's BGP advertised-routes per T2 peer (`show ip bgp neighbors <peer> advertised-routes json`) and asserts the VIP /32 is present.
- Call the helper at the end of `test_privatelink_basic_transform` in `tests/ha/test_ha_steady_state_pl.py`.

Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The smartswitch HA golden config was missing `advertise_prefix`, so the VIP was never advertised to T2 spine neighbors over BGP.

#### How did you do it?
Added the flag to the VNET entry and added a DUT-side check that verifies the VIP /32 is in each T2 peer's advertised-routes.

#### How did you verify/test it?
Ran `tests/ha/test_ha_steady_state_pl.py::test_privatelink_basic_transform` on `t1-smartswitch-ha`; the helper logs the VIP as advertised to all 16 T2 BGP sessions across both DUTs.
```
<module 'ha_bgp_utils' from '/var/src/sonic-mgmt-int/tests/ha/ha_bgp_utils.py'>
INFO     ha_bgp_utils:ha_bgp_utils.py:49 **********************03 -> 10.0.0.1: VIP 3.2.1.0/32 advertised
INFO     ha_bgp_utils:ha_bgp_utils.py:49 **********************03 -> 10.0.0.3: VIP 3.2.1.0/32 advertised
INFO     ha_bgp_utils:ha_bgp_utils.py:49 **********************03 -> 10.0.0.5: VIP 3.2.1.0/32 advertised
INFO     ha_bgp_utils:ha_bgp_utils.py:49 **********************03 -> 10.0.0.7: VIP 3.2.1.0/32 advertised
INFO     ha_bgp_utils:ha_bgp_utils.py:49 **********************03 -> 10.0.0.9: VIP 3.2.1.0/32 advertised
INFO     ha_bgp_utils:ha_bgp_utils.py:49 **********************03 -> 10.0.0.11: VIP 3.2.1.0/32 advertised
INFO     ha_bgp_utils:ha_bgp_utils.py:49 **********************03 -> 10.0.0.13: VIP 3.2.1.0/32 advertised
INFO     ha_bgp_utils:ha_bgp_utils.py:49 **********************03 -> 10.0.0.15: VIP 3.2.1.0/32 advertised
INFO     ha_bgp_utils:ha_bgp_utils.py:49 **********************04 -> 10.0.1.1: VIP 3.2.1.0/32 advertised
INFO     ha_bgp_utils:ha_bgp_utils.py:49 **********************04 -> 10.0.1.3: VIP 3.2.1.0/32 advertised
INFO     ha_bgp_utils:ha_bgp_utils.py:49 **********************04 -> 10.0.1.5: VIP 3.2.1.0/32 advertised
INFO     ha_bgp_utils:ha_bgp_utils.py:49 **********************04 -> 10.0.1.7: VIP 3.2.1.0/32 advertised
INFO     ha_bgp_utils:ha_bgp_utils.py:49 **********************04 -> 10.0.1.9: VIP 3.2.1.0/32 advertised
INFO     ha_bgp_utils:ha_bgp_utils.py:49 **********************04 -> 10.0.1.11: VIP 3.2.1.0/32 advertised
INFO     ha_bgp_utils:ha_bgp_utils.py:49 **********************04 -> 10.0.1.13: VIP 3.2.1.0/32 advertised
INFO     ha_bgp_utils:ha_bgp_utils.py:49 **********************04 -> 10.0.1.15: VIP 3.2.1.0/32 advertised
INFO     ha_bgp_utils:ha_bgp_utils.py:55 VIP 3.2.1.0/32 advertised to all T2 peers on ['**********************03', '**********************04']
```

Test passed: 
```
------------------------------------------ generated xml file: /var/src/sonic-mgmt-int/tests/logs/ha/test_ha_steady_state_pl.py::test_privatelink_basic_transform[vxlan].xml ------------------------------------------
----------------------------------------------------------------------------------------------- live log sessionfinish ------------------------------------------------------------------------------------------------
INFO     root:__init__.py:67 Can not get Allure report URL. Please check logs
==================================================================================== 1 passed, 437 warnings in 1054.90s (0:17:34) =====================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_privatelink_basic_transform[vxlan]>
```

#### Any platform specific information?
Only affects `t1-smartswitch-ha`.

#### Supported testbed topology if it's a new test case?
`t1-smartswitch-ha`

### Documentation