### PR TITLE
Issue 24892: Infra for creating/deleting subinterface for testcases in 'sub_port_interfaces' folder should use CLI commands instead of redis commands

### DIFF
--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -109,12 +109,12 @@ def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter, port_t
         Dictonary of sub-port parameters for configuration DUT and PTF host
         For example:
         {
-        'Ethernet4.10': {
+        'Eth4.10': {
             'ip': '172.16.0.1/30',
             'neighbor_port': 'eth1.10',
             'neighbor_ip': '172.16.0.2/30'
             },
-        'Ethernet4.20': {
+        'Eth4.20': {
             'ip': '172.16.0.5/30',
             'neighbor_port': 'eth1.20',
             'neighbor_ip': '172.16.0.6/30'
@@ -138,14 +138,8 @@ def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter, port_t
         vlan_ranges_dut = list(range(11, max_numbers_of_sub_ports + 11))
         vlan_ranges_ptf = list(range(11, max_numbers_of_sub_ports + 11))
 
-        # Linux has the limitation of 15 characters on an interface name,
-        # but name of LAG port should have prefix 'PortChannel' and suffix
-        # '<0-9999>' on SONiC. So max length of LAG port suffix have be 3 characters
-        # For example: 'PortChannel1.99'
-        if 'port_in_lag' in port_type:
-            vlan_range_end = min(100, max_numbers_of_sub_ports + 11)
-            vlan_ranges_dut = list(range(11, vlan_range_end))
-            vlan_ranges_ptf = list(range(11, vlan_range_end))
+        # Subinterfaces are generated with abbreviated parent names (Po/Eth),
+        # so keep the full requested max_numbers range for LAG ports as well.
 
     interface_num = 2
     ip_subnet = '172.16.0.0/16'
@@ -163,9 +157,10 @@ def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter, port_t
     subnets = [i for i, _ in zip(network.subnets(new_prefix=22), config_port_indices)]
 
     for port, ptf_port, subnet in zip(list(config_port_indices.values()), ptf_ports, subnets):
+        short_port = port.replace('Ethernet', 'Eth').replace('PortChannel', 'Po')
         for vlan_id_dut, vlan_id_ptf, net in zip(vlan_ranges_dut, vlan_ranges_ptf, subnet.subnets(new_prefix=30)):
             hosts_list = [i for i in net.hosts()]
-            sub_ports_config['{}.{}'.format(port, vlan_id_dut)] = {
+            sub_ports_config['{}.{}'.format(short_port, vlan_id_dut)] = {
                 'ip': '{}/{}'.format(hosts_list[0], prefix),
                 'neighbor_port': '{}.{}'.format(ptf_port, vlan_id_ptf),
                 'neighbor_ip': '{}/{}'.format(hosts_list[1], prefix)
@@ -198,7 +193,7 @@ def apply_config_on_the_dut(define_sub_ports_configuration, duthost, reload_dut_
         'sub_ports': define_sub_ports_configuration['sub_ports']
     }
 
-    parent_port_list = [sub_port.split('.')[0] for sub_port in list(define_sub_ports_configuration['sub_ports'].keys())]
+    parent_port_list = list(define_sub_ports_configuration['dut_ports'].values())
 
     for port in set(parent_port_list):
         remove_member_from_vlan(duthost, '1000', port)
@@ -207,7 +202,8 @@ def apply_config_on_the_dut(define_sub_ports_configuration, duthost, reload_dut_
     config_template = jinja2.Template(open(os.path.join(TEMPLATE_DIR, SUB_PORTS_TEMPLATE)).read())
 
     duthost.command("mkdir -p {}".format(DUT_TMP_DIR))
-    duthost.copy(content=config_template.render(sub_ports_vars), dest=sub_ports_config_path)
+    duthost.copy(content=config_template.render({'sub_ports': sub_ports_vars['sub_ports']}),
+                 dest=sub_ports_config_path)
     duthost.command('sonic-cfggen -j {} --write-to-db'.format(sub_ports_config_path))
 
     py_assert(wait_until(3, 1, 0, check_sub_port, duthost, list(sub_ports_vars['sub_ports'].keys())),
@@ -255,12 +251,14 @@ def apply_route_config(request, tbinfo, duthost, ptfhost, port_type, define_sub_
     namespaces = {}
 
     for port in list(dut_ports.values()):
+        short_port = port.replace('Ethernet', 'Eth').replace('PortChannel', 'Po')
         if 'same' in request.param:
-            sub_ports_on_port = random.sample([sub_port for sub_port in sub_ports_keys if port + '.' in sub_port], 2)
+            sub_ports_on_port = random.sample([sub_port for sub_port in sub_ports_keys
+                                               if short_port + '.' in sub_port], 2)
         else:
             sub_ports_on_port = [
-                random.choice([sub_port for sub_port in sub_ports_keys if port + '.' in sub_port]),
-                random.choice([sub_port for sub_port in sub_ports_keys if port + '.' not in sub_port])
+                random.choice([sub_port for sub_port in sub_ports_keys if short_port + '.' in sub_port]),
+                random.choice([sub_port for sub_port in sub_ports_keys if short_port + '.' not in sub_port])
             ]
             for sub_port in sub_ports_on_port:
                 sub_ports_keys.pop(sub_port)
@@ -370,8 +368,9 @@ def apply_route_config_for_port(request, tbinfo, duthost, ptfhost, port_type, de
             add_ip_to_ptf_port(ptfhost, ptf_port, ptf_port_ip)
 
         # Get two random sub-ports which are not part of the selected DUT interface
+        short_dut_port = dut_port.replace('Ethernet', 'Eth').replace('PortChannel', 'Po')
         sub_ports_on_port = random.sample([sub_port for sub_port in sub_ports_keys
-                                           if dut_port + '.' not in sub_port], 2)
+                                           if short_dut_port + '.' not in sub_port], 2)
 
         for sub_port in sub_ports_on_port:
             sub_ports_keys.pop(sub_port)
@@ -537,7 +536,8 @@ def apply_balancing_config(duthost, ptfhost, ptfadapter, define_sub_ports_config
     network = ipaddress.ip_network(network)
 
     for port, subnet in zip(list(dut_ports.values()), network.subnets(new_prefix=30)):
-        sub_ports_on_port = [sub_port for sub_port in sub_ports if port + '.' in sub_port]
+        short_port = port.replace('Ethernet', 'Eth').replace('PortChannel', 'Po')
+        sub_ports_on_port = [sub_port for sub_port in sub_ports if short_port + '.' in sub_port]
 
         sub_port_neighbors = [sub_ports[sub_port]['neighbor_port'] for sub_port in sub_ports_on_port]
         ptf_agent_updater.configure_ptf_nn_agent(sub_port_neighbors)

--- a/tests/sub_port_interfaces/sub_ports_helpers.py
+++ b/tests/sub_port_interfaces/sub_ports_helpers.py
@@ -419,7 +419,10 @@ def shutdown_port(duthost, interface):
         duthost: DUT host object
         interface: Interface of DUT
     """
-    duthost.shutdown(interface)
+    if constants.VLAN_SUB_INTERFACE_SEPARATOR in interface:
+        duthost.shell('sudo config interface shutdown {}'.format(interface))
+    else:
+        duthost.shutdown(interface)
     pytest_assert(wait_until(3, 1, 0, __check_interface_state, duthost, interface, 'down'),
                   "DUT's port {} didn't go down as expected".format(interface))
 
@@ -432,7 +435,10 @@ def startup_port(duthost, interface):
         duthost: DUT host object
         interface: Interface of DUT
     """
-    duthost.no_shutdown(interface)
+    if constants.VLAN_SUB_INTERFACE_SEPARATOR in interface:
+        duthost.shell('sudo config interface startup {}'.format(interface))
+    else:
+        duthost.no_shutdown(interface)
     pytest_assert(wait_until(3, 1, 0, __check_interface_state, duthost, interface),
                   "DUT's port {} didn't go up as expected".format(interface))
 
@@ -687,14 +693,14 @@ def create_sub_port_on_dut(duthost, sub_port_name, sub_port_ip):
 
     Args:
         duthost: DUT host object
-        sub_port_name: Sub-port name
+        sub_port_name: Sub-port name (abbreviated, e.g. Eth4.20 or Po1.20)
         sub_port_ip: IP address of sub-port
 
     """
+    vlan_id = sub_port_name.split('.')[1]
     cmds = []
-    vlan_vid = int(sub_port_name.split('.')[1])
-    cmds.append("config subinterface add {} {}".format(sub_port_name, vlan_vid))
-    cmds.append("config interface ip add {} {}".format(sub_port_name, sub_port_ip))
+    cmds.append('config subinterface add {} {}'.format(sub_port_name, vlan_id))
+    cmds.append('config interface ip add {} {}'.format(sub_port_name, sub_port_ip))
 
     duthost.shell_cmds(cmds=cmds)
 
@@ -869,8 +875,9 @@ def remove_sub_port(duthost, sub_port, ip):
         ip: IP address of port
     """
     cmds = []
-    cmds.append('config interface ip remove {} {}'.format(sub_port, ip))
-    cmds.append('redis-cli -n 4 del "VLAN_SUB_INTERFACE|{}"'.format(sub_port))
+    short_name = sub_port.replace('Ethernet', 'Eth').replace('PortChannel', 'Po')
+    cmds.append('config interface ip remove {} {}'.format(short_name, ip))
+    cmds.append('config subinterface del {}'.format(short_name))
 
     duthost.shell_cmds(cmds=cmds)
 

--- a/tests/sub_port_interfaces/templates/sub_port_config.j2
+++ b/tests/sub_port_interfaces/templates/sub_port_config.j2
@@ -2,7 +2,8 @@
     "VLAN_SUB_INTERFACE": {
 {% for sub_port, value in sub_ports.items() %}
         "{{ sub_port }}": {
-            "admin_status" : "up"
+            "admin_status" : "up",
+            "vlan" : "{{ sub_port.split('.')[1] }}"
         },
         "{{ sub_port }}|{{ value['ip'] }}": {}{% if not loop.last %},
 {% endif %}{% endfor %}

--- a/tests/sub_port_interfaces/test_show_subinterface.py
+++ b/tests/sub_port_interfaces/test_show_subinterface.py
@@ -19,6 +19,11 @@ def subintf_expected_config(duthost, apply_config_on_the_dut):
 
     for subinterface, config in list(subinterfaces.items()):
         interface, vlan = subinterface.split(constants.VLAN_SUB_INTERFACE_SEPARATOR)
+        # Convert abbreviated name to full interface name
+        if interface.startswith('Eth'):
+            interface = 'Ethernet' + interface[3:]
+        elif interface.startswith('Po'):
+            interface = 'PortChannel' + interface[2:]
         config["speed"] = show_int_status[interface]["speed"]
         config["mtu"] = show_int_status[interface]["mtu"]
         config["vlan"] = vlan
@@ -26,7 +31,7 @@ def subintf_expected_config(duthost, apply_config_on_the_dut):
     return subinterfaces
 
 
-def test_subinterface_status(duthost, subintf_expected_config):
+def test_subinterface_status(duthost, subintf_expected_config, reload_ptf_config):
     """
     Verify subinterface status after creation/deletion.
 

--- a/tests/sub_port_interfaces/test_sub_port_interfaces.py
+++ b/tests/sub_port_interfaces/test_sub_port_interfaces.py
@@ -6,6 +6,7 @@ import random
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
+from tests.common import constants
 from sub_ports_helpers import generate_and_verify_traffic
 from sub_ports_helpers import get_port_mtu
 from sub_ports_helpers import shutdown_port
@@ -154,7 +155,12 @@ class TestSubPorts(object):
         for sub_port in list(sub_ports.keys()):
             sub_port_mtu = int(get_port_mtu(duthost, sub_port))
             # Get name of parent port from name of sub-port
-            port = sub_port.split('.')[0]
+            port = sub_port.split(constants.VLAN_SUB_INTERFACE_SEPARATOR)[0]
+            # Convert abbreviated name to full interface name
+            if port.startswith('Eth'):
+                port = 'Ethernet' + port[3:]
+            elif port.startswith('Po'):
+                port = 'PortChannel' + port[2:]
             port_mtu = int(get_port_mtu(duthost, port))
 
             pytest_assert(sub_port_mtu == port_mtu, "MTU of {} doesn't inherit MTU of {}".format(sub_port, port))
@@ -181,7 +187,7 @@ class TestSubPorts(object):
 
         for sub_port, value in list(sub_ports.items()):
             # Get VLAN ID from name of sub-port
-            vlan_vid = int(sub_port.split('.')[1])
+            vlan_vid = int(sub_port.split(constants.VLAN_SUB_INTERFACE_SEPARATOR)[1])
             # Create a VLAN RIF
             setup_vlan(duthost, vlan_vid)
             # Delete a VLAN RIF

--- a/tests/sub_port_interfaces/test_sub_port_l2_forwarding.py
+++ b/tests/sub_port_interfaces/test_sub_port_l2_forwarding.py
@@ -32,11 +32,24 @@ def testbed_params(define_sub_ports_configuration, duthosts, rand_one_dut_hostna
     testbed_params = define_sub_ports_configuration["sub_ports"].copy()
     duthost = duthosts[rand_one_dut_hostname]
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    portchannel_members = cfg_facts.get('PORTCHANNEL_MEMBER', {})
     for sub_port, config in list(testbed_params.items()):
         port, vlanid = sub_port.split(constants.VLAN_SUB_INTERFACE_SEPARATOR)
         config["port"] = port
         config["vlanid"] = vlanid
-        config["neighbor_ptf_index"] = mg_facts["minigraph_ptf_indices"][port]
+        # Convert abbreviated name to full interface name for minigraph lookup
+        full_port = port
+        if full_port.startswith('Eth'):
+            full_port = 'Ethernet' + full_port[3:]
+        elif full_port.startswith('Po'):
+            full_port = 'PortChannel' + full_port[2:]
+        # For PortChannel, look up the member port's PTF index
+        if full_port.startswith('PortChannel'):
+            members = list(portchannel_members.get(full_port, {}).keys())
+            config["neighbor_ptf_index"] = mg_facts["minigraph_ptf_indices"][members[0]]
+        else:
+            config["neighbor_ptf_index"] = mg_facts["minigraph_ptf_indices"][full_port]
     return testbed_params
 
 
@@ -79,8 +92,8 @@ def generate_eth_packets(test_sub_port, testbed_params, ptfadapter):
     return packets
 
 
-def test_sub_port_l2_forwarding(apply_config_on_the_dut, duthosts, rand_one_dut_hostname, test_sub_port,
-                                generate_eth_packets, testbed_params, ptfadapter):
+def test_sub_port_l2_forwarding(apply_config_on_the_dut, reload_ptf_config, duthosts, rand_one_dut_hostname,
+                                test_sub_port, generate_eth_packets, testbed_params, ptfadapter):
     """Verify sub port doesn't have L2 forwarding capability."""
 
     @contextlib.contextmanager


### PR DESCRIPTION
**Summary:**
Fixes # (issue)
This is applicable for all testcases in file: **test_sub_port_interfaces.py**
The API **apply_config_on_the_dut** creates sub_interfaces on the DUT by directly modifying the CONFIG_DB via template 'templates/sub_port_config.j2'. The naming for the subinterface uses the entire parent interface name instead of the abbreviated format which is otherwise enforced via CLI.
Ex: Ethernet1 ----> Eth1.10. PortChannel200 ----> Po200.30
However the APIs for creating/deleting the sub_interface **create_sub_port_on_dut** and **remove_sub_port** respectively use CLI commands for doing so and this throws error as the sub_interface name is not as per the expected abbreviated format and few testcases(test_routing_between_sub_ports_unaffected_by_sub_ports_removal) fail.

This could be fixed in 2 ways:
**Solution 1:** As the config_db is modified directly without using CLI to create/delete the sub_interfaces during the test, use redis-cli for removing or recreating the sub_interfaces + ip address assigned to the sub_interfaces

**Solution 2:**
Modify the jinja template to populate config_db to create sub_ interfaces that follow the abbreviated format
Update all the helper apis to use the abbreviated sub_interface to perform the operations as ansible facts has the data in full name format.
Modify APIs create_sub_port_on_dut and remove_sub_port for deleting sub_interface and ip addressed assigned via CLI and not via redis-cli.
This PR has the changes as per **Solution 2.**

**Prior to the fix:**
~~~
admin@dut-hw4-t0:~$ show subinterfaces status
  Sub port interface    Speed    MTU    Vlan    Admin    Type
--------------------  -------  -----  ------  -------  ------
admin@dut-hw4-t0:~$ show int portchannel
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
       S - selected, D - deselected, * - not synced
  No.  Team Dev        Protocol     Ports
-----  --------------  -----------  -------------
  101  PortChannel101  LACP(A)(Up)  Ethernet28(S)
  102  PortChannel102  LACP(A)(Up)  Ethernet29(S)
  103  PortChannel103  LACP(A)(Up)  Ethernet30(S)
  104  PortChannel104  LACP(A)(Up)  Ethernet31(S)
admin@dut-hw4-t0:~$ show subinterfaces status
  Sub port interface    Speed    MTU    Vlan    Admin                  Type
--------------------  -------  -----  ------  -------  --------------------
        Ethernet1.20      10G   9100      20       up  802.1q-encapsulation
        Ethernet1.30      10G   9100      30       up  802.1q-encapsulation
        Ethernet1.40      10G   9100      40       up  802.1q-encapsulation
        Ethernet1.50      10G   9100      50       up  802.1q-encapsulation
        Ethernet2.20      10G   9100      20       up  802.1q-encapsulation
        Ethernet2.30      10G   9100      30       up  802.1q-encapsulation
        Ethernet2.40      10G   9100      40       up  802.1q-encapsulation
        Ethernet2.50      10G   9100      50       up  802.1q-encapsulation
admin@dut-hw4-t0:~$ sudo su
root@dut-hw4-t0:/home/admin# config subinterface add Ethernet1.60 60
Usage: config subinterface add [OPTIONS] <subinterface_name> <vid>
Try "config subinterface add -h" for help.

Error: subinterface needs to be shortname, not Ethernet1.60
root@dut-hw4-t0:/home/admin# config subinterface add Ethernet1.50 50
Usage: config subinterface add [OPTIONS] <subinterface_name> <vid>
Try "config subinterface add -h" for help.

Error: subinterface needs to be shortname, not Ethernet1.50
root@dut-hw4-t0:/home/admin#
root@dut-hw4-t0:/home/admin# show int portchannel
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
       S - selected, D - deselected, * - not synced
  No.  Team Dev        Protocol     Ports
-----  --------------  -----------  -------------
    1  PortChannel1    LACP(A)(Up)  Ethernet1(S)
    2  PortChannel2    LACP(A)(Up)  Ethernet2(S)
  101  PortChannel101  LACP(A)(Up)  Ethernet28(S)
  102  PortChannel102  LACP(A)(Up)  Ethernet29(S)
  103  PortChannel103  LACP(A)(Up)  Ethernet30(S)
  104  PortChannel104  LACP(A)(Up)  Ethernet31(S)
root@dut-hw4-t0:/home/admin#
root@dut-hw4-t0:/home/admin# show subinterfaces status
  Sub port interface    Speed    MTU    Vlan    Admin                  Type
--------------------  -------  -----  ------  -------  --------------------
     PortChannel1.20      10G   9100      20       up  802.1q-encapsulation
     PortChannel1.30      10G   9100      30       up  802.1q-encapsulation
     PortChannel1.40      10G   9100      40       up  802.1q-encapsulation
     PortChannel1.50      10G   9100      50       up  802.1q-encapsulation
     PortChannel2.20      10G   9100      20       up  802.1q-encapsulation
     PortChannel2.30      10G   9100      30       up  802.1q-encapsulation
     PortChannel2.40      10G   9100      40       up  802.1q-encapsulation
     PortChannel2.50      10G   9100      50       up  802.1q-encapsulation
root@dut-hw4-t0:/home/admin# config subinterface add PortChannel1.20 20
Usage: config subinterface add [OPTIONS] <subinterface_name> <vid>
Try "config subinterface add -h" for help.

Error: subinterface needs to be shortname, not PortChannel1.20
root@dut-hw4-t0:/home/admin#
~~~

**After the test script changes:**
~~~
admin@dut-hw4-t0:~$ show subinterfaces status
  Sub port interface    Speed    MTU    Vlan    Admin                  Type
--------------------  -------  -----  ------  -------  --------------------
             Eth1.20      10G   9100      20       up  802.1q-encapsulation
             Eth1.30      10G   9100      30       up  802.1q-encapsulation
             Eth1.40      10G   9100      40       up  802.1q-encapsulation
             Eth1.50      10G   9100      50       up  802.1q-encapsulation
             Eth2.20      10G   9100      20       up  802.1q-encapsulation
             Eth2.30      10G   9100      30       up  802.1q-encapsulation
             Eth2.40      10G   9100      40       up  802.1q-encapsulation
             Eth2.50      10G   9100      50       up  802.1q-encapsulation
admin@dut-hw4-t0:~$ show subinterfaces status
  Sub port interface    Speed    MTU    Vlan    Admin    Type
--------------------  -------  -----  ------  -------  ------
admin@dut-hw4-t0:~$ show subinterfaces status
  Sub port interface    Speed    MTU    Vlan    Admin                  Type
--------------------  -------  -----  ------  -------  --------------------
              Po1.20      10G   9100      20       up  802.1q-encapsulation
              Po1.30      10G   9100      30       up  802.1q-encapsulation
              Po1.40      10G   9100      40       up  802.1q-encapsulation
              Po1.50      10G   9100      50       up  802.1q-encapsulation
              Po2.20      10G   9100      20       up  802.1q-encapsulation
              Po2.30      10G   9100      30       up  802.1q-encapsulation
              Po2.40      10G   9100      40       up  802.1q-encapsulation
              Po2.50      10G   9100      50       up  802.1q-encapsulation
admin@dut-hw4-t0:~$
~~~

**Logs:**
[test_show_subinterface_logs.txt](https://github.com/user-attachments/files/28591137/test_show_subinterface_logs.txt)
[test_sub_port_interfaces_logs.txt](https://github.com/user-attachments/files/28591138/test_sub_port_interfaces_logs.txt)
[test_sub_port_l2_forwarding_logs.txt](https://github.com/user-attachments/files/28591139/test_sub_port_l2_forwarding_logs.txt)




<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
