### PR TITLE
[202511] Mark VNET decap test as T1 only

### DIFF
--- a/tests/vxlan/test_vnet_decap.py
+++ b/tests/vxlan/test_vnet_decap.py
@@ -10,7 +10,9 @@ from ptf.mask import Mask
 
 
 pytestmark = [
-    pytest.mark.topology("t0", "t1", "t1-64-lag", "t1-56-lag", "t1-lag"),
+    # The setup selects T0-facing BGP interfaces for VNET attachment. T0 DUTs
+    # do not have T0 neighbors, so this test only applies to T1 topologies.
+    pytest.mark.topology("t1", "t1-64-lag", "t1-56-lag", "t1-lag"),
     pytest.mark.disable_loganalyzer
 ]
 


### PR DESCRIPTION
### Description of PR

Summary:
Remove `t0` from `test_vnet_decap.py` topology mark and document why this test only applies to T1 topologies.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

`test_vnet_decap.py` setup calls `select_required_interfaces(..., "T0")`, which selects T0-facing established BGP interfaces for VNET attachment. T0 DUTs do not have T0 neighbors, so `t0`/`t0-64` runs fail during setup with:

```text
RuntimeError: There are not enough interfaces needed to perform the test. We need atleast 2 interfaces, but only 0 are available.
```

This test has been passing on T1 topologies and consistently failing on T0 topologies because the test requirements do not match T0 topology.

#### How did you do it?

Removed `t0` from the topology mark and added a short comment explaining that the test requires T0-facing BGP interfaces and therefore only applies to T1 topologies.

#### How did you verify/test it?

```text
python -m py_compile tests/vxlan/test_vnet_decap.py
```

#### Any platform specific information?

Observed on Mellanox SN4600C `t0-64` testbeds. The issue is topology-specific rather than platform-specific.

#### Supported testbed topology if it's a new test case?

Not a new test case. Supported topologies after this change: `t1`, `t1-64-lag`, `t1-56-lag`, `t1-lag`.

### Documentation

N/A