### PR TITLE
[dualtor] Improve ARP neighbor assertion diagnostics

### DIFF
--- a/tests/arp/test_arp_dualtor.py
+++ b/tests/arp/test_arp_dualtor.py
@@ -85,7 +85,14 @@ def clear_neighbor_table(duthosts, pause_arp_update, pause_garp_service):       
 def verify_neighbor_status(duthost, neigh_ip, expected_status):
     ip_version = 'v4' if ip_address(neigh_ip).version == 4 else 'v6'
     neighbor_table = duthost.switch_arptable()['ansible_facts']['arptable']
-    return expected_status.lower() in neighbor_table[ip_version][str(neigh_ip)]['state'].lower()
+    neighbor_entry = neighbor_table.get(ip_version, {}).get(str(neigh_ip))
+    if not neighbor_entry:
+        logger.info("Neighbor %s is not present in %s ARP table on %s",
+                    neigh_ip, ip_version, duthost.hostname)
+        return False
+
+    neighbor_state = neighbor_entry.get('state', '')
+    return expected_status.lower() in neighbor_state.lower()
 
 
 def test_proxy_arp_for_standby_neighbor(proxy_arp_enabled, ip_and_intf_info, restore_mux_auto_config,
@@ -201,10 +208,17 @@ def test_standby_unsolicited_neigh_learning(
     ping_cmd = "timeout 0.2 ping -c1 -W1 -i0.2 -n -q {}".format(neighbor_ip)
 
     rand_selected_dut.shell(ping_cmd, module_ignore_errors=True)
-    pytest_assert(wait_until(5, 1, 0, lambda: verify_neighbor_status(rand_selected_dut, neighbor_ip, REACHABLE)))
+    pytest_assert(
+        wait_until(5, 1, 0, lambda: verify_neighbor_status(rand_selected_dut, neighbor_ip, REACHABLE)),
+        "Neighbor {} should become {} on active ToR {}".format(neighbor_ip, REACHABLE, rand_selected_dut.hostname)
+    )
     rand_unselected_dut.shell("sudo ip neigh flush all")
 
     arp_update_cmd = "docker exec -t swss supervisorctl start arp_update"
     rand_selected_dut.shell(arp_update_cmd)
 
-    pytest_assert(wait_until(5, 1, 0, lambda: verify_neighbor_status(rand_unselected_dut, neighbor_ip, REACHABLE)))
+    pytest_assert(
+        wait_until(5, 1, 0, lambda: verify_neighbor_status(rand_unselected_dut, neighbor_ip, REACHABLE)),
+        "Neighbor {} should be learned as {} on standby ToR {} after arp_update on active ToR {}".format(
+            neighbor_ip, REACHABLE, rand_unselected_dut.hostname, rand_selected_dut.hostname)
+    )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
`test_standby_unsolicited_neigh_learning` can fail when the standby ToR does not learn the expected neighbor after `arp_update` runs on the active ToR. The previous failure output could be unclear because a missing neighbor entry could lead to a poor assertion result such as `Failed: None` or an unhelpful missing-key failure.
   
This PR improves the failure signal while preserving the existing test coverage.

#### How did you do it?
- Updated `verify_neighbor_status()` to handle a missing neighbor entry safely:
     - logs that the neighbor is absent from the ARP/NDP table
     - returns `False` instead of raising from a missing key
- Added explicit assertion messages for `test_standby_unsolicited_neigh_learning`:
     - active ToR should learn the neighbor as `REACHABLE`
     - standby ToR should learn the neighbor as `REACHABLE` after `arp_update` runs on the active ToR

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
