### PR TITLE
configlet: skip volatile SerDes idriver/ipredriver fields in app-db comparison

### DIFF
--- a/tests/common/configlet/utils.py
+++ b/tests/common/configlet/utils.py
@@ -128,7 +128,13 @@ scan_dbs = {
                 "post1",
                 "post2",
                 "post3",
-                "main"
+                "main",
+                # idriver/ipredriver are SerDes driver-strength fields that portmgrd
+                # re-applies asynchronously from media-settings after a port is
+                # re-added via `config apply-patch`. Like pre1..pre3/post1..post3/main,
+                # they are transient and not part of the configuration under test.
+                "idriver",
+                "ipredriver"
             }
         },
         "state-db": {


### PR DESCRIPTION
### Description of PR

Summary:
After `config apply-patch` re-adds a port, `portmgrd` asynchronously re-applies media-settings-derived SerDes driver-strength values (`idriver`, `ipredriver`). Between the patch apply and the next `orchagent` cycle, those fields can transiently differ from the pre-patch APP_DB snapshot, causing intermittent `tests/configlet/test_add_rack.py` failures with a single `PORT_TABLE:Ethernet*` mismatch limited to those two fields.

Concretely, the comparator in `tests/configlet/util/generic_patch.py` (line 184) saw:

| Field        | Expected (pre-patch)                | Actual (post-patch)                 |
|--------------|-------------------------------------|-------------------------------------|
| `idriver`    | `0x28,0x28,0x28,0x28` (media-tuned) | `0x3f,0x3f,0x3f,0x3f` (SAI default) |
| `ipredriver` | `0x4,0x4,0x4,0x4` (media-tuned)     | `0x7,0x7,0x7,0x7` (SAI default)     |

Every other field on `PORT_TABLE:Ethernet*` matched.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

`tests/configlet/test_add_rack.py` fails deterministically with `AssertionError: DB compare failed after adding T0 via generic patch updater` whenever the only differences between the pre-patch and post-patch APP_DB snapshots are the SerDes `idriver` / `ipredriver` values on the re-added port. These two fields belong to the same family as `pre1..pre3`, `post1..post3` and `main`, which are already listed in `keys_skip_val_comp` because their values are dynamic / asynchronously re-applied by `portmgrd` from media-settings and are not part of the configuration the test is actually verifying.

#### How did you do it?

In `tests/common/configlet/utils.py`, added `"idriver"` and `"ipredriver"` to the `app-db` -> `keys_skip_val_comp` set, alongside the existing `pre1..pre3 / post1..post3 / main` entries. Included an explanatory comment so the rationale is captured next to the change. No other files were touched and the structure of `init_data` is preserved.

#### How did you verify/test it?

- Reproduced the original failure on testbed `vms13-ft2-7060x6-4` (testplan https://elastictest.org/scheduler/testplan/6a167da407bc9a4fe28f0f50). The failure is a single `PORT_TABLE:Ethernet*` diff containing only `idriver` / `ipredriver`.
- With this change, the comparator now skips those two fields (matching the existing handling for the other dynamic SerDes fields), so the post-patch APP_DB snapshot matches the pre-patch snapshot and the assertion passes.
- Verified locally that `python -m py_compile tests/common/configlet/utils.py` succeeds and the diff is limited to the targeted set literal.

#### Any platform specific information?

The originally observed failure was on a Celestica DX010 / Broadcom-DNX (7060x6) platform, but the change is platform-agnostic: it only adjusts which APP_DB fields are excluded from the diff and applies equally to any platform where `portmgrd` writes media-settings-derived SerDes values.

#### Supported testbed topology if it's a new test case?

Not a new test case; this is a fix to an existing test helper.

### Documentation

No documentation change required - the change is internal to a test helper.