### PR TITLE
[dash]: Add apply_dash_configs helper to enforce DASH table write order

### DIFF
--- a/tests/common/dash_utils.py
+++ b/tests/common/dash_utils.py
@@ -1,4 +1,6 @@
 import logging
+import re
+from enum import IntEnum
 from os import path
 from time import sleep
 
@@ -11,6 +13,198 @@ from jinja2 import Template
 from constants import TEMPLATE_DIR
 
 logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+# DASH config ordering utility
+#
+# DASH objects pushed to the DPU via gNMI (``gnmi_utils.apply_messages``) have
+# inter-table dependencies (e.g. ``DASH_ENI_TABLE`` references a
+# ``DASH_VNET_TABLE`` and ``DASH_METER_POLICY_TABLE``;
+# ``DASH_ENI_ROUTE_TABLE`` binds an ENI to a ``DASH_ROUTE_GROUP_TABLE``).
+# Historically each test fixture has manually re-implemented the same
+# table-bucketing-and-apply order. ``apply_dash_configs`` below centralises
+# that policy: callers pass any number of config dicts keyed by
+# ``DASH_<TABLE_NAME>_TABLE:<key>`` and the helper groups + applies them in
+# the dependency order defined by ``DASH_TABLE_PHASE``.
+#
+# To add a new DASH table type, add an entry to ``DASH_TABLE_PHASE`` choosing
+# the ``DashPhase`` that satisfies its dependencies. To make an entry land in
+# a non-default phase from a specific call site, split it into its own dict
+# and rely on the registry; per-call overrides intentionally aren't supported.
+# --------------------------------------------------------------------------- #
+
+
+class DashPhase(IntEnum):
+    """Phases for applying DASH configurations in dependency order.
+
+    Lower-numbered phases are applied first on setup and deleted last on
+    teardown. Two table names may share a phase if they have no ordering
+    dependency relative to each other (or if their inter-dependency is
+    handled within a single gNMI batch by orchagent/SAI).
+
+    Phase contents (canonical ordering):
+      - ``GROUP_1`` — APPLIANCE
+      - ``GROUP_2`` — ROUTING_TYPE, METER_POLICY, OUTBOUND_PORT_MAP, VNET
+      - ``GROUP_3`` — METER_RULE
+      - ``GROUP_4`` — TUNNEL, OUTBOUND_PORT_MAP_RANGE, ENI, ROUTE_GROUP
+      - ``GROUP_5`` — ROUTE_RULE, ROUTE, VNET_MAPPING
+      - ``GROUP_6`` — ENI_ROUTE
+    """
+    GROUP_1 = 1
+    GROUP_2 = 2
+    GROUP_3 = 3
+    GROUP_4 = 4
+    GROUP_5 = 5
+    GROUP_6 = 6
+
+
+DASH_TABLE_PHASE = {
+    "APPLIANCE":               DashPhase.GROUP_1,
+    "ROUTING_TYPE":            DashPhase.GROUP_2,
+    "METER_POLICY":            DashPhase.GROUP_2,
+    "OUTBOUND_PORT_MAP":       DashPhase.GROUP_2,
+    "VNET":                    DashPhase.GROUP_2,
+    "METER_RULE":              DashPhase.GROUP_3,
+    "TUNNEL":                  DashPhase.GROUP_4,
+    "OUTBOUND_PORT_MAP_RANGE": DashPhase.GROUP_4,
+    "ENI":                     DashPhase.GROUP_4,
+    "ROUTE_GROUP":             DashPhase.GROUP_4,
+    "ROUTE_RULE":              DashPhase.GROUP_5,
+    "ROUTE":                   DashPhase.GROUP_5,
+    "VNET_MAPPING":            DashPhase.GROUP_5,
+    "ENI_ROUTE":               DashPhase.GROUP_6,
+}
+
+# Phase used for any ``DASH_<UNKNOWN>_TABLE`` key not present in
+# ``DASH_TABLE_PHASE``. Defaulting to the latest phase makes new tables
+# effectively "apply last / delete first", which is the safer fallback when
+# their real dependencies aren't yet known.
+DEFAULT_DASH_PHASE = DashPhase.GROUP_6
+
+# Captures DASH_<TABLE_NAME>_TABLE at the start of a redis-style key.
+# Greedy ``\w+`` correctly handles multi-word table names such as
+# ``DASH_OUTBOUND_PORT_MAP_RANGE_TABLE``.
+_DASH_KEY_RE = re.compile(r"^DASH_(\w+)_TABLE(?::|$)")
+
+
+def dash_table_name(key):
+    """Extract the DASH table name from a redis-style DASH key.
+
+    Args:
+        key: A string like ``"DASH_VNET_MAPPING_TABLE:Vnet1:10.0.0.1"`` or
+            just ``"DASH_APPLIANCE_TABLE"``.
+
+    Returns:
+        The table name without the ``DASH_`` prefix or ``_TABLE`` suffix
+        (e.g. ``"VNET_MAPPING"``, ``"APPLIANCE"``).
+
+    Raises:
+        ValueError: if ``key`` does not match the DASH table key shape.
+    """
+    m = _DASH_KEY_RE.match(key)
+    if not m:
+        raise ValueError("Not a DASH table key: {!r}".format(key))
+    return m.group(1)
+
+
+def bucket_dash_configs(*config_dicts):
+    """Merge config dicts and group entries by their :class:`DashPhase`.
+
+    Entries from later dicts that share a key with earlier dicts overwrite
+    the earlier value (the same semantics as ``{**a, **b}``), but a warning
+    is logged when the two values differ so silent config drift is visible.
+
+    Args:
+        *config_dicts: Any number of dicts keyed by
+            ``"DASH_<TABLE>_TABLE:<key>"``.
+
+    Returns:
+        A list of ``(phase, merged_dict)`` tuples sorted by ascending phase.
+        Empty if no input entries were supplied.
+
+    Raises:
+        ValueError: if any key is not a DASH table key.
+    """
+    by_phase = {}
+    seen = {}
+    for d in config_dicts:
+        for k, v in d.items():
+            if k in seen and seen[k] != v:
+                logger.warning(
+                    "Duplicate DASH key %s with conflicting values across input dicts; "
+                    "later value wins", k,
+                )
+            seen[k] = v
+            tbl = dash_table_name(k)
+            phase = DASH_TABLE_PHASE.get(tbl)
+            if phase is None:
+                logger.warning(
+                    "Unknown DASH table %r in key %r; defaulting to phase %s. "
+                    "Add an entry to DASH_TABLE_PHASE to silence this warning.",
+                    tbl, k, DEFAULT_DASH_PHASE.name,
+                )
+                phase = DEFAULT_DASH_PHASE
+            by_phase.setdefault(phase, {})[k] = v
+    return sorted(by_phase.items(), key=lambda item: item[0])
+
+
+def apply_dash_configs(
+    localhost, duthost, ptfhost, dpu_index, *config_dicts,
+    set_db=True, wait_after_apply=5, max_updates_in_single_cmd=1024,
+    apply_fn=None,
+):
+    """Apply DASH configs to the DPU in dependency order based on table name.
+
+    Buckets entries from all ``config_dicts`` by :class:`DashPhase` (see
+    ``DASH_TABLE_PHASE``) and calls the underlying gNMI apply function once
+    per non-empty phase, in ascending phase order on setup or descending
+    order when ``set_db=False`` (delete) so dependents are removed first.
+
+    Args:
+        localhost, duthost, ptfhost, dpu_index: passed through to ``apply_fn``.
+        *config_dicts: Any number of dicts keyed by
+            ``"DASH_<TABLE>_TABLE:<key>"``. Empty / ``None`` dicts are
+            tolerated and skipped (so callers can use conditional inclusion
+            patterns like ``*(extra if condition else [])``).
+        set_db: ``True`` (default) to write configs; ``False`` to delete.
+        wait_after_apply: seconds to wait after each phase's apply; forwarded
+            to ``apply_fn`` per phase.
+        max_updates_in_single_cmd: forwarded to ``apply_fn``.
+        apply_fn: optional callable matching the signature of
+            ``gnmi_utils.apply_messages``. Defaults to a lazy import so this
+            module does not require ``gnmi_utils`` to be on ``sys.path`` at
+            import time. Pass an injectable fake for unit tests.
+    """
+    if apply_fn is None:
+        # Lazy import: ``tests/common/dash_utils.py`` is imported by both
+        # DASH and HA tests, each of which provides its own ``gnmi_utils``
+        # module on ``sys.path`` with a compatible ``apply_messages``.
+        from gnmi_utils import apply_messages as _default_apply_fn
+        apply_fn = _default_apply_fn
+
+    non_empty = [d for d in config_dicts if d]
+    if not non_empty:
+        logger.info("apply_dash_configs called with no entries; nothing to do")
+        return
+
+    buckets = bucket_dash_configs(*non_empty)
+    if not set_db:
+        buckets = list(reversed(buckets))
+
+    op_label = "SET" if set_db else "DEL"
+    for phase, messages in buckets:
+        tables = sorted({dash_table_name(k) for k in messages})
+        logger.info(
+            "[%s] DASH phase %s (priority %d): %d entries across tables %s",
+            op_label, phase.name, int(phase), len(messages), tables,
+        )
+        apply_fn(
+            localhost, duthost, ptfhost, messages, dpu_index,
+            set_db=set_db,
+            wait_after_apply=wait_after_apply,
+            max_updates_in_single_cmd=max_updates_in_single_cmd,
+        )
 
 
 def safe_open_template(template_path):
