### PR TITLE
[Smartswitch] Combine the dpu online and process up timeout into one timeout

### DIFF
--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -28,7 +28,7 @@ SWITCH_MAX_TIMEOUT = 400
 INTF_MAX_TIMEOUT = 300
 INTF_TIME_INT = 5
 DPU_MAX_ONLINE_TIMEOUT = 360
-DPU_FULLY_STARTUP_TIMEOUT = 760
+DPU_READY_TIMEOUT = 760
 DPU_MAX_TIME_INT = 30
 REBOOT_CAUSE_TIMEOUT = 30
 REBOOT_CAUSE_INT = 10
@@ -713,7 +713,7 @@ def post_test_dpu_check(duthost, dpuhosts, dpu_name,
         f"DPU {dpu_name} is not operationally UP post the operation"
     )
     dpu_online_time = time.time() - check_start_time
-    dpu_proccess_up_timeout = DPU_FULLY_STARTUP_TIMEOUT - dpu_online_time
+    dpu_proccess_up_timeout = DPU_READY_TIMEOUT - dpu_online_time
 
     dpu_id = int(re.search(r'\d+', dpu_name).group())
     logging.info(f"Checking critical processes on {dpu_name}")

--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -5,6 +5,7 @@ import logging
 import pytest
 import re
 from datetime import datetime
+import time
 from tests.common.platform.device_utils import (  # noqa: F401,F403
     platform_api_conn, start_platform_api_service, get_configured_dpu_names
 )
@@ -27,7 +28,7 @@ SWITCH_MAX_TIMEOUT = 400
 INTF_MAX_TIMEOUT = 300
 INTF_TIME_INT = 5
 DPU_MAX_ONLINE_TIMEOUT = 360
-DPU_MAX_PROCESS_UP_TIMEOUT = 400
+DPU_FULLY_STARTUP_TIMEOUT = 760
 DPU_MAX_TIME_INT = 30
 REBOOT_CAUSE_TIMEOUT = 30
 REBOOT_CAUSE_INT = 10
@@ -705,17 +706,20 @@ def post_test_dpu_check(duthost, dpuhosts, dpu_name,
 
     logging.info(f"Checking {dpu_name} is UP post test")
     dpu_online_timeout = DPU_MAX_ONLINE_TIMEOUT + extra_dpu_online_timeout
+    check_start_time = time.time()
     pytest_assert(
         wait_until(dpu_online_timeout, DPU_MAX_TIME_INT, 0,
                    check_dpu_module_status, duthost, "on", dpu_name),
         f"DPU {dpu_name} is not operationally UP post the operation"
     )
+    dpu_online_time = time.time() - check_start_time
+    dpu_proccess_up_timeout = DPU_FULLY_STARTUP_TIMEOUT - dpu_online_time
 
     dpu_id = int(re.search(r'\d+', dpu_name).group())
     logging.info(f"Checking critical processes on {dpu_name}")
     pytest_assert(
         wait_until(
-            DPU_MAX_PROCESS_UP_TIMEOUT, DPU_MAX_TIME_INT, 0,
+            dpu_proccess_up_timeout, DPU_MAX_TIME_INT, 0,
             check_dpu_critical_processes, dpuhosts, dpu_id),
         f"Critical process check for {dpu_name} has been failed"
     )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In the post_test_dpu_check, the are 2 checks:
1. DPU online check - timeout 360s
2. DPU critical process check - timeout 400s

We want to combine the 2 timeouts into one. This. is because for Nvidia smartswitch, the DPU could be shown as online in the chassis module output very soon after reboot, the online indicates the DPU power on has finished. But at that time, the SONiC system is not start yet.
And in the following critical process check, the monit check takes very long time because monit is delayed by 300s in the startup flow. So if the DPU is on line too quickly, the critical process check may fail.

To overcome this, define a DPU_FULLY_STARTUP_UP_TIMEOUT, which is the sum of the 2 timeouts, and calculate the process up timeout based on the time consumed in the online step.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Stabilize the post_test_dpu_check.
#### How did you do it?
Combine the dpu online and process up timeout into one timeout by defining a DPU_FULLY_STARTUP_UP_TIMEOUT, which is the sum of the 2 timeouts, and calculating the process up timeout based on the time consumed in the online step.
#### How did you verify/test it?
Run the test on SN4280 testbed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
