### PR TITLE
Update lossy topology conditional markers

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -17,15 +17,23 @@
           't0-isolated-d16u16s1', 't0-isolated-v6-d16u16s1',
           't0-isolated-d16u16s2', 't0-isolated-v6-d16u16s2',
           't0-isolated-d256u256s2', 't0-isolated-v6-d256u256s2',
+          't0-isolated-d32u32s2-mix',
           't0-isolated-d32u32s2', 't0-isolated-v6-d32u32s2',
-          't1-isolated-d32u1s2',
+          't0-isolated-d96u32s2', 't0-isolated-v6-d96u32s2',
+          't1-isolated-v6-d128',
           't1-isolated-d224u8', 't1-isolated-v6-d224u8',
+          't1-isolated-d254u2', 't1-isolated-d254u2s1',
+          't1-isolated-d254u2s2',
           't1-isolated-d28u1', 't1-isolated-v6-d28u1',
           't1-isolated-d28u4',
+          't1-isolated-d32u1s2',
           't1-isolated-d448u15-lag', 't1-isolated-v6-d448u15-lag',
           't1-isolated-d448u16', 't1-isolated-v6-d448u16',
+          't1-isolated-d508u1s2', 't1-isolated-d510u2',
+          't1-isolated-d510u2s2',
           't1-isolated-d56u1-lag', 't1-isolated-v6-d56u1-lag',
