### PR TITLE
Fix localhost interpreter discovery to unblock nightly prepare scripts

### DIFF
--- a/ansible/devutil/devices/factory.py
+++ b/ansible/devutil/devices/factory.py
@@ -16,8 +16,10 @@ ansible_path = os.path.realpath(os.path.join(_self_dir, "../../"))
 
 
 def init_localhost(inventories=None, options={}, hostvars={}):
+    localhost_hostvars = hostvars.copy()
+    localhost_hostvars["ansible_python_interpreter"] = "/usr/bin/python3"
     try:
-        return AnsibleHost(inventories, "localhost", options=options.copy(), hostvars=hostvars.copy())
+        return AnsibleHost(inventories, "localhost", options=options.copy(), hostvars=localhost_hostvars.copy())
     except (NoAnsibleHostError, MultipleAnsibleHostsError) as e:
         logger.error(
             "Failed to initialize localhost from inventories '{}', exception: {}".format(str(inventories), repr(e))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Summary:

Fixes a failure pattern in the nightly Upgrade image prepare step. When Ansible runs a module on localhost, its default interpreter discovery (auto_legacy_silent) fabricates the script with #!/usr/bin/env python. On any worker whose cached :latest lacks the python symlink, /bin/sh then exits with rc=127 and message "/usr/bin/env python: not found", which aborts every prepare script (upgrade_image.py, get_dut_version.py, testbed_health_check.py, recover_testbed.py, upgrade_sonic.py) on its first localhost module call(typically conn_graph_facts).


The fix sets ansible_python_interpreter=/usr/bin/python3 as a default hostvar for the localhost AnsibleHost constructed in devutil.devices.factory.init_localhost. Any caller that passes its own hostvars still wins via merge. DUT-side host construction (init_host / init_sonichosts) is intentionally untouched.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
The pattern is the single biggest contributor to Upgrade image prepare failures in the May 2026 nightlies (≈9 of 35 = 26%). It is spreading because the base docker-sonic-mgmt:latest tag is mutable and was at some point republished without /usr/bin/python; every scheduler-worker that re-pulls :latest from that point onward begins failing. The failure happens on the veryfirst Ansible call inside upgrade_image.py, so the upgrade aborts before reaching any DUT.

#### How did you do it?

In ansible/devutil/devices/factory.py::init_localhost, build a defaults dict containing ansible_python_interpreter=/usr/bin/python3, merge caller-supplied hostvars on top, and pass themerged dict into the returned AnsibleHost. Caller-supplied hostvars override the default, so existing call sites that pass a custom interpreter (none today) keep their behavior.

#### How did you verify/test it?
Existing logs demonstrating failing testplans with this error message: `"module_stderr": "/bin/sh: 1: /usr/bin/env python: not found\n"`, see below: 
<img width="1695" height="485" alt="image" src="https://github.com/user-attachments/assets/1afbf7e8-4c66-4ea5-ba3e-155069c383fd" />
error message simply indicates the fix


#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation
N/A