### PR TITLE
[mmu probing] Add pool_size safety cap to upper bound algorithm

### DIFF
--- a/tests/saitests/mock/ut/test_ingress_drop_probing.py
+++ b/tests/saitests/mock/ut/test_ingress_drop_probing.py
@@ -327,7 +327,7 @@ class TestIngressDropProbingAlgorithmExecution(unittest.TestCase):
         )
 
         # Verify all phases executed
-        mock_upper.run.assert_called_once_with(24, 28, 5000, pg=3)
+        mock_upper.run.assert_called_once_with(24, 28, 5000, pool_size=5000, pg=3)
         mock_lower.run.assert_called_once_with(24, 28, 2000, pg=3)
         mock_range.run.assert_called_once_with(24, 28, 1000, 2000, pg=3)
 
@@ -557,7 +557,7 @@ class TestIngressDropProbingAlgorithmExecution(unittest.TestCase):
         )
 
         # Verify all algorithms receive traffic_keys
-        mock_upper.run.assert_called_once_with(24, 28, 5000, pg=3, queue=5, custom="value")
+        mock_upper.run.assert_called_once_with(24, 28, 5000, pool_size=5000, pg=3, queue=5, custom="value")
         mock_lower.run.assert_called_once_with(24, 28, 2000, pg=3, queue=5, custom="value")
         mock_range.run.assert_called_once_with(24, 28, 1000, 2000, pg=3, queue=5, custom="value")
 

--- a/tests/saitests/mock/ut/test_upper_bound_probing_algorithm.py
+++ b/tests/saitests/mock/ut/test_upper_bound_probing_algorithm.py
@@ -249,6 +249,83 @@ class TestUpperBoundProbingAlgorithm:
         assert complete_calls[0][0][2].value == IterationOutcome.UNREACHED.value
         assert complete_calls[1][0][2].value == IterationOutcome.REACHED.value
 
+    @pytest.mark.order(8120)
+    def test_run_pool_size_cap_triggers_abort(self):
+        """Test that algorithm aborts when current exceeds 3x pool_size"""
+        self.setUp()
+        # All checks return unreached — simulates dead PFC counter
+        self.mock_executor.check.return_value = (True, False)
+
+        algo = UpperBoundProbingAlgorithm(self.mock_executor, self.mock_observer)
+        # pool_size=100, initial_value=100: iter1=100, iter2=200, iter3=400 > 300 (3x100) → abort
+        result, phase_time = algo.run(
+            src_port=24, dst_port=28, initial_value=100, pool_size=100
+        )
+
+        assert result is None  # Aborted
+        # Should have run 2 iterations (100, 200) then abort at 400
+        assert self.mock_executor.check.call_count == 2
+        self.mock_observer.on_error.assert_called_once()
+        error_msg = self.mock_observer.on_error.call_args[0][0]
+        assert "3x pool_size" in error_msg
+        assert "100 pkt" in error_msg
+
+    @pytest.mark.order(8121)
+    def test_run_pool_size_cap_does_not_trigger_when_threshold_found(self):
+        """Test that pool_size cap does not interfere when threshold is found within range"""
+        self.setUp()
+        self.mock_executor.check.side_effect = [
+            (True, False),  # iter1: 100 → unreached
+            (True, True),   # iter2: 200 → reached (threshold found before cap)
+        ]
+
+        algo = UpperBoundProbingAlgorithm(self.mock_executor, self.mock_observer)
+        result, phase_time = algo.run(
+            src_port=24, dst_port=28, initial_value=100, pool_size=100
+        )
+
+        assert result == 200  # Found threshold
+        self.mock_observer.on_error.assert_not_called()
+
+    @pytest.mark.order(8122)
+    def test_run_pool_size_none_no_cap(self):
+        """Test that pool_size=None (default) disables the cap — backward compatible"""
+        self.setUp()
+        # 5 iterations all unreached, no pool_size cap
+        self.mock_executor.check.return_value = (True, False)
+
+        algo = UpperBoundProbingAlgorithm(self.mock_executor, self.mock_observer)
+        result, phase_time = algo.run(
+            src_port=24, dst_port=28, initial_value=100
+            # pool_size not passed → None → no cap
+        )
+
+        # Should run all 20 max_iterations without aborting on pool_size
+        assert result is None
+        assert self.mock_executor.check.call_count == 20
+        # Error should be "exceeded maximum iterations", not "3x pool_size"
+        error_msg = self.mock_observer.on_error.call_args[0][0]
+        assert "maximum iterations" in error_msg
+
+    @pytest.mark.order(8123)
+    def test_run_pool_size_cap_boundary(self):
+        """Test pool_size cap boundary: current exactly at 3x should NOT abort"""
+        self.setUp()
+        self.mock_executor.check.return_value = (True, False)
+
+        algo = UpperBoundProbingAlgorithm(self.mock_executor, self.mock_observer)
+        # pool_size=200, initial=100: iter1=100, iter2=200, iter3=400, iter4=800>600 → abort
+        # 400 is exactly 2x pool_size (not > 3x=600), so iter3 should run
+        result, phase_time = algo.run(
+            src_port=24, dst_port=28, initial_value=100, pool_size=200
+        )
+
+        assert result is None
+        # iter1=100, iter2=200, iter3=400, iter4=800>600 → 3 checks run, abort at 4th doubling
+        assert self.mock_executor.check.call_count == 3
+        error_msg = self.mock_observer.on_error.call_args[0][0]
+        assert "3x pool_size" in error_msg
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/saitests/probe/headroom_pool_probing.py
+++ b/tests/saitests/probe/headroom_pool_probing.py
@@ -371,7 +371,8 @@ class HeadroomPoolProbing(ProbingBase):
                     pg_results[-1]['pfc_xoff_threshold'] if pg_results else pool_size
                 )
                 pfc_upper, pfc_upper_time = pfc_algos['upper'].run(
-                    src_port_id, dst_port_id, pfc_upper_init, **traffic_keys
+                    src_port_id, dst_port_id, pfc_upper_init,
+                    pool_size=pool_size, **traffic_keys
                 )
                 total_time += pfc_upper_time
                 if pfc_upper is None:
