### PR TITLE
[fanout] Fix deploy_leaf bare-conditional under ansible-core 2.19+

### DIFF
--- a/ansible/roles/fanout/tasks/rootfanout_connect.yml
+++ b/ansible/roles/fanout/tasks/rootfanout_connect.yml
@@ -1,11 +1,12 @@
 # This playbook is trying to change root fanout switch port vlans when deploy leaf fanout or connect server to SONiC DUT
 # This playbook is called from fanout_connect.yml or fanout.yml
 
-- set_fact: deploy_leaf=false
+- set_fact:
+    deploy_leaf: false
   when: deploy_leaf is not defined
 
 - set_fact: dut="{{ leaf_name }}"
-  when: deploy_leaf
+  when: deploy_leaf | bool
 
 - set_fact:
     clean_before_add: "{{ clean_before_add | default('y') }}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Under ansible-core 2.19+ (`ALLOW_BROKEN_CONDITIONALS` defaults to
false), prepare fails at `roles/fanout/tasks/rootfanout_connect.yml:4`
with:

    Task failed: Conditional result (True) was derived from value of
    type 'str' at '.../rootfanout_connect.yml:4:13'. Conditionals must
    have a boolean result.

Root cause: `set_fact: deploy_leaf=false` uses the `key=value` inline
shorthand, which assigns the **string** `"false"` (not boolean False).
The next task's bare `when: deploy_leaf` then evaluates a non-empty
string, which ansible-core 2.19+ rejects.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Restore prepare on testbeds that use a root fanout under the current community `docker-sonic-mgmt:latest` (ansible-core ≥ 2.19). The buggy line is years old but only fails now because ansible-core 2.19+ tightened conditional type-checking.

#### How did you do it?
- Assign `deploy_leaf` via the **YAML dict form** so the value is a real boolean (not the string `"false"` the `key=value` shorthand produces).
- Add `| bool` on the bare `when:` as defense in depth, so the task works regardless of how `deploy_leaf` was set elsewhere.
- 
#### How did you verify/test it?
- YAML still parses cleanly (`python3 -c "import yaml; yaml.safe_load(open('ansible/roles/fanout/tasks/rootfanout_connect.yml'))"`).
- On a testbed that uses a root fanout (Hummingbird `humm208`) under the broken image, prepare reproducibly failed at `rootfanout_connect.yml:4`. With this patch, prepare reaches the next task ("Gathering connection facts about the DUTs or leaffanout device").

#### Any platform specific information?
N/A — playbook-only change; affects any testbed using a root fanout (root_fanout / FanoutRoot in the connection graph).

#### Supported testbed topology if it's a new test case?
N/A (not a new test).

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
