### PR TITLE
[mmu probing] pr20.fix: Fix positional arg and lossy_queue fallback bugs for Mellanox

### DIFF
--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -330,7 +330,12 @@ class TestQosProbe(QosSaiBase):
             qosConfig = dutQosConfig["param"][portSpeedCableLength]
 
         if lossyProfile not in qosConfig:
-            pytest.skip(f"{lossyProfile} is not defined in QoS config")
+            # Mellanox: lossy_queue_1 is defined at dutQosConfig["param"] level (sibling of
+            # "profile" key in qos_params.mellanox.yaml), not under the per-speed sub-dict.
+            # Legacy testQosSaiLossyQueue has the same fallback (test_qos_sai.py L1213-1216).
+            qosConfig = dutQosConfig["param"]
+            if lossyProfile not in qosConfig:
+                pytest.skip(f"{lossyProfile} is not defined in QoS config")
 
         platform_asic = dutTestParams["basicParams"].get("platform_asic", None)
         if platform_asic == "broadcom-dnx":
@@ -507,7 +512,7 @@ class TestQosProbe(QosSaiBase):
             src_port_vlans = [testPortIps[src_dut_index][src_asic_index][port]['vlan_id']
                               if 'vlan_id' in testPortIps[src_dut_index][src_asic_index][port]
                               else None for port in qosConfig["hdrm_pool_size"]["src_port_ids"]]
-        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, qosConfig["hdrm_pool_size"])
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, qosParams=qosConfig["hdrm_pool_size"])
 
         # begin - collect all available test ports for probing
         duthost = get_src_dst_asic_and_duts['src_dut']

