### PR TITLE
[BMC] Skip interface status checks for BMC platforms

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -63,6 +63,11 @@ def check_interface_status_of_up_ports(duthost):
     if duthost.is_bmc():
         return True
 
+    # Skip interface checks for BMC - BMC manages BMC network interface, not data plane ports
+    # BMC devices don't have front-panel ports - always return True
+    if duthost.is_bmc():
+        return True
+
     if duthost.is_multi_asic:
         up_ports = []
         for asic in duthost.frontend_asics:
@@ -100,6 +105,11 @@ def check_interface_status(dut, asic_index, interfaces, xcvr_skip_list):
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
     @param interfaces: List of interfaces that need to be checked.
     """
+    # BMC devices have no front-panel ports, skip interface checks
+    if dut.is_bmc():
+        logging.info("BMC device detected, skipping interface status check (no front-panel ports)")
+        return True
+
     asichost = dut.asic_instance(asic_index)
     namespace = asichost.get_asic_namespace()
     logging.info("Check interface status using cmd 'show interface'")


### PR DESCRIPTION

### Description of PR
Skip interface status checks for BMC platforms. BMC does not have any front panel ports and the checks are triggered in common paths (e.g. reboot, config reload).

### Type of change
- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Get sonic-mgmt tests to pass on BMC.

#### How did you do it?
Skip interface status checks on BMC platforms.

#### How did you verify/test it?
Ran cacl tests in sonic-mgmt

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

