### PR TITLE
[conditional_mark]: Enable log_fidelity tests on sonic-vpp

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -689,6 +689,7 @@ t1-lag-vpp:
   - ipfwd/test_mtu.py
   - ipfwd/test_dip_sip.py
   - lldp/test_lldp.py
+  - log_fidelity/test_bgp_shutdown.py
   - pc/test_po_voq.py
   - pc/test_lag_member.py
   - pc/test_po_update.py

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -448,17 +448,6 @@ ip/test_mgmt_ipv6_only.py::test_ntp_ipv6_only:
       - "asic_type in ['vpp']"
 
 #######################################
-#####         Log Fidelity        #####
-#######################################
-log_fidelity/test_bgp_shutdown.py::test_bgp_shutdown:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-#######################################
 #####         Memory Checker      #####
 #######################################
 memory_checker/test_memory_checker.py::test_memory_checker:


### PR DESCRIPTION
### Description of PR

Summary:
Enable the `log_fidelity` control plane test module on the SONiC-VPP KVM testbed (`t1-lag-vpp`).

The only test in this module — `log_fidelity/test_bgp_shutdown.py::test_bgp_shutdown` — was previously skipped on `asic_type == 'vpp'` with a stale reason `"Failed/Errored: To be included"`. Local verification on the SONiC-VPP KVM testbed shows the test now passes cleanly, so the skip is removed and the test is added to the `t1-lag-vpp` PR checker allowlist.

Fixes sonic-net/sonic-buildimage#25815

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
`log_fidelity/test_bgp_shutdown.py::test_bgp_shutdown` is currently skipped on sonic-vpp with a placeholder `Failed/Errored: To be included` reason. The test simply runs `config bgp shutdown all` and verifies that the expected `admin state is set to 'down'` message appears in syslog (then restores BGP). Both BGP control plane and syslog work on sonic-vpp today, so the test passes — the skip is no longer warranted, and the test should be running in the t1-lag-vpp PR checker.

#### How did you do it?
- Removed the `log_fidelity/test_bgp_shutdown.py::test_bgp_shutdown` skip block (and its section header) from `tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml`.
- Added `log_fidelity/test_bgp_shutdown.py` to the `t1-lag-vpp` allowlist in `.azure-pipelines/pr_test_scripts.yaml`.

#### How did you verify/test it?
Ran the test locally on the SONiC-VPP KVM testbed (`vms-kvm-vpp-t1-lag` / `vlab-vpp-01`) with `--ignore-conditional-mark`:

```
================== 1 passed, 52 warnings in 157.82s (0:02:37) ==================
```

The test executed `config bgp shutdown all`, found the expected log line `admin state is set to 'down'` in syslog, restored BGP via `config bgp startup all`, and post-test core dump / config / YANG validation all passed.

#### Any platform specific information?
sonic-vpp only — control plane test, no data plane changes.

#### Supported testbed topology if it's a new test case?
N/A — existing test, `topology('any')`. This PR enables it on `t1-lag-vpp`; it already runs on `t0`, `t1-lag`, and `onboarding_t1_multi_asic`.

### Documentation
N/A
