### PR TITLE
Fix BGP GR KeyError on missing failed result key

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -40,7 +40,7 @@ def check_results(results):
     """
     failed_results = {}
     for node_name, node_results in list(results.items()):
-        failed_node_results = [res for res in node_results if res['failed']]
+        failed_node_results = [res for res in node_results if res.get('failed', False)]
         if len(failed_node_results) > 0:
             failed_results[node_name] = failed_node_results
     if failed_results:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

**Summary:**
 BGP GR setup configures EOS neighbors in parallel and then checks each returned module result for failures. The helper currently uses direct indexing:

`  res['failed']`

  With newer Ansible 2.19+ callback/result handling, successful results can omit failed: false. The result is still successful, but direct indexing raises:
`  KeyError: 'failed'`

  This PR treats a missing failed key as success by using:
`res.get('failed', False)`


Fixes #25305

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

BGP GR tests fail during setup before reaching the actual BGP GR validation. The setup helper assumes every Ansible result includes a failed key, but newer Ansible callback/result handling can omit failed: false
  for successful eos_config results.

  Affected tests:

1.   bgp/test_bgp_gr_helper.py::test_bgp_gr_helper_routes_perserved
2.   bgp/test_bgp_gr_suppress_fib.py::test_bgp_gr_with_suppress_fib


#### How did you do it?
Changed tests/bgp/conftest.py from:

  res['failed']

  to:

  res.get('failed', False)

#### How did you verify/test it?
Ran the failed tests and they passed:

1.   bgp/test_bgp_gr_helper.py::test_bgp_gr_helper_routes_perserved
2.   bgp/test_bgp_gr_suppress_fib.py::test_bgp_gr_with_suppress_fib

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A