### PR TITLE
Update qos params for topo-t1-isolated-d128

### DIFF
--- a/tests/qos/files/qos_params.th5.yaml
+++ b/tests/qos/files/qos_params.th5.yaml
@@ -1300,7 +1300,7 @@ qos_params:
                 q_list: [0, 1, 3, 4, 5, 6]
                 q_pkt_cnt: [80, 100, 300, 100, 100, 700]
         topo-t1-isolated-d128: &topo-t1-isolated-d128
-            400000_40m: *topo-t1-isolated-d128_400000_40m
+            400000_40m: &topo-t1-isolated-d128_400000_40m
                 hdrm_pool_size:
                     dscps: [3, 4]
                     dst_port_id: 0
@@ -1409,5 +1409,5 @@ qos_params:
                 lossy_weight: 8
                 q_list: [0, 1, 3, 4, 5, 6]
                 q_pkt_cnt: [80, 100, 300, 100, 100, 700]
-            200000_5m: &topo-t1-isolated-d128_400000_40m
+            200000_5m: *topo-t1-isolated-d128_400000_40m
         topo-t1-isolated-d32: *topo-t1-isolated-d128

--- a/tests/qos/files/qos_params.th5.yaml
+++ b/tests/qos/files/qos_params.th5.yaml
@@ -1300,67 +1300,27 @@ qos_params:
                 q_list: [0, 1, 3, 4, 5, 6]
                 q_pkt_cnt: [80, 100, 300, 100, 100, 700]
         topo-t1-isolated-d128: &topo-t1-isolated-d128
-            200000_5m: &topo-t1-isolated-d128_200000_5m
+            400000_40m: *topo-t1-isolated-d128_400000_40m
                 hdrm_pool_size:
-                    dscps:
-                    - 3
-                    - 4
+                    dscps: [3, 4]
                     dst_port_id: 0
                     ecn: 1
-                    margin: 2
-                    pgs:
-                    - 3
-                    - 4
+                    margin: 4
+                    pgs: [3, 4]
                     pgs_num: 25
                     pkts_num_hdrm_full: 1755
                     pkts_num_hdrm_partial: 1208
-                    pkts_num_trig_pfc: 132925
-                    pkts_num_trig_pfc_multi:
-                    - 132925
-                    - 66500
-                    - 33287
-                    - 16680
-                    - 8377
-                    - 4226
-                    - 2150
-                    - 1112
-                    - 593
-                    - 333
-                    - 204
-                    - 139
-                    - 106
-                    - 90
-                    - 82
-                    - 78
-                    - 76
-                    - 75
-                    - 75
-                    - 74
-                    - 74
-                    - 74
-                    - 74
-                    - 74
-                    - 74
-                    src_port_ids:
-                    - 1
-                    - 2
-                    - 3
-                    - 4
-                    - 5
-                    - 6
-                    - 7
-                    - 8
-                    - 9
-                    - 10
-                    - 11
-                    - 12
-                    - 13
+                    pkts_num_trig_pfc: 133349
+                    pkts_num_trig_pfc_multi: [133349, 66711, 33393, 16733, 8404, 4239,
+                        2156, 1115, 595, 334, 204, 139, 107, 90, 82, 78, 76, 75, 75,
+                        74, 74, 74, 74, 74, 74]
+                    src_port_ids: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
                 lossy_queue_1:
-                    dscp: 8
+                    dscp: 0
                     ecn: 1
                     pg: 0
-                    pkts_num_margin: 2
-                    pkts_num_trig_egr_drp: 132859
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 133283
                 pkts_num_egr_mem: 376
                 pkts_num_leak_out: 0
                 wm_pg_headroom:
@@ -1368,9 +1328,9 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_margin: 2
-                    pkts_num_trig_ingr_drp: 134681
-                    pkts_num_trig_pfc: 132925
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 135105
+                    pkts_num_trig_pfc: 133349
                 wm_pg_shared_lossless:
                     cell_size: 254
                     dscp: 3
@@ -1378,61 +1338,61 @@ qos_params:
                     packet_size: 64
                     pg: 3
                     pkts_num_fill_min: 74
-                    pkts_num_margin: 2
-                    pkts_num_trig_pfc: 132925
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 133349
                 wm_pg_shared_lossy:
                     cell_size: 254
-                    dscp: 8
+                    dscp: 0
                     ecn: 1
                     packet_size: 64
                     pg: 0
                     pkts_num_fill_min: 7
-                    pkts_num_margin: 2
-                    pkts_num_trig_egr_drp: 132859
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 133283
                 wm_q_shared_lossless:
                     cell_size: 254
                     dscp: 3
                     ecn: 1
                     pkts_num_fill_min: 0
-                    pkts_num_margin: 2
-                    pkts_num_trig_ingr_drp: 134681
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 135105
                     queue: 3
                 wm_q_shared_lossy:
                     cell_size: 254
-                    dscp: 8
+                    dscp: 0
                     ecn: 1
                     pkts_num_fill_min: 7
-                    pkts_num_margin: 2
-                    pkts_num_trig_egr_drp: 132859
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 133283
                     queue: 0
                 xoff_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_margin: 2
-                    pkts_num_trig_ingr_drp: 134681
-                    pkts_num_trig_pfc: 132925
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 135105
+                    pkts_num_trig_pfc: 133349
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_margin: 2
-                    pkts_num_trig_ingr_drp: 134681
-                    pkts_num_trig_pfc: 132925
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 135105
+                    pkts_num_trig_pfc: 133349
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
                     pkts_num_dismiss_pfc: 14
-                    pkts_num_margin: 2
-                    pkts_num_trig_pfc: 132925
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 133349
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
                     pkts_num_dismiss_pfc: 14
-                    pkts_num_margin: 2
-                    pkts_num_trig_pfc: 132925
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 133349
             cell_size: 254
             hdrm_pool_wm_multiplier: 2
             wrr:
@@ -1440,7 +1400,7 @@ qos_params:
                 ecn: 1
                 limit: 80
                 q_list: [0, 1, 3, 4, 5, 6]
-                q_pkt_cnt: [50, 50, 100, 50, 50, 350]
+                q_pkt_cnt: [100, 100, 200, 100, 100, 700]
             wrr_chg:
                 dscp_list: [0, 47, 3, 4, 46, 44]
                 ecn: 1
@@ -1449,5 +1409,5 @@ qos_params:
                 lossy_weight: 8
                 q_list: [0, 1, 3, 4, 5, 6]
                 q_pkt_cnt: [80, 100, 300, 100, 100, 700]
-            400000_40m: *topo-t1-isolated-d128_200000_5m
+            200000_5m: &topo-t1-isolated-d128_400000_40m
         topo-t1-isolated-d32: *topo-t1-isolated-d128


### PR DESCRIPTION
### Description of PR
Update qos params for topo-t1-isolated-d128

### Back port request
- [x] 202511

### Approach
#### What is the motivation for this PR?
Update qos params for this topo after sai 14 upgrade and buffer changes

#### How did you do it?
Script generated

#### How did you verify/test it?
Manually verified