### PR TITLE
[process_monitoring] Wait for SONiC services after PDU reboot in recover_critical_processes

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -470,6 +470,16 @@ class SonicHost(AnsibleHostBase):
 
         file_content = self.shell("docker exec {} bash -c '[ -f /etc/supervisor/critical_processes ] \
                 && cat /etc/supervisor/critical_processes'".format(container_name), module_ignore_errors=True)
+        # If the docker exec failed (e.g. container is not running) the shell returns a non-zero rc
+        # with empty stdout_lines. The previous implementation would silently return succeeded=True with
+        # empty lists in that case, masking the real failure. Treat any non-zero rc as a failure so callers
+        # can react (retry, wait, fail) instead of believing every container is healthy.
+        if file_content.get("rc", 1) != 0:
+            logging.warning(
+                "Reading critical_processes file from container '%s' failed: rc=%s, stderr=%s",
+                container_name, file_content.get("rc"), file_content.get("stderr"))
+            return critical_group_list, critical_process_list, False
+
         for line in file_content["stdout_lines"]:
             line_info = line.strip().split(':')
             if len(line_info) != 2:

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -15,6 +15,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
 from tests.common.reboot import wait_for_startup
 from tests.common.platform.interface_utils import check_interface_status_of_up_ports
+from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.utilities import pdu_reboot, wait_until, kill_process_by_pid
 from tests.common.helpers.constants import DEFAULT_ASIC_ID, NAMESPACE_PREFIX
 from tests.common.helpers.dut_utils import get_program_info
@@ -650,6 +651,15 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
         # Wait for SSH to come back up
         wait_for_startup(duthost, localhost, delay=10, timeout=timeout)
         logger.info("SSH is up, waiting for critical processes...")
+
+        # SSH coming back up only means sshd is reachable; SONiC dockers and the
+        # config DB take significantly longer to come online after a cold boot.
+        # Without this gate, downstream calls (e.g. check_interface_status_of_up_ports
+        # -> sonic-cfggen) blow up with "Sonic database config file doesn't exist
+        # at /var/run/redis/sonic-db/database_config.json" because the database
+        # container has not started yet.
+        logger.info("Waiting for all critical processes to be healthy...")
+        wait_critical_processes(duthost)
 
         # Wait for all critical processes to be healthy
         ensure_all_critical_processes_running(duthost, containers_in_namespaces)


### PR DESCRIPTION
### Description of PR

Summary: Fix `recover_critical_processes` so a power-cycled DUT is actually verified healthy before running post-checks. Without this, when `test_monitoring_critical_processes` kills the `database` container the recovery fixture reports success while SONiC services are still coming up, which then crashes downstream teardown fixtures with `RuntimeError: Sonic database config file doesn't exist`.

Fixes # (no GitHub issue filed; observed on internal nightly testplan `t1.8102.202605.2_NightlyTest_20260601.2` for `process_monitoring/test_critical_process_monitoring.py`; root cause introduced by #21889)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

After #21889 ("Add database container into critical monitor"), `test_monitoring_critical_processes` kills the `database` container and `recover_critical_processes` performs a PDU power cycle. The current recovery flow only waits for SSH to become reachable (`wait_for_startup`) and then immediately calls `ensure_all_critical_processes_running` and `check_interface_status_of_up_ports`. On a real cold boot the SONiC dockers take much longer than SSH to come up, so the post-reboot checks crash.

Two compounding issues were identified:

1. `wait_for_startup()` only confirms sshd is reachable. Dockers (including `database`) typically need an additional 1-3 minutes after SSH is up to be ready.
2. `SonicHost.get_critical_group_and_process_lists()` ignores the rc of the `docker exec` it issues. When the container is not yet running the shell returns rc=1 with `stdout_lines=[]`; the parser silently returns `succeeded=True` with empty group/process lists. `ensure_all_critical_processes_running` therefore iterates over zero processes and logs `All critical processes are running` while in reality none are. The next call to `check_interface_status_of_up_ports` -> `duthost.get_running_config_facts()` -> `sonic-cfggen` then fails with:

`
RuntimeError: Sonic database config file doesn't exist at /var/run/redis/sonic-db/database_config.json
`

which cascades into `BaseExceptionGroup` (4 sub-exceptions) from module-scoped teardown fixtures (`config_reload_after_tests`, `core_dump_and_config_check`, `get_reboot_cause`, `yang_validation_check`).

#### How did you do it?

* `tests/common/devices/sonic.py`: in `get_critical_group_and_process_lists()`, check the rc of the `docker exec ... cat /etc/supervisor/critical_processes` shell call and return `succeeded=False` (with a warning log) when it is non-zero, so callers (`ensure_all_critical_processes_running` and `get_expected_alerting_messages_*`) can react via their existing `pytest_assert(succeeded, ...)` instead of being fooled by empty lists.
* `tests/process_monitoring/test_critical_process_monitoring.py`: in the `is_testing_database` branch of `recover_critical_processes`, call `wait_critical_processes(duthost)` immediately after `wait_for_startup` and before `ensure_all_critical_processes_running` / `check_interface_status_of_up_ports`. This uses the existing `wait_until`-based helper that polls `critical_services_fully_started` and therefore blocks until the `database` container (and the rest of the SONiC stack) is actually up.

#### How did you verify/test it?

* Reproduced the original failure from testplan `t1.8102.202605.2_NightlyTest_20260601.2` on `testbed-bjw-can-8102-1` and `testbed-bjw2-can-t1-8102-4` (Cisco-8102-C64, T1). On both testbeds `test_orchagent_heartbeat` errors at teardown with the `database_config.json` `RuntimeError` and the cascade of 4 fixture sub-exceptions.
* Local sanity: `python -c "import ast; ast.parse(...)` and flake8 on the modified files; no new warnings against the project's existing line-length convention.
* Will follow up with a fresh nightly rerun on the same testbeds once this is merged to confirm the post-power-cycle teardown completes cleanly.

#### Any platform specific information?

The buggy code path is only entered when `database` is NOT in `get_skip_containers` (i.e. recent master). For older branches (e.g. `202511`) that still `skip_containers.append("database")`, this code path is never taken so this PR is a no-op there; back-port to those branches is therefore unnecessary, but the changes are safe to back-port if desired. The `get_critical_group_and_process_lists` fix improves robustness on every platform that uses `ensure_all_critical_processes_running` (or the `_expected_alerting_messages_*` helpers) regardless of whether the database container is killed.

#### Supported testbed topology if it's a new test case?

N/A - bug fix to an existing test.

### Documentation

N/A - internal recovery logic, no user-facing behavior change.
