### PR TITLE
Skip unsupported counterpoll types in disable/enable helpers

### DIFF
--- a/tests/common/helpers/counterpoll_helper.py
+++ b/tests/common/helpers/counterpoll_helper.py
@@ -41,13 +41,30 @@ class ConterpollHelper:
                         counterpoll_before[counterpoll][CounterpollConstants.STATUS]))
 
     @staticmethod
+    def _run_command_ignore_errors(duthost, cmd):
+        """Run command handling both SonicHost and SonicAsic interfaces.
+
+        SonicAsic.command() does not support module_ignore_errors, so
+        we try that kwarg first and fall back to catching the exception.
+        """
+        try:
+            return duthost.command(cmd, module_ignore_errors=True)
+        except TypeError:
+            # SonicAsic.command() doesn't accept module_ignore_errors
+            try:
+                return duthost.command(cmd)
+            except Exception as e:
+                # Return a synthetic failed result
+                return {'rc': 1, 'stdout': str(e), 'stderr': str(e)}
+
+    @staticmethod
     def disable_counterpoll(duthost, counter_type_list):
         for counterpoll_type in counter_type_list:
-            result = duthost.command(
+            result = ConterpollHelper._run_command_ignore_errors(
+                duthost,
                 CounterpollConstants.COUNTERPOLL_DISABLE.format(
-                    counterpoll_type),
-                module_ignore_errors=True)
-            if result['rc'] != 0:
+                    counterpoll_type))
+            if result.get('rc', 0) != 0:
                 stdout = result.get('stdout', '').lower()
                 stderr = result.get('stderr', '').lower()
                 if 'not supported' in stdout or \
@@ -61,16 +78,16 @@ class ConterpollHelper:
                         "Failed to disable counterpoll "
                         "'{}': rc={}".format(
                             counterpoll_type,
-                            result['rc']))
+                            result.get('rc', -1)))
 
     @staticmethod
     def enable_counterpoll(duthost, counter_type_list):
         for counterpoll_type in counter_type_list:
-            result = duthost.command(
+            result = ConterpollHelper._run_command_ignore_errors(
+                duthost,
                 CounterpollConstants.COUNTERPOLL_ENABLE.format(
-                    counterpoll_type),
-                module_ignore_errors=True)
-            if result['rc'] != 0:
+                    counterpoll_type))
+            if result.get('rc', 0) != 0:
                 stdout = result.get('stdout', '').lower()
                 stderr = result.get('stderr', '').lower()
                 if 'not supported' in stdout or \
@@ -84,7 +101,7 @@ class ConterpollHelper:
                         "Failed to enable counterpoll "
                         "'{}': rc={}".format(
                             counterpoll_type,
-                            result['rc']))
+                            result.get('rc', -1)))
 
     @staticmethod
     def set_counterpoll_interval(duthost, counterpoll_type, interval):

--- a/tests/common/helpers/counterpoll_helper.py
+++ b/tests/common/helpers/counterpoll_helper.py
@@ -1,3 +1,5 @@
+import logging
+
 from tests.common.constants import CounterpollConstants
 
 
@@ -41,12 +43,48 @@ class ConterpollHelper:
     @staticmethod
     def disable_counterpoll(duthost, counter_type_list):
         for counterpoll_type in counter_type_list:
-            duthost.command(CounterpollConstants.COUNTERPOLL_DISABLE.format(counterpoll_type))
+            result = duthost.command(
+                CounterpollConstants.COUNTERPOLL_DISABLE.format(
+                    counterpoll_type),
+                module_ignore_errors=True)
+            if result['rc'] != 0:
+                stdout = result.get('stdout', '').lower()
+                stderr = result.get('stderr', '').lower()
+                if 'not supported' in stdout or \
+                        'not supported' in stderr:
+                    logging.warning(
+                        "Counterpoll type '%s' not supported "
+                        "on this platform, skipping",
+                        counterpoll_type)
+                else:
+                    raise Exception(
+                        "Failed to disable counterpoll "
+                        "'{}': rc={}".format(
+                            counterpoll_type,
+                            result['rc']))
 
     @staticmethod
     def enable_counterpoll(duthost, counter_type_list):
         for counterpoll_type in counter_type_list:
