### PR TITLE
[HFT] Fix InfluxDB launch args and per-port interval validation

### DIFF
--- a/tests/high_frequency_telemetry/utilities.py
+++ b/tests/high_frequency_telemetry/utilities.py
@@ -1604,7 +1604,7 @@ def start_influxdb(ptfhost, port=8181, timeout=30):
 
     ptfhost.shell(
         f"nohup influxdb3 serve --object-store memory --node-id test "
-        f"--http-bind={port} --without-auth "
+        f"--http-bind=0.0.0.0:{port} --without-auth "
         "> /var/log/influxdb3.log 2>&1 &",
         module_ignore_errors=False,
     )
@@ -1784,6 +1784,15 @@ def validate_influxdb_intervals(ptfhost, bucket="home", port=8181,
                 "passed": False}
 
     groups = parse_influxdb_json(result["stdout"])
+    # Split by object_name — OTel puts all ports under one measurement,
+    # so unsplit timestamps interleave and halve the inter-arrival delta.
+    sub_groups = {}
+    for measurement, rows in groups.items():
+        for row in rows:
+            obj = row.get("object_name", "")
+            key = f"{measurement}|{obj}" if obj else measurement
+            sub_groups.setdefault(key, []).append(row)
+    groups = sub_groups
     all_stats = {}
     violations = []
 


### PR DESCRIPTION
Summary: Fix InfluxDB launch args and per-port interval validation
Fixes # Fix InfluxDB launch args and per-port interval validation

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
PR https://github.com/sonic-net/sonic-mgmt/pull/21982 add new HFT case, but it has some test issue

#### How did you do it?
- start_influxdb: pass --http-bind=0.0.0.0:<port> instead of a bare port. influxdb3 3.x rejects "8181" as an invalid socket address and exits immediately, which caused the test to time out waiting for the health endpoint.

- validate_influxdb_intervals: re-group rows by (measurement, object_name) before computing inter-arrival deltas. The OTel exporter writes samples from all configured ports under the same measurement and distinguishes them via the object_name column, so without the per-port split, timestamps from different ports were interleaved and the deltas alternated between ~0ms and the real polling period. This halved the reported average and triggered false interval violations.

#### How did you verify/test it?
Regression test pass on SN5640

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
N/A
