### PR TITLE
[bgp/agg] Make BGP aggregate-address tests solid against per-DUT flakiness

### DIFF
--- a/tests/bgp/bgp_aggregate_helpers.py
+++ b/tests/bgp/bgp_aggregate_helpers.py
@@ -244,12 +244,34 @@ def withdraw_contributing_routes(setup, prefixes, ip_version="ipv4"):
 
 
 # ---- M2 (upstream) route verification helpers ----
-def check_route_on_neighbor(nbrhosts, neighbor, prefix):
+def _as_path_contains_asn(as_path_str, asn):
+    """Return True if ``asn`` appears as a token in a space-separated AS-path string."""
+    return str(asn) in as_path_str.split()
+
+
+def _eos_path_has_asn(path, asn):
+    """Return True if an EOS bgpRoutePaths entry's AS-path contains ``asn``."""
+    as_path_str = path.get('asPathEntry', {}).get('asPath', '')
+    return _as_path_contains_asn(as_path_str, asn)
+
+
+def _frr_path_has_asn(path, asn):
+    """Return True if an FRR/vtysh path entry's AS-path contains ``asn``."""
+    as_path_str = path.get('aspath', {}).get('string', '')
+    return _as_path_contains_asn(as_path_str, asn)
+
+
+def check_route_on_neighbor(nbrhosts, neighbor, prefix, expected_asn=None):
     """Check whether a prefix exists and is active in the BGP table of a neighbor VM.
 
     Returns True if the route is present with at least one BGP path, False otherwise.
     On EOS, a withdrawn route may briefly remain in bgpRouteEntries with empty
     bgpRoutePaths; checking for non-empty paths avoids false positives.
+
+    When ``expected_asn`` is provided, only paths whose AS-path contains that ASN
+    are counted.  This makes the check origin-aware so that stale or foreign
+    routes for the same prefix (e.g. left over from a previous run on a shared
+    neighbor VM, or originated by another DUT) do not cause false positives.
     """
     host = nbrhosts[neighbor]['host']
     route_info = host.get_route(prefix)
@@ -259,22 +281,31 @@ def check_route_on_neighbor(nbrhosts, neighbor, prefix):
             return False
         # Verify the entry has at least one BGP path (not a stale/withdrawn entry)
         paths = entries[prefix].get('bgpRoutePaths', [])
+        if expected_asn is not None:
+            paths = [p for p in paths if _eos_path_has_asn(p, expected_asn)]
         return len(paths) > 0
     else:
         # SonicHost — route_info is the JSON from vtysh show bgp
-        return bool(route_info) and 'paths' in route_info
+        if not route_info or 'paths' not in route_info:
+            return False
+        if expected_asn is not None:
+            return any(_frr_path_has_asn(p, expected_asn) for p in route_info['paths'])
+        return True
 
 
-def verify_route_on_m2(nbrhosts, upstream_neighbors, prefix, expected_present=True):
+def verify_route_on_m2(nbrhosts, upstream_neighbors, prefix, expected_present=True, expected_asn=None):
     """Verify a route is present or absent on upstream M2 neighbors.
 
     Checks at least one upstream neighbor (the first one) for the route.
     Uses wait_until for convergence tolerance.
+
+    When ``expected_asn`` is provided, only paths originated through that ASN
+    count as present, so stale/foreign routes for the same prefix are ignored.
     """
     neighbor = upstream_neighbors[0]
 
     def _check():