-          't1-isolated-d56u2', 't1-isolated-v6-d56u2' ]
+          't1-isolated-d56u2', 't1-isolated-v6-d56u2',
+          't2-isolated-d128s2' ]
     - &noVxlanTopos |
         topo_name in [
           't0-isolated-d32u32s2', 't0-isolated-d256u256s2',
@@ -248,6 +256,7 @@ arp/test_wr_arp.py:
       - "'standalone' in topo_name"
       - "is_mgmt_ipv6_only==True" # Does not support ipv6 mgmt ip on dut, specially the ferret server
       - "'isolated' in topo_name"
+      - *lossyTopos
       - "topo_type not in ['t0']"
       - "'f2' in topo_name"
 
@@ -266,9 +275,11 @@ autorestart/test_container_autorestart.py::test_containers_autorestart.*teamd.*:
 #######################################
 bfd:
   skip:
-    reason: "It is skipped for '202412' for now"
+    reason: "It is skipped for '202412' or lossy topologies for now"
+    conditions_logical_operator: or
     conditions:
       - "release in ['202412']"
+      - *lossyTopos
 
 bfd/test_bfd.py:
   skip:
@@ -740,9 +751,11 @@ clock/test_clock.py::test_config_clock_timezone:
 #######################################
 configlet:
   skip:
-    reason: "It is skipped for '202412' for now"
+    reason: "It is skipped for '202412' or lossy topologies for now"
+    conditions_logical_operator: or
     conditions:
       - "release in ['202412']"
+      - *lossyTopos
 
 configlet/test_add_rack.py:
   skip:
@@ -856,6 +869,12 @@ crm/test_crm_available.py:
 #######################################
 #####           dash              #####
 #######################################
+dash:
+  skip:
+    reason: "Dash tests are not supported on lossy topologies."
+    conditions:
+      - *lossyTopos
+
 dash/crm/test_dash_crm.py:
   skip:
     reason: "Currently dash tests are not supported on KVM"
@@ -1009,11 +1028,12 @@ decap/test_subnet_decap.py::test_vlan_subnet_decap:
 #######################################
 dhcp_relay:
   skip:
-    reason: "Not applicable to isolated topologies."
+    reason: "Not applicable to isolated topologies, BMC, or lossy topologies."
     conditions_logical_operator: or
     conditions:
       - "'isolated' in topo_name"
       - "'bmc' in topo_type"
+      - *lossyTopos
 
 dhcp_relay/test_dhcp_counter_stress.py::test_dhcpmon_relay_counters_stress:
   xfail:
@@ -1228,9 +1248,11 @@ dhcp_relay/test_dhcpv6_relay.py::test_interface_binding:
 #######################################
 dhcp_server:
   skip:
-    reason: "It is skipped for '202412' for now"
+    reason: "It is skipped for '202412' or lossy topologies for now"
+    conditions_logical_operator: or
     conditions:
       - "release in ['202412']"
+      - *lossyTopos
 
 #######################################
 #####             disk            #####
@@ -1304,9 +1326,11 @@ drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr:
 #######################################
 dualtor:
   skip:
-    reason: "It is skipped for '202412' for now"
+    reason: "It is skipped for '202412' or lossy topologies for now"
+    conditions_logical_operator: or
     conditions:
       - "release in ['202412']"
+      - *lossyTopos
 
 dualtor/test_bgp_block_loopback1.py:
   skip:
@@ -1429,9 +1453,11 @@ dualtor/test_tunnel_memory_leak.py::test_tunnel_memory_leak:
 
 dualtor_io:
   skip:
-    reason: "Testcase could only be executed on dualtor testbed."
+    reason: "Testcase could only be executed on dualtor testbed and is not supported on lossy topologies."
+    conditions_logical_operator: or
     conditions:
       - "'dualtor' not in topo_name"
+      - *lossyTopos
 
 dualtor_io/test_grpc_server_failure.py:
   skip:
@@ -1513,9 +1539,11 @@ dualtor_io/test_tor_failure.py:
 
 dualtor_mgmt:
   skip:
-    reason: "It is skipped for '202412' for now"
+    reason: "It is skipped for '202412' or lossy topologies for now"
+    conditions_logical_operator: or
     conditions:
       - "release in ['202412']"
+      - *lossyTopos
 
 dualtor_mgmt/test_dualtor_bgp_update_delay.py:
   xfail:
@@ -3392,9 +3420,11 @@ high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_full_counter
 #######################################
 http:
   skip:
-    reason: "It is skipped for '202412' for now"
+    reason: "It is skipped for '202412' or lossy topologies for now"
+    conditions_logical_operator: or
     conditions:
       - "release in ['202412']"
+      - *lossyTopos
 
 #######################################
 #####    iface_loopback_action    #####
@@ -3621,10 +3651,11 @@ ipfwd/test_nhop_group.py::test_nhop_group_member_order_capability:
 #######################################
 ixia:
   skip:
-    reason: "Ixia test only support on physical ixia testbed and it is not tested for now"
+    reason: "Ixia test only support on physical ixia testbed and it is not tested on lossy topologies for now"
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['vs']"
+      - *lossyTopos
       - "True"
 
 #######################################
@@ -3723,9 +3754,11 @@ log_fidelity/:
 #######################################
 macsec:
   skip:
-    reason: "Skip running on dualtor testbed"
+    reason: "Skip running on dualtor and lossy topologies"
+    conditions_logical_operator: or
     conditions:
       - "'dualtor' in topo_name"
+      - *lossyTopos
 
 macsec/test_dataplane.py::TestDataPlane::test_server_to_neighbor:
   skip:
@@ -3750,9 +3783,11 @@ macsec/test_interop_protocol.py::TestInteropProtocol::test_snmp:
 #######################################
 mclag:
   skip:
-    reason: "Skip running on dualtor testbed"
+    reason: "Skip running on dualtor and lossy topologies"
+    conditions_logical_operator: or
     conditions:
-       - "'dualtor' in topo_name"
+      - "'dualtor' in topo_name"
+      - *lossyTopos
 
 mclag/test_mclag_l3.py:
   skip:
@@ -3776,9 +3811,11 @@ memory_checker/test_memory_checker.py:
 #######################################
 mpls:
   skip:
-    reason: "MPLS feature is not enabled with image version, skipped"
+    reason: "MPLS feature is not enabled with image version, skipped on lossy topologies"
+    conditions_logical_operator: or
     conditions:
       - "'mpls' not in feature_status"
+      - *lossyTopos
 
 #######################################
 #####           mvrf              #####
@@ -3818,9 +3855,11 @@ mvrf/test_mgmtvrf.py::TestReboot::test_warmboot:
 #######################################
 mx:
   skip:
-    reason: "Test is only applicable to m0, mx, and m1 topologies"
+    reason: "Test is only applicable to m0, mx, and m1 topologies, not lossy topologies"
+    conditions_logical_operator: or
     conditions:
       - "topo_type not in ['m0', 'mx', 'm1']"
+      - *lossyTopos
 
 #######################################
 #####           nat               #####
@@ -3838,11 +3877,12 @@ nat:
 #######################################
 ospf:
   skip:
-    reason: "Neighbor type must be sonic, skip in PR testing and it is skipped for '202412' for now"
+    reason: "Neighbor type must be sonic, skip in PR testing and it is skipped for '202412' and lossy topologies for now"
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['vs']"
       - "release in ['202412']"
+      - *lossyTopos
 
 #######################################
 #####    override_config_table    #####
@@ -3982,8 +4022,10 @@ pfc/test_unknown_mac.py:
 #######################################
 pfc_asym:
   skip:
-    reason: "It is not tested for now"
+    reason: "It is not tested for now, including on lossy topologies"
+    conditions_logical_operator: or
     conditions:
+      - *lossyTopos
       - "True"
 
 pfc_asym/test_pfc_asym.py:
@@ -4124,6 +4166,18 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_info:
     conditions:
     - "https://github.com/sonic-net/sonic-buildimage/issues/23426 and ('sn4700' in platform or 'sn4280' in platform)"
 
+platform_tests/test_advanced_reboot.py:
+  skip:
+    reason: "Advanced reboot tests are not supported on lossy topologies."
+    conditions:
+      - *lossyTopos
+
+platform_tests/test_cont_warm_reboot.py:
+  skip:
+    reason: "Continuous warm reboot tests are not supported on lossy topologies."
+    conditions:
+      - *lossyTopos
+
 platform_tests/test_intf_fec.py::test_verify_fec_stats_counters:
   skip:
     reason: "Broadcom TH does not support FEC_SYMBOL_ERR at 50G"
@@ -4223,11 +4277,12 @@ qos:
 
 qos/test_buffer.py:
   skip:
-    reason: "These tests don't apply to cisco 8000 platforms or T2 or M* since they support only traditional model and it is skipped for '202412' for now"
+    reason: "These tests don't apply to cisco 8000 platforms, T2, M*, lossy topologies, or '202412' for now"
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['cisco-8000'] or topo_type in ['t2', 'lrh', 'urh']"
       - "topo_type in ['m0', 'mx', 'm1']"
+      - *lossyTopos
       - "release in ['202412']"
 
 qos/test_buffer.py::test_buffer_model_test:
@@ -4262,11 +4317,12 @@ qos/test_oq_watchdog.py:
 
 qos/test_pfc_counters.py:
   skip:
-    reason: "Not supported on SKU and It is skipped for '202412' for now"
+    reason: "Not supported on SKU, lossy topologies, and it is skipped for '202412' for now"
     conditions_logical_operator: or
     conditions:
       - "hwsku in ['Mellanox-SN5600-C256S1', 'Mellanox-SN5600-C224O8', 'Mellanox-SN5640-C512S2',
                    'Mellanox-SN5640-C448O16']"
