### PR TITLE
Fixing PMON status test failures

### DIFF
--- a/tests/platform_tests/daemon/conftest.py
+++ b/tests/platform_tests/daemon/conftest.py
@@ -1,0 +1,31 @@
+"""Shared fixtures for the PMON daemon tests."""
+import time
+
+import pytest
+
+
+def _get_daemon_duthost(request, duthosts):
+    """Resolve the DUT host for a daemon test module, honoring its `daemon_dut_hostname_fixture` override."""
+    hostname_fixture = getattr(request.module, "daemon_dut_hostname_fixture", "rand_one_dut_hostname")
+    return duthosts[request.getfixturevalue(hostname_fixture)]
+
+
+@pytest.fixture(scope="module")
+def disable_pmon_container_autorestart(request, duthosts, disable_container_autorestart, enable_container_autorestart):
+    """Disable pmon container autorestart so a killed daemon respawns in place instead of restarting the container."""
+    duthost = _get_daemon_duthost(request, duthosts)
+    daemon_name = request.module.daemon_name
+    disable_container_autorestart(duthost, testcase=daemon_name, feature_list=["pmon"])
+    yield
+    enable_container_autorestart(duthost, testcase=daemon_name, feature_list=["pmon"])
+
+
+@pytest.fixture
+def check_daemon_status(request, duthosts, disable_pmon_container_autorestart):
+    """Ensure the pmon daemon under test is running before the test starts."""
+    duthost = _get_daemon_duthost(request, duthosts)
+    daemon_name = request.module.daemon_name
+    daemon_status, _ = duthost.get_pmon_daemon_status(daemon_name)
+    if daemon_status != "RUNNING":
+        duthost.start_pmon_daemon(daemon_name)
+        time.sleep(10)

--- a/tests/platform_tests/daemon/test_chassisd.py
+++ b/tests/platform_tests/daemon/test_chassisd.py
@@ -29,6 +29,7 @@ expected_stopped_status = "STOPPED"
 expected_exited_status = "EXITED"
 
 daemon_name = "chassisd"
+daemon_dut_hostname_fixture = "enum_rand_one_per_hwsku_hostname"
 
 SIG_STOP_SERVICE = None
 SIG_TERM = "-15"
@@ -57,15 +58,6 @@ def teardown_module(duthosts, enum_rand_one_per_hwsku_hostname):
         time.sleep(10)
     logger.info("Tearing down: to make sure all the critical services, interfaces and transceivers are good")
     check_critical_processes(duthost, watch_secs=10)
-
-
-@pytest.fixture
-def check_daemon_status(duthosts, enum_rand_one_per_hwsku_hostname):
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
-    if daemon_status != "RUNNING":
-        duthost.start_pmon_daemon(daemon_name)
-        time.sleep(10)
 
 
 def check_expected_daemon_status(duthost, expected_daemon_status):

--- a/tests/platform_tests/daemon/test_fancontrol.py
+++ b/tests/platform_tests/daemon/test_fancontrol.py
@@ -28,6 +28,7 @@ expected_stopped_status = "STOPPED"
 expected_exited_status = "EXITED"
 
 daemon_name = "fancontrol"
+daemon_dut_hostname_fixture = "enum_supervisor_dut_hostname"
 
 SIG_STOP_SERVICE = None
 SIG_TERM = "-15"
@@ -54,15 +55,6 @@ def teardown_module(duthosts, enum_supervisor_dut_hostname):
     logger.info(
         "Tearing down: to make sure all the critical services, interfaces and transceivers are good")
     check_critical_processes(duthost, watch_secs=10)
-
-
-@pytest.fixture()
-def check_daemon_status(duthosts, enum_supervisor_dut_hostname):
-    duthost = duthosts[enum_supervisor_dut_hostname]
-    daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
-    if daemon_status != "RUNNING":
-        duthost.start_pmon_daemon(daemon_name)
-        time.sleep(10)
 
 
 def test_pmon_fancontrol_running_status(duthosts, enum_supervisor_dut_hostname):

