### PR TITLE
[cisco] [fanout] New implementation for Cisco fanout config deployment automation filtering, lane breakout, and dshell_client retry

### DIFF
--- a/ansible/roles/fanout/files/cisco/cisco_fanout_traps_clear.py
+++ b/ansible/roles/fanout/files/cisco/cisco_fanout_traps_clear.py
@@ -46,37 +46,57 @@ except Exception as e:
     sys.exit(1)
 """
 
-
 def start_dshell_client():
     """
     Starts the dshell_client service inside the syncd container.
-    Exits the script if this fails.
+    Retries if the syncd container's supervisor is not ready yet.
+    Exits the script if it cannot start after all retries.
     """
     print("Attempting to start dshell_client service...")
     cmd = ["docker", "exec", "syncd", "supervisorctl", "start", "dshell_client"]
 
-    try:
-        # Run command with a timeout to prevent hanging
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    max_retries = 18
+    retry_interval = 10
 
-        # Check return code
-        if result.returncode != 0:
+    for attempt in range(1, max_retries + 1):
+        try:
+            # Run command with a timeout to prevent hanging
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+
+            # Check return code
+            if result.returncode == 0:
+                print("dshell_client started successfully.")
+                return
+
             # Check if it failed because it is already running (supervisor specific)
             if "already started" in result.stdout or "already started" in result.stderr:
                 print("dshell_client is already running.")
                 return
 
+            # Supervisor socket not ready — transient error, retry
+            if "no such file" in result.stdout or "no such file" in result.stderr:
+                print(f"Attempt {attempt}/{max_retries}: syncd supervisor not ready yet. "
+                      f"Retrying in {retry_interval}s...")
+                time.sleep(retry_interval)
+                continue
+
+            # Unexpected error — fail immediately
             print(f"CRITICAL: Failed to start dshell_client. Return Code: {result.returncode}")
             print(f"Stdout: {result.stdout}")
             print(f"Stderr: {result.stderr}")
             sys.exit(1)
-        else:
-            print("dshell_client started successfully.")
 
-    except Exception as e:
-        print(f"CRITICAL: Execution error while starting dshell_client: {e}")
-        sys.exit(1)
+        except subprocess.TimeoutExpired:
+            print(f"Attempt {attempt}/{max_retries}: Command timed out. "
+                  f"Retrying in {retry_interval}s...")
+            time.sleep(retry_interval)
 
+        except Exception as e:
+            print(f"CRITICAL: Execution error while starting dshell_client: {e}")
+            sys.exit(1)
+
+    print("CRITICAL: Failed to start dshell_client after all retries.")
+    sys.exit(1)
 
 def attempt_trap_clear():
     # Strip empty lines and append quit()
@@ -105,11 +125,10 @@ def attempt_trap_clear():
         print(f"Execution error: {e}")
         return False
 
-
 def main():
     print("Starting Cisco 8102 Trap Clear Sequence...")
 
-    # 1. Start the service ONCE. Fail if it doesn't start.
+    # 1. Start dshell_client (retries until syncd supervisor is ready).
     start_dshell_client()
 
     # 2. Retry loop for SDK initialization (trap clearing)
@@ -125,7 +144,6 @@ def main():
 
     print("Timeout: Failed to clear traps after 10 minutes.")
     sys.exit(1)
-
 
 if __name__ == "__main__":
     main()

--- a/ansible/roles/fanout/tasks/cisco/fanout_sonic_cisco_minimal.yml
+++ b/ansible/roles/fanout/tasks/cisco/fanout_sonic_cisco_minimal.yml
@@ -5,7 +5,24 @@
     local_conn: "{{ device_conn[inventory_hostname] }}"
     local_hwsku: "{{ device_info[inventory_hostname]['HwSku'] }}"
 
-- name: Backup and remove current /etc/sonic/config_db.json
+- name: Set TPID configuration filters
+  set_fact:
+    # HwSKUs where TPID should be disabled (expandable list)
+    tpid_excluded_hwskus: "{{ tpid_excluded_hwskus | default([]) }}"
+    # Topologies where TPID should be disabled (expandable list)
+    tpid_excluded_topologies: "{{ tpid_excluded_topologies | default(['t2', 't2_2lc_min_ports-masic']) }}"
+    # Current topology name (passed from playbook or empty)
+    current_topo: "{{ topo_name | default('') | lower }}"
+
+- name: Determine if TPID should be enabled
+  set_fact:
+    tpid_enabled: >-
+      {{
+        (local_hwsku not in tpid_excluded_hwskus) and
+        (current_topo not in tpid_excluded_topologies)
+      }}
+
+- name: Backup current /etc/sonic/config_db.json
   shell: |
     if [ -f /etc/sonic/config_db.json ]; then
       mv /etc/sonic/config_db.json /etc/sonic/config_db.json_before_reset
@@ -13,7 +30,11 @@
   become: yes
   ignore_errors: yes
 
-- name: Reload configuration to generate default config_db.json from init_cfg.json
+- name: Generate clean default config_db.json based on HwSku
+  shell: sonic-cfggen -H -k {{ local_hwsku }} --print-data > /etc/sonic/config_db.json
+  become: yes
+
+- name: Reload configuration to flush old Redis DB and load clean config
   shell: config reload -y -f
   become: yes
   async: 600
@@ -39,6 +60,7 @@
     device_vlan_list: "{{ local_vlan_list }}"
     device_port_vlans: "{{ local_port_vlans }}"
     device_conn: "{{ local_conn }}"
+    tpid_enabled: "{{ tpid_enabled }}"
 
 - name: Apply minimal configuration to /etc/sonic/config_db.json
   shell: sonic-cfggen -j /tmp/cisco_minimal_config.json --write-to-db

--- a/ansible/roles/fanout/templates/sonic_deploy_cisco_minimal.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_cisco_minimal.j2
@@ -51,12 +51,26 @@
             {% if port_conf.speed == '100000' and lanes_list|length == 8 -%}
             "lanes": "{{ lanes_list[:4] | join(',') }}",
             "fec": "rs",
+            {# Logic: If 40G is requested on an 8-lane port, slice to 4 lanes and set no FEC #}
+            {% elif port_conf.speed == '40000' and lanes_list|length == 8 -%}
+            "lanes": "{{ lanes_list[:4] | join(',') }}",
+            {# Logic: If 10G is requested on a 4-lane port, slice to 1 lane (e.g. QSFP+ with 10G NIC) #}
+            {% elif port_conf.speed == '10000' and lanes_list|length == 4 -%}
+            "lanes": "{{ lanes_list[:1] | join(',') }}",
             {% else -%}
             "lanes": "{{ port_conf.lanes }}",
             {% endif -%}
             {% if 'peerdevice' in port_conf -%}
             "admin_status": "up",
             "description": "{{ port_conf.peerdevice }}{% if 'peerport' in port_conf %}:{{ port_conf.peerport }}{% endif %}",
+            {# TPID Configuration:
+               - Controlled by tpid_enabled (HwSKU and topology filtering from task)
+               - Only enabled for Access mode ports (DUT-facing connections)
+               - Disabled for Trunk mode ports (UCS/Server-facing connections)
+            #}
+            {% if tpid_enabled | default(true) and port_name in device_port_vlans and device_port_vlans[port_name].mode | lower == 'access' -%}
+            "tpid": "0x9100",
+            {% endif -%}
             {% else -%}
             "admin_status": "down",
             {% endif -%}


### PR DESCRIPTION
**DEPENDS ON:** [[master] [cisco] [fanout] New implementation for Cisco fanout config deployment automation
#22914](https://github.com/sonic-net/sonic-mgmt/pull/22914)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
- Generate clean config_db.json using `sonic-cfggen -H -k <HwSku>` instead of relying on init_cfg.json
- Update config reload to properly flush Redis DB with clean config (`config reload -y -f`)
- Add 40G support for 8-lane ports by slicing to 4 lanes (matching 100G behavior)
- Add 10G single-lane breakout for 4-lane QSFP+ ports (slice to 1 lane for 10G NIC connections)
- Enable TPID (`0x9100`) only for Access mode ports (DUT-facing connections)
- Disable TPID for Trunk mode ports (UCS/Server-facing connections)
- Add `tpid_excluded_hwskus` filter (expandable list, default empty)
- Add `tpid_excluded_topologies` filter (defaults to `t2`, `t2_2lc_min_ports-masic`)
- Pass `tpid_enabled` flag from task to template based on HwSKU and topology filtering
- Add retry logic for `dshell_client` startup to handle `syncd` supervisor readiness delays (up to 18 retries × 10s)

Fixes for https://miggbo.atlassian.net/browse/MIGSOFTWAR-37182

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

Cisco SONiC fanout deployment had several issues:
1. **Stale config**: Relying on `init_cfg.json` left stale entries in `config_db.json`, causing port and VLAN misconfigurations after deployment. Generating a clean config from the HwSku via `sonic-cfggen` ensures a deterministic baseline.
2. **Incorrect lane mapping**: 8-lane ports (e.g., OSFP) running at 100G or 40G must be sliced to 4 lanes to match the ASIC's expected lane count. Similarly, 4-lane QSFP+ ports running at 10G need to be sliced to a single lane.
3. **TPID misconfiguration**: Setting TPID `0x9100` on trunk (server-facing) ports caused QinQ tagging issues. TPID should only be applied to access (DUT-facing) ports, and should be excluded entirely for certain HwSKUs and topologies (e.g., T2).
4. **dshell_client race condition**: After config reload, the `syncd` supervisor socket may not be immediately available, causing `dshell_client` startup to fail. The trap-clear service now retries until the supervisor is ready.

#### How did you do it?

- **[fanout_sonic_cisco_minimal.yml](cci:7://file:///c:/Users/vhlushko/dev/src/sonic-test/sonic-mgmt/ansible/roles/fanout/tasks/cisco/fanout_sonic_cisco_minimal.yml:0:0-0:0)**: Added `sonic-cfggen -H -k` for clean config generation, TPID filtering logic with `tpid_excluded_hwskus` / `tpid_excluded_topologies` facts, and passes `tpid_enabled` to the template.
- **[sonic_deploy_cisco_minimal.j2](cci:7://file:///c:/Users/vhlushko/dev/src/sonic-test/sonic-mgmt/ansible/roles/fanout/templates/sonic_deploy_cisco_minimal.j2:0:0-0:0)**: Added Jinja2 lane-slicing logic for 100G/8-lane → 4-lane, 40G/8-lane → 4-lane, and 10G/4-lane → 1-lane breakout. TPID is conditionally rendered only when `tpid_enabled` is true and the port is in Access mode.
- **[cisco_fanout_traps_clear.py](cci:7://file:///c:/Users/vhlushko/dev/src/sonic-test/sonic-mgmt/ansible/roles/fanout/files/cisco/cisco_fanout_traps_clear.py:0:0-0:0)**: Refactored [start_dshell_client()](cci:1://file:///c:/Users/vhlushko/dev/src/sonic-test/sonic-mgmt/ansible/roles/fanout/files/cisco/cisco_fanout_traps_clear.py:48:0-98:15) with a retry loop (18 attempts × 10s) that handles supervisor socket unavailability (`"no such file"`), already-running state, timeouts, and unexpected errors.

#### How did you verify/test it?

- Deployed on Cisco 8102 (Silicon One) fanout switches with both 100G and 40G connected DUTs across multiple topologies (t0, t1, t2).
- Verified clean config_db.json generation produces correct PORT entries with proper lane counts.
- Confirmed TPID is set only on access ports and excluded on trunk ports and T2 topologies.
- Validated dshell_client starts reliably after config reload with syncd restart.
- Confirmed trap-clear service completes successfully with both old (< 1.66) and new (≥ 1.66) SDK constant naming.

#### Any platform specific information?

- Applies to **Cisco Silicon One** platforms (e.g., Cisco-8102-C64) running SONiC as fanout.
- The `dshell_client` and trap-clear logic is skipped for **Cisco VPP/Octeon** platforms (e.g., Cisco-C8220TG) via the existing `when` guard.
- 10G single-lane breakout targets **QSFP+** ports connected to 10G NICs.

#### Supported testbed topology if it's a new test case?

N/A — this is a fanout infrastructure fix, not a new test case. Applicable to any topology using Cisco SONiC fanout switches (t0, t1, t2, etc.).

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

No external documentation changes required. Inline comments in the task, template, and Python files document the new behavior and filtering logic.