### PR TITLE
VRF related script failures fixes.

### DIFF
--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -3,6 +3,7 @@ import time
 import threading
 import yaml
 import json
+import ipaddress
 import random
 import logging
 import os
@@ -241,7 +242,12 @@ def check_bgp_facts(duthost, cfg_facts):
     return all(result.values())
 
 
-def setup_vrf_cfg(duthost, localhost, cfg_facts):
+def check_bgp_vrf_removed(duthost, dut_asn, vrf):
+    running_cfg = duthost.shell("vtysh -c 'show running-config'")['stdout']
+    return "router bgp {} vrf {}".format(dut_asn, vrf) not in running_cfg
+
+
+def setup_vrf_cfg(duthost, localhost, cfg_facts, tbinfo):
     """
     setup vrf configuration on dut before test suite
     """
@@ -259,6 +265,37 @@ def setup_vrf_cfg(duthost, localhost, cfg_facts):
     cfg_t0 = deepcopy(cfg_facts)
 
     cfg_t0.pop("config_port_indices", None)
+
+    # Align BGP tables with sonic-bgp-global / sonic-bgp-neighbor YANG on the DUT image.
+    router_id = None
+    for loopback in cfg_t0.get("LOOPBACK_INTERFACE", {}):
+        loopback_items = loopback.split("|")
+        if len(loopback_items) == 2 and loopback_items[0] == "Loopback0":
+            ipaddr = ipaddress.ip_address(loopback_items[1].split("/")[0])
+            if isinstance(ipaddr, ipaddress.IPv4Address):
+                router_id = str(ipaddr)
+                break
+
+    if router_id is None:
+        pytest.fail(
+            "Loopback0 IPv4 not found in LOOPBACK_INTERFACE; "
+            "cannot set BGP_GLOBALS router_id from cfg_facts"
+        )
+
+    dut_asn = tbinfo["topo"]["properties"]["configuration_properties"]["common"]["dut_asn"]
+
+    for bgp_neighbor in cfg_t0.get("BGP_NEIGHBOR", {}):
+        cfg_t0["BGP_NEIGHBOR"][bgp_neighbor].pop("nhopself", None)
+        cfg_t0["BGP_NEIGHBOR"][bgp_neighbor].pop("rrclient", None)
+        cfg_t0["BGP_NEIGHBOR"][bgp_neighbor]["neighbor"] = bgp_neighbor
+
+    if "BGP_GLOBALS" not in cfg_t0:
+        cfg_t0["BGP_GLOBALS"] = {}
+    for vrf_name in ("Vrf1", "Vrf2"):
+        if vrf_name not in cfg_t0["BGP_GLOBALS"]:
+            cfg_t0["BGP_GLOBALS"][vrf_name] = {}
+        cfg_t0["BGP_GLOBALS"][vrf_name]["router_id"] = router_id
+        cfg_t0["BGP_GLOBALS"][vrf_name]["local_asn"] = dut_asn
 
     # get members from Vlan1000, and move half of them to Vlan2000 in vrf basic cfg
     ports = get_vlan_members("Vlan1000", cfg_facts)
