### PR TITLE
test: wait for "show mux status" readiness in check_mux_simulator

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -594,14 +594,30 @@ def _check_dut_mux_status(duthosts, duts_minigraph_facts, **kwargs):
     def _verify_show_mux_status(**kwargs):
         dut = kwargs['node']
         results = kwargs['results']
-        dut_mux_status = dut.show_and_parse("show mux status")
 
-        dut_parsed_mux_status = {}
+        dut_mux_status = []
+
+        def _show_mux_status_ready():
+            # Right after deploy/reboot, linkmgrd may not have populated the mux
+            # state in STATE_DB MUX_CABLE_TABLE for every port yet. In that case
+            # "show mux status" exits non-zero (e.g. "could not retrieve key state
+            # value for port ... inside table MUX_CABLE_TABLE"), which otherwise
+            # aborts the whole sanity check on the very first sample. Treat it as a
+            # transient not-ready condition and wait for the mux state to converge.
+            try:
+                dut_mux_status[:] = dut.show_and_parse("show mux status")
+            except RunAnsibleModuleFail as e:
+                logger.warning('"show mux status" is not ready yet on %s: %s' % (dut.hostname, repr(e)))
+                return False
+            return len(dut_mux_status) == len(port_cable_types)
+
+        wait_until(120, 10, 0, _show_mux_status_ready)
+
         dut_wrong_mux_status_ports = []
         check_result = {"failed": False, "check_item": "check_mux_simulator", "host": dut.hostname, "error_msg": []}
         logger.info('Verify that "show mux status" has output ON {}'.format(dut.hostname))
         if len(dut_mux_status) != len(port_cable_types):
-            check_result["error_msg"] = "Some ports doesn't have 'show mux status' output"
+            check_result["error_msg"].append("Some ports doesn't have 'show mux status' output")
             check_result["failed"] = True
 
         dut_parsed_mux_status = {}


### PR DESCRIPTION
### Description of PR

Summary: The dualtor `check_mux_simulator` pre-test sanity check sampled `show mux status` exactly once, with no retry. Shortly after deploy/reboot, `linkmgrd` may not have populated the mux state in `STATE_DB:MUX_CABLE_TABLE` for every port yet, so the CLI exits non-zero (`could not retrieve key state value for port ... inside table MUX_CABLE_TABLE`). That `RunAnsibleModuleFail` is raised inside the `parallel_run` worker and aborts the entire sanity check during setup — before the existing recovery/retry logic can run — so unrelated tests (e.g. `test_pretest`) error out intermittently.

This PR makes `_verify_show_mux_status` wait for `show mux status` to return state for all ports before parsing it, and fall through to a graceful failure only if it never converges.

Fixes #25253

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
`check_mux_simulator` intermittently aborts the pretest on dualtor testbeds, failing otherwise-unrelated tests. Mux state in `STATE_DB:MUX_CABLE_TABLE` is populated asynchronously after boot, but the check sampled it once and treated a transient "not ready yet" CLI failure as a hard error. Because the failure surfaces inside `parallel_run`, it short-circuits the whole check before the existing recovery path can retry.

#### How did you do it?
In `tests/common/plugins/sanity_check/checks.py` → `_check_dut_mux_status._verify_show_mux_status`:
- Added a bounded readiness wait (`wait_until(120, 10, 0, ...)`) that polls `show mux status` until it returns state for all ports, catching the transient `RunAnsibleModuleFail` instead of letting it crash the worker — mirroring the existing `bgp_facts` readiness wait already used in this file.
- If the state never converges, the existing length check now fails gracefully (no crash). Also fixed a coupled bug in that failure path: `error_msg` was assigned a `str` while the caller indexes it as a list (`error_msg[-1]`), previously yielding a meaningless `'t'`; it now appends to the list.

#### How did you verify/test it?
- `python3 -m py_compile` and `flake8 --max-line-length=120` pass on the changed file.
- Traced against the observed failure path: a transient non-zero `show mux status` is now retried rather than aborting the check; a persistent failure still fails the check (after the wait) with a meaningful message.
- The dualtor CI runs exercise this sanity check; a local dualtor VS reproduction is the recommended additional validation.

#### Any platform specific information?
Dualtor only — `check_mux_simulator` only runs on dualtor topologies. No ASIC/platform-specific behavior; applies to both virtual (VS) and physical dualtor.

#### Supported testbed topology if it's a new test case?
N/A — not a new test case; this hardens the existing dualtor sanity check.

### Documentation
N/A — no documentation changes.
