### PR TITLE
Filter for ROUTE_TABLE entries in fib-fetch

### DIFF
--- a/tests/common/fixtures/fib_utils.py
+++ b/tests/common/fixtures/fib_utils.py
@@ -35,7 +35,7 @@ def get_t2_fib_info(duthosts, duts_cfg_facts, duts_mg_facts, testname=None):
 
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
     fib_info = {}
-    route_key = 'ROUTE*'
+    route_key = 'ROUTE_TABLE:*'
     if 'test_ecmp_group_member_flap' in testname:
         route_key = 'ROUTE_TABLE:0\.0\.0\.0*'    # noqa: W605
 
@@ -192,7 +192,7 @@ def get_fib_info(duthost, dut_cfg_facts, duts_mg_facts, testname=None):
     """
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
     fib_info = {}
-    route_key = 'ROUTE*'
+    route_key = 'ROUTE_TABLE:*'
     if 'test_ecmp_group_member_flap' in testname:
         route_key = r'ROUTE_TABLE:0\.0\.0\.0*'
 


### PR DESCRIPTION
When running the get_fib_info fixture, filter for ROUTE_TABLE entries, in order to ignore transient entries for ROUTE_TABLE_DEL_SET, etc.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Improve test passrate, remove flaky failures at scale due to transient states and timing.

#### How did you do it?
I made the filter for ROUTE_TABLE* fib keys more targeted.

#### How did you verify/test it?
Verified that transient states in the fib, starting with ROUTE are ignored and only ROUTE_TABLE entries are returned.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
None
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
