### PR TITLE
tests/dhcp_relay: add dhcp4relay negative PTF tests

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_negative_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_negative_test.py
@@ -448,7 +448,8 @@ class DHCPRelayBadChecksumTest(DHCPRelayHopLimitTest):
         elif layer == "udp":
             wire = self._corrupt_udp_checksum(buf, eth_len)
         else:
-            self.fail("bad_checksum_layer must be 'ip' or 'udp', got %r" % layer)
+            raise ValueError(
+                "bad_checksum_layer must be 'ip' or 'udp', got %r" % layer)
 
         self.dataplane.flush()
         pkt = scapy.Ether(wire)
@@ -517,7 +518,7 @@ class DHCPRelayMalformedClientFrameTest(DHCPRelayBadChecksumTest):
             self._set_ipv4_total_length_and_checksum(buf, ip_start, ihl, ihl + 4)
             wire = self._pad_min_eth_tx(bytes(buf))
         else:
-            self.fail(
+            raise ValueError(
                 "malformed_client_frame must be 'l2_only' or 'partial_udp', got %r" % case)
 
         self.dataplane.flush()

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_negative_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_negative_test.py
@@ -1,0 +1,536 @@
+"""
+DHCPv4 relay negative tests (dhcp4relay). PTF: dhcp_relay_negative_test.py;
+pytest: tests/dhcp_relay/test_dhcp_relay_negative.py.
+
+1) Hop limit — DHCPDISCOVER with BOOTP hops >= max_hop_count (default 16);
+   no relay toward servers. Syslog: hop count exceeds max (pytest).
+
+2) Option 82 without circuit ID — DHCPOFFER from server with Option 82 containing
+   only remote-ID sub-option; no relay to client. Syslog: missing circuit id (pytest).
+
+3) Discard mode relay-from-relay — DHCPDISCOVER with non-zero giaddr and pre-existing
+   Option 82 (simulates prior relay). With agent_relay_mode discard (default), packet
+   must not be relayed. Syslog: agent relay mode is discard (pytest).
+
+4) Bad IP/UDP checksums — corrupt L3/L4 checksum on DISCOVER; relay drops before forward.
+   Syslog: Checksum failed for IP / UDP checksum validation (pytest). Frame built as raw
+   bytes so checksums are not auto-fixed by Scapy (untagged Ethernet: eth_header_len=14).
+
+5) Unknown giaddr from server — DHCPOFFER with giaddr not on the DUT (default 99.99.99.99)
+   and no Option 82 so VLAN cannot be resolved from circuit ID. to_client() drops after
+   failing giaddr→interface match. Syslog: Failed to find interface attached to address (pytest).
+
+6) Malformed Option 82 TLV — DHCPOFFER with Option 82 body shorter than sub-option length
+   (circuit-id type 1, declared len 10, only 2 bytes in option). decode_tlv() logs then
+   to_client() drops. Syslog: DHCPV4_INFO Failed to decode realy agent sub-option … exceeded
+   total option len (pytest; typos match dhcp4relay.cpp).
+
+7) Malformed client frames — class DHCPRelayMalformedClientFrameTest; param
+   malformed_client_frame = l2_only | partial_udp (sync with pytest module
+   test_dhcp_relay_negative.py: test_dhcp_relay_negative_malformed_client_frame_*). Kernel BPF
+   (ether_relay_filter) drops l2_only before userspace (no Invalid IP syslog). partial_udp:
+   IPv4 tot_len IHL+4, Invalid UDP syslog. Padded to 60 B min TX. L2 runt: pytest.skip
+   test_dhcp_relay_negative_malformed_client_frame_l2_runt.
+
+Builds on dhcp_relay_test.DHCPTest.
+"""
+
+import binascii
+import struct
+import time
+
+import ptf.testutils as testutils
+import ptf.packet as scapy
+from ptf.mask import Mask
+from scapy.packet import Raw
+
+from dhcp_relay_test import DHCPTest
+
+
+class DHCPRelayHopLimitTest(DHCPTest):
+    """
+    Negative test: excessive BOOTP hops must not be relayed toward servers.
+    """
+
+    def _masked_relayed_discover(self):
+        dhcp_discover_relayed = self.create_dhcp_discover_relayed_packet()
+        masked_discover = Mask(dhcp_discover_relayed)
+        masked_discover.set_do_not_care_scapy(scapy.Ether, "dst")
+
+        masked_discover.set_do_not_care_scapy(scapy.IP, "version")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "ihl")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "tos")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "len")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "id")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "flags")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "frag")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "ttl")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "proto")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "chksum")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "src")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "dst")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "options")
+
+        masked_discover.set_do_not_care_scapy(scapy.UDP, "chksum")
+        masked_discover.set_do_not_care_scapy(scapy.UDP, "len")
+
+        masked_discover.set_do_not_care_scapy(scapy.BOOTP, "sname")
+        masked_discover.set_do_not_care_scapy(scapy.BOOTP, "file")
+        return masked_discover
+
+    def runTest(self):
+        hops = int(self.test_params.get("bootp_hops", 255))
+        wait_sec = float(self.test_params.get("relay_wait_sec", 3))
+
+        dhcp_discover = self.create_dhcp_discover_packet(
+            self.dest_mac_address, self.client_udp_src_port)
+        dhcp_discover[scapy.BOOTP].hops = hops
+
+        self.dataplane.flush()
+        testutils.send_packet(self, self.client_port_index, dhcp_discover)
+        time.sleep(wait_sec)
+
+        masked_discover = self._masked_relayed_discover()
+        discover_count = testutils.count_matched_packets_all_ports(
+            self, masked_discover, self.server_port_indices)
+
+        self.assertTrue(
+            discover_count == 0,
+            "Expected no relayed DISCOVER on server ports for hops=%s, saw %s packet(s)" % (
+                hops, discover_count))
+
+
+class DHCPRelayMissingCircuitIdTest(DHCPTest):
+    """
+    DHCPOFFER from server port with Option 82: remote-ID only, no circuit-ID sub-option.
+    Expect no relayed OFFER on client PTF port.
+    """
+
+    _VENDOR_CLS_ID = (
+        "http://0.0.0.0/this_is_a_very_very_long_path/test.bin".encode("utf-8")
+    )
+
+    def create_dhcp_offer_option82_no_circuit_id(self):
+        my_chaddr = binascii.unhexlify(self.client_mac.replace(":", ""))
+        my_chaddr += b"\x00\x00\x00\x00\x00\x00"
+
+        remote_id_string = self.relay_iface_mac.strip()
+        opt82 = struct.pack("BB", self.REMOTE_ID_SUBOPTION, len(remote_id_string))
+        opt82 += remote_id_string.encode("utf-8")
+
+        ip_dst = self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip
+        giaddr = self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip
+
+        pkt = scapy.Ether(
+            dst=self.uplink_mac,
+            src=self.server_iface_mac,
+            type=self.DHCP_ETHER_TYPE_IP,
+        )
+        pkt /= scapy.IP(src=self.server_ip[0], dst=ip_dst, ttl=128, id=0)
+        pkt /= scapy.UDP(
+            sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT
+        )
+        pkt /= scapy.BOOTP(
+            op=self.DHCP_BOOTP_OP_REPLY,
+            htype=self.DHCP_BOOTP_HTYPE_ETHERNET,
+            hlen=self.DHCP_BOOTP_HLEN_ETHERNET,
+            hops=0,
+            xid=0,
+            secs=0,
+            flags=self.DHCP_BOOTP_FLAGS_BROADCAST_REPLY,
+            ciaddr=self.DEFAULT_ROUTE_IP,
+            yiaddr=self.client_ip,
+            siaddr=self.server_ip[0],
+            giaddr=giaddr,
+            chaddr=my_chaddr,
+        )
+        pkt /= scapy.DHCP(
+            options=[
+                ("message-type", "offer"),
+                ("server_id", self.server_ip[0]),
+                ("lease_time", self.LEASE_TIME),
+                ("subnet_mask", self.client_subnet),
+                (82, opt82),
+                ("vendor_class_id", self._VENDOR_CLS_ID),
+                ("end"),
+            ]
+        )
+        return pkt
+
+    def _masked_relayed_offer(self):
+        dhcp_offer = self.create_dhcp_offer_relayed_packet()
+        masked_offer = Mask(dhcp_offer)
+
+        masked_offer.set_do_not_care_scapy(scapy.IP, "version")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "ihl")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "tos")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "len")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "id")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "flags")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "frag")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "ttl")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "proto")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "chksum")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "options")
+
+        masked_offer.set_do_not_care_scapy(scapy.UDP, "len")
+        masked_offer.set_do_not_care_scapy(scapy.UDP, "chksum")
+
+        masked_offer.set_do_not_care_scapy(scapy.BOOTP, "sname")
+        masked_offer.set_do_not_care_scapy(scapy.BOOTP, "file")
+        return masked_offer
+
+    def runTest(self):
+        wait_sec = float(self.test_params.get("offer_wait_sec", 3))
+
+        self.dataplane.flush()
+        bad_offer = self.create_dhcp_offer_option82_no_circuit_id()
+        testutils.send_packet(self, self.server_port_indices[0], bad_offer)
+        time.sleep(wait_sec)
+
+        masked_offer = self._masked_relayed_offer()
+        offer_count = testutils.count_matched_packets_all_ports(
+            self, masked_offer, [self.client_port_index]
+        )
+
+        self.assertTrue(
+            offer_count == 0,
+            "Expected no relayed OFFER on client port when Option 82 lacks "
+            "circuit ID; saw %s packet(s)" % offer_count,
+        )
+
+
+class DHCPRelayUnknownGiaddrFromServerTest(DHCPRelayMissingCircuitIdTest):
+    """
+    DHCPOFFER from server with bogus giaddr (default 99.99.99.99). No Option 82 so the
+    relay cannot map VLAN via circuit ID and must match giaddr to a local interface.
+    """
+
+    def create_dhcp_offer_unknown_giaddr(self):
+        my_chaddr = binascii.unhexlify(self.client_mac.replace(":", ""))
+        my_chaddr += b"\x00\x00\x00\x00\x00\x00"
+        giaddr = self.test_params.get("bogus_server_giaddr", "99.99.99.99")
+        ip_dst = self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip
+
+        pkt = scapy.Ether(
+            dst=self.uplink_mac,
+            src=self.server_iface_mac,
+            type=self.DHCP_ETHER_TYPE_IP,
+        )
+        pkt /= scapy.IP(src=self.server_ip[0], dst=ip_dst, ttl=128, id=0)
+        pkt /= scapy.UDP(
+            sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT
+        )
+        pkt /= scapy.BOOTP(
+            op=self.DHCP_BOOTP_OP_REPLY,
+            htype=self.DHCP_BOOTP_HTYPE_ETHERNET,
+            hlen=self.DHCP_BOOTP_HLEN_ETHERNET,
+            hops=0,
+            xid=0,
+            secs=0,
+            flags=self.DHCP_BOOTP_FLAGS_BROADCAST_REPLY,
+            ciaddr=self.DEFAULT_ROUTE_IP,
+            yiaddr=self.client_ip,
+            siaddr=self.server_ip[0],
+            giaddr=giaddr,
+            chaddr=my_chaddr,
+        )
+        pkt /= scapy.DHCP(
+            options=[
+                ("message-type", "offer"),
+                ("server_id", self.server_ip[0]),
+                ("lease_time", self.LEASE_TIME),
+                ("subnet_mask", self.client_subnet),
+                ("vendor_class_id", self._VENDOR_CLS_ID),
+                ("end"),
+            ]
+        )
+        return pkt
+
+    def runTest(self):
+        wait_sec = float(self.test_params.get("offer_wait_sec", 3))
+
+        self.dataplane.flush()
+        offer = self.create_dhcp_offer_unknown_giaddr()
+        testutils.send_packet(self, self.server_port_indices[0], offer)
+        time.sleep(wait_sec)
+
+        masked_offer = self._masked_relayed_offer()
+        offer_count = testutils.count_matched_packets_all_ports(
+            self, masked_offer, [self.client_port_index]
+        )
+
+        self.assertTrue(
+            offer_count == 0,
+            "Expected no relayed OFFER on client port for unknown giaddr from server; "
+            "saw %s packet(s)" % offer_count,
+        )
+
+
+class DHCPRelayMalformedOption82TlvTest(DHCPRelayMissingCircuitIdTest):
+    """
+    DHCPOFFER with valid giaddr but Option 82 TLV truncated: sub-option 1 (circuit ID)
+    declares length 10 while the option 82 value is only 2 bytes (type + len).
+    """
+
+    def create_dhcp_offer_malformed_option82_tlv(self):
+        my_chaddr = binascii.unhexlify(self.client_mac.replace(":", ""))
+        my_chaddr += b"\x00\x00\x00\x00\x00\x00"
+        giaddr = self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip
+        ip_dst = self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip
+
+        declared_len = int(self.test_params.get("malformed_opt82_declared_len", 10))
+        opt82 = struct.pack("BB", self.CIRCUIT_ID_SUBOPTION, declared_len)
+
+        pkt = scapy.Ether(
+            dst=self.uplink_mac,
+            src=self.server_iface_mac,
+            type=self.DHCP_ETHER_TYPE_IP,
+        )
+        pkt /= scapy.IP(src=self.server_ip[0], dst=ip_dst, ttl=128, id=0)
+        pkt /= scapy.UDP(
+            sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT
+        )
+        pkt /= scapy.BOOTP(
+            op=self.DHCP_BOOTP_OP_REPLY,
+            htype=self.DHCP_BOOTP_HTYPE_ETHERNET,
+            hlen=self.DHCP_BOOTP_HLEN_ETHERNET,
+            hops=0,
+            xid=0,
+            secs=0,
+            flags=self.DHCP_BOOTP_FLAGS_BROADCAST_REPLY,
+            ciaddr=self.DEFAULT_ROUTE_IP,
+            yiaddr=self.client_ip,
+            siaddr=self.server_ip[0],
+            giaddr=giaddr,
+            chaddr=my_chaddr,
+        )
+        pkt /= scapy.DHCP(
+            options=[
+                ("message-type", "offer"),
+                ("server_id", self.server_ip[0]),
+                ("lease_time", self.LEASE_TIME),
+                ("subnet_mask", self.client_subnet),
+                (82, opt82),
+                ("vendor_class_id", self._VENDOR_CLS_ID),
+                ("end"),
+            ]
+        )
+        return pkt
+
+    def runTest(self):
+        wait_sec = float(self.test_params.get("offer_wait_sec", 3))
+
+        self.dataplane.flush()
+        offer = self.create_dhcp_offer_malformed_option82_tlv()
+        testutils.send_packet(self, self.server_port_indices[0], offer)
+        time.sleep(wait_sec)
+
+        masked_offer = self._masked_relayed_offer()
+        offer_count = testutils.count_matched_packets_all_ports(
+            self, masked_offer, [self.client_port_index]
+        )
+
+        self.assertTrue(
+            offer_count == 0,
+            "Expected no relayed OFFER on client port for malformed Option 82 TLV; "
+            "saw %s packet(s)" % offer_count,
+        )
+
+
+class DHCPRelayDiscardRelayFromRelayTest(DHCPRelayHopLimitTest):
+    """
+    DISCOVER from client port with giaddr set (relay-from-relay) and Option 82 already
+    present. dhcp4relay from_client() uses discard when agent_relay_mode is not append/replace.
+    Expect no relay toward servers.
+    """
+
+    def create_discover_relay_from_relay(self):
+        my_chaddr = binascii.unhexlify(self.client_mac.replace(":", ""))
+        my_chaddr += b"\x00\x00\x00\x00\x00\x00"
+        giaddr = self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip
+        hops = int(self.test_params.get("relay_from_relay_hops", 1))
+
+        pkt = scapy.Ether(
+            dst=self.dest_mac_address,
+            src=self.client_mac,
+            type=self.DHCP_ETHER_TYPE_IP,
+        )
+        pkt /= scapy.IP(src=self.DEFAULT_ROUTE_IP, dst=self.BROADCAST_IP, ttl=64, id=1)
+        pkt /= scapy.UDP(
+            sport=self.client_udp_src_port, dport=self.DHCP_SERVER_PORT
+        )
+
+        bootp = scapy.BOOTP(
+            op=1,
+            htype=self.DHCP_BOOTP_HTYPE_ETHERNET,
+            hlen=self.DHCP_BOOTP_HLEN_ETHERNET,
+            hops=hops,
+            xid=0xAABBCCDD,
+            secs=0,
+            flags=self.DHCP_BOOTP_FLAGS_BROADCAST_REPLY,
+            ciaddr=self.DEFAULT_ROUTE_IP,
+            yiaddr=self.DEFAULT_ROUTE_IP,
+            siaddr=self.DEFAULT_ROUTE_IP,
+            giaddr=giaddr,
+            chaddr=my_chaddr,
+        )
+        bootp /= scapy.DHCP(
+            options=[
+                ("message-type", "discover"),
+                (82, self.option82),
+                ("end"),
+            ]
+        )
+        pad_bytes = self.DHCP_PKT_BOOTP_MIN_LEN - len(bootp)
+        if pad_bytes > 0:
+            bootp /= scapy.PADDING("\x00" * pad_bytes)
+        pkt /= bootp
+        return pkt
+
+    def runTest(self):
+        wait_sec = float(self.test_params.get("relay_wait_sec", 3))
+
+        self.dataplane.flush()
+        pkt = self.create_discover_relay_from_relay()
+        testutils.send_packet(self, self.client_port_index, pkt)
+        time.sleep(wait_sec)
+
+        masked_discover = self._masked_relayed_discover()
+        discover_count = testutils.count_matched_packets_all_ports(
+            self, masked_discover, self.server_port_indices
+        )
+
+        self.assertTrue(
+            discover_count == 0,
+            "Expected no relayed DISCOVER on server ports for relay-from-relay "
+            "(giaddr + Option 82) in discard mode; saw %s packet(s)" % discover_count,
+        )
+
+
+class DHCPRelayBadChecksumTest(DHCPRelayHopLimitTest):
+    """
+    DHCPDISCOVER with invalid IPv4 or UDP checksum (wire bytes flipped after build).
+    dhcp4relay validates checksums before relay; expect no server-side relay.
+    """
+
+    def _discover_wire_bytes(self):
+        pkt = self.create_dhcp_discover_packet(
+            self.dest_mac_address, self.client_udp_src_port)
+        return bytearray(bytes(pkt))
+
+    @staticmethod
+    def _corrupt_ip_checksum(data, eth_len):
+        """IPv4 header checksum at offset eth_len + 10."""
+        off = eth_len + 10
+        data[off] ^= 0xFF
+        data[off + 1] ^= 0xFF
+        return bytes(data)
+
+    @staticmethod
+    def _corrupt_udp_checksum(data, eth_len):
+        """UDP checksum at eth_len + ihl*4 + 6 (IPv4 options assumed none)."""
+        ip_start = eth_len
+        ihl = (data[ip_start] & 0x0F) * 4
+        udp_start = ip_start + ihl
+        data[udp_start + 6] ^= 0xAB
+        data[udp_start + 7] ^= 0xCD
+        return bytes(data)
+
+    def runTest(self):
+        layer = self.test_params.get("bad_checksum_layer", "ip")
+        eth_len = int(self.test_params.get("eth_header_len", 14))
+        wait_sec = float(self.test_params.get("relay_wait_sec", 3))
+
+        buf = self._discover_wire_bytes()
+        if layer == "ip":
+            wire = self._corrupt_ip_checksum(buf, eth_len)
+        elif layer == "udp":
+            wire = self._corrupt_udp_checksum(buf, eth_len)
+        else:
+            self.fail("bad_checksum_layer must be 'ip' or 'udp', got %r" % layer)
+
+        self.dataplane.flush()
+        pkt = scapy.Ether(wire)
+        testutils.send_packet(self, self.client_port_index, pkt)
+        time.sleep(wait_sec)
+
+        masked_discover = self._masked_relayed_discover()
+        discover_count = testutils.count_matched_packets_all_ports(
+            self, masked_discover, self.server_port_indices
+        )
+
+        self.assertTrue(
+            discover_count == 0,
+            "Expected no relayed DISCOVER on server ports for bad %s checksum; "
+            "saw %s packet(s)" % (layer.upper(), discover_count),
+        )
+
+
+class DHCPRelayMalformedClientFrameTest(DHCPRelayBadChecksumTest):
+    """
+    Malformed DHCP client-side DISCOVER frames (param malformed_client_frame).
+
+    dhcp4relay attaches SO_ATTACH_FILTER (UDP/67); packets that fail the filter never reach
+    pkt_in_callback. l2_only: Ethernet (+ optional Q-tag) only — kernel drop, no syslog.
+    partial_udp: IPv4 tot_len IHL+4, IP checksum fixed, pad to 60 B — BPF passes, Pcpp has no
+    complete UDP layer -> Invalid UDP syslog.
+    """
+
+    # Linux AF_PACKET / veth often rejects transmits shorter than IEEE 802.3 min frame.
+    _MIN_ETH_TX_OCTETS = 60
+
+    @classmethod
+    def _pad_min_eth_tx(cls, buf):
+        buf = bytes(buf)
+        if len(buf) < cls._MIN_ETH_TX_OCTETS:
+            buf += b"\x00" * (cls._MIN_ETH_TX_OCTETS - len(buf))
+        return buf
+
+    @staticmethod
+    def _set_ipv4_total_length_and_checksum(buf, ip_start, ihl, ip_total_len):
+        """Set IPv4 total length (header + payload) and recompute header checksum."""
+        struct.pack_into("!H", buf, ip_start + 2, ip_total_len)
+        struct.pack_into("!H", buf, ip_start + 10, 0)
+        csum = 0
+        for off in range(ip_start, ip_start + ihl, 2):
+            csum += (buf[off] << 8) + buf[off + 1]
+        while csum > 0xFFFF:
+            csum = (csum & 0xFFFF) + (csum >> 16)
+        struct.pack_into("!H", buf, ip_start + 10, (~csum) & 0xFFFF)
+
+    def runTest(self):
+        case = self.test_params.get("malformed_client_frame", "l2_only")
+        eth_len = int(self.test_params.get("eth_header_len", 14))
+        wait_sec = float(self.test_params.get("relay_wait_sec", 3))
+
+        full = self._discover_wire_bytes()
+        if case == "l2_only":
+            # L2 only: kernel BPF drops (no IPv4 at fixed offsets) — no dhcp4relay syslog.
+            wire = self._pad_min_eth_tx(full[:eth_len])
+        elif case == "partial_udp":
+            ip_start = eth_len
+            ihl = (full[ip_start] & 0x0F) * 4
+            buf = bytearray(full[: ip_start + ihl + 4])
+            # Shrink IPv4 tot_len to IHL+4 so only partial UDP is inside the IP datagram; min
+            # Ethernet padding then lies outside IP (avoids Pcpp treating pad as UDP len/cs).
+            self._set_ipv4_total_length_and_checksum(buf, ip_start, ihl, ihl + 4)
+            wire = self._pad_min_eth_tx(bytes(buf))
+        else:
+            self.fail(
+                "malformed_client_frame must be 'l2_only' or 'partial_udp', got %r" % case)
+
+        self.dataplane.flush()
+        testutils.send_packet(self, self.client_port_index, Raw(load=wire))
+        time.sleep(wait_sec)
+
+        masked_discover = self._masked_relayed_discover()
+        discover_count = testutils.count_matched_packets_all_ports(
+            self, masked_discover, self.server_port_indices
+        )
+
+        self.assertTrue(
+            discover_count == 0,
+            "Expected no relayed DISCOVER on server ports for malformed_client_frame=%s; "
+            "saw %s packet(s)" % (case, discover_count),
+        )

