### PR TITLE
[conditional_mark]: Enable dns tests on sonic-vpp

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -678,6 +678,8 @@ t1-lag-vpp:
   - bgp/test_traffic_shift_sup.py
   - crm/test_crm.py
   - crm/test_crm_available.py
+  - dns/static_dns/test_static_dns.py
+  - dns/test_dns_resolv_conf.py
   - drop_packets/test_drop_counters.py
   - fib/test_fib.py
   - test_interfaces.py

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -173,25 +173,6 @@ decap/test_subnet_decap.py:
       - "asic_type in ['vpp']"
 
 #######################################
-#####           DNS               #####
-#######################################
-dns/static_dns/test_static_dns.py:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-dns/test_dns_resolv_conf.py::test_dns_resolv_conf:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-#######################################
 #####           Drop              #####
 #######################################
 drop_packets/test_configurable_drop_counters.py:


### PR DESCRIPTION
### Description of PR

Summary:
Enable the `dns` test module on the SONiC-VPP KVM testbed by removing two
stale VPP skip entries from `tests_mark_conditions_sonic_vpp.yaml`. All
`dns/*` tests now pass locally on `vms-kvm-vpp-t1-lag`.

Fixes sonic-net/sonic-buildimage#25806

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Issue sonic-net/sonic-buildimage#25806 asks us to enable the dns control-plane
test module on the SONiC-VPP KVM testbed. Today both dns test files are
unconditionally skipped on `asic_type == 'vpp'` via
`tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml`,
with the placeholder reason `"Failed/Errored: To be included"`.

#### How did you do it?

Removed the two `dns/...` blocks (and the now-empty `DNS` section header)
from `tests_mark_conditions_sonic_vpp.yaml`. No other files changed. The
`check_conditional_mark_sort` pre-commit hook still passes after the
removal.

#### How did you verify/test it?

Ran the full `dns/` suite locally on `vlab-vpp-01` (vms-kvm-vpp-t1-lag,
sonic-vpp `master.0-3f9cbc616`, hwsku `Force10-S6000`, Debian 13.5):

```
$ pytest dns/ \
    --inventory ../ansible/veos_vtb \
    --host-pattern all \
    --testbed_file ../ansible/vtestbed.yaml \
    --testbed vms-kvm-vpp-t1-lag \
    --skip_sanity --disable_loganalyzer \
    --assert plain --show-capture no -rsx -v

dns/static_dns/test_static_dns.py::test_static_dns_basic ............................................ PASSED
dns/static_dns/test_static_dns.py::TestStaticMgmtPortIP::
    test_dynamic_dns_not_working_when_static_ip_configured .......................................... PASSED
dns/static_dns/test_static_dns.py::TestDynamicMgmtPortIP::
    test_static_dns_is_not_changing_when_do_dhcp_renew .............................................. SKIPPED
dns/static_dns/test_static_dns.py::TestDynamicMgmtPortIP::
    test_dynamic_dns_working_when_no_static_ip_and_static_dns ....................................... SKIPPED
dns/static_dns/test_static_dns.py::test_static_dns_negative ......................................... PASSED
dns/test_dns_resolv_conf.py::test_dns_resolv_conf ................................................... PASSED

============ 4 passed, 2 skipped, 0 failed in 905.67s (0:15:05) ============
```

The two `SKIPPED` cases are skipped by the test logic itself
(`"Static ip address is configured, skip the test"`) and are not
specific to sonic-vpp.

#### Any platform specific information?

Targets the `vpp` `asic_type` only; no behavior change for other ASICs.

#### Supported testbed topology if it's a new test case?

N/A — not a new test case. Verified on `vms-kvm-vpp-t1-lag`.

### Documentation

N/A.
