### PR TITLE
[TH6] Fix/Stabilize crm_counts baseline for announce/withdraw (lt2 / large scale)

### DIFF
--- a/tests/stress/conftest.py
+++ b/tests/stress/conftest.py
@@ -5,7 +5,7 @@ import pytest
 
 from tests.common import config_reload
 from tests.common.utilities import wait_until
-from utils import get_crm_resource_status, check_queue_status, sleep_to_wait
+from utils import get_crm_resource_status, check_queue_status, sleep_to_wait, wait_crm_route_counts_stabilized
 
 CRM_POLLING_INTERVAL = 1
 CRM_DEFAULT_POLL_INTERVAL = 300
@@ -57,28 +57,34 @@ def withdraw_and_announce_existing_routes(duthosts, localhost, tbinfo, enum_rand
     logger.info("withdraw existing ipv4 and ipv6 routes")
     localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw", path="../ansible/")
 
-    result = wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") is True)
-    if not result:
-        logger.warning("Failed to process all withdraw requests in {} seconds".format(MAX_WAIT_TIME))
-
-    ipv4_route_used_before = get_crm_resource_status(duthost, "ipv4_route", "used", namespace)
-    ipv6_route_used_before = get_crm_resource_status(duthost, "ipv6_route", "used", namespace)
-
-    def routes_stable():
-        nonlocal ipv4_route_used_before, ipv6_route_used_before
-        ipv4_route_used_now = get_crm_resource_status(duthost, "ipv4_route", "used", namespace)
-        ipv6_route_used_now = get_crm_resource_status(duthost, "ipv6_route", "used", namespace)
-        ipv4_stable = ipv4_route_used_now == ipv4_route_used_before
-        ipv6_stable = ipv6_route_used_now == ipv6_route_used_before
-        ipv4_route_used_before = ipv4_route_used_now
-        ipv6_route_used_before = ipv6_route_used_now
-        return ipv4_stable and ipv6_stable
-
-    full_wait_time = MAX_WAIT_TIME + CRM_POLLING_INTERVAL * 100
-    result = wait_until(full_wait_time, CRM_POLLING_INTERVAL, CRM_POLLING_INTERVAL, routes_stable)
-    if not result:
-        pytest.fail("Routes failed to withdraw in {} seconds".format(full_wait_time))
-
+    wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") is True)
+    sleep_to_wait(CRM_POLLING_INTERVAL * 100)
+    # BGP queues can be idle while CRM/orch still reflects bulk route removal; baseline must be post-settle.
+    crm_stable_timeout = 600 if str(topo_name).startswith("lt2") else 240
+    logger.info(
+        "Waiting up to {}s for CRM ipv4/ipv6 route used to stabilize before baseline capture".format(
+            crm_stable_timeout,
+        )
+    )
+    crm_wait_kwargs = dict(
+        max_wait=crm_stable_timeout,
+        poll_interval=10,
+        stability_delta=10,
+    )
+    if str(topo_name).startswith("lt2"):
+        # lt2: CRM can drain for many minutes after BGP queues go idle; require a long flat window of
+        # stable-step samples so baseline is not taken on a temporary window of samples
+        crm_wait_kwargs.update(
+            consecutive_stable_required=3,
+            min_elapsed_before_stable_sec=120,
+            flat_window_samples=12,
+            flat_window_delta=25,
+        )
+    ipv4_route_used_before, ipv6_route_used_before = wait_crm_route_counts_stabilized(
+        duthost,
+        namespace,
+        **crm_wait_kwargs
+    )
     logger.info("ipv4 route used {}".format(ipv4_route_used_before))
     logger.info("ipv6 route used {}".format(ipv6_route_used_before))
 

--- a/tests/stress/conftest.py
+++ b/tests/stress/conftest.py
@@ -57,7 +57,9 @@ def withdraw_and_announce_existing_routes(duthosts, localhost, tbinfo, enum_rand
     logger.info("withdraw existing ipv4 and ipv6 routes")
     localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw", path="../ansible/")
 
-    wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") is True)
+    result = wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") is True)
+    if not result:
+        logger.warning("Failed to process all withdraw requests in {} seconds".format(MAX_WAIT_TIME))
     sleep_to_wait(CRM_POLLING_INTERVAL * 100)
     # BGP queues can be idle while CRM/orch still reflects bulk route removal; baseline must be post-settle.
     crm_stable_timeout = 600 if str(topo_name).startswith("lt2") else 240
@@ -93,7 +95,9 @@ def withdraw_and_announce_existing_routes(duthosts, localhost, tbinfo, enum_rand
     logger.info("announce existing ipv4 and ipv6 routes")
     localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce", path="../ansible/")
 
-    wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "outq") is True)
+    result = wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "outq") is True)
+    if not result:
+        logger.warning("Failed to process all announce requests in {} seconds".format(MAX_WAIT_TIME))
     sleep_to_wait(CRM_POLLING_INTERVAL * 5)
     logger.info("ipv4 route used {}".format(get_crm_resource_status(duthost, "ipv4_route", "used", namespace)))
     logger.info("ipv6 route used {}".format(get_crm_resource_status(duthost, "ipv6_route", "used", namespace)))

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -6,7 +6,13 @@ import pytest
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
-from utils import get_crm_resource_status, check_queue_status, sleep_to_wait, LOOP_TIMES_LEVEL_MAP
+from utils import (
+    get_crm_resource_status,
+    check_queue_status,
+    sleep_to_wait,
+    LOOP_TIMES_LEVEL_MAP,
+    crm_route_counts_near_baseline,
+)
 
 ALLOW_ROUTES_CHANGE_NUMS = 5
 CRM_POLLING_INTERVAL = 1
