### PR TITLE
Use wait_until for getting cpu queue shapers

### DIFF
--- a/tests/cpu_shaper/test_cpu_shaper.py
+++ b/tests/cpu_shaper/test_cpu_shaper.py
@@ -13,6 +13,7 @@ import re
 from tests.common import config_reload
 from tests.common.reboot import reboot
 from tests.common.platform.processes_utils import wait_critical_processes
+from tests.common.utilities import wait_until
 
 pytestmark = [
     pytest.mark.topology("t0", "t1"),
@@ -60,16 +61,25 @@ def test_cpu_queue_shaper(duthosts, localhost, enum_rand_one_per_hwsku_frontend_
     shaper values before and after reboot.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+
+    def cos_queues_present():
+        before_pps = get_cpu_queue_shaper(duthost)
+        missing = EXPECTED_COS_QUEUES - set(before_pps.keys())
+        return not bool(missing)
+
     try:
         reboot_type = request.config.getoption("--cpu_shaper_reboot_type")
+
+        # Validate all expected queues are present with non-zero shaper values
+        if not wait_until(300, 10, 1, cos_queues_present):
+            before_pps = get_cpu_queue_shaper(duthost)
+            missing = EXPECTED_COS_QUEUES - set(before_pps.keys())
+            assert False, f"CPU queue shaper missing for cos queues {missing} before reboot. Got: {before_pps}"
+
         # Read shaper config before reboot
         before_pps = get_cpu_queue_shaper(duthost)
         logger.info("CPU queue shaper before reboot: {}".format(before_pps))
 
-        # Validate all expected queues are present with non-zero shaper values
-        missing = EXPECTED_COS_QUEUES - set(before_pps.keys())
-        assert not missing, \
-            "CPU queue shaper missing for cos queues {} before reboot. Got: {}".format(missing, before_pps)
         assert all(before_pps[cos] > 0 for cos in EXPECTED_COS_QUEUES), \
             "CPU queue shaper has zero PPS before reboot: {}".format(before_pps)
         # Validate shaper values are close to original 600 PPS (allowing 5% tolerance)
@@ -86,14 +96,13 @@ def test_cpu_queue_shaper(duthosts, localhost, enum_rand_one_per_hwsku_frontend_
         # Wait for critical processes to be up
         wait_critical_processes(duthost)
 
-        # Read shaper config after reboot
-        after_pps = get_cpu_queue_shaper(duthost)
-        logger.info("CPU queue shaper after {} reboot: {}".format(reboot_type, after_pps))
-
         # Verify shaper config survived reboot unchanged
-        assert before_pps == after_pps, \
-            "CPU queue shaper changed after {} reboot: before={}, after={}".format(
-                reboot_type, before_pps, after_pps)
+        assert wait_until(300, 10, 1, lambda: get_cpu_queue_shaper(duthost) == before_pps), (
+                "CPU queue shaper changed after {} reboot: before={}, after={}".format(
+                    reboot_type, before_pps, get_cpu_queue_shaper(duthost)))
+
+        # Read shaper config after reboot
+        logger.info("CPU queue shaper after {} reboot: {}".format(reboot_type, get_cpu_queue_shaper(duthost)))
 
     finally:
         duthost.shell("rm -f {}/{}".format(DEST_DIR, BCM_CINT_FILENAME))


### PR DESCRIPTION
Use wait_until when getting and verifying cpu queue shapers before and after DUT reboot.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Improve passrate on scale testbeds by adding wait_until around cpu queue shaper verification, as state may not be initially consistent.

#### How did you do it?
Wrapped existing verification assertions with wait_until.

#### How did you verify/test it?
Verified that test passes on scale testbed.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
None
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
