### PR TITLE
Fix counterpoll unsupported types

### DIFF
--- a/tests/common/helpers/counterpoll_helper.py
+++ b/tests/common/helpers/counterpoll_helper.py
@@ -1,3 +1,4 @@
+import logging
 from tests.common.constants import CounterpollConstants
 
 
@@ -8,14 +9,13 @@ class ConterpollHelper:
 
     @staticmethod
     def get_available_counterpoll_types(duthost):
-        available_option_list = []
-        COMMANDS = 'Commands:'
-        counterpoll_show = duthost.command(CounterpollConstants.COUNTERPOLL_QUEST)[CounterpollConstants.STDOUT]
-        index = counterpoll_show.find(COMMANDS) + len(COMMANDS) + 1
-        for line in counterpoll_show[index:].splitlines():
-            available_option_list.append(line.split()[0])
-        return [option for option in available_option_list
-                if option not in CounterpollConstants.EXCLUDE_COUNTER_SUB_COMMAND]
+        logger = logging.getLogger(__name__)
+        current_status = ConterpollHelper.get_counterpoll_show_output(duthost)
+        available_types = [CounterpollConstants.COUNTERPOLL_MAPPING.get(counter[CounterpollConstants.TYPE])
+                           for counter in current_status]
+        available_types = [t for t in available_types if t]
+        logger.info("Available counterpoll types: {}".format(available_types))
+        return available_types
 
     @staticmethod
     def get_parsed_counterpoll_show(counterpoll_show):

--- a/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
+++ b/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
@@ -120,7 +120,8 @@ def test_counterpoll_queue_watermark_pg_drop(duthosts, localhost, enum_rand_one_
         config_apply_method = random.choice(["config reload", "switch reboot"])
     with allure.step("disabling all counterpolls"):
         for asic in duthost.asics:
-            ConterpollHelper.disable_counterpoll(asic, list(CounterpollConstants.COUNTERPOLL_MAPPING.values()))
+            available_types = ConterpollHelper.get_available_counterpoll_types(asic)
+            ConterpollHelper.disable_counterpoll(asic, available_types)
 
     # verify relevant counterpolls (queue/watermark/pg-drop) are disabled
     with allure.step("Verifying initial output of {} on {} ..."


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

 - Modify get_available_counterpoll_types() to use 'counterpoll show' output instead of parsing 'counterpoll --help'
 - Ensures only platform-supported counterpoll types are used
 - Fixes test_mac_move_during_switchover failures on platforms without full counterpoll support (e.g., flowcnt-route, flowcnt-trap, srv6)

Summary:
Fixes #24939 


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

This PR fixes `test_mac_move_during_switchover` failures caused by attempting to disable unsupported counterpoll types on platforms without full counterpoll support.

  The test framework was using `get_available_counterpoll_types()`  .It uses `counterpoll --help` command which  lists ALL possible counterpoll types (17 types), but platforms only support a subset. For example, ldp204 (Arista-7050CX3-32S-C32) doesn't support flowcnt-route, flowcnt-trap, srv6, switch, tunnel, wredport, or wredqueue.

  When tests attempted to disable unsupported types, the command failed with:
  ```
  cmd = ['counterpoll', 'flowcnt-route', 'disable']
  stdout = Route flow counter is not supported on this platform
  rc = 1
```

#### How did you do it?

  - Modified `get_available_counterpoll_types()` in `tests/common/helpers/counterpoll_helper.py` to parse `counterpoll show` output instead of `counterpoll --help`
  - The `counterpoll show` command only displays counter types that are actually supported on the platform
  - Updated `test_counterpoll_watermark.py` to use dynamically detected available types instead of assuming all types from COUNTERPOLL_MAPPING are supported


#### How did you verify/test it?
  - Verified the fix addresses the original failure on ldp204 (Arista-7050CX3-32S-C32) platform
  - The function now correctly returns only the 10 supported types instead of attempting to use all 17 types from the help text
  - Test `test_mac_move_during_switchover` no longer fails when trying to disable unsupported counterpoll types

#### Any platform specific information?
This fix is particularly important for platforms with limited counterpoll support.

#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
None