### PR TITLE
Fix test test_dpu_status_post_dpu_kernel_panic

### DIFF
--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -28,7 +28,7 @@ pytestmark = [
     pytest.mark.topology('smartswitch')
 ]
 
-kernel_panic_cmd = "sudo nohup bash -c 'sleep 10 && echo c > /proc/sysrq-trigger' &"
+kernel_panic_cmd = "sudo nohup bash -c 'sleep 5 && echo c > /proc/sysrq-trigger' &"
 memory_exhaustion_cmd = "sudo nohup bash -c 'sleep 5 && tail /dev/zero' &"
 DUT_ABSENT_TIMEOUT_FOR_KERNEL_PANIC = 100
 DUT_ABSENT_TIMEOUT_FOR_MEMORY_EXHAUSTION = 240
@@ -246,6 +246,9 @@ def test_dpu_status_post_dpu_kernel_panic(duthosts, dpuhosts,
                                                  platform_api_conn,
                                                  num_dpu_modules)
 
+    logging.info("Recording DPU boot times before DPU kernel panic")
+    pre_boot_times = get_all_dpu_uptimes(dpuhosts, dpu_on_list)
+
     triggered_dpu_on_list = []
     triggered_ip_list = []
     for index in range(len(dpu_on_list)):
@@ -261,9 +264,6 @@ def test_dpu_status_post_dpu_kernel_panic(duthosts, dpuhosts,
         triggered_ip_list.append(ip_address_list[index])
 
     pytest_assert(triggered_dpu_on_list, "No DPUs were triggered; all skipped due to missing dpuhosts")
-
-    logging.info("Recording DPU boot times before DPU kernel panic")
-    pre_boot_times = get_all_dpu_uptimes(dpuhosts, triggered_dpu_on_list)
 
     logging.info("Checking DPUs are not pingable")
     check_dpus_are_not_pingable(duthost, triggered_ip_list)

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -28,7 +28,7 @@ pytestmark = [
     pytest.mark.topology('smartswitch')
 ]
 
-kernel_panic_cmd = "sudo nohup bash -c 'sleep 5 && echo c > /proc/sysrq-trigger' &"
+kernel_panic_cmd = "sudo nohup bash -c 'sleep 10 && echo c > /proc/sysrq-trigger' &"
 memory_exhaustion_cmd = "sudo nohup bash -c 'sleep 5 && tail /dev/zero' &"
 DUT_ABSENT_TIMEOUT_FOR_KERNEL_PANIC = 100
 DUT_ABSENT_TIMEOUT_FOR_MEMORY_EXHAUSTION = 240


### PR DESCRIPTION
### Description of PR

Summary:
In the test test_dpu_status_post_dpu_kernel_panic, a kernel panic is triggered on the DPU and it expects automatically DPU reboot.
Before the reboot, the test wants to get the system uptime:
https://github.com/sonic-net/sonic-mgmt/blob/20c2d2873916a3f64fd5ad63ecb8ca8231370f9b/tests/smartswitch/platform_tests/test_reload_dpu.py#L268

Currently we have a 5s sleep before the kernel panic to allow us get the uptime. 
But sometimes it is not enough, so we should move the step to get the uptimes before triggering the kernel panic.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Test result
<img width="388" height="138" alt="image" src="https://github.com/user-attachments/assets/6cac0a74-76ef-4183-913e-1b602662cedd" />


### Approach
#### What is the motivation for this PR?
Fix test test_dpu_status_post_dpu_kernel_panic
#### How did you do it?
Moving the step to get the uptimes before triggering the kernel panic
#### How did you verify/test it?
Run the test on SN4280 smartswitch testbed.
#### Any platform specific information?
Change is only for smartswitch
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A