-        return check_route_on_neighbor(nbrhosts, neighbor, prefix) == expected_present
+        return check_route_on_neighbor(nbrhosts, neighbor, prefix, expected_asn) == expected_present
 
     action = "present" if expected_present else "absent"
     pytest_assert(
@@ -283,12 +314,13 @@ def verify_route_on_m2(nbrhosts, upstream_neighbors, prefix, expected_present=Tr
     )
 
 
-def verify_contributing_routes_on_m2(nbrhosts, upstream_neighbors, prefixes, expected_present=True):
+def verify_contributing_routes_on_m2(nbrhosts, upstream_neighbors, prefixes,
+                                     expected_present=True, expected_asn=None):
     """Verify contributing routes are present or absent on upstream M2 neighbors."""
     neighbor = upstream_neighbors[0]
     for prefix in prefixes:
         def _check(p=prefix):
-            return check_route_on_neighbor(nbrhosts, neighbor, p) == expected_present
+            return check_route_on_neighbor(nbrhosts, neighbor, p, expected_asn) == expected_present
         action = "present" if expected_present else "absent"
         pytest_assert(
             wait_until(120, 5, 0, _check),

--- a/tests/bgp/test_bgp_aggregate_address.py
+++ b/tests/bgp/test_bgp_aggregate_address.py
@@ -22,6 +22,7 @@ from bgp_bbr_helpers import config_bbr_by_gcu, get_bbr_default_state, is_bbr_ena
 
 from bgp_aggregate_helpers import (
     BGP_AGGREGATE_ADDRESS,
+    BGP_SETTLE_WAIT,
     PLACEHOLDER_PREFIX,
     AggregateCfg,
     dump_db,
@@ -31,6 +32,8 @@ from bgp_aggregate_helpers import (
     verify_bgp_aggregate_consistence,
     verify_bgp_aggregate_cleanup,
 )
+import time
+
 from tests.common.gcu_utils import create_checkpoint, rollback_or_reload, delete_checkpoint
 
 logger = logging.getLogger(__name__)
@@ -82,20 +85,40 @@ def test_bgp_aggregate_address(duthosts, rand_one_dut_hostname, ip_version, bbr_
     else:
         cfg = AggregateCfg(prefix=AGGR_V6, bbr_required=bbr_required, summary_only=summary_only, as_set=as_set)
 
-    # get default bbr state
-    bbr_enabled = is_bbr_enabled(duthost)
+    # Determine the BBR state to validate against.  A bbr-required aggregate
+    # only becomes "active" once bgpcfgd has actually applied BBR-enabled.  The
+    # ambient value read by is_bbr_enabled() (CONFIG_DB / constants.yml) can
+    # disagree with the operational state left behind by a previous run, which
+    # makes the predicted state wrong and the test flaky.  For bbr-required
+    # cases, force a real disabled->enabled transition so bgpcfgd reconciles to
+    # a deterministic, known state; restore the original state afterwards.
+    bbr_supported, original_bbr_state = get_bbr_default_state(duthost)
+    restore_bbr = False
+    if bbr_required and bbr_supported:
+        config_bbr_by_gcu(duthost, "disabled")
+        config_bbr_by_gcu(duthost, "enabled")
+        time.sleep(BGP_SETTLE_WAIT)
+        bbr_enabled = True
+        restore_bbr = original_bbr_state != "enabled"
+    else:
+        bbr_enabled = is_bbr_enabled(duthost)
 
-    # Apply aggregate via GCU
-    gcu_add_aggregate(duthost, cfg)
+    try:
+        # Apply aggregate via GCU
+        gcu_add_aggregate(duthost, cfg)
 
-    # Verify config db, state db and running config
-    verify_bgp_aggregate_consistence(duthost, bbr_enabled, cfg)
+        # Verify config db, state db and running config
+        verify_bgp_aggregate_consistence(duthost, bbr_enabled, cfg)
 
-    # Cleanup
-    gcu_remove_aggregate(duthost, cfg.prefix)
+        # Cleanup
+        gcu_remove_aggregate(duthost, cfg.prefix)
 
-    # Verify config db, state db and running config are cleanup
-    verify_bgp_aggregate_cleanup(duthost, cfg.prefix)
+        # Verify config db, state db and running config are cleanup
+        verify_bgp_aggregate_cleanup(duthost, cfg.prefix)
+    finally:
+        # Restore the original BBR state if we changed it
+        if restore_bbr:
+            config_bbr_by_gcu(duthost, original_bbr_state)
 
 
 # Test BBR Features State Change

--- a/tests/bgp/test_bgp_aggregate_address_bbr_dynamics.py
+++ b/tests/bgp/test_bgp_aggregate_address_bbr_dynamics.py
@@ -31,6 +31,7 @@ from bgp_aggregate_helpers import (
     gcu_add_aggregate,
     gcu_add_placeholder_aggregate,
     gcu_remove_aggregate,
+    safe_remove_aggregate,
     verify_bgp_aggregate_cleanup,
     verify_bgp_aggregate_consistence,
     verify_route_on_m2,
@@ -70,6 +71,7 @@ def setup_teardown(duthost):
 @pytest.fixture(scope="module")
 def m1_topo_setup(duthosts, rand_one_dut_hostname, tbinfo, nbrhosts, ptfhost):
     """Setup M0 (downstream) and M2 (upstream) neighbor info."""
+    duthost = duthosts[rand_one_dut_hostname]
     topo_type = tbinfo["topo"]["type"]
     if topo_type not in UPSTREAM_NEIGHBOR_MAP or topo_type not in DOWNSTREAM_NEIGHBOR_MAP:
         pytest.skip(f"Topology type {topo_type} not supported for neighbor-validated tests")
@@ -97,6 +99,9 @@ def m1_topo_setup(duthosts, rand_one_dut_hostname, tbinfo, nbrhosts, ptfhost):
     nhipv4 = tbinfo['topo']['properties']['configuration_properties']['common']['nhipv4']
     nhipv6 = tbinfo['topo']['properties']['configuration_properties']['common']['nhipv6']
 
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    dut_asn = mg_facts['minigraph_bgp_asn']
+
     return {
         'upstream_neighbors': upstream_neighbors,
         'downstream': downstream,
@@ -106,6 +111,7 @@ def m1_topo_setup(duthosts, rand_one_dut_hostname, tbinfo, nbrhosts, ptfhost):
         'nhipv4': nhipv4,
         'nhipv6': nhipv6,
         'ptfip': ptfhost.mgmt_ip,
+        'dut_asn': dut_asn,
     }
 
 
@@ -139,7 +145,14 @@ class TestGroup2BBRStateInteraction:
         self._skip_if_no_bbr(duthost)
         setup = m1_topo_setup
         upstream = setup['upstream_neighbors']
+        dut_asn = setup['dut_asn']
         cfg = AggregateCfg(prefix=AGGR_V4_1, bbr_required=True, summary_only=False, as_set=False)
+
+        # Establish a clean baseline: drop any leftover aggregate from a prior
+        # run (e.g. a failed module rollback) so a stale, DUT-originated route
+        # cannot mask the expected-absent assertion below.
+        safe_remove_aggregate(duthost, AGGR_V4_1)
+        verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=False, expected_asn=dut_asn)
 
         config_bbr_by_gcu(duthost, "disabled")
         announce_contributing_routes(setup, CONTRIBUTING_V4, "ipv4")
@@ -148,7 +161,7 @@ class TestGroup2BBRStateInteraction:
 
             # BBR disabled: aggregate inactive
             verify_bgp_aggregate_consistence(duthost, False, cfg)
-            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=False)
+            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=False, expected_asn=dut_asn)
 
             # Enable BBR
             config_bbr_by_gcu(duthost, "enabled")
@@ -156,7 +169,7 @@ class TestGroup2BBRStateInteraction:
 
             # BBR enabled: aggregate active
             verify_bgp_aggregate_consistence(duthost, True, cfg)
-            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=True)
+            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=True, expected_asn=dut_asn)
 
             gcu_remove_aggregate(duthost, cfg.prefix)
             verify_bgp_aggregate_cleanup(duthost, cfg.prefix)
