### PR TITLE
Improve `test_counterpoll_watermark.py` COUNTERS_DB interlock `check_counters_populated`

### DIFF
--- a/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
+++ b/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
@@ -65,7 +65,7 @@ def get_keys_on_asics(duthost, db_id, key):
     return {asic.asic_index: SonicDbCli(asic, db_id).get_keys(key) for asic in duthost.asics}
 
 
-def check_counters_populated(duthost, key):
+def check_counters_populated(duthost, key, num_expected_entries):
     """Check that COUNTERS_DB keys matching pattern exist on every ASIC.
 
     The original ``bool(keys.values())`` check was wrong: dict.values()
@@ -80,9 +80,9 @@ def check_counters_populated(duthost, key):
     for asic in duthost.asics:
         try:
             asic_keys = SonicDbCli(asic, "COUNTERS_DB").get_keys(key)
-            if not asic_keys:
+            if len(asic_keys) < num_expected_entries:
                 logging.debug(
-                    "No keys matching '%s' on asic%s yet",
+                    "Not enough keys matching '%s' on asic%s yet",
                     key, asic.asic_index)
                 return False
         except SonicDbKeyNotFound:
@@ -162,11 +162,19 @@ def test_counterpoll_queue_watermark_pg_drop(duthosts, localhost, enum_rand_one_
         timeout = 180 if duthost.is_multi_asic else 120
         pytest_assert(
             wait_until(timeout, 5, delay, check_counters_populated,
-                       duthost, MAPS_LONG_PREFIX.format('*')),
+                       duthost, MAPS_LONG_PREFIX.format('*'), 1),
             "COUNTERS_DB failed to populate after {}s "
             "(counterpoll: {}, method: {}, multi_asic: {})".format(
                 timeout, tested_counterpoll, config_apply_method,
                 duthost.is_multi_asic))
+        # Check each individual counter prefix for the right number of counters in COUNTERS_DB
+        for counters_maps in RELEVANT_MAPS[tested_counterpoll][MAPS]:
+            prefix = counters_maps['prefix']
+            num_expected_counters = len(counters_maps[MAPS])
+            pytest_assert(wait_until(120, 5, 0, check_counters_populated, duthost,
+                                     MAPS_LONG_PREFIX.format(prefix), num_expected_counters),
+                                     "Expected {} entries matching {}".format(
+                                         num_expected_counters, MAPS_LONG_PREFIX.format(prefix)))
     # verify QUEUE or PG maps are generated into COUNTERS_DB after enabling relevant counterpoll
     with allure.step("Verifying MAPS in COUNTERS_DB on {}...".format(duthost.hostname)):
         maps_dict = RELEVANT_MAPS[tested_counterpoll]

--- a/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
+++ b/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
@@ -174,7 +174,7 @@ def test_counterpoll_queue_watermark_pg_drop(duthosts, localhost, enum_rand_one_
             pytest_assert(wait_until(120, 5, 0, check_counters_populated, duthost,
                                      MAPS_LONG_PREFIX.format(prefix), num_expected_counters),
                                      "Expected {} entries matching {}".format(
-                                         num_expected_counters, MAPS_LONG_PREFIX.format(prefix)))
+                                     num_expected_counters, MAPS_LONG_PREFIX.format(prefix)))
     # verify QUEUE or PG maps are generated into COUNTERS_DB after enabling relevant counterpoll
     with allure.step("Verifying MAPS in COUNTERS_DB on {}...".format(duthost.hostname)):
         maps_dict = RELEVANT_MAPS[tested_counterpoll]

--- a/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
+++ b/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
@@ -173,8 +173,8 @@ def test_counterpoll_queue_watermark_pg_drop(duthosts, localhost, enum_rand_one_
             num_expected_counters = len(counters_maps[MAPS])
             pytest_assert(wait_until(120, 5, 0, check_counters_populated, duthost,
                                      MAPS_LONG_PREFIX.format(prefix), num_expected_counters),
-                                     "Expected {} entries matching {}".format(
-                                     num_expected_counters, MAPS_LONG_PREFIX.format(prefix)))
+                          "Expected {} entries matching {}".format(
+                              num_expected_counters, MAPS_LONG_PREFIX.format(prefix)))
     # verify QUEUE or PG maps are generated into COUNTERS_DB after enabling relevant counterpoll
     with allure.step("Verifying MAPS in COUNTERS_DB on {}...".format(duthost.hostname)):
         maps_dict = RELEVANT_MAPS[tested_counterpoll]


### PR DESCRIPTION
https://github.com/sonic-net/sonic-mgmt/issues/24900

### Description of PR
As described in https://github.com/sonic-net/sonic-mgmt/issues/24900 the `test_counterpoll_watermark.py` just waits until it sees a key in `COUNTERS_DB` that matches `COUNTERS_*_*_MAP` before proceeding with checking all the counters.
But we can see that sometimes the first keys that show up in `COUNTERS_DB` will match `COUNTERS_*_*_MAP` but won't match `COUNTERS_<test_prefix>_*_MAP`.

This PR changes the interlock `check_counters_populated` to check for a minimum expected number of counters and uses the expected counter's prefix (E.G. `COUNTERS_PG_*_MAP`) in addition to the catch all `COUNTERS_*_*_MAP`

When running the test we can see instances where this was required as we first see the `COUNTERS_*_*_MAP` poll succeed then we see multiple instances where the more specific prefix poll `COUNTERS_PG_*_MAP` fails for multiple polls before succeeding:
```
27/05/2026 10:37:22 sonic_db._run_and_check                  L0044 ERROR  | No command response:  COUNTERS_DB  keys COUNTERS_*_*_MAP
27/05/2026 10:37:28 sonic_db._run_and_check                  L0044 ERROR  | No command response:  COUNTERS_DB  keys COUNTERS_*_*_MAP
27/05/2026 10:37:33 sonic_db._run_and_check                  L0044 ERROR  | No command response:  COUNTERS_DB  keys COUNTERS_*_*_MAP
27/05/2026 10:37:38 sonic_db._run_and_check                  L0044 ERROR  | No command response:  COUNTERS_DB  keys COUNTERS_*_*_MAP
27/05/2026 10:37:43 sonic_db._run_and_check                  L0044 ERROR  | No command response:  COUNTERS_DB  keys COUNTERS_*_*_MAP
27/05/2026 10:37:49 sonic_db._run_and_check                  L0044 ERROR  | No command response:  COUNTERS_DB  keys COUNTERS_PG_*_MAP
27/05/2026 10:37:54 sonic_db._run_and_check                  L0044 ERROR  | No command response:  COUNTERS_DB  keys COUNTERS_PG_*_MAP
27/05/2026 10:37:59 sonic_db._run_and_check                  L0044 ERROR  | No command response:  COUNTERS_DB  keys COUNTERS_PG_*_MAP
27/05/2026 10:38:04 sonic_db._run_and_check                  L0044 ERROR  | No command response:  COUNTERS_DB  keys COUNTERS_PG_*_MAP
```

Summary:
Fixes #24900 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Reduce the flakiness of `test_counterpoll_watermark.py`

#### How did you do it?
Improve the interlock function `check_counters_populated`

#### How did you verify/test it?
Ran the test 30 times without any failures (previously would see a failure after a few runs)

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
