### PR TITLE
Gather distro facts before Ubuntu/Debian check

### DIFF
--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -23,6 +23,24 @@
 # your environment.
 
 # ---- Fail if Ubuntu < 22.04 or Debian < 13 ----
+# Callers of this role are inconsistent about fact gathering:
+#   * Some set `gather_facts: no` (testbed_renumber_vm_topology.yml,
+#     testbed_connect_vms.yml, testbed_disconnect_vms.yml, testbed_start_k8s_VMs.yml,
+#     testbed_stop_k8s_VMs.yml, testbed_connect_topo.yml) so that their `pre_tasks`
+#     can override ansible_user / ansible_password from vm_host_user etc. before any
+#     connection is made.
+#   * Others rely on the default `gather_facts: yes` (testbed_add_vm_topology.yml,
+#     testbed_remove_vm_topology.yml, testbed_start_VMs.yml, testbed_stop_VMs.yml).
+# Gather a minimal fact subset here, but only when the facts are missing, so the
+# checks work for both kinds of caller. `gather_subset: min` is cheap and skips the
+# expensive interface/hardware enumeration; the `when` guard makes it a no-op when
+# the caller already gathered facts.
+- name: Gather minimal host facts for distribution checks
+  setup:
+    gather_subset:
+      - min
+  when: ansible_distribution is not defined or ansible_distribution_version is not defined
+
 - name: Fail if distribution is not Ubuntu or Debian
   fail:
     msg: >-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

* Microsoft ADO (number only): 38615529

Fix the following restart-ptf failure:
```
TASK [vm_set : Fail if distribution is not Ubuntu or Debian] *******************
fatal: [STR2-ACS-SERV-28]: FAILED! => {
  "msg": "The conditional check 'ansible_distribution != \"Ubuntu\"' failed.
  The error was: error while evaluating conditional
  (ansible_distribution != \"Ubuntu\"): 'ansible_distribution' is undefined ..."
}
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
PR [#24219 ](https://github.com/sonic-net/sonic-mgmt/pull/24219) replaced the shell-based host distribution detection in
`ansible/roles/vm_set/tasks/main.yml` with conditionals that reference
the `ansible_distribution` and `ansible_distribution_version` facts.

Add a guarded setup: gather_subset: min task at the top of the role,
immediately before the distro/version gates.

#### How did you verify/test it?
run restart-ptf, no failure.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
