### PR TITLE
Fix get_pfcwd_config to return dict instead of None

### DIFF
--- a/tests/common/snappi_tests/qos_fixtures.py
+++ b/tests/common/snappi_tests/qos_fixtures.py
@@ -120,7 +120,7 @@ def lossy_prio_list(all_prio_list, lossless_prio_list):
 # the following functions are introduced.
 def get_pfcwd_config(duthost):
     if not duthost.is_multi_asic:
-        return (get_running_config(duthost, filter=".PFC_WD"))
+        return get_running_config(duthost, filter=".PFC_WD") or {}
     else:
         all_configs = []
         output = duthost.shell("ip netns | awk '{print $1}'")['stdout']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
When PFC_WD is not configured in CONFIG_DB, `get_pfcwd_config()` returns `None` for single-ASIC devices, causing test teardown to fail with `RuntimeError` in `reapply_pfcwd()`.

  PR #21065 added filter parameter to `get_running_config()`, which uses `jq .PFC_WD`. When the key doesn't exist, jq returns `"null"` which Python's `json.loads()` converts to `None`.

  The fix uses `or {}` to ensure `get_pfcwd_config()` always returns a dict (either populated or empty), which `reapply_pfcwd()` handles correctly.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #24946 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
QoS tests (e.g., `qos/test_tunnel_qos_remap.py`) fail during module teardown on devices without PFC watchdog configured. 
The `disable_pfcwd` fixture saves PFC_WD config at setup and restores it at teardown. 
 When there's no PFC_WD config, `get_pfcwd_config()` returns `None`, causing `reapply_pfcwd()` to raise:

RuntimeError: Script problem: Got an unsupported type of pfcwd_config:None

This causes test modules to fail with ERROR status even when all individual tests pass.

#### How did you do it?
 Modified get_pfcwd_config() in tests/common/snappi_tests/qos_fixtures.py (line 125):
Added  or {}
  # Before
  return (get_running_config(duthost, filter=".PFC_WD"))

  # After
  return get_running_config(duthost, filter=".PFC_WD") or {}

#### How did you verify/test it?
Test case: qos/test_tunnel_qos_remap.py

  Before fix:
  - Module teardown fails with RuntimeError: Script problem: Got an unsupported type of pfcwd_config:None
  - Test module marked as ERROR even though all 20 tests passed

  After fix:
  - Module teardown completes successfully
  - Empty dict {} is restored to device (no-op for empty PFC_WD config)
  - All tests pass without errors
  
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A