### PR TITLE
[manual cherry-pick][202511][cacl] Add dhcp_server_syslog iptables rule to expected rules

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -534,6 +534,13 @@ def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expecte
                                    .format(v['IPv6Address'],
                                            docker_network['bridge']['IPv6Address']))
 
+        # dhcp_server uses bridge networking; its startup script adds an iptables
+        # rule to allow syslog (UDP 514) past caclmgrd's catch-all DROP.
+        if "dhcp_server" in docker_network['container']:
+            iptables_rules.append(
+                "-A INPUT -i docker0 -p udp -m udp --dport 514"
+                " -m comment --comment dhcp_server_syslog -j ACCEPT")
+
     else:
         iptables_rules.append("-A INPUT -s {}/32 -d {}/32 -j ACCEPT".format(docker_network['container']['database'
                                                                             + str(asic_index)]['IPv4Address'],

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -626,12 +626,6 @@ bmp/test_docker_restart.py:
 #######################################
 #####            cacl             #####
 #######################################
-cacl/test_cacl_application.py:
-  skip:
-    reason: "skip test_cacl_application in PR test temporarily"
-    conditions:
-      - "asic_type in ['vs']"
-
 cacl/test_cacl_application.py::test_cacl_acl_loader_commands_internal:
   skip:
     reason: "test_cacl_acl_loader_commands_internal is only supported on t0/t1 testbed"


### PR DESCRIPTION
### Description of PR

Summary:
Manual cherry-pick of #24696 to `202511`: add the `dhcp_server_syslog` iptables rule to the expected CACL rules and remove the temporary VS skip for `cacl/test_cacl_application.py`.

This is opened manually because the bot cherry-pick PR #24746 is repeatedly blocked by unrelated 202511 KVM T0 Everflow/add-topology failures. This branch applies the same CACL change on a fresh `202511` base.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

`sonic-buildimage` PR #27255 introduced a `dhcp_server_syslog` iptables ACCEPT rule for bridge-mode `dhcp_server` traffic to UDP/514 so syslog is not blocked by `caclmgrd`'s catch-all DROP rule. The CACL application test must expect this rule on affected topologies.

#### How did you do it?

Manually applied the #24696 diff onto a fresh `202511` branch:
1. Add the expected `dhcp_server_syslog` iptables rule when `dhcp_server` is present in `docker_network['container']`.
2. Remove the blanket VS skip for `cacl/test_cacl_application.py`.

#### How did you verify/test it?

- `python3 -m py_compile tests/cacl/test_cacl_application.py`
- `git diff --check`

#### Any platform specific information?

Affects platforms/topologies running `dhcp_server` in bridge mode where the container adds the `dhcp_server_syslog` iptables rule.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.
