### PR TITLE
Fix the NTP polling step in deploy-mg playbook

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -1124,6 +1124,11 @@
           - name: Force rapid NTP polling with chrony
             become: true
             command: chronyc burst 4/4
+            register: chrony_burst_result
+            until: chrony_burst_result.rc == 0
+            retries: 3
+            delay: 2
+            changed_when: false
 
           - name: Wait for chrony synchronization (remaining correction < 0.5s)
             become: true


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Immediately running command "chronyc burst 4/4" after chrony.service restart may fail on some old slow platforms(for example 2700-a0). 
Add a retry for the chrony command.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Fix the NTP polling step in deploy-mg playbook
#### How did you do it?
Add a retry for the chrony command "chronyc burst 4/4".
#### How did you verify/test it?
Run the deploy-mg playbook on sn2700-a0 tetsbed. Issue is not observed again.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
