### PR TITLE
fix: make teardown cleanup idempotent in test_pktgen and route/utils

### DIFF
--- a/tests/route/utils.py
+++ b/tests/route/utils.py
@@ -1,4 +1,8 @@
 import json
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 def generate_intf_neigh(asichost, num_neigh, ip_version, mg_facts=None, is_backend_topology=False):
@@ -114,8 +118,24 @@ def prepare_dut(asichost, intf_neighs):
 def cleanup_dut(asichost, intf_neighs):
     for intf_neigh in intf_neighs:
         # Delete neighbor
-        asichost.run_ip_neigh_cmd(
-            "del " + intf_neigh["neighbor"] + " dev " + intf_neigh["interface"]
-        )
+        try:
+            asichost.run_ip_neigh_cmd(
+                "del " + intf_neigh["neighbor"] + " dev " + intf_neigh["interface"]
+            )
+        except Exception as err:
+            logger.warning(
+                "Failed to delete neighbor %s on %s during cleanup: %s",
+                intf_neigh["neighbor"],
+                intf_neigh["interface"],
+                err
+            )
         # remove interface
-        asichost.config_ip_intf(intf_neigh["interface"], intf_neigh["ip"], "remove")
+        try:
+            asichost.config_ip_intf(intf_neigh["interface"], intf_neigh["ip"], "remove")
+        except Exception as err:
+            logger.warning(
+                "Failed to remove IP %s from %s during cleanup: %s",
+                intf_neigh["ip"],
+                intf_neigh["interface"],
+                err
+            )

--- a/tests/test_pktgen.py
+++ b/tests/test_pktgen.py
@@ -46,23 +46,23 @@ def get_port_list(duthost, tbinfo):
     return list(mg_facts["minigraph_ports"].keys())
 
 
+def _run_cleanup(duthost):
+    for cmd in CLEANUP_CMDS:
+        duthost.shell(cmd, module_ignore_errors=True)
+    for asichost in duthost.asics:
+        for cmd in CLEANUP_ASIC_CMDS:
+            asichost.shell(cmd, module_ignore_errors=True)
+
+
 @pytest.fixture(scope='function', autouse='True')
 def clear_pktgen(duthosts, enum_dut_hostname):
     duthost = duthosts[enum_dut_hostname]
-    for cmd in CLEANUP_CMDS:
-        duthost.shell(cmd)
-    for asichost in duthost.asics:
-        for cmd in CLEANUP_ASIC_CMDS:
-            asichost.command(cmd)
+    _run_cleanup(duthost)
     duthost.shell("sonic-clear counters")
 
     yield
 
-    for cmd in CLEANUP_CMDS:
-        duthost.shell(cmd)
-    for asichost in duthost.asics:
-        for cmd in CLEANUP_ASIC_CMDS:
-            asichost.command(cmd)
+    _run_cleanup(duthost)
 
 
 def test_pktgen(duthosts, enum_dut_hostname, enum_frontend_asic_index, tbinfo, loganalyzer):


### PR DESCRIPTION
### Description of PR
Summary:
`test_pktgen` and `route/test_route_perf` reported `ERROR at teardown` when cleanup commands failed on an already-clean DUT state (e.g. deleting a neighbor or IP that was already removed). This masked whether the actual test passed or failed.

### Type of change
- [x] Bug fix

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Both tests use a teardown phase that runs cleanup commands unconditionally. If a prior partial run or retry had already cleaned up the state, these commands raised exceptions that surfaced as teardown `ERROR`, hiding whether the actual test body passed.

#### How did you do it?
**`tests/test_pktgen.py`**
- Extracted `_run_cleanup()` helper to deduplicate the pre-yield / post-yield cleanup logic.
- Switched cleanup shell calls to `module_ignore_errors=True` (using `duthost.shell()` for DUT-level commands and `asichost.shell()` for ASIC-level commands, since `SonicAsic.command()` does not accept `module_ignore_errors`).

**`tests/route/utils.py`**
- Wrapped `run_ip_neigh_cmd()` and `config_ip_intf()` calls in `cleanup_dut()` with `try/except` that logs a warning instead of raising, so teardown completes cleanly even if the state is already gone.

#### How did you verify/test it?
**Test results (Nokia IXR7220-H6-O256, 256-port lt2 topology):**
```
test_pktgen.py::test_pktgen[str4-Nokia-7220-Th6p-1-None]
1 passed in 97.31s (0:01:37)

route/test_route_perf.py::test_perf_add_remove_routes[4-str4-Nokia-7220-Th6p-1-None]  PASSED
route/test_route_perf.py::test_perf_add_remove_routes[6-str4-Nokia-7220-Th6p-1-None]  PASSED
2 passed in 660.81s (0:11:00)
```
No teardown ERRORs observed.

#### Any platform specific information?
Observed on Nokia IXR7220-H6-O256 but the teardown race is generic.

#### Supported testbed topology if it's a new test case?
N/A — existing test case improvement.

### Documentation
N/A