### PR TITLE
[database]: Add test to verify STATE_DB table cleanup on swss cold re…

### DIFF
--- a/tests/database/test_state_db_flush.py
+++ b/tests/database/test_state_db_flush.py
@@ -15,7 +15,7 @@ from tests.common.platform.processes_utils import wait_critical_processes
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2'),
+    pytest.mark.topology('t0', 't1', 't2', 'lt2', 'ft2'),
     pytest.mark.disable_loganalyzer
 ]
 

--- a/tests/database/test_state_db_flush.py
+++ b/tests/database/test_state_db_flush.py
@@ -15,7 +15,7 @@ from tests.common.platform.processes_utils import wait_critical_processes
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('any'),
+    pytest.mark.topology('t0', 't1', 't2'),
     pytest.mark.disable_loganalyzer
 ]
 
@@ -64,17 +64,6 @@ def _sentinel_key(table):
     return "{}|{}".format(table, SENTINEL_SUBKEY)
 
 
-def _set_state_db_entry(duthost, key, field, value):
-    """Set a field in a STATE_DB hash key."""
-    duthost.shell('sonic-db-cli STATE_DB HSET "{}" "{}" "{}"'.format(key, field, value))
-
-
-def _key_exists(duthost, key):
-    """Check whether a specific key exists in STATE_DB."""
-    result = duthost.shell('sonic-db-cli STATE_DB EXISTS "{}"'.format(key))
-    return result["stdout"].strip() == "1"
-
-
 def _is_service_hitting_start_limit(duthost, container_name):
     """Check if a service is hitting the systemd start-limit."""
     result = duthost.shell(
@@ -87,12 +76,42 @@ def _is_service_hitting_start_limit(duthost, container_name):
     return False
 
 
-def _restart_swss_and_wait(duthost):
-    """Cold-restart the swss service and wait for critical processes."""
-    duthost.shell("sudo systemctl reset-failed swss", module_ignore_errors=True)
-    duthost.shell("sudo systemctl restart swss")
+def test_state_db_cleanup_after_swss_restart(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                                             enum_frontend_asic_index):
+    """
+    Verify all orchagent-owned STATE_DB tables are cleaned up during swss cold restart.
 
-    # Clear start-limit for any service that may have hit it
+    Steps:
+        1. Populate a sentinel entry in every STATE_DB table that swss.sh cleans.
+        2. Confirm all sentinel entries exist.
+        3. Cold-restart swss for the given ASIC.
+        4. Verify every sentinel entry is removed from STATE_DB.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    asichost = duthost.asic_instance(enum_frontend_asic_index)
+    service_name = asichost.get_service_name("swss")
+    db_cli = "{} STATE_DB".format(asichost.sonic_db_cli)
+
+    # Populate sentinel keys for all tables
+    for table in STATE_DB_CLEANUP_TABLES:
+        key = _sentinel_key(table)
+        logger.info("Setting sentinel STATE_DB entry: {} (asic {})".format(key, enum_frontend_asic_index))
+        duthost.shell('{} HSET "{}" "test_field" "test_value"'.format(db_cli, key))
+
+    # Verify all sentinel keys were created
+    missing = []
+    for table in STATE_DB_CLEANUP_TABLES:
+        result = duthost.shell('{} EXISTS "{}"'.format(db_cli, _sentinel_key(table)))
+        if result["stdout"].strip() != "1":
+            missing.append(table)
+    pytest_assert(not missing,
+                  "Failed to create sentinel entries for tables: {}".format(missing))
+
+    # Cold-restart swss for this ASIC
+    logger.info("Cold-restarting {} on asic {}".format(service_name, enum_frontend_asic_index))
+    duthost.shell("sudo systemctl reset-failed {}".format(service_name), module_ignore_errors=True)
+    duthost.shell("sudo systemctl restart {}".format(service_name))
+
     for container in duthost.get_default_critical_services_list():
         if _is_service_hitting_start_limit(duthost, container):
             logger.info("{} hit start limit, resetting".format(container))
@@ -101,38 +120,12 @@ def _restart_swss_and_wait(duthost):
 
     wait_critical_processes(duthost)
 
-
-def test_state_db_cleanup_after_swss_restart(duthosts, rand_one_dut_hostname):
-    """
-    Verify all orchagent-owned STATE_DB tables are cleaned up during swss cold restart.
-
-    Steps:
-        1. Populate a sentinel entry in every STATE_DB table that swss.sh cleans.
-        2. Confirm all sentinel entries exist.
-        3. Cold-restart swss (single restart for all tables).
-        4. Verify every sentinel entry is removed from STATE_DB.
-    """
-    duthost = duthosts[rand_one_dut_hostname]
-
-    # Populate sentinel keys for all tables
-    for table in STATE_DB_CLEANUP_TABLES:
-        key = _sentinel_key(table)
-        logger.info("Setting sentinel STATE_DB entry: {}".format(key))
-        _set_state_db_entry(duthost, key, "test_field", "test_value")
-
-    # Verify all sentinel keys were created
-    missing = [t for t in STATE_DB_CLEANUP_TABLES if not _key_exists(duthost, _sentinel_key(t))]
-    pytest_assert(
-        not missing,
-        "Failed to create sentinel entries for tables: {}".format(missing)
-    )
-
-    logger.info("Cold-restarting swss service")
-    _restart_swss_and_wait(duthost)
-
     # Verify all sentinel keys are cleaned up
-    stale = [t for t in STATE_DB_CLEANUP_TABLES if _key_exists(duthost, _sentinel_key(t))]
-    pytest_assert(
-        not stale,
-        "STATE_DB entries not cleaned up after swss cold restart: {}".format(stale)
-    )
+    stale = []
+    for table in STATE_DB_CLEANUP_TABLES:
+        result = duthost.shell('{} EXISTS "{}"'.format(db_cli, _sentinel_key(table)))
+        if result["stdout"].strip() == "1":
+            stale.append(table)
+    pytest_assert(not stale,
+                  "STATE_DB entries not cleaned up after swss cold restart (asic {}): {}".format(
+                      enum_frontend_asic_index, stale))

--- a/tests/database/test_state_db_flush.py
+++ b/tests/database/test_state_db_flush.py
@@ -1,0 +1,138 @@
+"""
+Test STATE_DB table cleanup during swss cold restart.
+
+Verifies that tables owned by orchagent in STATE_DB are properly cleaned up
+when swss is restarted (non-warm-boot). This ensures stale state from a
+previous orchagent run does not persist across service restarts.
+"""
+import logging
+
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.platform.processes_utils import wait_critical_processes
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.disable_loganalyzer
+]
+
+# All STATE_DB tables that swss.sh cleans up on cold restart.
+# Sentinel keys use a fake sub-key that orchagent will never recreate,
+# so their absence after restart proves the cleanup ran.
+STATE_DB_CLEANUP_TABLES = [
+    "PORT_TABLE",
+    "MGMT_PORT_TABLE",
+    "VLAN_TABLE",
+    "VLAN_MEMBER_TABLE",
+    "LAG_TABLE",
+    "LAG_MEMBER_TABLE",
+    "INTERFACE_TABLE",
+    "MIRROR_SESSION",
+    "VRF_TABLE",
+    "FDB_TABLE",
+    "FG_ROUTE_TABLE",
+    "BUFFER_POOL",
+    "BUFFER_PROFILE",
+    "MUX_CABLE_TABLE",
+    "ADVERTISE_NETWORK_TABLE",
+    "VXLAN_TUNNEL_TABLE",
+    "VNET_ROUTE",
+    "MACSEC_PORT_TABLE",
+    "MACSEC_INGRESS_SA_TABLE",
+    "MACSEC_EGRESS_SA_TABLE",
+    "MACSEC_INGRESS_SC_TABLE",
+    "MACSEC_EGRESS_SC_TABLE",
+    "VRF_OBJECT_TABLE",
+    "VNET_MONITOR_TABLE",
+    "BFD_SESSION_TABLE",
+    "SYSTEM_NEIGH_TABLE",
+    "FABRIC_PORT_TABLE",
+    "TUNNEL_DECAP_TABLE",
+    "TUNNEL_DECAP_TERM_TABLE",
+    "HIGH_FREQUENCY_TELEMETRY_SESSION_TABLE",
+    "PROCESS_HEALTH",
+]
+
+SENTINEL_SUBKEY = "__test_sentinel__"
+
+
+def _sentinel_key(table):
+    """Return a sentinel STATE_DB key for the given table."""
+    return "{}|{}".format(table, SENTINEL_SUBKEY)
+
+
+def _set_state_db_entry(duthost, key, field, value):
+    """Set a field in a STATE_DB hash key."""
+    duthost.shell('sonic-db-cli STATE_DB HSET "{}" "{}" "{}"'.format(key, field, value))
+
+
+def _key_exists(duthost, key):
+    """Check whether a specific key exists in STATE_DB."""
+    result = duthost.shell('sonic-db-cli STATE_DB EXISTS "{}"'.format(key))
+    return result["stdout"].strip() == "1"
+
+
+def _is_service_hitting_start_limit(duthost, container_name):
+    """Check if a service is hitting the systemd start-limit."""
+    result = duthost.shell(
+        "sudo systemctl status {}.service | grep 'Active'".format(container_name),
+        module_ignore_errors=True
+    )
+    for line in result["stdout_lines"]:
+        if "start-limit-hit" in line:
+            return True
+    return False
+
+
+def _restart_swss_and_wait(duthost):
+    """Cold-restart the swss service and wait for critical processes."""
+    duthost.shell("sudo systemctl reset-failed swss", module_ignore_errors=True)
+    duthost.shell("sudo systemctl restart swss")
+
+    # Clear start-limit for any service that may have hit it
+    for container in duthost.get_default_critical_services_list():
+        if _is_service_hitting_start_limit(duthost, container):
+            logger.info("{} hit start limit, resetting".format(container))
+            duthost.shell("sudo systemctl reset-failed {}.service".format(container))
+            duthost.shell("sudo systemctl start {}.service".format(container))
+
+    wait_critical_processes(duthost)
+
+
+def test_state_db_cleanup_after_swss_restart(duthosts, rand_one_dut_hostname):
+    """
+    Verify all orchagent-owned STATE_DB tables are cleaned up during swss cold restart.
+
+    Steps:
+        1. Populate a sentinel entry in every STATE_DB table that swss.sh cleans.
+        2. Confirm all sentinel entries exist.
+        3. Cold-restart swss (single restart for all tables).
+        4. Verify every sentinel entry is removed from STATE_DB.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+
+    # Populate sentinel keys for all tables
+    for table in STATE_DB_CLEANUP_TABLES:
+        key = _sentinel_key(table)
+        logger.info("Setting sentinel STATE_DB entry: {}".format(key))
+        _set_state_db_entry(duthost, key, "test_field", "test_value")
+
+    # Verify all sentinel keys were created
+    missing = [t for t in STATE_DB_CLEANUP_TABLES if not _key_exists(duthost, _sentinel_key(t))]
+    pytest_assert(
+        not missing,
+        "Failed to create sentinel entries for tables: {}".format(missing)
+    )
+
+    logger.info("Cold-restarting swss service")
+    _restart_swss_and_wait(duthost)
+
+    # Verify all sentinel keys are cleaned up
+    stale = [t for t in STATE_DB_CLEANUP_TABLES if _key_exists(duthost, _sentinel_key(t))]
+    pytest_assert(
+        not stale,
+        "STATE_DB entries not cleaned up after swss cold restart: {}".format(stale)
+    )


### PR DESCRIPTION
### Description of PR
Summary: Add sonic-mgmt test to verify all orchagent-owned STATE_DB tables are cleaned up during swss cold restart.

Depends on sonic-net/sonic-buildimage#27657

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach

#### What is the motivation for this PR?

sonic-net/sonic-buildimage#27657 added `PROCESS_HEALTH*` to the `clean_up_tables STATE_DB` call in `swss.sh` to clear stale orchagent health status on cold restart. During review, it was identified that there are no sonic-mgmt tests covering STATE_DB table cleanup during swss cold restart — not just for `PROCESS_HEALTH`, but for any of the 31 tables in the cleanup list.

#### How did you do it?

Added test_state_db_flush.py with a single test `test_state_db_cleanup_after_swss_restart` that:

1. Populates a sentinel key (`TABLE|__test_sentinel__`) in each of the 31 STATE_DB tables that `swss.sh` is expected to clean on cold restart.
2. Verifies all sentinel keys were created.
3. Cold-restarts the swss service for the given ASIC.
4. Verifies all sentinel keys are removed after restart.

The test uses sentinel sub-keys that orchagent will never recreate, so their absence after restart proves the cleanup ran. Multi-ASIC is handled using `enum_frontend_asic_index` and `asichost.sonic_db_cli` for namespace-aware DB access. Supervisor nodes are excluded via `enum_rand_one_per_hwsku_frontend_hostname`.

#### How did you verify/test it?

Verified on t0 and t1 testbeds (single-ASIC) and t2 testbeds (multi-ASIC) with 202605. The test passes on images that include sonic-net/sonic-buildimage#27657.

#### Any platform specific information?

The test skips supervisor nodes on T2 platforms since they do not run swss. On multi-ASIC platforms, it restarts per-ASIC swss instances (`swss@0`, `swss@1`, etc.) and uses namespaced `sonic-db-cli -n asicN` for DB access.

#### Supported testbed topology if it's a new test case?

t0, t1, t2

### Documentation

N/A