### PR TITLE
[testbed_helper] Preserve host portion of ptf_ip/ptf_ipv6 in stdlib path

### DIFF
--- a/ansible/devutil/testbed_helper.py
+++ b/ansible/devutil/testbed_helper.py
@@ -32,9 +32,12 @@ class ParseTestbedTopoinfo():
                 addr = ipaddress.IPNetwork(network)
                 return str(addr.ip), str(addr.netmask)
             else:
-                # ipaddress library
-                addr = ipaddress.ip_network(network, strict=False)
-                return str(addr.network_address), str(addr.netmask)
+                # ipaddress library: use ip_interface to preserve the host
+                # portion of the address. ip_network(..., strict=False) would
+                # collapse the address to the network base (e.g. 172.16.201.11/18
+                # -> 172.16.192.0), which is wrong for ptf_ip/ptf_ipv6 values.
+                addr = ipaddress.ip_interface(network)
+                return str(addr.ip), str(addr.netmask)
 
         def _read_testbed_topo_from_yaml():
             """Read yaml testbed info file."""


### PR DESCRIPTION
### Description of PR
Summary:
Fixes a latent bug in `ansible/devutil/testbed_helper.ParseTestbedTopoinfo._cidr_to_ip_mask` that collapses every `ptf_ip` / `ptf_ipv6` to its network base address when the legacy `ipaddr` PyPI package is **not** installed.

Fixes # (issue): n/a

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

`_cidr_to_ip_mask` has two code paths:

```python
try:
    import ipaddr as ipaddress
except ImportError:
    import ipaddress

def _cidr_to_ip_mask(network):
    if hasattr(ipaddress, 'IPNetwork'):
        # ipaddr library
        addr = ipaddress.IPNetwork(network)
        return str(addr.ip), str(addr.netmask)          # keeps host
    else:
        # ipaddress library
        addr = ipaddress.ip_network(network, strict=False)
        return str(addr.network_address), str(addr.netmask)   # collapses host -> network base
```

The two branches return different things for the same input:

| Input               | `ipaddr` path (CI)  | stdlib path (local)   |
|---------------------|---------------------|------------------------|
| `172.16.201.11/18`  | `172.16.201.11`     | `172.16.192.0`         |
| `2603:...::8011/114`| `2603:...::8011`    | `2603:...::8000`       |

CI installs `ipaddr` explicitly in `.azure-pipelines/meta-check.yml`, so the bug is invisible there. Anyone running `ansible/scripts/meta/meta_validator.py` (or any other consumer of `get_testbed_facts`) locally without `ipaddr` installed sees every PTF in the same `/N` subnet collide on the network base — producing hundreds of spurious `E2001 conflict_ip` errors that don't exist in the YAML.

#### How did you do it?

Replace the stdlib fallback with `ipaddress.ip_interface(...)`, which is the direct stdlib equivalent of `ipaddr.IPNetwork`: `.ip` returns the host address, `.netmask` returns the netmask. Both branches now behave identically.

#### How did you verify/test it?

1. Reproduced the bug on a uv-managed venv without `ipaddr`:
   - `meta_validator.py` reported 621 `E2001` conflicts, with top buckets all on subnet-base addresses (`172.16.192.0`, `2603:...::8000`, etc.).
2. Installed `ipaddr` to confirm CI behavior matches: 621 errors -> 1 (a real duplicate ptf_ipv6 in our local testbed yaml, unrelated to this fix).
3. Applied this patch and re-ran with `ipaddr` uninstalled: same result as the `ipaddr`-installed run — the spurious storm is gone.

Sanity check:

```python
>>> import ipaddress
>>> a = ipaddress.ip_interface('172.16.201.11/18')
>>> str(a.ip), str(a.netmask)
('172.16.201.11', '255.255.192.0')
>>> b = ipaddress.ip_interface('2603:10e2:140:3000::8011/114')
>>> str(b.ip), str(b.netmask)
('2603:10e2:140:3000::8011', 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:c000')
```

`flake8 --max-line-length=120 ansible/devutil/testbed_helper.py` passes.

#### Any platform specific information?

None.

#### Supported testbed topology if it's a new test case?

Not applicable — bug fix in shared helper used by meta validator and other consumers.

### Documentation

No docs change required.
