### PR TITLE
[test_power_off_reboot]: Surface unreachable PDU as failure reason

### DIFF
--- a/tests/common/plugins/pdu_controller/pdu_manager.py
+++ b/tests/common/plugins/pdu_controller/pdu_manager.py
@@ -116,6 +116,15 @@ class PduManager():
         where all of them contributes to the status of one PSU.
         """
         self.PSUs = {}
+        """
+        Track every PSU that was requested via add_controller, regardless of
+        whether the PSU was successfully built. This lets callers distinguish
+        between "PSU not configured in inventory" and "PSU configured but its
+        PDU controller could not be built (e.g. SNMP timeout)".
+
+        Mapping: psu_name -> {feed_name: {"peerdevice": <pdu>, "peerport": <port>}}
+        """
+        self.configured_psu_peers = {}
 
     def add_controller(self, psu_name, psu_peer, pdu_info, pdu_vars):
         """
@@ -128,10 +137,35 @@ class PduManager():
                 }
             }
         """
+        self.configured_psu_peers[psu_name] = psu_peer
         psu = PSU(psu_name, self.dut_hostname)
         if not psu.build_psu(psu_peer, pdu_info, pdu_vars):
             return
         self.PSUs[psu_name] = psu
+
+    def get_unreachable_psus(self):
+        """
+            @summary: Return PSUs that were configured (in inventory or
+                      connection graph) but whose PDU controller could not be
+                      built. The most common cause is the peer PDU being
+                      unreachable over SNMP, but it can also be missing
+                      pdu_info / pdu_vars or unsupported protocol.
+
+            @return: dict mapping unreachable psu_name -> list of unique peer
+                     PDU device names configured for that PSU. Returns an
+                     empty dict when every configured PSU is reachable.
+        """
+        unreachable = {}
+        for psu_name, psu_peer in self.configured_psu_peers.items():
+            if psu_name in self.PSUs:
+                continue
+            pdu_devices = []
+            for feed_info in psu_peer.values():
+                peerdevice = feed_info.get("peerdevice")
+                if peerdevice and peerdevice not in pdu_devices:
+                    pdu_devices.append(peerdevice)
+            unreachable[psu_name] = pdu_devices
+        return unreachable
 
     def _get_controller(self, outlet):
         return self.PSUs[outlet['psu_name']].feeds[outlet['feed_name']].controller

--- a/tests/platform_tests/test_power_off_reboot.py
+++ b/tests/platform_tests/test_power_off_reboot.py
@@ -108,6 +108,26 @@ def test_power_off_reboot(duthosts, localhost, enum_supervisor_dut_hostname, con
     if pdu_ctrl is None:
         pytest.skip(
             "No PSU controller for %s, skip rest of the testing in this case" % duthost.hostname)
+    # Fail fast with a clear reason when a PDU is configured for one of the DUT's
+    # PSUs but the PDU could not be reached (typically an SNMP timeout). Without
+    # this check, the test would silently power-cycle only the reachable PSU and
+    # later fail with the misleading "DUT did not shutdown" message.
+    if hasattr(pdu_ctrl, "get_unreachable_psus"):
+        unreachable_psus = pdu_ctrl.get_unreachable_psus()
+        if unreachable_psus:
+            pytest.fail(
+                "PDU is not accessible for DUT {} PSU(s) {}. The configured peer "
+                "PDU(s) {} could not be initialized (most likely SNMP is not "
+                "reachable or the credentials are wrong). Power-off reboot cannot "
+                "guarantee a full power loss while any PSU remains powered, so "
+                "the test is failing early instead of reporting the misleading "
+                "'DUT did not shutdown' error. Please verify the PDU "
+                "reachability and re-run.".format(
+                    duthost.hostname,
+                    list(unreachable_psus.keys()),
+                    unreachable_psus,
+                )
+            )
     is_chassis = duthost.get_facts().get("modular_chassis")
     if is_chassis and duthost.is_supervisor_node():
         # Following is to accomodate for chassis, when no '--power_off_delay' option is given on pipeline run


### PR DESCRIPTION
### Description of PR

Summary:
Fixes the misleading failure message produced by `test_power_off_reboot` when one of the DUT's PDUs is unreachable.

The test currently fails with
`Exception: DUT <hostname> did not shutdown` whenever one of the configured PDUs cannot be reached over SNMP. The `PduManager` silently drops the PSU whose PDU controller fails to initialize, so the test only powers off the reachable PSU and then waits in vain for the DUT to shut down. Operators triaging the failure see "did not shutdown" and waste time investigating the DUT, when the real cause is a PDU connectivity / credentials problem.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Make `test_power_off_reboot` report the actual root cause when a PDU is unreachable, so triagers immediately see `PDU is not accessible` instead of the misleading `DUT did not shutdown`.

#### How did you do it?

1. `tests/common/plugins/pdu_controller/pdu_manager.py`
   - Track every PSU passed to `add_controller` in a new `configured_psu_peers` dict on `PduManager`, regardless of whether the PSU's PDU controller was successfully built.
   - Add `PduManager.get_unreachable_psus()` which returns `{psu_name: [pdu_device, ...]}` for PSUs that were configured but whose controller could not be built (typically SNMP timeout; also missing `pdu_info` / `pdu_vars` or unsupported protocol).
2. `tests/platform_tests/test_power_off_reboot.py`
   - After obtaining `pdu_ctrl`, call `get_unreachable_psus()` (guarded by `hasattr` for defensive compatibility with alternate controller implementations) and `pytest.fail` with a message naming the unreachable PDU(s) before attempting the power cycle.

#### How did you verify/test it?

- Standalone validation of `PduManager.get_unreachable_psus()` covering: one PDU unreachable, all PDUs reachable, and a multi-feed PSU pointing at the same PDU twice (verified the peer list is de-duplicated).
- `flake8 --max-line-length=120` clean on both modified files.
- `python -m py_compile` clean.
- The original failing scenario this addresses came from an internal nightly run where pdu-116 (10.3.154.117) failed SNMP probe with `No SNMP response received before timeout`; only PSU2 was powered off and the run failed 240s later with `DUT did not shutdown`. With this change the operator would instead immediately see `PDU is not accessible for DUT <hostname> PSU(s) ['PSU1']. The configured peer PDU(s) {'PSU1': ['pdu-116']} could not be initialized ...`.

#### Any platform specific information?

None — the change touches only the generic PDU manager and `test_power_off_reboot`.

#### Supported testbed topology if it's a new test case?

N/A (existing test, `topology('any')`).

### Documentation

N/A
