### PR TITLE
platform/test_reboot: derive expected interface state from running-config admin_status

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -103,13 +103,9 @@ def check_interface_status(dut, asic_index, interfaces, xcvr_skip_list):
     asichost = dut.asic_instance(asic_index)
     namespace = asichost.get_asic_namespace()
     logging.info("Check interface status using cmd 'show interface'")
-    # TODO Remove this logic when minigraph facts supports namespace in multi_asic
-    mg_ports = dut.minigraph_facts(host=dut.hostname)["ansible_facts"]["minigraph_ports"]
-    if asic_index is not None:
-        portmap = get_port_map(dut, asic_index)
-        # Check if the interfaces of this AISC is present in mg_ports
-        interface_list = {k: v for k, v in list(portmap.items()) if k in mg_ports}
-        mg_ports = interface_list
+    # Expected up/down comes from the running-config PORT table for this ASIC's namespace.
+    cfg_ports = dut.config_facts(host=dut.hostname, source="running",
+                                 namespace=namespace)["ansible_facts"].get("PORT", {})
     output = dut.command("show interface description")
     intf_status = parse_intf_status(output["stdout_lines"][2:])
     if dut.is_multi_asic:
@@ -121,18 +117,17 @@ def check_interface_status(dut, asic_index, interfaces, xcvr_skip_list):
         {ports_presence.split()[0]: ports_presence.split()[1] for ports_presence in check_inerfaces_presence_output}
     )
     for intf in interfaces:
-        expected_oper = "up" if intf in mg_ports else "down"
-        expected_admin = "up" if intf in mg_ports else "down"
+        if intf not in cfg_ports:
+            logging.info("Interface %s is not present in the running-config PORT table (namespace '%s')"
+                         % (intf, namespace))
+            return False
+        expected_status = cfg_ports[intf].get("admin_status", "down")
         if intf not in intf_status:
             logging.info("Missing status for interface %s" % intf)
             return False
-        if intf_status[intf]["oper"] != expected_oper:
-            logging.info("Oper status of interface %s is %s, expected '%s'" % (intf, intf_status[intf]["oper"],
-                                                                               expected_oper))
-            return False
-        if intf_status[intf]["admin"] != expected_admin:
-            logging.info("Admin status of interface %s is %s, expected '%s'" % (intf, intf_status[intf]["admin"],
-                                                                                expected_admin))
+        if intf_status[intf]["oper"] != expected_status or intf_status[intf]["admin"] != expected_status:
+            logging.info("Interface %s status mismatch: oper '%s', admin '%s', expected '%s' (from running-config)"
+                         % (intf, intf_status[intf]["oper"], intf_status[intf]["admin"], expected_status))
             return False
 
         # Cross check the interface SFP presence status
@@ -143,7 +138,8 @@ def check_interface_status(dut, asic_index, interfaces, xcvr_skip_list):
                 "Status is not expected, presence status: %s" % str({intf: interface_presence})
 
     logging.info("Check interface status using the interface_facts module")
-    intf_facts = dut.interface_facts(up_ports=mg_ports, namespace=namespace)["ansible_facts"]
+    up_ports = [intf for intf in interfaces if cfg_ports.get(intf, {}).get("admin_status") == "up"]
+    intf_facts = dut.interface_facts(up_ports=up_ports, namespace=namespace)["ansible_facts"]
     down_ports = intf_facts["ansible_interface_link_down_ports"]
     if len(down_ports) != 0:
         logging.info("Some interfaces are down: %s" % str(down_ports))
@@ -159,10 +155,12 @@ def check_all_interface_information(dut, interfaces, xcvr_skip_list):
         interface_list = get_port_map(dut, asic_index)
         interfaces_per_asic = {k: v for k, v in list(interface_list.items()) if k in interfaces}
         if not all_transceivers_detected(dut, asic_index, interfaces_per_asic, xcvr_skip_list):
-            logging.info("Not all transceivers are detected")
+            logging.info("Transceiver check failed on asic %s: not all transceivers are detected "
+                         "(see 'Interfaces not detected' above)" % asic_index)
             return False
         if not check_interface_status(dut, asic_index, interfaces_per_asic, xcvr_skip_list):
