### PR TITLE
[bgp] Wait for Zebra RIB convergence before asserting route counts in test_bgp_speaker

### DIFF
--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -286,6 +286,37 @@ def is_all_neighbors_learned(duthost, speaker_ips):
     return True
 
 
+def wait_for_rib_stable(duthost, timeout=120, poll_interval=10, stable_checks=2):
+    """Wait for Zebra RIB to finish installing routes after BGP convergence.
+
+    BGP sessions becoming established (bgpd layer) does not guarantee that
+    Zebra has finished installing all routes into the RIB.  The
+    memory_utilization fixture teardown may fire while Zebra is still
+    processing the route updates, causing a false memory alarm.  Polling
+    'show ip route summary' until the total route count is stable across
+    two consecutive checks ensures the RIB has fully converged before the
+    test tears down.
+    """
+    prev_count = None
+    stable_streak = 0
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        ipv4_summary, _ = duthost.get_ip_route_summary()
+        curr_count = ipv4_summary.get("Totals", {}).get("routes", 0)
+        if curr_count == prev_count:
+            stable_streak += 1
+            if stable_streak >= stable_checks:
+                logger.info("RIB stable: %d routes (confirmed %d times)", curr_count, stable_checks)
+                return
+        else:
+            stable_streak = 0
+        prev_count = curr_count
+        time.sleep(poll_interval)
+
+    logger.warning("wait_for_rib_stable: timed out after %ds, last route count=%s", timeout, prev_count)
+
+
 def bgp_speaker_announce_routes_common(common_setup_teardown, tbinfo, duthost,
                                        ptfhost, ipv4, ipv6, mtu,
                                        family, prefix, nexthop_ips, vlan_mac,
@@ -317,6 +348,8 @@ def bgp_speaker_announce_routes_common(common_setup_teardown, tbinfo, duthost,
         "DUT Host: {}"
         "Speaker IPs: {}"
     ).format(duthost, speaker_ips)
+
+    wait_for_rib_stable(duthost)
 
     logger.info("Verify nexthops and nexthop interfaces for accepted prefixes of the dynamic neighbors")
     rtinfo = duthost.get_ip_route_info(ipaddress.ip_network(prefix.encode().decode()))

--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -299,15 +299,18 @@ def wait_for_rib_stable(duthost, timeout=120, poll_interval=10, stable_checks=2)
     """
     prev_count = None
     stable_streak = 0
-    deadline = time.time() + timeout
+    start = time.time()
+    deadline = start + timeout
 
     while time.time() < deadline:
+        elapsed = time.time() - start
         ipv4_summary, _ = duthost.get_ip_route_summary()
         curr_count = ipv4_summary.get("Totals", {}).get("routes", 0)
         if curr_count == prev_count:
             stable_streak += 1
             if stable_streak >= stable_checks:
-                logger.info("RIB stable: %d routes (confirmed %d times)", curr_count, stable_checks)
+                logger.info("RIB stable: %d routes (confirmed %d times, elapsed=%.0fs)",
+                            curr_count, stable_checks, elapsed)
                 return
         else:
             stable_streak = 0


### PR DESCRIPTION
### Description of PR


Summary:
`test_bgp_speaker` was intermittently failing because it asserted route counts immediately after BGP session establishment, before Zebra finished installing routes into the RIB. This caused a flaky race condition where the expected number of routes was not yet present.

This PR adds a `wait_for_rib_stable()` helper that polls `show ip route summary` until the total route count is stable for two consecutive checks (with a 120-second timeout), ensuring the RIB has converged before the test proceeds.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/38172035

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`test_bgp_speaker` has a race condition: after BGP sessions come up, Zebra may still be installing routes into the kernel RIB. Asserting the route count before convergence is complete causes spurious failures on slower hardware (e.g., Arista 7060CX).

#### How did you do it?
Added `wait_for_rib_stable(duthost, timeout=120, poll_interval=10, stable_checks=2)`:
- Polls `duthost.get_ip_route_summary()` every 10 seconds
- Waits until the IPv4 total route count is identical for 2 consecutive polls
- Logs elapsed time and final stable count upon convergence
- Called in `test_bgp_speaker` before the route count assertion

#### How did you verify/test it?
Verified on ElasticTest internal test plan (ADO internal-202511 branch):
- Test plan `6a1a8fea81bb3768ca7f435c` — all runs **PASSED** after the fix was applied


#### Any platform specific information?


#### Supported testbed topology if it's a new test case?
N/A — existing test case improvement.

### Documentation

N/A