@@ -179,6 +192,7 @@ class TestGroup2BBRStateInteraction:
         self._skip_if_no_bbr(duthost)
         setup = m1_topo_setup
         upstream = setup['upstream_neighbors']
+        dut_asn = setup['dut_asn']
         cfg = AggregateCfg(prefix=AGGR_V4_1, bbr_required=True, summary_only=False, as_set=False)
 
         config_bbr_by_gcu(duthost, "enabled")
@@ -187,14 +201,14 @@ class TestGroup2BBRStateInteraction:
             gcu_add_aggregate(duthost, cfg)
 
             verify_bgp_aggregate_consistence(duthost, True, cfg)
-            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=True)
+            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=True, expected_asn=dut_asn)
 
             # Disable BBR
             config_bbr_by_gcu(duthost, "disabled")
             time.sleep(BGP_SETTLE_WAIT)
 
             verify_bgp_aggregate_consistence(duthost, False, cfg)
-            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=False)
+            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=False, expected_asn=dut_asn)
 
             gcu_remove_aggregate(duthost, cfg.prefix)
             verify_bgp_aggregate_cleanup(duthost, cfg.prefix)
@@ -216,28 +230,29 @@ class TestGroup2BBRStateInteraction:
         self._skip_if_no_bbr(duthost)
         setup = m1_topo_setup
         upstream = setup['upstream_neighbors']
+        dut_asn = setup['dut_asn']
         cfg = AggregateCfg(prefix=AGGR_V4_1, bbr_required=False, summary_only=False, as_set=False)
 
         announce_contributing_routes(setup, CONTRIBUTING_V4, "ipv4")
         try:
             gcu_add_aggregate(duthost, cfg)
