### PR TITLE
[BMC] Skip unsupported platform tests on BMC

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1002,6 +1002,7 @@ platform_tests/cli/test_show_platform.py::test_show_platform_psustatus:
     conditions:
       - "'nvda_bf' in platform"
       - "platform in ['arm64-elba-asic-flash128-r0']"
+      - "'bmc' in topo_type"
 
 platform_tests/cli/test_show_platform.py::test_show_platform_psustatus_json:
   xfail:
@@ -1015,6 +1016,7 @@ platform_tests/cli/test_show_platform.py::test_show_platform_psustatus_json:
     conditions:
       - "'nvda_bf' in platform"
       - "platform in ['arm64-elba-asic-flash128-r0']"
+      - "'bmc' in topo_type"
 
 platform_tests/cli/test_show_platform.py::test_show_platform_syseeprom:
   xfail:
@@ -1154,8 +1156,10 @@ platform_tests/mellanox/test_hw_management_service.py:
 
 platform_tests/mellanox/test_psu_power_threshold.py:
   skip:
-    reason: "Not available on BMC"
+    reason: "Test is skipped on Mellanox LD platform for it doesn't have PSU Power Threshold, or not available for BMC"
+    conditions_logical_operator: or
     conditions:
+      - "asic_type in ['mellanox'] and 'sn6600_ld' in platform"
       - "'bmc' in topo_type"
 
 platform_tests/mellanox/test_reboot_cause.py:
@@ -1426,9 +1430,11 @@ platform_tests/test_port_toggle.py:
 
 platform_tests/test_power_off_reboot.py:
   skip:
-    reason: "Skip power off reboot test for Wistron/Nokia-7215"
+    reason: "Skip power off reboot test for Wistron/Nokia-7215, or no PSU for BMC"
+    conditions_logical_operator: or
     conditions:
       - "(hwsku in ['Celestica-E1031-T48S4']) or ('sw_to3200k' in hwsku) or (platform in ['armhf-nokia_ixs7215_52x-r0']) or (is_multi_asic==True and release in ['201911'])"
+      - "'bmc' in topo_type"
 
 platform_tests/test_reboot.py::test_cold_reboot:
   xfail:
@@ -1551,6 +1557,12 @@ platform_tests/test_sensors.py::test_sensors:
 #######################################
 ##### test_sequential_restart.py  #####
 #######################################
+platform_tests/test_sequential_restart.py::test_restart_swss:
+  skip:
+    reason: "BMC does not support swss daemon"
+    conditions:
+      - "'bmc' in topo_type"
+
 platform_tests/test_sequential_restart.py::test_restart_syncd:
   skip:
     reason: "Restarting syncd is not supported yet"


### PR DESCRIPTION
Summary: [BMC] Skip unsupported platform tests on BMC
Fixes # (issue)

- test_show_platform_psustatus / _json: BMC has no PSUs
- test_psu_power_threshold: not available on BMC (combined with the existing Mellanox LD skip condition)
- test_power_off_reboot: BMC has no PSU to power off
- test_restart_swss: BMC does not support the swss daemon

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
