### PR TITLE
Add t1-isolated-d32u1s2 into lossy topology list

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -18,6 +18,7 @@
           't0-isolated-d16u16s2', 't0-isolated-v6-d16u16s2',
           't0-isolated-d256u256s2', 't0-isolated-v6-d256u256s2',
           't0-isolated-d32u32s2', 't0-isolated-v6-d32u32s2',
+          't1-isolated-d32u1s2',
           't1-isolated-d224u8', 't1-isolated-v6-d224u8',
           't1-isolated-d28u1', 't1-isolated-v6-d28u1',
           't1-isolated-d28u4',


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Topology t1-isolated-d32u1s2 was newly introduced in https://github.com/sonic-net/sonic-mgmt/pull/24521
Add t1-isolated-d32u1s2 into lossy topology list

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Add t1-isolated-d32u1s2 into lossy topology list
#### How did you do it?
Add t1-isolated-d32u1s2 into lossy topology list
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
