### PR TITLE
Fix Ansible boolean conditionals for 2.19+ compatibility

### DIFF
--- a/ansible/roles/fanout/tasks/rootfanout_connect.yml
+++ b/ansible/roles/fanout/tasks/rootfanout_connect.yml
@@ -5,7 +5,7 @@
   when: deploy_leaf is not defined
 
 - set_fact: dut="{{ leaf_name }}"
-  when: deploy_leaf
+  when: deploy_leaf | bool
 
 - set_fact:
     clean_before_add: "{{ clean_before_add | default('y') }}"

--- a/ansible/roles/test/tasks/ecmp.yml
+++ b/ansible/roles/test/tasks/ecmp.yml
@@ -26,7 +26,7 @@
       - 'address-family ipv4'
       - 'network 100.1.1.1/32'
       - 'quit'
-  when: "{{ ipv6 }} == False"
+  when: not (ipv6 | bool)
 
 - name: Initialize the array with the list of commands to be sent to the VM
   set_fact:
@@ -40,7 +40,7 @@
       - 'address-family ipv6'
       - 'network 2064:200::1/128'
       - 'quit'
-  when: "{{ ipv6 }} == True"
+  when: ipv6 | bool
 
 - name: Configure VMs to add loopback interface
   configure_vms: ip={{ item }} cmds={{ commands }}

--- a/ansible/roles/test/tasks/ecmp/link_down.yml
+++ b/ansible/roles/test/tasks/ecmp/link_down.yml
@@ -43,11 +43,11 @@
 
     - set_fact:
         config_cmd: ifconfig -a | grep -A 1 "lo0" | tail -1 | xargs | cut -d" " -f2 | cut -d":" -f2
-      when: "{{ ipv6 }} == False"
+      when: not (ipv6 | bool)
 
     - set_fact:
         config_cmd: ifconfig -a | grep -A 2 "lo0" | tail -1 | xargs | cut -d" " -f3 | cut -d"/" -f1
-      when: "{{ ipv6 }} == True"
+      when: ipv6 | bool
 
     - name: Ping destination VM from host VM.
       shell: "{{ config_cmd }}"
@@ -71,11 +71,11 @@
 
     - set_fact:
         ping_cmd: ping -n -i 0.004 {{ loopback_ip.stdout }} -c 30000 | grep "received" | cut -d"," -f2 | xargs | cut -d" " -f1
-      when: "{{ ipv6 }} == False"
+      when: not (ipv6 | bool)
 
     - set_fact:
         ping_cmd: ping6 {{ loopback_ip.stdout }} -i 0.004 -c 30000 | grep "received" | cut -d"," -f2 | xargs | cut -d" " -f1
-      when: "{{ ipv6 }} == True"
+      when: ipv6 | bool
 
     - name: Ping destination VM from host VM.
       shell: "{{ ping_cmd }}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Summary:
  Ansible 2.19+ enforces stricter type checking for boolean conditionals
  in when: clauses, causing fatal task failures that block fanout
  deployment and ECMP testing. This PR adds explicit | bool filters to
  all affected conditionals to ensure Ansible 2.19+ compatibility.

  The error occurs at:
  - ansible/roles/fanout/tasks/rootfanout_connect.yml line 8
  - ansible/roles/test/tasks/ecmp.yml lines 29, 43
  - ansible/roles/test/tasks/ecmp/link_down.yml lines 46, 50, 74, 78

Summary:
Fixes #24936 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
**add-topo was failing on master** 
`./testbed-cli.sh -t testbed.yaml -m veos -k ceos add-topo dt password.txt -vvv`

Ansible 2.19+ requires explicit boolean type conversion in conditional
expressions. Without the | bool filter, variables in when: clauses are
treated as strings, causing fatal errors:

 [ERROR]: Task failed: Conditional result (True) was derived from value
  of type 'str' at '/data/ansible/roles/fanout/tasks/rootfanout_connect.yml:4:13'.
  Conditionals must have a boolean result.

  fatal: [STR-ACS-SERV-01]: FAILED!

  This blocks critical workflows:
  - Fanout switch deployment fails at rootfanout_connect.yml
  - ECMP test configuration fails for IPv4/IPv6 routing
  - Link down test scenarios cannot execute
  

#### How did you do it?

Fixed boolean conditionals in 3 files by adding explicit | bool
  filters:
  1. ansible/roles/fanout/tasks/rootfanout_connect.yml (line 8):
     - Changed: `when: deploy_leaf`
     - To: `when: deploy_leaf | bool`

  2. ansible/roles/test/tasks/ecmp.yml (lines 29, 43):
     - Changed: `when: "{{ ipv6 }} == True"`
     - To: `when: ipv6 | bool`
     - Changed: `when: "{{ ipv6 }} == False"`
     - To: `when: not (ipv6 | bool)`

  3. ansible/roles/test/tasks/ecmp/link_down.yml (lines 46, 50, 74, 78):
     - Applied same ipv6 boolean fixes (4 occurrences)
     - Replaced True/False comparisons with | bool filter
      
#### How did you verify/test it?
add-topo passed without errors 
`./testbed-cli.sh -t testbed.yaml -m veos -k ceos add-topo dt password.txt -vvv`


#### Any platform specific information?
None
#### Supported testbed topology if it's a new test case?
None
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
None