### PR TITLE
[conditional_mark]: Skip test_show_platform_fan on BMC

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -983,6 +983,7 @@ platform_tests/cli/test_show_platform.py::test_show_platform_fan:
     reason: "Unsupported platform API"
     conditions:
       - "is_multi_asic==True and release in ['201911']"
+      - "'bmc' in topo_type"
 
 platform_tests/cli/test_show_platform.py::test_show_platform_firmware_status:
   skip:


### PR DESCRIPTION
Summary: Skip test_show_platform_fan on BMC
Fixes #
Add `"'bmc' in topo_type"` skip condition `platform_tests/cli/test_show_platform.py::test_show_platform_fan`. BMC platforms do not support the fan platform API

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
BMC platforms do not support the fan platform API, need skip related case on BMC

#### How did you do it?
Add `"'bmc' in topo_type"` skip condition `platform_tests/cli/test_show_platform.py::test_show_platform_fan`. BMC platforms do not support the fan platform API

#### How did you verify/test it?
Run regression pass

#### Any platform specific information?
BMC

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
