### PR TITLE
Increase timeout for bgp recovery

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -324,7 +324,7 @@ def check_bgp(duthosts, tbinfo):
         if (check_result['failed']):
             # try restart bgp and verify again
             _restart_bgp(dut)
-            wait_until(60, interval, 0, _check_bgp_status_helper)
+            wait_until(300, interval, 0, _check_bgp_status_helper)
             if (check_result['failed']):
                 for a_result in list(check_result.keys()):
                     if a_result != 'failed':


### PR DESCRIPTION
Restarting the bgp service results in swss restarting.  It may take longer than 60 seconds for all interfaces to be reprogrammed and all bgp sessions to become established.  Increasing the timer.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #25180

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Improve passrate on full-scale topologies by taking longer convergence times into account.

#### How did you do it?
Allowed up to 300 seconds of retries when checking bgp state in sanity checkers.

#### How did you verify/test it?
Verified sanity checks pass consistently on full-scale topologies.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
