### PR TITLE
[pfcwd] Workaround: exclude duplicate-neighbor VLAN ports from PFCWD storm threshold denominator

### DIFF
--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -717,6 +717,9 @@ def verify_all_ports_pfc_storm_in_expected_state(dut, storm_hndle, expected_stat
 
     # Verify each port
     ports_in_expected_state = 0
+    # Track per-port result so the duplicate-neighbor grouping below can recompute
+    # both the numerator and denominator consistently.
+    port_results = {}
     for test_port, queue_idx in ports_to_check:
         port_stats = pfcwd_stats_dict.get((test_port, queue_idx))
 
@@ -743,6 +746,8 @@ def verify_all_ports_pfc_storm_in_expected_state(dut, storm_hndle, expected_stat
             if ("storm" not in current_status) and (current_detect_count == current_restored_count):
                 is_in_expected_state = True
 
+        port_results[test_port] = port_results.get(test_port, False) or is_in_expected_state
+
         if is_in_expected_state:
             ports_in_expected_state += 1
             if expected_state == "storm" and stormed_ports_list is not None and test_port not in stormed_ports_list:
@@ -755,33 +760,48 @@ def verify_all_ports_pfc_storm_in_expected_state(dut, storm_hndle, expected_stat
         logger.warning("No ports found to verify")
         return False
 
-    # When multiple test ports share the same test_neighbor_addr (e.g. VLAN sub-ports
-    # on non-dualtor t0 topologies, where setup_pfc_test currently assigns a single
-    # VLAN neighbor IP to every VLAN port), at most one of those ports can actually
-    # receive PTF background traffic -- the DUT does one ND/ARP lookup and routes
-    # all traffic out a single port. Counting every duplicate against the
-    # storm-state threshold therefore inflates the denominator and causes false
-    # failures. Subtract the duplicate count so the percentage is computed against
-    # ports that are realistically reachable by background traffic.
-    if test_ports_info:
-        seen_ips = set()
-        duplicate_count = 0
+    # On non-dualtor t0 topologies, setup_pfc_test assigns a single VLAN neighbor IP
+    # (self.vlan_nw) to every VLAN port, so at most one of those ports can actually
+    # receive PTF background traffic -- the DUT does one ND/ARP lookup and routes all
+    # traffic out a single port. Counting every such VLAN port individually against the
+    # storm threshold inflates the denominator and causes false failures.
+    #
+    # To keep the numerator and denominator consistent, group VLAN ports that share a
+    # test_neighbor_addr and treat each group as one "effective" port (success = any
+    # member reached the expected state). Non-VLAN ports (routed interfaces and
+    # PortChannel members, which also share a neighbor IP by design in parse_pc_list)
+    # are always counted individually. This adjustment only applies to the storm phase.
+    if expected_state == "storm" and test_ports_info:
+        vlan_ip_groups = {}
+        standalone_ports = []
+        seen_ports = set()
         for port, _queue_idx in ports_to_check:
+            if port in seen_ports:
+                continue
+            seen_ports.add(port)
             info = test_ports_info.get(port, {}) or {}
             ip = info.get('test_neighbor_addr')
-            if not ip:
-                continue
-            if ip in seen_ips:
-                duplicate_count += 1
+            if info.get('test_port_type') == 'vlan' and ip:
+                vlan_ip_groups.setdefault(ip, []).append(port)
             else:
-                seen_ips.add(ip)
-        if duplicate_count > 0:
-            adjusted = total_ports - duplicate_count
+                standalone_ports.append(port)
+
+        # Only adjust when VLAN ports actually share an IP (the non-dualtor case).
+        if any(len(ports) > 1 for ports in vlan_ip_groups.values()):
+            effective_total = len(vlan_ip_groups) + len(standalone_ports)
+            effective_success = 0
+            for ip, ports in vlan_ip_groups.items():
+                if any(port_results.get(p, False) for p in ports):
+                    effective_success += 1
+            for port in standalone_ports:
+                if port_results.get(port, False):
+                    effective_success += 1
             logger.info(
-                "Adjusting total_ports from %d to %d (excluded %d ports that share "
-                "test_neighbor_addr with another port)",
-                total_ports, adjusted, duplicate_count)
-            total_ports = adjusted
+                "Adjusting for duplicate VLAN neighbor IPs: ports_in_expected_state %d->%d, "
+                "total_ports %d->%d",
+                ports_in_expected_state, effective_success, total_ports, effective_total)
+            ports_in_expected_state = effective_success
+            total_ports = effective_total
 
     success_percentage = (ports_in_expected_state / total_ports) * 100
     logger.info(f"{ports_in_expected_state}/{total_ports} ports ({success_percentage:.1f}%) "

--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -695,7 +695,7 @@ def _get_storm_test_ports(storm_hndle):
 
 def verify_all_ports_pfc_storm_in_expected_state(dut, storm_hndle, expected_state, selected_test_ports,
                                                  baseline_counters=None, threshold_percentage=100,
-                                                 stormed_ports_list=None):
+                                                 stormed_ports_list=None, test_ports_info=None):
     """Verify if threshold percentage of ports reached expected PFC storm state."""
     if dut.facts['asic_type'] == 'vs':
         return True
@@ -754,6 +754,34 @@ def verify_all_ports_pfc_storm_in_expected_state(dut, storm_hndle, expected_stat
     if total_ports == 0:
         logger.warning("No ports found to verify")
         return False
+
+    # When multiple test ports share the same test_neighbor_addr (e.g. VLAN sub-ports
+    # on non-dualtor t0 topologies, where setup_pfc_test currently assigns a single
+    # VLAN neighbor IP to every VLAN port), at most one of those ports can actually
+    # receive PTF background traffic -- the DUT does one ND/ARP lookup and routes
+    # all traffic out a single port. Counting every duplicate against the
+    # storm-state threshold therefore inflates the denominator and causes false
+    # failures. Subtract the duplicate count so the percentage is computed against
+    # ports that are realistically reachable by background traffic.
+    if test_ports_info:
+        seen_ips = set()
+        duplicate_count = 0
+        for port, _queue_idx in ports_to_check:
+            info = test_ports_info.get(port, {}) or {}
+            ip = info.get('test_neighbor_addr')
+            if not ip:
+                continue
+            if ip in seen_ips:
+                duplicate_count += 1
+            else:
+                seen_ips.add(ip)
+        if duplicate_count > 0:
+            adjusted = total_ports - duplicate_count
+            logger.info(
+                "Adjusting total_ports from %d to %d (excluded %d ports that share "
+                "test_neighbor_addr with another port)",
+                total_ports, adjusted, duplicate_count)
+            total_ports = adjusted
 
     success_percentage = (ports_in_expected_state / total_ports) * 100
     logger.info(f"{ports_in_expected_state}/{total_ports} ports ({success_percentage:.1f}%) "

--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -244,8 +244,9 @@ class TestPfcwdAllPortStorm(object):
                 timeout = max(timeout, 120)
             pytest_assert(
                 wait_until(timeout, 2, 5, verify_all_ports_pfc_storm_in_expected_state, duthost,
-                           storm_hndle, action, selected_test_ports, baseline_counters, threshold,
-                           stormed_ports_list, test_ports_info),
+                           storm_hndle, action, selected_test_ports,
+                           baseline_counters=baseline_counters, threshold_percentage=threshold,
+                           stormed_ports_list=stormed_ports_list, test_ports_info=test_ports_info),
                 f"Not enough ports reached {action} state (threshold: {threshold}%)"
             )
 
@@ -299,9 +300,11 @@ class TestPfcwdAllPortStorm(object):
 
         logger.info(f"--- {len(stormed_ports_list)} ports entered storm state ---")
         logger.info("--- Testing if PFC storm is restored on stormed ports ---")
+        # test_ports_info is intentionally not passed during restore: the duplicate-neighbor
+        # adjustment in verify_all_ports_pfc_storm_in_expected_state only applies to the storm
+        # phase, so it has no effect here.
         self.run_test(duthost, storm_hndle, expect_regex=[EXPECT_PFC_WD_RESTORE_RE],
                       syslog_marker="all_port_storm_restore", action="restore",
                       stormed_ports_list=stormed_ports_list,
                       selected_test_ports=selected_test_ports,
-                      test_ports_info=setup_pfc_test['test_ports'],
                       tbinfo=tbinfo)

--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -209,7 +209,7 @@ class TestPfcwdAllPortStorm(object):
     PFC_RESTORE_THRESHOLD_PERCENTAGE = 100
 
     def run_test(self, duthost, storm_hndle, expect_regex, syslog_marker, action, selected_test_ports,
-                 stormed_ports_list=None, tbinfo=None):
+                 stormed_ports_list=None, tbinfo=None, test_ports_info=None):
         """Storm generation/restoration on all ports and verification."""
         loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=syslog_marker)
         ignore_file = os.path.join(TEMPLATES_DIR, "ignore_pfc_wd_messages")
@@ -245,7 +245,7 @@ class TestPfcwdAllPortStorm(object):
             pytest_assert(
                 wait_until(timeout, 2, 5, verify_all_ports_pfc_storm_in_expected_state, duthost,
                            storm_hndle, action, selected_test_ports, baseline_counters, threshold,
-                           stormed_ports_list),
+                           stormed_ports_list, test_ports_info),
                 f"Not enough ports reached {action} state (threshold: {threshold}%)"
             )
 
