### PR TITLE
Ignore expected psud PSU absence log

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -75,6 +75,7 @@ SKIP_ERROR_LOG_PSU_ABSENCE = [
     '.*ERR pmon#psud:.*Fail to read model number: No key PN_VPD_FIELD in.*',
     '.*ERR pmon#psud:.*Fail to read serial number: No key SN_VPD_FIELD in.*',
     '.*ERR pmon#psud:.*Fail to read revision: No key REV_VPD_FIELD in.*',
+    r'.*ERR pmon#psud(\[\d+\])?: (PSU absence warning: )?PSU \d+ is not present\..*',
     r'.*ERR pmon#psud: Failed to read from file /var/run/hw-management/power/psu\d_volt.*',
     r'.*ERR pmon#thermalctld: Failed to read from file \/var\/run\/hw-management\/thermal\/.*FileNotFoundError.*',
     r'.*ERR pmon#thermalctld: Failed to read from file.*\/var\/run\/hw-management\/thermal\/psu.*ValueError.*',


### PR DESCRIPTION
### Description of PR

Summary: Add a LogAnalyzer ignore for expected psud PSU absence messages. During PSU absence flows, psud can log "PSU <n> is not present" either directly or with the "PSU absence warning:" prefix, and newer logs may include a PID suffix after psud. The new regex covers these expected ERR formats in SKIP_ERROR_LOG_PSU_ABSENCE without broadening the ignore to WARNING logs or other daemons.
It is safe to skip because this log is expected during the PSU absence flow, when psud reports that a powered-off or removed PSU is not present. The ignore regex is narrowly scoped to that exact psud ERR message format, so unrelated PSU/platform errors are still caught by LogAnalyzer.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Add a LogAnalyzer ignore for expected psud PSU absence messages. During PSU absence flows, psud can log "PSU <n> is not present" either directly or with the "PSU absence warning:" prefix, and newer logs may include a PID suffix after psud. The new regex covers these expected ERR formats in SKIP_ERROR_LOG_PSU_ABSENCE without broadening the ignore to WARNING logs or other daemons.

#### How did you do it?
add the ignore regex to SKIP_ERROR_LOG_PSU_ABSENCE
#### How did you verify/test it?
Run test case
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
