### PR TITLE
Testcase dhcp_relay/test_dhcpv4_relay.py failed as cannot remove VRF device

### DIFF
--- a/tests/dhcp_relay/test_dhcpv4_relay.py
+++ b/tests/dhcp_relay/test_dhcpv4_relay.py
@@ -635,6 +635,11 @@ def test_dhcp_relay_with_non_default_vrf(
         # VRF config cleanup
         duthost.shell(f"sudo config route del prefix vrf {CLIENT_VRF_NAME} 0.0.0.0/0 nexthop"
                       f" vrf {CLIENT_VRF_NAME} {first_params['nexthop']}")
+        duthost.shell(
+            "AS=$(sonic-cfggen -d -v \"DEVICE_METADATA['localhost']['bgp_asn']\") && "
+            "sudo vtysh -c 'configure terminal' -c \"no router bgp ${AS} vrf %s\"" % CLIENT_VRF_NAME,
+            module_ignore_errors=True,
+        )
         duthost.shell(f"sudo config vrf del {CLIENT_VRF_NAME}")
 
         # Restore all interface CONFIG_DB entries (base entry, IPs, and attributes).
@@ -839,7 +844,16 @@ def test_dhcp_relay_with_different_non_default_vrf(
         # VRF config cleanup
         duthost.shell(f"sudo config route del prefix vrf {SERVER_VRF_NAME} 0.0.0.0/0 nexthop"
                       f" vrf {SERVER_VRF_NAME} {first_params['nexthop']}")
-
+        duthost.shell(
+            "AS=$(sonic-cfggen -d -v \"DEVICE_METADATA['localhost']['bgp_asn']\") && "
+            "sudo vtysh -c 'configure terminal' -c \"no router bgp ${AS} vrf %s\"" % CLIENT_VRF_NAME,
+            module_ignore_errors=True,
+        )
+        duthost.shell(
+            "AS=$(sonic-cfggen -d -v \"DEVICE_METADATA['localhost']['bgp_asn']\") && "
+            "sudo vtysh -c 'configure terminal' -c \"no router bgp ${AS} vrf %s\"" % SERVER_VRF_NAME,
+            module_ignore_errors=True,
+        )
         duthost.shell(f"sudo config vrf del {CLIENT_VRF_NAME}")
         duthost.shell(f"sudo config vrf del {SERVER_VRF_NAME}")
 


### PR DESCRIPTION

### Description of PR

Fixes a teardown failure in tests/dhcp_relay/test_dhcpv4_relay.py where VRF deletion failed with:
Can not remove VRF device: Vrf01 is in use by 'router bgp 64601 vrf Vrf01', please remove the bgp config firstly

Issue: When interfaces are bound to a non-default VRF during the DHCP relay VRF tests, FRR auto-creates a BGP VRF instance (router bgp <asn> vrf Vrf01). The test cleanup was calling config vrf del without removing that BGP VRF configuration first, causing teardown to fail and leaving the DUT in a partially restored state.

Fix: Remove the VRF from BGP before performing the actual config vrf del in the required cleanup paths (finally blocks) of:

test_dhcp_relay_with_non_default_vrf (before deleting Vrf01)
test_dhcp_relay_with_different_non_default_vrf (before deleting Vrf01 and Vrf03)

Summary: Fixed removed VRF from BGP before actual VRF delete in required places.
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Teardown of DHCP relay VRF tests fails because Vrf01 is still in use by BGP (router bgp 64601 vrf Vrf01). BGP VRF config must be removed before the VRF device can be deleted.

#### How did you do it?
Added vtysh command to remove BGP VRF config before config vrf del:

AS=$(sonic-cfggen -d -v "DEVICE_METADATA['localhost']['bgp_asn']") && \
sudo vtysh -c 'configure terminal' -c "no router bgp ${AS} vrf <VRF_NAME>"
Applied in the finally blocks of both affected test cases, before the existing config vrf del calls.

#### How did you verify/test it?
Ran test_dhcpv4_relay.py on T0 topology
Confirmed teardown completes without the BGP VRF-in-use error.
Verified VRFs are removed and DUT config is restored after test.

#### Any platform specific information?
None.

#### Supported testbed topology if it's a new test case?
N/A — existing test improvement. Topology: T0.

### Documentation
N/A
