### PR TITLE
Disable loganalyer on test test_buffer_profile_create_remove_rollback

### DIFF
--- a/tests/generic_config_updater/test_incremental_qos.py
+++ b/tests/generic_config_updater/test_incremental_qos.py
@@ -260,6 +260,7 @@ def test_incremental_qos_config_updates(duthost, tbinfo, ensure_dut_readiness, c
         delete_tmpfile(duthost, tmpfile)
 
 
+@pytest.mark.disable_loganalyzer
 def test_buffer_profile_create_remove_rollback(duthost, ensure_dut_readiness, cli_namespace_prefix):
     """
     Test creating and removing a buffer profile via jsonpatch and rollback to checkpoint.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The test case applies a buffer profile config and try to revert to verify the GCU rollback functionality.
However, the config is actually invalid on some platforms, for example SN5640, so it causes syslog errors. 
But the invalid config can be successfully reverted by the GCU rollback in the test case. The test itself can also pass. And there is no orchagent crash and other side effects observed. 
Disable the loganalyzer on this test since we don't really care about it in this test case.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Disable loganalyer on test test_buffer_profile_create_remove_rollback to fix a loganalyzer test failure.
#### How did you do it?
Disable the loganalyzer on this test since we don't really care about it in this test case.
#### How did you verify/test it?
Run the test test_buffer_profile_create_remove_rollback on SN5640 testbed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
