### PR TITLE
Update dualtor yang validation logic

### DIFF
--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -50,7 +50,7 @@ def pytest_runtest_teardown(item, nextitem):
             logger.info("Restore CRM thresholds on {}. Execute: {}".format(hostname, cmd))
             # Restore default CRM thresholds
             dut.command(cmd)
-            
+
         logger.info("Execute test cleanup: dut {} {}".format(hostname, json.dumps(RESTORE_CMDS, indent=4)))
         # Restore DUT after specific test steps
         # Test case name is used to mitigate incorrect cleanup if some of tests was failed on cleanup step and list of
@@ -247,7 +247,7 @@ def get_vlan_prefix_len_per_ip_ver(asichost, tbinfo, ip_ver):
     mg_facts = asichost.get_extended_minigraph_facts(tbinfo)
     for vlan_port_data in mg_facts["minigraph_vlan_interfaces"]:
         if ipaddress.ip_interface(vlan_port_data['addr']).version == int(ip_ver):
-            logger.info(f"vlan interface {ip_ver} prefix is :{vlan_port_data['prefixlen']}")
+            logger.info(f"vlan interface {ip_ver} prefix is: {vlan_port_data['prefixlen']}")
             return vlan_port_data['prefixlen']
     assert False, f"Not find {ip_ver} prefix for vlan interface config"
 

--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -30,15 +30,6 @@ def pytest_runtest_teardown(item, nextitem):
     && sonic-db-cli CONFIG_DB hset 'CRM|Config' {threshold_name}_high_threshold {high} \
     && sonic-db-cli CONFIG_DB hset 'CRM|Config' {threshold_name}_low_threshold {low}\""
     if item.rep_setup.passed and not item.rep_call.skipped:
-        # Restore CRM threshods
-        if crm_threshold_name:
-            crm_thresholds = item.funcargs["crm_thresholds"]
-            cmd = restore_cmd.format(threshold_name=crm_threshold_name, high=crm_thresholds[crm_threshold_name]["high"],
-                                     low=crm_thresholds[crm_threshold_name]["low"])
-            logger.info("Restore CRM thresholds. Execute: {}".format(cmd))
-            # Restore default CRM thresholds
-            item.funcargs["duthost"].command(cmd)
-
         test_name = item.function.__name__
         duthosts = item.funcargs['duthosts']
         hostname = item.funcargs['enum_rand_one_per_hwsku_frontend_hostname']
@@ -51,6 +42,15 @@ def pytest_runtest_teardown(item, nextitem):
             logger.warning('fallback to use duthost {} instead from {} {}'.format(dut.hostname, duthosts, hostname))
             hostname = dut.hostname
 
+        # Restore CRM thresholds on the correct DUT
+        if crm_threshold_name:
+            crm_thresholds = item.funcargs["crm_thresholds"]
+            cmd = restore_cmd.format(threshold_name=crm_threshold_name, high=crm_thresholds[crm_threshold_name]["high"],
+                                     low=crm_thresholds[crm_threshold_name]["low"])
+            logger.info("Restore CRM thresholds on {}. Execute: {}".format(hostname, cmd))
+            # Restore default CRM thresholds
+            dut.command(cmd)
+            
         logger.info("Execute test cleanup: dut {} {}".format(hostname, json.dumps(RESTORE_CMDS, indent=4)))
         # Restore DUT after specific test steps
         # Test case name is used to mitigate incorrect cleanup if some of tests was failed on cleanup step and list of


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) https://github.com/sonic-net/sonic-mgmt/issues/25231

this fixes issue where when test_crm_neighbor is ran on dualtor, it chooses to restore default thresholds on wrong tor causing YANG validation to fail because no cleanup was done on tor that it was actually ran on. 'item.funcargs["duthost"]' could resolve to the wrong tor before, now it will resolve only after DUT selection logic which will choose the specific DUT selected that ran tests so that it will always restore threshold on proper tor

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
TC uses tor0 -> adds neighbors and sets threshold to 622555 on tor0 -> threshold needs to be cleaned up to default, but triggers restore threshold on tor1 -> tor0 still has 622555 set as high threshold -> YANG post test validation runs -> no cleanup on tor0 -> error thrown

#### How did you do it?
made code changes to update logic of selected tor on Dualtor topologies and ran test
#### How did you verify/test it?
ran testcase with change and didnt see bug
```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html ----------------------------------------------------------------------------------- generated xml file: /run_logs/isiddeeq/crm/test_crm_2026-03-10-19-53-45.xml ------------------------------------------------------------------------------------ INFO:root:Can not get Allure report URL. Please check logs ============================================================================================================= short test summary info ============================================================================================================== SKIPPED [1] crm/test_crm.py:618: Skipping IPv4 test on IPv6-only topology SKIPPED [1] crm/test_crm.py:1353: Unsupported topology, expected to run only on 'T0*' or 'M0/MX' topology =============================================================================================== 9 passed, 2 skipped, 1 warning in 1624.19s (0:27:04) ===============================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
