### PR TITLE
[test_service_warm_restart] skip service_warm_restart for cisco asic

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1542,10 +1542,10 @@ platform_tests/test_sequential_restart.py::test_restart_syncd:
 #######################################
 platform_tests/test_service_warm_restart.py:
   skip:
-    reason: "Skipped on mellanox and nvidia asic from 202411 and later / This test is not run on this topology currently"
+    reason: "Skipped on mellanox, nvidia, and cisco-8000 asic from 202411 and later / This test is not run on this topology currently"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox', 'nvidia']"
+      - "asic_type in ['mellanox', 'nvidia', 'cisco-8000']"
       - "topo_type not in ['t0']"
 
 #######################################


### PR DESCRIPTION
**Description of PR**
platform_tests.test_service_warm_restart: "Failed: Advanced-reboot failure"

Summary:
https://github.com/sonic-net/sonic-mgmt/pull/23575/changes

    def runRebootTest(self):
        # Run advanced-reboot.ReloadTest for item in preboot/inboot list
        count = 0

            if 1 < len(self.rebootData['sadList']) != count:
                time.sleep(TIME_BETWEEN_SUCCESSIVE_TEST_OPER)
            failed_list = [(testcase, failures) for testcase, failures in list(test_results.items())
                           if len(failures) != 0]
>       pytest_assert(len(failed_list) == 0, "Advanced-reboot failure. Failed test: {}, "
                                             "failure summary:\n{}".format(self.request.node.name, failed_list))
E       Failed: Advanced-reboot failure. Failed test: test_service_warm_restart[t0-yy38], failure summary:

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [] Test case improvement

### Back port request
- [X] 202411
- [X] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
testcase failing

#### How did you verify/test it?
vxr@vxr-vm:/data/tests$ ./run_tests.sh -n docker-ptf -d xxx-01 -O -u -l debug -e -s -e --disable_loganalyzer -m individual -p /data/tests/logs -c platform_tests/test_service_warm_restart.py

#### Any platform specific information?
cisco-8000

#### Supported testbed topology if it's a new test case?
Generic issue

### Documentation
