### PR TITLE
[bgp] Fix v6 'clear bgp ipv6 ... soft out' vtysh syntax in update timer test (#25211)

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -99,10 +99,14 @@ def _apply_outbound_route_filter(duthost, dut_asn, neighbor_ips, is_v6, namespac
     cmd = "vtysh {} {}".format(ns_option, " ".join("-c '{}'".format(c) for c in vtysh_cmds))
     duthost.shell(cmd)
 
-    # Soft-reset outbound so the filter takes effect immediately
+    # Soft-reset outbound so the filter takes effect immediately.
+    # Note: FRR vtysh syntax differs between v4 and v6:
+    #   v4: clear ip bgp <neighbor> soft out
+    #   v6: clear bgp ipv6 <neighbor> soft out  (word order is 'bgp ipv6', not 'ipv6 bgp')
+    clear_af = "bgp ipv6" if is_v6 else "ip bgp"
     for ip in neighbor_ips:
-        duthost.shell("vtysh {} -c 'clear {} bgp {} soft out'".format(
-            ns_option, "ipv6" if is_v6 else "ip", ip
+        duthost.shell("vtysh {} -c 'clear {} {} soft out'".format(
+            ns_option, clear_af, ip
         ))
 
 


### PR DESCRIPTION
### Description of PR

Fix vtysh syntax bug introduced by #22924 in `_apply_outbound_route_filter`. On v6-only topologies the helper issued `clear ipv6 bgp <neighbor> soft out`, but FRR's vtysh does not accept that word order — the canonical v6 form is `clear bgp ipv6 <neighbor> soft out`. As a result, `test_bgp_update_timer_session_down` and `test_bgp_update_timer_single_route` raised `RunAnsibleModuleFail` with `% Unknown command: clear ipv6 bgp ...` on topologies like `*-t0-isolated-v6-d32u32s2`.

Summary:
Fixes #25211

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

PR #22924 added an outbound route-map helper that performs a BGP soft clear after applying the filter. The v6 branch uses an invalid vtysh command, causing two BGP update timer tests to fail on v6-only topologies. The root cause was assuming the v6 form mirrors the v4 form, when in fact FRR uses two different orderings:

- v4: `clear ip bgp <neighbor> soft out`
- v6: `clear bgp ipv6 <neighbor> soft out` (note `bgp ipv6`, not `ipv6 bgp`)

#### How did you do it?

Special-cased the address-family token so the v6 path emits the correct word order, and added an inline comment so the next person doesn't trip on the FRR asymmetry. The new form matches the syntax already used elsewhere in this repo (`tests/bgp/conftest.py` uses `clear bgp ipv6 *`).

#### How did you verify/test it?

Direct FRR syntax probe on `vlab-03`:

- `vtysh -c 'clear ipv6 bgp <ip> soft out'` -> rc=1, `% Unknown command` (old, broken form)
- `vtysh -c 'clear bgp ipv6 <ip> soft out'` -> rc=0 (new form, accepted)
- `vtysh -c 'clear ip bgp <ip> soft out'` -> rc=0 (v4 path unchanged)

Pytest on `vms-kvm-t1-lag`:

- `bgp/test_bgp_update_timer.py::test_bgp_update_timer_session_down[vlab-03-default]` -> PASSED
- `bgp/test_bgp_update_timer.py::test_bgp_update_timer_single_route[vlab-03-default]` -> PASSED

#### Any platform specific information?

None — fix is generic FRR vtysh syntax.

#### Supported testbed topology if it's a new test case?

N/A (bug fix to existing test).

### Documentation

N/A.
