### PR TITLE
[TH6-128] Increase watchdog too_big_timeout value for Nokia-IXR7220-H6-O256

### DIFF
--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -230,3 +230,10 @@ x86_64-nexthop_.*:
     valid_timeout: 10
     greater_timeout: 16777
     too_big_timeout: 16778
+
+# th6-128 Nokia
+x86_64-nokia_ixr7220_h6_128-r0:
+  default:
+    valid_timeout: 30
+    greater_timeout: 170
+    too_big_timeout: 350


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This fixes the _**platform_tests**_ "api.test_watchdog.TestWatchdogApi#test_arm_too_big_timeout" test for Nokia TH6 platform, where watchdog test config defaults to 100 seconds value and throws the following error.

```python
>           pytest_assert(False, err_msg)
E           Failed: test_arm_too_big_timeout: Watchdog should be disarmed, but returned timeout of 100 seconds

err_msg    = 'test_arm_too_big_timeout: Watchdog should be disarmed, but returned timeout of 100 seconds'
self       = <tests.platform_tests.api.test_watchdog.TestWatchdogApi object at 0x7f9498447b00>

platform_tests/api/platform_api_test_base.py:32: Failed
``` 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
_watchdog.yml_ uses the following default parameters for Nokia TH6 _x86_64-nokia_ixr7220_h6_128-r0_ platform and '_too_big_timeout_' has the issue.

```
default:
  valid_timeout: 10     # A valid timeout the watchdog has to accept
  greater_timeout: 20   # A greater timeout value that watchdog has to accept, put None if single timeout value is a watchdog limitation
  too_big_timeout: 100  # A timeout which is too big for HW watchdog, put None if there is no such limitation
``` 

#### How did you do it?

- Increase the timeout from 100 to 350 for this platform, since acceptable timeout values are from 1 to 340.

#### How did you verify/test it?

- Run TestWatchdogApi#test_arm_too_big_timeout test with this new value and made sure test is passing.

#### Any platform specific information?

x86_64-nokia_ixr7220_h6_128-r0

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
