### PR TITLE
[topo] remove duplicated  addresses in topology t0-16

### DIFF
--- a/ansible/vars/topo_t0-16.yml
+++ b/ansible/vars/topo_t0-16.yml
@@ -281,7 +281,7 @@ configuration:
         ipv6: fc00::82/126
     bp_interface:
       ipv4: 10.10.246.33/24
-      ipv6: fc0a::3a/64
+      ipv6: fc0a::4a/64
 
   ARISTA06T1:
     properties:
@@ -303,4 +303,4 @@ configuration:
         ipv6: fc00::86/126
     bp_interface:
       ipv4: 10.10.246.34/24
-      ipv6: fc0a::3d/64
+      ipv6: fc0a::4d/64


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Removed duplication of IPv6 addresses on ARISTA VMs.
`ARISTA01T1:bp_interface:ipv6  == ARISTA05T1:bp_interface:ipv6`
`ARISTA02T1:bp_interface:ipv6  == ARISTA06T1:bp_interface:ipv6`
The duplications lead to unadvertised routes and failures of tests:


**Before fix:**
```
show ipv6 bgp summary

IPv6 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 6411
RIB entries 12811, using 1639808 bytes of memory
Peers 6, using 144432 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
fc00::7a       4  64600       6300       5845      6411      0       0  02:11:55             6400  ARISTA03T1
fc00::7e       4  64600       6301       5844      6411      0       0  02:11:55             6400  ARISTA04T1
fc00::72       4  64600       3105       5845      6411      0       0  02:11:55                1  ARISTA01T1
fc00::76       4  64600       3101       5845      6411      0       0  02:11:55                1  ARISTA02T1
fc00::82       4  64600       6306       5843      6411      0       0  02:11:56             6400  ARISTA05T1
fc00::86       4  64600       6311       5845      6411      0       0  02:11:55             6400  ARISTA06T1
```


**After the fix:**
```
show ipv6 bgp summary

IPv6 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 58792
RIB entries 12811, using 1639808 bytes of memory
Peers 6, using 144432 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
fc00::7a       4  64600       6500       6492     58792      0       0  00:00:47             6400  ARISTA03T1
fc00::7e       4  64600       6496       6491     58792      0       0  00:00:48             6400  ARISTA04T1
fc00::72       4  64600       3295       6493     58792      0       0  00:00:45             6400  ARISTA01T1
fc00::76       4  64600       3304       6491     58792      0       0  00:00:47             6400  ARISTA02T1
fc00::82       4  64600       6497       6493     58792      0       0  00:00:46             6400  ARISTA05T1
fc00::86       4  64600       6500       6492     58792      0       0  00:00:48             6400  ARISTA06T1
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Stable topology


#### How did you do it?
removed duplicated IPv6 addresses

#### How did you verify/test it?
Topology installed on the testbed and verified advertised routes.

