### PR TITLE
Update python interpreter discovery behavior for ansible

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -26,7 +26,9 @@ transport      = smart
 module_lang    = C
 max_diff_size  = 512000
 
-interpreter_python = auto_legacy_silent
+# auto_legacy_silent is deprecated; use auto instead
+# https://docs.ansible.com/projects/ansible/latest/reference_appendices/interpreter_discovery.html
+interpreter_python = auto
 
 # plays will gather facts by default, which contain information about
 # the remote system.


### PR DESCRIPTION
### Description of PR

Updates python interpreter discovery flag (required for ansible-core 2.21+). Causes failure during fact gathering in VM topology workflows

```
TASK [Gathering Facts] *********************************************************
task path: /var/src/sonic-mgmt/ansible/testbed_add_vm_topology.yml:33
redirecting (type: connection) ansible.builtin.smart to ansible.legacy.ssh
[ERROR]: Task failed: Action failed: The following modules failed to execute: ansible.legacy.setup.

Task failed: Action failed.

<<< caused by >>>

The following modules failed to execute: ansible.legacy.setup.

+--[ Sub-Event 1 of 1 ]---
| 
| The module interpreter 'auto_legacy_silent' was not found. Consider overriding the configured interpreter path for this host. See stdout/stderr for the returned output.
| 
+--[ End Sub-Event ]---

fatal: [STR-ACS-VSERV-01]: FAILED! => {"ansible_facts": {}, "changed": false, "failed_modules": {"ansible.legacy.setup": {"changed": false, "deprecations": [], "exception": "(traceback unavailable)", "failed": true, "module_stderr": "Warning: Permanently added '172.17.0.1' (ED25519) to the list of known hosts.\r\n/bin/sh: 1: auto_legacy_silent: not found\n", "module_stdout": "", "msg": "The module interpreter 'auto_legacy_silent' was not found.", "rc": 127, "warnings": []}}, "msg": "The following modules failed to execute: ansible.legacy.setup."}
```

This PR updates the flag to enable discovery.

Fixes #N/A

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Recent removal of gather_facts: no exposed an interpreter discovery regression: ansible-core 2.21

#### How did you do it?
Updated Ansible interpreter discovery configuration to a supported mode compatible with current ansible-core

#### How did you verify/test it?
In CI. TBD

#### Any platform specific information?
Affects environments using newer ansible-core (observed with 2.21.0 in sonic-mgmt container).

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
No documentation changes required.