### PR TITLE
Changes to BGP tests for DRH

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -472,7 +472,7 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
                 ptfhost.shell("ip address flush %s scope global" % conn["neighbor_intf"])
 
     @contextlib.contextmanager
-    def _setup_interfaces_t1_or_t2(mg_facts, peer_count):
+    def _setup_interfaces_t1_t2_drh(mg_facts, peer_count):
         try:
             connections = []
             is_backend_topo = "backend" in tbinfo["topo"]["name"]
@@ -622,11 +622,11 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
         setup_func = _setup_interfaces_dualtor
     elif tbinfo["topo"]["type"] in ["t0", "mx"]:
         setup_func = _setup_interfaces_t0_or_mx
-    elif tbinfo["topo"]["type"] in set(["t1", "t2", "m1", "lt2", "ft2", "c0"]):
-        setup_func = _setup_interfaces_t1_or_t2
+    elif tbinfo["topo"]["type"] in set(["t1", "t2", "m1", "lt2", "ft2", "c0", "lrh", "urh"]):
+        setup_func = _setup_interfaces_t1_t2_drh
     elif tbinfo["topo"]["type"] == "m0":
         if topo_scenario == "m0_l3_scenario":
-            setup_func = _setup_interfaces_t1_or_t2
+            setup_func = _setup_interfaces_t1_t2_drh
         else:
             setup_func = _setup_interfaces_t0_or_mx
     else:

--- a/tests/bgp/test_bgp_peer_shutdown.py
+++ b/tests/bgp/test_bgp_peer_shutdown.py
@@ -64,6 +64,15 @@ def common_setup_teardown(
         if dut_type == "FabricSpineRouter" and confed_asn is not None:
             # For FT2, we need to use vtysh to configure BGP neigh if BGP confed is enabled
             use_vtysh = True
+    elif dut_type in ["LowerRegionalHub"]:
+        neigh_type = "SpineRouter"  # or "UpperSpineRouter"
+        if confed_asn is not None:
+            use_vtysh = True
+    elif dut_type in ["UpperRegionalHub"]:
+        neigh_type = "LowerRegionalHub"
+        if confed_asn is not None:
+            use_vtysh = True
+
     else:
         neigh_type = "ToRRouter"
     logging.info(

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -165,7 +165,7 @@ def setup_bgp_peers(
             # For FT2, we need to use vtysh to configure BGP neigh if BGP confed is enabled
             use_vtysh = True
     elif dut_type in ["LowerRegionalHub"]:
-        neigh_type = "SpineRouter" # or "UpperSpineRouter"
+        neigh_type = "SpineRouter"  # or "UpperSpineRouter"
         if confed_asn is not None:
             use_vtysh = True
     elif dut_type in ["UpperRegionalHub"]:

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -164,6 +164,14 @@ def setup_bgp_peers(
         if dut_type == "FabricSpineRouter" and confed_asn is not None:
             # For FT2, we need to use vtysh to configure BGP neigh if BGP confed is enabled
             use_vtysh = True
+    elif dut_type in ["LowerRegionalHub"]:
+        neigh_type = "SpineRouter" # or "UpperSpineRouter"
+        if confed_asn is not None:
+            use_vtysh = True
+    elif dut_type in ["UpperRegionalHub"]:
+        neigh_type = "LowerRegionalHub"
+        if confed_asn is not None:
+            use_vtysh = True
     else:
         neigh_type = "ToRRouter"
 

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -186,6 +186,14 @@ def common_setup_teardown(
         if dut_type == "FabricSpineRouter" and confed_asn is not None:
             # For FT2, we need to use vtysh to configure an external BGP neighbor
             use_vtysh = True
+    elif dut_type in ["LowerRegionalHub"]:
+        neigh_type = "SpineRouter" # or "UpperSpineRouter"
+        if confed_asn is not None:
+            use_vtysh = True
+    elif dut_type in ["UpperRegionalHub"]:
+        neigh_type = "LowerRegionalHub"
+        if confed_asn is not None:
+            use_vtysh = True
     else:
         neigh_type = "ToRRouter"
 

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -187,7 +187,7 @@ def common_setup_teardown(
             # For FT2, we need to use vtysh to configure an external BGP neighbor
             use_vtysh = True
     elif dut_type in ["LowerRegionalHub"]:
-        neigh_type = "SpineRouter" # or "UpperSpineRouter"
+        neigh_type = "SpineRouter"  # or "UpperSpineRouter"
         if confed_asn is not None:
             use_vtysh = True
     elif dut_type in ["UpperRegionalHub"]:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #25224

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
BGP testcases were failing on DRH topologies
#### How did you do it?
Make necessary enhancements for BGP tests:
- `setup_func` needs to be defined for LRH/URH - uses same as t1/t2. 
    - Change the function name from `_setup_interfaces_t1_t2` -> `_setup_interfaces_t1_t2_drh` and attach LRH/URH behaviour
- `test_bgp_peer_shutdown.py`, `test_bgp_update_replication.py` & `test_bgp_update_timer.py`
    - Define neigh_type for LRH/URH respectively
    - use_vtysh if `confed_asn` is present.
#### How did you verify/test it?
Test on DRH topologies that they are passing (in combination with #24416 however)
#### Any platform specific information?
DRH topologies only
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