@@ -479,7 +480,8 @@ class HeadroomPoolProbing(ProbingBase):
                     pg_results[-1]['ingress_drop_threshold'] if pg_results else pool_size
                 )
                 drop_upper, drop_upper_time = drop_algos['upper'].run(
-                    src_port_id, dst_port_id, drop_upper_init, **traffic_keys
+                    src_port_id, dst_port_id, drop_upper_init,
+                    pool_size=pool_size, **traffic_keys
                 )
                 total_time += drop_upper_time
                 if drop_upper is None:

--- a/tests/saitests/probe/ingress_drop_probing.py
+++ b/tests/saitests/probe/ingress_drop_probing.py
@@ -400,7 +400,8 @@ class IngressDropProbing(ProbingBase):
             tuple: (lower_bound, upper_bound) or (None, None) on failure
         """
         # Phase 1: Upper bound discovery (exponential growth)
-        upper_bound, _ = algorithms["upper_bound"].run(src_port, dst_port, pool_size, **traffic_keys)
+        upper_bound, _ = algorithms["upper_bound"].run(
+            src_port, dst_port, pool_size, pool_size=pool_size, **traffic_keys)
         if upper_bound is None:
             ProbingObserver.console("[ERROR] Upper bound detection failed")
             return (None, None)

--- a/tests/saitests/probe/pfc_xoff_probing.py
+++ b/tests/saitests/probe/pfc_xoff_probing.py
@@ -395,7 +395,8 @@ class PfcXoffProbing(ProbingBase):
             tuple: (lower_bound, upper_bound) or (None, None) on failure
         """
         # Phase 1: Upper bound discovery (exponential growth)
-        upper_bound, _ = algorithms["upper_bound"].run(src_port, dst_port, pool_size, **traffic_keys)
+        upper_bound, _ = algorithms["upper_bound"].run(
+            src_port, dst_port, pool_size, pool_size=pool_size, **traffic_keys)
         if upper_bound is None:
             ProbingObserver.console("[ERROR] Upper bound detection failed")
             return (None, None)

