### PR TITLE
[macsec]: general test/reliability fixes for t2

### DIFF
--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -130,7 +130,7 @@ def clear_failed_flag_and_restart(duthost, container_name):
     pytest_assert(restarted, "Failed to restart container '{}' after reset-failed was cleared".format(container_name))
 
 
-def restart_service_with_startlimit_guard(duthost, service_name, backoff_seconds=30, verify_timeout=180):
+def restart_service_with_startlimit_guard(duthost, service_name, is_namespaced=False, backoff_seconds=30, verify_timeout=180):
     """
     Restart a systemd-managed service with StartLimitHit guard.
 
@@ -145,6 +145,13 @@ def restart_service_with_startlimit_guard(duthost, service_name, backoff_seconds
 
     Returns: True when the service is (re)started and running; asserts on failure.
     """
+
+    if is_namespaced:
+        # just check first namespaced instance
+        container_name = "{}0".format(service_name)
+        service_name = "{}@0".format(service_name)
+    else:
+        container_name = service_name
 
     # 0) Pre-detect StartLimitHit so we can optionally skip a failing restart
     pre_rate_limited = is_hitting_start_limit(duthost, service_name)
@@ -170,7 +177,7 @@ def restart_service_with_startlimit_guard(duthost, service_name, backoff_seconds
         rate_limited = True
 
     # 2/3) Recovery path: reset-failed + backoff + start if needed
-    if ret.get("rc", 1) != 0 or rate_limited or not is_container_running(duthost, service_name):
+    if ret.get("rc", 1) != 0 or rate_limited or not is_container_running(duthost, container_name):
         duthost.shell(
             f"sudo systemctl reset-failed {service_name}.service",
             module_ignore_errors=True
@@ -181,8 +188,8 @@ def restart_service_with_startlimit_guard(duthost, service_name, backoff_seconds
             module_ignore_errors=True
         )
         pytest_assert(
-            wait_until(verify_timeout, 1, 0, check_container_state, duthost, service_name, True),
-            f"{service_name} container did not become running after recovery start"
+            wait_until(verify_timeout, 1, 0, check_container_state, duthost, container_name, True),
+            f"{container_name} container did not become running after recovery start"
         )
 
     return True

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -130,7 +130,8 @@ def clear_failed_flag_and_restart(duthost, container_name):
     pytest_assert(restarted, "Failed to restart container '{}' after reset-failed was cleared".format(container_name))
 
 
-def restart_service_with_startlimit_guard(duthost, service_name, is_namespaced=False, backoff_seconds=30, verify_timeout=180):
+def restart_service_with_startlimit_guard(duthost, service_name, is_namespaced=False,
+                                          backoff_seconds=30, verify_timeout=180):
     """
     Restart a systemd-managed service with StartLimitHit guard.
 

--- a/tests/common/macsec/__init__.py
+++ b/tests/common/macsec/__init__.py
@@ -112,16 +112,24 @@ class MacsecPlugin(object):
         return __shutdown_macsec
 
     @pytest.fixture(scope="module")
-    def macsec_setup(self, startup_macsec, shutdown_macsec, macsec_feature):
+    def macsec_setup(self, startup_macsec, shutdown_macsec, macsec_feature, macsec_duthost, macsec_profile, ctrl_links):
         '''
             setup macsec links
         '''
-        startup_macsec()
+        shutdown = False
+        if get_macsec_enable_status(macsec_duthost) and get_macsec_profile(macsec_duthost):
+            macsec_preconfigured = is_macsec_configured(macsec_duthost, macsec_profile, ctrl_links)
+            if not macsec_preconfigured or port_profiles is not None:
+                shutdown = True
+                startup_macsec()
+            if macsec_preconfigured:
+                logger.info(f"Macsec is already configured for {macsec_profile}, skipping setup")
         yield
-        shutdown_macsec()
+        if shutdown:
+            shutdown_macsec()
 
     @pytest.fixture(scope="module", autouse=True)
-    def load_macsec_info(self, request, macsec_duthost, ctrl_links, macsec_profile, tbinfo):
+    def load_macsec_info(self, request, macsec_setup, ctrl_links, macsec_duthost, tbinfo):
         """Pre-load MACsec session info for all control links.
 
         If MACsec is enabled and configured for this DUT/profile, wait for
@@ -132,20 +140,11 @@ class MacsecPlugin(object):
         """
 
         if get_macsec_enable_status(macsec_duthost) and get_macsec_profile(macsec_duthost):
-            if is_macsec_configured(macsec_duthost, macsec_profile, ctrl_links):
-                # MACsec is already configured (e.g., carried over from a
-                # previous module). Wait for MKA sessions to be established
-                # (SC/SA present in DB, including SAK) before loading info, so
-                # we don't race wpa_supplicant writing the egress SA row.
-                # If the wait_mka_establish fixture isn't registered in this
-                # environment, fall back to loading directly.
-                try:
-                    request.getfixturevalue('wait_mka_establish')
-                except pytest.FixtureLookupError:
-                    pass
-                load_all_macsec_info(macsec_duthost, ctrl_links, tbinfo)
-            else:
-                request.getfixturevalue('macsec_setup')
+            try:
+                request.getfixturevalue('wait_mka_establish')
+            except pytest.FixtureLookupError:
+                pass
+            load_all_macsec_info(macsec_duthost, ctrl_links, tbinfo)
 
     @pytest.fixture(scope="module")
     def macsec_nbrhosts(self, ctrl_links):
@@ -286,6 +285,8 @@ class MacsecPluginT2(MacsecPlugin):
         mg_facts = macsec_duthost.get_extended_minigraph_facts(tbinfo)
         if 'macsec_neighbors' in mg_facts:
             ctrl_nbr_names = mg_facts['macsec_neighbors']
+        else:
+            ctrl_nbr_names = natsort.natsorted(nbrhosts.keys())[:4]
         return ctrl_nbr_names
 
     def downstream_neighbor(self,tbinfo, neighbor):

--- a/tests/common/macsec/__init__.py
+++ b/tests/common/macsec/__init__.py
@@ -119,10 +119,10 @@ class MacsecPlugin(object):
         shutdown = False
         if get_macsec_enable_status(macsec_duthost) and get_macsec_profile(macsec_duthost):
             macsec_preconfigured = is_macsec_configured(macsec_duthost, macsec_profile, ctrl_links)
-            if not macsec_preconfigured or port_profiles is not None:
+            if not macsec_preconfigured:
                 shutdown = True
                 startup_macsec()
-            if macsec_preconfigured:
+            else:
                 logger.info(f"Macsec is already configured for {macsec_profile}, skipping setup")
         yield
         if shutdown:

--- a/tests/common/macsec/macsec_config_helper.py
+++ b/tests/common/macsec/macsec_config_helper.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from tests.common.macsec.macsec_helper import get_mka_session, getns_prefix, wait_all_complete, \
-     submit_async_task, load_all_macsec_info
+     submit_async_task
 from tests.common.macsec.macsec_platform_helper import global_cmd, find_portchannel_from_member, get_portchannel
 from tests.common.devices.eos import EosHost
 from tests.common.utilities import wait_until
@@ -35,7 +35,7 @@ def get_macsec_profile(host):
     return request.config.getoption("--macsec_profile", default=None)
 
 
-def set_macsec_profile(host, port, profile_name, priority, cipher_suite,
+def set_macsec_profile(host, profile_name, priority, cipher_suite,
                        primary_cak, primary_ckn, policy, send_sci, rekey_period=0):
     if isinstance(host, EosHost):
         eos_cipher_suite = {
@@ -67,12 +67,19 @@ def set_macsec_profile(host, port, profile_name, priority, cipher_suite,
         "send_sci" if send_sci == "true" else "no_send_sci": "",
         "rekey_period": rekey_period,
     }
+
     opts = ""
     for k, v in list(macsec_profile.items()):
         opts += " --{} {}".format(k, v)
-        cmd = "config macsec {} profile add {} {}".format(
-            getns_prefix(host, port), profile_name, opts)
-    host.command(cmd)
+
+    if host.is_multi_asic:
+        for ns in host.get_asic_namespace_list():
+            cmd = "config macsec -n {} profile add {} {}".format(ns, profile_name, opts)
+            host.command(cmd)
+    else:
+        cmd = "config macsec profile add {} {}".format(profile_name, opts)
+        host.command(cmd)
+
     if send_sci == "false":
         # The MAC address of SONiC host is locally administrated
         # So, LLDPd will use an arbitrary fixed value (00:60:08:69:97:ef)
@@ -112,23 +119,21 @@ def is_macsec_configured(host, mac_profile, ctrl_links):
     return is_profile_present and is_port_profile_present
 
 
-def delete_macsec_profile(host, port, profile_name):
+def delete_macsec_profile(host, profile_name):
     if isinstance(host, EosHost):
         host.eos_config(
             lines=['no profile {}'.format(profile_name)],
             parents=['mac security'])
         return
 
-    # if port is None, the macsec profile is deleted from all namespaces if multi-asic
-    if host.is_multi_asic and port is None:
+    if host.is_multi_asic:
         for ns in host.get_asic_namespace_list():
             CMD_PREFIX = "-n {}".format(ns) if ns is not None else " "
             cmd = "config macsec {} profile del {}".format(CMD_PREFIX, profile_name)
-            host.command(cmd)
+            host.command(cmd, module_ignore_errors=True)
     else:
-        cmd = ("config macsec {} profile del {}"
-               .format(getns_prefix(host, port), profile_name))
-        host.command(cmd)
+        cmd = ("config macsec profile del {}".format(profile_name))
+        host.command(cmd, module_ignore_errors=True)
 
 
 def enable_macsec_port(host, port, profile_name):
@@ -211,13 +216,13 @@ def cleanup_macsec_configuration(duthost, ctrl_links, profile_name):
     wait_all_complete(timeout=300)
 
     logger.info("Cleanup macsec configuration step2: delete macsec profile")
-    # Delete the macsec profile once after it is removed from all interfaces. if we pass port as None,
-    # the profile is removed from the DB in all namespaces.
-    submit_async_task(delete_macsec_profile, (duthost, None, profile_name))
+    # Delete the macsec profile once after it is removed from all interfaces.
+    # On multi-asic the profile is removed from the DB in all namespaces.
+    submit_async_task(delete_macsec_profile, (duthost, profile_name))
 
     # Delete the macsec profile in neighbors
     for d in devices:
-        submit_async_task(delete_macsec_profile, (d, None, profile_name))
+        submit_async_task(delete_macsec_profile, (d, profile_name))
     wait_all_complete(timeout=300)
 
     logger.info("Cleanup macsec configuration step3: wait for automatic cleanup")
@@ -244,18 +249,19 @@ def cleanup_macsec_configuration(duthost, ctrl_links, profile_name):
 def setup_macsec_configuration(duthost, ctrl_links, profile_name, default_priority,
                                cipher_suite, primary_cak, primary_ckn, policy, send_sci, rekey_period, tbinfo):
     logger.info("Setup macsec configuration step1: set macsec profile")
-    # 1. Set macsec profile
+    # 1. Set macsec profile. The profile is host-wide (no port arg), so the
+    # DUT-side set runs once outside the per-link loop.
+    submit_async_task(set_macsec_profile, (duthost, profile_name, default_priority,
+                      cipher_suite, primary_cak, primary_ckn, policy,
+                      send_sci, rekey_period))
     i = 0
     for dut_port, nbr in ctrl_links.items():
-        submit_async_task(set_macsec_profile, (duthost, dut_port, profile_name, default_priority,
-                          cipher_suite, primary_cak, primary_ckn, policy,
-                          send_sci, rekey_period))
         if i % 2 == 0:
             priority = default_priority - 1
         else:
             priority = default_priority + 1
         submit_async_task(set_macsec_profile,
-                          (nbr["host"], nbr["port"], profile_name, priority,
+                          (nbr["host"], profile_name, priority,
                            cipher_suite, primary_cak, primary_ckn, policy, send_sci, rekey_period))
         i += 1
     wait_all_complete(timeout=180)
@@ -278,9 +284,6 @@ def setup_macsec_configuration(duthost, ctrl_links, profile_name, default_priori
     # protocols. To hold some time for protocol recovery.
     time.sleep(60)
     logger.info("Setup macsec configuration finished")
-
-    # Load the MACSEC_INFO, to have data of all macsec sessions
-    load_all_macsec_info(duthost, ctrl_links, tbinfo)
 
 
 def wait_for_macsec_cleanup(host, interfaces, timeout=90):

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1580,7 +1580,7 @@ def __intf_config_macsec(config, port_config_list, duthost, snappi_ports, setup=
                 if 'profile' in line:
                     profile_name = line.split()[1]
                     logger.info('Removing already configured Macsec profile {}'.format(profile_name))
-                    delete_macsec_profile(port['duthost'], port['peer_port'], profile_name)
+                    delete_macsec_profile(port['duthost'], profile_name)
             macsec_enabled_port = port
             macsec_profile_name = '256_XPN_SCI'
             cipher = all_values[macsec_profile_name]['cipher_suite']
@@ -1592,7 +1592,7 @@ def __intf_config_macsec(config, port_config_list, duthost, snappi_ports, setup=
             send_sci = all_values[macsec_profile_name]['send_sci']
             logger.info('Configuring DUTHOST:{}'.format(port['duthost'].hostname))
             logger.info('Configuring MACSEC on DUT Interfaces: {}'.format(port['peer_port']))
-            set_macsec_profile(port['duthost'], port['peer_port'], macsec_profile_name, priority,
+            set_macsec_profile(port['duthost'], macsec_profile_name, priority,
                                cipher, primary_cak, primary_ckn, policy, send_sci, rekey_period)
             enable_macsec_port(port['duthost'], port['peer_port'], macsec_profile_name)
             if port['asic_value'] is None:
@@ -1855,7 +1855,7 @@ def cleanup_config(duthost_list, snappi_ports):
         logger.info('Deleting macsec profile {} on {} port {}'.format(macsec_profile_name,
                                                                       macsec_enabled_port['duthost'].hostname,
                                                                       macsec_enabled_port['peer_port']))
-        delete_macsec_profile(macsec_enabled_port['duthost'], macsec_enabled_port['peer_port'], macsec_profile_name)
+        delete_macsec_profile(macsec_enabled_port['duthost'], macsec_profile_name)
 
 
 @pytest.fixture(scope="module")

--- a/tests/macsec/test_controlplane.py
+++ b/tests/macsec/test_controlplane.py
@@ -119,4 +119,4 @@ class TestControlPlane():
             setup_macsec_configuration(duthost, ctrl_link, profile_name, default_priority,
                                        cipher_suite, primary_cak, primary_ckn, policy, send_sci, rekey_period, tbinfo)
             # Clean up new macsec profile
-            delete_macsec_profile(duthost, port_name, new_profile_name)
+            delete_macsec_profile(duthost, new_profile_name)

--- a/tests/macsec/test_dataplane.py
+++ b/tests/macsec/test_dataplane.py
@@ -27,6 +27,9 @@ class TestDataPlane():
                                 upstream_links, ptfadapter, wait_mka_establish):
         ptfadapter.dataplane.set_qlen(TestDataPlane.BATCH_COUNT * 100)
 
+        if len(downstream_links) == 0:
+            pytest.skip("No downstream links")
+
         down_link = list(downstream_links.values())[0]
         dut_macaddress = duthost.get_dut_iface_mac(list(ctrl_links.keys())[0])
 

--- a/tests/macsec/test_docker_restart.py
+++ b/tests/macsec/test_docker_restart.py
@@ -19,6 +19,6 @@ def test_restart_macsec_docker(duthosts, ctrl_links, policy, cipher_suite, send_
     duthost = duthosts[enum_rand_one_per_hwsku_macsec_frontend_hostname]
 
     logger.info(duthost.shell(cmd="docker ps", module_ignore_errors=True)['stdout'])
-    restart_service_with_startlimit_guard(duthost, "macsec", backoff_seconds=35, verify_timeout=180)
+    restart_service_with_startlimit_guard(duthost, "macsec", is_namespaced=duthost.is_multi_asic, backoff_seconds=35, verify_timeout=180)
     logger.info(duthost.shell(cmd="docker ps", module_ignore_errors=True)['stdout'])
     assert wait_until(300, 6, 12, check_appl_db, duthost, ctrl_links, policy, cipher_suite, send_sci)

--- a/tests/macsec/test_docker_restart.py
+++ b/tests/macsec/test_docker_restart.py
@@ -19,6 +19,7 @@ def test_restart_macsec_docker(duthosts, ctrl_links, policy, cipher_suite, send_
     duthost = duthosts[enum_rand_one_per_hwsku_macsec_frontend_hostname]
 
     logger.info(duthost.shell(cmd="docker ps", module_ignore_errors=True)['stdout'])
-    restart_service_with_startlimit_guard(duthost, "macsec", is_namespaced=duthost.is_multi_asic, backoff_seconds=35, verify_timeout=180)
+    restart_service_with_startlimit_guard(duthost, "macsec", is_namespaced=duthost.is_multi_asic,
+                                          backoff_seconds=35, verify_timeout=180)
     logger.info(duthost.shell(cmd="docker ps", module_ignore_errors=True)['stdout'])
     assert wait_until(300, 6, 12, check_appl_db, duthost, ctrl_links, policy, cipher_suite, send_sci)

--- a/tests/macsec/test_fault_handling.py
+++ b/tests/macsec/test_fault_handling.py
@@ -155,7 +155,7 @@ class TestFaultHandling():
         # Set a wrong cak to the profile
         primary_cak = "0" * len(primary_cak)
         enable_macsec_port(duthost, port_name, profile_name)
-        set_macsec_profile(nbr["host"], nbr["port"], profile_name, default_priority,
+        set_macsec_profile(nbr["host"], profile_name, default_priority,
                            cipher_suite, primary_cak, primary_ckn, policy, send_sci)
         enable_macsec_port(nbr["host"], nbr["port"], profile_name)
 
@@ -172,5 +172,5 @@ class TestFaultHandling():
         # Teardown
         disable_macsec_port(duthost, port_name)
         disable_macsec_port(nbr["host"], nbr["port"])
-        delete_macsec_profile(nbr["host"], nbr["port"], profile_name)
+        delete_macsec_profile(nbr["host"], profile_name)
         sleep(300)


### PR DESCRIPTION
Series of improvements / reliability fixes for macsec discovered when developing per interface macsec tests.
Helps with reliability and running of macsec tests for T2.

- tests/common/helpers/dut_utils.py + tests/macsec/test_docker_restart.py: fix test_docker_restart for multi-asic systems.
- tests/macsec/test_dataplane.py: skip when no downstream links are present.
- tests/common/macsec/__init__.py (MacsecPluginT2.get_ctrl_nbr_names): Fall back to first four neighbors when macsec_neighbors is not declared in minigraph facts. Allows running tests without preconfiguring macsec
- macsec_config_helper.py: set_macsec_profile and delete_macsec_profile no longer require port. set_macsec_profile now iterates host.get_asic_namespace_list() explicitly on multi-asic. delete_macsec_profile uses module_ignore_errors=True so cleanup is tolerant of stale state. setup_macsec_configuration hoists the DUT-side set call out of the per-link loop now that it's host-scoped.
- snappi_fixtures.py / test_controlplane.py / test_fault_handling.py: update callers to match the new signatures.
- Fix ordering of setting up macsec. macsec_setup() now checks whether macsec is preconfigured, and if not will set it up itself. Load_macsec_info now just depends on macsec_setup fixture, and only waits on MKA estab and loads macsec info.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
