### PR TITLE
[process_monitoring]: skip database container; unblock test on VS

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4172,10 +4172,6 @@ process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical
     reason: "Testcase ignored due to issue: https://github.com/sonic-net/sonic-buildimage/issues/10336"
     conditions:
       - "https://github.com/sonic-net/sonic-buildimage/issues/10336"
-  skip:
-    reason: "Skip test on VS due to issue: https://github.com/sonic-net/sonic-buildimage/issues/10336"
-    conditions:
-      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-buildimage/issues/10336"
 
 process_monitoring/test_critical_process_monitoring.py::test_orchagent_heartbeat:
   skip:

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -560,7 +560,16 @@ def ensure_all_critical_processes_running(duthost, containers_in_namespaces):
 
 def get_skip_containers(duthost, tbinfo, skip_vendor_specific_container):
     skip_containers = []
-    # Skip database container for generate redis crash alerting messages.
+    # Skip 'database' container: killing redis cascades into every other
+    # container (rsyslog/loganalyzer/sonic-cfggen/orchagent all depend on it),
+    # which routinely degrades the DUT past the test's recovery window. On
+    # physical broadcom builds there is no FEATURE|database entry so the test
+    # never iterates database; on platforms that DO populate FEATURE|database
+    # (e.g. sonic-vpp where it is always_enabled) we explicitly skip it here
+    # to keep behavior consistent across platforms.
+    skip_containers.append("database")
+    # Skip 'gbsyncd' container, which is empty on most platforms and not
+    # expected to generate alerting messages on critical-process kills.
     skip_containers.append("gbsyncd")
     # Skip 'restapi' container since 'restapi' service will be restarted immediately after exited,
     # which will not trigger alarm message.


### PR DESCRIPTION
### Description of PR
Summary:
On platforms where `FEATURE|database` is populated in CONFIG_DB
(notably sonic-vpp, where it ships as `always_enabled`),
`test_monitoring_critical_processes` iterates the `database` container
and SIGKILLs `redis-server`. That kill cascades into every redis-dependent
container — rsyslog stops forwarding (loganalyzer can't fetch logs),
`sonic-cfggen -d` exits 1, orchagent/syncd start erroring on DB writes,
and the DUT slowly becomes unreachable. The test eventually fails during
`loganalyzer.analyze` with "Host unreachable in the inventory".

On Broadcom physical builds the FEATURE table simply doesn't contain
`database`, so the iteration loop quietly skips it and the test passes.
This PR makes that behavior explicit and platform-independent.

The companion sonic-vpp `syncd` SEGV/SIGABRT that previously made this
test crash hard (and required the universal VS-skip below) is fixed in
sonic-net/sonic-sairedis#1909. With both that fix and this skip in place,
the test runs cleanly on sonic-vpp KVM in ~8 min, matching the physical
reference run timing.

Fixes sonic-net/sonic-buildimage#25821

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Unblock `test_monitoring_critical_processes` on sonic-vpp (and any future
platform that populates `FEATURE|database`) so it follows the same
behavior as physical broadcom CI, where the test passes today.

#### How did you do it?
Two surgical changes:

1. **`tests/process_monitoring/test_critical_process_monitoring.py`** —
   `get_skip_containers()` already had a stale comment ("Skip database
   container for generate redis crash alerting messages.") but the code
   only skipped `gbsyncd`. Restore the original intent by adding
   `database` to `skip_containers` and re-wording the comment to
   explain why (redis kill cascades into every other container).

2. **`tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`** —
   Remove the `skip` block that silently skipped this test on every VS
   DUT (`asic_type in ['vs'] and <github URL>` — the URL evaluates
   truthy, so the gate was effectively unconditional for `vs`). The
   cited issue (#10336) is about a teamd/intfmgrd timing race on Broadcom
   physical, not about VS. The unconditional `xfail` block (which
   actually covers #10336) is left in place untouched.

#### How did you verify/test it?
Local run on sonic-vpp KVM testbed (`vlab-vpp-01` / `vms-kvm-vpp-t1-lag`)
with the sonic-sairedis #1909 v2 binary hot-swapped into the running
`syncd` container:

\\\
tests/process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical_processes
  PASSED  [501.93s]
\\\

syncd PID stayed RUNNING through the entire swss kill burst (orchagent,
portsyncd, neighsyncd, fdbsyncd, vlanmgrd, intfmgrd, portmgrd,
fabricmgrd, buffermgrd, vrfmgrd, nbrmgrd, vxlanmgrd, coppmgrd,
tunnelmgrd) and was cleanly SIGKILLed by the test's syncd-container
iteration. Mirrors the physical reference run
`7260cx3.t1.202511_NightlyTest_20260525.1` (Elastictest plan id
`6a141da095e3f84fd1e9a37e`).

#### Any platform specific information?
No platform-specific code paths. The change to `get_skip_containers` is
universal: it skips `database` on every platform. Physical broadcom is
unaffected because there is no `FEATURE|database` entry on those builds
to iterate in the first place — the test already wasn't killing redis
there.

#### Supported testbed topology if it's a new test case?
N/A — bug fix to an existing test.

### Documentation
N/A