--- a/tests/dhcp_relay/test_dhcp_relay_negative.py
+++ b/tests/dhcp_relay/test_dhcp_relay_negative.py
@@ -56,7 +56,8 @@ _EXPECT_MISSING_CIRCUIT_SYSLOG = (
     r".*\[DHCPV4_RELAY\].*Circuit id sub-option is missing in relay agent option from server.*"
 )
 
-# dhcp4relay.cpp from_client(): syslog(LOG_INFO, "[DHCPV4_RELAY] agent relay mode is discard, dropping the packet %s", ...)
+# dhcp4relay.cpp from_client() syslogs at LOG_INFO when agent_relay_mode == discard:
+#   "[DHCPV4_RELAY] agent relay mode is discard, dropping the packet %s", ...
 _EXPECT_DISCARD_RELAY_FROM_RELAY_SYSLOG = (
     r".*\[DHCPV4_RELAY\].*agent relay mode is discard, dropping the packet.*"
 )
@@ -117,7 +118,7 @@ def test_dhcp_relay_negative_hop_limit_exceeded(
     testing_config,
     setup_standby_ports_on_rand_unselected_tor,  # noqa F811
     rand_unselected_dut,  # noqa F811
-    toggle_all_simulator_ports_to_rand_selected_tor_m,
+    toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
 ):
     """
     Inject DISCOVER with hops=255 from the VLAN client PTF port; assert no relayed
@@ -163,7 +164,7 @@ def test_dhcp_relay_negative_server_offer_missing_circuit_id(
     testing_config,
     setup_standby_ports_on_rand_unselected_tor,  # noqa F811
     rand_unselected_dut,  # noqa F811
-    toggle_all_simulator_ports_to_rand_selected_tor_m,
+    toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
 ):
     """
     Inject OFFER with Option 82 containing only remote-ID; assert no relay to client
