### PR TITLE
Update CoPP neighbor miss PPS for Cisco asics

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -754,7 +754,10 @@ class VlanSubnetTest(PolicyTest):
 
         # Verify with different PPS if neighbor miss trap is supported by the platform
         if self.neighbor_miss_trap_supported:
-            self.PPS_LIMIT = 200
+            if self.asic_type == "cisco-8000":
+                self.PPS_LIMIT = 600
+            else:
+                self.PPS_LIMIT = 200
             self.PPS_LIMIT_MIN = self.PPS_LIMIT * 0.9
             self.PPS_LIMIT_MAX = self.PPS_LIMIT * 1.3
 
@@ -796,7 +799,10 @@ class VlanSubnetIPinIPTest(PolicyTest):
 
         # Verify with different PPS if neighbor miss trap is supported by the platform
         if self.neighbor_miss_trap_supported:
-            self.PPS_LIMIT = 200
+            if self.asic_type == "cisco-8000":
+                self.PPS_LIMIT = 600
+            else:
+                self.PPS_LIMIT = 200
             self.PPS_LIMIT_MIN = self.PPS_LIMIT * 0.9
             self.PPS_LIMIT_MAX = self.PPS_LIMIT * 1.3
 

--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -360,11 +360,8 @@ class DHCPTest(PolicyTest):
         # Marvell based platforms have cir/cbs in steps of 125
         if self.hw_sku in {"Nokia-M0-7215", "Nokia-7215"} or self.hw_sku.startswith("Nokia-7215-A1"):
             self.PPS_LIMIT = 250
-        # Cisco G100 based platform has CIR 600
-        elif self.asic_type == "cisco-8000" and "8111" in self.platform:
-            self.PPS_LIMIT = 600
         elif self.asic_type == "cisco-8000":
-            self.PPS_LIMIT = 400
+            self.PPS_LIMIT = 600
         # M0 devices have CIR of 300 for DHCP
         elif self.topo_type in {"m0", "mx", "m1"}:
             self.PPS_LIMIT = 300
@@ -409,11 +406,8 @@ class DHCP6Test(PolicyTest):
         # Marvell based platforms have cir/cbs in steps of 125
         if self.hw_sku in {"Nokia-M0-7215", "Nokia-7215"} or self.hw_sku.startswith("Nokia-7215-A1"):
             self.PPS_LIMIT = 250
-        # Cisco G100 based platform has CIR 600
-        elif self.asic_type == "cisco-8000" and "8111" in self.platform:
-            self.PPS_LIMIT = 600
         elif self.asic_type == "cisco-8000":
-            self.PPS_LIMIT = 400
+            self.PPS_LIMIT = 600
         # M0 devices have CIR of 300 for DHCP
         elif self.topo_type in {"m0", "mx", "m1"}:
             self.PPS_LIMIT = 300
@@ -480,11 +474,8 @@ class LLDPTest(PolicyTest):
         # Marvell based platforms have cir/cbs in steps of 125
         if self.hw_sku in {"Nokia-M0-7215", "Nokia-7215"} or self.hw_sku.startswith("Nokia-7215-A1"):
             self.PPS_LIMIT = 250
-        # Cisco G100 based platform has CIR 600
-        elif self.asic_type == "cisco-8000" and "8111" in self.platform:
-            self.PPS_LIMIT = 600
         elif self.asic_type == "cisco-8000":
-            self.PPS_LIMIT = 400
+            self.PPS_LIMIT = 600
         # M0 devices have CIR of 300 for DHCP
         elif self.topo_type in {"m0", "mx", "m1"}:
             self.PPS_LIMIT = 300
@@ -516,11 +507,8 @@ class UDLDTest(PolicyTest):
         # Marvell based platforms have cir/cbs in steps of 125
         if self.hw_sku in {"Nokia-M0-7215", "Nokia-7215"} or self.hw_sku.startswith("Nokia-7215-A1"):
             self.PPS_LIMIT = 250
-        # Cisco G100 based platform has CIR 600
-        elif self.asic_type == "cisco-8000" and "8111" in self.platform:
-            self.PPS_LIMIT = 600
         elif self.asic_type == "cisco-8000":
