### PR TITLE
Add disable_memory_utilization option for fwutil test cases

### DIFF
--- a/tests/platform_tests/fwutil/test_fwutil.py
+++ b/tests/platform_tests/fwutil/test_fwutil.py
@@ -5,7 +5,8 @@ import json
 from fwutil_common import call_fwutil, show_firmware, upload_platform, find_pattern
 
 pytestmark = [
-    pytest.mark.topology("any")
+    pytest.mark.topology("any"),
+    pytest.mark.disable_memory_utilization
 ]
 
 DEVICES_PATH = "/usr/share/sonic/device"

--- a/tests/platform_tests/fwutil/test_fwutil.py
+++ b/tests/platform_tests/fwutil/test_fwutil.py
@@ -5,8 +5,7 @@ import json
 from fwutil_common import call_fwutil, show_firmware, upload_platform, find_pattern
 
 pytestmark = [
-    pytest.mark.topology("any"),
-    pytest.mark.disable_memory_utilization
+    pytest.mark.topology("any")
 ]
 
 DEVICES_PATH = "/usr/share/sonic/device"
@@ -103,6 +102,7 @@ def test_fwutil_update_bad_config(duthost, component):
     assert found_bad_component
 
 
+@pytest.mark.disable_memory_utilization
 def test_fwutil_install_file(request, duthost, localhost, pdu_controller, component, fw_pkg,
                              ignore_fwutil_expected_dpu_reset_errors):
     """Tests manually installing firmware to a component from a file."""
@@ -115,6 +115,7 @@ def test_fwutil_install_file(request, duthost, localhost, pdu_controller, compon
                 basepath=os.path.join(DEVICES_PATH, duthost.facts['platform']))
 
 
+@pytest.mark.disable_memory_utilization
 def test_fwutil_install_url(request, duthost, localhost, pdu_controller, component, fw_pkg, host_firmware,
                             ignore_fwutil_expected_dpu_reset_errors):
     """Tests manually installing firmware to a component from a URL."""
@@ -127,6 +128,7 @@ def test_fwutil_install_url(request, duthost, localhost, pdu_controller, compone
                 basepath=host_firmware)
 
 
+@pytest.mark.disable_memory_utilization
 def test_fwutil_update_current(request, duthost, localhost, pdu_controller, component, fw_pkg,
                                ignore_fwutil_expected_dpu_reset_errors):
     """Tests updating firmware from current image using fwutil update"""
@@ -138,6 +140,7 @@ def test_fwutil_update_current(request, duthost, localhost, pdu_controller, comp
                 component=component)
 
 
+@pytest.mark.disable_memory_utilization
 def test_fwutil_update_next(request, duthost, localhost, pdu_controller, component, next_image, fw_pkg,
                             ignore_fwutil_expected_dpu_reset_errors):
     """Tests updating firmware from the "next" image using fwutil update"""
@@ -150,7 +153,10 @@ def test_fwutil_update_next(request, duthost, localhost, pdu_controller, compone
                 next_image=next_image)
 
 
-@pytest.mark.parametrize("reboot_type", ["none", "cold"])
+@pytest.mark.parametrize("reboot_type", [
+    "none",
+    pytest.param("cold", marks=pytest.mark.disable_memory_utilization)
+])
 def test_fwutil_auto(request, duthost, localhost, pdu_controller, fw_pkg, reboot_type):
     """Tests fwutil update all command ability to properly select firmware for install based on boot type."""
     call_fwutil(request,


### PR DESCRIPTION
### Description of PR

Summary:Add disable_memory_utilization option for fwutil test cases
The fwutil tests need to reboot the devices and not suitable to compare the memory usage before and after reboot
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
The fwutil tests need to reboot the devices and not suitable to compare the memory usage before and after reboot
#### How did you do it?
add disable_memory_utilization for the fwutil tests
#### How did you verify/test it?
Run the tests
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

