### PR TITLE
[test] Fix test_ip_packet checksum drop test for fanout platforms that modify checksums

### DIFF
--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -501,6 +501,60 @@ def is_mellanox_fanout(duthost, localhost):
     return True
 
 
+def get_unsupported_fanout_ports(duthost, localhost):
+    """
+    Identifies and returns the set of DUT interface ports connected to fanout devices
+    that modify packet checksums. Some platforms, when used as a fanout, recalculate
+    and correct the checksum of transit packets, causing the DUT to receive packets
+    with a valid checksum instead of the intended invalid one.
+    """
+    unsupported_fanout_skus = {"DellEMC-Z9332f-O32", "NH-5010-F-O64", "Arista-7280R4K-32QF-32DF-64O"}
+    unsupported_dut_ports = set()
+
+    if duthost.facts.get("asic_type") == "vs":
+        return unsupported_dut_ports
+
+    try:
+        dut_facts = localhost.conn_graph_facts(host=duthost.hostname,
+                                               filepath=LAB_CONNECTION_GRAPH_PATH)["ansible_facts"]
+    except RunAnsibleModuleFail as e:
+        logger.info("Get dut_facts failed, reason: %s", e.results.get('msg', e))
+        return unsupported_dut_ports
+
+    try:
+        dev_conn = dut_facts["device_conn"][duthost.hostname]
+    except KeyError:
+        logger.info("device_conn missing for %s in connection graph", duthost.hostname)
+        return unsupported_dut_ports
+
+    device_info = dut_facts.get("device_info", {})
+    fanout_sku_cache = {}
+
+    for dut_port, conn_metadata in dev_conn.items():
+        fanout_host = conn_metadata.get("peerdevice")
+        if not fanout_host:
+            continue
+
+        if fanout_host in fanout_sku_cache:
+            fanout_sku = fanout_sku_cache[fanout_host]
+        else:
+            fanout_sku = device_info.get(fanout_host, {}).get("HwSku")
+            if fanout_sku is None:
+                try:
+                    fanout_facts = localhost.conn_graph_facts(
+                        host=fanout_host, filepath=LAB_CONNECTION_GRAPH_PATH)["ansible_facts"]
+                    fanout_sku = fanout_facts["device_info"][fanout_host]["HwSku"]
+                except (RunAnsibleModuleFail, KeyError):
+                    fanout_sku_cache[fanout_host] = None
+                    continue
+            fanout_sku_cache[fanout_host] = fanout_sku
+
+        if fanout_sku in unsupported_fanout_skus:
+            unsupported_dut_ports.add(dut_port)
+
+    return unsupported_dut_ports
+
+
 def get_supervisor_for_linecard(duthost, duthosts, inv_files):
     """
     Returns the supervisor duthost for a given linecard duthost.

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -501,14 +501,14 @@ def is_mellanox_fanout(duthost, localhost):
     return True
 
 
-def get_unsupported_fanout_ports(duthost, localhost):
+def get_dut_ports_with_checksum_modifying_fanouts(duthost, localhost):
     """
     Identifies and returns the set of DUT interface ports connected to fanout devices
     that modify packet checksums. Some platforms, when used as a fanout, recalculate
     and correct the checksum of transit packets, causing the DUT to receive packets
     with a valid checksum instead of the intended invalid one.
     """
-    unsupported_fanout_skus = {"DellEMC-Z9332f-O32", "NH-5010-F-O64", "Arista-7280R4K-32QF-32DF-64O"}
+    checksum_modifying_fanout_skus = {"DellEMC-Z9332f-O32", "NH-5010-F-O64", "Arista-7280R4K-32QF-32DF-64O"}
     unsupported_dut_ports = set()
 
     if duthost.facts.get("asic_type") == "vs":
@@ -549,7 +549,7 @@ def get_unsupported_fanout_ports(duthost, localhost):
                     continue
             fanout_sku_cache[fanout_host] = fanout_sku
 
-        if fanout_sku in unsupported_fanout_skus:
+        if fanout_sku in checksum_modifying_fanout_skus:
             unsupported_dut_ports.add(dut_port)
 
     return unsupported_dut_ports

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -511,7 +511,9 @@ def get_dut_ports_with_checksum_modifying_fanouts(duthost, localhost):
     checksum_modifying_fanout_skus = {"DellEMC-Z9332f-O32", "NH-5010-F-O64", "Arista-7280R4K-32QF-32DF-64O"}
     unsupported_dut_ports = set()
 
-    if duthost.facts.get("asic_type") == "vs":
+    # Virtual testbeds (VS and VPP/KVM) have no physical fanout to inspect; short-circuit
+    # to avoid unnecessary/failing connection-graph lookups (consistent with is_mellanox_fanout).
+    if is_virtual_platform(duthost):
         return unsupported_dut_ports
 
     try:

--- a/tests/ip/test_ip_packet.py
+++ b/tests/ip/test_ip_packet.py
@@ -9,7 +9,7 @@ from ptf import mask, packet
 from collections import defaultdict
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.portstat_utilities import parse_portstat
-from tests.common.helpers.dut_utils import is_mellanox_fanout, get_unsupported_fanout_ports
+from tests.common.helpers.dut_utils import is_mellanox_fanout, get_dut_ports_with_checksum_modifying_fanouts
 from tests.common.utilities import parse_rif_counters, wait_until
 from tests.ip.ip_util import parse_interfaces, sum_ifaces_counts, random_mac
 
@@ -58,6 +58,56 @@ class TestIPPacket(object):
                     time.sleep(TestIPPacket.VPP_KVM_CHUNK_DELAY)
         else:
             testutils.send(ptfadapter, ptf_port_idx, pkt, count)
+
+    @staticmethod
+    def _select_checksum_safe_ingress(duthost, localhost, common_param, mg_facts):
+        """
+        Picks an ingress (PTF port idx, DUT iface) pair connected to a fanout that
+        preserves packet checksums. If the original ingress from common_param is
+        already safe, returns it unchanged; otherwise picks an alternate port in the
+        same namespace and recomputes the ASIC router MAC. Resolves the matching RIF
+        interface (portchannel when the ingress is a member of one, else the physical
+        port). Calls pytest.skip() if no safe ingress exists in the namespace.
+
+        Returns: (ptf_port_idx, ingress_iface, ingress_router_mac, rif_rx_ifaces,
+                  unsupported_ptf_ports)
+        """
+        (peer_ip_ifaces_pair, _, _, ptf_port_idx,
+         pc_ports_map, ptf_indices, ingress_router_mac) = common_param
+
+        unsupported_dut_ports = get_dut_ports_with_checksum_modifying_fanouts(duthost, localhost)
+        unsupported_ptf_ports = {ptf_indices[p] for p in unsupported_dut_ports if p in ptf_indices}
+
+        ingress_namespace = peer_ip_ifaces_pair[0][2]
+        ingress_iface = next((iface for iface, idx in ptf_indices.items() if idx == ptf_port_idx), None)
+        if ingress_iface is None:
+            pytest.skip("Failed to resolve DUT interface for the specified PTF port index")
+
+        if ptf_port_idx in unsupported_ptf_ports:
+            supported_ingress_ptf_ports = [
+                idx for iface, idx in ptf_indices.items()
+                if idx not in unsupported_ptf_ports
+                and iface.startswith("Ethernet")
+                and mg_facts["minigraph_neighbors"].get(iface, {}).get("namespace") == ingress_namespace]
+            if not supported_ingress_ptf_ports:
+                pytest.skip("All ingress ports in namespace '{}' connect to fanouts"
+                            " that modify the checksum".format(ingress_namespace))
+            ptf_port_idx = supported_ingress_ptf_ports[0]
+            ingress_iface = next(
+                (iface for iface, idx in ptf_indices.items() if idx == ptf_port_idx), ingress_iface)
+            logger.info("Switched ingress to %s (PTF %d)", ingress_iface, ptf_port_idx)
+
+            asic_id = duthost.get_asic_id_from_namespace(ingress_namespace)
+            ingress_router_mac = duthost.asic_instance(asic_id).get_router_mac()
+
+        # When the ingress physical port is a portchannel member, RIF counters
+        # are tracked against the portchannel; otherwise against the physical port.
+        rif_rx_ifaces = next(
+            (pc for pc, members in pc_ports_map.items() if ingress_iface in members),
+            ingress_iface,
+        )
+
+        return ptf_port_idx, ingress_iface, ingress_router_mac, rif_rx_ifaces, unsupported_ptf_ports
 
     @pytest.fixture(scope="class")
     def common_param(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
@@ -305,40 +355,12 @@ class TestIPPacket(object):
         asic_type = duthost.facts["asic_type"]
         if is_mellanox_fanout(duthost, localhost):
             pytest.skip("Not supported at Mellanox fanout")
-        (peer_ip_ifaces_pair, rif_rx_ifaces, rif_support, ptf_port_idx,
-         pc_ports_map, ptf_indices, ingress_router_mac) = common_param
-
-        # Some fanout platforms recalculate and correct packet checksums in transit,
-        # causing the DUT to receive a valid checksum instead of the intended invalid one.
-        # We skip ports connected to such fanouts to ensure the invalid checksum test is valid.
-        unsupported_dut_ports = get_unsupported_fanout_ports(duthost, localhost)
-        unsupported_ptf_ports = {ptf_indices[p] for p in unsupported_dut_ports if p in ptf_indices}
+        (_, _, rif_support, _,
+         pc_ports_map, ptf_indices, _) = common_param
 
         mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-        ingress_namespace = peer_ip_ifaces_pair[0][2]
-
-        ingress_iface = next((iface for iface, idx in ptf_indices.items() if idx == ptf_port_idx), None)
-        if ingress_iface is None:
-            pytest.skip("Failed to resolve DUT interface for the specified PTF port index")
-
-        # If current ingress PTF port is not supported, choose a supported one in the same namespace
-        if ptf_port_idx in unsupported_ptf_ports:
-            supported_ingress_ptf_ports = [
-                idx for iface, idx in ptf_indices.items()
-                if idx not in unsupported_ptf_ports
-                and iface.startswith("Ethernet")
-                and mg_facts["minigraph_neighbors"].get(iface, {}).get("namespace") == ingress_namespace]
-            if not supported_ingress_ptf_ports:
-                pytest.skip("All ingress ports in namespace '{}' connect to fanouts"
-                            " that modify the checksum".format(ingress_namespace))
-            ptf_port_idx = supported_ingress_ptf_ports[0]
-            ingress_iface = next((iface for iface, idx in ptf_indices.items() if idx == ptf_port_idx), ingress_iface)
-            logger.info("Switched ingress to %s (PTF %d)", ingress_iface, ptf_port_idx)
-
-            # Recompute router MAC and RIF interface for the new ingress port (multi-ASIC safe)
-            asic_id = duthost.get_asic_id_from_namespace(ingress_namespace)
-            ingress_router_mac = duthost.asic_instance(asic_id).get_router_mac()
-            rif_rx_ifaces = ingress_iface
+        ptf_port_idx, ingress_iface, ingress_router_mac, rif_rx_ifaces, unsupported_ptf_ports = \
+            self._select_checksum_safe_ingress(duthost, localhost, common_param, mg_facts)
 
         rx_port = ingress_iface
 

--- a/tests/ip/test_ip_packet.py
+++ b/tests/ip/test_ip_packet.py
@@ -9,7 +9,7 @@ from ptf import mask, packet
 from collections import defaultdict
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.portstat_utilities import parse_portstat
-from tests.common.helpers.dut_utils import is_mellanox_fanout
+from tests.common.helpers.dut_utils import is_mellanox_fanout, get_unsupported_fanout_ports
 from tests.common.utilities import parse_rif_counters, wait_until
 from tests.ip.ip_util import parse_interfaces, sum_ifaces_counts, random_mac
 
@@ -307,6 +307,41 @@ class TestIPPacket(object):
             pytest.skip("Not supported at Mellanox fanout")
         (peer_ip_ifaces_pair, rif_rx_ifaces, rif_support, ptf_port_idx,
          pc_ports_map, ptf_indices, ingress_router_mac) = common_param
+
+        # Some fanout platforms recalculate and correct packet checksums in transit,
+        # causing the DUT to receive a valid checksum instead of the intended invalid one.
+        # We skip ports connected to such fanouts to ensure the invalid checksum test is valid.
+        unsupported_dut_ports = get_unsupported_fanout_ports(duthost, localhost)
+        unsupported_ptf_ports = {ptf_indices[p] for p in unsupported_dut_ports if p in ptf_indices}
+
+        mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+        ingress_namespace = peer_ip_ifaces_pair[0][2]
+
+        ingress_iface = next((iface for iface, idx in ptf_indices.items() if idx == ptf_port_idx), None)
+        if ingress_iface is None:
+            pytest.skip("Failed to resolve DUT interface for the specified PTF port index")
+
+        # If current ingress PTF port is not supported, choose a supported one in the same namespace
+        if ptf_port_idx in unsupported_ptf_ports:
+            supported_ingress_ptf_ports = [
+                idx for iface, idx in ptf_indices.items()
+                if idx not in unsupported_ptf_ports
+                and iface.startswith("Ethernet")
+                and mg_facts["minigraph_neighbors"].get(iface, {}).get("namespace") == ingress_namespace]
+            if not supported_ingress_ptf_ports:
+                pytest.skip("All ingress ports in namespace '{}' connect to fanouts"
+                            " that modify the checksum".format(ingress_namespace))
+            ptf_port_idx = supported_ingress_ptf_ports[0]
+            ingress_iface = next((iface for iface, idx in ptf_indices.items() if idx == ptf_port_idx), ingress_iface)
+            logger.info("Switched ingress to %s (PTF %d)", ingress_iface, ptf_port_idx)
+
+            # Recompute router MAC and RIF interface for the new ingress port (multi-ASIC safe)
+            asic_id = duthost.get_asic_id_from_namespace(ingress_namespace)
+            ingress_router_mac = duthost.asic_instance(asic_id).get_router_mac()
+            rif_rx_ifaces = ingress_iface
+
+        rx_port = ingress_iface
+
         pkt = testutils.simple_ip_packet(
             eth_dst=ingress_router_mac,
             eth_src=ptfadapter.dataplane.get_mac(0, ptf_port_idx),
@@ -330,7 +365,17 @@ class TestIPPacket(object):
 
         out_rif_ifaces, out_ifaces = parse_interfaces(
             duthost.command("show ip route 10.156.94.34")["stdout_lines"], pc_ports_map)
-        out_ptf_indices = [ptf_indices[iface] for iface in out_ifaces]
+        egress_ptf_ports_all = [ptf_indices[i] for i in out_ifaces if i in ptf_indices]
+        egress_ptf_ports_supported = [
+            ptf_indices[i] for i in out_ifaces
+            if i in ptf_indices and ptf_indices[i] not in unsupported_ptf_ports]
+
+        out_ptf_indices = egress_ptf_ports_supported or egress_ptf_ports_all
+        if not out_ptf_indices:
+            pytest.skip("No egress PTF port indices are mapped to DUT interfaces")
+        if not egress_ptf_ports_supported:
+            logger.warning("All egress ports are on fanouts that modify checksums. "
+                           "Proceeding because packet should be dropped before egress.")
 
         duthost.command("portstat -c")
         if rif_support:
@@ -350,8 +395,8 @@ class TestIPPacket(object):
 
         # In different platforms, IP packets with specific checksum will be dropped in different layer
         # We use both layer 2 counter and layer 3 counter to check where packet are dropped
-        rx_ok = int(portstat_out[peer_ip_ifaces_pair[0][1][0]]["rx_ok"].replace(",", ""))
-        rx_drp = int(portstat_out[peer_ip_ifaces_pair[0][1][0]]["rx_drp"].replace(",", ""))
+        rx_ok = int(portstat_out[rx_port]["rx_ok"].replace(",", ""))
+        rx_drp = int(portstat_out[rx_port]["rx_drp"].replace(",", ""))
         rx_err = int(rif_counter_out[rif_rx_ifaces]["rx_err"].replace(",", "")) if rif_support else 0
         tx_ok = sum_ifaces_counts(portstat_out, out_ifaces, "tx_ok")
         tx_drp = sum_ifaces_counts(portstat_out, out_ifaces, "tx_drp")

--- a/tests/ip/test_ip_packet.py
+++ b/tests/ip/test_ip_packet.py
@@ -84,10 +84,16 @@ class TestIPPacket(object):
             pytest.skip("Failed to resolve DUT interface for the specified PTF port index")
 
         if ptf_port_idx in unsupported_ptf_ports:
+            # Only routed ports and port-channel members have a router interface (RIF).
+            # Restrict candidates to those so the RIF counter lookup below can't KeyError
+            # on a plain L2 port.
+            l3_ingress_ports = {intf["attachto"] for intf in mg_facts["minigraph_interfaces"]}
+            for members in pc_ports_map.values():
+                l3_ingress_ports.update(members)
             supported_ingress_ptf_ports = [
                 idx for iface, idx in ptf_indices.items()
                 if idx not in unsupported_ptf_ports
-                and iface.startswith("Ethernet")
+                and iface in l3_ingress_ports
                 and mg_facts["minigraph_neighbors"].get(iface, {}).get("namespace") == ingress_namespace]
             if not supported_ingress_ptf_ports:
                 pytest.skip("All ingress ports in namespace '{}' connect to fanouts"


### PR DESCRIPTION
### Description of PR

Some fanout platforms recalculate and correct packet checksums in transit. When the `test_ip_packet` checksum drop tests send a packet with an intentionally invalid checksum through such a fanout, the fanout "fixes" the checksum before forwarding it to the DUT. The DUT then receives a valid-checksum packet and does not drop it, causing the test to fail.

This PR adds detection of such fanout devices and automatically selects an ingress port connected to a fanout that preserves the original (invalid) checksum. It also ensures correct counter verification by reading rx/tx stats from the actual ingress port used.

Summary:
- Add `get_dut_ports_with_checksum_modifying_fanouts()` utility to identify DUT ports connected to fanout devices that modify packet checksums
- Skip those ports when selecting an ingress port for checksum drop tests
- Use namespace-aware port selection for multi-ASIC platforms, restricted to L3-capable ingress ports (routed ports / port-channel members) so the RIF counter lookup can't hit a plain L2 port
- Recompute router MAC and update rif_rx_ifaces when switching to a different ingress port
- Read rx counters from the actual ingress port used (not the original fixture port)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
The `test_ip_packet.py` checksum drop tests (`test_forward_ip_packet_with_invalid_checksum`, `test_forward_ip_packet_recomputed`) fail on testbeds where the fanout device recalculates and corrects packet checksums in transit. The DUT receives a valid-checksum packet instead of the intended invalid one, so it forwards the packet instead of dropping it.

#### How did you do it?
1. Added `get_dut_ports_with_checksum_modifying_fanouts()` in `dut_utils.py` that uses `conn_graph_facts` to look up the HwSku of each connected fanout device and returns the set of DUT ports connected to fanouts known to modify checksums. It short-circuits on virtual platforms (`is_virtual_platform`), which have no physical fanout to inspect.
2. In the checksum drop test, if the current ingress port is connected to such a fanout, the test selects an alternate ingress port in the same namespace that is connected to a fanout that preserves checksums. Candidates are restricted to L3-capable ports (routed ports and port-channel members) so the RIF counter lookup can't KeyError on a plain L2 port.
3. When switching ingress port, the test recomputes the router MAC for the correct ASIC and updates the rif_rx_ifaces to match the new port (port-channel when the ingress is a member of one, else the physical port).
4. Read rx counters from the port that was actually used for ingress.

#### How did you verify/test it?
Ran `test_ip_packet.py` on multiple testbeds:
- T2 topology with VOQ single-asic platforms (7 passed, 1 skipped)
- Verified the test correctly detects unsupported fanout ports and switches to a supported ingress port
- Confirmed rx_ok/rx_drp counters are read from the correct port after switching

#### Any platform specific information?
Affects testbeds where the fanout device modifies packet checksums in transit. The test gracefully skips if all available ingress ports in the namespace are connected to such fanouts.

#### Supported testbed topology if it's a new test case?
N/A — this is a fix to an existing test. Works on t2 and any topology.

### Documentation
N/A
