### PR TITLE
Remove ZMQ golden config override from generate_golden_config_db

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -998,29 +998,6 @@ class GenerateGoldenConfigDBModule(object):
 
         return json.dumps(golden_config_db, indent=4)
 
-    def update_zmq_config(self, config):
-        # for multi asic platform this config is per asic.
-
-        ori_config_db = json.loads(config)
-        rc, out, err = self.module.run_command("sudo cat /usr/local/yang-models/sonic-device_metadata.yang")
-        if "orch_northbond_route_zmq_enabled" in out:
-            if self.num_asics > 1:
-                ori_config_db = self._update_config_db_in_ns(
-                    ori_config_db, "DEVICE_METADATA/localhost",
-                    {"orch_northbond_route_zmq_enabled": "true"}
-                )
-            else:
-                if "DEVICE_METADATA" not in ori_config_db:
-                    ori_config_db["DEVICE_METADATA"] = {}
-                if "localhost" not in ori_config_db["DEVICE_METADATA"]:
-                    ori_config_db["DEVICE_METADATA"]["localhost"] = {}
-                if self.topo_name == "t1-smartswitch-ha":
-                    ori_config_db["DEVICE_METADATA"]["localhost"]["orch_northbond_route_zmq_enabled"] = "false"
-                else:
-                    ori_config_db["DEVICE_METADATA"]["localhost"]["orch_northbond_route_zmq_enabled"] = "true"
-
-        return json.dumps(ori_config_db, indent=4)
-
     def _parse_zebra_nexthop_from_minigraph(self):
         """Parse ZebraNexthop attribute directly from /etc/sonic/minigraph.xml."""
         try:
@@ -1056,7 +1033,7 @@ class GenerateGoldenConfigDBModule(object):
         """
         # Check if the installed YANG schema supports zebra_nexthop before injecting.
         # Older images may lack this leaf, causing load_minigraph --override_config to
-        # fail YANG validation. This mirrors the pattern used in update_zmq_config().
+        # fail YANG validation.
         rc, yang_content, _ = self.module.run_command(
             "sudo cat /usr/local/yang-models/sonic-device_metadata.yang")
         if rc != 0 or "zebra_nexthop" not in yang_content:
@@ -1241,9 +1218,6 @@ class GenerateGoldenConfigDBModule(object):
             module_msg = module_msg + " for c0"
         else:
             config = self.generate_default_init_config_db()
-
-        # update ZMQ config
-        config = self.update_zmq_config(config)
 
         # update dns config
         config = self.update_dns_config(config)


### PR DESCRIPTION
### Description of PR

Summary:
Remove the `update_zmq_config()` function from `generate_golden_config_db.py` that injects `orch_northbond_route_zmq_enabled` into `DEVICE_METADATA|localhost` in the golden config.

The northbound and southbound ZMQ knobs are being consolidated into a single `SYSTEM_DEFAULTS|swss_zmq` knob (sonic-net/sonic-buildimage#27674). This PR removes the golden config override, disabling ZMQ by default. ZMQ will be selectively re-enabled per topology in a follow-up PR once the new schema is deployed.

Depends on: sonic-net/sonic-buildimage#27674, sonic-net/sonic-swss#4630, sonic-net/sonic-sairedis#1922

### Type of change

- [x] Testbed and Framework(new/improvement)

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

The route performance knobs (`orch_northbond_route_zmq_enabled`, `orch_southbound_zmq_enabled`, `route_state_async_publish`, `async_swss_rec`) are being consolidated from individual `DEVICE_METADATA|localhost` fields into flat `SYSTEM_DEFAULTS` table entries. The YANG leaves for these fields are removed from `sonic-device_metadata.yang` in the buildimage PR. Without this change, `generate_golden_config_db.py` injects `orch_northbond_route_zmq_enabled` into the golden config, causing YANG validation failure on images with the leaves removed:

```
/etc/sonic/golden_config_db.json fails YANG validation!
All Keys are not parsed in DEVICE_METADATA
dict_keys(['orch_northbond_route_zmq_enabled'])
```

#### How did you do it?

- Removed `update_zmq_config()` method and its call site
- Cleaned up a stale comment referencing the removed function

#### How did you verify/test it?

- Python syntax validation passes
- The buildimage PR CI (Elastictest) was failing with `DEPLOY_MINIGRAPH_FAILED` due to this YANG validation error — this fix addresses that root cause

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A — infrastructure cleanup, not a new test case.

### Documentation

N/A