### PR TITLE
 Remove hardcoded smartswitch testbed skip

### DIFF
--- a/.azure-pipelines/testbed_health_check.py
+++ b/.azure-pipelines/testbed_health_check.py
@@ -369,10 +369,6 @@ class TestbedHealthChecker:
     def run_check(self):
         try:
 
-            # temporarily skip dpu smartswitch
-            if self.testbed_name in ["vms66-t1-8102-7", "vms12-t1-smartswitch-4280-02"]:
-                raise SkipCurrentTestbed()
-
             self.init_hosts()
 
             self.pre_check()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Removes the hardcoded skip block in `TestbedHealthChecker.run_check()` that short-circuits the health check for two smartswitch testbeds. 

Summary:
This block was added in a previous pr as a "temporary" workaround because check_bgp_session_state was reporting these smartswitch testbeds as unhealthy. Since DPU support has now been added, we dont need these testbeds to be skipped from the health check. 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Carrying the skip indefinitely hides real testbed health for two production smartswitch boxes and
defeats the soft-recovery path that has been recently introduced.
#### How did you do it?
Deleted the four lines of the skip block in run_check().
#### How did you verify/test it?
Manually triggered the health check against the testbed from a personal sonic-mgmt container with this fix applied. The probe correctly executed end-to-end and returned code=1 withhas_bgp_admin_down=true 

`2026-05-27 00:57:24,334 testbed_health_check.py#402 INFO - Check finished. Testbed is unhealthy: ["BGP neighbors that not established on str3-8102-07: ['10.0.0.33, idle', '10.0.0.35, idle', '10.0.0.37, idle', '10.0.0.39, idle', '10.0.0.41, idle', '10.0.0.43, idle', '10.0.0.45, idle', '10.0.0.47, idle', '10.0.0.49, idle', '10.0.0.51, idle', '10.0.0.53, idle', '10.0.0.55, idle', '10.0.0.57, idle', '10.0.0.59, idle', '10.0.0.61, idle', '10.0.0.63, idle', '10.0.0.65, idle', '10.0.0.67, idle', '10.0.0.69, idle', '10.0.0.71, idle', 'fc00::42, idle', 'fc00::46, idle', 'fc00::4a, idle', 'fc00::4e, idle', 'fc00::52, idle', 'fc00::56, idle', 'fc00::5a, idle', 'fc00::5e, idle', 'fc00::62, idle', 'fc00::66, idle', 'fc00::6a, idle', 'fc00::6e, idle', 'fc00::72, idle', 'fc00::76, idle', 'fc00::7a, idle', 'fc00::7e, idle', 'fc00::82, idle', 'fc00::86, idle', 'fc00::8a, idle', 'fc00::8e, idle', '10.0.0.1, idle', '10.0.0.5, idle', '10.0.0.9, idle', '10.0.0.13, idle', 'fc00::2, idle', 'fc00::a, idle', 'fc00::12, idle', 'fc00::1a, idle']"]`
Without the patch, SkipCurrentTestbed short-circuits the check and the testbed is always reported healthy, masking the actual health check result.

#### Any platform specific information?
N/a
#### Supported testbed topology if it's a new test case?
N/a
### Documentation

