### PR TITLE
Stabilize Everflow cleanup across retries

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -1067,12 +1067,14 @@ class BaseEverflowTest(object):
 
     @staticmethod
     def remove_mirror_config(duthost, session_name, config_method=CONFIG_MODE_CLI, module_ignore_errors=False):
+        command = None
         if config_method == CONFIG_MODE_CLI:
             command = "config mirror_session remove {}".format(session_name)
         elif config_method == CONFIG_MODE_CONFIGLET:
             pass
 
-        duthost.command(command, module_ignore_errors=module_ignore_errors)
+        if command is not None:
+            duthost.command(command, module_ignore_errors=module_ignore_errors)
 
     def apply_policer_config(self, duthost, policer_name, config_method, rate_limit=100):
         if duthost.facts["asic_type"] in ["marvell-prestera", "marvell"]:
@@ -1198,6 +1200,7 @@ class BaseEverflowTest(object):
 
     @staticmethod
     def remove_acl_rule_config(duthost, table_name, config_method=CONFIG_MODE_CLI, module_ignore_errors=False):
+        command = None
         if config_method == CONFIG_MODE_CLI:
             duthost.shell("if [ -e {0} ] && [ ! -d {0} ]; then rm -f {0}; fi; mkdir -p {0}".format(DUT_RUN_DIR))
             duthost.copy(src=os.path.join(FILE_DIR, EVERFLOW_RULE_DELETE_FILE),
@@ -1207,7 +1210,8 @@ class BaseEverflowTest(object):
         elif config_method == CONFIG_MODE_CONFIGLET:
             pass
 
-        duthost.command(command, module_ignore_errors=module_ignore_errors)
+        if command is not None:
+            duthost.command(command, module_ignore_errors=module_ignore_errors)
         time.sleep(2)
 
     @abstractmethod

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -1066,13 +1066,13 @@ class BaseEverflowTest(object):
             pass
 
     @staticmethod
-    def remove_mirror_config(duthost, session_name, config_method=CONFIG_MODE_CLI):
+    def remove_mirror_config(duthost, session_name, config_method=CONFIG_MODE_CLI, module_ignore_errors=False):
         if config_method == CONFIG_MODE_CLI:
             command = "config mirror_session remove {}".format(session_name)
         elif config_method == CONFIG_MODE_CONFIGLET:
             pass
 
-        duthost.command(command)
+        duthost.command(command, module_ignore_errors=module_ignore_errors)
 
     def apply_policer_config(self, duthost, policer_name, config_method, rate_limit=100):
         if duthost.facts["asic_type"] in ["marvell-prestera", "marvell"]:
@@ -1124,6 +1124,7 @@ class BaseEverflowTest(object):
                     self.apply_acl_table_config(duthost, table_name, "MIRROR", config_method,
                                                 bind_namespace=getattr(inst, 'namespace', None))
 
+            BaseEverflowTest.remove_acl_rule_config(duthost, table_name, config_method, module_ignore_errors=True)
             self.apply_acl_rule_config(duthost, table_name, setup_mirror_session["session_name"], config_method)
 
         yield
@@ -1196,16 +1197,17 @@ class BaseEverflowTest(object):
         time.sleep(2)
 
     @staticmethod
-    def remove_acl_rule_config(duthost, table_name, config_method=CONFIG_MODE_CLI):
+    def remove_acl_rule_config(duthost, table_name, config_method=CONFIG_MODE_CLI, module_ignore_errors=False):
         if config_method == CONFIG_MODE_CLI:
+            duthost.shell("if [ -e {0} ] && [ ! -d {0} ]; then rm -f {0}; fi; mkdir -p {0}".format(DUT_RUN_DIR))
             duthost.copy(src=os.path.join(FILE_DIR, EVERFLOW_RULE_DELETE_FILE),
-                         dest=DUT_RUN_DIR)
+                         dest=os.path.join(DUT_RUN_DIR, EVERFLOW_RULE_DELETE_FILE))
             command = "acl-loader update full {} --table_name {}" \
                 .format(os.path.join(DUT_RUN_DIR, EVERFLOW_RULE_DELETE_FILE), table_name)
         elif config_method == CONFIG_MODE_CONFIGLET:
             pass
 
-        duthost.command(command)
+        duthost.command(command, module_ignore_errors=module_ignore_errors)
         time.sleep(2)
 
     @abstractmethod


### PR DESCRIPTION
### Description of PR

Summary: Stabilize Everflow ACL/mirror cleanup so a retry after a previous
timeout recovers instead of failing on inherited state.
- Best-effort pre-cleanup of stale Everflow ACL rules in `setup_acl_table`
  before applying the mirror ACL rule, so a retry starts from a clean slate.
- In `remove_acl_rule_config`, make `/tmp/everflow` (`DUT_RUN_DIR`) robust: if a
  stale non-directory file is left behind, remove it and `mkdir -p`, then copy
  `acl-remove.json` to the exact path `acl-loader` reads
  (`/tmp/everflow/acl-remove.json`) instead of the directory.
- Thread `module_ignore_errors` through `remove_mirror_config` /
  `remove_acl_rule_config` so best-effort cleanup during retries and teardown
  never fails the run.
- Initialize `command` and guard the `duthost.command(...)` call in both helpers
  so the unimplemented `CONFIG_MODE_CONFIGLET` branch can't use an uninitialized
  variable.

Fixes # ADO: https://msazure.visualstudio.com/One/_workitems/edit/38865783

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): AB#38865783
Failure type: day-one flaky-teardown (stale Everflow/ACL state inherited across KVM retries); not a regression. No release-branch backport warranted — 202605 nightly does not exhibit this failure signature.

### Tested branch

- [ ] master
- [x] 202605
- [ ] N/A

### Test result

- 202605: 20260510.05 - clean run of `everflow/test_everflow_testbed.py` passed
  with the patch, no regression.
- Static checks: `python3 -m py_compile tests/everflow/everflow_test_utilities.py`
  and `git diff --check` clean; CodeQL "uninitialized local variable" alerts on
  both touched helpers resolved (CONFIGLET path now guarded), CodeQL green.

### Approach

#### What is the motivation for this PR?

Everflow KVM retries can inherit stale `test_session_1` / ACL state after a
previous timeout. The failure then shows up in teardown when `acl-loader` tries
to consume `/tmp/everflow/acl-remove.json` and the file is missing (or
`/tmp/everflow` was left as a plain file), followed by mirror-session YANG /
loganalyzer noise. Pre-cleaning ACL state and hardening the run-dir handling
lets a retry recover instead of failing on inherited state.

#### How did you do it?

See the summary bullets above: pre-clean stale ACL rules, harden `DUT_RUN_DIR`
creation/copy, thread `module_ignore_errors` through the remove helpers, and
guard the uninitialized `command` in the `CONFIG_MODE_CONFIGLET` branch of both
`remove_mirror_config` and `remove_acl_rule_config`.

#### How did you verify/test it?

Clean run of `everflow/test_everflow_testbed.py` on 202605 hardware
(image 20260510.05) with the patch (no regression); `py_compile` +
`git diff --check` clean; CodeQL uninitialized-variable alerts resolved.

#### Any platform specific information?

None — change is in shared Everflow test utilities.

#### Supported testbed topology if it's a new test case?

N/A — not a new test case; hardening of existing Everflow test utilities.

### Documentation

N/A — test utility change; no wiki/documentation update.
