### PR TITLE
[Nokia-IXR7220-H6-O256] Increase frr_bgp memory high threshold to 512 MB

### DIFF
--- a/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
@@ -376,7 +376,7 @@
           ],
           "memory_high_threshold": {
             "type": "value",
-            "value": 384
+            "value": 512
           }
         }
       },


### PR DESCRIPTION
### Description of PR
Nokia-IXR7220-H6-O256 has 256 ports and more BGP sessions than other variants, resulting in higher FRR BGP memory usage. Observed steady-state is ~368 MB with peaks up to ~389 MB, which exceeds the previous threshold of 384 MB and causes false memory alarms. Raise the `frr_bgp` `memory_high_threshold` from 384 MB to 512 MB.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
The `memory_utilization` test raises a false alarm on Nokia-IXR7220-H6-O256:
```
[ALARM]: frr_bgp:used, Current memory usage 389.0 MB exceeds high threshold 384.0 MB
```
The O256 platform has 256 ports and significantly more BGP sessions than other Nokia variants, leading to higher steady-state FRR BGP memory usage (~368 MB, peaks ~389 MB).

#### How did you do it?
Increased `memory_high_threshold` for `Nokia-IXR7220` from 384 MB to 512 MB in `memory_utilization_dependence.json`.

#### How did you verify/test it?
Verified current FRR BGP memory usage on `str4-Nokia-7220-Th6p-1` (Nokia-IXR7220-H6-O256):
```
Total heap allocated: 368 MiB
```
512 MB provides ~140 MB headroom above peak observed usage.

#### Any platform specific information?
Nokia-IXR7220-H6-O256 only.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation