### PR TITLE
[snappi][dataplane]: Add THP pinning FDB storm memory regression test

### DIFF
--- a/tests/snappi_tests/dataplane/files/thp_pinning_helper.py
+++ b/tests/snappi_tests/dataplane/files/thp_pinning_helper.py
@@ -68,7 +68,7 @@ def select_snappi_test_ports(snappi_ports, required_ports=5):
 
     selected_ports = sorted(
         eligible_groups,
-        key=lambda group: len(group),
+        key=len,
         reverse=True
     )[0][:required_ports]
     duthost = selected_ports[0]["duthost"]
@@ -116,6 +116,7 @@ def find_unused_vlan_id(duthost, start=3000, stop=3999):
         if vlan_id not in used_vlans:
             return vlan_id
     pytest.fail("No unused VLAN ID found in range {}-{}".format(start, stop))
+    return None
 
 
 def configure_dut_for_fdb_storm(duthost, ingress_ports, egress_port, pinning_ports, vlan_id):

--- a/tests/snappi_tests/dataplane/files/thp_pinning_helper.py
+++ b/tests/snappi_tests/dataplane/files/thp_pinning_helper.py
@@ -1,0 +1,483 @@
+import logging
+import time
+
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert, pytest_require
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TEST_VLAN_CIDR = "20.0.0.1/24"
+DEFAULT_TEST_VLAN_TGEN_SRC_IP = "20.0.0.2"
+DEFAULT_EGRESS_DUT_CIDR = "30.0.0.1/24"
+DEFAULT_EGRESS_TGEN_IP = "30.0.0.2"
+DEFAULT_EGRESS_TGEN_MAC = "02:00:00:00:00:02"
+DEFAULT_SRC_MAC_START = "12:34:56:78:00:01"
+DEFAULT_SRC_MAC_STEP = "00:00:00:00:00:01"
+DEFAULT_SRC_MAC_COUNT = 10000
+DEFAULT_TRAFFIC_PPS_PER_PORT = 200000
+DEFAULT_FRAME_SIZE = 256
+DEFAULT_PINNING_DURATION_SEC = 30 * 60
+DEFAULT_PINNING_PHASE1_SEC = 20 * 60
+DEFAULT_PINNING_ACCUM_INTERVAL_SEC = 120
+DEFAULT_PINNING_CHURN_INTERVAL_SEC = 10
+DEFAULT_AHP_THRESHOLD_KB = 1024 * 1024
+DEFAULT_AHP_THRESHOLD_WINDOW_SEC = 10 * 60
+DEFAULT_MONITOR_INTERVAL_SEC = 30
+DEFAULT_MEM_MONITOR_LOG = "/tmp/orchagent_mem_monitor.txt"
+DEFAULT_PINNING_SCRIPT = "/tmp/thp_pinning_workload.sh"
+DEFAULT_PINNING_LOG = "/tmp/thp_pinning_workload.log"
+
+PINNING_PORT_PROFILES = [
+    {
+        "route_base": "10.88",
+        "ip_cidr": "10.88.0.1/24",
+        "nh": "10.88.0.2",
+        "churn_base": "172.88",
+        "churn_nh": "10.88.0.100",
+        "mac_prefix": "00:aa:bb:ee",
+        "churn_mac_prefix": "00:cc:dd:ee",
+    },
+    {
+        "route_base": "10.92",
+        "ip_cidr": "10.92.0.1/24",
+        "nh": "10.92.0.2",
+        "churn_base": "172.92",
+        "churn_nh": "10.92.0.100",
+        "mac_prefix": "00:aa:bb:cc",
+        "churn_mac_prefix": "00:cc:dd:cc",
+    },
+]
+
+
+def select_snappi_test_ports(snappi_ports, required_ports=5):
+    """Select direct Snappi ports connected to one single-ASIC DUT."""
+    ports_by_dut = {}
+    for port in snappi_ports:
+        ports_by_dut.setdefault(port["peer_device"], []).append(port)
+
+    eligible_groups = [
+        ports
+        for ports in ports_by_dut.values()
+        if len(ports) >= required_ports
+    ]
+    pytest_require(
+        eligible_groups,
+        "Need at least {} Snappi ports connected to the same DUT".format(required_ports)
+    )
+
+    selected_ports = sorted(
+        eligible_groups,
+        key=lambda group: len(group),
+        reverse=True
+    )[0][:required_ports]
+    duthost = selected_ports[0]["duthost"]
+    pytest_require(
+        duthost.facts.get("num_asic", 1) == 1,
+        "THP pinning FDB storm test currently supports single-ASIC DUTs only"
+    )
+
+    return duthost, selected_ports[:4], selected_ports[4]
+
+
+def select_pinning_ports(duthost, excluded_ports, required_ports=2):
+    """Select admin-up, oper-up Ethernet ports not used by the FDB storm."""
+    excluded_ports = set(excluded_ports)
+    status = duthost.get_interfaces_status()
+    candidates = []
+    for intf, info in status.items():
+        if not intf.startswith("Ethernet") or intf in excluded_ports:
+            continue
+        if info.get("admin", "up") == "up" and info.get("oper") == "up":
+            candidates.append(intf)
+
+    candidates = sorted(candidates, key=_natural_port_sort_key)
+    pytest_require(
+        len(candidates) >= required_ports,
+        "Need {} admin-up, oper-up non-storm ports for THP pinning, got {}".format(
+            required_ports, candidates)
+    )
+    return candidates[:required_ports]
+
+
+def _natural_port_sort_key(port_name):
+    digits = "".join(ch for ch in port_name if ch.isdigit())
+    return int(digits) if digits else 0
+
+
+def find_unused_vlan_id(duthost, start=3000, stop=3999):
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
+    used_vlans = {
+        int(vlan.replace("Vlan", ""))
+        for vlan in config_facts.get("VLAN", {})
+        if vlan.startswith("Vlan") and vlan.replace("Vlan", "").isdigit()
+    }
+    for vlan_id in range(start, stop + 1):
+        if vlan_id not in used_vlans:
+            return vlan_id
+    pytest.fail("No unused VLAN ID found in range {}-{}".format(start, stop))
+
+
+def configure_dut_for_fdb_storm(duthost, ingress_ports, egress_port, pinning_ports, vlan_id):
+    """Configure 4 ingress ports in one VLAN and one routed egress port."""
+    test_ports = [port["peer_port"] for port in ingress_ports] + [egress_port["peer_port"]] + pinning_ports
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
+
+    for port in test_ports:
+        _remove_port_from_vlan_members(duthost, config_facts, port)
+        _remove_port_from_portchannel_members(duthost, config_facts, port)
+        _remove_port_ip_addresses(duthost, config_facts, port)
+
+    _run_checked(duthost, "sudo config vlan add {}".format(vlan_id))
+    _run_checked(duthost, "sudo config interface ip add Vlan{} {}".format(vlan_id, DEFAULT_TEST_VLAN_CIDR))
+    for port in ingress_ports:
+        _run_checked(duthost, "sudo config vlan member add -u {} {}".format(vlan_id, port["peer_port"]))
+
+    _run_checked(
+        duthost,
+        "sudo config interface ip add {} {}".format(egress_port["peer_port"], DEFAULT_EGRESS_DUT_CIDR)
+    )
+    _run_checked(
+        duthost,
+        "sudo ip neigh replace {} lladdr {} dev {}".format(
+            DEFAULT_EGRESS_TGEN_IP, DEFAULT_EGRESS_TGEN_MAC, egress_port["peer_port"])
+    )
+
+    for pinning_port, profile in zip(pinning_ports, PINNING_PORT_PROFILES):
+        _run_checked(duthost, "sudo config interface ip add {} {}".format(pinning_port, profile["ip_cidr"]))
+
+    for port in test_ports:
+        _run_checked(duthost, "sudo config interface startup {}".format(port), ignore_errors=True)
+
+    duthost.shell("sudo sonic-clear fdb all", module_ignore_errors=True)
+    duthost.shell("sudo sonic-clear arp", module_ignore_errors=True)
+    time.sleep(10)
+
+
+def _remove_port_from_vlan_members(duthost, config_facts, port):
+    for vlan, members in config_facts.get("VLAN_MEMBER", {}).items():
+        if port in members:
+            vlan_id = vlan.replace("Vlan", "")
+            _run_checked(
+                duthost,
+                "sudo config vlan member del {} {}".format(vlan_id, port),
+                ignore_errors=True
+            )
+
+
+def _remove_port_from_portchannel_members(duthost, config_facts, port):
+    for member_key in config_facts.get("PORTCHANNEL_MEMBER", {}):
+        portchannel = None
+        member = None
+        if isinstance(member_key, str) and "|" in member_key:
+            portchannel, member = member_key.split("|", 1)
+        elif isinstance(config_facts["PORTCHANNEL_MEMBER"].get(member_key), dict):
+            members = config_facts["PORTCHANNEL_MEMBER"].get(member_key, {})
+            if port in members:
+                portchannel, member = member_key, port
+        if member == port:
+            _run_checked(
+                duthost,
+                "sudo config portchannel member del {} {}".format(portchannel, port),
+                ignore_errors=True
+            )
+
+
+def _remove_port_ip_addresses(duthost, config_facts, port):
+    for addr in config_facts.get("INTERFACE", {}).get(port, {}):
+        if "/" in addr:
+            _run_checked(
+                duthost,
+                "sudo config interface ip remove {} {}".format(port, addr),
+                ignore_errors=True
+            )
+
+
+def _run_checked(duthost, cmd, ignore_errors=False):
+    logger.info("Running on DUT %s: %s", duthost.hostname, cmd)
+    result = duthost.shell(cmd, module_ignore_errors=ignore_errors)
+    if not ignore_errors:
+        pytest_assert(result["rc"] == 0, "Command failed: {}\n{}".format(cmd, result.get("stderr", "")))
+    return result
+
+
+def generate_fdb_storm_config(testbed_config, ingress_ports, egress_port, duration_sec=DEFAULT_PINNING_DURATION_SEC):
+    """Generate stateless direct Snappi flows for the FDB storm."""
+    egress_port_name = _snappi_port_name(testbed_config, egress_port)
+
+    for index, ingress_port in enumerate(ingress_ports):
+        flow = testbed_config.flows.flow(name="THP FDB storm {}".format(index))[-1]
+        flow.tx_rx.port.tx_name = _snappi_port_name(testbed_config, ingress_port)
+        flow.tx_rx.port.rx_name = egress_port_name
+
+        eth, ipv4 = flow.packet.ethernet().ipv4()
+        eth.src.increment.start = DEFAULT_SRC_MAC_START
+        eth.src.increment.step = DEFAULT_SRC_MAC_STEP
+        eth.src.increment.count = DEFAULT_SRC_MAC_COUNT
+        eth.dst.value = ingress_port["duthost"].facts["router_mac"]
+
+        ipv4.src.value = _ingress_src_ip(index)
+        ipv4.dst.value = DEFAULT_EGRESS_TGEN_IP
+
+        flow.size.fixed = DEFAULT_FRAME_SIZE
+        flow.rate.pps = DEFAULT_TRAFFIC_PPS_PER_PORT
+        flow.duration.fixed_seconds.seconds = duration_sec
+        flow.metrics.enable = True
+        flow.metrics.loss = True
+
+    return testbed_config
+
+
+def _snappi_port_name(testbed_config, snappi_port):
+    return testbed_config.ports[int(snappi_port["port_id"])].name
+
+
+def _ingress_src_ip(index):
+    return "20.0.0.{}".format(index + 2)
+
+
+def render_thp_pinning_script(pinning_ports,
+                              duration_sec=DEFAULT_PINNING_DURATION_SEC,
+                              phase1_sec=DEFAULT_PINNING_PHASE1_SEC,
+                              accum_interval_sec=DEFAULT_PINNING_ACCUM_INTERVAL_SEC,
+                              churn_interval_sec=DEFAULT_PINNING_CHURN_INTERVAL_SEC):
+    profiles = PINNING_PORT_PROFILES[:len(pinning_ports)]
+    arrays = {
+        "PORTS": pinning_ports,
+        "ROUTE_BASES": [profile["route_base"] for profile in profiles],
+        "NEXTHOPS": [profile["nh"] for profile in profiles],
+        "CHURN_BASES": [profile["churn_base"] for profile in profiles],
+        "CHURN_NEXTHOPS": [profile["churn_nh"] for profile in profiles],
+        "MAC_PREFIXES": [profile["mac_prefix"] for profile in profiles],
+        "CHURN_MAC_PREFIXES": [profile["churn_mac_prefix"] for profile in profiles],
+    }
+    array_lines = "\n".join(_bash_array(name, values) for name, values in arrays.items())
+    return """#!/bin/bash
+set -u
+
+DURATION={duration_sec}
+PHASE1_END={phase1_sec}
+ACCUM_INTERVAL={accum_interval_sec}
+CHURN_INTERVAL={churn_interval_sec}
+START_TIME=$(date +%s)
+CYCLE=0
+ACCUM_BATCH=0
+PORT_COUNT={port_count}
+
+{array_lines}
+
+echo "THP pinning workload started: $(date)"
+echo "Duration: $DURATION seconds, phase1: $PHASE1_END seconds"
+echo "Ports: ${{PORTS[*]}}"
+
+PID=$(pgrep -x orchagent | head -n 1)
+echo "Orchagent PID: $PID"
+if [ -n "$PID" ]; then
+    awk '/VmRSS/{{print "Baseline RSS:", $2, $3}}' /proc/$PID/status
+    sudo grep AnonHugePages /proc/$PID/smaps_rollup | awk '{{print "Baseline AnonHP:", $2, $3}}'
+fi
+
+while true; do
+    ELAPSED=$(( $(date +%s) - START_TIME ))
+    if [ "$ELAPSED" -ge "$DURATION" ]; then
+        echo "$(date): workload duration elapsed"
+        break
+    fi
+
+    CYCLE=$((CYCLE + 1))
+    if [ "$ELAPSED" -lt "$PHASE1_END" ]; then
+        ACCUM_BATCH=$((ACCUM_BATCH + 1))
+        echo "$(date): Phase 1 cycle $CYCLE batch $ACCUM_BATCH"
+        for idx in $(seq 0 $((PORT_COUNT - 1))); do
+            route_base=${{ROUTE_BASES[$idx]}}
+            nexthop=${{NEXTHOPS[$idx]}}
+            port=${{PORTS[$idx]}}
+            mac_prefix=${{MAC_PREFIXES[$idx]}}
+            for i in $(seq 1 5); do
+                item=$(( (ACCUM_BATCH - 1) * 5 + i ))
+                sudo config route add prefix "${{route_base}}.${{item}}.0/24" nexthop "$nexthop"
+                sudo ip neigh replace "${{nexthop%.*}}.$((item + 10))" \\
+                    lladdr "${{mac_prefix}}:$(printf '%02x' $((ACCUM_BATCH % 256))):$(printf '%02x' $i)" \\
+                    dev "$port"
+            done
+        done
+        echo "Accumulated objects: $((ACCUM_BATCH * 5 * PORT_COUNT)) routes and neighbors"
+        sleep "$ACCUM_INTERVAL"
+    else
+        echo "$(date): Phase 2 churn cycle $CYCLE"
+        for idx in $(seq 0 $((PORT_COUNT - 1))); do
+            churn_base=${{CHURN_BASES[$idx]}}
+            churn_nexthop=${{CHURN_NEXTHOPS[$idx]}}
+            port=${{PORTS[$idx]}}
+            churn_mac_prefix=${{CHURN_MAC_PREFIXES[$idx]}}
+            for i in $(seq 1 10); do
+                sudo config route add prefix "${{churn_base}}.${{i}}.0/24" nexthop "$churn_nexthop"
+                sudo ip neigh replace "${{churn_nexthop%.*}}.$((i + 10))" \\
+                    lladdr "${{churn_mac_prefix}}:$(printf '%02x' $((CYCLE % 256))):$(printf '%02x' $i)" \\
+                    dev "$port"
+            done
+            sleep 1
+            for i in $(seq 1 10); do
+                sudo config route del prefix "${{churn_base}}.${{i}}.0/24" nexthop "$churn_nexthop" 2>/dev/null
+                sudo ip neigh del "${{churn_nexthop%.*}}.$((i + 10))" dev "$port" 2>/dev/null
+            done
+        done
+        sleep "$CHURN_INTERVAL"
+    fi
+
+    PID=$(pgrep -x orchagent | head -n 1)
+    if [ -n "$PID" ]; then
+        RSS=$(awk '/VmRSS/{{print $2}}' /proc/$PID/status)
+        AHP=$(sudo grep AnonHugePages /proc/$PID/smaps_rollup | awk '{{print $2}}')
+        echo "orchagent RSS: ${{RSS}} kB | AnonHugePages: ${{AHP}} kB"
+    else
+        echo "orchagent is not running"
+    fi
+done
+""".format(duration_sec=duration_sec,
+           phase1_sec=phase1_sec,
+           accum_interval_sec=accum_interval_sec,
+           churn_interval_sec=churn_interval_sec,
+           port_count=len(pinning_ports),
+           array_lines=array_lines)
+
+
+def _bash_array(name, values):
+    quoted_values = " ".join('"{}"'.format(value) for value in values)
+    return "{}=({})".format(name, quoted_values)
+
+
+def start_thp_pinning_workload(duthost, script):
+    duthost.copy(content=script, dest=DEFAULT_PINNING_SCRIPT)
+    duthost.shell("sudo chmod +x {}".format(DEFAULT_PINNING_SCRIPT))
+    result = duthost.shell(
+        "nohup sudo bash {} > {} 2>&1 & echo $!".format(DEFAULT_PINNING_SCRIPT, DEFAULT_PINNING_LOG)
+    )
+    pid = result["stdout"].strip().splitlines()[-1]
+    pytest_assert(pid.isdigit(), "Failed to start THP pinning workload: {}".format(result["stdout"]))
+    return int(pid)
+
+
+def stop_thp_pinning_workload(duthost, pid):
+    if pid is None:
+        return
+    duthost.shell("if kill -0 {pid} 2>/dev/null; then sudo kill {pid}; fi".format(pid=pid),
+                  module_ignore_errors=True)
+
+
+def cleanup_thp_pinning_objects(duthost, pinning_ports):
+    """Remove accumulated and churn objects created by the pinning workload."""
+    profiles = PINNING_PORT_PROFILES[:len(pinning_ports)]
+    for port, profile in zip(pinning_ports, profiles):
+        cmd = """
+for i in $(seq 1 1000); do
+    sudo config route del prefix "{route_base}.$i.0/24" nexthop "{nh}" 2>/dev/null
+    sudo ip neigh del "{nh_base}.$((i + 10))" dev "{port}" 2>/dev/null
+done
+for i in $(seq 1 10); do
+    sudo config route del prefix "{churn_base}.$i.0/24" nexthop "{churn_nh}" 2>/dev/null
+    sudo ip neigh del "{churn_nh_base}.$((i + 10))" dev "{port}" 2>/dev/null
+done
+""".format(route_base=profile["route_base"],
+           nh=profile["nh"],
+           nh_base=profile["nh"].rsplit(".", 1)[0],
+           churn_base=profile["churn_base"],
+           churn_nh=profile["churn_nh"],
+           churn_nh_base=profile["churn_nh"].rsplit(".", 1)[0],
+           port=port)
+        duthost.shell(cmd, module_ignore_errors=True)
+
+
+def monitor_dut_health(duthost,
+                       workload_pid,
+                       pinning_ports,
+                       duration_sec=DEFAULT_PINNING_DURATION_SEC,
+                       interval_sec=DEFAULT_MONITOR_INTERVAL_SEC,
+                       ahp_threshold_kb=DEFAULT_AHP_THRESHOLD_KB,
+                       ahp_threshold_window_sec=DEFAULT_AHP_THRESHOLD_WINDOW_SEC):
+    """Monitor DUT health and fail on steep orchagent AnonHugePages growth."""
+    duthost.shell("sudo rm -f {}; sudo touch {}".format(DEFAULT_MEM_MONITOR_LOG, DEFAULT_MEM_MONITOR_LOG),
+                  module_ignore_errors=True)
+    reboot_history_before = _get_reboot_history(duthost)
+    start = time.time()
+    last_sample = None
+
+    while time.time() - start <= duration_sec + interval_sec:
+        elapsed = int(time.time() - start)
+        last_sample = collect_memory_sample(duthost, elapsed, pinning_ports)
+
+        if elapsed <= ahp_threshold_window_sec and last_sample["anon_huge_pages_kb"] > ahp_threshold_kb:
+            pytest_assert(
+                False,
+                "orchagent AnonHugePages exceeded {} kB within {} seconds: sample={}".format(
+                    ahp_threshold_kb, ahp_threshold_window_sec, last_sample)
+            )
+
+        if elapsed > 0 and elapsed % 120 == 0:
+            pytest_assert(duthost.critical_services_fully_started(), "Critical services are not fully started")
+
+        if not _process_is_running(duthost, workload_pid):
+            pytest_assert(
+                elapsed >= duration_sec,
+                "THP pinning workload exited before expected duration; see {}".format(DEFAULT_PINNING_LOG)
+            )
+            break
+
+        time.sleep(interval_sec)
+
+    reboot_history_after = _get_reboot_history(duthost)
+    pytest_assert(
+        reboot_history_after == reboot_history_before,
+        "Reboot history changed during THP pinning FDB storm test"
+    )
+    return last_sample
+
+
+def collect_memory_sample(duthost, elapsed_sec, pinning_ports):
+    port_regex = "|".join(pinning_ports)
+    cmd = r'''
+PID=$(pgrep -x orchagent | head -n 1)
+if [ -z "$PID" ]; then
+    echo "orchagent is not running"
+    exit 2
+fi
+MEM_AVAILABLE=$(awk '/MemAvailable/ {{print $2}}' /proc/meminfo)
+MEM_FREE=$(awk '/MemFree/ {{print $2}}' /proc/meminfo)
+RSS=$(awk '/VmRSS/ {{print $2}}' /proc/$PID/status)
+AHP=$(sudo grep AnonHugePages /proc/$PID/smaps_rollup | awk '{{print $2}}')
+ROUTE_COUNT=$(ip route show | grep -Ec '^(10\.88|10\.92|172\.88|172\.92)\.')
+NEIGH_COUNT=$(ip neigh show | grep -Ec 'dev ({port_regex})( |$)')
+LINE="timestamp=$(date +%s) elapsed_sec={elapsed_sec} orchagent_pid=$PID"
+LINE="$LINE mem_available_kb=$MEM_AVAILABLE mem_free_kb=$MEM_FREE"
+LINE="$LINE orchagent_rss_kb=$RSS anon_huge_pages_kb=$AHP"
+LINE="$LINE route_count=$ROUTE_COUNT neigh_count=$NEIGH_COUNT"
+echo "$LINE" | sudo tee -a {monitor_log}
+'''.format(elapsed_sec=elapsed_sec, port_regex=port_regex, monitor_log=DEFAULT_MEM_MONITOR_LOG)
+    result = duthost.shell(cmd)
+    sample = _parse_key_value_sample(result["stdout"].strip().splitlines()[-1])
+    return sample
+
+
+def _parse_key_value_sample(line):
+    sample = {}
+    for item in line.split():
+        if "=" not in item:
+            continue
+        key, value = item.split("=", 1)
+        try:
+            sample[key] = int(value)
+        except ValueError:
+            sample[key] = value
+    return sample
+
+
+def _process_is_running(duthost, pid):
+    result = duthost.shell(
+        "if kill -0 {} 2>/dev/null; then echo running; else echo stopped; fi".format(pid),
+        module_ignore_errors=True
+    )
+    return "running" in result["stdout"]
+
+
+def _get_reboot_history(duthost):
+    return duthost.shell("show reboot history | head -n 5", module_ignore_errors=True)["stdout"]