--- a/tests/saitests/mock/ut/test_probe_bugfixes.py
+++ b/tests/saitests/mock/ut/test_probe_bugfixes.py
@@ -1,0 +1,219 @@
+"""
+Unit tests for probe bug fixes:
+  1. HeadroomPoolProbe: updateTestPortIdIp positional-arg fix (qosParams keyword)
+  2. EgressDropProbe: lossy_queue fallback to dutQosConfig["param"] level
+
+These tests validate the fix logic in isolation without importing the full
+TestQosProbe class (which requires heavy fixtures from QosSaiBase).
+"""
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: updateTestPortIdIp positional-arg
+# ---------------------------------------------------------------------------
+# The function signature is:
+#   updateTestPortIdIp(self, dutConfig, get_src_dst_asic_and_duts,
+#                      portSpeedCableLength=None, qosParams=None)
+#
+# Bug: the call site passed qosConfig["hdrm_pool_size"] as the 3rd positional
+#      arg, binding it to portSpeedCableLength instead of qosParams.
+# Fix: use keyword arg qosParams=qosConfig["hdrm_pool_size"]
+
+def _simulate_updateTestPortIdIp(portSpeedCableLength=None, qosParams=None):
+    """Simulate the function to verify which parameter receives the value."""
+    return {"portSpeedCableLength": portSpeedCableLength, "qosParams": qosParams}
+
+
+class TestPositionalArgFix:
+    """Verify that hdrm_pool_size dict reaches qosParams, not portSpeedCableLength."""
+
+    def test_buggy_positional_call(self):
+        """OLD code: 3rd positional arg goes to portSpeedCableLength (wrong)."""
+        hdrm_data = {"src_port_ids": [0, 1], "dst_port_id": 2}
+        result = _simulate_updateTestPortIdIp(hdrm_data)  # positional
+        assert result["portSpeedCableLength"] == hdrm_data, \
+            "Positional call should bind to portSpeedCableLength (the bug)"
+        assert result["qosParams"] is None
+
+    def test_fixed_keyword_call(self):
+        """NEW code: keyword arg goes to qosParams (correct)."""
+        hdrm_data = {"src_port_ids": [0, 1], "dst_port_id": 2}
+        result = _simulate_updateTestPortIdIp(qosParams=hdrm_data)  # keyword
+        assert result["qosParams"] == hdrm_data, \
+            "Keyword call should bind to qosParams (the fix)"
+        assert result["portSpeedCableLength"] is None
+
+    def test_both_params_independent(self):
+        """Both parameters can be set independently."""
+        result = _simulate_updateTestPortIdIp(
+            portSpeedCableLength="100000_3m", qosParams={"key": "val"})
+        assert result["portSpeedCableLength"] == "100000_3m"
+        assert result["qosParams"] == {"key": "val"}
+
+    def test_no_args_defaults(self):
+        """Both default to None."""
+        result = _simulate_updateTestPortIdIp()
+        assert result["portSpeedCableLength"] is None
+        assert result["qosParams"] is None
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: EgressDropProbe lossy_queue fallback
+# ---------------------------------------------------------------------------
+# Replicate the fixed lookup logic from testQosEgressDropProbe:
+#   1) Look in speed-specific qosConfig (dutQosConfig["param"][speedCableLen])
+#   2) If not found, fall back to dutQosConfig["param"] (top-level)
+#   3) If still not found, pytest.skip
+#
+# Keep in sync with: tests/qos/test_qos_probe.py :: testQosEgressDropProbe
+
+def _resolve_lossy_profile(dutQosConfig, portSpeedCableLength, lossyProfile):
+    """Replicate the fixed lossy profile lookup logic.
+
+    Returns (qosConfig_dict, skipped_reason_or_None).
+    """
+    qosConfig = dutQosConfig["param"][portSpeedCableLength]
+    if lossyProfile not in qosConfig:
+        qosConfig = dutQosConfig["param"]
+        if lossyProfile not in qosConfig:
+            return None, f"{lossyProfile} is not defined in QoS config"
+    return qosConfig, None
+
+
+class TestLossyQueueFallback:
+    """Verify lossy_queue_1 lookup with 2-level fallback."""
+
+    @pytest.fixture
+    def broadcom_config(self):
+        """Broadcom: lossy_queue_1 is inside the speed-specific sub-dict."""
+        return {
+            "param": {
+                "100000_3m": {
+                    "lossy_queue_1": {"dscp": 8, "ecn": 1, "pg": 0},
+                    "other_key": "value",
+                },
+            }
+        }
+
+    @pytest.fixture
+    def mellanox_config(self):
+        """Mellanox: lossy_queue_1 is at the top-level param dict,
+        not inside the per-speed sub-dict."""
+        return {
+            "param": {
+                "100000_3m": {
+                    "headroom_pool_size": "1024",
+                },
+                "lossy_queue_1": {"dscp": 8, "ecn": 1, "pg": 0},
+            }
+        }
+
+    @pytest.fixture
+    def missing_config(self):
+        """Neither level has lossy_queue_1."""
+        return {
+            "param": {
+                "100000_3m": {
+                    "headroom_pool_size": "1024",
+                },
+            }
+        }
+
+    def test_broadcom_direct_lookup(self, broadcom_config):
+        """Broadcom: found in speed-specific sub-dict (no fallback needed)."""
+        cfg, skip = _resolve_lossy_profile(broadcom_config, "100000_3m", "lossy_queue_1")
+        assert skip is None
+        assert "lossy_queue_1" in cfg
+        assert cfg is broadcom_config["param"]["100000_3m"]
+
+    def test_mellanox_fallback_to_param(self, mellanox_config):
+        """Mellanox: NOT in speed sub-dict, found at param level (fallback)."""
+        cfg, skip = _resolve_lossy_profile(mellanox_config, "100000_3m", "lossy_queue_1")
+        assert skip is None
+        assert "lossy_queue_1" in cfg
+        assert cfg is mellanox_config["param"]
+
+    def test_missing_skip(self, missing_config):
+        """Neither level has lossy_queue_1 → skip."""
+        cfg, skip = _resolve_lossy_profile(missing_config, "100000_3m", "lossy_queue_1")
+        assert cfg is None
+        assert "not defined" in skip
+
+    def test_mellanox_speed_dict_untouched(self, mellanox_config):
+        """Verify fallback doesn't modify the speed-specific dict."""
+        speed_dict_before = dict(mellanox_config["param"]["100000_3m"])
+        _resolve_lossy_profile(mellanox_config, "100000_3m", "lossy_queue_1")
+        assert mellanox_config["param"]["100000_3m"] == speed_dict_before
+
+    def test_custom_profile_name(self):
+        """Fallback works for any profile name, not just lossy_queue_1."""
+        config = {
+            "param": {
+                "50000_1m": {},
+                "custom_lossy": {"dscp": 10},
+            }
+        }
+        cfg, skip = _resolve_lossy_profile(config, "50000_1m", "custom_lossy")
+        assert skip is None
+        assert cfg["custom_lossy"]["dscp"] == 10
+
+    def test_profile_in_both_levels_prefers_speed(self):
+        """If profile exists in BOTH levels, speed-specific takes precedence."""
+        config = {
+            "param": {
+                "100000_3m": {
+                    "lossy_queue_1": {"dscp": 8, "source": "speed"},
+                },
+                "lossy_queue_1": {"dscp": 8, "source": "param"},
+            }
+        }
+        cfg, skip = _resolve_lossy_profile(config, "100000_3m", "lossy_queue_1")
+        assert skip is None
+        assert cfg["lossy_queue_1"]["source"] == "speed", \
+            "Speed-specific config should take precedence over param-level"
+
+
+class TestLossyQueueEdgeCases:
+    """Edge cases for the fallback logic."""
+
+    def test_empty_speed_dict(self):
+        """Speed dict is empty → falls back to param level."""
+        config = {
+            "param": {
+                "100000_3m": {},
+                "lossy_queue_1": {"dscp": 8},
+            }
+        }
+        cfg, skip = _resolve_lossy_profile(config, "100000_3m", "lossy_queue_1")
+        assert skip is None
+        assert cfg is config["param"]
+
+    def test_empty_param_dict_skips(self):
+        """Param-level also has nothing → skip."""
+        config = {
+            "param": {
+                "100000_3m": {},
+            }
+        }
+        _, skip = _resolve_lossy_profile(config, "100000_3m", "lossy_queue_1")
+        assert skip is not None
+
+    def test_breakout_sku_scenario(self):
+        """Simulates breakout SKU where config comes from ["breakout"] sub-key.
+        The fallback still applies the same way."""
+        config = {
+            "param": {
+                "100000_3m": {
+                    "breakout": {
+                        # In real code, qosConfig = this breakout dict
+                    }
+                },
+                "lossy_queue_1": {"dscp": 8},
+            }
+        }
+        # Simulating: qosConfig = config["param"]["100000_3m"]["breakout"]
+        breakout_config = config["param"]["100000_3m"]["breakout"]
+        if "lossy_queue_1" not in breakout_config:
+            fallback = config["param"]
+            assert "lossy_queue_1" in fallback


