### PR TITLE
conditional_mark: skip test_continous_pfc on Nokia IXR7220-H6-128

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4261,6 +4261,12 @@ qos/test_pfc_counters.py:
                    'Mellanox-SN5640-C448O16']"
       - "release in ['202412']"
 
+qos/test_pfc_counters.py::test_continous_pfc:
+  skip:
+    reason: "PFC RX counters do not increment reliably on Nokia TH6 with current image/fanout combination"
+    conditions:
+      - "platform in ['x86_64-nokia_ixr7220_h6_128-r0']"
+
 qos/test_pfc_counters.py::test_pfc_unpause:
   # The test case expects both XON and XOFF frames to be supported.
   # In wistron platform the port PFC stats count only XOFF frames. Hence skipping this case.


### PR DESCRIPTION
### Description of PR
Summary:
Skip `qos/test_pfc_counters.py::test_continous_pfc` on Nokia IXR7220-H6-128 (`x86_64-nokia_ixr7220_h6_128-r0`). `SAI_PORT_STAT_PFC_*_RX_PKTS` counters do not increment on this platform when PFC frames are received, causing the assertion `expected 10 PFC RX frames, got 0` to always fail.

### Type of change
- [x] Bug fix

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
`test_continous_pfc` verifies that received PFC frames increment the per-priority port counter in COUNTERS_DB. On Nokia IXR7220-H6-O256 the fanout sends 10 PFC frames (via `pfc_gen.py`), but the DUT counter remains at 0.

**Debugging findings:**
- `SAI_PORT_STAT_PFC_[0-7]_RX_PKTS` keys **do exist** in COUNTERS_DB (polled via FLEX_COUNTER/PORT) but remain at `0` after frames are received.
- Nokia SAI only registers `SAI_PORT_STAT_PFC_{3,4}_ON2OFF_RX_PKTS` (state-transition counters for lossless priorities) — indicating the SAI tracks PFC pause/resume events but **does not count individual PFC frame arrivals**.
- The fanout was accessible during the nightly test run (the `continue`-early-exit path in the test was not taken — the assertion fired and failed with the actual `0` value).
- Root cause is in the Nokia SAI/SDK layer; requires a Nokia image-side fix.

#### How did you do it?
Added a skip condition for `qos/test_pfc_counters.py::test_continous_pfc` in `tests_mark_conditions.yaml` targeting platform `x86_64-nokia_ixr7220_h6_128-r0`.

#### How did you verify/test it?
**Test results (Nokia IXR7220-H6-O256, 256-port lt2 topology):**
```
qos/test_pfc_counters.py::test_continous_pfc
1 skipped in 1.09s
```
Test is correctly skipped on Nokia IXR7220-H6-128 and runs on all other platforms.

#### Any platform specific information?
Nokia IXR7220-H6-O256 (`x86_64-nokia_ixr7220_h6_128-r0`). The skip should be removed once Nokia SAI correctly increments `SAI_PORT_STAT_PFC_*_RX_PKTS` counters on frame reception.

#### Supported testbed topology if it is a new test case?
N/A

### Documentation
N/A