@@ -83,17 +89,43 @@ def test_announce_withdraw_route(duthosts, localhost, tbinfo, get_function_compl
         announce_withdraw_routes(duthost, namespace, localhost, ptf_ip, topo_name)
         loop_times -= 1
 
-    sleep_to_wait(CRM_POLLING_INTERVAL * 120)
+    # BGP InQ/OutQ can be 0 while CRM/orch still reflects bulk route churn (e.g common on lt2 TH6 topo).
+    crm_settle_timeout = 600 if str(topo_name).startswith("lt2") else 120
+    crm_settle_interval = 10
+    logger.info(
+        "Waiting up to {}s (poll every {}s) for CRM ipv4/ipv6 route used to match baseline ±{}".format(
+            crm_settle_timeout, crm_settle_interval, ALLOW_ROUTES_CHANGE_NUMS)
+    )
+    crm_ok = wait_until(
+        crm_settle_timeout,
+        crm_settle_interval,
+        0,
+        crm_route_counts_near_baseline,
+        duthost,
+        namespace,
+        ipv4_route_used_before,
+        ipv6_route_used_before,
+        ALLOW_ROUTES_CHANGE_NUMS,
+    )
 
     ipv4_route_used_after = get_crm_resource_status(duthost, "ipv4_route", "used", namespace)
     ipv6_route_used_after = get_crm_resource_status(duthost, "ipv6_route", "used", namespace)
 
     # Do not check route used for vs tests because vs testbed do not have real asic
     if asic_type != "vs":
-        pytest_assert(abs(ipv4_route_used_after - ipv4_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
-                      "ipv4 route used after is not equal to it used before")
-        pytest_assert(abs(ipv6_route_used_after - ipv6_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
-                      "ipv6 route used after is not equal to it used before")
+        pytest_assert(
+            crm_ok,
+            "CRM route counts did not return to baseline within {}s (ipv4 before={}, after={}, "
+            "ipv6 before={}, after={}; expected abs(delta) < {} for both)".format(
+                crm_settle_timeout,
+                ipv4_route_used_before,
+                ipv4_route_used_after,
+                ipv6_route_used_before,
+                ipv6_route_used_after,
+                ALLOW_ROUTES_CHANGE_NUMS,
+            ),
+        )
+
     end_time_frr_daemon_memory = get_frr_daemon_memory_usage(duthost, frr_demons_to_check, namespace)
     logging.info(f"memory usage at end: {end_time_frr_daemon_memory}")
     check_memory_usage_is_expected(duthost, frr_demons_to_check, start_time_frr_daemon_memory,

--- a/tests/stress/utils.py
+++ b/tests/stress/utils.py
@@ -1,10 +1,14 @@
+import logging
 import re
 import time
+from collections import deque
 
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
+from tests.common.utilities import wait_until
 
 TOPO_FILENAME_TEMPLATE = 'topo_{}.yml'
 SHOW_BGP_SUMMARY_CMD = "show ip bgp summary"
+SHOW_BGP_SUMMARY_CMD_V6 = "show ipv6 bgp summary"
 LOOP_TIMES_LEVEL_MAP = {
     'debug': 1,
     'basic': 10,
@@ -19,15 +23,145 @@ def get_crm_resource_status(duthost, resource, status, namespace=DEFAULT_NAMESPA
 
 
 def check_queue_status(duthost, queue):
-    bgp_neighbors = duthost.show_and_parse(SHOW_BGP_SUMMARY_CMD)
-    bgp_neighbor_addr_regex = re.compile(r"^([0-9]{1,3}\.){3}[0-9]{1,3}")
-    for neighbor in bgp_neighbors:
-        if "neighbhor" in neighbor:
-            neigh = neighbor["neighbhor"]
-        else:
-            neigh = neighbor["neighbor"]
-        if bgp_neighbor_addr_regex.match(neigh) and int(neighbor[queue]) != 0:
+    """True when InQ/OutQ are idle for both IPv4 and IPv6 BGP peers.
+
+    T2 (e.g. lt2) may finish IPv4 updates while IPv6 peers still drain;
+    waiting on IPv4-only caused announce/withdraw to continue before routes left ASIC/CRM.
+    """
+    if not bgp_peer_queue_rows_idle(duthost, SHOW_BGP_SUMMARY_CMD, queue, ipv4_peers_only=True):
+        return False
+    if not bgp_peer_queue_rows_idle(duthost, SHOW_BGP_SUMMARY_CMD_V6, queue, ipv4_peers_only=False):
+        return False
+    return True
+
+
+def crm_route_counts_near_baseline(duthost, namespace, ipv4_before, ipv6_before, tolerance):
+    """True when CRM ipv4/ipv6 route used counts are within tolerance of baseline."""
+    v4 = get_crm_resource_status(duthost, "ipv4_route", "used", namespace)
+    v6 = get_crm_resource_status(duthost, "ipv6_route", "used", namespace)
+    if v4 is None or v6 is None:
+        return False
+    return abs(v4 - ipv4_before) < tolerance and abs(v6 - ipv6_before) < tolerance
+
+
+def wait_crm_route_counts_stabilized(
+    duthost,
+    namespace,
+    max_wait=300,
+    poll_interval=10,
+    stability_delta=10,
+    consecutive_stable_required=3,
+    min_elapsed_before_stable_sec=0,
+    flat_window_samples=0,
+    flat_window_delta=25,
+):
+    """Wait until CRM ipv4/ipv6 route 'used' look settled.
+
+    BGP InQ/OutQ can be idle while ASIC/CRM counts are still moving after large route withdraws; the stress
+    test baseline must be taken after CRM settles.
+
+    A single pair of samples within `stability_delta` is not enough on lt2: ipv6 (and sometimes ipv4)
+    CRM can decrease slowly (<= delta every poll) for minutes, so we require consecutive stable polls,
+    optionally a minimum wall time, and optionally a rolling window where max-min across recent stable
+    samples must be small
+    """
+    state = {"pv4": None, "pv6": None, "streak": 0}
+    start_ts = time.time()
+    history = deque(maxlen=flat_window_samples) if flat_window_samples else None
+
+    def stable():
+        v4 = get_crm_resource_status(duthost, "ipv4_route", "used", namespace)
+        v6 = get_crm_resource_status(duthost, "ipv6_route", "used", namespace)
+        if v4 is None or v6 is None:
             return False
+        if state["pv4"] is None:
+            state["pv4"], state["pv6"] = v4, v6
+            state["streak"] = 0
+            if history is not None:
+                history.clear()
+            return False
+        ok = (
+            abs(v4 - state["pv4"]) <= stability_delta
+            and abs(v6 - state["pv6"]) <= stability_delta
+        )
+        state["pv4"], state["pv6"] = v4, v6
+        if ok:
+            state["streak"] += 1
+            if history is not None:
+                history.append((v4, v6))
+        else:
+            state["streak"] = 0
+            if history is not None:
+                history.clear()
+        elapsed = time.time() - start_ts
+        if history is not None:
+            if len(history) < flat_window_samples:
+                return False
+            v4s = [p[0] for p in history]
+            v6s = [p[1] for p in history]
+            if (
+                max(v4s) - min(v4s) > flat_window_delta
+                or max(v6s) - min(v6s) > flat_window_delta
+            ):
+                return False
+        return (
+            state["streak"] >= consecutive_stable_required
+            and elapsed >= min_elapsed_before_stable_sec
+        )
+
+    settled = wait_until(max_wait, poll_interval, 0, stable)
+    if not settled:
+        logging.warning(
+            "CRM ipv4/ipv6 route used did not stabilize within {}s (delta<={} between polls, "
+            "need {} consecutive stable polls, min_elapsed={}s, flat_window={}/{}); "
+            "using last sample v4={} v6={}".format(
+                max_wait, stability_delta, consecutive_stable_required, min_elapsed_before_stable_sec,
+                flat_window_samples, flat_window_delta, state["pv4"], state["pv6"])
+        )
+    return state["pv4"], state["pv6"]
+
+
+def neighbor_cell(neighbor):
+    if "neighbhor" in neighbor:
+        return neighbor["neighbhor"]
+    return neighbor.get("neighbor")
+
+
+def bgp_peer_queue_rows_idle(duthost, show_cmd, queue, ipv4_peers_only):
+    """Return True when all relevant BGP peers have queue counter == 0."""
+    try:
+        ipv4_regex = re.compile(r"^([0-9]{1,3}\.){3}[0-9]{1,3}$")
+        bgp_neighbors = duthost.show_and_parse(show_cmd)
+    except Exception:
+        # Broad catch: show_and_parse / CLI can fail transiently
+        logging.debug(
+            "check_queue_status: failed to parse {}".format(show_cmd),
+            exc_info=True
+        )
+        return True
+
+    if not bgp_neighbors:
+        return True
+
+    for neighbor in bgp_neighbors:
+        neigh = neighbor_cell(neighbor)
+        if neigh is None:
+            continue
+        if neigh.startswith("Neighbhor") or neigh.startswith("Neighbor") or neigh.startswith("---"):
+            continue
+        if ipv4_peers_only:
+            if not ipv4_regex.match(neigh):
+                continue
+        else:
+            # IPv6 unicast summary: peer addresses contain ':' (skip v4-mapped if any)
+            if ":" not in neigh or ipv4_regex.match(neigh):
+                continue
+        try:
+            if int(neighbor[queue]) != 0:
+                return False
+        except (KeyError, ValueError, TypeError):
+            # Parser row missing queue column or non-integer
+            continue
     return True
 
 

--- a/tests/stress/utils.py
+++ b/tests/stress/utils.py
@@ -138,7 +138,7 @@ def bgp_peer_queue_rows_idle(duthost, show_cmd, queue, ipv4_peers_only):
             "check_queue_status: failed to parse {}".format(show_cmd),
             exc_info=True
         )
-        return True
+        return False
 
     if not bgp_neighbors:
         return True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR,

- Refines withdraw_and_announce_existing_routes CRM baseline capture with wait_crm_route_counts_stabilized and lt2-specific timeouts/sampling, on top of #[24756 ](https://github.com/sonic-net/sonic-mgmt/pull/24756)changes, for large-scale route churn where CRM lags BGP or moves slowly between polls.
- Replaces the post-loop fixed CRM sleep in _test_announce_withdraw_route_ with _wait_until_ + _crm_route_counts_near_baseline_, again with longer settle time.
- Extends check_queue_status to require both _show ip bgp summary_ and _show ipv6 bgp summary_ queues idle (_fixes cases where IPv4 finished while IPv6 was still draining on large T2-style topologies_).

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Stress route testing (_test_announce_withdraw_route and the withdraw_and_announce_existing_routes fixture_) compares CRM ipv4_route / ipv6_route used before and after announce/withdraw. 
On large-scale topologies (especially lt2 / TH6-scale route counts), we saw **flakes** and **false failures** because:

- BGP queues could look idle while CRM was still catching up (orch / CRM updates lag bulk BGP work).
- check_queue_status only inspected IPv4 show ip bgp summary, so IPv6 peers could still be updating while the test treated BGP as done.

- CRM counts could drift slowly between polls (within a small band for a long time), so a strict back-to-back “no change” gate ([sonic-mgmt#24756](https://github.com/sonic-net/sonic-mgmt/pull/24756)) or a fixed post-loop sleep did not always match how long CRM needed to return to baseline.

- This PR tightens when we trust CRM readings and when we consider BGP, **_without changing the functional intent of the stress test._**

#### How did you do it?

- **withdraw_and_announce_existing_routes**: After withdraw and the existing BGP InQ wait, call _wait_crm_route_counts_stabilized_ **before yielding baseline CRM values**, with longer max_wait and stricter sampling on lt2 (_consecutive stable polls, minimum elapsed time, flat-window checks where configured_), complementing upstream #24756 for slow CRM movement.
- **test_announce_withdraw_route**: Replace the fixed post-loop CRM sleep with wait_until + crm_route_counts_near_baseline, with a longer settle window on lt2 than on other topologies, then assert with a clear error message if CRM does not return near baseline.
- **check_queue_status / utils.py**: Treat BGP as idle only when both show ip bgp summary and show ipv6 bgp summary show InQ/OutQ (or the relevant queue) at zero for the applicable peers; add small helpers for parsing and CRM comparison.

#### How did you verify/test it?

- Tested it on 128 port max topo setup, which is 256 ports with breakout config and made sure the test passes without any issues.

#### Any platform specific information?

x86_64-nokia_ixr7220_h6_128-r0

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
Attaching test_stress_routes log file below for reference.
[test_stress_routes.zip](https://github.com/user-attachments/files/28809113/test_stress_routes.zip)

