### PR TITLE
[loganalyzer] Add ignore rules for broadcom-dnx recycle port attribute errors in syncd

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -517,3 +517,7 @@ r, ".* ERR auditd.*: auditd queue full reporting limit reached - ending dropped 
 # ctrmgrd k8s join warnings (old k8s version incompatibility with Docker 28.x)
 r, ".* ERR ctrmgrd\.py: Refer file .* for troubleshooting tips.*"
 r, ".* ERR ctrmgrd\.py:.*\[WARNING SystemVerification\]:.*Docker version is not on the list of validated versions.*"
+
+# Memory Broadcom-DNX recycle port attribute errors (unsupported attrs 149/170 on Q3D)
+r, ".* ERR syncd#syncd:.*_brcm_sai_get_recycle_port_attribute.*Unknown port attribute.*"
+r, ".* ERR syncd#syncd:.*_brcm_sai_get_recycle_port_attribute.*Error processing port attributes.*"


### PR DESCRIPTION
```
### Description of PR

On broadcom-dnx platforms, `syncd` logs errors when querying unsupported port attributes (149/170) on recycle ports:

```
ERR syncd#syncd: _brcm_sai_get_recycle_port_attribute: Unknown port attribute (149)
ERR syncd#syncd: _brcm_sai_get_recycle_port_attribute: Error processing port attributes
```

These errors are benign — the SAI implementation attempts to query port attributes that are not supported on recycle ports and logs the failure, but it does not affect switch functionality or data plane behavior. However, the loganalyzer treats these as unexpected errors and flags otherwise passing tests as failures.

This PR adds ignore patterns to `loganalyzer_common_ignore.txt` to suppress these known benign errors.

Summary:
Add loganalyzer ignore rules for broadcom-dnx recycle port attribute errors to prevent false test failures.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Multiple tests fail on broadcom-dnx platforms due to the loganalyzer catching `_brcm_sai_get_recycle_port_attribute` error messages in syslog. These errors are logged by the SAI on every config reload or startup and are not indicative of any actual issue — they are simply unsupported attribute queries on recycle ports.

#### How did you do it?
Added two regex patterns to `loganalyzer_common_ignore.txt`:
- `_brcm_sai_get_recycle_port_attribute.*Unknown port attribute`
- `_brcm_sai_get_recycle_port_attribute.*Error processing port attributes`

#### How did you verify/test it?
- Ran nightly tests on broadcom-dnx VOQ platforms and confirmed that tests previously failing due to loganalyzer now pass
- Verified the ignore patterns match the exact syslog messages produced by syncd

#### Any platform specific information?
Affects broadcom-dnx platforms only. The errors originate from the Memory_BMP SAI implementation when querying recycle port attributes. Other platforms do not produce these log messages, so the ignore rules have no effect on them.

#### Supported testbed topology if it's a new test case?
N/A — bug fix, not a new test case.

### Documentation
N/A
```