### PR TITLE
tests/common/fixtures/split_vlan: snapshot and restore DHCPV4_RELAY across VLAN split

### DIFF
--- a/tests/common/fixtures/split_vlan.py
+++ b/tests/common/fixtures/split_vlan.py
@@ -27,6 +27,7 @@ def setup_multiple_vlans_and_teardown(request, rand_selected_dut, rand_unselecte
     first_vlan_info['dhcp_relay'] = running_config['DHCP_RELAY'].get(first_vlan_name, {}).get('dhcp_servers', [])
     first_vlan_info['dhcpv6_servers'] = running_config['VLAN'][first_vlan_name].get('dhcpv6_servers', [])
     first_vlan_info['dhcpv6_relay'] = running_config['DHCP_RELAY'].get(first_vlan_name, {}).get('dhcpv6_servers', [])
+    first_vlan_info['dhcpv4_relay'] = running_config.get('DHCPV4_RELAY', {}).get(first_vlan_name, {})
     disabled_host_interfaces = tbinfo['topo']['properties']['topology'].get('disabled_host_interfaces', [])
     connected_ptf_ports_idx = [interface for interface in
                                tbinfo['topo']['properties']['topology'].get('host_interfaces', [])
@@ -69,6 +70,7 @@ def generate_sub_vlans_config_patch(vlan_name, vlan_info, vlan_member_with_ptf_i
     sub_vlans_info, config_patch = [], []
     config_patch += remove_vlan_patch(vlan_name) \
         + remove_dhcpv6_relay_patch(vlan_name) \
+        + remove_dhcpv4_relay_patch(vlan_name, vlan_info.get('dhcpv4_relay', {})) \
         + [remove_vlan_ip_patch(vlan_name, ip)[0] for ip in vlan_info['interface_ipv4']] \
         + [remove_vlan_ip_patch(vlan_name, ip)[0] for ip in vlan_info['interface_ipv6']] \
         + [remove_vlan_member_patch(vlan_name, member)[0] for member in vlan_info['members']]
@@ -98,6 +100,7 @@ def generate_sub_vlans_config_patch(vlan_name, vlan_info, vlan_member_with_ptf_i
         new_members_with_ptf_idx = info['members_with_ptf_idx']
         config_patch += add_vlan_patch(new_vlan_name, vlan_info['dhcp_servers'], vlan_info['dhcpv6_servers']) \
             + add_dhcpv6_relay_patch(new_vlan_name, vlan_info['dhcpv6_relay']) \
+            + add_dhcpv4_relay_patch(new_vlan_name, vlan_info.get('dhcpv4_relay', {})) \
             + add_vlan_ip_patch(new_vlan_name, new_interface_ipv4) \
             + add_vlan_ip_patch(new_vlan_name, new_interface_ipv6) \
             + [add_vlan_member_patch(new_vlan_name, member)[0] for member, _ in new_members_with_ptf_idx]
@@ -163,6 +166,27 @@ def remove_dhcpv6_relay_patch(vlan_name):
     patch = [{
         "op": "remove",
         "path": "/DHCP_RELAY/%s" % vlan_name
+    }]
+    return patch
+
+
+def add_dhcpv4_relay_patch(vlan_name, dhcpv4_relay_config):
+    if not dhcpv4_relay_config:
+        return []
+    patch = [{
+        "op": "add",
+        "path": "/DHCPV4_RELAY/%s" % vlan_name,
+        "value": dhcpv4_relay_config
+    }]
+    return patch
+
+
+def remove_dhcpv4_relay_patch(vlan_name, dhcpv4_relay_config):
+    if not dhcpv4_relay_config:
+        return []
+    patch = [{
+        "op": "remove",
+        "path": "/DHCPV4_RELAY/%s" % vlan_name
     }]
     return patch
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

setup_multiple_vlans_and_teardown() captures the first VLAN's config so it can be torn down and re-applied as N sub-VLANs and then restored on teardown. The snapshot covers VLAN, DHCP_RELAY (legacy v4 helpers) and the v6 relay entry, but not the new DHCPV4_RELAY table used by the SONiC DHCPv4 relay (dhcp4relay).

On a DUT where DHCPV4_RELAY is populated for the chosen VLAN, splitting the VLAN leaves the original DHCPV4_RELAY[<first_vlan>] entry pointing at a VLAN that no longer exists, and the sub-VLANs are created without their corresponding DHCPV4_RELAY entries. dhcp4relay then logs "vlan not found"-style errors for the duration of every DHCPv6 multi-VLAN test that depends on this fixture (e.g. the dhcpv6 relay tests under tests/dhcp_relay), and the affected sub-VLANs do not get their DHCPv4 relay programmed back when the test tears down.

Fix: extend the snapshot/restore cycle to DHCPV4_RELAY.

  - In setup_multiple_vlans_and_teardown(), capture running_config['DHCPV4_RELAY'][first_vlan_name] (defaulting to {}) into first_vlan_info['dhcpv4_relay'].

  - In generate_sub_vlans_config_patch(), emit a remove_dhcpv4_relay_patch() alongside the existing remove_dhcpv6_relay_patch() before deleting the original VLAN, and an add_dhcpv4_relay_patch() alongside add_dhcpv6_relay_patch() for each sub-VLAN.

  - Both helpers no-op when the original VLAN had no DHCPV4_RELAY entry, so this is a strict superset of the existing behaviour and is a no-op on platforms / topologies that do not use the new dhcp4relay.

No test logic changed; only the JSON config patch list emitted by the fixture is extended.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
DHCPv6 multi-VLAN tests under `tests/dhcp_relay` (and any other suite that consumes `setup_multiple_vlans_and_teardown` on a DUT running the new sonic-dhcp-relay) are unreliable today on images where `DHCPV4_RELAY` is configured for the VLAN being split:

- During the test, `dhcp4relay` continuously emits errors for the missing VLAN, polluting syslog and any log-based assertions.
- On teardown, the original `DHCPV4_RELAY[<first_vlan>]` entry is restored but the helper entries that existed for the sub-VLANs are leaked / inconsistent, leaving the DUT in a degraded state for the *next* test that runs against the same testbed.

This change is a pure fixture-layer fix: it makes the snapshot/restore complete with respect to `DHCPV4_RELAY` so any DHCPv6 (or DHCPv4) test exercising VLAN splitting cleans up after itself the same way it already does for `VLAN`, `DHCP_RELAY`, and the v6 relay entries.

#### How did you do it?

Single-file change in `tests/common/fixtures/split_vlan.py`, three logical edits:

1. **Snapshot.** In `setup_multiple_vlans_and_teardown()`, after the existing `dhcp_servers / dhcp_relay / dhcpv6_servers / dhcpv6_relay` captures, add:
   ```python
   first_vlan_info['dhcpv4_relay'] = running_config.get('DHCPV4_RELAY', {}).get(first_vlan_name, {})
   ```
   The double `.get(..., {})` keeps the fixture safe on platforms where `DHCPV4_RELAY` is absent from the running config.

2. **Patch emission.** In `generate_sub_vlans_config_patch()`, mirror the existing v6-relay handling for v4:
   - prepend `remove_dhcpv4_relay_patch(vlan_name, vlan_info.get('dhcpv4_relay', {}))` to the original-VLAN teardown patch list, alongside `remove_dhcpv6_relay_patch(vlan_name)`;
   - inside the per-sub-VLAN loop, append `add_dhcpv4_relay_patch(new_vlan_name, vlan_info.get('dhcpv4_relay', {}))` next to `add_dhcpv6_relay_patch(...)`.

3. **Helpers.** Two new module-level helpers added after `remove_dhcpv6_relay_patch`:
   - `add_dhcpv4_relay_patch(vlan_name, dhcpv4_relay_config)`: returns `[]` when `dhcpv4_relay_config` is empty; otherwise emits a single `add` JSON-patch op against `/DHCPV4_RELAY/<vlan>` with the captured value.
   - `remove_dhcpv4_relay_patch(vlan_name, dhcpv4_relay_config)`: returns `[]` when `dhcpv4_relay_config` is empty; otherwise emits a single `remove` JSON-patch op against `/DHCPV4_RELAY/<vlan>`.

   Both helpers being no-ops on empty input is what makes this change safe on platforms / topologies that do not configure `DHCPV4_RELAY`.

#### How did you verify/test it?

- **Static**: `flake8` / project linter on the modified file - no new warnings.
- **Functional (DUT with `dhcp4relay`)**: Ran the DHCPv6 multi-VLAN relay tests under `tests/dhcp_relay` on a DUT image where `DHCPV4_RELAY` is populated for `Vlan1000`:
  - Before the fix: `dhcp4relay` syslog filled with "vlan not found"-style errors for the entire duration of the split window; on teardown, sub-VLAN `DHCPV4_RELAY` entries were missing.
  - After the fix: no `dhcp4relay` errors during the split; `DHCPV4_RELAY` shows the expected sub-VLAN entries during the split and the original entry restored on teardown (verified with `sonic-cfggen -d -v 'DHCPV4_RELAY'` before/during/after).
- **Functional (DUT without `dhcp4relay`)**: Same suite on an image where `DHCPV4_RELAY` is absent — `add_dhcpv4_relay_patch` / `remove_dhcpv4_relay_patch` short-circuit to `[]`, the emitted patch list is byte-identical to pre-PR behaviour, suite passes unchanged.

#### Any platform specific information?

No platform-specific code path. The change is gated entirely on whether the captured `DHCPV4_RELAY` config is empty:

- Platforms / images that ship the new SONiC DHCPv4 relay and have `DHCPV4_RELAY` configured for the split VLAN benefit from the fix.
- Platforms that still use the legacy ISC v4 relay (`VLAN[<vlan>]['dhcp_servers']` / `DHCP_RELAY[<vlan>]['dhcp_servers']`) and have no `DHCPV4_RELAY` table will see the helpers return `[]` and the patch list will be identical to today's behaviour - strict no-op.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
