### PR TITLE
[BMC][config_reload] Skip swss readiness gate in config_system_checks_passed

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -35,26 +35,34 @@ def config_system_checks_passed(duthost, delayed_services=[]):
         logging.info(fail_reason['stdout_lines'])
         return False
 
-    logging.info("Checking if Orchagent up for at least 2 min")
-    if duthost.is_multi_asic:
-        for asic in duthost.asics:
-            out = duthost.shell("systemctl show swss@{}.service --property ActiveState --value".format(asic.asic_index))
+    if duthost.is_bmc():
+        # BMC devices (DEVICE_METADATA.localhost.type == 'NetworkBmc') have no
+        # front-side ASIC. swss/syncd are intentionally not running, so the
+        # swss readiness gate below would never pass on BMC.
+        logging.info("Skipping swss readiness gate on BMC device")
+    else:
+        logging.info("Checking if Orchagent up for at least 2 min")
+        if duthost.is_multi_asic:
+            for asic in duthost.asics:
+                out = duthost.shell(
+                    "systemctl show swss@{}.service --property ActiveState --value".format(asic.asic_index))
+                if out["stdout"] != "active":
+                    return False
+
+                cmd = ("ps -o etimes -p $(systemctl show swss@{}.service --property ExecMainPID --value)"
+                       " | sed '1d'").format(asic.asic_index)
+                out = duthost.shell(cmd)
+                if int(out['stdout'].strip()) < 120:
+                    return False
+        else:
+            out = duthost.shell("systemctl show swss.service --property ActiveState --value")
             if out["stdout"] != "active":
                 return False
 
             out = duthost.shell(
-                "ps -o etimes -p $(systemctl show swss@{}.service --property ExecMainPID --value) | sed '1d'".format(
-                    asic.asic_index))
+                "ps -o etimes -p $(systemctl show swss.service --property ExecMainPID --value) | sed '1d'")
             if int(out['stdout'].strip()) < 120:
                 return False
-    else:
-        out = duthost.shell("systemctl show swss.service --property ActiveState --value")
-        if out["stdout"] != "active":
-            return False
-
-        out = duthost.shell("ps -o etimes -p $(systemctl show swss.service --property ExecMainPID --value) | sed '1d'")
-        if int(out['stdout'].strip()) < 120:
-            return False
 
     logging.info("Checking delayed services: %s", delayed_services)
     for service in delayed_services:


### PR DESCRIPTION
### Description of PR

BMC devices (`DEVICE_METADATA.localhost.type == 'NetworkBmc'`) have no front-side ASIC. `swss`/`syncd` are intentionally not running there, so the existing readiness gate in `tests/common/config_reload.py::config_system_checks_passed()` ΓÇö which waits for `systemctl show swss.service --property ActiveState` to be `"active"` ΓÇö never passes.

Result: every reload-using test on BMC (e.g. `platform_tests/test_reload_config.py::test_reload_configuration`, `::test_reload_configuration_checks`) times out the full 360 s window and fails with:

```
AssertionError: System checks did not pass within the allotted time after config reload.
```

This PR short-circuits the swss readiness gate when `duthost.is_bmc()` is true.

`SonicHost.is_bmc()` is the canonical BMC-detection helper already used by `tests/bmc/conftest.py`, `tests/cacl/test_cacl_function.py`, `tests/process_monitoring/test_critical_process_monitoring.py`, and is implemented as a single cached lookup (`self._facts.get('router_type', '') == 'NetworkBmc'`) ΓÇö no extra shell call, no parser risk. Behavior on every non-BMC device is unchanged.

### Verified manifestation

R3 baseline on Komodo BMC (build `internal.161861823-bff76049fe`, 2026-04-28):

| Test | Runtime | Result | Error |
|---|---|---|---|
| `test_reload_configuration[host1-komodo-bmc]` | 424 s | failure | `AssertionError: System checks did not pass within the allotted time after config reload.` |
| `test_reload_configuration_checks[host1-komodo-bmc]` | 614 s | failure | `AssertionError: System checks did not pass within the allotted time after config reload on  Delayed services: []` |

Both runtimes are dominated by the 360 s `wait_until` window where `config_system_checks_passed()` returns `False` every 20 s on the swss check.

### Summary
Fixes #

### Type of change
- [x] Bug fix

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Stop wasting 6+ minutes per reload-using test on BMC waiting for a service that is intentionally not running.

#### How did you do it?
Wrapped the existing multi-asic / single-asic swss readiness block with `if duthost.is_bmc(): ... else: <existing block>`. No other changes.

#### How did you verify/test it?
- `python3 -m py_compile tests/common/config_reload.py` clean.
- Static review against the failure data above.
- CI will exercise the reload tests on non-BMC platforms.
- Will re-verify `test_reload_configuration[host1-komodo-bmc]` and `::test_reload_configuration_checks` on Komodo BMC after merge.

#### Any platform specific information?
Only affects the path where `DEVICE_METADATA.localhost.type == 'NetworkBmc'`. No-op everywhere else.

#### Supported testbed topology if it's a new test case?
N/A ΓÇö helper change.

### Documentation
N/A

Workitem link: https://msazure.visualstudio.com/One/_workitems/edit/37906237