### PR TITLE
[202411] Update test_arp_update to make it more stable

### DIFF
--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -35,6 +35,12 @@ def neighbor_learned(dut, target_ip):
     return neigh_output and ("REACHABLE" in neigh_output or "STALE" in neigh_output)
 
 
+def appl_db_neighbor_syncd(dut, vlan_name, target_ip, exp_mac):
+    asic_db_mac = dut.shell(f"sonic-db-cli APPL_DB hget 'NEIGH_TABLE:{vlan_name}:{target_ip}' 'neigh'")['stdout']
+    logger.info(f"DUT neighbor mac: {asic_db_mac} of entry {vlan_name}:{target_ip}")
+    return exp_mac.lower() == asic_db_mac.lower()
+
+
 def ip_version_string(version):
     return f"ipv{version}"
 
@@ -66,10 +72,7 @@ def test_kernel_asic_mac_mismatch(
     neighbor_info = rand_selected_dut.shell(f"ip neigh show {target_ip}")["stdout"].split()
     pt_assert(neighbor_info[2] == vlan_name)
 
-    asic_db_mac = rand_selected_dut.shell(
-        f"sonic-db-cli APPL_DB hget 'NEIGH_TABLE:{vlan_name}:{target_ip}' 'neigh'"
-    )['stdout']
-    pt_assert(neighbor_info[4].lower() == asic_db_mac.lower())
+    wait_until(5, 1, 0, appl_db_neighbor_syncd, rand_selected_dut, vlan_name, target_ip, neighbor_info[4])
 
     logger.info(f"Neighbor {target_ip} has been learned, APPL_DB and kernel are in sync")
 


### PR DESCRIPTION

### Description of PR
APPL_DB may not be synced when checking mac address of specific vlan and ip 
Add a loop check for the APPL_DB


Summary:
Fixes # (issue)

### Type of change


- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [x] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
APPL_DB may not be synced when checking mac address of specific vlan and ip
#### How did you do it?
Add a loop check for the APPL_DB
#### How did you verify/test it?
Run it in local setup
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

