### PR TITLE
[conditional_mark][bgp] Skip test_bgpmon_v6 on q3d (Jericho3) ASIC

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -643,6 +643,12 @@ bgp/test_bgpmon.py::test_bgpmon:
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/20754 and '-v6-' in topo_name"
 
+bgp/test_bgpmon_v6.py:
+  skip:
+    reason: "Not supported on Broadcom q3d (Jericho3) ASIC"
+    conditions:
+      - "asic_type == 'broadcom' and asic_gen == 'q3d'"
+
 bgp/test_bgpmon_v6.py::test_bgpmon_no_ipv6_resolve_via_default:
   skip:
     reason: "Not applicable for passive bgpmon_v6"


### PR DESCRIPTION
### Description of PR

`bgp/test_bgpmon_v6.py` is not currently supported on q3d (Jericho3) ASIC. Rather than enumerating individual platform strings (which has to be updated every time a new q3d-based SKU is onboarded), this PR adds a single conditional-mark entry keyed on `asic_type == 'broadcom' and asic_gen == 'q3d'`. This is the same idiom already used elsewhere in tests_mark_conditions.yaml (e.g. around lines 2800, 3926, 5226).

Summary:
Fixes # (N/A)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
`bgp/test_bgpmon_v6.py` does not pass on q3d (Jericho3) ASIC. We want a skip rule that is generic across the whole q3d family rather than hard-coded to one platform string, so newly onboarded q3d SKUs are covered automatically.

#### How did you do it?
Added a single `bgp/test_bgpmon_v6.py` entry in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` that skips the file when `asic_type == 'broadcom' and asic_gen == 'q3d'`. The `asic_gen` value is derived from `hwsku` by `read_asic_name()` in `tests/common/plugins/conditional_mark/__init__.py`, and `'q3d'` is already an established `asic_gen` identifier in that function. Existing q3d conditions can be found at lines 2800, 3926, and 5226 of the YAML.

#### How did you verify/test it?
- Validated the YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(open('tests/common/plugins/conditional_mark/tests_mark_conditions.yaml'))"`).
- Confirmed the `asic_type == 'broadcom' and asic_gen == 'q3d'` pattern is already used in the same file, so the conditional-mark plugin's expression evaluator handles it.

#### Any platform specific information?
Skip applies to q3d (Jericho3) ASIC family. Any q3d-based hwsku is picked up automatically via the `asic_gen` derivation from `hwsku`.

#### Supported testbed topology if it's a new test case?
N/A — this is a skip rule for an existing test, not a new test case.

### Documentation
N/A — no user-facing behavior or new feature; only a conditional-mark skip rule update.