### PR TITLE
[TH6] Count only fans' name element under chassis->fans in platform.json device file

### DIFF
--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -349,7 +349,10 @@ class TestChassisApi(PlatformApiTestBase):
                 pytest.skip("No fans found on device")
 
         if duthost.facts.get("chassis"):
-            expected_num_fans = len(duthost.facts.get("chassis").get('fans'))
+            fans = duthost.facts.get("chassis").get('fans')
+            expected_num_fans = (
+                sum(1 for f in fans if isinstance(f, dict) and f.get("name")) if fans else 0
+            )
             pytest_assert(num_fans == expected_num_fans,
                           "Number of fans ({}) does not match expected number ({})"
                           .format(num_fans, expected_num_fans))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- This PR fixes issue with _test_fans_ test under test_chassis.py for verifying the total number of fans defined.
- With the changes introduced as part of #27249 sonic-buildimage PR, we have a new field called "_supported_speeds_" under "chassis->fans" in platform.json device file.

```python
        if duthost.facts.get("chassis"):
            expected_num_fans = len(duthost.facts.get("chassis").get('fans'))
>           pytest_assert(num_fans == expected_num_fans,
                          "Number of fans ({}) does not match expected number ({})"
                          .format(num_fans, expected_num_fans))
E           Failed: Number of fans (16) does not match expected number (17)
``` 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

- With the changes introduced as part of #27249 sonic-buildimage PR, we have a new field called "_supported_speeds_" under "chassis->fans" in platform.json device file.
- Current _test_fans_ test in sonic-mgmt, counts _expected_num_fans_ based on the total number of '_fans_' element under '_chassis->fans_', which is not as expected.

```python
        if duthost.facts.get("chassis"):
            expected_num_fans = len(duthost.facts.get("chassis").get('fans'))
>           pytest_assert(num_fans == expected_num_fans,
                          "Number of fans ({}) does not match expected number ({})"
                          .format(num_fans, expected_num_fans))
E           Failed: Number of fans (16) does not match expected number (17)
``` 

#### How did you do it?

- Instead of that, if fans field is present, count based on the fans' "_name_" element, which would give the correct _expected_num_fans_ number.

#### How did you verify/test it?

- Ran the test_fans test with the changes and made sure it is passing without any issues.

#### Any platform specific information?

x86_64-nokia_ixr7220_h6_128-r0

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
