### PR TITLE
[tests/common] Fix typo: rename REBOOT_TYPE_HISTOYR_QUEUE to REBOOT_T…

### DIFF
--- a/tests/common/platform/reboot_utils.py
+++ b/tests/common/platform/reboot_utils.py
@@ -3,7 +3,7 @@ import logging
 from tests.common.reboot import (
     sync_reboot_history_queue_with_dut,
     reboot,
-    REBOOT_TYPE_HISTOYR_QUEUE,
+    REBOOT_TYPE_HISTORY_QUEUE,
     REBOOT_TYPE_COLD,
     wait_for_startup,
 )
@@ -51,7 +51,7 @@ def reboot_and_check(localhost, dut, interfaces, xcvr_skip_list,
 
     # Append the last reboot type to the queue
     logging.info("Append the latest reboot type to the queue")
-    REBOOT_TYPE_HISTOYR_QUEUE.append(reboot_type)
+    REBOOT_TYPE_HISTORY_QUEUE.append(reboot_type)
 
     if interfaces_checker is not None:
         interfaces_checker(dut, interfaces, xcvr_skip_list, reboot_type=reboot_type)

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -172,7 +172,7 @@ reboot_ss_ctrl_dict = {
 }
 
 MAX_NUM_REBOOT_CAUSE_HISTORY = 10
-REBOOT_TYPE_HISTOYR_QUEUE = deque([], MAX_NUM_REBOOT_CAUSE_HISTORY)
+REBOOT_TYPE_HISTORY_QUEUE = deque([], MAX_NUM_REBOOT_CAUSE_HISTORY)
 REBOOT_CAUSE_HISTORY_TITLE = ["name", "cause", "time", "user", "comment"]
 
 # Retry logic config
@@ -601,7 +601,7 @@ def sync_reboot_history_queue_with_dut(dut):
     @param dut: The AnsibleHost object of DUT.
     """
 
-    global REBOOT_TYPE_HISTOYR_QUEUE
+    global REBOOT_TYPE_HISTORY_QUEUE
     global MAX_NUM_REBOOT_CAUSE_HISTORY
 
     # Initialize local deque for storing DUT reboot cause history
@@ -643,12 +643,12 @@ def sync_reboot_history_queue_with_dut(dut):
     # If the reboot cause history is received from DUT,
     # we sync the two queues. TO that end,
     # Clear the current reboot history queue
-    REBOOT_TYPE_HISTOYR_QUEUE.clear()
+    REBOOT_TYPE_HISTORY_QUEUE.clear()
 
     # For each item in the DUT reboot queue,
     # iterate through every item in the reboot dict until
     # a "cause" match is found. Then add that key to the
-    # reboot history queue REBOOT_TYPE_HISTOYR_QUEUE
+    # reboot history queue REBOOT_TYPE_HISTORY_QUEUE
     # If no cause is found add 'Unknown' as reboot type.
 
     # NB: appendleft used because queue received from DUT
@@ -658,13 +658,13 @@ def sync_reboot_history_queue_with_dut(dut):
         dict_iter_found = False
         for dict_iter in (reboot_ctrl_dict):
             if re.search(reboot_ctrl_dict[dict_iter]["cause"], reboot_type["cause"]):
-                logger.info("Adding {} to REBOOT_TYPE_HISTOYR_QUEUE".format(dict_iter))
-                REBOOT_TYPE_HISTOYR_QUEUE.appendleft(dict_iter)
+                logger.info("Adding {} to REBOOT_TYPE_HISTORY_QUEUE".format(dict_iter))
+                REBOOT_TYPE_HISTORY_QUEUE.appendleft(dict_iter)
                 dict_iter_found = True
                 break
         if not dict_iter_found:
-            logger.info("Adding {} to REBOOT_TYPE_HISTOYR_QUEUE".format(REBOOT_TYPE_UNKNOWN))
-            REBOOT_TYPE_HISTOYR_QUEUE.appendleft(REBOOT_TYPE_UNKNOWN)
+            logger.info("Adding {} to REBOOT_TYPE_HISTORY_QUEUE".format(REBOOT_TYPE_UNKNOWN))
+            REBOOT_TYPE_HISTORY_QUEUE.appendleft(REBOOT_TYPE_UNKNOWN)
 
 
 def check_reboot_cause_history(dut, reboot_type_history_queue):


### PR DESCRIPTION
## Issue 2: Typo — `REBOOT_TYPE_HISTOYR_QUEUE` should be `REBOOT_TYPE_HISTORY_QUEUE`

### 📝 Issue Description (copy this for the GitHub Issue)

```
**Title:** [Cleanup] Fix persistent typo: REBOOT_TYPE_HISTOYR_QUEUE → REBOOT_TYPE_HISTORY_QUEUE

**Description:**

The global variable `REBOOT_TYPE_HISTOYR_QUEUE` in `tests/common/reboot.py` contains a
persistent spelling error — "HISTOYR" instead of "HISTORY". This typo propagates to:

- `tests/common/reboot.py` (definition + 8 usages)
- `tests/common/platform/reboot_utils.py` (import + 1 usage)

**Impact:**
- Reduces code readability and searchability.
- Developers searching for "HISTORY" will not find this variable.
- Makes the codebase look less maintained, which can discourage contributions.

**Location:**
- `tests/common/reboot.py` — lines 175, 604, 646, 651, 661, 662, 666, 667
- `tests/common/platform/reboot_utils.py` — lines 6, 54
```

### 🔀 PR Description (copy this when creating the PR)

```
## What is the motivation for this PR?

Fix a persistent typo in the global variable name `REBOOT_TYPE_HISTOYR_QUEUE` — "HISTOYR"
should be "HISTORY". The typo appears in `tests/common/reboot.py` (definition and all usages)
and in `tests/common/platform/reboot_utils.py` (import and usage).

## How did you do it?

Renamed `REBOOT_TYPE_HISTOYR_QUEUE` → `REBOOT_TYPE_HISTORY_QUEUE` across both files:
- `tests/common/reboot.py` — variable definition, global declaration, all references, and
  log messages (8 occurrences)
- `tests/common/platform/reboot_utils.py` — import statement and usage (2 occurrences)

## How did you verify/test it?

- `grep -r "HISTOYR"` returns zero matches after the fix.
- `grep -r "HISTORY_QUEUE"` returns all expected matches.
- No functional change; this is a pure rename.

## Which area should reviewers focus on?

- `tests/common/reboot.py` — ensure all references were updated consistently.
- `tests/common/platform/reboot_utils.py` — ensure import matches the renamed export.
```

**Branch:** `fix/reboot-history-queue-typo`
**PR URL:** https://github.com/saiashok0981/sonic-mgmt/pull/new/fix/reboot-history-queue-typo

---