### PR TITLE
Add HW/SW_FLEXDB_COUNTERS_PER_PORT gated by hw/sw pfcwd

### DIFF
--- a/tests/generic_config_updater/test_pfcwd_status.py
+++ b/tests/generic_config_updater/test_pfcwd_status.py
@@ -5,6 +5,7 @@ import pytest
 from collections import defaultdict
 
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.pfcwd_helper import is_pfcwd_hw_recovery_enabled
 from tests.common.utilities import wait_until
 from tests.common.helpers.dut_utils import verify_orchagent_running_or_assert
 from tests.common.gu_utils import apply_patch, expect_op_success, expect_op_failure
@@ -20,7 +21,8 @@ logger = logging.getLogger(__name__)
 
 READ_FLEXDB_TIMEOUT = 20
 READ_FLEXDB_INTERVAL = 5
-FLEXDB_COUNTERS_PER_PORT = 3
+SW_FLEXDB_COUNTERS_PER_PORT = 3
+HW_FLEXDB_COUNTERS_PER_PORT = 2
 
 
 @pytest.fixture(autouse=True)
@@ -95,7 +97,10 @@ def ensure_dut_readiness(duthost, extract_pfcwd_config):
 
     pfcwd_config = extract_pfcwd_config
     number_of_ports = len(pfcwd_config)
-    check_config_update(duthost, number_of_ports * FLEXDB_COUNTERS_PER_PORT)
+    if is_pfcwd_hw_recovery_enabled(duthost):
+        check_config_update(duthost, number_of_ports * HW_FLEXDB_COUNTERS_PER_PORT)
+    else:
+        check_config_update(duthost, number_of_ports * SW_FLEXDB_COUNTERS_PER_PORT)
 
     yield
 
@@ -232,10 +237,14 @@ def test_stop_pfcwd(duthost, enum_rand_one_frontend_asic_index,
         4. Validates that orchagent is running fine pre and post test
     """
     pfcwd_config = extract_pfcwd_config
-    initial_count = len(pfcwd_config) * FLEXDB_COUNTERS_PER_PORT
+    flexdb_counters_per_port = (
+        HW_FLEXDB_COUNTERS_PER_PORT
+        if is_pfcwd_hw_recovery_enabled(duthost)
+        else SW_FLEXDB_COUNTERS_PER_PORT)
+    initial_count = len(pfcwd_config) * flexdb_counters_per_port
 
     if port == 'single':
-        expected_count = initial_count - FLEXDB_COUNTERS_PER_PORT
+        expected_count = initial_count - flexdb_counters_per_port
     else:
         expected_count = 0
     json_patch = list()
@@ -282,11 +291,15 @@ def test_start_pfcwd(duthost, enum_rand_one_frontend_asic_index,
         4. Validates that orchagent is running fine pre and post test
     """
     pfcwd_config = extract_pfcwd_config
+    flexdb_counters_per_port = (
+        HW_FLEXDB_COUNTERS_PER_PORT
+        if is_pfcwd_hw_recovery_enabled(duthost)
+        else SW_FLEXDB_COUNTERS_PER_PORT)
 
     if port == 'single':
-        expected_count = FLEXDB_COUNTERS_PER_PORT
+        expected_count = flexdb_counters_per_port
     else:
-        expected_count = len(pfcwd_config) * FLEXDB_COUNTERS_PER_PORT
+        expected_count = len(pfcwd_config) * flexdb_counters_per_port
     json_patch = list()
     exp_str = 'Ethernet'
     op = 'add'


### PR DESCRIPTION
### Description of PR

Summary:  
`test_pfcwd_status.py` currently fails on DUTs running hardware PFCWD because it assumes a hard-coded `FLEXDB_COUNTERS_PER_PORT = 3`, which is only valid for software PFCWD.

This change updates the test to account for whether hardware PFCWD recovery is enabled, so the expected FLEX DB counter count matches the actual HW vs SW behavior.

Reviewer start point: `tests/generic_config_updater/test_pfcwd_status.py`, specifically the logic around the expected FLEX DB counters per port.

Dependency: teardown currently hits a `config pfcwd start_default` issue, but that fix already exists as an internal cherry-pick of upstream `sonic-net/sonic-utilities#4384` (`private-sonic-utilities#615`), so the dependency should align cleanly with upstream.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

`test_pfcwd_status.py` currently fails on DUTs with hardware PFCWD because the test hard-codes `FLEXDB_COUNTERS_PER_PORT = 3`, which is only true for software PFCWD.

#### How did you do it?

Gated the expected `FLEXDB_COUNTERS_PER_PORT` value based on `is_pfcwd_hw_recover_enabled(duthost)` so the test uses the correct expectation for hardware vs software PFCWD behavior.

#### How did you verify/test it?

Verified on XGS device running HW PFCWD (with the aforementioned cherry-pick), where the full `generic_config_updater/test_pfcwd_status.py` run passed all 4 test cases after this change.

```text
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
ansible: 2.18.17
rootdir: /var/AzDevOps/sonic-mgmt/tests
configfile: pytest.ini
plugins: ansible-26.4.0, allure-pytest-2.16.0, html-4.2.0, repeat-0.9.4, stress-1.0.1, cov-7.1.0, metadata-3.1.1, xdist-3.8.0
collected 4 items

generic_config_updater/test_pfcwd_status.py::test_stop_pfcwd[None-single] PASSED
generic_config_updater/test_pfcwd_status.py::test_stop_pfcwd[None-all] PASSED
generic_config_updater/test_pfcwd_status.py::test_start_pfcwd[None-single] PASSED
generic_config_updater/test_pfcwd_status.py::test_start_pfcwd[None-all] PASSED

================= 4 passed, 230 warnings in 759.87s (0:12:39) ==================
```

#### Any platform specific information?

This issue affects hardware-PFCWD platforms; the original failures were observed on Broadcom XGS systems running HW PFCWD.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

No documentation update needed; this is a test case improvement, not a new feature or new test case.