### PR TITLE
[test_watchdog]: Skip cleanly when watchdog platform API is unimplemented

### DIFF
--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -46,7 +46,13 @@ class TestWatchdogApi(PlatformApiTestBase):
             duthost.shell("systemctl disable watchdog.timer --now")
             duthost.shell("watchdogutil disarm")
 
-        assert not watchdog.is_armed(platform_api_conn)
+        # None means the platform-api Watchdog is not implemented; skip instead of
+        # letting later None comparisons raise TypeError.
+        armed_state = watchdog.is_armed(platform_api_conn)
+        if armed_state is None:
+            pytest.skip("Watchdog platform API is not implemented on this platform "
+                        "(is_armed returned None)")
+        assert not armed_state
 
         try:
             yield


### PR DESCRIPTION
Summary: Skip cleanly when watchdog platform API is unimplemented
Fixes # 
The autouse fixture `watchdog_not_running` in `tests/platform_tests/api/test_watchdog.py` uses:

```python
assert not watchdog.is_armed(platform_api_conn)
```

This silently passes when `is_armed()` returns `None` (because `not None` is `True`). On platforms where the Watchdog platform API is not implemented, the fixture lets the test proceed and the test body then crashes with misleading errors when later API calls (`arm` / `disarm` / `get_remaining_time`) also return `None` and get compared with operators.

`watchdog.is_armed()` has three distinct return states. Handle each one correctly:

| Return value | Meaning | New behavior |
|---|---|---|
| `None` | platform-api server returned null — `Chassis.get_watchdog()` or its methods are not implemented on this platform | `pytest.skip` |
| `True` | watchdog is already armed by something else; precondition broken | `AssertionError` (unchanged) |
| `False` | watchdog is disarmed; happy path | proceed (unchanged) |

Since the fixture is `autouse=True` and function-scoped, the skip applies to every test in `TestWatchdogApi`, so any platform without watchdog API support (e.g. chipless / bring-up platforms) gets a clean skip instead of one failed + several broken cases.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
The autouse fixture `watchdog_not_running` in `tests/platform_tests/api/test_watchdog.py` uses:

```python
assert not watchdog.is_armed(platform_api_conn)
```

This silently passes when `is_armed()` returns `None` (because `not None` is `True`). On platforms where the Watchdog platform API is not implemented, the fixture lets the test proceed and the test body then crashes with misleading errors when later API calls (`arm` / `disarm` / `get_remaining_time`) also return `None` and get compared with operators.

`watchdog.is_armed()` has three distinct return states. Handle each one correctly:

| Return value | Meaning | New behavior |
|---|---|---|
| `None` | platform-api server returned null — `Chassis.get_watchdog()` or its methods are not implemented on this platform | `pytest.skip` |
| `True` | watchdog is already armed by something else; precondition broken | `AssertionError` (unchanged) |
| `False` | watchdog is disarmed; happy path | proceed (unchanged) |

Since the fixture is `autouse=True` and function-scoped, the skip applies to every test in `TestWatchdogApi`, so any platform without watchdog API support (e.g. chipless / bring-up platforms) gets a clean skip instead of one failed + several broken cases.


#### How did you do it?

#### How did you verify/test it?
Regression pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