-            self.PPS_LIMIT = 400
+            self.PPS_LIMIT = 600
         # M0 devices have CIR of 300 for DHCP
         elif self.topo_type in {"m0", "mx", "m1"}:
             self.PPS_LIMIT = 300

--- a/tests/copp/scripts/update_copp_config.py
+++ b/tests/copp/scripts/update_copp_config.py
@@ -95,9 +95,12 @@ def generate_limited_pps_config(pps_limit, input_config_file, output_config_file
                 # queue1_group3 is used by neighbor_miss trap.
                 # test_copp.py tests the neighbor_miss trap with default CBS/CIR
                 # values on platforms that support it.
-                # The default value is 200 PPS for queue1_group3
+                # Cisco-8000 HW policer granularity requires CIR=600 for accurate metering.
                 if tg == "queue1_group3":
                     if neighbor_miss_trap_supported:
+                        if asic_type == "cisco-8000":
+                            group_config["cir"] = "600"
+                            group_config["cbs"] = "600"
                         continue
                 if "cir" in group_config:
                     group_config["cir"] = pps_limit

--- a/tests/copp/scripts/update_copp_config.py
+++ b/tests/copp/scripts/update_copp_config.py
@@ -87,8 +87,8 @@ def generate_limited_pps_config(pps_limit, input_config_file, output_config_file
             # configuration as this is lower than 600 PPS
             if tg == "queue4_group3":
                 if asic_type == "cisco-8000":
-                    group_config["cir"] = "400"
-                    group_config["cbs"] = "400"
+                    group_config["cir"] = "600"
+                    group_config["cbs"] = "600"
                 else:
                     continue
             else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
On Cisco-8000 platforms, the neighbor_miss CoPP tests consistently fails on newer ASICs because the SAI policer at CIR=200 is programmed at ~144 in HW well below the test's expected range of [180, 260]. This creates a discpancy between HW and SONiC configured PPS causing it to fail and report a lower policed value being reported. This change raises the neighbor_miss policer rate to 600 PPS on Cisco-8000 to accommodate the hardware policer's metering granularity at lower CIR values (on P200) so that are sending enough traffic for hardware to translate to same PPS being configured. As well as this, we see same behavior for UDLD,LLDP,DHCP,DHCP6 tests as well so we are updating the default PPS for cisco ASICs to be 600 for these testcases

When issue started being seen: when this new neighbor miss testcase was added with this [PR](https://github.com/sonic-net/sonic-mgmt/pull/18326)

Affected branches: master, 202511, 202605. 

202511 (amongst other streams) needs this change because on P200 asics, ASIC requires a minimum value to have HW adhere to PPS set. 200 PPS for neighbor miss is far too low for P200, so we have increased it in this PR to 600 PPS to ensure we do not have reading issues (as mentioned above). Logs of it passing on 202511 are attached below and has been tested with 202605, 202511, and master images. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Raise cir/cbs value for neighbor miss CoPP testcase to handle granularity accuracy of reported PPS value in sdk on lower PPS
#### How did you do it?
updated testcase to use 600PPS for neighbor miss testcases
#### How did you verify/test it?
ran the testcases with the changes 

<img width="585" height="250" alt="image" src="https://github.com/user-attachments/assets/379a1c91-ac1c-4795-9dcf-9f12e17fe796" />

202511 P200 results
<img width="656" height="151" alt="image" src="https://github.com/user-attachments/assets/48b7ea23-aa59-4ec9-8b47-a17210f07735" />
```

--------------------------------------------------------------- generated xml file: /run_logs/isiddeeq/copp/test_copp.py::TestCOPP::test_trap_neighbor_miss_2026-06-03-21-07-03.xml ----------------------------------------------------------------
-------------------------------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------------------------------
03/06/2026 21:23:20 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
===================================================================================================== 4 passed, 1 warning in 975.13s (0:16:15) =====================================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_trap_neighbor_miss[6-VlanSubnetIPinIP-titan-t0-dut]>
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
