### PR TITLE
[Cherry-pick] [24667] [TH6-128] bgp tests - multi-vrf support for EOS neighbor hosts (#24667)

### DIFF
--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -935,3 +935,30 @@ def initial_tsa_check_before_and_after_test(duthosts):
     with SafeThreadPoolExecutor(max_workers=8) as executor:
         for linecard in duthosts.frontend_nodes:
             executor.submit(run_tsb_on_linecard_and_verify, linecard)
+
+
+def eos_bgp_neighbor_config_parents(tbinfo, nbrhosts, logical_neighbor_name, neigh_remote_as):
+    """
+    Parents list for ansible eos_config under neighbor BGP (default or multi-VRF / converged cEOS).
+
+    Prefer nbrhosts[logical]['is_multi_vrf_peer'] from conftest; if absent, derive from
+    topo_is_multi_vrf + convergence_data (covers stale tbinfo/nbrhosts cache mismatches).
+    """
+    nbr = nbrhosts.get(logical_neighbor_name) or {}
+    if nbr.get("is_multi_vrf_peer") and nbr.get("multi_vrf_data"):
+        mvd = nbr["multi_vrf_data"]
+        return [
+            "router bgp {}".format(mvd["primary_host_asn"]),
+            "vrf {}".format(mvd["vrf"]),
+        ]
+
+    props = tbinfo.get("topo", {}).get("properties", {})
+    if props.get("topo_is_multi_vrf") and props.get("convergence_data", {}).get("convergence_mapping"):
+        conv_map = props["convergence_data"]["convergence_mapping"]
+        cfg = props.get("configuration", {})
+        for prime_name, logical_names in conv_map.items():
+            if logical_neighbor_name in logical_names and prime_name in cfg:
+                primary_asn = cfg[prime_name]["bgp"]["asn"]
+                return ["router bgp {}".format(primary_asn), "vrf {}".format(logical_neighbor_name)]
+
+    return ["router bgp {}".format(neigh_remote_as)]

--- a/tests/bgp/test_bgp_authentication.py
+++ b/tests/bgp/test_bgp_authentication.py
@@ -6,6 +6,7 @@ import logging
 import pytest
 import time
 
+from tests.bgp.bgp_helpers import eos_bgp_neighbor_config_parents
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.config_reload import config_reload
@@ -76,6 +77,12 @@ def setup(tbinfo, nbrhosts, duthosts, enum_frontend_dut_hostname, request):
             peer_group_v6 is None or neigh_asn is None):
         pytest.skip("Failed to get neighbor info")
 
+    # EOS/cEOS: converged (multi-VRF) uses "router bgp <primary_asn> vrf <hostname>", not default vrf.
+    if is_sonic_neigh:
+        neigh_eos_bgp_parents = None
+    else:
+        neigh_eos_bgp_parents = eos_bgp_neighbor_config_parents(tbinfo, nbrhosts, tor1, neigh_asn)
+
     dut_ip_v4 = tbinfo['topo']['properties']['configuration'][tor1]['bgp']['peers'][dut_asn][0]
     dut_ip_v6 = tbinfo['topo']['properties']['configuration'][tor1]['bgp']['peers'][dut_asn][1]
 
@@ -112,6 +119,7 @@ def setup(tbinfo, nbrhosts, duthosts, enum_frontend_dut_hostname, request):
         'asic_index': asic_index,
         'neigh_asic_index': neigh_asic_index,
         'is_sonic_neigh': is_sonic_neigh,
+        'neigh_eos_bgp_parents': neigh_eos_bgp_parents,
     }
 
     logger.debug("DUT BGP Config: {}".format(duthost.shell("show run bgp", module_ignore_errors=True)))
@@ -261,7 +269,7 @@ def configure_password_on_neighbor(setup):
 
         logger.debug(setup['neighhost'].eos_config(
             lines=cmd,
-            parents=['router bgp {}'.format(setup['neigh_asn'])],
+            parents=setup['neigh_eos_bgp_parents'],
         ))
 
         logger.debug(setup['neighhost'].eos_command(commands=["show run | section bgp"]))
@@ -291,7 +299,7 @@ def remove_password_on_neighbor(setup):
 
         logger.debug(setup['neighhost'].eos_config(
             lines=cmd,
-            parents=['router bgp {}'.format(setup['neigh_asn'])],
+            parents=setup['neigh_eos_bgp_parents'],
         ))
 
         logger.debug(setup['neighhost'].eos_command(commands=["show run | section bgp"]))

