### PR TITLE
Cisco: console server: Reduce the delay factor multiplier for console_link_wiring and console_loopback tests.

### DIFF
--- a/tests/console/test_console_link_wiring.py
+++ b/tests/console/test_console_link_wiring.py
@@ -41,7 +41,7 @@ def _verify_one_line(duthost, console_fanout, creds, target_line, same_host):
     packet_size = 64
     delay_factor = 3.2
     if duthost.facts['platform'].startswith("arm64-c8220tg_48a"):
-        delay_factor *= 25.0
+        delay_factor *= 2
 
     # Estimate a reasonable data transfer time based on configured baud rate
     timeout_sec = (packet_size * 10) * delay_factor / int(baud_rate)

--- a/tests/console/test_console_loopback.py
+++ b/tests/console/test_console_loopback.py
@@ -75,7 +75,7 @@ def test_console_loopback_echo(setup_c0, creds, conn_graph_facts, baud_rate, flo
         if duthost.facts['platform'] in ['arm64-nokia_ixs7215_c1xa-r0']:
             delay_factor *= 10.0
     if duthost.facts['platform'].startswith('arm64-c8220tg_48a'):
-        delay_factor *= 25.0
+        delay_factor *= 4.0
 
     dutip, dutuser, dutpass = get_host_ip_and_creds(duthost, creds)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Reduce the delay factor multiplier for cisco console platform.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511
- [X] 202512
- [X] 202605

### Approach
#### What is the motivation for this PR?
Due to recent improvements in console line handling, cisco console platform doesn't need delay_factor to be multiplied by 25 as introduced by https://github.com/sonic-net/sonic-mgmt/pull/23878. 

In this PR, we are reducing it down to 2 and 4 for link_wiring and loopback.

#### How did you do it?
Reduced the delay factor.

#### How did you verify/test it?
Ran it in c0 and c0-lo topologies:
```
SKIPPED [4] console/test_console_availability.py:136: This test is applicable to virtual setup only.
SKIPPED [8] console/test_console_stress.py:112: test requires topology in Mark(name='topology', args=('c0-lo',), kwargs={})
============================================================================= 64 passed, 12 skipped, 1 warning in 3156.91s (0:52:36) =============================================================================
sonic@arctos_cicd_all_202603:/data/tests$ 
```

```
SKIPPED [4] console/test_console_availability.py:136: This test is applicable to virtual setup only.
SKIPPED [4] console/test_console_loopback.py:121: ping-pong test requires a separate console fanout; on DUT 'c0lo-dut' the console fanout is the DUT itself, so the bridging socat process and the reverse-SSH picocom would contend for the same tty device
SKIPPED [8] console/test_console_stress.py:112: test requires topology in Mark(name='topology', args=('c0-lo',), kwargs={})
============================================================================= 60 passed, 16 skipped, 1 warning in 2559.43s (0:42:39) =============================================================================
sonic@arctos_cicd_all_202603:/data/tests$ 
```
#### Any platform specific information?
Specific to cisco console only.