### PR TITLE
[devutil]: avoid extra_vars leak when pinning localhost python interpreter

### DIFF
--- a/ansible/devutil/devices/factory.py
+++ b/ansible/devutil/devices/factory.py
@@ -43,15 +43,37 @@ def _resolve_localhost_python_interpreter():
 
 
 def init_localhost(inventories=None, options={}, hostvars={}):
-    localhost_hostvars = hostvars.copy()
-    localhost_hostvars["ansible_python_interpreter"] = _resolve_localhost_python_interpreter()
     try:
-        return AnsibleHost(inventories, "localhost", options=options.copy(), hostvars=localhost_hostvars.copy())
+        ah = AnsibleHost(inventories, "localhost", options=options.copy(), hostvars=hostvars.copy())
     except (NoAnsibleHostError, MultipleAnsibleHostsError) as e:
         logger.error(
             "Failed to initialize localhost from inventories '{}', exception: {}".format(str(inventories), repr(e))
         )
         return None
+
+    # Pin ansible_python_interpreter for localhost only, by setting it as a
+    # host-level variable on the inventory Host object.
+    #
+    # We deliberately do NOT pass this through the ``hostvars`` kwarg of
+    # AnsibleHost: that path lands in ``VariableManager.extra_vars`` (see
+    # ``AnsibleHostsBase.__init__``), and ansible-core's
+    # ``ansible.utils.vars.load_extra_vars`` caches its return dict on the
+    # function object. Every VariableManager constructed afterwards in the
+    # same process shares the same ``_extra_vars`` dict, so a mutation here
+    # would leak ``ansible_python_interpreter`` to every subsequent play --
+    # including ones targeting real DUTs that do not have the controller's
+    # interpreter path. extra_vars also have the highest precedence in
+    # ansible, so they would override the DUTs' inventory/group vars.
+    interpreter = _resolve_localhost_python_interpreter()
+    try:
+        for h in ah.im.get_hosts("localhost"):
+            h.set_variable("ansible_python_interpreter", interpreter)
+    except Exception as e:
+        logger.warning(
+            "Failed to pin ansible_python_interpreter='{}' on localhost: {}".format(interpreter, repr(e))
+        )
+
+    return ah
 
 
 def init_host(inventories, host_pattern, options={}, hostvars={}):


### PR DESCRIPTION
### Description of PR
Summary: Fix testbed health check failure caused by `ansible_python_interpreter` leaking from localhost to DUTs after #24967.

Fixes the regression observed on the new `docker-sonic-mgmt` (uv-venv) image:

```
testbed_health_check.py::init_hosts: ["str3-8102-01"] -> AnsibleModule::"dut_basic_facts" failed
module_stderr: "/bin/sh: 1: /opt/venv/bin/python3: not found"
rc: 127
```

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
PR #24967 made `init_localhost` set `ansible_python_interpreter` on localhost via the `hostvars` kwarg of `AnsibleHost`. That path runs through `AnsibleHostsBase.__init__`:

```python
if hostvars:
    self.vm.extra_vars.update(hostvars)
```

ansible-core's `ansible.utils.vars.load_extra_vars` caches its return dict on the function object:

```python
def load_extra_vars(loader):
    if not getattr(load_extra_vars, 'extra_vars', None):
        ...
        setattr(load_extra_vars, 'extra_vars', extra_vars)
    return load_extra_vars.extra_vars
```

And `VariableManager.__init__` does `self._extra_vars = load_extra_vars(...)`. So every `VariableManager` constructed afterwards in the same process **shares the same `_extra_vars` dict object**. Mutating it for localhost leaks the value globally, and `extra_vars` have the highest precedence in ansible -- they override the DUT inventory/group vars.

On the new image `sys.executable` is `/opt/venv/bin/python3`. After `init_localhost`, the next `init_sonichosts(...)` against the DUT inherits `ansible_python_interpreter=/opt/venv/bin/python3`, and the SONiC DUT does not have `/opt/venv/bin/python3` -> `rc=127`.

The same leak existed before #24967 with `/usr/bin/python3` but was harmless because that path also exists on SONiC DUTs.

#### How did you do it?
Set `ansible_python_interpreter` directly on the localhost inventory `Host` object via `Host.set_variable`, instead of going through the `hostvars`/`extra_vars` channel. That keeps the override scoped to localhost and out of the shared `extra_vars` dict. The resolver itself (env override -> `sys.executable` -> `/usr/bin/python3`) is preserved.

#### How did you verify/test it?
- Confirmed the leak path by reading ansible-core 2.18 `vars/manager.py` (`self._extra_vars = load_extra_vars(...)`) and `utils/vars.py` (`load_extra_vars` caches via `setattr(load_extra_vars, 'extra_vars', ...)`).
- Verified the new code path mutates only the localhost `Host` object's variables (host-vars precedence, not extra_vars).
- Syntax check (`python -m py_compile`) passes.

#### Any platform specific information?
None. Affects every testbed running on the new `docker-sonic-mgmt` image where `sys.executable` is not present on the DUT.

#### Supported testbed topology if it's a new test case?
N/A (bug fix in shared infra).

### Documentation
N/A
