### PR TITLE
[cherry-pick][202511] Update test_fdb.py to generate unique dummy mac set for any port_index

### DIFF
--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -259,7 +259,7 @@ def setup_fdb(ptfadapter, vlan_table, router_mac, pkt_type, dummy_mac_count):
 
                 # Send packets to switch to populate the layer 2 table with dummy MACs for each port
                 # Totally 10 dummy MACs for each port, send 1 packet for each dummy MAC
-                dummy_macs = ['{}:{:02x}:{:02x}'.format(DUMMY_MAC_PREFIX, port_index, i)
+                dummy_macs = ['{}:{:02x}:{:02x}'.format(DUMMY_MAC_PREFIX, port_index % 256, i)
                               for i in range(dummy_mac_count)]
 
                 for dummy_mac in dummy_macs:

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -259,8 +259,14 @@ def setup_fdb(ptfadapter, vlan_table, router_mac, pkt_type, dummy_mac_count):
 
                 # Send packets to switch to populate the layer 2 table with dummy MACs for each port
                 # Totally 10 dummy MACs for each port, send 1 packet for each dummy MAC
-                dummy_macs = ['{}:{:02x}:{:02x}'.format(DUMMY_MAC_PREFIX, port_index % 256, i)
-                              for i in range(dummy_mac_count)]
+                dummy_macs = [
+                    '{}:{:02x}:{:02x}'.format(
+                        DUMMY_MAC_PREFIX,
+                        (port_index >> 4) & 0xff,  # use high 8 bits of port_index to generate the first MAC value
+                        ((port_index & 0xf) << 4) | (i & 0xf)  # use the low 4 bits to generate the last MAC value
+                    )
+                    for i in range(dummy_mac_count)
+                ]
 
                 for dummy_mac in dummy_macs:
                     if pkt_type == "ethernet":


### PR DESCRIPTION
Cherry-picking https://github.com/sonic-net/sonic-mgmt/pull/23866 & https://github.com/sonic-net/sonic-mgmt/pull/24087

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Generate unique dummy mac set for any port_index to avoid duplicated mac learning on different ports
It would lead to packet forwarding failure


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [] 202511

### Approach
#### What is the motivation for this PR?
When the available port number is larger than 256, there would be a chance that the generated dummy macs would be dupplicated for different ports.
It would lead to traffic forwarding failure.
#### How did you do it?
Update the algorithm to generate dummy mac to avoid the dupplicated mac
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
