### PR TITLE
Fix test_m2o_fluctuating_lossless

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -1486,6 +1486,85 @@ def get_pfcQueueGroupSize(default=8):
     return default
 
 
+def get_queue_scheduler_weight_dict(host_ans, asic_value=None, port=None,
+                                    qos_map_profile=None):
+    """
+    Build a per-queue scheduler/weight map for an interface by joining the
+    ``QUEUE`` and ``SCHEDULER`` config-DB tables, and optionally annotating
+    each queue with one of its DSCP values via ``DSCP_TO_TC_MAP`` and
+    ``TC_TO_QUEUE_MAP``.
+
+    Args:
+        host_ans: Ansible host instance of the device.
+        asic_value: asic namespace; pass ``None`` (default) or the string
+            ``"None"`` for single-asic devices.
+        port (str, optional): interface name to read ``QUEUE`` for. Defaults
+            to the first interface present in ``QUEUE``.
+        qos_map_profile (str, optional): name of the profile inside
+            ``DSCP_TO_TC_MAP`` / ``TC_TO_QUEUE_MAP`` to use for the ``dscp``
+            field. Defaults to the first profile (typically ``"AZURE"``).
+            If the maps are missing, ``dscp`` is set to ``None``.
+
+    Returns:
+        dict[int, dict]: ``{queue: {"scheduler": <name>, "type": <DWRR/...>,
+        "weight": <int>, "dscp": <int|None>}}``. The result always covers
+        queues 0-7; any queue not present in the per-port ``QUEUE`` config
+        (or whose scheduler is missing from ``SCHEDULER``) falls back to a
+        default entry with equal DWRR weight 15.
+    """
+    if asic_value in (None, "None"):
+        config_facts = host_ans.config_facts(host=host_ans.hostname,
+                                             source="running")["ansible_facts"]
+    else:
+        config_facts = host_ans.config_facts(host=host_ans.hostname,
+                                             source="running",
+                                             namespace=asic_value)["ansible_facts"]
+
+    queue_cfg_all = config_facts.get("QUEUE") or {}
+    scheduler_cfg = config_facts.get("SCHEDULER") or {}
+
+    dscp_to_tc = config_facts.get("DSCP_TO_TC_MAP") or {}
+    tc_to_queue = config_facts.get("TC_TO_QUEUE_MAP") or {}
+    if qos_map_profile is None and dscp_to_tc:
+        qos_map_profile = next(iter(dscp_to_tc))
+    dscp_to_tc_map = dscp_to_tc.get(qos_map_profile, {}) if qos_map_profile else {}
+    tc_to_queue_map = tc_to_queue.get(qos_map_profile, {}) if qos_map_profile else {}
+
+    queue_to_dscp = {}
+    for dscp, tc in dscp_to_tc_map.items():
+        q = tc_to_queue_map.get(str(tc))
+        if q is not None:
+            queue_to_dscp.setdefault(int(q), int(dscp))
+
+    # default entry with equal DWRR weight 15
+    result = {
+        q: {"scheduler": None, "type": "DWRR", "weight": 15,
+            "dscp": queue_to_dscp.get(q)}
+        for q in range(8)
+    }
+
+    if not queue_cfg_all:
+        return result
+
+    if port is None:
+        port = next(iter(queue_cfg_all))
+    if port not in queue_cfg_all:
+        raise KeyError("Port {} not found in QUEUE config (available: {})".format(port, sorted(queue_cfg_all)))
+
+    for q, value in queue_cfg_all[port].items():
+        scheduler = value.get("scheduler")
+        if scheduler is None or scheduler not in scheduler_cfg:
+            continue
+        sched = scheduler_cfg[scheduler]
+        result[int(q)] = {
+            "scheduler": scheduler,
+            "type": sched.get("type"),
+            "weight": int(sched["weight"]),
+            "dscp": queue_to_dscp.get(int(q)),
+        }
+    return result
+
+
 @lru_cache
 def get_testbed_from_args():
     parser = ArgumentParser()

--- a/tests/common/unit_tests/snappi_tests/README.md
+++ b/tests/common/unit_tests/snappi_tests/README.md
@@ -1,0 +1,48 @@
+# Unit Tests for `tests/common/snappi_tests/`
+
+This directory contains unit tests for modules under
+`tests/common/snappi_tests/`.
+
+## Running Unit Tests
+
+### Run all unit tests in this directory
+```bash
+# From repository root
+python3 -m pytest --noconftest tests/common/unit_tests/snappi_tests/ -v
+```
+
+### Run a specific test file
+```bash
+python3 -m pytest --noconftest \
+  tests/common/unit_tests/snappi_tests/unit_test_common_helpers.py -v
+```
+
+### Run a specific test case
+```bash
+python3 -m pytest --noconftest \
+  tests/common/unit_tests/snappi_tests/unit_test_common_helpers.py::test_get_queue_scheduler_weight_dict \
+  -v
+```
+
+## Why `--noconftest`
+
+`tests/conftest.py` pulls in integration-test dependencies (for example,
+`paramiko`) that are not needed for these isolated unit tests. Using
+`--noconftest` keeps the run lightweight and avoids unrelated import
+failures.
+
+The target module `tests/common/snappi_tests/common_helpers.py` itself
+imports heavy dependencies (`tests.conftest`, `ipaddr`, mellanox helpers,
+etc.) at import time. To stay dependency-free, the unit tests load only the
+function under test by parsing the source with `ast` and `exec`-ing the
+single function definition in an isolated namespace. No real DUT, Ansible
+inventory, or Snappi environment is required.
+
+If your environment has the full sonic-mgmt test dependencies installed and
+you intentionally want global fixtures, you can remove `--noconftest`.
+
+## Requirements
+
+- Python 3
+- `pytest`
+- `unittest.mock` (built into Python standard library)

