### PR TITLE
Use assertions in arp test to avoid IndexError

### DIFF
--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -157,12 +157,16 @@ def test_kernel_asic_mac_mismatch(
 
     rand_selected_dut.shell(f"ping -c1 -W1 {target_ip}; true")
 
-    wait_until(10, 1, 0, neighbor_learned, rand_selected_dut, target_ip)
+    pt_assert(wait_until(10, 1, 0, neighbor_learned, rand_selected_dut, target_ip),
+              f"Neighbor {target_ip} not learned on {rand_selected_dut}")
 
     neighbor_info = rand_selected_dut.shell(f"ip neigh show {target_ip}")["stdout"].split()
+    target_mac = neighbor_info[4]
+
     pt_assert(neighbor_info[2] == vlan_name)
 
-    wait_until(5, 1, 0, appl_db_neighbor_syncd, rand_selected_dut, vlan_name, target_ip, neighbor_info[4])
+    pt_assert(wait_until(5, 1, 0, appl_db_neighbor_syncd, rand_selected_dut, vlan_name, target_ip, target_mac),
+              f"APPL_DB not synced for vlan {vlan_name}, ip {target_ip} on {rand_selected_dut}")
 
     logger.info(f"Neighbor {target_ip} has been learned, APPL_DB and kernel are in sync")
 
@@ -173,14 +177,17 @@ def test_kernel_asic_mac_mismatch(
     asic_db_mac = rand_selected_dut.shell(
         f"sonic-db-cli APPL_DB hget 'NEIGH_TABLE:{vlan_name}:{target_ip}' 'neigh'"
     )['stdout']
-    pt_assert(neighbor_info[4].lower() != asic_db_mac.lower(),
+    pt_assert(target_mac.lower() != asic_db_mac.lower(),
               f"APPL_DB MAC was not corrupted: expected 00:00:00:00:00:00 but got {asic_db_mac}. "
               "Ensure arp_update is stopped before modifying APPL_DB.")
     logger.info("APPL_DB and kernel are out of sync (expected)")
 
     rand_selected_dut.shell("docker exec swss supervisorctl start arp_update")
 
-    wait_until(10, 1, 0, lambda dut, ip: not neighbor_learned(dut, ip), rand_selected_dut, target_ip)
+    pt_assert(
+        wait_until(30, 2, 0, appl_db_neighbor_syncd, rand_selected_dut, vlan_name, target_ip, target_mac),
+        f"APPL_DB not re-synced to kernel MAC {target_mac} for {target_ip} on {rand_selected_dut}"
+    )
 
 
 def test_ptf_arp_learns_mac(


### PR DESCRIPTION
Currently, wait_until is used to allow arp to learn, sync, and unlearn entries.  These calls are not wrapped in pytest_assert, nor are their return values verified.  This may result in errors due to incomplete neighbor entries, which may mask actual issues.

Use pytest_assert to verify state in arp after wait_until has completed.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Remove IndexError which may mask actual issues in favor of a timeout based on arp state.

#### How did you do it?
Added enclosing wait_until which verifies arp state when removing/adding/syncing entries.

#### How did you verify/test it?
Verified that test passes, verified that IndexError is no longer thrown.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
None
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