--- a/tests/bgp/test_ipv6_nlri_over_ipv4.py
+++ b/tests/bgp/test_ipv6_nlri_over_ipv4.py
@@ -9,6 +9,7 @@ import re
 import time
 
 import pytest
+from tests.bgp.bgp_helpers import eos_bgp_neighbor_config_parents
 from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
@@ -86,6 +87,14 @@ def setup(tbinfo, nbrhosts, duthosts, enum_frontend_dut_hostname, request):
     dut_ip_v4 = tbinfo['topo']['properties']['configuration'][neigh_name]['bgp']['peers'][dut_asn][0]
     dut_ip_v6 = tbinfo['topo']['properties']['configuration'][neigh_name]['bgp']['peers'][dut_asn][1].lower()
 
+    neigh_eos_vrf = None
+    neigh_eos_bgp_parents = None
+    if not is_sonic_neigh:
+        neigh_eos_bgp_parents = eos_bgp_neighbor_config_parents(
+            tbinfo, nbrhosts, neigh_name, neigh_asn[neigh_name])
+        if len(neigh_eos_bgp_parents) > 1 and neigh_eos_bgp_parents[1].startswith("vrf "):
+            neigh_eos_vrf = neigh_eos_bgp_parents[1].split(None, 1)[1]
+
     neigh_namespace = DEFAULT_NAMESPACE
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     for dut_port, neigh in mg_facts['minigraph_neighbors'].items():
@@ -111,11 +120,20 @@ def setup(tbinfo, nbrhosts, duthosts, enum_frontend_dut_hostname, request):
         neigh_nlri_route = neigh_nlri_routes[len(neigh_nlri_routes) - 3].split()[1]
     else:
         logger.debug(neigh_host.eos_command(commands=["clear bgp * soft"]))
-        cmd = "show ipv6 bgp peers {} received-routes".format(dut_ip_v6)
-        neigh_nlri_routes = neigh_host.eos_command(commands=[cmd])['stdout'][0].split('\n')
-        neigh_nlri_route_output = neigh_nlri_routes[len(neigh_nlri_routes) - 1]
+        if neigh_eos_vrf:
+            # EOS: vrf after received-routes (same pattern as "routes vrf", not "peers ... vrf ... received-routes")
+            cmd = "show ipv6 bgp peers {} received-routes vrf {}".format(dut_ip_v6, neigh_eos_vrf)
+        else:
+            cmd = "show ipv6 bgp peers {} received-routes".format(dut_ip_v6)
+        neigh_nlri_routes = [
+            ln for ln in neigh_host.eos_command(commands=[cmd])['stdout'][0].split('\n') if ln.strip()
+        ]
+        pytest_assert(len(neigh_nlri_routes) >= 1, "Neighbor received-routes empty (cmd={})".format(cmd))
+        neigh_nlri_route_output = neigh_nlri_routes[-1]
         logger.debug("neighbor routes: {}".format(neigh_nlri_route_output))
-        neigh_nlri_route = neigh_nlri_route_output.split()[2]
+        parts = neigh_nlri_route_output.split()
+        pytest_assert(len(parts) >= 3, "Unexpected neighbor NLRI line: {}".format(neigh_nlri_route_output))
+        neigh_nlri_route = parts[2]
 
     setup_info = {
         'duthost': duthost,
@@ -137,6 +155,8 @@ def setup(tbinfo, nbrhosts, duthosts, enum_frontend_dut_hostname, request):
         'asic_index': asic_index,
         'neigh_asic_index': neigh_asic_index,
         'is_sonic_neigh': is_sonic_neigh,
+        'neigh_eos_vrf': neigh_eos_vrf,
+        'neigh_eos_bgp_parents': neigh_eos_bgp_parents,
     }
 
     logger.debug("DUT BGP Config: {}".format(duthost.shell('show run bgp')['stdout']))
@@ -166,11 +186,15 @@ def test_nlri(setup):
     # show current adjacency
     cmd = "show ipv6 route {} -n {}".format(setup['dut_nlri_route'], setup['dut_namespace'])
     logger.debug("DUT Route from neighbor: {}".format(setup['duthost'].shell(cmd)['stdout']))
-    cmd = "show ipv6 route {}".format(setup['neigh_nlri_route'])
     if setup['is_sonic_neigh']:
