### PR TITLE
Fix golden config losing BGP confederation on multi-ASIC T2 devices

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -275,12 +275,17 @@ class GenerateGoldenConfigDBModule(object):
     def overwrite_feature_golden_config_db_multiasic(self, config, feature_key, auto_restart="enabled",
                                                      state="enabled", feature_data=None):
         full_config = json.loads(config)
-        if full_config == {} or "FEATURE" not in full_config.get("localhost", {}):
-            # need dump running config FEATURE + selected feature
-            gold_config_db = self.get_multiasic_feature_config()
-        else:
-            # need existing config + selected feature
-            gold_config_db = full_config
+        if "FEATURE" not in full_config.get("localhost", {}):
+            # Merge running config FEATURE into existing config instead of replacing,
+            # to preserve other tables (e.g. BGP_DEVICE_GLOBAL) already in full_config.
+            feature_config = self.get_multiasic_feature_config()
+            for ns, ns_data in feature_config.items():
+                if ns in full_config:
+                    full_config[ns].update(ns_data)
+                else:
+                    full_config[ns] = ns_data
+
+        gold_config_db = full_config
 
         if feature_data is None:
             feature_data = {


### PR DESCRIPTION
### Description of PR

Fix `overwrite_feature_golden_config_db_multiasic()` replacing entire golden config with only FEATURE tables, causing BGP confederation config to be lost on multi-ASIC T2 devices.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ]  202405
- [ ]  202411
- [ ]  202505
- [x] 202511

### Approach

#### What is the motivation for this PR?

On multi-ASIC T2 devices, `deploy-mg` would lose BGP confederation configuration (`BGP_DEVICE_GLOBAL|CONFED`) because `overwrite_feature_golden_config_db_multiasic()` replaced the entire golden config with only FEATURE tables from running config.

`get_multiasic_feature_config()` fetches running config and filters to keep only FEATURE tables:

```json
// Input: full running config from "show runningconfiguration all"
{
  "localhost": { "FEATURE": {...}, "DEVICE_METADATA": {...}, ... },
  "asic0": { "FEATURE": {...}, "BGP_NEIGHBOR": {...}, ... },
  "asic1": { "FEATURE": {...}, "BGP_NEIGHBOR": {...}, ... }
}

// Output: only FEATURE per namespace
{
  "localhost": {"FEATURE": {...}},
  "asic0": {"FEATURE": {...}},
  "asic1": {"FEATURE": {...}}
}
```

When `generate_ut2_golden_config_db()` produces config containing BGP confederation but no FEATURE in localhost:

```json
{
  "localhost": {"DNS_NAMESERVER": {...}},
  "asic0": {"BGP_DEVICE_GLOBAL": {"CONFED": {"asn": "65100", "peers": "65300"}}},
  "asic1": {"BGP_DEVICE_GLOBAL": {"CONFED": {"asn": "65100", "peers": "65300"}}}
}
```

The old code entered the[ `"FEATURE" not in full_config["localhost"]` ](https://github.com/LinJin23/sonic-mgmt/blame/45dea3bb5c605b4044013c1c85e8619b5002e696/ansible/library/generate_golden_config_db.py#L141)branch and **replaced the entire config** with `get_multiasic_feature_config()` output — discarding `BGP_DEVICE_GLOBAL|CONFED`.

#### How did you do it?

Changed the logic to merge FEATURE tables into the existing config (using `dict.update()`) instead of replacing the entire config when FEATURE is missing from localhost.

After fix, the golden config correctly contains both:

```json
{
  "localhost": {"DNS_NAMESERVER": {...}, "FEATURE": {...}},
  "asic0": {"BGP_DEVICE_GLOBAL": {"CONFED": {"asn": "65100", "peers": "65300"}}, "FEATURE": {...}},
  "asic1": {"BGP_DEVICE_GLOBAL": {"CONFED": {"asn": "65100", "peers": "65300"}}, "FEATURE": {...}}
}
```

#### How did you verify/test it?

Deployed on Arista UT2 DUT. Confirmed BGP confederation preserved after deploy-mg and all 26 BGP sessions established.

#### Any platform specific information?

Affects multi-ASIC T2 platforms using BGP confederation (e.g., Arista-7280DR3AM-36).

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
