### PR TITLE
chore: xfail gcu/test_apply_patch_perf

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2514,6 +2514,12 @@ generic_config_updater/add_cluster/test_port_speed_change.py:
       - "hwsku not in ['Nokia-IXR7250E-36x400G']"
       - "asic_type in ['vs']"
 
+generic_config_updater/test_apply_patch_perf.py:
+  xfail:
+    reason: "This test has been failing since https://github.com/sonic-net/sonic-buildimage/pull/26584, awaiting feature owner to triage, tracked by https://github.com/sonic-net/sonic-mgmt/issues/24984"
+    conditions:
+      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/24984"
+
 generic_config_updater/test_bgp_prefix.py::test_bgp_prefix_tc1_suite:
   skip:
     reason: "Cisco 8122 backend compute ai platform is not supported. Skip on VS platform due to low success rate."


### PR DESCRIPTION
### Description of PR

Mark `generic_config_updater/test_apply_patch_perf.py` as `xfail` on the `vs` (KVM virtual switch) platform while the performance regression that makes it flaky is triaged by the feature owner.

Summary:
Fixes # (N/A — flaky-test mitigation)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

`test_apply_patch_perf.py` has become flaky on `vs`/KVM PR runs and is failing legitimate PRs that have nothing to do with GCU. Over the last 30 days of KVM PR runs, the whole module passes only **~93.5%** of the time, so roughly **1 in 15** PR runs hits a spurious failure here.

Per-case pass rates (KVM PR, last 30d):

| Test case | Pass rate |
|---|---|
| `test_perf_multi_operation` | 96.7% |
| `test_perf_ntp_server` | 98.2% |
| `test_perf_acl_table_add` | 99.1% |
| `test_perf_port_mtu_replace` | 99.3% |
| `test_perf_acl_port_removal` | 99.7% |
| `test_perf_acl_rules_add` | 99.9% |

The failures are all the timing-budget assertion, e.g.:

```
Failed: Multi-op took 12.4s, budget 12.3s
Failed: Multi-op took 11.5s, budget 11.0s
```

i.e. the measured time only marginally exceeds the computed budget — a classic too-tight-budget flake, not a functional failure.

**Root cause:** the regression coincides with sonic-net/sonic-buildimage#26584 (porting `sonic-yang-mgmt` from the libyang1 to the libyang3 Python bindings). The test derives its budget from a per-run measurement of `SonicYang.loadData()`; libyang3 made `loadData()` faster, which shrank the computed budget. But the multi-operation apply-patch path is not purely libyang-bound, so its wall-clock time did not shrink proportionally — leaving the budget too tight and the assertion intermittently failing. The test code itself has not changed.

#### How did you do it?

Added an `xfail` conditional mark for `generic_config_updater/test_apply_patch_perf.py` scoped to `asic_type in ['vs']` in `tests_mark_conditions.yaml`, with a reason that points at sonic-buildimage#26584 and notes it is awaiting feature-owner triage. This stops the flake from failing unrelated PRs while preserving signal everywhere else (the mark is `xfail`, so an unexpected pass is still reported as `XPASS`).

#### How did you verify/test it?

Validated against historical KVM PR results (last 30 days): confirmed the failure signature is exclusively the `took Xs, budget Ys` timing assertion and that `test_perf_multi_operation` is the dominant contributor. Verified the mark targets only `vs` and does not affect physical platforms.

#### Any platform specific information?

Scoped to `asic_type in ['vs']` (KVM) only. Physical-platform coverage is unaffected.

#### Supported testbed topology if it's a new test case?

N/A — not a new test case.

### Documentation
N/A
