### PR TITLE
[crm] Add 1-count margin to CRM threshold tests to fix race-induced flakiness

### DIFF
--- a/tests/common/helpers/crm.py
+++ b/tests/common/helpers/crm.py
@@ -6,19 +6,30 @@ CRM_POLLING_INTERVAL = 1
 EXPECT_EXCEEDED = ".* THRESHOLD_EXCEEDED .*"
 EXPECT_CLEAR = ".* THRESHOLD_CLEAR .*"
 
+# Margin (in absolute counts or percentage points) between the observed CRM
+# counter value and the configured threshold. The margin absorbs small
+# fluctuations between the moment the test reads the counter and the moment
+# crmd polls the counter and compares it to the threshold, preventing
+# spurious "THRESHOLD_EXCEEDED message missing" failures caused by a transient
+# counter drift of one unit. Without the margin, configuring `high = used`
+# means a single-count decrease between read and crmd poll silently skips the
+# transition log and fails the test (frequently observed on cisco-8000 for
+# nexthop_group object, ipv6 neighbor and ipv6 nexthop resources).
+CRM_THRESHOLD_MARGIN = 1
+
 THR_VERIFY_CMDS = OrderedDict([
     ("exceeded_used", "bash -c \"crm config thresholds {{crm_cli_res}}  type used; \
-         crm config thresholds {{crm_cli_res}} low {{crm_used|int - 1}}; \
-         crm config thresholds {{crm_cli_res}} high {{crm_used|int}}\""),
+         crm config thresholds {{crm_cli_res}} low {{crm_used|int - 2}}; \
+         crm config thresholds {{crm_cli_res}} high {{crm_used|int - 1}}\""),
     ("clear_used", "bash -c \"crm config thresholds {{crm_cli_res}} type used && \
-         crm config thresholds {{crm_cli_res}} low {{crm_used|int}} && \
-         crm config thresholds {{crm_cli_res}} high {{crm_used|int + 1}}\""),
+         crm config thresholds {{crm_cli_res}} low {{crm_used|int + 1}} && \
+         crm config thresholds {{crm_cli_res}} high {{crm_used|int + 2}}\""),
     ("exceeded_free", "bash -c \"crm config thresholds {{crm_cli_res}} type free && \
-         crm config thresholds {{crm_cli_res}} low {{crm_avail|int - 1}} && \
-         crm config thresholds {{crm_cli_res}} high {{crm_avail|int}}\""),
+         crm config thresholds {{crm_cli_res}} low {{crm_avail|int - 2}} && \
+         crm config thresholds {{crm_cli_res}} high {{crm_avail|int - 1}}\""),
     ("clear_free", "bash -c \"crm config thresholds {{crm_cli_res}} type free && \
-         crm config thresholds {{crm_cli_res}} low {{crm_avail|int}} && \
-         crm config thresholds {{crm_cli_res}} high {{crm_avail|int + 1}}\""),
+         crm config thresholds {{crm_cli_res}} low {{crm_avail|int + 1}} && \
+         crm config thresholds {{crm_cli_res}} high {{crm_avail|int + 2}}\""),
     ("exceeded_percentage", "bash -c \"crm config thresholds {{crm_cli_res}} type percentage && \
          crm config thresholds {{crm_cli_res}} low {{th_lo|int}} && \
          crm config thresholds {{crm_cli_res}} high {{th_hi|int}}\""),

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -284,21 +284,29 @@ def verify_thresholds(duthost, asichost, **kwargs):
                 continue
             used_percent = get_used_percent(kwargs["crm_used"], kwargs["crm_avail"])
             if key == "exceeded_percentage":
-                if used_percent < 1:
+                # Need at least 2% used so we can leave a 1-point margin below
+                # the observed value (high = used_percent - 1). Without the
+                # margin a single-count counter drift between read and crmd
+                # poll causes the THRESHOLD_EXCEEDED log to be skipped.
+                if used_percent < 2:
                     logger.warning("The used percentage for {} is {} and \
                                    verification for exceeded_percentage is skipped"
                                    .format(kwargs["crm_cli_res"], used_percent))
                     continue
-                kwargs["th_lo"] = used_percent - 1
-                kwargs["th_hi"] = used_percent
+                kwargs["th_lo"] = used_percent - 2
+                kwargs["th_hi"] = used_percent - 1
                 loganalyzer.expect_regex = [EXPECT_EXCEEDED]
             elif key == "clear_percentage":
-                if used_percent >= 100 or used_percent < 1:
+                # Symmetric to exceeded_percentage: leave a 1-point margin
+                # above the observed value (low = used_percent + 1) so a
+                # transient upward drift does not skip THRESHOLD_CLEAR. This
+                # requires used_percent <= 98 to keep low/high <= 100.
+                if used_percent >= 99 or used_percent < 1:
                     logger.warning("The used percentage for {} is {} and verification for clear_percentage is skipped"
                                    .format(kwargs["crm_cli_res"], used_percent))
                     continue