@@ -116,16 +310,16 @@ def verify_tunnel_packets(ptfadapter, ports, exp_dpu_to_vm_pkt, tunnel_endpoint_
             if pkt_repr["IP"].dst in tunnel_endpoint_counts:
                 tunnel_endpoint_counts[pkt_repr["IP"].dst] += 1
                 logging.debug(
-                    f"Packet sent to tunnel endpoint {pkt_repr['IP'].dst} matches:\
-                        \n{result.format()} \nExpected:\n{exp_dpu_to_vm_pkt}"
+                    f"Packet sent to tunnel endpoint {pkt_repr['IP'].dst} matches: \
+                        \n{result.format()} \nExpected: \n{exp_dpu_to_vm_pkt}"
                 )
                 return
             else:
                 pytest.fail(
                     f"Received packet has unexpected dst IP {pkt_repr['IP'].dst}, \
                         expected one of {tunnel_endpoint_counts.keys()} \
-                        \n{result.format()} \nExpected:\n{exp_dpu_to_vm_pkt}"
+                        \n{result.format()} \nExpected: \n{exp_dpu_to_vm_pkt}"
                 )
         else:
             pytest.fail(f"Got expected packet on unexpected port {result.port}: {pkt_repr}")
-    pytest.fail(f"DP poll failed:\n{result.format()}")
+    pytest.fail(f"DP poll failed: \n{result.format()}")

--- a/tests/common/unit_tests/fixtures/unit_test_dash_utils.py
+++ b/tests/common/unit_tests/fixtures/unit_test_dash_utils.py
@@ -1,0 +1,557 @@
+"""Unit tests for the DASH config ordering helpers in
+``tests/common/dash_utils.py``.
+
+These tests load the target module in isolation using ``importlib`` so we
+don't drag in the wider sonic-mgmt fixture stack. The module also does
+``from constants import TEMPLATE_DIR`` at import time; we stub that out with
+a fake ``constants`` module before loading so no DASH-test path needs to be
+on ``sys.path``.
+
+Run with::
+
+    python3 -m pytest --noconftest tests/common/unit_tests/fixtures/unit_test_dash_utils.py -v
+"""
+
+import importlib.util
+import logging
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+MODULE_PATH = (Path(__file__).resolve().parents[3]
+               / "common" / "dash_utils.py")
+
+
+def _install_stub_modules():
+    """Install minimal stubs for modules ``dash_utils`` imports at module load
+    time so the unit tests don't depend on the sonic-mgmt test path layout."""
+    if "constants" not in sys.modules:
+        constants_stub = types.ModuleType("constants")
+        constants_stub.TEMPLATE_DIR = "/tmp/_unit_test_template_dir"
+        sys.modules["constants"] = constants_stub
+
+    # ``dash_utils`` also imports ``ptf.packet``, ``ptf.testutils``, ``pytest``,
+    # and ``jinja2``. ptf isn't installed in lightweight unit-test environments,
+    # so stub it; the other three should be present.
+    if "ptf" not in sys.modules:
+        ptf_stub = types.ModuleType("ptf")
+        ptf_packet_stub = types.ModuleType("ptf.packet")
+        ptf_testutils_stub = types.ModuleType("ptf.testutils")
+        sys.modules["ptf"] = ptf_stub
+        sys.modules["ptf.packet"] = ptf_packet_stub
+        sys.modules["ptf.testutils"] = ptf_testutils_stub
+
+
+def _load_target_module():
+    _install_stub_modules()
+    spec = importlib.util.spec_from_file_location(
+        "unit_target_dash_utils", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    # Register in sys.modules so test helpers can also resolve it by name
+    # (and so any internal `importlib.import_module` lookups work).
+    sys.modules["unit_target_dash_utils"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def dash_utils():
+    return _load_target_module()
+
+
+@pytest.fixture(autouse=True)
+def _bypass_repo_log_format(monkeypatch):
+    """The repo's ``tests/pytest.ini`` configures ``log_format`` with a
+    custom ``%(funcNamewithModule)s`` field that is injected by the
+    ``log_section_start`` pytest plugin. Under ``--noconftest`` that plugin
+    isn't loaded, so any log record emitted during a test crashes pytest's
+    auto-attached ``LogCaptureHandler`` with ``KeyError: 'funcNamewithModule'``.
+
+    Replace pytest's percent-style formatter with a plain ``%(message)s``
+    formatter for the duration of every test so emitted warnings don't blow
+    up unrelated tests."""
+    try:
+        import _pytest.logging as _pylog
+    except ImportError:  # pragma: no cover - pytest internals always present
+        return
+    plain = logging.Formatter("%(message)s")
+    monkeypatch.setattr(
+        _pylog.PercentStyleMultiline, "format",
+        lambda self, record: plain.format(record),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# dash_table_name
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("key,expected", [
+    ("DASH_APPLIANCE_TABLE", "APPLIANCE"),
+    ("DASH_APPLIANCE_TABLE:100", "APPLIANCE"),
+    ("DASH_VNET_TABLE:Vnet1", "VNET"),
+    ("DASH_VNET_MAPPING_TABLE:Vnet1:10.2.0.100", "VNET_MAPPING"),
+    ("DASH_ENI_TABLE:497f23d7-f0ac-4c99-a98f-59b470e8c7bd", "ENI"),
+    ("DASH_ENI_ROUTE_TABLE:eni-id", "ENI_ROUTE"),
+    ("DASH_ROUTING_TYPE_TABLE:privatelink", "ROUTING_TYPE"),
+    ("DASH_OUTBOUND_PORT_MAP_TABLE:portmap_1", "OUTBOUND_PORT_MAP"),
+    ("DASH_OUTBOUND_PORT_MAP_RANGE_TABLE:portmap_1:8001-9000",
+     "OUTBOUND_PORT_MAP_RANGE"),
+    ("DASH_ROUTE_RULE_TABLE:eni:100:1.2.3.4/32", "ROUTE_RULE"),
+])
+def test_dash_table_name_parses_real_keys(dash_utils, key, expected):
+    assert dash_utils.dash_table_name(key) == expected
+
+
+@pytest.mark.parametrize("bad_key", [
+    "",
+    "FOO",
+    "VNET_TABLE:x",                  # missing DASH_ prefix
+    "DASH_VNET:foo",                 # missing _TABLE suffix
+    "dash_vnet_table:foo",           # wrong case
+    "PREFIX_DASH_VNET_TABLE:foo",    # DASH_ not at start
+])
+def test_dash_table_name_rejects_non_dash_keys(dash_utils, bad_key):
+    with pytest.raises(ValueError):
+        dash_utils.dash_table_name(bad_key)
+
+
+# --------------------------------------------------------------------------- #
+# bucket_dash_configs
+# --------------------------------------------------------------------------- #
+
+# --------------------------------------------------------------------------- #
+# Canonical phase assignment for every known DASH table. Pinning these in a
+# data-driven test makes accidental registry edits visible.
+# --------------------------------------------------------------------------- #
+
+_EXPECTED_TABLE_PHASES = {
+    "APPLIANCE":               "GROUP_1",
+    "ROUTING_TYPE":            "GROUP_2",
+    "METER_POLICY":            "GROUP_2",
+    "OUTBOUND_PORT_MAP":       "GROUP_2",
+    "VNET":                    "GROUP_2",
+    "METER_RULE":              "GROUP_3",
+    "TUNNEL":                  "GROUP_4",
+    "OUTBOUND_PORT_MAP_RANGE": "GROUP_4",
+    "ENI":                     "GROUP_4",
+    "ROUTE_GROUP":             "GROUP_4",
+    "ROUTE_RULE":              "GROUP_5",
+    "ROUTE":                   "GROUP_5",
+    "VNET_MAPPING":            "GROUP_5",
+    "ENI_ROUTE":               "GROUP_6",
+}
+
+
+def test_registry_contains_all_known_tables_with_expected_phases(dash_utils):
+    actual = {tbl: phase.name
+              for tbl, phase in dash_utils.DASH_TABLE_PHASE.items()}
+    assert actual == _EXPECTED_TABLE_PHASES
+
+
+@pytest.mark.parametrize("table,phase_name", sorted(_EXPECTED_TABLE_PHASES.items()))
+def test_each_table_buckets_into_its_canonical_phase(dash_utils, table, phase_name):
+    cfg = {"DASH_{}_TABLE:k".format(table): {"v": 1}}
+    buckets = dash_utils.bucket_dash_configs(cfg)
+    assert len(buckets) == 1
+    phase, _ = buckets[0]
+    assert phase.name == phase_name, (
+        "{} expected in phase {} but landed in {}".format(
+            table, phase_name, phase.name))
+
+
+def test_bucket_groups_by_phase_and_sorts_ascending(dash_utils):
+    appliance = {"DASH_APPLIANCE_TABLE:100": {"sip": "10.1.0.5"}}
+    vnet = {"DASH_VNET_TABLE:Vnet1": {"vni": 1000}}
+    eni = {"DASH_ENI_TABLE:eni-id": {"vnet": "Vnet1"}}
+    eni_route = {"DASH_ENI_ROUTE_TABLE:eni-id": {"group_id": "rg1"}}
+
+    # Pass them out of order to confirm the helper sorts.
+    buckets = dash_utils.bucket_dash_configs(eni_route, vnet, appliance, eni)
+
+    phases = [p for p, _ in buckets]
+    assert phases == sorted(phases)
+    phase_names = [p.name for p in phases]
+    # APPLIANCE first (GROUP_1); VNET in GROUP_2; ENI in GROUP_4; ENI_ROUTE in GROUP_6.
+    assert phase_names == ["GROUP_1", "GROUP_2", "GROUP_4", "GROUP_6"]
+
+
+def test_bucket_merges_same_phase_dicts_into_one_batch(dash_utils):
+    # TUNNEL, OUTBOUND_PORT_MAP_RANGE, ENI, ROUTE_GROUP all live in GROUP_4.
+    tunnel = {"DASH_TUNNEL_TABLE:T1": {"vni": 100}}
+    port_map_range = {"DASH_OUTBOUND_PORT_MAP_RANGE_TABLE:pm1:8001-9000": {}}
+    eni = {"DASH_ENI_TABLE:eni-id": {"vnet": "Vnet1"}}
+    route_group = {"DASH_ROUTE_GROUP_TABLE:rg1": {"guid": "g"}}
+
+    buckets = dash_utils.bucket_dash_configs(
+        tunnel, port_map_range, eni, route_group)
+    assert len(buckets) == 1
+    phase, merged = buckets[0]
+    assert phase == dash_utils.DashPhase.GROUP_4
+    assert set(merged) == {
+        "DASH_TUNNEL_TABLE:T1",
+        "DASH_OUTBOUND_PORT_MAP_RANGE_TABLE:pm1:8001-9000",
+        "DASH_ENI_TABLE:eni-id",
+        "DASH_ROUTE_GROUP_TABLE:rg1",
+    }
+
+
+def test_bucket_empty_input_returns_empty_list(dash_utils):
+    assert dash_utils.bucket_dash_configs() == []
+    assert dash_utils.bucket_dash_configs({}, {}) == []
+
+
+def test_bucket_warns_on_conflicting_duplicate_key(dash_utils, caplog):
+    a = {"DASH_VNET_TABLE:Vnet1": {"vni": 1000}}
+    b = {"DASH_VNET_TABLE:Vnet1": {"vni": 9999}}  # same key, different value
+    with caplog.at_level(logging.WARNING, logger=dash_utils.logger.name):
+        buckets = dash_utils.bucket_dash_configs(a, b)
+    # Later value wins (matches {**a, **b} semantics).
+    _, merged = buckets[0]
+    assert merged["DASH_VNET_TABLE:Vnet1"] == {"vni": 9999}
+    assert any("Duplicate DASH key" in r.message for r in caplog.records)
+
+
+def test_bucket_does_not_warn_on_identical_duplicate(dash_utils, caplog):
+    a = {"DASH_VNET_TABLE:Vnet1": {"vni": 1000}}
+    b = {"DASH_VNET_TABLE:Vnet1": {"vni": 1000}}
+    with caplog.at_level(logging.WARNING, logger=dash_utils.logger.name):
+        dash_utils.bucket_dash_configs(a, b)
+    assert not any("Duplicate DASH key" in r.message for r in caplog.records)
+
+
+def test_bucket_unknown_table_falls_back_to_default_phase_with_warning(
+        dash_utils, caplog):
+    cfg = {"DASH_FUTURE_NEW_TABLE:x": {"foo": "bar"}}
+    with caplog.at_level(logging.WARNING, logger=dash_utils.logger.name):
+        buckets = dash_utils.bucket_dash_configs(cfg)
+    assert len(buckets) == 1
+    phase, _ = buckets[0]
+    assert phase == dash_utils.DEFAULT_DASH_PHASE
+    assert any("Unknown DASH table" in r.message for r in caplog.records)
+
+
+def test_bucket_rejects_non_dash_key(dash_utils):
+    with pytest.raises(ValueError):
+        dash_utils.bucket_dash_configs({"not_a_dash_key": {}})
+
+
+# --------------------------------------------------------------------------- #
+# apply_dash_configs
+# --------------------------------------------------------------------------- #
+
+def _fake_apply_fn():
+    """Return a MagicMock that records each apply call's keys + set_db flag."""
+    return MagicMock()
+
+
+def _apply_call_table_summary(dash_utils, call):
+    """Pull out (set_db, sorted list of DASH table names) from a fake call."""
+    args = call.args
+    # apply_fn(localhost, duthost, ptfhost, messages, dpu_index, set_db=..., ...)
+    messages = args[3]
+    set_db = call.kwargs.get("set_db", True)
+    tables = sorted({dash_utils.dash_table_name(k) for k in messages})
+    return set_db, tables
+
+
+def test_apply_calls_apply_fn_in_phase_order_for_set(dash_utils):
+    fake = _fake_apply_fn()
+    appliance = {"DASH_APPLIANCE_TABLE:100": {"sip": "10.1.0.5"}}
+    vnet = {"DASH_VNET_TABLE:Vnet1": {"vni": 1000}}
+    eni = {"DASH_ENI_TABLE:eni-id": {"vnet": "Vnet1"}}
+    eni_route = {"DASH_ENI_ROUTE_TABLE:eni-id": {"group_id": "rg1"}}
+
+    dash_utils.apply_dash_configs(
+        "lh", "dh", "ph", 0,
+        eni_route, vnet, appliance, eni,   # out of order
+        apply_fn=fake,
+    )
+
+    summaries = [_apply_call_table_summary(dash_utils, c)
+                 for c in fake.call_args_list]
+    # APPLIANCE (GROUP_1), VNET (GROUP_2), ENI (GROUP_4), ENI_ROUTE (GROUP_6).
+    assert summaries == [
+        (True, ["APPLIANCE"]),
+        (True, ["VNET"]),
+        (True, ["ENI"]),
+        (True, ["ENI_ROUTE"]),
+    ]
+
+
+def test_apply_reverses_order_for_set_db_false(dash_utils):
+    fake = _fake_apply_fn()
+    appliance = {"DASH_APPLIANCE_TABLE:100": {"sip": "10.1.0.5"}}
+    eni = {"DASH_ENI_TABLE:eni-id": {"vnet": "Vnet1"}}
+    eni_route = {"DASH_ENI_ROUTE_TABLE:eni-id": {"group_id": "rg1"}}
+
+    dash_utils.apply_dash_configs(
+        "lh", "dh", "ph", 0,
+        appliance, eni, eni_route,
+        set_db=False,
+        apply_fn=fake,
+    )
+
+    summaries = [_apply_call_table_summary(dash_utils, c)
+                 for c in fake.call_args_list]
+    # On delete we tear down dependents first.
+    assert summaries == [
+        (False, ["ENI_ROUTE"]),
+        (False, ["ENI"]),
+        (False, ["APPLIANCE"]),
+    ]
+
+
+def test_apply_merges_same_phase_into_single_call(dash_utils):
+    fake = _fake_apply_fn()
+    vnet = {"DASH_VNET_TABLE:Vnet1": {"vni": 1000}}
+    meter_policy = {"DASH_METER_POLICY_TABLE:MP": {"ip_version": "v4"}}
+    port_map = {"DASH_OUTBOUND_PORT_MAP_TABLE:pm1": {}}
+
+    dash_utils.apply_dash_configs(
+        "lh", "dh", "ph", 0, vnet, meter_policy, port_map, apply_fn=fake,
+    )
+    # All three are in GROUP_2, so a single apply call.
+    assert fake.call_count == 1
+    _, tables = _apply_call_table_summary(dash_utils, fake.call_args_list[0])
+    assert tables == ["METER_POLICY", "OUTBOUND_PORT_MAP", "VNET"]
+
+
+def test_apply_meter_policy_before_meter_rule(dash_utils):
+    """METER_RULE references METER_POLICY by name; METER_POLICY lands in
+    GROUP_2 and METER_RULE in GROUP_3 (between GROUP_2 and GROUP_4) so
+    meter rules are programmed after their parent policy but before any
+    ENI binds to that policy."""
+    fake = _fake_apply_fn()
+    policy = {"DASH_METER_POLICY_TABLE:MP": {"ip_version": "v4"}}
+    rule = {"DASH_METER_RULE_TABLE:MP:1": {"priority": 0}}
+
+    dash_utils.apply_dash_configs(
+        "lh", "dh", "ph", 0, rule, policy, apply_fn=fake)
+    summaries = [_apply_call_table_summary(dash_utils, c)
+                 for c in fake.call_args_list]
+    assert summaries == [(True, ["METER_POLICY"]), (True, ["METER_RULE"])]
+
+
+def test_apply_meter_rule_before_eni(dash_utils):
+    """METER_RULE must land before ENI so meter rules are present before
+    any ENI binds to their parent METER_POLICY."""
+    fake = _fake_apply_fn()
+    rule = {"DASH_METER_RULE_TABLE:MP:1": {"priority": 0}}
+    eni = {"DASH_ENI_TABLE:eni-id": {"vnet": "Vnet1"}}
+
+    dash_utils.apply_dash_configs(
+        "lh", "dh", "ph", 0, eni, rule, apply_fn=fake)
+    summaries = [_apply_call_table_summary(dash_utils, c)
+                 for c in fake.call_args_list]
+    assert summaries == [(True, ["METER_RULE"]), (True, ["ENI"])]
+
+
+def test_apply_port_map_before_port_map_range(dash_utils):
+    """OUTBOUND_PORT_MAP_RANGE references OUTBOUND_PORT_MAP by name;
+    OUTBOUND_PORT_MAP lands in GROUP_2 and the RANGE in GROUP_4."""
+    fake = _fake_apply_fn()
+    port_map = {"DASH_OUTBOUND_PORT_MAP_TABLE:pm1": {}}
+    port_map_range = {"DASH_OUTBOUND_PORT_MAP_RANGE_TABLE:pm1:8001-9000": {}}
+
+    dash_utils.apply_dash_configs(
+        "lh", "dh", "ph", 0, port_map_range, port_map, apply_fn=fake)
+    summaries = [_apply_call_table_summary(dash_utils, c)
+                 for c in fake.call_args_list]
+    assert summaries == [
+        (True, ["OUTBOUND_PORT_MAP"]),
+        (True, ["OUTBOUND_PORT_MAP_RANGE"]),
+    ]
+
+
+def test_apply_eni_before_route_rule(dash_utils):
+    """Under the canonical phase ordering ENI lands in GROUP_4 and
+    ROUTE_RULE in GROUP_5, so ROUTE_RULE is applied after ENI exists."""
+    fake = _fake_apply_fn()
+    eni = {"DASH_ENI_TABLE:eni-id": {"vnet": "Vnet1"}}
+    rule = {"DASH_ROUTE_RULE_TABLE:eni-id:100:1.2.3.4/32": {"priority": 0}}
+
+    dash_utils.apply_dash_configs("lh", "dh", "ph", 0, eni, rule, apply_fn=fake)
+    summaries = [_apply_call_table_summary(dash_utils, c)
+                 for c in fake.call_args_list]
+    assert summaries == [(True, ["ENI"]), (True, ["ROUTE_RULE"])]
+
+
+def test_apply_with_no_configs_is_noop(dash_utils):
+    fake = _fake_apply_fn()
+    dash_utils.apply_dash_configs("lh", "dh", "ph", 0, apply_fn=fake)
+    dash_utils.apply_dash_configs("lh", "dh", "ph", 0, {}, {}, apply_fn=fake)
+    fake.assert_not_called()
+
+
+def test_apply_skips_falsy_input_dicts(dash_utils):
+    """Callers use patterns like ``*(extra if cond else [])`` which may yield
+    nothing; we should silently ignore empty dicts."""
+    fake = _fake_apply_fn()
+    appliance = {"DASH_APPLIANCE_TABLE:100": {"sip": "10.1.0.5"}}
+    dash_utils.apply_dash_configs(
+        "lh", "dh", "ph", 0, appliance, {}, apply_fn=fake,
+    )
+    assert fake.call_count == 1
+
+
+def test_apply_forwards_dpu_index_and_wait_kwargs(dash_utils):
+    fake = _fake_apply_fn()
+    appliance = {"DASH_APPLIANCE_TABLE:100": {"sip": "10.1.0.5"}}
+    dash_utils.apply_dash_configs(
+        "lh", "dh", "ph", 7, appliance,
+        wait_after_apply=12, max_updates_in_single_cmd=64,
+        apply_fn=fake,
+    )
+    call = fake.call_args_list[0]
+    # Positional args: localhost, duthost, ptfhost, messages, dpu_index
+    assert call.args[:3] == ("lh", "dh", "ph")
+    assert call.args[4] == 7
+    assert call.kwargs["wait_after_apply"] == 12
+    assert call.kwargs["max_updates_in_single_cmd"] == 64
+    assert call.kwargs["set_db"] is True
+
+
+def test_apply_default_apply_fn_lazy_import(dash_utils, monkeypatch):
+    """When ``apply_fn`` is not provided, the helper should lazy-import
+    ``gnmi_utils.apply_messages``. We stub that module to confirm it gets
+    called with the expected positional + keyword arguments."""
+    recorded = {}
+
+    def fake_apply_messages(localhost, duthost, ptfhost, messages, dpu_index,
+                            set_db=True, wait_after_apply=5,
+                            max_updates_in_single_cmd=1024):
+        recorded["args"] = (localhost, duthost, ptfhost, messages, dpu_index)
+        recorded["kwargs"] = {
+            "set_db": set_db,
+            "wait_after_apply": wait_after_apply,
+            "max_updates_in_single_cmd": max_updates_in_single_cmd,
+        }
+
+    gnmi_stub = types.ModuleType("gnmi_utils")
+    gnmi_stub.apply_messages = fake_apply_messages
+    monkeypatch.setitem(sys.modules, "gnmi_utils", gnmi_stub)
+
+    appliance = {"DASH_APPLIANCE_TABLE:100": {"sip": "10.1.0.5"}}
+    dash_utils.apply_dash_configs("lh", "dh", "ph", 0, appliance)
+
+    assert recorded["args"][:3] == ("lh", "dh", "ph")
+    assert recorded["args"][4] == 0
+    assert recorded["kwargs"]["set_db"] is True
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end check: the canonical phase ordering must split a representative
+# fixture's configs into exactly these gNMI batches (using the
+# ``test_fnic_basic.py``-style config bundle, which omits METER_RULE):
+#   1. GROUP_1 — APPLIANCE
+#   2. GROUP_2 — VNET, ROUTING_TYPE, METER_POLICY
+#   4. GROUP_4 — TUNNEL, ENI, ROUTE_GROUP, OUTBOUND_PORT_MAP*
+#   5. GROUP_5 — ROUTE_RULE, ROUTE, VNET_MAPPING
+#   6. GROUP_6 — ENI_ROUTE
+# (GROUP_3 / METER_RULE is empty here; fixtures that push METER_RULE
+# produce 6 batches.)
+# Sentinel configs below share only the DASH table-name part of each
+# privatelink_config.py dict; values are placeholders.
+# --------------------------------------------------------------------------- #
+
+_SENTINEL = {
+    "APPLIANCE_FNIC_CONFIG":      {"DASH_APPLIANCE_TABLE:100": {"k": "appl"}},
+    "ROUTING_TYPE_PL_CONFIG":     {"DASH_ROUTING_TYPE_TABLE:privatelink": {"k": "rtpl"}},
+    "ROUTING_TYPE_VNET_CONFIG":   {"DASH_ROUTING_TYPE_TABLE:vnet": {"k": "rtvnet"}},
+    "VNET_CONFIG":                {"DASH_VNET_TABLE:Vnet1": {"k": "vnet"}},
+    "ROUTE_GROUP1_CONFIG":        {"DASH_ROUTE_GROUP_TABLE:RG1": {"k": "rg"}},
+    "METER_POLICY_V4_CONFIG":     {"DASH_METER_POLICY_TABLE:MP": {"k": "mp"}},
+    "PE_VNET_MAPPING_CONFIG":     {"DASH_VNET_MAPPING_TABLE:Vnet1:10.2.0.100": {"k": "pe"}},
+    "PE_SUBNET_ROUTE_CONFIG":     {"DASH_ROUTE_TABLE:RG1:10.2.0.0/16": {"k": "rpe"}},
+    "VM_VNET_MAPPING_CONFIG":     {"DASH_VNET_MAPPING_TABLE:Vnet1:10.0.0.11": {"k": "vm"}},
+    "VM_SUBNET_ROUTE_CONFIG":     {"DASH_ROUTE_TABLE:RG1:10.0.0.0/16": {"k": "rvm"}},
+    "VM_VNI_ROUTE_RULE_CONFIG":   {"DASH_ROUTE_RULE_TABLE:eni:2001:vm/32": {"k": "rrvm"}},
+    "INBOUND_VNI_ROUTE_RULE_CONFIG": {"DASH_ROUTE_RULE_TABLE:eni:100:pe/32": {"k": "rrin"}},
+    "TRUSTED_VNI_ROUTE_RULE_CONFIG": {"DASH_ROUTE_RULE_TABLE:eni:800:vm/32": {"k": "rrtr"}},
+    "ENI_FNIC_PL_CONFIG":         {"DASH_ENI_TABLE:eni-id": {"k": "enipl"}},
+    "ENI_FNIC_CONFIG":            {"DASH_ENI_TABLE:eni-id": {"k": "enifn"}},
+    "ENI_ROUTE_GROUP1_CONFIG":    {"DASH_ENI_ROUTE_TABLE:eni-id": {"k": "enirg"}},
+}
+
+
+def _migrated_test_fnic_basic_batches(dash_utils, is_pensando):
+    """Run the migrated fixture's apply_dash_configs invocation through a
+    fake apply_fn and return the captured merged messages per call."""
+    s = _SENTINEL
+    route_rule_configs = []
+    if not is_pensando:
+        route_rule_configs = [
+            s["VM_VNI_ROUTE_RULE_CONFIG"],
+            s["INBOUND_VNI_ROUTE_RULE_CONFIG"],
+            s["TRUSTED_VNI_ROUTE_RULE_CONFIG"],
+        ]
+    fake = _fake_apply_fn()
+    dash_utils.apply_dash_configs(
+        "lh", "dh", "ph", 0,
+        s["APPLIANCE_FNIC_CONFIG"],
+        s["ROUTING_TYPE_PL_CONFIG"],
+        s["ROUTING_TYPE_VNET_CONFIG"],
+        s["VNET_CONFIG"],
+        s["ROUTE_GROUP1_CONFIG"],
+        s["METER_POLICY_V4_CONFIG"],
+        s["PE_VNET_MAPPING_CONFIG"],
+        s["PE_SUBNET_ROUTE_CONFIG"],
+        s["VM_VNET_MAPPING_CONFIG"],
+        s["VM_SUBNET_ROUTE_CONFIG"],
+        *route_rule_configs,
+        s["ENI_FNIC_PL_CONFIG"],
+        s["ENI_ROUTE_GROUP1_CONFIG"],
+        apply_fn=fake,
+    )
+    return [c.args[3] for c in fake.call_args_list]
+
+
+def _expected_test_fnic_basic_batches(is_pensando):
+    """The canonical phase ordering should yield exactly these batches for
+    the migrated ``test_fnic_basic.py`` setup."""
+    s = _SENTINEL
+    routes_batch = {
+        **s["PE_VNET_MAPPING_CONFIG"],
+        **s["PE_SUBNET_ROUTE_CONFIG"],
+        **s["VM_VNET_MAPPING_CONFIG"],
+        **s["VM_SUBNET_ROUTE_CONFIG"],
+    }
+    if not is_pensando:
+        routes_batch.update(s["VM_VNI_ROUTE_RULE_CONFIG"])
+        routes_batch.update(s["INBOUND_VNI_ROUTE_RULE_CONFIG"])
+        routes_batch.update(s["TRUSTED_VNI_ROUTE_RULE_CONFIG"])
+    return [
+        # GROUP_1: APPLIANCE
+        dict(s["APPLIANCE_FNIC_CONFIG"]),
+        # GROUP_2: VNET + ROUTING_TYPE + METER_POLICY
+        {**s["ROUTING_TYPE_PL_CONFIG"], **s["ROUTING_TYPE_VNET_CONFIG"],
+         **s["VNET_CONFIG"], **s["METER_POLICY_V4_CONFIG"]},
+        # GROUP_4: ROUTE_GROUP + ENI (GROUP_3 is empty — no METER_RULE here)
+        {**s["ROUTE_GROUP1_CONFIG"], **s["ENI_FNIC_PL_CONFIG"]},
+        # GROUP_5: ROUTES (+ ROUTE_RULE on non-Pensando)
+        routes_batch,
+        # GROUP_6: ENI_ROUTE
+        dict(s["ENI_ROUTE_GROUP1_CONFIG"]),
+    ]
+
+
+@pytest.mark.parametrize("is_pensando", [False, True],
+                         ids=["non-pensando", "pensando"])
+def test_pilot_migration_matches_expected_phase_batches(
+        dash_utils, is_pensando):
+    """The migrated ``test_fnic_basic.py`` setup should produce exactly the
+    5 phase-bucketed batches defined above."""
+    expected = _expected_test_fnic_basic_batches(is_pensando)
+    actual = _migrated_test_fnic_basic_batches(dash_utils, is_pensando)
+
+    assert len(actual) == len(expected), (
+        "batch count differs: actual={}, expected={}".format(
+            len(actual), len(expected)))
+    for i, (act, exp) in enumerate(zip(actual, expected)):
+        assert set(act) == set(exp), (
+            "batch {} key sets differ:\n  actual only: {}\n  expected only: {}"
+            .format(i, set(act) - set(exp), set(exp) - set(act)))

--- a/tests/dash/test_config_churn.py
+++ b/tests/dash/test_config_churn.py
@@ -1,3 +1,4 @@
+# flake8: noqa: E231
 import logging
 import time
 
@@ -8,6 +9,7 @@ from dash_api.route_type_pb2 import RoutingType
 from gnmi_utils import apply_messages
 
 from tests.common import config_reload
+from tests.common.dash_utils import apply_dash_configs
 from tests.common.helpers.assertions import pytest_assert
 from tests.dash.sairedis_utils import (get_sairedis_line_count,
                                        parse_sairedis_changes)
@@ -33,44 +35,37 @@ def common_setup_teardown(
         yield
         return
     dpuhost = dpuhosts[dpu_index]
-    logger.info(pl.ROUTING_TYPE_PL_CONFIG)
-
-    base_config_messages = {
-        **pl.APPLIANCE_FNIC_CONFIG,
-        **pl.ROUTING_TYPE_PL_CONFIG,
-        **pl.ROUTING_TYPE_VNET_CONFIG,
-        **pl.VNET_CONFIG,
-        **pl.ROUTE_GROUP1_CONFIG,
-        **pl.METER_POLICY_V4_CONFIG,
-    }
-    logger.info(base_config_messages)
-
-    apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index)
-
-    route_and_mapping_messages = {
-        **pl.PE_VNET_MAPPING_CONFIG,
-        **pl.PE_SUBNET_ROUTE_CONFIG,
-        **pl.VM_VNET_MAPPING_CONFIG,
-        **pl.VM_SUBNET_ROUTE_CONFIG,
-    }
-    logger.info(route_and_mapping_messages)
-    apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index)
 
     # inbound routing not implemented in Pensando SAI yet, so skip route rule programming
+    route_rule_configs = []
     if "pensando" not in dpuhost.facts["asic_type"]:
-        route_rule_messages = {
-            **pl.VM_VNI_ROUTE_RULE_CONFIG,
-            **pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
-            **pl.TRUSTED_VNI_ROUTE_RULE_CONFIG,
-        }
-        logger.info(route_rule_messages)
-        apply_messages(localhost, duthost, ptfhost, route_rule_messages, dpuhost.dpu_index)
+        route_rule_configs = [
+            pl.VM_VNI_ROUTE_RULE_CONFIG,
+            pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
+            pl.TRUSTED_VNI_ROUTE_RULE_CONFIG,
+        ]
 
-    logger.info(pl.ENI_FNIC_CONFIG)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_FNIC_CONFIG, dpuhost.dpu_index)
-
-    logger.info(pl.ENI_ROUTE_GROUP1_CONFIG)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index)
+    # ``apply_dash_configs`` buckets entries by DASH table name and applies
+    # them in dependency order (see ``DashPhase`` in ``tests/common/dash_utils.py``):
+    # GROUP_1 (APPLIANCE) -> GROUP_2 (ROUTING_TYPE/METER_POLICY/OUTBOUND_PORT_MAP/VNET) ->
+    # GROUP_3 (METER_RULE) -> GROUP_4 (TUNNEL/OUTBOUND_PORT_MAP_RANGE/ENI/ROUTE_GROUP) ->
+    # GROUP_5 (ROUTE_RULE/ROUTE/VNET_MAPPING) -> GROUP_6 (ENI_ROUTE).
+    apply_dash_configs(
+        localhost, duthost, ptfhost, dpuhost.dpu_index,
+        pl.APPLIANCE_FNIC_CONFIG,
+        pl.ROUTING_TYPE_PL_CONFIG,
+        pl.ROUTING_TYPE_VNET_CONFIG,
+        pl.VNET_CONFIG,
+        pl.ROUTE_GROUP1_CONFIG,
+        pl.METER_POLICY_V4_CONFIG,
+        pl.PE_VNET_MAPPING_CONFIG,
+        pl.PE_SUBNET_ROUTE_CONFIG,
+        pl.VM_VNET_MAPPING_CONFIG,
+        pl.VM_SUBNET_ROUTE_CONFIG,
+        *route_rule_configs,
+        pl.ENI_FNIC_CONFIG,
+        pl.ENI_ROUTE_GROUP1_CONFIG,
+    )
 
     yield
 
@@ -99,7 +94,7 @@ def test_route_bind_churn(localhost, duthost, ptfhost, dpuhosts, dpu_index):
     pe_subnet_route_group2_config = {
         f"DASH_ROUTE_TABLE:{pl.ROUTE_GROUP2}:{pl.PE_CA_SUBNET}": {
             "routing_type": RoutingType.ROUTING_TYPE_VNET,
-            "vnet": pl.VNET2,
+            "vnet": pl.VNET1,
             "metering_class_or": "2048",
             "metering_class_and": "4095",
         }
@@ -273,15 +268,24 @@ def test_vnet_churn(localhost, duthost, ptfhost, dpuhosts, dpu_index):
         **pl.VM_SUBNET_ROUTE_CONFIG,
     }
     apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index, False)
