### PR TITLE
Increase test_gnoi_system_reboot_warm wait for critical processes timeout to support slower platforms

### DIFF
--- a/tests/gnmi/test_gnoi_system_reboot.py
+++ b/tests/gnmi/test_gnoi_system_reboot.py
@@ -144,7 +144,7 @@ def test_gnoi_system_reboot_warm(duthosts, rand_one_dut_hostname, localhost, gnm
 
     # Wait for critical processes before ending
     # Warm reboot takes longer for containers to restart; use an extended timeout
-    wait_critical_processes(duthost, timeout=360)
+    wait_critical_processes(duthost, timeout=600)
 
     # Wait for gNMI container to be running
     wait_until(120, 10, 0, is_gnmi_container_running, duthost)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #25956 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Slower platforms such as Upperlake are failing the wait for critical processes check in gnmi tests.

#### How did you do it?
Increased the timeout for this check.

#### How did you verify/test it?
Verified `test_gnoi_system_reboot_warm` passes with the change.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
