### PR TITLE
fix: fix get_duts_version prioritise main dut first

### DIFF
--- a/.azure-pipelines/get_dut_version.py
+++ b/.azure-pipelines/get_dut_version.py
@@ -7,6 +7,7 @@ import os
 import sys
 
 import yaml
+from natsort import natsorted
 
 _self_dir = os.path.dirname(os.path.abspath(__file__))
 base_path = os.path.realpath(os.path.join(_self_dir, ".."))
@@ -114,6 +115,12 @@ def get_duts_version(sonichosts, output=None):
                 dut_info["Docker images"].append(image)
 
             ret[dut] = dut_info
+
+        # Sort keys so that each NPU is followed by its DPUs in natural order
+        # (e.g. dpu-0, dpu-1, ..., dpu-10 instead of dpu-0, dpu-1, dpu-10, dpu-2).
+        # NPU hostnames are a strict prefix of their DPU hostnames, so natural
+        # sort groups each NPU with its DPUs automatically.
+        ret = {hostname: ret[hostname] for hostname in natsorted(ret)}
 
         # ---- Output handling ----
         if output:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix get_dut_version return the main DUT first. Currently the order is determine by  whoever finished performing init_testbed_sonichosts i.e ansible command execution, which is fragile.

Fixes # (issue) 38213269

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Fix get_dut_version to return the correct one (the dut) information. Previously it's dependent on ansible command finished executing on init_testbed_sonichosts. For DPU smartswitch, we observed that sometimes the DPU finished executing first, which returns the dpu information instead of dut

#### How did you do it?

We provide a natsort, so this will prioritise the testbed first given we follow the format `testbed`, `testbed-dpu-1`, etc...

#### How did you verify/test it?
Manual verification

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
