### PR TITLE
Add ignore_expected_loganalyzer_exceptions fixture to test_lldp_entry_table_after_lldp_restart

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -468,7 +468,7 @@ def test_lldp_entry_table_after_all_batched_flap(
 
 # Test case 5: Verify LLDP_ENTRY_TABLE after system reboot
 def test_lldp_entry_table_after_lldp_restart(
-    duthosts, enum_rand_one_per_hwsku_frontend_hostname, db_instance
+    duthosts, enum_rand_one_per_hwsku_frontend_hostname, db_instance, ignore_expected_loganalyzer_exceptions,
 ):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     lldp_entry_keys, show_lldp_table_int_list, lldpctl_output = get_lldp_data(duthost, db_instance)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Fixes intermittent teardown failures in `lldp.test_lldp_syncd::test_lldp_entry_table_after_lldp_restart` caused by transient `monit 'routeCheck' status failed` ERR lines in syslog after the LLDP container is restarted.

```      
2026 Jun  9 05:41:07.331542 vlab-03 ERR monit[91284]: 'routeCheck' status failed (255) -- Failure results: {{#012    "": {#012        "Unaccounted_ROUTE_ENTRY_TABLE_entries": [#012            "10.0.0.38/31",#012            "100.1.0.21/32",#012            "192.168.32.0/25",#012            "192.168.32.128/25",#012            "192.217.224.0/25",#012            "20c0:a820:0:80::/64",#012            "20c0:a820::/64",#012            "fc00::4c/126"#012        ]#012    }#012}}#012Failed. Look at reported mismatches above#012add: {#012    "": []#012}#012del: {#012    "": []#012}
```

 This is a one-line fix: the test was missing the `ignore_expected_loganalyzer_exceptions` fixture in its signature, so the existing ignore-regex (added in PR #15258) was never installed for this test. Its sibling tests (`test_lldp_entry_table_after_cont_flap`, `test_lldp_entry_table_after_all_batched_flap`) already declare the same fixture and pass cleanly.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

`test_lldp_entry_table_after_lldp_restart` has been flaking at ~12% on `vlab-03` for weeks. The test body itself passes — the failure happens at teardown when loganalyzer flags an `ERRmonit[...]: 'routeCheck' status failed` line that is emitted momentarily while LLDP is being restarted (`systemctl restart lldp`). Routes briefly fail their consistency check while LLDPrepopulates neighbor info, then recover on the next monit poll.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?
N/a
#### Supported testbed topology if it's a new test case?
N/a
### Documentation
N/a
