### PR TITLE
Add support for hwsku Mellanox-SN5640-C508O1X2 and topology t1-isolated-d32u1s2

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -983,6 +983,20 @@
             seconds: 5
           when: use_ipv6_mgmt|default(false)|bool
 
+        - name: Configure Mellanox-SN5640-C508O1X2 Ethernet508 subport after minigraph load
+          block:
+          - name: Set Ethernet508 subport for Mellanox-SN5640-C508O1X2 uneven port 64 breakout
+            become: true
+            shell: sonic-db-cli CONFIG_DB hset "PORT|Ethernet508" subport 2
+
+          - name: Save subport configuration
+            become: true
+            shell: config save -y
+          when:
+          - init_cfg_profile is not defined
+          - hwsku is defined
+          - hwsku == 'Mellanox-SN5640-C508O1X2'
+
         - name: execute cli "config load_minigraph -y" to apply new minigraph
           become: true
           shell: config load_minigraph -y

--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -1,5 +1,3 @@
-
-
 def _port_alias_to_name_map_50G(all_ports, s100G_ports,):
     new_map = {}
     # 50G ports
@@ -614,6 +612,19 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
             port_alias_to_name_map['etp65'] = "Ethernet512"
             if hwsku == "Mellanox-SN5610N-C224O8":
                 port_alias_to_name_map['etp66'] = "Ethernet520"
+        elif hwsku == "Mellanox-SN5640-C508O1X2":
+            # 63 OSFP x 8x100G; port 64: 4x100G (etp64a-d) + 400G (etp64e -> Ethernet508)
+            split_alias_list = ["a", "b", "c", "d", "e", "f", "g", "h"]
+            for i in range(1, 64):
+                for idx, split_alias in enumerate(split_alias_list):
+                    alias = "etp{}{}".format(i, split_alias)
+                    eth_name = "Ethernet{}".format((i - 1) * 8 + idx)
+                    port_alias_to_name_map[alias] = eth_name
+            for idx, split_alias in enumerate(["a", "b", "c", "d"]):
+                port_alias_to_name_map["etp64{}".format(split_alias)] = "Ethernet{}".format((64 - 1) * 8 + idx)
+            port_alias_to_name_map["etp64e"] = "Ethernet508"
+            port_alias_to_name_map['etp65'] = "Ethernet512"
+            port_alias_to_name_map['etp66'] = "Ethernet520"
         elif hwsku in ["Mellanox-SN5640-C512S2"]:
             split_alias_list = ["a", "b", "c", "d", "e", "f", "g", "h"]
             for i in range(1, 65):

--- a/ansible/roles/fanout/library/port_config_gen.py
+++ b/ansible/roles/fanout/library/port_config_gen.py
@@ -71,6 +71,7 @@ return:
 
 class PortConfigGenerator(object):
 
+    C508O1X2_HWSKU = "Mellanox-SN5640-C508O1X2"
     MACHINE_CONF = "/host/machine.conf"
     SONIC_VERSION_FILE = "/etc/sonic/sonic_version.yml"
     HWSKU_DIR_PREFIX = "/usr/share/sonic/device/"
@@ -323,6 +324,7 @@ class PortConfigGenerator(object):
                 self.fanout_port_config[port_name] = port_config
 
         self._derive_subports()
+        self._apply_c508o1x2_port64()
 
     def _derive_subports(self):
         """Derive subport attribute for ports sharing the same physical index.
@@ -351,6 +353,26 @@ class PortConfigGenerator(object):
                 alias = port_config.get('alias', '')
                 if alias and alias[-1].isalpha():
                     port_config['subport'] = str(ord(alias[-1]) - ord('a') + 1)
+
+    def _apply_c508o1x2_port64(self):
+        """Port 64 breakout on C508O1X2; Ethernet508 uses CONFIG_DB subport 2."""
+        if self.fanout_hwsku != self.C508O1X2_HWSKU:
+            return
+
+        port64_cfg = {
+            "Ethernet508": {
+                "name": "Ethernet508", "lanes": "508,509,510,511", "speed": "400000",
+                "index": "64", "alias": "etp64e", "subport": "2",
+            }
+        }
+        for port_name, fields in port64_cfg.items():
+            if port_name in self.fanout_port_config:
+                self.fanout_port_config[port_name].update(fields)
+            else:
+                self.fanout_port_config[port_name] = fields.copy()
+
+        for stale_port in ("Ethernet509", "Ethernet510", "Ethernet511"):
+            self.fanout_port_config.pop(stale_port, None)
 
 
 def main():

--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202511.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202511.yml
@@ -85,7 +85,7 @@
 
 - name: build fanout startup config
   template:
-    src: "sonic_deploy_202505.j2"
+    src: "sonic_deploy_202511.j2"
     dest: "/tmp/base_config.json"
 
 - name: generate config_db.json


### PR DESCRIPTION

### Description of PR
The last port at switch and fanout switch would be configured as un even split port
4 x 100G port + 1 x 400G port


Summary:
Fixes # (issue)

### Type of change


- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Add support for hwsku Mellanox-SN5640-C508O1X2 and topology t1-isolated-d32u1s2
#### How did you do it?
The main part is to support uneven split port at switch and fanout switch
#### How did you verify/test it?
Run it locally and do regressions
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

