### PR TITLE
fix: ansible 2.19+ authentication failure

### DIFF
--- a/ansible/plugins/connection/multi_passwd_ssh.py
+++ b/ansible/plugins/connection/multi_passwd_ssh.py
@@ -65,6 +65,14 @@ DOCUMENTATION += """
 CONNECTION_TIMEOUT_ERR_FLAG1 = "Connection timed out"
 CONNECTION_TIMEOUT_ERR_FLAG2 = "No route to host"
 
+# Sample SSH permission-denied messages that should be treated as auth failures:
+# 'Failed to connect to the host via ssh: ... admin@10.0.0.1: Permission denied (publickey,password).'
+# ansible-core <2.19 raised this as AnsibleAuthenticationFailure when using sshpass.
+# ansible-core 2.19 changed the default password mechanism to `ssh_askpass`, and
+# in that path the same condition is raised as a plain AnsibleConnectionFailure.
+# We classify it here so altpasswords are still retried.
+PERMISSION_DENIED_ERR_FLAG = "Permission denied"
+
 
 def _password_retry(func):
     """
@@ -94,6 +102,18 @@ def _password_retry(func):
                 return results
             except AnsibleAuthenticationFailure:
                 # if there is no more altpassword to try, raise
+                if not conn_passwords:
+                    raise
+            except AnsibleConnectionFailure as e:
+                # ansible-core 2.19's default password_mechanism=ssh_askpass
+                # surfaces SSH "Permission denied" as a plain AnsibleConnectionFailure
+                # instead of AnsibleAuthenticationFailure. Recognise that case
+                # here so the next ansible_altpassword is still tried; for any
+                # other connection failure (timeout, no route to host, ...) we
+                # re-raise so the outer wrapper can fall through to IPv6.
+                err_msg = getattr(e, "message", "") or str(e)
+                if PERMISSION_DENIED_ERR_FLAG not in err_msg:
+                    raise
                 if not conn_passwords:
                     raise
             finally:


### PR DESCRIPTION
### Description of PR

Summary:
Fix the multi-password retry path in our custom `multi_passwd_ssh` connection plugin so it keeps working after the ansible-core 2.18 → 2.19 upgrade. Without this, any DUT / PTF / vm_host whose current password is in `ansible_altpasswords` (rather than the primary `ansible_ssh_pass`) is reported as unreachable, because the first wrong password aborts the whole connection instead of triggering a retry.

Fixes # (issue) 3779203

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

> NB: backport is only needed for release branches that have already picked up ansible-core 2.19 (or that will, via the ansible 12.x bump). Tick whichever ones apply in your environment — `master` alone is enough to unblock current daily runs.

### Approach
#### What is the motivation for this PR?

After the recent ansible bump (ansible 11.x → 12.x, i.e. ansible-core 2.18 → 2.19), testbed health checks and prepare steps started failing fleet-wide with errors of the form:

```
Failed to connect to the host via ssh: ... <admin>@<dut-mgmt-ip>: Permission denied (publickey,password).
```

on hosts that had been working before — including DUTs that had been password-rotated, where the current password lives in `ansible_altpasswords` and the primary `ansible_ssh_pass` is the previous one.

Root cause: ansible-core 2.19 added a new `password_mechanism` option for the builtin `ssh` connection plugin and changed its default from the legacy `sshpass` path to `ssh_askpass`. The two paths classify SSH authentication failures differently:

| ansible-core | Default mechanism | "Permission denied" raised as |
|---|---|---|
| ≤ 2.18 | sshpass | `AnsibleAuthenticationFailure` |
| 2.19+ | ssh_askpass | `AnsibleConnectionFailure` |

Our custom `multi_passwd_ssh` plugin (`ansible/plugins/connection/multi_passwd_ssh.py`) only treats `AnsibleAuthenticationFailure` as "try the next password in `ansible_altpasswords`". Under 2.19 that exception type is no longer raised for password failures, so the retry loop never iterates — the very first wrong password aborts the connection and the host shows up as unreachable. `AnsibleConnectionFailure` was already caught by the *outer* wrapper, but only to fall through to the IPv6 address (and only on "Connection timed out" / "No route to host"), so "Permission denied" silently slipped through.

