### PR TITLE
tests/snappi/ecn: scale dequeue WRED thresholds to data burst

### DIFF
--- a/tests/snappi_tests/ecn/test_dequeue_ecn_with_snappi.py
+++ b/tests/snappi_tests/ecn/test_dequeue_ecn_with_snappi.py
@@ -20,6 +20,26 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
+# Per-ASIC egress buffer cell size (bytes). WRED kmin/kmax are quantized to
+# this granularity by the ASIC, so test thresholds must be multiples of it.
+_BRCM_CELL_SIZE = {'td2': 208, 'td3': 256, 'td4': 256,
+                   'th': 208, 'th2': 208, 'th3': 208, 'th4': 208, 'th5': 254}
+_MLNX_CELL_SIZE = 144  # conservative default across spc1..spc5 (96/144/192)
+_CISCO_CELL_SIZE = 384
+
+
+def _get_cell_size(duthost):
+    asic_type = duthost.facts['asic_type']
+    if asic_type == 'cisco-8000':
+        return _CISCO_CELL_SIZE
+    if asic_type == 'mellanox':
+        return _MLNX_CELL_SIZE
+    asic = duthost.get_asic_name()
+    if asic in _BRCM_CELL_SIZE:
+        return _BRCM_CELL_SIZE[asic]
+    # Fallback: 256 is a safe upper bound for unknown Broadcom-class ASICs.
+    return 256
+
 
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_dequeue_ecn(request,
@@ -86,11 +106,34 @@ def test_dequeue_ecn(request,
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
     snappi_extra_params.packet_capture_type = packet_capture.IP_CAPTURE
     snappi_extra_params.is_snappi_ingress_port_cap = True
-    snappi_extra_params.ecn_params = {'kmin': 50000, 'kmax': 51000, 'pmax': 100}
     data_flow_pkt_size = 1024
-    data_flow_pkt_count = 101
     num_iterations = 1
-    logger.info("Running ECN dequeue test with params: {}".format(snappi_extra_params.ecn_params))
+
+    # Derive packet count from the platform's buffer cell size so the
+    # dequeue window is long enough for the queue to deterministically
+    # start above kmax and drain below kmin despite PFC-release /
+    # first-packet timing jitter. The [kmin, kmax] band spans 60% of
+    # burst_bytes; require it to be at least MIN_BAND_CELLS cells wide.
+    cell_size = _get_cell_size(duthosts[0])
+    cell_per_pkt = (data_flow_pkt_size + cell_size - 1) // cell_size
+    MIN_BAND_CELLS = 300
+    SAFETY_MARGIN = 1.5
+    min_pkt_count = int(SAFETY_MARGIN * MIN_BAND_CELLS / (0.60 * cell_per_pkt)) + 1
+    data_flow_pkt_count = min_pkt_count
+
+    # Scale WRED thresholds to the data burst, aligned to the buffer cell
+    # size, so the egress queue depth straddles [kmin, kmax] across the
+    # dequeue window: starts above kmax (first packet 100% marked) and
+    # drops below kmin before the last packet (last packet not marked).
+    burst_bytes = data_flow_pkt_count * cell_per_pkt * cell_size
+    kmax = (int(burst_bytes * 0.80) // cell_size) * cell_size
+    kmin = (int(burst_bytes * 0.20) // cell_size) * cell_size
+    pytest_assert(kmax - kmin >= MIN_BAND_CELLS * cell_size,
+                  "Burst too small for cell_size={}: kmin={}, kmax={}".format(
+                      cell_size, kmin, kmax))
+    snappi_extra_params.ecn_params = {'kmin': kmin, 'kmax': kmax, 'pmax': 100}
+    logger.info("Running ECN dequeue test with params: {} (cell_size={}, pkt_count={})".format(
+        snappi_extra_params.ecn_params, cell_size, data_flow_pkt_count))
 
     snappi_extra_params.traffic_flow_config.data_flow_config = {
             "flow_pkt_size": data_flow_pkt_size,


### PR DESCRIPTION
### Description of PR

Summary:
Replace hardcoded `kmin=50000` / `kmax=51000` in `test_dequeue_ecn` with values derived from the configured data burst (`data_flow_pkt_count * data_flow_pkt_size`). Use `kmax = 80%` and `kmin = 20%` of the burst, cell-aligned to the platform's egress buffer cell size, so the egress queue depth is above `kmax` when the first packet dequeues (marked) and below `kmin` when the last packet dequeues (unmarked), regardless of platform queue accounting granularity.

Also derives `data_flow_pkt_count` from the platform cell size so the `[kmin, kmax]` band is wide enough (`MIN_BAND_CELLS * cell_size`, with a `SAFETY_MARGIN`) to absorb PFC-release / first-packet timing jitter on all supported ASICs (Broadcom TD2/TD3/TD4/TH/TH2/TH3/TH4/TH5, Mellanox SPC, Cisco-8000).

Fixes false `last packet should not be marked` failures on platforms (e.g. Broadcom Trident 7050CX3) where the small fixed thresholds were exceeded for the entire dequeue window.

Fixes # https://github.com/sonic-net/sonic-mgmt/issues/25004

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
The hardcoded ECN thresholds `kmin=50000` / `kmax=51000` were tuned for a specific platform/queue-accounting model. On platforms with different buffer cell sizes — notably Broadcom Trident (7050CX3, cell size 256 B) — the egress queue depth stayed above `kmax` for the entire dequeue window, so the last packet was still ECN-marked and the test failed with `The last packet should not be marked`. The fixed 1 KB band also gave no headroom for PFC-release / first-packet timing jitter, making the test inherently flaky.

#### How did you do it?
- Compute `kmax` and `kmin` from the actual data burst:
  - `burst_bytes = data_flow_pkt_count * cell_per_pkt * cell_size`
  - `kmax = floor(0.80 * burst_bytes / cell_size) * cell_size`
  - `kmin = floor(0.20 * burst_bytes / cell_size) * cell_size`
  This places the band at `[20%, 80%]` of the burst, so the queue depth deterministically straddles `[kmin, kmax]` during dequeue.
- Add a per-ASIC cell-size lookup (`_get_cell_size`) covering Broadcom (TD2/TD3/TD4/TH/TH2/TH3/TH4/TH5), Mellanox (conservative 144 B across SPC1–SPC5), and Cisco-8000 (384 B), with a 256 B fallback.
- Derive `data_flow_pkt_count` from cell size so the band is at least `MIN_BAND_CELLS * cell_size` wide:
  - `min_pkt_count = int(SAFETY_MARGIN * MIN_BAND_CELLS / (0.60 * cell_per_pkt)) + 1`
  with `MIN_BAND_CELLS = 300` and `SAFETY_MARGIN = 1.5`.
- Cell-align `kmin`/`kmax` (SAI quantizes WRED thresholds to whole cells) and assert the resulting band still meets `MIN_BAND_CELLS * cell_size`.

#### How did you verify/test it?
- Ran `test_dequeue_ecn` on `7050cx3` (Broadcom TD3, cell size 256 B): test now passes deterministically; first packet ECN-marked, last packet not marked.
- Ran on existing passing platforms (no behavior change beyond larger, cell-aligned thresholds) — still passes.
- Verified derived values for 7050CX3: `pkt_count = 188`, `burst = 192,512 B`, `kmax = 153,856 B (601 cells)`, `kmin = 38,400 B (150 cells)`, actual band = 451 cells (≥ 300 required).

#### Any platform specific information?
Cell sizes used:
- Broadcom: TD2/TH/TH2/TH3/TH4 = 208 B, TD3/TD4 = 256 B, TH5 = 254 B
- Mellanox: 144 B (conservative across SPC1–SPC5; actual is 96/144/192)
- Cisco-8000: 384 B
- Unknown Broadcom-class ASICs: 256 B fallback

#### Supported testbed topology if it's a new test case?
N/A — existing test (`multidut-tgen`, `tgen`).

### Documentation
<img width="1027" height="669" alt="image" src="https://github.com/user-attachments/assets/7fbff352-7bf0-4df3-85b0-c5b1a9656d96" />

For TD3/7050CX3 (cell_size=256, cell_per_pkt=4) according to [ref doc](https://port-buffers.forwardingplane.net/concepts/broadcom-trident3/)

| | SAFETY_MARGIN = 1 | SAFETY_MARGIN = 1.5 |
|---|---|---|
| min_pkt_count | 126 | **188** |
| kmin | 25,600 | **38,400** |
| kmax | 103,168 | **153,856** |
| band (kmax−kmin) | 77,568 B = 303 cells | **115,456 B = 451 cells** |