### PR TITLE
[BGP Vnet] Fix VNET config template

### DIFF
--- a/tests/bgp/templates/vnet_config_db.j2
+++ b/tests/bgp/templates/vnet_config_db.j2
@@ -3,11 +3,10 @@
 {%     if k == 'BGP_NEIGHBOR' %}
     "BGP_NEIGHBOR": {
 {%         set neighbors = cfg_t0['BGP_NEIGHBOR'] %}
-{%         set vnet1_names = ['ARISTA01T1', 'ARISTA02T1'] %}
 {%         set ns = namespace(entries=[]) %}
 {%         for neigh, data in neighbors.items() | sort %}
 {%             set is_ipv6 = ':' in neigh %}
-{%             set is_vnet1 = data['name'] in vnet1_names %}
+{%             set is_vnet1 = data['name'] in vnet1_neighbor_names %}
 {%             if is_vnet1 %}
 {%                 set ns.entries = ns.entries + [('Vnet1|' ~ neigh, data)] %}
 {%             elif is_ipv6 %}
@@ -22,7 +21,7 @@
     "BGP_PEER_RANGE": {
 {%         set neighbors = cfg_t0['BGP_NEIGHBOR'] %}
 {%         for neigh, data in neighbors.items() %}
-{%             if data['name'] == 'ARISTA03T1' and ':' not in neigh %}
+{%             if data['name'] == vnet2_dynamic_peer_name and ':' not in neigh %}
         "Vnet2|BGPSLBPassive": {
             "ip_range": [
                 "{{ data['local_addr'] }}/29"
@@ -46,23 +45,12 @@
 {%     elif k == 'PORTCHANNEL_INTERFACE' %}
     "PORTCHANNEL_INTERFACE": {
 {%        for pc in cfg_t0['PORTCHANNEL_INTERFACE'] | sort %}
-{#     each pc have 3 keys: pc, pc|ipv4 and pc|ipv6 #}
-{%             if cfg_t0['PORTCHANNEL_INTERFACE'] | length == 12  %}
-{%                 if pc in ['PortChannel101', 'PortChannel102'] %}
+{%             if pc in vnet1_portchannels %}
         "{{ pc }}": {"vnet_name": "Vnet1"}
-{%-                elif pc in ['PortChannel103', 'PortChannel104'] %}
+{%-            elif pc in vnet2_portchannels %}
         "{{ pc }}": {"vnet_name": "Vnet2"}
-{%-                else %}
-        "{{ pc }}": {{ cfg_t0['PORTCHANNEL_INTERFACE'][pc] }}
-{%-                endif %}
 {%-            else %}
-{%                 if pc in ['PortChannel101', 'PortChannel102', 'PortChannel103', 'PortChannel104'] %}
-        "{{ pc }}": {"vnet_name": "Vnet1"}
-{%-                elif pc in ['PortChannel105', 'PortChannel106', 'PortChannel107', 'PortChannel108'] %}
-        "{{ pc }}": {"vnet_name": "Vnet2"}
-{%-                else %}
         "{{ pc }}": {{ cfg_t0['PORTCHANNEL_INTERFACE'][pc] }}
-{%-                endif %}
 {%-            endif %}
 {%-            if not loop.last %},{% endif %}
 

--- a/tests/bgp/test_bgp_vnet.py
+++ b/tests/bgp/test_bgp_vnet.py
@@ -93,8 +93,18 @@ def setup_vnet_cfg(duthost, localhost, cfg_facts):
     vlan_ports = {'Vlan1000': ports[:len(ports)//2],
                   'Vlan2000': ports[len(ports)//2:]}
 
+    portchannels = natsorted([pc for pc in cfg_t0.get('PORTCHANNEL_INTERFACE', {}) if '|' not in pc])
+    all_t1_names = natsorted(set(
+        attrs['name'] for attrs in cfg_t0.get('BGP_NEIGHBOR', {}).values() if attrs.get('name')
+    ))
+    vnet1_num = 2
+
     extra_vars = {'cfg_t0': cfg_t0,
-                  'vlan_ports': vlan_ports}
+                  'vlan_ports': vlan_ports,
+                  'vnet1_portchannels': portchannels[:vnet1_num],
+                  'vnet2_portchannels': portchannels[vnet1_num:],
+                  'vnet1_neighbor_names': all_t1_names[:vnet1_num],
+                  'vnet2_dynamic_peer_name': all_t1_names[vnet1_num]}
 
     duthost.host.options['variable_manager'].extra_vars.update(extra_vars)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix VNET config template PortChannel VRF assignment for topologies with more than 4 PCs.
PC103/104 were incorrectly assigned to Vnet1 instead of Vnet2, causing BGP peers
ARISTA03T1/04T1 to have no route in Vnet2 VRF and leads test_bgp_vnet.py to fail.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605

### Approach
#### What is the motivation for this PR?
Test failed on topos with >4 PC

#### How did you do it?
Fixed the logic of PC assignment

#### How did you verify/test it?
Test passed on topos with 4,6,8 PCs

