### PR TITLE
connections: add opt-in legacy KEX override for console SSH sessions

### DIFF
--- a/tests/common/connections/ssh_console_conn.py
+++ b/tests/common/connections/ssh_console_conn.py
@@ -1,11 +1,130 @@
+import logging
 import time
 import re
+import threading
+from contextlib import contextmanager
 from .base_console_conn import CONSOLE_SSH_DIGI_CONFIG, BaseConsoleConn, CONSOLE_SSH
 try:
     from netmiko.ssh_exception import NetMikoAuthenticationException
 except ImportError:
     from netmiko.exceptions import NetMikoAuthenticationException
 from paramiko.ssh_exception import SSHException
+
+
+logger = logging.getLogger(__name__)
+
+# Serialize the temporary global Transport._preferred_kex mutation so concurrent
+# non-console SSH sessions in the same process are not exposed to the legacy
+# preference list while a console connection is being established.
+_CONSOLE_KEX_OVERRIDE_LOCK = threading.Lock()
+
+# Console SSH legacy KEX configuration. Populated by pytest_configure via
+# configure_console_ssh_legacy_kex() based on --use-console-ssh-legacy-kex
+# and --console-ssh-kex-algos. Default state is "disabled".
+_LEGACY_KEX_DEFAULTS = (
+    "diffie-hellman-group14-sha1",
+    "diffie-hellman-group1-sha1",
+)
+_legacy_kex_enabled = False
+_legacy_kex_algos = ()
+
+
+def configure_console_ssh_legacy_kex(enabled, algos=None):
+    """
+    Configure the legacy KEX override applied to console SSH connections.
+
+    Intended to be called once from pytest_configure with values from the
+    --use-console-ssh-legacy-kex and --console-ssh-kex-algos CLI options.
+
+    Args:
+        enabled: Bool. When False (default) no KEX override is applied.
+        algos: Optional iterable or comma-separated string of KEX algorithm
+            names. When None/empty, a built-in legacy default list is used.
+    """
+    global _legacy_kex_enabled, _legacy_kex_algos
+    _legacy_kex_enabled = bool(enabled)
+
+    parsed = ()
+    if algos:
+        if isinstance(algos, str):
+            parsed = tuple(a.strip() for a in algos.split(",") if a.strip())
+        else:
+            parsed = tuple(s for s in (str(a).strip() for a in algos) if s)
+    _legacy_kex_algos = parsed
+
+
+def get_console_ssh_legacy_kex_status():
+    """Return (enabled, effective_algos_tuple) snapshot for diagnostics/logging."""
+    override = _get_console_kex_override()
+    return _legacy_kex_enabled, tuple(override) if override else ()
+
+
+def _get_console_kex_override():
+    """
+    Build an optional KEX preference override for Paramiko console SSH sessions.
+
+    Disabled by default. Enabled via --use-console-ssh-legacy-kex (with
+    optional --console-ssh-kex-algos="algo1,algo2,..."), wired in by
+    pytest_configure -> configure_console_ssh_legacy_kex().
+    """
+    if not _legacy_kex_enabled:
+        return None
+    if _legacy_kex_algos:
+        return _legacy_kex_algos
+    return _LEGACY_KEX_DEFAULTS
+
+
+@contextmanager
+def _console_kex_override():
+    """
+    Temporarily prepend the configured legacy KEX algorithms to
+    paramiko.Transport._preferred_kex for the duration of the with-block,
+    then restore the original value.
+
+    Paramiko does not expose a per-connection KEX preference hook on
+    SSHClient, so we mutate the class attribute. The mutation is scoped to
+    this context manager (covering only the netmiko/paramiko connect call
+    for a single console session) and serialized via a module-level lock to
+    prevent multiple console connection attempts from interleaving overrides.
+    Note: other Paramiko sessions created in other threads during this
+    window may still observe the overridden list.
+    """
+    kex_override = _get_console_kex_override()
+    if not kex_override:
+        yield
+        return
+
+    try:
+        from paramiko.transport import Transport
+    except Exception as e:
+        logger.warning("Failed to import paramiko Transport for KEX override: %s", e)
+        yield
+        return
+
+    _CONSOLE_KEX_OVERRIDE_LOCK.acquire()
+    # Use __dict__ to distinguish a class-level override we previously set
+    # from the default class attribute, so restoration is exact.
+    had_attr = "_preferred_kex" in Transport.__dict__
+    original = Transport.__dict__.get("_preferred_kex")
+    try:
+        current = tuple(getattr(Transport, "_preferred_kex", ()))
+        # Preserve current order but move requested KEX algos to the front.
+        merged = tuple(dict.fromkeys(kex_override + current))
+        Transport._preferred_kex = merged
+        logger.info("Console SSH legacy/custom KEX override enabled (scoped): %s", merged)
+        yield
+    finally:
+        try:
+            if had_attr:
+                Transport._preferred_kex = original
+            else:
+                # Should not normally happen (Transport defines it), but be safe.
+                try:
+                    del Transport._preferred_kex
+                except AttributeError:
+                    pass
+        finally:
+            _CONSOLE_KEX_OVERRIDE_LOCK.release()
 
 
 class SSHConsoleConn(BaseConsoleConn):
