### PR TITLE
Ensure Router Advertisements are disabled on renumber_topo as well as existing mgmt interface

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -353,6 +353,13 @@
     become: yes
     when: dpu_targets is defined and dpu_targets | length > 0
 
+  - name: Don't accept ipv6 router advertisements on PTF mgmt interface if it exists
+    command: >
+      docker exec -i ptf_{{ vm_set_name }}
+      sh -c 'test ! -e /proc/sys/net/ipv6/conf/mgmt/accept_ra ||
+             sysctl -w net.ipv6.conf.mgmt.accept_ra=0'
+    become: yes
+
   - name: Change MAC address for PTF interfaces
     include_tasks: ptf_change_mac.yml
     when: topo != 'fullmesh' and not (ptf_use_docker_network | default(false))

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -141,6 +141,10 @@
     command: docker exec -i ptf_{{ vm_set_name }} sysctl -w net.ipv6.route.max_size=168000
     become: yes
 
+  - name: Don't accept ipv6 router advertisements for docker container ptf_{{ vm_set_name }}
+    command: docker exec -i ptf_{{ vm_set_name }} sysctl -w net.ipv6.conf.default.accept_ra=0
+    become: yes
+
   - name: Create file to store dut type in PTF
     command: docker exec -i ptf_{{ vm_set_name }} sh -c 'echo {{ hostvars[duts_name.split(',')[0]]['type'] }} > /sonic/dut_type.txt'
     when:
@@ -194,6 +198,13 @@
       is_vs_chassis: "{{ is_vs_chassis | default(false) }}"
     become: yes
     when: "'bmc' not in topo"
+
+  - name: Don't accept ipv6 router advertisements on PTF mgmt interface if it exists
+    command: >
+      docker exec -i ptf_{{ vm_set_name }}
+      sh -c 'test ! -e /proc/sys/net/ipv6/conf/mgmt/accept_ra ||
+             sysctl -w net.ipv6.conf.mgmt.accept_ra=0'
+    become: yes
 
   - name: Change MAC address for PTF interfaces
     include_tasks: ptf_change_mac.yml


### PR DESCRIPTION
… pre-existing

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
We noticed that some PTF containers had accept_ra=1 on nightly tests, causing a bad route to be discovered and the DUT becoming unreachable. Currently the accept_ra is only applied to default template interface during add_topo.yml. The proposed fix is to ensure accept_ra is forced to 0 in all additional scenarios:

1. after interface is configured and set up, should explicitly set mgmt.accept_ra=0
2. on renumber_topo.yml, since this may be run without add_topo.

#### How did you do it?
Added sysctl calls in the appropriate place in accept_topo.yml and renumber_topo.yml. For renumber_topo, we duplicate the default.accept_ra=0 that was pre-existing in add_topo and to both we also add an explicit set of mgmt.accept_ra=0 if the interface exists.

#### How did you verify/test it?
testbed-cli was used to remove, add and renumber the topology. The value of net.ipv6.conf.mgmt.accept_ra was checked after this and it was set correctly to 0, and the bad route did not appear.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
