### PR TITLE
Skip syslog/test_syslog_source_ip.py for BMC

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5352,11 +5352,12 @@ syslog/test_syslog.py:
 
 syslog/test_syslog_source_ip.py:
   skip:
-    reason: "Vs setup doesn't work when creating mgmt vrf"
+    reason: "Vs setup doesn't work when creating mgmt vrf. BMC does not have routable ports to support this test."
     conditions_logical_operator: or
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/16997"
       - "asic_type in ['vs']"
+      - "'bmc' in topo_type"
 
 syslog/test_syslog_source_ip.py::TestSSIP::test_syslog_protocol_filter_severity:
   skip:


### PR DESCRIPTION
BCM it does not have routed interfaces

### Description of PR

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Reuse the existing SONiC tests for BMC

#### How did you do it?
Ran the reused tests and analyzed the failures

#### How did you verify/test it?
Ran the test, overrode other skips. Obtained "no routed interfaces" skip


#### Any platform specific information?
BMC

#### Supported testbed topology if it's a new test case?

### Documentation

