### PR TITLE
Have everflow IPV6 setup fixture respect defined plt wait time

### DIFF
--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -228,8 +228,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                        config_method, rules=EVERFLOW_V6_RULES)
             self.apply_ip_type_rule(duthost, 6)
             # Wait for ACL rules to be programmed
-            pytest_assert(wait_until(120, 2, 0, everflow_utils.validate_acl_rules_in_asic_db, duthost),
-                          "ACL rules are not programmed")
+            everflow_utils.wait_for_acl_rules_in_asic_db(duthost)
 
         everflow_utils.wait_for_acl_rules_in_asic_db(everflow_dut)
 

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -13,8 +13,6 @@ import random
 from .everflow_test_utilities import setup_info, skip_ipv6_everflow_tests                                 # noqa: F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor    # noqa: F401
 from tests.common.macsec.macsec_helper import MACSEC_INFO
-from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import wait_until
 
 pytestmark = [
     pytest.mark.topology("t0", "t1", "t2", "lrh", "urh", "lt2", "ft2", "m0", "m1")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #25212

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
In everflow ipv6 tests in setup_acl_table, there is a `wait_until` on `validate_acl_rules_in_asic_db` that uses fixed timeout causing failures.
#### How did you do it?
Change `wait_until` with fixed timeout to use existing common function `wait_for_acl_rules_in_asic_db `
#### How did you verify/test it?
Reran tests that was consistently passing to make sure it's consistently passing (with appropriately defined plt wait defined for everflow)
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
