### PR TITLE
Revert omrelp "could not connect to remote server" lognalayzer ignore

### DIFF
--- a/tests/generic_config_updater/test_syslog.py
+++ b/tests/generic_config_updater/test_syslog.py
@@ -306,7 +306,6 @@ def test_syslog_server_tc1_suite(rand_selected_dut, cfg_facts, loganalyzer):
     if loganalyzer:
         ignoreRegex = [
             r".*omrelp\[.*\]: error 'error opening connection to remote peer'.*",
-            r".*omrelp: could not connect to remote server, librelp error \d+.*",
             r".*omrelp\[.*\]: error 'server closed relp session, session broken', object .* - action may not work as intended.*",  # noqa: E501
             r".*omrelp\[.*\]: error 'error waiting on required session state, session broken', object .* - action may not work as intended.*",  # noqa: E501
         ]

--- a/tests/syslog/test_syslog.py
+++ b/tests/syslog/test_syslog.py
@@ -24,7 +24,6 @@ def test_syslog(rand_selected_dut, dummy_syslog_server_ip_a, dummy_syslog_server
     if loganalyzer:
         ignoreRegex = [
             r".*omrelp\[.*\]: error 'error opening connection to remote peer'.*",
-            r".*omrelp: could not connect to remote server, librelp error \d+.*",
             r".*omrelp\[.*\]: error 'server closed relp session, session broken', object .* - action may not work as intended.*",  # noqa: E501
             r".*omrelp\[.*\]: error 'error waiting on required session state, session broken', object .* - action may not work as intended.*",  # noqa: E501
         ]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: From https://github.com/sonic-net/sonic-mgmt/pull/24574#issuecomment-4539607205 comment, the root cause is actually from the dns/static_dns/test_static_dns.py which make the syslog server unresponsive for 20 minutes. This will affect the test runs after test_static_dns.py. The real fix should be to find out what caused it.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
test_static_dns caused syslog to shutdown, previous loganalyzer ignore may cover the problem. We need to revert it to expose the problem

#### How did you do it?
Revert previous commit from https://github.com/sonic-net/sonic-mgmt/pull/24574

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
