### PR TITLE
gnmi: detect TLS / connection failures in gnmi_set and gnmi_get helpers

### DIFF
--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -18,6 +18,41 @@ GNMI_PORT = 0
 # Wait 15 seconds after starting GNMI server
 GNMI_SERVER_START_WAIT_TIME = 15
 
+# Substrings that indicate py_gnmicli.py failed even though the shell rc may
+# still be 0. py_gnmicli catches several exceptions internally (notably TLS
+# handshake failures from PTF/DUT clock skew) and prints them to stdout before
+# exiting cleanly; without sentinel detection the helpers below would treat
+# those calls as successful and the caller's later assertion would fire with a
+# misleading message (e.g. "CONFIG_DB write didn't take effect" when the Set
+# actually never reached the server).
+_PY_GNMICLI_FAILURE_SENTINELS = (
+    "GRPC error",
+    "rpc error",
+    "Client receives an exception",
+    "indicating gNMI server is shut down",
+    "Tls handshake failed",
+    "CERTIFICATE_VERIFY_FAILED",
+    "certificate is not yet valid",
+)
+
+
+def _py_gnmicli_failure_reason(rc, stdout, stderr):
+    """Return a short reason string if py_gnmicli output indicates a failed
+    RPC, or None if the call looks clean.
+
+    A non-zero rc is always a failure. Otherwise we scan stdout+stderr for
+    the failure sentinels above. Keep this list permissive — masking a real
+    failure as success is far more harmful than the occasional false-positive,
+    because the masked failure surfaces as a confusing assertion later.
+    """
+    if rc != 0:
+        return "rc=%s" % rc
+    combined = "%s\n%s" % (stdout or "", stderr or "")
+    for sentinel in _PY_GNMICLI_FAILURE_SENTINELS:
+        if sentinel in combined:
+            return "output contains %r" % sentinel
+    return None
+
 
 def apply_cert_config(duthost):
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
@@ -268,12 +303,14 @@ def gnmi_set(duthost, ptfhost, delete_list, update_list, replace_list, cert=None
     stdout = output.get("stdout") or ""
     stderr = output.get("stderr") or ""
     rc = output.get("rc", 1)
-    combined = f"{stdout}\n{stderr}"
 
-    if rc != 0 or "GRPC error" in combined or "rpc error" in combined:
+    reason = _py_gnmicli_failure_reason(rc, stdout, stderr)
+    if reason:
         dump_gnmi_log(duthost)
         dump_system_status(duthost)
-        raise Exception(f"py_gnmicli failed rc={rc}\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}")
+        raise Exception(
+            "py_gnmicli failed (%s)\nSTDOUT:\n%s\nSTDERR:\n%s" % (reason, stdout, stderr)
+        )
 
 
 def gnmi_get(duthost, ptfhost, path_list):
@@ -312,6 +349,18 @@ def gnmi_get(duthost, ptfhost, path_list):
         dump_system_status(duthost)
         result = msg.split(error, 1)
         raise Exception("GRPC error:" + result[1])
+    # Detect connection-level / TLS handshake failures that py_gnmicli prints
+    # to stdout while still exiting 0 (most commonly cert-not-yet-valid clock
+    # skew). Without this, a failed handshake reads as an empty response and
+    # the caller's later parsing trips with a misleading error.
+    reason = _py_gnmicli_failure_reason(
+        output.get('rc', 1), output.get('stdout', ''), output.get('stderr', ''))
+    if reason:
+        dump_gnmi_log(duthost)
+        dump_system_status(duthost)
+        raise Exception(
+            "py_gnmicli failed (%s)\nSTDOUT:\n%s\nSTDERR:\n%s"
+            % (reason, output.get('stdout', ''), output.get('stderr', '')))
     mark = 'The GetResponse is below\n' + '-'*25 + '\n'
     if mark in msg:
         result = msg.split(mark, 1)


### PR DESCRIPTION
## What I'm doing and why

`tests/gnmi/helper.py::gnmi_set` and `gnmi_get` invoke `py_gnmicli.py` on the
PTF and currently consider the call successful as long as `rc == 0` and stdout
does **not** contain the literal substring `GRPC error` / `rpc error`.

`py_gnmicli.py` catches a number of exceptions internally — most importantly
TLS handshake failures (e.g. `CERTIFICATE_VERIFY_FAILED: certificate is not
yet valid` from PTF/DUT clock skew) — prints a line like

```
Client receives an exception 'failed to connect to all addresses; last error: ... CERTIFICATE_VERIFY_FAILED: certificate is not yet valid: OK' indicating gNMI server is shut down and Exiting ...
```

to stdout, and exits **0**. Neither sentinel substring is present, so the
helper returns silently and the caller's later parsing trips with a misleading
message — a failing Set surfaces as "CONFIG_DB write didn't take effect",
and a negative-path test surfaces as "Set request with invalid path" — both
hiding the real TLS error from the test owner.

This was uncovered while triaging an internal nightly failure on
`gnmi.test_gnmi_configdb_incremental_01` (Mellanox-SN2700, 20251110): the
test reported "Incremental config failed to toggle interface Ethernet0
status" but the captured pytest log showed py_gnmicli had printed
`CERTIFICATE_VERIFY_FAILED: certificate is not yet valid` immediately before
the FAILED block. The same swallow-the-error mechanism explains a sibling
failure on Cisco-8101 and the matching `incremental_02` negative-path
failures seen on the same runs.

## How

Extracts the failure-detection into a small `_py_gnmicli_failure_reason()`
helper that scans for the union of GRPC/rpc error substrings plus TLS
handshake / cert-validation / "Client receives an exception … gNMI server is
shut down" sentinels. `gnmi_set` and `gnmi_get` both consult it.

Back-compat: the existing `"GRPC error\n"` split path in `gnmi_get` is left
untouched (some callers grep that exception text), and the new sentinel
check fires only after that path doesn't match.

## Sentinel list

```python
_PY_GNMICLI_FAILURE_SENTINELS = (
    "GRPC error",
    "rpc error",
    "Client receives an exception",
    "indicating gNMI server is shut down",
    "Tls handshake failed",
    "CERTIFICATE_VERIFY_FAILED",
    "certificate is not yet valid",
)
```

Permissive on purpose — masking a real failure as success is far more harmful
than the occasional false-positive, because the masked failure surfaces as a
confusing assertion later in the test rather than at the actual gNMI call site.

## Local checks

- `python -m py_compile tests/gnmi/helper.py` ✓
- `flake8 --max-line-length=120 tests/gnmi/helper.py` ✓
