### PR TITLE
[test] Fix missing fixture imports in test_upgrade_gnoi.py

### DIFF
--- a/tests/upgrade_path/test_upgrade_gnoi.py
+++ b/tests/upgrade_path/test_upgrade_gnoi.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from tests.common.fixtures.grpc_fixtures import gnmi_tls  # noqa: F401
+from tests.common.fixtures.grpc_fixtures import gnmi_tls, ptf_grpc, ptf_gnoi, setup_gnoi_tls_server  # noqa: F401
 from tests.upgrade_path.test_upgrade_path import setup_upgrade_test
 from tests.common.helpers.upgrade_helpers import perform_gnoi_upgrade, GnoiUpgradeConfig
 
@@ -29,7 +29,7 @@ def gnoi_upgrade_path_lists(request):
 def test_upgrade_via_gnoi(
     localhost, duthosts, ptfhost, rand_one_dut_hostname,
     nbrhosts, fanouthosts, tbinfo, request,
-    gnoi_upgrade_path_lists, ptf_gnoi,  # noqa: F811
+    gnoi_upgrade_path_lists, gnmi_tls, ptf_gnoi,  # noqa: F811
     conn_graph_facts, xcvr_skip_list
 ):
     duthost = duthosts[rand_one_dut_hostname]


### PR DESCRIPTION
Import ptf_grpc, ptf_gnoi, setup_gnoi_tls_server from grpc_fixtures. Add gnmi_tls as fixture parameter to resolve AttributeError on .gnoi.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
 
 Summary:
 Fix missing fixture imports in test_upgrade_gnoi.py causing `fixture 'ptf_gnoi' not found` error.
 
 The test referenced `ptf_gnoi` as a parameter but never imported it (or its dependencies
 `ptf_grpc`, `setup_gnoi_tls_server`) from `grpc_fixtures`. Also added `gnmi_tls` as a
 fixture parameter so it resolves correctly instead of raising AttributeError on `.gnoi`.
 
 ### Type of change
 
 - [x] Bug fix
 - [ ] Testbed and Framework(new/improvement)
 - [ ] New Test case
     - [ ] Skipped for non-supported platforms
 - [ ] Test case improvement
 
 ### Back port request
 - [ ] 202311
 - [ ] 202405
 - [ ] 202411
 - [ ] 202505
 - [ ] 202511
 - [ ] 202512
 - [ ] 202605
 
 ### Approach
 #### What is the motivation for this PR?
 
 `test_upgrade_via_gnoi` fails at collection time with:
 

fixture 'ptf_gnoi' not found
available fixtures: ...

 
 #### How did you do it?
 
 - Imported `ptf_grpc`, `ptf_gnoi`, and `setup_gnoi_tls_server` from `tests.common.fixtures.grpc_fixtures`.
 - Added `gnmi_tls` to the test function signature so it resolves as a fixture instance.
 
 #### How did you verify/test it?
 
 Ran `pytest --collect-only tests/upgrade_path/test_upgrade_gnoi.py` — collection succeeds without fixture errors.
 
 #### Any platform specific information?
 
 N/A
 
 #### Supported testbed topology if it's a new test case?
 
 N/A (existing test fix)
 
 ### Documentation
 
 N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
