### PR TITLE
Fix logic for comparison between CONFIG_DB and ASIC_DB wred profile config

### DIFF
--- a/tests/generic_config_updater/test_ecn_config_update.py
+++ b/tests/generic_config_updater/test_ecn_config_update.py
@@ -67,6 +67,12 @@ def get_asic_db_values(duthost, fields, cli_namespace_prefix):
             continue
         wred_data = ast.literal_eval(wred_data)
         values = {}
+        ecn_data = {k.replace('SAI_WRED_ATTR_', '').lower(): v for k, v in wred_data.items()
+                    if k.startswith('SAI_WRED_ATTR')}
+        delta = determine_delta_values(ecn_data, fields, True)
+        if all(delta[f] == 0 for f in fields):
+            logger.info(f"Skipping WRED object {wred_object}: all deltas are 0, no real value change possible.")
+            continue
         for field in fields:
             values[field] = int(wred_data[WRED_MAPPING[field]])
         if values:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #23597

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Since https://github.com/sonic-net/sonic-mgmt/pull/23319 was merged into 202511 we have been seeing failures in some variants of test_ecn_config_updates. This is because some of the wred profiles are being filtered out based on a "delta" value, but later it verifies these values against the unfiltered raw data from ASIC_DB, causing the check to fail in error.

#### How did you do it?
The fix for this is to also filter the set of wred objects from ASIC_DB by the same criteria as the CONFIG_DB wred profiles during the verification step.

#### How did you verify/test it?
Verified the affected testcases are now passing with the change in our automated test runs.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