+        cmd = "show ipv6 route {}".format(setup['neigh_nlri_route'])
         logger.debug("Neighbor Route from DUT: {}".format(setup['neighhost'].shell(cmd)['stdout']))
+    elif setup.get('neigh_eos_vrf'):
+        cmd = "show ipv6 route vrf {} {}".format(setup['neigh_eos_vrf'], setup['neigh_nlri_route'])
+        logger.debug("Neighbor Route from DUT: {}".format(setup['neighhost'].eos_command(commands=[cmd])['stdout'][0]))
     else:
-        logger.debug("Neighbor Route from DUT: {}".format(setup['neighhost'].eos_command(commands=[cmd])['stdout']))
+        cmd = "show ipv6 route {}".format(setup['neigh_nlri_route'])
+        logger.debug("Neighbor Route from DUT: {}".format(setup['neighhost'].eos_command(commands=[cmd])['stdout'][0]))
 
     # remove current neighbor adjacency
     cmd = 'vtysh -n {} -c "config" -c "router bgp {}" -c "no neighbor {} peer-group {}" \
@@ -205,7 +229,7 @@ def test_nlri(setup):
 
         setup['neighhost'].eos_config(
             lines=cmds,
-            parents=['router bgp {}'.format(setup['neigh_asn'])],
+            parents=setup['neigh_eos_bgp_parents'],
         )
 
     wait_until(
@@ -219,6 +243,7 @@ def test_nlri(setup):
         setup['dut_ip_v6'],
         False,
         setup['is_sonic_neigh'],
+        setup.get('neigh_eos_vrf'),
     )
 
     # clear BGP table
@@ -239,11 +264,16 @@ def test_nlri(setup):
         "neigh_ip_v6 route still exists in DUT",
     )
 
-    cmd = "show ipv6 route {}".format(setup['neigh_nlri_route'])
     if setup['is_sonic_neigh']:
-        neigh_route_out = setup['neighhost'].shell(cmd)['stdout']
+        neigh_route_cmd_rm = "show ipv6 route {}".format(setup['neigh_nlri_route'])
+        neigh_route_out = setup['neighhost'].shell(neigh_route_cmd_rm)['stdout']
+    elif setup.get('neigh_eos_vrf'):
+        neigh_route_cmd_rm = "show ipv6 route vrf {} {}".format(
+            setup['neigh_eos_vrf'], setup['neigh_nlri_route'])
+        neigh_route_out = setup['neighhost'].eos_command(commands=[neigh_route_cmd_rm])['stdout'][0]
     else:
-        neigh_route_out = setup['neighhost'].eos_command(commands=[cmd])['stdout'][0]
+        neigh_route_cmd_rm = "show ipv6 route {}".format(setup['neigh_nlri_route'])
+        neigh_route_out = setup['neighhost'].eos_command(commands=[neigh_route_cmd_rm])['stdout'][0]
 
     pytest_assert(setup['dut_ip_v6'] not in neigh_route_out, "No route to IPv6 DUT.")
 
@@ -283,23 +313,42 @@ def test_nlri(setup):
             "Neighbor BGP Config After Peer Config: {}".format(setup['neighhost'].shell('show run bgp')['stdout'])
         )
     else:
-        cmds = [
-            "neighbor NLRI peer group",
-            "address-family ipv4",
-            "neighbor NLRI allowas-in",
-            "neighbor NLRI send-community",
-            "neighbor NLRI rib-in pre-policy retain all",
-            "address-family ipv6",
-            # "neighbor NLRI activate",
-            "neighbor NLRI allowas-in",
-            "neighbor NLRI rib-in pre-policy retain all",
-            "neighbor {} peer group NLRI".format(setup['dut_ip_v4']),
-            "neighbor {} remote-as {}".format(setup['dut_ip_v4'], setup['dut_asn']),
-        ]
+        # Get the IPv6 address of the neighbor interface to use as next-hop
+        neigh_ipv6_addr = setup['neigh_ip_v6']
 
