### PR TITLE
[ansible/golden_config_db]: Disable acms in smartswitch DPU extra config

### DIFF
--- a/ansible/golden_config_db/smartswitch_dpu_extra.json
+++ b/ansible/golden_config_db/smartswitch_dpu_extra.json
@@ -9,6 +9,9 @@
         }
     },
     "FEATURE": {
+        "acms": {
+            "state": "disabled"
+        },
         "lldp": {
             "state": "disabled"
         },


### PR DESCRIPTION
### Description of PR
Summary:
Fixes # N/A

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
ACMS should be explicitly disabled in the SmartSwitch DPU extra golden config to align the generated DPU feature state with expected test behavior.

#### How did you do it?
Added an explicit `acms` entry under `FEATURE` in `ansible/golden_config_db/smartswitch_dpu_extra.json` with `"state": "disabled"`.

#### How did you verify/test it?
Verified the JSON change and committed it on a dedicated branch. No test run was performed in this environment.

#### Any platform specific information?
Applies to SmartSwitch DPU golden configuration usage.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation