### PR TITLE
[TH6] [Nokia-IXR7220-H6] fan_speed tests fix for supported_speeds in platform.json device file

### DIFF
--- a/tests/common/helpers/platform_api/fan_discrete_speed_helper.py
+++ b/tests/common/helpers/platform_api/fan_discrete_speed_helper.py
@@ -1,0 +1,90 @@
+"""
+Shared helpers for chassis / fan-drawer fan tests on platforms with discrete PWM steps
+from `chassis.fans.supported_speeds` in platform.json (via `duthost.facts`).
+"""
+
+import logging
+import random
+
+from tests.common.helpers.platform_api import fan, fan_drawer_fan
+
+logger = logging.getLogger(__name__)
+
+# Fan - for these SKUs; use `chassis.fans.supported_speeds` in platform.json
+FAN_SPEED_DISCRETE_PLATFORMS = (
+    "x86_64-nokia_ixr7220_h6_128-r0",
+    "x86_64-nokia_ixr7220_h6_64-r0",
+)
+
+
+def fan_speed_uses_platform_discrete_list(duthost):
+    return duthost.facts.get("platform") in FAN_SPEED_DISCRETE_PLATFORMS
+
+
+def parse_supported_speeds_csv(raw, log_ctx):
+    """Parse comma-separated integer speeds from platform.json."""
+    if raw is None:
+        return None
+    text = raw if isinstance(raw, str) else str(raw)
+    out = []
+    for part in text.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            out.append(int(part))
+        except ValueError:
+            logger.warning(
+                "Ignoring non-integer supported_speeds token %r (%s)",
+                part,
+                log_ctx,
+            )
+    return out or None
+
+
+def get_chassis_fans_supported_speeds(duthost):
+    """
+    Read the common discrete fan table from `chassis.fans.supported_speeds` in platform.json (via duthost.facts).
+    """
+    chassis = duthost.facts.get("chassis") or {}
+    fans = chassis.get("fans")
+    if not fans or not isinstance(fans, list):
+        return None
+    for entry in fans:
+        if not isinstance(entry, dict):
+            continue
+        raw = entry.get("supported_speeds")
+        if raw is not None:
+            return parse_supported_speeds_csv(raw, "chassis.fans supported_speeds")
+    return None
+
+
+def pick_initial_discrete_target_speed(num_fans, chassis_speeds, is_controllable, get_smin, get_smax):
+    """
+    Pick one discrete speed using the first controllable fan index for min/max bounds.
+    """
+    if not chassis_speeds:
+        return None
+    for probe in range(num_fans):
+        if not is_controllable(probe):
+            continue
+        smin = get_smin(probe)
+        smax = get_smax(probe)
+        in_range = [s for s in chassis_speeds if smin <= s <= smax]
+        pick_from = in_range if in_range else chassis_speeds
+        return random.choice(pick_from)
+    return None
+
+
+def fan_drawer_speed_within_tolerance(platform_api_conn, j, i):
+    """True when fan-drawer fan speed is within platform API under/over tolerance for target."""
+    under = fan_drawer_fan.is_under_speed(platform_api_conn, j, i)
+    over = fan_drawer_fan.is_over_speed(platform_api_conn, j, i)
+    return not under and not over
+
+
+def chassis_fan_speed_within_tolerance(platform_api_conn, i):
+    """True when chassis fan speed is within platform API under/over tolerance for target."""
+    under = fan.is_under_speed(platform_api_conn, i)
+    over = fan.is_over_speed(platform_api_conn, i)
+    return not under and not over

--- a/tests/platform_tests/api/test_chassis_fans.py
+++ b/tests/platform_tests/api/test_chassis_fans.py
@@ -4,9 +4,16 @@ import time
 import pytest
 
 from tests.common.helpers.platform_api import chassis, fan
+from tests.common.helpers.platform_api.fan_discrete_speed_helper import (
+    chassis_fan_speed_within_tolerance,
+    fan_speed_uses_platform_discrete_list,
+    get_chassis_fans_supported_speeds,
+    pick_initial_discrete_target_speed,
+)
 from .platform_api_test_base import PlatformApiTestBase
 from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service    # noqa: F401
 from tests.common.helpers.thermal_control_test_helper import start_thermal_control_daemon, stop_thermal_control_daemon
+from tests.common.utilities import wait_until
 
 ###################################################
 # TODO: Remove this after we transition to Python 3
