### PR TITLE
[acl] Fix ACL rule count mismatch on one_vlan_a (single-VLAN) setup

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -1284,7 +1284,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
                     rule_id = 32
                 else:
                     rule_id = 30
-            elif setup["topo"] in ["m0_vlan", "mx"] or setup["vlan_config"] == "two_vlan_a":
+            elif setup["topo"] in ["m0_vlan", "mx"] or setup["vlan_config"] in ["one_vlan_a", "two_vlan_a"]:
                 if ip_version == "ipv6":
                     rule_id = 34 if vlan_name == "Vlan1000" else 36
                 else:
@@ -1317,7 +1317,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
                     rule_id = 33
                 else:
                     rule_id = 31
-            elif setup["topo"] in ["m0_vlan", "mx"] or setup["vlan_config"] == "two_vlan_a":
+            elif setup["topo"] in ["m0_vlan", "mx"] or setup["vlan_config"] in ["one_vlan_a", "two_vlan_a"]:
                 if ip_version == "ipv6":
                     rule_id = 35 if vlan_name == "Vlan1000" else 37
                 else:


### PR DESCRIPTION
### Description of PR
In [tests/acl/test_acl.py], test_dest_ip_match_forwarded and test_dest_ip_match_dropped choose the expected ACL rule_id based on topology and VLAN configuration. The branch that handles VLAN setups previously only matched two_vlan_a:
`elif setup["topo"] in ["m0_vlan", "mx"] or setup["vlan_config"] == "two_vlan_a":`

This PR extends that condition to also include one_vlan_a:
`elif setup["topo"] in ["m0_vlan", "mx"] or setup["vlan_config"] in ["one_vlan_a", "two_vlan_a"]:`

Summary:
Fixes # [(issue)](https://github.com/sonic-net/sonic-mgmt/issues/25086)

### Type of change
- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
On testbeds configured with a single VLAN (vlan_config == "one_vlan_a"), the ACL tests test_dest_ip_match_forwarded and test_dest_ip_match_dropped fail with an "ACL rule count mismatch" error. The DUT is actually forwarding/dropping traffic correctly, but the test computes the wrong expected rule_id and ends up checking the wrong counter, so the test fails for the wrong reason. This PR fixes the test logic so single-VLAN setups are handled correctly.

#### How did you do it?
In [tests/acl/test_acl.py] the branch that selects the expected rule_id for VLAN-based setups previously only matched two_vlan_a:
`elif setup["topo"] in ["m0_vlan", "mx"] or setup["vlan_config"] == "two_vlan_a":`

Extended it to also include one_vlan_a, since single-VLAN setups behave the same as two-VLAN setups for rule_id selection (the choice is keyed off vlan_name):
`elif setup["topo"] in ["m0_vlan", "mx"] or setup["vlan_config"] in ["one_vlan_a", "two_vlan_a"]:`

The same one-line change is applied at both call sites in BaseAclTest (in the test_dest_ip_match_forwarded and test_dest_ip_match_dropped rule-id selection blocks).

#### How did you verify/test it?
Ran tests/acl/test_acl.py on a one_vlan_a testbed: test_dest_ip_match_forwarded and test_dest_ip_match_dropped now pass. Before the fix, both failed with an ACL rule count mismatch.
Ran the same tests on a two_vlan_a testbed to confirm no regression — the selected rule_id is unchanged and the tests still pass.
No other ACL tests are affected since the change only extends an elif condition.

#### Any platform specific information?
No. The change is purely in the test code (tests/acl/test_acl.py) and is not tied to any ASIC, vendor, or platform. It applies anywhere the ACL test runs on a single-VLAN topology.

#### Supported testbed topology if it's a new test case?
N/A
