### PR TITLE
[202511] consolidated docker-sonic-mgmt fixes for ansible upgrade

### DIFF
--- a/ansible/plugins/callback/yaml.py
+++ b/ansible/plugins/callback/yaml.py
@@ -16,10 +16,14 @@ if sys.version_info.major > 2:
 else:
     represent_unicode = yaml.representer.SafeRepresenter.represent_unicode
 from ansible.parsing.yaml.dumper import AnsibleDumper
-AnsibleDumper.add_representer(
-    AnsibleUnsafeText,
-    represent_unicode,
-)
+
+# In ansible-core >= 2.20, AnsibleDumper is a factory function, not a class.
+# Only call add_representer if it's actually a class with that method.
+if isinstance(AnsibleDumper, type) and hasattr(AnsibleDumper, 'add_representer'):
+    AnsibleDumper.add_representer(
+        AnsibleUnsafeText,
+        represent_unicode,
+    )
 
 DOCUMENTATION = '''
     callback: yaml

--- a/ansible/plugins/filter/filters.py
+++ b/ansible/plugins/filter/filters.py
@@ -26,7 +26,8 @@ class FilterModule(object):
             'first_n_elements': first_n_elements,
             'expand_properties': expand_properties,
             'first_ip_of_subnet': first_ip_of_subnet,
-            'path_join': path_join
+            'path_join': path_join,
+            'network_in_usable': network_in_usable
         }
 
 
@@ -222,6 +223,26 @@ def first_ip_of_subnet(value):
 def path_join(paths):
     """Join path strings."""
     return os.path.join(*paths)
+
+
+def network_in_usable(value, test):
+    """Check if an IP address (value) is in the same network as test address.
+
+    Both value and test can be in CIDR notation (e.g., '10.0.0.1/24').
+    Returns True if both addresses are in the same subnet (based on value's prefix).
+    This is a replacement for the ansible.utils ipaddr filter 'network_in_usable'.
+    """
+    try:
+        # Parse value as an interface address (with prefix)
+        val_iface = ipaddress.ip_interface(str(value).strip())
+        val_network = val_iface.network
+
+        # Parse test as an IP address (strip prefix if present)
+        test_addr = ipaddress.ip_address(str(test).strip().split('/')[0])
+
+        return test_addr in val_network
+    except (ValueError, TypeError):
+        return False
 
 
 class MultiServersUtils:

--- a/ansible/roles/eos/tasks/ceos.yml
+++ b/ansible/roles/eos/tasks/ceos.yml
@@ -6,7 +6,8 @@
   become: yes
 
 - name: set force_restart=yes for ceos container
-  set_fact: force_restart=yes
+  set_fact:
+    force_restart: yes
 
 - name: Check if ceos container responses to snmp
   when: ctninfo.exists
@@ -17,7 +18,8 @@
     ignore_errors: true
 
   - name: set force_restart=no for ceos container
-    set_fact: force_restart=no
+    set_fact:
+      force_restart: no
     when: snmp_data.ansible_facts.ansible_sysname is defined
 
 - include_vars: group_vars/vm_host/ceos.yml
@@ -98,7 +100,8 @@
   delegate_to: "{{ VM_host[0] }}"
 
 - name: set container_reachable=False for ceos container
-  set_fact: container_reachable=False
+  set_fact:
+    container_reachable: false
 
 # loop four times, if all containers are reachable in any iteration, the rest loop will be skipped
 - name: make sure container's mgmt-ip is reachable

--- a/ansible/roles/eos/templates/m0-mx.j2
+++ b/ansible/roles/eos/templates/m0-mx.j2
@@ -1,4 +1,4 @@
-{% set converged = topo_is_multi_vrf|default(false) %}
+{% set converged = topo_is_multi_vrf|default(false)|bool %}
 {% set host = configuration[hostname] %}
 {% if converged %}
     {% set conv_config = convergence_data["converged_peers"][hostname] %}

--- a/ansible/roles/eos/templates/t0-v6-leaf.j2
+++ b/ansible/roles/eos/templates/t0-v6-leaf.j2
@@ -1,4 +1,4 @@
-{% set converged = topo_is_multi_vrf|default(false) %}
+{% set converged = topo_is_multi_vrf|default(false)|bool %}
 {% set host = configuration[hostname] %}
 {% if converged %}
     {% set conv_config = convergence_data["converged_peers"][hostname] %}

--- a/ansible/roles/eos/templates/t1-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-lag-tor.j2
@@ -1,5 +1,5 @@
 {% set host = configuration[hostname] %}
-{% set converged = topo_is_multi_vrf|default(false) %}
+{% set converged = topo_is_multi_vrf|default(false)|bool %}
 {% if converged %}
     {% set conv_config = convergence_data["converged_peers"][hostname] %}
     {% set conv_mapping = convergence_data["convergence_mapping"][hostname] %}

--- a/ansible/roles/vm_set/tasks/kickstart_vm.yml
+++ b/ansible/roles/vm_set/tasks/kickstart_vm.yml
@@ -111,6 +111,12 @@
 
   when: not skip_this_vm and (vm_type | lower) == "vsonic"
 
+# Initialize cisco_vmhost before the block so that ansible-core >= 2.20 does not
+# fail when eagerly templating delegate_to on skipped tasks.
+- set_fact:
+    cisco_vmhost: ""
+  when: cisco_vmhost is not defined
+
 - block:
   - name: Wait until vm {{ vm_name }} is loaded
     cisco_kickstart: telnet_port={{ serial_port }}

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -1,12 +1,19 @@
 # This role creates a set of VM with veos or SONiC or cisco or Ubuntu for Kubernetes master
 # Input parameters for the role:
-# - action: 'start', 'stop' or 'renumber' for creating, removing, or renumbering vm set respectively
+# - vm_set_action: 'start', 'stop' or 'renumber' for creating, removing, or renumbering vm set respectively
 # - id: sequence number for vm set on the host.
 # - external_port: interface which will be used as parent for vlan interface creation
 # - vlan_base: first vlan id for the VMs
 # - VMs: a dictionary which contains hostnames of VMs as a key and a dictionary with parameters (num, memory, mgmt_ip) for every VM.
 # - topology: a dictionary which contains hostnames of VMs as a key and vlans value which define a topology (numbers of connected ports for every VM)
 # - mgmt_bridge: linux bridge which is used for management interface connections
+
+# Backward compatibility: 'action' was renamed to 'vm_set_action' because 'action' is
+# a reserved variable name in ansible-core >= 2.20. Accept both old and new names.
+- name: Map legacy 'action' variable to 'vm_set_action'
+  set_fact:
+    vm_set_action: "{{ action }}"
+  when: vm_set_action is not defined and action is defined
 
 # Variables used by the role are mostly defined in files under ansible/group_vars/vm_host directory.
 # Supported neighbor types are: veos, sonic, cisco, ubuntu, k8s
@@ -414,23 +421,23 @@
 
     - name: Stop VMs
       include_tasks: stop.yml
-      when: action == 'stop'
+      when: vm_set_action == 'stop'
 
     - name: Start VMs
       include_tasks: start.yml
-      when: action == 'start'
+      when: vm_set_action == 'start'
 
     - name: Connect VMs
       include_tasks: connect_vms.yml
-      when: action == 'connect_vms'
+      when: vm_set_action == 'connect_vms'
 
     - name: Disconnect VMs
       include_tasks: disconnect_vms.yml
-      when: action == 'disconnect_vms'
+      when: vm_set_action == 'disconnect_vms'
 
     - name: Renumber topology
       include_tasks: renumber_topo.yml
-      when: action == 'renumber_topo'
+      when: vm_set_action == 'renumber_topo'
 
   when: vm_required is defined and vm_required == True
 
@@ -449,19 +456,19 @@
 
 - name: Add topology
   include_tasks: add_topo.yml
-  when: action == 'add_topo'
+  when: vm_set_action == 'add_topo'
 
 - name: Remove topology
   include_tasks: remove_topo.yml
-  when: action == 'remove_topo'
+  when: vm_set_action == 'remove_topo'
 
 - name: Stop Kubernetes VMs
   include_tasks: stop_k8s.yml
-  when: action == 'stop_k8s'
+  when: vm_set_action == 'stop_k8s'
 
 - name: Start Kubernetes VMs
   include_tasks: start_k8s.yml
-  when: action == 'start_k8s'
+  when: vm_set_action == 'start_k8s'
 
 - name: Manage the dut state
   include_tasks: manage_duts.yml

--- a/ansible/roles/vm_set/tasks/manage_duts.yml
+++ b/ansible/roles/vm_set/tasks/manage_duts.yml
@@ -1,27 +1,27 @@
 - block:
     - name: Start SONiC VM
       include_tasks: start_sonic_vm.yml
-      when: action == 'start_sonic_vm' and hostvars[dut_name]['type'] == 'kvm'
+      when: vm_set_action == 'start_sonic_vm' and hostvars[dut_name]['type'] == 'kvm'
 
     - name: Stop SONiC VM
       include_tasks: stop_sonic_vm.yml
-      when: action == 'stop_sonic_vm' and hostvars[dut_name]['type'] == 'kvm'
+      when: vm_set_action == 'stop_sonic_vm' and hostvars[dut_name]['type'] == 'kvm'
 
     - name: Start SID
       include_tasks: start_sid.yml
-      when: action == 'start_sid' and hostvars[dut_name]['type'] == 'simx'
+      when: vm_set_action == 'start_sid' and hostvars[dut_name]['type'] == 'simx'
 
     - name: Stop SID
       include_tasks: stop_sid.yml
-      when: action == 'stop_sid' and hostvars[dut_name]['type'] == 'simx'
+      when: vm_set_action == 'stop_sid' and hostvars[dut_name]['type'] == 'simx'
 
     - name: Start 8000e-sonic sim
       include_tasks: start_8000e_sonic.yml
-      when: action == 'start_8000e_sonic' and hostvars[dut_name]['type'] == '8000e'
+      when: vm_set_action == 'start_8000e_sonic' and hostvars[dut_name]['type'] == '8000e'
 
     - name: Stop 8000e-sonic sim
       include_tasks: stop_8000e_sonic.yml
-      when: action == 'stop_8000e_sonic' and hostvars[dut_name]['type'] == '8000e'
+      when: vm_set_action == 'stop_8000e_sonic' and hostvars[dut_name]['type'] == '8000e'
 
   when:
     - hostvars[dut_name] is defined
@@ -30,13 +30,13 @@
 - block:
     - name: Start SONiC DPU VM
       include_tasks: start_dpu_vm.yml
-      when: action == 'start_sonic_vm'
+      when: vm_set_action == 'start_sonic_vm'
 
     - name: Stop SONiC VM
       include_tasks: stop_vsonic_dpu_vm.yml
       vars:
         dpu_name: "{{ item }}"
       with_items: "{{ dpu_targets }}"
-      when: action == 'stop_sonic_vm'
+      when: vm_set_action == 'stop_sonic_vm'
 
   when: dpu_targets is defined and dpu_targets | length > 0

--- a/ansible/roles/vm_set/tasks/start_sonic_vm.yml
+++ b/ansible/roles/vm_set/tasks/start_sonic_vm.yml
@@ -1,6 +1,6 @@
 - set_fact:
     sonic_vm_storage_location: "{{ home_path }}/sonic-vm"
-    when: sonic_vm_storage_location is not defined
+  when: sonic_vm_storage_location is not defined
 
 - set_fact:
     disable_updategraph: False

--- a/ansible/roles/vm_set/tasks/start_vm.yml
+++ b/ansible/roles/vm_set/tasks/start_vm.yml
@@ -65,7 +65,7 @@
 - name: Define vm {{ vm_name }}, hwsku {{ hwsku }}
   virt: name={{ vm_name }}
         command=define
-        xml="{{ lookup('template', 'templates/{{ vm_xml_template }}') }}"
+        xml="{{ lookup('template', 'templates/' ~ vm_xml_template) }}"
         uri=qemu:///system
   when: vm_name not in vm_list_defined.list_vms
   become: yes

--- a/ansible/roles/vm_set/tasks/start_vsonic_dpu_vm.yml
+++ b/ansible/roles/vm_set/tasks/start_vsonic_dpu_vm.yml
@@ -23,7 +23,7 @@
 - name: Define vm {{ vm_name }}
   virt: name={{ vm_name }}
         command=define
-        xml="{{ lookup('template', 'templates/{{ vm_xml_template }}') }}"
+        xml="{{ lookup('template', 'templates/' ~ vm_xml_template) }}"
         uri=qemu:///system
   when: vm_name not in vm_list_defined.list_vms
   become: yes

--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -134,11 +134,11 @@
     when: base_topo == "t2" and (is_vs_testbed | default(false))
 
   roles:
-    - { role: vm_set, action: 'stop_sonic_vm', when force_stop_sonic_vm is defined }
-    - { role: vm_set, action: 'start_sonic_vm' }
-    - { role: vm_set, action: 'start_sid' }
-    - { role: vm_set, action: 'start_8000e_sonic' }
-    - { role: vm_set, action: 'add_topo' }
+    - { role: vm_set, vm_set_action: 'stop_sonic_vm', when force_stop_sonic_vm is defined }
+    - { role: vm_set, vm_set_action: 'start_sonic_vm' }
+    - { role: vm_set, vm_set_action: 'start_sid' }
+    - { role: vm_set, vm_set_action: 'start_8000e_sonic' }
+    - { role: vm_set, vm_set_action: 'add_topo' }
 
 - hosts: servers:&eos
   gather_facts: no
@@ -169,7 +169,8 @@
           include_vars: "vars/topo_{{ topo }}.yml"
 
         - name: Set default value for topo_is_multi_vrf
-          set_fact: topo_is_multi_vrf=False
+          set_fact:
+            topo_is_multi_vrf: false
           when: topo_is_multi_vrf is not defined
 
         - name: Find current server group

--- a/ansible/testbed_announce_routes.yml
+++ b/ansible/testbed_announce_routes.yml
@@ -40,7 +40,8 @@
     include_vars: "vars/topo_{{ topo }}.yml"
 
   - name: Set default value for topo_is_multi_vrf
-    set_fact: topo_is_multi_vrf=False
+    set_fact:
+      topo_is_multi_vrf: false
     when: topo_is_multi_vrf is not defined
 
   tasks:

--- a/ansible/testbed_connect_topo.yml
+++ b/ansible/testbed_connect_topo.yml
@@ -58,4 +58,4 @@
     when: duts_name.split(',')|length > 1
 
   roles:
-    - { role: vm_set, action: 'add_topo', when external_port is not defined }
+    - { role: vm_set, vm_set_action: 'add_topo', when external_port is not defined }

--- a/ansible/testbed_connect_vms.yml
+++ b/ansible/testbed_connect_vms.yml
@@ -61,4 +61,4 @@
     when: duts_name.split(',')|length > 1
 
   roles:
-    - { role: vm_set, action: 'connect_vms' }
+    - { role: vm_set, vm_set_action: 'connect_vms' }

--- a/ansible/testbed_disconnect_vms.yml
+++ b/ansible/testbed_disconnect_vms.yml
@@ -61,4 +61,4 @@
     when: duts_name.split(',')|length > 1
 
   roles:
-    - { role: vm_set, action: 'disconnect_vms' }
+    - { role: vm_set, vm_set_action: 'disconnect_vms' }

--- a/ansible/testbed_remove_vm_topology.yml
+++ b/ansible/testbed_remove_vm_topology.yml
@@ -100,7 +100,7 @@
     when: base_topo == "t2" and (is_vs_testbed | default(false))
 
   roles:
-    - { role: vm_set, action: 'remove_topo' }
-    - { role: vm_set, action: 'stop_sid' }
-    - { role: vm_set, action: 'stop_sonic_vm' }
-    - { role: vm_set, action: 'stop_8000e_sonic' }
+    - { role: vm_set, vm_set_action: 'remove_topo' }
+    - { role: vm_set, vm_set_action: 'stop_sid' }
+    - { role: vm_set, vm_set_action: 'stop_sonic_vm' }
+    - { role: vm_set, vm_set_action: 'stop_8000e_sonic' }

--- a/ansible/testbed_renumber_vm_topology.yml
+++ b/ansible/testbed_renumber_vm_topology.yml
@@ -107,4 +107,4 @@
     when: base_topo == "t2" and (is_vs_testbed | default(false))
 
   roles:
-    - { role: vm_set, action: 'renumber_topo' }
+    - { role: vm_set, vm_set_action: 'renumber_topo' }

--- a/ansible/testbed_start_VMs.yml
+++ b/ansible/testbed_start_VMs.yml
@@ -19,4 +19,4 @@
   gather_facts: no
   tasks:
   roles:
-    - { role: vm_set, action: 'start' }
+    - { role: vm_set, vm_set_action: 'start' }

--- a/ansible/testbed_start_k8s_VMs.yml
+++ b/ansible/testbed_start_k8s_VMs.yml
@@ -7,4 +7,4 @@
   vars_files:
     - group_vars/all/creds.yml
   roles:
-    - { role: vm_set, action: 'start_k8s' }
+    - { role: vm_set, vm_set_action: 'start_k8s' }

--- a/ansible/testbed_stop_VMs.yml
+++ b/ansible/testbed_stop_VMs.yml
@@ -13,4 +13,4 @@
 - hosts: servers:&vm_host
   gather_facts: no
   roles:
-  - { role: vm_set, action: 'stop' }
+  - { role: vm_set, vm_set_action: 'stop' }

--- a/ansible/testbed_stop_k8s_VMs.yml
+++ b/ansible/testbed_stop_k8s_VMs.yml
@@ -5,4 +5,4 @@
 - hosts: k8s_servers:&k8s_vm_host
   gather_facts: no
   roles:
-  - { role: vm_set, action: 'stop_k8s' }
+  - { role: vm_set, vm_set_action: 'stop_k8s' }

--- a/tests/common/devices/base.py
+++ b/tests/common/devices/base.py
@@ -2,7 +2,11 @@ import inspect
 import json
 import logging
 import collections
+import signal
+import threading
+from contextlib import contextmanager
 from multiprocessing.pool import ThreadPool
+import ansible
 from pytest_ansible.results import AdHocResult, ModuleResult
 
 from tests.common.errors import RunAnsibleModuleFail
@@ -24,6 +28,51 @@ _avm.load_extra_vars = _safe_load_extra_vars
 
 
 logger = logging.getLogger(__name__)
+
+
+def ansible_tqm_has_signal_registration():
+    version = getattr(ansible, "__version__", "0.0.0")
+    try:
+        major, minor = version.split(".")[:2]
+        return (int(major), int(minor)) >= (2, 19)
+    except (TypeError, ValueError):
+        return False
+
+
+_signal_patch_lock = threading.RLock()
+_signal_patch_ref_count = 0
+_original_signal = None
+
+
+@contextmanager
+def suppress_signal_registration_for_non_main_thread():
+    """Temporarily bypass signal registration from worker threads for ansible-core 2.19+."""
+    if not ansible_tqm_has_signal_registration() or threading.current_thread() is threading.main_thread():
+        yield
+        return
+
+    global _signal_patch_ref_count, _original_signal
+    with _signal_patch_lock:
+        if _signal_patch_ref_count == 0:
+            _original_signal = signal.signal
+
+            def _thread_safe_signal(signum, handler):
+                if threading.current_thread() is threading.main_thread():
+                    return _original_signal(signum, handler)
+                return signal.getsignal(signum)
+
+            signal.signal = _thread_safe_signal
+        _signal_patch_ref_count += 1
+
+    try:
+        yield
+    finally:
+        with _signal_patch_lock:
+            _signal_patch_ref_count -= 1
+            if _signal_patch_ref_count == 0 and _original_signal is not None:
+                signal.signal = _original_signal
+                _original_signal = None
+
 
 # HACK: This is a hack for issue https://github.com/sonic-net/sonic-mgmt/issues/1941 and issue
 # https://github.com/ansible/pytest-ansible/issues/47
@@ -114,7 +163,8 @@ class AnsibleHostBase(object):
 
         if module_async:
             def run_module(module_args, complex_args):
-                return self.module(*module_args, **complex_args)[self.hostname]
+                with suppress_signal_registration_for_non_main_thread():
+                    return self.module(*module_args, **complex_args)[self.hostname]
             pool = ThreadPool()
             result = pool.apply_async(run_module, (module_args, complex_args))
             return pool, result
@@ -122,7 +172,8 @@ class AnsibleHostBase(object):
         module_args = json.loads(json.dumps(module_args, cls=AnsibleHostBase.CustomEncoder))
         complex_args = json.loads(json.dumps(complex_args, cls=AnsibleHostBase.CustomEncoder))
 
-        adhoc_res: AdHocResult = self.module(*module_args, **complex_args)
+        with suppress_signal_registration_for_non_main_thread():
+            adhoc_res: AdHocResult = self.module(*module_args, **complex_args)
 
         if self.module_name == "meta":
             # The meta module is special in Ansible - it doesn't execute on remote hosts, it controls Ansible's behavior

--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -21,14 +21,25 @@ logger = logging.getLogger(__name__)
 
 
 def patch_ansible_worker_process():
-    """Patch AnsibleWorkerProcess to avoid logging deadlock after fork."""
+    """
+    Patch AnsibleWorkerProcess to avoid logging deadlock after fork.
+
+    ansible-core <= 2.18 also called self._save_stdin() to dup stdin
+    across the fork; that helper (and self._new_stdin) was removed in
+    ansible-core 2.19, so we only invoke it when present.
+    """
+
+    has_save_stdin = hasattr(WorkerProcess, "_save_stdin")
 
     def start(self):
-        self._save_stdin()
-        try:
+        if has_save_stdin:
+            self._save_stdin()
+            try:
+                return super(WorkerProcess, self).start()
+            finally:
+                self._new_stdin.close()
+        else:
             return super(WorkerProcess, self).start()
-        finally:
-            self._new_stdin.close()
 
     WorkerProcess.start = start
 


### PR DESCRIPTION
### Description of PR

The PR contains consolidated backport fixes from 3 PRs -

- https://github.com/sonic-net/sonic-mgmt/pull/24477
- https://github.com/sonic-net/sonic-mgmt/pull/24679
- https://github.com/sonic-net/sonic-mgmt/pull/24748

---

(1) From #24477 

Upgrading ansible from 11.10.0 to latest. This introduces two compatibility issues:

**1. WorkerProcess._save_stdin removed**

ansible-core 2.18 invokes the WorkerProcess `_save_stdin()` method to duplicate stdin across fork:
https://github.com/ansible/ansible/blob/stable-2.18/lib/ansible/executor/process/worker.py#L102

ansible-core 2.19 removed this method and no longer dups stdin. The patch in parallel.py maintains backward compatibility by checking for the method's existence before invoking it. This can be reverted after ansible-core 2.19+ is confirmed stable across all CI and container environments.

**2. Signal registration restricted to main thread in ansible-core 2.19+**

ansible-core 2.19 introduced a fix for signal propagation:
https://github.com/ansible/ansible/pull/85907

This fix registers signal handlers in `TaskQueueManager.__init__`. Since sonic-mgmt invokes DutHosts fixtures from within thread pools, tests crash with:
```
ValueError: signal only works in main thread of the main interpreter
```

The patch in base.py adds `_suppress_signal_registration_for_non_main_thread()` context manager that:
- Detects ansible-core 2.19+
- Temporarily patches `signal.signal()` to bypass registration from worker threads
- Returns the default handler instead to avoid the ValueError
- Includes warning logs when signal registration is bypassed, for visibility into edge cases

All threadpools remain active (not globally serialized), preserving performance.

(2) From #24679 

Fix Ansible playbook and Jinja2 template compatibility for ansible-core 2.20 (Ansible 13.6) while maintaining backward compatibility with ansible-core 2.18 (Ansible 11.10).

In ansible-core 2.20, the inline set_fact: key=value syntax treats False/True/yes/no as strings instead of booleans. The string "False" is truthy in Jinja2, which caused the add-topo flow to fail: the topo_is_multi_vrf variable evaluated as truthy and errored on all cEOS VM creation/startup. Also, container_reachable=False (string "False", truthy) caused the when: not container_reachable reachability check loop to be skipped.

(3) From #24748 

Fix ansible testbed playbooks for compatibility with ansible-core 2.20 (ansible 13.6) while maintaining backward compatibility with ansible-core 2.18 (ansible 11.10).

ansible-core 2.20 introduced several breaking changes that cause testbed-cli.sh commands (start-topo-vms, stop-topo-vms.) to fail. This PR addresses all of them.

---

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Upgrading from ansible 11.10.0 to latest requires these changes.

#### How did you do it?

See description above

#### How did you verify/test it?

Local vs tests

#### Any platform specific information?

NA

#### Supported testbed topology if it's a new test case?

NA


### Documentation

NA