-            logging.info("Not all interfaces are up")
+            logging.info("Interface state check failed on asic %s: one or more interfaces are not in their "
+                         "expected admin/oper state (see the per-interface line above)" % asic_index)
             return False
 
     return True

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -119,8 +119,11 @@ def check_interfaces_and_services(dut, interfaces, xcvr_skip_list,
             interfaces_wait_time))
         result = wait_until(interfaces_wait_time, 20, 0, check_all_interface_information, dut, interfaces,
                             xcvr_skip_list)
-        assert result, "Not all transceivers are detected or interfaces are up in {} seconds".format(
-            interfaces_wait_time)
+        assert result, (
+            "Post-reboot readiness check failed after {} seconds: either some transceivers were not detected, "
+            "or one or more interfaces were not in their expected admin/oper state. See the preceding "
+            "'transceiver_utils'/'interface_utils' log lines for the specific interface(s) and the reason."
+            .format(interfaces_wait_time))
 
         logging.info("Check transceiver status")
         for asic_index in dut.get_frontend_asic_ids():


### PR DESCRIPTION
### Description of PR

Summary:
Fixes #  https://github.com/sonic-net/sonic-mgmt/issues/25127
This PR fixes a topology-specific bug in `platform_tests/test_reboot.py` on PTF-style testbeds.

Today, `check_interface_status()` derives the expected admin/oper status of each cabled interface from `minigraph_ports`. That works on topologies where `minigraph_ports` is populated, but fails on PTF-style topologies where `minigraph_ports` is empty even though `minigraph_neighbors` is populated and the relevant front-panel ports are configured `admin_status: up` in the running config.

As a result, all cabled ports are incorrectly expected to be down. After reboot, ports that correctly return to operational up state trip the check, causing failures such as:

```
AssertionError: Not all transceivers are detected or interfaces are up in 300 seconds
```

The transceivers are detected correctly. The actual repeated failure is that the helper expects ports like `Ethernet256` to remain down when they are configured admin-up and correctly come back up.

This issue is topology-correlated rather than platform- or hardware-specific:
- Reproduces on ptf8 testbeds across multiple platforms
- Does not reproduce on t1/t2 testbeds where `minigraph_ports` is populated
- Does not affect the reboot-cause-only path because that flow returns before the interface-status check

This change makes the running-config `PORT.admin_status` in CONFIG_DB the source of truth for expected interface state in `check_interface_status()`. A port configured `admin_status: up` is expected to be admin up and oper up; otherwise it is expected down.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

Make `test_reboot` and other consumers of `check_interface_status()` work correctly on PTF-style topologies where `minigraph_ports` is empty but cabled ports are configured admin-up in the running config.

#### How did you do it?

Updated `check_interface_status()` to use the running-config `PORT.admin_status` for the target namespace/ASIC as the primary source of truth for expected interface state.

Specifically:
- Read port state from `config_facts(namespace=...)` for the relevant ASIC namespace
- Determine expected up/down status from `PORT.admin_status`
- Pass the same admin-up interface set into `interface_facts(up_ports=...)`
- Remove the dependency on `minigraph_ports` / port-map-based expectations
- Keep the logic scoped to the interfaces under test

#### How did you verify/test it?

Verified through log analysis and hardware testing:
- Root cause confirmed from reboot test logs showing transceiver detection succeeded while interface-state validation failed
- Reproduced consistently on ptf8 testbeds and correlated with empty `minigraph_ports`
- Validated on NH-4010 ptf8 with `test_cold_reboot[cli_based]`, which passed after the change
- Confirmed the previous implementation fails the same case with the original `minigraph_ports`-based logic
- t0/t1/t2 behavior is unchanged by construction because their cabled ports are both admin-up and represented in topology metadata

#### Any platform specific information?

The issue was observed on NH-4010 (`x86_64-nexthop_4010-r1`) under ptf8 topology, but the bug is topology-dependent and was reproducible across multiple ptf8 testbeds rather than tied to a specific hardware platform.

#### Supported testbed topology if it's a new test case?

Not a new test case. Fix applies to existing reboot coverage and is relevant to PTF-style topologies, including ptf8.

### Documentation

Not applicable.
