### PR TITLE
[conditional_mark][bgp] Skip test_traffic_shift_lc on non-chassis platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -684,6 +684,12 @@ bgp/test_traffic_shift_sup.py:
     conditions:
       - "'t2_single_node' in topo_name"
 
+bgp/test_traffic_shift_lc.py:
+  skip:
+    reason: "test_traffic_shift_lc is only applicable to modular chassis platforms"
+    conditions:
+      - "is_chassis==False"
+
 bmp/:
   skip:
     reason: "https://github.com/sonic-net/sonic-buildimage/issues/23777"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -678,17 +678,17 @@ bgp/test_traffic_shift.py::test_load_minigraph_with_traffic_shift_away:
       - "asic_type in ['vs']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6471
 
-bgp/test_traffic_shift_sup.py:
-  skip:
-    reason: "Not supported on T2 single node topology"
-    conditions:
-      - "'t2_single_node' in topo_name"
-
 bgp/test_traffic_shift_lc.py:
   skip:
     reason: "test_traffic_shift_lc is only applicable to modular chassis platforms"
     conditions:
       - "is_chassis==False"
+
+bgp/test_traffic_shift_sup.py:
+  skip:
+    reason: "Not supported on T2 single node topology"
+    conditions:
+      - "'t2_single_node' in topo_name"
 
 bmp/:
   skip:


### PR DESCRIPTION
### Description of PR

`test_traffic_shift_lc.py` is designed for chassis linecards but currently runs on any t2 topology. On fixed-form-factor (non-chassis) VOQ platforms, `get_bgp_confed_asn()` returns `None` after minigraph reload, causing `int(None)` crash in `route_checker.parse_routes_process`.

Add conditional_mark skip rule using `is_chassis==False`, consistent with existing chassis-only test skips (e.g., `bgp/reliable_tsa/test_reliable_tsa_flaky.py` and `test_reliable_tsa_stable.py`).

Summary:
Skip `test_traffic_shift_lc.py` on non-chassis platforms to prevent `int(None)` crash.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

`test_traffic_shift_lc.py` tests TSA/TSB functionality on chassis linecards. When run on non-chassis T2 platforms (single-node VOQ), the test crashes because `get_bgp_confed_asn()` returns `None` after minigraph reload, and `route_checker.parse_routes_process` calls `int(None)`.

#### How did you do it?

Added a `bgp/test_traffic_shift_lc.py` entry in tests_mark_conditions.yaml with the condition `is_chassis==False`. This uses the `is_chassis` fact from the `dut_basic_facts` module. This is the same pattern used by `bgp/reliable_tsa/test_reliable_tsa_flaky.py` and `test_reliable_tsa_stable.py`.

#### How did you verify/test it?

Ran `test_traffic_shift_lc.py` on a non-chassis single-asic VOQ platform:

Result: **5 skipped** with reason `test_traffic_shift_lc is only applicable to modular chassis platforms`.

Before the fix, all 5 tests crashed with `AttributeError` / `TypeError`.

#### Any platform specific information?

Affects any non-chassis (fixed-form-factor) VOQ platform running T2 topology. No impact on actual chassis platforms where `is_chassis==True`.

#### Supported testbed topology if it's a new test case?

N/A — skip rule for an existing test.

### Documentation

N/A