### PR DESCRIPTION
### Description of PR

Summary:
Fix two probe bugs affecting Mellanox platforms:

1. **HeadroomPoolProbe positional arg bug**: `updateTestPortIdIp()` was called with `qosConfig["hdrm_pool_size"]` as the 3rd positional argument, which binds to `portSpeedCableLength` instead of `qosParams`. Fixed by using the keyword argument `qosParams=qosConfig["hdrm_pool_size"]`.

2. **EgressDropProbe lossy_queue fallback**: On Mellanox, `lossy_queue_1` is defined at the `dutQosConfig["param"]` level (sibling of the `"profile"` key in `qos_params.mellanox.yaml`), not inside the per-speed sub-dict. The probe skipped with "lossy_queue_1 is not defined" instead of falling back. Added a 2-level lookup matching legacy `testQosSaiLossyQueue` behavior (`test_qos_sai.py` L1213-1216).

Fixes https://github.com/sonic-net/sonic-mgmt/issues/24738

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

**Bug 1 — positional arg**: `updateTestPortIdIp(self, dutConfig, get_src_dst_asic_and_duts, portSpeedCableLength=None, qosParams=None)` has two optional keyword parameters. The HeadroomPoolProbe call site passed `qosConfig["hdrm_pool_size"]` positionally as the 3rd arg, so it was silently assigned to `portSpeedCableLength` instead of `qosParams`. This caused incorrect port-ID resolution during headroom pool probing.

**Bug 2 — lossy fallback**: On Mellanox platforms, the QoS YAML structure places `lossy_queue_1` at the `dutQosConfig["param"]` level rather than inside the per-speed-cable-length sub-dict (e.g., `param["100000_3m"]`). The EgressDropProbe only checked the speed sub-dict and would `pytest.skip` instead of probing. The legacy `testQosSaiLossyQueue` test already handles this with a fallback (`test_qos_sai.py` L1213-1216).

#### How did you do it?

1. Changed line 510: `self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, qosConfig["hdrm_pool_size"])` → `self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, qosParams=qosConfig["hdrm_pool_size"])`

2. Added fallback at line 332-338: if `lossyProfile` is not in the speed-specific `qosConfig`, retry lookup at `dutQosConfig["param"]` level before skipping.

3. Added 13 unit tests in `test_probe_bugfixes.py` covering:
   - Positional arg: verifies buggy vs fixed call binding behavior
   - Lossy fallback: Broadcom direct lookup, Mellanox fallback, missing-skip, precedence, edge cases

#### How did you verify/test it?

1. **New Unit Tests**: 13 tests all pass
2. **Existing UT regression**: 496 passed (1 pre-existing failure — Unicode `✓` char on Windows, unrelated)
3. **Existing IT regression**: 99 passed (no regression)

#### Any platform specific information?

- **Mellanox SPC1/SPC3**: Both bugs affect Mellanox platforms. The lossy fallback is specifically needed because Mellanox YAML places `lossy_queue_1` at the param level.
- **Broadcom/Cisco-8000**: No impact — these platforms define lossy profiles in the speed sub-dict.

#### Supported testbed topology if it's a new test case?

N/A — bug fix for existing probe tests. Works on any topology that runs QoS probe tests (t0, t1).

### Documentation

No documentation changes needed.