### PR TITLE
[process_monitoring] qualify group processes with group name on restart

### DIFF
--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -494,10 +494,6 @@ def ensure_process_is_running(duthost, container_name, critical_process):
     Returns:
         None.
     """
-    if critical_process in ["dhcp6relay", "dhcprelayd"]:
-        # For dhcp-relay container, the process name in supervisord started 'dhcp-relay: + the process name'
-        critical_process = "dhcp-relay" + ":" + critical_process
-
     logger.info("Checking whether process '{}' in container '{}' is running..."
                 .format(critical_process, container_name))
     program_status, program_pid = get_program_info(duthost, container_name, critical_process)
@@ -555,7 +551,8 @@ def ensure_all_critical_processes_running(duthost, containers_in_namespaces):
             for critical_group in critical_group_list:
                 group_program_info = get_group_program_info(duthost, container_name_in_namespace, critical_group)
                 for program_name in group_program_info:
-                    ensure_process_is_running(duthost, container_name_in_namespace, program_name)
+                    ensure_process_is_running(duthost, container_name_in_namespace,
+                                              critical_group + ":" + program_name)
 
 
 def get_skip_containers(duthost, tbinfo, skip_vendor_specific_container):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Summary:
ensure_all_critical_processes_running (the recover_critical_processes teardown fixture) passed the bare program name to ensure_process_is_running for grouped supervisord processes, so the restart ran supervisorctl start \<program\> instead of supervisorctl start \<group\>:\<program\>. supervisord rejects the bare name with ERROR (no such process), the fixture raises RunAnsibleModuleFail, and the run is marked FAIL_ENV.

This was previously masked for dhcp6relay/dhcprelayd by a hardcoded if-statement, but other grouped processes such as dhcp-relay:isc-dhcpv4-relay-unified and dhcpmon:dhcpmon-Vlan1000 fell through (there was no explicit check for these other processes).

Summary:
Fixes #25153

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Grouped supervisord processes that were not running at teardown could never be restarted, turning a transient process state into a `FAIL_ENV` for the whole test run.

#### How did you do it?
Build the qualified `group:program` name at the call site (consistent with the kill path), and drop the now-redundant `dhcp6relay`/`dhcprelayd` special-case prefix block in `ensure_process_is_running`. The ungrouped path (iterating `critical_process_list`) is untouched — bare names are correct there.

#### How did you verify/test it?
Static analysis against a failing run where `supervisorctl start isc-dhcpv4-relay-unified` returned `ERROR (no such process)` while supervisord status reported `dhcp-relay:isc-dhcpv4-relay-unified  STOPPED`. 

Re-run test_critical_process_monitoring.py to confirm the test doesn't fail on this error.

#### Any platform specific information?
None.

#### Supported testbed topology if it's a new test case?
N/A — existing test.

### Documentation
N/A.

