### PR TITLE
Add traffic test for dash-ha launch with no peer

### DIFF
--- a/tests/ha/test_ha_launch_with_no_peer.py
+++ b/tests/ha/test_ha_launch_with_no_peer.py
@@ -19,7 +19,8 @@ from tests.common.helpers.assertions import pytest_assert
 
 
 pytestmark = [
-    pytest.mark.topology("t1-smartswitch-ha")
+    pytest.mark.topology("t1-smartswitch-ha"),
+    pytest.mark.skip_check_dut_health
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/ha/test_ha_launch_with_no_peer.py
+++ b/tests/ha/test_ha_launch_with_no_peer.py
@@ -2,12 +2,18 @@ import os
 import json
 import pytest
 import logging
+import ptf.testutils as testutils
+from constants import (
+    LOCAL_PTF_INTF,
+    REMOTE_PTF_RECV_INTF,
+)
 from conftest import (
     activate_scope_per_dut,
     deactivate_dash_ha_from_json_util,
     ha_scope_per_dut,
     remove_setup_dash_ha_from_json_util
 )
+from packets import outbound_pl_packets
 from ha_utils import verify_ha_state, wait_for_pending_operation_id, ha_scope_config, ha_set_config, apply_ha_messages
 from tests.common.helpers.assertions import pytest_assert
 
@@ -136,8 +142,23 @@ def activate_dash_ha(duthost, dpuhost, localhost, ptfhost, setup_gnmi_server,
     logger.info(f"HA: Activate completed for {duthost.hostname}")
 
 
+def verify_primary_standalone_traffic(ptfadapter, dash_pl_config):
+    primary_config = dash_pl_config[0]
+    send_pkt, exp_pkt = outbound_pl_packets(primary_config, "vxlan")
+
+    logger.info("HA: verify PL traffic sent to primary NPU while primary is standalone")
+    ptfadapter.dataplane.flush()
+    testutils.send(ptfadapter, primary_config[LOCAL_PTF_INTF], send_pkt, count=1)
+    testutils.verify_packet_any_port(
+        ptfadapter,
+        exp_pkt,
+        primary_config[REMOTE_PTF_RECV_INTF],
+    )
+
+
 def test_ha_launch_with_no_peer(request, duthosts, dpuhosts, localhost, ptfhost, setup_ha_config,
-                                ha_owner, setup_gnmi_server, primary_vdpu_key, standby_vdpu_key):
+                                ha_owner, setup_gnmi_server, primary_vdpu_key, standby_vdpu_key,
+                                setup_dash_pl_pipeline, ptfadapter, dash_pl_config):
 
     logger.info("HA: activate only primary")
     try:
@@ -148,6 +169,7 @@ def test_ha_launch_with_no_peer(request, duthosts, dpuhosts, localhost, ptfhost,
         pytest_assert(verify_ha_state(duthosts[0], scope_key=primary_vdpu_key, expected_state="standalone",
                                       timeout=150),
                       "HA: Primary state is not standalone")
+        verify_primary_standalone_traffic(ptfadapter, dash_pl_config)
 
         logger.info("HA: activate standby with standalone primary")
         setup_dash_ha(duthosts[1], dpuhosts, localhost, ptfhost, setup_gnmi_server, ha_owner, role_index=1)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add traffic test to HA launch with no peer test case. Ack the contributions to Vivek (Nvidia)
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
