### PR TITLE
[arp] Wait for neighbor MAC ping readiness on VPP

### DIFF
--- a/tests/arp/test_neighbor_mac.py
+++ b/tests/arp/test_neighbor_mac.py
@@ -110,7 +110,7 @@ class TestNeighborMac:
         ptfhost.shell("ifconfig {} hw ether {}".format(self.PTF_HOST_IF, neighborMac))
         ptfhost.shell("ifconfig {} up".format(self.PTF_HOST_IF))
         pytest_assert(
-            wait_until(self.PTF_INTERFACE_READY_TIMEOUT, 1, 0, self.__isPtfInterfaceReady, ptfhost),
+            wait_until(self.PTF_INTERFACE_READY_TIMEOUT, 1, 0, self.__is_ptf_interface_ready, ptfhost),
             "{} is not ready with IP {}/24 after MAC update".format(self.PTF_HOST_IF, self.PTF_HOST_IP)
         )
 
@@ -173,32 +173,32 @@ class TestNeighborMac:
             interfaceIp
         ])
 
-    def __isPtfInterfaceReady(self, ptfhost):
-        linkResult = ptfhost.shell(
+    def __is_ptf_interface_ready(self, ptfhost):
+        link_result = ptfhost.shell(
             "ip -o link show dev {}".format(self.PTF_HOST_IF),
             module_ignore_errors=True
         )
-        addrResult = ptfhost.shell(
+        addr_result = ptfhost.shell(
             "ip -o addr show dev {}".format(self.PTF_HOST_IF),
             module_ignore_errors=True
         )
-        linkOutput = linkResult.get("stdout", "")
-        addrOutput = addrResult.get("stdout", "")
-        isReady = (
-            linkResult.get("rc") == 0 and
-            addrResult.get("rc") == 0 and
-            "state UP" in linkOutput and
-            "LOWER_UP" in linkOutput and
-            "{}/24".format(self.PTF_HOST_IP) in addrOutput
+        link_output = link_result.get("stdout", "")
+        addr_output = addr_result.get("stdout", "")
+        is_ready = (
+            link_result.get("rc") == 0 and
+            addr_result.get("rc") == 0 and
+            "state UP" in link_output and
+            "LOWER_UP" in link_output and
+            "{}/24".format(self.PTF_HOST_IP) in addr_output
         )
-        if not isReady:
+        if not is_ready:
             logger.info(
                 "PTF interface is not ready yet link_rc=%s addr_rc=%s link_output:\n%s\naddr_output:\n%s",
-                linkResult.get("rc"), addrResult.get("rc"), linkOutput, addrOutput
+                link_result.get("rc"), addr_result.get("rc"), link_output, addr_output
             )
-        return isReady
+        return is_ready
 
-    def __pingDutFromPtf(self, ptfhost):
+    def __ping_dut_from_ptf(self, ptfhost):
         return ptfhost.shell(
             "ping {} -c 3 -I {}".format(self.DUT_INTF_IP, self.PTF_HOST_IP),
             module_ignore_errors=True
@@ -223,31 +223,31 @@ class TestNeighborMac:
         """
         duthost = duthosts[rand_one_dut_hostname]
         self.__configureNeighborIp(ptfhost, macIndex)
-        pingResult = {}
-        pingAttempts = 0
+        ping_result = {}
+        ping_attempts = 0
 
-        def pingDut():
-            nonlocal pingAttempts
-            pingAttempts += 1
-            pingResult.clear()
-            pingResult.update(self.__pingDutFromPtf(ptfhost))
-            logger.info("PTF ping attempt %s rc=%s", pingAttempts, pingResult.get("rc"))
-            return pingResult.get("rc") == 0
+        def ping_dut():
+            nonlocal ping_attempts
+            ping_attempts += 1
+            ping_result.clear()
+            ping_result.update(self.__ping_dut_from_ptf(ptfhost))
+            logger.info("PTF ping attempt %s rc=%s", ping_attempts, ping_result.get("rc"))
+            return ping_result.get("rc") == 0
 
         is_vpp = duthost.facts.get("asic_type") == "vpp"
         if is_vpp:
-            pingSucceeded = wait_until(self.PING_RETRY_TIMEOUT, 1, 0, pingDut)
+            ping_succeeded = wait_until(self.PING_RETRY_TIMEOUT, 1, 0, ping_dut)
         else:
-            pingSucceeded = pingDut()
+            ping_succeeded = ping_dut()
 
         pytest_assert(
-            pingSucceeded,
+            ping_succeeded,
             "Failed to ping DUT interface {} from PTF IP {}{}, stdout: {}, stderr: {}".format(
                 self.DUT_INTF_IP,
                 self.PTF_HOST_IP,
                 " within {} seconds".format(self.PING_RETRY_TIMEOUT) if is_vpp else "",
-                pingResult.get("stdout", ""),
-                pingResult.get("stderr", "")
+                ping_result.get("stdout", ""),
+                ping_result.get("stderr", "")
             )
         )
 

--- a/tests/arp/test_neighbor_mac.py
+++ b/tests/arp/test_neighbor_mac.py
@@ -174,19 +174,28 @@ class TestNeighborMac:
         ])
 
     def __isPtfInterfaceReady(self, ptfhost):
-        result = ptfhost.shell(
-            "ip -o link show dev {intf}; ip -o addr show dev {intf}".format(intf=self.PTF_HOST_IF),
+        linkResult = ptfhost.shell(
+            "ip -o link show dev {}".format(self.PTF_HOST_IF),
             module_ignore_errors=True
         )
-        output = result.get("stdout", "")
+        addrResult = ptfhost.shell(
+            "ip -o addr show dev {}".format(self.PTF_HOST_IF),
+            module_ignore_errors=True
+        )
+        linkOutput = linkResult.get("stdout", "")
+        addrOutput = addrResult.get("stdout", "")
         isReady = (
-            result.get("rc") == 0 and
-            "UP" in output and
-            "LOWER_UP" in output and
-            "{}/24".format(self.PTF_HOST_IP) in output
+            linkResult.get("rc") == 0 and
+            addrResult.get("rc") == 0 and
+            "state UP" in linkOutput and
+            "LOWER_UP" in linkOutput and
+            "{}/24".format(self.PTF_HOST_IP) in addrOutput
         )
         if not isReady:
-            logger.info("PTF interface is not ready yet rc=%s output:\n%s", result.get("rc"), output)
+            logger.info(
+                "PTF interface is not ready yet link_rc=%s addr_rc=%s link_output:\n%s\naddr_output:\n%s",
+                linkResult.get("rc"), addrResult.get("rc"), linkOutput, addrOutput
+            )
         return isReady
 
     def __pingDutFromPtf(self, ptfhost):
@@ -204,7 +213,8 @@ class TestNeighborMac:
             the neighbor MAC 2 times.
 
             Args:
-                duthost (AnsibleHost): Device Under Test (DUT)
+                duthosts (AnsibleHost): Device Under Test (DUT) hosts
+                rand_one_dut_hostname (str): selected DUT hostname
                 ptfhost (PTFHost): PTF instance used
                 macIndex (Fixture<int>): Index in the TEST_MAC list
 

--- a/tests/arp/test_neighbor_mac.py
+++ b/tests/arp/test_neighbor_mac.py
@@ -111,7 +111,7 @@ class TestNeighborMac:
         ptfhost.shell("ifconfig {} up".format(self.PTF_HOST_IF))
         pytest_assert(
             wait_until(self.PTF_INTERFACE_READY_TIMEOUT, 1, 0, self.__is_ptf_interface_ready, ptfhost),
-            "{} is not ready with IP {}/24 after MAC update".format(self.PTF_HOST_IF, self.PTF_HOST_IP)
+            "{} is not ready with IP {} after MAC update".format(self.PTF_HOST_IF, self.PTF_HOST_IP)
         )
 
     def __startInterface(self, duthost):

--- a/tests/arp/test_neighbor_mac.py
+++ b/tests/arp/test_neighbor_mac.py
@@ -189,7 +189,7 @@ class TestNeighborMac:
             addr_result.get("rc") == 0 and
             "state UP" in link_output and
             "LOWER_UP" in link_output and
-            "{}/24".format(self.PTF_HOST_IP) in addr_output
+            self.PTF_HOST_IP in addr_output
         )
         if not is_ready:
             logger.info(

--- a/tests/arp/test_neighbor_mac.py
+++ b/tests/arp/test_neighbor_mac.py
@@ -24,6 +24,8 @@ class TestNeighborMac:
     DUT_INTF_IP = "20.0.0.1"
     DUT_INTF_NETMASK = "24"
     TEST_MAC = ["00:c0:ca:c0:1a:05", "00:c0:ca:c0:1a:06"]
+    PTF_INTERFACE_READY_TIMEOUT = 10
+    PING_RETRY_TIMEOUT = 30
 
     @pytest.fixture(scope="module", autouse=True)
     def interfaceConfig(self, duthosts, rand_one_dut_hostname):
@@ -107,6 +109,10 @@ class TestNeighborMac:
         ptfhost.shell("ifconfig {} down".format(self.PTF_HOST_IF))
         ptfhost.shell("ifconfig {} hw ether {}".format(self.PTF_HOST_IF, neighborMac))
         ptfhost.shell("ifconfig {} up".format(self.PTF_HOST_IF))
+        pytest_assert(
+            wait_until(self.PTF_INTERFACE_READY_TIMEOUT, 1, 0, self.__isPtfInterfaceReady, ptfhost),
+            "{} is not ready with IP {}/24 after MAC update".format(self.PTF_HOST_IF, self.PTF_HOST_IP)
+        )
 
     def __startInterface(self, duthost):
         """
@@ -167,8 +173,30 @@ class TestNeighborMac:
             interfaceIp
         ])
 
+    def __isPtfInterfaceReady(self, ptfhost):
+        result = ptfhost.shell(
+            "ip -o link show dev {intf}; ip -o addr show dev {intf}".format(intf=self.PTF_HOST_IF),
+            module_ignore_errors=True
+        )
+        output = result.get("stdout", "")
+        isReady = (
+            result.get("rc") == 0 and
+            "UP" in output and
+            "LOWER_UP" in output and
+            "{}/24".format(self.PTF_HOST_IP) in output
+        )
+        if not isReady:
+            logger.info("PTF interface is not ready yet rc=%s output:\n%s", result.get("rc"), output)
+        return isReady
+
+    def __pingDutFromPtf(self, ptfhost):
+        return ptfhost.shell(
+            "ping {} -c 3 -I {}".format(self.DUT_INTF_IP, self.PTF_HOST_IP),
+            module_ignore_errors=True
+        )
+
     @pytest.fixture(autouse=True)
-    def configureNeighborIpAndPing(self, ptfhost, macIndex):
+    def configureNeighborIpAndPing(self, duthosts, rand_one_dut_hostname, ptfhost, macIndex):
         """
             Configure Neighbor/Interface IP
 
@@ -183,8 +211,35 @@ class TestNeighborMac:
             Returns:
                 None
         """
+        duthost = duthosts[rand_one_dut_hostname]
         self.__configureNeighborIp(ptfhost, macIndex)
-        ptfhost.shell("ping {} -c 3 -I {}".format(self.DUT_INTF_IP, self.PTF_HOST_IP))
+        pingResult = {}
+        pingAttempts = 0
+
+        def pingDut():
+            nonlocal pingAttempts
+            pingAttempts += 1
+            pingResult.clear()
+            pingResult.update(self.__pingDutFromPtf(ptfhost))
+            logger.info("PTF ping attempt %s rc=%s", pingAttempts, pingResult.get("rc"))
+            return pingResult.get("rc") == 0
+
+        is_vpp = duthost.facts.get("asic_type") == "vpp"
+        if is_vpp:
+            pingSucceeded = wait_until(self.PING_RETRY_TIMEOUT, 1, 0, pingDut)
+        else:
+            pingSucceeded = pingDut()
+
+        pytest_assert(
+            pingSucceeded,
+            "Failed to ping DUT interface {} from PTF IP {}{}, stdout: {}, stderr: {}".format(
+                self.DUT_INTF_IP,
+                self.PTF_HOST_IP,
+                " within {} seconds".format(self.PING_RETRY_TIMEOUT) if is_vpp else "",
+                pingResult.get("stdout", ""),
+                pingResult.get("stderr", "")
+            )
+        )
 
         time.sleep(2)
 


### PR DESCRIPTION
Wait for the PTF interface to report UP/LOWER_UP with the configured IP after changing its MAC. Retry the initial PTF-to-DUT ping on VPP to tolerate asynchronous ARP readiness while keeping non-VPP behavior to a single ping.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix flaky `arp/test_neighbor_mac.py` failures on VPP where the initial PTF-to-DUT ping can happen too early after changing the PTF interface MAC.
The test changes the PTF `eth0` MAC, brings the interface back up, then immediately pings the DUT interface IP to trigger neighbor learning. On VPP, this can race with asynchronous datapath/ARP readiness. Debug runs showed the first ping can fail with `Destination Host Unreachable`, while the same ping succeeds after a short wait.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
`arp/test_neighbor_mac.py::TestNeighborMac::testNeighborMac[0]` has been flaky on `t1-lag-vpp`. PTF-side packet capture showed ARP requests were sent immediately after the PTF MAC change, but no ARP reply was received in the initial ping window. A delayed manual retry succeeded, indicating a timing/race issue rather than a permanent datapath failure.

#### How did you do it?
- Wait for the PTF interface to report `state UP`, `LOWER_UP`, and the configured PTF IP after changing its MAC.
- Retry the initial PTF-to-DUT ping for up to 30 seconds only on VPP.
- Keep non-VPP behavior to a single ping.
- Log ping attempt count and return code for visibility.

#### How did you verify/test it?
The following tests got passed in the full regression test:
arp/test_neighbor_mac.py::TestNeighborMac::testNeighborMac[0] PASSED     [ 50%]
arp/test_neighbor_mac.py::TestNeighborMac::testNeighborMac[1] PASSED     [100%]

#### Any platform specific information?
The ping retry is enabled only for VPP (asic_type == "vpp"). Other platforms still execute a single ping after the PTF interface readiness check.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
