### PR TITLE
[snappi-macsec] Fix the dut_sci_id, in_flight_flow_metrics and tgen_frames issue while executing with macsec flag

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1553,7 +1553,7 @@ def __intf_config_macsec(config, port_config_list, duthost, snappi_ports, setup=
             config_facts = facts['ansible_facts']
             int_addrs = list(config_facts['INTERFACE'][peer_port].keys())
             subnet = [ele for ele in int_addrs if "." in ele]
-            if port['port_id'] == 0 and int(subnet[0].split("/")[1]) > int(static_prefix_length):
+            if int(port['port_id']) == 0 and int(subnet[0].split("/")[1]) > int(static_prefix_length):
                 logger.info('Removing existing IP {} from interface {}'.format(subnet[0], port['peer_port']))
                 reconfigure_port = port
                 reconfigure_port['original_subnet'] = subnet[0]
@@ -1584,7 +1584,7 @@ def __intf_config_macsec(config, port_config_list, duthost, snappi_ports, setup=
         all_values = json.load(f)
 
     for port in ports:
-        port_id = port['port_id']
+        port_id = int(port['port_id'])
         dutIp = port['ipGateway']
         tgenIp = port['ipAddress']
         prefix_length = int(port['prefix'])

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1530,9 +1530,15 @@ def __intf_config_macsec(config, port_config_list, duthost, snappi_ports, setup=
     Returns:
         True if we successfully configure the interfaces or False
     """
+    ports = []
+    for port in snappi_ports:
+        if port['peer_device'] == duthost.hostname:
+            ports.append(port)
     if not setup:
-        # Return True when setup=False. The test explicitly will cleanup macsec config.
+        for port in ports:
+            gen_data_flow_dest_ip(port['ipAddress'], duthost, port['peer_port'], port['asic_value'], setup)
         return True
+
     global macsec_enabled_port, macsec_profile_name, reconfigure_port
     ptype = "--snappi_macsec" in sys.argv
     num_of_non_macsec_snappi_devices = 7
@@ -1572,26 +1578,19 @@ def __intf_config_macsec(config, port_config_list, duthost, snappi_ports, setup=
                 pytest_assert(False, "No IP address found for peer port {}".format(peer_port))
             port['ipGateway'], port['prefix'] = subnet[0].split("/")
             port['subnet'] = subnet[0]
-    ports = []
-    for port in snappi_ports:
-        if port['peer_device'] == duthost.hostname:
-            ports.append(port)
-    if ptype:
-        macsec_var_file = os.path.expanduser("../tests/snappi_tests/macsec_profile.json")
-        with open(macsec_var_file, "r") as f:
-            all_values = json.load(f)
+
+    macsec_var_file = os.path.expanduser("../tests/snappi_tests/macsec_profile.json")
+    with open(macsec_var_file, "r") as f:
+        all_values = json.load(f)
+
     for port in ports:
         port_id = port['port_id']
         dutIp = port['ipGateway']
         tgenIp = port['ipAddress']
         prefix_length = int(port['prefix'])
         mac = __gen_mac(port_id+num_of_non_macsec_snappi_devices)
-        if not setup:
-            gen_data_flow_dest_ip(tgenIp, duthost, port['peer_port'], port['asic_value'], setup)
         if setup:
             gen_data_flow_dest_ip(tgenIp, duthost, port['peer_port'], port['asic_value'], setup)
-        if setup is False:
-            continue
         port['intf_config_changed'] = True
         if ptype and port_id == 1:
             device = config.devices.device(name='Device Port {}'.format(port_id))[-1]
@@ -1605,7 +1604,7 @@ def __intf_config_macsec(config, port_config_list, duthost, snappi_ports, setup=
                 if 'profile' in line:
                     profile_name = line.split()[1]
                     logger.info('Removing already configured Macsec profile {}'.format(profile_name))
-                    delete_macsec_profile(port['duthost'], profile_name)
+                    delete_macsec_profile(port['duthost'], port['peer_port'], profile_name)
             macsec_enabled_port = port
             macsec_profile_name = '256_XPN_SCI'
             cipher = all_values[macsec_profile_name]['cipher_suite']
@@ -1870,9 +1869,6 @@ def cleanup_config(duthost_list, snappi_ports):
                                 format(reconfigure_port['asic_value'], reconfigure_port['peer_port'],
                                        reconfigure_port['original_subnet'].split('/')[0],
                                        reconfigure_port['original_subnet'].split('/')[1]))
-            logger.info('Disabling MACsec on {} port {}'.
-                        format(macsec_enabled_port['duthost'].hostname,
-                               macsec_enabled_port['peer_port']))
         logger.info('Disabling MACsec on {} port {}'.
                     format(macsec_enabled_port['duthost'].hostname,
                            macsec_enabled_port['peer_port']))

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1530,6 +1530,9 @@ def __intf_config_macsec(config, port_config_list, duthost, snappi_ports, setup=
     Returns:
         True if we successfully configure the interfaces or False
     """
+    if not setup:
+        # Return True when setup=False. The test explicitly will cleanup macsec config.
+        return True
     global macsec_enabled_port, macsec_profile_name, reconfigure_port
     ptype = "--snappi_macsec" in sys.argv
     num_of_non_macsec_snappi_devices = 7

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1604,7 +1604,7 @@ def __intf_config_macsec(config, port_config_list, duthost, snappi_ports, setup=
                 if 'profile' in line:
                     profile_name = line.split()[1]
                     logger.info('Removing already configured Macsec profile {}'.format(profile_name))
-                    delete_macsec_profile(port['duthost'], port['peer_port'], profile_name)
+                    delete_macsec_profile(port['duthost'], profile_name)
             macsec_enabled_port = port
             macsec_profile_name = '256_XPN_SCI'
             cipher = all_values[macsec_profile_name]['cipher_suite']

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -677,8 +677,12 @@ def run_traffic(duthost,
         dp = ixnet.Topology.find().DeviceGroup.find().Ethernet.find().Mka.find().DelayProtect
         dp.Single(False)
         sci_id = ixnet.Topology.find()[1].DeviceGroup.find()[0].Ethernet.find()[0].StaticMacsec.find()[0].DutSciMac
-        dut_port = snappi_extra_params.base_flow_config["tx_port_config"].peer_port
-        sci_id.Single(duthost.get_dut_iface_mac(dut_port))
+        sci_mac = ''
+        for port in snappi_extra_params.multi_dut_params.multi_dut_ports:
+            if port['port_id'] == 1:
+                sci_mac = port['duthost'].get_dut_iface_mac(port['peer_port'])
+        pytest_assert(sci_mac, "dut_sci_mac not found for the macsec configuration on tgen")
+        sci_id.Single(sci_mac)
         for ti in ixnet.Traffic.TrafficItem.find():
             ti.EnableMacsecEgressOnlyAutoConfig = False
             ti.Tracking.find()[0].TrackBy = []
@@ -821,13 +825,6 @@ def run_traffic(duthost,
                             flow_names.append(fs['Traffic Item'] + "-" + fs['PGID'])
                             tx_frames.append(fs['Tx Frames'])
                             rx_frames.append(fs['Rx Frames'])
-                logger.info("In-flight traffic statistics for flows: {}".format(flow_names))
-                logger.info("In-flight TX frames: {}".format(tx_frames))
-                logger.info("In-flight RX frames: {}".format(rx_frames))
-                in_flight_flow_metrics = fetch_snappi_flow_metrics(api, all_flow_names)
-                flow_names = [metric.name for metric in in_flight_flow_metrics if metric.name in data_flow_names]
-                tx_frames = [metric.frames_tx for metric in in_flight_flow_metrics if metric.name in data_flow_names]
-                rx_frames = [metric.frames_rx for metric in in_flight_flow_metrics if metric.name in data_flow_names]
                 rows = list(zip(flow_names, tx_frames, rx_frames))
                 logger.info(
                     "In-flight traffic statistics for flows:\n%s",
@@ -1384,6 +1381,14 @@ def verify_pause_frame_count_dut(rx_dut,
                               "PFC pause frames should not be transmitted and counted in TX PFC counters")
 
 
+def _int_if_str(v):
+    """
+    Converts string to integer if value is string.
+    No change if value is integer.
+    """
+    return int(v) if isinstance(v, str) else v
+
+
 def verify_tx_frame_count_dut(duthost,
                               api,
                               snappi_extra_params,
@@ -1428,6 +1433,9 @@ def verify_tx_frame_count_dut(duthost,
 
         # Collect metrics from DUT once all flows have stopped
         tx_dut_frames, tx_dut_drop_frames = get_tx_frame_count(duthost, peer_port)
+
+        tgen_tx_frames = _int_if_str(tgen_tx_frames)
+        tx_dut_frames = _int_if_str(tx_dut_frames)
 
         # Verify metrics between TGEN and DUT
         pytest_assert(abs(tgen_tx_frames - tx_dut_frames)/tgen_tx_frames <= tx_frame_count_deviation,
@@ -1477,10 +1485,13 @@ def verify_rx_frame_count_dut(duthost,
                     break
 
         # Collect metrics from DUT once all flows have stopped
-        rx_frames, rx_drop_frames = get_rx_frame_count(duthost, peer_port)
+        rx_dut_frames, rx_drop_frames = get_rx_frame_count(duthost, peer_port)
+
+        tgen_rx_frames = _int_if_str(tgen_rx_frames)
+        rx_dut_frames = _int_if_str(rx_dut_frames)
 
         # Verify metrics between TGEN and DUT
-        pytest_assert(abs(tgen_rx_frames - rx_frames)/tgen_rx_frames <= rx_frame_count_deviation,
+        pytest_assert(abs(tgen_rx_frames - rx_dut_frames)/tgen_rx_frames <= rx_frame_count_deviation,
                       "Additional frames are received outside of deviation. Possible PFC frames are counted.")
         pytest_assert(rx_drop_frames <= rx_drop_frame_count_tol, "No frames should be dropped")
 

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -645,6 +645,113 @@ def check_for_crc_errors(api, snappi_extra_params):
                                 row['CRC Errors'], m_port['peer_port'], m_port['peer_device'], row['Port Name']))
 
 
+def _eth_matches_macsec_port(eth, static_macsec, port):
+    """Return True if an IxNetwork Ethernet/StaticMacsec endpoint matches a MACsec port."""
+    port_id = int(port['port_id'])
+    eth_name = str(eth.Name)
+    if re.match(r'Ethernet Port {}$'.format(port_id), eth_name):
+        return True
+    tgen_ip = port.get('ipAddress')
+    if tgen_ip:
+        try:
+            return static_macsec.SourceIp.Values[0] == tgen_ip
+        except (AttributeError, IndexError, TypeError):
+            pass
+    return False
+
+
+def _configure_macsec_dut_sci_macs(ixnet, multi_dut_ports):
+    """
+    Set DutSciMac on each TGEN MACsec endpoint to the interface MAC of the DUT or
+    line-card that owns the corresponding ingress MACsec port (port_id >= 1).
+    """
+    macsec_ports = [p for p in multi_dut_ports if int(p['port_id']) >= 1]
+    pytest_assert(macsec_ports, "No MACsec ports (port_id >= 1) found for DutSciMac configuration")
+
+    eths = ixnet.Topology.find().DeviceGroup.find().Ethernet.find()
+    for port in macsec_ports:
+        port_id = int(port['port_id'])
+        sci_mac = port['duthost'].get_dut_iface_mac(port['peer_port'])
+        pytest_assert(
+            sci_mac,
+            "dut_sci_mac not found for port_id {} peer_port {} on {}".format(
+                port_id, port['peer_port'], port['duthost'].hostname))
+        matched = False
+        for eth in eths:
+            static_macsec_list = eth.StaticMacsec.find()
+            if not static_macsec_list:
+                continue
+            static_macsec = static_macsec_list[0]
+            if not _eth_matches_macsec_port(eth, static_macsec, port):
+                continue
+            static_macsec.DutSciMac.Single(sci_mac)
+            matched = True
+            logger.info(
+                "Set DutSciMac to %s for port_id %s (%s on %s)",
+                sci_mac, port_id, port['peer_port'], port['duthost'].hostname)
+            break
+        pytest_assert(
+            matched,
+            "No TGEN MACsec endpoint found for port_id {} peer_port {} on {}".format(
+                port_id, port['peer_port'], port['duthost'].hostname))
+
+
+def _log_in_flight_tgen_stats(tgen_stats, data_flow_names):
+    """Log per-flow TX/RX frame counts and throughput from ``tgen_curr_stats`` output."""
+    rows = []
+    for flow_name in data_flow_names:
+        key = flow_name.replace(' ', '_').lower()
+        rows.append([
+            flow_name,
+            tgen_stats.get(key + '_tx_pkts', 'n/a'),
+            tgen_stats.get(key + '_rx_pkts', 'n/a'),
+            tgen_stats.get(key + '_txrate_Gbps', 'n/a'),
+            tgen_stats.get(key + '_rxrate_Gbps', 'n/a'),
+        ])
+    logger.info(
+        "In-flight traffic statistics for flows:\n%s",
+        tabulate(rows, headers=["Flow", "Tx", "Rx", "Tx Gbps", "Rx Gbps"], tablefmt="psql"),
+    )
+
+
+def _capture_in_flight_tgen_stats(api, all_flow_names, ptype):
+    """Sample in-flight TGEN statistics for downstream verification.
+
+    Non-MACsec: Snappi flow metric objects (``.name``, ``.frames_tx``, etc.).
+    MACsec: IxNetwork Flow Statistics rows from ``fetch_flow_metrics_for_macsec``.
+    """
+    if not ptype:
+        return fetch_snappi_flow_metrics(api, all_flow_names)
+    return fetch_flow_metrics_for_macsec(api).Rows
+
+
+def _log_in_flight_stats(api, in_flight_flow_metrics, data_flow_names, ptype, snappi_extra_params):
+    """Log in-flight traffic statistics (format depends on MACsec vs non-MACsec)."""
+    if not ptype:
+        traf_metrics = StatViewAssistant(
+            api._ixnetwork, 'Traffic Item Statistics').Rows
+        log_stats = tgen_curr_stats(traf_metrics, in_flight_flow_metrics, data_flow_names)
+        _log_in_flight_tgen_stats(log_stats, data_flow_names)
+    else:
+        _log_in_flight_macsec_flow_stats(in_flight_flow_metrics, data_flow_names, snappi_extra_params)
+
+
+def _log_in_flight_macsec_flow_stats(in_flight_flow_metrics, data_flow_names, snappi_extra_params):
+    """Log per-flow TX/RX frame counts from in-flight MACsec TGEN flow statistics."""
+    flow_names, tx_frames, rx_frames = [], [], []
+    for fs in in_flight_flow_metrics:
+        if int(fs['PGID']) in snappi_extra_params.flow_name_prio_map.values() and \
+           fs['Rx Port'] == snappi_extra_params.base_flow_config["rx_port_name"]:
+            flow_names.append(fs['Traffic Item'] + "-" + fs['PGID'])
+            tx_frames.append(fs['Tx Frames'])
+            rx_frames.append(fs['Rx Frames'])
+    rows = list(zip(flow_names, tx_frames, rx_frames))
+    logger.info(
+        "In-flight traffic statistics for flows:\n%s",
+        tabulate(rows, headers=["Flow", "Tx", "Rx"], tablefmt="psql"),
+    )
+
+
 def run_traffic(duthost,
                 api,
                 config,
@@ -676,13 +783,8 @@ def run_traffic(duthost,
         ixnet = api._ixnetwork
         dp = ixnet.Topology.find().DeviceGroup.find().Ethernet.find().Mka.find().DelayProtect
         dp.Single(False)
-        sci_id = ixnet.Topology.find()[1].DeviceGroup.find()[0].Ethernet.find()[0].StaticMacsec.find()[0].DutSciMac
-        sci_mac = ''
-        for port in snappi_extra_params.multi_dut_params.multi_dut_ports:
-            if port['port_id'] == 1:
-                sci_mac = port['duthost'].get_dut_iface_mac(port['peer_port'])
-        pytest_assert(sci_mac, "dut_sci_mac not found for the macsec configuration on tgen")
-        sci_id.Single(sci_mac)
+        _configure_macsec_dut_sci_macs(
+            ixnet, snappi_extra_params.multi_dut_params.multi_dut_ports)
         for ti in ixnet.Traffic.TrafficItem.find():
             ti.EnableMacsecEgressOnlyAutoConfig = False
             ti.Tracking.find()[0].TrackBy = []
@@ -805,40 +907,18 @@ def run_traffic(duthost,
 
             if poll_iter == 5:
                 logger.info("Polling TGEN for in-flight traffic statistics...")
-                if not ptype:
-                    in_flight_flow_metrics = fetch_snappi_flow_metrics(api, all_flow_names)
-                    flow_names = [
-                        metric.name for metric in in_flight_flow_metrics if metric.name in data_flow_names
-                    ]
-                    tx_frames = [
-                        metric.frames_tx for metric in in_flight_flow_metrics if metric.name in data_flow_names
-                    ]
-                    rx_frames = [
-                        metric.frames_rx for metric in in_flight_flow_metrics if metric.name in data_flow_names
-                    ]
-                else:
-                    flow_names, tx_frames, rx_frames = [], [], []
-                    in_flight_flow_metrics = fetch_flow_metrics_for_macsec(api).Rows
-                    for fs in in_flight_flow_metrics:
-                        if int(fs['PGID']) in snappi_extra_params.flow_name_prio_map.values() and \
-                           fs['Rx Port'] == snappi_extra_params.base_flow_config["rx_port_name"]:
-                            flow_names.append(fs['Traffic Item'] + "-" + fs['PGID'])
-                            tx_frames.append(fs['Tx Frames'])
-                            rx_frames.append(fs['Rx Frames'])
-                rows = list(zip(flow_names, tx_frames, rx_frames))
-                logger.info(
-                    "In-flight traffic statistics for flows:\n%s",
-                    tabulate(rows, headers=["Flow", "Tx", "Rx"], tablefmt="psql"),
-                    )
+                in_flight_flow_metrics = _capture_in_flight_tgen_stats(
+                    api, all_flow_names, ptype)
+                _log_in_flight_stats(
+                    api, in_flight_flow_metrics, data_flow_names, ptype, snappi_extra_params)
 
         logger.info("DUT polling complete")
     else:
         time.sleep(exp_dur_sec*(2/5))  # no switch polling required, only TGEN polling
         logger.info("Polling TGEN for in-flight traffic statistics...")
-        if not ptype:
-            in_flight_flow_metrics = fetch_snappi_flow_metrics(api, all_flow_names)  # fetch in-flight metrics from TGEN
-        else:
-            in_flight_flow_metrics = fetch_flow_metrics_for_macsec(api).Rows
+        in_flight_flow_metrics = _capture_in_flight_tgen_stats(api, all_flow_names, ptype)
+        _log_in_flight_stats(
+            api, in_flight_flow_metrics, data_flow_names, ptype, snappi_extra_params)
         time.sleep(exp_dur_sec*(3/5))
 
     attempts = 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Following changes are done in the pull-request:
- The dut_sci_id required on tgen side is taken from the first DUT defined in the duthost list and will work if both Rx and Tx ports are on the same DUT. However, it will not work when they are from different DUTs or line-cards.
- The in_flight_flow_metrics is called twice; one for non-macsec and other for macsec case. However, it is called again causing the macsec case to fail.
- The tgen_tx_frames and tgen_rx_frames are strings from macsec. They fail when there is check if loss percentage is less than loss_tolerance level.
- The tgen_port_info function calls setup_dut_port twice. Once with setup=True and in the end again with setup=False. In case of setup=False, the __intf_config_macsec does not check for setup flag and hence will end up reconfiguring macsec again. There is an explicit cleanup_config defined in the test, which will cleanup the MACSEC config.

Summary:
Fixes #25099 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
The pull-request fixes the issues mentioned in the description above.
The fixes will resolve issues seen while running multi-line-card test with macsec enabled on egress port and plain IP on the ingress port.

#### How did you do it?
- DUT_SCI_ID: Checking for port_id == 1 to determine the MACSEC endpoint and using the mac_address of the DUT to configure the dut_sci_id on the tgen.
- in_flight_flow_metrics: Removed the duplicate in_flight_flow_metrics called outside the if-else statement (with and without ptype). 
- tgen_tx_frames and tgen_rx_frames: Create a small function to check if the value is string. If yes, then convert to integer. If not, then simply return the value as is.
- Function __intf_config_macsec with setup == False: Added an implicit code in function to return True when it is called with setup==False flag. The explicit cleanup_config called in the test_script should clean-up the MACSEC configuration on the DUT.

#### How did you verify/test it?
Ran the test manually on local clone.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
