### PR TITLE
[test] Fix FEC predicted FLR validation to accept nan% accuracy

### DIFF
--- a/tests/layer1/test_fec_error.py
+++ b/tests/layer1/test_fec_error.py
@@ -83,14 +83,15 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
         Expected format :
             * 0
             * 7.81e-10 (89%)
+            * 3.38e+00 (nan%)
         """
         # Pattern for just "0"
         if value_string == "0":
             return True
 
         # Pattern for scientific notation with required accuracy percentage
-        # e.g., "7.81e-10 (89%)"
-        pattern = r'^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)\s+\(\d+%\)$'
+        # e.g., "7.81e-10 (89%)" or "3.38e+00 (nan%)"
+        pattern = r'^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)\s+\((\d+|nan)%\)$'
         if re.match(pattern, value_string):
             return True
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The predicted FLR regex rejects valid device output like '3.38e+00 (nan%)' because it only accepts digit percentages. When FLR is saturated (>1), hardware reports accuracy as 'nan' since it's meaningless. Update regex to accept both numeric and 'nan' accuracy values.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
