### PR TITLE
[ci] switch to use sonic-ubuntu-1c-2 agent pool to unblock PR checker

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ stages:
     displayName: "Detect skip_expiry changes"
     timeoutInMinutes: 10
     continueOnError: false
-    pool: sonic-ubuntu-1c
+    pool: sonic-ubuntu-1c-2
     steps:
     - checkout: self
       clean: true
@@ -82,7 +82,7 @@ stages:
     displayName: "Static Analysis"
     timeoutInMinutes: 10
     continueOnError: false
-    pool: sonic-ubuntu-1c
+    pool: sonic-ubuntu-1c-2
     steps:
     - template: .azure-pipelines/pre-commit-check.yml
 
@@ -90,7 +90,7 @@ stages:
     displayName: "Validate Test Cases"
     timeoutInMinutes: 30
     continueOnError: false
-    pool: sonic-ubuntu-1c
+    pool: sonic-ubuntu-1c-2
     steps:
     - template: .azure-pipelines/pytest-collect-only.yml
       parameters:
@@ -99,21 +99,21 @@ stages:
   - job: dependency_check
     displayName: "Dependency Check"
     timeoutInMinutes: 10
-    pool: sonic-ubuntu-1c
+    pool: sonic-ubuntu-1c-2
     steps:
       - template: .azure-pipelines/dependency-check.yml
 
   - job: markers_check
     displayName: "Markers Check"
     timeoutInMinutes: 10
-    pool: sonic-ubuntu-1c
+    pool: sonic-ubuntu-1c-2
     steps:
       - template: .azure-pipelines/markers-check.yml
 
   - job: meta_check
     displayName: "Meta check"
     timeoutInMinutes: 10
-    pool: sonic-ubuntu-1c
+    pool: sonic-ubuntu-1c-2
     steps:
       - template: .azure-pipelines/meta-check.yml
 
@@ -132,7 +132,7 @@ stages:
     displayName: "Run tools/skip_expiry unit tests"
     timeoutInMinutes: 15
     continueOnError: false
-    pool: sonic-ubuntu-1c
+    pool: sonic-ubuntu-1c-2
     steps:
     - checkout: self
       clean: true


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
switch to sonic-ubuntu-1c-2 agent pool to unblock pr checker
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
