### PR TITLE
Fix: add port name for acl interface parsing

### DIFF
--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -478,6 +478,8 @@ def parse_dpg(dpg, hname):
                           " is attached to a Vlan interface, which is currently not supported", file=sys.stderr)
                 elif member in port_alias_to_name_map:
                     acl_intfs.append(port_alias_to_name_map[member])
+                elif member in ports:
+                    acl_intfs.append(member)
             if acl_intfs:
                 acls[aclname] = acl_intfs
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Due to PR #22166 - 
in ansible/templates/minigraph_dpg.j2 template for non-multi asic , _AttachTo_ field under acl interface are filled with port_alias_map[intf_alias] - which are the interfaces names (Ethernet*) not the port names (etp*). Therefore, modification is needed when parsing dpg file. 
I added an additional condition to check if the port name is in the ports dictionary, and if so adding it to acl_intfs.

Before this change, mg_facts["minigraph_acls"] was empty due to no member being added to acl_intfs 
and we get an error when fetching mg_facts["minigraph_acls"]["DataAcl"].



Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
mg_facts["minigraph_acls"] was empty due to no member being added to acl_intfs  - no condition matched,
and we get an error when fetching mg_facts["minigraph_acls"]["DataAcl"]

#### How did you do it?
I added an additional condition to check if the port name is in the ports dictionary, and if so adding it to acl_intfs.

#### How did you verify/test it?
Internal regression

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