+        # Configure route-map to set IPv6 next-hop for route advertisements.
+        # This is needed because when advertising IPv6 NLRI over an IPv4 BGP session,
+        # the IPv6 next-hop must be explicitly set. Without this route-map, the IPv6
+        # routes would be advertised with an invalid or missing next-hop, causing the
+        # DUT to reject them. The route-map sets the IPv6 next-hop to the neighbor's
+        # own IPv6 address, ensuring the DUT can properly install the IPv6 routes.
         setup['neighhost'].eos_config(
-            lines=cmds,
-            parents=['router bgp {}'.format(setup['neigh_asn'])],
+            lines=[
+                "set ipv6 next-hop {}".format(neigh_ipv6_addr),
+            ],
+            parents=["route-map SET_IPV6_NH_TO_SELF permit 10"]
+        )
+
+        # Configure BGP peer-group at global level using eos_config
+        setup['neighhost'].eos_config(
+            lines=[
+                "neighbor NLRI peer group",
+                "neighbor NLRI allowas-in",
+                "neighbor NLRI send-community",
+                "neighbor NLRI rib-in pre-policy retain all",
+                "neighbor {} peer group NLRI".format(setup['dut_ip_v4']),
+                "neighbor {} remote-as {}".format(setup['dut_ip_v4'], setup['dut_asn']),
+            ],
+            parents=setup['neigh_eos_bgp_parents'],
+        )
+
+        # Configure IPv6 address-family and activate the neighbor along with applying the route map
+        setup['neighhost'].eos_config(
+            lines=[
+                "neighbor NLRI route-map SET_IPV6_NH_TO_SELF out",
+                "neighbor NLRI activate",
+                ],
+            parents=setup['neigh_eos_bgp_parents'] + ["address-family ipv6"],
         )
 
         logger.debug("Neighbor BGP Config After Peer Config: {}".format(
@@ -317,6 +366,7 @@ def test_nlri(setup):
         setup['dut_ip_v6'],
         False,
         setup['is_sonic_neigh'],
+        setup.get('neigh_eos_vrf'),
     )
 
     bgp_facts = setup['duthost'].bgp_facts(instance_id=setup['asic_index'])['ansible_facts']
@@ -334,12 +384,20 @@ def test_nlri(setup):
         ),
         "Routing entry for DUT not established.",
     )
-
-    cmd = "show ipv6 route {}".format(setup['neigh_nlri_route'])
     if setup['is_sonic_neigh']:
-        neigh_route_out = setup['neighhost'].shell(cmd)['stdout']
+        neigh_route_cmd = "show ipv6 route {}".format(setup['neigh_nlri_route'])
+    elif setup.get('neigh_eos_vrf'):
+        neigh_route_cmd = "show ipv6 route vrf {} {}".format(
+            setup['neigh_eos_vrf'], setup['neigh_nlri_route'])
     else:
-        neigh_route_out = setup['neighhost'].eos_command(commands=[cmd])['stdout'][0]
+        neigh_route_cmd = "show ipv6 route {}".format(setup['neigh_nlri_route'])
+
+    def verify_neigh_route():
+        if setup['is_sonic_neigh']:
+            neigh_route_out = setup['neighhost'].shell(neigh_route_cmd)['stdout']
+        else:
+            neigh_route_out = setup['neighhost'].eos_command(commands=[neigh_route_cmd])['stdout'][0]
+        return setup['neigh_nlri_route'] in neigh_route_out
 
     pytest_assert("Routing entry for {}".format(setup['neigh_nlri_route']) in neigh_route_out,
                   "Routing entry for neighbor not established.")
@@ -373,7 +431,7 @@ def parse_dut_received_routes(command_output):
     return routes
 
 
-def check_bgp_summary(host, neighbor_v4, v4_present, neighbor_v6, v6_present, is_sonic_neigh):
+def check_bgp_summary(host, neighbor_v4, v4_present, neighbor_v6, v6_present, is_sonic_neigh, eos_vrf=None):
     if is_sonic_neigh:
         ipv4_sum = host.shell(cmd="show ip bgp summary")[u'stdout']
         is_present = neighbor_v4 in ipv4_sum
