### PR TITLE
console: use fanout SONiC creds for reverse-SSH to console fanout

### DIFF
--- a/tests/common/helpers/console_helper.py
+++ b/tests/common/helpers/console_helper.py
@@ -83,7 +83,14 @@ def get_host_ip_and_creds(host, creds):
     (DUT, console fanout, etc.); centralizes the inventory dance every
     console test used to repeat verbatim.
     """
-    ip = host.host.options['inventory_manager'].get_host(host.hostname).vars['ansible_host']
+    inv_host = host.host.options['inventory_manager'].get_host(host.hostname)
+    ip = inv_host.vars['ansible_host']
+
+    group_names = inv_host.get_vars().get('group_names', []) or []
+    is_fanout = 'fanout' in group_names and 'sonic' not in group_names
+    if is_fanout and creds.get('fanout_sonic_user') and creds.get('fanout_sonic_password'):
+        return ip, creds['fanout_sonic_user'], creds['fanout_sonic_password']
+
     return ip, creds['sonicadmin_user'], creds['sonicadmin_password']
 
 


### PR DESCRIPTION
The console tests share a helper get_host_ip_and_creds(host, creds) that returned creds['sonicadmin_user']/creds['sonicadmin_password'] for any host. The creds fixture is built by creds_on_dut(duthost), and its sonicadmin_password is validated against the DUT's mgmt IP only. For a SONiC console fanout (a separate device with its own admin credentials), this caused test_console_link_wiring to fail reverse-SSH into the fanout with 'Permission denied, please try again.'

Detect fanout-only hosts via inventory group membership and return creds['fanout_sonic_user']/creds['fanout_sonic_password'] from group_vars/fanout/secrets.yml in that case. DUT and other callers are unaffected.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
