### PR TITLE
fix(route): add Nokia IXR7220 H6 to l3_alpm_template ALPM check in test_route_perf

### DIFF
--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -107,8 +107,9 @@ def check_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_
     asic_id = enum_rand_one_frontend_asic_index
 
     if (asic == "broadcom"):
-        if "x86_64-arista_7060x6" in platform:
-            # For all TH5 family devices, l3_alpm_template is set in config.bcm
+        if "x86_64-arista_7060x6" in platform or "x86_64-nokia_ixr7220_h6" in platform:
+            # For TH5 (Arista 7060x6) and TH6 (Nokia IXR7220 H6) family devices,
+            # l3_alpm_template is set in config.bcm instead of l3_alpm_enable
             # * 1 - Combined (By default)
             # * 2 - Parallel
             pytest_assert(


### PR DESCRIPTION
### Description of PR

Summary:
The `check_config` fixture in `tests/route/test_route_perf.py` determines the ALPM configuration before running route scale tests. For Broadcom platforms it takes two paths:
1. `x86_64-arista_7060x6` (TH5) → reads `l3_alpm_template` from `config.bcm` via `get_l3_alpm_template_from_config_bcm()`
2. All other Broadcom → runs `bcmcmd "conf show l3_alpm_enable"` and asserts `== "l3_alpm_enable=2"`

Nokia IXR7220 H6 (`x86_64-nokia_ixr7220_h6_128-r0`) uses the **BCM56990 (Tomahawk 6)** chip, which, like TH5, uses `l3_alpm_template` in `config.bcm` and does **not** support the legacy `l3_alpm_enable` register. Because the platform string does not match `x86_64-arista_7060x6`, it falls into path 2, where `bcmcmd "conf show l3_alpm_enable"` returns `'Command not supported for this device'`, causing both `test_perf_add_remove_routes` parametrizations to ERROR at setup before any tests run.

Observed in Elastictest nightly plan `6a1a1d589262108863d7b605` (testbed `vms13-lt2-nokia-th6-1`).

### Type of change

- [x] Bug fix

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

`test_perf_add_remove_routes` fails at setup (PYTEST_ERROR) on Nokia IXR7220 H6 because `bcmcmd "conf show l3_alpm_enable"` is not supported on the BCM56990 (TH6) chip.

#### How did you do it?

Extended the `l3_alpm_template` condition in `check_config` to also match `x86_64-nokia_ixr7220_h6`:

```python
# Before
if "x86_64-arista_7060x6" in platform:

# After
if "x86_64-arista_7060x6" in platform or "x86_64-nokia_ixr7220_h6" in platform:
```

This routes Nokia TH6 through `get_l3_alpm_template_from_config_bcm()`, which reads the correct `l3_alpm_template` value from the SAI `config.bcm` file — the same mechanism already used for TH5.

#### How did you verify/test it?

- Verified in nightly test logs that `bcmcmd "conf show l3_alpm_enable"` returns `'Command not supported for this device'` on Nokia TH6 (Elastictest plan `6a1a1d589262108863d7b605`).
- Nokia TH6 SAI profile uses `l3_alpm_template` in `config.bcm` (same mechanism as TH5/Arista 7060x6).

#### Any platform specific information?

Nokia IXR7220 H6, platform string `x86_64-nokia_ixr7220_h6_128-r0`, hwsku `Nokia-IXR7220-H6-O256`, BCM56990 (Tomahawk 6) ASIC.

#### Supported testbed topology if it's a new test case?

N/A — bug fix only.

### Documentation

N/A