--- a/tests/common/unit_tests/snappi_tests/unit_test_common_helpers.py
+++ b/tests/common/unit_tests/snappi_tests/unit_test_common_helpers.py
@@ -1,0 +1,111 @@
+"""Unit test for ``get_queue_scheduler_weight_dict`` in
+``tests/common/snappi_tests/common_helpers.py``.
+
+The target module imports heavy sonic-mgmt deps at import time, so we
+extract the function under test via ``ast`` and exec it in an isolated
+namespace.
+
+Run with::
+
+    python3 -m pytest --noconftest \\
+        tests/common/unit_tests/snappi_tests/unit_test_common_helpers.py -v
+"""
+
+import ast
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+MODULE_PATH = (Path(__file__).resolve().parents[3] /
+               "common/snappi_tests/common_helpers.py")
+
+
+def _load(name):
+    tree = ast.parse(MODULE_PATH.read_text())
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            ns = {}
+            exec(compile(ast.Module(body=[node], type_ignores=[]),
+                         str(MODULE_PATH), "exec"), ns)
+            return ns[name]
+    raise LookupError(name)
+
+
+# Minimal config_facts modeling the str-msn2700-22 (Mellanox-SN2700) DUT,
+# trimmed to the keys read by ``get_queue_scheduler_weight_dict``:
+#   scheduler.0 -> lossy queues, DWRR weight 14
+#   scheduler.1 -> lossless queues 3 & 4, DWRR weight 15
+CONFIG_FACTS = {
+    "QUEUE": {
+        "Ethernet100": {
+            "0": {"scheduler": "scheduler.0"},
+            "1": {"scheduler": "scheduler.0"},
+            "2": {"scheduler": "scheduler.0"},
+            "3": {"scheduler": "scheduler.1",
+                  "wred_profile": "AZURE_LOSSLESS"},
+            "4": {"scheduler": "scheduler.1",
+                  "wred_profile": "AZURE_LOSSLESS"},
+            "5": {"scheduler": "scheduler.0"},
+            "6": {"scheduler": "scheduler.0"},
+        },
+    },
+    "SCHEDULER": {
+        "scheduler.0": {"type": "DWRR", "weight": "14"},
+        "scheduler.1": {"type": "DWRR", "weight": "15"},
+    },
+    "DSCP_TO_TC_MAP": {
+        "AZURE": {
+            "0": "1", "1": "1", "10": "1", "11": "1", "12": "1", "13": "1",
+            "14": "1", "15": "1", "16": "1", "17": "1", "18": "1", "19": "1",
+            "2": "1", "20": "1", "21": "1", "22": "1", "23": "1", "24": "1",
+            "25": "1", "26": "1", "27": "1", "28": "1", "29": "1", "3": "3",
+            "30": "1", "31": "1", "32": "1", "33": "1", "34": "1", "35": "1",
+            "36": "1", "37": "1", "38": "1", "39": "1", "4": "4", "40": "1",
+            "41": "1", "42": "1", "43": "1", "44": "1", "45": "1", "46": "5",
+            "47": "1", "48": "6", "49": "1", "5": "2", "50": "1", "51": "1",
+            "52": "1", "53": "1", "54": "1", "55": "1", "56": "1", "57": "1",
+            "58": "1", "59": "1", "6": "1", "60": "1", "61": "1", "62": "1",
+            "63": "1", "7": "1", "8": "0", "9": "1",
+        },
+    },
+    "TC_TO_QUEUE_MAP": {
+        "AZURE": {str(i): str(i) for i in range(8)},
+    },
+}
+
+EXPECTED = {
+    0: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 14, "dscp": 8},
+    1: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 14, "dscp": 0},
+    2: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 14, "dscp": 5},
+    3: {"scheduler": "scheduler.1", "type": "DWRR", "weight": 15, "dscp": 3},
+    4: {"scheduler": "scheduler.1", "type": "DWRR", "weight": 15, "dscp": 4},
+    5: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 14, "dscp": 46},
+    6: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 14, "dscp": 48},
+    # Queue 7 is not in the per-port QUEUE config; falls back to default.
+    7: {"scheduler": None, "type": "DWRR", "weight": 15, "dscp": None},
+}
+
+
+def test_get_queue_scheduler_weight_dict():
+    host = MagicMock()
+    host.hostname = "test_dut"
+    host.config_facts.return_value = {"ansible_facts": CONFIG_FACTS}
+
+    assert _load("get_queue_scheduler_weight_dict")(host) == EXPECTED
+
+
+def test_get_queue_scheduler_weight_dict_defaults_when_unconfigured():
+    """When QUEUE/SCHEDULER are absent, fall back to 8 queues w/ equal weights."""
+    host = MagicMock()
+    host.hostname = "test_dut"
+    facts = {k: v for k, v in CONFIG_FACTS.items()
+             if k not in ("QUEUE", "SCHEDULER")}
+    host.config_facts.return_value = {"ansible_facts": facts}
+
+    result = _load("get_queue_scheduler_weight_dict")(host)
+    assert set(result) == set(range(8))
+    assert {v["weight"] for v in result.values()} == {15}
+    assert {v["type"] for v in result.values()} == {"DWRR"}
+    # DSCP annotations from DSCP_TO_TC_MAP / TC_TO_QUEUE_MAP still apply.
+    assert result[0]["dscp"] == 8
+    assert result[3]["dscp"] == 3

