### PR TITLE
vlan/test_vlan_ping: use 'ip -6 neigh replace' to make static_neighbo…

### DIFF
--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -35,8 +35,8 @@ def static_neighbor_entry(duthost, dic, oper, ip_version="both"):
             if oper == "add":
                 logger.debug("adding ipv6 static arp entry for ip %s on DUT" % (member['ipv6']))
                 duthost.shell(
-                    "sudo ip -6 neigh add {0} lladdr {1} dev Vlan{2}".format(member['ipv6'], member['mac'],
-                                                                             member['Vlanid']))
+                    "sudo ip -6 neigh replace {0} lladdr {1} dev Vlan{2}".format(member['ipv6'], member['mac'],
+                                                                                 member['Vlanid']))
             elif oper == "del":
                 logger.debug("deleting ipv6 static arp entry for ip %s on DUT" % (member['ipv6']))
                 duthost.shell("sudo ip -6 neigh del {0} lladdr {1} dev Vlan{2}".format(member['ipv6'], member['mac'],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Failures with the test_vlan_ping show the test setup aborting with RTNETLINK answers: File exists when calling sudo ip -6 neigh add for the static neighbor entry, a stale permanent neighbor entry was left in the kernel by a prior run that didn't reach teardown (e.g. SIGABRT in the sanity-check fixture, pytest hard-killed). This PR makes the idempotent by switching ip -6 neigh add to ip -6 neigh replace.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

vlan.test_vlan_ping::test_vlan_ping is one of the highest-hit P0 flakes in the dashboard. Investigation in Kusto shows the dominant signature (≈90 PR-KVM failures + ≈20 failures in the last 30 days) is:

 cmd  = sudo ip -6 neigh add fc02:1000::2 lladdr <mac> dev Vlan1000
 rc   = 2
 stderr = RTNETLINK answers: File exists

The failure is in the test's own setup step static_neighbor_entry(..., "add"). If any prior run on the same DUT left a permanent neighbor entry behind (SIGABRT in a sanity-check fixture, pytest hard-killed, container/Ansible timeout mid-teardown), the next run's ip -6 neigh add is rejected by the kernel with -EEXIST and the test before doing anything useful.

#### How did you do it?

Swap ip -6 neigh add for ip -6 neigh replace in static_neighbor_entry(). The change will atomically create-or-overwrite the entry.

#### How did you verify/test it?

- Kusto query against V2TestCases for the last 30 days confirms the File exists signature is the dominant failure cluster. 
 - The ip neigh replace command is well-established in iproute2 and is already used in setup_static_neighbor_entry() for the same reason
 - Patch is a strict superset of add semantics on a clean DUT, so this is non-regressive: any testbed where add would have succeeded, replace also succeeds with identical kernel stateafterwards.

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A
