### PR TITLE
Fix CRM ACL entry counter update

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -105,7 +105,7 @@ def apply_acl_config(duthost, asichost, test_name, collector, entry_num=1):
     # Define test cleanup commands
     RESTORE_CMDS[test_name].append("rm -rf {}".format(dut_conf_file_path))
     RESTORE_CMDS[test_name].append("acl-loader delete")
-
+    expected_used = entry_num
     if entry_num == 1:
         logger.info("Generating config for ACL rule, ACL table - DATAACL")
         duthost.template(src=os.path.join(template_dir, acl_rules_template), dest=dut_conf_file_path, force=True)
@@ -116,7 +116,7 @@ def apply_acl_config(duthost, asichost, test_name, collector, entry_num=1):
         for seq_id in range(2, entry_num + 2):
             acl_entry_config[str(seq_id)] = copy.deepcopy(acl_entry_template)
             acl_entry_config[str(seq_id)]["config"]["sequence-id"] = seq_id
-
+        expected_used = len(acl_entry_config.keys())
         with tempfile.NamedTemporaryFile(suffix=".json", prefix="acl_config", mode="w") as fp:
             json.dump(acl_config, fp)
             fp.flush()
@@ -144,6 +144,14 @@ def apply_acl_config(duthost, asichost, test_name, collector, entry_num=1):
                   "ACL configuration did not propagate within timeout")
 
     collector["acl_tbl_key"] = get_acl_tbl_key(asichost)
+
+    logger.info("Waiting for ACL entry counter update")
+    acl_entry_stats_cmd = "{db_cli} COUNTERS_DB HMGET {acl_tbl_key} \
+                            crm_stats_acl_entry_used \
+                            crm_stats_acl_entry_available"\
+                            .format(db_cli=asichost.sonic_db_cli, acl_tbl_key=collector["acl_tbl_key"])
+    wait_for_crm_counter_update(acl_entry_stats_cmd, duthost, expected_used=expected_used, oper_used=">=",
+                                timeout=CRM_UPDATE_TIME, interval=CRM_POLLING_INTERVAL)
 
 
 def generate_mac(num):
@@ -1339,7 +1347,6 @@ def test_acl_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_f
     acl_tbl_key = asic_collector["acl_tbl_key"]
 
     RESTORE_CMDS["crm_threshold_name"] = "acl_counter"
-
     crm_stats_acl_counter_used = 0
     crm_stats_acl_counter_available = 0
 


### PR DESCRIPTION
fix: wait for counter update based on CRM polling in apply_acl_config

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Wait for ACL entry CRM counters to update after applying ACL config in `apply_acl_config`, using the existing CRM polling interval instead of assuming counters are ready immediately.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
CRM ACL entry counter tests could race: ACL config was applied but counter stats had not yet updated, causing flaky failures.

#### How did you do it?
In `apply_acl_config`, after the ACL table key is available, call `wait_for_crm_counter_update` with the ACL entry stats command and the expected used count.

#### How did you verify/test it?
Internal regression 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
