### PR TITLE
Fix/console ssh kex compat

### DIFF
--- a/tests/common/connections/base_console_conn.py
+++ b/tests/common/connections/base_console_conn.py
@@ -48,6 +48,11 @@ class BaseConsoleConn(CiscoBaseConnection):
             if key in kwargs:
                 del kwargs[key]
 
+        # Allow legacy SSH KEX algorithms for older console servers (e.g. Digi)
+        # that may not support modern key exchange methods.
+        if 'disabled_algorithms' not in kwargs:
+            kwargs['disabled_algorithms'] = {"kex": []}
+
         for i in range(0, len(all_passwords)):
             kwargs['password'] = all_passwords[i]
             try:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Paramiko (the Python SSH library) recently started blocking legacy KEX (Key Exchange) algorithms by default in newer versions. When the sonic-mgmt container connects to older console servers (like Digi), the SSH handshake fails because:

 1. The console server only supports older KEX algorithms (e.g., diffie-hellman-group14-sha1)
 2. Paramiko's default disabled_algorithms blocks those
 3. No common KEX algorithm can be negotiated → connection fails

Before:
<img width="1222" height="40" alt="image" src="https://github.com/user-attachments/assets/52b15e27-0ae4-4e73-ba1c-cd080f6302ca" />
After:
<img width="1149" height="89" alt="image" src="https://github.com/user-attachments/assets/9a291fcf-40e3-46aa-8cbd-7f66beffd1d3" />

<!--
-->

Summary:
Fixes # (issue)
to fix the failing dut_console/test_escape_character.py 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
Motivation: Newer versions of Paramiko disable certain legacy KEX algorithms by default, causing SSH connections to older console servers (like Digi) to fail during key exchange negotiation.

How: In base_console_conn.py, if the caller hasn't explicitly set disabled_algorithms, we default to {"kex": []} — an empty blocklist that permits all KEX algorithms, including legacy ones needed by older servers.

Verified: Tested console connectivity to a Digi console server that previously failed with a KEX mismatch error.


### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
