### PR TITLE
Move vxlan sport to func scope.

### DIFF
--- a/tests/ha/conftest.py
+++ b/tests/ha/conftest.py
@@ -398,7 +398,8 @@ def _apply_vxlan_udp_sport_range(dpuhosts):
         {
             "SWITCH_TABLE:switch": {
                 "vxlan_sport": VXLAN_UDP_BASE_SRC_PORT,
-                "vxlan_mask": VXLAN_UDP_SRC_PORT_MASK
+                "vxlan_mask": VXLAN_UDP_SRC_PORT_MASK,
+                "vxlan_port": "4789"
             },
             "OP": "SET"
         }
@@ -409,9 +410,6 @@ def _apply_vxlan_udp_sport_range(dpuhosts):
     for dpuhost in dpuhosts:
         dpuhost.copy(content=json.dumps(vxlan_sport_config, indent=4), dest=config_path, verbose=False)
         apply_swssconfig_file(dpuhost, config_path)
-        if 'pensando' in dpuhost.facts['asic_type']:
-            logger.warning("Applying Pensando DPU VXLAN sport workaround")
-            dpuhost.shell("pdsctl debug update device --vxlan-port 4789 --vxlan-src-ports 5120-5247")
 
 
 @pytest.fixture(scope="module")

--- a/tests/ha/conftest.py
+++ b/tests/ha/conftest.py
@@ -836,7 +836,7 @@ def apply_dash_pl_pipeline_config(localhost, duthosts, dpuhosts, ptfhost):
 
 @pytest.fixture(scope="function")
 def setup_dash_pl_pipeline(
-     localhost, duthosts, ptfhost, dpu_index, skip_config,
+    localhost, duthosts, ptfhost, dpu_index, skip_config,
     dpuhosts, setup_npu_dpu, ensure_vxlan_udp_sport_range
 ):
     if skip_config:

--- a/tests/ha/conftest.py
+++ b/tests/ha/conftest.py
@@ -393,12 +393,7 @@ def vxlan_udp_dport(request, duthost):
     config_vxlan_udp_dport(duthost, 4789)
 
 
-@pytest.fixture(scope="module")
-def set_vxlan_udp_sport_range(dpuhosts):
-    """
-    Configure VXLAN UDP source port range in dpu configuration.
-
-    """
+def _apply_vxlan_udp_sport_range(dpuhosts):
     vxlan_sport_config = [
         {
             "SWITCH_TABLE:switch": {
@@ -417,11 +412,34 @@ def set_vxlan_udp_sport_range(dpuhosts):
         if 'pensando' in dpuhost.facts['asic_type']:
             logger.warning("Applying Pensando DPU VXLAN sport workaround")
             dpuhost.shell("pdsctl debug update device --vxlan-port 4789 --vxlan-src-ports 5120-5247")
+
+
+@pytest.fixture(scope="module")
+def set_vxlan_udp_sport_range(dpuhosts):
+    """
+    Configure VXLAN UDP source port range in dpu configuration.
+
+    """
+    _apply_vxlan_udp_sport_range(dpuhosts)
     yield
     for dpuhost in dpuhosts:
         if str(VXLAN_UDP_BASE_SRC_PORT) in dpuhost.shell("redis-cli -n 0"
                                                          " hget SWITCH_TABLE:switch vxlan_sport")['stdout']:
             config_reload(dpuhost, safe_reload=True, yang_validate=False)
+
+
+@pytest.fixture(scope="function")
+def ensure_vxlan_udp_sport_range(set_vxlan_udp_sport_range, dpuhosts):
+    dpuhosts_to_configure = []
+    for dpuhost in dpuhosts:
+        vxlan_sport = dpuhost.shell("redis-cli -n 0"
+                                    " hget SWITCH_TABLE:switch vxlan_sport")['stdout']
+        if str(VXLAN_UDP_BASE_SRC_PORT) not in vxlan_sport:
+            dpuhosts_to_configure.append(dpuhost)
+
+    if dpuhosts_to_configure:
+        logger.info("Re-applying VXLAN source port config after per-test cleanup reset")
+        _apply_vxlan_udp_sport_range(dpuhosts_to_configure)
 
 
 @pytest.fixture(scope="module")
@@ -819,7 +837,7 @@ def apply_dash_pl_pipeline_config(localhost, duthosts, dpuhosts, ptfhost):
 @pytest.fixture(scope="function")
 def setup_dash_pl_pipeline(
      localhost, duthosts, ptfhost, dpu_index, skip_config,
-     dpuhosts, setup_npu_dpu, set_vxlan_udp_sport_range
+    dpuhosts, setup_npu_dpu, ensure_vxlan_udp_sport_range
 ):
     if skip_config:
         yield

--- a/tests/ha/test_ha_bfd_pin.py
+++ b/tests/ha/test_ha_bfd_pin.py
@@ -38,7 +38,7 @@ def common_setup_teardown(
     setup_ha_config,
     setup_dash_ha_from_json_func_scope,
     setup_gnmi_server,
-    set_vxlan_udp_sport_range,
+    ensure_vxlan_udp_sport_range,
     setup_npu_dpu  # noqa: F811
 ):
     if skip_config:

--- a/tests/ha/test_ha_bgp_down.py
+++ b/tests/ha/test_ha_bgp_down.py
@@ -38,7 +38,7 @@ def common_setup_teardown(
     setup_ha_config,
     setup_dash_ha_from_json_func_scope,
     setup_gnmi_server,
-    set_vxlan_udp_sport_range,
+    ensure_vxlan_udp_sport_range,
     setup_npu_dpu  # noqa: F811
 ):
     if skip_config:

--- a/tests/ha/test_ha_config_reload.py
+++ b/tests/ha/test_ha_config_reload.py
@@ -37,7 +37,7 @@ def common_setup_teardown(
     setup_ha_config,
     setup_dash_ha_from_json_func_scope,
     setup_gnmi_server,
-    set_vxlan_udp_sport_range,
+    ensure_vxlan_udp_sport_range,
     setup_npu_dpu  # noqa: F811
 ):
     if skip_config:

--- a/tests/ha/test_ha_dpu_power_down.py
+++ b/tests/ha/test_ha_dpu_power_down.py
@@ -45,7 +45,7 @@ def common_setup_teardown(
     setup_ha_config,
     setup_dash_ha_from_json_func_scope,
     setup_gnmi_server,
-    set_vxlan_udp_sport_range,
+    ensure_vxlan_udp_sport_range,
     setup_npu_dpu  # noqa: F811
 ):
     if skip_config:

--- a/tests/ha/test_ha_npu_reboot.py
+++ b/tests/ha/test_ha_npu_reboot.py
@@ -118,7 +118,7 @@ def common_setup_teardown(
     setup_ha_config,
     setup_dash_ha_from_json_func_scope,
     setup_gnmi_server,
-    set_vxlan_udp_sport_range,
+    ensure_vxlan_udp_sport_range,
     setup_npu_dpu  # noqa: F811
 ):
     if skip_config:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Supporting function scoped version of apply_vxlan_udp_sport_range. In case of dpu reload/reboot/process crash it needs to be applied again between test cases.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Need to re-apply vxlan sport config on DPU between test cases.

#### How did you do it?
Added a function scoped version of apply_vxlan_udp_sport_range for the relevant test cases to use.

#### How did you verify/test it?
Ran sonic-mgmt HA test cases in HA testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
