### PR TITLE
Add xfail for test_cacl_tc1_acl_table_suite.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2652,6 +2652,18 @@ generic_config_updater/test_cacl:
       - "asic_type in ['cisco-8000']"
       - "https://github.com/sonic-net/sonic-buildimage/issues/20378"
 
+generic_config_updater/test_cacl.py::test_cacl_application_nondualtor:
+  xfail:
+    reason: "xfail due to GitHub issue: https://github.com/sonic-net/sonic-buildimage/issues/27584"
+    conditions:
+      - "https://github.com/sonic-net/sonic-buildimage/issues/27584"
+
+generic_config_updater/test_cacl.py::test_cacl_tc1_acl_table_suite:
+  xfail:
+    reason: "xfail due to GitHub issue: https://github.com/sonic-net/sonic-buildimage/issues/27584"
+    conditions:
+      - "https://github.com/sonic-net/sonic-buildimage/issues/27584"
+
 generic_config_updater/test_dhcp_relay.py:
   skip:
     reason: "Need to skip for Cisco backend platform/ generic_config_updater is not a supported feature for T2"


### PR DESCRIPTION

### Description of PR
Summary:
Add xfail markers for CACL test cases affected by a caclmgrd iptables flush issue that removes the dhcp_server syslog rule due to https://github.com/sonic-net/sonic-buildimage/issues/27584 

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- master: passed
- 202605: passed


### Approach
#### What is the motivation for this PR?
When CACL (Control-plane ACL) configuration is updated in CONFIG_DB, `caclmgrd` flushes and rebuilds all host iptables rules. However, the `dhcp_server` container adds a syslog exception rule (`-A INPUT -i docker0 -p udp --dport 514 -m comment --comment dhcp_server_syslog -j ACCEPT`) directly to the kernel during its startup, bypassing CONFIG_DB. Since this rule is not represented in CONFIG_DB, `caclmgrd` does not regenerate it after the flush.
As a result, any CACL table modification triggers the iptables flush and permanently removes the `dhcp_server_syslog` rule for the remainder of the session. This causes the `dhcp_server` container to lose its syslog connectivity, leading to downstream service failures that cause the following test cases to fail:
- `test_cacl_application_nondualtor`
- `test_cacl_tc1_acl_table_suite`

#### How did you do it?
Added `xfail` entries in `tests_mark_conditions.yaml` for the two affected test cases, referencing the upstream issue sonic-net/sonic-buildimage#27584. The xfail markers will be automatically removed once the upstream fix lands and the issue is closed.
#### How did you verify/test it?
Verified that the affected test cases are marked as `xfail` instead of `FAILED` when the dhcp_server syslog iptables rule is removed by CACL updates.
#### Any platform specific information?
Any
#### Supported testbed topology if it's a new test case?
Any
### Documentation
NA