### PR TITLE
[202511] bgp: fix test_bgp_vnet setup failure on topologies without a Vnet2 dynamic peer

### DIFF
--- a/tests/bgp/test_bgp_vnet.py
+++ b/tests/bgp/test_bgp_vnet.py
@@ -105,12 +105,24 @@ def setup_vnet_cfg(duthost, localhost, cfg_facts):
     reboot(duthost, localhost)
 
     bgp_asn = cfg_facts.get('DEVICE_METADATA', {}).get('localhost', {}).get('bgp_asn', '')
-    duthost.shell(
-        "vtysh "
-        "-c 'configure terminal' "
-        "-c 'router bgp {} vrf Vnet2' "
-        "-c 'address-family ipv4 unicast' "
-        "-c 'neighbor BGPSLBPassive allowas-in 1'".format(bgp_asn))
+
+    # The BGPSLBPassive dynamic peer-group only exists when an IPv4 ARISTA03T1 neighbor is
+    # present (see the BGP_PEER_RANGE guard in templates/vnet_config_db.j2). Topologies that
+    # lack such a neighbor never create the peer-group: this includes IPv6-only topologies
+    # and topologies whose VM naming has no ARISTA03T1 (e.g. the stride-8 t0-isolated-* d32u32
+    # variants, both v6 and dual-stack). Configuring allowas-in on a non-existent peer-group
+    # fails with "Specify remote-as or peer-group commands first", so only run it when the
+    # IPv4 dynamic peer is actually present.
+    has_ipv4_dynamic_peer = any(
+        data.get('name') == 'ARISTA03T1' and ':' not in neigh
+        for neigh, data in cfg_facts.get('BGP_NEIGHBOR', {}).items())
+    if has_ipv4_dynamic_peer:
+        duthost.shell(
+            "vtysh "
+            "-c 'configure terminal' "
+            "-c 'router bgp {} vrf Vnet2' "
+            "-c 'address-family ipv4 unicast' "
+            "-c 'neighbor BGPSLBPassive allowas-in 1'".format(bgp_asn))
 
 
 # fixtures


### PR DESCRIPTION
## Description of PR

`tests/bgp/test_bgp_vnet.py` fails at the `setup_vnet` fixture with:

```
% Specify remote-as or peer-group commands first
```

leading to `Failed: Vnet testing setup failed`. Reproduced on `t0-isolated-v6-d32u32s2`, but the trigger is **not** IPv6-specific (see below).

### Root cause

`setup_vnet_cfg` unconditionally runs (added in #24074):

```
vtysh -c 'configure terminal' -c 'router bgp <asn> vrf Vnet2' -c 'address-family ipv4 unicast' -c 'neighbor BGPSLBPassive allowas-in 1'
```

But the `BGPSLBPassive` dynamic peer-group is only created when an **IPv4** `ARISTA03T1` neighbor exists — see the `BGP_PEER_RANGE` guard in `tests/bgp/templates/vnet_config_db.j2` (`data['name'] == 'ARISTA03T1' and ':' not in neigh`).

Any topology that lacks an IPv4 `ARISTA03T1` neighbor never writes `BGP_PEER_RANGE`, so `bgpcfgd` never creates the peer-group in `Vnet2` and the `allowas-in` command fails with a non-zero return code, raising inside the fixture's `try` block and triggering `pytest.fail("Vnet testing setup failed")`.

This affects more than IPv6-only topologies:
- **IPv6-only** topologies (e.g. `t0-isolated-v6-d32u32s2`) — `ARISTA03T1`, if present, is IPv6 only.
- **Topologies with no `ARISTA03T1` VM at all** — e.g. the stride-8 `t0-isolated-*` d32u32 variants (`ARISTA01T1, ARISTA09T1, ARISTA17T1, …`). This includes the **dual-stack/IPv4** `t0-isolated-d32u32s2`, which has IPv4 neighbors but still no `ARISTA03T1`, so it hits the identical failure.

Standard t0 topologies (`t0-64`, `t0-56`, `t0-isolated-d128u128s2`, …) do have an IPv4 `ARISTA03T1`, which is why #24074 passed CI on `t0-64` and the regression went unnoticed.

### Fix

Guard the `allowas-in` configuration with the same condition the template uses, so it only runs when an IPv4 dynamic peer is actually present. The check keys off the real `BGP_NEIGHBOR` config (not the IP family), so it correctly covers both the IPv6-only and the "no ARISTA03T1" cases. This is safe because the AS-path-loop scenario `allowas-in` was added to handle does not apply when there are no IPv4 dynamic peers.

This is the 202511 backport of #25171 (master fix for #25167).

### Type of change

- [x] Bug fix

### Approach

#### What is the motivation for this PR?

Unblock `tests/bgp/test_bgp_vnet.py` on topologies that have no IPv4 `ARISTA03T1` dynamic peer, where the entire module currently fails at fixture setup.

#### How did you do it?

Compute `has_ipv4_dynamic_peer` from `cfg_facts['BGP_NEIGHBOR']` using the same `ARISTA03T1` + non-IPv6 condition the config template uses, and only issue the `allowas-in` vtysh command when it is true.

#### How did you verify/test it?

Logic mirrors the template guard exactly. On topologies without an IPv4 `ARISTA03T1` the command is skipped (there is no peer-group to configure); on topologies that do have one, behavior is unchanged.

### Which release branch to backport (provide reason below if selected)

This PR targets 202511 directly as the backport of #25171. Companion to #24074 / #24272, which landed the `allowas-in` change on both `master` and `202511`. The same setup failure occurs on `202511`, so this fix is needed there as well.