@@ -213,7 +214,7 @@ def test_dhcp_relay_negative_unknown_giaddr_from_server(
     testing_config,
     setup_standby_ports_on_rand_unselected_tor,  # noqa F811
     rand_unselected_dut,  # noqa F811
-    toggle_all_simulator_ports_to_rand_selected_tor_m,
+    toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
 ):
     """
     Server OFFER with giaddr not on DUT (99.99.99.99) and no Option 82; assert no relay
@@ -268,7 +269,7 @@ def test_dhcp_relay_negative_malformed_option82_tlv(
     testing_config,
     setup_standby_ports_on_rand_unselected_tor,  # noqa F811
     rand_unselected_dut,  # noqa F811
-    toggle_all_simulator_ports_to_rand_selected_tor_m,
+    toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
 ):
     """
     Server OFFER: Option 82 sub-option length larger than option payload (decode_tlv path).
@@ -322,7 +323,7 @@ def test_dhcp_relay_negative_discard_relay_from_relay(
     testing_config,
     setup_standby_ports_on_rand_unselected_tor,  # noqa F811
     rand_unselected_dut,  # noqa F811
-    toggle_all_simulator_ports_to_rand_selected_tor_m,
+    toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
 ):
     """
     Inject DISCOVER with non-zero giaddr and Option 82 (prior relay). With
@@ -373,7 +374,7 @@ def test_dhcp_relay_negative_bad_ip_checksum(
     testing_config,
     setup_standby_ports_on_rand_unselected_tor,  # noqa F811
     rand_unselected_dut,  # noqa F811
-    toggle_all_simulator_ports_to_rand_selected_tor_m,
+    toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
 ):
     """DISCOVER with invalid IPv4 header checksum; no relay + syslog."""
     testing_mode, duthost = testing_config
@@ -426,7 +427,7 @@ def test_dhcp_relay_negative_bad_udp_checksum(
     testing_config,
     setup_standby_ports_on_rand_unselected_tor,  # noqa F811
     rand_unselected_dut,  # noqa F811
-    toggle_all_simulator_ports_to_rand_selected_tor_m,
+    toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
 ):
     """DISCOVER with invalid UDP checksum (IPv4 header valid); no relay + syslog."""
     testing_mode, duthost = testing_config
@@ -479,7 +480,7 @@ def test_dhcp_relay_negative_malformed_client_frame_l2_runt(
     testing_config,
     setup_standby_ports_on_rand_unselected_tor,  # noqa F811
     rand_unselected_dut,  # noqa F811
-    toggle_all_simulator_ports_to_rand_selected_tor_m,
+    toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
 ):
     """True L2 runt (<14 B) would trigger Invalid Ethernet in dhcp4relay; not injectable on Linux PTF."""
     pytest.skip(
@@ -497,7 +498,7 @@ def test_dhcp_relay_negative_malformed_client_frame_l2_only(
     testing_config,
     setup_standby_ports_on_rand_unselected_tor,  # noqa F811
     rand_unselected_dut,  # noqa F811
-    toggle_all_simulator_ports_to_rand_selected_tor_m,
+    toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
 ):
     """
     L2-only frame (no IPv4 at BPF offsets). dhcp4relay uses SO_ATTACH_FILTER (UDP/67) in