--- a/tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py
@@ -3,7 +3,8 @@ from tests.common.helpers.assertions import pytest_assert, pytest_require       
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts  # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id                     # noqa: F401
 from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector, stop_pfcwd, \
-    disable_packet_aging, sec_to_nanosec, get_interface_stats                           # noqa: F401
+    disable_packet_aging, sec_to_nanosec, get_interface_stats, \
+    get_queue_scheduler_weight_dict                                                     # noqa: F401
 from tests.common.snappi_tests.port import select_ports                                 # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import run_traffic, \
@@ -18,11 +19,135 @@ TEST_FLOW_NAME = 'Test Flow'
 TEST_FLOW_AGGR_RATE_PERCENT = [20, 10]
 BG_FLOW_NAME = 'Background Flow'
 BG_FLOW_AGGR_RATE_PERCENT = [20, 20]
+BG_LOSS_TOLERANCE_PERCENT = 1
 DATA_PKT_SIZE = 1024
 DATA_FLOW_DURATION_SEC = 10
 DATA_FLOW_DELAY_SEC = 5
 SNAPPI_POLL_DELAY_SEC = 2
 UDP_PORT_START = 5000
+
+
+def get_expected_bg_loss_percent(egress_duthost,
+                                 test_prio_list,
+                                 test_flow_rate_percent,
+                                 bg_prio_list,
+                                 bg_flow_rate_percent,
+                                 asic_value=None,
+                                 port=None,
+                                 qos_map_profile=None):
+    """
+    Compute the expected per-Background-Flow loss percent for the m2o
+    fluctuating-lossless scenario by deriving each flow's egress-queue DWRR
+    weight from ``get_queue_scheduler_weight_dict``.
+
+    Args:
+        egress_duthost: the DUT whose egress port is the congestion point
+        test_prio_list (list[int]): priorities (TCs) of the test flows
+        test_flow_rate_percent (list[int]): per-test-flow line-rate percents,
+            aligned with ``test_prio_list``
+        bg_prio_list (list[int]): priorities (TCs) of the background flows
+            (one flow per priority, on a distinct queue)
+        bg_flow_rate_percent (list[int]): line-rate percents used to generate
+            the background flows; all entries are expected to be equal
+        asic_value: asic namespace of the egress port; ``None`` for single-asic
+            DUTs.
+        port (str, optional): egress port whose ``QUEUE``/``SCHEDULER`` config
+            should drive the weight lookup. Defaults to the first interface in
+            ``QUEUE``, which may not be the congested port on multi-port DUTs.
+        qos_map_profile (str, optional): profile name inside ``DSCP_TO_TC_MAP``
+            / ``TC_TO_QUEUE_MAP``. Defaults to the first profile.
+
+    Returns:
+        float: expected per-Background-Flow loss percent
+    """
+    cfg_args = {"host": egress_duthost.hostname, "source": "running"}
+    if asic_value not in (None, "None"):
+        cfg_args["namespace"] = asic_value
+    config_facts = egress_duthost.config_facts(**cfg_args)["ansible_facts"]
+    q_weight_dict = get_queue_scheduler_weight_dict(
+        egress_duthost,
+        asic_value=asic_value,
+        port=port,
+        qos_map_profile=qos_map_profile)
+    pytest_assert(q_weight_dict,
+                  "FAIL: Unable to read queue scheduler weights from config DB")
+
+    def _prio_to_queue(prio):
+        """Map a SONiC traffic-class (priority) to its egress queue."""
+        tc_to_queue_all = config_facts.get('TC_TO_QUEUE_MAP') or {}
+        pytest_assert(tc_to_queue_all, "FAIL: TC_TO_QUEUE_MAP is missing from config DB")
+        profile = qos_map_profile or next(iter(tc_to_queue_all))
+        tc_to_queue_map = tc_to_queue_all.get(profile) or {}
+        pytest_assert(tc_to_queue_map, "FAIL: TC_TO_QUEUE_MAP profile '{}' is missing".format(profile))
+        pytest_assert(str(prio) in tc_to_queue_map,
+                      "FAIL: TC {} missing from TC_TO_QUEUE_MAP profile '{}'".format(prio, profile))
+        return int(tc_to_queue_map[str(prio)])
+
+    def _compute_dwrr_allocation(queue_demand, queue_weight):
+        """
+        Run the DWRR allocation algorithm: iteratively give each active queue
+        its weight-proportional share of the remaining bandwidth. Queues
+        whose demand is below their share take only what they need; the
+        leftover is redistributed by weight among the remaining queues.
+        """
+        allocated = {q: 0.0 for q in queue_demand}
+        active = {q for q, d in queue_demand.items() if d > 0}
+        remaining_bw = 100.0
+        while active:
+            total_weight = sum(queue_weight[q] for q in active)
+            newly_satisfied = [
+                q for q in active
+                if remaining_bw * queue_weight[q] / total_weight
+                >= queue_demand[q] - allocated[q]
+            ]
+            if newly_satisfied:
+                for q in newly_satisfied:
+                    pending = queue_demand[q] - allocated[q]
+                    allocated[q] = queue_demand[q]
+                    remaining_bw -= pending
+                    active.discard(q)
+            else:
+                for q in active:
+                    allocated[q] += remaining_bw * queue_weight[q] / total_weight
+                return allocated
+        return allocated
+
+    queue_demand = {}
+    queue_weight = {}
+
+    def _add_demand(prio, rate):
+        q = _prio_to_queue(prio)
+        pytest_assert(q in q_weight_dict,
+                      "FAIL: No scheduler weight found for queue {} (TC {})".format(q, prio))
+        queue_demand[q] = queue_demand.get(q, 0.0) + rate
+        queue_weight[q] = q_weight_dict[q]["weight"]
+
+    # zip() silently ignores extra entries when lists differ in length; validate equal length first.
+    pytest_assert(
+        len(test_prio_list) == len(test_flow_rate_percent),
+        "FAIL: test_prio_list and test_flow_rate_percent must have same length (got {} and {})".format(
+            len(test_prio_list), len(test_flow_rate_percent)))
+    for prio, rate in zip(test_prio_list, test_flow_rate_percent):
+        _add_demand(prio, rate)
+
+    pytest_assert(bg_flow_rate_percent, "FAIL: bg_flow_rate_percent must be non-empty")
+
+    # Current assumption: all bg_flow_rate_percent entries must be equal; relax once unequal rates are supported.
+    pytest_assert(
+        len(set(bg_flow_rate_percent)) == 1,
+        "FAIL: bg_flow_rate_percent entries must be equal, got {}".format(bg_flow_rate_percent))
+
+    bg_rate_per_flow = bg_flow_rate_percent[0]
+    for prio in bg_prio_list:
+        _add_demand(prio, bg_rate_per_flow)
+
+    allocated = _compute_dwrr_allocation(queue_demand, queue_weight)
+
+    losses = []
+    for prio in bg_prio_list:
+        q = _prio_to_queue(prio)
+        losses.append((queue_demand[q] - allocated[q]) / queue_demand[q] * 100)
+    return sum(losses) / len(losses)
 
 
 def run_m2o_fluctuating_lossless_test(api,
@@ -154,10 +279,22 @@ def run_m2o_fluctuating_lossless_test(api,
 
     pytest_assert(abs(drop_percentage - 8) < 1, 'FAIL: Drop packets must be around 8 percent')
 
+    expected_bg_loss_percent = get_expected_bg_loss_percent(
+        egress_duthost=egress_duthost,
+        test_prio_list=test_prio_list,
+        test_flow_rate_percent=TEST_FLOW_AGGR_RATE_PERCENT,
+        bg_prio_list=bg_prio_list,
+        bg_flow_rate_percent=BG_FLOW_AGGR_RATE_PERCENT,
+        asic_value=rx_port.get('asic_value'),
+        port=dut_tx_port)
+    logger.info('Expected per-Background-Flow loss: {:.2f}% (tolerance +/- {}%)'.format(
+        expected_bg_loss_percent, BG_LOSS_TOLERANCE_PERCENT))
+
     """ Verify Results """
     verify_m2o_fluctuating_lossless_result(flow_stats,
                                            tx_port,
-                                           rx_port)
+                                           rx_port,
+                                           expected_bg_loss_percent)
 
 
 def __gen_traffic(testbed_config,
@@ -394,7 +531,8 @@ def __gen_data_flow(testbed_config,
 
 def verify_m2o_fluctuating_lossless_result(rows,
                                            tx_port,
-                                           rx_port):
+                                           rx_port,
+                                           expected_bg_loss_percent):
     """
     Verifies the required loss % from the Traffic Items Statistics
 
@@ -402,13 +540,21 @@ def verify_m2o_fluctuating_lossless_result(rows,
         rows (list): Traffic Item Statistics from snappi config
         tx_port (list): Ingress Ports
         rx_port : Egress Port
+        expected_bg_loss_percent (float): expected per-Background-Flow loss
+            percent (derived from the egress DWRR scheduler weights)
     Returns:
         N/A
     """
     background_loss = 0
+    background_flow_count = 0
     for row in rows:
         if 'Test Flow' in row.name:
             pytest_assert(int(row.loss) == 0, "FAIL: {} must have 0% loss".format(row.name))
         elif 'Background Flow' in row.name:
+            background_flow_count += 1
             background_loss += float(row.loss)
-    pytest_assert((abs(background_loss/4) - 10) < 1, "Each Background Flow must have an avg of 10% loss ")
+    pytest_assert(background_flow_count > 0, "FAIL: No Background Flow rows found in traffic stats")
+    avg_loss = background_loss / background_flow_count
+    pytest_assert(abs(avg_loss - expected_bg_loss_percent) < BG_LOSS_TOLERANCE_PERCENT,
+                  "Each Background Flow must have an avg of {:.2f}% loss (got {:.2f}%)".format(
+                      expected_bg_loss_percent, avg_loss))

--- a/tests/snappi_tests/unit_tests/pfc/README.md
+++ b/tests/snappi_tests/unit_tests/pfc/README.md
@@ -1,0 +1,83 @@
+# Unit Tests for `tests/snappi_tests/pfc/`
+
+This directory contains unit tests for modules under
+`tests/snappi_tests/pfc/`.
+
+## Running Unit Tests
+
+### Run all unit tests in this directory
+```bash
+# From repository root
+python3 -m pytest --noconftest tests/snappi_tests/unit_tests/pfc/ -v
+```
+
+### Run a specific test file
+```bash
+python3 -m pytest --noconftest \
+  tests/snappi_tests/unit_tests/pfc/unit_test_m2o_fluctuating_lossless_helper.py -v
+```
+
+### Run a specific test case
+```bash
+python3 -m pytest --noconftest \
+  "tests/snappi_tests/unit_tests/pfc/unit_test_m2o_fluctuating_lossless_helper.py::test_expected_bg_loss_matches_analytical_dwrr_split[mixed_weights_15_14-0-11.2676]" \
+  -v
+```
+
+## What `unit_test_m2o_fluctuating_lossless_helper.py` covers
+
+The test reproduces the IxNetwork Flow Statistics observed on
+SN4700 / 7260CX3 for the `m2o_fluctuating_lossless` scenario and validates
+that `get_expected_bg_loss_percent` returns a value matching the analytical
+DWRR split.
+
+Fixed scenario inputs:
+
+| Parameter                 | Value           |
+| ------------------------- | --------------- |
+| `test_prio_list`          | `[3, 4]`        |
+| `test_flow_rate_percent`  | `[20, 10]`      |
+| `bg_prio_list`            | `[0, 1, 2, 5]`  |
+| `bg_flow_rate_percent`    | `[20, 20, 20, 20]` |
+
+Parametrized DWRR weight profiles (vary only the scheduler weights):
+
+| Case                  | Q0/Q1/Q2/Q5/Q6 | Q3/Q4 | Expected per-BG loss |
+| --------------------- | -------------- | ----- | -------------------- |
+| `mixed_weights_15_14` | 14             | 15    | ~11.27% (IxNetwork measured 11.259%) |
+| `uniform_weights_15`  | 15             | 15    | 10.0% (fair share)   |
+
+Tolerance: `abs=0.01`.
+
+## Why `--noconftest`
+
+`tests/conftest.py` pulls in integration-test dependencies (for example,
+`paramiko`) that are not needed for these isolated unit tests. Using
+`--noconftest` keeps the run lightweight and avoids unrelated import
+failures.
+
+The target module
+`tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py` itself
+imports heavy sonic-mgmt deps (`tests.conftest`, mellanox helpers, etc.)
+at import time. To stay dependency-free, the test parses the source with
+`ast`, picks just the top-level `get_expected_bg_loss_percent` definition
+(its `_prio_to_queue` / `_compute_dwrr_allocation` / `_add_demand` helpers
+are nested inside it and come along for free) and `exec`s it into a fresh
+namespace. Two names are then injected into that namespace so the function
+can run standalone:
+
+- `get_queue_scheduler_weight_dict` — replaced with a `MagicMock` returning
+  a canned per-queue weight dict, so no DUT / Ansible inventory / Snappi
+  environment is required.
+- `pytest_assert` — replaced with a tiny stub (`assert condition, message`)
+  so the helper's input-validation asserts work without importing
+  `tests.common.helpers.assertions`.
+
+If your environment has the full sonic-mgmt test dependencies installed and
+you intentionally want global fixtures, you can drop `--noconftest`.
+
+## Requirements
+
+- Python 3
+- `pytest`
+- `unittest.mock` (built into the Python standard library)

--- a/tests/snappi_tests/unit_tests/pfc/unit_test_m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/unit_tests/pfc/unit_test_m2o_fluctuating_lossless_helper.py
@@ -1,0 +1,176 @@
+"""Unit tests for ``tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py``.
+
+The reference scenario reproduces the IxNetwork Flow Statistics (DWRR weights: lossless=15, lossy=14)::
+
+    Row  Tx Port  Rx Port  Traffic Item                     Loss %
+    1    Port 1   Port 0   Test Flow 1 -> 0 Rate:20         0.000
+    2    Port 2   Port 0   Test Flow 2 -> 0 Rate:10         0.000
+    3    Port 1   Port 0   1 Background Flow 1 -> 0 Rate:20 11.259
+    4    Port 2   Port 0   2 Background Flow 2 -> 0 Rate:20 11.259
+    5    Port 1   Port 0   3 Background Flow 1 -> 0 Rate:20 11.259
+    6    Port 2   Port 0   4 Background Flow 2 -> 0 Rate:20 11.259
+
+Aggregate offered load is 110% (20 + 10 + 4*20), so ~10% over-subscription
+hits the lossy queues. With DWRR weights 15 (Q3, Q4) vs 14 (Q0/Q1/Q2/Q5)
+the analytical per-BG-flow loss is ~11.27% — within the helper's 1%
+tolerance of the IxNetwork-measured 11.259%.
+
+The target module imports heavy sonic-mgmt deps at top level, so we extract
+just ``get_expected_bg_loss_percent`` (and its nested helpers) via ``ast``
+and exec it into a shared namespace, mirroring the lightweight pattern in
+``tests/common/unit_tests/fixtures/unit_test_conn_graph_facts.py``.
+
+Run with::
+
+    python3 -m pytest --noconftest \\
+        tests/snappi_tests/unit_tests/pfc/unit_test_m2o_fluctuating_lossless_helper.py \\
+        -v
+"""
+
+import ast
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+MODULE_PATH = (Path(__file__).resolve().parents[3] /
+               "snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py")
+
+FUNCTION_NAMES = ("get_expected_bg_loss_percent",)
+
+
+def _load_functions(names):
+    """Load the named top-level functions into a single shared namespace.
+
+    The shared namespace is what each function sees as its globals, so calls
+    between the loaded functions resolve correctly. Names not loaded (e.g.
+    ``get_queue_scheduler_weight_dict``) can be injected by the caller.
+    """
+    source = MODULE_PATH.read_text()
+    tree = ast.parse(source)
+    selected = [node for node in tree.body
+                if isinstance(node, ast.FunctionDef) and node.name in names]
+    missing = set(names) - {n.name for n in selected}
+    if missing:
+        raise LookupError(
+            "Missing functions {} in {}".format(sorted(missing), MODULE_PATH))
+    module = ast.Module(body=selected, type_ignores=[])
+
+    def _pytest_assert(condition, message=""):
+        assert condition, message
+
+    ns = {"pytest_assert": _pytest_assert}
+    exec(compile(module, str(MODULE_PATH), "exec"), ns)
+    return ns
+
+
+@pytest.fixture
+def helper_ns():
+    """Fresh namespace per test so injected stubs don't leak across tests."""
+    return _load_functions(FUNCTION_NAMES)
+
+
+# Two DWRR weight profiles, indexed for parametrization.
+#   [0] mixed weights: lossless queues (Q3, Q4) heavier than lossy queues
+#       — the SN4700 / 7260CX3 default observed in the IxNetwork screenshot.
+#   [1] uniform weights: every queue at weight 15, modeling a platform where
+#       lossless and lossy schedulers are configured identically.
+SCHEDULER_WEIGHT_DICT = [
+    {
+        0: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 14, "dscp": 8},
+        1: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 14, "dscp": 0},
+        2: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 14, "dscp": 5},
+        3: {"scheduler": "scheduler.1", "type": "DWRR", "weight": 15, "dscp": 3},
+        4: {"scheduler": "scheduler.1", "type": "DWRR", "weight": 15, "dscp": 4},
+        5: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 14, "dscp": 46},
+        6: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 14, "dscp": 48},
+    },
+    {
+        0: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 15, "dscp": 8},
+        1: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 15, "dscp": 0},
+        2: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 15, "dscp": 5},
+        3: {"scheduler": "scheduler.1", "type": "DWRR", "weight": 15, "dscp": 3},
+        4: {"scheduler": "scheduler.1", "type": "DWRR", "weight": 15, "dscp": 4},
+        5: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 15, "dscp": 46},
+        6: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 15, "dscp": 48},
+    },
+]
+
+CONFIG_FACTS = {
+    "TC_TO_QUEUE_MAP": {
+        "AZURE": {str(i): str(i) for i in range(7)},
+    },
+}
+
+# IxNetwork scenario parameters (matches the m2o_fluctuating_lossless test):
+TEST_PRIO_LIST = [3, 4]              # lossless TC3 / TC4
+TEST_FLOW_RATE_PERCENT = [20, 10]    # Test Flow 1 / Test Flow 2
+BG_PRIO_LIST = [0, 1, 2, 5]          # 4 lossy background TCs
+BG_FLOW_RATE_PERCENT = [20, 20, 20, 20]
+
+
+def _make_egress_duthost(config_facts=None):
+    """Create a mock egress DUT whose ``config_facts(...)`` returns the
+    canned config_facts dict."""
+    duthost = MagicMock()
+    duthost.config_facts.return_value = {
+        "ansible_facts": config_facts or CONFIG_FACTS,
+    }
+    return duthost
+
+
+def _inject_weight_stub(helper_ns, weight_dict=None):
+    """Inject a stub for ``get_queue_scheduler_weight_dict`` into the loaded
+    namespace so ``get_expected_bg_loss_percent`` can resolve it."""
+    helper_ns["get_queue_scheduler_weight_dict"] = MagicMock(
+        return_value=weight_dict if weight_dict is not None
+        else SCHEDULER_WEIGHT_DICT[0])
+
+
+# -- Tests for get_expected_bg_loss_percent ----------------------------------
+@pytest.mark.parametrize(
+    "case_id, weight_dict_idx, expected_loss",
+    [
+        # SCHEDULER_WEIGHT_DICT[0] — mixed weights (lossless=15, lossy=14):
+        #   Q4 (demand 10) is satisfied first; Q3 + 4 lossy queues split the
+        #   remaining 90% by weight 15:14:14:14:14 (sum 71). Each lossy queue
+        #   gets 90*14/71 = 17.746%.
+        #   Per-BG loss = (20 - 17.746) / 20 * 100 = 11.267%
+        #   Measured by IxNetwork: 11.259% (within the 1% tolerance).
+        ("mixed_weights_15_14", 0, 11.2676),
+        # SCHEDULER_WEIGHT_DICT[1] — uniform weights (all queues = 15):
+        #   With equal weights the DWRR split is fair-share by active queue.
+        #   Iter 1: 6 active queues, share = 100/6 = 16.667%
+        #     Q4 demand 10 < 16.667 → satisfied with 10.
+        #   Iter 2: 5 active queues, remaining 90%, share = 18% each
+        #     All five remaining queues have demand ≥ 18 → fallback split,
+        #     each gets exactly 18%.
+        #   Per-BG loss = (20 - 18) / 20 * 100 = 10.0%
+        ("uniform_weights_15", 1, 10.0),
+    ],
+)
+def test_expected_bg_loss_matches_analytical_dwrr_split(
+        helper_ns, case_id, weight_dict_idx, expected_loss):
+    """Per-BG-flow loss must match the analytical DWRR split.
+
+    Inputs vary only by the egress scheduler weight profile. The fluctuating
+    m2o test parameters are held constant::
+
+        test_prio_list           = [3, 4]
+        test_flow_rate_percent   = [20, 10]
+        bg_prio_list             = [0, 1, 2, 5]
+        bg_flow_rate_percent     = [20, 20, 20, 20]
+    """
+    _inject_weight_stub(helper_ns, SCHEDULER_WEIGHT_DICT[weight_dict_idx])
+    duthost = _make_egress_duthost()
+
+    result = helper_ns["get_expected_bg_loss_percent"](
+        egress_duthost=duthost,
+        test_prio_list=TEST_PRIO_LIST,
+        test_flow_rate_percent=TEST_FLOW_RATE_PERCENT,
+        bg_prio_list=BG_PRIO_LIST,
+        bg_flow_rate_percent=BG_FLOW_RATE_PERCENT,
+    )
+
+    assert result == pytest.approx(expected_loss, abs=0.01)


