### PR TITLE
[vm_set]: Fix remove-topo bringing down host NIC when PTF container i…

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -1631,7 +1631,13 @@ class VMTopology(object):
         Remove veth interface from docker
         """
         logging.info("=== Cleanup port, int_if: %s, ext_if: %s, tmp_name: %s ===" % (ext_if, int_if, tmp_name))
-        if VMTopology.intf_exists(int_if, pid=self.pid):
+        # When the PTF container is absent, self.pid is None and the interface that used to live
+        # inside the container (e.g. eth0/mgmt/backplane) is already gone with the container. The
+        # in-container manipulation below must be skipped in that case: intf_exists()/iface_down()
+        # with pid=None fall back to the host root namespace and would operate on a same-named host
+        # interface (e.g. eth0), knocking the host off the network. Only the host-side peer (ext_if,
+        # which is uniquely named per vm_set) still needs to be cleaned up.
+        if self.pid is not None and VMTopology.intf_exists(int_if, pid=self.pid):
             # Name it back to temp name in PTF container to avoid potential conflicts
             VMTopology.iface_down(int_if, pid=self.pid)
             VMTopology.cmd("nsenter -t %s -n ip link set dev %s name %s" % (self.pid, int_if, tmp_name))


### PR DESCRIPTION
### Description of PR

Summary: Fix `remove-topo` bringing down the host's primary NIC (e.g. `eth0`) when the testbed's PTF container is not running, which disconnects the host and requires a reboot to recover.

Fixes #25293

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

When `remove-topo` runs while the testbed's PTF container (`ptf_<vm_set_name>`) is not running — either already removed or merely stopped/`Exited` — the teardown brings down the **host's** primary network interface, disconnecting the host (it needs a reboot to recover).

Root cause: in `ansible/roles/vm_set/library/vm_topology.py`, `remove_veth_if_from_docker()` lacks the `self.pid is None` guard that its siblings `remove_dut_if_from_docker()` and `remove_dut_vlan_subif_from_docker()` already have. When the PTF container is not running, `get_pid()` returns `None` (it gates on `State.Running`), so `init()` sets `self.pid = None`. The `unbind` path then calls `remove_injected_fp_ports_from_docker()` → `remove_veth_if_from_docker(int_if="eth0", ...)` (PTF front-panel data ports are `ethN`). With `pid=None`, `intf_exists()`/`iface_down()` fall back to the **host root namespace**, so `ip link set eth0 down` is executed on the host's own `eth0`.

#### How did you do it?

Guard the in-container interface manipulation with `self.pid is not None`. When the PTF container is not running, the in-container interface is already gone with the container, so only the uniquely-named host-side peer veth (`ext_if`, e.g. `inje-<vm_set>-N`) needs to be deleted — which the code still does unconditionally.

#### How did you verify/test it?

- `python -m py_compile` and `flake8 --max-line-length=120` pass on the modified file.
- Unit-level check with `VMTopology.cmd` mocked (no real commands executed): the pre-fix code issues `ip link set eth0 down` in the host namespace when `pid=None`; the fixed code does not, while still deleting the host-side peer veth; the PTF-present path (`pid` set) is unchanged.
- Live test on a KVM VS testbed host whose default route is on `eth0`: with `ptf_vms6-2` in `Exited` state, ran `./testbed-cli.sh -m veos_vtb -t vtestbed.yaml -k ceos remove-topo vms-kvm-vpp-t1-lag password.txt`. Result: PLAY RECAP `failed=0`; `eth0` stayed UP for the entire run (a 2s-interval watchdog logged 0 interventions over ~5 min); external connectivity (`https://github.com` → HTTP 200) was intact afterward; the topology was fully torn down.

Note: `vm_topology.py` requires root + network namespaces and is not covered by unit tests in this repo.

#### Any platform specific information?

Affects any VS/KVM testbed host that uses `eth0` (or another `ethN`/`mgmt`/`backplane` name) as a real host interface. No platform-specific behavior in the fix.

#### Supported testbed topology if it's a new test case?

N/A (bug fix in testbed teardown framework).

### Documentation

N/A
