### PR TITLE
Fix: Ignore benign omrelp session-broken errors 

### DIFF
--- a/tests/generic_config_updater/test_syslog.py
+++ b/tests/generic_config_updater/test_syslog.py
@@ -307,6 +307,8 @@ def test_syslog_server_tc1_suite(rand_selected_dut, cfg_facts, loganalyzer):
         ignoreRegex = [
             r".*omrelp\[.*\]: error 'error opening connection to remote peer'.*",
             r".*omrelp: could not connect to remote server, librelp error \d+.*",
+            r".*omrelp\[.*\]: error 'server closed relp session, session broken', object .* - action may not work as intended.*",  # noqa: E501
+            r".*omrelp\[.*\]: error 'error waiting on required session state, session broken', object .* - action may not work as intended.*",  # noqa: E501
         ]
         loganalyzer[rand_selected_dut.hostname].ignore_regex.extend(ignoreRegex)
 

--- a/tests/syslog/test_syslog.py
+++ b/tests/syslog/test_syslog.py
@@ -25,6 +25,8 @@ def test_syslog(rand_selected_dut, dummy_syslog_server_ip_a, dummy_syslog_server
         ignoreRegex = [
             r".*omrelp\[.*\]: error 'error opening connection to remote peer'.*",
             r".*omrelp: could not connect to remote server, librelp error \d+.*",
+            r".*omrelp\[.*\]: error 'server closed relp session, session broken', object .* - action may not work as intended.*",  # noqa: E501
+            r".*omrelp\[.*\]: error 'error waiting on required session state, session broken', object .* - action may not work as intended.*",  # noqa: E501
         ]
         loganalyzer[rand_selected_dut.hostname].ignore_regex.extend(ignoreRegex)
 


### PR DESCRIPTION
…yslog flakiness

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

loganalyzer_common_ignore.txt was missing ignore patterns for rsyslog's outbound RELP module (omrelp). On KVM testbeds, rsyslog is configured with an omrelp forwarder targeting240.127.1.1:2514 (the docker bridge IP) where no RELP server listens. rsyslog retries this connection on a ~30-second backoff timer and logs two ERR lines each time: server closed relp session, session broken and error waiting on required session state, session broken. When this retry fires inside a test's LogAnalyzer marker window, those lines are caught by the matchregex and fail the test — even though the DUT is completely healthy. This causes test_syslog to flake intermittently. 

Summary:
Fixes Pr Test Flakiness 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
test_syslog is a top P0 flaky test in the PR pipeline (~340+ hits in 30 days). Root cause: rsyslog's omrelp module periodically retries a pre-existing unreachable RELP forwarder(240.127.1.1:2514) on KVM testbeds. The retry logs two ERR lines to syslog which LogAnalyzer catches and incorrectly treats as a test failure. The DUT is fully healthy when these linesappear — all BGP sessions, processes, and interfaces are normal.

#### How did you do it?

Added two ignore regexes to loganalyzer_common_ignore.txt immediately after the existing imrelp ignores. 

#### How did you verify/test it?

Looking at a recent testplan where this test failed, the above claim can be seen as evidence as per the logs: 

For attempt 0: the test failed and was marked as flaky, due to the omrelp timer firing inside the log analyser's window: 
<img width="1689" height="982" alt="image" src="https://github.com/user-attachments/assets/586a0dc8-224f-4173-be88-5573420e0613" />
For the second attempt, the test passed only because of timing where the timings did not collide, see below: 

<img width="1658" height="1062" alt="image" src="https://github.com/user-attachments/assets/ca691146-ff00-457a-86cc-2c7afc72a4c5" />


#### Any platform specific information?
 Affects KVM-based VS testbeds (vms-kvm-*) where 240.127.1.1 is the docker bridge IP.
#### Supported testbed topology if it's a new test case?
N/A 
### Documentation
N/A
