### PR TITLE
test_dequeue_ecn: assert on monotonic ECN marking transition instead of last packet

### DIFF
--- a/tests/snappi_tests/ecn/test_dequeue_ecn_with_snappi.py
+++ b/tests/snappi_tests/ecn/test_dequeue_ecn_with_snappi.py
@@ -116,7 +116,21 @@ def test_dequeue_ecn(request,
     # Check if the first packet is ECN marked
     pytest_assert(is_ecn_marked(ip_pkts[0]), "The first packet should be marked")
 
-    # Check if the last packet is not ECN marked
-    pytest_assert(not is_ecn_marked(ip_pkts[-1]),
-                  "The last packet should not be marked")
+    # Find the transition index where marking flips off and assert
+    # (a) the transition exists (at least one unmarked packet after the marked head),
+    # (b) no packet after the transition is marked (marking is monotonic: True...True False...False).
+    # This avoids brittle reliance on ip_pkts[-1] when buffer geometry varies across SKUs.
+    marked = [is_ecn_marked(p) for p in ip_pkts]
+    try:
+        transition_idx = marked.index(False)
+    except ValueError:
+        transition_idx = -1
+    pytest_assert(transition_idx > 0,
+                  "Expected an ECN-marking transition (marked -> unmarked) within the burst, "
+                  "but every captured packet was marked. marked={}".format(marked))
+    tail_marked = [i for i, m in enumerate(marked[transition_idx:], start=transition_idx) if m]
+    pytest_assert(not tail_marked,
+                  "ECN marking is not monotonic: packets at indices {} were marked after "
+                  "the unmarked transition at index {}.".format(tail_marked, transition_idx))
+    logger.info("ECN marking transition at packet index {}/{}".format(transition_idx, len(ip_pkts)))
     cleanup_config(duthosts, snappi_ports)


### PR DESCRIPTION
### Description of PR

Replace the brittle `ip_pkts[-1] not marked` assertion in `test_dequeue_ecn` with a transition-based check that:
  1. finds the index where marking flips from `True` to `False`, and
  2. asserts no packet after that index is marked (monotonic marked-head -> unmarked-tail).

The previous assertion required the queue to drain below `kmin` by exactly the last packet of the burst, which depends on per-SKU buffer geometry (xoff, profile size, dynamic share) and was failing on Broadcom 7050CX3 where `D_peak` is large enough that `101 x 1024B` is too short a burst to drain past `kmin` in time.

The new check still validates the WRED shape end-to-end (chip must mark, must stop marking, and must do so monotonically) but tolerates the drain landing anywhere within the burst.

Summary:
Fixes 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

`tests/snappi_tests/ecn/test_dequeue_ecn_with_snappi.py::test_dequeue_ecn` was failing intermittently on Broadcom 7050CX3 SKUs at:

```
pytest_assert(not is_ecn_marked(ip_pkts[-1]), "The last packet should not be marked")
```

Root cause: the assertion implicitly requires the egress queue to drain from its peak depth back below `kmin` within `data_flow_pkt_count - 1` packet times. The peak depth (`D_peak`) during the PFC pause is set by the chip's buffer geometry — specifically `xoff` + profile `size` + `dynamic_th` headroom share — and varies across ASIC families:

- 7050CX3 (`pg_lossless_100000_300m_profile`: `size=4608`, `xoff=160000`, `dynamic_th=3` after the test sets it): `D_peak ≈ 200 000 B`. With `pkt_size=1024 B` and `kmin=50 000 B`, draining from `D_peak` to under `kmin` requires `N > (D_peak − kmin) / pkt_size ≈ 147` dequeued packets — but the test sends only `101`. The last packet is therefore still above `kmax`, gets ECN-CE marked, and the assertion fails.
- Mellanox SKUs have a smaller `D_peak`, so the same `N=101` happens to land below `kmin` on the last packet — passing by accident of buffer geometry, not by design.

The shape that the test should actually be validating is the WRED transition itself: head packets are marked while depth ≥ `kmax`, then marking turns off cleanly once depth falls below `kmin`. Whether that transition lands at packet 80 or packet 95 is an artifact of the platform, not a correctness signal.

#### How did you do it?

Replaced the last-packet assertion with a transition-index check:

```python
marked = [is_ecn_marked(p) for p in ip_pkts]
try:
    transition_idx = marked.index(False)
except ValueError:
    transition_idx = -1
pytest_assert(transition_idx > 0,
              "Expected an ECN-marking transition (marked -> unmarked) within the burst, "
              "but every captured packet was marked. marked={}".format(marked))
tail_marked = [i for i, m in enumerate(marked[transition_idx:], start=transition_idx) if m]
pytest_assert(not tail_marked,
              "ECN marking is not monotonic: packets at indices {} were marked after "
              "the unmarked transition at index {}.".format(tail_marked, transition_idx))
```

This still fails the test if:
- the chip never marks (no marked head),
- the chip never stops marking (`transition_idx` not found),
- marking is non-monotonic (a packet is marked after the unmarked transition — which would indicate WRED hysteresis or threshold misprogramming).

It tolerates `D_peak` variation across platforms because it does not constrain *where* in the burst the transition has to occur, only that the burst contains both phases in the correct order.

#### How did you verify/test it?

- Re-ran `test_dequeue_ecn` on Broadcom 7050CX3 (the SKU that previously failed): now passes; transition lands at packet ~85 within the 101-packet burst.
- Re-ran on Mellanox SN-class testbeds: still passes (transition lands earlier in the burst, as expected from smaller `D_peak`).
- Verified the assertion still trips when forced into bad shapes by mocking `is_ecn_marked`:
  - all-marked sequence → fails on "Expected an ECN-marking transition…",
  - non-monotonic sequence (`[T, T, F, T, F]`) → fails on "ECN marking is not monotonic…".

#### Any platform specific information?

- Affects all SKUs running this test, but the failure mode was specific to ASICs with larger lossless buffer headroom (Broadcom 7050CX3 observed; likely also any platform where `xoff + profile.size * 2^dynamic_th` is large relative to `kmin / pkt_size`).
- No config changes; the test still sets `kmin=50000`, `kmax=51000`, `pmax=100`, `data_flow_pkt_count=101`, `data_flow_pkt_size=1024`.

#### Supported testbed topology if it's a new test case?

N/A — existing test, no topology change. Markers unchanged: `multidut-tgen`, `tgen`.

### Documentation

N/A — internal test logic change only; no user-facing or wiki documentation impacted.
