### PR TITLE
Fix test test_override_config_table.py and test_override_config_table_masic.py for smartswitch

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1531,7 +1531,8 @@ def get_running_config(duthost, asic=None, filter=None):
     return json.loads(duthost.shell(f"sonic-cfggen {ns} -d --print-data {fil}")['stdout'])
 
 
-def reload_minigraph_with_golden_config(duthost, json_data, safe_reload=True):
+def reload_minigraph_with_golden_config(duthost, json_data, safe_reload=True,
+                                        safe_reload_ignored_dockers=[]):
     """
     for multi-asic/single-asic devices, we only have 1 golden_config_db.json
     """
@@ -1540,7 +1541,7 @@ def reload_minigraph_with_golden_config(duthost, json_data, safe_reload=True):
     duthost.copy(content=json.dumps(json_data, indent=4), dest=golden_config)
     try:
         config_reload(duthost, config_source="minigraph", safe_reload=safe_reload, override_config=True,
-                      wait_for_bgp=True)
+                      wait_for_bgp=True, safe_reload_ignored_dockers=safe_reload_ignored_dockers)
     finally:
         # Cleanup golden config because some other test or device recover may reload config with golden config
         duthost.command('mv {} {}_backup'.format(golden_config, golden_config))

--- a/tests/override_config_table/test_override_config_table.py
+++ b/tests/override_config_table/test_override_config_table.py
@@ -22,6 +22,10 @@ pytestmark = [
 
 LOSSY_HWSKU = mellanox_data.LOSSY_ONLY_HWSKUS + broadcom_data.LOSSY_ONLY_HWSKUS
 
+# These are the critical services that are not included in the golden config under test
+# nor the default config. After the minigraph load they will be disabled.
+SMARTSWITCH_SAFE_RELOAD_IGNORED_DOCKERS = ["dhcp_relay", "dhcp_server"]
+
 
 @pytest.fixture(scope="module", autouse=True)
 def check_image_version(duthost):
@@ -63,7 +67,8 @@ def setup_env(duthosts, golden_config_exists_on_dut, tbinfo, enum_rand_one_per_h
         backup_config(duthost, GOLDEN_CONFIG, GOLDEN_CONFIG_BACKUP)
 
     # Reload test env with minigraph
-    config_reload(duthost, config_source="minigraph", safe_reload=True, wait_for_bgp=True)
+    config_reload(duthost, config_source="minigraph", safe_reload=True, wait_for_bgp=True,
+                  safe_reload_ignored_dockers=SMARTSWITCH_SAFE_RELOAD_IGNORED_DOCKERS)
     running_config = get_running_config(duthost)
 
     yield running_config
@@ -84,13 +89,14 @@ def setup_env(duthosts, golden_config_exists_on_dut, tbinfo, enum_rand_one_per_h
     config_reload(duthost, safe_reload=True, wait_for_bgp=True)
 
 
-def load_minigraph_with_golden_empty_input(duthost):
+def load_minigraph_with_golden_empty_input(duthost, safe_reload_ignored_dockers):
     """Test Golden Config with empty input
     """
     initial_config = get_running_config(duthost)
 
     empty_input = {}
-    reload_minigraph_with_golden_config(duthost, empty_input)
+    reload_minigraph_with_golden_config(
+        duthost, empty_input, safe_reload_ignored_dockers=safe_reload_ignored_dockers)
 
     current_config = get_running_config(duthost)
     for table in initial_config:
@@ -109,7 +115,7 @@ def load_minigraph_with_golden_empty_input(duthost):
             )
 
 
-def load_minigraph_with_golden_partial_config(duthost):
+def load_minigraph_with_golden_partial_config(duthost, safe_reload_ignored_dockers):
     """Test Golden Config with partial config.
 
     Here we assume all config contain SYSLOG_SERVER table
@@ -120,7 +126,8 @@ def load_minigraph_with_golden_partial_config(duthost):
             "10.0.0.200": {}
         }
     }
-    reload_minigraph_with_golden_config(duthost, partial_config)
+    reload_minigraph_with_golden_config(
+        duthost, partial_config, safe_reload_ignored_dockers=safe_reload_ignored_dockers)
 
     current_config = get_running_config(duthost)
     pytest_assert(
@@ -129,11 +136,12 @@ def load_minigraph_with_golden_partial_config(duthost):
     )
 
 
-def load_minigraph_with_golden_full_config(duthost, full_config):
+def load_minigraph_with_golden_full_config(duthost, full_config, safe_reload_ignored_dockers):
     """Test Golden Config fully override minigraph config
     """
     # Test if the config has been override by full_config
-    reload_minigraph_with_golden_config(duthost, full_config)
+    reload_minigraph_with_golden_config(
+        duthost, full_config, safe_reload_ignored_dockers=safe_reload_ignored_dockers)
 
     current_config = get_running_config(duthost)
     for table in full_config:
@@ -152,7 +160,7 @@ def load_minigraph_with_golden_full_config(duthost, full_config):
             )
 
 
-def load_minigraph_with_golden_empty_table_removal(duthost):
+def load_minigraph_with_golden_empty_table_removal(duthost, safe_reload_ignored_dockers):
     """Test Golden Config with empty table removal.
 
     Here we assume all config contain SYSLOG_SERVER table
@@ -161,7 +169,8 @@ def load_minigraph_with_golden_empty_table_removal(duthost):
         "SYSLOG_SERVER": {
         }
     }
-    reload_minigraph_with_golden_config(duthost, empty_table_removal)
+    reload_minigraph_with_golden_config(
+        duthost, empty_table_removal, safe_reload_ignored_dockers=safe_reload_ignored_dockers)
 
     current_config = get_running_config(duthost)
     pytest_assert(
@@ -182,8 +191,13 @@ def test_load_minigraph_with_golden_config(duthosts, setup_env,
         loganalyzer[duthost.hostname].expect_regex = []
         loganalyzer[duthost.hostname].ignore_regex = []
 
-    load_minigraph_with_golden_empty_input(duthost)
-    load_minigraph_with_golden_partial_config(duthost)
+    if duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_smartswitch"):
+        safe_reload_ignored_dockers = SMARTSWITCH_SAFE_RELOAD_IGNORED_DOCKERS
+    else:
+        safe_reload_ignored_dockers = []
+
+    load_minigraph_with_golden_empty_input(duthost, safe_reload_ignored_dockers)
+    load_minigraph_with_golden_partial_config(duthost, safe_reload_ignored_dockers)
     full_config = setup_env
-    load_minigraph_with_golden_full_config(duthost, full_config)
-    load_minigraph_with_golden_empty_table_removal(duthost)
+    load_minigraph_with_golden_full_config(duthost, full_config, safe_reload_ignored_dockers)
+    load_minigraph_with_golden_empty_table_removal(duthost, safe_reload_ignored_dockers)

--- a/tests/override_config_table/test_override_config_table_masic.py
+++ b/tests/override_config_table/test_override_config_table_masic.py
@@ -92,15 +92,14 @@ def setup_env(duthosts, tbinfo, enum_rand_one_per_hwsku_frontend_hostname):
     config_reload(duthost, safe_reload=True)
 
 
-def load_minigraph_with_golden_empty_input(duthost, safe_reload_ignored_dockers=[]):
+def load_minigraph_with_golden_empty_input(duthost):
     """Test Golden Config with empty input
     """
     initial_host_config = get_running_config(duthost)
     initial_asic0_config = get_running_config(duthost, "asic0")
 
     empty_input = {}
-    reload_minigraph_with_golden_config(
-        duthost, empty_input, safe_reload_ignored_dockers=safe_reload_ignored_dockers)
+    reload_minigraph_with_golden_config(duthost, empty_input)
 
     # Test host running config override
     host_current_config = get_running_config(duthost)

--- a/tests/override_config_table/test_override_config_table_masic.py
+++ b/tests/override_config_table/test_override_config_table_masic.py
@@ -34,6 +34,16 @@ def check_image_version(duthost):
     skip_release(duthost, ["201811", "201911", "202012", "202106", "202111"])
 
 
+@pytest.fixture(scope="module", autouse=True)
+def skip_single_asic(duthost):
+    """
+    Skips this test if the DUT is a single-asic platform
+    """
+    if not duthost.is_multi_asic:
+        pytest.skip("Skip override-config-table multi-asic testing on single-asic platforms,\
+                    test provided golden config format is not compatible with single-asics")
+
+
 @pytest.fixture(scope="module")
 def setup_env(duthosts, tbinfo, enum_rand_one_per_hwsku_frontend_hostname):
     """
@@ -82,14 +92,15 @@ def setup_env(duthosts, tbinfo, enum_rand_one_per_hwsku_frontend_hostname):
     config_reload(duthost, safe_reload=True)
 
 
-def load_minigraph_with_golden_empty_input(duthost):
+def load_minigraph_with_golden_empty_input(duthost, safe_reload_ignored_dockers=[]):
     """Test Golden Config with empty input
     """
     initial_host_config = get_running_config(duthost)
     initial_asic0_config = get_running_config(duthost, "asic0")
 
     empty_input = {}
-    reload_minigraph_with_golden_config(duthost, empty_input)
+    reload_minigraph_with_golden_config(
+        duthost, empty_input, safe_reload_ignored_dockers=safe_reload_ignored_dockers)
 
     # Test host running config override
     host_current_config = get_running_config(duthost)
@@ -200,9 +211,6 @@ def test_load_minigraph_with_golden_config(duthosts, setup_env, tbinfo, enum_ran
     don't have CLI to get new golden config that contains 'localhost' and 'asicxx'
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    if not duthost.is_multi_asic:
-        pytest.skip("Skip override-config-table multi-asic testing on single-asic platforms,\
-                    test provided golden config format is not compatible with single-asics")
     topo_type = tbinfo["topo"]["type"]
     if topo_type == 't2' and not is_upstream_t2_dut(duthost, tbinfo):
         # Skip empty golden-config testing on upstream linecards,


### PR DESCRIPTION
### Description of PR

Summary:
1. For the test test_override_config_table.py, it fails in the critical process check in the fixture setup_env on dhcp_server and dhcp_relay because they are not enabled in the new config after minigraph reload. We need ignore them in the safe reload check.

2. For the test test_override_config_table_masic.py, it has the same failure in setup_env but actually the test should be skipped on smartswitch testbed as the dut is single asic. Move the skip condition in multi asic test body to an auto run fixture, so the setup_env can be skipped.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
master: Test test_override_config_table.py is passing SN4280 smartswitch litmode. Test test_override_config_table_masic.py is skipped on SN4280 as expected.
<img width="972" height="128" alt="image" src="https://github.com/user-attachments/assets/b8016db8-f7aa-46fb-b677-a33017edecb7" />

### Approach
#### What is the motivation for this PR?
Fix test test_override_config_table.py and test_override_config_table_masic.py for smartswitch
#### How did you do it?
Please see the summary
#### How did you verify/test it?
Run the tests on SN4280 testbed.
#### Any platform specific information?
The fix is for smartswitch
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A
