### PR TITLE
Check for dhcp-server before loading to config_db.

### DIFF
--- a/tests/bgp/templates/vnet_config_db.j2
+++ b/tests/bgp/templates/vnet_config_db.j2
@@ -69,15 +69,19 @@
 {%        endfor %}
     },
 {%     elif k == 'VLAN' %}
+{%         set vlan1000 = cfg_t0['VLAN']['Vlan1000'] %}
+{%         set dhcp_list = vlan1000.get('dhcp_servers', []) %}
     "VLAN": {
         "Vlan1000": {
+{%          if dhcp_list %}
             "dhcp_servers": [
-{%              for dhcp in cfg_t0['VLAN']['Vlan1000']['dhcp_servers'] %}
+{%              for dhcp in dhcp_list %}
                 {{ dhcp | to_nice_json }}{% if not loop.last %},
 {% endif %}
 {% endfor %}
 
             ],
+{%          endif %}
             "vlanid": "1000"},
         "Vlan2000": {
             "vlanid": "2000"}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

On DUTs where has_sonic_dhcpv4_relay is True, the db_migrator moves dhcp_servers from the VLAN table to the DHCPV4_RELAY table during boot. Check for dhcp_servers under VLAN table and then load DHCP_Server configurations.

Summary:
Fixes # 39095

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
The bgp/test_bgp_vnet.py suite fails at module setup on DUTs where DHCP DB migration has run: IPv4 DHCP relay data is no longer on VLAN|Vlan1000 as dhcp_servers (it moves to DHCPV4_RELAY / dhcpv4_servers when has_sonic_dhcpv4_relay is true).

The Jinja template bgp/templates/vnet_config_db.j2 used to always dereference cfg_t0['VLAN']['Vlan1000']['dhcp_servers'], which raises AnsibleUndefinedVariable / 'dict object' has no attribute 'dhcp_servers' when that key is missing. That aborts setup_vnet_cfg before any BGP/VNET test runs; the fixture’s recovery path can reboot and worsen the session.

#### How did you do it?
vnet_config_db.j2 (config generation)
Treat dhcp_servers on Vlan1000 as optional: use vlan1000.get('dhcp_servers', []) and only emit the dhcp_servers JSON array when the list is non-empty. Treat dhcpv6_servers on Vlan1000 the same way (still present on VLAN on many migrated systems) so the rendered snippet does not drop IPv6 server entries the DUT still has. No logic that copies DHCPV4_RELAY|dhcpv4_servers back into VLAN|dhcp_servers in the custom block: after migration, dhcp_servers simply omits from the generated Vlan1000 when absent, while DHCPV4_RELAY (and the rest of cfg_t0) continues to pass through the template’s generic {% else %} branch for any key not specially rewritten—so relay config is not stripped from the overall config_db shape when it exists in facts. test_bgp_vnet.py (only if included in this PR)
Map DUT Ethernet* members to PTF port indices via mg_facts (minigraph_ptf_indices / minigraph_port_indices, with a small EthernetN // 4 fallback), instead of assuming // 4 everywhere. test_bgp_vnet_route_forwarding: pass mg_facts, derive send/expect ports from that mapping, assert when no Vnet1 ports are resolved, and tighten the PTF Mask / flush behavior used for egress matching.

#### How did you verify/test it?
On a failing DUT (e.g. physical T0 with relay migration):

sonic-cfggen -d --var-json VLAN — confirm Vlan1000 has no dhcp_servers (or only dhcpv6_servers + vlanid). sonic-cfggen -d --var-json DHCPV4_RELAY — confirm dhcpv4_servers holds the IPv4 server list where applicable. sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "has_sonic_dhcpv4_relay" — True where migration applies. sonic-cfggen -m <minigraph.xml> --var-json VLAN — optional: show pre-migration minigraph still had dhcp_servers for comparison. Re-run pytest bgp/test_bgp_vnet.py (or at least setup_vnet / template render path) and confirm no AnsibleUndefinedVariable on dhcp_servers. (Add: ran test_bgp_vnet_route_forwarding / full suite on the same topology if the Python/PTF changes are part of the PR.)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
