### PR TITLE
[TH6] test_snmp_loopback: Update fetching snmpget for multi-vrf peers

### DIFF
--- a/tests/common/helpers/snmp_helpers.py
+++ b/tests/common/helpers/snmp_helpers.py
@@ -68,6 +68,10 @@ def get_snmp_output(ip, duthost, nbr, creds_all_duts, oid='.1.3.6.1.2.1.1.1.0'):
     Get snmp output from duthost using specific ip to query
     snmp query is sent from neighboring ceos/vsonic
 
+    On converged multi-VRF cEOS neighbors, DUT loopback routes are present in peer
+    VRF stack on the neighbor VM under namespace named 'ns-<EOS_VRF_NAME>'.
+    Run 'sudo ip netns exec ns-<vrf> snmpget'
+
      Args:
         ip(str): IP of dut to be used to send SNMP query
         duthost: duthost
@@ -87,17 +91,25 @@ def get_snmp_output(ip, duthost, nbr, creds_all_duts, oid='.1.3.6.1.2.1.1.1.0'):
     ip_tbl_rule_add = "sudo {} -I INPUT 1 -p udp --dport 161 -d {} -j ACCEPT".format(
         iptables_cmd, ip)
     duthost.shell(ip_tbl_rule_add)
-    # DUT IP is only accessible through VRF from neighboring devices if the neighbor is a multi-VRF peer
-    # This enhancement only handles the case where the neighbor is EoS
-    vrf_prefix = ""
-    if nbr.get("is_multi_vrf_peer", False):
-        vrf = nbr.get("multi_vrf_data", {}).get("vrf", "")
-        if vrf:
-            vrf_prefix = "sudo ip netns exec ns-{}".format(vrf)
     if isinstance(nbr["host"], EosHost):
-        eos_snmpget = "bash {} snmpget -v2c -c {} {} {}".format(
-            vrf_prefix, creds_all_duts[duthost.hostname]['snmp_rocommunity'], ip, oid)
-        out = nbr['host'].eos_command(commands=[eos_snmpget])
+        community = creds_all_duts[duthost.hostname]['snmp_rocommunity']
+        if nbr.get("is_multi_vrf_peer") and nbr.get("multi_vrf_data", {}).get("vrf"):
+            vrf = nbr["multi_vrf_data"]["vrf"]
+            # cEOS maps each EOS VRF to Linux netns "ns-<vrf>".
+            netns = "ns-{}".format(vrf)
+            cmd = "sudo ip netns exec {} snmpget -v2c -c {} {} {}".format(
+                netns, community, ip, oid)
+            raw = nbr["host"].shell(cmd)
+            out = dict(raw)
+            lines = list(out.get("stdout_lines") or [])
+            if not lines and out.get("stdout"):
+                lines = [ln for ln in out["stdout"].splitlines()]
+            # Match eos_command: one list per logical command, each a list of lines
+            out["stdout_lines"] = [lines]
+        else:
+            eos_snmpget = "bash snmpget -v2c -c {} {} {}".format(
+                community, ip, oid)
+            out = nbr['host'].eos_command(commands=[eos_snmpget])
     else:
         command = "docker exec snmp snmpwalk -v 2c -c {} {} {}".format(
                   creds_all_duts[duthost.hostname]['snmp_rocommunity'], ip, oid)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- This PR adds support for EOS **snmpget** commands on neighbor hosts if the DUT has multi_vrf topo.
- Following tests failed to adapt the neighbor host commands and this PR helps to fix the same.
 _snmp.test_snmp_loopback#test_snmp_loopback_

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

- _test_snmp_loopback_ fail if the DUT has multi_vrf topo and fail to adapt the neighbor host EOS _snmpget_ commands.

#### How did you do it?

- If the topo is multi_vrf, change the snmpget command to include multi_vrf data. For example, _**sudo ip netns exec ns-vrfname snmpget**_

#### How did you verify/test it?

- Ran the _test_snmp_loopback_ tests and made sure all are passing without any issues.

#### Any platform specific information?

- x86_64-nokia_ixr7220_h6_128-r0

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
<img width="877" height="80" alt="image" src="https://github.com/user-attachments/assets/096412c5-cd54-4a06-a642-7a705466ba0d" />
