### PR TITLE
[memory_checker] bump test_memory_checker_recover recover timeout to 200s for Nokia-7215 only

### DIFF
--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -665,13 +665,22 @@ def test_memory_checker_recover(memory_checker_dut_and_container, test_setup_and
     loganalyzer.expect_regex = container.get_restart_expected_logre()
     marker = loganalyzer.init()
 
-    # Bumped from 30s -> 200s to match the same wait helper used by
-    # consumes_memory_and_checks_container_restart() elsewhere in this file.
-    # The 30s budget was too tight on slow ARM/Marvell-Prestera platforms
-    # (Nokia-7215 ~48% pass rate vs 100% elsewhere). 200s gives monit's 5s
-    # cycle plenty of headroom under load while still failing fast on a
-    # real regression.
-    timeout_status_change = 200
+    # monit has a 5s cycle interval per test parameters, so 30s (~6 cycles)
+    # is normally plenty for the status to change. The 4GB Marvell-Prestera
+    # Nokia-7215 / Nokia-M0-7215, however, run under higher memory/CPU
+    # pressure on newer branches (notably 202511) and monit cannot hold its
+    # 5s cadence during the memory-stress window, intermittently missing the
+    # 30s budget (~45% nightly flake; confirmed expected platform behavior
+    # with the Nokia-7215 platform owner). Give only those two SKUs extra
+    # headroom. The 8GB Nokia-7215-A1 variants are not affected and are
+    # intentionally excluded, matching the exact-SKU gating already used for
+    # these platforms in platform_tests/test_reboot.py and test_reload_config.py.
+    # wait_monit_mem_* early-exit on success, so the larger ceiling never adds
+    # runtime on a healthy run.
+    if duthost.facts["hwsku"] in {"Nokia-7215", "Nokia-M0-7215"}:
+        timeout_status_change = 200
+    else:
+        timeout_status_change = 30
 
     container.start_consume_memory()
     container.wait_monit_mem_last_failed(timeout_status_change)

--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -665,7 +665,13 @@ def test_memory_checker_recover(memory_checker_dut_and_container, test_setup_and
     loganalyzer.expect_regex = container.get_restart_expected_logre()
     marker = loganalyzer.init()
 
-    timeout_status_change = 30  # monit has a 5s cycle interval per test parameters
+    # Bumped from 30s -> 200s to match the same wait helper used by
+    # consumes_memory_and_checks_container_restart() elsewhere in this file.
+    # The 30s budget was too tight on slow ARM/Marvell-Prestera platforms
+    # (Nokia-7215 ~48% pass rate vs 100% elsewhere). 200s gives monit's 5s
+    # cycle plenty of headroom under load while still failing fast on a
+    # real regression.
+    timeout_status_change = 200
 
     container.start_consume_memory()
     container.wait_monit_mem_last_failed(timeout_status_change)


### PR DESCRIPTION
### Description of PR

Summary: Fix flaky `test_memory_checker_recover` on the Nokia-7215 family by raising the local `timeout_status_change` from **30s → 200s for those platforms only**. All other platforms keep the original 30s.

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): **Microsoft ADO 38927874** — `[SONiC_Nightly][Failed_Case][memory_checker.test_memory_checker][test_memory_checker_recover][20260510][M0_MX][marvell-prestera]`. Related sibling item on the same module/platform: Microsoft ADO 38927892.

Failure type: **day-one** (not a regression). The 30s recover budget has always been too tight for this 4GB Marvell-Prestera hardware; no change on 202511 introduced it. It became visible on 202511 because the higher memory/CPU pressure on that branch stops monit holding its 5s cadence during the memory-stress window.

Why 202511 needs the fix: `test_memory_checker_recover` flakes at ~45% on Nokia-7215 / Nokia-M0-7215 nightlies and 0% on all other SKUs, so on those two platforms it blocks validation of unrelated changes. It is already Approved and Included for 202605.

#### Background

`tests/memory_checker/test_memory_checker.py::test_memory_checker_recover` calls `container.wait_monit_mem_last_failed(timeout_status_change)` followed by `container.wait_monit_mem_last_ok(timeout_status_change)` to verify that monit's memory checker can recover after a synthetic memory-pressure event. The wait helpers poll on a 1s interval and **early-exit as soon as monit reports the expected status** — the timeout is just an upper bound (`wait_monit_mem_last_ok` is `wait_until(timeout, 1, 0, predicate)`), not a sleep.

#### Symptom

The test is reliable on every platform except the **4GB Marvell-Prestera Nokia-7215 family** (Nokia-7215 / Nokia-M0-7215). Kusto history (last 365d, branch `internal-202511`) across **45 SKUs** that run this test:

| HwSku | ASIC | RAM | Attempts | Recover-timeout FAIL | Flaky rate |
|---|---|---|---|---|---|
| Nokia-M0-7215 | marvell-prestera | 4 GB | 51 | 23 | **45.1%** |
| Nokia-7215 | marvell-prestera | 4 GB | 47 | 21 | **44.7%** |
| _all other 43 SKUs_ | — | — | — | 0 | **0%** |

Even the **8GB** Nokia-7215-A1 variants (`Nokia-7215-A1-G48S4`, `Nokia-7215-A1-MGX-G48S4`, 168 runs combined) are **0% flaky** — confirming this is a low-memory-pressure characteristic, not a generic timeout issue.

The Nokia-7215 **platform owner confirmed the slow monit recovery is expected**: under the higher memory/CPU pressure on newer branches (notably 202511), monit cannot hold its 5s cadence during the memory-stress window, so a 30s (~6 cycle) budget is too tight and fails deterministically.

#### Fix

Gate the larger recover budget to the two affected exact SKUs; every other platform keeps the original 30s. The 8GB Nokia-7215-A1 variants are deliberately **excluded**, since they are not affected — which is why this is an exact-SKU match rather than a `"7215" in hwsku` substring test:

```python
if duthost.facts["hwsku"] in {"Nokia-7215", "Nokia-M0-7215"}:
    timeout_status_change = 200
else:
    timeout_status_change = 30
```

This mirrors the exact-SKU gating already used for these same platforms in `platform_tests/test_reboot.py` and `test_reload_config.py`, so the file stays consistent with its neighbours.

200s matches the detect-side budget already used in this same file (`wait_monit_mem_last_failed(200)` in `consumes_memory_and_checks_container_restart()`; module default `MONIT_MEMORY_CHECK_TIMEOUT = 700`). Because the wait helpers early-exit on success, a healthy 7215 run still completes in a few seconds — only a genuine recover regression ever approaches 200s.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Tested branch

- [x] master
- [x] 202511

### Test result

Both runs used `repeat_times=10` with `retry_times=0`, so every failure is counted — no retries to mask flakes. The test was run on the worst-affected SKU.

**202511:** 10/10 PASSED.
- Platform / topology: Nokia-M0-7215 (marvell-prestera, 4GB), `m0`, physical testbed `testbed-bjw2-can-7215-7`
- Image: `SONiC.20251110.43`
- Code: the 202511 branch with this patch applied
- Test: `memory_checker/test_memory_checker.py::test_memory_checker_recover`, 10 repeats, retry 0
- Result: 10 tests / 10 passed / 0 failed / 0 errors. Per-repeat durations 457–951s (mean ~724s).
- Against the ~45% historical failure rate on this SKU, ten consecutive passes by chance is about `0.55^10 ≈ 0.25%`.

**master:** 10/10 PASSED (pre-merge validation), Nokia-M0-7215, `m0` topology, same 10-repeat / no-retry configuration.

> _Microsoft devs:_ full testplans (results, logs, configuration) are at
> 202511: https://elastictest.org/scheduler/testplan/6a7bfdd819239aa976852bed
> master: https://elastictest.org/scheduler/testplan/6a0ffc35444a2b83283f27f5

### Approach

#### What is the motivation for this PR?

`test_memory_checker_recover` flakes at ~45% on Nokia-7215 / Nokia-M0-7215 nightly runs (and 0% everywhere else), blocking validation of unrelated changes on those platforms.

#### How did you do it?

Gated the recover-side `timeout_status_change` to 200s for the two affected exact SKUs (`Nokia-7215`, `Nokia-M0-7215`) and kept the original 30s for all other platforms, including the unaffected 8GB Nokia-7215-A1 variants. No behavior change on any other SKU.

#### How did you verify/test it?

Ran the patched test 10x consecutively on Nokia-M0-7215 m0 topology with `retry_times=0` (raw flake measurement), on both master and 202511. Got 10/10 PASSED on each, on the worst-flake SKU. See the **Test result** section above for the per-branch details and testplan links.

#### Any platform specific information?

The change only affects **Nokia-7215 and Nokia-M0-7215**. All other platforms, including the 8GB Nokia-7215-A1 variants, are untouched and keep the original 30s budget.

#### Supported testbed topology if it's a new test case?

N/A — bug fix only.

### Documentation

N/A — no behavior change visible to users.
