### PR TITLE
[DRH] Temporarily use T2 announce routes behaviour for DRH topologies

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -148,7 +148,7 @@ def get_change_routes_ports(vm, topo):
 
 def get_topo_type(topo_name):
     pattern = re.compile(
-        r'^(t0-mclag|t0|t1|ptf|fullmesh|dualtor|t2|mgmttor|m0|mc0|mx|m1|c0|dpu|smartswitch-t1|lt2|ft2)')
+        r'^(t0-mclag|t0|t1|ptf|fullmesh|dualtor|t2|mgmttor|m0|mc0|mx|m1|c0|dpu|smartswitch-t1|lt2|ft2|lrh|urh)')
     match = pattern.match(topo_name)
     if not match:
         return "unsupported"
@@ -158,6 +158,9 @@ def get_topo_type(topo_name):
         topo_type = 't0'
     if topo_type in ['mc0']:
         topo_type = 'm0'
+    # Temporarily map DRH topos to T2 routes
+    if topo_type in ['lrh', 'urh']:
+        topo_type = 't2'
     return topo_type
 
 
@@ -1304,12 +1307,12 @@ def fib_t2_lag(topo, ptf_ip, action="announce", topo_routes={}):
         else:
             m = re.match(r"(\d+)\.(\d+)@(\d+)", value['vlans'][0])
             dut_index = int(m.group(1))
-        if 'T1' in key or 'LT2' in key:
+        if 'T1' in key or 'LT2' in key or (key.endswith('T2') or 'LRH' in key):  # Temporarily map DRH to T2 routes
             if dut_index not in t1_vms:
                 t1_vms[dut_index] = list()
             t1_vms[dut_index].append(key)
 
-        if 'T3' in key:
+        if 'T3' in key or ('FRH' in key or 'URH' in key or 'RWA' in key):  # Temporarily map DRH to T2 routes
             if dut_index not in t3_vms:
                 t3_vms[dut_index] = list()
             t3_vms[dut_index].append(key)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Addresses (does not fully resolve/fix) #24809

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Unblock testing on new LRH & URH topologies by using T2 announce routes behvaiour while true DRH behvaiour is being defined.
#### How did you do it?
Map LRH & URH to T2, and add neighbor suffixes to `fib_t2_lag` function
#### How did you verify/test it?
`redeploy-topo` and `deploy-mg` to physical testbed using LRH & URH topos
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A