### PR TITLE
[devutil]: avoid extra_vars leak when pinning localhost python interpreter

### DIFF
--- a/ansible/devutil/devices/factory.py
+++ b/ansible/devutil/devices/factory.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import sys
 import yaml
 
 from .ansible_hosts import AnsibleHost
@@ -15,14 +16,63 @@ _self_dir = os.path.dirname(os.path.abspath(__file__))
 ansible_path = os.path.realpath(os.path.join(_self_dir, "../../"))
 
 
+def _resolve_localhost_python_interpreter():
+    """Return a python interpreter that has the sonic-mgmt dependencies
+    (PyYAML, ansible, etc.) available on the controller.
+
+    Historically the localhost interpreter was hardcoded to
+    ``/usr/bin/python3``. The new ``docker-sonic-mgmt`` image installs every
+    dependency into a uv-managed venv at ``/opt/venv`` and leaves
+    ``/usr/bin/python3`` bare; calling ansible modules on localhost via the
+    bare system python then fails with
+    ``ModuleNotFoundError: No module named 'yaml'``.
+
+    Resolution order:
+      1. ``LOCALHOST_PYTHON_INTERPRETER`` env override.
+      2. ``sys.executable`` -- the interpreter actually running this code,
+         which by definition has our deps.
+      3. ``/usr/bin/python3`` legacy fallback.
+    """
+    override = os.environ.get("LOCALHOST_PYTHON_INTERPRETER")
+    if override:
+        return override
+    if sys.executable and os.path.exists(sys.executable):
+        return sys.executable
+    return "/usr/bin/python3"
+
+
 def init_localhost(inventories=None, options={}, hostvars={}):
     try:
-        return AnsibleHost(inventories, "localhost", options=options.copy(), hostvars=hostvars.copy())
+        ah = AnsibleHost(inventories, "localhost", options=options.copy(), hostvars=hostvars.copy())
     except (NoAnsibleHostError, MultipleAnsibleHostsError) as e:
         logger.error(
             "Failed to initialize localhost from inventories '{}', exception: {}".format(str(inventories), repr(e))
         )
         return None
+
+    # Pin ansible_python_interpreter for localhost only, by setting it as a
+    # host-level variable on the inventory Host object.
+    #
+    # We deliberately do NOT pass this through the ``hostvars`` kwarg of
+    # AnsibleHost: that path lands in ``VariableManager.extra_vars`` (see
+    # ``AnsibleHostsBase.__init__``), and ansible-core's
+    # ``ansible.utils.vars.load_extra_vars`` caches its return dict on the
+    # function object. Every VariableManager constructed afterwards in the
+    # same process shares the same ``_extra_vars`` dict, so a mutation here
+    # would leak ``ansible_python_interpreter`` to every subsequent play --
+    # including ones targeting real DUTs that do not have the controller's
+    # interpreter path. extra_vars also have the highest precedence in
+    # ansible, so they would override the DUTs' inventory/group vars.
+    interpreter = _resolve_localhost_python_interpreter()
+    try:
+        for h in ah.im.get_hosts("localhost"):
+            h.set_variable("ansible_python_interpreter", interpreter)
+    except Exception as e:
+        logger.warning(
+            "Failed to pin ansible_python_interpreter='{}' on localhost: {}".format(interpreter, repr(e))
+        )
+
+    return ah
 
 
 def init_host(inventories, host_pattern, options={}, hostvars={}):

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4162,16 +4162,6 @@ portstat/test_portstat.py:
 #######################################
 #####     process_monitoring      #####
 #######################################
-process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical_processes:
-  xfail:
-    reason: "Testcase ignored due to issue: https://github.com/sonic-net/sonic-buildimage/issues/10336"
-    conditions:
-      - "https://github.com/sonic-net/sonic-buildimage/issues/10336"
-  skip:
-    reason: "Skip test on VS due to issue: https://github.com/sonic-net/sonic-buildimage/issues/10336"
-    conditions:
-      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-buildimage/issues/10336"
-
 process_monitoring/test_critical_process_monitoring.py::test_orchagent_heartbeat:
   skip:
     reason: This test is intended for Orchagent freeze scenario during warm-reboot. It is not required for T1 devices, and not supported on 202412 release.

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -597,7 +597,7 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
 
         # Check if this is a virtual switch (KVM) testbed (no PDU available)
         if is_vs_device(duthost):
-            num_asics = duthost.facts.get("num_asics", 1)
+            num_asics = duthost.facts.get("num_asic", 1)
             if num_asics > 1:
                 # Multi-ASIC VS: after killing the global database container, SSH
                 # becomes unresponsive (sshd depends on the global namespace database).
@@ -670,7 +670,7 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
         # (/var/run/redis{N}/sonic-db/).  All of them must be present before
         # "config reload" can run successfully.
         db_config_files = ["/var/run/redis/sonic-db/database_config.json"]
