### PR TITLE
Fix wait_until call of check-table

### DIFF
--- a/tests/common/gu_utils.py
+++ b/tests/common/gu_utils.py
@@ -535,18 +535,20 @@ def expect_acl_table_match_multiple_bindings(duthost,
 
             first_line = output[0]
             first_line_diff = set(first_line.values()) ^ set(expected_first_line_content)
-            pytest_assert(set(first_line.values()) == set(expected_first_line_content),
-                          "First line content does not match. Difference: {}".format(first_line_diff))
+            if not set(first_line.values()) == set(expected_first_line_content):
+                logger.warning(f"First line content does not match. Difference: {first_line_diff}")
+                return False
 
             table_bindings = [first_line["binding"]]
             for i in range(len(output)):
                 table_bindings.append(output[i]["binding"])
             table_bindings_diff = set(table_bindings) ^ set(expected_bindings)
-            pytest_assert(set(table_bindings) == set(expected_bindings),
-                          "ACL Table bindings don't fully match. Difference: {}".format(table_bindings_diff))
+            if not set(table_bindings) == set(expected_bindings):
+                logger.warning(f"ACL Table bindings don't fully match. Difference: {table_bindings_diff}")
+                return False
             return True
 
-        wait_until(30, 5, 0, check_table)
+        pytest_assert(wait_until(30, 5, 0, check_table), "ACL table does not contain expected bindings")
 
 
 def expect_acl_rule_match(duthost, rulename, expected_content_list, setup):


### PR DESCRIPTION
Test generic_config/generic_config_updater.test_dynamic_acl calls the helper check_table via wait_until.  The wait_until API expects that verification methods return boolean True/False, but verification in check_table uses pytest_assert. The pytest_assert API, on failure, calls pytest.fail which ruins any potential retries and indeed the usefullness of wait_until.

Return booleans in all cases in check_table so that wait_until actually retries as expected.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Improve overall passrate, test stability.

#### How did you do it?
Converted use of pytest_assert to boolean return values, with logging.

#### How did you verify/test it?
Verified that with the changes in this PR, the use of wait_until does actually result in the desired retry behavior.  Test passes.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
None.
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
