### PR TITLE
In everflow tests, apply T2 changes to all VoQ switches (& minor improvements)

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -1364,7 +1364,8 @@ class BaseEverflowTest(object):
         src_port_set = set()
         src_port_metadata_map = {}
 
-        if 't2' in setup['topo'] and 'lt2' not in setup['topo'] and 'ft2' not in setup['topo']:
+        if (('t2' in setup['topo'] and 'lt2' not in setup['topo'] and 'ft2' not in setup['topo'])
+                or duthost.facts.get('switch_type') == 'voq'):
             src_port_set.add(src_port)
             src_port_metadata_map[src_port] = (None, 1, setup[direction]['everflow_dut'],
                                                setup[direction]['everflow_namespace'])
@@ -1453,9 +1454,8 @@ class BaseEverflowTest(object):
                     else:
                         mirror_packet_sent[packet.IPv6].hlim -= 1
 
-                    if 't2' in setup['topo']:
-                        if duthost.facts['switch_type'] == "voq":
-                            mirror_packet_sent[packet.Ether].src = setup[direction]["ingress_router_mac"]
+                    if duthost.facts['switch_type'] == "voq":
+                        mirror_packet_sent[packet.Ether].src = setup[direction]["ingress_router_mac"]
                     elif direction == 'downstream' and setup.get("dualtor", False):
                         # On dualtor deployment, the SRC_MAC of the downstream mirror packet is the VLAN MAC
                         mirror_packet_sent[packet.Ether].src = setup[direction]["vlan_mac"]

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -487,12 +487,9 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario):
     """
     duthost = None
     topo = tbinfo['topo']['name']
-    if 't2' in topo:
-        if len(duthosts) == 1:
-            downstream_duthost = upstream_duthost = duthost = duthosts[rand_one_dut_hostname]
-        else:
-            pytest_assert(len(duthosts) > 2, "Test must run on whole chassis")
-            downstream_duthost, upstream_duthost = get_t2_duthost(duthosts, tbinfo)
+    if 't2' in topo and len(duthosts) > 1:
+        pytest_assert(len(duthosts) > 2, "Test must run on whole chassis")
+        downstream_duthost, upstream_duthost = get_t2_duthost(duthosts, tbinfo)
     else:
         downstream_duthost = upstream_duthost = duthost = duthosts[rand_one_dut_hostname]
 
@@ -630,7 +627,7 @@ def validate_acl_rules_in_asic_db(duthost):
         asic_rules = asic.shell(asic_cmd)['stdout_lines']
 
         if len(config_rules) != len(asic_rules):
-            logging.error("ACL rules count mismatch in ASIC {}: CONFIG_DB={}, ASIC_DB={}".format(
+            logging.warning("ACL rules count mismatch in ASIC {}: CONFIG_DB={}, ASIC_DB={}".format(
                 asic.asic_index if duthost.is_multi_asic else "single",
                 len(config_rules), len(asic_rules)))
             return False
@@ -654,6 +651,7 @@ def wait_for_acl_rules_in_asic_db(duthost):
         wait_until(acl_rule_wait_time, 10, 0, validate_acl_rules_in_asic_db, duthost),
         "ACL rules in ASIC DB did not match CONFIG DB within {} seconds".format(acl_rule_wait_time)
     )
+    logging.info("Successfully validated ACL rules")
 
 
 # TODO: This should be refactored to some common area of sonic-mgmt.

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -68,7 +68,10 @@ def partial_ptf_runner(request, ptfhost, erspan_ip_ver):  # noqa F811
                   'mirror_stage': mirror_type,
                   'expect_received': expect_receive,
                   'check_ttl': ('False' if setup_info[direction]['everflow_dut'].is_multi_asic or
-                                "t2" in setup_info["topo"] else 'True')}
+                                "t2" in setup_info["topo"] or
+                                setup_info[direction]['everflow_dut'].facts.get('switch_type') == 'voq'
+                                else 'True')
+                    }
         params.update(kwargs)
         # On dualtor testbed, the dst_mac for upstream traffic is vlan MAC,
         # while the src_mac for mirrored traffic is router MAC
@@ -617,9 +620,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
         everflow_dut = setup_info[dest_port_type]['everflow_dut']
         remote_dut = setup_info[dest_port_type]['remote_dut']
 
-        if tbinfo['topo']['type'] == "t2":
-            if everflow_dut.facts['switch_type'] == "voq":
-                pytest.skip("Skip test as is not supported on a VoQ chassis.")
+        if everflow_dut.facts['switch_type'] == "voq":
+            pytest.skip("Skip test as is not supported on a VoQ chassis.")
 
         # Remaining Scenario not applicable for this topology
         if len(setup_info[dest_port_type]["dest_port"]) <= 2:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #25148

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Everflow tests was failing on VoQ switches where topology was not T2.

Also, very minor improvements/cleanup:
- Consolidate nested if t2 and if duthosts > 1
- Add log when successfully validated ACL rules
- Change logging level from ERROR to WARNING when ACL rules are mismatched, because we wait_until it matches, it is not a definitive error
#### How did you do it?
Apply T2-specific test changes to all VoQ switches where appropriate.
#### How did you verify/test it?
Rerun the failing tests and confirm it's passing.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