-        num_asics = duthost.facts.get("num_asics", 1)
+        num_asics = duthost.facts.get("num_asic", 1)
         if num_asics > 1:
             for asic_idx in range(num_asics):
                 db_config_files.append(
@@ -812,7 +812,7 @@ def test_monitoring_critical_processes(
             # unresponsive after killing the global database container.  On
             # single-ASIC VS, SSH stays alive and the fixture issues the reboot
             # directly via the "sleep 2" path (so no pre-scheduling needed there).
-            if is_vs_device(duthost) and duthost.facts.get("num_asics", 1) > 1:
+            if is_vs_device(duthost) and duthost.facts.get("num_asic", 1) > 1:
                 reboot_delay = 120  # seconds -- generous to allow per-ASIC kills to finish
                 duthost.shell(
                     'nohup bash -c "sleep {d} && echo 1 > /proc/sys/kernel/sysrq '

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -10,7 +10,8 @@ import pytest
 
 from pkg_resources import parse_version
 from tests.common import config_reload
-from tests.common.constants import KVM_PLATFORM
+from tests.common.vs_data import is_vs_device
+
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
 from tests.common.reboot import wait_for_startup
@@ -596,10 +597,8 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
     if is_testing_database:
         logger.info("Database container was tested - performing power cycle...")
 
-        # Check if this is a KVM testbed (no PDU available)
-        is_kvm = duthost.facts.get('platform') == KVM_PLATFORM
-
-        if is_kvm:
+        # Check if this is a virtual switch (KVM) testbed (no PDU available)
+        if is_vs_device(duthost):
             # For KVM testbed, use kernel-level reboot since config DB is corrupted
             # and normal reboot commands won't work
             logger.info("KVM testbed detected - using kernel SysRq trigger for immediate reboot...")
@@ -728,8 +727,8 @@ def test_monitoring_critical_processes(
     stop_critical_processes(duthost, non_database_containers)
 
     wait_time = 70
-    # For KVM DUT, there's a delay(~25s) that syncd process raises SIGKILL signal after been killed
-    if duthost.facts['platform'] == KVM_PLATFORM:
+    # For VS (KVM) DUT, there's a delay(~25s) that syncd process raises SIGKILL signal after been killed
+    if is_vs_device(duthost):
         wait_time = 90
 
     # Wait for sometime such that Supervisord/Monit has a chance to write alerting message into syslog.

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -3,6 +3,7 @@ Test the feature of monitoring critical processes on 20191130 image (Monit),
 202012 and newer images (Supervisor)
 """
 from collections import defaultdict
+import re
 import time
 import logging
 
@@ -32,6 +33,12 @@ CONTAINER_CHECK_INTERVAL_SECS = 1
 CONTAINER_RESTART_THRESHOLD_SECS = 180
 POST_CHECK_INTERVAL_SECS = 1
 POST_CHECK_THRESHOLD_SECS = 600
+
+# Delay (seconds) between issuing the SysRq kernel reboot and when it fires.
+# Used on multi-ASIC VS: the reboot is scheduled just before the global DB
+# kill so that SSH is still alive when the nohup command is issued, but the
+# kernel reboot fires shortly after the global DB container is stopped.
+MULTI_ASIC_VS_REBOOT_DELAY_SEC = 15
 
 # Critical processes that are listed in the image's per-container critical_processes
 # file but are not actually runnable on BMC topology (BMC image runs a reduced set
@@ -648,7 +655,7 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
         # Get timeout values based on chassis type
         timeout = 300
         wait_time = 120
-        if duthost.get_facts().get("modular_chassis"):
+        if duthost.facts.get("modular_chassis"):
             wait_time = max(wait_time, 600)
             timeout = max(timeout, 420)
 
@@ -661,7 +668,7 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
         # Wait for database_config.json first, then use config_reload for a clean
         # recovery that also waits for BGP sessions to re-establish.
         db_config_timeout = 120
-        if duthost.get_facts().get("modular_chassis"):
+        if duthost.facts.get("modular_chassis"):
             db_config_timeout = max(db_config_timeout, 600)
 
         # Build list of database_config.json files to wait for.
@@ -689,8 +696,8 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
 
         db_config_ready = wait_until(db_config_timeout, 5, 0, _all_db_configs_ready)
         if not db_config_ready:
-            pytest_assert(False,
-                          "database_config.json not ready after %ds -- DUT recovery incomplete" % db_config_timeout)
+            # Fail fast here to protect subsequent tests from a sick DUT.
+            pytest.fail("database_config.json not ready after %ds -- DUT recovery incomplete" % db_config_timeout)
 
         logger.info("Database config ready, performing config reload for clean recovery...")
         config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
@@ -751,8 +758,10 @@ def test_monitoring_critical_processes(
     #   Phase 1 - kill non-database processes, wait, verify syslog alerts
     #   Phase 2 - kill database processes last; the recover_critical_processes
     #             fixture handles DUT recovery via reboot
-    database_containers = {k: v for k, v in containers_in_namespaces.items() if k.startswith("database")}
-    non_database_containers = {k: v for k, v in containers_in_namespaces.items() if not k.startswith("database")}
+    database_containers = {k: v for k, v in containers_in_namespaces.items()
+                           if re.fullmatch(r"database(\d+)?", k)}
+    non_database_containers = {k: v for k, v in containers_in_namespaces.items()
+                               if not re.fullmatch(r"database(\d+)?", k)}
 
     # Generate expected alerting messages only for non-database containers.
     # Database alerting cannot be reliably verified via syslog because killing
@@ -786,45 +795,66 @@ def test_monitoring_critical_processes(
     # unstable after this, so no further syslog verification is performed.
     # Recovery strategy differs by topology:
     #   - Multi-ASIC VS: SSH hangs after killing global database, so a SysRq
-    #     reboot is pre-scheduled HERE (while SSH is still alive).  The fixture
-    #     waits for that scheduled reboot.
+    #     reboot is scheduled just before the global-DB kill (while SSH is still
+    #     alive).  The fixture waits for that scheduled reboot.
     #   - Single-ASIC VS: SSH stays alive after killing global database, so
     #     the fixture issues a 2-second SysRq reboot directly.
     #   - Physical: fixture uses PDU power-cycle.
     if database_containers:
         logger.info("Killing database container critical processes (DUT will become unstable)...")
-        try:
-            # On multi-ASIC, database has namespace_ids=[None, "0", "1",...].
-            # Killing the global database (None) destroys the config DB and causes
-            # SSH to hang on subsequent operations.  Reorder namespace_ids so that
-            # per-ASIC namespaces are killed first (SSH remains stable) and the
-            # global namespace (DEFAULT_ASIC_ID / None) is killed last.  After the
-            # global database kill the DUT will become unstable, but no further SSH
-            # calls are needed -- the recover_critical_processes fixture handles
-            # DUT recovery via SysRq reboot (KVM) or PDU power-cycle (physical).
-            ordered_database_containers = {}
-            for k, ns_ids in database_containers.items():
-                per_asic = [nid for nid in ns_ids if nid != DEFAULT_ASIC_ID]
-                global_ns = [nid for nid in ns_ids if nid == DEFAULT_ASIC_ID]
-                ordered_database_containers[k] = per_asic + global_ns
 
-            # Pre-schedule SysRq ONLY for multi-ASIC VS where SSH becomes
-            # unresponsive after killing the global database container.  On
-            # single-ASIC VS, SSH stays alive and the fixture issues the reboot
-            # directly via the "sleep 2" path (so no pre-scheduling needed there).
-            if is_vs_device(duthost) and duthost.facts.get("num_asic", 1) > 1:
-                reboot_delay = 120  # seconds -- generous to allow per-ASIC kills to finish
-                duthost.shell(
-                    'nohup bash -c "sleep {d} && echo 1 > /proc/sys/kernel/sysrq '
-                    '&& echo b > /proc/sysrq-trigger" > /dev/null 2>&1 &'.format(d=reboot_delay),
-                    module_ignore_errors=True)
-                logger.info("Multi-ASIC VS: pre-scheduled SysRq kernel reboot in {} seconds "
-                            "(SSH will become unresponsive after global database kill).".format(reboot_delay))
+        # On multi-ASIC, database has namespace_ids=[None, "0", "1",...].
+        # Killing the global database (None) destroys the config DB and causes
+        # SSH to hang on subsequent operations.  Split into two steps:
+        #   1. Kill per-ASIC namespaces first (SSH remains stable).
+        #   2. Schedule SysRq reboot (while SSH is still alive on multi-ASIC VS).
+        #   3. Kill global namespace last (SSH may hang after this).
+        per_asic_db_containers = {}
+        global_db_containers = {}
+        for k, ns_ids in database_containers.items():
+            per_asic = [nid for nid in ns_ids if nid != DEFAULT_ASIC_ID]
+            global_ns = [nid for nid in ns_ids if nid == DEFAULT_ASIC_ID]
+            if per_asic:
+                per_asic_db_containers[k] = per_asic
+            if global_ns:
+                global_db_containers[k] = global_ns
 
-            stop_critical_processes(duthost, ordered_database_containers)
-            logger.info("Database critical processes killed successfully.")
-        except Exception as e:
-            logger.warning("Exception during database process kill (expected due to DUT instability): %s", e)
+        # Step 1: Kill per-ASIC database containers. SSH is stable here.
+        # Exceptions are unexpected and should propagate.
+        if per_asic_db_containers:
+            logger.info("Killing per-ASIC database containers (SSH still stable)...")
+            stop_critical_processes(duthost, per_asic_db_containers)
+            logger.info("Per-ASIC database containers killed successfully.")
+
+        # Step 2: Pre-schedule SysRq for multi-ASIC VS AFTER per-ASIC kills
+        # complete, just before the global DB kill.  A short delay is enough
+        # because we only need SSH to deliver the global kill command before
+        # the kernel reboots.
+        if is_vs_device(duthost) and duthost.facts.get("num_asic", 1) > 1:
+            duthost.shell(
+                'nohup bash -c "sleep {d} && echo 1 > /proc/sys/kernel/sysrq '
+                '&& echo b > /proc/sysrq-trigger" > /dev/null 2>&1 &'.format(
+                    d=MULTI_ASIC_VS_REBOOT_DELAY_SEC),
+                module_ignore_errors=True)
+            logger.info("Multi-ASIC VS: SysRq kernel reboot scheduled in %ds "
+                        "(SSH will become unresponsive after global database kill).",
+                        MULTI_ASIC_VS_REBOOT_DELAY_SEC)
+
+        # Step 3: Kill global database container last.
+        # On multi-ASIC VS, SSH becomes unresponsive after this -- that is expected.
+        # On single-ASIC VS and physical DUTs, SSH should stay alive.
+        if global_db_containers:
+            logger.info("Killing global database container (DUT may become unstable)...")
+            try:
+                stop_critical_processes(duthost, global_db_containers)
+                logger.info("Global database container killed successfully.")
+            except Exception as e:
+                # SSH disconnect is only expected on multi-ASIC VS where sshd
+                # depends on the global namespace database.
+                if is_vs_device(duthost) and duthost.facts.get("num_asic", 1) > 1:
+                    logger.warning("Multi-ASIC VS: global DB kill caused SSH disconnect (expected): %s", e)
+                else:
+                    raise
 
 
 def test_orchagent_heartbeat(duthosts, rand_one_dut_hostname, tbinfo, skip_vendor_specific_container):

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -597,13 +597,28 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
 
         # Check if this is a virtual switch (KVM) testbed (no PDU available)
         if is_vs_device(duthost):
-            # SysRq reboot was pre-scheduled in Phase 2 of the test (before killing
-            # any database container), while SSH was still alive.  After the global
-            # database container was killed SSH became unresponsive, so we cannot
-            # issue a new SysRq command here.  The DUT will reboot from the
-            # pre-scheduled command; just wait for it to come back up.
-            logger.info("KVM testbed: SysRq reboot was pre-scheduled in Phase 2; "
-                        "waiting for DUT to come back up...")
+            num_asics = duthost.facts.get("num_asics", 1)
+            if num_asics > 1:
+                # Multi-ASIC VS: after killing the global database container, SSH
+                # becomes unresponsive (sshd depends on the global namespace database).
+                # The SysRq reboot was pre-scheduled in Phase 2 while SSH was still
+                # alive.  Just wait here for the scheduled reboot to complete.
+                logger.info("Multi-ASIC KVM: SysRq reboot was pre-scheduled in Phase 2; "
+                            "waiting for DUT to come back up...")
+            else:
+                # Single-ASIC VS: SSH remains alive after killing the global database
+                # container (sshd does not depend on the database on single-ASIC KVM).
+                # Issue the SysRq reboot now; the DUT will reboot in ~2 seconds and
+                # wait_for_startup will wait for it to come back up.
+                logger.info("Single-ASIC KVM: issuing SysRq kernel reboot...")
+                try:
+                    duthost.shell(
+                        'nohup bash -c "sleep 2 && echo 1 > /proc/sys/kernel/sysrq '
+                        '&& echo b > /proc/sysrq-trigger" > /dev/null 2>&1 &',
+                        module_ignore_errors=True)
+                    logger.info("Kernel reboot trigger command issued successfully")
+                except Exception as e:
+                    logger.info("Reboot trigger (expected disconnect on immediate reboot): {}".format(str(e)))
         else:
             # For physical testbed, use PDU reboot
             logger.info("Physical testbed - performing power cycle via PDU...")
@@ -769,11 +784,13 @@ def test_monitoring_critical_processes(
 
     # Phase 2: Kill database critical processes last.  The DUT will become
     # unstable after this, so no further syslog verification is performed.
-    # For VS (KVM) devices the SysRq reboot is pre-scheduled HERE (while SSH is
-    # alive) because SSH becomes unresponsive after the global database is killed,
-    # preventing the fixture from issuing the reboot command later.
-    # The recover_critical_processes fixture then waits for DUT recovery
-    # (VS: waits for pre-scheduled reboot; physical: PDU power-cycle).
+    # Recovery strategy differs by topology:
+    #   - Multi-ASIC VS: SSH hangs after killing global database, so a SysRq
+    #     reboot is pre-scheduled HERE (while SSH is still alive).  The fixture
+    #     waits for that scheduled reboot.
+    #   - Single-ASIC VS: SSH stays alive after killing global database, so
+    #     the fixture issues a 2-second SysRq reboot directly.
+    #   - Physical: fixture uses PDU power-cycle.
     if database_containers:
         logger.info("Killing database container critical processes (DUT will become unstable)...")
         try:
@@ -791,19 +808,17 @@ def test_monitoring_critical_processes(
                 global_ns = [nid for nid in ns_ids if nid == DEFAULT_ASIC_ID]
                 ordered_database_containers[k] = per_asic + global_ns
 
-            # For VS (KVM) devices: pre-schedule a SysRq reboot BEFORE killing any
-            # database process.  After the global database container's redis is
-            # killed, the DUT becomes unresponsive to new SSH connections, making it
-            # impossible for the recover_critical_processes fixture to trigger the
-            # reboot via SSH.  Pre-scheduling here (while SSH is still alive) ensures
-            # the DUT reboots even after SSH becomes unresponsive.
-            if is_vs_device(duthost):
+            # Pre-schedule SysRq ONLY for multi-ASIC VS where SSH becomes
+            # unresponsive after killing the global database container.  On
+            # single-ASIC VS, SSH stays alive and the fixture issues the reboot
+            # directly via the "sleep 2" path (so no pre-scheduling needed there).
+            if is_vs_device(duthost) and duthost.facts.get("num_asics", 1) > 1:
                 reboot_delay = 120  # seconds -- generous to allow per-ASIC kills to finish
                 duthost.shell(
                     'nohup bash -c "sleep {d} && echo 1 > /proc/sys/kernel/sysrq '
                     '&& echo b > /proc/sysrq-trigger" > /dev/null 2>&1 &'.format(d=reboot_delay),
                     module_ignore_errors=True)
-                logger.info("Pre-scheduled SysRq kernel reboot in {} seconds "
+                logger.info("Multi-ASIC VS: pre-scheduled SysRq kernel reboot in {} seconds "
                             "(SSH will become unresponsive after global database kill).".format(reboot_delay))
 
             stop_critical_processes(duthost, ordered_database_containers)

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -762,7 +762,20 @@ def test_monitoring_critical_processes(
     if database_containers:
         logger.info("Killing database container critical processes (DUT will become unstable)...")
         try:
-            stop_critical_processes(duthost, database_containers)
+            # On multi-ASIC, database has namespace_ids=[None, "0", "1",...].
+            # Killing the global database (None) destroys the config DB and causes
+            # SSH to hang on subsequent operations.  Reorder namespace_ids so that
+            # per-ASIC namespaces are killed first (SSH remains stable) and the
+            # global namespace (DEFAULT_ASIC_ID / None) is killed last.  After the
+            # global database kill the DUT will become unstable, but no further SSH
+            # calls are needed -- the recover_critical_processes fixture handles
+            # DUT recovery via SysRq reboot (KVM) or PDU power-cycle (physical).
+            ordered_database_containers = {}
+            for k, ns_ids in database_containers.items():
+                per_asic = [nid for nid in ns_ids if nid != DEFAULT_ASIC_ID]
+                global_ns = [nid for nid in ns_ids if nid == DEFAULT_ASIC_ID]
+                ordered_database_containers[k] = per_asic + global_ns
+            stop_critical_processes(duthost, ordered_database_containers)
             logger.info("Database critical processes killed successfully.")
         except Exception as e:
             logger.warning("Exception during database process kill (expected due to DUT instability): %s", e)

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -659,7 +659,6 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
         ensure_all_critical_processes_running(duthost, containers_in_namespaces)
 
         # Wait for database config file to be ready before checking interfaces.
-        # On multi-ASIC, also check per-namespace config files (e.g. redis0/sonic-db/database_config.json).
         logger.info("Waiting for database_config.json to be ready...")
         db_config_ready = wait_until(wait_time, 5, 0,
                                      lambda: duthost.shell(
@@ -721,8 +720,8 @@ def test_monitoring_critical_processes(
     #   Phase 1 - kill non-database processes, wait, verify syslog alerts
     #   Phase 2 - kill database processes last; the recover_critical_processes
     #             fixture handles DUT recovery via reboot
-    database_containers = {k: v for k, v in containers_in_namespaces.items() if k == "database"}
-    non_database_containers = {k: v for k, v in containers_in_namespaces.items() if k != "database"}
+    database_containers = {k: v for k, v in containers_in_namespaces.items() if k.startswith("database")}
+    non_database_containers = {k: v for k, v in containers_in_namespaces.items() if not k.startswith("database")}
 
     # Generate expected alerting messages only for non-database containers.
     # Database alerting cannot be reliably verified via syslog because killing

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -703,16 +703,29 @@ def test_monitoring_critical_processes(
 
     containers_in_namespaces = get_containers_namespace_ids(duthost, skip_containers)
 
+    # Separate database from other containers.  Killing redis in the database
+    # container destabilizes the entire DUT (config DB is emptied), so we use
+    # a two-phase approach:
+    #   Phase 1 - kill non-database processes, wait, verify syslog alerts
+    #   Phase 2 - kill database processes last; the recover_critical_processes
+    #             fixture handles DUT recovery via reboot
+    database_containers = {k: v for k, v in containers_in_namespaces.items() if k == "database"}
+    non_database_containers = {k: v for k, v in containers_in_namespaces.items() if k != "database"}
+
+    # Generate expected alerting messages only for non-database containers.
+    # Database alerting cannot be reliably verified via syslog because killing
+    # redis destabilizes the system before all messages can be written.
     if "20191130" in duthost.os_version:
-        expected_alerting_messages = get_expected_alerting_messages_monit(duthost, containers_in_namespaces)
+        expected_alerting_messages = get_expected_alerting_messages_monit(duthost, non_database_containers)
     else:
         expected_alerting_messages = get_expected_alerting_messages_supervisor(
-            duthost, containers_in_namespaces)
+            duthost, non_database_containers)
 
     loganalyzer.expect_regex.extend(expected_alerting_messages)
     marker = loganalyzer.init()
 
-    stop_critical_processes(duthost, containers_in_namespaces)
+    # Phase 1: Kill non-database critical processes and verify syslog alerts.
+    stop_critical_processes(duthost, non_database_containers)
 
     wait_time = 70
     # For KVM DUT, there's a delay(~25s) that syncd process raises SIGKILL signal after been killed
@@ -726,6 +739,18 @@ def test_monitoring_critical_processes(
     logger.info("Checking the alerting messages from syslog...")
     loganalyzer.analyze(marker)
     logger.info("Found all the expected alerting messages from syslog!")
+
+    # Phase 2: Kill database critical processes last.  The DUT will become
+    # unstable after this, so no further syslog verification is performed.
+    # The recover_critical_processes fixture handles DUT recovery via
+    # SysRq reboot (KVM) or PDU power-cycle (physical).
+    if database_containers:
+        logger.info("Killing database container critical processes (DUT will become unstable)...")
+        try:
+            stop_critical_processes(duthost, database_containers)
+            logger.info("Database critical processes killed successfully.")
+        except Exception as e:
+            logger.warning("Exception during database process kill (expected due to DUT instability): %s", str(e))
 
 
 def test_orchagent_heartbeat(duthosts, rand_one_dut_hostname, tbinfo, skip_vendor_specific_container):

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -15,7 +15,6 @@ from tests.common.vs_data import is_vs_device
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
 from tests.common.reboot import wait_for_startup
-from tests.common.platform.interface_utils import check_interface_status_of_up_ports
 from tests.common.utilities import pdu_reboot, wait_until, kill_process_by_pid
 from tests.common.helpers.constants import DEFAULT_ASIC_ID, NAMESPACE_PREFIX
 from tests.common.helpers.dut_utils import get_program_info
@@ -638,7 +637,7 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
                 raise
 
         logger.info("Waiting for DUT to boot up after power cycle...")
-        # Wait for DUT to come back up after PDU power cycle
+        # Wait for DUT to come back up after power cycle
         # Get timeout values based on chassis type
         timeout = 300
         wait_time = 120
@@ -648,16 +647,15 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
 
         # Wait for SSH to come back up
         wait_for_startup(duthost, localhost, delay=10, timeout=timeout)
-        logger.info("SSH is up, waiting for critical processes...")
+        logger.info("SSH is up, performing config reload to ensure clean state...")
 
-        # Wait for all critical processes to be healthy
+        # After a dirty reboot (SysRq/PDU), use config_reload to properly
+        # initialize the system.  On multi-ASIC devices the per-namespace
+        # database config files may not be ready immediately after boot,
+        # so a config_reload is more reliable than manual process/interface checks.
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+
         ensure_all_critical_processes_running(duthost, containers_in_namespaces)
-        logger.info("All critical processes are running")
-
-        # Wait for interfaces to come up
-        logger.info("Checking interface status...")
-        check_interface_status_of_up_ports(duthost)
-        logger.info("All interfaces are up")
 
         logger.info("DUT recovered successfully after power cycle!")
     else:

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -11,6 +11,7 @@ import pytest
 from pkg_resources import parse_version
 from tests.common import config_reload
 from tests.common.vs_data import is_vs_device
+from tests.common.platform.interface_utils import check_interface_status_of_up_ports
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
@@ -649,14 +650,27 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
         wait_for_startup(duthost, localhost, delay=10, timeout=timeout)
         logger.info("SSH is up, waiting for critical processes to recover...")
 
-        # After a dirty reboot (SysRq/PDU), avoid config_reload here because
-        # /var/run/redis/sonic-db/database_config.json (on tmpfs) may not exist
-        # yet — even "config reload -h" crashes without it.  Instead, just
-        # ensure all critical processes are running (uses docker exec
-        # supervisorctl, which has no database_config dependency).  The
-        # postcheck_critical_processes_status call below will then poll for
-        # up to 10 minutes until BGP sessions are re-established.
+        # After a dirty reboot (SysRq/PDU), /var/run/redis/sonic-db/database_config.json
+        # (on tmpfs) may not exist yet — even "config reload -h" crashes without it.
+        # So we avoid config_reload and instead:
+        # 1. Ensure all critical processes are running (docker exec supervisorctl, no db dependency)
+        # 2. Wait for database_config.json to appear (needed for interface/config queries)
+        # 3. Check that all admin-up interfaces are operationally up
         ensure_all_critical_processes_running(duthost, containers_in_namespaces)
+
+        # Wait for database config file to be ready before checking interfaces.
+        # On multi-ASIC, also check per-namespace config files (e.g. redis0/sonic-db/database_config.json).
+        logger.info("Waiting for database_config.json to be ready...")
+        db_config_ready = wait_until(wait_time, 5, 0,
+                                     lambda: duthost.shell(
+                                         "test -f /var/run/redis/sonic-db/database_config.json",
+                                         module_ignore_errors=True)["rc"] == 0)
+        if db_config_ready:
+            logger.info("Database config ready, verifying interfaces come up...")
+            pytest_assert(wait_until(300, 20, 0, check_interface_status_of_up_ports, duthost),
+                          "Not all ports that are admin up on are operationally up after reboot")
+        else:
+            logger.warning("database_config.json not ready after %ds, skipping interface check", wait_time)
 
         logger.info("DUT recovered successfully after power cycle!")
     else:

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -13,7 +13,6 @@ from tests.common import config_reload
 from tests.common.vs_data import is_vs_device
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
-from tests.common.platform.interface_utils import check_interface_status_of_up_ports
 from tests.common.reboot import wait_for_startup
 from tests.common.utilities import pdu_reboot, wait_until, kill_process_by_pid
 from tests.common.helpers.constants import DEFAULT_ASIC_ID, NAMESPACE_PREFIX
@@ -651,10 +650,8 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
 
         # After a dirty reboot (SysRq/PDU), /var/run/redis/sonic-db/database_config.json
         # (on tmpfs) may not exist yet -- even "config reload -h" crashes without it.
-        # So we avoid config_reload and instead:
-        # 1. Wait for database_config.json to appear (supervisor sockets need time too)
-        # 2. Ensure all critical processes are running (docker exec supervisorctl)
-        # 3. Check that all admin-up interfaces are operationally up
+        # Wait for database_config.json first, then use config_reload for a clean
+        # recovery that also waits for BGP sessions to re-establish.
         db_config_timeout = 120
         if duthost.get_facts().get("modular_chassis"):
             db_config_timeout = max(db_config_timeout, 600)
@@ -668,12 +665,10 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
             pytest_assert(False,
                           "database_config.json not ready after %ds -- DUT recovery incomplete" % db_config_timeout)
 
-        logger.info("Database config ready, ensuring all critical processes are running...")
-        ensure_all_critical_processes_running(duthost, containers_in_namespaces)
+        logger.info("Database config ready, performing config reload for clean recovery...")
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
 
-        logger.info("Verifying interfaces come up...")
-        pytest_assert(wait_until(300, 20, 0, check_interface_status_of_up_ports, duthost),
-                      "Not all ports that are admin up are operationally up after reboot")
+        ensure_all_critical_processes_running(duthost, containers_in_namespaces)
 
         logger.info("DUT recovered successfully after power cycle!")
     else:

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -11,10 +11,9 @@ import pytest
 from pkg_resources import parse_version
 from tests.common import config_reload
 from tests.common.vs_data import is_vs_device
-from tests.common.platform.interface_utils import check_interface_status_of_up_ports
-
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
+from tests.common.platform.interface_utils import check_interface_status_of_up_ports
 from tests.common.reboot import wait_for_startup
 from tests.common.utilities import pdu_reboot, wait_until, kill_process_by_pid
 from tests.common.helpers.constants import DEFAULT_ASIC_ID, NAMESPACE_PREFIX
@@ -651,25 +650,30 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
         logger.info("SSH is up, waiting for critical processes to recover...")
 
         # After a dirty reboot (SysRq/PDU), /var/run/redis/sonic-db/database_config.json
-        # (on tmpfs) may not exist yet — even "config reload -h" crashes without it.
+        # (on tmpfs) may not exist yet -- even "config reload -h" crashes without it.
         # So we avoid config_reload and instead:
-        # 1. Ensure all critical processes are running (docker exec supervisorctl, no db dependency)
-        # 2. Wait for database_config.json to appear (needed for interface/config queries)
+        # 1. Wait for database_config.json to appear (supervisor sockets need time too)
+        # 2. Ensure all critical processes are running (docker exec supervisorctl)
         # 3. Check that all admin-up interfaces are operationally up
-        ensure_all_critical_processes_running(duthost, containers_in_namespaces)
+        db_config_timeout = 120
+        if duthost.get_facts().get("modular_chassis"):
+            db_config_timeout = max(db_config_timeout, 600)
 
-        # Wait for database config file to be ready before checking interfaces.
         logger.info("Waiting for database_config.json to be ready...")
-        db_config_ready = wait_until(wait_time, 5, 0,
+        db_config_ready = wait_until(db_config_timeout, 5, 0,
                                      lambda: duthost.shell(
                                          "test -f /var/run/redis/sonic-db/database_config.json",
                                          module_ignore_errors=True)["rc"] == 0)
-        if db_config_ready:
-            logger.info("Database config ready, verifying interfaces come up...")
-            pytest_assert(wait_until(300, 20, 0, check_interface_status_of_up_ports, duthost),
-                          "Not all ports that are admin up on are operationally up after reboot")
-        else:
-            pytest_assert(False, "database_config.json not ready after %ds — DUT recovery incomplete" % wait_time)
+        if not db_config_ready:
+            pytest_assert(False,
+                          "database_config.json not ready after %ds -- DUT recovery incomplete" % db_config_timeout)
+
+        logger.info("Database config ready, ensuring all critical processes are running...")
+        ensure_all_critical_processes_running(duthost, containers_in_namespaces)
+
+        logger.info("Verifying interfaces come up...")
+        pytest_assert(wait_until(300, 20, 0, check_interface_status_of_up_ports, duthost),
+                      "Not all ports that are admin up are operationally up after reboot")
 
         logger.info("DUT recovered successfully after power cycle!")
     else:
@@ -696,6 +700,11 @@ def test_monitoring_critical_processes(
     This function will check whether names of critical processes will appear
     in the syslog if the autorestart were disabled and these critical processes
     were stopped.
+
+    Note: Database container alerting messages are intentionally not validated
+    by this test. Killing redis destabilizes the DUT before syslog messages
+    can be reliably written. Database containers are killed in a separate
+    phase solely to exercise the recovery path.
 
     Args:
         duthosts: list of DUTs.
@@ -761,7 +770,7 @@ def test_monitoring_critical_processes(
             stop_critical_processes(duthost, database_containers)
             logger.info("Database critical processes killed successfully.")
         except Exception as e:
-            logger.warning("Exception during database process kill (expected due to DUT instability): %s", str(e))
+            logger.warning("Exception during database process kill (expected due to DUT instability): %s", e)
 
 
 def test_orchagent_heartbeat(duthosts, rand_one_dut_hostname, tbinfo, skip_vendor_specific_container):

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -597,20 +597,13 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
 
         # Check if this is a virtual switch (KVM) testbed (no PDU available)
         if is_vs_device(duthost):
-            # For KVM testbed, use kernel-level reboot since config DB is corrupted
-            # and normal reboot commands won't work
-            logger.info("KVM testbed detected - using kernel SysRq trigger for immediate reboot...")
-            try:
-                # Use kernel's SysRq trigger to force immediate reboot
-                # This bypasses all userspace processes and goes directly to kernel
-                # 'b' = immediately reboot the system without syncing or unmounting
-                duthost.shell(
-                    'nohup bash -c "sleep 2 && echo 1 > /proc/sys/kernel/sysrq && echo b > /proc/sysrq-trigger" '
-                    '> /dev/null 2>&1 &',
-                    module_ignore_errors=True)
-                logger.info("Kernel reboot trigger command issued successfully")
-            except Exception as e:
-                logger.info("Reboot trigger command execution (expected to disconnect): {}".format(str(e)))
+            # SysRq reboot was pre-scheduled in Phase 2 of the test (before killing
+            # any database container), while SSH was still alive.  After the global
+            # database container was killed SSH became unresponsive, so we cannot
+            # issue a new SysRq command here.  The DUT will reboot from the
+            # pre-scheduled command; just wait for it to come back up.
+            logger.info("KVM testbed: SysRq reboot was pre-scheduled in Phase 2; "
+                        "waiting for DUT to come back up...")
         else:
             # For physical testbed, use PDU reboot
             logger.info("Physical testbed - performing power cycle via PDU...")
@@ -776,8 +769,11 @@ def test_monitoring_critical_processes(
 
     # Phase 2: Kill database critical processes last.  The DUT will become
     # unstable after this, so no further syslog verification is performed.
-    # The recover_critical_processes fixture handles DUT recovery via
-    # SysRq reboot (KVM) or PDU power-cycle (physical).
+    # For VS (KVM) devices the SysRq reboot is pre-scheduled HERE (while SSH is
+    # alive) because SSH becomes unresponsive after the global database is killed,
+    # preventing the fixture from issuing the reboot command later.
+    # The recover_critical_processes fixture then waits for DUT recovery
+    # (VS: waits for pre-scheduled reboot; physical: PDU power-cycle).
     if database_containers:
         logger.info("Killing database container critical processes (DUT will become unstable)...")
         try:
@@ -794,6 +790,22 @@ def test_monitoring_critical_processes(
                 per_asic = [nid for nid in ns_ids if nid != DEFAULT_ASIC_ID]
                 global_ns = [nid for nid in ns_ids if nid == DEFAULT_ASIC_ID]
                 ordered_database_containers[k] = per_asic + global_ns
+
+            # For VS (KVM) devices: pre-schedule a SysRq reboot BEFORE killing any
+            # database process.  After the global database container's redis is
+            # killed, the DUT becomes unresponsive to new SSH connections, making it
+            # impossible for the recover_critical_processes fixture to trigger the
+            # reboot via SSH.  Pre-scheduling here (while SSH is still alive) ensures
+            # the DUT reboots even after SSH becomes unresponsive.
+            if is_vs_device(duthost):
+                reboot_delay = 120  # seconds -- generous to allow per-ASIC kills to finish
+                duthost.shell(
+                    'nohup bash -c "sleep {d} && echo 1 > /proc/sys/kernel/sysrq '
+                    '&& echo b > /proc/sysrq-trigger" > /dev/null 2>&1 &'.format(d=reboot_delay),
+                    module_ignore_errors=True)
+                logger.info("Pre-scheduled SysRq kernel reboot in {} seconds "
+                            "(SSH will become unresponsive after global database kill).".format(reboot_delay))
+
             stop_critical_processes(duthost, ordered_database_containers)
             logger.info("Database critical processes killed successfully.")
         except Exception as e:

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -647,14 +647,15 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
 
         # Wait for SSH to come back up
         wait_for_startup(duthost, localhost, delay=10, timeout=timeout)
-        logger.info("SSH is up, performing config reload to ensure clean state...")
+        logger.info("SSH is up, waiting for critical processes to recover...")
 
-        # After a dirty reboot (SysRq/PDU), use config_reload to properly
-        # initialize the system.  On multi-ASIC devices the per-namespace
-        # database config files may not be ready immediately after boot,
-        # so a config_reload is more reliable than manual process/interface checks.
-        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
-
+        # After a dirty reboot (SysRq/PDU), avoid config_reload here because
+        # /var/run/redis/sonic-db/database_config.json (on tmpfs) may not exist
+        # yet — even "config reload -h" crashes without it.  Instead, just
+        # ensure all critical processes are running (uses docker exec
+        # supervisorctl, which has no database_config dependency).  The
+        # postcheck_critical_processes_status call below will then poll for
+        # up to 10 minutes until BGP sessions are re-established.
         ensure_all_critical_processes_running(duthost, containers_in_namespaces)
 
         logger.info("DUT recovered successfully after power cycle!")

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -656,11 +656,30 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
         if duthost.get_facts().get("modular_chassis"):
             db_config_timeout = max(db_config_timeout, 600)
 
-        logger.info("Waiting for database_config.json to be ready...")
-        db_config_ready = wait_until(db_config_timeout, 5, 0,
-                                     lambda: duthost.shell(
-                                         "test -f /var/run/redis/sonic-db/database_config.json",
-                                         module_ignore_errors=True)["rc"] == 0)
+        # Build list of database_config.json files to wait for.
+        # On multi-ASIC devices swsscommon.SonicDBConfig.load_sonic_global_db_config()
+        # loads both the global config (/var/run/redis/sonic-db/) and per-ASIC configs
+        # (/var/run/redis{N}/sonic-db/).  All of them must be present before
+        # "config reload" can run successfully.
+        db_config_files = ["/var/run/redis/sonic-db/database_config.json"]
+        num_asics = duthost.facts.get("num_asics", 1)
+        if num_asics > 1:
+            for asic_idx in range(num_asics):
+                db_config_files.append(
+                    "/var/run/redis{}/sonic-db/database_config.json".format(asic_idx)
+                )
+
+        logger.info("Waiting for database_config.json to be ready (files: {})...".format(db_config_files))
+
+        def _all_db_configs_ready():
+            for db_config_file in db_config_files:
+                if duthost.shell(
+                        "test -f {}".format(db_config_file),
+                        module_ignore_errors=True)["rc"] != 0:
+                    return False
+            return True
+
+        db_config_ready = wait_until(db_config_timeout, 5, 0, _all_db_configs_ready)
         if not db_config_ready:
             pytest_assert(False,
                           "database_config.json not ready after %ds -- DUT recovery incomplete" % db_config_timeout)

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -670,7 +670,7 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
             pytest_assert(wait_until(300, 20, 0, check_interface_status_of_up_ports, duthost),
                           "Not all ports that are admin up on are operationally up after reboot")
         else:
-            logger.warning("database_config.json not ready after %ds, skipping interface check", wait_time)
+            pytest_assert(False, "database_config.json not ready after %ds — DUT recovery incomplete" % wait_time)
 
         logger.info("DUT recovered successfully after power cycle!")
     else:


### PR DESCRIPTION
### Description of PR
Summary: Fix testbed health check failure caused by `ansible_python_interpreter` leaking from localhost to DUTs after #24967.

Fixes the regression observed on the new `docker-sonic-mgmt` (uv-venv) image:

```
testbed_health_check.py::init_hosts: ["str3-8102-01"] -> AnsibleModule::"dut_basic_facts" failed
module_stderr: "/bin/sh: 1: /opt/venv/bin/python3: not found"
rc: 127
```

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
PR #24967 made `init_localhost` set `ansible_python_interpreter` on localhost via the `hostvars` kwarg of `AnsibleHost`. That path runs through `AnsibleHostsBase.__init__`:

```python
if hostvars:
    self.vm.extra_vars.update(hostvars)
```

ansible-core's `ansible.utils.vars.load_extra_vars` caches its return dict on the function object:

```python
def load_extra_vars(loader):
    if not getattr(load_extra_vars, 'extra_vars', None):
        ...
        setattr(load_extra_vars, 'extra_vars', extra_vars)
    return load_extra_vars.extra_vars
```

And `VariableManager.__init__` does `self._extra_vars = load_extra_vars(...)`. So every `VariableManager` constructed afterwards in the same process **shares the same `_extra_vars` dict object**. Mutating it for localhost leaks the value globally, and `extra_vars` have the highest precedence in ansible -- they override the DUT inventory/group vars.

On the new image `sys.executable` is `/opt/venv/bin/python3`. After `init_localhost`, the next `init_sonichosts(...)` against the DUT inherits `ansible_python_interpreter=/opt/venv/bin/python3`, and the SONiC DUT does not have `/opt/venv/bin/python3` -> `rc=127`.

The same leak existed before #24967 with `/usr/bin/python3` but was harmless because that path also exists on SONiC DUTs.

#### How did you do it?
Set `ansible_python_interpreter` directly on the localhost inventory `Host` object via `Host.set_variable`, instead of going through the `hostvars`/`extra_vars` channel. That keeps the override scoped to localhost and out of the shared `extra_vars` dict. The resolver itself (env override -> `sys.executable` -> `/usr/bin/python3`) is preserved.

#### How did you verify/test it?
- Confirmed the leak path by reading ansible-core 2.18 `vars/manager.py` (`self._extra_vars = load_extra_vars(...)`) and `utils/vars.py` (`load_extra_vars` caches via `setattr(load_extra_vars, 'extra_vars', ...)`).
- Verified the new code path mutates only the localhost `Host` object's variables (host-vars precedence, not extra_vars).
- Syntax check (`python -m py_compile`) passes.

#### Any platform specific information?
None. Affects every testbed running on the new `docker-sonic-mgmt` image where `sys.executable` is not present on the DUT.

#### Supported testbed topology if it's a new test case?
N/A (bug fix in shared infra).

### Documentation
N/A
