### PR TITLE
[lldp] Fix NameError by adding missing import time in test_lldp_syncd

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -2,6 +2,7 @@
 # Test plan in docs/testplan/LLDP-syncd-test-plan.md
 import pytest
 import json
+import time
 from tests.common.helpers.sonic_db import SonicDbCli
 import logging
 from tests.common.reboot import reboot, REBOOT_TYPE_COLD


### PR DESCRIPTION
### Description of PR

Summary:
PR https://github.com/sonic-net/sonic-mgmt/pull/25085 removed the import time statement because no one was using it at the time. However, PR https://github.com/sonic-net/sonic-mgmt/pull/24876 — which adds code that uses time — was merged afterward, which caused the issue.

`tests/lldp/test_lldp_syncd.py` uses `time.sleep()` inside the `wait_for_lldp_appl_db()` helper, but the `time` module is never imported. As soon as the `lldpctl` stabilization retry loop is entered, the test raises:

```
NameError: name 'time' is not defined. Did you forget to import 'time'?
  File "tests/lldp/test_lldp_syncd.py", line 73, in wait_for_lldp_appl_db
    time.sleep(poll_interval)
```

This is a deterministic (100%) failure of `test_lldp_syncd.py` whenever the retry/poll path runs. The fix adds the missing `import time` to the stdlib import block.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`test_lldp_syncd.py` fails immediately with `NameError("name 'time' is not defined")` because the `time` module is referenced (`time.sleep(poll_interval)` and `time.sleep(appl_db_poll_interval)`) but never imported. The test cannot pass on any platform until this import is added.

#### How did you do it?
Added `import time` to the module-level import block, alongside the other stdlib imports (`json`, `logging`).

#### How did you verify/test it?
- Confirmed the file references `time.` in two places (`wait_for_lldp_appl_db` retry loops) with no corresponding import.
- Verified `python -c "import ast; ast.parse(open('tests/lldp/test_lldp_syncd.py').read())"` parses cleanly after the change.
- Single-line, import-only change with no behavioral impact beyond resolving the `NameError`.

- **internal-202605 backport verification (Elastictest):** cherry-picked this commit onto `dev/xuliping/20260722_internal-202605_lldp-syncd-import-time` and ran `lldp/test_lldp_syncd.py` on testbed `testbed-bjw2-can-t0-7260-1` (t0, Arista-7260CX3, internal-202605 image). Job: https://elastictest.org/scheduler/testplan/6a60098c5c1a4704448798f6 — **result SUCCESS**: `test_lldp_syncd` 6 passed / 0 failed / 0 errors (pretest 12 passed / 2 skipped, posttest 5 passed). Confirms the `NameError` is resolved on 202605.
#### Any platform specific information?
None — platform-independent Python import fix.

#### Supported testbed topology if it's a new test case?
N/A — existing test fix.

### Documentation
N/A