### PR TITLE
[ci] switch to use sonic-ubuntu-1c-2 agent pool to unblock PR checker

### DIFF
--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -7,7 +7,7 @@ parameters:
 - name: PRE_TEST_AGENT_POOL
   type: object
   default:
-    name: sonic-ubuntu-1c
+    name: sonic-ubuntu-1c-2
 
 - name: BUILD_REASON
   type: string

--- a/.azure-pipelines/probe-tests/jobs/run-probe-tests.yml
+++ b/.azure-pipelines/probe-tests/jobs/run-probe-tests.yml
@@ -14,7 +14,7 @@ jobs:
     condition: ${{ parameters.condition }}
     displayName: 'Run Probe UT/IT'
     timeoutInMinutes: 15
-    pool: sonic-ubuntu-1c
+    pool: sonic-ubuntu-1c-2
     steps:
       - checkout: self
       - template: /.azure-pipelines/probe-tests/steps/run-probe-tests.yml

--- a/.azure-pipelines/probe-tests/stages/probe-tests.yml
+++ b/.azure-pipelines/probe-tests/stages/probe-tests.yml
@@ -21,7 +21,7 @@ stages:
       - job: check_probe_changes
         displayName: 'Check if changes affect MMU probe code'
         timeoutInMinutes: 5
-        pool: sonic-ubuntu-1c
+        pool: sonic-ubuntu-1c-2
         steps:
           - checkout: self
           - script: |

--- a/.azure-pipelines/sonic_vpp/sonic-vpp-nightly.yml
+++ b/.azure-pipelines/sonic_vpp/sonic-vpp-nightly.yml
@@ -36,7 +36,7 @@ stages:
         displayName: "kvmtest-t1-lag-vpp by Elastictest"
         timeoutInMinutes: 480
         continueOnError: false
-        pool: sonic-ubuntu-1c
+        pool: sonic-ubuntu-1c-2
         steps:
           - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
             parameters:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
switch to use sonic-ubuntu-1c-2 agent pool to unblock PR checker
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
