### PR TITLE
Skip some gNMI/gNOI cases on BMC

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2882,6 +2882,12 @@ gnmi/test_gnmi_configdb.py::test_gnmi_configdb_polling_01:
     conditions:
       - "'bmc' in topo_type"
 
+gnmi/test_gnmi_configdb.py::test_gnmi_configdb_set_authenticate:
+  skip:
+    reason: "gNMI SetRequest on CONFIG_DB invokes org.SONiC.HostService.gcu DBus, not provided by BMC image"
+    conditions:
+      - "'bmc' in topo_type"
+
 gnmi/test_gnmi_configdb.py::test_gnmi_configdb_streaming_onchange_01:
   skip:
     reason: "dut ipv6 mgmt ip not supported"
@@ -2906,10 +2912,11 @@ gnmi/test_gnmi_configdb.py::test_gnmi_configdb_streaming_sample_01:
 
 gnmi/test_gnmi_configdb.py::test_gnmi_configdb_subscribe_authenticate:
   skip:
-    reason: "dut ipv6 mgmt ip not supported"
+    reason: "dut ipv6 mgmt ip not supported / Implicitly depends on cloudtype written by test_gnmi_configdb_set_authenticate, which is skipped/fails on BMC"
+    conditions_logical_operator: or
     conditions:
-      - "is_mgmt_ipv6_only==True"
-      - "https://github.com/sonic-net/sonic-mgmt/issues/20395"
+      - "is_mgmt_ipv6_only==True and https://github.com/sonic-net/sonic-mgmt/issues/20395"
+      - "'bmc' in topo_type"
 
 gnmi/test_gnmi_countersdb.py:
   xfail:
@@ -2981,6 +2988,18 @@ gnmi/test_gnmic.py:
 gnmi/test_gnoi_killprocess.py:
   skip:
     reason: "Test noisy due to restart issue not relevant to GNOI. Disabling them to rewrite."
+
+gnmi/test_gnoi_os.py:
+  skip:
+    reason: "The SONiC.HostService is not provided by BMC image"
+    conditions:
+      - "'bmc' in topo_type"
+
+gnmi/test_gnoi_system_reboot.py:
+  skip:
+    reason: "The SONiC.HostService is not provided by BMC image"
+    conditions:
+      - "'bmc' in topo_type"
 
 gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_halt:
   skip:


### PR DESCRIPTION
Summary: Skip some gNMI/gNOI cases on BMC
Fixes #
No SONiC.HostService on BMC, some gNMI/gNOI cases cannot run, skip them.
- Skip test_gnmi_configdb_set_authenticate on BMC (relies on org.SONiC.HostService.gcu DBus)
- Skip test_gnmi_configdb_subscribe_authenticate on BMC (implicitly depends on cloudtype written by set_authenticate)
- Skip test_gnoi_os.py on BMC (relies on SONiC.HostService)
- Skip test_gnoi_system_reboot.py on BMC (relies on SONiC.HostService)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
No SONiC.HostService on BMC, some gNMI/gNOI cases cannot run, skip them.
- Skip test_gnmi_configdb_set_authenticate on BMC (relies on org.SONiC.HostService.gcu DBus)
- Skip test_gnmi_configdb_subscribe_authenticate on BMC (implicitly depends on cloudtype written by set_authenticate)
- Skip test_gnoi_os.py on BMC (relies on SONiC.HostService)
- Skip test_gnoi_system_reboot.py on BMC (relies on SONiC.HostService)

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
