### PR TITLE
chore: enable vrf converged topo

### DIFF
--- a/ansible/ceos_topo_converger.py
+++ b/ansible/ceos_topo_converger.py
@@ -12,6 +12,7 @@ import sys
 
 CEOSLAB_INTF_LIMIT = 127  # 128, minus one for backplane interface
 BASE_VLAN_ID = 2000
+DEFAULT_MAX_FP_NUM = 4
 
 
 class ListIndentDumper(yaml.Dumper):
@@ -75,10 +76,22 @@ class SonicTopoConverger:
 
             for label in device_properties:
                 if label in labels:
-                    if label not in cur_prime_devs or create_new_prime:
-                        cur_prime_devs[label] = device
+                    # Key the prime selection on (label, ASN) so peers sharing
+                    # a role but using distinct ASNs (e.g. the two ToRs on the
+                    # dpu topology, ASN 65200 vs 65201) each become their own
+                    # prime VM. Without the ASN in the key both would collapse
+                    # into a single ``router bgp <first-asn>`` process and the
+                    # second peer would never establish BGP (DUT expects the
+                    # other ASN). Topologies where every peer under a role
+                    # shares one ASN (t0/t1/t2/vpp/multi-asic-t1) collapse to
+                    # the same primes as before, so behavior is unchanged
+                    # there.
+                    asn = config[device].get("bgp", {}).get("asn")
+                    prime_key = (label, asn)
+                    if prime_key not in cur_prime_devs or create_new_prime:
+                        cur_prime_devs[prime_key] = device
                         self.prime_devices.append(device)
-                    prime = cur_prime_devs[label]
+                    prime = cur_prime_devs[prime_key]
                     if prime not in self.prime_device_mapping:
                         self.prime_device_mapping[prime] = []
                     self.prime_device_mapping[prime].append(device)
@@ -259,6 +272,29 @@ class SonicTopoConverger:
         key = "configuration"
         new_topo[key] = old_topo[key].copy()
         new_topo["convergence_data"] = self.converge_peers(interface_indexes, offsets)
+
+        # After convergence, each prime cEOSLab peer needs one front-panel
+        # interface per merged sub-peer (each connects to one DUT FP port via
+        # one ``br-<vmname>-N`` OVS bridge). The default ``max_fp_num`` of 4
+        # works for stock topologies, but converged primes routinely hold many
+        # more (e.g. 16 on a t1-lag spine prime, 32 on a t2 T3 prime). Without
+        # bumping max_fp_num, ``create_bridges`` / ``ceos_network`` create only
+        # 4 br-VM-N bridges + 4 veth pairs into the cEOS container, and the
+        # subsequent ``vm_topology bind`` fails with "Too many vlans".
+        #
+        # Surface the required count as ``max_fp_num_provided`` at the topo
+        # root so ``roles/vm_set/tasks/start.yml`` (which already honors this
+        # override via set_fact) bumps max_fp_num for the whole vm_set. Cap at
+        # CEOSLAB_INTF_LIMIT to stay within cEOSLab's per-container interface
+        # ceiling, and never go below the default so single-vlan converged
+        # topologies (e.g. dpu) keep the existing minimum.
+        max_prime_vlans = max(
+            (len(vm.get("vlans", [])) for vm in new_topo["topology"]["VMs"].values()),
+            default=0,
+        )
+        required_fp_num = max(DEFAULT_MAX_FP_NUM, min(max_prime_vlans, CEOSLAB_INTF_LIMIT))
+        if required_fp_num > DEFAULT_MAX_FP_NUM:
+            self.converged_topo["max_fp_num_provided"] = required_fp_num
 
     def run(self) -> None:
         self.parse_properties()

--- a/ansible/ceos_topo_converger.py
+++ b/ansible/ceos_topo_converger.py
@@ -226,10 +226,13 @@ class SonicTopoConverger:
 
         # We don't need to change the host_interfaces portion of the passed topo, so
         # copy
-        # it over as is.
-        key = "host_interfaces"
-        if key in old_topo:
-            new_topo[key] = old_topo[key].copy()
+        # it over as is.  The same applies to disabled_host_interfaces, which must be
+        # preserved so the DUT minigraph keeps those ports admin-down; dropping it
+        # turns previously-disabled host interfaces into active ports and breaks
+        # buffer/qos deployment checks (e.g. qos/test_buffer.py).
+        for key in ("host_interfaces", "disabled_host_interfaces"):
+            if key in old_topo:
+                new_topo[key] = old_topo[key].copy()
 
         key = "VMs"
         # Save off which vm had which interface index as we will need this later

--- a/ansible/ceos_topo_converger.py
+++ b/ansible/ceos_topo_converger.py
@@ -76,22 +76,10 @@ class SonicTopoConverger:
 
             for label in device_properties:
                 if label in labels:
-                    # Key the prime selection on (label, ASN) so peers sharing
-                    # a role but using distinct ASNs (e.g. the two ToRs on the
-                    # dpu topology, ASN 65200 vs 65201) each become their own
-                    # prime VM. Without the ASN in the key both would collapse
-                    # into a single ``router bgp <first-asn>`` process and the
-                    # second peer would never establish BGP (DUT expects the
-                    # other ASN). Topologies where every peer under a role
-                    # shares one ASN (t0/t1/t2/vpp/multi-asic-t1) collapse to
-                    # the same primes as before, so behavior is unchanged
-                    # there.
-                    asn = config[device].get("bgp", {}).get("asn")
-                    prime_key = (label, asn)
-                    if prime_key not in cur_prime_devs or create_new_prime:
-                        cur_prime_devs[prime_key] = device
+                    if label not in cur_prime_devs or create_new_prime:
+                        cur_prime_devs[label] = device
                         self.prime_devices.append(device)
-                    prime = cur_prime_devs[prime_key]
+                    prime = cur_prime_devs[label]
                     if prime not in self.prime_device_mapping:
                         self.prime_device_mapping[prime] = []
                     self.prime_device_mapping[prime].append(device)
@@ -160,6 +148,12 @@ class SonicTopoConverger:
             intf_counter_base = 1
             eth_intf_index = 1
             offset = 0
+            # Per-prime allocator for any *additional* Port-Channels (see below).
+            # Primary Port-Channels consume channel ids in [intf_counter_base,
+            # intf_counter_base + len(peer_list) - 1] (one per VRF), so start the
+            # extra-channel counter just above that range to keep every
+            # channel-group id globally unique on the prime.
+            next_extra_po = len(peer_list) + intf_counter_base
             for i, peer_name in enumerate(peer_list):
                 #  For simplicity, VRFs are just peer names.
                 vlan_id = BASE_VLAN_ID + offset_mapping[peer_name]
@@ -171,22 +165,47 @@ class SonicTopoConverger:
                 intf_index = i + intf_counter_base
                 vrf = {f"Vlan{vlan_id}": {}}
 
+                # A peer may attach to more than one Port-Channel (e.g. dualtor
+                # T1s peer with BOTH ToRs via two separate single-member LAGs).
+                # Allocate a globally-unique converged channel-group id per
+                # original Port-Channel: the primary (lowest-numbered) keeps
+                # ``intf_index`` so single-Port-Channel topologies
+                # (t0/t1/t2/dpu/...) render byte-identically, while any extra
+                # Port-Channel gets a fresh id from ``next_extra_po`` (outside the
+                # per-VRF primary range) so it never collides with another VRF's
+                # primary channel. ``lacp_remap`` maps each original channel-group
+                # number to its converged id so member Ethernets stay bundled with
+                # the correct Port-Channel.
+                po_names = sorted(
+                    (name for name in peer_intfs if name.startswith("Port-Channel")),
+                    key=lambda name: int(name[len("Port-Channel"):]),
+                )
+                lacp_remap = {}
+                for po_name in po_names:
+                    orig_ch = int(po_name[len("Port-Channel"):])
+                    if not lacp_remap:
+                        lacp_remap[orig_ch] = intf_index
+                    else:
+                        lacp_remap[orig_ch] = next_extra_po
+                        next_extra_po += 1
+
                 for intf, config in peer_intfs.items():
                     if "Ethernet" not in intf:
                         continue
                     eth_intf = f"Ethernet{eth_intf_index}"
                     vrf[eth_intf] = deepcopy(peer_intfs[intf])
                     # Update lacp channel-group to match the new Port-Channel index
-                    if "lacp" in vrf[eth_intf] and "Port-Channel1" in peer_intfs:
-                        vrf[eth_intf]["lacp"] = intf_index
+                    if "lacp" in vrf[eth_intf] and lacp_remap:
+                        vrf[eth_intf]["lacp"] = lacp_remap.get(
+                                peer_intfs[intf]["lacp"], intf_index)
                     orig_intf_map[intf] = eth_intf
                     eth_intf_index += 1
 
-                if "Port-Channel1" in peer_intfs:
-                    po_intf = f"Port-Channel{intf_index}"
-                    orig_intf_map["Port-Channel1"] = po_intf
-                    vrf[po_intf] = deepcopy(
-                            peer_intfs["Port-Channel1"])
+                for po_name in po_names:
+                    orig_ch = int(po_name[len("Port-Channel"):])
+                    po_intf = f"Port-Channel{lacp_remap[orig_ch]}"
+                    orig_intf_map[po_name] = po_intf
+                    vrf[po_intf] = deepcopy(peer_intfs[po_name])
                 if "Loopback0" in peer_intfs:
                     lo_intf = f"Loopback{intf_index}"
                     orig_intf_map["Loopback0"] = lo_intf
