### PR TITLE
Fix test_bgp_update_timer for UpperSpineRouter with BGP confederation

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -182,8 +182,7 @@ def common_setup_teardown(
         neigh_type = "LeafRouter"
     elif dut_type in ["UpperSpineRouter", "FabricSpineRouter"]:
         neigh_type = "LowerSpineRouter"
-        if dut_type == "FabricSpineRouter" and confed_asn is not None:
-            # For FT2, we need to use vtysh to configure an external BGP neighbor
+        if confed_asn is not None:
             use_vtysh = True
     else:
         neigh_type = "ToRRouter"


### PR DESCRIPTION
### Description of PR

For UpperSpineRouter and FabricSpineRouter with BGP confederation, BGP neighbors in `test_bgp_update_timer` need to be configured via vtysh to bypass bgpcfgd route policies that filter route propagation between ExaBGP peers.

The existing code only set `use_vtysh = True` for FabricSpineRouter with confederation, but UpperSpineRouter has the same requirement. Simplified the two separate `dut_type` checks into a single `confed_asn` check since both UpperSpineRouter and FabricSpineRouter are already in the same `elif` branch.

Without this fix, the test fails on UpperSpineRouter confederation testbeds because zero BGP update packets are captured.

Summary:
Fix `test_bgp_update_timer` to use vtysh for UpperSpineRouter with BGP confederation, matching the existing FabricSpineRouter behavior.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

`test_bgp_update_timer` fails on UpperSpineRouter testbeds with BGP confederation. The test captures zero BGP update packets because ExaBGP neighbors are configured via configDB/bgpcfgd, which applies route policies that block route propagation between the two ExaBGP peers.

FabricSpineRouter already had a fix for this (`use_vtysh = True` when `confed_asn is not None`), but UpperSpineRouter was missing the same handling.

#### How did you do it?

Replaced the FabricSpineRouter-specific `dut_type` check with a unified `confed_asn is not None` check that applies to both UpperSpineRouter and FabricSpineRouter, since both are already in the same `elif` branch. This ensures vtysh is used to configure BGP neighbors directly in FRR, bypassing bgpcfgd policies.

#### How did you verify/test it?

Ran `test_bgp_update_timer_single_route` on an UpperSpineRouter testbed with BGP confederation (`t2_single_node_min` topology, confed_asn configured). Test passed.

The change is safe for non-confederation testbeds since `confed_asn` is `None` when confederation is not configured, so `use_vtysh` remains `False`.

#### Any platform specific information?

None. The fix is platform-independent — it applies to the test infrastructure logic for any UpperSpineRouter or FabricSpineRouter with BGP confederation.

#### Supported testbed topology if it's a new test case?

N/A — existing test case bug fix.

### Documentation

N/A