### PR TITLE
Add xfail for dhcp_relay/test_dhcp_relay.py

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1200,6 +1200,10 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_with_source_port_ip_in_relay_enab
     conditions_logical_operator: or
     conditions:
       - "'dualtor' in topo_name and release in ['201811', '201911']"
+  xfail:
+    reason: "xfail due to GitHub issues: https://github.com/sonic-net/sonic-buildimage/issues/27586"
+    conditions:
+      - "https://github.com/sonic-net/sonic-buildimage/issues/27586"
 
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_with_source_port_ip_in_relay_enabled[sonic-relay-agent]:
   skip:
@@ -1212,6 +1216,10 @@ dhcp_relay/test_dhcp_relay.py::test_interface_binding:
     reason: "Skip test_interface_binding in old release version"
     conditions:
       - "release in ['201811', '201911', '202106']"
+  xfail:
+    reason: "xfail due to GitHub issues: https://github.com/sonic-net/sonic-buildimage/issues/27586"
+    conditions:
+      - "https://github.com/sonic-net/sonic-buildimage/issues/27586"
 
 dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_restart_with_stress:
   skip:
@@ -1282,6 +1290,10 @@ dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_default:
     reason: "Skip test_dhcp_relay_default in old release version"
     conditions:
       - "release in ['201811', '201911', '202106']"
+  xfail:
+    reason: "xfail due to GitHub issues: https://github.com/sonic-net/sonic-buildimage/issues/27586"
+    conditions:
+      - "https://github.com/sonic-net/sonic-buildimage/issues/27586"
 
 dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_start_with_uplinks_down:
   skip:


### PR DESCRIPTION

### Description of PR
Summary:
Add xfail markers for DHCP relay test cases that are affected by a dhcpmon crash issue.
Due to issue: https://github.com/sonic-net/sonic-buildimage/issues/27586


### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
`dhcpmon` crashes during startup when the management interface (`eth0`) has more than one IPv6 link-local address (LLA). This is caused by a strict validation in `initialize_intf_mac_and_ip_addr()` (introduced in sonic-net/sonic-dhcpmon#62) that requires exactly one IPv6 LLA per interface. Some systems have both a kernel-generated LLA and a statically configured management LLA on `eth0`, which is valid Linux IPv6 behavior but causes `dhcpmon` to exit.
When `dhcpmon` exits, supervisor marks it as `FATAL`, and the affected DHCP relay test cases fail during teardown with:
Failed: dhcp_relay is not ready after restarting
This impacts the following test cases:
- `test_dhcp_relay_with_source_port_ip_in_relay_enabled`
- `test_interface_binding`
- `test_dhcp_relay_default`

#### How did you do it?
Added `xfail` entries in `tests_mark_conditions.yaml` for the three affected test cases, referencing the upstream issue sonic-net/sonic-buildimage#27586. The xfail markers will be automatically removed once the upstream fix lands and the issue is closed.
#### How did you verify/test it?
Verified that the affected test cases are marked as `xfail` instead of `FAILED` when running on systems with multiple IPv6 LLAs on eth0.
#### Any platform specific information?
Any
#### Supported testbed topology if it's a new test case?
Any
### Documentation
NA
