### PR TITLE
[telemetry] Fix intermittent test_poll_mode_present_table_delayed_key failures

### DIFF
--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -134,17 +134,16 @@ def generate_client_cli(duthost, gnxi_path, method=METHOD_GET, xpath="COUNTERS/E
     if subscribe_mode == SUBSCRIBE_MODE_POLL:
         poll_cmd = " --subscribe_mode {0} --polling_interval {1} --update_count {2} --max_sync_count {3} --timeout {4}"
         cmd += poll_cmd.format(subscribe_mode, polling_interval, update_count, max_sync_count, timeout)
-        return cmd
-
-    if method == METHOD_SUBSCRIBE:
+    elif method == METHOD_SUBSCRIBE:
         cmd += " --subscribe_mode {0} --submode {1} --interval {2} --update_count {3} --create_connections {4}".format(
                 subscribe_mode,
                 submode, intervalms,
                 update_count, create_connections)
-        if filter_event_regex != "":
-            cmd += " --filter_event_regex {}".format(filter_event_regex)
         if timeout > 0:
             cmd += " --timeout {}".format(timeout)
+
+    if filter_event_regex != "" and method == METHOD_SUBSCRIBE:
+        cmd += " --filter_event_regex {}".format(filter_event_regex)
     return cmd
 
 

--- a/tests/telemetry/test_telemetry_poll.py
+++ b/tests/telemetry/test_telemetry_poll.py
@@ -95,7 +95,8 @@ def test_poll_mode_present_table_delayed_key(duthosts, enum_rand_one_per_hwsku_h
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
                               subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=2,
                               xpath="FAKE_APPL_DB_TABLE_0 FAKE_APPL_DB_TABLE_1/fake_key1", target="APPL_DB",
-                              max_sync_count=-1, update_count=20, timeout=60, namespace=namespace)
+                              max_sync_count=-1, update_count=20, filter_event_regex="dummy1", timeout=60,
+                              namespace=namespace)
 
     def callback(show_gnmi_out):
         result = str(show_gnmi_out)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Improve telemetry update counting in  gNMI poll-mode test `test_poll_mode_present_table_delayed_key` by counting only update packets that match the subscribed telemetry data instead of counting every update received by the client.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix


### Approach
#### What is the motivation for this PR?

There is an existing PR #23022 that mitigates this issue by increasing the gNMI client `timeout`, `update_count` and `poll_interval` values, effectively giving the expected `APPL_DB` update a larger reception window. However, intermittent failures caused by race conditions can still occur.

In poll mode, the client exits either when the timeout expires or when it receives the configured number of update packets (`update_count`). The previous implementation counted all received update packets, regardless of whether they were actually related to the active test subscription.

As a result, unrelated telemetry traffic could satisfy `update_count` before the expected `APPL_DB` update was received, causing the polling session to terminate prematurely and leading to intermittent failures.

A more reliable approach is to filter updates using `filter_event_regex` so that only packets matching the expected payload are counted toward `update_count`. This makes the test deterministic and eliminates the need to increase timeout values to work around timing-related race conditions.

#### How did you do it?

* Modified `generate_client_cli()` to support `filter_event_regex` for `SUBSCRIBE_MODE_POLL`.
* Modified `test_poll_mode_present_table_delayed_key` to pass `filter_event_regex="dummy1"` when creating the gNMI poll-mode client

#### How did you verify/test it?

Executed `test_poll_mode_present_table_delayed_key` 50 consecutive times to verify the fix eliminates the time-related race conditions. 

The test was also validated using the original `timeout`, `update_count` and `poll_interval` values that existed prior to PR #23022.


**Note:** Since I do not have permission to manage labels on this repository. Could a maintainer please add the Request for `202511` branch label?