### PR TITLE
chore: enable pc VPP tests p1

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3959,6 +3959,13 @@ pc/:
     conditions:
       - "'bmc' in topo_type"
 
+pc/test_lag_2.py::test_lag\[.*-single_lag\]:
+  regex: true
+  skip:
+    reason: "single_lag test cannot run on virtual testbeds because there is no leaf fanout switch to perform the minlink test"
+    conditions:
+      - "asic_type in ['vs', 'vpp']"
+
 pc/test_lag_2.py::test_lag_db_status_with_po_update:
   skip:
     reason: "Only support t1-lag, t1-56-lag, t1-28-lag, t1-64-lag and t2 topology"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -482,31 +482,7 @@ override_config_table/test_override_config_table.py::test_load_minigraph_with_go
 #######################################
 #####          PC                 #####
 #######################################
-pc/test_lag_2.py::test_lag:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
 pc/test_lag_member_forwarding.py::test_lag_member_forwarding_packets:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-pc/test_po_cleanup.py::test_po_cleanup:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-pc/test_po_cleanup.py::test_po_cleanup_after_reload:
   skip:
     reason: >
             Failed/Errored: To be included

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -299,9 +299,6 @@ def skip_if_no_lags(duthosts):
                                       "fallback"])
 def test_lag(common_setup_teardown, duthosts, tbinfo, nbrhosts, fanouthosts,
              conn_graph_facts, enum_dut_portchannel_with_completeness_level, testcase, request):     # noqa: F811
-    # We can't run single_lag test on vtestbed since there is no leaffanout
-    if testcase == "single_lag" and is_vtestbed(duthosts[0]):
-        pytest.skip("Skip single_lag test on vtestbed")
     if 'PortChannel201' in enum_dut_portchannel_with_completeness_level:
         pytest.skip("PortChannel201 is a specific configuration of t0-56-po2vlan topo, which is not supported by test")
 

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -40,7 +40,7 @@ def common_setup_teardown(copy_acstests_directory, copy_ptftests_directory, ptfh
 
 
 def is_vtestbed(duthost):
-    return duthost.facts['asic_type'].lower() == "vs"
+    return duthost.facts['asic_type'].lower() in ["vs", "vpp"]
 
 
 class LagTest:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Part 1 of enabling PortChannel (PC) tests on VPP testbeds.

This PR enables the first batch of PC tests that can already run on VPP:
  - `pc/test_lag_2.py::test_lag`
  - `pc/test_po_cleanup.py::test_po_cleanup`
  - `pc/test_po_cleanup.py::test_po_cleanup_after_reload`

`pc/test_lag_member_forwarding.py::test_lag_member_forwarding_packets` is intentionally still skipped for VPP. That test needs additional VPP SAI behavior in `sonic-sairedis`, which is being worked on separately and is not part of this PR.

Fixes # (issue): https://github.com/sonic-net/sonic-buildimage/issues/25771

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Increase VPP test coverage for PortChannel scenarios by enabling the PC tests that are already compatible with the current VPP SAI implementation. 

#### How did you do it?

#### How did you verify/test it?

Ran each newly enabled test 2 times in and can confirm they are all passing: https://elastictest.org/scheduler/testplan/6a1f6c532296f2ad62e47b80

#### Any platform specific information?

VPP platform

#### Supported testbed topology if it's a new test case?

t1-lag-vpp

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
