### PR TITLE
Ensure get_bmc_data is callable.

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -219,7 +219,10 @@ class GenerateGoldenConfigDBModule(object):
         return False
 
     def is_bmc_device(self):
-        return device_info.get_bmc_data() is not None
+        get_bmc_data = getattr(device_info, "get_bmc_data", None)
+        if not callable(get_bmc_data):
+            return False
+        return get_bmc_data() is not None
 
     def has_otel_image(self):
         rc, out, _ = self.module.run_command("docker images --format '{{.Repository}}'")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The change in https://github.com/sonic-net/sonic-mgmt/pull/24585 will cause minigraph deploy to fail if the DUT image does not have the change to support sonic_py_common.device_info.get_bmc_data(). Adding a check to ensure it is callable first to maintain backwards compatibility. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Deploy minigraph was failing on images that do not support sonic_py_common.device_info.get_bmc_data() (e.x, 202511).

#### How did you do it?
Add a check to ensure this is callable and return false if it is not.

#### How did you verify/test it?
Before fix:
```
...
fatal: [MtFuji-dut01]: FAILED! => {
    "changed": false,
    "msg": "Task failed: Module failed: module 'sonic_py_common.device_info' has no attribute 'get_bmc_data'"
}
fatal: [MtFuji-dut02]: FAILED! => {
    "changed": false,
    "msg": "Task failed: Module failed: module 'sonic_py_common.device_info' has no attribute 'get_bmc_data'"
}
...
PLAY RECAP *********************************************************************
MtFuji-dut01               : ok=71   changed=8    unreachable=0    failed=1    skipped=70   rescued=0    ignored=0   
MtFuji-dut02               : ok=71   changed=8    unreachable=0    failed=1    skipped=69   rescued=0    ignored=0  
```

Deployed minigraph successfully after fix:
```
PLAY RECAP *********************************************************************
MtFuji-dut01               : ok=94   changed=23   unreachable=0    failed=0    skipped=114  rescued=0    ignored=0   
MtFuji-dut02               : ok=93   changed=23   unreachable=0    failed=0    skipped=112  rescued=0    ignored=0  
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
