### PR TITLE
[SNAPPI] Unifying code inside snappi_fixtuer.py

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -562,16 +562,17 @@ def snappi_testbed_config(conn_graph_facts, fanout_graph_facts,     # noqa: F811
     def _is_enabled(val):
         return str(val).lower() in ['on', 'true', 'yes', '1']
 
-    lt_values = []
-    rs_fec_values = []
-    for sp in snappi_ports:
-        p = sp.get('peer_port')
-        attrs = port_table.get(p, {})
-        if 'link_training' in attrs:
-            lt_values.append(_is_enabled(attrs.get('link_training')))
-        if 'fec' in attrs:
-            fec_val = str(attrs.get('fec', '')).lower()
-            rs_fec_values.append(fec_val.startswith('rs'))
+    lt_values = [
+        _is_enabled(port_table.get(sp.get('peer_port'), {}).get('link_training'))
+        for sp in snappi_ports
+        if 'link_training' in port_table.get(sp.get('peer_port'), {})
+    ]
+
+    rs_fec_values = [
+        str(port_table.get(sp.get('peer_port'), {}).get('fec', '')).lower().startswith('rs')
+        for sp in snappi_ports
+        if 'fec' in port_table.get(sp.get('peer_port'), {})
+    ]
 
     # Enable only if ALL ports have it enabled
     lt_enable = all(lt_values) if lt_values else False
@@ -585,26 +586,17 @@ def snappi_testbed_config(conn_graph_facts, fanout_graph_facts,     # noqa: F811
     if is_pfc_enabled:
         pfc = l1_config.flow_control.ieee_802_1qbb
         pfc.pfc_delay = 0
+        mapping = {}
         if pfcQueueGroupSize == 8:
-            pfc.pfc_class_0 = 0
-            pfc.pfc_class_1 = 1
-            pfc.pfc_class_2 = 2
-            pfc.pfc_class_3 = 3
-            pfc.pfc_class_4 = 4
-            pfc.pfc_class_5 = 5
-            pfc.pfc_class_6 = 6
-            pfc.pfc_class_7 = 7
+            mapping = {i: i for i in range(8)}
         elif pfcQueueGroupSize == 4:
-            pfc.pfc_class_0 = pfcQueueValueDict[0]
-            pfc.pfc_class_1 = pfcQueueValueDict[1]
-            pfc.pfc_class_2 = pfcQueueValueDict[2]
-            pfc.pfc_class_3 = pfcQueueValueDict[3]
-            pfc.pfc_class_4 = pfcQueueValueDict[4]
-            pfc.pfc_class_5 = pfcQueueValueDict[5]
-            pfc.pfc_class_6 = pfcQueueValueDict[6]
-            pfc.pfc_class_7 = pfcQueueValueDict[7]
+            mapping = {i: pfcQueueValueDict[i] for i in range(8)}
         else:
-            pytest_assert(False, 'pfcQueueGroupSize value is not 4 or 8')
+            pytest_assert(False, "pfcQueueGroupSize value is not 4 or 8")
+
+        for i, value in mapping.items():
+            setattr(pfc, f"pfc_class_{i}", value)
+
     else:
         logger.info('PFC is not enabled on the DUT, skipping PFC configuration on TGEN')
 
@@ -1102,154 +1094,93 @@ def tgen_ports(duthost, get_snappi_ports, conn_graph_facts, fanout_graph_facts, 
     return snappi_ports
 
 
-def snappi_multi_base_config(duthost_list,
-                             snappi_ports,
-                             snappi_api,
-                             setup=True):
+def snappi_base_config(duthost_list, snappi_ports, snappi_api, setup=True, multi_mode=False):
     """
-    Generate snappi API config and port config information for the testbed
-    This function takes care of mixed-speed interfaces by removing assert and printing info log.
-    l1_config is added to both the snappi_ports instead of just one.
+    Unified Snappi API config and port config generator for testbed.
 
     Args:
-        duthost_list (pytest fixture): list of DUTs
-        snappi_ports: list of snappi ports
-        snappi_api(pytest fixture): Snappi API fixture
+        duthost_list: List of DUT hosts.
+        snappi_ports: List of snappi port dictionaries.
+        snappi_api: Snappi API fixture.
         setup (bool): Indicates if functionality is called to create or clear the setup.
+        multi_mode: True to use multi-base behavior (mixed speeds, per-port L1 config).
+                    False to use DUT-base behavior (single speed check, uniform per-port L1 settings).
+
     Returns:
-        - config (obj): Snappi API config of the testbed
-        - port_config_list (list): list of port configuration information
-        - snappi_ports (list): list of snappi_ports selected for the test.
+        Result of setup_dut_ports call (config, port_config_list, etc.)
     """
 
-    """ Generate L1 config """
+    def setup_pfc(pfc):
+        pfc.pfc_delay = 0
+        if pfcQueueGroupSize == 8:
+            for i in range(8):
+                setattr(pfc, f'pfc_class_{i}', i)
+        elif pfcQueueGroupSize == 4:
+            for i in range(8):
+                setattr(pfc, f'pfc_class_{i}', pfcQueueValueDict[i])
+        else:
+            pytest_assert(False, 'pfcQueueGroupSize value is not 4 or 8')
 
     config = snappi_api.config()
     tgen_ports = [port['location'] for port in snappi_ports]
+    new_snappi_ports = [
+        dict(list(sp.items()) + [('port_id', i)])
+        for i, sp in enumerate(snappi_ports) if sp['location'] in tgen_ports
+    ]
 
-    new_snappi_ports = [dict(list(sp.items()) + [('port_id', i)])
-                        for i, sp in enumerate(snappi_ports) if sp['location'] in tgen_ports]
+    # Add ports to config
+    for sp in new_snappi_ports:
+        config.ports.port(name=f'Port {sp["port_id"]}', location=sp['location'])
 
-    # Printing info level if ingress and egress interfaces are of different speeds.
-    if (len(set([sp['speed'] for sp in new_snappi_ports])) > 1):
-        logger.info('Rx and  Tx ports have different link speeds')
-    [config.ports.port(name='Port {}'.format(sp['port_id']), location=sp['location']) for sp in new_snappi_ports]
+    if not multi_mode:
+        pytest_assert(len(set([sp['speed'] for sp in new_snappi_ports])) == 1,
+                      'Ports have different link speeds')
 
-    # Generating L1 config for both the snappi_ports.
+    # Mixed speed allowed, just log info if speeds differ
+    if len(set([sp['speed'] for sp in new_snappi_ports])) > 1:
+        logger.info('Rx and Tx ports have different link speeds')
+
+    if not multi_mode:
+        config.options.port_options.location_preemption = True
+
+    location_to_port_index = {sp['location']: i for i, sp in enumerate(new_snappi_ports)}
+
+    # Per-port L1 config
     for port in config.ports:
-        for index, snappi_port in enumerate(new_snappi_ports):
-            if snappi_port['location'] == port.location:
-                l1_config = config.layer1.layer1()[-1]
-                l1_config.name = 'L1 config {}'.format(index)
-                l1_config.port_names = [port.name]
-                l1_config.speed = 'speed_'+str(int(int(snappi_port['speed'])/1000))+'_gbps'
-                l1_config.ieee_media_defaults = False
-                l1_config.auto_negotiate = False
-                l1_config.auto_negotiation.link_training = False
-                l1_config.auto_negotiation.rs_fec = True
-                pfc = l1_config.flow_control.ieee_802_1qbb
-                pfc.pfc_delay = 0
-            if pfcQueueGroupSize == 8:
-                pfc.pfc_class_0 = 0
-                pfc.pfc_class_1 = 1
-                pfc.pfc_class_2 = 2
-                pfc.pfc_class_3 = 3
-                pfc.pfc_class_4 = 4
-                pfc.pfc_class_5 = 5
-                pfc.pfc_class_6 = 6
-                pfc.pfc_class_7 = 7
-            elif pfcQueueGroupSize == 4:
-                pfc.pfc_class_0 = pfcQueueValueDict[0]
-                pfc.pfc_class_1 = pfcQueueValueDict[1]
-                pfc.pfc_class_2 = pfcQueueValueDict[2]
-                pfc.pfc_class_3 = pfcQueueValueDict[3]
-                pfc.pfc_class_4 = pfcQueueValueDict[4]
-                pfc.pfc_class_5 = pfcQueueValueDict[5]
-                pfc.pfc_class_6 = pfcQueueValueDict[6]
-                pfc.pfc_class_7 = pfcQueueValueDict[7]
-            else:
-                pytest_assert(False, 'pfcQueueGroupSize value is not 4 or 8')
+        index = location_to_port_index.get(port.location)
+        if index is not None:
+            l1_config = config.layer1.layer1()[-1]
+            l1_config.name = f'L1 config {index}'
+            l1_config.port_names = [port.name]
+            l1_config.speed = f'speed_{int(int(new_snappi_ports[index]["speed"]) / 1000)}_gbps'
+            l1_config.ieee_media_defaults = False
+            l1_config.auto_negotiate = False
+            l1_config.auto_negotiation.link_training = False
+            l1_config.auto_negotiation.rs_fec = True
+            l1_config.auto_negotiate = new_snappi_ports[index].get('autoneg', False)
+            l1_config.auto_negotiation.link_training = new_snappi_ports[index].get('link_training', False)
+            l1_config.auto_negotiation.rs_fec = new_snappi_ports[index].get('fec', False)
+            setup_pfc(l1_config.flow_control.ieee_802_1qbb)
 
     port_config_list = []
 
-    return (setup_dut_ports(
+    # Call existing setup function unchanged
+    return setup_dut_ports(
         setup=setup,
         duthost_list=duthost_list,
         config=config,
         port_config_list=port_config_list,
-        snappi_ports=new_snappi_ports))
+        snappi_ports=new_snappi_ports,
+    )
 
 
-def snappi_dut_base_config(duthost_list,
-                           snappi_ports,
-                           snappi_api,
-                           setup=True):
-    """
-    Generate snappi API config and port config information for the testbed
-    Args:
-        duthost_list (pytest fixture): list of DUTs
-        snappi_ports: list of snappi ports
-        snappi_api(pytest fixture): Snappi API fixture
-    Returns:
-        - config (obj): Snappi API config of the testbed
-        - port_config_list (list): list of port configuration information
-    """
+# Preserve old functions by calling merged with mode flag
+def snappi_multi_base_config(duthost_list, snappi_ports, snappi_api, setup=True):
+    return snappi_base_config(duthost_list, snappi_ports, snappi_api, setup=setup, multi_mode=True)
 
-    """ Generate L1 config """
 
-    config = snappi_api.config()
-    tgen_ports = [port['location'] for port in snappi_ports]
-
-    new_snappi_ports = [dict(list(sp.items()) + [('port_id', i)])
-                        for i, sp in enumerate(snappi_ports) if sp['location'] in tgen_ports]
-    pytest_assert(len(set([sp['speed'] for sp in new_snappi_ports])) == 1, 'Ports have different link speeds')
-    [config.ports.port(name='Port {}'.format(sp['port_id']), location=sp['location']) for sp in new_snappi_ports]
-    speed_gbps = int(int(new_snappi_ports[0]['speed'])/1000)
-
-    config.options.port_options.location_preemption = True
-    l1_config = config.layer1.layer1()[-1]
-    l1_config.name = 'L1 config'
-    l1_config.port_names = [port.name for port in config.ports]
-    l1_config.speed = 'speed_{}_gbps'.format(speed_gbps)
-    l1_config.ieee_media_defaults = False
-    l1_config.auto_negotiate = False
-    if is_snappi_multidut(duthost_list):
-        l1_config.auto_negotiation.link_training = False
-    else:
-        l1_config.auto_negotiation.link_training = True
-    l1_config.auto_negotiation.rs_fec = True
-
-    pfc = l1_config.flow_control.ieee_802_1qbb
-    pfc.pfc_delay = 0
-    if pfcQueueGroupSize == 8:
-        pfc.pfc_class_0 = 0
-        pfc.pfc_class_1 = 1
-        pfc.pfc_class_2 = 2
-        pfc.pfc_class_3 = 3
-        pfc.pfc_class_4 = 4
-        pfc.pfc_class_5 = 5
-        pfc.pfc_class_6 = 6
-        pfc.pfc_class_7 = 7
-    elif pfcQueueGroupSize == 4:
-        pfc.pfc_class_0 = pfcQueueValueDict[0]
-        pfc.pfc_class_1 = pfcQueueValueDict[1]
-        pfc.pfc_class_2 = pfcQueueValueDict[2]
-        pfc.pfc_class_3 = pfcQueueValueDict[3]
-        pfc.pfc_class_4 = pfcQueueValueDict[4]
-        pfc.pfc_class_5 = pfcQueueValueDict[5]
-        pfc.pfc_class_6 = pfcQueueValueDict[6]
-        pfc.pfc_class_7 = pfcQueueValueDict[7]
-    else:
-        pytest_assert(False, 'pfcQueueGroupSize value is not 4 or 8')
-
-    port_config_list = []
-
-    return (setup_dut_ports(
-        setup=setup,
-        duthost_list=duthost_list,
-        config=config,
-        port_config_list=port_config_list,
-        snappi_ports=new_snappi_ports))
+def snappi_dut_base_config(duthost_list, snappi_ports, snappi_api, setup=True):
+    return snappi_base_config(duthost_list, snappi_ports, snappi_api, setup=setup, multi_mode=False)
 
 
 def setup_dut_ports(
@@ -1859,165 +1790,171 @@ def cleanup_config(duthost_list, snappi_ports):
 
 
 @pytest.fixture(scope="module")
-def multidut_snappi_ports_for_bgp(duthosts,                                # noqa: F811
-                                  tbinfo,                                  # noqa: F811
-                                  conn_graph_facts,                        # noqa: F811
-                                  fanout_graph_facts_multidut):            # noqa: F811
-    """
-    Populate snappi ports and connected DUT ports info of T1 and T2 testbed and returns as a list
-    Args:
-        duthost (pytest fixture): duthost fixture
-        tbinfo (pytest fixture): fixture provides information about testbed
-        conn_graph_facts (pytest fixture): connection graph
-        fanout_graph_facts_multidut (pytest fixture): fanout graph
-    Return:
-        return tuple of duts and snappi ports
-    """
-    multidut_snappi_ports = []
-
-    for duthost in duthosts:
-        snappi_fanout = get_peer_snappi_chassis(conn_data=conn_graph_facts,
-                                                dut_hostname=duthost.hostname)
-        if snappi_fanout is None:
-            continue
-        snappi_fanout = snappi_fanout[0]
-        snappi_fanout_id = list(fanout_graph_facts_multidut.keys()).index(snappi_fanout)
-        snappi_fanout_list = SnappiFanoutManager(fanout_graph_facts_multidut)
-        snappi_fanout_list.get_fanout_device_details(device_number=snappi_fanout_id)
-        snappi_ports = snappi_fanout_list.get_ports(peer_device=duthost.hostname)
-        port_speed = None
-        for i in range(len(snappi_ports)):
-            if port_speed is None:
-                port_speed = int(snappi_ports[i]['speed'])
-
-            elif port_speed != int(snappi_ports[i]['speed']):
-                """ All the ports should have the same bandwidth """
-                return None
-
-        for port in snappi_ports:
-            port['location'] = get_snappi_port_location(port)
-            port['speed'] = speed_type[port['speed']]
-            port['api_server_ip'] = tbinfo['ptf_ip']
-        multidut_snappi_ports = multidut_snappi_ports + snappi_ports
-    return multidut_snappi_ports
-
-
-@pytest.fixture(scope="module")
-def get_snappi_ports_single_dut(duthosts,  # noqa: F811
-                                conn_graph_facts,  # noqa: F811
-                                fanout_graph_facts,  # noqa: F811
+def multidut_snappi_ports_for_bgp(duthosts,
                                 tbinfo,
-                                snappi_api_serv_ip,
-                                rand_one_dut_hostname,
-                                rand_one_dut_portname_oper_up
-                                ):  # noqa: F811
+                                conn_graph_facts,
+                                fanout_graph_facts_multidut):  # noqa: F811
+    """Backward-compatible wrapper calling unified port logic."""
+    multidut_snappi_ports = _get_snappi_ports_unified(
+        duthosts=duthosts,
+        conn_graph_facts=conn_graph_facts,
+        fanout_graph_facts=None,
+        fanout_graph_facts_multidut=fanout_graph_facts_multidut,
+        tbinfo=tbinfo,
+        rand_one_dut_hostname=None,
+    )
+    speeds = {int(p["speed"]) for p in multidut_snappi_ports}
+    if len(speeds) != 1:
+        logger.error(f"Port speeds not uniform: {speeds}")
+        return None
+    else:
+        port_speed = speeds.pop()
+        for port in multidut_snappi_ports:
+            port['speed'] = speed_type[port['speed']]
+        logger.info(f"Using uniform port speed: {port_speed}")
+        return multidut_snappi_ports
 
-    if is_snappi_multidut(duthosts):
-        return []
 
-    duthost = duthosts[rand_one_dut_hostname]
+def _get_snappi_ports_unified(duthosts,
+                              conn_graph_facts,             # noqa: F811
+                              fanout_graph_facts,           # noqa: F811
+                              fanout_graph_facts_multidut,  # noqa: F811
+                              tbinfo,
+                              rand_one_dut_hostname):
+    """
+    Unified fixture:
+    Returns Snappi port information for both
+        • single-DUT topology
+        • multi-DUT topology
 
-    """ Generate L1 config """
-    snappi_fanouts = get_peer_snappi_chassis(conn_data=conn_graph_facts,
-                                             dut_hostname=duthost.hostname)
+    The function:
+      • Detects topology (multi-DUT or not)
+      • Gathers peer Snappi chassis ports per DUT
+      • Reads FEC / link-training / autoneg settings from DUT PORT table
+      • Attaches ASIC, API server, speed type, port_id, etc.
+    """
 
-    pytest_assert(snappi_fanouts is not None, 'Fail to get snappi_fanout')
-    snappi_fanout_list = SnappiFanoutManager(fanout_graph_facts)
+    # Select DUT list based on topology
+    multi_dut = is_snappi_multidut(duthosts)
+    # Pick correct fanout graph per topology
+    fanout_graph = fanout_graph_facts_multidut if multi_dut else fanout_graph_facts
+    # Single-DUT → Only one DUT is used
+    dut_list = duthosts if multi_dut else [duthosts[rand_one_dut_hostname]]
+
     snappi_ports_all = []
-    for snappi_fanout in snappi_fanouts:
-        snappi_fanout_id = list(fanout_graph_facts.keys()).index(snappi_fanout)
-        snappi_fanout_list.get_fanout_device_details(device_number=snappi_fanout_id)
-        snappi_ports = snappi_fanout_list.get_ports(peer_device=duthost.hostname)
-        # Add snappi ports for each chassis connetion
-        for sp in snappi_ports:
-            snappi_ports_all.append(sp)
+    for duthost in dut_list:
+        # Pull current PORT table from DUT
+        try:
+            run_facts = duthost.config_facts(host=duthost.hostname,
+                                             source="running")['ansible_facts']
+            port_table = run_facts.get('PORT', {})
+        except Exception as e:
+            logger.warning(f"Failed to read PORT table on {duthost.hostname}: {e}")
+            port_table = {}
 
-        for port in snappi_ports_all:
-            port['intf_config_changed'] = False
-            port['api_server_ip'] = tbinfo['ptf_ip']
-            port['asic_type'] = duthost.facts["asic_type"]
-            port['duthost'] = duthost
-            port['snappi_speed_type'] = speed_type[port['speed']]
-            if duthost.facts["num_asic"] > 1:
-                port['asic_value'] = duthost.get_port_asic_instance(port['peer_port']).namespace
-            else:
-                port['asic_value'] = None
-    for index, port in enumerate(snappi_ports_all):
-        port['port_id'] = str(index + 1)
+        # Find Snappi chassis connected to this DUT
+        snappi_fanouts = get_peer_snappi_chassis(conn_data=conn_graph_facts,
+                                                 dut_hostname=duthost.hostname)
+        if not snappi_fanouts:
+            continue
+
+        fanout_mgr = SnappiFanoutManager(fanout_graph)
+        # Process all fanouts for this DUT
+        for snappi_fanout in snappi_fanouts:
+            fanout_id = list(fanout_graph.keys()).index(snappi_fanout)
+            # Load fanout info into manager
+            fanout_mgr.get_fanout_device_details(device_number=fanout_id)
+            # Get Snappi ports that connect to this DUT
+            tgen_ports = fanout_mgr.get_ports(peer_device=duthost.hostname)
+            # For each port connected to this DUT, enrich attributes
+            for port in tgen_ports:
+                dut_port_info = port_table.get(port.get('peer_port'), {})
+                # Populate DUT-related interface attributes
+                port.update({
+                    'autoneg': dut_port_info.get('autoneg') == 'on',
+                    'fec': str(dut_port_info.get('fec', '')).lower().startswith('rs'),
+                    'link_training': str(dut_port_info.get('link_training', '')).lower() in ['on', 'true', 'yes', '1'],
+                    'intf_config_changed': False,
+                    'api_server_ip': tbinfo['ptf_ip'],
+                    'asic_type': duthost.facts["asic_type"],
+                    'duthost': duthost,
+                    'snappi_speed_type': speed_type[port['speed']],
+                })
+
+                # For multi-ASIC devices, assign ASIC namespace
+                if duthost.facts["num_asic"] > 1:
+                    port['asic_value'] = duthost.get_port_asic_instance(
+                        port['peer_port']
+                    ).namespace
+                else:
+                    port['asic_value'] = None
+
+            snappi_ports_all.extend(tgen_ports)
+
+    # Assign stable port IDs
+    for idx, port in enumerate(snappi_ports_all, 1):
+        port['port_id'] = str(idx)
+
     return snappi_ports_all
 
 
 @pytest.fixture(scope="module")
-def get_snappi_ports_multi_dut(duthosts,  # noqa: F811
-                               tbinfo,  # noqa: F811
-                               conn_graph_facts,  # noqa: F811
-                               fanout_graph_facts_multidut,
-                               ):  # noqa: F811
-    """
-    Populate snappi ports and connected DUT ports info of T1 and T2 testbed and returns as a list
-    Args:
-        duthost (pytest fixture): duthost fixture
-        tbinfo (pytest fixture): fixture provides information about testbed
-        conn_graph_facts (pytest fixture): connection graph
-        fanout_graph_facts_multidut (pytest fixture): fanout graph
-    Return: (list)
-        [{  'api_server_ip': '10.36.78.59',
-            'asic_type': 'broadcom',
-            'asic_value': None,
-            'card_id': '4',
-            'duthost': <MultiAsicSonicHost sonic-s6100-dut2>,
-            'ip': '10.36.78.53',
-            'location': '10.36.78.53;4;7',
-            'peer_device': 'sonic-s6100-dut1',
-            'peer_port': 'Ethernet72',
-            'port_id': '7',
-            'snappi_speed_type': 'speed_100_gbps',
-            'speed': '100000'
-        },
-        {   'api_server_ip': '10.36.78.59',
-            'asic_type': 'broadcom',
-            'asic_value': 'asic0',
-            'card_id': '4',
-            'duthost': <MultiAsicSonicHost sonic-s6100-dut2>,
-            'ip': '10.36.78.53',
-            'location': '10.36.78.53;4;8',
-            'peer_device': 'sonic-s6100-dut2',
-            'peer_port': 'Ethernet76',
-            'port_id': '8',
-            'snappi_speed_type': 'speed_100_gbps',
-            'speed': '100000'
-        }]
-    """
-    multidut_snappi_ports = []
+def get_snappi_ports_single_dut(duthosts,
+                                conn_graph_facts,                       # noqa: F811
+                                fanout_graph_facts,                     # noqa: F811
+                                tbinfo,
+                                rand_one_dut_hostname):
+    """Backward-compatible wrapper calling unified port logic."""
+    return _get_snappi_ports_unified(
+        duthosts=duthosts,
+        conn_graph_facts=conn_graph_facts,
+        fanout_graph_facts=fanout_graph_facts,
+        fanout_graph_facts_multidut=None,
+        tbinfo=tbinfo,
+        rand_one_dut_hostname=rand_one_dut_hostname,
+    )
 
-    if not is_snappi_multidut(duthosts):
-        return []
 
-    for duthost in duthosts:
-        snappi_fanouts = get_peer_snappi_chassis(conn_data=conn_graph_facts,
-                                                 dut_hostname=duthost.hostname)
-        if snappi_fanouts is None:
-            continue
-        snappi_fanout_list = SnappiFanoutManager(fanout_graph_facts_multidut)
-        for snappi_fanout in snappi_fanouts:
-            snappi_fanout_id = list(fanout_graph_facts_multidut.keys()).index(snappi_fanout)
-            snappi_fanout_list.get_fanout_device_details(device_number=snappi_fanout_id)
-            snappi_ports = snappi_fanout_list.get_ports(peer_device=duthost.hostname)
+@pytest.fixture(scope="module")
+def get_snappi_ports_multi_dut(duthosts,
+                               conn_graph_facts,                # noqa: F811
+                               fanout_graph_facts_multidut,     # noqa: F811
+                               tbinfo):
+    """Backward-compatible wrapper calling unified port logic."""
+    return _get_snappi_ports_unified(
+        duthosts=duthosts,
+        conn_graph_facts=conn_graph_facts,
+        fanout_graph_facts=None,
+        fanout_graph_facts_multidut=fanout_graph_facts_multidut,
+        tbinfo=tbinfo,
+        rand_one_dut_hostname=None,
+    )
 
-            for port in snappi_ports:
-                port['intf_config_changed'] = False
-                port['api_server_ip'] = tbinfo['ptf_ip']
-                port['asic_type'] = duthost.facts["asic_type"]
-                port['duthost'] = duthost
-                port['snappi_speed_type'] = speed_type[port['speed']]
-                if duthost.facts["num_asic"] > 1:
-                    port['asic_value'] = duthost.get_port_asic_instance(port['peer_port']).namespace
-                else:
-                    port['asic_value'] = None
-            multidut_snappi_ports = multidut_snappi_ports + snappi_ports
-    for index, port in enumerate(multidut_snappi_ports):
-        port['port_id'] = str(index + 1)
-    return multidut_snappi_ports
+
+@pytest.fixture(scope="module")
+def multidut_snappi_ports_for_bgp(duthosts,
+                                  tbinfo,
+                                  conn_graph_facts,     # noqa: F811
+                                  fanout_graph_facts_multidut):  # noqa: F811
+    """Backward-compatible wrapper calling unified port logic."""
+    multidut_snappi_ports = _get_snappi_ports_unified(
+        duthosts=duthosts,
+        conn_graph_facts=conn_graph_facts,
+        fanout_graph_facts=None,
+        fanout_graph_facts_multidut=fanout_graph_facts_multidut,
+        tbinfo=tbinfo,
+        rand_one_dut_hostname=None,
+    )
+    speeds = {int(p["speed"]) for p in multidut_snappi_ports}
+    if len(speeds) != 1:
+        logger.error(f"Port speeds not uniform: {speeds}")
+        return None
+    else:
+        port_speed = speeds.pop()
+        for port in multidut_snappi_ports:
+            port['speed'] = speed_type[port['speed']]
+        logger.info(f"Using uniform port speed: {port_speed}")
+        return multidut_snappi_ports
 
 
 def is_snappi_multidut(duthosts):
@@ -2037,15 +1974,16 @@ def get_snappi_ports(duthosts, request):
     Args:
         duthosts (pytest fixture): list of DUTs
         request (pytest fixture): request fixture
-    Return: (list)
+    Returns:
+        list: (list)
     """
-    # call the fixture based on the testbed type for minimize the impact
-    # use the same fixture for different testbeds in the future if possible?
-    if is_snappi_multidut(duthosts):
-        snappi_ports = request.getfixturevalue("get_snappi_ports_multi_dut")
-    else:
-        snappi_ports = request.getfixturevalue("get_snappi_ports_single_dut")
-    return snappi_ports
+    fixture_name = (
+        "get_snappi_ports_multi_dut"
+        if is_snappi_multidut(duthosts)
+        else "get_snappi_ports_single_dut"
+    )
+    logger.info(f"Selecting snappi port fixture: {fixture_name}")
+    return request.getfixturevalue(fixture_name)
 
 
 def get_snappi_ports_for_rdma(snappi_port_list, rdma_ports, tx_port_count, rx_port_count, testbed):

--- a/tests/snappi_tests/lacp/files/lacp_dut_helper.py
+++ b/tests/snappi_tests/lacp/files/lacp_dut_helper.py
@@ -158,10 +158,10 @@ def __tgen_bgp_config(snappi_api,
     layer1.name = 'port settings'
     layer1.port_names = [port.name for port in config.ports]
     layer1.ieee_media_defaults = False
-    layer1.auto_negotiation.rs_fec = False
-    layer1.auto_negotiation.link_training = False
+    layer1.auto_negotiation.rs_fec = temp_tg_port[0].get('fec', False)
+    layer1.auto_negotiation.link_training = temp_tg_port[0].get('link_training', False)
     layer1.speed = temp_tg_port[0]['speed']
-    layer1.auto_negotiate = False
+    layer1.auto_negotiate = temp_tg_port[0].get('autoneg', False)
 
     # Source
     config.devices.device(name='Tx')

--- a/tests/snappi_tests/lacp/files/lacp_physical_helper.py
+++ b/tests/snappi_tests/lacp/files/lacp_physical_helper.py
@@ -221,10 +221,10 @@ def __tgen_bgp_config(snappi_api,
     layer1.name = 'port settings'
     layer1.port_names = [port.name for port in config.ports]
     layer1.ieee_media_defaults = False
-    layer1.auto_negotiation.rs_fec = False
-    layer1.auto_negotiation.link_training = False
+    layer1.auto_negotiation.rs_fec = temp_tg_port[0].get('fec', False)
+    layer1.auto_negotiation.link_training = temp_tg_port[0].get('link_training', False)
     layer1.speed = temp_tg_port[0]['speed']
-    layer1.auto_negotiate = False
+    layer1.auto_negotiate = temp_tg_port[0].get('autoneg', False)
 
     # Source
     config.devices.device(name='Tx')


### PR DESCRIPTION
### Description of PR
Unifying code
- Read running config to get L1 settings and apply those to snappi ports.
- Unified snappi_dut_base_config and snappi_multi_base_config
- Unified get_snappi_ports_single_dut, get_snappi_ports_multi_dut and multidut_snappi_ports_for_bgp

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
#### Test Script log:
```
collected 1 item                                                                                                                                                              

------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------
INFO     root:__init__.py:53 Completeness level not set during test execution. Setting to default level: 1
INFO     root:__init__.py:151 Test has no defined levels. Continue without test completeness checks
INFO     tests.conftest:conftest.py:411 Inventory file: ['../ansible/snappi-sonic']
INFO     tests.common.fixtures.ptfhost_utils:ptfhost_utils.py:326 Skip running icmp_responder at session level, it is only for dualtor testbed with active-active mux ports.
INFO     tests.common.helpers.dut_utils:dut_utils.py:623 dut sonic-s6100-dut1 belongs to groups ['snappi-sonic', 'sonic', 'sonic_dell64_40', 'fanout']
INFO     root:dut_utils.py:648 skip empty var file /root/sonic-mgmt/tests/common/helpers/../../../ansible/group_vars/all/corefile_uploader.yml
INFO     root:dut_utils.py:648 skip empty var file /root/sonic-mgmt/tests/common/helpers/../../../ansible/group_vars/all/env.yml
INFO     paramiko.transport:transport.py:1938 Connected (version 2.0, client OpenSSH_9.2p1)
INFO     paramiko.transport:transport.py:1938 Auth banner: b'Debian GNU/Linux 12 \\n \\l\n\n'
INFO     paramiko.transport:transport.py:1938 Authentication (password) successful!
INFO     tests.common.plugins.sanity_check:__init__.py:448 Skip sanity check according to command line argument
INFO     tests.conftest:conftest.py:2949 Dumping Disk and Memory Space information before test on sonic-s6100-dut1
INFO     tests.conftest:conftest.py:2953 Collecting core dumps before test on sonic-s6100-dut1
INFO     tests.conftest:conftest.py:2962 Collecting running config before test on sonic-s6100-dut1
INFO     tests.conftest:conftest.py:3248 Skipping temporarily_disable_route_check fixture
INFO     root:conftest.py:1709 Using DUTs ['sonic-s6100-dut1'] in testbed 'vms-snappi-sonic'
INFO     tests.conftest:conftest.py:706 Randomly select dut sonic-s6100-dut1 for testing
INFO     root:__init__.py:69 -------------------- fixture snappi_api_serv_ip setup starts --------------------
INFO     root:__init__.py:76 -------------------- fixture snappi_api_serv_ip setup ends --------------------
INFO     root:__init__.py:69 -------------------- fixture snappi_api_serv_port setup starts --------------------
INFO     root:__init__.py:76 -------------------- fixture snappi_api_serv_port setup ends --------------------
INFO     root:__init__.py:81 -------------------- fixture snappi_api setup starts --------------------
WARNING  snappi:snappi.py:106 Version check is disabled
INFO     root:__init__.py:85 -------------------- fixture snappi_api setup ends --------------------
INFO     tests.conftest:conftest.py:742 Randomly select dut sonic-s6100-dut1 for testing
INFO     root:__init__.py:69 -------------------- fixture tgen_ports setup starts --------------------
INFO     root:__init__.py:76 -------------------- fixture tgen_ports setup ends --------------------
INFO     root:__init__.py:77 Log analyzer is disabled
INFO     tests.common.plugins.memory_utilization:__init__.py:143 Hostname: sonic-s6100-dut1, Hwsku: Mellanox-SN2700, Platform: x86_64-mlnx_msn2700-r0
INFO     tests.common.plugins.memory_utilization.memory_utilization:memory_utilization.py:409 Loading memory monitoring commands for hwsku: Mellanox-SN2700
INFO     tests.common.plugins.memory_utilization.memory_utilization:memory_utilization.py:23 Registering command: name=monit, cmd=sudo monit validate, memory_params={'memory_usage': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 10}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 70}}}, memory_check=<function parse_monit_validate_output at 0x7fb4fbf3f4c0>
INFO     tests.common.plugins.memory_utilization.memory_utilization:memory_utilization.py:23 Registering command: name=top, cmd=top -b -n 1, memory_params={'bgpd': {'memory_increase_threshold': {'type': 'value', 'value': 128}, 'memory_high_threshold': None}, 'zebra': {'memory_increase_threshold': {'type': 'value', 'value': 128}, 'memory_high_threshold': None}}, memory_check=<function parse_top_output at 0x7fb4fbf3eb60>
INFO     tests.common.plugins.memory_utilization.memory_utilization:memory_utilization.py:23 Registering command: name=free, cmd=free -m, memory_params={'used': {'memory_increase_threshold': {'type': 'percentage', 'value': '20%'}, 'memory_high_threshold': None}}, memory_check=<function parse_free_output at 0x7fb4fbf3f420>
INFO     tests.common.plugins.memory_utilization.memory_utilization:memory_utilization.py:23 Registering command: name=docker, cmd=docker stats --no-stream, memory_params={'snmp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 4}}, 'pmon': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 8}}, 'lldp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 4}}, 'gnmi': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 6}}, 'radv': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 3}}, 'syncd': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 7}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 22}}, 'bgp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 4}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 14}}, 'teamd': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 5}}, 'swss': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 5}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 10}}, 'database': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 6}}}, memory_check=<function parse_docker_stats_output at 0x7fb4fbf3f560>
INFO     tests.common.plugins.memory_utilization.memory_utilization:memory_utilization.py:23 Registering command: name=frr_bgp, cmd=vtysh -c "show memory bgp", memory_params={'used': {'memory_increase_threshold': [{'type': 'percentage', 'value': '50%'}, {'type': 'value', 'value': 64}, {'type': 'comparison', 'value': 'max'}], 'memory_high_threshold': {'type': 'value', 'value': 256}}}, memory_check=<function parse_frr_memory_output at 0x7fb4fbf3f600>
INFO     tests.common.plugins.memory_utilization.memory_utilization:memory_utilization.py:23 Registering command: name=frr_zebra, cmd=vtysh -c "show memory zebra", memory_params={'used': {'memory_increase_threshold': [{'type': 'percentage', 'value': '50%'}, {'type': 'value', 'value': 64}, {'type': 'comparison', 'value': 'max'}], 'memory_increase_fail_threshold': {'type': 'value', 'value': 128}, 'memory_high_threshold': {'type': 'value', 'value': 128}}}, memory_check=<function parse_frr_memory_output at 0x7fb4fbf3f600>
INFO     root:conftest.py:3766 skip setup dualtor mux cables on non-dualtor testbed
INFO     tests.common.plugins.memory_utilization.memory_utilization:memory_utilization.py:675 Total FRR memory used: 25.7 MB, holding: 18874368.0 bytes, small: 0.0 bytes, ordinary: 8115200.0 bytes
INFO     tests.common.plugins.memory_utilization.memory_utilization:memory_utilization.py:675 Total FRR memory used: 39.6 MB, holding: 34603008.0 bytes, small: 0.0 bytes, ordinary: 6870016.0 bytes
INFO     tests.common.plugins.memory_utilization:__init__.py:64 Before test: collected memory_values {'before_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 22.0}, 'top': {'zebra': 18.8, 'bgpd': 29.3}, 'free': {'used': 3612}, 'docker': {'gnmi': 0.8, 'lldp': 0.8, 'pmon': 1.7, 'radv': 0.5, 'syncd': 9.5, 'bgp': 1.4, 'teamd': 0.6, 'swss': 2.6, 'database': 1.4}, 'frr_bgp': {'used': 25.7}, 'frr_zebra': {'used': 39.6}}}, 'after_test': {'sonic-s6100-dut1': {}}}
-------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:222 Removing configured IP and IPv6 Address from Ethernet76
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:222 Removing configured IP and IPv6 Address from Ethernet68
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:222 Removing configured IP and IPv6 Address from Ethernet72
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:235 Configuring Ethernet76 to PortChannel1 with IPs 24.1.1.1,2004::1
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:235 Configuring Ethernet68 to PortChannel2 with IPs 22.1.1.1,2002::1
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:235 Configuring Ethernet72 to PortChannel3 with IPs 23.1.1.1,2003::1
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:262 Configuring BGP v4 Neighbor 22.1.1.2
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:262 Configuring BGP v4 Neighbor 23.1.1.2
WARNING  ixnetwork_restpy.connection:connection.py:351 Verification of certificates is disabled
WARNING  ixnetwork_restpy.connection:connection.py:351 Unable to connect to http://10.36.77.53:11009.
WARNING  root:snappi_api.py:1522 Test_Port_1 connectedLinkDown
WARNING  root:snappi_api.py:1522 Test_Port_2 connectedLinkDown
WARNING  root:snappi_api.py:1522 Test_Port_3 connectedLinkDown
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:465 Starting all protocols ...
INFO     tests.common.utilities:utilities.py:121 Pause 30 seconds, reason: For Protocols To start
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:480 |---- Test_Port_2 Link Flap Iteration : 1 ----|
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:484 Starting Traffic
INFO     tests.common.utilities:utilities.py:121 Pause 30 seconds, reason: For Traffic To start
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:493 Simulating Link Failure on Test_Port_2 link
INFO     tests.common.utilities:utilities.py:121 Pause 30 seconds, reason: For Link to go down
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:507 Traffic has converged after link flap
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:513 CP/DP Convergence Time (ms): 33145.781
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:519 Simulating Link Up on Test_Port_2 at the end of iteration 1
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:526 Stopping Traffic
INFO     tests.common.utilities:utilities.py:121 Pause 20 seconds, reason: For Traffic To Stop
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:480 |---- Test_Port_3 Link Flap Iteration : 1 ----|
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:484 Starting Traffic
INFO     tests.common.utilities:utilities.py:121 Pause 30 seconds, reason: For Traffic To start
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:493 Simulating Link Failure on Test_Port_3 link
INFO     tests.common.utilities:utilities.py:121 Pause 30 seconds, reason: For Link to go down
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:507 Traffic has converged after link flap
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:513 CP/DP Convergence Time (ms): 32680.174
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:519 Simulating Link Up on Test_Port_3 at the end of iteration 1
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:526 Stopping Traffic
INFO     tests.common.utilities:utilities.py:121 Pause 20 seconds, reason: For Traffic To Stop
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:544 
+--------------------------+--------------+-----------------+--------------+----------------+---------------------------------------------+
| Event Name               | Route Type   |   No. of Routes |   Iterations |   Delta Frames |   Avg Calculated Data Convergence Time (ms) |
|--------------------------+--------------+-----------------+--------------+----------------+---------------------------------------------|
| Test_Port_2 Link Failure | IPv4         |            1000 |            1 |             27 |                                       33145 |
| Test_Port_3 Link Failure | IPv4         |            1000 |            1 |             27 |                                       32680 |
+--------------------------+--------------+-----------------+--------------+----------------+---------------------------------------------+
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:991 Wait until all critical services are fully started
INFO     tests.snappi_tests.bgp.files.bgp_convergence_helper:bgp_convergence_helper.py:994 Convergence Test Completed
 
```