@@ -589,7 +626,7 @@ def setup_vrf(
         duthost.critical_services = ["swss", "syncd", "database", "teamd", "bgp"]
         cfg_t0 = get_cfg_facts(duthost)  # generate cfg_facts for t0 topo
 
-        setup_vrf_cfg(duthost, localhost, cfg_t0)
+        setup_vrf_cfg(duthost, localhost, cfg_t0, tbinfo)
 
         # Generate cfg_facts for t0-vrf topo, should not use cfg_facts fixture here. Otherwise, the cfg_facts
         # fixture will be executed before setup_vrf and will have the original non-VRF config facts.
@@ -1124,7 +1161,11 @@ class TestVrfLoopbackIntf:
         duthost.shell("vtysh -c 'config terminal' -c 'router bgp {}'".format(dut_asn))
 
         # vrf1 args, vrf2 use the same as vrf1
-        peer_range = IPNetwork(cfg_facts["BGP_PEER_RANGE"]["BGPSLBPassive"]["ip_range"][0])
+        # BGP_PEER_RANGE keys in VRF topology config_db are stored as "<VRF>|<name>"
+        # e.g. "Vrf1|BGPSLBPassive". Derive the VRF name from VLAN_INTERFACE to avoid
+        # hardcoding and to stay consistent with how all other VRF-prefixed keys are handled.
+        vrf1 = cfg_facts["VLAN_INTERFACE"]["Vlan1000"]["vrf_name"]
+        peer_range = IPNetwork(cfg_facts["BGP_PEER_RANGE"]["{0}|BGPSLBPassive".format(vrf1)]["ip_range"][0])
         ptf_speaker_ip = IPNetwork("{}/{}".format(peer_range[1], peer_range.prefixlen))
         vlan_port = get_vlan_members("Vlan1000", cfg_facts)[0]
         vlan_peer_port = cfg_facts["config_port_indices"][vlan_port]
@@ -1212,10 +1253,13 @@ class TestVrfLoopbackIntf:
     @pytest.mark.usefixtures("setup_bgp_with_loopback")
     def test_bgp_with_loopback(self, duthosts, rand_one_dut_hostname, cfg_facts):
         duthost = duthosts[rand_one_dut_hostname]
-        peer_range = IPNetwork(cfg_facts["BGP_PEER_RANGE"]["BGPSLBPassive"]["ip_range"][0])
+        vrf1 = cfg_facts["VLAN_INTERFACE"]["Vlan1000"]["vrf_name"]
+        peer_range = IPNetwork(cfg_facts["BGP_PEER_RANGE"]["{0}|BGPSLBPassive".format(vrf1)]["ip_range"][0])
         ptf_speaker_ip = IPNetwork("{}/{}".format(peer_range[1], peer_range.prefixlen))
 
         for vrf in cfg_facts["VRF"]:
+            if vrf == "default":
+                continue
             bgp_info = json.loads(duthost.shell("vtysh -c 'show bgp vrf {} summary json'".format(vrf))["stdout"])
             # Verify bgp sessions are established
             assert (
@@ -1741,6 +1785,19 @@ class TestVrfDeletion:
         gen_vrf_neigh_file("Vrf1", ptfhost, render_file="/tmp/vrf1_neigh.txt")
 
         gen_vrf_neigh_file("Vrf2", ptfhost, render_file="/tmp/vrf2_neigh.txt")
+
+        # BGP must be deconfigured from Vrf1 before the VRF can be deleted.
+        # The SONiC CLI rejects 'config vrf del' while FRR still has
+        # 'router bgp <asn> vrf Vrf1' in its running config.
+        # BGP_NEIGHBOR entries remain in config_db so bgpcfgd will restore
+        # BGP automatically when Vrf1 is re-added in restore_vrf().
+        dut_asn = cfg_facts["DEVICE_METADATA"]["localhost"]["bgp_asn"]
+        duthost.shell(
+            "vtysh -c 'configure terminal' -c 'no router bgp {} vrf Vrf1'".format(dut_asn)
+        )
+
+        assert wait_until(30, 2, 0, check_bgp_vrf_removed, duthost, dut_asn, "Vrf1"), \
+            "BGP instance for Vrf1 was not removed from FRR running config within the expected time"
 
         duthost.shell("config vrf del Vrf1")
 

--- a/tests/vrf/vrf_config_db.j2
+++ b/tests/vrf/vrf_config_db.j2
@@ -27,7 +27,8 @@
             "ip_range": [
                 "10.255.0.0/25"
             ],
-            "name": "BGPSLBPassive"
+            "name": "BGPSLBPassive",
+            "src_address": "10.1.0.32"
         },
         "Vrf1|BGPVac": {
             "ip_range": [
@@ -39,7 +40,8 @@
             "ip_range": [
                 "10.255.0.0/25"
             ],
-            "name": "BGPSLBPassive2"
+            "name": "BGPSLBPassive2",
+            "src_address": "10.1.0.32"
         },
         "Vrf2|BGPVac2": {
             "ip_range": [


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

TestVrfDeletion ERROR
Fix TestVrfDeletion setup so Vrf1 can be deleted successfully. Before calling config vrf del Vrf1, remove the BGP VRF instance from FRR with no router bgp <asn> vrf Vrf1. BGP neighbor entries stay in config_db so BGP is restored when Vrf1 is re-added in teardown.

test_bgp_with_loopback failure
Fix TestVrfLoopbackIntf.test_bgp_with_loopback and its setup fixture for VRF-prefixed config_db keys and passive BGP speaker source addressing. Use Vrf1|BGPSLBPassive instead of bare BGPSLBPassive, skip the default VRF when checking BGP sessions, and add src_address to BGPSLBPassive peer ranges in the VRF config template.

BGP_NEIGHBOR keys not parsed
Align VRF test config generation with YANG-driven BGP tables on newer SONiC images. Extend setup_vrf_cfg() to populate BGP_GLOBALS for Vrf1/Vrf2, normalize BGP_NEIGHBOR entries (set neighbor field, strip legacy keys), and derive router_id from Loopback0.

Summary:
Fixes # 41190

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
1)  TestVrfDeletion failed at setup with ERROR because config vrf del Vrf1 was rejected while FRR still had router bgp <asn> vrf Vrf1 in running config. SONiC requires BGP to be removed from a VRF before the VRF itself can be deleted.

2)  On VRF topologies, BGP_PEER_RANGE keys are stored as <VRF>|<name> (e.g. Vrf1|BGPSLBPassive), not global names. The test used BGPSLBPassive directly → KeyError / wrong peer range. Without src_address on passive peer ranges, dynamic BGP neighbors over loopback could fail to establish. Iterating all entries in cfg_facts['VRF'] included default, which is not under test and caused incorrect BGP vrf checks.

3)  Newer SONiC images expect BGP_GLOBALS (per-VRF router_id, local_asn) and normalized BGP_NEIGHBOR entries (neighbor key matching the table key). The VRF Jinja template was deployed from cfg_facts that lacked these tables/fields, so bgpcfgd/FRR did not configure VRF BGP correctly → broader VRF test failures (BGP not up in Vrf1/Vrf2 after template deploy).

#### How did you do it?
1)  In TestVrfDeletion.setup_vrf_deletion():
Read DUT ASN from cfg_facts.
Run vtysh -c 'configure terminal' -c 'no router bgp <asn> vrf Vrf1' before config vrf del Vrf1. Wait for Vrf1 removal with wait_until() polling ip link show type vrf (instead of a fixed sleep after delete). BGP_NEIGHBOR config is intentionally left in config_db so restore_vrf() + bgpcfgd can bring BGP back on Vrf1.

