### PR TITLE
[memory_utilization] Add topology-specific threshold overrides

### DIFF
--- a/tests/common/plugins/memory_utilization/README.md
+++ b/tests/common/plugins/memory_utilization/README.md
@@ -455,10 +455,8 @@ Example: raise the `bgpd` increase threshold from the COMMON 128 MB up to 192 MB
 
 ```json
 {
-  "TOPO": {
-    "topo-m1-128": ["m1-128"]
-  },
-  "topo-m1-128": [
+  "TOPO": ["m1-128"],
+  "m1-128": [
     {
       "name": "top",
       "cmd": "top -b -n 1",
@@ -478,8 +476,12 @@ Example: raise the `bgpd` increase threshold from the COMMON 128 MB up to 192 MB
 ```
 
 Notes:
-- `TOPO` collection keys (e.g., `topo-m1-128`) must not collide with `HWSKU` collection keys
-  since both reference top-level lists by name. Prefix with `topo-` to avoid clashes.
+- `TOPO` is a flat list of topology names that have an override block.
+- Each topo name listed in `TOPO` has a matching top-level key holding the list of memory items
+  to override (in the example above, the `"m1-128"` key).
+- Pick topo-section keys that don't collide with `HWSKU` collection keys, since both reference
+  top-level lists by name. Topology names from `tbinfo["topo"]["name"]` are usually distinctive
+  enough (e.g., `m1-128`, `dualtor-aa`).
 - Only the `memory_params` entries you specify are merged; everything else from the COMMON /
   HWSKU layers is preserved.
 - A topology block can also introduce a new command not present in COMMON.

