### PR TITLE
[snmp][flaky fix]Retry SNMP-vs-DUT compare to fix test_snmp_interfaces flakiness

### DIFF
--- a/tests/snmp/test_snmp_interfaces.py
+++ b/tests/snmp/test_snmp_interfaces.py
@@ -259,6 +259,50 @@ def verify_snmp_speed(facts, snmp_facts, results):
     return results
 
 
+def _compare_snmp_facts(duthost, snmp_facts, ports_list, namespace=None):
+    """Run the SNMP-vs-DUT comparison once. Returns the diff dict (empty == match)."""
+    dut_facts = collect_all_facts(duthost, ports_list, namespace)
+    ports_snmps = verify_port_snmp(dut_facts, snmp_facts)
+    speed_snmp = verify_snmp_speed(dut_facts, snmp_facts, ports_snmps)
+    return verify_port_ifindex(snmp_facts, speed_snmp)
+
+
+def _wait_for_snmp_match(duthost, localhost, creds_all_duts, initial_snmp_facts,
+                         ports_list, namespace=None, timeout=60, interval=10):
+    """
+    Compare DUT facts against SNMP facts with retry to absorb operstatus races.
+
+    The first attempt reuses the module-scoped ``initial_snmp_facts`` (fast path).
+    If that comparison reports a diff, subsequent retries re-fetch fresh SNMP facts
+    so transient mismatches between SNMP walk time and DUT state (commonly seen as
+    ``operstatus: unknown`` on the management port or PortChannel during startup)
+    can settle without failing the test.
+
+    Asserts via ``pytest_assert`` if no attempt succeeds within ``timeout`` seconds.
+    """
+    hostip = duthost.host.options['inventory_manager'].get_host(
+        duthost.hostname).vars['ansible_host']
+    snmp_community = creds_all_duts[duthost.hostname]["snmp_rocommunity"]
+
+    state = {'snmp_facts': initial_snmp_facts, 'first_pass': True, 'last_diff': {}}
+
+    def attempt():
+        if not state['first_pass']:
+            logger.info("Re-fetching SNMP facts before retry")
+            state['snmp_facts'] = get_snmp_facts(
+                duthost, localhost, host=hostip, version="v2c",
+                community=snmp_community, wait=True)['ansible_facts']
+        state['first_pass'] = False
+        state['last_diff'] = _compare_snmp_facts(
+            duthost, state['snmp_facts'], ports_list, namespace)
+        if state['last_diff']:
+            logger.info("SNMP comparison diff (will retry): {}".format(state['last_diff']))
+        return not state['last_diff']
+
+    pytest_assert(wait_until(timeout, interval, 0, attempt),
+                  "Unexpected comparsion of SNMP: {}".format(state['last_diff']))
+
+
 def verify_snmp_counter(duthost, localhost, creds_all_duts, hostip, mg_facts, rif_interface, rif_counters,
                         port_counters, num_port_intfs):
     """
@@ -334,7 +378,8 @@ def test_snmp_interfaces(duthosts, enum_rand_one_per_hwsku_hostname, snmp_interf
 
 
 @pytest.mark.bsl
-def test_snmp_mgmt_interface(duthosts, enum_rand_one_per_hwsku_hostname, snmp_interfaces_module_facts):
+def test_snmp_mgmt_interface(duthosts, enum_rand_one_per_hwsku_hostname, snmp_interfaces_module_facts,
+                             localhost, creds_all_duts):
     """compare the snmp facts between observed states and target state"""
 
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -355,15 +400,15 @@ def test_snmp_mgmt_interface(duthosts, enum_rand_one_per_hwsku_hostname, snmp_in
     if duthost.num_asics() == 1:
         ports_list = []
         ports_list.extend(list(config_facts.get('MGMT_INTERFACE', {}).keys()))
-        dut_facts = collect_all_facts(duthost, ports_list)
-        ports_snmps = verify_port_snmp(dut_facts, snmp_facts)
-        speed_snmp = verify_snmp_speed(dut_facts, snmp_facts, ports_snmps)
-        result = verify_port_ifindex(snmp_facts, speed_snmp)
-        pytest_assert(
-            not result, "Unexpected comparsion of SNMP: {}".format(result))
+        # Retry the comparison to absorb operstatus race during startup
+        # (mgmt port operstatus may report 'unknown' if STATE_DB hasn't settled
+        # by the time of the initial module-scoped SNMP walk).
+        _wait_for_snmp_match(duthost, localhost, creds_all_duts,
+                             snmp_facts, ports_list)
 
 
-def test_snmp_interfaces_mibs(duthosts, enum_rand_one_per_hwsku_hostname, snmp_interfaces_module_facts):
+def test_snmp_interfaces_mibs(duthosts, enum_rand_one_per_hwsku_hostname, snmp_interfaces_module_facts,
+                              localhost, creds_all_duts):
     """Verify correct behaviour of port MIBs ifIndex, ifMtu, ifSpeed,
        ifAdminStatus, ifOperStatus, ifAlias, ifHighSpeed, ifType """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -377,12 +422,11 @@ def test_snmp_interfaces_mibs(duthosts, enum_rand_one_per_hwsku_hostname, snmp_i
         for i in ['port_name_to_alias_map', 'PORTCHANNEL']:
             ports_list.extend(list(config_facts.get(i, {}).keys()))
 
-        dut_facts = collect_all_facts(duthost, ports_list, asic.namespace)
-        ports_snmps = verify_port_snmp(dut_facts, snmp_facts)
-        speed_snmp = verify_snmp_speed(dut_facts, snmp_facts, ports_snmps)
-        result = verify_port_ifindex(snmp_facts, speed_snmp)
-        pytest_assert(
-            not result, "Unexpected comparsion of SNMP: {}".format(result))
+        # Retry the comparison to absorb operstatus race during startup
+        # (PortChannel/physical port operstatus may transiently mismatch the
+        # cached SNMP walk if state hasn't fully settled).
+        _wait_for_snmp_match(duthost, localhost, creds_all_duts,
+                             snmp_facts, ports_list, asic.namespace)
 
 
 def test_snmp_interfaces_error_discard(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_all_duts,


### PR DESCRIPTION
### Description of PR

Stabilize the SNMP interface tests by adding a `wait_until` retry around the SNMP-vs-DUT comparison, mirroring the pattern already used by `test_snmp_interfaces_error_discard`.

Summary: Fixes flakiness in `test_snmp_mgmt_interface` and `test_snmp_interfaces_mibs` caused by operstatus race against a stale module-scoped SNMP walk.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

`snmp_interfaces_module_facts` is a **module-scoped** fixture — one SNMP walk is captured at setup and all three tests (`test_snmp_interfaces`, `test_snmp_mgmt_interface`, `test_snmp_interfaces_mibs`) compare DUT state against that snapshot. The DUT side fetches `oper_status` from `STATE_DB MGMT_PORT_TABLE` / `APPL_DB PORT_TABLE` at compare time. If interface state hasn't fully settled when the SNMP walk happened, or shifts between walk and compare, the one-shot comparison fails with messages like:

```
Failed: Unexpected comparsion of SNMP: {'eth0': {'operstatus': 'unknown'}}
Failed: Unexpected comparsion of SNMP: {'PortChannel101': {'operstatus': 'up'}}
```

Pass-rate analysis from `V2TestCases` in the SonicTestData Kusto cluster over the last 90 days across all branches:

| Failure mode                                | Failures | %      |
|---------------------------------------------|---------:|-------:|
| loganalyzer_teardown (other components)     |      609 |  61.6% |
| snmp_counter (already retried)              |      154 |  15.6% |
| other / uncategorized                       |      102 |  10.3% |
| **eth0_operstatus_race**                    |   **70** | **7.1%** |
| sanity_check (testbed)                      |       22 |   2.2% |
| memory_alarm (other)                        |       21 |   2.1% |
| teardown_other                              |        8 |   0.8% |
| **port_operstatus_race**                    |    **2** |  0.2%  |
| snmp_compare_other                          |        1 |   0.1% |

This PR targets the `*_operstatus_race` slice (~7.3% of failures), which is the largest single failure mode actually attributable to the SNMP test itself. On 202511 the affected cases sit at ~94.8-95.2% pass rate today; with this retry they should approach the 99%+ band.

The 4th test (`test_snmp_interfaces_error_discard`) already uses this exact pattern via `wait_until(60, 10, 0, verify_snmp_counter, ...)` at the bottom of the file — this PR just extends the same protection to the two siblings that need it.

#### How I did it

- Extract the existing in-line comparison into a small helper `_compare_snmp_facts(...)` that returns the diff dict (empty == match).
- Add `_wait_for_snmp_match(...)` that runs the comparison with `wait_until(60, 10, 0, ...)`:
  - The **first attempt** reuses the cached module-scoped SNMP facts (no extra walk cost on the happy path).
  - **Subsequent retries** re-fetch fresh SNMP facts via `get_snmp_facts(...)`, so transient races can settle.
  - Asserts via `pytest_assert` with the last observed diff if no attempt succeeds.
- Refactor `test_snmp_mgmt_interface` and `test_snmp_interfaces_mibs` to call the helper. Signature additions: `localhost`, `creds_all_duts` (matching what `test_snmp_interfaces_error_discard` already takes).
- `test_snmp_interfaces` (membership-only check) is **not modified** — it doesn't compare operstatus.

#### How I verified it

- `python -c "import ast; ast.parse(open('tests/snmp/test_snmp_interfaces.py').read())"` — syntax OK
- Helper structure mirrors the existing `verify_snmp_counter` + `wait_until(60, 10, 0, ...)` pattern at the bottom of the same file, so the timing / retry semantics are consistent with what already runs in production
- Will rely on PR-test pipelines (`Test impacted-area-kvmtest-t0`, `-t1-lag`, etc.) for runtime validation; the happy-path latency is unchanged (first attempt uses the cached fixture)

#### Any platform specific information?

None — fix is in the generic test layer.
