### PR TITLE
[passw_hardening] Snapshot/restore policies in teardown to avoid spurious config_reload

### DIFF
--- a/tests/passw_hardening/conftest.py
+++ b/tests/passw_hardening/conftest.py
@@ -3,22 +3,20 @@ from tests.common.utilities import skip_release
 from . import passw_hardening_utils
 
 
-def set_default_passw_hardening_policies(duthosts, enum_rand_one_per_hwsku_hostname):
+@pytest.fixture(scope="module")
+def passw_policies_snapshot(duthosts, enum_rand_one_per_hwsku_hostname, passw_version_required):
+    """Snapshot the DUT's current password hardening policies once per module.
+
+    The teardown of clean_passw_policies restores exactly these values. Previously it
+    reset the policies to hard-coded "default" values; whenever those drifted from the
+    real SONiC boot defaults (defined in init_cfg.json.j2), the module-scoped config
+    check detected a CONFIG_DB diff and ran config_reload, which restarted BGP and
+    produced spurious "bgpd memory increased" alarms on the next, unrelated test.
+    Capturing the actual values keeps the restore correct even if the image defaults
+    change.
+    """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-
-    passw_hardening_ob_dis = passw_hardening_utils.PasswHardening(state='disabled',
-                                                                  expiration='100',
-                                                                  expiration_warning='15',
-                                                                  history='12',
-                                                                  len_min='8',
-                                                                  reject_user_passw_match='true',
-                                                                  lower_class='true',
-                                                                  upper_class='true',
-                                                                  digit_class="true",
-                                                                  special_class='true')
-
-    passw_hardening_utils.config_and_review_policies(duthost, passw_hardening_ob_dis,
-                                                     passw_hardening_utils.PAM_PASSWORD_CONF_DEFAULT_EXPECTED)
+    return passw_hardening_utils.get_passw_policies(duthost)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -36,9 +34,10 @@ def passw_version_required(duthosts, enum_rand_one_per_hwsku_hostname):
 
 
 @pytest.fixture(scope="function")
-def clean_passw_policies(duthosts, enum_rand_one_per_hwsku_hostname):
+def clean_passw_policies(duthosts, enum_rand_one_per_hwsku_hostname, passw_policies_snapshot):
     yield
-    set_default_passw_hardening_policies(duthosts, enum_rand_one_per_hwsku_hostname)
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    passw_hardening_utils.restore_passw_policies(duthost, passw_policies_snapshot)
 
 
 @pytest.fixture(scope="function")

--- a/tests/passw_hardening/passw_hardening_utils.py
+++ b/tests/passw_hardening/passw_hardening_utils.py
@@ -1,3 +1,4 @@
+import ast
 import logging
 import os
 import difflib
@@ -48,6 +49,57 @@ class PasswHardening:
             "digits-class": digit_class,
             "special-class": special_class
         }
+
+
+def get_passw_policies(duthost):
+    """Snapshot the current PASSW_HARDENING|POLICIES hash from CONFIG_DB.
+
+    Returns a dict keyed by CONFIG_DB field names, or None when the key is absent or
+    the output cannot be parsed (in which case the caller should skip restoration).
+    """
+    result = duthost.shell('sonic-db-cli CONFIG_DB hgetall "PASSW_HARDENING|POLICIES"',
+                           module_ignore_errors=True)
+    output = result['stdout'].strip()
+    if result['rc'] != 0 or not output:
+        logging.warning("Could not read PASSW_HARDENING|POLICIES from CONFIG_DB: %s", result.get('stderr'))
+        return None
+    try:
+        policies = ast.literal_eval(output)
+    except (ValueError, SyntaxError):
+        logging.warning("Could not parse PASSW_HARDENING|POLICIES output: %r", output)
+        return None
+    if not isinstance(policies, dict):
+        logging.warning("Unexpected PASSW_HARDENING|POLICIES output: %r", output)
+        return None
+    return policies
+
+
+def restore_passw_policies(duthost, snapshot):
+    """Restore PASSW_HARDENING policies to the values captured by get_passw_policies().
+
+    Only fields whose live value differs from the snapshot are re-applied, so a test
+    that did not touch the policies issues zero CLI commands (and therefore creates no
+    CONFIG_DB diff that would trigger a config_reload on the next test). CONFIG_DB field
+    names use underscores while the `config passw-hardening policies` CLI uses hyphens,
+    so each field is converted with '_' -> '-'. 'state' is applied last so the feature
+    is only (re)enabled/disabled after every dependent field has been written.
+    """
+    if not snapshot:
+        logging.warning("No password hardening policies snapshot to restore; skipping")
+        return
+    current = get_passw_policies(duthost)
+    # If the live state cannot be read, conservatively restore every snapshot field.
+    fields_to_restore = [field for field in snapshot
+                         if current is None or snapshot[field] != current.get(field)]
+    if not fields_to_restore:
+        logging.info("Password hardening policies unchanged since snapshot; nothing to restore")
+        return
+    ordered_fields = [field for field in fields_to_restore if field != "state"]
+    if "state" in fields_to_restore:
+        ordered_fields.append("state")
+    for field in ordered_fields:
+        cli_key = field.replace("_", "-")
+        duthost.command("sudo config passw-hardening policies {} {}".format(cli_key, snapshot[field]))
 
 
 def config_user(duthost, username, mode='add'):


