### PR TITLE
Check received count instead of port level counters when traps not enabled case

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -276,14 +276,9 @@ class PolicyTest(ControlPlaneBaseTest):
                 "Actual PPS: {} Expected PPS range: {} - {}".format(rx_pps, self.PPS_LIMIT_MIN, self.PPS_LIMIT_MAX)
         else:
             self.log("Checking constraints (NoPolicyApplied):")
-            self.log(
-                "rx_pps (%d) <= PPS_LIMIT_MIN (%d): %s" %
-                (int(rx_pps),
-                 int(self.PPS_LIMIT_MIN),
-                 str(rx_pps <= self.PPS_LIMIT_MIN))
-            )
-            assert rx_pps <= self.PPS_LIMIT_MIN, "Copp policer constraint check failed, Actual PPS: {} " \
-                "Expected PPS range: 0 - {}".format(rx_pps, self.PPS_LIMIT_MIN)
+            # for no traps case, check on the recevied packets instead of port level counters
+            assert recv_count == 0, "Copp policer constraint check failed, Actual Received Packets: {} " \
+                "Expected Received Packets: {}".format(recv_count, 0)
 
 
 # SONIC config contains policer CIR=600 for ARP

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -120,6 +120,7 @@ class TestCOPP(object):
         if duthost.is_multi_asic:
             namespace = random.choice(duthost.asics)
 
+        has_trap = True
         # Skip the check if the protocol is "Default"
         if protocol != "Default":
             trap_ids = PROTOCOL_TO_TRAP_ID.get(protocol)
@@ -130,6 +131,7 @@ class TestCOPP(object):
             else:
                 feature_list, _ = duthost.get_feature_status()
                 trap_installed = copp_utils.is_trap_installed(duthost, trap_ids[0], namespace)
+                has_trap = trap_installed
                 if feature_name in feature_list and feature_list[feature_name] == "enabled":
                     pytest_assert(trap_installed,
                                   f"Trap {trap_ids[0]} for protocol {protocol} is not installed")
@@ -147,6 +149,7 @@ class TestCOPP(object):
                      protocol,
                      copp_testbed,
                      dut_type,
+                     has_trap=has_trap,
                      is_smartswitch_light_mode=is_smartswitch_light_mode)
 
     @pytest.mark.parametrize("protocol", ["IP2ME",
@@ -351,7 +354,7 @@ def test_verify_copp_configuration_cli(duthosts, enum_rand_one_per_hwsku_fronten
     show_copp_config = copp_utils.parse_show_copp_configuration(duthost, namespace)
 
     pytest_assert(trap in show_copp_config,
-                  f"Trap {trap} not found in show copp configuration output")
+                  f"Trap {trap} not found as part of show copp configuration output")
     pytest_assert(trap_group == show_copp_config[trap]["trap_group"],
                   f"Trap group mismatch for trap {trap} (expected: \
                   {trap_group}, actual: {show_copp_config[trap]['trap_group']})")


### PR DESCRIPTION

### Description of PR
When traps are not enabled, PPS check is checking port level counters. But there may be other traps grouped together and these other traps might be seeing the packets. There are cases when these other packets are reaching 1pps causing the test to fail.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
For traps not enabled case, copp test is failing sometimes for DHCP trap.
DHCP traps are grouped with UDLD, LLDP.

#### How did you do it?
Checked for actual matched DHCP packet count instead of port level counters on the ptf side.

#### How did you verify/test it?
Ran the copp test multiple times over period of few weeks. The test used to fail frequently before, but no longer failing now.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
