### PR TITLE
[mmu probing] Improve HeadroomPool observer output clarity

### DIFF
--- a/tests/saitests/probe/headroom_pool_probing.py
+++ b/tests/saitests/probe/headroom_pool_probing.py
@@ -306,7 +306,7 @@ class HeadroomPoolProbing(ProbingBase):
             dscp = flow_config.dscp
 
             ProbingObserver.console(f"\n{'='*60}")
-            ProbingObserver.console(f"PG #{i+1}/{num_flows}: src={src_port_id}, dst={dst_port_id}, pg={pg}")
+            ProbingObserver.console(f"Iter #{i+1}/{num_flows}: src={src_port_id}, dst={dst_port_id}, pg={pg}")
             ProbingObserver.console(f"{'='*60}")
 
             # Set ptftest context for this flow
@@ -560,7 +560,7 @@ class HeadroomPoolProbing(ProbingBase):
                     'headroom': pg_headroom
                 })
 
-                ProbingObserver.console(f"\n[Result] PG #{i+1} Headroom = {pg_headroom} cells")
+                ProbingObserver.console(f"\n[Result] Iter #{i+1} Headroom = {pg_headroom} cells")
                 ProbingObserver.console(f"         Total accumulated = {total_headroom} cells")
 
                 pg_success = True
@@ -568,7 +568,7 @@ class HeadroomPoolProbing(ProbingBase):
 
             # Unified cleanup on PG failure
             if not pg_success:
-                ProbingObserver.console(f"  Skipping PG #{i+1} due to {fail_reason}")
+                ProbingObserver.console(f"  Skipping Iter #{i+1} due to {fail_reason}")
                 self.buffer_ctrl.drain_buffer([dst_port_id])
                 continue
 


### PR DESCRIPTION
## Description

Rename `PG #N` to `Iter #N` in HeadroomPool probe observer output for clarity.

### Problem

The HeadroomPool probe iterates through multiple PGs (priority groups), exhausting the shared pool one PG at a time. The observer output labels each iteration as `PG #1`, `PG #2`, etc., which is confusing because:
- The iteration number is NOT the PG number (PG is printed separately as `pg=3`, `pg=4`, etc.)
- `PG #1` could be any actual PG (e.g., pg=3), depending on the flow config
- In multi-iteration output, `Iter #` more clearly conveys the sequential probing order

### Changes

3 label renames in `headroom_pool_probing.py`:
- `PG #N/M` → `Iter #N/M` (iteration header)
- `[Result] PG #N` → `[Result] Iter #N` (result line)
- `Skipping PG #N` → `Skipping Iter #N` (failure skip)

No logic changes — output text only.