### PR DESCRIPTION
### Description of PR

The `clean_passw_policies` teardown in `tests/passw_hardening` reset the password hardening policies to a set of hard-coded &#34;default&#34; values. Whenever those hard-coded values drifted from the real SONiC boot defaults (defined in `init_cfg.json.j2`), the module-scoped config check detected a `CONFIG_DB` diff and ran `config_reload`. That `config_reload` restarts BGP, which produces spurious `bgpd memory increased` alarms on the **next, unrelated test** (e.g. `test_snmp_memory`), causing flaky failures.

This PR replaces the hard-coded reset with a **snapshot/restore** approach:
- `get_passw_policies()` captures the DUT&#39;s actual `PASSW_HARDENING|POLICIES` values once per module.
- `restore_passw_policies()` in teardown re-applies **only the fields that changed** during the test.

A test that does not touch the policies now issues **zero** CLI commands in teardown, so no `CONFIG_DB` diff is created and no `config_reload` is triggered.

Summary:
Fixes spurious `test_snmp_memory` (and other downstream) failures caused by password hardening teardown triggering `config_reload`.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/38230412

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`test_snmp_memory` (and other tests) intermittently fail with `bgpd memory increased` alarms. Root cause: the password hardening test teardown resets policies to hard-coded &#34;default&#34; values that drift from the image&#39;s real boot defaults. The resulting `CONFIG_DB` diff triggers `config_reload` → BGP restart → memory alarm on the subsequent test.

#### How did you do it?
- Added `get_passw_policies(duthost)` to snapshot the live `PASSW_HARDENING|POLICIES` hash from `CONFIG_DB` (parsed with `ast.literal_eval`; returns `None` and logs a warning on read/parse failure).
- Added `restore_passw_policies(duthost, snapshot)` which reads the live state at teardown and re-applies only the fields whose value differs from the snapshot. `state` is applied last. If the live state cannot be read, it conservatively restores every snapshot field. CONFIG_DB field names (underscores) are mapped to the `config passw-hardening policies` CLI subcommands (hyphens) via `field.replace(&#39;_&#39;, &#39;-&#39;)`, removing the previous hand-maintained key map.
- Replaced the module fixture so it snapshots the actual values (`passw_policies_snapshot`); `clean_passw_policies` now restores from that snapshot.

#### How did you verify/test it?
- Verified `sonic-db-cli CONFIG_DB hgetall &#34;PASSW_HARDENING|POLICIES&#34;` output and `ast.literal_eval` parsing on a live DUT (Arista-7050CX3).
- Confirmed all 10 DB fields map 1:1 to `config passw-hardening policies` CLI subcommands via pure `_`→`-` transform.
- Unit-simulated the restore diff logic: unchanged → 0 commands; changed fields → only those re-applied with `state` last; live-read `None` → restore all; snapshot `None` → skip.
- flake8 (max-line-length=120) clean; `py_compile` passes.

#### Any platform specific information?
None. The fix is platform-agnostic.

#### Supported testbed topology if it&#39;s a new test case?
N/A — existing test improvement.

### Documentation
N/A

### Elastic Test Jobs
- testbed-bjw3-can-7050c-11: https://elastictest.org/scheduler/testplan/6a28e79d2047c3c4a9f924b1