### PR TITLE
[TH6] Increase timeout for H6-128 bulk PFC_WD apply patch

### DIFF
--- a/tests/common/gu_utils.py
+++ b/tests/common/gu_utils.py
@@ -16,7 +16,10 @@ GCU_FIELD_OPERATION_CONF_FILE = "gcu_field_operation_validators.conf.json"
 GET_HWSKU_CMD = "sonic-cfggen -d -v DEVICE_METADATA.localhost.hwsku"
 GCUTIMEOUT_MAP = {
     'armhf-nokia_ixs7215_52x-r0': 1200,
-    'x86_64-nvidia_sn5640-r0': 3600  # Increase timeout due to issue #22370
+    'x86_64-nvidia_sn5640-r0': 3600,  # Increase timeout due to issue #22370
+    # H6-128: bulk PFC_WD apply-patch (256 ports); default 600s
+    # triggers a false TimeoutError even after the command has already succeeded (test_pfcwd_status).
+    'x86_64-nokia_ixr7220_h6_128-r0': 1800,
 }
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- This PR fixes _test_pfcwd_status_ tests under _generic_config_updater_ test suite for _x86_64-nokia_ixr7220_h6_128-r0_ platform.
- When test tries to do PFC_WD apply patch for 256 ports, test command sometimes times out even though the patch apply command is succeeded.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

- _test_pfcwd_status_ tests under _generic_config_updater_ test suite for _x86_64-nokia_ixr7220_h6_128-r0_ platform fails with the following issue eventhough the gcu apply patch command gets succeeded.


```python
        output = duthost.shell(cmds, module_ignore_errors=True)
        elapsed_time = time.time() - start_time
        gcu_timeout = get_gcu_timeout(duthost)
        if elapsed_time > gcu_timeout:
            logger.error("Command took too long: {} seconds".format(elapsed_time))
>           raise TimeoutError("Command execution timeout: {} seconds".format(elapsed_time))
E           TimeoutError: Command execution timeout: 726.0890581607819 seconds

``` 
#### How did you do it?

- Increase default timeout 600s to 1800 seconds timeout under GCUTIMEOUT_MAP of tests/common/gu_utils.py for _x86_64-nokia_ixr7220_h6_128-r0_

#### How did you verify/test it?

- Ran _test_pfcwd_status_  tests with the change and made sure tests are passing without any issues.

#### Any platform specific information?

 _x86_64-nokia_ixr7220_h6_128-r0_ 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
<img width="892" height="120" alt="image" src="https://github.com/user-attachments/assets/81f4a89a-ff1d-4bf7-b909-b7a8cdf43d4e" />
