### PR TITLE
Updated hwsku definitions in the port_utils.py file , added  Cisco-8101-32FH-O

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -465,7 +465,7 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
         elif hwsku == "Cisco-8102-C64":
             for i in range(0, 64):
                 port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % (i * 4)
-        elif hwsku in ["Cisco-8101-O32", "Cisco-8111-C32", "Cisco-8111-O32"]:
+        elif hwsku in ["Cisco-8101-O32", "Cisco-8111-C32", "Cisco-8111-O32", "Cisco-8101-32FH-O"]:
             for i in range(0, 32):
                 port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % (i * 8)
         elif hwsku in ["Cisco-8111-O64"]:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes error msg
**Did not find port for 'Ethernet240' in the ports based on hwsku 'Cisco-8101-32FH-O' for host**

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Failed testcases in drop_packets and pfcwd  suite
#### How did you do it?
Added HWSKU with corresponding platform to [port_utils.py](https://github.com/sonic-net/sonic-mgmt/compare/master...eyakubch:port_utils_extension?expand=1#diff-2e3adf42b9b205770272a4157e3b5cf3c430d8b897f36be2a891d8aeb049cd86)
#### How did you verify/test it?
Run pfcwd suite
#### Any platform specific information?
Cisco-8101-32FH-O
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