--- a/tests/snappi_tests/dataplane/files/thp_pinning_helper.py
+++ b/tests/snappi_tests/dataplane/files/thp_pinning_helper.py
@@ -482,6 +482,7 @@ def monitor_dut_health(duthost,
                   module_ignore_errors=True)
     reboot_history_before = _get_reboot_history(duthost)
     start = time.time()
+    last_health_check = 0
     baseline_sample = None
     last_sample = None
 
@@ -502,7 +503,8 @@ def monitor_dut_health(duthost,
                     ahp_diff_kb, ahp_diff_threshold_kb, duration_sec, baseline_sample, last_sample)
             )
 
-        if elapsed > 0 and elapsed % 120 == 0:
+        if elapsed - last_health_check >= 120:
+            last_health_check = elapsed
             pytest_assert(duthost.critical_services_fully_started(), "Critical services are not fully started")
 
         if not _process_is_running(duthost, workload_pid):

--- a/tests/snappi_tests/dataplane/files/thp_pinning_helper.py
+++ b/tests/snappi_tests/dataplane/files/thp_pinning_helper.py
@@ -17,16 +17,16 @@ DEFAULT_SRC_MAC_STEP = "00:00:00:00:00:01"
 DEFAULT_SRC_MAC_COUNT = 10000
 DEFAULT_TRAFFIC_PPS_PER_PORT = 200000
 DEFAULT_FRAME_SIZE = 256