+    apply_messages(localhost, duthost, ptfhost, pl.ROUTE_GROUP1_CONFIG, dpuhost.dpu_index, False)
+    apply_messages(localhost, duthost, ptfhost, pl.METER_POLICY_V4_CONFIG, dpuhost.dpu_index, False)
     apply_messages(localhost, duthost, ptfhost, pl.VNET_CONFIG, dpuhost.dpu_index, False)
 
     time.sleep(2)
 
     new_vni = "3001"
     vnet_config_v2 = {f"DASH_VNET_TABLE:{pl.VNET1}": {"vni": new_vni, "guid": pl.VNET1_GUID}}
+    eni_fnic_config_v2 = dict(pl.ENI_FNIC_CONFIG)  # deep copy to avoid modifying the original
+    eni_key = list(eni_fnic_config_v2.keys())[0]
+    # Update pl_sip_encoding to reflect the new VNI of 3001
+    eni_fnic_config_v2[eni_key]["pl_sip_encoding"] = f"::b90b:64:ff71:0:0/{pl.PL_ENCODING_MASK}"
+
     apply_messages(localhost, duthost, ptfhost, vnet_config_v2, dpuhost.dpu_index)
+    apply_messages(localhost, duthost, ptfhost, pl.ROUTE_GROUP1_CONFIG, dpuhost.dpu_index)
+    apply_messages(localhost, duthost, ptfhost, pl.METER_POLICY_V4_CONFIG, dpuhost.dpu_index)
     apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_FNIC_CONFIG, dpuhost.dpu_index)