--- a/tests/common/plugins/memory_utilization/README.md
+++ b/tests/common/plugins/memory_utilization/README.md
@@ -20,6 +20,7 @@
 - [Advanced Usage](#advanced-usage)
   - [Global Memory Items](#global-memory-items)
   - [HWSKU-Specific Memory Items](#hwsku-specific-memory-items)
+  - [Topology-Specific Memory Items](#topology-specific-memory-items)
   - [Test-Specific Memory Items](#test-specific-memory-items)
 - [Troubleshooting](#troubleshooting)
 
@@ -434,6 +435,54 @@ Example:
 ```
 
 In this example, specific Arista SKUs will use a higher memory_high_threshold (85% instead of 70%).
+
+### Topology-Specific Memory Items
+
+Some topologies (e.g., `m1-128`) put extra pressure on certain daemons such as `bgpd` because of the
+larger number of neighbors. You can raise thresholds for a specific topology in
+`memory_utilization_dependence.json` using a `TOPO` section that mirrors the `HWSKU` pattern.
+
+Override precedence (later wins):
+
+```
+COMMON (common.json) -> COMMON (dependence.json) -> HWSKU -> TOPO
+```
+
+Topology overrides are matched against `tbinfo["topo"]["name"]` (e.g., `m1-128`, `t1-lag`,
+`dualtor-aa`).
+
+Example: raise the `bgpd` increase threshold from the COMMON 128 MB up to 192 MB only on `m1-128`:
+
+```json
+{
+  "TOPO": {
+    "topo-m1-128": ["m1-128"]
+  },
+  "topo-m1-128": [
+    {
+      "name": "top",
+      "cmd": "top -b -n 1",
+      "memory_params": {
+        "bgpd": {
+          "memory_increase_threshold": {
+            "type": "value",
+            "value": 192
+          },
+          "memory_high_threshold": null
+        }
+      },
+      "memory_check": "parse_top_output"
+    }
+  ]
+}
+```
+
+Notes:
+- `TOPO` collection keys (e.g., `topo-m1-128`) must not collide with `HWSKU` collection keys
+  since both reference top-level lists by name. Prefix with `topo-` to avoid clashes.
+- Only the `memory_params` entries you specify are merged; everything else from the COMMON /
+  HWSKU layers is preserved.
+- A topology block can also introduce a new command not present in COMMON.
 
 ### Test-Specific Memory Items
 

--- a/tests/common/plugins/memory_utilization/__init__.py
+++ b/tests/common/plugins/memory_utilization/__init__.py
@@ -184,15 +184,23 @@ def memory_utilization(duthosts, request):
     memory_monitors = {}
     memory_values = {"before_test": {}, "after_test": {}}
 
+    topo_name = None
+    try:
+        tbinfo = request.getfixturevalue("tbinfo")
+        topo_name = tbinfo.get("topo", {}).get("name")
+    except Exception as e:
+        logger.warning("Could not resolve tbinfo for topo-specific memory thresholds: {}".format(e))
+
     for duthost in duthosts:
         if duthost.topo_type == 't2':
             continue
         memory_monitor = MemoryMonitor(ansible_host=duthost)
         memory_values["before_test"][duthost.hostname] = {}
         memory_values["after_test"][duthost.hostname] = {}
-        logger.info("Hostname: {}, Hwsku: {}, Platform: {}".format(
-            duthost.hostname, duthost.sonichost._facts["hwsku"], duthost.sonichost._facts["platform"]))
-        memory_monitor.parse_and_register_commands(hwsku=duthost.sonichost._facts["hwsku"])
+        logger.info("Hostname: {}, Hwsku: {}, Platform: {}, Topo: {}".format(
+            duthost.hostname, duthost.sonichost._facts["hwsku"], duthost.sonichost._facts["platform"], topo_name))
+        memory_monitor.parse_and_register_commands(
+            hwsku=duthost.sonichost._facts["hwsku"], topo_name=topo_name)
         memory_monitors[duthost.hostname] = memory_monitor
 
     yield memory_monitors, memory_values

--- a/tests/common/plugins/memory_utilization/memory_utilization.py
+++ b/tests/common/plugins/memory_utilization/memory_utilization.py
@@ -520,9 +520,13 @@ class MemoryMonitor:
             logger.debug("Formatted simple threshold as: {}".format(result))
             return result
 
-    def parse_and_register_commands(self, hwsku=None):
-        """Initialize the MemoryMonitor by reading commands from JSON files and registering them."""
-        logger.info("Loading memory monitoring commands for hwsku: {}".format(hwsku))
+    def parse_and_register_commands(self, hwsku=None, topo_name=None):
+        """Initialize the MemoryMonitor by reading commands from JSON files and registering them.
+
+        Override precedence (later overrides earlier):
+            COMMON (common.json) -> COMMON (dependence.json) -> HWSKU -> TOPO
+        """
+        logger.info("Loading memory monitoring commands for hwsku: {}, topo: {}".format(hwsku, topo_name))
 
         parameter_dict = {}
         with open(MEMORY_UTILIZATION_COMMON_JSON_FILE, 'r') as file:
@@ -582,6 +586,39 @@ class MemoryMonitor:
                                 else:
                                     # New command specific to this hwsku
                                     logger.info("Adding new hwsku-specific command: {}".format(name))
+                                    parameter_dict[name] = {
+                                        'name': name,
+                                        'cmd': command,
+                                        'memory_params': memory_params,
+                                        'memory_check_fn': memory_check_fn,
+                                        'order': item.get('order', 0)
+                                    }
+
+            if topo_name:
+                topo_found = any(topo_name in topo_list for topo_list in data.get("TOPO", {}).values())
+                if topo_found:
+                    for key, value in data["TOPO"].items():
+                        if topo_name in value:
+                            for item in data[key]:
+                                name = item["name"]
+                                command = item["cmd"]
+                                memory_params = item["memory_params"]
+                                memory_check_fn = item["memory_check"]
+
+                                # Check if this command already exists (from common or hwsku config)
+                                if name in parameter_dict:
+                                    logger.info("Merging topo-specific config for command: {}".format(name))
+                                    # Merge memory_params instead of overwriting
+                                    existing_params = parameter_dict[name]['memory_params']
+                                    for mem_item, thresholds in memory_params.items():
+                                        logger.debug("Overriding memory params for {}:{}".format(name, mem_item))
+                                        existing_params[mem_item] = thresholds
+                                    # Update cmd and memory_check_fn if needed
+                                    parameter_dict[name]['cmd'] = command
+                                    parameter_dict[name]['memory_check_fn'] = memory_check_fn
+                                else:
+                                    # New command specific to this topo
+                                    logger.info("Adding new topo-specific command: {}".format(name))
                                     parameter_dict[name] = {
                                         'name': name,
                                         'cmd': command,

--- a/tests/common/plugins/memory_utilization/memory_utilization.py
+++ b/tests/common/plugins/memory_utilization/memory_utilization.py
@@ -595,37 +595,34 @@ class MemoryMonitor:
                                     }
 
             if topo_name:
-                topo_found = any(topo_name in topo_list for topo_list in data.get("TOPO", {}).values())
-                if topo_found:
-                    for key, value in data["TOPO"].items():
-                        if topo_name in value:
-                            for item in data[key]:
-                                name = item["name"]
-                                command = item["cmd"]
-                                memory_params = item["memory_params"]
-                                memory_check_fn = item["memory_check"]
+                if topo_name in data.get("TOPO", []):
+                    for item in data.get(topo_name, []):
+                        name = item["name"]
+                        command = item["cmd"]
+                        memory_params = item["memory_params"]
+                        memory_check_fn = item["memory_check"]
 
-                                # Check if this command already exists (from common or hwsku config)
-                                if name in parameter_dict:
-                                    logger.info("Merging topo-specific config for command: {}".format(name))
-                                    # Merge memory_params instead of overwriting
-                                    existing_params = parameter_dict[name]['memory_params']
-                                    for mem_item, thresholds in memory_params.items():
-                                        logger.debug("Overriding memory params for {}:{}".format(name, mem_item))
-                                        existing_params[mem_item] = thresholds
-                                    # Update cmd and memory_check_fn if needed
-                                    parameter_dict[name]['cmd'] = command
-                                    parameter_dict[name]['memory_check_fn'] = memory_check_fn
-                                else:
-                                    # New command specific to this topo
-                                    logger.info("Adding new topo-specific command: {}".format(name))
-                                    parameter_dict[name] = {
-                                        'name': name,
-                                        'cmd': command,
-                                        'memory_params': memory_params,
-                                        'memory_check_fn': memory_check_fn,
-                                        'order': item.get('order', 0)
-                                    }
+                        # Check if this command already exists (from common or hwsku config)
+                        if name in parameter_dict:
+                            logger.info("Merging topo-specific config for command: {}".format(name))
+                            # Merge memory_params instead of overwriting
+                            existing_params = parameter_dict[name]['memory_params']
+                            for mem_item, thresholds in memory_params.items():
+                                logger.debug("Overriding memory params for {}:{}".format(name, mem_item))
+                                existing_params[mem_item] = thresholds
+                            # Update cmd and memory_check_fn if needed
+                            parameter_dict[name]['cmd'] = command
+                            parameter_dict[name]['memory_check_fn'] = memory_check_fn
+                        else:
+                            # New command specific to this topo
+                            logger.info("Adding new topo-specific command: {}".format(name))
+                            parameter_dict[name] = {
+                                'name': name,
+                                'cmd': command,
+                                'memory_params': memory_params,
+                                'memory_check_fn': memory_check_fn,
+                                'order': item.get('order', 0)
+                            }
 
         for param in sorted(parameter_dict.values(), key=lambda x: x.get('order', 0)):
             # Normalize thresholds in memory_params to ensure consistent behavior

--- a/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
@@ -10,9 +10,7 @@
     "Cisco-C8220TG": ["Cisco-C8220TG-48A-O", "Cisco-C8220TG-G1S2"],
     "Mellanox-SN6600":["Mellanox-SN6600_LD-V512C2", "Mellanox-SN6600_LD-V448P16C2"]
   },
-  "TOPO": {
-    "topo-m1-128": ["m1-128"]
-  },
+  "TOPO": ["m1-128"],
   "COMMON": [
     {
       "name": "top",
@@ -443,7 +441,7 @@
       "memory_check": "parse_frr_memory_output"
     }
   ],
-  "topo-m1-128": [
+  "m1-128": [
     {
       "name": "top",
       "cmd": "top -b -n 1",

--- a/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
@@ -10,6 +10,9 @@
     "Cisco-C8220TG": ["Cisco-C8220TG-48A-O", "Cisco-C8220TG-G1S2"],
     "Mellanox-SN6600":["Mellanox-SN6600_LD-V512C2", "Mellanox-SN6600_LD-V448P16C2"]
   },
+  "TOPO": {
+    "topo-m1-128": ["m1-128"]
+  },
   "COMMON": [
     {
       "name": "top",
@@ -438,6 +441,22 @@
         }
       },
       "memory_check": "parse_frr_memory_output"
+    }
+  ],
+  "topo-m1-128": [
+    {
+      "name": "top",
+      "cmd": "top -b -n 1",
+      "memory_params": {
+        "bgpd": {
+          "memory_increase_threshold": {
+            "type": "value",
+            "value": 192
+          },
+          "memory_high_threshold": null
+        }
+      },
+      "memory_check": "parse_top_output"
     }
   ]
 }


### PR DESCRIPTION
The memory_utilization plugin currently supports overriding thresholds only at COMMON (global) and HWSKU (per-hardware) scopes. Some topologies — notably m1-128 — exercise daemons such as bgpd much more heavily than the COMMON defaults assume, leading to spurious 'memory usage increased by ... exceeds increase threshold' alarms even when behavior is expected for that topology.

This change adds a third override scope, TOPO, that mirrors the existing HWSKU pattern in memory_utilization_dependence.json:

  COMMON (common.json) -> COMMON (dependence.json) -> HWSKU -> TOPO

The fixture resolves tbinfo['topo']['name'] and passes it to parse_and_register_commands, which merges any matching TOPO collection on top of the HWSKU-merged config (TOPO wins on conflicts).

Also raises the bgpd memory_increase_threshold from 128 MB to 192 MB specifically on m1-128, which was the motivating failure case (observed increase ~129 MB on a 128 MB limit).

Behavior is unchanged for any topology without a TOPO entry.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

Cherry-picked this PR onto the internal 202603 branch and ran `bgp/test_bgp_peer_shutdown.py` on an m1-128 physical testbed (HwSKU `Arista-7050CX3-32C-S128`). The same testcase was run twice, varying only the `memory_increase_threshold` value in the new `m1-128` TOPO block:

**Run 1 — threshold set to 1 MB (expected to fail):** test ERRORs in teardown as expected. Plugin log shows the TOPO override is merged in:
```
Loading memory monitoring commands for hwsku: Arista-7050CX3-32C-S128, topo: m1-128
Merging topo-specific config for command: top
Calculated increase threshold for top:bgpd: 1.0
...
ERROR [ALARM]: top:bgpd memory usage increased by 121.8 MB,
              exceeds increase threshold 1.0 MB (previous: 82.5 MB, current: 204.3 MB)
=========== 1 passed, 1 error in 867.21s ===========
```

**Run 2 — threshold set to 192 MB (expected to pass):** test passes cleanly with no memory error. Plugin log:
```
Merging topo-specific config for command: top
Calculated increase threshold for top:bgpd: 192.0
bgpd: before=92.9 MB, after=118.1 MB (increase = 25.2 MB, below 192)
=========== 1 passed in 862.01s ===========
```

Same testcase, same testbed — flips between FAIL and PASS purely by changing the TOPO threshold value, confirming the override path works end-to-end. Behavior for topologies without a TOPO entry is unchanged.

Note: `bgp/test_bgp_fact.py` was tried first but is a passive facts-collection test — bgpd RES didn't move at all between before/after, so it can't demonstrate the fail/pass contrast at any threshold. `test_bgp_peer_shutdown` actually churns BGP sessions on m1-128 and produces real bgpd memory growth.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
