### PR TITLE
[vm_set] Gather distribution facts before distro support checks

### DIFF
--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -22,6 +22,18 @@
 # downloaded from the URLs defined in the variables. Please update the URLs to the actual URLs of the image files in
 # your environment.
 
+# Gather distribution facts (ansible_distribution / ansible_distribution_version) when they
+# are not already available. Several playbooks that include this role run with
+# `gather_facts: no` (e.g. testbed_renumber_vm_topology.yml), in which case these facts are
+# undefined and the distribution checks below fail with "'ansible_distribution' is undefined".
+- name: Gather distribution facts if not already gathered
+  setup:
+    gather_subset:
+      - "!all"
+      - "!min"
+      - distribution
+  when: ansible_distribution is not defined
+
 # ---- Fail if Ubuntu < 22.04 or Debian < 13 ----
 - name: Fail if distribution is not Ubuntu or Debian
   fail:


### PR DESCRIPTION
### Description of PR

Summary:
The `vm_set` role's Ubuntu/Debian support checks (added in #24219) read `ansible_distribution` / `ansible_distribution_version`. Playbooks that include this role with `gather_facts: no` (e.g. `testbed_renumber_vm_topology.yml`) leave these facts undefined, so testbed preparation fails with `'ansible_distribution' is undefined`.

This PR adds a `setup` task gated on `ansible_distribution is not defined` that gathers the `distribution` fact subset, making the role self-sufficient regardless of the including play's `gather_facts` setting. It is a no-op when facts are already gathered.

Fixes # (issue)

ADO: https://msazure.visualstudio.com/One/_workitems/edit/38367933

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The distro support checks introduced in #24219 assume `ansible_distribution*` facts are always populated. Roles are reusable across many plays, and several testbed playbooks run with `gather_facts: no`, so those facts are undefined and the role aborts before doing any work.

#### How did you do it?
Added a `setup` task at the top of `ansible/roles/vm_set/tasks/main.yml` that gathers only the `distribution` fact subset, gated on `when: ansible_distribution is not defined`. This is cheap and idempotent — when the including play already gathered facts, the task is skipped.

#### How did you verify/test it?
Ran a testbed playbook that includes the `vm_set` role with `gather_facts: no` (`testbed_renumber_vm_topology.yml`); preparation no longer fails with `'ansible_distribution' is undefined` and the distribution checks evaluate correctly. Verified it remains a no-op when facts are already gathered.

Verify job (elastictest): `6a28af2b729d944bd21c9ac9`

#### Any platform specific information?
None — affects only the Ubuntu/Debian distribution gating in the `vm_set` role.

#### Supported testbed topology if it's a new test case?
N/A — not a new test case.

### Documentation
N/A