@@ -190,10 +197,26 @@ class TestChassisFans(PlatformApiTestBase):
                                    localhost, platform_api_conn):   # noqa: F811
 
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        use_discrete = fan_speed_uses_platform_discrete_list(duthost)
+        chassis_discrete_speeds = get_chassis_fans_supported_speeds(duthost) if use_discrete else None
         fans_skipped = 0
 
         for i in range(self.num_fans):
-            speed_target_val = 25
+            if use_discrete:
+                speed_target_val = pick_initial_discrete_target_speed(
+                    self.num_fans,
+                    chassis_discrete_speeds,
+                    lambda p: self.get_fan_facts(duthost, p, True, "speed", "controllable"),
+                    lambda p: self.get_fan_facts(duthost, p, 1, "speed", "minimum"),
+                    lambda p: self.get_fan_facts(duthost, p, 100, "speed", "maximum"),
+                )
+                if speed_target_val is None:
+                    pytest.fail(
+                        "Chassis fans: no controllable fan for discrete speed pick (platform {})".format(
+                            duthost.facts.get("platform"))
+                    )
+            else:
+                speed_target_val = 25
             speed_controllable = self.get_fan_facts(duthost, i, True, "speed", "controllable")
             if not speed_controllable:
                 logger.info("test_get_fans_target_speed: Skipping chassis fan {} (speed not controllable)"
@@ -204,7 +227,8 @@ class TestChassisFans(PlatformApiTestBase):
             speed_minimum = self.get_fan_facts(duthost, i, 25, "speed", "minimum")
             speed_maximum = self.get_fan_facts(duthost, i, 100, "speed", "maximum")
             if speed_minimum > speed_target_val or speed_maximum < speed_target_val:
-                speed_target_val = random.randint(speed_minimum, speed_maximum)
+                speed_target_val = self.get_fan_facts(duthost, i, random.randint(speed_minimum, speed_maximum),
+                                                      "speed", "default")
 
             speed_set = fan.set_speed(platform_api_conn, i, speed_target_val)       # noqa F841
             # For x3b platform fan, the corresponding kernel driver (Max31790) ramps up the duty cycle to new value
@@ -234,8 +258,29 @@ class TestChassisFans(PlatformApiTestBase):
 
         fans_skipped = 0
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        use_discrete = fan_speed_uses_platform_discrete_list(duthost)
+        chassis_discrete_speeds = get_chassis_fans_supported_speeds(duthost) if use_discrete else None
+        if use_discrete and not chassis_discrete_speeds:
+            pytest.fail(
+                "Discrete fan speed platforms require a `supported_speeds` field on an entry under "
+                "`chassis.fans` in platform.json (platform {})".format(duthost.facts.get("platform"))
+            )
+
         if duthost.facts["asic_type"] in ["cisco-8000"]:
             target_speed = random.randint(40, 60)
+        elif use_discrete:
+            target_speed = pick_initial_discrete_target_speed(
+                self.num_fans,
+                chassis_discrete_speeds,
+                lambda p: self.get_fan_facts(duthost, p, True, "speed", "controllable"),
+                lambda p: self.get_fan_facts(duthost, p, 1, "speed", "minimum"),
+                lambda p: self.get_fan_facts(duthost, p, 100, "speed", "maximum"),
+            )
+            if target_speed is None:
+                pytest.fail(
+                    "Chassis fans: no controllable fan for discrete speed pick (platform {})".format(
+                        duthost.facts.get("platform"))
+                )
         else:
             target_speed = random.randint(1, 100)
 
@@ -248,24 +293,48 @@ class TestChassisFans(PlatformApiTestBase):
 
             speed_minimum = self.get_fan_facts(duthost, i, 1, "speed", "minimum")
             speed_maximum = self.get_fan_facts(duthost, i, 100, "speed", "maximum")
-            if speed_minimum > target_speed or speed_maximum < target_speed:
-                target_speed = random.randint(speed_minimum, speed_maximum)
+            if use_discrete:
+                in_range = [s for s in chassis_discrete_speeds if speed_minimum <= s <= speed_maximum]
+                pick_from = in_range if in_range else chassis_discrete_speeds
+                if target_speed not in pick_from:
+                    target_speed = random.choice(pick_from)
+            else:
+                if speed_minimum > target_speed or speed_maximum < target_speed:
+                    target_speed = random.randint(speed_minimum, speed_maximum)
 
             speed = fan.get_speed(platform_api_conn, i)
             speed_delta = abs(speed-target_speed)
 
             speed_set = fan.set_speed(platform_api_conn, i, target_speed)       # noqa: F841
-            time_wait = 10 if speed_delta > 40 else 5
-            time.sleep(self.get_fan_facts(duthost, i, time_wait, "speed", "delay"))
+            if use_discrete:
+                settled = wait_until(
+                    10, 2, 0,
+                    chassis_fan_speed_within_tolerance,
+                    platform_api_conn, i,
+                )
+                act_speed = fan.get_speed(platform_api_conn, i)
+                self.expect(
+                    settled,
+                    "Chassis fan {} speed change from {} to {} did not settle within tolerance "
+                    "within 10s (2s poll), actual speed {}".format(i, speed, target_speed, act_speed),
+                )
+            else:
+                time_wait = 10 if speed_delta > 40 else 5
+                time.sleep(self.get_fan_facts(duthost, i, time_wait, "speed", "delay"))
 
-            act_speed = fan.get_speed(platform_api_conn, i)
-            under_speed = fan.is_under_speed(platform_api_conn, i)
-            over_speed = fan.is_over_speed(platform_api_conn, i)
-            self.expect(not under_speed and not over_speed,
-                        "Fan {} speed change from {} to {} is not within tolerance, actual speed {}"
-                        .format(i, speed, target_speed, act_speed))
+                act_speed = fan.get_speed(platform_api_conn, i)
+                under_speed = fan.is_under_speed(platform_api_conn, i)
+                over_speed = fan.is_over_speed(platform_api_conn, i)
+                self.expect(not under_speed and not over_speed,
+                            "Fan {} speed change from {} to {} is not within tolerance, actual speed {}"
+                            .format(i, speed, target_speed, act_speed))
 
         if fans_skipped == self.num_fans:
+            if use_discrete:
+                pytest.skip(
+                    "skipped as every chassis fan was skipped (not controllable, or no controllable fan "
+                    "for discrete speed pick)"
+                )
             pytest.skip("skipped as all chassis fans' speed is not controllable")
 
         self.assert_expectations()

--- a/tests/platform_tests/api/test_fan_drawer_fans.py
+++ b/tests/platform_tests/api/test_fan_drawer_fans.py
@@ -5,7 +5,14 @@ import time
 import pytest
 
 from tests.common.helpers.platform_api import chassis, fan_drawer, fan_drawer_fan
+from tests.common.helpers.platform_api.fan_discrete_speed_helper import (
+    fan_drawer_speed_within_tolerance,
+    fan_speed_uses_platform_discrete_list,
+    get_chassis_fans_supported_speeds,
+    pick_initial_discrete_target_speed,
+)
 from tests.common.helpers.thermal_control_test_helper import start_thermal_control_daemon, stop_thermal_control_daemon
+from tests.common.utilities import wait_until
 from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service    # noqa: F401
 from .platform_api_test_base import PlatformApiTestBase
 
@@ -243,6 +250,8 @@ class TestFanDrawerFans(PlatformApiTestBase):
                                    platform_api_conn, suspend_and_resume_hw_tc_on_mellanox_device):        # noqa: F811
 
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        use_discrete = fan_speed_uses_platform_discrete_list(duthost)
+        chassis_discrete_speeds = get_chassis_fans_supported_speeds(duthost) if use_discrete else None
         fan_drawers_skipped = 0
 
         for j in range(self.num_fan_drawers):