-            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=True)
+            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=True, expected_asn=dut_asn)
 
             # Toggle: enabled -> disabled -> enabled
             config_bbr_by_gcu(duthost, "enabled")
             time.sleep(BGP_SETTLE_WAIT)
             verify_bgp_aggregate_consistence(duthost, True, cfg)
-            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=True)
+            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=True, expected_asn=dut_asn)
 
             config_bbr_by_gcu(duthost, "disabled")
             time.sleep(BGP_SETTLE_WAIT)
             verify_bgp_aggregate_consistence(duthost, False, cfg)
-            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=True)
+            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=True, expected_asn=dut_asn)
 
             config_bbr_by_gcu(duthost, "enabled")
             time.sleep(BGP_SETTLE_WAIT)
             verify_bgp_aggregate_consistence(duthost, True, cfg)
-            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=True)
+            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=True, expected_asn=dut_asn)
 
             gcu_remove_aggregate(duthost, cfg.prefix)
             verify_bgp_aggregate_cleanup(duthost, cfg.prefix)
@@ -259,6 +274,7 @@ class TestGroup2BBRStateInteraction:
         self._skip_if_no_bbr(duthost)
         setup = m1_topo_setup
         upstream = setup['upstream_neighbors']
+        dut_asn = setup['dut_asn']
         cfg_a = AggregateCfg(prefix=AGGR_V4_1, bbr_required=True, summary_only=False, as_set=False)
         cfg_b = AggregateCfg(prefix=EXTRA_AGGR_V4_1, bbr_required=False, summary_only=False, as_set=False)
 
@@ -272,22 +288,22 @@ class TestGroup2BBRStateInteraction:
             # Both received with BBR enabled
             verify_bgp_aggregate_consistence(duthost, True, cfg_a)
             verify_bgp_aggregate_consistence(duthost, True, cfg_b)
-            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=True)
-            verify_route_on_m2(nbrhosts, upstream, EXTRA_AGGR_V4_1, expected_present=True)
+            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=True, expected_asn=dut_asn)
+            verify_route_on_m2(nbrhosts, upstream, EXTRA_AGGR_V4_1, expected_present=True, expected_asn=dut_asn)
 
             # Disable BBR: A withdrawn, B still received
             config_bbr_by_gcu(duthost, "disabled")
             time.sleep(BGP_SETTLE_WAIT)
             verify_bgp_aggregate_consistence(duthost, False, cfg_a)
             verify_bgp_aggregate_consistence(duthost, False, cfg_b)
-            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=False)
-            verify_route_on_m2(nbrhosts, upstream, EXTRA_AGGR_V4_1, expected_present=True)
+            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=False, expected_asn=dut_asn)
+            verify_route_on_m2(nbrhosts, upstream, EXTRA_AGGR_V4_1, expected_present=True, expected_asn=dut_asn)
 
             # Enable BBR: both received again
             config_bbr_by_gcu(duthost, "enabled")
             time.sleep(BGP_SETTLE_WAIT)
-            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=True)
-            verify_route_on_m2(nbrhosts, upstream, EXTRA_AGGR_V4_1, expected_present=True)
+            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=True, expected_asn=dut_asn)
+            verify_route_on_m2(nbrhosts, upstream, EXTRA_AGGR_V4_1, expected_present=True, expected_asn=dut_asn)
 
             gcu_remove_aggregate(duthost, cfg_a.prefix)
             gcu_remove_aggregate(duthost, cfg_b.prefix)
@@ -311,13 +327,14 @@ class TestGroup2BBRStateInteraction:
         self._skip_if_no_bbr(duthost)
         setup = m1_topo_setup
         upstream = setup['upstream_neighbors']
+        dut_asn = setup['dut_asn']
         cfg = AggregateCfg(prefix=AGGR_V4_1, bbr_required=True, summary_only=False, as_set=False)
 
         config_bbr_by_gcu(duthost, "enabled")
         announce_contributing_routes(setup, CONTRIBUTING_V4, "ipv4")
         try:
             gcu_add_aggregate(duthost, cfg)
-            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=True)
+            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=True, expected_asn=dut_asn)
 
             # Rapid toggles
             config_bbr_by_gcu(duthost, "disabled")