@@ -294,6 +294,7 @@ class TestPfcwdAllPortStorm(object):
                           action="storm",
                           stormed_ports_list=stormed_ports_list,
                           selected_test_ports=selected_test_ports,
+                          test_ports_info=setup_pfc_test['test_ports'],
                           tbinfo=tbinfo)
 
         logger.info(f"--- {len(stormed_ports_list)} ports entered storm state ---")
@@ -302,4 +303,5 @@ class TestPfcwdAllPortStorm(object):
                       syslog_marker="all_port_storm_restore", action="restore",
                       stormed_ports_list=stormed_ports_list,
                       selected_test_ports=selected_test_ports,
+                      test_ports_info=setup_pfc_test['test_ports'],
                       tbinfo=tbinfo)


### PR DESCRIPTION
### Description of PR

Summary:
> **Note:** This PR is an interim **workaround**, not the final fix. A follow-up PR will deliver the root-cause solution (assign a unique `test_neighbor_addr` per VLAN sub-port in `setup_pfc_test`). This PR is safe to land first because it only adjusts the denominator math — it changes no traffic, no ARP, and no port selection.

`test_pfcwd_all_port_storm.py::test_all_port_storm_restore` fails on non-dualtor t0 testbeds (e.g. t0-56-o8v48, t0-116) because PFCWD does not fire on most VLAN sub-ports — but the threshold math still counts them in the denominator.

