### PR TITLE
[bgp] Ignore transient TACACS / memory_checker syslog noise in scale_stress teardown

### DIFF
--- a/tests/bgp/test_bgp_aggregate_address_scale_stress.py
+++ b/tests/bgp/test_bgp_aggregate_address_scale_stress.py
@@ -147,6 +147,43 @@ def _generate_contributing_route(aggregate_prefix):
 
 # ---- Fixtures ----
 
+@pytest.fixture(autouse=True)
+def ignore_disruption_loganalyzer_noise(duthosts, loganalyzer):
+    """Ignore transient ERR syslog noise during scale_stress teardown.
+
+    Direct CONFIG_DB writes and config reloads briefly break DUT->TACACS
+    reachability and bounce dockers. Three signatures result:
+      - `iptables: nss_tacplus: failed to connect TACACS+ server ...`:
+        the common-ignore entry at loganalyzer_common_ignore.txt:360
+        has an unescaped '+' (regex quantifier) so the literal text
+        never matches. Re-add with a properly-escaped `\\+`.
+      - `iptables: tac_connect_single: ... Network is unreachable`:
+        no common-ignore entry at all.
+      - `memory_checker: cgroup memory usage file ... does not exist`:
+        race where memory_checker reads a docker cgroup file after the
+        container has been bounced by config reload.
+
+    Tests in this module pick a random DUT via `rand_one_dut_hostname`,
+    so register the ignores on every DUT in the testbed rather than
+    just `duthosts[0]`.
+    """
+    if not loganalyzer:
+        yield
+        return
+    for dut in duthosts:
+        if dut.hostname in loganalyzer:
+            loganalyzer[dut.hostname].ignore_regex.extend([
+                r".* ERR iptables: nss_tacplus: failed to connect TACACS\+ server .*",
+                r".* ERR iptables: tac_connect_single: connection to .* failed: Network is unreachable.*",
+                (
+                    r".* ERR memory_checker: \[memory_checker\] cgroup memory usage file "
+                    r"'/sys/fs/cgroup/system\.slice/docker-[0-9a-f]+\.scope/memory\.current' "
+                    r"of container '[0-9a-f]+' does not exist on device.*"
+                ),
+            ])
+    yield
+
+
 @pytest.fixture(scope="module", autouse=True)
 def setup_teardown(duthost):
     """Module-level checkpoint / rollback + multi-ASIC guard."""


### PR DESCRIPTION
### Description of PR

Skip transient TACACS / `memory_checker` `ERR` syslog lines that the loganalyzer flags during teardown of `test_bgp_aggregate_address_scale_stress.py` (introduced in #23666).

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

`test_bgp_aggregate_address_scale_stress.py` pushes 1000 aggregates via GCU and exercises config reloads. Each iptables / docker churn briefly disrupts the DUT->TACACS path and bounces dockers, producing transient `ERR` syslog lines that loganalyzer matches in teardown and turns into spurious test errors.

A recent internal nightly run had three sequential retry attempts (different DUTs each time: `bjw2-can-7050c-1`, `c-3`, `c-2`) and every attempt failed teardown on the same two tests (`test_7_1_large_scale_aggregate_deployment`, `test_7_2_data_plane_under_scale`) for the same syslog patterns — strong signal that this is environmental noise, not an image regression.

Sample matched lines:

```
ERR iptables: tac_connect_single: connection to <ip>:49 failed: Network is unreachable
ERR iptables: nss_tacplus: failed to connect TACACS+ server <ip>, ret=-9: Network is unreachable
ERR memory_checker: [memory_checker] cgroup memory usage file '/sys/fs/cgroup/system.slice/docker-<sha>.scope/memory.current' of container '<sha>' does not exist on device! Exiting ...
```

Why the existing common ignore doesn't catch them:

- `ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt:360` tries to ignore the `nss_tacplus` line but uses an unescaped `+` in `TACACS+` — in Python regex `+` is a quantifier, so the pattern never matches the literal `TACACS+` text.
- `iptables: tac_connect_single` has no common-ignore at all.
- The `memory_checker` cgroup race (memory_checker reads a docker cgroup file after the container has been bounced) has no common-ignore at all.

#### How did you do it?

Added an `autouse` fixture `ignore_disruption_loganalyzer_noise` to the scale_stress module that extends `loganalyzer[duthost.hostname].ignore_regex` with properly-escaped patterns for the three signatures above. This mirrors the existing fixture in the sibling `tests/bgp/test_bgp_aggregate_address_resilience.py` (lines 83-101), which already solves the same problem for the resilience tests.

Kept the fix module-local rather than touching the global common-ignore file, to scope the suppression to tests that actually trigger this noise.

#### How did you verify/test it?

- Parsed the file with `ast` — syntax clean.
- `flake8 --max-line-length=120` — clean.
- Replayed the three matched syslog lines from the failing nightly attempts against the added regex patterns — all three match.
- Verified the regex covers each retry attempt's distinct match set (TACACS pair in all three; memory_checker on attempt 1 only).

#### Any platform specific information?

None — TACACS + memory_checker noise patterns are independent of ASIC vendor.

#### Supported testbed topology if it's a new test case?

n/a (bug fix to an existing test).

### Documentation

Fixture docstring explains why each pattern is needed and references the buggy unescaped `+` in the common-ignore file.
