### PR TITLE
everflow inner source MAC setting for T2 Non-VOQ Case

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -1519,6 +1519,14 @@ class BaseEverflowTest(object):
                     else:
                         mirror_packet_sent[packet.Ether].src = setup[direction]["egress_router_mac"]
 
+                    if 't2' in setup['topo']:
+                        if duthost.facts['switch_type'] == "chassis-packet":
+                            # On non-VOQ T2, payload SMAC depends on forwarding path.
+                            # ttl_dec==1 corresponds to cross-namespace path; ttl_dec==0 to same-namespace path.
+                            if src_port_metadata_map[src_port][1] == 1:
+                                mirror_packet_sent[packet.Ether].src = setup[direction]["ingress_router_mac"]
+                            else:
+                                mirror_packet_sent[packet.Ether].src = setup[direction]["egress_router_mac"]
                 if multi_binding_acl:
                     inner_packet.set_do_not_care_scapy(packet.Ether, "dst")
                     inner_packet.set_do_not_care_scapy(packet.Ether, "src")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Fixes # (https://github.com/sonic-net/sonic-buildimage/issues/29341)
There is a logical bug in the handling of the inner source MAC address for the T2 non-VOQ (packet mode) case.
In packet mode (non-VOQ) on T2, the inner source MAC address in the expected packet should be updated based on the Everflow traffic path.

If the Everflow packet crosses different namespaces (i.e., the ingress and egress interfaces are in different namespaces), the inner source MAC address should be set to the ingress router MAC address.
If the Everflow packet is forwarded within the same namespace, the inner source MAC address should be set to setup[direction]["egress_router_mac"].
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
