### PR TITLE
 [autorestart]: Add skip_check_dut_health marker to test_container_autorestart

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -17,7 +17,8 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('any'),
-    pytest.mark.disable_memory_utilization
+    pytest.mark.disable_memory_utilization,
+    pytest.mark.skip_check_dut_health,
 ]
 
 CONTAINER_CHECK_INTERVAL_SECS = 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add `pytest.mark.skip_check_dut_health` to the module-level `pytestmark`
 in `tests/autorestart/test_container_autorestart.py`.

Companion PR — https://github.com/sonic-net/sonic-mgmt/pull/25263. Adding the existing `skip_check_dut_health` marker brings this module in
 line with other utility / maintenance / recovery test modules that already
 declare it. It resolves errors like seen below: 
```
>           pt_assert(False, "pre-test YANG validation failed:\n" + "\n".join(error_summary))
E           Failed: pre-test YANG validation failed:
E           vlab-03: Host unreachable in the inventory

duthosts   = [<MultiAsicSonicHost vlab-03>]
error_summary = ['vlab-03: Host unreachable in the inventory']
host       = 'vlab-03'
pre_failures = {'vlab-03': {'error': 'Host unreachable in the inventory', 'failed': True}}
pre_results = {'vlab-03': {'error': 'Host unreachable in the inventory', 'failed': True}}
request    = <SubRequest 'yang_validation_check' for <Function test_containers_autorestart[vlab-03-None-bgp]>>
result     = {'error': 'Host unreachable in the inventory', 'failed': True}
run_yang_validation_all = <function yang_validation_check.<locals>.run_yang_validation_all at 0x7d866926cc20>
skip_yang  = False

conftest.py:4131: Failed
______ ERROR at teardown of test_containers_autorestart[vlab-03-None-bgp] ______
```

Summary:
Fixes # (no GitHub issue — internal PR-flake triage)
### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
 `autorestart.test_container_autorestart::test_containers_autorestart[vlab-03-None-bgp]`
 (and other parameterizations of the same test) is flaky on PR validation
 runs.

#### How did you do it?
 Added a single marker to the existing module-level `pytestmark` list,
 keeping the existing markers intact:

 ```python
 pytestmark = [
     pytest.mark.topology('any'),
     pytest.mark.disable_memory_utilization,
     pytest.mark.skip_check_dut_health,    # NEW
 ]
```

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A