@@ -35,7 +154,12 @@ class SSHConsoleConn(BaseConsoleConn):
         kwargs['password'] = kwargs['console_password']
         kwargs['host'] = kwargs['console_host']
         kwargs['device_type'] = "_ssh"
-        super(SSHConsoleConn, self).__init__(**kwargs)
+
+        # Optional, opt-in compatibility path for legacy console servers.
+        # Scope the global Transport._preferred_kex mutation to only the
+        # connection establishment of this console session.
+        with _console_kex_override():
+            super(SSHConsoleConn, self).__init__(**kwargs)
 
     def session_preparation(self):
         session_init_msg = self._test_channel_read()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -422,6 +422,21 @@ def pytest_addoption(parser):
                      help="MUX_CABLE neighbor_mode value (host-route|prefix-route). "
                           "Only applies to dualtor/dualtor_io suites.")
 
+    ##########################################
+    #   Console SSH options                  #
+    ##########################################
+    parser.addoption("--use-console-ssh-legacy-kex", "--use_console_ssh_legacy_kex",
+                     action="store_true", default=False, dest="use_console_ssh_legacy_kex",
+                     help="Opt-in compatibility for legacy console SSH servers that only support "
+                          "older Diffie-Hellman KEX algorithms. When set, the connection's "
+                          "paramiko.Transport._preferred_kex is temporarily prepended with legacy "
+                          "algorithms for the duration of the console connect only.")
+    parser.addoption("--console-ssh-kex-algos", "--console_ssh_kex_algos",
+                     action="store", default="", type=str, dest="console_ssh_kex_algos",
+                     help="Comma-separated list of KEX algorithms to prepend for console SSH. "
+                          "Only applied when --use-console-ssh-legacy-kex is set. "
+                          "Defaults to diffie-hellman-group14-sha1,diffie-hellman-group1-sha1.")
+
 
 def pytest_configure(config):
     if config.getoption("enable_macsec"):
@@ -431,6 +446,14 @@ def pytest_configure(config):
         else:
             config.pluginmanager.register(MacsecPluginT0())
     converge_topo_if_needed(config)
+
+    # Propagate console SSH KEX override choice into the connections module so
+    # SSHConsoleConn can apply it without reading environment variables.
+    from tests.common.connections import ssh_console_conn
+    ssh_console_conn.configure_console_ssh_legacy_kex(
+        enabled=config.getoption("use_console_ssh_legacy_kex"),
+        algos=config.getoption("console_ssh_kex_algos"),
+    )
 
 
 def _load_testbed_config(tbfile, tbname):


### PR DESCRIPTION
### Description of PR

Summary:
Console servers with older firmware only offer legacy KEX algorithms (e.g. `diffie-hellman-group14-sha1`) that newer Paramiko versions no longer include by default. This causes `Incompatible ssh peer (no acceptable kex algorithm)` failures during reboot tests when attempting to collect console logs.

