### PR TITLE
[qos] Fix ineffective exabgp route withdraw in test_qos_dscp_mapping causing BGP prefix leak

### DIFF
--- a/tests/qos/qos_helpers.py
+++ b/tests/qos/qos_helpers.py
@@ -410,7 +410,7 @@ def install_route_from_exabgp(operation, ptfip, route, port):
     """
     route_data = [route]
     url = "http://{}:{}".format(ptfip, port)
-    command = "{} attribute next-hop self nlri {}".format(operation, ' '.join(route_data))
+    command = "{} attributes next-hop self nlri {}".format(operation, ' '.join(route_data))
     data = {"command": command}
     logger.info("url: {}".format(url))
     logger.info("command: {}".format(data))


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (issue)

`qos/test_qos_dscp_mapping.py` uses the `route_config` module fixture to announce one IPv4 `/32` route (`10.10.10.<n>/32`) to each upstream T1 neighbor's exabgp instance, and is expected to withdraw them all in teardown. The withdraw helper in `tests/qos/qos_helpers.py::install_route_from_exabgp` builds the exabgp API command with the **singular** keyword `attribute`:

```python
command = "{} attribute next-hop self nlri {}".format(operation, ' '.join(route_data))
```

exabgp's command grammar is asymmetric: the `announce` parser tolerates the singular `attribute` (so the route installs), but the `withdraw` parser only accepts the **plural** `attributes` and silently rejects the singular form. The exabgp HTTP API returns `OK` (HTTP 200) on receipt regardless, so the assertion passes and the test reports PASSED even though the withdraw never took effect.

The failing withdraw command, captured directly from the exabgp process log on the PTF:

```
# command sent by the test (singular "attribute"):
withdraw attribute next-hop self nlri 10.10.10.99/32

# exabgp rejects it:
/tmp/exabgp-ARISTA01T1.out.log:
03:44:10 | 122875 | api | command from process not understood : withdraw attribute next-hop self nlri 10.10.10.99/32
03:44:36 | 122875 | api | command from process not understood : withdraw attribute next-hop self nlri 10.10.10.99/32
```

Because the withdraw is a no-op, every completed run leaves the `10.10.10.<n>/32` routes advertised in the upstream exabgp adj-rib-out. The DUT keeps receiving them, so each T1 neighbor's `PfxRcd` is inflated by exactly 1 (e.g. 6399 -> 6400 on `t0-isolated-d96u32s2`), which subsequently fails BGP prefix-count assertions in later test modules. The stale routes persist across passing runs and are only cleared by restarting exabgp (full topology redeploy).

Fix: use the correct plural keyword `attributes`, matching the already-working `tests/bgp/test_bgp_suppress_fib.py::install_route_from_exabgp`. With this change the withdraw is accepted and the routes are removed on teardown.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

The QoS DSCP-mapping test leaks IPv4 `/32` routes into upstream exabgp peers that are never withdrawn, inflating each T1 neighbor's `PfxRcd` (6399 -> 6400) on the DUT. This causes spurious BGP prefix-count failures in subsequent test modules.

#### How did you do it?

Changed the exabgp API command keyword in `tests/qos/qos_helpers.py::install_route_from_exabgp` from the singular `attribute` to the plural `attributes`, so that the `withdraw` operation is parsed and applied by exabgp instead
of being silently rejected.

#### How did you verify/test it?

Reproduced and confirmed directly against exabgp on the PTF:

```bash
# singular form (current code) - announce works, withdraw rejected
curl -s -d 'command=announce attribute next-hop self nlri 10.10.10.99/32' http://<ptf_ip>:5000   # OK, route installed
curl -s -d 'command=withdraw attribute next-hop self nlri 10.10.10.99/32' http://<ptf_ip>:5000   # OK, but route remains
# exabgp log: "command from process not understood : withdraw attribute next-hop self nlri 10.10.10.99/32"

# plural form (this fix) - withdraw accepted
curl -s -d 'command=withdraw attributes next-hop self nlri 10.10.10.99/32' http://<ptf_ip>:5000  # route removed
```

On (`t0-isolated-d96u32s2`):
- Before fix: after running `qos/test_qos_dscp_mapping.py`, each ARISTAxxT1 `PfxRcd` = 6400 and
  stale `10.10.10.<n>/32` routes remained (`show ip bgp neighbors <ip> received-routes`).
- After fix: teardown withdraws cleanly; `show ip bgp neighbors <ip> received-routes | grep -c
  10.10.10` returns 0 and every T1 returns to `PfxRcd` = 6399.

#### Any platform specific information?

None. The defect is in the test's exabgp helper and is platform-independent; it was observed on Broadcom (TH5, Arista-7060X6) but applies to any topology that runs this test.

#### Supported testbed topology if it's a new test case?

N/A (existing test, runs on `t0`, `t1`).

### Documentation

N/A