### PR TITLE
[mmu probing] pr18.fix: Skip mock UT/IT tests from nightly pipeline collection

### DIFF
--- a/tests/saitests/mock/conftest.py
+++ b/tests/saitests/mock/conftest.py
@@ -1,0 +1,34 @@
+"""Prevent mock UT/IT test collection in nightly pipeline runs.
+
+Mock tests (under it/ and ut/) are for probe development only:
+- UT: Unit tests for individual probe components
+- IT: Integration tests for probe algorithms with mocked PTF
+
+These tests use local pytest.ini with testpaths=. and are designed
+to run directly from their own directories:
+    cd tests/saitests/mock/it && pytest .
+    cd tests/saitests/mock/ut && pytest .
+
+When pytest collects from tests/ (nightly/CI), the mock test files
+cause collection errors because their import-time path manipulation
+(sys.path.insert for probe/, PTF mock injection) runs before
+conditional_mark can apply skip marks. This conftest prevents
+pytest from even entering the mock subdirectories during nightly
+collection, avoiding both collection errors and false test failures.
+
+Related: https://msazure.visualstudio.com/One/_workitems/edit/38000718
+"""
+
+
+def pytest_ignore_collect(collection_path, config):
+    """Skip all mock test subdirectories during nightly collection.
+
+    This hook runs during collection, before test file import,
+    so it prevents the import-time errors that bypass YAML-based
+    conditional skip marks.
+
+    When running directly from mock/it/ or mock/ut/ (with their own
+    pytest.ini setting rootdir=.), this conftest is outside the
+    rootdir and is NOT loaded, so local development runs unaffected.
+    """
+    return True


### PR DESCRIPTION
### Description of PR

Summary:
Skip mock UT/IT probe tests from nightly pipeline collection to prevent false test failures.

Fixes https://msazure.visualstudio.com/One/_workitems/edit/38000718

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Mock tests under `tests/saitests/mock/it/` and `tests/saitests/mock/ut/` are designed for probe development PR validation only. When nightly pipelines collect tests from the `tests/` directory, these mock test files cause collection errors due to import-time path manipulation (`sys.path.insert` for probe module, PTF mock injection). This results in false "Test failed and no xml file created" entries in nightly test reports.

**Why `tests_mark_conditions.yaml` (conditional_mark) cannot fix this:**

The conditional_mark plugin works via the `pytest_collection_modifyitems` hook, which runs **after** pytest has already collected (imported) all test files. The mock tests crash during the import/collection phase itself — `probe_test_helper.py` calls `setup_test_environment()` at module level, which does `sys.path.insert()` and `sys.modules` injection for PTF mocks. When these imports fail or produce unexpected side effects during nightly collection, pytest reports collection errors **before** `pytest_collection_modifyitems` has a chance to apply any skip marks.

This is why the existing `saitests: skip: True` rule in `tests_mark_conditions.yaml` does not prevent the mock tests from appearing as failures in nightly — the YAML-based skip operates too late in the pytest lifecycle.

The fix must operate at the **collection phase**, not the **mark modification phase**. `pytest_ignore_collect` runs during directory scanning, before any test file is imported, which is the correct interception point.

#### How did you do it?

Added a `conftest.py` at `tests/saitests/mock/` with a `pytest_ignore_collect` hook that unconditionally returns `True`. This blocks collection at the directory scanning phase, before any test file imports occur.

This is safe for PR CI because `mock/it/` and `mock/ut/` each have their own `pytest.ini` (with `testpaths=.`) which anchors pytest's rootdir inside those directories. Since pytest only loads conftest.py files within or below rootdir, `mock/conftest.py` is NOT loaded when running directly from `it/` or `ut/`.

**pytest lifecycle — where each mechanism operates:**

```
pytest startup
  │
  ├─ Directory scanning ◄── pytest_ignore_collect (THIS FIX) ── blocks here
  │    └─ Import test files ◄── collection errors happen here (too late for YAML skip)
  │
  ├─ pytest_collection_modifyitems ◄── conditional_mark YAML (operates here, too late)
  │
  └─ Test execution
```

**Behavior matrix:**

| Scenario | Command | rootdir | mock/conftest.py loaded? | Result |
|----------|---------|---------|:---:|--------|
| Nightly | `cd tests/ && pytest ...` | `tests/` | Yes | Mock tests blocked |
| PR CI (IT) | `cd mock/it/ && pytest .` | `mock/it/` | No | Tests run normally |
| PR CI (UT) | `cd mock/ut/ && pytest .` | `mock/ut/` | No | Tests run normally |

#### How did you verify/test it?

- Verified pytest rootdir determination: `mock/it/pytest.ini` and `mock/ut/pytest.ini` anchor rootdir inside their respective directories, placing `mock/conftest.py` outside the conftest loading scope.
- Confirmed the pytest conftest loading rule: conftest.py files above rootdir are never loaded (documented pytest behavior).

#### Any platform specific information?

N/A — this is a test framework change, not platform-specific.

#### Supported testbed topology if it's a new test case?

N/A — no new test case.

### Documentation

N/A