### PR TITLE
Fix dualtor_io pmon timeout and KeyError with latest Ansible

### DIFF
--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -588,7 +588,7 @@ class DualTorIO:
         # filter to filter out all the packets destined to the PTF backplane interface.
         output = self.ptfhost.shell('cat /sys/class/net/backplane/address',
                                     module_ignore_errors=True)
-        if not output['failed']:
+        if not output.get('failed', False):
             ptf_bp_mac = output['stdout']
             self.sniff_filter = '({}) and (not ether dst {})'.format(self.sniff_filter, ptf_bp_mac)
 

--- a/tests/common/dualtor/tor_failure_utils.py
+++ b/tests/common/dualtor/tor_failure_utils.py
@@ -164,7 +164,7 @@ def check_mux_feature(duthost):
 
 
 def check_mux_container(duthost):
-    output = duthost.shell("docker inspect -f '{{ '{{' }} .State.Status {{ '}}' }}' mux")['stdout_lines']
+    output = duthost.shell("docker inspect -f '{{ .State.Status }}' mux")['stdout_lines']
     return "running" in str(output)
 
 
@@ -189,7 +189,7 @@ def wait_for_mux_container(duthost):
 
 
 def check_pmon_container(duthost):
-    output = duthost.shell("docker inspect -f '{{ '{{' }} .State.Status {{ '}}' }}' pmon")['stdout_lines']
+    output = duthost.shell("docker inspect -f '{{ .State.Status }}' pmon")['stdout_lines']
     return "running" in str(output)
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->


**Summary:**
These changes are required for the latest Ansible runtime upgrade.

  `dualtor_io/test_tor_failure.py` can fail because the mux/pmon readiness helper relies on nested Jinja escaping inside a Docker Go-template command. With Ansible-core 2.19+, the nested expression can be passed to
  Docker literally, causing Docker template parsing to fail and the pmon readiness polling to time out.

  This PR:
  - Uses the direct Docker Go template `{{ .State.Status }}` when checking mux and pmon container state.
  - Handles successful Ansible shell results that may not include an explicit `failed: false` key by using `output.get("failed", False)`.
  
Fixes #25173 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
`dualtor_io/test_tor_failure.py` failed because the pmon readiness helper timed out even 
though the container check command itself was failing before it could read the container state.

  Affected tests include:

  - `dualtor_io/test_tor_failure.py::test_active_tor_reboot_upstream`
  - `dualtor_io/test_tor_failure.py::test_active_tor_reboot_downstream_standby`
  - `dualtor_io/test_tor_failure.py::test_standby_tor_reboot_upstream`
  - `dualtor_io/test_tor_failure.py::test_standby_tor_reboot_downstream_active`

#### How did you do it?

##### Issue 1

  This failure is related to the Ansible-core 2.19 template trust model change. The 2.19 porting guide notes that Ansible no longer implicitly templates all strings. Because of that, the nested Jinja escape used
  for Docker's Go template can be passed to Docker literally:

  `docker inspect -f '{{ '{{' }} .State.Status {{ '}}' }}' pmon`

  Docker then fails with:

  `template parsing error: template: :1: unexpected "{" in command`

  The fix uses Docker's Go template directly:

  `docker inspect -f '{{ .State.Status }}' pmon`

  The same fix is applied to the mux container readiness check.

  Note: this direct form is intended for Ansible 2.19+. 

##### Issue 2 
Successful Ansible result may not include failed

  tests/common/dualtor/dual_tor_io.py directly accessed:

  output["failed"]

  With the newer Ansible runtime, a successful module result may omit the failed key. This can cause KeyError.

  The fix safely reads the value with a default:

  output.get("failed", False)

  Example newer Ansible result where failed is missing:

 ```
 {
    "changed": false,
    "commands": ["router bgp 64600", "graceful-restart restart-time 300"],
    "updates": ["router bgp 64600", "graceful-restart restart-time 300"],
    "session": "ansible_178088953263"
  }

```
  Earlier Ansible shell results included:

 ```
 {
    "changed": true,
    "stdout": "running",
    "rc": 0,
    "failed": false
  }
```

 
#### How did you verify/test it?
Ran  dualtor_io/test_tor_failure.py and it passed  on dualtor 

#### Any platform specific information?
N/A 

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A