### PR TITLE
Revert "[BMC] Skip GCU test_ntp/test_monitor_config cases that need Loopback0 / switch ports" (#24617)

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2698,11 +2698,9 @@ generic_config_updater/test_mmu_dynamic_threshold_config_update.py::test_dynamic
 
 generic_config_updater/test_monitor_config.py::test_monitor_config_tc1_suite:
   skip:
-    reason: "Not applicable: ERSPAN meter is not supported on Cisco-8000; no switch ports for ACL_TABLE on BMC."
-    conditions_logical_operator: or
+    reason: "This test is not run on this asic type or version currently / ERSPAN meter is not supported for Cisco Platform"
     conditions:
       - "asic_type in ['cisco-8000']"
-      - "'bmc' in topo_type"
 
 generic_config_updater/test_multiasic_addcluster.py:
   skip:
@@ -2725,12 +2723,6 @@ generic_config_updater/test_multiasic_linkcrc.py:
     conditions_logical_operator: or
     conditions:
       - "(is_multi_asic is False)"
-      - "'bmc' in topo_type"
-
-generic_config_updater/test_ntp.py::test_ntp_server_change_source_intf:
-  skip:
-    reason: "Loopback0 is not present on BMC platforms (no routing data plane); sonic-ntp YANG validation rejects src_intf=Loopback0."
-    conditions:
       - "'bmc' in topo_type"
 
 generic_config_updater/test_packet_trimming_config_asymmetric.py:


### PR DESCRIPTION
This reverts #24617 (commit 008c9dc1d5446b917f764856ae9616a1d463fb65).

The PR binary search analyzer identified this commit as the root cause of test regression(s).

**Binary search details:**
- Checker: `t1_checker`
- Test file: `configlet/test_add_rack.py`
- Test case: `test_add_rack`
- Analyzer run: `bd35af5b-c80c-4abb-874c-3152227af21d`


---
*Auto-generated by PR binary search analyzer.*