@@ -386,12 +444,16 @@ def check_bgp_summary(host, neighbor_v4, v4_present, neighbor_v6, v6_present, is
             return False
         return True
     else:
-        ipv4_sum = host.eos_command(commands=["show ip bgp summary"])['stdout'][0]
+        if eos_vrf:
+            ipv4_sum = host.eos_command(commands=["show ip bgp summary vrf {}".format(eos_vrf)])['stdout'][0]
+            ipv6_sum = host.eos_command(commands=["show ipv6 bgp summary vrf {}".format(eos_vrf)])['stdout'][0]
+        else:
+            ipv4_sum = host.eos_command(commands=["show ip bgp summary"])['stdout'][0]
+            ipv6_sum = host.eos_command(commands=["show ipv6 bgp summary"])['stdout'][0]
         is_present = neighbor_v4 in ipv4_sum
         if is_present != v4_present:
             return False
 
-        ipv6_sum = host.eos_command(commands=["show ipv6 bgp summary"])['stdout'][0]
         is_present = neighbor_v6 in ipv6_sum
         if is_present != v6_present:
             return False

--- a/tests/bgp/test_passive_peering.py
+++ b/tests/bgp/test_passive_peering.py
@@ -10,6 +10,7 @@ import time
 from tests.common.config_reload import config_reload
 from tests.common.devices.eos import EosHost
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
+from tests.bgp.bgp_helpers import eos_bgp_neighbor_config_parents
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +70,13 @@ def setup(tbinfo, nbrhosts, duthosts, rand_one_dut_front_end_hostname, request):
     dut_ip_v4 = tbinfo['topo']['properties']['configuration'][neigh_name]['bgp']['peers'][dut_asn][0]
     dut_ip_v6 = tbinfo['topo']['properties']['configuration'][neigh_name]['bgp']['peers'][dut_asn][1]
 
+    # EOS/cEOS converged: eos_config parents (nbrhosts flag or tbinfo convergence_data fallback)
+    if is_sonic:
+        neigh_eos_bgp_parents = None
+    else:
+        neigh_eos_bgp_parents = eos_bgp_neighbor_config_parents(
+            tbinfo, nbrhosts, neigh_name, neigh_asn[neigh_name])
+
     # verify sessions are established
     logger.debug(duthost.shell('show ip bgp summary')['stdout'])
     logger.debug(duthost.shell('show ipv6 bgp summary')['stdout'])
@@ -89,7 +97,8 @@ def setup(tbinfo, nbrhosts, duthosts, rand_one_dut_front_end_hostname, request):
         'peer_group_v6': peer_group_v6,
         'asic_index': asic_index,
         'neigh_asic_index': neigh_asic_index,
-        'is_sonic': is_sonic
+        'is_sonic': is_sonic,
+        'neigh_eos_bgp_parents': neigh_eos_bgp_parents,
     }
 
     logger.debug('Setup_info: {}'.format(setup_info))
@@ -155,7 +164,8 @@ def test_bgp_passive_peering_ipv4(setup):
         setup['neighhost'].shell(cmd, module_ignore_errors=True)
     else:
         cmd = ["neighbor {} password 0 {}".format(setup['dut_ip_v4'], peer_password)]
-        logger.debug(setup['neighhost'].eos_config(lines=cmd, parents="router bgp {}".format(setup['neigh_asn'])))
+        logger.debug(setup['neighhost'].eos_config(
+            lines=cmd, parents=setup['neigh_eos_bgp_parents']))
         logger.debug(setup['neighhost'].eos_command(commands=["show run | section bgp"]))
 
     time.sleep(bgp_config_sleeptime)
@@ -212,7 +222,8 @@ def test_bgp_passive_peering_ipv6(setup):
         setup['neighhost'].shell(cmd, module_ignore_errors=True)
     else:
         cmd = ["neighbor {} password 0 {}".format(setup['dut_ip_v6'], peer_password)]
-        logger.debug(setup['neighhost'].eos_config(lines=cmd, parents="router bgp {}".format(setup['neigh_asn'])))
+        logger.debug(setup['neighhost'].eos_config(
+            lines=cmd, parents=setup['neigh_eos_bgp_parents']))
         logger.debug(setup['neighhost'].eos_command(commands=["show run | section bgp"]))
 
     time.sleep(bgp_config_sleeptime)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This is a cherry-pick PR #24667 from master to 202512 branch.

- This PR adds support for EOS commands on neighbor hosts if the DUT has multi_vrf topo.
- Following tests failed to adapt the neighbor host commands and this PR helps to fix the same.
   test_passive_peering.py, test_bgp_authentication.py, test_ipv6_nlri_over_ipv4.py

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

- test_passive_peering.py, test_bgp_authentication.py, test_ipv6_nlri_over_ipv4.py tests fail if the DUT has multi_vrf topo and fail to adapt the neighbor host EOS commands.

#### How did you do it?

- If the topo is multi_vrf, change the "router bgp" config to include multi_vrf data for all the neighbor hosts.

#### How did you verify/test it?

- Ran the above-mentioned tests and made sure all are passing without any issues.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