@@ -263,6 +282,18 @@ class SonicTopoConverger:
         if key in old_topo:
             new_topo[key] = old_topo[key].copy()
 
+        # Preserve top-level topology metadata that minigraph generation reads
+        # directly off the topology dict (ansible/library/topo_facts.py).
+        # dut_num in particular sizes the per-DUT interface_indexes lists:
+        # multi-linecard chassis topologies (t2 variants carry dut_num 3-6)
+        # have VM vlans with dut_index > 0, so dropping dut_num makes
+        # topo_facts default it to 1 and raise "IndexError: list index out of
+        # range" during deploy-mg. Single-DUT topos omit dut_num (defaults to
+        # 1), so this is a no-op for them.
+        for key in ("dut_num", "topo_type"):
+            if key in old_topo:
+                new_topo[key] = old_topo[key]
+
         new_topo = self.converged_topo
         old_topo = self.topo
         key = "configuration_properties"
@@ -283,8 +314,10 @@ class SonicTopoConverger:
         # subsequent ``vm_topology bind`` fails with "Too many vlans".
         #
         # Surface the required count as ``max_fp_num_provided`` at the topo
-        # root so ``roles/vm_set/tasks/start.yml`` (which already honors this
-        # override via set_fact) bumps max_fp_num for the whole vm_set. Cap at
+        # root so the vm_set role bumps max_fp_num for the whole vm_set. The
+        # override is applied in ``roles/vm_set/tasks/main.yml`` (common to
+        # every action, including ``add_topo`` which actually creates the
+        # br-VM-N bridges) and ``roles/vm_set/tasks/start.yml``. Cap at
         # CEOSLAB_INTF_LIMIT to stay within cEOSLab's per-container interface
         # ceiling, and never go below the default so single-vlan converged
         # topologies (e.g. dpu) keep the existing minimum.

--- a/ansible/roles/eos/tasks/ceos_config.yml
+++ b/ansible/roles/eos/tasks/ceos_config.yml
@@ -57,3 +57,20 @@
   template: src="{{ base_topo }}-{{ props.swrole }}.j2"
             dest="/{{ ceos_image_mount_dir }}/ceos_{{ vm_set_name }}_{{ inventory_hostname }}/startup-config"
   delegate_to: "{{ VM_host[0] }}"
+
+# Converged-only: append a stock-compat backplane shim (untagged VLAN 1 path,
+# Vlan1 SVI in the prime peer's VRF carrying its bp_interface IP, and BGP
+# network advertisement of that subnet). Keeps the existing t0-leaf.j2 /
+# t1-lag-*.j2 templates untouched. Skipped on stock topologies and on
+# converged hosts that have no bp_interface (e.g. servers).
+- name: append converged backplane stock-compat shim to startup-config
+  become: yes
+  blockinfile:
+    path: "/{{ ceos_image_mount_dir }}/ceos_{{ vm_set_name }}_{{ inventory_hostname }}/startup-config"
+    marker: "! {mark} CONVERGED BACKPLANE STOCK-COMPAT SHIM"
+    block: "{{ lookup('template', 'ceos_bp_compat.j2') }}"
+    insertbefore: EOF
+  delegate_to: "{{ VM_host[0] }}"
+  when:
+    - topo_is_multi_vrf | default(false) | bool
+    - configuration[hostname]['bp_interface'] is defined