@@ -328,7 +345,7 @@ class TestGroup2BBRStateInteraction:
             # After settling, aggregates should be received (final state: enabled)
             time.sleep(ROUTE_PROPAGATION_WAIT)
             verify_bgp_aggregate_consistence(duthost, True, cfg)
-            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=True)
+            verify_route_on_m2(nbrhosts, upstream, AGGR_V4_1, expected_present=True, expected_asn=dut_asn)
 
             gcu_remove_aggregate(duthost, cfg.prefix)
             verify_bgp_aggregate_cleanup(duthost, cfg.prefix)

--- a/tests/bgp/test_bgp_aggregate_address_scale_stress.py
+++ b/tests/bgp/test_bgp_aggregate_address_scale_stress.py
@@ -49,8 +49,15 @@ from tests.common.config_reload import config_reload as config_reload_func
 
 logger = logging.getLogger(__name__)
 
+# This is a capacity/stress module that intentionally installs ~1000 aggregate
+# addresses and runs 100 rapid add/remove cycles.  Doing so legitimately grows
+# bgpd RSS (FRR/glibc does not return freed heap to the OS after cleanup), so
+# the autouse memory_utilization monitor flags the increase as a leak.  That is
+# expected for this stress test, so opt the module out of memory-increase
+# gating to avoid flaky teardown failures.
 pytestmark = [
     pytest.mark.topology("m1"),
+    pytest.mark.disable_memory_utilization,
 ]
 
 # ---- Test data ----


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fixes flaky failures in the BGP aggregate-address test suite that reproduced on some DUTs/testbeds but not others. The tests were correctly exercising the feature, but their verification logic was sensitive to ambient/stale state on shared testbeds. These changes make the checks origin-aware and the BBR state deterministic and exempt the stress module from memory-increase gating, without weakening any real product assertion.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202603

### Approach
#### What is the motivation for this PR?
Several BGP aggregate-address tests failed intermittently depending on which DUT
they ran on. Investigation showed the failures came from test fragility, not
product regressions:

1. **Route verification was not origin-aware. ** `check_route_on_neighbor`    counted *any* BGP path for a prefix. A stale/foreign route for the same prefix on a shared veos neighbor (left by a prior run or originated by   another DUT) caused false "present" results and failed expected-absent assertions.

2. **`test_bgp_aggregate_address` trusted ambient BBR state.** A `bbr-required`  aggregate only becomes `active` once bgpcfgd has actually applied  BBR-enabled. The value read by `is_bbr_enabled()` (CONFIG_DB / constants.yml)  could disagree with bgpcfgd's operational state on a DUT carrying state from  a previous run, so the predicted STATE_DB value was wrong and the test timed  out. The `_when_bbr_changed` variant, which performs a real BBR transition, always passed — confirming the gap.

3. **The scale/stress module tripped the global memory monitor.** All three stress tests pass, but installing ~1000 aggregates and running 100 rapid add/remove cycles legitimately grows `bgpd` RSS (FRR/glibc does not return freed heap to the OS). The autouse `memory_utilization` fixture flagged this  expected growth as a leak, and whether it crossed the 128MB increase  threshold varied by DUT baseline.

#### How did you do it?
- `bgp_aggregate_helpers.py`: add AS-path parsing helpers and an optional `expected_asn` parameter to check_route_on_neighbor`, `verify_route_on_m2`, and `verify_contributing_routes_on_m2` so only paths originated through the DUT's ASN count as present (EOS and FRR/vtysh formats both handled).
- `test_bgp_aggregate_address_bbr_dynamics.py`: resolve the DUT ASN in `m1_topo_setup`, thread `expected_asn` through all M2 verifications, and add a clean expected-absent baseline (via `safe_remove_aggregate`) in the first test.
- `test_bgp_aggregate_address.py`: for `bbr-required` cases, force a real
  `disabled -> enabled` BBR transition so bgpcfgd reconciles to a deterministic
  state, then restore the original state in `finally`.
- `test_bgp_aggregate_address_scale_stress.py`: add
  `pytest.mark.disable_memory_utilization` (the documented opt-out) so expected bgpd memory growth no longer fails teardown.

#### How did you verify/test it?
Ran the affected modules across multiple testbeds (the DUTs that previously diverged). Functional assertions (STATE_DB/CONFIG_DB/FRR consistency, M2 route presence/absence, data-plane forwarding, add/remove cycling, DUT health) are unchanged and still enforced.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
