### PR TITLE
[ecmp] Add Arista-7060CX-32S-Q32

### DIFF
--- a/tests/ecmp/test_ecmp_sai_value.py
+++ b/tests/ecmp/test_ecmp_sai_value.py
@@ -192,7 +192,8 @@ def check_ecmp_offset_value(duthost, asic_name, topo_type, hwsku):
                           Expected {}, but got {}.".format(392, offset_count))
     elif topo_type == "t1":
         offset_count = offset_list.count('0xa')
-        if hwsku in ["Arista-7060CX-32S-C32", "Arista-7050QX32S-Q32", "Arista-7050-QX-32S"]:
+        if hwsku in ["Arista-7060CX-32S-C32", "Arista-7050QX32S-Q32", "Arista-7050-QX-32S",
+                     "Arista-7060CX-32S-Q32"]:
             pytest_assert(offset_count >= 33, "the count of 0xa OFFSET_ECMP is not correct. \
                           Expected >= 33, but got {}.".format(offset_count))
         else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

This HwSKU was added to the list of Broadcom SKUs in
https://github.com/sonic-net/sonic-mgmt/pull/24060. Before this change,
tests/ecmp/test_ecmp_sai_value.py would skip, in code, this SKU. Now
that it's added, we need to adapt the test to it.

In particular, its expected value of ECMP Offset count should be 33,
not the default value of 67.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
The expected offset count in this test was incorrect for the HwSKU Arista-7060CX-32S-Q32.

#### How did you do it?
I changed the expected value to 67, the same as similar other SKUs, like Arista-7050QX32S-Q32.

#### How did you verify/test it?
I applied this change to a T1 cluster with an Upperlake DUT and verified that it fixes the test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