+    apply_messages(localhost, duthost, ptfhost, eni_fnic_config_v2, dpuhost.dpu_index)
     apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index)
 
     time.sleep(2)

--- a/tests/dash/test_dash_metering.py
+++ b/tests/dash/test_dash_metering.py
@@ -1,3 +1,4 @@
+# flake8: noqa: E231
 import logging
 import time
 
@@ -11,7 +12,7 @@ from packets import rand_udp_port_packets
 from tests.common.helpers.assertions import pytest_assert
 from configs.privatelink_config import TUNNEL1_ENDPOINT_IPS, TUNNEL2_ENDPOINT_IPS
 from tests.common import config_reload
-from tests.common.dash_utils import verify_tunnel_packets
+from tests.common.dash_utils import apply_dash_configs, verify_tunnel_packets
 from dash_eni_counter_utils import get_eni_counter_oid, get_eni_meter_counters
 
 logger = logging.getLogger(__name__)
@@ -51,93 +52,60 @@ def common_setup_teardown(
         yield
         return
     dpuhost = dpuhosts[dpu_index]
-    logger.info(pl.ROUTING_TYPE_PL_CONFIG)
 
     if single_endpoint:
         tunnel_config = pl.TUNNEL1_CONFIG
-    else:
-        tunnel_config = pl.TUNNEL2_CONFIG
-
-    base_config_messages = {
-        **pl.APPLIANCE_FNIC_CONFIG,
-        **pl.ROUTING_TYPE_PL_CONFIG,
-        **pl.ROUTING_TYPE_VNET_CONFIG,
-        **pl.VNET_CONFIG,
-        **pl.METER_POLICY_V4_CONFIG,
-        **pl.ROUTE_GROUP1_CONFIG,
-        **pl.ROUTE_GROUP2_CONFIG,
-        **pl.ROUTE_GROUP3_CONFIG,
-        **tunnel_config,
-    }
-    logger.info(base_config_messages)
-
-    apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index)
-
-    if single_endpoint:
         rg1_vm_subnet_route_config = pl.VM_SUBNET_ROUTE_WITH_TUNNEL_SINGLE_ENDPOINT
         rg2_vm_subnet_route_config = pl.RG2_VM_SUBNET_ROUTE_WITH_TUNNEL_SINGLE_ENDPOINT
         rg3_vm_subnet_route_config = pl.RG3_VM_SUBNET_ROUTE_WITH_TUNNEL_SINGLE_ENDPOINT
     else:
+        tunnel_config = pl.TUNNEL2_CONFIG
         rg1_vm_subnet_route_config = pl.VM_SUBNET_ROUTE_WITH_TUNNEL_MULTI_ENDPOINT
         rg2_vm_subnet_route_config = pl.RG2_VM_SUBNET_ROUTE_WITH_TUNNEL_MULTI_ENDPOINT
         rg3_vm_subnet_route_config = pl.RG3_VM_SUBNET_ROUTE_WITH_TUNNEL_MULTI_ENDPOINT
 
-    # Route-Group1 rule creation
-    route_messages = {
-        **pl.PE_SUBNET_ROUTE_CONFIG,
-        **rg1_vm_subnet_route_config
-    }
-    logger.info(route_messages)
-    apply_messages(localhost, duthost, ptfhost, route_messages, dpuhost.dpu_index)
-
-    # Route-Group2 rule creation
-    route_messages = {
-        **pl.METERCLASSOR_PE_SUBNET_ROUTE_CONFIG,
-        **rg2_vm_subnet_route_config,
-    }
-    logger.info(route_messages)
-    apply_messages(localhost, duthost, ptfhost, route_messages, dpuhost.dpu_index)
-
-    # Route-Group3 rule creation
-    route_messages = {
-        **pl.METERCLASSAND_PE_SUBNET_ROUTE_CONFIG,
-        **rg3_vm_subnet_route_config,
-    }
-    logger.info(route_messages)
-    apply_messages(localhost, duthost, ptfhost, route_messages, dpuhost.dpu_index)
-
     # inbound routing not implemented in Pensando SAI yet, so skip route rule programming
