### PR TITLE
Revert "[ci] switch to use sonic-ubuntu-1c-2 agent pool to unblock PR checker"

### DIFF
--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -7,7 +7,7 @@ parameters:
 - name: PRE_TEST_AGENT_POOL
   type: object
   default:
-    name: sonic-ubuntu-1c-2
+    name: sonic-ubuntu-1c
 
 - name: BUILD_REASON
   type: string

--- a/.azure-pipelines/probe-tests/jobs/run-probe-tests.yml
+++ b/.azure-pipelines/probe-tests/jobs/run-probe-tests.yml
@@ -14,7 +14,7 @@ jobs:
     condition: ${{ parameters.condition }}
     displayName: 'Run Probe UT/IT'
     timeoutInMinutes: 15
-    pool: sonic-ubuntu-1c-2
+    pool: sonic-ubuntu-1c
     steps:
       - checkout: self
       - template: /.azure-pipelines/probe-tests/steps/run-probe-tests.yml

--- a/.azure-pipelines/probe-tests/stages/probe-tests.yml
+++ b/.azure-pipelines/probe-tests/stages/probe-tests.yml
@@ -21,7 +21,7 @@ stages:
       - job: check_probe_changes
         displayName: 'Check if changes affect MMU probe code'
         timeoutInMinutes: 5
-        pool: sonic-ubuntu-1c-2
+        pool: sonic-ubuntu-1c
         steps:
           - checkout: self
           - script: |

--- a/.azure-pipelines/sonic_vpp/sonic-vpp-nightly.yml
+++ b/.azure-pipelines/sonic_vpp/sonic-vpp-nightly.yml
@@ -36,7 +36,7 @@ stages:
         displayName: "kvmtest-t1-lag-vpp by Elastictest"
         timeoutInMinutes: 480
         continueOnError: false
-        pool: sonic-ubuntu-1c-2
+        pool: sonic-ubuntu-1c
         steps:
           - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
             parameters:


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#25218
agents in sonic-ubuntu-1c are working now