### PR TITLE
[202405]Update portchannel ip configuration command in generic hash script

### DIFF
--- a/tests/hash/generic_hash_helper.py
+++ b/tests/hash/generic_hash_helper.py
@@ -140,8 +140,8 @@ def restore_configuration(duthost):
             duthost.shell(f'config vlan del {vlan}')
         # Re-config ip interface
         for ip_interface in ip_interface_to_restore:
-            duthost.shell(f"config interface ip add {ip_interface['attachto']} "
-                          f"{ip_interface['addr']}/{ip_interface['mask']}")
+            formatted_ip_addr = format_ip_mask(f"{ip_interface['addr']}/{ip_interface['mask']}")
+            duthost.shell(f"config interface ip add {ip_interface['attachto']} {formatted_ip_addr}")
         # Re-config vlan interface
         if vlan_member_to_restore:
             duthost.shell(f"config vlan member add {vlan_member_to_restore['vlan_id']} "


### PR DESCRIPTION

### Description of PR
Currently, CLI/SWSS doesn't have a way to normalize the IP mask notation regardless of what was provided by user.
The code change here is to replace dotted decimal notation when adding ip address for portchannel.
Replace dot split mask during portchannel ip configuration would make the portchannel related test more stable.


Summary:
Fixes # (issue)

### Type of change


- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Make the portchannel related script stable.
#### How did you do it?
Replace dot split mask during portchannel ip configuration
#### How did you verify/test it?
Run it in internal regression.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

