### PR TITLE
Wait for bgp in config reload operation for suppress fib test

### DIFF
--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -822,7 +822,7 @@ def param_reboot(request, duthost, localhost, loganalyzer):
         logger.info("Randomly choose {} from reload, cold, warm, fast".format(reboot_type))
 
     if reboot_type == "reload":
-        config_reload(duthost, safe_reload=True, ignore_loganalyzer=loganalyzer)
+        config_reload(duthost, safe_reload=True, ignore_loganalyzer=loganalyzer, wait_for_bgp=True)
         wait_until(120, 10, 0, check_interface_status, duthost)
         # Wait for BGP sessions to re-establish, consistent with do_and_wait_reboot()
         bgp_neighbors = duthost.get_bgp_neighbors_per_asic(state="all")


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Wait for bgp in config reload operation in suppress fib test 
It would avoid bgp failed to establish after stopping orchagent


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
BGP sessions failed to establish after stopping orchagent, and it could persist for long time.
#### How did you do it?
Wait for bgp in config reload operation in suppress fib test 
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
