### PR TITLE
[conditional_mark] Fix test_console_availability skip rule to OR conditions

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -761,6 +761,7 @@ console/:
 console/test_console_availability.py:
   skip:
     reason: "This test is applicable to virtual setup only."
+    conditions_logical_operator: OR
     conditions:
       - "asic_type in ['vpp'] and platform.startswith('arm64-c8220tg_48a_o')"
       - "platform in ['arm64-nokia_ixs7215_c1xa-r0']"


### PR DESCRIPTION


PR #24618 added a second condition for Nokia-7215-C1 under the existing test_console_availability skip rule without specifying conditions_logical_operator. The default operator is AND, so the two platform-specific predicates were AND'ed together and could never both match, causing the skip to never trigger on either platform.

Set conditions_logical_operator: OR so each platform predicate is evaluated independently and the test is correctly skipped on both arm64-c8220tg_48a_o* (vpp) and arm64-nokia_ixs7215_c1xa-r0 hardware.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