-                kwargs["th_lo"] = used_percent
-                kwargs["th_hi"] = used_percent + 1
+                kwargs["th_lo"] = used_percent + 1
+                kwargs["th_hi"] = used_percent + 2
                 loganalyzer.expect_regex = [EXPECT_CLEAR]
 
         kwargs['crm_used'], kwargs['crm_avail'] = get_crm_stats(kwargs['crm_cmd'], duthost)


### PR DESCRIPTION
### Description of PR

Summary:
Fix a long-standing race condition in `tests/crm/test_crm.py` that causes intermittent `THRESHOLD_EXCEEDED` / `THRESHOLD_CLEAR` log-missing failures (`test_crm_nexthop_group`, `test_crm_neighbor`, `test_crm_nexthop` — especially on cisco-8000 platforms).

`verify_thresholds()` reads the current CRM counter and then configures the threshold high/low **equal** to that value. crmd polls the live SAI counter on its own cadence, so any single-count drift between the test read and the next crmd poll (neighbor reaper, route churn, ASIC reconciliation) leaves the counter on the wrong side of the boundary, the state transition is silently skipped, and after the 10 s `CRM_UPDATE_TIME` wait LogAnalyzer fails with:

```
LogAnalyzerError: Expected Messages that are missing:
.* THRESHOLD_EXCEEDED .*
```

Internal triage shows this signature firing **17–86 times per week for the last 4+ months**, concentrated on cisco-8000 and on resources whose counter values are smallest or most volatile (`test_crm_nexthop_group` False/object variant, `test_crm_neighbor` ipv6, `test_crm_nexthop` ipv6). The `True`/member variant of the same test, which uses a much larger pool of counters, is not affected. This pattern (chronic flake, no regression boundary) matches a race rather than a real defect.

Sample failing case from the triaged run:

```
test_crm_nexthop_group[str2-8101-06-None-False-2.2.2.0/24]
crm config thresholds nexthop group object type used
crm config thresholds nexthop group object low 166
crm config thresholds nexthop group object high 167          # crm_used was read as 167
... 10 s pass, no THRESHOLD_EXCEEDED in syslog ...
LogAnalyzerError: match: 0, expected_missing_match: 1
```

Fixes # (issue): no GitHub issue; reproduced via internal Kusto + elastictest testplan `6a13af2981bb3768ca7f394a`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

`tests/crm/test_crm.py::verify_thresholds()` configures `high = used` / `low = avail` exactly, so it is racing crmd's own counter poll. A 1-count drift in the unfavourable direction silently skips the EXCEEDED/CLEAR state transition and the test fails. The flake has been chronic on cisco-8000 for >4 months without any product regression — it is purely a test-side timing issue.

#### How did you do it?

Shift the configured high/low thresholds by **one count** so the boundary crmd is asked to cross is one unit below (for `exceeded_*`) or above (for `clear_*`) the value the test observed.

`tests/common/helpers/crm.py` — `THR_VERIFY_CMDS`:

```python
("exceeded_used", "... low {{crm_used|int - 2}};  high {{crm_used|int - 1}}"),
("clear_used",    "... low {{crm_used|int + 1}};  high {{crm_used|int + 2}}"),
("exceeded_free", "... low {{crm_avail|int - 2}}; high {{crm_avail|int - 1}}"),
("clear_free",    "... low {{crm_avail|int + 1}}; high {{crm_avail|int + 2}}"),
```

`tests/crm/test_crm.py` — `verify_thresholds()` percentage path: applied the same 1-point margin (`th_lo = used_percent - 2 / + 1`, `th_hi = used_percent - 1 / + 2`) and tightened the skip conditions from `< 1` → `< 2` (exceeded) and `>= 100` → `>= 99` (clear) so we don't generate an invalid threshold pair near the 0% / 100% edges.

A single-count counter drift in the unfavourable direction is now absorbed by the margin and crmd still crosses the configured threshold, emitting the expected log. The test semantics are preserved: it still verifies crmd correctly emits `THRESHOLD_EXCEEDED` / `THRESHOLD_CLEAR` when the configured threshold is crossed; it just stops asking crmd to react to a boundary the SAI counter is sitting exactly on.

#### How did you verify/test it?

- Reasoned-through coverage: every case that previously produced an EXCEEDED/CLEAR log under a stable counter still produces one with the new thresholds; cases that previously failed because the counter drifted by 1 in the unfavourable direction now still produce the log.
- `python -c "import ast; ast.parse(...)"` clean on both files.
- `flake8 --max-line-length=120 tests/common/helpers/crm.py tests/crm/test_crm.py` clean.
- Reviewed against crmd state-machine behaviour (`counter` crossing `highThreshold` / `lowThreshold`) and confirmed margin = 1 works regardless of strict vs non-strict comparison.

#### Any platform specific information?

The race is observable on every platform but only flakes in practice on cisco-8000 (and occasionally vlab), because their `nexthop_group` object pool and ipv6 neighbor/nexthop counts are small enough that a 1-count drift is not absorbed by noise. The fix is platform-agnostic.

#### Supported testbed topology if it's a new test case?

N/A — bug fix to an existing test.

### Documentation

N/A — no user-facing or doc-affecting change; only test-helper margin adjustments.
