### PR TITLE
[tests/console]: drive setup_c0 from serial_links.csv instead of topo_c0.yml

### DIFF
--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -3,9 +3,6 @@ import pytest
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts  # noqa: F401
 
 
-console_lines = list(map(str, range(1, 49)))
-
-
 @pytest.fixture(scope="module", autouse=True)
 def skip_if_os_not_support(duthost):
     not_support_os_versions = ['201803', '201807', '201811', '201911']
@@ -23,21 +20,29 @@ def skip_if_console_feature_disabled(console_facts):
 
 
 @pytest.fixture(scope='module')
-def setup_c0(request, duthost, tbinfo):
-    # Verify console lines are configured as expected
-    # we have a console_facts fixture but it's probably better to run it every time it's called
-    topo_console_intfs = tbinfo["topo"]["properties"]["topology"]["console_interfaces"]
+def setup_c0(request, duthost, tbinfo, conn_graph_facts):    # noqa: F811
+    # Verify the DUT's wired console lines (from *_serial_links.csv via
+    # conn_graph_facts) match the DUT's configured baud rate / flow control.
+    dut_serial_links = conn_graph_facts.get('device_serial_link', {}).get(duthost.hostname, {})
+    if not dut_serial_links:
+        pytest.fail(
+            "No serial links found for DUT '{}' in *_serial_links.csv".format(duthost.hostname))
+
     dut_console_config = duthost.console_facts()["ansible_facts"]["console_facts"]["lines"]
-    for topo_console_intf in topo_console_intfs:
-        line_number, baud_rate, flow_control = topo_console_intf.split(".")
+    for line_number, link in dut_serial_links.items():
+        if line_number not in dut_console_config:
+            pytest.fail(
+                "Line {} is wired to DUT '{}' in *_serial_links.csv but is not configured on the DUT"
+                .format(line_number, duthost.hostname))
         dut_line_config = dut_console_config[line_number]
-        if dut_line_config["baud_rate"] != int(baud_rate):
-            pytest.fail("Baud rate mismatch for line {}: expect {}, got {}".format(line_number, baud_rate,
-                                                                                   dut_line_config["baud_rate"]))
-        if dut_line_config["flow_control"] != bool(int(flow_control)):
-            pytest.fail("Flow control mismatch for line {}: expect {}, got {}".format(line_number,
-                                                                                      bool(int(flow_control)),
-                                                                                      dut_line_config["flow_control"]))
+        expected_baud = int(link.get("baud_rate", "9600"))
+        expected_flow = bool(int(link.get("flow_control", "0")))
+        if dut_line_config["baud_rate"] != expected_baud:
+            pytest.fail("Baud rate mismatch for line {}: expect {}, got {}".format(
+                line_number, expected_baud, dut_line_config["baud_rate"]))
+        if dut_line_config["flow_control"] != expected_flow:
+            pytest.fail("Flow control mismatch for line {}: expect {}, got {}".format(
+                line_number, expected_flow, dut_line_config["flow_control"]))
 
     if tbinfo["topo"]["name"] == "c0":
         fanouthosts = request.getfixturevalue("fanouthosts")
@@ -50,11 +55,6 @@ def setup_c0(request, duthost, tbinfo):
         console_fanout = duthost
     else:
         pytest.fail("Test requires c0 or c0-lo topology")
-
-    console_facts = duthost.console_facts()['ansible_facts']['console_facts']
-    if len(console_facts["lines"]) != len(console_lines):
-        pytest.fail("C0 topo test requires DUT with 48 console lines configured, got {}"
-                    .format(len(console_facts["lines"])))
 
     return duthost, console_fanout
 


### PR DESCRIPTION

The `setup_c0` fixture in `tests/console/conftest.py` validated the DUT's console line configuration against two hard-coded sources of truth:

1. `tbinfo["topo"]["properties"]["topology"]["console_interfaces"]` — the topology file's static list of 48 lines (`topo_c0.yml`).
2. `console_lines = list(map(str, range(1, 49)))` — the expected line count, also baked at 48.

The actual console tests (`test_console_loopback.py`, refactored in PR #24168; `test_console_link_wiring.py`, refactored in PR #24783) already source their per-DUT wiring from
`ansible/files/sonic_<inv>_serial_links.csv` via
`conn_graph_facts['device_serial_link']`. They adapt to whatever lines are actually wired for the DUT under test.

`setup_c0`, however, still failed any DUT whose CSV doesn't enumerate exactly 48 contiguous lines — a regression that surfaces as soon as a testbed's serial-link inventory is updated to reflect what's really wired. For example, when a `Cisco-C8220TG` DUT was re-inventoried with only 2 wired lines, `setup_c0` failed at
`dut_line_config = dut_console_config[line_number]` with `KeyError: '3'`, even though the refactored loopback test only needs lines 1 and 2.

Switch `setup_c0` to the same source of truth: iterate over the lines recorded in `*_serial_links.csv` for this DUT, and verify each is configured on the DUT with the expected baud rate / flow control. Drop the hard-coded 48-line length check. The fanout-resolution logic and the `c0` / `c0-lo` topology branching are unchanged.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

Ran the full `tests/console/` suite on a physical `c0` testbed (Cisco-C8220TG DUT with 2 wired serial lines in `*_serial_links.csv`) on top of `202603`:

| Test | Result |
|---|---|
| `test_console_loopback.py::test_console_loopback_echo[enable-9600]` | ✅ PASSED |
| `test_console_loopback.py::test_console_loopback_echo[enable-115200]` | ✅ PASSED |
| `test_console_loopback.py::test_console_loopback_echo[disable-9600]` | ✅ PASSED |
| `test_console_loopback.py::test_console_loopback_echo[disable-115200]` | ✅ PASSED |
| `test_console_loopback.py::test_console_loopback_pingpong[enable-9600]` | ✅ PASSED |
| `test_console_loopback.py::test_console_loopback_pingpong[enable-115200]` | ✅ PASSED |
| `test_console_loopback.py::test_console_loopback_pingpong[disable-9600]` | ✅ PASSED |
| `test_console_loopback.py::test_console_loopback_pingpong[disable-115200]` | ✅ PASSED |
| `test_console_link_wiring.py::test_console_link_wiring` | ✅ PASSED |

Before this change, `setup_c0` failed on the same DUT at `KeyError: '3'` because the CSV only enumerates lines 1 and 2; after this change, the fixture only checks the lines actually wired and all tests pass.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

