### PR TITLE
grpc_fixtures: Respect DUT parametrization

### DIFF
--- a/tests/common/fixtures/grpc_fixtures.py
+++ b/tests/common/fixtures/grpc_fixtures.py
@@ -5,8 +5,8 @@ This module provides coupled pytest fixtures that bundle server configuration
 with matched clients, preventing misuse from decoupled server/client setup.
 
 Primary fixtures:
-    gnmi_tls:       Module-scoped fixture that sets up TLS and yields GnmiFixture
-    gnmi_plaintext: Module-scoped fixture for plaintext mode, yields GnmiFixture
+    gnmi_tls:       Function-scoped fixture that sets up TLS and yields GnmiFixture
+    gnmi_plaintext: Function-scoped fixture for plaintext mode, yields GnmiFixture
 
 Deprecated fixtures (kept for backward compatibility):
     setup_gnoi_tls_server: Thin wrapper around gnmi_tls, yields None
@@ -44,6 +44,33 @@ _GRPCURL_ARCH_MAP = {
     "arm64": "linux_arm64",
     "armhf": "linux_armv6",
 }
+
+
+def _get_target_duthost(duthosts, request):
+    """
+    Select DUT based on test parametrization or fallback to duthosts[0].
+
+    Args:
+        duthosts: All DUT host instances
+        request: Pytest request object for introspection
+
+    Returns:
+        duthost: The selected DUT host instance
+    """
+    dut_selectors = [
+        'enum_rand_one_per_hwsku_frontend_hostname',
+        'enum_rand_one_per_hwsku_hostname',
+        'rand_one_dut_hostname'
+    ]
+
+    for selector in dut_selectors:
+        if selector in request.fixturenames:
+            dut_name = request.getfixturevalue(selector)
+            duthost = duthosts[dut_name]
+            logger.info(f"_get_target_duthost: selected DUT {duthost.hostname}")
+            return duthost
+
+    return duthosts[0]
 
 
 def _ensure_grpcurl_on_dut(duthost):
@@ -169,8 +196,8 @@ class GnmiFixture:
         logger.info("Post-reboot TLS reconfiguration completed")
 
 
-@pytest.fixture(scope="module")
-def gnmi_tls(request, duthost, ptfhost):
+@pytest.fixture(scope="function")
+def gnmi_tls(request, duthosts, ptfhost):
     """
     Set up gNMI/gNOI environment and yield a coupled GnmiFixture.
 
@@ -200,6 +227,8 @@ def gnmi_tls(request, duthost, ptfhost):
             assert isinstance(result["time"], int)
             assert gnmi_tls.port == 50052
     """
+    duthost = _get_target_duthost(duthosts, request)
+
     transport = getattr(request, 'param', 'tls')
 
     if transport == 'uds':
@@ -299,8 +328,8 @@ def gnmi_tls(request, duthost, ptfhost):
             logger.error(f"Failed to cleanup certificates: {e}")
 
 
-@pytest.fixture(scope="module")
-def gnmi_plaintext(duthost, ptfhost):
+@pytest.fixture(scope="function")
+def gnmi_plaintext(request, duthosts, ptfhost):
     """
     Plaintext gNMI/gNOI fixture — no TLS, no server reconfiguration.
 
@@ -312,6 +341,8 @@ def gnmi_plaintext(duthost, ptfhost):
         def test_plaintext(gnmi_plaintext):
             services = gnmi_plaintext.grpc.list_services()
     """
+    duthost = _get_target_duthost(duthosts, request)
+
     host = duthost.mgmt_ip
     port = grpc_config.DEFAULT_PLAINTEXT_PORT
     target = f"{host}:{port}"
@@ -372,7 +403,7 @@ def _gnmi_uds_flow(duthost):
 # Deprecated fixtures — kept for backward compatibility during migration
 # ---------------------------------------------------------------------------
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def setup_gnoi_tls_server(gnmi_tls):
     """
     Deprecated: use gnmi_tls instead.
@@ -385,12 +416,15 @@ def setup_gnoi_tls_server(gnmi_tls):
 
 
 @pytest.fixture
-def ptf_grpc(ptfhost, duthost):
+def ptf_grpc(ptfhost, duthosts, request):
     """
     Deprecated: use gnmi_tls.grpc or gnmi_plaintext.grpc instead.
 
     Auto-configured gRPC client using GNMIEnvironment for discovery.
     """
+
+    duthost = _get_target_duthost(duthosts, request)
+
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     client = PtfGrpc(ptfhost, env, duthost=duthost, insecure=True)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Summary:
  All gRPC fixtures incorrectly used the global `duthost` fixture
  which always returns `duthosts[0]`, ignoring test-level DUT
  parametrization. This broke tests that need to select specific
  DUTs via parametrization fixtures like `enum_rand_one_per_hwsku_frontend_hostname`.
 (e.g., test_cold_reboot on dual-tor testbeds)..

  The fix adds a `_get_target_duthost()` helper that introspects
  the test's fixture parameters to detect DUT selection, and changes
  all affected fixtures to function scope with `duthosts` parameter
  instead of `duthost`.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #24684 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach

#### What is the motivation for this PR?
Tests using gRPC fixtures with DUT parametrization were failing
 because the fixtures always connected to `duthosts[0]` instead of
 respecting the test's selected DUT. This affected:
  - `tests/platform_tests/test_reboot.py::test_cold_reboot`
  - `tests/upgrade_path/test_upgrade_gnoi.py::test_upgrade_via_gnoi`
  - `tests/smartswitch/platform_tests/test_reload_dpu.py::
    test_cold_reboot_dpus`

#### How did you do it?
 1. Changed all gRPC fixtures (`gnmi_tls`, `gnmi_plaintext`,
     `setup_gnoi_tls_server`, `ptf_grpc`) from module to function
     scope
  2. Changed fixture signatures from `duthost` parameter to
     `duthosts` parameter
  3. Added `_get_target_duthost(duthosts, request)` helper that:
     - Checks if test has DUT selector fixtures
       (`enum_rand_one_per_hwsku_frontend_hostname`, etc.)
     - Returns the selected DUT if parametrization detected
     - Falls back to `duthosts[0]` for backward compatibility with
       non-parametrized tests

  **Why change scope from module to function?**
        Module-scoped fixtures are created once per test file and reuse
        the same `duthost` parameter (which always returns `duthosts[0]`)
        for all tests, even when individual tests specify different DUTs
        via parametrization.
       Function-scoped fixtures are created fresh for each test, allowing
       `_get_target_duthost()` to inspect each test's parameters and
       select the correct DUT. This is a necessary trade-off: fixtures
       now run setup/teardown per test instead of per module, but this
       ensures each test runs on the correct DUT.

#### How did you verify/test it?
    Tested tests/platform_tests/test_reboot.py::test_cold_reboot
    Tested gnmi/ full suite for regression

#### Any platform specific information?
None 
#### Supported testbed topology if it's a new test case?
None 
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
