### PR TITLE
[Smartswitch] Call common reboot function in test_cold_reboot_switch

### DIFF
--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -439,8 +439,8 @@ def test_cold_reboot_switch(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname
     logging.info("Starting switch reboot...")
     logging.info("Recording DPU boot times before switch cold reboot")
     pre_boot_times = get_all_dpu_uptimes(dpuhosts, dpu_on_list)
-
-    perform_reboot(duthost, REBOOT_TYPE_COLD, None)
+    reboot(duthost, localhost, reboot_type=REBOOT_TYPE_COLD,
+           wait_for_ssh=False)
 
     logging.info("Executing post test check")
     post_test_switch_check(duthost, localhost,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Currently we call the perform_reboot in tests.smartswitch.common.reboot to reboot the switch in test_cold_reboot_switch.
The method doesn't have the step to check the switch ssh down.
But in the later step post_test_switch_check, it checks the ssh started state. This step could immediately pass and cause failure because the switch is still rebooting.
We should use the common reboot function which has the step to wait ssh down. Same as in test case test_dpu_status_post_switch_reboot.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Fix test issue in test_cold_reboot_switch
#### How did you do it?
Call common reboot function in test_cold_reboot_switch
#### How did you verify/test it?
Run the test on SN4280 smartswitch testbed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