--- a/ansible/roles/eos/templates/ceos_bp_compat.j2
+++ b/ansible/roles/eos/templates/ceos_bp_compat.j2
@@ -1,0 +1,58 @@
+{#
+  Converged backplane stock-compat shim.
+
+  Rendered ONLY for converged topologies (topo_is_multi_vrf=true) and only
+  for peer cEOS hosts that have a bp_interface defined. Appended to the
+  cEOS startup-config AFTER the main role template renders.
+
+  Purpose: stock tests (e.g. bgp.test_bgp_stress_link_flap monitor) reach
+  the DUT from PTF via the legacy untagged backplane path
+    PTF backplane (10.10.246.254/22) -> bp_bridge -> cEOS -> DUT
+  In converged mode the per-VRF VLAN sub-interface model leaves untagged
+  ingress unresolved.  This shim restores that path by:
+
+    1. Allowing untagged frames (VLAN 1) on the trunk backplane port.
+    2. Adding an interface Vlan1 SVI in the prime peer's own VRF carrying
+       the original bp_interface IP (matches what stock kvm-t0 advertises).
+    3. Advertising the bp_interface subnet from the same prime VRF's BGP
+       process so DUT learns the return path to PTF .254.
+
+  EOS startup-config semantics MERGE successive blocks targeting the same
+  interface / router bgp instance, so the additions below stack onto the
+  earlier per-VRF config emitted by the main template without conflict.
+#}
+{% set host = configuration[hostname] %}
+{% set conv_config = convergence_data["converged_peers"][hostname] %}
+!
+! ===== converged-vrf stock-compat backplane shim =====
+!
+interface {{ bp_ifname }}
+ switchport trunk allowed vlan add 1
+!
+interface Vlan1
+ description {{ hostname }} legacy backplane
+ vrf {{ hostname }}
+{% if host['bp_interface']['ipv4'] is defined %}
+ ip address {{ host['bp_interface']['ipv4'] }}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ host['bp_interface']['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
+router bgp {{ conv_config['bgp']['asn'] }}
+ vrf {{ hostname }}
+  address-family ipv4
+{% if host['bp_interface']['ipv4'] is defined %}
+   network {{ host['bp_interface']['ipv4'] | ansible.utils.ipaddr('subnet') }}
+{% endif %}
+  exit
+  address-family ipv6
+{% if host['bp_interface']['ipv6'] is defined %}
+   network {{ host['bp_interface']['ipv6'] | ansible.utils.ipaddr('subnet') }}
+{% endif %}
+  exit
+ exit
+!

--- a/ansible/roles/eos/templates/ceos_converged.j2
+++ b/ansible/roles/eos/templates/ceos_converged.j2
@@ -1,0 +1,189 @@
+{#
+  Shared converged (multi-VRF) cEOS startup-config -- single source of truth.
+
+  Rendered for ANY converged topology (topo_is_multi_vrf=true) regardless of
+  base topo / swrole, because the converged config is a pure function of the
+  converger output (convergence_data) plus per-peer configuration; it does not
+  depend on the per-topology stock template. Topologies whose per-topo template
+  never grew a converged branch (t0-64-32, t2, dpu, ...) include this file so
+  every merged sub-peer's interface IP and BGP neighbor is rendered instead of
+  being silently dropped. Logic mirrors the converged path already proven on
+  t0-leaf.j2 / t1-lag-*.j2.
+#}
+{% set host = configuration[hostname] %}
+    {% set conv_config = convergence_data["converged_peers"][hostname] %}
+    {% set conv_mapping = convergence_data["convergence_mapping"][hostname] %}
+    {% set ptf_bp_addrs = convergence_data["ptf_backplane_addrs"] %}
+{% set mgmt_ip = ansible_host %}
+{% if vm_type is defined and vm_type == "ceos" %}
+    {% set mgmt_if_index = 0 %}
+{% else %}
+    {% set mgmt_if_index = 1 %}
+{% endif %}
+no schedule tech-support
+!
+{% if vm_type is defined and vm_type == "ceos" %}
+agent LicenseManager shutdown
+agent PowerFuse shutdown
+agent PowerManager shutdown
+agent Thermostat shutdown
+agent LedPolicy shutdown
+agent StandbyCpld shutdown
+agent Bfd shutdown
+{% endif %}
+!
+hostname {{ hostname }}
+!
+vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
+!
+vrf instance MGMT
+    {% for vrf_name in conv_config['vrf'] %}
+vrf instance {{vrf_name}}
+    {% endfor %}
+!
+spanning-tree mode mstp
+!
+aaa root secret 0 123456
+!
+username admin privilege 15 role network-admin secret 0 123456
+!
+clock timezone UTC
+!
+lldp run
+lldp management-address Management{{ mgmt_if_index }}
+lldp management-address vrf MGMT
+!
+snmp-server community {{ snmp_rocommunity }} ro
+snmp-server vrf MGMT
+!
+ip routing
+ip routing vrf MGMT
+    {% for vrf_name in conv_config['vrf'] %}
+ip routing vrf {{vrf_name}}
+    {% endfor %}
+ipv6 unicast-routing
+    {% for vrf_name in conv_config['vrf'] %}
+ipv6 unicast-routing vrf {{vrf_name}}
+    {% endfor %}
+!
+{% if disable_ceos_mgmt_gateway is defined and disable_ceos_mgmt_gateway == 'yes'%}
+{% elif vm_mgmt_gw is defined %}
+ip route vrf MGMT 0.0.0.0/0 {{ vm_mgmt_gw }}
+{% else %}
+ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
+{% endif %}
+!
+interface Management {{ mgmt_if_index }}
+ description TO LAB MGMT SWITCH
+{% if vm_type is defined and vm_type == "ceos" %}
+ vrf MGMT
+{% else %}
+ vrf forwarding MGMT
+{% endif %}
+ ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
+ no shutdown
+!
+interface {{ bp_ifname }}
+!
+ description backplane
+ mtu 9214
+ switchport trunk allowed vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
+ switchport mode trunk
+ no shutdown
+!
+    {% for vrf in conv_mapping %}
+        {% for if_name, if_data in conv_config['vrf'][vrf].items() %}
+interface {{ if_name }}
+            {% if if_name.startswith('Vlan') %}
+ description {{ vrf }} backplane
+            {% endif %}
+            {% if if_name.startswith('Loopback') %}
+ description {{ vrf }} LOOPBACK
+            {% endif %}
+            {% if if_name.startswith('Port-Channel') %}
+ port-channel min-links 1
+ mtu 9214
+ no switchport
+            {% endif %}
+            {% if if_name.startswith('Ethernet') %}
+ mtu 9214
+ no switchport
+            {% endif %}
+ vrf {{ vrf }}
+            {% if if_data['lacp'] is defined %}
+ channel-group {{ if_data['lacp'] }} mode active
+ lacp rate normal
+            {% endif %}
+            {% if if_data['ipv4'] is defined %}
+ ip address {{ if_data['ipv4'] }}
+            {% endif %}
+            {% if if_data['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ if_data['ipv6'] }}
+ ipv6 nd ra suppress
+ ipv6 nd dad disabled
+            {% endif %}
+ no shutdown
+!
+        {% endfor %}
+    {% endfor %}
+!
+router bgp {{ conv_config['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
+    {% for vrf in conv_config['vrf'] %}
+ vrf {{ vrf }}
+        {% set vrf_bgp = configuration[vrf]['bgp'] %}
+        {% set vrf_intfs = conv_config['vrf'][vrf] %}
+        {% set lo_config = vrf_intfs|get_first_loopback %}
+        {% if vrf_bgp['router-id'] is defined %}
+  router-id {{ vrf_bgp['router-id'] }}
+        {% else %}
+            {% if lo_config['ipv4'] is defined %}
+  router-id {{ lo_config['ipv4']|ansible.utils.ipaddr('address') }}
+            {% endif %}
+        {% endif %}
+  local-as {{ vrf_bgp['asn'] }}
+        {% for asn, remote_ips in vrf_bgp['peers'].items() %}
+            {% for remote_ip in remote_ips %}
+  neighbor {{ remote_ip }} remote-as {{ asn }}
+  neighbor {{ remote_ip }} description {{ asn }}
+  neighbor {{ remote_ip }} next-hop-self
+                {% if remote_ip|ipv6 %}
+  address-family ipv6
+   neighbor {{ remote_ip }} activate
+  exit
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
+        {% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} remote-as {{ vrf_bgp['asn'] }}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} next-hop-peer
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} description exabgp_v4
+        {% endif %}
+        {% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} remote-as {{ vrf_bgp['asn'] }}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} next-hop-peer
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} description exabgp_v6
+        {% endif %}
+  address-family ipv4
+        {% if lo_config['ipv4'] is defined %}
+   network {{ lo_config['ipv4'] }}
+        {% endif %}
+  exit
+  address-family ipv6
+   neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} activate
+        {% if lo_config['ipv6'] is defined %}
+   network {{ lo_config['ipv6'] }}
+        {% endif %}
+  exit
+ exit
+    {% endfor %}
+!
+management api http-commands
+ no protocol https
+ protocol http
+ no shutdown
+!
+end

--- a/ansible/roles/eos/templates/dpu-tor.j2
+++ b/ansible/roles/eos/templates/dpu-tor.j2
@@ -1,3 +1,8 @@
+{# Converged (multi-VRF) topologies render the shared converged config; the
+   stock body below is used unchanged on non-converged topologies. #}
+{% if topo_is_multi_vrf | default(false) | bool %}
+{% include 'ceos_converged.j2' %}
+{% else %}
 {% set host = configuration[hostname] %}
 {% set mgmt_ip = ansible_host %}
 {% if vm_type is defined and vm_type == "ceos" %}
@@ -138,3 +143,4 @@ management api http-commands
  no shutdown
 !
 end
+{% endif %}

--- a/ansible/roles/eos/templates/t0-leaf-lag-2.j2
+++ b/ansible/roles/eos/templates/t0-leaf-lag-2.j2
@@ -1,3 +1,8 @@
+{# Converged (multi-VRF) topologies render the shared converged config; the
+   stock body below is used unchanged on non-converged topologies. #}
+{% if topo_is_multi_vrf | default(false) | bool %}
+{% include 'ceos_converged.j2' %}
+{% else %}
 {% set host = configuration[hostname] %}
 {% set mgmt_ip = ansible_host %}
 {% if vm_type is defined and vm_type == "ceos" %}
@@ -138,3 +143,4 @@ management api http-commands
  no shutdown
 !
 end
+{% endif %}

--- a/ansible/roles/eos/templates/t1-8-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-8-lag-spine.j2
@@ -1,3 +1,8 @@
+{# Converged (multi-VRF) topologies render the shared converged config; the
+   stock body below is used unchanged on non-converged topologies. #}
+{% if topo_is_multi_vrf | default(false) | bool %}
+{% include 'ceos_converged.j2' %}
+{% else %}
 {% set host = configuration[hostname] %}
 {% set mgmt_ip = ansible_host %}
 {% if vm_type is defined and vm_type == "ceos" %}
@@ -136,3 +141,4 @@ management api http-commands
  no shutdown
 !
 end
+{% endif %}

--- a/ansible/roles/eos/templates/t1-8-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-8-lag-tor.j2
@@ -1,3 +1,8 @@
+{# Converged (multi-VRF) topologies render the shared converged config; the
+   stock body below is used unchanged on non-converged topologies. #}
+{% if topo_is_multi_vrf | default(false) | bool %}
+{% include 'ceos_converged.j2' %}
+{% else %}
 {% set host = configuration[hostname] %}
 {% set mgmt_ip = ansible_host %}
 {% set tornum = host['tornum'] %}
@@ -140,3 +145,4 @@ management api http-commands
  no shutdown
 !
 end
+{% endif %}

--- a/ansible/roles/eos/templates/t2-core.j2
+++ b/ansible/roles/eos/templates/t2-core.j2
@@ -1,3 +1,8 @@
+{# Converged (multi-VRF) topologies render the shared converged config; the
+   stock body below is used unchanged on non-converged topologies. #}
+{% if topo_is_multi_vrf | default(false) | bool %}
+{% include 'ceos_converged.j2' %}
+{% else %}
 {% set host = configuration[hostname] %}
 {% set mgmt_ip = ansible_host %}
 {% if vm_type is defined and vm_type == "ceos" %}
@@ -160,3 +165,4 @@ management api http-commands
  no shutdown
 !
 end
+{% endif %}

--- a/ansible/roles/eos/templates/t2-leaf.j2
+++ b/ansible/roles/eos/templates/t2-leaf.j2
@@ -1,3 +1,8 @@
+{# Converged (multi-VRF) topologies render the shared converged config; the
+   stock body below is used unchanged on non-converged topologies. #}
+{% if topo_is_multi_vrf | default(false) | bool %}
+{% include 'ceos_converged.j2' %}
+{% else %}
 {% set host = configuration[hostname] %}
 {% set mgmt_ip = ansible_host %}
 {% if vm_type is defined and vm_type == "ceos" %}
@@ -152,3 +157,4 @@ management api http-commands
  no shutdown
 !
 end
+{% endif %}

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -610,7 +610,8 @@ class VMTopology(object):
         self.add_ip_to_docker_if(BP_PORT_NAME, mgmt_ip, mgmt_ipv6)
         VMTopology.iface_disable_txoff(BP_PORT_NAME, self.pid)
 
-    def add_bp_port_with_vlans_to_docker(self, vlan_data, vrf_map, multi_vrf_config):
+    def add_bp_port_with_vlans_to_docker(self, vlan_data, vrf_map, multi_vrf_config,
+                                         ptf_bp_ip_addr=None, ptf_bp_ipv6_addr=None):
         rev_vrf_map = {}
         for peer, vrfs in vrf_map.items():
             for vrf in vrfs:
@@ -618,6 +619,13 @@ class VMTopology(object):
 
         self.add_br_if_to_docker(
             self.bp_bridge, PTF_BP_IF_TEMPLATE % self.vm_set_name, BP_PORT_NAME)
+
+        # Stock-compat: also give the parent backplane the legacy
+        # ptf_bp_ip address (e.g. 10.10.246.254/22, fc0a::ff/64) so untagged
+        # backplane-based tests (e.g. bgp_stress_link_flap monitor) keep working
+        # on converged VRF topologies. Per-VRF VLAN sub-interfaces are added below.
+        if ptf_bp_ip_addr or ptf_bp_ipv6_addr:
+            self.add_ip_to_docker_if(BP_PORT_NAME, ptf_bp_ip_addr, ptf_bp_ipv6_addr)
 
         for vrf, data in vlan_data.items():
             vlan_id = data.get("vlan")
@@ -2409,7 +2417,11 @@ def main():
                     vlan_data = multi_vrf_data.get("ptf_backplane_addrs", {})
                     vrf_map = multi_vrf_data.get("convergence_mapping", {})
                     multi_vrf_config = multi_vrf_data.get("converged_peers", {})
-                    net.add_bp_port_with_vlans_to_docker(vlan_data, vrf_map, multi_vrf_config)
+                    net.add_bp_port_with_vlans_to_docker(
+                        vlan_data, vrf_map, multi_vrf_config,
+                        ptf_bp_ip_addr=ptf_bp_ip_addr,
+                        ptf_bp_ipv6_addr=ptf_bp_ipv6_addr,
+                    )
                 else:
                     net.add_bp_port_to_docker(ptf_bp_ip_addr, ptf_bp_ipv6_addr)
                 if is_vs_chassis:
@@ -2595,7 +2607,11 @@ def main():
                     vlan_data = multi_vrf_data.get("ptf_backplane_addrs", {})
                     vrf_map = multi_vrf_data.get("convergence_mapping", {})
                     multi_vrf_config = multi_vrf_data.get("converged_peers", {})
-                    net.add_bp_port_with_vlans_to_docker(vlan_data, vrf_map, multi_vrf_config)
+                    net.add_bp_port_with_vlans_to_docker(
+                        vlan_data, vrf_map, multi_vrf_config,
+                        ptf_bp_ip_addr=ptf_bp_ip_addr,
+                        ptf_bp_ipv6_addr=ptf_bp_ipv6_addr,
+                    )
                 else:
                     net.add_bp_port_to_docker(ptf_bp_ip_addr, ptf_bp_ipv6_addr)
 

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -257,6 +257,21 @@
     topo_is_multi_vrf: False
   when: topo_is_multi_vrf is not defined
 
+# Honor the converger-provided front-panel count for EVERY vm_set action, not
+# just 'start'. A converged (multi-VRF) cEOS prime hosts many merged sub-peers,
+# so the converger surfaces the required fp count as max_fp_num_provided at the
+# topo root. The 'add_topo' action creates the br-<vm>-N OVS bridges
+# (add_ceos_list.yml "Create VMs network") and then binds them; without this
+# override max_fp_num stays at the default 4, only 4 bridges are created, and
+# the subsequent bind fails with "Too many vlans. Maximum is 4". start.yml has
+# its own copy for the 'start' action; doing it here covers add_topo /
+# connect_vms / renumber too. Gated on max_fp_num_provided so stock and
+# non-converged topologies are byte-identical.
+- name: Pick provided max num of fp
+  set_fact:
+    max_fp_num: "{{ max_fp_num_provided }}"
+  when: max_fp_num_provided is defined
+
 - name: Check VM type
   fail:
     msg: "Cannot support this VM type {{ vm_type }}"

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -216,6 +216,18 @@ function converge_topo_if_needed
     backup_file="${topo_file}".bak
 
     if [[ "$use_converged_peers" == "True" ]]; then
+        # The converged (multi-VRF) peer model is implemented for cEOS
+        # neighbors only: a single cEOS VM hosts every merged sub-peer as a VRF,
+        # and only the cEOS startup-config templates render that VRF config.
+        # SONiC-VS / cisco / csonic neighbors have no converged render path, so
+        # reshaping the topology for them produces a DUT minigraph whose BGP
+        # neighbors the unconverged VS peers can't answer ("Not all bgp sessions
+        # established"). Gate on vm_type so non-cEOS deployments of a
+        # converged-enabled testbed behave exactly as they did historically.
+        if [[ "$vm_type" != "ceos" ]]; then
+            echo "use_converged_peers is true but vm_type='$vm_type' is not ceos; skipping converge (converged peer model is cEOS-only)."
+            return
+        fi
         echo "use_converged_peers is true, converging topo..."
 
         if [[ -f "$backup_file" ]];then

--- a/ansible/vtestbed.yaml
+++ b/ansible/vtestbed.yaml
@@ -13,6 +13,7 @@
     - vlab-01
   inv_name: veos_vtb
   auto_recover: 'False'
+  use_converged_peers: True
   comment: Tests virtual switch vm
 
 - conf-name: vms-kvm-t0-csonic
@@ -27,6 +28,7 @@
   dut:
     - vlab-01
   inv_name: veos_vtb
+  use_converged_peers: True
   auto_recover: 'False'
   comment: Tests cSONiC virtual switch VMs without PortChannels
 
@@ -58,6 +60,7 @@
     - vlab-02
   inv_name: veos_vtb
   auto_recover: 'False'
+  use_converged_peers: True
   comment: Tests virtual switch vm
 
 - conf-name: vms-kvm-t1-lag
@@ -73,6 +76,7 @@
     - vlab-03
   inv_name: veos_vtb
   auto_recover: 'False'
+  use_converged_peers: True
   comment: Tests virtual switch vm
 
 - conf-name: vms-kvm-t0-2
@@ -104,6 +108,7 @@
     - vlab-06
   inv_name: veos_vtb
   auto_recover: 'False'
+  use_converged_peers: True
   comment: Dual-TOR testbed
 
 - conf-name: vms-kvm-multi-asic-t1-lag
@@ -134,6 +139,7 @@
     - vlab-08
   inv_name: veos_vtb
   auto_recover: 'False'
+  use_converged_peers: True
   comment: Tests multi-asic virtual switch vm
 
 - conf-name: vms-kvm-t2
@@ -151,6 +157,7 @@
     - vlab-t2-1-sup
   inv_name: veos_vtb
   auto_recover: 'False'
+  use_converged_peers: True
   comment: T2 Virtual chassis with Multi-ASIC LCs
 
 - conf-name: vms-kvm-t0-3
@@ -350,6 +357,7 @@
     - vlab-01
   inv_name: veos_vtb
   auto_recover: False
+  use_converged_peers: True
   comment: Tests virtual switch vm as DPU
 
 - conf-name: vms-kvm-t1
@@ -524,6 +532,7 @@
     - vlab-vpp-01
   inv_name: veos_vtb
   auto_recover: 'False'
+  use_converged_peers: True
   comment: Tests virtual vpp switch vm
 
 - conf-name: vms-kvm-vpp-t1
@@ -554,6 +563,7 @@
     - vlab-vpp-02
   inv_name: veos_vtb
   auto_recover: 'False'
+  use_converged_peers: True
   comment: Tests virtual vpp switch vm
 
 - conf-name: vms-kvm-dual-vpp-t0-1

--- a/ansible/vtestbed.yaml
+++ b/ansible/vtestbed.yaml
@@ -28,7 +28,10 @@
   dut:
     - vlab-01
   inv_name: veos_vtb
-  use_converged_peers: True
+  # TODO(converged-peers): csonic neighbors are non-cEOS, so the converged
+  # (multi-VRF) peer model is gated off in conftest.py / testbed-cli.sh and
+  # never runs here. Re-enable once converged peers support csonic.
+  # use_converged_peers: True
   auto_recover: 'False'
   comment: Tests cSONiC virtual switch VMs without PortChannels
 
@@ -548,6 +551,7 @@
     - vlab-vpp-01
   inv_name: veos_vtb
   auto_recover: 'False'
+  use_converged_peers: True
   comment: Tests virtual vpp switch vm
 
 - conf-name: vms-kvm-vpp-t0
@@ -580,6 +584,7 @@
     - vlab-vpp-04
   inv_name: veos_vtb
   auto_recover: 'False'
+  use_converged_peers: True
   comment: Dual-TOR VPP testbed
 
 - conf-name: vms-kvm-dual-vpp-t0-2
@@ -597,4 +602,5 @@
     - vlab-vpp-06
   inv_name: veos_vtb
   auto_recover: 'False'
+  use_converged_peers: True
   comment: Active-Active Dual-TOR VPP testbed

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -21,6 +21,7 @@ from tests.common.helpers.parallel import parallel_run
 from tests.common.utilities import wait_until
 from tests.common.utilities import is_ipv6_only_topology
 from tests.common.utilities import testbed_is_multi_vrf
+from tests.common.utilities import get_neighbor_exabgp_vm_offset
 from tests.bgp.traffic_checker import get_traffic_shift_state
 from tests.bgp.constants import TS_NORMAL
 from tests.common.devices.eos import EosHost
@@ -303,7 +304,13 @@ def bgp_allow_list_setup(tbinfo, nbrhosts, duthosts, rand_one_dut_hostname):
     if upstream_neighbors:
         other_neighbors += upstream_neighbors[0:2]
 
-    downstream_offset = tbinfo['topo']['properties']['topology']['VMs'][downstream]['vm_offset']
+    # On converged (multi-VRF) topologies ``VMs[downstream]['vm_offset']`` is the
+    # collapsed *prime* offset, which maps to a different neighbor's exabgp
+    # instance. The per-neighbor exabgp instances are keyed by the ORIGINAL
+    # offset, so use that (via get_neighbor_exabgp_vm_offset) to post the
+    # announce to the intended downstream's exabgp. On stock topologies this
+    # returns the neighbor's own vm_offset, so behavior is unchanged.
+    downstream_offset = get_neighbor_exabgp_vm_offset(nbrhosts, tbinfo, downstream)
     downstream_exabgp_port = EXABGP_BASE_PORT + downstream_offset
     downstream_exabgp_port_v6 = EXABGP_BASE_PORT_V6 + downstream_offset
 

--- a/tests/bgp/test_bgp_bbr.py
+++ b/tests/bgp/test_bgp_bbr.py
@@ -19,6 +19,7 @@ from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.helpers.parallel import reset_ansible_local_tmp
 from tests.common.helpers.parallel import parallel_run
 from tests.common.utilities import wait_until, delete_running_config
+from tests.common.utilities import get_neighbor_exabgp_vm_offset
 from tests.common.gu_utils import apply_patch, expect_op_success
 from tests.common.gu_utils import generate_tmpfile, delete_tmpfile
 from tests.common.gu_utils import format_json_patch_for_multiasic
@@ -179,7 +180,7 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo, nbrhosts):
             other_vms.append(neigh['name'])
 
     # Announce route to one of the T0 VM
-    tor1_offset = tbinfo['topo']['properties']['topology']['VMs'][tor1]['vm_offset']
+    tor1_offset = get_neighbor_exabgp_vm_offset(nbrhosts, tbinfo, tor1)
     tor1_exabgp_port = EXABGP_BASE_PORT + tor1_offset
     tor1_exabgp_port_v6 = EXABGP_BASE_PORT_V6 + tor1_offset
 

--- a/tests/bgp/test_bgp_multipath_relax.py
+++ b/tests/bgp/test_bgp_multipath_relax.py
@@ -22,7 +22,14 @@ def get_t0_neigh(tbinfo, topo_config):
     get all t0 router names which has vips defined
     """
     dut_t0_neigh = []
-    for vm in list(tbinfo['topo']['properties']['topology']['VMs'].keys()):
+    # Enumerate from the topology ``configuration`` (which lists every logical
+    # neighbor) rather than ``topology.VMs``. On converged (multi-VRF) topologies
+    # ``topology.VMs`` only contains the collapsed prime devices (one per role),
+    # so merged sub-peers (e.g. ARISTA03T0) that also advertise the vips prefix
+    # are absent there, leaving fewer than 2 multipath sources. The per-neighbor
+    # ``configuration`` is preserved intact by the converger, so it carries every
+    # logical T0 and its ``vips`` on both stock and converged topologies.
+    for vm in list(topo_config.keys()):
         if 'T0' in vm:
             if 'vips' in topo_config[vm]:
                 dut_t0_neigh.append(vm)

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -22,6 +22,120 @@ FEC_MAP = {
 }
 
 
+_INTF_TOKEN_RE = re.compile(r'(?<=\binterface\s)(\S+)|(?<=\binterfaces\s)(\S+)')
+
+
+def _apply_intf_map(value, intf_map):
+    """Translate interface tokens via ``intf_map`` (converged-peer aware).
+
+    On converged (multi-VRF) topologies a single cEOS VM hosts every logical
+    neighbor and the per-logical-neighbor interface name (e.g. ``Ethernet1``
+    from minigraph) maps to a different physical interface on the shared VM
+    (e.g. ``Ethernet4``). ``ceos_topo_converger`` records that mapping in
+    ``intf_map`` (``{logical: converged}``).
+
+    This rewrites ``interface <name>`` / ``interfaces <name>`` tokens inside
+    ``value`` (string, dict with ``command`` key, or list of either) so test
+    code can keep using the per-logical name from minigraph.  Returns ``value``
+    untouched when ``intf_map`` is empty (stock topology) so behavior is
+    byte-identical there.
+    """
+    if not intf_map or value is None:
+        return value
+
+    def _sub(match):
+        name = match.group(1) or match.group(2)
+        return intf_map.get(name, name)
+
+    def _rewrite_one(item):
+        if isinstance(item, str):
+            return _INTF_TOKEN_RE.sub(_sub, item)
+        if isinstance(item, dict) and isinstance(item.get('command'), str):
+            new_item = dict(item)
+            new_item['command'] = _INTF_TOKEN_RE.sub(_sub, item['command'])
+            return new_item
+        return item
+
+    if isinstance(value, list):
+        return [_rewrite_one(item) for item in value]
+    return _rewrite_one(value)
+
+
+def _vrf_scope_bgp_parents(parents, vrf, prime_asn):
+    """Rewrite ``router bgp <asn>`` config parents to be VRF-scoped.
+
+    On converged (multi-VRF) topologies a single cEOS VM hosts every logical
+    neighbor as a VRF under one global ``router bgp <prime_asn>`` process.
+    Legacy test code targets ``router bgp <asn>`` in the default VRF, which on
+    such a VM lands in the wrong place. This rewrites those parents to
+    ``router bgp <prime_asn>`` / ``vrf <vrf>`` so existing test code works
+    unchanged.
+
+    Returns ``parents`` untouched when no VRF scoping applies (vrf unset, no
+    ``router bgp`` parent, or the parents are already VRF-scoped).
+    """
+    if not vrf or parents is None:
+        return parents
+    as_list = parents if isinstance(parents, list) else [parents]
+    if any(str(p).strip().startswith('vrf ') for p in as_list):
+        return parents
+    rewritten = []
+    changed = False
+    for parent in as_list:
+        if str(parent).strip().startswith('router bgp'):
+            rewritten.append('router bgp {}'.format(prime_asn))
+            rewritten.append('vrf {}'.format(vrf))
+            changed = True
+        else:
+            rewritten.append(parent)
+    return rewritten if changed else parents
+
+
+_BASH_PREFIX_RE = re.compile(r'^(\s*)bash\s+')
+_BASH_ALREADY_SCOPED_RE = re.compile(r'^\s*bash\s+(?:sudo\s+)?ip\s+netns\s+exec\b')
+
+
+def _vrf_scope_bash_commands(commands, vrf):
+    """Wrap ``bash <cmd>`` invocations with ``sudo ip netns exec ns-<vrf>``.
+
+    On converged (multi-VRF) cEOS hosts BGP/data-plane routes live in the
+    per-VRF Linux network namespace ``ns-<vrf>`` (Arista's standard mapping
+    between EOS VRFs and Linux namespaces). A plain ``bash <cmd>`` invocation
+    via the EOS CLI runs in the *default* namespace which on converged has
+    no route to DUT data-plane IPs, so any network tool (snmpget, ping,
+    curl, traceroute, ...) fails with "Network is unreachable".
+
+    This rewrites ``bash <cmd>`` into
+    ``bash sudo ip netns exec ns-<vrf> <cmd>`` so the tool runs in the VRF
+    that carries the BGP-learned routes to the DUT. Native EOS CLI commands
+    (no ``bash`` prefix) and already-namespaced commands are left untouched.
+    Returns ``commands`` unchanged when no VRF is set (stock topology).
+    """
+    if not vrf or commands is None:
+        return commands
+    scope_prefix = 'bash sudo ip netns exec ns-{} '.format(vrf)
+
+    def _rewrite_text(text):
+        if not _BASH_PREFIX_RE.match(text):
+            return text
+        if _BASH_ALREADY_SCOPED_RE.match(text):
+            return text
+        return _BASH_PREFIX_RE.sub(scope_prefix, text, count=1)
+
+    def _rewrite_one(item):
+        if isinstance(item, str):
+            return _rewrite_text(item)
+        if isinstance(item, dict) and isinstance(item.get('command'), str):
+            new_item = dict(item)
+            new_item['command'] = _rewrite_text(item['command'])
+            return new_item
+        return item
+
+    if isinstance(commands, list):
+        return [_rewrite_one(c) for c in commands]
+    return _rewrite_one(commands)
+
+
 class EosHost(AnsibleHostBase):
     """
     @summary: Class for Eos switch
@@ -47,6 +161,17 @@ class EosHost(AnsibleHostBase):
         self.shell_user = shell_user
         self.shell_passwd = shell_passwd
         self.is_multi_asic = False
+        # VRF scoping for converged (multi-VRF) topologies. When set, BGP config
+        # parents are transparently rewritten to be VRF-scoped in eos_config().
+        # Left as None on stock topologies so behavior is byte-identical.
+        self.bgp_vrf = None
+        self.bgp_prime_asn = None
+        # Interface-name translation for converged topologies. When set, any
+        # ``interface <name>`` / ``interfaces <name>`` token in eos_config()
+        # parents/lines and eos_command() commands is translated through this
+        # ``{logical: converged}`` map so tests can keep using the per-logical
+        # name reported by minigraph. Left as None on stock topologies.
+        self.intf_map = None
         AnsibleHostBase.__init__(self, ansible_adhoc, hostname)
         self.localhost = ansible_adhoc(inventory='localhost', connection='local',
                                        host_pattern="localhost")["localhost"]
@@ -82,6 +207,48 @@ class EosHost(AnsibleHostBase):
 
     def __repr__(self):
         return self.__str__()
+
+    def eos_config(self, *args, **kwargs):
+        """VRF-aware wrapper around the ``eos_config`` Ansible module.
+
+        All EosHost config writes (config(), shutdown(), no_shutdown_bgp(),
+        and direct test calls) funnel through here. On converged topologies
+        BGP config parents are transparently VRF-scoped and per-logical
+        interface names are translated to the converged VM's actual interface
+        names; on stock topologies the call is passed through unchanged.
+        """
+        if self.intf_map:
+            for key in ('parents', 'lines'):
+                if key in kwargs:
+                    kwargs[key] = _apply_intf_map(kwargs[key], self.intf_map)
+        if 'parents' in kwargs:
+            kwargs['parents'] = _vrf_scope_bgp_parents(
+                kwargs['parents'], self.bgp_vrf, self.bgp_prime_asn)
+        ansible_eos_config = self.__getattr__('eos_config')
+        return ansible_eos_config(*args, **kwargs)
+
+    def eos_command(self, *args, **kwargs):
+        """Converged-peer-aware wrapper around the ``eos_command`` Ansible module.
+
+        On converged topologies two transparent rewrites happen:
+
+        * ``interface <name>`` / ``interfaces <name>`` tokens in ``commands``
+          are translated through ``intf_map`` so tests can keep using the
+          per-logical-neighbor name from minigraph.
+        * ``bash <cmd>`` invocations are wrapped with
+          ``bash sudo ip netns exec ns-<bgp_vrf> <cmd>`` so network tools
+          (snmpget, ping, ...) execute in the VRF that holds the BGP routes
+          to the DUT instead of the route-less default namespace.
+
+        On stock topologies the call is passed through unchanged.
+        """
+        if self.intf_map and 'commands' in kwargs:
+            kwargs['commands'] = _apply_intf_map(kwargs['commands'], self.intf_map)
+        if self.bgp_vrf and 'commands' in kwargs:
+            kwargs['commands'] = _vrf_scope_bash_commands(
+                kwargs['commands'], self.bgp_vrf)
+        ansible_eos_command = self.__getattr__('eos_command')
+        return ansible_eos_command(*args, **kwargs)
 
     @retry(RunAnsibleModuleFail, tries=3, delay=5)
     def shutdown(self, interface_name):

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -492,12 +492,38 @@ class EosHost(AnsibleHostBase):
     def get_route(self, prefix, vrf=None):
         cmd = 'show ip bgp' if ipaddress.ip_network(prefix.encode().decode()).version == 4 else 'show ipv6 bgp'
         cmd = '{} {}'.format(cmd, prefix)
-        if vrf:
-            cmd = '{} vrf {}'.format(cmd, vrf)
-        return self.eos_command(commands=[{
+        # In converged (multi-VRF) mode, routes for this logical neighbor
+        # live under the per-neighbor VRF on the prime EOS peer (``self.bgp_vrf``).
+        # When the caller passes no explicit ``vrf=``, auto-scope to
+        # ``self.bgp_vrf`` and surface the returned ``vrfs/<bgp_vrf>`` entry
+        # under ``vrfs/default`` so existing readers that hardcode 'default'
+        # (e.g. tests/bgp/test_bgp_bbr.py, tests/filterleaf/filterleaf_helpers.py,
+        # tests/vlan/test_vlan_ports_down.py) keep working. We alias rather
+        # than rename so the original VRF key is still present for any caller
+        # that iterates ``vrfs.keys()``. Callers that pass an explicit
+        # ``vrf=`` (e.g. tests/bgp/bgp_helpers.py) get the response unmodified.
+        # On stock topologies ``self.bgp_vrf`` is None and behavior is
+        # byte-identical.
+        effective_vrf = vrf
+        alias_as_default = False
+        if effective_vrf is None and self.bgp_vrf:
+            effective_vrf = self.bgp_vrf
+            alias_as_default = True
+        if effective_vrf:
+            cmd = '{} vrf {}'.format(cmd, effective_vrf)
+        out = self.eos_command(commands=[{
             'command': cmd,
             'output': 'json'
         }])['stdout'][0]
+        if alias_as_default and isinstance(out, dict) and isinstance(out.get('vrfs'), dict):
+            vrfs = out['vrfs']
+            if effective_vrf in vrfs:
+                # Overwrite any existing 'default' entry: in converged mode the
+                # actual default VRF on the prime carries the backplane
+                # config, not this logical neighbor's routes, so legacy callers
+                # expect the per-neighbor view here.
+                vrfs['default'] = vrfs[effective_vrf]
+        return out
 
     def run_command_json(self, cmd):
         return self.eos_command(commands=[{

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -136,6 +136,112 @@ def _vrf_scope_bash_commands(commands, vrf):
     return _rewrite_one(commands)
 
 
+_SHOW_BGP_RE = re.compile(r'^\s*show\s+(?:ip|ipv6)\s+bgp\b', re.IGNORECASE)
+
+
+def _vrf_scope_eos_reads(commands, vrf):
+    """VRF-scope raw ``show ip|ipv6 bgp`` reads on converged hosts.
+
+    Tests that read the BGP table with a plain
+    ``run_command('show ip bgp ...')`` hit the prime's *default* VRF, which on
+    a converged peer carries only the backplane -- the logical neighbor's
+    learned/advertised routes live under its per-neighbor VRF (same rationale
+    as ``get_route``). This injects ``vrf <vrf>`` into such reads, before any
+    ``| <filter>`` pipe where EOS requires it (``show ip bgp ... vrf X`` is
+    valid, ``show ip bgp vrf X ...`` is not).
+
+    Only plain string commands are rewritten; the structured ``dict`` commands
+    built by ``get_route``/``run_command_json`` are left untouched (``get_route``
+    already scopes its own VRF). Commands that already carry an explicit
+    ``vrf`` token, and non ``show ... bgp`` commands (e.g.
+    ``show run | grep 'router bgp'``), are left untouched. Returns ``commands``
+    unchanged when no VRF is set so stock topologies are byte-identical.
+    """
+    if not vrf or commands is None:
+        return commands
+
+    def _rewrite_text(text):
+        if not _SHOW_BGP_RE.match(text):
+            return text
+        if re.search(r'\bvrf\b', text, re.IGNORECASE):
+            return text
+        if '|' in text:
+            head, _, tail = text.partition('|')
+            return '{} vrf {} |{}'.format(head.rstrip(), vrf, tail)
+        return '{} vrf {}'.format(text.rstrip(), vrf)
+
+    def _rewrite_one(item):
+        if isinstance(item, str):
+            return _rewrite_text(item)
+        return item
+
+    if isinstance(commands, list):
+        return [_rewrite_one(c) for c in commands]
+    return _rewrite_one(commands)
+
+
+# Loopback IDs created ad-hoc by tests via the lowercase
+# ``interface loopback <N>`` idiom collide with the converged prime's per-VRF
+# ``Loopback<N>`` interfaces (each merged sub-peer owns a small-numbered
+# Loopback for its router-id). EOS interface names are global, so a test
+# creating ``loopback 10`` would otherwise steal ``Loopback10`` from another
+# VRF. On converged hosts we shift the test's loopback id by this offset into
+# an unused range (well above the per-VRF loopback space, which is bounded by
+# the cEOS interface limit) and place it in the neighbor's VRF. Validated on
+# the cEOS lab image (``Loopback1010`` accepted).
+_CONVERGED_TEST_LOOPBACK_OFFSET = 1000
+
+_ROUTER_BGP_RE = re.compile(r'^\s*router\s+bgp\s+\d+', re.IGNORECASE)
+# Match only the lowercase ad-hoc idiom (``interface loopback <N>``); the
+# converged prime's real interfaces render as capitalized ``Loopback<N>`` and
+# must not be renumbered.
+_TEST_LOOPBACK_RE = re.compile(r'^(\s*)interface\s+loopback\s+(\d+)\s*$')
+
+
+def _vrf_scope_eos_config(commands, vrf, prime_asn):
+    """VRF-scope ad-hoc BGP/loopback config pushed via ``run_command_list``.
+
+    Some tests push config by feeding ``eos_command`` a ``configure``-prefixed
+    list of native CLI lines (instead of ``eos_config``). On converged hosts
+    that config must be VRF-scoped exactly like ``eos_config`` does:
+
+    * ``router bgp <asn>`` -> ``router bgp <prime_asn>`` followed by
+      ``vrf <vrf>`` so the nested ``address-family``/``network`` statements
+      land in the neighbor's VRF rather than the prime's default process.
+    * ``interface loopback <N>`` -> a collision-free
+      ``Loopback<N + offset>`` (see ``_CONVERGED_TEST_LOOPBACK_OFFSET``)
+      followed by ``vrf <vrf>``, so the connected host route used to source an
+      advertised ``network`` exists in the right VRF instead of clobbering a
+      sub-peer's Loopback.
+
+    Returns ``commands`` unchanged when no VRF is set, the input is not a list,
+    or nothing matches -- so stock topologies and ordinary command lists are
+    byte-identical.
+    """
+    if not vrf or not isinstance(commands, list):
+        return commands
+    if not any(isinstance(c, str)
+               and (_ROUTER_BGP_RE.match(c) or _TEST_LOOPBACK_RE.match(c))
+               for c in commands):
+        return commands
+    rewritten = []
+    for cmd in commands:
+        if isinstance(cmd, str):
+            loopback_match = _TEST_LOOPBACK_RE.match(cmd)
+            if loopback_match:
+                indent, num = loopback_match.group(1), int(loopback_match.group(2))
+                rewritten.append('{}interface Loopback{}'.format(
+                    indent, num + _CONVERGED_TEST_LOOPBACK_OFFSET))
+                rewritten.append('vrf {}'.format(vrf))
+                continue
+            if _ROUTER_BGP_RE.match(cmd) and prime_asn:
+                rewritten.append('router bgp {}'.format(prime_asn))
+                rewritten.append('vrf {}'.format(vrf))
+                continue
+        rewritten.append(cmd)
+    return rewritten
+
+
 class EosHost(AnsibleHostBase):
     """
     @summary: Class for Eos switch
@@ -230,7 +336,7 @@ class EosHost(AnsibleHostBase):
     def eos_command(self, *args, **kwargs):
         """Converged-peer-aware wrapper around the ``eos_command`` Ansible module.
 
-        On converged topologies two transparent rewrites happen:
+        On converged topologies these transparent rewrites happen:
 
         * ``interface <name>`` / ``interfaces <name>`` tokens in ``commands``
           are translated through ``intf_map`` so tests can keep using the
@@ -239,6 +345,12 @@ class EosHost(AnsibleHostBase):
           ``bash sudo ip netns exec ns-<bgp_vrf> <cmd>`` so network tools
           (snmpget, ping, ...) execute in the VRF that holds the BGP routes
           to the DUT instead of the route-less default namespace.
+        * raw ``show ip|ipv6 bgp ...`` reads are VRF-scoped (``vrf <bgp_vrf>``
+          injected before any ``| <filter>`` pipe) so they read the logical
+          neighbor's routes instead of the prime's default VRF.
+        * ad-hoc ``router bgp``/``interface loopback`` config lines pushed
+          through ``run_command_list`` are VRF-scoped and de-collided the same
+          way ``eos_config`` scopes BGP config (see ``_vrf_scope_eos_config``).
 
         On stock topologies the call is passed through unchanged.
         """
@@ -247,6 +359,10 @@ class EosHost(AnsibleHostBase):
         if self.bgp_vrf and 'commands' in kwargs:
             kwargs['commands'] = _vrf_scope_bash_commands(
                 kwargs['commands'], self.bgp_vrf)
+            kwargs['commands'] = _vrf_scope_eos_reads(
+                kwargs['commands'], self.bgp_vrf)
+            kwargs['commands'] = _vrf_scope_eos_config(
+                kwargs['commands'], self.bgp_vrf, self.bgp_prime_asn)
         ansible_eos_command = self.__getattr__('eos_command')
         return ansible_eos_command(*args, **kwargs)
 

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1787,3 +1787,25 @@ def testbed_is_multi_vrf(tbinfo):
     if val:
         return str(val).lower() == 'true'
     return False
+
+
+def get_neighbor_exabgp_vm_offset(nbrhosts, tbinfo, neighbor_name):
+    """Return the vm_offset used to derive a neighbor's exabgp API port.
+
+    The per-neighbor exabgp instances are created from the ORIGINAL topology
+    offsets. On a converged (multi-VRF) topology those original offsets are
+    preserved per logical neighbor in ``multi_vrf_data['vm_offset_mapping']``
+    (sourced from ``convergence_data['vm_offset_mapping']``), while
+    ``tbinfo['topo']['properties']['topology']['VMs']`` only carries the
+    collapsed *prime* offsets. Route-injection helpers that compute
+    ``EXABGP_BASE_PORT + offset`` must therefore use the per-neighbor original
+    offset, otherwise they post the announce to the wrong exabgp instance (a
+    different VRF) and the route never reaches the intended neighbor.
+
+    On stock topologies the neighbor is its own VM and this simply returns the
+    VM's ``vm_offset``, so behavior is unchanged there.
+    """
+    neighbor = nbrhosts.get(neighbor_name, {})
+    if neighbor.get('is_multi_vrf_peer', False):
+        return neighbor['multi_vrf_data']['vm_offset_mapping']
+    return tbinfo['topo']['properties']['topology']['VMs'][neighbor_name]['vm_offset']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -465,6 +465,22 @@ def converge_topo_if_needed(config):
         if not use_converged_peers:
             logger.info(f"use_converged_peers=False for testbed '{tbname}', skipping converge")
             return
+
+        # The converged (multi-VRF) peer model is implemented for cEOS neighbors
+        # only (see ansible/testbed-cli.sh::converge_topo_if_needed and the
+        # cEOS startup-config templates). For SONiC-VS / cisco / csonic
+        # neighbors there is no converged render path, so reshaping the in-memory
+        # topology here would make tbinfo disagree with the actually-deployed
+        # (unconverged) testbed. Gate on neighbor_type so non-cEOS runs keep the
+        # historical, byte-identical behavior.
+        neighbor_type = config.getoption("--neighbor_type")
+        if neighbor_type not in ("eos", "ceos"):
+            logger.info(
+                f"use_converged_peers=True for testbed '{tbname}' but neighbor_type="
+                f"'{neighbor_type}' is not cEOS; skipping converge (converged peer "
+                f"model is cEOS-only)")
+            return
+
         logger.info(f"use_converged_peers=True for testbed '{tbname}', starting converge...")
 
         topo_name = tb_config.get('topo', '').strip()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1112,6 +1112,10 @@ def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request):
                     'multi_vrf_data': multi_vrf_data if multi_vrf_peer else None,
                 }
             )
+            if multi_vrf_peer:
+                device['host'].bgp_vrf = multi_vrf_data['vrf']
+                device['host'].bgp_prime_asn = multi_vrf_data['primary_host_asn']
+                device['host'].intf_map = multi_vrf_data['orig_intf_map']
         elif neighbor_type == "csonic":
             # cSONiC neighbors are docker-sonic-vs containers accessed via
             # "docker exec" (CsonicHost), not over SSH. Handle them before the

--- a/tests/vxlan/test_vxlan_route_advertisement.py
+++ b/tests/vxlan/test_vxlan_route_advertisement.py
@@ -300,7 +300,7 @@ class Test_VxLAN_route_Advertisement():
             result = t2device['host'].run_command(cmd)
             while len(result['stdout'][0]) == 0 and retry_count > 0:
                 time.sleep(10)
-                result = self.vxlan_test_setup['t2']['host'].run_command(cmd)
+                result = t2device['host'].run_command(cmd)
                 retry_count = retry_count - 1
             if len(result['stdout'][0]) == 0:
                 py_assert(False, "Routes not propogated to the T2.")


### PR DESCRIPTION
### Description of PR

Enable the converged (multi-VRF) cEOS peer model across the virtual testbeds and add the framework changes needed so existing tests pass on every converged topology — one solution that fits all cEOS topologies, almost entirely without per-test-case edits (the framework adapts transparently; the only test touches are a single shared-helper call and one fix for a pre-existing bug).

In converged mode a single cEOS VM hosts every logical neighbor as a VRF under one BGP process, and each logical neighbor's interface is renamed on the shared VM. This breaks several assumptions baked into the framework: (1) EOS config writes target `router bgp <asn>` in the default VRF; (2) tests reference per-logical interface names from minigraph; (3) the legacy untagged backplane reachability (PTF `bp` ↔ cEOS ↔ DUT) is split into per-VRF VLAN sub-interfaces; (4) `bash <cmd>` invocations on the cEOS run in the default Linux netns, while all data routes live in per-VRF `ns-<vrf>` namespaces; and (5) tests that *read* the BGP table or push *ad-hoc* CLI assume the default VRF and global interface names.

### Type of change

- [x] Testbed and Framework (improvement)

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach

#### Problem

1. `EosHost.eos_config()` calls land in the default VRF on converged VMs → BGP config writes (`shutdown`, `no_shutdown_bgp`, neighbor tweaks) silently miss.
2. `EosHost.eos_command()` / `eos_config()` calls reference per-logical interface names (e.g. `Ethernet1`) that don't exist on the shared converged VM.
3. PTF backplane interface has no IP on the parent device in converged mode, so untagged backplane traffic (used by e.g. BGP monitor / link-flap tests) has no return path.
4. `ceos_topo_converger` dropped `disabled_host_interfaces` from the converged topo, turning previously-admin-down ports into active ports and breaking buffer/QoS deployment.
5. `bash <cmd>` invocations on the cEOS (e.g. `snmp/test_snmp_loopback.py`) run in the route-less default Linux netns on converged, so they must be re-scoped into the per-VRF `ns-<vrf>` namespace that carries the route to the DUT.
6. **Several per-role startup-config templates never grew a converged branch** (`t0-64-32-leaf`, `t2-leaf`, `t2-core`, `dpu-tor`, `t1-8-lag-spine`, `t1-8-lag-tor`). On a converged topology they rendered only the prime's own config and silently dropped every merged sub-peer's interface IP and BGP neighbor — so the DUT's sessions to those sub-peers never established (pre-test BGP sanity failed), and the per-VRF Linux namespace `ns-<vrf>` was never created (so the netns-scoped `snmpget` failed with *"Cannot open network namespace"*).
7. **The converger selected one prime per `(role, ASN)`**, which exploded the prime count on real multi-ASN fabrics (e.g. `t1-lag` → 17, `t1-lag-vpp` → 17, `t2` → 49). Each converged cEOS reserves significant memory, so this exhausted testbed RAM and failed `add-topo`.
8. **Convergence also ran for non-cEOS neighbor deployments** (SONiC-VS / cisco / csonic), which have no converged render path. Reshaping the topology there produced a DUT minigraph whose BGP neighbors the unconverged VS peers could not answer → *"Not all bgp sessions are established"*.
9. **`add-topo` failed with *"Too many vlans. Maximum is 4"*** on converged topologies whose prime holds more than 4 front-panel links (`t1-lag`, `t1-lag-vpp`, `t2`). The converger surfaces the required front-panel count as `max_fp_num_provided`, but that override was only applied by the `start` vm_set action — while the cEOS front-panel bridges/veths are created by the `add_topo` action, which kept the default `max_fp_num=4`. Only 4 bridges were created and the subsequent bind failed.
10. **`deploy-mg` failed with *"IndexError: list index out of range"*** in `topo_facts` on multi-linecard `t2` topologies. The converger dropped the topology-level `dut_num`, so minigraph generation defaulted it to 1 and overflowed the per-DUT `interface_indexes` list for sub-peers whose VM vlans carry `dut_index > 0`.
11. **Raw BGP-table reads hit the wrong VRF.** Tests that read the BGP table with a plain `EosHost.run_command('show ip bgp …')` — e.g. `vxlan/test_vxlan_route_advertisement.py`'s scale check (`show ip bgp community <c> | grep …`) — read the prime's *default* VRF on a converged VM, which holds no logical-neighbor routes. The read returned empty, so the route check failed (and a retry path then surfaced a latent crash, see below).
12. **Ad-hoc route advertisement landed in the wrong VRF and clobbered a loopback.** Tests that advertise a network from a neighbor by pushing native CLI via `run_command_list(["interface loopback N", …, "router bgp X", "network …"])` — e.g. `vxlan/test_vnet_bgp_route_precedence.py` — put the `router bgp`/`network` in the default VRF (the DUT never learned the route), and the lowercase `interface loopback N` idiom collided with the prime's real `LoopbackN` (interface names are global on EOS), corrupting another VRF's loopback.
13. **exabgp port math used the wrong VM offset.** The exabgp route-injector port is derived from a neighbor's VM offset; tests such as `bgp/test_bgp_bbr.py` computed it from the *prime's* offset instead of the merged neighbor's *original* offset, so they connected to the wrong exabgp instance.
14. **A latent test bug crashed the scale retry path.** `vxlan/test_vxlan_route_advertisement.py`'s scale retry indexed a list with a string key (`self.vxlan_test_setup['t2']['host']`, where `['t2']` is a list) → `TypeError`. This crashes on **any** topology once the retry branch is reached; converged mode merely made the empty-read retry far more likely.

#### Solution

All framework changes are common-code and gated so non-converged / non-cEOS paths are byte-identical. The only test touches are a single shared-helper call (item 13) and a one-line fix for the pre-existing crash (item 14).

| File | Change | Gate |
|---|---|---|
| `tests/common/devices/eos.py` | Wrap `eos_config()` / `eos_command()` to rewrite `router bgp <asn>` parents into `router bgp <prime_asn>` / `vrf <vrf>`, translate `interface <name>` tokens via `intf_map`, and rewrite `bash <cmd>` into `bash sudo ip netns exec ns-<vrf> <cmd>`. **`eos_command()` also VRF-scopes raw `show ip\|ipv6 bgp` reads (inject `vrf <vrf>` before any `\| grep`, where EOS requires it) and ad-hoc `router bgp` / `interface loopback` config pushed via `run_command_list` — adding `vrf <vrf>` and renaming the throwaway `interface loopback N` to a collision-free `Loopback<N+1000>` in the VRF.** VRF-aware `get_route()`. | `self.bgp_vrf` / `self.intf_map` — both `None` on stock |
| `tests/common/utilities.py` | Add `get_neighbor_exabgp_vm_offset()`: map a converged neighbor back to its **original** VM offset (from `multi_vrf_data`) so exabgp-port math targets the correct instance. | returns the neighbor's unchanged offset on stock |
| `tests/conftest.py` | Populate `bgp_vrf`, `bgp_prime_asn`, `intf_map` on each `EosHost` from `multi_vrf_data` in `nbrhosts`; **only converge the topology when the neighbor type is cEOS** so SONiC-VS / cisco / csonic runs keep historical behavior. | `if multi_vrf_peer:` / `neighbor_type in (eos, ceos)` |
| `ansible/roles/eos/templates/ceos_converged.j2` (**new**) | Single shared converged startup-config, rendered as a pure function of the converger output (`convergence_data`) plus per-peer configuration — independent of base topo / role. | `topo_is_multi_vrf` |
| `ansible/roles/eos/templates/{t0-64-32-leaf, t2-leaf, t2-core, dpu-tor, t1-8-lag-spine, t1-8-lag-tor}.j2` | Include `ceos_converged.j2` when converged; the existing stock body is preserved unchanged in the `{% else %}` branch. | `when: topo_is_multi_vrf` |
| `ansible/ceos_topo_converger.py` | Select **one prime per role** (not per role+ASN). Each merged sub-peer is a VRF with its own `local-as`, so a single prime correctly serves sub-peers with different ASNs and the prime count stays minimal (e.g. `dpu` → 1, `t1-lag`/`t1-lag-vpp`/`t2` → 2). Also preserve `disabled_host_interfaces`; surface the converged front-panel count as `max_fp_num_provided`; and preserve the topology-level `dut_num` / `topo_type` so multi-linecard minigraph generation sizes the per-DUT interface lists correctly (fixes the `deploy-mg` `IndexError`). | n/a — converger only runs in converged mode |
| `ansible/roles/vm_set/tasks/main.yml` | Apply the converger's `max_fp_num_provided` override for **every** vm_set action (not just `start`), so the `add_topo` bridge/veth creation matches the converged front-panel count (fixes the `add-topo` *"Too many vlans"*). | `when: max_fp_num_provided is defined` |
| `ansible/roles/eos/tasks/ceos_config.yml` + `ansible/roles/eos/templates/ceos_bp_compat.j2` (new) | Append a stock-compat backplane shim (untagged VLAN 1 on the trunk, `Vlan1` SVI in the prime VRF carrying the host `bp_interface` IP, advertise that subnet via BGP). | `when: topo_is_multi_vrf and configuration[hostname]['bp_interface'] is defined` |
| `ansible/roles/vm_set/library/vm_topology.py` | Assign the legacy backplane IP (`ptf_bp_ip[v6]_addr`) to the PTF parent backplane in addition to the per-VRF sub-interfaces. | Only the `if is_multi_vrf:` branch of `add_bp_port_with_vlans_to_docker()` |
| `tests/bgp/test_bgp_bbr.py` | One-line change: derive the exabgp port from `get_neighbor_exabgp_vm_offset()` instead of the raw (prime) offset. | helper is a no-op on stock |
| `tests/vxlan/test_vxlan_route_advertisement.py` | One-line fix for the pre-existing crash: the scale retry used `self.vxlan_test_setup['t2']['host']` (indexing a list with a string) → corrected to the `t2device['host']` loop variable. | not converged-specific (genuine bugfix) |
| `ansible/testbed-cli.sh` | **Only converge the topology when deploying with `-k ceos`**; non-cEOS vm types skip convergence. | `if vm_type == ceos` |
| `ansible/vtestbed.yaml` | Enable `use_converged_peers: True` on the virtual testbeds; convergence then applies only to their cEOS deployments via the gates above. | n/a |

#### Verification

Validated on virtual testbeds (cEOS neighbors), confirming the converged render and the gating:

- **`dpu`** — converges to a single prime hosting both ToR VRFs with per-VRF `local-as` (ASN 65200 and 65201). `add-topo` + `deploy-mg` succeed; the DUT establishes **both** BGP sessions and exchanges routes; `bgp/test_bgp_fact.py` passes including the pre-test BGP sanity check that previously failed.
- **`multi-asic` (`t1-8-lag`)** — the shared template now renders the per-VRF config, so the `ns-<vrf>` Linux namespaces are created on the prime (the missing namespace that previously made `snmp/test_snmp_loopback.py` fail with *"Cannot open network namespace"*).
- **`t1-lag` / `t1-lag-vpp` / `t2`** — full `add-topo` → `deploy-mg` → test cycle now succeeds end-to-end on virtual testbeds; `bgp/test_bgp_fact.py` passes with every DUT BGP session established, including the LAG (Port-Channel) neighbors. One-prime-per-role keeps the prime count low (`add-topo` no longer exhausts memory); the `max_fp_num_provided` override now applied at `add_topo` creates the correct number of front-panel bridges (no more *"Too many vlans"*); and preserving `dut_num` lets multi-linecard `t2` minigraph generation succeed (no more `deploy-mg` `IndexError`). On `t1-lag-vpp` the LAGs come up over the VPP dataplane (SONiC `teamd` LACP punted via linux-cp) with no platform-image change required.
- **Per-test triage (cEOS neighbors):**
  - `bgp/test_bgp_bbr.py` (`t1-lag`) — passes; the exabgp-offset helper resolves the port to the merged neighbor's original instance.
  - `vxlan/test_vnet_bgp_route_precedence.py` (`test_vnet_route_after_bgp` + `multi_flap`, `t1-lag-vpp`) — 2 passed; the VRF-scoped `router bgp`/`network` and de-collided loopback let the DUT learn the advertised route.
  - `vxlan/test_vxlan_route_advertisement.py::test_scale_route_advertisement_with_community` (`v4_in_v4`, `v6_in_v4`, `t1-lag-vpp`) — 2 passed. With VRF-scoping, the scale read `show ip bgp community <c> vrf <vrf> | grep` returns the full 4000-route set, where the un-scoped read returned 0.
- **Non-cEOS deployments** (SONiC-VS / cisco / csonic) skip convergence entirely (gated in both `testbed-cli.sh` and `conftest.py`) and remain byte-identical to historical behavior.
- Stock topology paths are unchanged when `topo_is_multi_vrf` / `is_multi_vrf` is false, and when `self.bgp_vrf` is `None` — verified by code inspection of the gating conditions, by unit-exercising the new `eos.py` rewrites (stock inputs pass through unchanged), and by Jinja-parsing every wrapped template.

#### Any platform specific information?

Converged peer model only; cEOS neighbors only. Non-cEOS neighbor types (SONiC-VS / cisco / csonic) are explicitly excluded from convergence at both the deploy (`testbed-cli.sh`) and test (`conftest.py`) layers, so they keep their existing behavior.