Concretely, this is what was breaking jobs such as `testbed_health_check.py::init_hosts → SonicHosts.dut_basic_facts()` and prepare-step `vm_set : get host distribution` on rotated DUTs / vm_hosts.

#### How did you do it?

Local change in `ansible/plugins/connection/multi_passwd_ssh.py`: in the inner `_conn_with_multi_pwd` retry loop, also catch `AnsibleConnectionFailure` whose message contains `Permission denied`, and treat it the same way as `AnsibleAuthenticationFailure` — pop the next candidate and retry. Other `AnsibleConnectionFailure`s (timeout, no route to host, etc.) are re-raised unchanged so the existing outer IPv6 fall-through still works.

```python
except AnsibleConnectionFailure as e:
    err_msg = getattr(e, "message", "") or str(e)
    if PERMISSION_DENIED_ERR_FLAG not in err_msg:
        raise          # not an auth failure → preserve original behaviour
    if not conn_passwords:
        raise          # exhausted ansible_altpasswords
```

Why this approach rather than forcing `password_mechanism = sshpass` in `ansible.cfg`:

- Localised — only changes our custom plugin, no global SSH behaviour change.
- No new runtime dependency. Doesn't require `sshpass` to be present in the container image.
- Doesn't interact with the stock `ssh` connection plugin used by groups that don't opt into `multi_passwd_ssh` (e.g. `fanout`).
- Future-proof — ansible-core upstream is moving away from `sshpass`; `ssh_askpass` will eventually be the only mechanism. Our plugin no longer relies on which one is in use.

No `ansible.cfg`, group_vars, host_vars, secrets, or playbook changes — single-file, ~15-line diff.

#### How did you verify/test it?

Reproduced on a sonic-mgmt runtime container against a representative testbed (DUT in the `sonic` group, ansible-core 2.19) where the current device password is the second entry of `ansible_altpasswords` (i.e. the retry path is required).

**Before the fix**, with the primary `ansible_ssh_pass` not matching the rotated DUT password (so we depend on `ansible_altpasswords`):

```
testbed_health_check.py#161 init_hosts → dut_basic_facts failed:
  <admin>@<dut-mgmt-ip>: Permission denied (publickey,password).
HostsUnreachable
```

**After the fix**, identical environment and command:

```
testbed_health_check.py#214 init_hosts ends
testbed_health_check.py#249 pre_check starts
testbed_health_check.py#264 {'hostname': '<dut-hostname>', 'reachable': True, 'failed': False, ...}
...
testbed_health_check.py#387 Check finished. Testbed is healthy.
```

Same run, same DUT, same ansible-core 2.19 — only difference is the patched `multi_passwd_ssh.py`. Verified on the dedicated runtime check container with the exported `ANSIBLE_CONFIG` / `ANSIBLE_CONNECTION_PLUGINS` env vars that the runtime uses in production.

Cross-check on a separate sonic-mgmt host where the primary password already matches the DUT: behaviour is unchanged (auth succeeds on first try, no retry occurs) — the change is a no-op on the happy path.

#### Any platform specific information?

No platform-specific logic. The fix touches a connection plugin, so it applies to every host group that uses `ansible_connection: multi_passwd_ssh`: `sonic`, `ptf`, `mgmt`, `l1_switch`, `server`, `vm_host`. The stock `ssh` connection plugin used by other groups (e.g. `fanout`) is unaffected.

Requires ansible-core ≥ 2.13 (unchanged from existing plugin requirements); behaviour is correct on both pre-2.19 (sshpass path) and 2.19+ (ssh_askpass path).

#### Supported testbed topology if it's a new test case?

N/A — not a test case.

### Documentation

N/A — no user-facing behaviour change, no new feature.
