### PR TITLE
[tests/common] Fix compare_crm_facts using wrong data source for righ…

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -629,7 +629,7 @@ def compare_crm_facts(left, right):
         }
 
     right_acl_group = {}
-    for ag in left['acl_group']:
+    for ag in right['acl_group']:
         key = '{}|{}|{}'.format(ag['resource name'], ag['bind point'], ag['stage'])
         right_acl_group[key] = {
             'available': ag['available count'],


### PR DESCRIPTION
## Issue 1: Bug — `compare_crm_facts` uses wrong data source for `right_acl_group`

### 📝 Issue Description (copy this for the GitHub Issue)

```
**Title:** [Bug] compare_crm_facts builds right_acl_group from left['acl_group'] — ACL group comparison is always self-equal

**Description:**

In `tests/common/utilities.py`, the function `compare_crm_facts()` is intended to compare CRM
(Critical Resource Monitoring) facts between two snapshots (`left` and `right`). However, the
`right_acl_group` dictionary is incorrectly populated by iterating over `left['acl_group']`
instead of `right['acl_group']`.

**Impact:**
- The ACL group comparison always compares left data with itself, so it can **never detect
  differences** in ACL group resources between two CRM snapshots.
- Any test relying on `compare_crm_facts()` to verify ACL group CRM resource changes is
  silently passing even when there are real discrepancies.

**Location:**
- File: `tests/common/utilities.py`
- Function: `compare_crm_facts()`
- Line ~632: `for ag in left['acl_group']:` should be `for ag in right['acl_group']:`

**Steps to Reproduce:**
1. Call `compare_crm_facts(left, right)` where `left` and `right` have different ACL group data.
2. Observe that `unmatched` list is always empty for ACL groups.

**Expected Behavior:**
The function should detect differences in ACL group resources between the two snapshots.

**Actual Behavior:**
The function never detects ACL group differences because it compares `left` with `left`.
```

### 🔀 PR Description (copy this when creating the PR)

```
## What is the motivation for this PR?

Fix a bug in `compare_crm_facts()` where the `right_acl_group` dictionary was incorrectly
populated by iterating over `left['acl_group']` instead of `right['acl_group']`. This caused
the ACL group comparison to always compare left data with itself, silently masking any actual
differences in ACL group CRM resources.

## How did you do it?

Changed the iterator source from `left['acl_group']` to `right['acl_group']` when building
the `right_acl_group` dictionary (line ~632 in `tests/common/utilities.py`).

## How did you verify/test it?

- Code inspection confirms the data source mismatch.
- The fix is a one-line change with clear intent — the right-side comparison dict must
  be built from the right-side data.

## Which area should reviewers focus on?

- `tests/common/utilities.py` — the `compare_crm_facts()` function, specifically the loop
  that builds `right_acl_group`.
```

**Branch:** `fix/compare-crm-facts-wrong-data-source`
**PR URL:** https://github.com/saiashok0981/sonic-mgmt/pull/new/fix/compare-crm-facts-wrong-data-source

---