### PR TITLE
Use config reload -y -f in ansible/testbed_set_l2_mode.yml to apply new config_db.json

### DIFF
--- a/ansible/testbed_set_l2_mode.yml
+++ b/ansible/testbed_set_l2_mode.yml
@@ -37,8 +37,8 @@
       dest: /etc/sonic/config_db.json
     become: yes
 
-  - name: Execute cli "config reload -y" to apply new config_db.json
-    shell: config reload -y
+  - name: Execute cli "config reload -y -f" to apply new config_db.json
+    shell: config reload -y -f
     become: yes
 
   - name: Wait for switch to become reachable again


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:Use config reload -y -f in ansible/testbed_set_l2_mode.yml to apply new config_db.json
Fixes # (issue) The previous test case will trigger config reload and if missing -f here, the config reload command will report swss not ready error

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
The previous test case will trigger config reload and if missing -f here, the config reload command will report swss not ready error
#### How did you do it?
Add -f option for config reload command
#### How did you verify/test it?
Run the deploy script
#### Any platform specific information?
n/a
#### Supported testbed topology if it's a new test case?
n/a
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