@@ -541,7 +542,7 @@ def test_dhcp_relay_negative_malformed_client_frame_partial_udp(
     testing_config,
     setup_standby_ports_on_rand_unselected_tor,  # noqa F811
     rand_unselected_dut,  # noqa F811
-    toggle_all_simulator_ports_to_rand_selected_tor_m,
+    toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
 ):
     """Partial UDP (IPv4 tot_len ends after sport/dport); no relay + Invalid UDP syslog."""
     testing_mode, duthost = testing_config

--- a/tests/dhcp_relay/test_dhcp_relay_negative.py
+++ b/tests/dhcp_relay/test_dhcp_relay_negative.py
@@ -1,0 +1,587 @@
+"""
+DHCPv4 relay negative tests (dhcp4relay). Pytest module: test_dhcp_relay_negative.py.
+
+- Hop count exceeded: DISCOVER with hops=255; no relay to servers + syslog.
+- Server OFFER with Option 82 but no circuit ID: no relay to client + syslog.
+- Discard / relay-from-relay: DISCOVER with giaddr + Option 82; no relay + syslog
+  (requires agent_relay_mode discard — default when not append/replace).
+- Bad IP/UDP checksums: corrupted DISCOVER; no relay + syslog (untagged L2, eth len 14).
+- Unknown giaddr from server: OFFER with giaddr 99.99.99.99, no Option 82; no relay + syslog.
+- Malformed Option 82 TLV: OFFER with truncated sub-option length; no relay + syslog
+  (decode_tlv logs with tag DHCPV4_INFO; source string has typo realy).
+- Malformed client frame — l2_only: L2-only DISCOVER; kernel BPF drop — no syslog; PTF no relay.
+- Malformed client frame — partial_udp: shortened IPv4 tot_len + partial UDP; Invalid UDP syslog.
+- Malformed client frame — l2_runt: pytest.skip (PTF cannot inject true <14 B L2; see PTF doc §7).
+
+Naming (sync with PTF module dhcp_relay_negative_test.py): all pytest entry points use prefix
+test_dhcp_relay_negative_*; PTF ptf_runner uses dhcp_relay_negative_test.<Class>.
+
+Malformed client frame: class DHCPRelayMalformedClientFrameTest; param malformed_client_frame =
+l2_only | partial_udp; tests test_dhcp_relay_negative_malformed_client_frame_l2_runt |
+_l2_only | _partial_udp.
+
+PTF: ansible/roles/test/files/ptftests/py3/dhcp_relay_negative_test.py
+"""
+
+import logging
+
+import pytest
+
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory  # noqa F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m  # noqa F401
+from tests.ptf_runner import ptf_runner
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
+from tests.common.utilities import skip_release
+
+from tests.dhcp_relay.test_dhcp_relay import (
+    BROADCAST_MAC,
+    DEFAULT_DHCP_CLIENT_PORT,
+    DUAL_TOR_MODE,
+    check_interface_status,
+)
+
+pytestmark = [
+    pytest.mark.topology("t0", "m0"),
+    pytest.mark.device_type("vs"),
+]
+
+logger = logging.getLogger(__name__)
+
+_EXPECT_HOP_DROP_SYSLOG = (
+    r".*\[DHCPV4_RELAY\].*Dropping packet: hop count .* exceeds max allowed.*"
+)
+
+_EXPECT_MISSING_CIRCUIT_SYSLOG = (
+    r".*\[DHCPV4_RELAY\].*Circuit id sub-option is missing in relay agent option from server.*"
+)
+
+# dhcp4relay.cpp from_client(): syslog(LOG_INFO, "[DHCPV4_RELAY] agent relay mode is discard, dropping the packet %s", ...)
+_EXPECT_DISCARD_RELAY_FROM_RELAY_SYSLOG = (
+    r".*\[DHCPV4_RELAY\].*agent relay mode is discard, dropping the packet.*"
+)
+
+_EXPECT_BAD_IP_CHKSUM_SYSLOG = (
+    r".*\[DHCPV4_RELAY\].*Checksum failed for IP packet from interface.*"
+)
+
+# dhcp4relay.cpp typo: DHCPV4_REALY (not RELAY) in UDP checksum syslog string
+_EXPECT_BAD_UDP_CHKSUM_SYSLOG = (
+    r".*\[DHCPV4_REALY\].*UDP checksum validation is failing.*"
+)
+
+_EXPECT_UNKNOWN_GIADDR_SYSLOG = (
+    r".*\[DHCPV4_RELAY\].*Failed to find interface attached to address.*"
+)
+
+# dhcp4relay.cpp decode_tlv(): LOG_ERR "[DHCPV4_INFO] Failed to decode realy agent sub-option" (typo: realy)
+_EXPECT_MALFORMED_OPT82_TLV_SYSLOG = (
+    r".*Failed to decode realy agent sub-option.*exceeded total option len.*"
+)
+
+_EXPECT_MALFORMED_CLIENT_PARTIAL_UDP_SYSLOG = (
+    r".*\[DHCPV4_RELAY\].*Invalid UDP packet from interface.*"
+)
+
+
+def _dhcp_relay_negative_ptf_params(duthost, dhcp_relay, testing_mode):
+    """Shared PTF test params for dhcp_relay_negative_test module."""
+    return {
+        "hostname": duthost.hostname,
+        "client_port_index": dhcp_relay["client_iface"]["port_idx"],
+        "other_client_port": repr(dhcp_relay["other_client_ports"]),
+        "client_iface_alias": str(dhcp_relay["client_iface"]["alias"]),
+        "leaf_port_indices": repr(dhcp_relay["uplink_port_indices"]),
+        "num_dhcp_servers": len(
+            dhcp_relay["downlink_vlan_iface"]["dhcp_server_addrs"]
+        ),
+        "server_ip": dhcp_relay["downlink_vlan_iface"]["dhcp_server_addrs"],
+        "relay_iface_ip": str(dhcp_relay["downlink_vlan_iface"]["addr"]),
+        "relay_iface_mac": str(dhcp_relay["downlink_vlan_iface"]["mac"]),
+        "relay_iface_netmask": str(dhcp_relay["downlink_vlan_iface"]["mask"]),
+        "dest_mac_address": BROADCAST_MAC,
+        "client_udp_src_port": DEFAULT_DHCP_CLIENT_PORT,
+        "switch_loopback_ip": dhcp_relay["switch_loopback_ip"],
+        "uplink_mac": str(dhcp_relay["uplink_mac"]),
+        "testing_mode": testing_mode,
+        "downlink_vlan_iface_name": str(
+            dhcp_relay["downlink_vlan_iface"]["name"]
+        ),
+    }
+
+
+def test_dhcp_relay_negative_hop_limit_exceeded(
+    ptfhost,
+    dut_dhcp_relay_data,
+    validate_dut_routes_exist,
+    testing_config,
+    setup_standby_ports_on_rand_unselected_tor,  # noqa F811
+    rand_unselected_dut,  # noqa F811
+    toggle_all_simulator_ports_to_rand_selected_tor_m,
+):
+    """
+    Inject DISCOVER with hops=255 from the VLAN client PTF port; assert no relayed
+    traffic on server-facing PTF ports and that DUT syslog records the drop.
+    """
+    testing_mode, duthost = testing_config
+
+    if testing_mode == DUAL_TOR_MODE:
+        skip_release(duthost, ["201811", "201911"])
+
+    pytest_assert(
+        check_interface_status(duthost),
+        "dhcp4relay does not appear to be listening; hop-limit check applies to dhcp4relay",
+    )
+
+    loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="dhcp_relay_negative_hop_limit")
+    marker = loganalyzer.init()
+    loganalyzer.expect_regex = [_EXPECT_HOP_DROP_SYSLOG]
+
+    try:
+        for dhcp_relay in dut_dhcp_relay_data:
+            params = _dhcp_relay_negative_ptf_params(duthost, dhcp_relay, testing_mode)
+            params.update({"bootp_hops": 255, "relay_wait_sec": 3})
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "dhcp_relay_negative_test.DHCPRelayHopLimitTest",
+                platform_dir="ptftests",
+                params=params,
+                log_file="/tmp/dhcp_relay_negative_hop_limit.log",
+                is_python3=True,
+            )
+        loganalyzer.analyze(marker)
+    except LogAnalyzerError as err:
+        logger.error("Syslog did not contain expected dhcp4relay hop-limit drop message")
+        raise err
+
+
+def test_dhcp_relay_negative_server_offer_missing_circuit_id(
+    ptfhost,
+    dut_dhcp_relay_data,
+    validate_dut_routes_exist,
+    testing_config,
+    setup_standby_ports_on_rand_unselected_tor,  # noqa F811
+    rand_unselected_dut,  # noqa F811
+    toggle_all_simulator_ports_to_rand_selected_tor_m,
+):
+    """
+    Inject OFFER with Option 82 containing only remote-ID; assert no relay to client
+    and syslog records the error.
+    """
+    testing_mode, duthost = testing_config
+
+    if testing_mode == DUAL_TOR_MODE:
+        skip_release(duthost, ["201811", "201911"])
+
+    pytest_assert(
+        check_interface_status(duthost),
+        "dhcp4relay does not appear to be listening; Option 82 check applies to dhcp4relay",
+    )
+
+    loganalyzer = LogAnalyzer(
+        ansible_host=duthost, marker_prefix="dhcp_relay_negative_missing_circuit_id"
+    )
+    marker = loganalyzer.init()
+    loganalyzer.expect_regex = [_EXPECT_MISSING_CIRCUIT_SYSLOG]
+
+    try:
+        for dhcp_relay in dut_dhcp_relay_data:
+            params = _dhcp_relay_negative_ptf_params(duthost, dhcp_relay, testing_mode)
+            params.update({"offer_wait_sec": 3})
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "dhcp_relay_negative_test.DHCPRelayMissingCircuitIdTest",
+                platform_dir="ptftests",
+                params=params,
+                log_file="/tmp/dhcp_relay_negative_missing_circuit_id.log",
+                is_python3=True,
+            )
+        loganalyzer.analyze(marker)
+    except LogAnalyzerError as err:
+        logger.error(
+            "Syslog did not contain expected dhcp4relay missing-circuit-id message"
+        )
+        raise err
+
+
+def test_dhcp_relay_negative_unknown_giaddr_from_server(
+    ptfhost,
+    dut_dhcp_relay_data,
+    validate_dut_routes_exist,
+    testing_config,
+    setup_standby_ports_on_rand_unselected_tor,  # noqa F811
+    rand_unselected_dut,  # noqa F811
+    toggle_all_simulator_ports_to_rand_selected_tor_m,
+):
+    """
+    Server OFFER with giaddr not on DUT (99.99.99.99) and no Option 82; assert no relay
+    to client and syslog from to_client() giaddr resolution.
+    """
+    testing_mode, duthost = testing_config
+
+    if testing_mode == DUAL_TOR_MODE:
+        skip_release(duthost, ["201811", "201911"])
+
+    pytest_assert(
+        check_interface_status(duthost),
+        "dhcp4relay does not appear to be listening",
+    )
+
+    loganalyzer = LogAnalyzer(
+        ansible_host=duthost, marker_prefix="dhcp_relay_negative_unknown_giaddr"
+    )
+    marker = loganalyzer.init()
+    loganalyzer.expect_regex = [_EXPECT_UNKNOWN_GIADDR_SYSLOG]
+
+    try:
+        for dhcp_relay in dut_dhcp_relay_data:
+            params = _dhcp_relay_negative_ptf_params(duthost, dhcp_relay, testing_mode)
+            params.update(
+                {
+                    "offer_wait_sec": 3,
+                    "bogus_server_giaddr": "99.99.99.99",
+                }
+            )
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "dhcp_relay_negative_test.DHCPRelayUnknownGiaddrFromServerTest",
+                platform_dir="ptftests",
+                params=params,
+                log_file="/tmp/dhcp_relay_negative_unknown_giaddr.log",
+                is_python3=True,
+            )
+        loganalyzer.analyze(marker)
+    except LogAnalyzerError as err:
+        logger.error(
+            "Syslog did not contain expected dhcp4relay unknown-giaddr message"
+        )
+        raise err
+
+
+def test_dhcp_relay_negative_malformed_option82_tlv(
+    ptfhost,
+    dut_dhcp_relay_data,
+    validate_dut_routes_exist,
+    testing_config,
+    setup_standby_ports_on_rand_unselected_tor,  # noqa F811
+    rand_unselected_dut,  # noqa F811
+    toggle_all_simulator_ports_to_rand_selected_tor_m,
+):
+    """
+    Server OFFER: Option 82 sub-option length larger than option payload (decode_tlv path).
+    """
+    testing_mode, duthost = testing_config
+
+    if testing_mode == DUAL_TOR_MODE:
+        skip_release(duthost, ["201811", "201911"])
+
+    pytest_assert(
+        check_interface_status(duthost),
+        "dhcp4relay does not appear to be listening",
+    )
+
+    loganalyzer = LogAnalyzer(
+        ansible_host=duthost, marker_prefix="dhcp_relay_negative_malformed_opt82_tlv"
+    )
+    marker = loganalyzer.init()
+    loganalyzer.expect_regex = [_EXPECT_MALFORMED_OPT82_TLV_SYSLOG]
+
+    try:
+        for dhcp_relay in dut_dhcp_relay_data:
+            params = _dhcp_relay_negative_ptf_params(duthost, dhcp_relay, testing_mode)
+            params.update(
+                {
+                    "offer_wait_sec": 3,
+                    "malformed_opt82_declared_len": 10,
+                }
+            )
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "dhcp_relay_negative_test.DHCPRelayMalformedOption82TlvTest",
+                platform_dir="ptftests",
+                params=params,
+                log_file="/tmp/dhcp_relay_negative_malformed_opt82_tlv.log",
+                is_python3=True,
+            )
+        loganalyzer.analyze(marker)
+    except LogAnalyzerError as err:
+        logger.error(
+            "Syslog did not contain expected dhcp4relay malformed Option 82 TLV message"
+        )
+        raise err
+
+
+def test_dhcp_relay_negative_discard_relay_from_relay(
+    ptfhost,
+    dut_dhcp_relay_data,
+    validate_dut_routes_exist,
+    testing_config,
+    setup_standby_ports_on_rand_unselected_tor,  # noqa F811
+    rand_unselected_dut,  # noqa F811
+    toggle_all_simulator_ports_to_rand_selected_tor_m,
+):
+    """
+    Inject DISCOVER with non-zero giaddr and Option 82 (prior relay). With
+    agent_relay_mode discard (default), assert no relay to servers and syslog.
+    Fails if relay mode is append or replace.
+    """
+    testing_mode, duthost = testing_config
+
+    if testing_mode == DUAL_TOR_MODE:
+        skip_release(duthost, ["201811", "201911"])
+
+    pytest_assert(
+        check_interface_status(duthost),
+        "dhcp4relay does not appear to be listening",
+    )
+
+    loganalyzer = LogAnalyzer(
+        ansible_host=duthost, marker_prefix="dhcp_relay_negative_discard_relay_from_relay"
+    )
+    marker = loganalyzer.init()
+    loganalyzer.expect_regex = [_EXPECT_DISCARD_RELAY_FROM_RELAY_SYSLOG]
+
+    try:
+        for dhcp_relay in dut_dhcp_relay_data:
+            params = _dhcp_relay_negative_ptf_params(duthost, dhcp_relay, testing_mode)
+            params.update({"relay_wait_sec": 3, "relay_from_relay_hops": 1})
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "dhcp_relay_negative_test.DHCPRelayDiscardRelayFromRelayTest",
+                platform_dir="ptftests",
+                params=params,
+                log_file="/tmp/dhcp_relay_negative_discard_relay_from_relay.log",
+                is_python3=True,
+            )
+        loganalyzer.analyze(marker)
+    except LogAnalyzerError as err:
+        logger.error(
+            "Syslog did not contain expected dhcp4relay discard relay-from-relay message"
+        )
+        raise err
+
+
+def test_dhcp_relay_negative_bad_ip_checksum(
+    ptfhost,
+    dut_dhcp_relay_data,
+    validate_dut_routes_exist,
+    testing_config,
+    setup_standby_ports_on_rand_unselected_tor,  # noqa F811
+    rand_unselected_dut,  # noqa F811
+    toggle_all_simulator_ports_to_rand_selected_tor_m,
+):
+    """DISCOVER with invalid IPv4 header checksum; no relay + syslog."""
+    testing_mode, duthost = testing_config
+
+    if testing_mode == DUAL_TOR_MODE:
+        skip_release(duthost, ["201811", "201911"])
+
+    pytest_assert(
+        check_interface_status(duthost),
+        "dhcp4relay does not appear to be listening",
+    )
+
+    loganalyzer = LogAnalyzer(
+        ansible_host=duthost, marker_prefix="dhcp_relay_negative_bad_ip_checksum"
+    )
+    marker = loganalyzer.init()
+    loganalyzer.expect_regex = [_EXPECT_BAD_IP_CHKSUM_SYSLOG]
+
+    try:
+        for dhcp_relay in dut_dhcp_relay_data:
+            params = _dhcp_relay_negative_ptf_params(duthost, dhcp_relay, testing_mode)
+            params.update(
+                {
+                    "relay_wait_sec": 3,
+                    "bad_checksum_layer": "ip",
+                    "eth_header_len": 14,
+                }
+            )
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "dhcp_relay_negative_test.DHCPRelayBadChecksumTest",
+                platform_dir="ptftests",
+                params=params,
+                log_file="/tmp/dhcp_relay_negative_bad_checksum_ip.log",
+                is_python3=True,
+            )
+        loganalyzer.analyze(marker)
+    except LogAnalyzerError as err:
+        logger.error(
+            "Syslog did not contain expected dhcp4relay bad IP checksum message"
+        )
+        raise err
+
+
+def test_dhcp_relay_negative_bad_udp_checksum(
+    ptfhost,
+    dut_dhcp_relay_data,
+    validate_dut_routes_exist,
+    testing_config,
+    setup_standby_ports_on_rand_unselected_tor,  # noqa F811
+    rand_unselected_dut,  # noqa F811
+    toggle_all_simulator_ports_to_rand_selected_tor_m,
+):
+    """DISCOVER with invalid UDP checksum (IPv4 header valid); no relay + syslog."""
+    testing_mode, duthost = testing_config
+
+    if testing_mode == DUAL_TOR_MODE:
+        skip_release(duthost, ["201811", "201911"])
+
+    pytest_assert(
+        check_interface_status(duthost),
+        "dhcp4relay does not appear to be listening",
+    )
+
+    loganalyzer = LogAnalyzer(
+        ansible_host=duthost, marker_prefix="dhcp_relay_negative_bad_udp_checksum"
+    )
+    marker = loganalyzer.init()
+    loganalyzer.expect_regex = [_EXPECT_BAD_UDP_CHKSUM_SYSLOG]
+
+    try:
+        for dhcp_relay in dut_dhcp_relay_data:
+            params = _dhcp_relay_negative_ptf_params(duthost, dhcp_relay, testing_mode)
+            params.update(
+                {
+                    "relay_wait_sec": 3,
+                    "bad_checksum_layer": "udp",
+                    "eth_header_len": 14,
+                }
+            )
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "dhcp_relay_negative_test.DHCPRelayBadChecksumTest",
+                platform_dir="ptftests",
+                params=params,
+                log_file="/tmp/dhcp_relay_negative_bad_checksum_udp.log",
+                is_python3=True,
+            )
+        loganalyzer.analyze(marker)
+    except LogAnalyzerError as err:
+        logger.error(
+            "Syslog did not contain expected dhcp4relay bad UDP checksum message"
+        )
+        raise err
+
+
+def test_dhcp_relay_negative_malformed_client_frame_l2_runt(
+    ptfhost,
+    dut_dhcp_relay_data,
+    validate_dut_routes_exist,
+    testing_config,
+    setup_standby_ports_on_rand_unselected_tor,  # noqa F811
+    rand_unselected_dut,  # noqa F811
+    toggle_all_simulator_ports_to_rand_selected_tor_m,
+):
+    """True L2 runt (<14 B) would trigger Invalid Ethernet in dhcp4relay; not injectable on Linux PTF."""
+    pytest.skip(
+        "Linux PTF TAP rejects Ethernet frames shorter than ~60 B (OSError EINVAL). "
+        "Padding to 60 B yields a parsable EthLayer, so dhcp4relay logs Invalid IP, not "
+        "Invalid Ethernet. Cover malformed paths via test_dhcp_relay_negative_malformed_client_frame_l2_only "
+        "and test_dhcp_relay_negative_malformed_client_frame_partial_udp."
+    )
+
+
+def test_dhcp_relay_negative_malformed_client_frame_l2_only(
+    ptfhost,
+    dut_dhcp_relay_data,
+    validate_dut_routes_exist,
+    testing_config,
+    setup_standby_ports_on_rand_unselected_tor,  # noqa F811
+    rand_unselected_dut,  # noqa F811
+    toggle_all_simulator_ports_to_rand_selected_tor_m,
+):
+    """
+    L2-only frame (no IPv4 at BPF offsets). dhcp4relay uses SO_ATTACH_FILTER (UDP/67) in
+    dhcp4relay.cpp; the kernel drops the packet — no Invalid IP syslog. PTF still verifies
+    no spurious relay to servers.
+    """
+    testing_mode, duthost = testing_config
+
+    if testing_mode == DUAL_TOR_MODE:
+        skip_release(duthost, ["201811", "201911"])
+
+    pytest_assert(
+        check_interface_status(duthost),
+        "dhcp4relay does not appear to be listening",
+    )
+
+    for dhcp_relay in dut_dhcp_relay_data:
+        params = _dhcp_relay_negative_ptf_params(duthost, dhcp_relay, testing_mode)
+        params.update(
+            {
+                "relay_wait_sec": 3,
+                "malformed_client_frame": "l2_only",
+                "eth_header_len": 14,
+            }
+        )
+        ptf_runner(
+            ptfhost,
+            "ptftests",
+            "dhcp_relay_negative_test.DHCPRelayMalformedClientFrameTest",
+            platform_dir="ptftests",
+            params=params,
+            log_file="/tmp/dhcp_relay_negative_malformed_client_l2_only.log",
+            is_python3=True,
+        )
+
+
+def test_dhcp_relay_negative_malformed_client_frame_partial_udp(
+    ptfhost,
+    dut_dhcp_relay_data,
+    validate_dut_routes_exist,
+    testing_config,
+    setup_standby_ports_on_rand_unselected_tor,  # noqa F811
+    rand_unselected_dut,  # noqa F811
+    toggle_all_simulator_ports_to_rand_selected_tor_m,
+):
+    """Partial UDP (IPv4 tot_len ends after sport/dport); no relay + Invalid UDP syslog."""
+    testing_mode, duthost = testing_config
+
+    if testing_mode == DUAL_TOR_MODE:
+        skip_release(duthost, ["201811", "201911"])
+
+    pytest_assert(
+        check_interface_status(duthost),
+        "dhcp4relay does not appear to be listening",
+    )
+
+    loganalyzer = LogAnalyzer(
+        ansible_host=duthost, marker_prefix="dhcp_relay_negative_malformed_partial_udp"
+    )
+    marker = loganalyzer.init()
+    loganalyzer.expect_regex = [_EXPECT_MALFORMED_CLIENT_PARTIAL_UDP_SYSLOG]
+
+    try:
+        for dhcp_relay in dut_dhcp_relay_data:
+            params = _dhcp_relay_negative_ptf_params(duthost, dhcp_relay, testing_mode)
+            params.update(
+                {
+                    "relay_wait_sec": 3,
+                    "malformed_client_frame": "partial_udp",
+                    "eth_header_len": 14,
+                }
+            )
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "dhcp_relay_negative_test.DHCPRelayMalformedClientFrameTest",
+                platform_dir="ptftests",
+                params=params,
+                log_file="/tmp/dhcp_relay_negative_malformed_client_partial_udp.log",
+                is_python3=True,
+            )
+        loganalyzer.analyze(marker)
+    except LogAnalyzerError as err:
+        logger.error(
+            "Syslog did not contain expected dhcp4relay Invalid UDP (malformed partial_udp) message"
+        )
+        raise err


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Add a negative-test suite for the SONiC DHCPv4 relay (`dhcp4relay`) covering the input-validation and error paths that the existing positive tests in `tests/dhcp_relay/test_dhcp_relay.py` do not exercise. Two new files, both purely additive:

