### PR TITLE
Enable monit refresh for the test case test_lo_interface_tc2_vrf_change and test_vlan_interface_tc1_suite

### DIFF
--- a/tests/generic_config_updater/test_lo_interface.py
+++ b/tests/generic_config_updater/test_lo_interface.py
@@ -385,6 +385,7 @@ def test_lo_interface_tc1_suite(duthosts, rand_one_dut_front_end_hostname, cfg_f
     lo_interface_tc1_remove(duthost, lo_intf)
 
 
+@pytest.mark.enable_monit_refresh
 def test_lo_interface_tc2_vrf_change(duthosts, rand_one_dut_front_end_hostname, lo_intf):
     """ Replace lo interface vrf
 

--- a/tests/generic_config_updater/test_vlan_interface.py
+++ b/tests/generic_config_updater/test_vlan_interface.py
@@ -413,6 +413,7 @@ def vlan_interface_tc1_remove(duthost, vlan_info):
         delete_tmpfile(duthost, tmpfile)
 
 
+@pytest.mark.enable_monit_refresh
 def test_vlan_interface_tc1_suite(rand_selected_dut, vlan_info, loganalyzer, tbinfo, duthost):
     if loganalyzer:
         if tbinfo["topo"]["name"] == "m0-2vlan":


### PR DESCRIPTION
### Description of PR

Summary:
Enable fresh Monit reads for `test_lo_interface_tc2_vrf_change` and `test_vlan_interface_tc1_suite`. These tests modify interface configuration and can otherwise compare stale Monit samples, causing false memory-utilization teardown alarms.

Fixes #27966

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #27966
Failure type: other - intermittent stale Monit data false alarm

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- 202605: `test_lo_interface_tc2_vrf_change` and `test_vlan_interface_tc1_suite` passed.

### Approach

#### What is the motivation for this PR?

Both tests change interface configuration and may cause the memory-utilization fixture to compare stale pre-change Monit samples with current data. This can fail teardown even when the test operation succeeds.

#### How did you do it?

Added the existing `@pytest.mark.enable_monit_refresh` marker to the two affected tests. This uses the memory-utilization plugin's fresh-read path rather than disabling memory checking.

#### How did you verify/test it?

`test_lo_interface_tc2_vrf_change` and `test_vlan_interface_tc1_suite` passed on 202605.

#### Any platform specific information?

No. The change only refreshes Monit data for the affected tests.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

No documentation change is required.