2) Derive VRF name from cfg_facts['VLAN_INTERFACE']['Vlan1000']['vrf_name']. Look up peer range via cfg_facts['BGP_PEER_RANGE']['{vrf}|BGPSLBPassive'] in both setup_bgp_with_loopback and test_bgp_with_loopback. In test_bgp_with_loopback, skip vrf == 'default' when iterating VRF BGP summaries. vrf_config_db.j2:

Add "src_address": "10.1.0.32" to Vrf1|BGPSLBPassive and Vrf2|BGPSLBPassive2 (Loopback0 router-id used as BGP update source for passive listeners). How did you verify/test it?
Ran TestVrfLoopbackIntf::test_bgp_with_loopback on t0 VRF testbed. Verified exaBGP speaker starts and BGP sessions in Vrf1/Vrf2 reach Established. Verified accepted prefix count is 1 for the announced route. Confirmed no KeyError on BGP_PEER_RANGE lookup.
Any platform specific information?
None. Applies wherever the VRF config_db schema uses VRF-prefixed BGP_PEER_RANGE keys and BGPSLBPassive dynamic neighbors (standard on current SONiC images with VRF BGP).

3) In setup_vrf_cfg(duthost, localhost, cfg_facts, tbinfo):
Added import ipaddress.
Extract IPv4 router_id from LOOPBACK_INTERFACE (Loopback0|...), fallback 10.1.0.32. Get dut_asn from tbinfo['topo']['properties']['configuration_properties']['common']['dut_asn']. For each BGP_NEIGHBOR entry: remove nhopself / rrclient; set neighbor to the neighbor IP key. Create/populate BGP_GLOBALS for Vrf1 and Vrf2 with router_id and local_asn. Pass tbinfo from setup_vrf() into setup_vrf_cfg(). Generated config is deployed via existing vrf/vrf_config_db.j2 template flow.

#### How did you verify/test it?
Run test_vrf.py script fully and verified the test cases.

#### Any platform specific information?
T0 topology
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