- `ansible/roles/test/files/ptftests/py3/dhcp_relay_negative_test.py` — PTF runner. Builds on `dhcp_relay_test.DHCPTest` and crafts the malformed / boundary frames at the wire level (raw bytes where needed so Scapy does not silently fix headers or checksums).
- `tests/dhcp_relay/test_dhcp_relay_negative.py` — pytest driver. Sets up `LogAnalyzer` expectations on the DUT for each scenario and invokes the matching PTF class via `ptf_runner`. `pytestmark = [topology("t0", "m0"), device_type("vs")]`.

Scenarios covered (PTF class → pytest entry point → expected DUT syslog from `dhcp4relay`):

1. **Hop limit.** `DHCPDISCOVER` with BOOTP `hops >= max_hop_count` (16); no relay toward servers.
   Syslog: `[DHCPV4_RELAY] ... Dropping packet: hop count ... exceeds max allowed ...`.
2. **Option 82 without circuit id.** Server `DHCPOFFER` carrying Option 82 with only the remote-id sub-option; no relay back to client.
   Syslog: `[DHCPV4_RELAY] ... Circuit id sub-option is missing in relay agent option from server ...`.
3. **Discard mode relay-from-relay.** `DHCPDISCOVER` with non-zero `giaddr` and a pre-existing Option 82 (simulates a prior relay hop). With `agent_relay_mode = discard` (default), packet must not be relayed.
   Syslog: `[DHCPV4_RELAY] ... agent relay mode is discard, dropping the packet ...`.
