### PR TITLE
Fix srv6/test_srv6_dataplane.py skip condition for non-TH5 broadcom platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5153,7 +5153,7 @@ srv6/test_srv6_dataplane.py:
     conditions:
       - "asic_type not in ['mellanox', 'broadcom', 'vpp'] or (release != 'master' and release != '202412' and release < '202511')"
       - "asic_type == 'mellanox' and asic_gen in ['spc1', 'spc2', 'spc3']"
-      - "'Arista-7060X6-64PE' in hwsku and 'Arista-7060X6-64PE-B' not in hwsku"
+      - "asic_type == 'broadcom' and 'Arista-7060X6-64PE-B' not in hwsku"
       - "topo_name in ['t0-isolated-d96u32s2', 't1-isolated-d128', 't1-isolated-d32']"
   xfail:
     reason: "Test case has issue on the t0-isolated-d256u256s2 topo."


### PR DESCRIPTION
### Description of PR

Summary:
Fix the conditional mark for `srv6/test_srv6_dataplane.py` to properly skip all non-TH5 broadcom platforms. The existing condition only checked for the specific `Arista-7060X6-64PE` (non-B variant) hwsku but missed other non-TH5 broadcom platforms like `Arista-7260CX3-C64` (TH2), causing tests to run and fail on unsupported hardware.

ADO:37638929

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

The `srv6/test_srv6_dataplane.py` test should only run on TH5 broadcom platforms (`Arista-7060X6-64PE-B-*`). However, the skip condition was too narrow — it only blocked the non-B variant of Arista-7060X6-64PE:
`
Arista-7060X6-64PE' in hwsku and 'Arista-7060X6-64PE-B' not in hwsku
`

This missed all other non-TH5 broadcom platforms (e.g., `Arista-7260CX3-C64`), causing the test to run and fail on them.


#### How did you do it?

Replace the narrow hwsku check with a broader condition that skips all broadcom platforms except TH5:
`
"asic_type == 'broadcom' and 'Arista-7060X6-64PE-B' not in hwsku"
`

#### How did you verify/test it?

Verified by evaluating the condition logic:
- For `Arista-7260CX3-C64` (TH2): `asic_type == 'broadcom'` ✓ AND `'Arista-7060X6-64PE-B' not in hwsku` ✓ → **SKIP** (correct)
- For `Arista-7060X6-64PE-B-256` (TH5): `asic_type == 'broadcom'` ✓ AND `'Arista-7060X6-64PE-B' not in hwsku` ✗ → **RUN** (correct)
- For `Arista-7060X6-64PE-C64` (non-B): `asic_type == 'broadcom'` ✓ AND `'Arista-7060X6-64PE-B' not in hwsku` ✓ → **SKIP** (correct)

#### Any platform specific information?

Only TH5 broadcom platforms (`Arista-7060X6-64PE-B-*`) should run this test.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A