### PR TITLE
Fix fw_pkg fixture to always parametrize fw_pkg_name

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -12,6 +12,7 @@ from tests.common.platform.device_utils import MGFX_HWSKU, MGFX_XCVR_INTF
 from tests.common.platform.transceiver_utils import get_passive_cable_port_list, get_cmis_cable_ports_and_ver
 from tests.common.helpers.firmware_helper import PLATFORM_COMP_PATH_TEMPLATE
 from tests.common.platform.interface_utils import get_ports_with_flat_memory
+from tests.common.helpers.platform_api import bmc
 
 logger = logging.getLogger(__name__)
 
@@ -183,8 +184,9 @@ def check_pmon_uptime_minutes(duthost, minimal_runtime=6):
 
 def pytest_generate_tests(metafunc):
     val = metafunc.config.getoption('--fw-pkg')
-    if 'fw_pkg_name' in metafunc.fixturenames and val:
-        metafunc.parametrize('fw_pkg_name', val.split(','), scope="module")
+    if 'fw_pkg_name' in metafunc.fixturenames:
+        param_values = val.split(',') if val else [None]
+        metafunc.parametrize('fw_pkg_name', param_values, scope="module")
 
     if 'power_off_delay' in metafunc.fixturenames:
         delays = metafunc.config.getoption('power_off_delay')
@@ -275,7 +277,11 @@ def cmis_cable_ports_and_ver(duthosts):
 
 
 @pytest.fixture(scope='module')
-def fw_pkg(fw_pkg_name):
+def fw_pkg(duthosts, enum_rand_one_per_hwsku_hostname, fw_pkg_name):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    if not bmc.is_bmc_exists(duthost):
+        pytest.skip("BMC is not present, skipping BMC platform API tests")
+
     if fw_pkg_name is None:
         pytest.skip("No fw package specified.")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->

### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
When the `--fw-pkg` CLI option is not provided, `test_bmc_firmware_update` fails with "fixture 'fw_pkg_name' not found" error during setup instead of being properly skipped.
`pytest_generate_tests()` only parametrizes `fw_pkg_name` when the `--fw-pkg` option is provided. This causes fixture collection to fail before any skip logic can execute.

Summary:
Fixes #24949 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach

#### What is the motivation for this PR?
BMC firmware update tests fail during fixture collection when the `--fw-pkg` CLI option is not provided. Instead of being properly skipped, the tests fail with:

  file /data/tests/platform_tests/conftest.py, line 277
    @pytest.fixture(scope='module')
    def fw_pkg(fw_pkg_name):
  E       fixture 'fw_pkg_name' not found

#### How did you do it?

1. Always parametrize fw_pkg_name 
2. Add BMC existence check in fw_pkg fixture 

#### How did you verify/test it?
 Before fix (without --fw-pkg option):
  - Fixture collection fails with fixture 'fw_pkg_name' not found
  - 4 tests marked as ERROR

  After fix (without --fw-pkg option):
  - fw_pkg_name parametrized with [None]
  - fw_pkg() fixture executes and skips properly
  - Tests marked as SKIPPED 

#### Any platform specific information?
Arista  x86_64-arista_7050cx3_32s without BMC Support

#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A