### PR TITLE
snappi: read IxNetwork API credentials from ansible inventory

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -80,6 +80,8 @@ def snappi_api_serv_port(tbinfo, duthosts, rand_one_dut_hostname):
 @pytest.fixture(scope='module')
 def snappi_api(snappi_api_serv_ip,
                snappi_api_serv_port,
+               duthosts,
+               rand_one_dut_hostname,
                tbinfo):
     """
     Fixture for session handle,
@@ -87,6 +89,8 @@ def snappi_api(snappi_api_serv_ip,
     Args:
         snappi_api_serv_ip (pytest fixture): snappi_api_serv_ip fixture
         snappi_api_serv_port (pytest fixture): snappi_api_serv_port fixture
+        duthosts (pytest fixture): The duthosts fixture.
+        rand_one_dut_hostname (pytest fixture): hostname of a random DUT.
         tbinfo (pytest fixture): fixture provides information about testbed.
     """
 
@@ -104,9 +108,22 @@ def snappi_api(snappi_api_serv_ip,
         location = "https://" + snappi_api_serv_ip + ":" + str(snappi_api_serv_port)
         api = snappi.api(location=location, ext="ixnetwork")
 
-        # TODO - Uncomment to use. Prefer to use environment vars to retrieve this information
-        # api._username = "<please mention the username if other than default username>"
-        # api._password = "<please mention the password if other than default password>"
+        # Read IxNetwork credentials from the DUT's ansible inventory variable
+        # `snappi_api_server.user` / `.password` (same source as the rest_port
+        # read by snappi_api_serv_port). When a key is absent the value stays
+        # None and the snappi library default applies, preserving behavior for
+        # testbeds that don't define these keys.
+        duthost = duthosts[rand_one_dut_hostname]
+        snappi_api_server = (duthost.host.options['variable_manager']
+                             ._hostvars[duthost.hostname]
+                             .get('snappi_api_server', {}))
+        snappi_api_serv_user = snappi_api_server.get('user')
+        snappi_api_serv_password = snappi_api_server.get('password')
+
+        if snappi_api_serv_user:
+            api._username = snappi_api_serv_user
+        if snappi_api_serv_password:
+            api._password = snappi_api_serv_password
 
     yield api
 


### PR DESCRIPTION
### Description of PR

Summary:
The `snappi_api` fixture previously had the IxNetwork API username/password hardcoded behind a commented-out TODO, so any site whose IxNetwork uses non-default credentials had to edit the fixture locally. This change reads those credentials from the DUT's ansible inventory variable `snappi_api_server.user` / `snappi_api_server.password` — the same inventory source already used to read `rest_port` (`snappi_api_serv_port`). Credentials now live in the testbed inventory instead of in test code.

When those keys are absent, the values stay `None` and the snappi library defaults apply, so behavior is unchanged for testbeds that don't define them.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
IxNetwork API credentials were hardcoded (commented out) in the `snappi_api` fixture. Sites whose IxNetwork uses non-default credentials had to patch the fixture in place. Reading them from the ansible inventory keeps credentials out of the test code and is consistent with how `snappi_api_serv_port` already reads `rest_port` from the same `snappi_api_server` inventory variable.

#### How did you do it?
In the `snappi_api` fixture, added the `duthosts` and `rand_one_dut_hostname` fixtures, looked up the `snappi_api_server` host var for the selected DUT, and set `api._username` / `api._password` from its `user` / `password` keys when present. Absent keys leave the snappi library defaults in place, preserving existing behavior.

#### How did you verify/test it?
```
INFO     tests.snappi_tests.ecn.test_red_accuracy_with_snappi:test_red_accuracy_with_snappi.py:113 Running ECN red accuracy test with ECN params: {'kmin': 500000, 'kmax': 900000, 'pmax': 5}
INFO     tests.snappi_tests.ecn.test_red_accuracy_with_snappi:test_red_accuracy_with_snappi.py:114 Running ECN red accuracy test for 1 iterations
INFO     tests.snappi_tests.ecn.files.helper:helper.py:346 Stopping PFC watchdog
INFO     tests.snappi_tests.ecn.files.helper:helper.py:349 Disabling packet aging if necessary
INFO     tests.snappi_tests.ecn.files.helper:helper.py:352 Enabling WRED queue counters
INFO     tests.snappi_tests.ecn.files.helper:helper.py:357 Configuring WRED and ECN thresholds
INFO     tests.snappi_tests.ecn.files.helper:helper.py:372 Enabling ECN markings
INFO     tests.snappi_tests.ecn.files.helper:helper.py:401 Generating base flow config
INFO     tests.snappi_tests.ecn.files.helper:helper.py:406 Setting test flow config params
INFO     tests.snappi_tests.ecn.files.helper:helper.py:414 Setting pause flow config params
INFO     tests.snappi_tests.ecn.files.helper:helper.py:428 Generating test flows
INFO     tests.snappi_tests.ecn.files.helper:helper.py:435 Generating pause flows
INFO     tests.snappi_tests.ecn.files.helper:helper.py:446 Setting packet capture port to Port 0
INFO     tests.snappi_tests.ecn.files.helper:helper.py:450 Running 1 iteration(s)
INFO     tests.snappi_tests.ecn.files.helper:helper.py:452 Running iteration 0
INFO     tests.snappi_tests.ecn.files.helper:helper.py:454 Packet capture file: ECN_cap-0.pcapng
INFO     tests.snappi_tests.ecn.files.helper:helper.py:462 Clearing DUT counters before iter 0 traffic
INFO     tests.snappi_tests.ecn.files.helper:helper.py:466 Running traffic
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:616 Wait for Arp to Resolve ...
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:627 Starting packet capture ...
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:639 Starting transmit on all flows ...
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:685 Polling TGEN for in-flight traffic statistics...
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:693 Checking if all flows have stopped. Attempt #1
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:693 Checking if all flows have stopped. Attempt #2
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:700 All test and background traffic flows stopped
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:711 Stopping packet capture ...
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:717 Retrieving and saving packet capture to ECN_cap-0.pcapng
WARNING  root:snappi_api.py:1518 Capture was not stopped for this port Port 0
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:723 Dumping per-flow statistics
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:725 Stopping transmit on all remaining flows
INFO     tests.snappi_tests.ecn.files.helper:helper.py:500 Queue counters after iter 0 (prio 3):
```
#### Any platform specific information?
None — this affects only the snappi/IxNetwork API session setup.

#### Supported testbed topology if it's a new test case?
N/A — not a new test case; applies to snappi tgen testbeds.

### Documentation
N/A — no documentation/wiki changes required.