### PR DESCRIPTION
### Description of PR
Summary:
The m2o_fluctuating_lossless test had a hard-coded background-loss expectation that started failing on DUTs whose egress DWRR scheduler weights differ (e.g. where lossless and lossy queues both run weight 15 and the analytical loss is ~10%, vs. ~11.27% on another DUT where lossless=15 / lossy=14). Instead of assuming the same queue/scheduler weights, derive the expected per-BG-flow loss at runtime from the DUT's QUEUE / SCHEDULER tables.

Fixes https://github.com/sonic-net/sonic-mgmt/issues/24992

### Type of change
- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
`test_m2o_fluctuating_lossless` asserts that each Background Flow sees a specific loss percentage at the egress congestion point. The previous expectation was a hard-coded constant tuned for one DUT's DWRR weights, so the test became fragile / broken on DUTs with different scheduler configurations. The expected loss is fully determined by:

- the test/background flows' offered rates and target TCs, and
- the egress port's per-queue DWRR weights.

We can compute it analytically rather than hard-coding it.

#### How did you do it?
1. **`tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py`**
   - New helper `get_expected_bg_loss_percent(...)` that:
     - Reads `TC_TO_QUEUE_MAP` from `config_facts` (with `host`/`source`/`namespace` honoring `asic_value`).
     - Reads per-queue DWRR weights via `get_queue_scheduler_weight_dict`, depending on `asic_value`, `port`, and `qos_map_profile`.
     - Builds a `queue_demand` / `queue_weight` map from the test + background flows.
     - Runs an iterative DWRR allocator (queues whose demand is under their weight share are satisfied first; the rest split the remainder by weight).
     - Returns the average per-Background-Flow loss percent.
   - `run_m2o_fluctuating_lossless_test` now calls this helper (passing `asic_value` and the egress `port`) and the result drives the assertion in `verify_m2o_fluctuating_lossless_result` with a `BG_LOSS_TOLERANCE_PERCENT = 1` tolerance — replacing the hard-coded value.
   - `pytest_assert` guards on `bg_flow_rate_percent` (non-empty + all entries equal — current limitation, called out in a comment) and on the queue-weight lookup so the test fails fast with a clear message rather than `KeyError`/`ZeroDivisionError`.

