### PR TITLE
Fix FDB CRM counter recovery wait after fdbclear

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -1526,13 +1526,14 @@ def test_crm_fdb_entry(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum
     # Wait for FDB clear to complete using wait_until polling
     logger.info("Waiting for FDB clear to complete...")
     fdb_clear_result = {'used': None, 'avail': None}
+    check_fdb_available = not is_cel_e1031_device(duthost)
 
     def _fdb_final_clear():
         used, avail = get_crm_stats(get_fdb_stats, duthost)
         fdb_clear_result['used'] = used
         fdb_clear_result['avail'] = avail
-        if used == 0:
-            logger.debug("FDB cleared successfully")
+        if used == 0 and (not check_fdb_available or avail >= crm_stats_fdb_entry_available):
+            logger.debug("FDB cleared successfully and CRM counters recovered")
             return True
         return False
 
@@ -1547,6 +1548,6 @@ def test_crm_fdb_entry(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum
     # Verify "crm_stats_fdb_entry_available" counter was incremented
     # For E1031, refer CS00012270660, SDK for Helix4 chip does not support retrieving max l2 entry, HW and
     # SW CRM available counter would be out of sync, so this is not applicable for e1031 device
-    if not is_cel_e1031_device(duthost):
+    if check_fdb_available:
         pytest_assert(new_crm_stats_fdb_entry_available - crm_stats_fdb_entry_available >= 0,
                       "Counter 'crm_stats_fdb_entry_available' was not incremented")

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -1526,13 +1526,16 @@ def test_crm_fdb_entry(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum
     # Wait for FDB clear to complete using wait_until polling
     logger.info("Waiting for FDB clear to complete...")
     fdb_clear_result = {'used': None, 'avail': None}
-    check_fdb_available = not is_cel_e1031_device(duthost)
+    # On CEL E1031, Helix4 SDK does not support retrieving max L2 entry
+    # (CS00012270660), so CRM FDB available can remain out of sync after
+    # updates. Only require the FDB used counter to return to zero there.
+    skip_fdb_available_recovery_check = is_cel_e1031_device(duthost)
 
     def _fdb_final_clear():
         used, avail = get_crm_stats(get_fdb_stats, duthost)
         fdb_clear_result['used'] = used
         fdb_clear_result['avail'] = avail
-        if used == 0 and (not check_fdb_available or avail >= crm_stats_fdb_entry_available):
+        if used == 0 and (skip_fdb_available_recovery_check or avail >= crm_stats_fdb_entry_available):
             logger.debug("FDB cleared successfully and CRM counters recovered")
             return True
         return False
@@ -1548,6 +1551,6 @@ def test_crm_fdb_entry(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum
     # Verify "crm_stats_fdb_entry_available" counter was incremented
     # For E1031, refer CS00012270660, SDK for Helix4 chip does not support retrieving max l2 entry, HW and
     # SW CRM available counter would be out of sync, so this is not applicable for e1031 device
-    if check_fdb_available:
+    if not skip_fdb_available_recovery_check:
         pytest_assert(new_crm_stats_fdb_entry_available - crm_stats_fdb_entry_available >= 0,
                       "Counter 'crm_stats_fdb_entry_available' was not incremented")


### PR DESCRIPTION
### Description of PR

Summary:
Wait for both the FDB used counter to drop to zero and the available counter to recover before validating final CRM stats. This avoids a race where the test reads Redis after FdbOrch updates used resources but before CrmOrch refreshes available resources from SAI.

Fixes #27750

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #27750
Failure type: other

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master: passed
- 202605: passed

### Approach
#### What is the motivation for this PR?

The test can read Redis after the used FDB counter is updated but before the available counter is refreshed, causing a false failure.

#### How did you do it?

Wait for the FDB used counter to reach zero and the available counter to recover to at least its baseline before validating final CRM statistics.

#### How did you verify/test it?

Confirmed the public PR CI passed across all reported validation jobs.

#### Any platform specific information?

No platform-specific behavior is introduced.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

No documentation change is required.