### PR TITLE
25261: [EosHost] stale Ansible connection vars cause EOS auth failures and wrong VM in parallel BGP tests

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -21,6 +21,20 @@ FEC_MAP = {
     'rs': 'reed-solomon'
 }
 
+# Keys set by EosHost for network_cli / ssh sessions. Cleared before each update so
+# connection settings from a prior VM do not bleed into the next (sonic-mgmt #1941).
+CONNECTION_EXTRA_VAR_KEYS = (
+    'ansible_connection',
+    'ansible_network_os',
+    'ansible_user',
+    'ansible_password',
+    'ansible_ssh_user',
+    'ansible_ssh_pass',
+    'ansible_become',
+    'ansible_become_method',
+    'ansible_become_password',
+)
+
 
 _INTF_TOKEN_RE = re.compile(r'(?<=\binterface\s)(\S+)|(?<=\binterfaces\s)(\S+)')
 
@@ -282,6 +296,13 @@ class EosHost(AnsibleHostBase):
         self.localhost = ansible_adhoc(inventory='localhost', connection='local',
                                        host_pattern="localhost")["localhost"]
 
+    def _reset_network_connection(self):
+        """Close persistent network_cli socket so the next module uses current extra_vars."""
+        try:
+            self.host.meta('reset_connection')
+        except Exception as err:
+            logger.warning('meta reset_connection on %s failed: %s', self.hostname, err)
+
     def __getattr__(self, module_name):
         if module_name.startswith('eos_'):
             evars = {
@@ -291,7 +312,9 @@ class EosHost(AnsibleHostBase):
                 'ansible_password': self.eos_passwd,
                 'ansible_ssh_user': self.eos_user,
                 'ansible_ssh_pass': self.eos_passwd,
-                'ansible_become_method': 'enable'
+                'ansible_become': True,
+                'ansible_become_method': 'enable',
+                'ansible_become_password': self.eos_passwd,
             }
         else:
             if not self.shell_user or not self.shell_passwd:
@@ -303,9 +326,14 @@ class EosHost(AnsibleHostBase):
                 'ansible_password': self.shell_passwd,
                 'ansible_ssh_user': self.shell_user,
                 'ansible_ssh_pass': self.shell_passwd,
-                'ansible_become_method': 'sudo'
+                'ansible_become_method': 'sudo',
             }
-        self.host.options['variable_manager'].extra_vars.update(evars)
+        extra_vars = self.host.options['variable_manager'].extra_vars
+        for key in CONNECTION_EXTRA_VAR_KEYS:
+            extra_vars.pop(key, None)
+        extra_vars.update(evars)
+        if module_name.startswith('eos_'):
+            self._reset_network_connection()
         return super(EosHost, self).__getattr__(module_name)
 
     def __str__(self):

--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -1,3 +1,4 @@
+import copy
 import ansible
 import datetime
 import logging
@@ -218,12 +219,13 @@ def parallel_run(
             if init_result:
                 init_result["host"] = node.hostname
                 results[node.hostname] = init_result
-            kwargs['node'] = node
-            kwargs['results'] = results
+            process_kwargs = copy.deepcopy(kwargs)
+            process_kwargs['node'] = node
+            process_kwargs['results'] = results
             process_name = "{}--{}".format(target.__name__, node)
             worker = SonicProcess(
                         name=process_name, target=target, args=args,
-                        kwargs=kwargs
+                        kwargs=process_kwargs
                     )
             worker.start()
             tasks_running += 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
    Fix intermittent BGP test failures against vEOS neighbors caused by stale Ansible network_cli connection state in EosHost and shared kwargs mutation in parallel_run.
    
    Changes:
    tests/common/devices/eos.py
    Add CONNECTION_EXTRA_VAR_KEYS and clear those keys from extra_vars before each module dispatch (addresses sonic-mgmt #1941).
    Set full EOS enable context: ansible_become, ansible_become_method, ansible_become_password.
    Set ansible_network_cli_persistent: False so each eos_* call opens a fresh SSH session to the intended inventory host.
    
    tests/common/helpers/parallel.py
    copy.deepcopy(kwargs) per worker before setting node and results, so the parent loop does not corrupt arguments passed to concurrently spawned subprocesses.


Summary:
Fixes # 25261

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
    BGP tests that query multiple vEOS neighbors via EosHost.eos_command fail intermittently on T1 LAG topologies (e.g. mathilda-01, t1-lag / t1-64-lag).
    
    Observed failures:
    RunAnsibleModuleFail: Failed to authenticate: Authentication failed
    parallel_run workers (e.g. check_other_vms--ARISTA01T2, check_other_neigh--ARISTA01T2)
    Wrong EOS identity — log shows [VM0117] but BGP reports spine routerId 100.1.0.3 instead of ToR 100.1.0.30
    Serial tests such as test_bgp_bounce
    Root cause: EosHost.__getattr__ only called extra_vars.update(evars) without clearing prior connection keys, without ansible_become_password, and with default persistent network_cli — so SSH sessions could be reused or pointed at the wrong VM. In parallel_run, mutating a shared kwargs dict while spawning workers made this worse in subprocesses.

#### How did you do it?
    EosHost (eos.py): Reset-then-apply pattern for Ansible connection variables on every module invocation:
    
    Define an allowlist of connection-related extra_vars keys.
    pop each key before update(evars).
    For eos_* modules, supply complete network_cli + enable credentials and disable persistent connections.
    parallel_run (parallel.py): Give each SonicProcess worker its own deep-copied kwargs dict so node and results are assigned per worker without the parent overwriting kwargs['node'] for already-started or not-yet-picked-up children.
    
    Works together with the existing base.py load_extra_vars copy patch on this branch (prevents global extra_vars cache pollution).
    

#### How did you verify/test it?
Run BGP scripts such as test_bgp_bbr.py; test_bgp_bounce.py {t1-64-lag topology}

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
