### PR TITLE
fix test_lag_2 for conv topo

### DIFF
--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -85,6 +85,30 @@ class LagTest:
     def __check_intf_state(self, vm_host, intf, expect):
         return vm_host.check_intf_link_state(vm_host, intf) == expect
 
+    def __resolve_vm_neighbor_intf(self, peer_device, neighbor_intf):
+        """Map minigraph neighbor port to the interface name on converged cEOS."""
+        peer_info = self.nbrhosts.get(peer_device) or {}
+        if peer_info.get('is_multi_vrf_peer') and peer_info.get('multi_vrf_data'):
+            return peer_info['multi_vrf_data']['orig_intf_map'][neighbor_intf]
+
+        props = self.tbinfo.get('topo', {}).get('properties', {})
+        convergence_data = props.get('convergence_data', {})
+        if props.get('topo_is_multi_vrf') and convergence_data.get('convergence_mapping'):
+            for primary, logical_names in convergence_data['convergence_mapping'].items():
+                if peer_device in logical_names:
+                    intf_mapping = convergence_data['converged_peers'][primary]['intf_mapping']
+                    return intf_mapping[peer_device]['orig_intf_map'][neighbor_intf]
+
+        return neighbor_intf
+
+    def __get_vm_peer_for_dut_intf(self, dut_intf):
+        """Return (vm_host, neighbor_intf_on_ceos, logical_peer_name) for a DUT interface."""
+        peer_device = self.vm_neighbors[dut_intf]['name']
+        neighbor_intf = self.vm_neighbors[dut_intf]['port']
+        vm_host = self.nbrhosts[peer_device]['host']
+        neighbor_intf = self.__resolve_vm_neighbor_intf(peer_device, neighbor_intf)
+        return vm_host, neighbor_intf, peer_device
+
     def __verify_lag_lacp_timing(self, lacp_timer, exp_iface):
         if exp_iface is None:
             return
@@ -166,7 +190,8 @@ class LagTest:
 
         neighbor_lag_intfs = []
         for po_intf in po_interfaces:
-            neighbor_lag_intfs.append(self.vm_neighbors[po_intf]['port'])
+            port = self.vm_neighbors[po_intf]['port']
+            neighbor_lag_intfs.append(self.__resolve_vm_neighbor_intf(peer_device, port))
 
         try:
             lag_rate_current_setting = None
@@ -211,10 +236,8 @@ class LagTest:
                                       lag_facts, neighbor_intf, deselect_time=5)
 
         # Figure out remote VM and interface info for the lag member and run minlink test
-        peer_device = self.vm_neighbors[intf]['name']
-        neighbor_intf = self.vm_neighbors[intf]['port']
-        self.__verify_lag_minlink(self.nbrhosts[peer_device]['host'], lag_name,
-                                  lag_facts, neighbor_intf, deselect_time=95)
+        vm_host, neighbor_intf, _ = self.__get_vm_peer_for_dut_intf(intf)
+        self.__verify_lag_minlink(vm_host, lag_name, lag_facts, neighbor_intf, deselect_time=95)
 
     def run_lag_fallback_test(self, lag_name, lag_facts):
         logger.info("Start checking lag fall back for: %s" % lag_name)
@@ -223,9 +246,7 @@ class LagTest:
         po_fallback = lag_facts['lags'][lag_name]['po_config']['runner']['fallback']
 
         # Figure out remote VM and interface info for the lag member and run lag fallback test
-        peer_device = self.vm_neighbors[intf]['name']
-        neighbor_intf = self.vm_neighbors[intf]['port']
-        vm_host = self.nbrhosts[peer_device]['host']
+        vm_host, neighbor_intf, _ = self.__get_vm_peer_for_dut_intf(intf)
 
         wait_timeout = 120
         delay = 5


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
test_lag_2 did not work with converge topo
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
test_lag_2 fails with converged topo as the lookup did not get right neighbor and interface info 
#### How did you do it?
add function to lookup based of converged info if multi vrf topo 
#### How did you verify/test it?
ran it against converge topo and non converged topo 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