-DEFAULT_PINNING_DURATION_SEC = 30 * 60
+DEFAULT_PINNING_DURATION_SEC = 15 * 60
 DEFAULT_PINNING_PHASE1_SEC = 20 * 60
 DEFAULT_PINNING_ACCUM_INTERVAL_SEC = 120
 DEFAULT_PINNING_CHURN_INTERVAL_SEC = 10
-DEFAULT_AHP_THRESHOLD_KB = 1024 * 1024
-DEFAULT_AHP_THRESHOLD_WINDOW_SEC = 10 * 60
+DEFAULT_AHP_DIFF_THRESHOLD_KB = 500 * 1024
 DEFAULT_MONITOR_INTERVAL_SEC = 30
 DEFAULT_MEM_MONITOR_LOG = "/tmp/orchagent_mem_monitor.txt"
 DEFAULT_PINNING_SCRIPT = "/tmp/thp_pinning_workload.sh"
 DEFAULT_PINNING_LOG = "/tmp/thp_pinning_workload.log"
+THP_ENABLED_PATH = "/sys/kernel/mm/transparent_hugepage/enabled"
 
 PINNING_PORT_PROFILES = [
     {
@@ -50,7 +50,7 @@ PINNING_PORT_PROFILES = [
 ]
 
 
-def select_snappi_test_ports(snappi_ports, required_ports=5):
+def select_snappi_test_ports(snappi_ports, required_ports=3):
     """Select direct Snappi ports connected to one single-ASIC DUT."""
     ports_by_dut = {}
     for port in snappi_ports:
@@ -77,27 +77,38 @@ def select_snappi_test_ports(snappi_ports, required_ports=5):
         "THP pinning FDB storm test currently supports single-ASIC DUTs only"
     )
 
-    return duthost, selected_ports[:4], selected_ports[4]
+    return duthost, selected_ports[:-1], selected_ports[-1]
 
 
-def select_pinning_ports(duthost, excluded_ports, required_ports=2):
+def select_pinning_ports(duthost, excluded_ports, required_ports=2, fallback_ports=None):
     """Select admin-up, oper-up Ethernet ports not used by the FDB storm."""
     excluded_ports = set(excluded_ports)
+    fallback_ports = fallback_ports or []
     status = duthost.get_interfaces_status()
     candidates = []
     for intf, info in status.items():
-        if not intf.startswith("Ethernet") or intf in excluded_ports:
+        if not _is_front_panel_port(intf) or intf in excluded_ports:
             continue
         if info.get("admin", "up") == "up" and info.get("oper") == "up":
             candidates.append(intf)
 
     candidates = sorted(candidates, key=_natural_port_sort_key)
+    if len(candidates) < required_ports:
+        for intf in fallback_ports:
+            info = status.get(intf, {})
+            if (intf not in candidates and _is_front_panel_port(intf)
+                    and info.get("admin", "up") == "up" and info.get("oper") == "up"):
+                candidates.append(intf)
     pytest_require(
         len(candidates) >= required_ports,
-        "Need {} admin-up, oper-up non-storm ports for THP pinning, got {}".format(
+        "Need {} admin-up, oper-up eligible ports for THP pinning, got {}".format(
             required_ports, candidates)
     )
     return candidates[:required_ports]
+
+
+def _is_front_panel_port(port_name):
+    return port_name.startswith("Ethernet") and port_name[len("Ethernet"):].isdigit()
 
 
 def _natural_port_sort_key(port_name):
@@ -120,7 +131,7 @@ def find_unused_vlan_id(duthost, start=3000, stop=3999):
 
 
 def configure_dut_for_fdb_storm(duthost, ingress_ports, egress_port, pinning_ports, vlan_id):
-    """Configure 4 ingress ports in one VLAN and one routed egress port."""
+    """Configure ingress ports in one VLAN and one routed egress port."""
     test_ports = [port["peer_port"] for port in ingress_ports] + [egress_port["peer_port"]] + pinning_ports
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
 
@@ -389,29 +400,50 @@ done
         duthost.shell(cmd, module_ignore_errors=True)
 
 
+def get_thp_enabled_mode(duthost):
+    result = duthost.shell("cat {}".format(THP_ENABLED_PATH))
+    for mode in result["stdout"].split():
+        if mode.startswith("[") and mode.endswith("]"):
+            return mode.strip("[]")
+    pytest.fail("Failed to parse THP enabled mode from: {}".format(result["stdout"]))
+
+
+def set_thp_enabled_mode(duthost, mode):
+    pytest_assert(mode in ("always", "madvise", "never"), "Unsupported THP mode: {}".format(mode))
+    _run_checked(duthost, "echo {} | sudo tee {} >/dev/null".format(mode, THP_ENABLED_PATH))
+    active_mode = get_thp_enabled_mode(duthost)
+    pytest_assert(active_mode == mode, "Expected THP mode {}, got {}".format(mode, active_mode))
+
+
 def monitor_dut_health(duthost,
                        workload_pid,
                        pinning_ports,
                        duration_sec=DEFAULT_PINNING_DURATION_SEC,
                        interval_sec=DEFAULT_MONITOR_INTERVAL_SEC,
-                       ahp_threshold_kb=DEFAULT_AHP_THRESHOLD_KB,
-                       ahp_threshold_window_sec=DEFAULT_AHP_THRESHOLD_WINDOW_SEC):
-    """Monitor DUT health and fail on steep orchagent AnonHugePages growth."""
+                       ahp_diff_threshold_kb=DEFAULT_AHP_DIFF_THRESHOLD_KB):
+    """Monitor DUT health and fail on orchagent AnonHugePages growth above the threshold."""
     duthost.shell("sudo rm -f {}; sudo touch {}".format(DEFAULT_MEM_MONITOR_LOG, DEFAULT_MEM_MONITOR_LOG),
                   module_ignore_errors=True)
     reboot_history_before = _get_reboot_history(duthost)
     start = time.time()
+    baseline_sample = None
     last_sample = None
 
     while time.time() - start <= duration_sec + interval_sec:
         elapsed = int(time.time() - start)
         last_sample = collect_memory_sample(duthost, elapsed, pinning_ports)
+        if baseline_sample is None:
+            baseline_sample = last_sample
 
-        if elapsed <= ahp_threshold_window_sec and last_sample["anon_huge_pages_kb"] > ahp_threshold_kb:
+        ahp_diff_kb = last_sample["anon_huge_pages_kb"] - baseline_sample["anon_huge_pages_kb"]
+        last_sample["anon_huge_pages_diff_kb"] = ahp_diff_kb
+        last_sample["orchagent_rss_diff_kb"] = last_sample["orchagent_rss_kb"] - baseline_sample["orchagent_rss_kb"]
+        if ahp_diff_kb > ahp_diff_threshold_kb:
             pytest_assert(
                 False,
-                "orchagent AnonHugePages exceeded {} kB within {} seconds: sample={}".format(
-                    ahp_threshold_kb, ahp_threshold_window_sec, last_sample)
+                "orchagent AnonHugePages grew by {} kB, exceeding {} kB within {} seconds: "
+                "baseline={}, sample={}".format(
+                    ahp_diff_kb, ahp_diff_threshold_kb, duration_sec, baseline_sample, last_sample)
             )
 
         if elapsed > 0 and elapsed % 120 == 0:

--- a/tests/snappi_tests/dataplane/files/thp_pinning_helper.py
+++ b/tests/snappi_tests/dataplane/files/thp_pinning_helper.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import time
 
 import pytest
@@ -18,7 +19,7 @@ DEFAULT_SRC_MAC_COUNT = 10000
 DEFAULT_TRAFFIC_PPS_PER_PORT = 200000
 DEFAULT_FRAME_SIZE = 256
 DEFAULT_PINNING_DURATION_SEC = 15 * 60
-DEFAULT_PINNING_PHASE1_SEC = 20 * 60
+DEFAULT_PINNING_PHASE1_SEC = 5 * 60
 DEFAULT_PINNING_ACCUM_INTERVAL_SEC = 120
 DEFAULT_PINNING_CHURN_INTERVAL_SEC = 10
 DEFAULT_AHP_DIFF_THRESHOLD_KB = 500 * 1024
@@ -80,10 +81,9 @@ def select_snappi_test_ports(snappi_ports, required_ports=3):
     return duthost, selected_ports[:-1], selected_ports[-1]
 
 
-def select_pinning_ports(duthost, excluded_ports, required_ports=2, fallback_ports=None):
+def select_pinning_ports(duthost, excluded_ports, required_ports=2):
     """Select admin-up, oper-up Ethernet ports not used by the FDB storm."""
     excluded_ports = set(excluded_ports)
-    fallback_ports = fallback_ports or []
     status = duthost.get_interfaces_status()
     candidates = []
     for intf, info in status.items():
@@ -93,15 +93,9 @@ def select_pinning_ports(duthost, excluded_ports, required_ports=2, fallback_por
             candidates.append(intf)
 
     candidates = sorted(candidates, key=_natural_port_sort_key)
-    if len(candidates) < required_ports:
-        for intf in fallback_ports:
-            info = status.get(intf, {})
-            if (intf not in candidates and _is_front_panel_port(intf)
-                    and info.get("admin", "up") == "up" and info.get("oper") == "up"):
-                candidates.append(intf)
     pytest_require(
         len(candidates) >= required_ports,
-        "Need {} admin-up, oper-up eligible ports for THP pinning, got {}".format(
+        "Need {} dedicated admin-up, oper-up ports for THP pinning, got {}".format(
             required_ports, candidates)
     )
     return candidates[:required_ports]
@@ -132,6 +126,7 @@ def find_unused_vlan_id(duthost, start=3000, stop=3999):
 
 def configure_dut_for_fdb_storm(duthost, ingress_ports, egress_port, pinning_ports, vlan_id):
     """Configure ingress ports in one VLAN and one routed egress port."""
+    _get_pinning_profiles(pinning_ports)
     test_ports = [port["peer_port"] for port in ingress_ports] + [egress_port["peer_port"]] + pinning_ports
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
 
@@ -155,7 +150,7 @@ def configure_dut_for_fdb_storm(duthost, ingress_ports, egress_port, pinning_por
             DEFAULT_EGRESS_TGEN_IP, DEFAULT_EGRESS_TGEN_MAC, egress_port["peer_port"])
     )
 
-    for pinning_port, profile in zip(pinning_ports, PINNING_PORT_PROFILES):
+    for pinning_port, profile in zip(pinning_ports, _get_pinning_profiles(pinning_ports)):
         _run_checked(duthost, "sudo config interface ip add {} {}".format(pinning_port, profile["ip_cidr"]))
 
     for port in test_ports:
@@ -240,6 +235,54 @@ def generate_fdb_storm_config(testbed_config, ingress_ports, egress_port, durati
     return testbed_config
 
 
+def verify_fdb_storm_traffic(snappi_api, timeout_sec=60, interval_sec=5):
+    """Verify every configured FDB storm flow transmits and receives frames."""
+    start = time.time()
+    last_metrics = []
+    while time.time() - start <= timeout_sec:
+        last_metrics = _get_traffic_metrics(snappi_api)
+        if last_metrics["flow_metrics"]:
+            if all(_get_frame_count(metric, "frames_tx") > 0 and
+                   _get_frame_count(metric, "frames_rx") > 0 for metric in last_metrics["flow_metrics"]):
+                return
+        elif (any(_get_frame_count(metric, "frames_tx") > 0 for metric in last_metrics["port_metrics"]) and
+              any(_get_frame_count(metric, "frames_rx") > 0 for metric in last_metrics["port_metrics"])):
+            return
+        time.sleep(interval_sec)
+
+    pytest_assert(
+        False,
+        "FDB storm traffic did not transmit and receive frames: flows={}, ports={}".format(
+            [_format_traffic_metric(metric) for metric in last_metrics["flow_metrics"]],
+            [_format_traffic_metric(metric) for metric in last_metrics["port_metrics"]])
+    )
+
+
+def _get_traffic_metrics(snappi_api):
+    flow_request = snappi_api.metrics_request()
+    flow_request.flow.flow_names = []
+    port_request = snappi_api.metrics_request()
+    port_request.port.port_names = []
+    return {
+        "flow_metrics": list(snappi_api.get_metrics(flow_request).flow_metrics),
+        "port_metrics": list(snappi_api.get_metrics(port_request).port_metrics),
+    }
+
+
+def _get_frame_count(metric, field):
+    return int(float(getattr(metric, field, 0) or 0))
+
+
+def _format_traffic_metric(metric):
+    return {
+        "name": getattr(metric, "name", ""),
+        "frames_tx": _get_frame_count(metric, "frames_tx"),
+        "frames_rx": _get_frame_count(metric, "frames_rx"),
+        "frames_tx_rate": getattr(metric, "frames_tx_rate", 0),
+        "frames_rx_rate": getattr(metric, "frames_rx_rate", 0),
+    }
+
+
 def _snappi_port_name(testbed_config, snappi_port):
     return testbed_config.ports[int(snappi_port["port_id"])].name
 
@@ -253,7 +296,7 @@ def render_thp_pinning_script(pinning_ports,
                               phase1_sec=DEFAULT_PINNING_PHASE1_SEC,
                               accum_interval_sec=DEFAULT_PINNING_ACCUM_INTERVAL_SEC,
                               churn_interval_sec=DEFAULT_PINNING_CHURN_INTERVAL_SEC):
-    profiles = PINNING_PORT_PROFILES[:len(pinning_ports)]
+    profiles = _get_pinning_profiles(pinning_ports)
     arrays = {
         "PORTS": pinning_ports,
         "ROUTE_BASES": [profile["route_base"] for profile in profiles],
@@ -373,16 +416,28 @@ def start_thp_pinning_workload(duthost, script):
 def stop_thp_pinning_workload(duthost, pid):
     if pid is None:
         return
-    duthost.shell("if kill -0 {pid} 2>/dev/null; then sudo kill {pid}; fi".format(pid=pid),
-                  module_ignore_errors=True)
+    duthost.shell("""
+if sudo kill -0 {pid} 2>/dev/null; then
+    sudo kill {pid}
+    for i in $(seq 1 10); do
+        if ! sudo kill -0 {pid} 2>/dev/null; then
+            exit 0
+        fi
+        sleep 1
+    done
+    sudo kill -9 {pid}
+fi
+""".format(pid=pid), module_ignore_errors=True)
 
 
 def cleanup_thp_pinning_objects(duthost, pinning_ports):
     """Remove accumulated and churn objects created by the pinning workload."""
-    profiles = PINNING_PORT_PROFILES[:len(pinning_ports)]
+    profiles = _get_pinning_profiles(pinning_ports)
+    max_accumulated_routes = int(math.ceil(
+        float(DEFAULT_PINNING_PHASE1_SEC) / DEFAULT_PINNING_ACCUM_INTERVAL_SEC)) * 5
     for port, profile in zip(pinning_ports, profiles):
         cmd = """
-for i in $(seq 1 1000); do
+for i in $(seq 1 {max_accumulated_routes}); do
     sudo config route del prefix "{route_base}.$i.0/24" nexthop "{nh}" 2>/dev/null
     sudo ip neigh del "{nh_base}.$((i + 10))" dev "{port}" 2>/dev/null
 done
@@ -390,7 +445,8 @@ for i in $(seq 1 10); do
     sudo config route del prefix "{churn_base}.$i.0/24" nexthop "{churn_nh}" 2>/dev/null
     sudo ip neigh del "{churn_nh_base}.$((i + 10))" dev "{port}" 2>/dev/null
 done
-""".format(route_base=profile["route_base"],
+""".format(max_accumulated_routes=max_accumulated_routes,
+           route_base=profile["route_base"],
            nh=profile["nh"],
            nh_base=profile["nh"].rsplit(".", 1)[0],
            churn_base=profile["churn_base"],
@@ -468,6 +524,7 @@ def monitor_dut_health(duthost,
 
 def collect_memory_sample(duthost, elapsed_sec, pinning_ports):
     port_regex = "|".join(pinning_ports)
+    route_regex = _route_prefix_regex(pinning_ports)
     cmd = r'''
 PID=$(pgrep -x orchagent | head -n 1)
 if [ -z "$PID" ]; then
@@ -478,14 +535,17 @@ MEM_AVAILABLE=$(awk '/MemAvailable/ {{print $2}}' /proc/meminfo)
 MEM_FREE=$(awk '/MemFree/ {{print $2}}' /proc/meminfo)
 RSS=$(awk '/VmRSS/ {{print $2}}' /proc/$PID/status)
 AHP=$(sudo grep AnonHugePages /proc/$PID/smaps_rollup | awk '{{print $2}}')
-ROUTE_COUNT=$(ip route show | grep -Ec '^(10\.88|10\.92|172\.88|172\.92)\.')
+ROUTE_COUNT=$(ip route show | grep -Ec '^({route_regex})\.')
 NEIGH_COUNT=$(ip neigh show | grep -Ec 'dev ({port_regex})( |$)')
 LINE="timestamp=$(date +%s) elapsed_sec={elapsed_sec} orchagent_pid=$PID"
 LINE="$LINE mem_available_kb=$MEM_AVAILABLE mem_free_kb=$MEM_FREE"
 LINE="$LINE orchagent_rss_kb=$RSS anon_huge_pages_kb=$AHP"
 LINE="$LINE route_count=$ROUTE_COUNT neigh_count=$NEIGH_COUNT"
 echo "$LINE" | sudo tee -a {monitor_log}
-'''.format(elapsed_sec=elapsed_sec, port_regex=port_regex, monitor_log=DEFAULT_MEM_MONITOR_LOG)
+'''.format(elapsed_sec=elapsed_sec,
+           port_regex=port_regex,
+           route_regex=route_regex,
+           monitor_log=DEFAULT_MEM_MONITOR_LOG)
     result = duthost.shell(cmd)
     sample = _parse_key_value_sample(result["stdout"].strip().splitlines()[-1])
     return sample
@@ -506,10 +566,26 @@ def _parse_key_value_sample(line):
 
 def _process_is_running(duthost, pid):
     result = duthost.shell(
-        "if kill -0 {} 2>/dev/null; then echo running; else echo stopped; fi".format(pid),
+        "if sudo kill -0 {} 2>/dev/null; then echo running; else echo stopped; fi".format(pid),
         module_ignore_errors=True
     )
     return "running" in result["stdout"]
+
+
+def _get_pinning_profiles(pinning_ports):
+    pytest_require(
+        len(pinning_ports) <= len(PINNING_PORT_PROFILES),
+        "Need {} THP pinning profiles, but only {} are defined".format(
+            len(pinning_ports), len(PINNING_PORT_PROFILES))
+    )
+    return PINNING_PORT_PROFILES[:len(pinning_ports)]
+
+
+def _route_prefix_regex(pinning_ports):
+    prefixes = []
+    for profile in _get_pinning_profiles(pinning_ports):
+        prefixes.extend([profile["route_base"], profile["churn_base"]])
+    return "|".join(prefix.replace(".", r"\.") for prefix in prefixes)
 
 
 def _get_reboot_history(duthost):

--- a/tests/snappi_tests/dataplane/test_thp_pinning_fdb_storm.py
+++ b/tests/snappi_tests/dataplane/test_thp_pinning_fdb_storm.py
@@ -2,8 +2,11 @@ import logging
 
 import pytest
 
-from tests.common.config_reload import config_reload
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut  # noqa: F401
+from tests.common.fixtures.conn_graph_facts import (  # noqa: F401
+    conn_graph_facts,
+    fanout_graph_facts,
+    fanout_graph_facts_multidut,
+)
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.snappi_tests.snappi_fixtures import (  # noqa: F401
     cleanup_config,
@@ -16,30 +19,33 @@ from tests.common.snappi_tests.snappi_fixtures import (  # noqa: F401
     snappi_port_selection,
     tgen_port_info,
 )
+from tests.snappi_tests.dataplane.files.helper import start_stop
 from tests.snappi_tests.dataplane.files.thp_pinning_helper import (
     DEFAULT_PINNING_DURATION_SEC,
-    cleanup_thp_pinning_objects,
     configure_dut_for_fdb_storm,
     find_unused_vlan_id,
     generate_fdb_storm_config,
+    get_thp_enabled_mode,
     monitor_dut_health,
     render_thp_pinning_script,
     select_pinning_ports,
     select_snappi_test_ports,
+    set_thp_enabled_mode,
     start_thp_pinning_workload,
     stop_thp_pinning_workload,
 )
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology("multidut-tgen", "tgen")]
-
-CONFIG_DB_BACKUP = "/tmp/thp_pinning_fdb_storm_config_db.json"
+pytestmark = [
+    pytest.mark.topology("multidut-tgen", "tgen"),
+    pytest.mark.disable_memory_utilization,
+]
 
 
 @pytest.fixture(autouse=True, scope="module")
 def number_of_tx_rx_ports():
-    yield (1, 4)
+    yield (1, 2)
 
 
 @pytest.mark.disable_loganalyzer
@@ -48,28 +54,35 @@ def test_thp_pinning_fdb_storm_direct_snappi(duthosts,             # noqa: F811
                                              tgen_port_info,       # noqa: F811
                                              get_snappi_ports):    # noqa: F811
     """
-    Verify THP pinning does not drive orchagent AnonHugePages above 1 GB within 10 minutes.
+    Verify THP pinning under madvise does not grow orchagent AnonHugePages by more than 500 MB in 15 minutes.
     """
     testbed_config, port_config_list, snappi_ports = tgen_port_info
     pytest_assert(port_config_list, "PFC/PFCWD direct Snappi setup did not provide port configuration")
     duthost, ingress_ports, egress_port = select_snappi_test_ports(snappi_ports)
     excluded_ports = [
         port["peer_port"]
-        for port in get_snappi_ports
+        for port in ingress_ports
         if port["peer_device"] == duthost.hostname
     ]
-    pinning_ports = select_pinning_ports(duthost, excluded_ports)
+    pinning_ports = select_pinning_ports(
+        duthost,
+        excluded_ports,
+        required_ports=1,
+        fallback_ports=[egress_port["peer_port"]]
+    )
     vlan_id = find_unused_vlan_id(duthost)
     workload_pid = None
     traffic_started = False
+    original_thp_mode = None
 
     logger.info("FDB storm ingress ports: %s", [port["peer_port"] for port in ingress_ports])
     logger.info("FDB storm routed egress port: %s", egress_port["peer_port"])
     logger.info("THP pinning ports: %s", pinning_ports)
 
-    duthost.shell("sudo cp /etc/sonic/config_db.json {}".format(CONFIG_DB_BACKUP))
-
     try:
+        original_thp_mode = get_thp_enabled_mode(duthost)
+        logger.info("Original THP enabled mode: %s", original_thp_mode)
+        set_thp_enabled_mode(duthost, "madvise")
         configure_dut_for_fdb_storm(duthost, ingress_ports, egress_port, pinning_ports, vlan_id)
         config = generate_fdb_storm_config(
             testbed_config,
@@ -79,9 +92,7 @@ def test_thp_pinning_fdb_storm_direct_snappi(duthosts,             # noqa: F811
         )
         snappi_api.set_config(config)
 
-        cs = snappi_api.control_state()
-        cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.START
-        snappi_api.set_control_state(cs)
+        start_stop(snappi_api, operation="start", op_type="traffic")
         traffic_started = True
 
         workload_pid = start_thp_pinning_workload(
@@ -92,12 +103,8 @@ def test_thp_pinning_fdb_storm_direct_snappi(duthosts,             # noqa: F811
         logger.info("Final memory sample: %s", final_sample)
     finally:
         if traffic_started:
-            cs = snappi_api.control_state()
-            cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.STOP
-            snappi_api.set_control_state(cs)
+            start_stop(snappi_api, operation="stop", op_type="traffic")
         stop_thp_pinning_workload(duthost, workload_pid)
-        cleanup_thp_pinning_objects(duthost, pinning_ports)
-        duthost.shell("sudo cp {} /etc/sonic/config_db.json".format(CONFIG_DB_BACKUP),
-                      module_ignore_errors=True)
-        config_reload(duthost)
+        if original_thp_mode is not None:
+            set_thp_enabled_mode(duthost, original_thp_mode)
         cleanup_config(duthosts, snappi_ports)

--- a/tests/snappi_tests/dataplane/test_thp_pinning_fdb_storm.py
+++ b/tests/snappi_tests/dataplane/test_thp_pinning_fdb_storm.py
@@ -22,6 +22,7 @@ from tests.common.snappi_tests.snappi_fixtures import (  # noqa: F401
 from tests.snappi_tests.dataplane.files.helper import start_stop
 from tests.snappi_tests.dataplane.files.thp_pinning_helper import (
     DEFAULT_PINNING_DURATION_SEC,
+    cleanup_thp_pinning_objects,
     configure_dut_for_fdb_storm,
     find_unused_vlan_id,
     generate_fdb_storm_config,
@@ -33,6 +34,7 @@ from tests.snappi_tests.dataplane.files.thp_pinning_helper import (
     set_thp_enabled_mode,
     start_thp_pinning_workload,
     stop_thp_pinning_workload,
+    verify_fdb_storm_traffic,
 )
 
 logger = logging.getLogger(__name__)
@@ -57,18 +59,17 @@ def test_thp_pinning_fdb_storm_direct_snappi(duthosts,             # noqa: F811
     Verify THP pinning under madvise does not grow orchagent AnonHugePages by more than 500 MB in 15 minutes.
     """
     testbed_config, port_config_list, snappi_ports = tgen_port_info
-    pytest_assert(port_config_list, "PFC/PFCWD direct Snappi setup did not provide port configuration")
+    pytest_assert(port_config_list, "Direct Snappi setup did not provide port configuration")
     duthost, ingress_ports, egress_port = select_snappi_test_ports(snappi_ports)
     excluded_ports = [
         port["peer_port"]
-        for port in ingress_ports
+        for port in ingress_ports + [egress_port]
         if port["peer_device"] == duthost.hostname
     ]
     pinning_ports = select_pinning_ports(
         duthost,
         excluded_ports,
-        required_ports=1,
-        fallback_ports=[egress_port["peer_port"]]
+        required_ports=1
     )
     vlan_id = find_unused_vlan_id(duthost)
     workload_pid = None
@@ -94,6 +95,7 @@ def test_thp_pinning_fdb_storm_direct_snappi(duthosts,             # noqa: F811
 
         start_stop(snappi_api, operation="start", op_type="traffic")
         traffic_started = True
+        verify_fdb_storm_traffic(snappi_api)
 
         workload_pid = start_thp_pinning_workload(
             duthost,
@@ -105,6 +107,7 @@ def test_thp_pinning_fdb_storm_direct_snappi(duthosts,             # noqa: F811
         if traffic_started:
             start_stop(snappi_api, operation="stop", op_type="traffic")
         stop_thp_pinning_workload(duthost, workload_pid)
+        cleanup_thp_pinning_objects(duthost, pinning_ports)
         if original_thp_mode is not None:
             set_thp_enabled_mode(duthost, original_thp_mode)
         cleanup_config(duthosts, snappi_ports)

--- a/tests/snappi_tests/dataplane/test_thp_pinning_fdb_storm.py
+++ b/tests/snappi_tests/dataplane/test_thp_pinning_fdb_storm.py
@@ -10,7 +10,6 @@ from tests.common.snappi_tests.snappi_fixtures import (  # noqa: F401
     get_snappi_ports,
     get_snappi_ports_multi_dut,
     get_snappi_ports_single_dut,
-    is_snappi_multidut,
     snappi_api,
     snappi_api_serv_ip,
     snappi_api_serv_port,

--- a/tests/snappi_tests/dataplane/test_thp_pinning_fdb_storm.py
+++ b/tests/snappi_tests/dataplane/test_thp_pinning_fdb_storm.py
@@ -1,0 +1,104 @@
+import logging
+
+import pytest
+
+from tests.common.config_reload import config_reload
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut  # noqa: F401
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.snappi_tests.snappi_fixtures import (  # noqa: F401
+    cleanup_config,
+    get_snappi_ports,
+    get_snappi_ports_multi_dut,
+    get_snappi_ports_single_dut,
+    is_snappi_multidut,
+    snappi_api,
+    snappi_api_serv_ip,
+    snappi_api_serv_port,
+    snappi_port_selection,
+    tgen_port_info,
+)
+from tests.snappi_tests.dataplane.files.thp_pinning_helper import (
+    DEFAULT_PINNING_DURATION_SEC,
+    cleanup_thp_pinning_objects,
+    configure_dut_for_fdb_storm,
+    find_unused_vlan_id,
+    generate_fdb_storm_config,
+    monitor_dut_health,
+    render_thp_pinning_script,
+    select_pinning_ports,
+    select_snappi_test_ports,
+    start_thp_pinning_workload,
+    stop_thp_pinning_workload,
+)
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.topology("multidut-tgen", "tgen")]
+
+CONFIG_DB_BACKUP = "/tmp/thp_pinning_fdb_storm_config_db.json"
+
+
+@pytest.fixture(autouse=True, scope="module")
+def number_of_tx_rx_ports():
+    yield (1, 4)
+
+
+@pytest.mark.disable_loganalyzer
+def test_thp_pinning_fdb_storm_direct_snappi(duthosts,             # noqa: F811
+                                             snappi_api,           # noqa: F811
+                                             tgen_port_info,       # noqa: F811
+                                             get_snappi_ports):    # noqa: F811
+    """
+    Verify THP pinning does not drive orchagent AnonHugePages above 1 GB within 10 minutes.
+    """
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
+    pytest_assert(port_config_list, "PFC/PFCWD direct Snappi setup did not provide port configuration")
+    duthost, ingress_ports, egress_port = select_snappi_test_ports(snappi_ports)
+    excluded_ports = [
+        port["peer_port"]
+        for port in get_snappi_ports
+        if port["peer_device"] == duthost.hostname
+    ]
+    pinning_ports = select_pinning_ports(duthost, excluded_ports)
+    vlan_id = find_unused_vlan_id(duthost)
+    workload_pid = None
+    traffic_started = False
+
+    logger.info("FDB storm ingress ports: %s", [port["peer_port"] for port in ingress_ports])
+    logger.info("FDB storm routed egress port: %s", egress_port["peer_port"])
+    logger.info("THP pinning ports: %s", pinning_ports)
+
+    duthost.shell("sudo cp /etc/sonic/config_db.json {}".format(CONFIG_DB_BACKUP))
+
+    try:
+        configure_dut_for_fdb_storm(duthost, ingress_ports, egress_port, pinning_ports, vlan_id)
+        config = generate_fdb_storm_config(
+            testbed_config,
+            ingress_ports,
+            egress_port,
+            duration_sec=DEFAULT_PINNING_DURATION_SEC
+        )
+        snappi_api.set_config(config)
+
+        cs = snappi_api.control_state()
+        cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.START
+        snappi_api.set_control_state(cs)
+        traffic_started = True
+
+        workload_pid = start_thp_pinning_workload(
+            duthost,
+            render_thp_pinning_script(pinning_ports)
+        )
+        final_sample = monitor_dut_health(duthost, workload_pid, pinning_ports)
+        logger.info("Final memory sample: %s", final_sample)
+    finally:
+        if traffic_started:
+            cs = snappi_api.control_state()
+            cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.STOP
+            snappi_api.set_control_state(cs)
+        stop_thp_pinning_workload(duthost, workload_pid)
+        cleanup_thp_pinning_objects(duthost, pinning_ports)
+        duthost.shell("sudo cp {} /etc/sonic/config_db.json".format(CONFIG_DB_BACKUP),
+                      module_ignore_errors=True)
+        config_reload(duthost)
+        cleanup_config(duthosts, snappi_ports)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add a direct Snappi dataplane regression test for THP pinning with FDB storm traffic; sets THP to madvise and fails if orchagent AnonHugePages grows by more than 500 MB within 15 minutes.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] New Test case
    - [X] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [X] 202411
- [X] 202505
- [X] 202511
- [ ] 202512
- [X] 202605

### Approach
#### What is the motivation for this PR?
Cover a production issue where FDB storm traffic plus THP pinning caused orchagent hugepage growth and device memory exhaustion.
#### How did you do it?
Added a direct Snappi test with 4 VLAN ingress ports, 1 routed egress port, 2 pinning ports, DUT memory monitoring, and cleanup.
#### How did you verify/test it?
On a lab switch
Test results:
```
Final memory sample: {                                                                                                              
     'elapsed_sec': 918,                                                                                                                     
     'orchagent_rss_kb': 683612,                                                                                                                          
     'anon_huge_pages_kb': 63488,                                                                                     
     'anon_huge_pages_diff_kb': -2048,                                                                                                                                      
     'orchagent_rss_diff_kb': 583148                                                                                                                                        
   }   

   Running on DUT STR-7050CX3-C19-U37: echo always | sudo tee /sys/kernel/mm/transparent_hugepage/enabled >/dev/null  
   PASSED                                    
   ================= 1 passed, 147 warnings in 1418.55s (0:23:38) =================    
   ```

#### Any platform specific information?
Requires a direct Snappi-connected single-ASIC DUT with at least 5 Snappi ports plus 2 separate admin-up non-Snappi pinning ports.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
