### PR TITLE
[snmp] Improve error message in test_snmp_psu.py

### DIFF
--- a/tests/snmp/test_snmp_psu.py
+++ b/tests/snmp/test_snmp_psu.py
@@ -62,6 +62,8 @@ def test_snmp_psu_status(duthosts, enum_supervisor_dut_hostname, snmp_psu_module
         return
 
     psu_keys = natsorted(redis_get_keys(duthost, 'STATE_DB', 'PSU_INFO|*'))
+    assert psu_keys, "No PSU_INFO keys found in STATE_DB."
+
     for psu_indx, operstatus in snmp_facts['snmp_psu'].items():
         get_presence = duthost.shell(
             "redis-cli -n 6 hget '{}' presence".format(psu_keys[int(psu_indx)-1]))
@@ -97,4 +99,4 @@ def redis_get_keys(duthost, db_id, pattern):
     logging.debug('Getting keys from redis by command: {}'.format(cmd))
     output = duthost.shell(cmd)
     content = output['stdout'].strip()
-    return content.split('\n') if content else None
+    return content.split('\n') if content else []

--- a/tests/snmp/test_snmp_psu.py
+++ b/tests/snmp/test_snmp_psu.py
@@ -62,7 +62,7 @@ def test_snmp_psu_status(duthosts, enum_supervisor_dut_hostname, snmp_psu_module
         return
 
     psu_keys = natsorted(redis_get_keys(duthost, 'STATE_DB', 'PSU_INFO|*'))
-    assert psu_keys, "No PSU_INFO keys found in STATE_DB."
+    pytest_assert(psu_keys, "No PSU_INFO keys found in STATE_DB.")
 
     for psu_indx, operstatus in snmp_facts['snmp_psu'].items():
         get_presence = duthost.shell(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In test_snmp_psu.py::test_snmp_psu_status, when for whatever reason redis doesn't have PSU_INFO keys in its STATE_DB table, the test crashes with the uninformative error "TypeError: 'NoneType' object is not iterable".

This change adds an assertion with a more informative error message.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Tested branch
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Test result

202511: Kusto ID 8e934852-22c4-4fbe-99a9-ec33daae4e8d
202605: Kusto ID df81d5f1-8bd0-42af-801b-3bdc728f3ac9

### Approach
#### What is the motivation for this PR?
There were some failures in this test which were hard to debug because the error message was uninformative.

#### How did you do it?
I added an extra assert with a descriptive message for the case when the STATE_DB table doesn't have PSU_INFO keys.

#### How did you verify/test it?
I ran the test in a dut with a faulty psud process. I verified that it showed the new error message instead of the previous, uninformative one.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
