### PR TITLE
[platform_tests/sfp] Improve error messages when sfputil error-status output is empty

### DIFF
--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -396,6 +396,25 @@ def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_h
     physical_port_index_map = get_physical_port_indices(duthost, conn_graph_facts["device_conn"][duthost.hostname])
     admin_up_port_set = set(duthost.get_admin_up_ports())
 
+    # When the DB-backed variant ('sudo sfputil show error-status', without --fetch-from-hardware)
+    # returns no per-port rows, the command read an empty STATE_DB TRANSCEIVER_STATUS table.
+    # Fail loudly with actionable diagnostics so the failure is not misread as a per-interface bug.
+    # The hardware-direct variant ('--fetch-from-hardware') bypasses STATE_DB so the same check
+    # does not apply to it.
+    if cmd_sfp_error_status == "sudo sfputil show error-status" and not parsed_presence:
+        assert False, (
+            "'{}' returned no per-port rows: STATE_DB 'TRANSCEIVER_STATUS|*' table appears to be "
+            "empty (key count: {}). Raw command output: {!r}. "
+            "This typically indicates xcvrd/pmon has not populated the TRANSCEIVER_STATUS table "
+            "on this DUT. Try '{} --fetch-from-hardware' to bypass STATE_DB and confirm the SFP "
+            "hardware is reachable; if that succeeds, investigate xcvrd on the DUT."
+        ).format(
+            cmd_sfp_error_status,
+            len(state_db_ports_list),
+            sfp_error_status.get('stdout', ''),
+            cmd_sfp_error_status,
+        )
+
     for intf in dev_conn:
         if intf not in xcvr_skip_list[duthost.hostname]:
             expected_state = 'OK'
@@ -411,7 +430,16 @@ def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_h
                                "not supported on this port)".format(intf))
                 continue
             assert intf in parsed_presence, (
-                "Interface '{}' is not in parsed_presence.".format(intf)
+                "Interface '{}' is missing from parsed output of '{}'. "
+                "Parsed ports ({}): {}. STATE_DB 'TRANSCEIVER_STATUS|*' key count: {}. "
+                "Raw command output: {!r}."
+            ).format(
+                intf,
+                cmd_sfp_error_status,
+                len(parsed_presence),
+                sorted(parsed_presence.keys()),
+                len(state_db_ports_list),
+                sfp_error_status.get('stdout', ''),
             )
             assert parsed_presence[intf] == expected_state, (
                 "Interface '{}' error status check failed. "


### PR DESCRIPTION
### Description of PR

<!--
Discussed with reviewer offline. This PR only improves diagnostic messages
for an existing assertion in `test_check_sfputil_error_status`; it does not
change pass/fail behavior beyond making failures self-explanatory.
-->

Summary:
Improve the failure messages of `test_check_sfputil_error_status` in
`tests/platform_tests/sfp/test_sfputil.py` so that the common case of an
empty `STATE_DB:TRANSCEIVER_STATUS|*` table is reported with actionable
diagnostics instead of a misleading per-interface assertion.

Fixes # (no issue — surfaced by nightly run
[testplan 6a1d426a2e709824fb4064a7](https://elastictest.org/scheduler/testplan/6a1d426a2e709824fb4064a7?testcase=platform_tests%2Fsfp%2Ftest_sfputil.py&type=console)
on `bjw-can-8102-1` / Cisco-8102-C64, branch 202511)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

`sudo sfputil show error-status` reads from the `STATE_DB:TRANSCEIVER_STATUS`
table; `sudo sfputil show error-status --fetch-from-hardware` queries the
SFP/CMIS API directly.

On a recent nightly run, the DB-backed variant produced only the header
lines (no per-port rows) because the `TRANSCEIVER_STATUS` table on the DUT
was empty (xcvrd/pmon did not populate it on that image/platform). The
existing test then failed with:

```
AssertionError: Interface 'Ethernet0' is not in parsed_presence.
```

That message points at the first interface in `dev_conn` and looks like a
per-port issue, when the real cause is that the entire DB table is empty.
The hardware-direct variant passed in the same run, confirming the SFPs
were fine and the gap was in the DB write path.

#### How did you do it?

1. Added an explicit early failure right after parsing for the DB-backed
   command when `parsed_presence` is empty. The new assertion clearly
   states the STATE_DB table is empty, includes the
   `TRANSCEIVER_STATUS|*` key count and raw command output, and suggests
   running the `--fetch-from-hardware` variant as a follow-up diagnostic.
2. Enriched the existing per-interface `assert intf in parsed_presence`
   message with the command being tested, the list of ports that *did*
   parse, the STATE_DB key count, and the raw command output — so any
   future per-port failure is also self-explanatory.

Behavior is unchanged: the test still **fails** when the DB-backed command
returns no rows (no silent skip); only the failure message becomes more
informative.

#### How did you verify/test it?

- `python -m py_compile tests/platform_tests/sfp/test_sfputil.py` — clean.
- `python -m flake8 --max-line-length=120 tests/platform_tests/sfp/test_sfputil.py`
  — clean.
- Manually replayed the failing scenario in a Python REPL:
  - `parsed_presence = {}`, `state_db_ports_list = []`,
    `sfp_error_status['stdout'] = 'Port    Error Status\n------  --------------'`,
    `cmd_sfp_error_status = "sudo sfputil show error-status"`
    → the new assertion fires with the expected message naming the empty
      STATE_DB table.
  - Same `parsed_presence` empty but with
    `cmd_sfp_error_status = "sudo sfputil show error-status --fetch-from-hardware"`
    → early check is skipped (only the per-interface assertion applies, as
      before).
- Did not re-run the full pytest on a physical testbed in this PR; happy
  to do so on request once a testbed is available.

#### Any platform specific information?

No platform-specific code paths are changed. The new diagnostic is
guarded by the exact command string `"sudo sfputil show error-status"`,
so the hardware-direct variant and the existing Mellanox SW-control
branch are unaffected.

#### Supported testbed topology if it's a new test case?

N/A — not a new test case.

### Documentation

N/A — error-message-only improvement.