### PR TITLE
[multi_passwd_ssh] Retry remaining passwords when SSH stderr is censored by no_log

### DIFF
--- a/ansible/plugins/connection/multi_passwd_ssh.py
+++ b/ansible/plugins/connection/multi_passwd_ssh.py
@@ -70,6 +70,13 @@ CONNECTION_TIMEOUT_ERR_FLAG2 = "No route to host"
 # the "Permission denied" message to distinguish auth failures from
 # connectivity failures (timeout, no route to host, etc.).
 PERMISSION_DENIED_ERR_FLAG = "Permission denied"
+# When a task has `no_log: true`, Ansible censors the underlying SSH stderr
+# before the connection plugin sees it. In that case the error message no
+# longer contains "Permission denied", so the auth-failure detection above
+# would mis-classify wrong-password attempts as real connectivity failures
+# and abort the retry loop. Detect the censorship marker so we can still
+# iterate through remaining passwords.
+NO_LOG_CENSORED_FLAG = "censored due to no log"
 
 
 def _password_retry(func):
@@ -106,8 +113,17 @@ def _password_retry(func):
                 # ansible-core 2.19+ with ssh_askpass raises AnsibleConnectionFailure
                 # (not AnsibleAuthenticationFailure) for "Permission denied" auth failures.
                 # Treat it as an auth failure so the retry loop still iterates.
+                # If the task sets `no_log: true`, the SSH stderr is censored before
+                # this plugin can inspect it, so "Permission denied" will be absent
+                # from `err_msg`. In that case we cannot tell auth failure from a
+                # real connectivity failure; assume it may be auth and keep trying
+                # the remaining passwords rather than aborting prematurely.
                 err_msg = getattr(e, "message", "") or str(e)
-                if PERMISSION_DENIED_ERR_FLAG not in err_msg:
+                is_auth_failure = (
+                    PERMISSION_DENIED_ERR_FLAG in err_msg
+                    or NO_LOG_CENSORED_FLAG in err_msg
+                )
+                if not is_auth_failure:
                     raise  # not an auth failure; preserve original behaviour
                 if not conn_passwords:
                     raise  # exhausted all passwords


### PR DESCRIPTION
### Description of PR

Summary:
Fix `multi_passwd_ssh` connection plugin so that the password-retry loop is not prematurely aborted when a task sets `no_log: true` under ansible-core 2.19+.

Fixes # (no GitHub issue filed; reproduced on `master` while running `testbed-cli.sh add-topo`, which invokes `config_sonic_basedon_testbed.yml` → "Rotate the password" task).

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Under ansible-core 2.19+, the default SSH password mechanism is `ssh_askpass`, and authentication failures surface as `AnsibleConnectionFailure` rather than `AnsibleAuthenticationFailure`. The plugin distinguishes auth failures from real connectivity issues by string-matching `"Permission denied"` in the exception message (see PERMISSION_DENIED_ERR_FLAG, introduced when adding 2.19 support).

However, when the task sets `no_log: true` (e.g. the `Rotate the password` task in `ansible/config_sonic_basedon_testbed.yml`, which echoes a credential on the shell command line), Ansible **censors the underlying SSH stderr before this plugin sees it**. The exception message becomes something like:

```
Failed to connect to the host via ssh: <error censored due to no log>
```

`"Permission denied"` is no longer present, so the existing check classifies the failure as a real connectivity failure, re-raises immediately, and the retry loop never advances to the next entry in `ansible_altpasswords`. The task is reported as `UNREACHABLE`, and because `ignore_errors: true` does **not** suppress `UNREACHABLE` results, the playbook aborts — even though the *next* password in the list would have authenticated successfully.

Concrete repro (an `n3000`-style DUT that recently had its password rotated, with the new password supplied via `ansible_altpasswords`):

```
TASK [Rotate the password] *****************************************
<DUT> rc=255, stdout and stderr censored due to no log
fatal: [DUT]: UNREACHABLE! => { ... }
```

Removing `no_log: true` from the task makes the same run succeed, because the plain stderr does contain `"Permission denied"` and the retry loop then walks through the password list to the working one. The verbose log shows two `Permission denied` attempts followed by a third successful attempt.

#### How did you do it?

In `ansible/plugins/connection/multi_passwd_ssh.py`, expand the auth-failure detection in the `AnsibleConnectionFailure` handler to also treat the no-log censorship marker (`"censored due to no log"`) as a possible authentication failure. When the marker is present we genuinely cannot tell whether SSH failed for auth or for connectivity, so it's safer to keep iterating through the remaining passwords than to abort on the first attempt. If all passwords are exhausted, the original exception is still re-raised.

Behaviour for **genuine** connectivity failures is unchanged: those carry markers like `"Connection timed out"` / `"No route to host"` and are still handled by the IPv6-fallback path further up in `wrapped()`.

#### How did you verify/test it?

- Re-ran `./testbed-cli.sh -t testbed.yaml -m veos -k ceos add-topo <tb> password.txt -vvv` against a DUT whose current password is the second entry in `ansible_altpasswords`, with `no_log: True` left in place on the `Rotate the password` task. With this patch the plugin now retries with the second password, the task succeeds, and the playbook continues. Without the patch the same setup fails with `UNREACHABLE`.
- Re-ran the same flow with a deliberately unreachable host (host powered off / wrong IP). The connection still correctly fails through to the IPv6-fallback / unreachable path — no behaviour change.
- `flake8 --max-line-length=120 ansible/plugins/connection/multi_passwd_ssh.py` — no new warnings introduced. (Two pre-existing E721 warnings on lines 149 and 171 are unrelated and unchanged.)

#### Any platform specific information?

No — the change is in an Ansible connection plugin and affects all platforms whose deploy/test flow uses tasks with `no_log: true` together with `ansible_altpasswords` under ansible-core 2.19+.

#### Supported testbed topology if it's a new test case?

N/A — not a test case.

### Documentation

N/A — no doc/Wiki change required; behaviour matches the documented intent of the plugin (retry across all configured passwords on auth failure).
