### PR TITLE
[test_acl_outer_vlan]: pick PortChannel members with matching speed

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -10,6 +10,7 @@ import json
 import ptf.testutils as testutils
 from ptf import mask
 from scapy.all import Ether, IP
+from collections import defaultdict
 
 from tests.common.utilities import wait_until
 from tests.common.config_reload import config_reload
@@ -130,7 +131,23 @@ def vlan_setup_info(rand_selected_dut, tbinfo):
     vlan_setup['default_vlan'] = minigraph_vlan['name']
     # 4 interfaces are required to cover all test scenarios
     pytest_require(len(minigraph_vlan['members']) >= 4, "There is no sufficient ports for testing")
-    ports_for_test = minigraph_vlan['members'][:4]
+
+    # Pick a pair of ports with the same speed for the PortChannel (LAG members must match speed),
+    # then pick 2 more ports for untagged Vlan members.
+    port_table = rand_selected_dut.config_facts(
+        host=rand_selected_dut.hostname, source="running")['ansible_facts'].get('PORT', {})
+    speed_groups = defaultdict(list)
+    for port in minigraph_vlan['members']:
+        speed = port_table.get(port, {}).get('speed')
+        if speed is not None:
+            speed_groups[speed].append(port)
+    lag_pair = next((ports[:2] for ports in speed_groups.values() if len(ports) >= 2), None)
+    pytest_require(lag_pair is not None,
+                   "No pair of Vlan members with matching speed found for PortChannel setup")
+    remaining_ports = [p for p in minigraph_vlan['members'] if p not in lag_pair]
+    pytest_require(len(remaining_ports) >= 2,
+                   "Not enough additional Vlan members for untagged ports")
+    ports_for_test = list(lag_pair) + remaining_ports[:2]
 
     portchannel_setup = {
         DUT_LAG_NAME: {

--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -10,6 +10,7 @@ import json
 import ptf.testutils as testutils
 from ptf import mask
 from scapy.all import Ether, IP
+from collections import defaultdict
 
 from tests.common.utilities import wait_until
 from tests.common.config_reload import config_reload
@@ -130,7 +131,21 @@ def vlan_setup_info(rand_selected_dut, tbinfo):
     vlan_setup['default_vlan'] = minigraph_vlan['name']
     # 4 interfaces are required to cover all test scenarios
     pytest_require(len(minigraph_vlan['members']) >= 4, "There is no sufficient ports for testing")
-    ports_for_test = minigraph_vlan['members'][:4]
+
+    # Pick a pair of ports with the same speed for the PortChannel (LAG members must match speed),
+    # then pick 2 more ports for untagged Vlan members.
+    port_table = rand_selected_dut.config_facts(
+        host=rand_selected_dut.hostname, source="running")['ansible_facts'].get('PORT', {})
+    speed_groups = defaultdict(list)
+    for port in minigraph_vlan['members']:
+        speed = port_table.get(port, {}).get('speed')
+        if speed is not None:
+            speed_groups[speed].append(port)
+    lag_pair = next((ports[:2] for ports in speed_groups.values() if len(ports) >= 2), None)
+    pytest_require(lag_pair is not None,
+                   "No pair of Vlan members with matching speed found for PortChannel setup")
+    remaining_ports = [p for p in minigraph_vlan['members'] if p not in lag_pair]
+    ports_for_test = lag_pair + remaining_ports[:2]
 
     portchannel_setup = {
         DUT_LAG_NAME: {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Instead of blindly using the first 2 default Vlan members as LAG members
(which fails when their speeds differ), pick a pair with matching speed
from CONFIG_DB PORT table and use the remaining ports as untagged Vlan members.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Test executed on SKU with a different speed on ports

#### How did you do it?
Added logic to take ports with matching speed 

#### How did you verify/test it?
Test passed on SKU with a different speed on ports

