### PR TITLE
[TH6-128] Increase post-check timeout for TH6-128 after autorestart tests

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -29,6 +29,7 @@ DHCP_SERVER = "dhcp_server"
 POST_CHECK_INTERVAL_SECS = 1
 POST_CHECK_THRESHOLD_SECS = 360
 POST_CHECK_THRESHOLD_SECS_T2 = 600
+POST_CHECK_THRESHOLD_SECS_TH6_128 = 600
 PROGRAM_STATUS = "RUNNING"
 
 
@@ -461,8 +462,11 @@ def postcheck_critical_processes_status(duthost, feature_autorestart_states, up_
             if is_hiting_start_limit(duthost, feature_name):
                 clear_failed_flag_and_restart(duthost, feature_name, feature_name)
 
-    post_check_threshold = POST_CHECK_THRESHOLD_SECS_T2 if duthost.get_facts().get("modular_chassis") \
-        else POST_CHECK_THRESHOLD_SECS
+    post_check_threshold = POST_CHECK_THRESHOLD_SECS
+    if duthost.get_facts().get("modular_chassis"):
+        post_check_threshold = POST_CHECK_THRESHOLD_SECS_T2
+    if duthost.sonichost.facts['platform'] == 'x86_64-nokia_ixr7220_h6_128-r0':
+        post_check_threshold = POST_CHECK_THRESHOLD_SECS_TH6_128
 
     critical_proceses = wait_until(
         post_check_threshold, POST_CHECK_INTERVAL_SECS, 0,


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- This PR fixes issues with '_postcheck_critical_processes_status_' during the teardown of autorestart tests.
- Seeing issues with '_syncd_' & '_teamd_' container autorestart tests, where portchannel/bgp take longer time to come up in established state for _x86_64-nokia_ixr7220_h6_128-r0_ platform.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

- For autorestart tests, during test teardown, '_postcheck_critical_processes_status_' fails for containers like '_syncd_' & '_teamd_', because the portchannel/bgp take longer time to come up in established state for _x86_64-nokia_ixr7220_h6_128-r0_ platform.

#### How did you do it?

- Increase the post_check_threshold timeout to 600 seconds for _x86_64-nokia_ixr7220_h6_128-r0_ platform; 

#### How did you verify/test it?

- Ran the autorestart tests for containers such as 'teamd' & 'syncd' and made sure tests are passing without any issues.

#### Any platform specific information?

- _x86_64-nokia_ixr7220_h6_128-r0_

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
<img width="1276" height="587" alt="image" src="https://github.com/user-attachments/assets/c66ea539-89b4-4a8f-aaff-a668b0a5cdc8" />
<img width="1381" height="623" alt="image" src="https://github.com/user-attachments/assets/76a6191e-7f17-4fdb-8a14-c8a2b7af7097" />
