### PR TITLE
Add enable_monit_refresh marker for srv6 dataplane test case

### DIFF
--- a/tests/srv6/test_srv6_dataplane.py
+++ b/tests/srv6/test_srv6_dataplane.py
@@ -292,6 +292,7 @@ class SRv6Base():
 
 class TestSRv6DataPlaneBase(SRv6Base):
 
+    @pytest.mark.enable_monit_refresh
     def test_srv6_full_func(self, config_setup, srv6_crm_total_sids,
                             setup_standby_ports_on_rand_unselected_tor,       # noqa: F811
                             toggle_all_simulator_ports_to_rand_selected_tor,  # noqa: F811


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Summary:
Add `@pytest.mark.enable_monit_refresh` to `test_srv6_full_func` in tests/srv6/test_srv6_dataplane.py.

The autouse memory_utilization plugin snapshots DUT memory before and after each test to detect leaks, reading monit's cached per-process memory. By default that read isn't refreshed, so it can return stale data from monit's previous cycle — which intermittently fails the memory_utilization fixture on test_srv6_full_func. The marker opts this test into the plugin's fresh-read path (sudo monit validate followed by a freshness retry on monit status) so the before/after comparison uses current data.

No functional change to SRv6; this affects only memory-measurement accuracy for this test, at the cost of a few extra seconds per setup/teardown when the monit cache is stale. The refresh stays off by default for all other tests.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Memory utilization fixture failure from time to time at case test_srv6_full_func
#### How did you do it?
Add the enable_monit_refresh for case test_srv6_full_func
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