+    route_rule_configs = []
     if 'pensando' not in dpuhost.facts['asic_type']:
-        route_rule_messages = {
-            **pl.VM_VNI_ROUTE_RULE_CONFIG,
-            **pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
-            **pl.TRUSTED_VNI_ROUTE_RULE_CONFIG
-        }
-        logger.info(route_rule_messages)
-        apply_messages(localhost, duthost, ptfhost, route_rule_messages, dpuhost.dpu_index)
+        route_rule_configs = [
+            pl.VM_VNI_ROUTE_RULE_CONFIG,
+            pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
+            pl.TRUSTED_VNI_ROUTE_RULE_CONFIG,
+        ]
 
-    meter_rule_messages = {
-        **pl.METER_RULE2_V4_CONFIG,
-    }
-    logger.info(meter_rule_messages)
-    apply_messages(localhost, duthost, ptfhost, meter_rule_messages, dpuhost.dpu_index)
-
-    logger.info(pl.ENI_FNIC_CONFIG)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_FNIC_CONFIG, dpuhost.dpu_index)
-
-    logger.info(pl.ENI_ROUTE_GROUP1_CONFIG)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index)
+    # ``apply_dash_configs`` buckets entries by DASH table name and applies
+    # them in dependency order (see ``DashPhase`` in ``tests/common/dash_utils.py``):
+    # GROUP_1 (APPLIANCE) -> GROUP_2 (ROUTING_TYPE/METER_POLICY/OUTBOUND_PORT_MAP/VNET) ->
+    # GROUP_3 (METER_RULE) -> GROUP_4 (TUNNEL/OUTBOUND_PORT_MAP_RANGE/ENI/ROUTE_GROUP) ->
+    # GROUP_5 (ROUTE_RULE/ROUTE/VNET_MAPPING) -> GROUP_6 (ENI_ROUTE).
+    apply_dash_configs(
+        localhost, duthost, ptfhost, dpuhost.dpu_index,
+        pl.APPLIANCE_FNIC_CONFIG,
+        pl.ROUTING_TYPE_PL_CONFIG,
+        pl.ROUTING_TYPE_VNET_CONFIG,
+        pl.VNET_CONFIG,
+        pl.METER_POLICY_V4_CONFIG,
+        pl.ROUTE_GROUP1_CONFIG,
+        pl.ROUTE_GROUP2_CONFIG,
+        pl.ROUTE_GROUP3_CONFIG,
+        tunnel_config,
+        pl.PE_SUBNET_ROUTE_CONFIG,
+        rg1_vm_subnet_route_config,
+        pl.METERCLASSOR_PE_SUBNET_ROUTE_CONFIG,
+        rg2_vm_subnet_route_config,
+        pl.METERCLASSAND_PE_SUBNET_ROUTE_CONFIG,
+        rg3_vm_subnet_route_config,
+        *route_rule_configs,
+        pl.METER_RULE2_V4_CONFIG,
+        pl.ENI_FNIC_CONFIG,
+        pl.ENI_ROUTE_GROUP1_CONFIG,
+    )
 
     yield
 
     # Route rule removal is broken so config reload to cleanup for now
     # https://github.com/sonic-net/sonic-buildimage/issues/23590
     config_reload(dpuhost, safe_reload=True, yang_validate=False)