-            duthost.command(CounterpollConstants.COUNTERPOLL_ENABLE.format(counterpoll_type))
+            result = duthost.command(
+                CounterpollConstants.COUNTERPOLL_ENABLE.format(
+                    counterpoll_type),
+                module_ignore_errors=True)
+            if result['rc'] != 0:
+                stdout = result.get('stdout', '').lower()
+                stderr = result.get('stderr', '').lower()
+                if 'not supported' in stdout or \
+                        'not supported' in stderr:
+                    logging.warning(
+                        "Counterpoll type '%s' not supported "
+                        "on this platform, skipping",
+                        counterpoll_type)
+                else:
+                    raise Exception(
+                        "Failed to enable counterpoll "
+                        "'{}': rc={}".format(
+                            counterpoll_type,
+                            result['rc']))
 
     @staticmethod
     def set_counterpoll_interval(duthost, counterpoll_type, interval):


### PR DESCRIPTION
### Description of PR

Summary:
After PR #24026 added new counter types (`flowcnt-route`, `srv6`, `switch`, `phy`, `wredport`) to `COUNTERPOLL_MAPPING`, `test_counterpoll_watermark` started failing on platforms that don't support all counter types (e.g., Pensando-elba, Arista-7060CX-32S).

The root cause is that `counterpoll flowcnt-route disable` returns "Route flow counter is not supported on this platform" with `rc=1`, which makes `disable_counterpoll()` raise an unhandled exception.

This fix makes `disable_counterpoll()` and `enable_counterpoll()` tolerant of unsupported counter types by:
- Using `module_ignore_errors=True` to avoid hard failures
- Logging a warning when a platform reports "not supported"
- Only raising exceptions for genuine unexpected errors

Regression introduced by: https://github.com/sonic-net/sonic-mgmt/pull/24026

Address this error:
```
    raise RunAnsibleModuleFail("run module {} failed".format(module_name), hostname_res)
tests.common.errors.RunAnsibleModuleFail: run module command failed, Ansible Results =>
failed = True
changed = True
rc = 1
cmd = ['counterpoll', 'flowcnt-route', 'disable']
start = 2026-05-12 12:52:02.836322
end = 2026-05-12 12:52:03.081859
delta = 0:00:00.245537
msg = non-zero return code
invocation = {'module_args': {'_raw_params': 'counterpoll flowcnt-route disable', '_uses_shell': False, 'expand_argument_vars': True, 'stdin_add_newline': True, 'strip_empty_ends': True, 'argv': None, 'chdir': None, 'executable': None, 'creates': None, 'removes': None, 'stdin': None}}
_ansible_no_log = False
stdout =
Route flow counter is not supported on this platformstderr =
```

ADO:37940567




### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

PR #24026 (merged May 1, 2026) added missing counter types to `COUNTERPOLL_MAPPING` to fix a `KeyError` in restore. However, this caused `test_counterpoll_watermark` to call `counterpoll <type> disable` for ALL mapped types, including `flowcnt-route` which is not supported on many platforms.

Kusto data confirms: zero `flowcnt-route` failures before May 1, first failures appear May 9 after the change propagated to nightly test images.

#### How did you do it?

Modified `disable_counterpoll()` and `enable_counterpoll()` in `tests/common/helpers/counterpoll_helper.py` to:
1. Pass `module_ignore_errors=True` to `duthost.command()`
2. Check if the error message contains "not supported"
3. If yes, log a warning and skip (graceful degradation)
4. If no, raise an Exception with the error details (preserve error visibility for real failures)

#### How did you verify/test it?

Test evidence:
```
Results (479.92s (0:07:59)):
       1 passed
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_counterpoll_queue_watermark_pg_drop[bjw2-can-7260-12]>

```
#### Any platform specific information?

Affected platforms (from Kusto data):
- Pensando-elba (all topologies)
- Arista-7060CX-32S

#### Supported testbed topology if it's a new test case?

N/A (bug fix)

### Documentation

N/A