### PR TITLE
[Mellanox] Add a DPU shutdown time check in test case test_cold_reboot_dpus

### DIFF
--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -6,6 +6,7 @@ import logging
 import pytest
 import re
 import time
+from contextlib import contextmanager, nullcontext
 from tests.common.cisco_data import is_cisco_device
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.processes_utils import wait_critical_processes
@@ -39,6 +40,27 @@ EXTRA_DPU_ONLINE_TIMEOUT_FOR_WATCHDOG = 40
 def invocation_type(request):
     """Parametrize reboot tests to run with both gNOI and CLI reboot paths."""
     return request.param
+
+
+@contextmanager
+def mellanox_dpu_shutdown_check(duthost, dpu_on_list):
+    """Rotate logs before DPU reboot and validates DPU shutdown times after."""
+    duthost.shell("/usr/sbin/logrotate -f /etc/logrotate.conf > /dev/null 2>&1")
+
+    yield
+
+    dpu_down_log_pattern = r"dpuctl_plat.*(dpu\d).*Total time taken = (\d+\.\d+) for going down"
+    syslog = duthost.shell("sudo cat /var/log/syslog")['stdout']
+    matches = re.findall(dpu_down_log_pattern, syslog)
+    logging.info(f"Found {len(matches)} DPU down logs")
+    logging.info(f"Time taken for DPUs to shutdown: {matches}")
+    if len(matches) != len(dpu_on_list):
+        pytest_assert(False, "Didn't find expected number of DPU down logs.")
+    dpu_down_times = [float(match[1]) for match in matches]
+    max_dpu_down_time = max(dpu_down_times)
+    min_dpu_down_time = min(dpu_down_times)
+    pytest_assert(max_dpu_down_time - min_dpu_down_time < 20,
+                  "The DPUs shutdown time should not differ too much")
 
 
 @pytest.mark.disable_loganalyzer