-    # apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, pl.ENI_TRUSTED_VNI_CONFIG, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, meter_rule_messages, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index, False)
 
 
 @pytest.mark.parametrize("metering_tc", ['ENI_METERPOLICY_HIT', 'MAPPING_METERCLASS_HIT',

--- a/tests/dash/test_dash_privatelink.py
+++ b/tests/dash/test_dash_privatelink.py
@@ -7,9 +7,9 @@ import random
 import ptf.packet as scapy
 from constants import LOCAL_PTF_INTF, REMOTE_PTF_RECV_INTF, REMOTE_PTF_SEND_INTF
 from constants import VXLAN_UDP_BASE_SRC_PORT, VXLAN_UDP_SRC_PORT_MASK
-from gnmi_utils import apply_messages
 from packets import outbound_pl_packets, inbound_pl_packets
 from tests.common.config_reload import config_reload
+from tests.common.dash_utils import apply_dash_configs
 
 logger = logging.getLogger(__name__)
 
@@ -39,53 +39,38 @@ def common_setup_teardown(
     if skip_config:
         return
     dpuhost = dpuhosts[dpu_index]
-    logger.info(pl.ROUTING_TYPE_PL_CONFIG)
-    base_config_messages = {
-        **pl.APPLIANCE_CONFIG,
-        **pl.ROUTING_TYPE_PL_CONFIG,
-        **pl.VNET_CONFIG,
-        **pl.ROUTE_GROUP1_CONFIG,
-        **pl.METER_POLICY_V4_CONFIG
-    }
-    logger.info(base_config_messages)
 
-    apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index)
-
-    route_and_mapping_messages = {
-        **pl.PE_VNET_MAPPING_CONFIG,
-        **pl.PE_SUBNET_ROUTE_CONFIG,
-        **pl.VM_SUBNET_ROUTE_CONFIG
-    }
-
+    # ``INBOUND_VNI_ROUTE_RULE_CONFIG`` is only programmed on Bluefield DPUs;
+    # on other platforms ROUTE_RULE entries are skipped at the source.
+    bluefield_route_rule_configs = []
     if 'bluefield' in dpuhost.facts['asic_type']:
-        route_and_mapping_messages.update({
-            **pl.INBOUND_VNI_ROUTE_RULE_CONFIG
-        })
+        bluefield_route_rule_configs = [pl.INBOUND_VNI_ROUTE_RULE_CONFIG]
 
-    logger.info(route_and_mapping_messages)
-    apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index)
-
-    meter_rule_messages = {
-        **pl.METER_RULE1_V4_CONFIG,
-        **pl.METER_RULE2_V4_CONFIG,
-    }
-    logger.info(meter_rule_messages)
-    apply_messages(localhost, duthost, ptfhost, meter_rule_messages, dpuhost.dpu_index)
-
-    logger.info(pl.ENI_CONFIG)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_CONFIG, dpuhost.dpu_index)
-
-    logger.info(pl.ENI_ROUTE_GROUP1_CONFIG)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index)
+    # ``apply_dash_configs`` buckets entries by DASH table name and applies
+    # them in dependency order (see ``DashPhase`` in ``tests/common/dash_utils.py``):
+    # GROUP_1 (APPLIANCE) -> GROUP_2 (ROUTING_TYPE/METER_POLICY/OUTBOUND_PORT_MAP/VNET) ->
+    # GROUP_3 (METER_RULE) -> GROUP_4 (TUNNEL/OUTBOUND_PORT_MAP_RANGE/ENI/ROUTE_GROUP) ->
+    # GROUP_5 (ROUTE_RULE/ROUTE/VNET_MAPPING) -> GROUP_6 (ENI_ROUTE).
+    apply_dash_configs(
+        localhost, duthost, ptfhost, dpuhost.dpu_index,
+        pl.APPLIANCE_CONFIG,
+        pl.ROUTING_TYPE_PL_CONFIG,
+        pl.VNET_CONFIG,
+        pl.ROUTE_GROUP1_CONFIG,
+        pl.METER_POLICY_V4_CONFIG,
+        pl.PE_VNET_MAPPING_CONFIG,
+        pl.PE_SUBNET_ROUTE_CONFIG,
+        pl.VM_SUBNET_ROUTE_CONFIG,
+        *bluefield_route_rule_configs,
+        pl.METER_RULE1_V4_CONFIG,
+        pl.METER_RULE2_V4_CONFIG,
+        pl.ENI_CONFIG,
+        pl.ENI_ROUTE_GROUP1_CONFIG,
+    )
 
     yield
 
     config_reload(dpuhost, safe_reload=True, yang_validate=False)
-    # apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, pl.ENI_CONFIG, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, meter_rule_messages, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index, False)
 
 
 @pytest.mark.parametrize("encap_proto", ["vxlan", "gre"])

--- a/tests/dash/test_fnic.py
+++ b/tests/dash/test_fnic.py
@@ -1,16 +1,14 @@
-import logging
-
 import configs.privatelink_config as pl
 import ptf.testutils as testutils
 import ptf.packet as scapy
 import pytest
+import logging
 from constants import LOCAL_PTF_INTF, REMOTE_PTF_RECV_INTF, REMOTE_PTF_SEND_INTF
-from gnmi_utils import apply_messages
 from packets import rand_udp_port_packets
 from tests.common.helpers.assertions import pytest_assert
 from configs.privatelink_config import TUNNEL1_ENDPOINT_IPS, TUNNEL2_ENDPOINT_IPS
 from tests.common import config_reload
-from tests.common.dash_utils import verify_tunnel_packets
+from tests.common.dash_utils import apply_dash_configs, verify_tunnel_packets
 
 logger = logging.getLogger(__name__)
 
@@ -49,72 +47,53 @@ def common_setup_teardown(
         yield
         return
     dpuhost = dpuhosts[dpu_index]
-    logger.info(pl.ROUTING_TYPE_PL_CONFIG)
 
     if single_endpoint:
         tunnel_config = pl.TUNNEL1_CONFIG
-    else:
-        tunnel_config = pl.TUNNEL2_CONFIG
-
-    base_config_messages = {
-        **pl.APPLIANCE_FNIC_CONFIG,
-        **pl.ROUTING_TYPE_PL_CONFIG,
-        **pl.ROUTING_TYPE_VNET_CONFIG,
-        **pl.VNET_CONFIG,
-        **pl.ROUTE_GROUP1_CONFIG,
-        **pl.METER_POLICY_V4_CONFIG,
-        **tunnel_config,
-    }
-    logger.info(base_config_messages)
-
-    apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index)
-
-    if single_endpoint:
         vm_subnet_route_config = pl.VM_SUBNET_ROUTE_WITH_TUNNEL_SINGLE_ENDPOINT
     else:
+        tunnel_config = pl.TUNNEL2_CONFIG
         vm_subnet_route_config = pl.VM_SUBNET_ROUTE_WITH_TUNNEL_MULTI_ENDPOINT
-    route_and_mapping_messages = {
-        **pl.PE_VNET_MAPPING_CONFIG,
-        **pl.PE_SUBNET_ROUTE_CONFIG,
-        **pl.VM_VNET_MAPPING_CONFIG,
-        **vm_subnet_route_config
-    }
-    logger.info(route_and_mapping_messages)
-    apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index)
 
     # inbound routing not implemented in Pensando SAI yet, so skip route rule programming
+    route_rule_configs = []
     if 'pensando' not in dpuhost.facts['asic_type']:
-        route_rule_messages = {
-            **pl.VM_VNI_ROUTE_RULE_CONFIG,
-            **pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
-            **pl.TRUSTED_VNI_ROUTE_RULE_CONFIG
-        }
-        logger.info(route_rule_messages)
-        apply_messages(localhost, duthost, ptfhost, route_rule_messages, dpuhost.dpu_index)
+        route_rule_configs = [
+            pl.VM_VNI_ROUTE_RULE_CONFIG,
+            pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
+            pl.TRUSTED_VNI_ROUTE_RULE_CONFIG,
+        ]
 
