### PR TITLE
[Snappi] Fix multi_base_traffic_config to use dict-style dut_port_config

### DIFF
--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -2011,9 +2011,10 @@ def multi_base_traffic_config(testbed_config,
                 rx_mac (str): MAC address of ixia RX port ex. '00:00:fa:ce:fa:ce'
                 tx_port_name (str): name of ixia TX port ex. 'Port 1'
                 rx_port_name (str): name of ixia RX port ex. 'Port 2'
-                dut_port_config (list): a list of two dictionaries of tx and rx ports on the peer (switch) side,
-                                        and the associated test priorities
-                                        ex. [{'Ethernet4':[3, 4]}, {'Ethernet8':[3, 4]}]
+                dut_port_config (dict): a dictionary with "Tx" and "Rx" keys, each containing a list of
+                                        dictionaries of ports on the peer (switch) side and associated
+                                        test priorities
+                                        ex. {"Tx": [{'Ethernet4':[3, 4]}], "Rx": [{'Ethernet8':[3, 4]}]}
                 test_flow_name_dut_rx_port_map (dict): Mapping of test flow name to DUT RX port(s)
                                                   ex. {'flow1': [Ethernet4, Ethernet8]}
                 test_flow_name_dut_tx_port_map (dict): Mapping of test flow name to DUT TX port(s)
@@ -2029,11 +2030,11 @@ def multi_base_traffic_config(testbed_config,
     base_flow_config["rx_port_config"] = rx_port_config
 
     # Instantiate peer ports in dut_port_config
-    dut_port_config = []
+    dut_port_config = {"Tx": [], "Rx": []}
     tx_dict = {str(tx_port_config.peer_port): []}
     rx_dict = {str(rx_port_config.peer_port): []}
-    dut_port_config.append(tx_dict)
-    dut_port_config.append(rx_dict)
+    dut_port_config["Tx"].append(tx_dict)
+    dut_port_config["Rx"].append(rx_dict)
     base_flow_config["dut_port_config"] = dut_port_config
 
     base_flow_config["tx_mac"] = tx_port_config.mac


### PR DESCRIPTION
### Description of PR

`multi_base_traffic_config()` in traffic_generation.py returns `dut_port_config` as a list `[tx_dict, rx_dict]`, while `base_traffic_config()` returns it as a dict `{"Tx": [...], "Rx": [...]}`. All accessors in traffic_generation.py (including `run_traffic_and_collect_stats`, `verify_egress_queue_frame_count`, and `generate_test_flows`) use dict-style access with `"Tx"` and `"Rx"` keys.

This inconsistency causes a `TypeError: list indices must be integers or slices, not str` when any test using `multi_base_traffic_config()` reaches these accessor functions. Affected helpers include pfcwd_actions_helper.py, `mixed_speed_multidut_helper.py`, and `pfc_congestion_helper.py`.

Fix: Update `multi_base_traffic_config()` to return dict-style `dut_port_config`, consistent with `base_traffic_config()`.

Summary:
Fixes TypeError in `run_traffic_and_collect_stats` and `verify_egress_queue_frame_count` when `dut_port_config` is populated via `multi_base_traffic_config()`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ x] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

All 6 test_pfcwd_actions.py tests fail with `TypeError: list indices must be integers or slices, not str` because `multi_base_traffic_config()` returns `dut_port_config` as a list while all consumers expect a dict with `"Tx"` and `"Rx"` keys. The same issue affects tests using `mixed_speed_multidut_helper.py` and `pfc_congestion_helper.py`.

#### How did you do it?

Updated `multi_base_traffic_config()` to construct `dut_port_config` as `{"Tx": [], "Rx": []}` and use `dut_port_config["Tx"].append(tx_dict)` / `dut_port_config["Rx"].append(rx_dict)` instead of a plain list with `.append()`. This matches the format used by `base_traffic_config()`. Updated the docstring accordingly.

The change is 1 file, 7 insertions, 6 deletions — limited to `multi_base_traffic_config()` and its docstring.

#### How did you verify/test it?

Ran `test_pfcwd_actions.py::test_pfcwd_drop_90_10` on a pizzabox DUT with Snappi traffic generator:
```
pytest snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_drop_90_10
```
Result: **1 passed, 1 skipped** (skipped is the 100G speed variant; DUT has 400G ports). Full 15-minute traffic run with 4 polling iterations completed successfully.

Before the fix, the same test failed immediately with:
```
TypeError: list indices must be integers or slices, not str
```

#### Any platform specific information?

No — this is a test framework bug, not platform-specific.

#### Supported testbed topology if it's a new test case?

N/A — this is a bug fix, not a new test case.

### Documentation

N/A — bug fix only, no new features.