Add an opt-in mechanism controlled by two pytest CLI options that prepend legacy KEX algorithms to Paramiko's preferred list when establishing the console connection:

- `--use-console-ssh-legacy-kex` — enable the override (uses safe defaults: `diffie-hellman-group14-sha1,diffie-hellman-group1-sha1`)
- `--console-ssh-kex-algos=<csv>` — optional, override the default list with a custom comma-separated set

The KEX mutation is scoped to the single `connect()` call via a context manager + module lock, so Paramiko's global `Transport._preferred_kex` is restored immediately after each console session.

Fixes https://github.com/sonic-net/sonic-mgmt/issues/24833

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Reboot tests (warm, cold, fast) call `create_duthost_console` to establish an SSH session to the console server for log collection during the reboot window. With newer Paramiko versions shipped in the Python 3.12 test container, the default KEX algorithm list no longer includes legacy algorithms like `diffie-hellman-group14-sha1`. Console servers running older firmware only offer these legacy algorithms, causing connection failure after 3 retries with:

```
paramiko.ssh_exception.IncompatiblePeer: Incompatible ssh peer (no acceptable kex algorithm)
```

This prevents console log capture during reboots, reducing diagnostic visibility when failures occur.

#### How did you do it?

- `tests/common/connections/ssh_console_conn.py`
  - Added `configure_console_ssh_legacy_kex(enabled, algos=None)` setter and `get_console_ssh_legacy_kex_status()` reader exposing module-level opt-in state. `algos` accepts either a comma-separated string or an iterable.
  - Added `_console_kex_override()` context manager protected by a module-level `threading.Lock`. It saves and restores `paramiko.transport.Transport.__dict__["_preferred_kex"]` (distinguishing a previously-set instance attribute from the class default) and prepends the override algorithms only for the wrapped call.
  - `SSHConsoleConn.__init__` wraps `super().__init__(**kwargs)` (which performs the SSH connect) in `with _console_kex_override():` — the global mutation window is bounded by the connect call.
  

- `tests/conftest.py`
  - Registered two pytest CLI options (with `--use_..._...` aliases for consistency with other options):
    - `--use-console-ssh-legacy-kex` (store_true)
    - `--console-ssh-kex-algos=<csv>` (string)
  - In `pytest_configure`, the option values are propagated to the connections module via `ssh_console_conn.configure_console_ssh_legacy_kex(...)`. The import is local to keep the connections module decoupled from pytest.

The override is disabled by default; existing testbeds are unaffected unless `--use-console-ssh-legacy-kex` is passed on the pytest command line.

#### How did you verify/test it?

- Verified that without the flag, `Transport._preferred_kex` is untouched (no override applied; default Paramiko behavior).
- Verified that with `--use-console-ssh-legacy-kex`, the legacy algorithms are prepended for the duration of the SSH connect and restored afterwards (Transport class default unchanged after the connect returns).

```
DEBUG:netmiko:Clear buffer detects data in the channel
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:[find_prompt()]:
DEBUG:netmiko:read_channel: 
INFO:tests.common.reboot:creating dut console succeeds
INFO:tests.common.reboot:Console connection established successfully
````

#### Any platform specific information?

No — this is generic to any testbed using console servers with legacy SSH firmware.

#### Supported testbed topology if it's a new test case?

N/A — this is a framework fix, not a new test case.

### Documentation
Usage example: 
```
cd tests

# with default diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1)
./run_tests.sh -n <testbed> -t <topo> -c platform_tests/test_reboot.py \
    -e "--use-console-ssh-legacy-kex"

# or with a custom KEX list
./run_tests.sh -n <testbed> -t <topo> -c platform_tests/test_reboot.py \
    -e "--use-console-ssh-legacy-kex --console-ssh-kex-algos=diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1"
````

Or
```
# with default diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1
pytest ... --use-console-ssh-legacy-kex 

# or with a custom KEX list
pytest ... --use-console-ssh-legacy-kex --console-ssh-kex-algos="other-kex-algo1,other-kex-algo2".
```