Root cause: `setup_pfc_test` calls `get_ip_in_range(num=1)`, then assigns the same `test_neighbor_addr` (e.g. `fc02:1000::2`) to every VLAN sub-port in `TrafficPorts.__build_vlan_port_list`. PTF background traffic therefore only reaches one VLAN port — PFC pause frames arrive on every port (FANOUT side), but only the port that holds the shared neighbor has queued egress to trigger PFCWD. Result: 9 / 31 = 29% storm detection, below the 75% threshold → FAIL.

ADO: 38421308

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
-->
- master / 202511: validated in the original PR runs (Mellanox SN4700 physical, tests=60, pass=38 / fail=0 / skip=17) — see the runs listed under "How did you verify/test it?" below.
- 202605: `internal-202605` image `SONiC.20260510.11` — cherry-pick verified on branch `dev/xuliping/20260820_internal-202605_pfcwd-storm-dup-neighbor`, running `pfcwd/test_pfcwd_all_port_storm.py` with repeat x3, retry 0. Result: all 4 jobs FINISHED / SUCCESS.

  | Testbed | Topo / HW | Image | Result |
  |---|---|---|---|
  | vms26-dual-t0-8101c1-02 | dualtor-aa / Cisco-8101 | internal-202605 `sonic-cisco-8000.bin` | ✅ SUCCESS (repeat 2/3 pass; #0 infra flake, unrelated — dualtor is unaffected by this fix) — [plan](https://elastictest.org/scheduler/testplan/6a86778a51f39cced790f076) |
  | testbed-bjw2-can-t0-7060-10 | t0 / Arista-7060CX | internal-202605 `sonic-aboot-broadcom-legacy-th.swi` | ✅ SUCCESS (3/3 pass) — [plan](https://elastictest.org/scheduler/testplan/6a86778e533c0a0b426156db) |
  | testbed-bjw3-can-t0-7060-6 | t0 / Arista-7060CX | internal-202605 `sonic-aboot-broadcom-legacy-th.swi` | ✅ SUCCESS (3/3 pass) — [plan](https://elastictest.org/scheduler/testplan/6a867791eb9272f85921d9c9) |
  | testbed-bjw2-can-t1-4600c-3 | t1-64-lag / Mellanox-SN4600C | internal-202605 `sonic-mellanox.bin` | ✅ SUCCESS (3/3 pass) — [plan](https://elastictest.org/scheduler/testplan/6a86779651f39cced790f078) |

### Approach

#### What is the motivation for this PR?

PFCWD all-port-storm restore is the canary test for PFCWD on every nightly. It fails systematically on every non-dualtor t0 topology with more than 12 storm-enabled ports because of a test-framework bug, not a product bug. PR #22345 added a partial filter but still leaves `total_ports` counting the duplicated VLAN sub-ports.

This is the **workaround**; root-cause fix is on a separate branch and will follow up in a subsequent PR.

#### How did you do it?

Added an optional `test_ports_info` parameter to `verify_all_ports_pfc_storm_in_expected_state` in `tests/common/helpers/pfcwd_helper.py`. When passed during the storm phase, the function groups VLAN ports that share a `test_neighbor_addr` and treats each group as one effective port (success = any member stormed), keeping numerator and denominator consistent. Routed interfaces and PortChannel members (which share a neighbor IP by design) are always counted individually. Topologies where every VLAN port has a unique neighbor (T1 / T2 / dualtor / dualtor-aa) are completely unchanged.

`test_pfcwd_all_port_storm.py` plumbs `setup_pfc_test['test_ports']` through `run_test` to the verify call (storm phase only).

#### How did you verify/test it?

End-to-end validation and regression runs on Elastictest:

| # | Topology / Testbed | HW | Plan | Status |
|---|---|---|---|---|
| 1 | non-dualtor t0-56-o8v48 — `vms66-t0-4700-1` (initial validation) | Mellanox SN4700 | [6a225052729d944bd21c94d1](https://elastictest.org/scheduler/testplan/6a225052729d944bd21c94d1) | ✅ **PASSED** (tests=22, pass=17, fail=0, skip=4) |
| 2 | T1 — `testbed-bjw3-can-t1-7060-1` | Arista 7060CX legacy-th | [6a22633803b7f75ed1c221b4](https://elastictest.org/scheduler/testplan/6a22633803b7f75ed1c221b4) | ⏳ EXECUTING |
| 3 | dualtor — `tbtk5a-dual-7050-1` | Arista 7050CX3 | [6a22633a03b7f75ed1c221b6](https://elastictest.org/scheduler/testplan/6a22633a03b7f75ed1c221b6) | ⏳ LOCK_TESTBED |
| 4 | non-dualtor t0 — `tbtk5a-t0-7050-14` | Arista 7050CX3 | [6a22633c729d944bd21c94f1](https://elastictest.org/scheduler/testplan/6a22633c729d944bd21c94f1) | ⏳ PREPARE_TESTBED |

**Smoking-gun log line on the SN4700 validation run:**
```
Adjusting total_ports from 31 to 9 (excluded 22 ports that share test_neighbor_addr with another port)
```
Restore stage: 9 / 9 ports detected storm (100%), well above 75% threshold. Same 9 ports detected as before the fix (8 PortChannel uplinks + 1 VLAN representative), confirming PFCWD itself behaves correctly — only the denominator math was wrong.

#### Cross-platform regression runs (2026-06-13)

Broad `pfcwd` feature runs across Arista / Cisco / Mellanox platforms on `internal-202511`, each with the correct per-platform image (Arista `.swi` / legacy-th `.swi`, Cisco `sonic-cisco-8000.bin`, Mellanox `sonic-mellanox.bin`):

| Testbed | HW / Topo | Plan |
|---|---|---|
| `vms64-t0-4700-1` | Mellanox SN4700 / t0-56-o8v48 | [6a2e1edf53b3182993b4fd85](https://elastictest.org/scheduler/testplan/6a2e1edf53b3182993b4fd85) |
| `vms66-t0-4700-1` | Mellanox SN4700 / t0-56-o8v48 | [6a2e1edd95ed954f0d3d7d1c](https://elastictest.org/scheduler/testplan/6a2e1edd95ed954f0d3d7d1c) |
| `testbed-bjw3-can-t0-7060-8` | Arista 7060CX legacy-th / t0 | [6a2ce3df53b3182993b4fca3](https://elastictest.org/scheduler/testplan/6a2ce3df53b3182993b4fca3) |
| `vms6-t1-7060` | Arista 7060CX legacy-th / t1-lag | [6a2ce3e02047c3c4a9f92a30](https://elastictest.org/scheduler/testplan/6a2ce3e02047c3c4a9f92a30) |
| `tbtk5a-t1-7260-14` | Arista 7260CX3 / t1-64-lag | [6a2ce3e12296f2ad62e48c29](https://elastictest.org/scheduler/testplan/6a2ce3e12296f2ad62e48c29) |
| `testbed-bjw2-can-t1-8101-1` | Cisco 8101 / t1-lag | [6a2ce3e3729d944bd21ca0b9](https://elastictest.org/scheduler/testplan/6a2ce3e3729d944bd21ca0b9) |
| `testbed-bjw2-can-t1-8102-5` | Cisco 8102 / t1-64-lag | [6a2ce3e595ed954f0d3d7c2a](https://elastictest.org/scheduler/testplan/6a2ce3e595ed954f0d3d7c2a) |
| `testbed-bjw2-can-t0-4600c-1` | Mellanox SN4600C / t0-64 | [6a2ce3e72047c3c4a9f92a32](https://elastictest.org/scheduler/testplan/6a2ce3e72047c3c4a9f92a32) |
| `testbed-bjw2-can-t0-4600c-2` | Mellanox SN4600C / t0-64 | [6a2ce3e92296f2ad62e48c2b](https://elastictest.org/scheduler/testplan/6a2ce3e92296f2ad62e48c2b) |
| `testbed-bjw2-can-t1-4600c-3` | Mellanox SN4600C / t1-64-lag | [6a2ce3ea2047c3c4a9f92a34](https://elastictest.org/scheduler/testplan/6a2ce3ea2047c3c4a9f92a34) |
| `testbed-bjw-can-2700-2` | Mellanox SN2700 / t0 | [6a2ce3ec729d944bd21ca0bb](https://elastictest.org/scheduler/testplan/6a2ce3ec729d944bd21ca0bb) |
| `testbed-bjw2-can-t0-7260-2` | Arista 7260CX3 / t0-116 | [6a2ce3ee729d944bd21ca0bd](https://elastictest.org/scheduler/testplan/6a2ce3ee729d944bd21ca0bd) |

#### Physical testbed validation (final, 2026-06-15)

Two completed physical-testbed runs on Mellanox SN4700, both SUCCESS:

| | Job 1 | Job 2 |
|---|---|---|
| **Plan ID** | `6a2f3c2a95ed954f0d3d7dfb` | `6a2f3c282047c3c4a9f92c37` |
| **Testbed** | `vms64-t0-4700-1` | `vms66-t0-4700-1` |
| **Status / Result** | FINISHED · SUCCESS ✅ | FINISHED · SUCCESS ✅ |
| **Tests** | 60 (38 pass / 0 fail / 17 skip) | 60 (38 pass / 0 fail / 17 skip) |
| **Finished** | 2026-06-15 02:31 | 2026-06-15 02:26 |

Common to both:
- **Platform:** Mellanox SN4700-O8V48 (spc3), topology `t0-56-o8v48`
- **Feature:** pfcwd (8 modules + pre/post test, all PASSED)
- **Image:** internal-202511 `sonic-mellanox.bin` → OS `SONiC.20251110.35`
- **mgmt branch:** `dev/xuliping/20260613_internal-202511_pfcwd-storm-traffic-filter`
- **common_param:** `--completeness_level=debug --sad_case_list=sad_bgp,sad_lag_member,sad_lag,sad_vlan_port,sad_inboot --allow_recover --topology t0-56-o8v48,any`

#### Any platform specific information?

Affects every non-dualtor t0 topology with > 12 PFC-enabled storm ports (common on SN4700, 7050, 7260, 7170, 8101). Dualtor topologies use `MUX_CABLE[port]['server_ipvN']` which already gives a unique IP per port, so dualtor / dualtor-aa are unaffected. T1 / T2 have no VLAN sub-ports.

#### Supported testbed topology if it's a new test case?

N/A — bug fix.

### Documentation

N/A