### PR TITLE
[process_monitoring] Enable test_critical_process_monitoring on sonic-vpp

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -697,6 +697,7 @@ t1-lag-vpp:
   - pc/test_lag_2.py
   - pc/test_retry_count.py
   - portstat/test_portstat.py
+  - process_monitoring/test_critical_process_monitoring.py
   - route/test_default_route.py
   - route/test_static_route.py
   - route/test_forced_mgmt_route.py

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -600,17 +600,6 @@ platform_tests:
       - "asic_type in ['vpp'] and platform in ['x86_64-kvm_x86_64-r0']"
 
 #######################################
-#####      Process Monitoring     #####
-#######################################
-process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical_processes:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-#######################################
 #####           QOS               #####
 #######################################
 qos:

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -570,6 +570,12 @@ def get_skip_containers(duthost, tbinfo, skip_vendor_specific_container):
         skip_containers.append("radv")
     if "202412" in duthost.os_version:
         skip_containers.append("gnmi")
+    # On sonic-vpp, syncd-vpp does not survive a redis (database container) restart
+    # like Broadcom dummy_syncd does, and killing the database container also breaks
+    # the rsyslog path used by LogAnalyzer markers. Skip the database container so
+    # the rest of the critical-process monitoring still gets exercised on VPP.
+    if duthost.facts.get("asic_type") == "vpp":
+        skip_containers.append("database")
     skip_containers = skip_containers + skip_vendor_specific_container
     return skip_containers
 


### PR DESCRIPTION
### Description of PR

Summary:
Fixes #25821

Enable `tests/process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical_processes` on the `t1-lag-vpp` PR test pipeline.

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

GitHub issue [sonic-net/sonic-buildimage#25821](https://github.com/sonic-net/sonic-buildimage/issues/25821) asks for `test_critical_process_monitoring` to be enabled on sonic-vpp. The test was suppressed in `tests_mark_conditions_sonic_vpp.yaml` with a stale reason of `Failed/Errored: To be included`. When the skip is removed, the test runs but fails because of a sonic-vpp-specific platform behavior, not a real defect in the test itself.

#### How did you do it?

Three small changes:

1. **`tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml`** — remove the `process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical_processes` skip block so the test is no longer suppressed on sonic-vpp.

2. **`tests/process_monitoring/test_critical_process_monitoring.py`** — in `get_skip_containers`, append the `database` container to `skip_containers` when `duthost.facts['asic_type'] == 'vpp'`. On sonic-vpp, `syncd-vpp` does not survive a Redis restart the way Broadcom `dummy_syncd` does, and killing the `database` container also breaks the rsyslog path that the `LogAnalyzer` end-marker depends on. Skipping the `database` container on VPP follows the same pattern that the test already uses to skip `gbsyncd`, `restapi`, `radv`, `gnmi` etc.; the rest of the critical containers are still exercised on VPP.

3. **`.azure-pipelines/pr_test_scripts.yaml`** — add `process_monitoring/test_critical_process_monitoring.py` to the `t1-lag-vpp` allowlist (alphabetically, between `portstat/test_portstat.py` and `route/test_default_route.py`). The test is already in the `t0`, `t1-lag` and `onboarding` allowlists.

#### How did you verify/test it?

Run on `vms-kvm-vpp-t1-lag` (`vlab-vpp-01`):

```
tests/process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical_processes PASSED
1 passed, 253 warnings in 487.09s (0:08:07)
```

Without the `get_skip_containers` change the same test fails either by `syncd-vpp` being in EXITED state when the test tries to kill it (alphabetical kill order kills `database` first, `syncd-vpp` follows it down), or — if syncd is killed first — by `LogAnalyzer`'s `add_end_marker` not finding its marker in `/var/log/syslog` within 120 s after the database container is brought down. Skipping the `database` container on VPP avoids both failure modes.

#### Any platform specific information?

Yes — the `database`-container skip is gated on `asic_type == 'vpp'` only, so other platforms keep their existing behavior. Long-term, this can be removed once `sonic-platform-vpp` hardens `syncd-vpp` so it survives a database (Redis) restart the same way Broadcom `dummy_syncd` does.

#### Supported testbed topology if it's a new test case?

Not a new test case — enabling an existing test on the existing `t1-lag-vpp` topology.

### Documentation

N/A