@@ -250,7 +259,21 @@ class TestFanDrawerFans(PlatformApiTestBase):
             fans_skipped = 0
 
             for i in range(num_fans):
-                speed_target_val = 25
+                if use_discrete:
+                    speed_target_val = pick_initial_discrete_target_speed(
+                        num_fans,
+                        chassis_discrete_speeds,
+                        lambda p: self.get_fan_facts(duthost, j, p, True, "speed", "controllable"),
+                        lambda p: self.get_fan_facts(duthost, j, p, 1, "speed", "minimum"),
+                        lambda p: self.get_fan_facts(duthost, j, p, 100, "speed", "maximum"),
+                    )
+                    if speed_target_val is None:
+                        pytest.fail(
+                            "Chassis fans: no controllable fan for discrete speed pick (platform {})".format(
+                                duthost.facts.get("platform"))
+                        )
+                else:
+                    speed_target_val = 25
                 speed_controllable = self.get_fan_facts(duthost, j, i, True, "speed", "controllable")
                 if not speed_controllable:
                     logger.info("test_get_fans_target_speed: Skipping fandrawer {} fan {} (speed not controllable)"
@@ -261,7 +284,8 @@ class TestFanDrawerFans(PlatformApiTestBase):
                 speed_minimum = self.get_fan_facts(duthost, j, i, 25, "speed", "minimum")
                 speed_maximum = self.get_fan_facts(duthost, j, i, 100, "speed", "maximum")
                 if speed_minimum > speed_target_val or speed_maximum < speed_target_val:
-                    speed_target_val = random.randint(speed_minimum, speed_maximum)
+                    speed_target_val = self.get_fan_facts(duthost, j, i, random.randint(speed_minimum, speed_maximum),
+                                                          "speed", "default")
 
                 speed_set = fan_drawer_fan.set_speed(platform_api_conn, j, i, speed_target_val)     # noqa F841
                 # For x3b platform fan, the corresponding kernel driver (Max31790) ramps up the duty cycle to new value
@@ -297,11 +321,33 @@ class TestFanDrawerFans(PlatformApiTestBase):
 
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         fan_drawers_skipped = 0
+        use_discrete = fan_speed_uses_platform_discrete_list(duthost)
+        chassis_discrete_speeds = get_chassis_fans_supported_speeds(duthost) if use_discrete else None
+        if use_discrete and not chassis_discrete_speeds:
+            pytest.fail(
+                "Discrete fan speed platforms require a `supported_speeds` field on an entry under "
+                "`chassis.fans` in platform.json (platform {})".format(duthost.facts.get("platform"))
+            )
 
         for j in range(self.num_fan_drawers):
-            target_speed = random.randint(1, 100)
             num_fans = fan_drawer.get_num_fans(platform_api_conn, j)
             fans_skipped = 0
+
+            if use_discrete:
+                target_speed = pick_initial_discrete_target_speed(
+                    num_fans,
+                    chassis_discrete_speeds,
+                    lambda p: self.get_fan_facts(duthost, j, p, True, "speed", "controllable"),
+                    lambda p: self.get_fan_facts(duthost, j, p, 1, "speed", "minimum"),
+                    lambda p: self.get_fan_facts(duthost, j, p, 100, "speed", "maximum"),
+                )
+                if target_speed is None:
+                    pytest.fail(
+                        "Fan drawer {}: no controllable fan for discrete speed pick (platform {})".format(
+                            j, duthost.facts.get("platform"))
+                    )
+            else:
+                target_speed = random.randint(1, 100)
 
             for i in range(num_fans):
                 speed_controllable = self.get_fan_facts(duthost, j, i, True, "speed", "controllable")
@@ -313,27 +359,52 @@ class TestFanDrawerFans(PlatformApiTestBase):
 
                 speed_minimum = self.get_fan_facts(duthost, j, i, 1, "speed", "minimum")
                 speed_maximum = self.get_fan_facts(duthost, j, i, 100, "speed", "maximum")
-                if speed_minimum > target_speed or speed_maximum < target_speed:
-                    target_speed = random.randint(speed_minimum, speed_maximum)
+                if use_discrete:
+                    in_range = [s for s in chassis_discrete_speeds if speed_minimum <= s <= speed_maximum]
+                    pick_from = in_range if in_range else chassis_discrete_speeds
+                    if target_speed not in pick_from:
+                        target_speed = random.choice(pick_from)
+                else:
+                    if speed_minimum > target_speed or speed_maximum < target_speed:
+                        target_speed = random.randint(speed_minimum, speed_maximum)
 
                 speed = fan_drawer_fan.get_speed(platform_api_conn, j, i)
                 speed_delta = abs(speed-target_speed)
 
                 speed_set = fan_drawer_fan.set_speed(platform_api_conn, j, i, target_speed)     # noqa: F841
-                time_wait = 10 if speed_delta > 40 else 5
-                time.sleep(self.get_fan_facts(duthost, j, i, time_wait, "speed", "delay"))
+                if use_discrete:
+                    # Large steps can take longer than a fixed sleep; poll tolerance.
+                    settled = wait_until(
+                        10, 2, 0,
+                        fan_drawer_speed_within_tolerance,
+                        platform_api_conn, j, i,
+                    )
+                    act_speed = fan_drawer_fan.get_speed(platform_api_conn, j, i)
+                    self.expect(
+                        settled,
+                        "Fan drawer {} fan {} speed change from {} to {} did not settle within tolerance "
+                        "within 10s (2s poll), actual speed {}".format(j, i, speed, target_speed, act_speed),
+                    )
+                else:
+                    time_wait = 10 if speed_delta > 40 else 5
+                    time.sleep(self.get_fan_facts(duthost, j, i, time_wait, "speed", "delay"))
 
-                act_speed = fan_drawer_fan.get_speed(platform_api_conn, j, i)
-                under_speed = fan_drawer_fan.is_under_speed(platform_api_conn, j, i)
-                over_speed = fan_drawer_fan.is_over_speed(platform_api_conn, j, i)
-                self.expect(not under_speed and not over_speed,
-                            "Fan drawer {} fan {} speed change from {} to {} is not within tolerance, actual speed {}"
-                            .format(j, i, speed, target_speed, act_speed))
+                    act_speed = fan_drawer_fan.get_speed(platform_api_conn, j, i)
+                    under_speed = fan_drawer_fan.is_under_speed(platform_api_conn, j, i)
+                    over_speed = fan_drawer_fan.is_over_speed(platform_api_conn, j, i)
+                    self.expect(not under_speed and not over_speed,
+                                "Fan drawer {} fan {} speed change from {} to {} is not within tolerance, "
+                                "actual speed {}".format(j, i, speed, target_speed, act_speed))
 
             if fans_skipped == num_fans:
                 fan_drawers_skipped += 1
 
         if fan_drawers_skipped == self.num_fan_drawers:
+            if use_discrete:
+                pytest.skip(
+                    "skipped as every fan drawer fan was skipped (not controllable, or no controllable fan "
+                    "in a drawer for discrete speed pick)"
+                )
             pytest.skip("skipped as all fandrawer fans' speed is not controllable")
 
         self.assert_expectations()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR fixes the following fan speed related tests issues under **_test_chassis_fans_** and **_test_fan_drawer_fans_** test suites for _Nokia-IXR7220-H6-O256_ and _Nokia-IXR7220-H6-64_.

- _test_get_fans_target_speed_
- _test_set_fans_speed_

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

- For _Nokia-IXR7220-H6-O256_ and _Nokia-IXR7220-H6-64_, _test_get_fans_target_speed_ and _test_set_fans_speed_ tests of **_test_chassis_fans_** and **_test_fan_drawer_fans_** test suites are failing with the following errors. For example,

```python
>           pytest_assert(False, err_msg)
E           Failed: Fan drawer 0 fan 1 speed change from 62 to 26 is not within tolerance, actual speed 31, Fan drawer 3 fan 1 speed change from 63 to 26 is not within tolerance, actual speed 31, Fan drawer 5 fan 0 speed change from 63 to 6 is not within tolerance, actual speed 31, Fan drawer 5 fan 1 speed change from 62 to 6 is not within tolerance, actual speed 32, Fan drawer 7 fan 0 speed change from 62 to 13 is not within tolerance, actual speed 31, Fan drawer 7 fan 1 speed change from 63 to 6 is not within tolerance, actual speed 32

err_msg    = 'Fan drawer 0 fan 1 speed change from 62 to 26 is not within tolerance, actual speed 31, Fan drawer 3 fan 1 speed chan...thin tolerance, actual speed 31, Fan drawer 7 fan 1 speed change from 63 to 6 is not within tolerance, actual speed 32'
self       = <tests.platform_tests.api.test_fan_drawer_fans.TestFanDrawerFans object at 0x7fd5dd2efec0>

platform_tests/api/platform_api_test_base.py:32: Failed
``` 

- The test picks a random integer (1-100), sets it, and then verifies is_under_speed() and is_over_speed() for _test_set_fans_speed_
- Similarly, the test_get_fans_target_speed sets speed to default min and immediately reads back get_target_speed()

#### How did you do it?

- For these _Nokia-IXR7220-H6-O256_ and _Nokia-IXR7220-H6-64_ supported speeds are introduced in platform.json device files as part of PR#[27249](https://github.com/sonic-net/sonic-buildimage/pull/27249/)
- Modify tests to use these supported speeds for these platforms and for other platforms, use the existing path.

#### How did you verify/test it?

- Ran all the speed related tests on H6-128 DUT and made sure all tests are passing as expected.

#### Any platform specific information?

- HWSkU - _Nokia-IXR7220-H6-O256_ and _Nokia-IXR7220-H6-64_

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
<img width="882" height="791" alt="image" src="https://github.com/user-attachments/assets/cd8e91ba-5ec4-40ab-9912-2cecd5a4b97c" />
