### PR TITLE
[backport] Fix Ansible playbook compatibility for ansible-core 2.20 (Ansible 13.6)

### DIFF
--- a/ansible/roles/eos/tasks/ceos.yml
+++ b/ansible/roles/eos/tasks/ceos.yml
@@ -6,7 +6,8 @@
   become: yes
 
 - name: set force_restart=yes for ceos container
-  set_fact: force_restart=yes
+  set_fact:
+    force_restart: yes
 
 - name: Check if ceos container responses to snmp
   when: ctninfo.exists
@@ -17,7 +18,8 @@
     ignore_errors: true
 
   - name: set force_restart=no for ceos container
-    set_fact: force_restart=no
+    set_fact:
+      force_restart: no
     when: snmp_data.ansible_facts.ansible_sysname is defined
 
 - include_vars: group_vars/vm_host/ceos.yml
@@ -98,7 +100,8 @@
   delegate_to: "{{ VM_host[0] }}"
 
 - name: set container_reachable=False for ceos container
-  set_fact: container_reachable=False
+  set_fact:
+    container_reachable: false
 
 # loop four times, if all containers are reachable in any iteration, the rest loop will be skipped
 - name: make sure container's mgmt-ip is reachable


### PR DESCRIPTION
### Description of PR

#### Backport with partial changes applicable from #24679

Summary:

Fix Ansible playbook compatibility for ansible-core 2.20 (Ansible 13.6) while maintaining backward compatibility with ansible-core 2.18 (Ansible 11.10).

In ansible-core 2.20, the inline `set_fact: key=value` syntax treats `False`/`True`/`yes`/`no` as **strings** instead of booleans.

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Upgrading from Ansible 11.10 (ansible-core 2.18.6) to Ansible 13.6 (ansible-core 2.20.5) broke the `add-topo` testbed provisioning. 

#### How did you do it?

Converted inline `set_fact: key=value` to YAML mapping syntax so boolean values are preserved across Ansible versions:

#### How did you verify/test it?

Ran `./testbed-cli.sh -m veos_vtb -t vtestbed.yaml add-topo vms-kvm-t0 ./password.txt` with Ansible 13.6 (ansible-core 2.20.5). Changes are backward compatible with Ansible 11.10 (ansible-core 2.18.6).

#### Any platform specific information?

N/A — affects testbed provisioning infrastructure only.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A