### PR TITLE
[TH6-128] Ignore port_config.ini copy command for TH6-128 Nokia HWSKU

### DIFF
--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -576,6 +576,14 @@ def commands_to_check(duthosts, enum_rand_one_per_hwsku_hostname):
                         add_asic_arg("/{}", cmds.copy_config_cmds, num),
                 }
             )
+        # Nokia IXR7220 H6 O256: generate_dump noop list does not include port_config.ini copy.
+        # Generic HWSKU changes - copy_config_cmds
+        if duthost.facts.get("hwsku") == "Nokia-IXR7220-H6-O256":
+            cmds_to_check["copy_config_cmds"] = [
+                c for c in cmds_to_check["copy_config_cmds"]
+                if not (isinstance(c, str) and "port_config.ini" in c)
+            ]
+
     # Remove /proc/dma for armh
     elif duthost.facts["asic_type"] in ["marvell-prestera", "marvell", "nokia-vs"]:
         if 'armhf-' in duthost.facts["platform"] or 'arm64-' in duthost.facts["platform"]:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- This PR fixes issue with Generic HWSKU changes w.r.t _test_techsupport_commands_ test under test_techsupport.py test suite.
- The test fails with the following error, after the changes introduced as part of Generic HWSKU changes https://github.com/sonic-net/sonic-buildimage/issues/24494
- Platform : _x86_64-nokia_ixr7220_h6_128-r0_
```python
        for key, commands in cmd_not_found.items():
            error_message += "Commands not found for '{}': ".format(key) + '; '.join(commands) + '\n'
    
>       pytest_assert(len(cmd_not_found) == 0, error_message)
E       Failed: Commands not found for 'copy_config_cmds': cp ./port_config.ini
``` 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

- _test_techsupport_commands_ test fails with the following issue,
```python
        for key, commands in cmd_not_found.items():
            error_message += "Commands not found for '{}': ".format(key) + '; '.join(commands) + '\n'
    
>       pytest_assert(len(cmd_not_found) == 0, error_message)
E       Failed: Commands not found for 'copy_config_cmds': cp ./port_config.ini
``` 

#### How did you do it?

- Ignore "port_config.ini" copy from the copy_config_cmds list for _x86_64-nokia_ixr7220_h6_128-r0_ platform.

#### How did you verify/test it?

- Ran _test_techsupport_commands_ test after the changes and made sure test is passing without any issues.

#### Any platform specific information?

- _x86_64-nokia_ixr7220_h6_128-r0_

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
<img width="890" height="201" alt="image" src="https://github.com/user-attachments/assets/7de5c2fe-de02-421b-98de-4376efba24e0" />