+      - *lossyTopos
       - "release in ['202412']"
 
 qos/test_pfc_counters.py::test_pfc_unpause:
@@ -4279,10 +4335,11 @@ qos/test_pfc_counters.py::test_pfc_unpause:
 
 qos/test_pfc_pause.py:
   skip:
-    reason: "This test is not run on this asic type or version or topology currently and also skip for 202412 for now"
+    reason: "This test is not run on this asic type, version, topology, or lossy topologies currently and also skip for 202412 for now"
     conditions_logical_operator: or
     conditions:
       - "topo_type not in ['t0']"
+      - *lossyTopos
       - "release in ['202412']"
 
 qos/test_pfc_pause.py::test_pfc_pause_lossless:
@@ -4328,11 +4385,12 @@ qos/test_qos_dscp_mapping.py::TestQoSSaiDSCPQueueMapping_IPIP_Base::test_dscp_to
 
 qos/test_qos_masic.py:
   skip:
-    reason: "QoS tests for multi-ASIC only. Supported topos: t1-lag, t1-64-lag, t1-56-lag, t1-backend. / M* topo does not support qos. / KVM do not support swap syncd."
+    reason: "QoS tests for multi-ASIC only. Supported topos: t1-lag, t1-64-lag, t1-56-lag, t1-backend. / M* and lossy topo does not support qos. / KVM do not support swap syncd."
     conditions_logical_operator: or
     conditions:
       - "is_multi_asic==False or topo_name not in ['t1-lag', 't1-64-lag', 't1-56-lag', 't1-backend']"
       - "topo_type in ['m0', 'mx', 'm1']"
