### PR TITLE
Fix test_static_route_ecmp flaky failure due to async hardware forwarding after config reload

### DIFF
--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -321,6 +321,20 @@ def static_route_context(duthost, unselected_duthost, ptfadapter, ptfhost, tbinf
         for nexthop_addr in nexthop_addrs:
             duthost.shell(ping_cmd.format(nexthop_addr), module_ignore_errors=True)
 
+        # On some platforms hardware forwarding table commit after config reload
+        # can lag behind. Poll until traffic is actually forwarded on the correct
+        # nexthop ports, then run the definitive flow-counter test.
+        def _hw_forwarding_ready_ctx():
+            try:
+                generate_and_verify_traffic(
+                    duthost, ptfadapter, tbinfo, ip_dst, nexthop_devs, ipv6=ipv6)
+                return True
+            except Exception:
+                return False
+        pytest_assert(
+            wait_until(300, 5, 5, _hw_forwarding_ready_ctx),
+            "Traffic not forwarded on expected nexthop ports within 300s after operation"
+        )
         # Verify traffic forwarding after operation
         with RouteFlowCounterTestContext(
             is_route_flow_counter_supported_flag,
@@ -419,6 +433,21 @@ def run_static_route_test(duthost, unselected_duthost, ptfadapter, ptfhost, tbin
             wait_all_bgp_up(duthost)
             for nexthop_addr in nexthop_addrs:
                 duthost.shell("timeout 1 ping -c 1 -w 1 {}".format(nexthop_addr), module_ignore_errors=True)
+
+            # On some platforms hardware forwarding table commit after config reload
+            # can lag behind. Poll until traffic is actually forwarded on the correct
+            # nexthop ports, then run the definitive flow-counter test.
+            def _hw_forwarding_ready():
+                try:
+                    generate_and_verify_traffic(
+                        duthost, ptfadapter, tbinfo, ip_dst, nexthop_devs, ipv6=ipv6)
+                    return True
+                except Exception:
+                    return False
+            pytest_assert(
+                wait_until(300, 5, 5, _hw_forwarding_ready),
+                "Traffic not forwarded on expected nexthop ports within 300s after config reload"
+            )
             with RouteFlowCounterTestContext(is_route_flow_counter_supported, duthost,
                                              [prefix], {prefix: {'packets': COUNT}}):
                 generate_and_verify_traffic(duthost, ptfadapter, tbinfo, ip_dst, nexthop_devs, ipv6=ipv6)


### PR DESCRIPTION

Problem:
`test_static_route_ecmp` and `test_static_route_ecmp_ipv6` fail intermittently after config reload. After `wait_all_bgp_up` completes, the test calls `generate_and_verify_traffic` immediately, but on some platforms the hardware forwarding table has not yet committed the static route, causing a false failure.

Root Cause:
After config reload, BGP reconvergence floods the hardware forwarding pipeline with a large number of routes. On some platforms the hardware pipeline is saturated by this BGP route flood and can take considerable time to commit the static route to the forwarding table. The existing code proceeded to the traffic test immediately after BGP session establishment with no tolerance for this hardware programming lag.

Fix:
Add a polling loop that probes actual traffic forwarding every 5 seconds (with a 5-second initial delay) for up to 300 seconds. The poller catches all exceptions to tolerate transient dataplane errors during the unstable post-reload window. The definitive flow-counter test runs only after hardware forwarding is confirmed.

Tests run:
01:41:53.550  - test_static_route_ecmp[mathilda-01]                        /  / Passed
01:41:53.550  - test_static_route_ecmp_ipv6[mathilda-01]                   /  / Passed

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
