### PR TITLE
Skip test_arp_extended::test_arp_garp_out_of_subnet_not_learned on V6 topo

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -173,6 +173,12 @@ arp/test_arp_extended.py::test_arp_garp_enabled:
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/19904 and '-v6-' in topo_name"
 
+arp/test_arp_extended.py::test_arp_garp_out_of_subnet_not_learned:
+  skip:
+    reason: "Skip IPv4 GARP out-of-subnet test on IPv6-only topologies"
+    conditions:
+      - "'-v6-' in topo_name"
+
 arp/test_arp_extended.py::test_proxy_arp[v4-:
   skip:
     reason: "skip for IPv6-only topologies"


### PR DESCRIPTION
### Description of PR

Summary:Skip test_arp_extended::test_arp_garp_out_of_subnet_not_learned on V6 topo
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