+      - *lossyTopos
       - "asic_type in ['vs']"
 
 qos/test_qos_probe.py:
@@ -4657,11 +4715,19 @@ radv/test_radv_ipv6_ra.py::test_unsolicited_router_advertisement_with_m_flag:
 #######################################
 #####          read_mac           #####
 #######################################
+read_mac:
+  skip:
+    reason: "Read_mac tests are not supported on lossy topologies."
+    conditions:
+      - *lossyTopos
+
 read_mac/test_read_mac_metadata.py:
   skip:
     reason: "Read_mac test needs specific variables and image urls, currently do not support on KVM and regular nightly test."
+    conditions_logical_operator: or
     conditions:
       - "asic_type in ['vs']"
+      - *lossyTopos
 
 #######################################
 #####           reboot            #####
@@ -4675,6 +4741,12 @@ reboot/test_reboot_blocking_mode.py:
 #######################################
 #####      reset_factory          #####
 #######################################
+reset_factory:
+  skip:
+    reason: "Reset factory tests are not supported on lossy topologies."
+    conditions:
+      - *lossyTopos
+
 reset_factory/test_reset_factory.py:
   skip:
     reason: "This case has a known issue which leaves the DUT in a bad state. Skipping until the issue is addressed. Also skipped on BMC due to a system clock image issue."
@@ -4682,6 +4754,7 @@ reset_factory/test_reset_factory.py:
     conditions:
       - https://github.com/sonic-net/sonic-mgmt/issues/11103
       - "'bmc' in topo_type"
+      - *lossyTopos
 
 #######################################
 #####         restapi             #####
@@ -4972,13 +5045,24 @@ show_techsupport/test_techsupport.py::test_techsupport:
 
 
 #######################################
+#####        smartswitch          #####
+#######################################
+smartswitch:
+  skip:
+    reason: "Smartswitch tests are not supported on lossy topologies."
+    conditions:
+      - *lossyTopos
+
+#######################################
 #####         snappi_tests        #####
 #######################################
 snappi_tests:
   skip:
-    reason: "Snappi test only support on physical tgen testbed"
+    reason: "Snappi test only support on physical tgen testbed and is not supported on lossy topologies"
+    conditions_logical_operator: or
     conditions:
       - "asic_type in ['vs']"
+      - *lossyTopos
 
 snappi_tests/bgp/test_bgp_convergence_performance.py:
   xfail:
@@ -5098,11 +5182,19 @@ snappi_tests/reboot:
 #####            snmp             #####
 #######################################
 
+snmp:
+  skip:
+    reason: "SNMP tests are not supported on lossy topologies."
+    conditions:
+      - *lossyTopos
+
 snmp/:
   skip:
     reason: 'SNMP tests may depend on ASIC-specific MIBs, not available on BMC'
+    conditions_logical_operator: or
     conditions:
       - "'bmc' in topo_type"
+      - *lossyTopos
 
 snmp/test_snmp_default_route.py:
   xfail:
@@ -5588,9 +5680,11 @@ test_nbr_health.py:
 #######################################
 test_pktgen.py:
   skip:
-    reason: "No need in M0/Mx/M1"
+    reason: "No need in M0/Mx/M1 or lossy topologies"
+    conditions_logical_operator: or
     conditions:
       - "topo_type in ['bmc', 'm0', 'm1', 'mx']"
+      - *lossyTopos
 
 #######################################
 #####         pretest             #####
@@ -5606,9 +5700,11 @@ test_pretest.py::test_disable_rsyslog_rate_limit:
 #######################################
 test_vs_chassis_setup.py:
   skip:
-    reason: "Skip vs_chassis setup on non-vs testbeds"
+    reason: "Skip vs_chassis setup on non-vs testbeds and lossy topologies"
+    conditions_logical_operator: or
     conditions:
       - "asic_type not in ['vs']"
