### PR TITLE
Enable autorestart when the feature is disabled by previous config reload

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -587,10 +587,12 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
             ] is False and len(v["exited_critical_process"]) > 0
         ]
 
-        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
-        # after config reload, the feature autorestart config is reset,
-        # so, before next test, enable again
-        enable_autorestart(duthost)
+        try:
+            config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+        finally:
+            # After config reload, the feature autorestart config is reset.
+            # Re-enable it even if reload raises, so the next parameter is not affected.
+            enable_autorestart(duthost)
 
         if (duthost.get_facts().get("modular_chassis") and
                 duthost.facts["asic_type"] == "cisco-8000" and


### PR DESCRIPTION
### Description of PR

Summary: Enable autorestart when the feature is disabled by previous config reload
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Currently, if the config reload is failed, the autorestart will be disabled and the enable function never be executed.
#### How did you do it?
add a try finally block to ensure the enable function can always be run
#### How did you verify/test it?
Run the test 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation