### PR TITLE
lldp_syncd failure due to not enough converge time

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -34,6 +34,61 @@ def ignore_expected_loganalyzer_exceptions(duthosts, loganalyzer):
                 ]
             )
 
+@pytest.fixture(scope="module", autouse=True)
+def wait_for_lldp_appl_db(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    appl_db = []
+    for asic in duthost.asics:
+        appl_db.append(SonicDbCli(asic, APPL_DB))
+    is_chassis = duthost.get_facts().get("modular_chassis")
+    if duthost.facts['switch_type'] == "voq" and (not is_chassis and len(duthost.asics) > 1):
+        appl_db.append(SonicDbCli(duthost, APPL_DB))
+
+    def lldpctl_ifaces():
+        try:
+            ifaces = get_lldpctl_output(duthost)["lldp"]["interface"]
+            names = list(ifaces.keys()) if isinstance(ifaces, dict) else [list(i.keys())[0] for i in ifaces]
+            return set(n for n in names if "Ethernet-BP" not in n and "Ethernet-IB" not in n)
+        except Exception:
+            return set()
+
+    # Wait for lldpctl output to stabilize (same set across 2 consecutive polls = all active neighbors learned)
+    # Using deterministic polling: max 25 retries with 10s interval
+    max_lldpctl_retries = 25
+    poll_interval = 10
+    prev, stable_count = set(), 0
+    for retry in range(max_lldpctl_retries):
+        current = lldpctl_ifaces()
+        if current and current == prev:
+            stable_count += 1
+            logger.info("lldpctl stable ({}/2): {} interfaces (retry {}/{})".format(
+                stable_count, len(current), retry + 1, max_lldpctl_retries))
+            if stable_count > 2:
+                break
+        else:
+            logger.info("lldpctl: {} interfaces (changed or empty), retry {}/{}".format(
+                len(current), retry + 1, max_lldpctl_retries))
+            stable_count = 0
+        prev = current
+        time.sleep(poll_interval)
+    else:
+        pytest.fail("lldpctl did not stabilize after {} retries. Last seen: {}".format(
+            max_lldpctl_retries, sorted(prev)))
+
+    expected = prev
+    logger.info("lldpd stable with {} active neighbors: {}".format(len(expected), sorted(expected)))
+
+    # Wait for APPL_DB convergence: max 10 retries with 3s interval
+    max_appl_db_retries = 10
+    appl_db_poll_interval = 3
+    for retry in range(max_appl_db_retries):
+        if expected <= set(get_lldp_entry_keys(appl_db)):
+            logger.info("All {} interfaces converged in APPL_DB (retry {}/{})".format(
+                len(expected), retry + 1, max_appl_db_retries))
+            return
+        time.sleep(appl_db_poll_interval)
+    pytest.fail("APPL_DB did not converge after {} retries. Missing: {}".format(
+        max_appl_db_retries, sorted(expected - set(get_lldp_entry_keys(appl_db)))))
 
 @pytest.fixture(autouse="True")
 def db_instance(duthosts, enum_rand_one_per_hwsku_frontend_hostname):

--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -34,6 +34,7 @@ def ignore_expected_loganalyzer_exceptions(duthosts, loganalyzer):
                 ]
             )
 
+
 @pytest.fixture(scope="module", autouse=True)
 def wait_for_lldp_appl_db(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
@@ -89,6 +90,7 @@ def wait_for_lldp_appl_db(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         time.sleep(appl_db_poll_interval)
     pytest.fail("APPL_DB did not converge after {} retries. Missing: {}".format(
         max_appl_db_retries, sorted(expected - set(get_lldp_entry_keys(appl_db)))))
+
 
 @pytest.fixture(autouse="True")
 def db_instance(duthosts, enum_rand_one_per_hwsku_frontend_hostname):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Summary:
Add module-scoped autouse fixture wait_for_lldp_appl_db in test_lldp_syncd.py.
Before any test in the module runs, wait until LLDP neighbor discovery is stable, then until APPL_DB has matching LLDP_ENTRY_TABLE keys.

### Root cause:
test_lldp_syncd can fail intermittently because:

the before testcase l2/test_l2_configure.py doing the config reload -y in the last which causing lldp_syncd to fail .
lldpd is still learning neighbors when tests start (interface set still changing).
APPL_DB lags behind lldpctl (orchagent/syncd not yet populated).
Tests then assert on incomplete LLDP_ENTRY_TABLE data and flake.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Failed testcase because of not enough converge time
#### How did you do it?
added enough converge time before starting testcase
#### How did you verify/test it?
Run test_lldp_syncd.py along with l2/test_l2_configure.py
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
