### PR TITLE
Fix test_srv6_vlan_forwarding when no ipv6 mgmt for ptf docker

### DIFF
--- a/tests/srv6/test_srv6_vlan_forwarding.py
+++ b/tests/srv6/test_srv6_vlan_forwarding.py
@@ -24,6 +24,7 @@ pytestmark = [
 
 def run_srv6_downstrean_traffic_test(duthost, dut_mac, ptf_src_port, ptf_dst_port,
                                      neighbor_ip, ptfadapter, ptfhost, with_srh):
+    ptf_mgmt_ipv6 = ptfhost.mgmt_ipv6 if ptfhost.mgmt_ipv6 else "1000::1"
     for i in range(0, 10):
         # generate a random payload
         payload = ''.join(random.choices(string.ascii_letters + string.digits, k=20))
@@ -31,7 +32,7 @@ def run_srv6_downstrean_traffic_test(duthost, dut_mac, ptf_src_port, ptf_dst_por
             injected_pkt = simple_ipv6_sr_packet(
                 eth_dst=dut_mac,
                 eth_src=ptfadapter.dataplane.get_mac(0, ptf_src_port).decode(),
-                ipv6_src=ptfhost.mgmt_ipv6,
+                ipv6_src=ptf_mgmt_ipv6,
                 ipv6_dst="fcbb:bbbb:1:2::",
                 srh_seg_left=1,
                 srh_nh=41,
@@ -39,7 +40,7 @@ def run_srv6_downstrean_traffic_test(duthost, dut_mac, ptf_src_port, ptf_dst_por
             )
         else:
             injected_pkt = Ether(dst=dut_mac, src=ptfadapter.dataplane.get_mac(0, ptf_src_port).decode()) \
-                / IPv6(src=ptfhost.mgmt_ipv6, dst="fcbb:bbbb:1:2::") \
+                / IPv6(src=ptf_mgmt_ipv6, dst="fcbb:bbbb:1:2::") \
                 / IPv6() / UDP(dport=4791) / Raw(load=payload)
 
         expected_pkt = injected_pkt.copy()
@@ -222,11 +223,12 @@ def test_srv6_uN_no_vlan_flooding(setup_downstream_uN, proxy_arp_enabled, ptfada
     ptfadapter.dataplane.flush()
     # generate a random payload
     payload = ''.join(random.choices(string.ascii_letters + string.digits, k=20))
+    ptf_mgmt_ipv6 = ptfhost.mgmt_ipv6 if ptfhost.mgmt_ipv6 else "1000::1"
     if with_srh:
         injected_pkt = simple_ipv6_sr_packet(
             eth_dst=dut_mac,
             eth_src=ptfadapter.dataplane.get_mac(0, ptf_src_port).decode(),
-            ipv6_src=ptfhost.mgmt_ipv6,
+            ipv6_src=ptf_mgmt_ipv6,
             ipv6_dst="fcbb:bbbb:1:2::",
             srh_seg_left=0,
             srh_nh=41,
@@ -234,7 +236,7 @@ def test_srv6_uN_no_vlan_flooding(setup_downstream_uN, proxy_arp_enabled, ptfada
         )
     else:
         injected_pkt = Ether(dst=dut_mac, src=ptfadapter.dataplane.get_mac(0, ptf_src_port).decode()) \
-            / IPv6(src=ptfhost.mgmt_ipv6, dst="fcbb:bbbb:1:2::") \
+            / IPv6(src=ptf_mgmt_ipv6, dst="fcbb:bbbb:1:2::") \
             / IPv6() / UDP(dport=4791) / Raw(load=payload)
 
     expected_pkt = injected_pkt.copy()


### PR DESCRIPTION
fix the test_srv6_vlan_forwarding.py to use the ptf_mgmt_ipv6 if it is available

Change-Id: I2e3f3d40b6ae31d0e2ce8fa4d5bad79acf918e15

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Fix SRv6 test issue - when there is no ipv6 mgmt for ptf docker, use default.


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
test is broken when no ipv6 mgmt in configured on ptf docker. same is applied for test_srv6_dataplane.py.

#### How did you do it?
Added default value to use for ipv6 when none if configured in docker.

#### How did you verify/test it?
internal regression 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
