### PR TITLE
tests/bgp: route c0 topology to t1/t2 setup in setup_interfaces

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -622,7 +622,7 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
         setup_func = _setup_interfaces_dualtor
     elif tbinfo["topo"]["type"] in ["t0", "mx"]:
         setup_func = _setup_interfaces_t0_or_mx
-    elif tbinfo["topo"]["type"] in set(["t1", "t2", "m1", "lt2", "ft2"]):
+    elif tbinfo["topo"]["type"] in set(["t1", "t2", "m1", "lt2", "ft2", "c0"]):
         setup_func = _setup_interfaces_t1_or_t2
     elif tbinfo["topo"]["type"] == "m0":
         if topo_scenario == "m0_l3_scenario":


### PR DESCRIPTION
The c0 topology connects the DUT to its VM neighbors via routed L3 interfaces (no VLAN, no host_interfaces), structurally identical to t1/m1. Without this entry, the setup_interfaces fixture in tests/bgp/conftest.py falls through to: raise TypeError("Unsupported topology: c0") causing every BGP test that uses the fixture (e.g. test_bgp_update_timer, test_bgp_peer_shutdown) to fail at setup on c0 / c0-lo testbeds.

Add c0 to the t1/t2 dispatch set so it uses _setup_interfaces_t1_or_t2.

Verified on physical testbed testbed-bjw3-can-8220-3 (topo: c0-lo, hwsku: Cisco-C8220TG-G1S2):

  - bgp/test_bgp_update_timer.py: 2 passed

  - bgp/test_bgp_peer_shutdown.py: 1 passed

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