--- a/tests/platform_tests/daemon/test_ledd.py
+++ b/tests/platform_tests/daemon/test_ledd.py
@@ -57,15 +57,6 @@ def teardown_module(duthosts, rand_one_dut_hostname):
     check_critical_processes(duthost, watch_secs=10)
 
 
-@pytest.fixture()
-def check_daemon_status(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
-    daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
-    if daemon_status != "RUNNING":
-        duthost.start_pmon_daemon(daemon_name)
-        time.sleep(10)
-
-
 def check_expected_daemon_status(duthost, expected_daemon_status):
     daemon_status, _ = duthost.get_pmon_daemon_status(daemon_name)
     return daemon_status == expected_daemon_status

--- a/tests/platform_tests/daemon/test_pcied.py
+++ b/tests/platform_tests/daemon/test_pcied.py
@@ -77,15 +77,6 @@ def teardown_module(duthosts, rand_one_dut_hostname):
     check_critical_processes(duthost, watch_secs=10)
 
 
-@pytest.fixture
-def check_daemon_status(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
-    daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
-    if daemon_status != "RUNNING":
-        duthost.start_pmon_daemon(daemon_name)
-        time.sleep(10)
-
-
 def check_expected_daemon_status(duthost, expected_daemon_status):
     daemon_status, _ = duthost.get_pmon_daemon_status(daemon_name)
     return daemon_status == expected_daemon_status
@@ -219,7 +210,7 @@ def test_pmon_pcied_term_and_start_status(check_daemon_status, duthosts,
                   "{} status for SIG_TERM should not be {} with pid:{}!"
                   .format(daemon_name, daemon_status, daemon_pid))
 
-    time.sleep(10)
+    wait_until(120, 10, 0, check_expected_daemon_status, duthost, expected_running_status)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(post_daemon_status == expected_running_status,

--- a/tests/platform_tests/daemon/test_psud.py
+++ b/tests/platform_tests/daemon/test_psud.py
@@ -29,6 +29,7 @@ expected_stopped_status = "STOPPED"
 expected_exited_status = "EXITED"
 
 daemon_name = "psud"
+daemon_dut_hostname_fixture = "enum_supervisor_dut_hostname"
 
 SIG_STOP_SERVICE = None
 SIG_TERM = "-15"
@@ -58,15 +59,6 @@ def teardown_module(duthosts, enum_supervisor_dut_hostname):
     logger.info(
         "Tearing down: to make sure all the critical services, interfaces and transceivers are good")
     check_critical_processes(duthost, watch_secs=10)
-
-
-@pytest.fixture
-def check_daemon_status(duthosts, enum_supervisor_dut_hostname):
-    duthost = duthosts[enum_supervisor_dut_hostname]
-    daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
-    if daemon_status != "RUNNING":
-        duthost.start_pmon_daemon(daemon_name)
-        time.sleep(10)
 
 
 def check_if_daemon_restarted(duthost, daemon_name, pre_daemon_pid):

--- a/tests/platform_tests/daemon/test_syseepromd.py
+++ b/tests/platform_tests/daemon/test_syseepromd.py
@@ -60,15 +60,6 @@ def teardown_module(duthosts, rand_one_dut_hostname):
     check_critical_processes(duthost, watch_secs=10)
 
 
-@pytest.fixture
-def check_daemon_status(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
-    daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
-    if daemon_status != "RUNNING":
-        duthost.start_pmon_daemon(daemon_name)
-        time.sleep(10)
-
-
 def check_expected_daemon_status(duthost, expected_daemon_status):
     daemon_status, _ = duthost.get_pmon_daemon_status(daemon_name)
     return daemon_status == expected_daemon_status


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/25013 
Fix failing PMON daemon term/kill tests (test_pcied, test_syseepromd, test_psud, and the same pattern in test_ledd/test_chassisd/test_fancontrol) by
disabling pmon container autorestart for the duration of these tests via a shared fixture so a killed daemon respawns in place.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [x] 202605

### Approach
#### What is the motivation for this PR?
with pmon auto_restart=enabled (production default), killing a critical daemon makes supervisor-proc-exit-listener terminate supervisord, restarting the whole container and resetting the PID namespace, so post_pid > pre_pid fails. This surfaces under run_optimal (the TestEngine/CI mode), which skips the pretest phase that would otherwise disable autorestart.

#### How did you do it?
Replaced a lingering time.sleep(10) with wait_until(50, 10, 0, check_expected_daemon_status,…). similar to what was done in [24384](https://github.com/sonic-net/sonic-mgmt/pull/24384)
Add a shared, module-scoped disable_pmon_container_autorestart fixture (plus a shared check_daemon_status) in tests/platform_tests/daemon/conftest.py, scoped to feature_list=["pmon"] and restored on teardown.

### Tested branch (Please provide the tested image version)

- [x] 202505 - A private copy of 202505 with nexthop platform support
- [x] 202511 - 202511.1209618-790412450
- [x] 202605 - 202605.1209635-c02e69d87

### Test result

All runs on NH-4010-F (x86_64-nexthop_4010-r1, Broadcom TH5), t0 topology, with this PR's commit
cherry-picked onto each branch. Impacted tests: `tests/platform_tests/daemon/`
(test_pcied, test_psud, test_syseepromd, test_ledd, test_fancontrol, test_chassisd), run in
`run_optimal` mode (the mode where the original failures surfaced).

- 202505: image `202505.Nexthop.170124-8c55d538aa` (202505-based build; the public 202505 branch
  does not contain nexthop platform support) — test_pcied 4/4 PASS, test_psud 4/4 PASS,
  test_syseepromd 4/4 PASS. test_ledd / test_fancontrol skipped (daemons not enabled on this
  platform), test_chassisd skipped (t2-only).
- 202511: public image `202511.1209618-790412450` (sonic-net Azure build 1209618) — test_pcied 4/4
  PASS, test_psud 4/4 PASS, test_syseepromd 4/4 PASS; same expected skips as above.
- 202605: public image `202605.1209635-c02e69d87` (sonic-net Azure build 1209635) — test_pcied 4/4
  PASS, test_psud 5/5 PASS, test_syseepromd 4/4 PASS; same expected skips as above.

Test result logs:

[202505-test_chassisd.test.log](https://github.com/user-attachments/files/31760584/202505-test_chassisd.test.log)
[202505-test_fancontrol.test.log](https://github.com/user-attachments/files/31760587/202505-test_fancontrol.test.log)
[202505-test_ledd.test.log](https://github.com/user-attachments/files/31760588/202505-test_ledd.test.log)
[202505-test_pcied.test.log](https://github.com/user-attachments/files/31760589/202505-test_pcied.test.log)
[202505-test_psud.test.log](https://github.com/user-attachments/files/31760591/202505-test_psud.test.log)
[202505-test_syseepromd.test.log](https://github.com/user-attachments/files/31760592/202505-test_syseepromd.test.log)
[202511-test_chassisd.test.log](https://github.com/user-attachments/files/31760593/202511-test_chassisd.test.log)
[202511-test_fancontrol.test.log](https://github.com/user-attachments/files/31760597/202511-test_fancontrol.test.log)
[202511-test_ledd.test.log](https://github.com/user-attachments/files/31760598/202511-test_ledd.test.log)
[202511-test_pcied.test.log](https://github.com/user-attachments/files/31760599/202511-test_pcied.test.log)
[202511-test_psud.test.log](https://github.com/user-attachments/files/31760600/202511-test_psud.test.log)
[202511-test_syseepromd.test.log](https://github.com/user-attachments/files/31760601/202511-test_syseepromd.test.log)
[202605-test_chassisd.test.log](https://github.com/user-attachments/files/31760602/202605-test_chassisd.test.log)
[202605-test_fancontrol.test.log](https://github.com/user-attachments/files/31760603/202605-test_fancontrol.test.log)
[202605-test_ledd.test.log](https://github.com/user-attachments/files/31760604/202605-test_ledd.test.log)
[202605-test_pcied.test.log](https://github.com/user-attachments/files/31760605/202605-test_pcied.test.log)
[202605-test_psud.test.log](https://github.com/user-attachments/files/31760606/202605-test_psud.test.log)
[202605-test_syseepromd.test.log](https://github.com/user-attachments/files/31760607/202605-test_syseepromd.test.log)


#### Any platform specific information?
None

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A