### PR TITLE
Add xfail for dhcpv4_relay non_default_vrf tests (GitHub#27608)

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1253,6 +1253,18 @@ dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_option82_suboptions[server_id_o
     conditions:
       - "True"
 
+dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_with_different_non_default_vrf:
+  xfail:
+    reason: "xfail due to community issue: https://github.com/sonic-net/sonic-buildimage/issues/27608"
+    conditions:
+      - "https://github.com/sonic-net/sonic-buildimage/issues/27608"
+
+dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_with_non_default_vrf:
+  xfail:
+    reason: "xfail due to community issue: https://github.com/sonic-net/sonic-buildimage/issues/27608"
+    conditions:
+      - "https://github.com/sonic-net/sonic-buildimage/issues/27608"
+
 dhcp_relay/test_dhcpv6_relay.py:
   skip:
     reason: "Need to skip for platform x86_64-8111_32eh_o-r0"


### PR DESCRIPTION

### Description of PR
Summary:
Add xfail markers for DHCPv4 relay VRF test cases affected by a stale RIF race condition during VRF bind (https://github.com/sonic-net/sonic-buildimage/issues/27608).

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
During `config interface vrf bind`, orchagent can fail to remove the old router interface (RIF) because it is still referenced by existing neighbor, next-hop, or next-hop-group objects More details in https://github.com/sonic-net/sonic-buildimage/issues/27608.

The following test cases are affected:
- `test_dhcp_relay_with_non_default_vrf`
- `test_dhcp_relay_with_different_non_default_vrf`

#### How did you do it?
Added `xfail` entries in `tests_mark_conditions.yaml` for the two affected test cases.

#### How did you verify/test it?
Verified that the affected test cases are marked as `xfail` instead of `FAILED` when running 
- `test_dhcp_relay_with_non_default_vrf`
- `test_dhcp_relay_with_different_non_default_vrf`

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?
Any

### Documentation
NA
