### PR TITLE
Update the xfail of test test_bgp_prefix_tc1_suite to track with sonic-buildimage issue #27818

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2635,9 +2635,9 @@ generic_config_updater/test_bgp_prefix.py::test_bgp_prefix_tc1_suite:
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/18445"
       - "'isolated' in topo_name"
   xfail:
-    reason: "BGP allowed-prefix GCU validation fails across platforms, tracked by https://github.com/sonic-net/sonic-mgmt/issues/25549"
+    reason: "BGP allowed-prefix GCU validation fails across platforms, tracked by https://github.com/sonic-net/sonic-buildimage/issues/27818"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/25549"
+      - "https://github.com/sonic-net/sonic-buildimage/issues/27818"
 
 generic_config_updater/test_bgp_speaker.py::test_bgp_speaker_tc1_test_config:
   xfail:


### PR DESCRIPTION
### Description of PR

Summary:
The test generic_config_updater/test_bgp_prefix.py::test_bgp_prefix_tc1_suite is failing due to issue https://github.com/sonic-net/sonic-buildimage/issues/27818

The xfail was added to track the sonic-mgmt issue https://github.com/sonic-net/sonic-mgmt/issues/25549, but actually this is an image issue. Update the xfail condition.

Failure in test log:
```
rand_selected_front_end_dut = 
enum_rand_one_frontend_asic_index = None, community = 'empty'
cli_namespace_prefix = ''

    @pytest.mark.parametrize("community", ["empty", "1010:1010"])
    def test_bgp_prefix_tc1_suite(rand_selected_front_end_dut, enum_rand_one_frontend_asic_index, community,
                                  cli_namespace_prefix):
        """ Test suite for bgp prefix for v4 and v6 w/ and w/o community ID
    
        Sample CONFIG_DB entry:
        BGP_ALLOWED_PREFIXES|DEPLOYMENT_ID|0
        BGP_ALLOWED_PREFIXES|DEPLOYMENT_ID|0|1010:1010
        """
        asic_namespace = rand_selected_front_end_dut.get_namespace_from_asic_id(enum_rand_one_frontend_asic_index)
        community_table = "" if community == "empty" else "|" + community
    
        bgp_prefix_test_setup(rand_selected_front_end_dut, cli_namespace_prefix)
        bgp_prefix_tc1_add_config(rand_selected_front_end_dut, community, community_table, cli_namespace_prefix,
                                  namespace=asic_namespace)
        bgp_prefix_tc1_xfail(rand_selected_front_end_dut, community_table, namespace=asic_namespace)
>       bgp_prefix_tc1_replace(rand_selected_front_end_dut, community, community_table, cli_namespace_prefix,
                               namespace=asic_namespace)

asic_namespace = None
cli_namespace_prefix = ''
community  = 'empty'
community_table = ''
enum_rand_one_frontend_asic_index = None
rand_selected_front_end_dut = 

generic_config_updater/test_bgp_prefix.py:294: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
generic_config_updater/test_bgp_prefix.py:223: in bgp_prefix_tc1_replace
    expect_op_success(duthost, output)
        cli_namespace_prefix = ''
        community  = 'empty'
        community_table = ''
        duthost    = 
        json_patch = [{'op': 'replace', 'path': '/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v6/0', 'value': 'fc01:30::/64'}, {'op': 'replace', 'path': '/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4/0', 'value': '10.30.0.0/16'}]
        namespace  = None
        output     = {'failed': True, 'changed': True, 'stdout': 'Patch Applier: localhost: Patch application starting.\nPatch Applier: loc...XES/BGP_ALLOWED_PREFIXES_LIST[deployment=\'DEPLOYMENT_ID\'][id=\'0\']/prefixes_v4 (line 1)'], '_ansible_no_log': False}
        tmpfile    = '/tmp/tmp.vUekG6W5fs'
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

duthost = 
output = {'failed': True, 'changed': True, 'stdout': 'Patch Applier: localhost: Patch application starting.\nPatch Applier: loc...XES/BGP_ALLOWED_PREFIXES_LIST[deployment=\'DEPLOYMENT_ID\'][id=\'0\']/prefixes_v4 (line 1)'], '_ansible_no_log': False}

    def expect_op_success(duthost, output):
        """Expected success from apply-patch output
        """
>       pytest_assert(not output['rc'], "Command is not running successfully")
E       Failed: Command is not running successfully

duthost    = 
output     = {'failed': True, 'changed': True, 'stdout': 'Patch Applier: localhost: Patch application starting.\nPatch Applier: loc...XES/BGP_ALLOWED_PREFIXES_LIST[deployment=\'DEPLOYMENT_ID\'][id=\'0\']/prefixes_v4 (line 1)'], '_ansible_no_log': False}

common/gu_utils.py:160: Failed
```

Errors in syslog:
2026 Jun  6 14:47:01.385275 r-sn2700-40 ERR bgp#bgpcfgd: BGPAllowListMgr::Received BGP ALLOWED 'SET' message with invalid input[prefixes_v4]:''
2026 Jun  6 14:47:02.392520 r-sn2700-40 ERR bgp#bgpcfgd: BGPAllowListMgr::Received BGP ALLOWED 'SET' message with invalid input[prefixes_v4]:''


### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Update the xfail of test test_bgp_prefix_tc1_suite to track with sonic-buildimage issue
https://github.com/sonic-net/sonic-buildimage/issues/27818
#### How did you do it?
Replace the sonic-mgmt issue with the sonic-buildimage issue
#### How did you verify/test it?
Run the test generic_config_updater/test_bgp_prefix.py::test_bgp_prefix_tc1_suite and verify it's skipped.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A
