### PR TITLE
[202511][generic_config_updater] Disable loganalyzer for test_mgmt_interface to avoid TACACS+ teardown noise

### DIFF
--- a/tests/generic_config_updater/test_mgmt_interface.py
+++ b/tests/generic_config_updater/test_mgmt_interface.py
@@ -10,6 +10,7 @@ from tests.common.gu_utils import create_checkpoint, delete_checkpoint, rollback
 from tests.common.utilities import wait_for_file_changed, FORCED_MGMT_ROUTE_PRIORITY
 
 pytestmark = [
+    pytest.mark.disable_loganalyzer,
     pytest.mark.topology('any'),
 ]
 


### PR DESCRIPTION
### Description of PR

Summary:
Backport of #24854 (master) to 202511.

`generic_config_updater/test_mgmt_interface.py::test_forced_mgmt_routes_update` applies a JSON patch to `MGMT_INTERFACE|eth0|<addr>.forced_mgmt_routes`, which causes `hostcfgd` to re-render `/etc/network/interfaces` and briefly bounce `eth0`. During that short window the TACACS+ subsystem cannot reach the configured TACACS server and emits ERR-level messages such as:

```
ERR journalctl: tac_connect_single: connection failed with <ip>:49: Transport endpoint is not connected
ERR journalctl: nss_tacplus: failed to connect TACACS+ server <ip>:49, ret=-9: Transport endpoint is not connected
```

The test logic itself passes — only the autouse `loganalyzer` fixture errors out at teardown because those lines aren't covered by the existing `journalctl`-prefixed entries in `loganalyzer_common_ignore.txt`. This results in a false-positive failure in nightly runs (observed on `t1.8101.202605.O8C48` / `str2-8101-05`, elastictest plan `6a13af2981bb3768ca7f394a`).

The sibling test `tests/route/test_forced_mgmt_route.py` already handles the identical operation by marking itself with `pytest.mark.disable_loganalyzer`. Mirror that here.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Eliminate a recurring false-positive teardown failure in `test_forced_mgmt_routes_update` caused by expected, transient TACACS+ connection errors that occur whenever `eth0` is re-rendered. Backport to the 202511 release branch to fix nightly runs on that train.

#### How did you do it?
Added `pytest.mark.disable_loganalyzer` to the module-level `pytestmark` in `tests/generic_config_updater/test_mgmt_interface.py`, matching the approach already used by `tests/route/test_forced_mgmt_route.py` for the same scenario.

#### How did you verify/test it?
- Confirmed via the failing run (`elastictest.org/scheduler/testplan/6a13af2981bb3768ca7f394a`) that the test body passes (`1 passed`) and only the loganalyzer teardown raises (`1 error`) with the TACACS+ messages above.
- Confirmed post-test DUT sanity check passes, i.e. the underlying functionality is healthy.
- The change is a single-line pytest marker; no functional behavior of the test is altered.

#### Any platform specific information?
None. The TACACS+ noise occurs on any DUT that has TACACS+ configured and runs this mgmt-interface test.

#### Supported testbed topology if it's a new test case?
N/A — not a new test case. The existing `topology('any')` marker is unchanged.

### Documentation
N/A
