### PR TITLE
Update stress acl test to support topology t1-isolated-d32u1s2

### DIFF
--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -40,6 +40,7 @@ LOG_EXPECT_ACL_RULE_FAILED_RE = ".*Failed to create ACL rule.*"
 ACL_RULE_NUMS = 10
 
 DEFAULT_MAX_ACL_ENTRIES = 200
+PTF_TIMEOUT = 10
 
 # key: platform name
 # value: max number of ACL entries supported by the platform
@@ -200,7 +201,8 @@ def prepare_test_port(rand_selected_dut, tbinfo):
                 (topo == "t0" and ("T1" in neighbor["name"] or "PT0" in neighbor["name"])) or \
                 (topo == "m0" and "M1" in neighbor["name"]) or (topo == "mx" and "M0" in neighbor["name"]) or \
                 (topo == "m1" and ("MA" in neighbor["name"] or "MB" in neighbor["name"])) or \
-                (topo_name in ("t1-isolated-d32", "t1-isolated-d128") and "T0" in neighbor["name"]):
+                (topo_name in ("t1-isolated-d32", "t1-isolated-d128", "t1-isolated-d32u1s2")
+                 and "T0" in neighbor["name"]):
             upstream_ports[neighbor['namespace']].append(interface)
             upstream_port_ids.append(port_id)
             ipv4_addr = [bgp_neighbor['addr'] for bgp_neighbor in mg_facts['minigraph_bgp']
@@ -247,7 +249,7 @@ def verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports,
         ptfadapter.dataplane.flush()
         testutils.send(test=ptfadapter, port_id=ptf_src_port, pkt=pkt)
         if verity_status == "forward" or acl_id == del_rule_id:
-            testutils.verify_packet_any_port(test=ptfadapter, pkt=exp_pkt, ports=ptf_dst_ports)
+            testutils.verify_packet_any_port(test=ptfadapter, pkt=exp_pkt, ports=ptf_dst_ports, timeout=PTF_TIMEOUT)
         elif verity_status == "drop" and acl_id != del_rule_id:
             testutils.verify_no_packet_any(test=ptfadapter, pkt=exp_pkt, ports=ptf_dst_ports)
 


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
1.Support topology t1-isolated-d32u1s2
2.Support run on sn5640 platform

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
1. Run stress acl test on topology t1-isolated-d32u1s2
2. Make sure when running it on SN5640, the PTF could validate packet received
#### How did you do it?
1. Add the topology support for t1-isolated-d32u1s2
2. Increase the ptf packet validation timeout value
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