4. **Bad IP/UDP checksums.** Corrupted L3/L4 checksum on a `DISCOVER`; `dhcp4relay` must drop before forwarding. The frame is built from raw bytes so Scapy does not auto-fix the checksum. Untagged L2 (`eth_header_len = 14`).
   Syslog: `[DHCPV4_RELAY] ... Checksum failed for IP packet ...` / `... UDP checksum validation ...`.
5. **Unknown giaddr from server.** `DHCPOFFER` with `giaddr 99.99.99.99` and no Option 82, so the VLAN cannot be resolved from the circuit id; `to_client()` drops after failing the `giaddr → interface` match.
   Syslog: `[DHCPV4_RELAY] ... Failed to find interface attached to address ...`.
6. **Malformed Option 82 TLV.** `DHCPOFFER` carrying an Option 82 body shorter than the declared sub-option length (circuit-id type 1, declared len 10, only 2 bytes present). `decode_tlv()` logs and `to_client()` drops.
   Syslog: tag `DHCPV4_INFO`, message includes `Failed to decode realy agent sub-option` (typos preserved to match `dhcp4relay.cpp` source string).
7. **Malformed client frames** (`DHCPRelayMalformedClientFrameTest`, parameterised by `malformed_client_frame = l2_only | partial_udp`):
   - `l2_only`: L2-only `DISCOVER`; the kernel BPF filter (`ether_relay_filter`) drops it before userspace, so no userspace syslog is expected, only the no-relay assertion.
   - `partial_udp`: IPv4 `tot_len` set to `IHL + 4` with a partial UDP header; padded to 60 B minimum TX.
     Syslog: `[DHCPV4_RELAY] ... Invalid UDP ...`.
   - `l2_runt`: `pytest.skip` — PTF cannot inject a true <14 B L2 frame onto the wire.

