### PR TITLE
Add xfail condition for dash/test_dash_smartswitch_crm.py::TestDashCRM::test_dash_crm_cleanup

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -981,6 +981,12 @@ dash/test_dash_privatelink_redirect.py:
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/16407"
       - "hwsku not in ['Cisco-8102-28FH-DPU-O-T1', 'Mellanox-SN4280-O8C40', 'Mellanox-SN4280-O28', 'Cisco-8102-28FH-DPU-O']"
 
+dash/test_dash_smartswitch_crm.py::TestDashCRM::test_dash_crm_cleanup:
+  xfail:
+    reason: "Skip cleanup test"
+    conditions:
+      - "https://github.com/sonic-net/sonic-buildimage/issues/23590"
+
 dash/test_dash_smartswitch_vnet.py:
   skip:
     conditions_logical_operator: or


### PR DESCRIPTION

### Description of PR
Summary:
Add xfail marker for `test_dash_crm_cleanup` which is blocked by a DASH Route Rule Table deletion bug due to https://github.com/sonic-net/sonic-buildimage/issues/23590


### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
The DASH CRM cleanup test (`test_dash_crm_cleanup`) fails because SAI rejects the DEL operation for `DASH_ROUTE_RULE_TABLE` entries with non-zero priority. Since sonic-net/sonic-swss#3534 removed the internal cache, orchagent relies solely on the key (ENI:VNI:Prefix) to delete SAI objects. However, SAI also requires the priority attribute for deletion, which is not part of the key. This causes the route rule deletion to fail with `SAI_STATUS_OBJECT_IN_USE`, which in turn blocks the deletion of dependent ENI and VNET objects, leaving the CRM resource counters non-zero after cleanup.

#### How did you do it?
Added an `xfail` entry in `tests_mark_conditions.yaml` for `test_dash_crm_cleanup`, referencing the upstream issue sonic-net/sonic-buildimage#23590. The xfail marker will be automatically removed once the upstream fix lands and the issue is closed.

#### How did you verify/test it?
Verified on SN4280 (SmartSwitch) that the test is marked as `xfail` instead of `FAILED`.
#### Any platform specific information?
Platform with DPU
#### Supported testbed topology if it's a new test case?
NA
### Documentation
NA