@@ -376,36 +398,24 @@ def test_cold_reboot_dpus(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname,
     # For Nvidia smartswitch, the DPUs shutdown time should not differ too much.
     # We will check it in post_test_dpus_check.
     # Rotate the log to make sure the DPU down logs in syslog are what we want.
-    if is_mellanox_devices(duthost.facts['hwsku']):
-        duthost.shell("/usr/sbin/logrotate -f /etc/logrotate.conf > /dev/null 2>&1")
+    additional_checks = mellanox_dpu_shutdown_check(duthost, dpu_on_list) \
+        if is_mellanox_devices(duthost.facts['hwsku']) \
+        else nullcontext()
 
-    with SafeThreadPoolExecutor(max_workers=num_dpu_modules) as executor:
-        logging.info("Rebooting all DPUs in parallel")
-        for dpu_name in dpu_on_list:
-            executor.submit(perform_reboot, duthost, REBOOT_TYPE_COLD, dpu_name, invocation_type,
-                            ptf_gnoi=gnmi_tls.gnoi)
+    with additional_checks:
+        with SafeThreadPoolExecutor(max_workers=num_dpu_modules) as executor:
+            logging.info("Rebooting all DPUs in parallel")
+            for dpu_name in dpu_on_list:
+                executor.submit(perform_reboot, duthost, REBOOT_TYPE_COLD, dpu_name, invocation_type,
+                                ptf_gnoi=gnmi_tls.gnoi)
 
-    logging.info("Executing post test dpu check")
-    post_test_dpus_check(duthost, dpuhosts,
-                         dpu_on_list, ip_address_list,
-                         num_dpu_modules,
-                         re.compile(r"reboot|Non-Hardware",
-                                    re.IGNORECASE),
-                         pre_boot_times=pre_boot_times)
-
-    if is_mellanox_devices(duthost.facts['hwsku']):
-        dpu_down_log_pattern = r"dpuctl_plat.*(dpu\d).*Total time taken = (\d+\.\d+) for going down"
-        syslog = duthost.shell("sudo cat /var/log/syslog")['stdout']
-        matches = re.findall(dpu_down_log_pattern, syslog)
-        logging.info(f"Found {len(matches)} DPU down logs")
-        logging.info(f"Time taken for DPUs to shutdown: {matches}")
-        if len(matches) != len(dpu_on_list):
-            pytest_assert(False, "Didn't find expected number of DPU down logs.")
-        dpu_down_times = [float(match[1]) for match in matches]
-        max_dpu_down_time = max(dpu_down_times)
-        min_dpu_down_time = min(dpu_down_times)
-        pytest_assert(max_dpu_down_time - min_dpu_down_time < 20,
-                      "The DPUs shutdown time should not differ too much")
+        logging.info("Executing post test dpu check")
+        post_test_dpus_check(duthost, dpuhosts,
+                             dpu_on_list, ip_address_list,
+                             num_dpu_modules,
+                             re.compile(r"reboot|Non-Hardware",
+                                        re.IGNORECASE),
+                             pre_boot_times=pre_boot_times)
 
 
 @pytest.mark.disable_loganalyzer

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -373,6 +373,12 @@ def test_cold_reboot_dpus(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname,
     logging.info("Recording DPU boot times before cold reboot")
     pre_boot_times = get_all_dpu_uptimes(dpuhosts, dpu_on_list)
 
+    # For Nvidia smartswitch, the DPUs shutdown time should not differ too much.
+    # We will check it in post_test_dpus_check.
+    # Rotate the log to make sure the DPU down logs in syslog are what we want.
+    if is_mellanox_devices(duthost.facts['hwsku']):
+        duthost.shell("/usr/sbin/logrotate -f /etc/logrotate.conf > /dev/null 2>&1")
+
     with SafeThreadPoolExecutor(max_workers=num_dpu_modules) as executor:
         logging.info("Rebooting all DPUs in parallel")
         for dpu_name in dpu_on_list:
@@ -386,6 +392,20 @@ def test_cold_reboot_dpus(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname,
                          re.compile(r"reboot|Non-Hardware",
                                     re.IGNORECASE),
                          pre_boot_times=pre_boot_times)
+
+    if is_mellanox_devices(duthost.facts['hwsku']):
+        dpu_down_log_pattern = r"dpuctl_plat.*(dpu\d).*Total time taken = (\d+\.\d+) for going down"
+        syslog = duthost.shell("sudo cat /var/log/syslog")['stdout']
+        matches = re.findall(dpu_down_log_pattern, syslog)
+        logging.info(f"Found {len(matches)} DPU down logs")
+        logging.info(f"Time taken for DPUs to shutdown: {matches}")
+        if len(matches) != len(dpu_on_list):
+            pytest_assert(False, "Didn't find expected number of DPU down logs.")
+        dpu_down_times = [float(match[1]) for match in matches]
+        max_dpu_down_time = max(dpu_down_times)
+        min_dpu_down_time = min(dpu_down_times)
+        pytest_assert(max_dpu_down_time - min_dpu_down_time < 20,
+                      "The DPUs shutdown time should not differ too much")
 
 
 @pytest.mark.disable_loganalyzer

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -34,6 +34,7 @@ DUT_ABSENT_TIMEOUT_FOR_KERNEL_PANIC = 100
 DUT_ABSENT_TIMEOUT_FOR_MEMORY_EXHAUSTION = 240
 MAX_COOL_OFF_TIME = 300
 EXTRA_DPU_ONLINE_TIMEOUT_FOR_WATCHDOG = 40
+MAX_DPU_DOWN_TIME_SPREAD_SECS = 20
 
 
 @pytest.fixture(params=["gnoi_based", "cli_based"])
@@ -50,17 +51,19 @@ def mellanox_dpu_shutdown_check(duthost, dpu_on_list):
     yield
 
     dpu_down_log_pattern = r"dpuctl_plat.*(dpu\d).*Total time taken = (\d+\.\d+) for going down"
-    syslog = duthost.shell("sudo cat /var/log/syslog")['stdout']
+    syslog = duthost.shell(f"grep -E '{dpu_down_log_pattern}' /var/log/syslog")['stdout']
     matches = re.findall(dpu_down_log_pattern, syslog)
     logging.info(f"Found {len(matches)} DPU down logs")
     logging.info(f"Time taken for DPUs to shutdown: {matches}")
-    if len(matches) != len(dpu_on_list):
-        pytest_assert(False, "Didn't find expected number of DPU down logs.")
+    pytest_assert(len(matches) == len(dpu_on_list),
+                  f"Expected {len(dpu_on_list)} DPU down logs, found {len(matches)}: {matches}")
     dpu_down_times = [float(match[1]) for match in matches]
     max_dpu_down_time = max(dpu_down_times)
     min_dpu_down_time = min(dpu_down_times)
-    pytest_assert(max_dpu_down_time - min_dpu_down_time < 20,
-                  "The DPUs shutdown time should not differ too much")
+    delta = max_dpu_down_time - min_dpu_down_time
+    pytest_assert(delta < MAX_DPU_DOWN_TIME_SPREAD_SECS,
+                  f"DPU shutdown times differ too much: {matches} "
+                  f"(delta={delta:.2f}s)")  # noqa: E231
 
 
 @pytest.mark.disable_loganalyzer


### PR DESCRIPTION
### Description of PR

Summary:
For Nvidia smartswitch, the DPUs shutdown time during the dpu reboot should not differ too much. 
Add a check for it in the test case test_cold_reboot_dpus.

The shutdown time will be printed in the test log:
```
Time taken for DPUs to shutdown: [('dpu2', '14.751288265997573'), ('dpu0', '13.878449802999967'), ('dpu3', '14.315802813998744'), ('dpu1', '15.931488177000574')]
```
The max time - min time is expected to be less than 20s.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Add a DPU down time check in test case test_cold_reboot_dpus
#### How did you do it?
If it's Nvidia smartswitch, find the DPUs shutdown time from NPU syslog and validate them.
#### How did you verify/test it?
Run the test test_cold_reboot_dpus on SN4280 testbed.
<img width="364" height="268" alt="image" src="https://github.com/user-attachments/assets/b326702e-b001-4465-ab67-a7e0e8a611fc" />

#### Any platform specific information?
Only for Nvidia smartswitch
#### Supported testbed topology if it's a new test case?
Not a new test.
### Documentation
N/A
