### PR TITLE
Fix psud test to honor PSU skip list

### DIFF
--- a/tests/platform_tests/daemon/test_psud.py
+++ b/tests/platform_tests/daemon/test_psud.py
@@ -15,6 +15,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.daemon_utils import check_pmon_daemon_enable_status
 from tests.common.platform.processes_utils import check_critical_processes
 from tests.common.utilities import compose_dict_from_cli, skip_release, wait_until
+from tests.platform_tests.cli.util import get_skip_mod_list
 
 logger = logging.getLogger(__name__)
 
@@ -183,6 +184,7 @@ def test_pmon_psud_psu_status_and_led(duthosts, enum_supervisor_dut_hostname, da
     pytest_assert(data_before_restart['keys'], "No PSU_INFO keys found in STATE_DB")
     pytest_assert(data_before_restart['data'], "No PSU_INFO data found in STATE_DB")
 
+    psu_skip_list = get_skip_mod_list(duthost, ['psus'])
     present_psu_count = 0
     psu_status_failures = []
     psu_led_failures = []
@@ -190,6 +192,10 @@ def test_pmon_psud_psu_status_and_led(duthosts, enum_supervisor_dut_hostname, da
     for psu_key, psu_data in data_before_restart['data'].items():
         psu_name = psu_key.replace("PSU_INFO|", "")
         presence = psu_data.get("presence", "false")
+
+        if psu_name in psu_skip_list:
+            logger.info("PSU {} is in skip list, skipping validation".format(psu_name))
+            continue
 
         if presence.lower() != "true":
             logger.info("PSU {} is not present, skipping status and LED check".format(psu_name))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #24942 
This PR fixes `test_pmon_psud_psu_status_and_led` by honoring the platform PSU skip list during validation.

The test was validating all PSUs found in STATE_DB without checking if they are in the platform's skip list, 
causing false failures on platforms where certain PSU slots are intentionally disabled, not
populated, or have known issues configured in the skip list.

Example failure without this fix:
  Failed: PSU status check failed: psu2 status is 'false', expected 'true'
  psu_led_failures = ["psu2 led_status is 'red', expected 'green' or 'N/A'"]

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
The test `test_pmon_psud_psu_status_and_led` validates PSU status and LED for all PSUs in STATE_DB without checking if PSUs are in the platform skip list. Platforms may have PSU slots  that are in the  skip list , and these should not be validated.
Without this fix, the test fails when it validates PSUs that should be skipped

#### How did you do it?
  - Added import for `get_skip_mod_list` utility function from `tests.platform_tests.cli.util` (line 20)
  - Retrieved PSU skip list using `get_skip_mod_list(duthost, ['psus'])` before the validation loop (line 187)
  - Added check to skip PSUs that are in the skip list before validating their presence, status, and LED (lines 196-198)
  - Added logging to indicate when PSUs are skipped due to being in skip list
  
#### How did you verify/test it?
  - Verified that PSUs in the skip list are now excluded from validation
  - Test passes on platforms with PSU skip lists configured
  - PSUs not in skip list are still properly validated for status and LED

#### Any platform specific information?
This fix applies to any platform that has PSUs defined in the skip list 

#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A