### PR TITLE
skip mac move guard tests on kvm

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2309,6 +2309,18 @@ fdb/test_fdb_mac_learning.py::TestFdbMacLearning::testFdbMacLearning:
     conditions:
       - "'dualtor-aa' in topo_name and https://github.com/sonic-net/sonic-mgmt/issues/16110"
 
+fdb/test_fdb_mac_move.py::test_fdb_mac_move_guard_disable_mac_learning:
+  skip:
+    reason: "Currently not supported on virtual switch."
+    conditions:
+      - "asic_type in ['vs']"
+
+fdb/test_fdb_mac_move.py::test_fdb_mac_move_guard_disable_port:
+  skip:
+    reason: "Currently not supported on virtual switch."
+    conditions:
+      - "asic_type in ['vs']"
+
 #######################################
 #####            fib              #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Skip mac move guard tests on KVM
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/25158

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Due to libsaivs bug, MAC moves are not notified in VS - https://github.com/sonic-net/sonic-mgmt/issues/25158
Hence the mac move tests fail in KVM
#### How did you do it?
Disable the tests on KVM
#### How did you verify/test it?
Ran the tests and verified that the tests are skipped on KVMs
#### Any platform specific information?
The tests fail on VS
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
