### PR TITLE
[BMC] Fix is_bmc_device() to use DEVICE_METADATA.type instead of bmc.json presence

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -219,7 +219,7 @@ class GenerateGoldenConfigDBModule(object):
         return False
 
     def is_bmc_device(self):
-        return device_info.get_bmc_data() is not None
+        return device_info.get_localhost_info('type') == 'NetworkBmc'
 
     def has_otel_image(self):
         rc, out, _ = self.module.run_command("docker images --format '{{.Repository}}'")


### PR DESCRIPTION
### Description of PR

Fixes the bug introduced by #24585 that caused the swss/syncd FEATURE to be disabled on real switches (Switch-Host side of switch-with-BMC platforms), not just on standalone BMC devices.

The previous implementation used `device_info.get_bmc_data() is not None`. `get_bmc_data()` returns truthy whenever `/etc/sonic/bmc.json` exists, and that file is provisioned on **both** sides of a switch-with-BMC platform (the Switch-Host has it so it can reach the BMC's Redis; the Switch-BMC has it so it can reach the host's Redis). So `is_bmc_device()` mistakenly flagged switch hosts as BMC devices.

Fix: use `DEVICE_METADATA.localhost.type == 'NetworkBmc'`, which is the same strict marker that `tests/common/devices/sonic.py:285` (`SonicHost.is_bmc()`) and `ansible/library/sonic_basic_facts.py` already rely on. Only standalone BMC instances carry that type.

Fixes #24974

### Summary
Fixes # (issue) 24974

### Type of change
- [x] Bug fix

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
PR #24585 introduced `is_bmc_device()` to gate the BMC-only behavior of disabling the swss/syncd FEATURE during deployment. The helper as written wrongly matches Switch-Host devices that have a BMC attached, which then disables swss/syncd on real switches and breaks NVIDIA's switch-with-BMC deployments.

#### How did you do it?
Replaced `device_info.get_bmc_data() is not None` with `device_info.get_localhost_info('type') == 'NetworkBmc'`. That field is only set on standalone BMC ConfigDB and is what the rest of the codebase already uses to identify BMC devices.

#### How did you verify/test it?
Static review against the existing BMC detection patterns in:
- `tests/common/devices/sonic.py:285` (`SonicHost.is_bmc()`)
- `ansible/library/sonic_basic_facts.py:441` (populates `router_type` from the same `DEVICE_METADATA.type`)

CI will exercise the deployment flow on both BMC and non-BMC platforms.

#### Any platform specific information?
Affects deployment of any platform that has a `bmc.json` provisioned on the switch host side (i.e., switch-with-BMC SKUs such as NVIDIA's). Standalone BMC platforms continue to behave as intended by #24585.

#### Supported testbed topology if it's a new test case?
N/A ╬ô├ç├╢ bugfix to the deployment helper.

### Documentation
N/A


### Empirical confirmation on Komodo BMC (2026-06-02)

Verified the new condition on a live Komodo BMC running SONiC.master.1125559-f9827de19:

```
admin@host1-komodo-bmc:~$ sonic-cfggen -d -v "DEVICE_METADATA['localhost']['type']"
NetworkBmc
```

So `device_info.get_localhost_info('type') == 'NetworkBmc'` evaluates as expected on a real BMC device, and the same call returns a different role (`ToRRouter`, `LeafRouter`, etc.) on switches ΓÇö including switches that have a BMC attached, which is the exact scenario this PR fixes.


Workitem link: https://dev.azure.com/msazure/One/_workitems/edit/38207843
