### PR TITLE
[autorestart]: Add per-container watchdog to prevent phantom "no xml file" failures

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -3,9 +3,13 @@ Test the auto-restart feature of containers
 """
 import logging
 import re
+import signal
+import time
 from collections import defaultdict
+from contextlib import contextmanager
 
 import pytest
+from _pytest.outcomes import OutcomeException
 
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
@@ -30,6 +34,85 @@ POST_CHECK_INTERVAL_SECS = 1
 POST_CHECK_THRESHOLD_SECS = 360
 POST_CHECK_THRESHOLD_SECS_T2 = 600
 PROGRAM_STATUS = "RUNNING"
+
+# Per-container watchdog budget for a single parametrized autorestart case.
+# Each test_containers_autorestart[<feature>] exercises exactly one container; the
+# slowest legitimate container (telemetry) finishes in ~22 min, so 40 min gives a
+# comfortable ~1.8x margin for healthy runs. A container that hangs during
+# stop/restart or post-check is interrupted here and fails with a junit entry,
+# instead of blocking until the framework's module-level timeout (~155 min) kills
+# the run and discards all results as phantom "no xml file" failures.
+SINGLE_CONTAINER_TEST_TIMEOUT_SECS = 2400
+
+# Upper bound for the best-effort config_reload that recovers the DUT after a
+# per-container hang. A healthy `config_reload(safe_reload, wait_for_bgp)` -- even
+# on a slow/modular topology -- completes well within this; if recovery itself
+# exceeds it, something is badly wrong and we just log and fail the case anyway.
+RECOVERY_RELOAD_TIMEOUT_SECS = 600
+
+
+class ContainerAutorestartTimeout(BaseException):
+    """Raised when a single container's autorestart sub-test exceeds its watchdog budget.
+
+    Inherits from BaseException (not Exception) on purpose. The autorestart sub-test
+    polls DUT state through common.utilities.wait_until, whose retry loop catches
+    ``except Exception`` and treats any error as "condition not met yet, keep polling".
+    A plain Exception raised from the SIGALRM handler would be swallowed there, the
+    one-shot alarm consumed, and the case would then run unbounded -- defeating the
+    watchdog. As a BaseException (like KeyboardInterrupt/SystemExit and pytest's own
+    OutcomeException) it bypasses those ``except Exception`` loops and propagates up to
+    the per-case handler in test_containers_autorestart.
+    """
+
+
+@contextmanager
+def single_container_timeout(container_name, timeout_secs=SINGLE_CONTAINER_TEST_TIMEOUT_SECS):
+    """Interrupt a single container's autorestart sub-test if it hangs.
+
+    Uses SIGALRM so a blocked SSH/docker call is actually interrupted -- a thread
+    based timer cannot break out of a blocking C-level read. The signal interrupts
+    the blocking syscall and, because the handler raises, the exception propagates
+    out instead of the call being retried. Only effective on the main thread on
+    POSIX; on platforms without SIGALRM, or when not running on the main thread, it
+    is a no-op and execution falls back to the framework's module-level timeout.
+    """
+    if not hasattr(signal, "SIGALRM"):
+        yield
+        return
+
+    def _on_timeout(signum, frame):
+        raise ContainerAutorestartTimeout(
+            "Autorestart test for container '{}' exceeded {} seconds and was interrupted. "
+            "The container most likely hung during stop/restart or post-check.".format(
+                container_name, timeout_secs)
+        )
+
+    try:
+        previous_handler = signal.signal(signal.SIGALRM, _on_timeout)
+    except ValueError:
+        # signal handlers can only be installed on the main thread.
+        logger.warning("single_container_timeout disabled for '%s': not on main thread", container_name)
+        yield
+        return
+
+    # signal.alarm() returns the seconds left on any previously scheduled alarm
+    # (0 if none). Save it so the watchdog restores -- rather than silently cancels
+    # -- a SIGALRM that pytest, the framework, or another fixture may have armed,
+    # instead of clobbering process-global timer state. Arming inside the try also
+    # keeps the handler restoration in finally even if signal.alarm() ever raised.
+    previous_alarm_remaining = 0
+    armed_at = time.monotonic()
+    try:
+        previous_alarm_remaining = signal.alarm(timeout_secs)
+        yield
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous_handler)
+        if previous_alarm_remaining > 0:
+            # Re-arm the pre-existing alarm, debited by the time we held it
+            # (at least 1s -- alarm(0) would cancel it instead).
+            elapsed = int(time.monotonic() - armed_at)
+            signal.alarm(max(1, previous_alarm_remaining - elapsed))
 
 
 @pytest.fixture(autouse=True, scope='module')
@@ -628,4 +711,32 @@ def test_containers_autorestart(duthosts, enum_rand_one_per_hwsku_hostname, enum
     asic = duthost.asic_instance(enum_rand_one_asic_index)
     service_name = asic.get_service_name(enum_dut_feature)
     container_name = asic.get_docker_name(enum_dut_feature)
-    run_test_on_single_container(duthost, container_name, service_name, tbinfo)
+    try:
+        with single_container_timeout(container_name):
+            run_test_on_single_container(duthost, container_name, service_name, tbinfo)
+    except ContainerAutorestartTimeout as timeout_err:
+        # Recover the DUT before failing so the remaining per-container cases in this
+        # module are not poisoned by a half-restarted container, then surface the hang
+        # as a normal failure (with junit) instead of a phantom run. The recovery is
+        # itself bounded so it cannot hang the module either.
+        logger.error(str(timeout_err))
+        try:
+            with single_container_timeout(container_name, timeout_secs=RECOVERY_RELOAD_TIMEOUT_SECS):
+                config_reload(duthost, safe_reload=True, wait_for_bgp=True)
+                enable_autorestart(duthost)
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except ContainerAutorestartTimeout as recovery_timeout_err:
+            # Recovery itself exceeded RECOVERY_RELOAD_TIMEOUT_SECS. ContainerAutorestartTimeout
+            # is a BaseException (so wait_until cannot swallow it) and is therefore not caught by
+            # the (Exception, OutcomeException) handler below; catch it explicitly here, log it,
+            # and still fail with the original hang reason rather than letting it propagate raw.
+            logger.error("Recovery after hang on container '%s' itself timed out: %s",
+                         container_name, recovery_timeout_err)
+        except (Exception, OutcomeException) as recovery_err:
+            # Recovery itself failed -- e.g. a config_reload assertion such as BGP-not-converged,
+            # which pytest raises as Failed (an OutcomeException, not a plain Exception). Log it
+            # with the traceback but still fail with the original hang reason so triage sees which
+            # container hung rather than a masked recovery error.
+            logger.exception("Recovery after hang on container '%s' failed: %s", container_name, recovery_err)
+        pytest.fail(str(timeout_err))


### PR DESCRIPTION
### Description of PR

Summary: Adds a dependency-free per-container watchdog (SIGALRM) to `test_containers_autorestart` so an intermittently hung container is interrupted and fails as a normal, junit-emitting case — instead of silently running into the framework's module-level timeout (~155 min), which kills the run with **no junit** and produces the phantom `Test failed and no xml file created` (which zeroes out every container in the module and is hard to triage).

Fixes the `autorestart.test_container_autorestart` baseline "no xml file created" failures observed on KVM `t1-lag`.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
On KVM `t1-lag`, `autorestart.test_container_autorestart` intermittently (~1–7%) hangs on a single container during stop/restart or post-check. The test is parametrized per container (`test_containers_autorestart[<feature>]`), but there is no per-case time bound. When one container hangs, the case never returns; the run continues until the framework's module-level auto-timeout (~155 min, e.g. `autorestart.py has been running for 155.34 minutes`), at which point the module is killed and **no junit XML is produced**. Elastictest then records the whole module as `failure / "Test failed and no xml file created"`, which is filed as a consistent baseline failure even though the test logic itself is sound. The silent, all-or-nothing nature also makes it very hard to tell *which* container hung.

#### How did you do it?
Wrap each parametrized container case in `single_container_timeout` — a SIGALRM-based watchdog with a 40 min budget (~1.8× the slowest legitimate container; telemetry tops out around ~22 min, so healthy runs never trip it). On a hang it raises `ContainerAutorestartTimeout`, so the case fails with a junit entry that names the container that hung; the DUT is then recovered with a bounded `config_reload` so the remaining per-container cases in the module are not poisoned; and the module finishes well under the 155 min ceiling — eliminating the phantom. SIGALRM is the same mechanism `pytest-timeout`'s signal method uses; since `pytest-timeout` is not part of this test harness, a `@pytest.mark.timeout` marker would be a silent no-op, so the watchdog is implemented directly with stdlib `signal`. It no-ops safely off the main thread and on non-POSIX platforms (Windows), falling back to the existing module-level timeout.

#### How did you verify/test it?
- `py_compile` and `flake8 --max-line-length=120` are clean.
- A companion injection branch (forced hang on one container + a lowered budget) deterministically exercises the watchdog: the hung case fails with `ContainerAutorestartTimeout` and a junit entry, the bounded recovery `config_reload` runs, the remaining container cases still pass, and no "no xml file" phantom is produced.
- Happy-path validation on KVM `t1-lag` via this PR's impacted-area run (no behavior change for non-hanging containers).
- **Physical hardware A/B (Arista-7060CX-32S, `t0`):** on this platform the `bgp` container reliably hangs during autorestart, which gives a clean before/after comparison on real hardware:
  - **Without this fix (base branch):** [Elastictest result](https://elastictest.org/scheduler/shared/testplan/6a2fa7a003b7f75ed1c22f43?token=ef7cc6ec-142d-4a9b-8a05-2049a5b36cb7) — the hung case runs unbounded for hours and had to be cancelled; the module produces **no junit** (the `Test failed and no xml file created` phantom — the symptom this PR fixes).
  - **With this fix:** [Elastictest result](https://elastictest.org/scheduler/shared/testplan/6a2e692253b3182993b4fddd?token=79d0d62c-d75e-4f6b-8ffc-18405cb38e44) — the watchdog bounds the hung `bgp` case (~44 min) and it **fails cleanly with a junit entry naming the container**; the DUT is then recovered and the remaining containers still pass.

#### Any platform specific information?
The watchdog relies on `signal.SIGALRM`, which is POSIX-only; on platforms without it (e.g. Windows) or when the test is not on the main thread, it is a no-op and behavior is unchanged. SONiC test runs execute on Linux, so the watchdog is active where it matters.

#### Supported testbed topology if it's a new test case?
N/A — existing test (`topology('any')`); no topology change.

### Documentation
N/A
