### PR TITLE
[vmhost] Remove deprecated include_delegate_to get_vars argument

### DIFF
--- a/tests/common/devices/vmhost.py
+++ b/tests/common/devices/vmhost.py
@@ -16,6 +16,6 @@ class VMHost(AnsibleHostBase):
         if not hasattr(self, "_external_port"):
             vm = self.host.options["variable_manager"]
             im = self.host.options["inventory_manager"]
-            hostvars = vm.get_vars(host=im.get_host(self.hostname), include_delegate_to=False)
+            hostvars = vm.get_vars(host=im.get_host(self.hostname))
             setattr(self, "_external_port", hostvars.get("external_port", ''))
         return getattr(self, "_external_port")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Remove deprecated include_delegate_to get_vars argument 

With the newer Ansible runtime, dualtor tests using `VMHost.external_port` fail with:

```text
TypeError: VariableManager.get_vars() got an unexpected keyword argument 'include_delegate_to'
```

The failing code is:

```python
hostvars = vm.get_vars(host=im.get_host(self.hostname), include_delegate_to=False)
```

Ansible 2.18 accepted `include_delegate_to` but marked it deprecated/no-op. The newer runtime removed the argument, so direct use of the internal API now raises `TypeError`.



Fixes #25169 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Ansible 2.18 accepted `include_delegate_to` but marked it deprecated/no-op. 
The newer runtime removed the argument, so direct use of the internal API now raises `TypeError`.

#### How did you do it?
Remove the no-op `include_delegate_to=False` argument from `tests/common/devices/vmhost.py`.

#### How did you verify/test it?
Ran on dualtor and these tests Pass 

1. dualtor/test_orchagent_slb.py::test_orchagent_slb
2. dualtor/test_tunnel_memory_leak.py::test_tunnel_memory_leak

#### Any platform specific information?
None
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A