### PR TITLE
[conftest]: Honor skip_check_dut_health marker in yang_validation_check

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4128,6 +4128,14 @@ def yang_validation_check(request, duthosts):
         logger.info("Skipping YANG validation post-check due to --skip_yang flag")
         return
 
+    for m in request.node.iter_markers():
+        if m.name == "skip_check_dut_health":
+            logger.info(
+                "Skipping YANG validation: module marked skip_check_dut_health"
+            )
+            yield
+            return
+
     def run_yang_validation_all(stage):
         """Run YANG validation on all DUTs and return results"""
         validation_results = {}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Make the autouse `yang_validation_check` module-scoped fixture in `tests/conftest.py`
 honor the `skip_check_dut_health` marker, matching the existing precedent set by
 `core_dump_and_config_check` in the same file.

Today, `yang_validation_check` runs unconditionally for every test module, including
 maintenance / recovery / reboot / upgrade / HA modules that intentionally operate
 against a transiently unreachable or unhealthy DUT. This causes flakes, see below:

``` 
autorestart/test_container_autorestart.py::test_containers_autorestart[vlab-03-None-bgp] ERROR [  5%]

==================================== ERRORS ====================================
_______ ERROR at setup of test_containers_autorestart[vlab-03-None-bgp] ________

item = <Function test_containers_autorestart[vlab-03-None-bgp]>

```

Summary:
Fixes Flaky test

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
`test_posttest::test_restore_container_autorestart[vlab-03]` (and several other
 maintenance modules) is flaky on PR validation runs. 

#### How did you do it?
 Added an early-yield gate inside `yang_validation_check`, immediately after the
 existing `--skip_yang` flag handling, that follows the same idiom used by
 `core_dump_and_config_check` (`tests/conftest.py:3117-3119`):

 ```python
 for m in request.node.iter_markers():
     if m.name == "skip_check_dut_health":
         logger.info(
             "Skipping YANG validation: module marked skip_check_dut_health"
         )
         yield
         return
```

#### Any platform specific information?
N/a
#### Supported testbed topology if it's a new test case?
N/a
### Documentation
N/a
