### PR TITLE
[tests/common] Fix str2bool parameter shadowing built-in str type

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -711,13 +711,13 @@ def check_qos_db_fv_reference_with_table(duthost):
     return False
 
 
-def str2bool(str):
+def str2bool(value):
     """
     This is used as a type when add option for pytest
-    :param str: The input string value
+    :param value: The input string value
     :return: False if value is 0 or false, else True
     """
-    return str.lower() not in ["0", "false", "no"]
+    return value.lower() not in ["0", "false", "no"]
 
 
 def setup_ferret(duthost, ptfhost, tbinfo):


### PR DESCRIPTION

## Issue 3: Code Quality — `str2bool()` parameter shadows Python built-in `str`

### 📝 Issue Description (copy this for the GitHub Issue)

```
**Title:** [Code Quality] str2bool() parameter name shadows Python built-in `str` type

**Description:**

In `tests/common/utilities.py`, the `str2bool()` function uses `str` as its parameter name:

```python
def str2bool(str):
    return str.lower() not in ["0", "false", "no"]
```

This shadows Python's built-in `str` type within the function scope.

**Impact:**
- Violates Python best practices (PEP 8 / W0622 — redefining built-in).
- Any future code added inside `str2bool()` that calls `str()` would get the parameter
  value instead of the built-in type, leading to confusing `TypeError` exceptions.
- Static analysis tools (pylint, flake8) flag this as a warning.
- Per the sonic-mgmt code review guidelines: "The naming of variables and functions should
  imply the purpose" — `str` is not descriptive of a boolean-convertible input.

**Location:**
- File: `tests/common/utilities.py`
- Function: `str2bool()`
- Line ~714

**Suggested Fix:**
Rename the parameter from `str` to `value`.
```

### 🔀 PR Description (copy this when creating the PR)

```
## What is the motivation for this PR?

The `str2bool()` function in `tests/common/utilities.py` uses `str` as its parameter name,
which shadows Python's built-in `str` type. This violates PEP 8 guidelines (W0622) and can
cause subtle bugs if the function body is ever extended to use `str()` as a constructor.

Per the sonic-mgmt code review guidelines: "The naming of variables and functions should
imply the purpose."

## How did you do it?

Renamed the parameter from `str` to `value` in the function signature, docstring, and
function body.

## How did you verify/test it?

- The function signature change is backwards-compatible since `str2bool` is always called
  with a positional argument.
- `grep -rn "str2bool"` confirms no callers use `str=` as a keyword argument.
- No functional change; pure rename.

## Which area should reviewers focus on?

- `tests/common/utilities.py` — the `str2bool()` function.
```

**Branch:** `fix/str2bool-shadowing-builtin`
**PR URL:** https://github.com/saiashok0981/sonic-mgmt/pull/new/fix/str2bool-shadowing-builtin

---

## Summary Table

| # | Issue Title | Branch | Type |
|---|------------|--------|------|
| 1 | `compare_crm_facts` wrong data source for `right_acl_group` | `fix/compare-crm-facts-wrong-data-source` | Bug Fix |
| 2 | `REBOOT_TYPE_HISTOYR_QUEUE` typo → `HISTORY` | `fix/reboot-history-queue-typo` | Cleanup |
| 3 | `str2bool()` parameter shadows built-in `str` | `fix/str2bool-shadowing-builtin` | Code Quality |