2. **`tests/common/snappi_tests/common_helpers.py`**
   - New `get_queue_scheduler_weight_dict(host_ans, asic_value=None, port=None, qos_map_profile=None)` that joins `QUEUE` + `SCHEDULER` from config_facts and annotates each queue with one DSCP via `DSCP_TO_TC_MAP` + `TC_TO_QUEUE_MAP`.
   - If a DUT has no `QUEUE`/`SCHEDULER` config, returns a default 8-queue equal-weight DWRR map (weight 15) so callers always get a usable structure.

3. **Unit tests (no DUT / no Snappi required)**
   - `tests/common/unit_tests/snappi_tests/unit_test_common_helpers.py` — covers `get_queue_scheduler_weight_dict` against a `CONFIG_FACTS` fixture mirroring real `ansible -m config_facts` output from a DUT, plus a defaults-when-unconfigured case.
   - `tests/snappi_tests/unit_tests/pfc/unit_test_m2o_fluctuating_lossless_helper.py` — parametrized analytical-DWRR check of `get_expected_bg_loss_percent`:
     - `mixed_weights_15_14` → expected ~11.27% (matches IxNetwork-measured 11.259% on a DUT with lossless 15 weight and lossy 14 weight.).
     - `uniform_weights_15` → expected 10.0% (fair share).

   - Each unit-test directory has a README documenting `--noconftest` invocation and the extraction mechanism.

