### PR TITLE
Update qos params for topo-ft2-64

### DIFF
--- a/tests/qos/files/qos_params.th5.yaml
+++ b/tests/qos/files/qos_params.th5.yaml
@@ -216,25 +216,24 @@ qos_params:
         topo-ft2-64: &topo-ft2-64
             800000_5m:
                 hdrm_pool_size:
-                    dscps:
-                    - 3
-                    - 4
+                    dscps: [3, 4]
                     dst_port_id: 0
                     ecn: 1
                     margin: 4
-                    pgs:
-                    - 3
-                    - 4
+                    pgs: [3, 4]
                     pgs_num: 13
                     pkts_num_hdrm_full: 2853
                     pkts_num_hdrm_partial: 1124
-                    pkts_num_trig_pfc: 141861
+                    pkts_num_trig_pfc: 142285
+                    pkts_num_trig_pfc_multi: [142285, 71159, 35597, 17815, 8925, 4479,
+                        2257, 1145, 590, 312, 173, 103, 69]
+                    src_port_ids: [1, 2, 3, 4, 5, 6, 7]
                 lossy_queue_1:
                     dscp: 8
                     ecn: 1
                     pg: 0
                     pkts_num_margin: 4
-                    pkts_num_trig_egr_drp: 141835
+                    pkts_num_trig_egr_drp: 142259
                 pkts_num_egr_mem: 714
                 pkts_num_leak_out: 0
                 wm_pg_headroom:
@@ -243,8 +242,8 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_margin: 4
-                    pkts_num_trig_ingr_drp: 144715
-                    pkts_num_trig_pfc: 141861
+                    pkts_num_trig_ingr_drp: 145139
+                    pkts_num_trig_pfc: 142285
                 wm_pg_shared_lossless:
                     cell_size: 254
                     dscp: 3
@@ -253,7 +252,7 @@ qos_params:
                     pg: 3
                     pkts_num_fill_min: 34
                     pkts_num_margin: 4
-                    pkts_num_trig_pfc: 141861
+                    pkts_num_trig_pfc: 142285
                 wm_pg_shared_lossy:
                     cell_size: 254
                     dscp: 8
@@ -262,14 +261,14 @@ qos_params:
                     pg: 0
                     pkts_num_fill_min: 7
                     pkts_num_margin: 4
-                    pkts_num_trig_egr_drp: 141835
+                    pkts_num_trig_egr_drp: 142259
                 wm_q_shared_lossless:
                     cell_size: 254
                     dscp: 3
                     ecn: 1
                     pkts_num_fill_min: 0
                     pkts_num_margin: 4
-                    pkts_num_trig_ingr_drp: 144715
+                    pkts_num_trig_ingr_drp: 145139
                     queue: 3
                 wm_q_shared_lossy:
                     cell_size: 254
@@ -277,38 +276,38 @@ qos_params:
                     ecn: 1
                     pkts_num_fill_min: 7
                     pkts_num_margin: 4
-                    pkts_num_trig_egr_drp: 141835
+                    pkts_num_trig_egr_drp: 142259
                     queue: 0
                 xoff_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
                     pkts_num_margin: 4
-                    pkts_num_trig_ingr_drp: 144715
-                    pkts_num_trig_pfc: 141861
+                    pkts_num_trig_ingr_drp: 145139
+                    pkts_num_trig_pfc: 142285
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
                     pkts_num_margin: 4
-                    pkts_num_trig_ingr_drp: 144715
-                    pkts_num_trig_pfc: 141861
+                    pkts_num_trig_ingr_drp: 145139
+                    pkts_num_trig_pfc: 142285
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
                     pkts_num_dismiss_pfc: 14
                     pkts_num_margin: 4
-                    pkts_num_trig_pfc: 141861
+                    pkts_num_trig_pfc: 142285
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
                     pkts_num_dismiss_pfc: 14
                     pkts_num_margin: 4
-                    pkts_num_trig_pfc: 141861
+                    pkts_num_trig_pfc: 142285
             cell_size: 254
-            hdrm_pool_wm_multiplier: 1
+            hdrm_pool_wm_multiplier: 2
             wrr:
                 ecn: 1
                 limit: 80


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fixes: #25995

Update qos params for topo-ft2-64

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Update qos params for this topo after sai 14 upgrade and buffer changes
#### How did you do it?
Script generated
#### How did you verify/test it?
Verified by manual qos testing
