### PR TITLE
[vm_set] Attach PTF mgmt port to mgmt bridge for portless (BMC) topo

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -270,7 +270,15 @@
       topo_config: "{{ configuration | default({}) }}"
       is_vs_chassis: "{{ is_vs_chassis | default(false) }}"
     become: yes
-    when: not enable_async and "bmc" not in topo
+    # For VM topos this single bind call binds all VMs and attaches the PTF mgmt port.
+    # For portless (BMC) topos there are no VMs, but this bind call is still required to
+    # attach the PTF mgmt port to the Linux mgmt bridge (vm_topology handles 0-VM gracefully).
+    # Skip it only when the PTF is attached to the bridge via a Docker network instead.
+    # Note: the async bind below loops over VM_targets (empty for BMC), so it can never
+    # attach the mgmt port; BMC must therefore always use this non-async bind.
+    when: >-
+      (not enable_async and 'bmc' not in topo)
+      or ('bmc' in topo and not (ptf_use_docker_network | default(false)))
 
   - name: Bind topology {{ topo }} to VMs. base vm = {{ VM_base }} (async mode)
     loop: "{{ VM_targets|flatten(levels=1) }}"

--- a/ansible/roles/vm_set/tasks/remove_topo.yml
+++ b/ansible/roles/vm_set/tasks/remove_topo.yml
@@ -66,7 +66,13 @@
       multi_vrf: "{{ topo_is_multi_vrf }}"
       multi_vrf_data: "{{ convergence_data|default({}) }}"
     become: yes
-    when: not enable_async and "bmc" not in topo
+    # Portless (BMC) topos have no VMs, but unbind must still detach the PTF mgmt port from
+    # the Linux mgmt bridge for a clean teardown (vm_topology handles 0-VM gracefully).
+    # Skip only when the PTF is attached to the bridge via a Docker network. The async unbind
+    # below loops over VM_hosts (empty for BMC), so BMC must use this non-async unbind.
+    when: >-
+      (not enable_async and 'bmc' not in topo)
+      or ('bmc' in topo and not (ptf_use_docker_network | default(false)))
 
   - name: Unbind topology {{ topo }} to VMs. base vm = {{ VM_base }} (async mode)
     loop: "{{ VM_hosts | flatten(levels=1) }}"

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -193,7 +193,10 @@
       netns_mgmt_ip_addr: "{{ netns_mgmt_ip if netns_mgmt_ip is defined else omit }}"
       is_vs_chassis: "{{ is_vs_chassis | default(false) }}"
     become: yes
-    when: "'bmc' not in topo"
+    # Portless (BMC) topos have no VMs, but renumber must still re-attach the PTF mgmt port
+    # to the Linux mgmt bridge after the container is recreated (vm_topology handles 0-VM
+    # gracefully). Skip only when the PTF is attached to the bridge via a Docker network.
+    when: "'bmc' not in topo or not (ptf_use_docker_network | default(false))"
 
   - name: Change MAC address for PTF interfaces
     include_tasks: ptf_change_mac.yml


### PR DESCRIPTION
### Description of PR

Summary:
Follow-up fix for #23813.

PR #23813 added support for portless **BMC** (Baseboard Management Controller) topos, but it guarded the `vm_topology` **bind / renumber / unbind** tasks with `"bmc" not in topo`, skipping them entirely for BMC topos.

Those `vm_topology` commands are the **only** place that attaches the PTF container's `mgmt` interface to the Linux management bridge (via `add_mgmt_port_to_docker`). Skipping them works *only* when `ptf_use_docker_network=true`, where Docker attaches the container to the bridge directly — which is how #23813 was tested due to testbed limitations at the time.

On a **regular server** (Linux mgmt bridge, no docker network), the PTF `mgmt` port is therefore never attached, leaving the PTF with no management connectivity.

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Make BMC (0-VM, portless) topo deployment work on a regular server using the Linux management bridge, not just with `ptf_use_docker_network`. Today `add-topo` leaves the PTF container's `mgmt` interface unattached to the mgmt bridge.

#### How did you do it?
The `bind` / `renumber` / `unbind` commands in `vm_topology` already handle a 0-VM topo gracefully: they attach/detach the PTF `mgmt` port and skip all VM-specific work when `vms_exists` is false. So instead of skipping the whole task for BMC, run it for BMC **when not using a docker network**:

- `add_topo.yml` — non-async bind now also runs for BMC when `ptf_use_docker_network` is false.
- `renumber_topo.yml` — renumber now also runs for BMC when `ptf_use_docker_network` is false.
- `remove_topo.yml` — non-async unbind now also runs for BMC when `ptf_use_docker_network` is false (clean teardown).

The **non-async** path is used because the async path loops over `VM_targets` / `VM_hosts`, which is empty for BMC and would never call `add_mgmt_port_to_docker`. The BMC condition is intentionally independent of `enable_async` so the mgmt port is always attached. The async tasks keep their `"bmc" not in topo` guard, so BMC never double-runs.

When `ptf_use_docker_network=true` the tasks are still skipped (Docker manages the mgmt attachment), preserving the behavior validated in #23813.

#### How did you verify/test it?
- Validated YAML parses (`check-yaml`) and `git diff --check` (no whitespace errors).
- Verified the `when` boolean logic with a truth table over `{topo in [t0, bmc], ptf_use_docker_network, enable_async}`: non-BMC behavior is unchanged; BMC + Linux bridge now runs bind/renumber/unbind; BMC + docker network stays skipped; no double execution with the async tasks.
- Pending: end-to-end `add-topo` / `remove-topo` on a BMC testbed attached to a Linux mgmt bridge (no docker network).

#### Any platform specific information?
Applies to portless BMC (NetworkBmc) testbeds — no data-plane ports, no VMs.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