-    meter_rule_messages = {
-        **pl.METER_RULE1_V4_CONFIG,
-        **pl.METER_RULE2_V4_CONFIG,
-    }
-    logger.info(meter_rule_messages)
-    apply_messages(localhost, duthost, ptfhost, meter_rule_messages, dpuhost.dpu_index)
-
-    logger.info(pl.ENI_FNIC_CONFIG)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_FNIC_CONFIG, dpuhost.dpu_index)
-
-    logger.info(pl.ENI_ROUTE_GROUP1_CONFIG)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index)
+    # ``apply_dash_configs`` buckets entries by DASH table name and applies
+    # them in dependency order (see ``DashPhase`` in ``tests/common/dash_utils.py``):
+    # GROUP_1 (APPLIANCE) -> GROUP_2 (ROUTING_TYPE/METER_POLICY/OUTBOUND_PORT_MAP/VNET) ->
+    # GROUP_3 (METER_RULE) -> GROUP_4 (TUNNEL/OUTBOUND_PORT_MAP_RANGE/ENI/ROUTE_GROUP) ->
+    # GROUP_5 (ROUTE_RULE/ROUTE/VNET_MAPPING) -> GROUP_6 (ENI_ROUTE).
+    apply_dash_configs(
+        localhost, duthost, ptfhost, dpuhost.dpu_index,
+        pl.APPLIANCE_FNIC_CONFIG,
+        pl.ROUTING_TYPE_PL_CONFIG,
+        pl.ROUTING_TYPE_VNET_CONFIG,
+        pl.VNET_CONFIG,
+        pl.ROUTE_GROUP1_CONFIG,
+        pl.METER_POLICY_V4_CONFIG,
+        tunnel_config,
+        pl.PE_VNET_MAPPING_CONFIG,
+        pl.PE_SUBNET_ROUTE_CONFIG,
+        pl.VM_VNET_MAPPING_CONFIG,
+        vm_subnet_route_config,
+        *route_rule_configs,
+        pl.METER_RULE1_V4_CONFIG,
+        pl.METER_RULE2_V4_CONFIG,
+        pl.ENI_FNIC_CONFIG,
+        pl.ENI_ROUTE_GROUP1_CONFIG,
+    )
 
     yield
 
     # Route rule removal is broken so config reload to cleanup for now
     # https://github.com/sonic-net/sonic-buildimage/issues/23590
     config_reload(dpuhost, safe_reload=True, yang_validate=False)
-    # apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, pl.ENI_TRUSTED_VNI_CONFIG, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, meter_rule_messages, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index, False)
 
 
 @pytest.mark.parametrize("encap_proto", ["vxlan", "gre"])

--- a/tests/dash/test_plnsg.py
+++ b/tests/dash/test_plnsg.py
@@ -10,9 +10,8 @@ from constants import (
     VXLAN_UDP_BASE_SRC_PORT,
     VXLAN_UDP_SRC_PORT_MASK,
 )
-from gnmi_utils import apply_messages
 from packets import inbound_pl_packets, plnsg_packets
-from tests.common.dash_utils import verify_tunnel_packets
+from tests.common.dash_utils import apply_dash_configs, verify_tunnel_packets
 from tests.common.helpers.assertions import pytest_assert as pt_assert
 import ptf.packet as scapy
 
@@ -42,59 +41,44 @@ def config_setup_teardown(
         yield
         return
     dpuhost = dpuhosts[dpu_index]
-    logger.info(pl.ROUTING_TYPE_PL_CONFIG)
 
     if single_endpoint:
         tunnel_config = pl.TUNNEL3_CONFIG
-    else:
-        tunnel_config = pl.TUNNEL4_CONFIG
-
-    base_config_messages = {
-        **pl.APPLIANCE_CONFIG,
-        **pl.ROUTING_TYPE_PL_CONFIG,
-        **pl.ROUTING_TYPE_VNET_CONFIG,
-        **pl.VNET_CONFIG,
-        **pl.VNET2_CONFIG,
-        **pl.ROUTE_GROUP1_CONFIG,
-        **pl.METER_POLICY_V4_CONFIG,
-        **tunnel_config,
-    }
-    logger.info(base_config_messages)
-
-    apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index)
-
-    if single_endpoint:
         vnet_mapping_config = pl.PE_PLNSG_SINGLE_ENDPOINT_VNET_MAPPING_CONFIG
     else:
+        tunnel_config = pl.TUNNEL4_CONFIG
         vnet_mapping_config = pl.PE_PLNSG_MULTI_ENDPOINT_VNET_MAPPING_CONFIG
-    route_and_mapping_messages = {
-        **vnet_mapping_config,
-        **pl.PE_SUBNET_ROUTE_CONFIG,
-        **pl.VM_SUBNET_ROUTE_CONFIG,
-    }
-    logger.info(route_and_mapping_messages)
-    apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index)
 
+    route_rule_configs = []
     if 'pensando' not in dpuhost.facts['asic_type']:
-        route_rule_messages = {
-            **pl.VM_VNI_ROUTE_RULE_CONFIG,
-            **pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
-        }
-        logger.info(route_rule_messages)
-        apply_messages(localhost, duthost, ptfhost, route_rule_messages, dpuhost.dpu_index)
+        route_rule_configs = [
+            pl.VM_VNI_ROUTE_RULE_CONFIG,
+            pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
+        ]
 
-    meter_rule_messages = {
-        **pl.METER_RULE1_V4_CONFIG,
-        **pl.METER_RULE2_V4_CONFIG,
-    }
-    logger.info(meter_rule_messages)
-    apply_messages(localhost, duthost, ptfhost, meter_rule_messages, dpuhost.dpu_index)
-
-    logger.info(pl.ENI_CONFIG)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_CONFIG, dpuhost.dpu_index)
-
-    logger.info(pl.ENI_ROUTE_GROUP1_CONFIG)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index)
+    # ``apply_dash_configs`` buckets entries by DASH table name and applies
+    # them in dependency order (see ``DashPhase`` in ``tests/common/dash_utils.py``):
+    # GROUP_1 (APPLIANCE) -> GROUP_2 (ROUTING_TYPE/METER_POLICY/OUTBOUND_PORT_MAP/VNET) ->
+    # GROUP_3 (METER_RULE) -> GROUP_4 (TUNNEL/OUTBOUND_PORT_MAP_RANGE/ENI/ROUTE_GROUP) ->
+    # GROUP_5 (ROUTE_RULE/ROUTE/VNET_MAPPING) -> GROUP_6 (ENI_ROUTE).
+    apply_dash_configs(
+        localhost, duthost, ptfhost, dpuhost.dpu_index,
+        pl.APPLIANCE_CONFIG,
+        pl.ROUTING_TYPE_PL_CONFIG,
+        pl.ROUTING_TYPE_VNET_CONFIG,
+        pl.VNET_CONFIG,
+        pl.ROUTE_GROUP1_CONFIG,
+        pl.METER_POLICY_V4_CONFIG,
+        tunnel_config,
+        vnet_mapping_config,
+        pl.PE_SUBNET_ROUTE_CONFIG,
+        pl.VM_SUBNET_ROUTE_CONFIG,
+        *route_rule_configs,
+        pl.METER_RULE1_V4_CONFIG,
+        pl.METER_RULE2_V4_CONFIG,
+        pl.ENI_CONFIG,
+        pl.ENI_ROUTE_GROUP1_CONFIG,
+    )
 
     yield
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
A recent orchagent change removed the retry-mechanism for out-of-order DASH configurations (https://github.com/sonic-net/sonic-swss/pull/4566). Existing sonic-mgmt DASH test have been programming DASH configs in the wrong order and  relying on the retry mechanism to program configs once all prerequisite DASH configs exist. Since the retry no longer occurs in orchagent, sonic-mgmt tests now need to ensure that configs are sent in the correct order.

#### How did you do it?
Add a new utility to sort all DASH configs for a given test module and program them in the correct order in tests/common/dash_utils.py:

  - `DashPhase` enum (GROUP_1..GROUP_6) names the phases in dependency order.
  - `DASH_TABLE_PHASE` registry maps each known DASH table name to its phase. New DASH tables only need a single entry here.
  - `apply_dash_configs(localhost, duthost, ptfhost, dpu_index, *dicts, set_db=True, ...)` accepts any number of config dicts keyed by `DASH_<TABLE>_TABLE:<key>`, groups them by phase, and applies them in ascending phase order on setup or descending order on teardown (`set_db=False`). The underlying `apply_messages` is lazy-imported so the helper works in both tests/dash/ and tests/ha/ contexts.

The following test fixtures are migrated:

  - tests/dash/test_fnic.py
  - tests/dash/test_dash_privatelink.py
  - tests/dash/test_dash_metering.py
  - tests/dash/test_plnsg.py
  - tests/dash/test_config_churn.py  (setup fixture only; churn test bodies retain raw apply_messages for sairedis-tracking precision)

Each fixture's previous hand-rolled bucketing collapses to a single `apply_dash_configs(...)` call. Platform-conditional bundles (Pensando / Bluefield) are spread via `*list` patterns.

A small fix to test_config_churn churn-body cleanup ordering and an ENI pl_sip_encoding update for the new VNI are included; these were necessary follow-ups when re-running the churn tests with the new fixture batching.

Unit tests: tests/common/unit_tests/fixtures/unit_test_dash_utils.py covers key parsing, bucketing, ordering, same-phase merging, conflict warnings, unknown-table fallback, reverse-order delete, lazy-import default apply_fn, and an end-to-end positive assertion of the expected batches for a representative fixture. Run with:

    python3 -m pytest --noconftest \
      tests/common/unit_tests/fixtures/unit_test_dash_utils.py -v

#### How did you verify/test it?
Run the migrated tests on a smartswitch testbed and verify that they pass.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
