### PR TITLE
[telemetry]: Fix test_poll_mode_delete DEADLINE_EXCEEDED race in POLL mode

### DIFF
--- a/tests/telemetry/test_telemetry_poll.py
+++ b/tests/telemetry/test_telemetry_poll.py
@@ -142,7 +142,7 @@ def test_poll_mode_delete(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
                               subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=2,
                               xpath="FAKE_APPL_DB_TABLE_0 FAKE_APPL_DB_TABLE_1/fake_key1", target="APPL_DB",
-                              max_sync_count=15, update_count=0, timeout=30, namespace=namespace)
+                              max_sync_count=15, update_count=0, timeout=60, namespace=namespace)
 
     def callback(show_gnmi_out):
         result = str(show_gnmi_out)
@@ -156,7 +156,7 @@ def test_poll_mode_delete(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
     wait_until(5, 1, 0, check_gnmi_cli_running, duthost, ptfhost)
 
     modify_fake_appdb_table(duthost, False, 2, namespace)  # Remove all added tables
-    client_thread.join(30)
+    client_thread.join(60)
 
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)


### PR DESCRIPTION
### Description of PR

Fix the flaky `test_poll_mode_delete` failure where the test reports `broken` with `StatusCode.DEADLINE_EXCEEDED` / "context deadline exceeded" even though the DUT returned **all** expected data (15 sync responses and both delete notifications).

Summary:

The 2nd poll command uses `max_sync_count=15` with `polling_interval=2s`, so the gNMI POLL session needs ~30s — exactly equal to its `timeout=30`. In POLL mode `py_gnmicli.py` only breaks out of the response loop after fetching one **extra** `(N+1)`th response (the `sync_count == max_sync_count` break check sits at the top of `for response in responses`, so the loop must pull the next item before it can break). That `(N+1)`th response arrives at ~`15×2 = 30s`. On slower platforms the gNMI session deadline fires before it is received, so the client exits with `DEADLINE_EXCEEDED` (rc=1); `invoke_py_cli_from_ptf` then fails its `rc == 0` assert and the worker thread re-raises → test `broken`. The delete notifications themselves were already captured earlier in the session, so this is purely an exit-code/timeout race, not a data problem.

This zero-margin configuration was introduced by #23384 (`max_sync_count` 6 → 15) which did not raise the timeout:

| scenario (polling_interval=2)   | (N+1)th resp arrives | timeout | margin       |
|---------------------------------|----------------------|---------|--------------|
| max_sync_count=6 (pre-#23384)   | 7th ≈ 6×2 = 12s      | 30s     | 18s — stable |
| max_sync_count=15 (#23384, now) | 16th ≈ 15×2 = 30s    | 30s     | 0s — race    |
| max_sync_count=15 (this fix)    | 16th ≈ 15×2 = 30s    | 60s     | 30s — stable |

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

Make `test_poll_mode_delete` deterministic on slower platforms. The fix from #23384 (raising `max_sync_count` 6 → 15 to give the server more time to catch the DB delete) accidentally made the session length equal the gNMI `timeout`, turning a "No delete responses" race into a "DEADLINE_EXCEEDED" race.

#### How did you do it?

Keep #23384's larger sync budget (`max_sync_count=15`) but raise the 2nd poll command's `timeout` 30 → 60 (and `client_thread.join` 30 → 60), giving the break-trigger `(N+1)`th response headroom before the deadline. This mirrors the `timeout=60` already used by `test_poll_mode_present_table_delayed_key` in the same module.

#### How did you verify/test it?
Regression test pass

#### Any platform specific information?

