### PR TITLE
[snappi_tests/ecn] Parameterize ECN dequeue test by ASIC type

### DIFF
--- a/tests/snappi_tests/ecn/test_dequeue_ecn_with_snappi.py
+++ b/tests/snappi_tests/ecn/test_dequeue_ecn_with_snappi.py
@@ -21,6 +21,15 @@ logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
 
+# Per-ASIC ECN dequeue test parameters.
+# Broadcom devices have a different queue kmin and require more packets to be
+# sent to see the marked packets at the end of the flow.
+ECN_PARAMS_BY_ASIC = {
+    'default':  {'ecn_params': {'kmin': 50000, 'kmax': 51000, 'pmax': 100}, 'pkt_count': 101},
+    'broadcom': {'ecn_params': {'kmin': 40000, 'kmax': 51000, 'pmax': 100}, 'pkt_count': 301},
+}
+
+
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_dequeue_ecn(request,
                      snappi_api,                    # noqa: F811
@@ -51,6 +60,9 @@ def test_dequeue_ecn(request,
     Returns:
         N/A
     """
+    def _get_ecn_test_params(duthost):
+        asic_type = duthost.facts['asic_type']
+        return ECN_PARAMS_BY_ASIC.get(asic_type, ECN_PARAMS_BY_ASIC['default'])
 
     skip_ecn_tests(duthosts[0])
     for testbed_subtype, rdma_ports in multidut_port_info.items():
@@ -86,9 +98,12 @@ def test_dequeue_ecn(request,
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
     snappi_extra_params.packet_capture_type = packet_capture.IP_CAPTURE
     snappi_extra_params.is_snappi_ingress_port_cap = True
-    snappi_extra_params.ecn_params = {'kmin': 50000, 'kmax': 51000, 'pmax': 100}
+
     data_flow_pkt_size = 1024
-    data_flow_pkt_count = 101
+    ecn_test_params = _get_ecn_test_params(duthosts[0])
+    snappi_extra_params.ecn_params = ecn_test_params['ecn_params']
+    data_flow_pkt_count = ecn_test_params['pkt_count']
+
     num_iterations = 1
     logger.info("Running ECN dequeue test with params: {}".format(snappi_extra_params.ecn_params))
 


### PR DESCRIPTION
### Description of PR

Summary:
Parameterize the ECN dequeue snappi test by ASIC type. Broadcom devices use `kmin=40000` and 301 packets to ensure marked packets appear at the end of the flow; all other ASICs fall back to the default `kmin=50000` and 101 packets.

Fixes # https://github.com/sonic-net/sonic-mgmt/issues/25004

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
On Broadcom ASICs, the previous ECN parameters (`kmin=50000`, 101 packets) did not reliably produce ECN-marked packets at the start of the flow nor unmarked packets at the end, causing `test_dequeue_ecn` to be flaky/fail on Broadcom platforms. Other ASICs work correctly with the existing values.

#### How did you do it?
Replaced the inline override with a module-level `ECN_PARAMS_BY_ASIC` dictionary keyed by `asic_type`, plus a small helper `_get_ecn_test_params(asic_type)` that returns the entry for the DUT's ASIC, falling back to `'default'`. The test body now reads `ecn_params` and `pkt_count` from that lookup instead of branching on `asic_type`. Adding new per-ASIC tuning is now a one-line dictionary entry.

#### How did you verify/test it?
Ran `test_dequeue_ecn` on a Broadcom-based snappi testbed: marked packets are observed at the start of the captured flow and the last packet is unmarked, and the assertions pass. Default-path behavior is unchanged for non-Broadcom ASICs (same `kmin/kmax/pmax` and packet count as before).

#### Any platform specific information?
Broadcom-specific tuning only; behavior on other ASICs is unchanged.

#### Supported testbed topology if it's a new test case?
N/A — existing test (`multidut-tgen`, `tgen`).

### Documentation
N/A