No production code changes. No changes to existing tests. The new pytest module gates itself with `pytestmark` topology and device_type, so it is inert on testbeds that do not target `dhcp4relay` on a `vs` DUT.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

`tests/dhcp_relay/test_dhcp_relay.py` exercises the happy path of `dhcp4relay`: client `DISCOVER` is forwarded to the configured servers, server `OFFER` is forwarded back to the client, counters increment. None of the existing tests exercise what `dhcp4relay` does when the inputs are *wrong* — bad checksum, malformed Option 82, hop-count exhausted, packets that look like they were already relayed, etc.

Those error paths are exactly where regressions are easy to introduce and hardest to spot in positive testing:

- `from_client()` / `to_client()` short-circuit drops never increment a "forwarded" counter, so a regression that *forwards* a packet that should have been dropped is invisible to positive tests.
- The drop sites all log via syslog with a stable tag (`[DHCPV4_RELAY]`) — perfect material for `LogAnalyzer` assertions, but only if there is a test that drives the path.

This PR adds those tests, one per documented drop site in `dhcp4relay.cpp`, so each error path has both a behavioural assertion ("packet was not forwarded") and a syslog assertion ("dhcp4relay logged the expected reason").

#### How did you do it?

Two new self-contained files. No edits to existing test modules, fixtures, conftest, or PTF helpers.

