### PR TITLE
update syslog rate limit control

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -573,30 +573,32 @@ class MultiAsicSonicHost(object):
                 if service_name in self.sonichost.critical_services:
                     services.append(service_name)
 
+        enable_interval_pattern = r'SysSock\.RateLimit\.Interval="[1-9][0-9]*"'
+        disable_interval_value = "SysSock.RateLimit.Interval=\"0\""
+        default_interval_value = "SysSock.RateLimit.Interval=\"300\""
+
         for docker in services:
             # This is to avoid gbsyncd check fo VS test_disable_rsyslog_rate_limit
             # we are still getting whatever enabled feature in test_disable_rsyslog_rate_limit
             # and gbsyncd feature will be added to services
             if self.get_facts()['asic_type'] == 'vs' and "gbsyncd" in docker:
                 continue
-            cmd_disable_rate_limit = (
-                r"docker exec -i {} sed -i "
-                r"'s/^\$SystemLogRateLimit/#\$SystemLogRateLimit/g' "
-                r"/etc/rsyslog.conf"
-            )
-            cmd_enable_rate_limit = (
-                r"docker exec -i {} sed -i "
-                r"'s/^#\$SystemLogRateLimit/\$SystemLogRateLimit/g' "
-                r"/etc/rsyslog.conf"
-            )
-            cmd_reload = r"docker exec -i {} supervisorctl restart rsyslogd"
+            cmd_reload = f"docker exec -i {docker} supervisorctl restart rsyslogd"
             cmds = []
 
             if rl_option == 'disable':
-                cmds.append(cmd_disable_rate_limit.format(docker))
+                cmds.append(
+                    f"docker exec -i {docker} sed -i "
+                    f"'s/{enable_interval_pattern}/{disable_interval_value}/g' "
+                    f"/etc/rsyslog.conf"
+                )
             else:
-                cmds.append(cmd_enable_rate_limit.format(docker))
-            cmds.append(cmd_reload.format(docker))
+                cmds.append(
+                    f"docker exec -i {docker} sed -i "
+                    f"'s/{disable_interval_value}/{default_interval_value}/g' "
+                    f"/etc/rsyslog.conf"
+                )
+            cmds.append(cmd_reload)
             self.sonichost.shell_cmds(cmds=cmds)
 
     def get_bgp_neighbors(self, namespace=None):


### PR DESCRIPTION
### Description of PR


Summary:
Fixes the issue introduced by https://github.com/sonic-net/sonic-buildimage/pull/18113

The rate limit configuration in rsyslog.conf is changed from
```
$SystemLogRateLimitInterval 300
$SystemLogRateLimitBurst 20000
```
to
```
module(load="imuxsock" SysSock.RateLimit.Interval="300" SysSock.RateLimit.Burst="20000")
```
The function modify_syslog_rate_limit() is invalid because the expected pattern is missing, while this function is used in pretest to disable rate limit for containers, lead to later test failures when error log is suppressed.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
fix invalid function
#### How did you do it?
replace the expected pattern with updated one
#### How did you verify/test it?
after running the pretest, verify that the syslog rate limit is disabled correctly
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
N/A
