### PR TITLE
[mmu probing] pr23: Rename 'PG #' to 'Iter #' in HeadroomPool observer output

### DIFF
--- a/tests/saitests/mock/ut/test_headroom_pool_probing.py
+++ b/tests/saitests/mock/ut/test_headroom_pool_probing.py
@@ -1250,4 +1250,65 @@ class TestBufferCleanupOnPgFailure:
         drain_calls = [c for c in instance.buffer_ctrl.drain_buffer.call_args_list
                        if c[0][0] == [36]]
         assert len(drain_calls) > 0, \
-            "drain_buffer([36]) should be called for PG #1's dst_port on failure"
+            "drain_buffer([36]) should be called for Iter #1's dst_port on failure"
+
+
+@pytest.mark.order(4660)
+class TestHeadroomPoolProbingIterDisplay(unittest.TestCase):
+    """Verify probe() console output uses 'Iter #' prefix (not 'PG #')."""
+
+    @pytest.mark.order(4660)
+    @patch('headroom_pool_probing.ProbingObserver')
+    def test_console_output_uses_iter_prefix(self, mock_observer_class):
+        """Console messages must use 'Iter #N' instead of 'PG #N'."""
+        instance = TestHeadroomPoolProbingInstance()
+
+        mock_stream_mgr = MagicMock()
+        mock_stream_mgr.flows = {
+            (24, 36, frozenset([('pg', 3)])): MagicMock(dscp=3),
+        }
+        instance.stream_mgr = mock_stream_mgr
+
+        instance.get_pool_size = MagicMock(return_value=10000)
+        mock_observer_class.console = MagicMock()
+        mock_observer_class.report_probing_result = MagicMock()
+
+        instance._get_observer_configs = MagicMock(return_value={
+            'upper': MagicMock(), 'lower': MagicMock(),
+            'range': MagicMock(), 'point': MagicMock()
+        })
+        instance.create_executor = MagicMock(return_value=MagicMock())
+        instance._build_result = MagicMock(return_value={'success': True, 'total_headroom': 0})
+        instance._report_results = MagicMock(return_value=MagicMock())
+
+        upper_lower_count = [0]
+
+        def mock_upper_lower(*args, **kwargs):
+            upper_lower_count[0] += 1
+            return (2000, 1.0)
+
+        def mock_range_point(*args, **kwargs):
+            return (1000, 1005, 1.0)
+
+        with patch('headroom_pool_probing.UpperBoundProbingAlgorithm') as mock_upper, \
+             patch('headroom_pool_probing.LowerBoundProbingAlgorithm') as mock_lower, \
+             patch('headroom_pool_probing.ThresholdRangeProbingAlgorithm') as mock_range, \
+             patch('headroom_pool_probing.ThresholdPointProbingAlgorithm') as mock_point:
+
+            mock_upper.return_value.run.side_effect = mock_upper_lower
+            mock_lower.return_value.run.side_effect = mock_upper_lower
+            mock_range.return_value.run.side_effect = mock_range_point
+            mock_point.return_value.run.side_effect = mock_range_point
+
+            HeadroomPoolProbing.probe(instance)
+
+        console_calls = [str(c) for c in mock_observer_class.console.call_args_list]
+        iter_calls = [c for c in console_calls if 'Iter #' in c]
+        pg_calls = [c for c in console_calls if 'PG #' in c]
+
+        assert len(iter_calls) >= 1, (
+            f"Expected 'Iter #' in console output, got: {console_calls}"
+        )
+        assert len(pg_calls) == 0, (
+            f"'PG #' should not appear in console output, found: {pg_calls}"
+        )

--- a/tests/saitests/probe/headroom_pool_probing.py
+++ b/tests/saitests/probe/headroom_pool_probing.py
@@ -306,7 +306,7 @@ class HeadroomPoolProbing(ProbingBase):
             dscp = flow_config.dscp
 
             ProbingObserver.console(f"\n{'='*60}")
-            ProbingObserver.console(f"PG #{i+1}/{num_flows}: src={src_port_id}, dst={dst_port_id}, pg={pg}")
+            ProbingObserver.console(f"Iter #{i+1}/{num_flows}: src={src_port_id}, dst={dst_port_id}, pg={pg}")
             ProbingObserver.console(f"{'='*60}")
 
             # Set ptftest context for this flow
@@ -560,7 +560,7 @@ class HeadroomPoolProbing(ProbingBase):
                     'headroom': pg_headroom
                 })
 
-                ProbingObserver.console(f"\n[Result] PG #{i+1} Headroom = {pg_headroom} cells")
+                ProbingObserver.console(f"\n[Result] Iter #{i+1} Headroom = {pg_headroom} cells")
                 ProbingObserver.console(f"         Total accumulated = {total_headroom} cells")
 
                 pg_success = True
@@ -568,7 +568,7 @@ class HeadroomPoolProbing(ProbingBase):
 
             # Unified cleanup on PG failure
             if not pg_success:
-                ProbingObserver.console(f"  Skipping PG #{i+1} due to {fail_reason}")
+                ProbingObserver.console(f"  Skipping Iter #{i+1} due to {fail_reason}")
                 self.buffer_ctrl.drain_buffer([dst_port_id])
                 continue
 


### PR DESCRIPTION
### What is the motivation for this PR?

The HeadroomPool probing console output labels each flow iteration as `PG #N`, which is misleading — the iteration counter tracks flow iterations (src/dst/pg combinations), not PG indices directly. This causes confusion when reading probe logs, especially when multiple flows share the same PG.

### How did you do it?

Renamed 3 `ProbingObserver.console()` labels in `headroom_pool_probing.py`:
- `PG #{i+1}/{num_flows}` → `Iter #{i+1}/{num_flows}` (iteration header)
- `[Result] PG #{i+1}` → `[Result] Iter #{i+1}` (success result)
- `Skipping PG #{i+1}` → `Skipping Iter #{i+1}` (failure skip)

### How did you verify/test it?

- Added new UT `TestHeadroomPoolProbingIterDisplay::test_console_output_uses_iter_prefix` that asserts `Iter #` appears in console output and `PG #` does not
- 519 unit tests pass (1 pre-existing failure unrelated to this change)
- flake8 clean (`--max-line-length=120`)