--- a/tests/saitests/probe/upper_bound_probing_algorithm.py
+++ b/tests/saitests/probe/upper_bound_probing_algorithm.py
@@ -68,7 +68,8 @@ class UpperBoundProbingAlgorithm:
         self.observer = observer
         self.verification_attempts = verification_attempts
 
-    def run(self, src_port: int, dst_port: int, initial_value: int, **traffic_keys) -> Tuple[Optional[int], float]:
+    def run(self, src_port: int, dst_port: int, initial_value: int,
+            pool_size: int = None, **traffic_keys) -> Tuple[Optional[int], float]:
         """
         Run upper bound discovery algorithm
 
@@ -76,6 +77,10 @@ class UpperBoundProbingAlgorithm:
             src_port: Source port for traffic generation
             dst_port: Destination port for threshold detection
             initial_value: Starting value (typically buffer_pool_size)
+            pool_size: Optional pool size in packet units for safety cap.
+                       When provided, algorithm aborts if current exceeds 3x pool_size.
+                       This prevents runaway when threshold is not triggerable
+                       (e.g., dead PFC counter on Mellanox pg=4).
             **traffic_keys: Traffic identification keys (e.g., pg=3, queue=5)
 
         Returns:
@@ -120,6 +125,17 @@ class UpperBoundProbingAlgorithm:
                 else:
                     # Continue exponential growth
                     current *= 2
+                    # Safety cap: abort if current exceeds 3x pool_size
+                    # Prevents runaway when threshold is not triggerable (dead counter).
+                    # 3x gives ~1.5 extra doublings beyond pool capacity — generous enough
+                    # to find thresholds even with misconfigured pool_size, but prevents
+                    # sending 10x+ pool_size packets which causes SAI thrift errors.
+                    if pool_size is not None and current > pool_size * 3:
+                        self.observer.on_error(
+                            f"Upper bound exceeded 3x pool_size ({pool_size} pkt), "
+                            f"threshold likely not triggerable at current={current} pkt"
+                        )
+                        return (None, phase_time)
 
             self.observer.on_error(f"Upper bound discovery exceeded maximum iterations ({max_iterations})")
             return (None, phase_time)


### PR DESCRIPTION
## Description

Add a safety cap to the upper-bound probing algorithm that prevents runaway when the threshold is not triggerable.

### Problem

When a PFC/IngressDrop threshold is not triggerable (e.g., dead PFC counter on certain Mellanox PGs), the exponential doubling loop continues to 2^20 x initial_value, sending enormous traffic that causes SAI thrift timeout errors.

### Solution

- Accept an optional `pool_size` parameter (in packet units) in `UpperBoundProbingAlgorithm.run()`
- When `current` exceeds 3x `pool_size`, abort early with `None` (threshold not found)
- 3x multiplier gives ~1.5 extra doublings beyond pool capacity -- generous enough to find thresholds near pool_size, but prevents sending 10x+ pool_size packets
- Pass `pool_size` from all callers: HeadroomPoolProbing (PFC + IngressDrop), IngressDropProbing, PfcXoffProbing
- When `pool_size` is not provided (default `None`), no cap is applied (backward compatible)

### Changes

| File | Change |
|------|--------|
| `upper_bound_probing_algorithm.py` | Add `pool_size` param + 3x safety cap logic |
| `headroom_pool_probing.py` | Pass `pool_size=pool_size` to PFC + IngressDrop upper bound |
| `ingress_drop_probing.py` | Pass `pool_size=pool_size` to upper bound |
| `pfc_xoff_probing.py` | Pass `pool_size=pool_size` to upper bound |
| `test_upper_bound_probing_algorithm.py` | 4 new tests: cap triggers, no-abort, None=no cap, boundary |
| `test_ingress_drop_probing.py` | Update 2 mock assertions for `pool_size` param |

### Tests

All 41 existing + new unit tests pass.

### Dependencies

Depends on PR #24784 (merged)
