### PR TITLE
Retry transient Monit failures and add targeted recovery

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -853,7 +853,7 @@ def check_monit(duthosts):
 
         logger.info("Checking status of each Monit service...")
         networking_uptime = dut.get_networking_uptime().seconds
-        timeout = max((MONIT_STABILIZE_MAX_TIME - networking_uptime), 0)
+        timeout = max((MONIT_STABILIZE_MAX_TIME - networking_uptime), MIN_PROCESS_CHECK_TIMEOUT)
         interval = 20
         logger.info("networking_uptime = {} seconds, timeout = {} seconds, interval = {} seconds"
                     .format(networking_uptime, timeout, interval))

--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -92,6 +92,25 @@ def _recover_services(dut, result):
     return 'reboot' if 'database' in services else 'config_reload'
 
 
+def _recover_monit(dut, wait_time):
+    """Lightweight recovery for monit-only sanity failures.
+    This helper reloads Monit's config and forces a fresh poll of every
+    supervised entity. The framework's post-recover sanity check then
+    re-evaluates and will escalate further if the failure is persistent.
+    """
+    effective_wait = max(wait_time, 60)
+    logging.warning("Restoring monit on {} (wait {}s for one poll cycle)"
+                    .format(dut.hostname, effective_wait))
+    dut.shell(
+        "sudo monit reload; sleep 5; sudo monit restart all",
+        module_ignore_errors=True,
+    )
+    wait(
+        effective_wait,
+        msg="Wait {} seconds for monit to re-poll all services after restart.".format(effective_wait),
+    )
+
+
 @reset_ansible_local_tmp
 def _neighbor_vm_recover_bgpd(node=None, results=None):
     """Function for restoring BGP on neighbor VMs using the parallel_run tool.
@@ -232,6 +251,15 @@ def adaptive_recover(ptfhost, dut, localhost, fanouthosts, nbrhosts, tbinfo, che
                 action = neighbor_vm_restore(dut, nbrhosts, tbinfo, result)
             elif result['check_item'] in ['processes', 'mux_simulator']:
                 action = 'config_reload'
+            elif result['check_item'] == 'monit' and 'services_status' in result:
+                _recover_monit(dut, wait_time)
+                action = 'monit_restart'
+                logging.warning(
+                    "Restoring {} with proposed action: {}, performed inline "
+                    "(does not change outstanding_action: {})"
+                    .format(result, action, outstanding_action)
+                )
+                continue
             else:
                 action = 'reboot'
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Fixes a class of `Sanity_check_failed` plan aborts where the check_monit sanity item reports a transient services-status hiccup, the framework's adaptive_recover falls through to its catch-all and reboots the DUT, the reboot doesn't recover the original (already-transient) condition, and the whole test plan dies.  

Summary:
Fixes # internal triage from April/May 2026 nightly analysis

### Type of change
- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
check_monit is a sanity fixture that polls monit summary and flags any supervised entity not in OK. As of before the fix: 

 1. check_monit runs its own retry loop, but the loop floor is max (MONIT_STABILIZE_MAX_TIME - networking_uptime, 0) — once the DUT has been up for a while, the timeout collapses to 0 and the loop executes once, so a single bad poll fails the check.
 2. When check_monit fails, adaptive_recover has no Monit-specific branch — every monit item falls into the else: action = 'reboot' catch-all. 
 3. The reboot doesn't resolve the underlying Monit observation either, so the post-recover re-sanity fails too and the plan is killed.

#### How did you do it?
Two surgical changes, both inside tests/common/plugins/sanity_check/:
1. checks.py (1-line alignment) — change check_monit's retry floor from 0 to MIN_PROCESS_CHECK_TIMEOUT, matching the existing idiom in check_interfaces and check_processes. Now the retry loop runs ~9 polls × 20s = ~180s per invocation, which absorbs the vast majority of single-poll transients before sanity even thinks about escalating.
2. recover.py (new targeted recovery) — add a _recover_monit(dut, wait_time) helper that runs sudo monit reload; sleep 5; sudo monit restart all. 

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A