### PR TITLE
Skip unsupported platform_tests cases on BMC platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5417,6 +5417,18 @@ telemetry/test_events.py:
       - "asic_type in ['vs']"
       - https://github.com/sonic-net/sonic-buildimage/issues/19943
 
+telemetry/test_events.py::test_events:
+  skip:
+    reason: "Sub-event bgp_events requires BGP neighbors, not applicable on BMC."
+    conditions:
+      - "'bmc' in topo_type"
+
+telemetry/test_events.py::test_events_cache_overflow:
+  skip:
+    reason: "Requires eventd systemd unit which is not loaded on BMC."
+    conditions:
+      - "'bmc' in topo_type"
+
 telemetry/test_telemetry.py:
   skip:
     reason: "Skip telemetry test for 201911 and older branches"
@@ -5491,10 +5503,11 @@ telemetry/test_telemetry_cert_rotation.py::test_telemetry_post_cert_del:
 
 telemetry/test_telemetry_poll.py::test_poll_mode_default_route:
   skip:
-    reason: "dut ipv6 mgmt ip not supported"
+    conditions_logical_operator: or
+    reason: "dut ipv6 mgmt ip not supported or not applicable on BMC because requires upstream BGP neighbor and default route"
     conditions:
-      - "is_mgmt_ipv6_only==True"
-      - "https://github.com/sonic-net/sonic-mgmt/issues/20395"
+      - "is_mgmt_ipv6_only==True and https://github.com/sonic-net/sonic-mgmt/issues/20395"
+      - "'bmc' in topo_type"
 
 telemetry/test_telemetry_poll.py::test_poll_mode_delete:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1146,6 +1146,18 @@ platform_tests/mellanox/test_check_sfp_using_ethtool.py:
       - "asic_type not in ['mellanox', 'nvidia-bluefield']"
       - "'bmc' in topo_type"
 
+platform_tests/mellanox/test_hw_management_service.py:
+  skip:
+    reason: "Not available on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
+platform_tests/mellanox/test_psu_power_threshold.py:
+  skip:
+    reason: "Not available on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
 platform_tests/mellanox/test_reboot_cause.py:
   skip:
     reason: "Platform does not support platform_tests/mellanox/test_reboot_cause.py. sn4280 driver doesn't support reset_from_asic and reset_reload_bios
@@ -1345,14 +1357,18 @@ platform_tests/test_memory_exhaustion.py:
 platform_tests/test_platform_info.py::test_show_platform_fanstatus_mocked:
   skip:
     reason: "Test disabled on Mellanox platforms as it could be un-stable and interfered by the thermal algorithm."
+    conditions_logical_operator: or
     conditions:
       - "asic_type in ['mellanox']"
+      - "'bmc' in topo_type"
 
 platform_tests/test_platform_info.py::test_show_platform_temperature_mocked:
   skip:
     reason: "Test not supported on Mellanox Platforms."
+    conditions_logical_operator: or
     conditions:
       - "asic_type in ['mellanox']"
+      - "'bmc' in topo_type"
 
 platform_tests/test_platform_info.py::test_thermal_control_fan_status:
   skip:
@@ -1361,6 +1377,7 @@ platform_tests/test_platform_info.py::test_thermal_control_fan_status:
     conditions:
       - "is_multi_asic==True and release in ['201911']"
       - "asic_type in ['mellanox']"
+      - "'bmc' in topo_type"
 
 platform_tests/test_platform_info.py::test_thermal_control_load_invalid_format_json:
   #Thermal policies are implemented as part of BSP layer in Cisco 8000 platform, so there is no need for loading JSON file,


### PR DESCRIPTION
Summary: Skip unsupported platform_tests cases on BMC platform
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Skip unsupported platform_tests cases on BMC platform

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
