### PR TITLE
[telemetry]: port validate_yang_events.py to libyang3 Python bindings

### DIFF
--- a/tests/telemetry/validate_yang_events.py
+++ b/tests/telemetry/validate_yang_events.py
@@ -1,4 +1,4 @@
-import yang as ly
+import libyang as ly
 import sys
 import json
 import argparse
@@ -30,7 +30,7 @@ class YangValidator:
         try:
             yangFiles = glob(YANG_DIR + "/*.yang")
             for file in yangFiles:
-                module = self.ctx.parse_module_path(file, ly.LYS_IN_YANG)
+                module = self.ctx.parse_module(file, ly.IOType.FILEPATH, "yang")
                 if module is None:
                     logging.info("Could not load module from file {}".format(file))
                     raise Exception(INVALID_YANG_ERROR)
@@ -57,8 +57,8 @@ class YangValidator:
             data_json = "{\"" + self.yangModule + ":" + self.yangModule + "\":" + data_json + "}"
 
             try:
-                self.ctx.parse_data_mem(data_json, ly.LYD_JSON,
-                                        ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+                self.ctx.parse_data_mem(data_json, "json",
+                                        no_state=True, strict=True)
             except Exception as e:
                 logging.info("Exception thrown: {}".format(e))
                 raise e

--- a/tests/telemetry/validate_yang_events.py
+++ b/tests/telemetry/validate_yang_events.py
@@ -58,7 +58,8 @@ class YangValidator:
 
             try:
                 self.ctx.parse_data_mem(data_json, "json",
-                                        no_state=True, strict=True)
+                                        no_state=True, strict=True,
+                                        json_string_datatypes=True)
             except Exception as e:
                 logging.info("Exception thrown: {}".format(e))
                 raise e


### PR DESCRIPTION
### Description of PR

Summary:
Port `tests/telemetry/validate_yang_events.py` from the libyang1 Python bindings (`import yang`) to the libyang3 Python bindings (`import libyang`).

The libyang1 Python bindings are being removed from the SONiC base image as part of the SONiC-wide libyang3 upgrade tracked in [sonic-net/sonic-buildimage#22385](https://github.com/sonic-net/sonic-buildimage/issues/22385). [sonic-net/sonic-buildimage#26584](https://github.com/sonic-net/sonic-buildimage/pull/26584) (merged) ports `sonic-yang-mgmt` and replaces `libyang1`/`libyang_cpp`/`libyang-py3` with `libyang3`/`libyang3-py3` in the base image — so any remaining `import yang` user on the DUT will break once those base-image changes propagate.

`validate_yang_events.py` is copied to the DUT by `tests/telemetry/conftest.py` and invoked by `tests/telemetry/test_events.py::validate_yang` via `python ~/validate_yang_events.py -f <op_file> -y <yang_file>` to validate event JSON output against its YANG model. It is the only remaining `import yang` consumer in this repo.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Keep `test_events` working once the base image switches to libyang3. The current script imports the libyang1 SWIG `yang` module and uses constants (`LYS_IN_YANG`, `LYD_JSON`, `LYD_OPT_CONFIG`, `LYD_OPT_STRICT`) that do not exist in the libyang3 Python bindings; without this change, the on-DUT validation step will fail with `ModuleNotFoundError: No module named 'yang'` (or an `AttributeError` on the constants) on any image built after [sonic-net/sonic-buildimage#26584](https://github.com/sonic-net/sonic-buildimage/pull/26584).

#### How did you do it?

Applied the libyang1 → libyang3 API mapping documented in [sonic-net/sonic-buildimage#26584](https://github.com/sonic-net/sonic-buildimage/pull/26584):

| Operation | libyang1 | libyang3 |
|---|---|---|
| Import | `import yang as ly` | `import libyang as ly` |
| Module loading | `ctx.parse_module_path(f, ly.LYS_IN_YANG)` | `ctx.parse_module(f, ly.IOType.FILEPATH, "yang")` |
| Data parsing | `ctx.parse_data_mem(d, ly.LYD_JSON, ly.LYD_OPT_CONFIG \| ly.LYD_OPT_STRICT)` | `ctx.parse_data_mem(d, "json", no_state=True, strict=True)` |

`LYD_OPT_CONFIG` maps to `no_state=True` (config-only — reject any operational/state nodes in the data tree) and `LYD_OPT_STRICT` maps to `strict=True` (fail on unknown or unresolved schema references), preserving the original validation semantics.

`ly.Context(YANG_DIR)` is unchanged — the single-argument form is valid in both libyang1 and libyang3.

#### How did you verify/test it?

See CI/CD results.

#### Any platform specific information?

None. The validator runs on the DUT against `/usr/local/yang-models/*.yang`.

#### Supported testbed topology if it's a new test case?

N/A — this is not a new test case; it is a port of an existing helper script consumed by `tests/telemetry/test_events.py`, which already declares `pytest.mark.topology('any')`.

### Documentation
N/A — no user-facing or testbed-config behavior change.