### PR TITLE
[Bug fix] Make localhost ansible_python_interpreter venv-aware (fix yaml ModuleNotFoundError)

### DIFF
--- a/ansible/devutil/devices/factory.py
+++ b/ansible/devutil/devices/factory.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import sys
 import yaml
 
 from .ansible_hosts import AnsibleHost
@@ -15,9 +16,35 @@ _self_dir = os.path.dirname(os.path.abspath(__file__))
 ansible_path = os.path.realpath(os.path.join(_self_dir, "../../"))
 
 
+def _resolve_localhost_python_interpreter():
+    """Return a python interpreter that has the sonic-mgmt dependencies
+    (PyYAML, ansible, etc.) available.
+
+    Historically this was hardcoded to ``/usr/bin/python3``. That assumes the
+    sonic-mgmt docker image installs every dependency into system python,
+    which is no longer true: the new ``docker-sonic-mgmt`` image installs
+    everything into a uv-managed venv at ``/opt/venv`` and leaves
+    ``/usr/bin/python3`` bare. Calling Ansible modules on localhost via the
+    bare system python then fails with
+    ``ModuleNotFoundError: No module named 'yaml'``.
+
+    Resolution order:
+      1. ``LOCALHOST_PYTHON_INTERPRETER`` env override.
+      2. ``sys.executable`` -- the interpreter actually running this code,
+         which by definition has our deps.
+      3. ``/usr/bin/python3`` legacy fallback.
+    """
+    override = os.environ.get("LOCALHOST_PYTHON_INTERPRETER")
+    if override:
+        return override
+    if sys.executable and os.path.exists(sys.executable):
+        return sys.executable
+    return "/usr/bin/python3"
+
+
 def init_localhost(inventories=None, options={}, hostvars={}):
     localhost_hostvars = hostvars.copy()
-    localhost_hostvars["ansible_python_interpreter"] = "/usr/bin/python3"
+    localhost_hostvars["ansible_python_interpreter"] = _resolve_localhost_python_interpreter()
     try:
         return AnsibleHost(inventories, "localhost", options=options.copy(), hostvars=localhost_hostvars.copy())
     except (NoAnsibleHostError, MultipleAnsibleHostsError) as e:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md
-->
### Description of PR

Summary:
Fixes the `ModuleNotFoundError: No module named 'yaml'` failure seen in nightly `PREPARE_TESTBED` runs when the sonic-mgmt container is built from the latest `docker-sonic-mgmt` image (which moves Python dependencies into a uv-managed venv at `/opt/venv`).

`init_localhost()` in `ansible/devutil/devices/factory.py` hardcodes `ansible_python_interpreter = "/usr/bin/python3"` for the localhost connection. On the legacy image this worked because every dependency was installed into system python. On the new image, `/usr/bin/python3` is bare (no `yaml`, no `ansible`), so any Ansible module call on localhost — e.g. `conn_graph_facts` invoked from `.azure-pipelines/upgrade_image.py` — fails immediately.

The fix replaces the hardcoded path with a resolver that prefers `sys.executable` (the interpreter actually running the test code, which by definition has all deps), with an env-var override and the original path as final fallback.

Companion PR: `sonic-net/sonic-buildimage` adds a `.pth` file in the `docker-sonic-mgmt` image so any caller of `/usr/bin/python3` also resolves venv packages.

Fixes # (n/a — internal triage)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Nightly testbed prepare on Cisco-8000 fails 25+ retries because `upgrade_image.py` → `conn_graph_facts` Ansible module on localhost can't import `yaml`. Root cause is a hardcoded interpreter path that doesn't account for the new docker image's venv layout.

#### How did you do it?
Replaced the hardcoded `/usr/bin/python3` with `_resolve_localhost_python_interpreter()` which returns, in order:
1. `$LOCALHOST_PYTHON_INTERPRETER` if set (escape hatch).
2. `sys.executable` — the interpreter currently running the test framework, which by definition has all deps.
3. `/usr/bin/python3` — original legacy fallback.

This works on:
- Legacy images where everything is in system python (`sys.executable` already points there).
- New images where deps live in `/opt/venv` (`sys.executable == /opt/venv/bin/python`).
- Any future relocation — the framework simply follows itself.

DUT hosts are unaffected because `init_localhost` only sets the var on the localhost hostvars dict; DUT inventory groups continue to use their inventory-defined interpreter.

#### How did you verify/test it?
Reproduced inside `docker-sonic-mgmt:latest` on a Beijing lab server:
```
cd /data/sonic-mgmt-int/ansible && python ../.azure-pipelines/upgrade_image.py \
    -i bjw2 -t testbed-bjw2-can-t1-8102-6 \
    -u http://.../sonic-cisco-8000.bin
```
Before: `Module failed: No module named 'yaml'` on `conn_graph_facts`.
After: `conn_graph_facts` succeeds, script proceeds into DUT ping and `reduce_and_add_sonic_images` upgrade flow.

#### Any platform specific information?
None — affects all platforms; just unblocks nightly runs that use the latest `docker-sonic-mgmt` image.

#### Supported testbed topology if it's a new test case?
N/A.

### Documentation
N/A — internal framework fix; no user-facing behaviour change.
