### PR TITLE
[lldp] Replace fixed sleep with BGP convergence wait in test_lldp_entry_table_after_syncd_orchagent

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -394,7 +394,14 @@ def test_lldp_entry_table_after_syncd_orchagent(
         duthost.shell("sudo systemctl restart swss")
     assert wait_until(600, 5, 120, duthost.critical_services_fully_started), \
         "Not all critical services are fully started"
-    time.sleep(60)
+    # Wait for BGP sessions to reach Established state instead of a fixed sleep,
+    # to avoid a downstream memory-alarm false positive caused by bgpd warming up
+    # in the next test case.
+    bgp_neighbors = list(duthost.get_bgp_neighbors().keys())
+    pytest_assert(
+        wait_until(300, 10, 30, duthost.check_bgp_session_state, bgp_neighbors),
+        "BGP sessions did not reach Established state after swss restart",
+    )
     # Wait until all interfaces are up and lldp entries are populated
     for interface in lldp_entry_keys:
         result = wait_until(300, 2, 0, verify_lldp_entry, db_instance, [interface])

--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -11,7 +11,6 @@ from tests.common.utilities import (
     group_interfaces_by_asic
 )
 from tests.common.helpers.assertions import pytest_assert
-import time
 
 logger = logging.getLogger(__name__)
 

--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -368,7 +368,12 @@ def test_lldp_entry_table_content(
 
 
 # Test case 2: Verify LLDP_ENTRY_TABLE after restart syncd and orchagent
+# This test deliberately restarts swss/syncd, which cascades to a bgp container
+# restart. The memory_utilization fixture's before/after snapshots become
+# meaningless across such a restart (bgpd RSS drops to ~0 then warms back up),
+# so disable memory monitoring for this test.
 @pytest.mark.disable_loganalyzer
+@pytest.mark.disable_memory_utilization
 def test_lldp_entry_table_after_syncd_orchagent(
     duthosts, enum_rand_one_per_hwsku_frontend_hostname, db_instance
 ):


### PR DESCRIPTION
### Description of PR

Summary:
This PR makes two related fixes to `tests/lldp/test_lldp_syncd.py::test_lldp_entry_table_after_syncd_orchagent`, which deliberately restarts `swss`/`syncd` and cascades to a `bgp` container restart.

#### Commit 1 — Replace `time.sleep(60)` with a BGP convergence wait
After restarting `swss`/`syncd`, the test currently waits a hardcoded `time.sleep(60)` before proceeding. On a DUT with many BGP neighbors (e.g., T1/T2 with 7050CX3), 60 seconds is **not enough** for bgpd to fully re-converge after the cascade restart.

This leaves bgpd in a warming-up state by the time the test ends. The **next test** (e.g. `test_lldp_entry_table_after_cont_flap`) then takes its memory baseline snapshot while bgpd RSS is still low. When bgpd subsequently reaches its normal post-init RSS during the next test, the framework&#39;s memory monitor reports a large increase (e.g. +139 MB &gt; 128 MB threshold) and fails the next test with a **false-positive memory alarm**.

Replace `time.sleep(60)` with `wait_until(duthost.check_bgp_session_state, ...)` so the test deterministically waits for all BGP sessions to reach `Established` state before exiting.

#### Commit 2 — Disable `memory_utilization` check for this test
This test deliberately restarts swss/syncd, which cascades to a `bgp` container restart. The `memory_utilization` fixture takes before/after snapshots that become meaningless across such a restart (bgpd RSS drops to ~0 then warms back up over several minutes), so the in-test memory delta has no signal.

Add `@pytest.mark.disable_memory_utilization` to make the test intent explicit and prevent future framework changes (e.g. alarming on volatility or absolute decreases) from flagging this test on a meaningless measurement. This is consistent with other restart-style tests (e.g. `test_advanced_reboot`, `test_warm_reboot`, `test_container_autorestart`).

ADO: https://msazure.visualstudio.com/One/_workitems/edit/38230412

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?
Observed in plan `6a1b270895e3f84fd1e9ace9` (7050cx3.m1-128.202603 NightlyTest, branch `20260310.11`) on `testbed-bjw3-can-7050c-6`:

- `test_lldp_entry_table_after_syncd_orchagent` restarted swss/syncd (which cascades to bgp container)
- `time.sleep(60)` returned while bgpd RSS was still 67.9 MB (mid-convergence)
- Next test `test_lldp_entry_table_after_cont_flap` took its &#34;before&#34; snapshot: bgpd = 67.9 MB
- 16 minutes later, bgpd had warmed up to its normal 207.1 MB
- Framework reported `+139.2 MB &gt; 128 MB threshold` → ALARM → next test FAILED

`vtysh show memory bgp` (FRR internal allocator counter) showed a consistent 204 MB both before and after the next test — proving bgpd did not actually leak memory. Only `top` RSS appeared to grow because the baseline was taken too early.

#### How did you do it?

**Commit 1 — wait for BGP convergence instead of sleep(60):**
```python
bgp_neighbors = list(duthost.get_bgp_neighbors().keys())
pytest_assert(
    wait_until(300, 10, 30, duthost.check_bgp_session_state, bgp_neighbors),
    &#34;BGP sessions did not reach Established state after swss restart&#34;,
)
```
- Uses existing `duthost.get_bgp_neighbors()` to dynamically fetch the neighbor list (works on all topologies)
- Uses existing `duthost.check_bgp_session_state()` (default expected state = `&#34;established&#34;`)
- Parameters: `timeout=300s`, `interval=10s`, `delay=30s`

**Commit 2 — disable memory check on this test:**
```python
@pytest.mark.disable_loganalyzer
@pytest.mark.disable_memory_utilization     # NEW
def test_lldp_entry_table_after_syncd_orchagent(...):
```

The two changes are complementary:
- **Commit 1** prevents pollution of the next test (wait for BGP convergence before exit)
- **Commit 2** disables the meaningless measurement on this test itself

#### How did you verify/test it?
Logic review against existing helpers (`get_bgp_neighbors`, `check_bgp_session_state`, `wait_until`, `disable_memory_utilization` marker) — all are widely used elsewhere in sonic-mgmt.

Behavior change matrix for Commit 1:
- Healthy fast DUT (T0): exits in ~20–30 s (faster than old 60s sleep)
- Slow DUT (T1 with many neighbors): waits up to 300 s for actual convergence (vs. silently returning after insufficient 60s)

A real run on testbed-bjw3-can-7050c-7 / 7050c-6 will be needed to confirm the next-test memory alarm cascade no longer fires.

#### Any platform specific information?
None — both changes are platform-agnostic. The helpers used are standard sonic-mgmt helpers.

#### Supported testbed topology if it&#39;s a new test case?
N/A — not a new test case. The existing test continues to run on all topologies where it currently runs.

### Documentation
N/A

### Elastic Test Jobs
- testbed-bjw3-can-7050c-7: https://elastictest.org/scheduler/testplan/6a20dc922047c3c4a9f91c7c
- testbed-bjw3-can-7050c-8: https://elastictest.org/scheduler/testplan/6a20dc94729d944bd21c92e0
- testbed-bjw3-can-7050c-11: https://elastictest.org/scheduler/testplan/6a20dc962296f2ad62e47dbc