### PR TITLE
Skip test_hft_config_deletion_stream due to community issue.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3378,6 +3378,12 @@ high_frequency_telemetry:
       - "'t2' in topo_type"
       - "topo_type in ['lrh', 'urh']"
 
+high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_config_deletion_stream:
+  skip:
+    reason: "Skip due to https://github.com/sonic-net/sonic-mgmt/issues/24907 on sn6600_ld platform"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/24907 and platform in ['x86_64-nvidia_sn6600_ld-r0']"
+
 high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_full_counters:
   skip:
     reason: "In SN5640 platform, it doesn't support multiple types in one session. In 7060X6 platform, it hasn't supported any HFT tests yet."


### PR DESCRIPTION
Skip test_hft_config_deletion_stream due to an test issue.

The issue is that Phase1 validation fails with empty Msg/s when expected_poll_interval is None
https://github.com/sonic-net/sonic-mgmt/issues/24907

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
test failed because of open issue so need to skip by it.

#### How did you do it?
add skip on tests/common/plugins/conditional_mark/tests_mark_conditions.yaml

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