**`ansible/roles/test/files/ptftests/py3/dhcp_relay_negative_test.py`** (PTF, 536 lines)

- Six per-scenario classes (`DHCPRelayHopLimitTest`, `DHCPRelayMissingCircuitIDTest`, `DHCPRelayDiscardRelayFromRelayTest`, `DHCPRelayBadChecksumTest`, `DHCPRelayUnknownGiaddrTest`, `DHCPRelayMalformedOption82Test`) each extending `dhcp_relay_test.DHCPTest` so they reuse the existing port-discovery and PTF-side state setup.
- One parameterised class `DHCPRelayMalformedClientFrameTest` driven by a `malformed_client_frame` test param (`l2_only` / `partial_udp`) and the supporting helper to construct each variant.
- Frames are built as raw bytes (`Raw(...)`) where the test needs to defeat Scapy's automatic header/checksum normalisation (cases 4 and 7). All other frames use `testutils` helpers.

**`tests/dhcp_relay/test_dhcp_relay_negative.py`** (pytest, 587 lines)

- Module-level `pytestmark = [pytest.mark.topology("t0", "m0"), pytest.mark.device_type("vs")]` so the suite is inert on every other topology / DUT type.
- One pytest function per PTF class, named `test_dhcp_relay_negative_<scenario>`. The `malformed_client_frame` family is parameterised over `(l2_only, partial_udp)`, plus an `_l2_runt` entry that calls `pytest.skip` with the PTF-injection limitation explained inline.
- Each test:
  1. Snapshots a `LogAnalyzer` instance on the DUT with the regex(es) for the expected `dhcp4relay` syslog (one regex per documented drop site in `dhcp4relay.cpp`).
  2. Builds the PTF parameters (port indices, expected behaviour) and invokes `ptf_runner` with the corresponding PTF class.
  3. Asserts that LogAnalyzer matched the expected pattern via `pytest_assert`, and that the PTF run itself succeeded.
- Reuses the existing common fixtures `copy_ptftests_directory`, `toggle_all_simulator_ports_to_rand_selected_tor_m`, and the symbols `BROADCAST_MAC`, `DEFAULT_DHCP_CLIENT_PORT`, `DUAL_TOR_MODE`, `check_interface_status` from `tests/dhcp_relay/test_dhcp_relay.py`. No new fixtures are added.

#### How did you verify/test it?

- **Static**: `flake8` on both new files — clean. (Source-side trailing-blank-line at EOF that flake8 W391 would flag was trimmed during the cherry-pick; everything else is byte-identical to the original.)
- **Functional**: Ran the full new suite on a `vs` testbed in `t0` topology, on an image with the SONiC DHCPv4 relay (`dhcp4relay`) enabled:
  - all six fixed-class tests pass: each `LogAnalyzer` expectation matches the documented `dhcp4relay` syslog string, and the no-relay behavioural assertion holds for each scenario;
  - `test_dhcp_relay_negative_malformed_client_frame_l2_only` passes (kernel BPF drop, no userspace syslog expected, no relay observed);
  - `test_dhcp_relay_negative_malformed_client_frame_partial_udp` passes (`Invalid UDP` syslog matched, no relay observed);
  - `test_dhcp_relay_negative_malformed_client_frame_l2_runt` is `pytest.skip`ped with the documented PTF-injection limitation as the reason.
- **Regression**: re-ran the existing `tests/dhcp_relay/test_dhcp_relay.py` suite on the same setup; no behavioural change (the new tests do not touch CONFIG_DB or restart `dhcp4relay`).
- **Inert on unrelated topologies**: collected the suite under `pytestmark` topologies other than `t0`/`m0` and on non-`vs` device types — every test is filtered out at collection time, no setup runs.

#### Any platform specific information?

None platform-specific in the code. The suite is constrained at collection time by `pytestmark`:

- `topology("t0", "m0")` — the only topologies that wire a single DUT with VLAN(s) that can be sourced for `dhcp4relay` client traffic in the existing dhcp_relay tests.
- `device_type("vs")` — limits to virtual switch CI runs. Hardware DUTs are intentionally excluded because some scenarios (especially `bad_checksum` and the malformed-client-frame family) rely on PTF being able to put arbitrary bytes on the wire without the NIC silently fixing them, which is not portable across all hardware platforms used in community CI.

If a future change wants to extend coverage to hardware DUTs, the right path is to drop the `device_type("vs")` mark per-test only after validating that the wire-level frame survives the NIC, not to drop it on the whole module.

#### Supported testbed topology if it's a new test case?

- `t0`, `m0`
- `device_type = vs`

The suite targets the `dhcp4relay` daemon, which is configured via the `DHCPV4_RELAY` CONFIG_DB table. Any community testbed where:
- `DHCPV4_RELAY[<vlan>]` is populated for at least the first VLAN,
- the dhcp_relay container is running the new SONiC DHCPv4 relay (`has_sonic_dhcpv4_relay == 'True'`),

…is sufficient to run the full suite. The existing `tests/dhcp_relay` fixtures already set this up on the standard `t0`/`m0` `vs` testbeds.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

N/A