#### How did you verify/test it?
- Unit tests pass:
```
python3 -m pytest --noconftest   "tests/snappi_tests/unit_tests/pfc/unit_test_m2o_fluctuating_lossless_helper.py"   -v
====================================== test session starts =======================================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/ediwibowo/workspace/sonic-mgmt-int/tests
configfile: pytest.ini
collected 2 items                                                                                

tests/snappi_tests/unit_tests/pfc/unit_test_m2o_fluctuating_lossless_helper.py::test_expected_bg_loss_matches_analytical_dwrr_split[mixed_weights_15_14-0-11.2676] PASSED [ 50%]
tests/snappi_tests/unit_tests/pfc/unit_test_m2o_fluctuating_lossless_helper.py::test_expected_bg_loss_matches_analytical_dwrr_split[uniform_weights_15-1-10.0] PASSED [100%]
```
  Both files pass (4 tests total), including the analytical-DWRR cases that reproduce the IxNetwork-measured 11.259% on DUT with lossless 15 and lossy 14 within the 1% tolerance and 10.0% on a uniform-weight platform.
- Integration/Snappi tests pass on DUT with with lossless 15 and lossy 14
```
python3 -m  pytest snappi_tests/pfc/test_m2o_fluctuating_lossless.py --inventory ../ansible/ixia,../ansible/veos --host-pattern <DUT>  --dpu-pattern None --testbed <testbed> --testbed_file ../ansible/testbed.yaml --log-cli-level warning --log-file-level debug --kube_master unset --showlocals --assert plain --show-capture no -rav --allow_recover --ignore=ptftests --ignore=acstests --ignore=saitests --ignore=scripts --ignore=k8s --ignore=sai_qualify --log-file logs/snappi_tests/pfc/focused_retry_check.log --junitxml=logs/snappi_tests/pfc/focused_retry_check.xml -s --trim_inv --skip_sanity --disable_loganalyzer --maxfail=1 
...
snappi_tests/pfc/test_m2o_fluctuating_lossless.py::test_m2o_fluctuating_lossless[tgen_port_info0]  PASSED
````

#### Any platform specific information?
This change removes the platform-specific hard-coded loss expectation. The test should now self-adjust to any DUT whose `QUEUE`/`SCHEDULER` tables are readable via `config_facts`.

#### Supported testbed topology if it's a new test case?
N/A — existing test, unchanged topology requirements.

### Documentation
Traffic flows of a DUT with lossless 15 weight and lossy 15 weight:
<img width="635" height="344" alt="image" src="https://github.com/user-attachments/assets/9ef76b58-67a2-41ed-98ad-d7e1584961ef" />