+      - *lossyTopos
 
 #######################################
 #####         upgrade_path        #####
@@ -5619,10 +5715,12 @@ upgrade_path:
       Skipped due to one or more unsupported conditions:
       - Upgrade path test needs base and target image lists, currently do not support on KVM.
       - Not supported on t1 topology
+      - Not supported on lossy topologies
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['vs']"
       - "'t1' in topo_type and asic_type in ['marvell-teralynx']"
+      - *lossyTopos
 
 upgrade_path/test_multi_hop_upgrade_path.py:
   skip:
@@ -5675,11 +5773,12 @@ vlan/test_vlan_ping.py:
 #######################################
 voq:
   skip:
-    reason: "Cisco 8800 doesn't support voq tests and not supported on this DUT topology"
+    reason: "Cisco 8800 doesn't support voq tests and not supported on this DUT topology or lossy topologies"
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['cisco-8000']"
       - "'t2' not in topo_name and topo_type not in ['lrh', 'urh']"
+      - *lossyTopos
 
 voq/test_fabric_cli_and_db.py:
   skip:
@@ -6082,6 +6181,15 @@ vxlan/test_vxlan_vnet_bgp_subintf.py:
       - "release in ['202511']"
 
 #######################################
+#####            wan              #####
+#######################################
+wan:
+  skip:
+    reason: "WAN tests are not supported on lossy topologies."
+    conditions:
+      - *lossyTopos
+
+#######################################
 #####           wan_lacp          #####
 #######################################
 wan/lacp/test_wan_lag_min_link.py::test_lag_min_link:
@@ -6097,9 +6205,11 @@ wan/lacp/test_wan_lag_min_link.py::test_lag_min_link:
 #######################################
 wol:
   skip:
-    reason: "Not supported on this DUT topology"
+    reason: "Not supported on this DUT topology or lossy topologies"
+    conditions_logical_operator: or
     conditions:
       - "topo_type not in ['mx', 'm0']"
+      - *lossyTopos
 
 #######################################
 #####             zmq             #####


### PR DESCRIPTION
### Description of PR

Summary:
Update conditional test markers so lossy topologies exclude unsupported test modules and scripts.

This PR updates the shared `lossyTopos` anchor with the applicable lossy topology list and applies it to the requested module-level and script-level skip rules.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Lossy topologies do not support several test modules and reboot/QoS scripts. Without centralized conditional markers, those tests can still be collected and executed on unsupported lossy testbeds.

#### How did you do it?

- Updated the existing `lossyTopos` YAML anchor with the applicable lossy topology list.
- Added `lossyTopos` skip conditions for the requested modules:
  `pfcwd`, `dualtor`, `snappi_tests`, `ixia`, `wan`, `dualtor_io`, `bfd`, `configlet`, `dash`, `dhcp_relay`, `dhcp_server`, `dualtor_mgmt`, `http`, `macsec`, `mclag`, `mpls`, `mx`, `ospf`, `pfc_asym`, `read_mac`, `reset_factory`, `smartswitch`, `test_pktgen.py`, `test_vs_chassis_setup.py`, `upgrade_path`, `voq`, `wol`, `snmp`.
- Added `lossyTopos` skip conditions for the requested scripts:
  `arp/test_wr_arp.py`, `platform_tests/test_advanced_reboot.py`, `platform_tests/test_cont_warm_reboot.py`, `pfcwd/test_pfcwd_warm_reboot.py`, `qos/test_buffer.py`, `qos/test_pfc_counters.py`, `qos/test_pfc_pause.py`, `qos/test_qos_masic.py`.

#### How did you verify/test it?

- Parsed `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` with a YAML parser.
- Ran a conditional marker sort-order check equivalent to `.hooks/pre_commit_hooks/check_conditional_mark_sort.py`.
- Ran `git diff --check`.

#### Any platform specific information?

N/A. This only updates conditional marker metadata for lossy topologies.

#### Supported testbed topology if it's a new test case?

N/A. No new test case is added.

### Documentation

N/A. No documentation update is needed for conditional marker metadata.