### PR TITLE
Wait for vtysh readiness before issuing show ip bgp queries to avoid forever-hang on freshly-restarted bgpd

### DIFF
--- a/ansible/library/bgp_facts.py
+++ b/ansible/library/bgp_facts.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 from ansible.module_utils.basic import AnsibleModule
 import re
+import time
 
 DOCUMENTATION = '''
 module:         bgp_facts
@@ -98,19 +99,36 @@ class BgpModule(object):
         """
             Collect bgp information by reading output of 'vtysh' command line tool
         """
-        docker_cmd = 'docker exec -i {} vtysh -c "show ip bgp {}" '.format(
-            instance, command_str)
-        try:
-            rc, self.out, err = self.module.run_command(
-                docker_cmd, executable='/bin/bash', use_unsafe_shell=True)
-        except Exception as e:
-            self.module.fail_json(msg=str(e))
+        deadline = time.time() + 120
+        interval = 2
+        last_rc, last_err = None, ''
+        while True:
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                break
+            per_call = min(20, max(5, int(remaining)))
+            docker_cmd = 'timeout -k 5 {t} docker exec -i {inst} vtysh -c "show ip bgp {cmd}" '.format(
+                t=per_call, inst=instance, cmd=command_str)
+            try:
+                rc, self.out, err = self.module.run_command(
+                    docker_cmd, executable='/bin/bash', use_unsafe_shell=True)
+            except Exception as e:
+                self.module.fail_json(msg=str(e))
 
-        if rc != 0:
-            self.module.fail_json(msg="Command failed rc=%d, out=%s, err=%s" %
-                                      (rc, self.out, err))
+            if rc == 0:
+                return
+            last_rc, last_err = rc, err
 
-        return
+            sleep_for = min(interval, max(0, deadline - time.time()))
+            if sleep_for <= 0:
+                break
+            time.sleep(sleep_for)
+            interval = min(interval * 2, 10)
+
+        self.module.fail_json(
+            msg="bgp_facts: 'show ip bgp %s' in container '%s' did not succeed within 120s "
+                "(last rc=%s, err=%r); caller should retry" % (
+                    command_str, instance, last_rc, last_err))
 
     def parse_summary(self):
         regex_asn = re.compile(r'.*local AS number (\d+).*')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Summary:
 ansible/library/bgp_facts.py could hang indefinitely when called against a DUT whose bgp container had just restarted (or was otherwise slow to bring vtysh up). supervisord reports bgpd RUNNING the moment the binary launches, but bgpd may still be parsing config, opening its vty socket, or rebuilding peer FSMs. Issuing the real vtysh -c "show ip bgp ..." inside that window blocks on the vty socket with no internal timeout, so module.run_command(...) never returns. This burns the caller's entire wait_until budget (e.g. 360s in check_bgp_session_state_all_asics) in a single un-cancellable call. The only thing that eventually releases the call is the SSH transport's idle timeout (~11 min on elastictest), at which point the test fails far past its budget.

This PR adds a exponential backoff retry mechanism to the existing function. 

Symptom Logs: 
```
supervisorctl status", "docker exec swss supervisorctl status", "docker exec syncd supervisorctl status", "docker exec teamd supervisorctl status"], "continue_on_fail": true, "timeout": 60}}, "changed": false, "exception": "(traceback unavailable)", "_ansible_no_log": false}
10/06/2026 17:19:51 utilities.wait_until                     L0162 DEBUG  | check_all_critical_processes_status is True, exit early with True
10/06/2026 17:19:51 utilities.wait_until                     L0137 DEBUG  | Wait until check_bgp_session_state_all_asics is True, timeout is 360 seconds, checking interval is 1, delay is 0 seconds
10/06/2026 17:19:51 utilities.wait_until                     L0147 DEBUG  | Time elapsed: 0.000000 seconds
10/06/2026 17:19:51 base._run                                L0177 DEBUG  | /var/src/sonic-mgmt/tests/common/devices/base.py::_run_wrapper#163: [vlab-03] AnsibleModule::bgp_facts, args=[], kwargs={}
10/06/2026 17:31:59 transport._log                           L1938 DEBUG  | EOF in transport thread
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

bgp_facts() is called by 42 test files plus shared infrastructure used by every test run, including:

Every one of these calls bgp_facts() right after an event that creates the FRR-readiness race window (reboot, config_reload, container restart, sanity recovery). All of them are exposed to the same hang — we just happen to have caught it in test_container_autorestart because it kills containers deliberately
#### How did you do it?
```python
deadline = time.time() + 120
interval = 2
while time.time() < deadline:
    rc, out, err = run_command(
        f'timeout -k 5 {per_call} docker exec -i {instance} '
        f'vtysh -c "show ip bgp {command_str}"'
    )
    if rc == 0:
        return
    time.sleep(min(interval, deadline - time.time()))
    interval = min(interval * 2, 10)
fail_json(msg="...did not succeed within 120s; caller should retry")
```

#### How did you verify/test it?
 End-to-end verification on vlab-03 (KVM testbed) using ansible -i veos_vtb vlab-03 -m bgp_facts, covering all four meaningful states:

 Scenario 1 — healthy bgpd (happy path)
```
   $ time ansible -i veos_vtb vlab-03 -m bgp_facts -a num_npus=1 ...
   vlab-03 | SUCCESS => {
       "bgp_statistics": {
           "ipv4": 24,
           "ipv4_admin_down": 0,
           "ipv4_idle": 0,
           "ipv6": 24,
           ...
       }
   }
   real    0m1.857s
1.857s — probe passes first try, full 24 IPv4 + 24 IPv6 peers returned.
```
 Scenario 2 — vtysh hung (SIGSTOP bgpd)
```
   $ sudo docker exec bgp kill -SIGSTOP 61   # freeze bgpd
   $ time ansible -i veos_vtb vlab-03 -m bgp_facts ...
   vlab-03 | FAILED! => {
       "msg": "bgp_facts: vtysh in container 'bgp' not responsive within 120s
               (last probe rc=124, err=''); bgpd likely still initialising,
               caller should retry"
   }
   real    2m16.437s

Clean 2m16s failure with retryable message (was: forever-hang until SSH timeout ~11 min).
```
 Scenario 3 — recovery (SIGCONT bgpd)
```
   $ sudo docker exec bgp kill -SIGCONT 61
   $ time ansible -i veos_vtb vlab-03 -m bgp_facts ...
   vlab-03 | SUCCESS => { ... }
   real    0m4.988s
4.988s — probe loop detects readiness within one backoff cycle, real query runs.
```
#### Any platform specific information?
 N/A
#### Supported testbed topology if it's a new test case?
 N/A
### Documentation
 N/A
