### PR TITLE
Fixing `test_vnet_decap` test failure on T0

### DIFF
--- a/tests/common/vxlan_ecmp_utils.py
+++ b/tests/common/vxlan_ecmp_utils.py
@@ -121,17 +121,18 @@ class Ecmp_Utils(object):
             "for the DUT:{} from minigraph.".format(af, duthost.hostname))
 
     def select_required_interfaces(
-            self, duthost, number_of_required_interfaces, minigraph_data, af):
+            self, duthost, number_of_required_interfaces, minigraph_data, af, topo="T1"):
         '''
         Pick the required number of interfaces to use for tests.
         These interfaces will be selected based on if they are currently
-        running a established BGP.  The interfaces will be picked from the T0
-        facing side.
+        running a established BGP.  The interfaces will be picked from those that face
+        the neighbors of the specified topology (i.e., T0 if topo == "T1" or T1 if topo == "T0").
         '''
+        neigh_topo = "T1" if topo == "T0" else "T0"
         bgp_interfaces = self.get_all_interfaces_running_bgp(
             duthost,
             minigraph_data,
-            "T0")
+            neigh_topo)
 
         # Randomly pick the interface from the above list
         list_of_bgp_ips = []

--- a/tests/vxlan/test_vnet_decap.py
+++ b/tests/vxlan/test_vnet_decap.py
@@ -85,7 +85,9 @@ def setup(request, duthosts, rand_one_dut_hostname, tbinfo, inner_ip_version, ou
     ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=VXLAN_DST_PORT, dutmac=router_mac)
     minigraph_facts = duthost.get_extended_minigraph_facts(tbinfo)
     outer_ip_version_str = f"v{outer_ip_version}"
-    vnet_interface = ecmp_utils.select_required_interfaces(duthost, 1, minigraph_facts, outer_ip_version_str)[0]
+    topo = tbinfo["topo"]["type"].upper()
+    vnet_interface = ecmp_utils.select_required_interfaces(duthost, 1, minigraph_facts, outer_ip_version_str,
+                                                           topo=topo)[0]
     vxlan_tunnel = ecmp_utils.create_vxlan_tunnel(duthost, minigraph_facts, outer_ip_version_str)
     inner_ip_version_str = f"v{inner_ip_version}"
     encap_type = f"{inner_ip_version_str}_in_{outer_ip_version_str}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR fixes a test failure that happens on T0 topologies for tests in `test_vnet_decap.py`.

Summary:
Microsoft ADO ID: 37999353
Fixing `test_vnet_decap` test failure on T0.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
This PR enabled `test_vnet_decap.py` to run on T0 topologies: #24446
However, `Ecmp_Utils::select_required_interfaces` assumes that the device has T1 topology. This results in the following error when the test is run on a device with T0 topology:
```
Error: failed on setup with "RuntimeError: There are not enough interfaces needed to perform the test. We need atleast 2 interfaces, but only 0 are available."
```
This PR fixes this issue.

#### How did you do it?
Modified `Ecmp_Utils::select_required_interfaces` to accept the topology of the testbed as a parameter (with the default value of `T1` to ensure backward compatibility).

#### How did you verify/test it?
Ran the tests on both a T1 and a T0 switch:
```
vxlan/test_vnet_decap.py::test_vnet_decap[inner_ipv4-outer_ipv4] PASSED                                                                               [ 25%]
vxlan/test_vnet_decap.py::test_vnet_decap[inner_ipv4-outer_ipv6] PASSED                                                                               [ 50%]
vxlan/test_vnet_decap.py::test_vnet_decap[inner_ipv6-outer_ipv6] PASSED                                                                               [ 75%]
vxlan/test_vnet_decap.py::test_vnet_decap[inner_ipv6-outer_ipv4] PASSED                                                                               [100%]
```

#### Any platform specific information?
This test runs only on Cisco-8000 and Mellanox platforms.

#### Supported testbed topology if it's a new test case?
T0 and T1 (and their variations).

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A