### PR TITLE
[conditional_mark]: Enable NTP IPv6-only management test on sonic-vpp

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -418,17 +418,6 @@ golden_config_infra/test_config_reload_with_rendered_golden_config.py::test_rend
       - "asic_type in ['vpp']"
 
 #######################################
-#####           IP                #####
-#######################################
-ip/test_mgmt_ipv6_only.py::test_ntp_ipv6_only:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-#######################################
 #####         Memory Checker      #####
 #######################################
 memory_checker/test_memory_checker.py::test_memory_checker:


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Remove the stale VPP conditional skip for `ip/test_mgmt_ipv6_only.py::test_ntp_ipv6_only`.

The test does not contain any VPP-specific skip logic in code and now passes on the SONiC-VPP KVM testbed. Keeping it skipped in `tests_mark_conditions_sonic_vpp.yaml` unnecessarily excludes IPv6-only NTP management coverage from `t1-lag-vpp` PR testing.

Fixes sonic-net/sonic-buildimage#25768

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach

#### What is the motivation for this PR?

`tests_mark_conditions_sonic_vpp.yaml` still skipped `test_ntp_ipv6_only` for `asic_type == 'vpp'` with the placeholder reason `Failed/Errored: To be included`.

The test itself has no VPP-specific skip or limitation, and `t1-lag-vpp` already includes `ip/test_mgmt_ipv6_only.py` in PR test selection. Removing this stale skip enables the existing IPv6-only NTP management coverage on SONiC-VPP.

#### How did you do it?

Removed the `ip/test_mgmt_ipv6_only.py::test_ntp_ipv6_only` skip block from `tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml`.

Also removed the now-empty `IP` section header from that file.

#### How did you verify/test it?

Verified that the test code has no VPP-specific skip logic.

Ran `ip/test_mgmt_ipv6_only.py::test_ntp_ipv6_only` locally on `vlab-vpp-01`
(vms-kvm-vpp-t1-lag):

```text
ip/test_mgmt_ipv6_only.py::test_ntp_ipv6_only[True] PASSED               [100%]
```

Also ran `ip/test_mgmt_ipv6_only.py` on the same testbed:

```text
=========== 9 passed, 1 skipped, 549 warnings in 2078.11s (0:34:38) ============
```

The skipped cases are unrelated to this VPP conditional mark removal.

#### Any platform specific information?

This only affects SONiC-VPP conditional marking. Other ASIC platforms are unchanged.

#### Supported testbed topology if it's a new test case?

N/A. This is not a new test case.

Validated on:

```text
vms-kvm-vpp-t1-lag / vlab-vpp-01
```

### Documentation

N/A.

