### PR TITLE
Fix tgen_port_info fixture to yield and cleanup DUT ports

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -2535,7 +2535,11 @@ def tgen_port_info(request: pytest.FixtureRequest, snappi_port_selection, get_sn
         if not snappi_ports:
             pytest.skip(f"Unsupported combination for {flatten_skeleton_parameter}")
 
-        return snappi_dut_base_config(duthosts, snappi_ports, snappi_api, setup=True)
+        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(
+            duthosts, snappi_ports, snappi_api, setup=True)
+        yield (testbed_config, port_config_list, snappi_ports)
+        logger.info('Snappi cleanup after test')
+        setup_dut_ports(False, duthosts, testbed_config, port_config_list, snappi_ports)
 
 
 def flatten_list(lst):


### PR DESCRIPTION
Summary: Fix `tgen_port_info` fixture to properly yield and cleanup DUT ports after test completion. Previously the fixture used `return` which meant DUT port cleanup (`setup_dut_ports(False, ...)`) was never called after tests finished, leaving ports in a configured state.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202605

### Approach
#### What is the motivation for this PR?
The `tgen_port_info` fixture in `snappi_fixtures.py` was using `return snappi_dut_base_config(...)` which meant the teardown/cleanup of DUT ports never executed after the test completed. This could leave DUT ports in a modified state between tests, causing flaky test failures.

#### How did you do it?
Changed the fixture to:
1. Unpack the result of `snappi_dut_base_config()` into `testbed_config`, `port_config_list`, and `snappi_ports`
2. `yield` the tuple to the test
3. After the test completes (teardown phase), call `setup_dut_ports(False, ...)` to restore DUT ports to their original state

#### How did you verify/test it?
Verified that the fixture correctly yields the config and performs cleanup by running snappi tests on a testbed with the fix applied.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A - this is a bug fix to an existing fixture.

### Documentation
N/A