### PR TITLE
Update the topology marker of test_dpu_show_platform_temperature.py

### DIFF
--- a/tests/smartswitch/platform_tests/test_dpu_show_platform_temperature.py
+++ b/tests/smartswitch/platform_tests/test_dpu_show_platform_temperature.py
@@ -5,7 +5,7 @@ from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
 
 
 pytestmark = [
-    pytest.mark.topology('dpu', 'smartswitch')
+    pytest.mark.topology('any')
 ]
 
 # NVIDIA Smartswitch DPU platform


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The topo is not actually relevant for this test, it can run on any topo as long as the duthost is the DPU.
And the smartswitch topo is only for tests that involves both switch and DPU.
The test is running only on Nvidia DPUs due to the skip condition in
[tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml.](https://github.com/sonic-net/sonic-mgmt/blob/b419a6f37b1c38392081b178ddd0d9fe6fd3cf9c/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml#L1588-L1595)
So we can safely change the topo marker to "any".

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Update the topology marker of test_dpu_show_platform_temperature.py
#### How did you do it?
Change the topo marker to "any".
#### How did you verify/test it?
Run the test on SN4280 testbed with one DPU as the duthost.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
