### PR TITLE
[qos] Enable test_qos_dscp_mapping on T1 downstream-only topologies

### DIFF
--- a/tests/qos/qos_helpers.py
+++ b/tests/qos/qos_helpers.py
@@ -404,6 +404,37 @@ def get_upstream_exabgp_port(nbrhosts, tbinfo, exabgp_base_port):
     return [_ + exabgp_base_port for _ in port_offset_list]
 
 
+def get_downstream_vm_offset(nbrhosts, tbinfo):
+    """
+    Get ports offset of exabgp port for the downstream tier.
+
+    Used as a fallback "remote side" on topologies that have no upstream tier
+    (e.g. an isolated T1 where the DUT only has downstream T0 neighbors).
+    """
+    port_offset_list = []
+    if 't1' in tbinfo['topo']['type']:
+        vm_filter = 'T0'
+    else:
+        # t0 (and others) have no BGP-speaking downstream tier to use as remote side
+        return port_offset_list
+    vm_name_list = [vm_name for vm_name in nbrhosts.keys() if vm_name.endswith(vm_filter)]
+    for vm_name in vm_name_list:
+        if nbrhosts[vm_name].get('is_multi_vrf_peer', False):
+            port_offset = nbrhosts[vm_name]['multi_vrf_data']['vm_offset_mapping']
+        else:
+            port_offset = tbinfo['topo']['properties']['topology']['VMs'][vm_name]['vm_offset']
+        port_offset_list.append((port_offset))
+    return port_offset_list
+
+
+def get_downstream_exabgp_port(nbrhosts, tbinfo, exabgp_base_port):
+    """
+    Get exabgp ports for the downstream tier (fallback remote side).
+    """
+    port_offset_list = get_downstream_vm_offset(nbrhosts, tbinfo)
+    return [_ + exabgp_base_port for _ in port_offset_list]
+
+
 def install_route_from_exabgp(operation, ptfip, route, port):
     """
     Install or withdraw ip route by exabgp

--- a/tests/qos/qos_helpers.py
+++ b/tests/qos/qos_helpers.py
@@ -407,9 +407,7 @@ def get_upstream_exabgp_port(nbrhosts, tbinfo, exabgp_base_port):
 def get_downstream_vm_offset(nbrhosts, tbinfo):
     """
     Get ports offset of exabgp port for the downstream tier.
-
-    Used as a fallback "remote side" on topologies that have no upstream tier
-    (e.g. an isolated T1 where the DUT only has downstream T0 neighbors).
+    Used as a fallback on topologies that have no upstream tier
     """
     port_offset_list = []
     if 't1' in tbinfo['topo']['type']:
@@ -429,7 +427,7 @@ def get_downstream_vm_offset(nbrhosts, tbinfo):
 
 def get_downstream_exabgp_port(nbrhosts, tbinfo, exabgp_base_port):
     """
-    Get exabgp ports for the downstream tier (fallback remote side).
+    Get exabgp ports for the downstream tier.
     """
     port_offset_list = get_downstream_vm_offset(nbrhosts, tbinfo)
     return [_ + exabgp_base_port for _ in port_offset_list]

--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -16,7 +16,8 @@ from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_port
 from tests.common.helpers.ptf_tests_helper import downstream_links, upstream_links, select_random_link, \
     get_stream_ptf_ports, get_dut_pair_port_from_ptf_port, apply_dscp_cfg_setup, apply_dscp_cfg_teardown  # noqa F401
 from tests.common.utilities import get_ipv4_loopback_ip, get_dscp_to_queue_value, find_egress_queue, \
-    get_egress_queue_pkt_count_all_port_prio, wait_until, get_vlan_from_port
+    get_egress_queue_pkt_count_all_port_prio, wait_until, get_vlan_from_port, \
+    get_day_of_week_distributed_ports_from_buckets
 from tests.common.helpers.assertions import pytest_assert
 from tests.qos.qos_helpers import get_upstream_exabgp_port, get_downstream_exabgp_port, announce_route
 from tests.common.fixtures.duthost_utils import dut_qos_maps_module  # noqa F401
@@ -68,12 +69,12 @@ def route_config(nbrhosts, tbinfo):
                                                       exabgp_base_port=BASE_EXABGP_PORT)
         # downstream_vm_names[i] corresponds to exabgp_port_list[i].
         downstream_vm_names = [vm_name for vm_name in nbrhosts.keys() if vm_name.endswith('T0')]
-        # Use a fixed number of downstream neighbors as the remote side. This count
-        # becomes step in the test's range(0, 64, step) loop, so
-        # MAX_DOWNSTREAM_REMOTE_RECEIVERS is a divisor of 64 to keep every DSCP value
-        # covered exactly once with no value > 63 generated.
-        exabgp_port_list = exabgp_port_list[:MAX_DOWNSTREAM_REMOTE_RECEIVERS]
-        remote_vm_names = downstream_vm_names[:MAX_DOWNSTREAM_REMOTE_RECEIVERS]
+        # Select a fixed number of downstream neighbors as the remote side
+        paired_ports = list(zip(exabgp_port_list, downstream_vm_names))
+        selected_pairs = get_day_of_week_distributed_ports_from_buckets(
+            paired_ports, MAX_DOWNSTREAM_REMOTE_RECEIVERS)
+        exabgp_port_list = [port for port, _ in selected_pairs]
+        remote_vm_names = [name for _, name in selected_pairs]
 
     if not exabgp_port_list:
         pytest.skip("No BGP-speaking remote neighbors available to announce inner routes from")

--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -18,7 +18,7 @@ from tests.common.helpers.ptf_tests_helper import downstream_links, upstream_lin
 from tests.common.utilities import get_ipv4_loopback_ip, get_dscp_to_queue_value, find_egress_queue, \
     get_egress_queue_pkt_count_all_port_prio, wait_until, get_vlan_from_port
 from tests.common.helpers.assertions import pytest_assert
-from tests.qos.qos_helpers import get_upstream_exabgp_port, announce_route
+from tests.qos.qos_helpers import get_upstream_exabgp_port, get_downstream_exabgp_port, announce_route
 from tests.common.fixtures.duthost_utils import dut_qos_maps_module  # noqa F401
 
 logger = logging.getLogger(__name__)
@@ -33,6 +33,7 @@ DEFAULT_TTL = 64
 DEFAULT_ECN = 1
 DEFAULT_PKT_COUNT = 500
 BASE_EXABGP_PORT = 5000
+MAX_DOWNSTREAM_REMOTE_RECEIVERS = 4
 WITHDRAW = 'withdraw'
 ANNOUNCE = 'announce'
 DUMMY_OUTER_SRC_IP = '8.8.8.8'
@@ -55,25 +56,48 @@ def completeness_level(pytestconfig):
 @pytest.fixture(scope='module')
 def route_config(nbrhosts, tbinfo):
     ptf_ip = tbinfo['ptf_ip']
-    upstream_exabgp_port_list = get_upstream_exabgp_port(nbrhosts=nbrhosts,
-                                                         tbinfo=tbinfo,
-                                                         exabgp_base_port=BASE_EXABGP_PORT)
-    upstream_vm_num = len(upstream_exabgp_port_list)
-    inner_dst_ip_list = [INNER_DST_IP_PREFIX + str(i + 1) for i in range(upstream_vm_num)]
+    remote_side = "upstream"
+    remote_vm_names = []
+    exabgp_port_list = get_upstream_exabgp_port(
+        nbrhosts=nbrhosts, tbinfo=tbinfo, exabgp_base_port=BASE_EXABGP_PORT)
+    # When the DUT has no upstream tier fall back to using the downstream neighbors as the remote side.
+    if not exabgp_port_list:
+        remote_side = "downstream"
+        exabgp_port_list = get_downstream_exabgp_port(nbrhosts=nbrhosts,
+                                                      tbinfo=tbinfo,
+                                                      exabgp_base_port=BASE_EXABGP_PORT)
+        # downstream_vm_names[i] corresponds to exabgp_port_list[i].
+        downstream_vm_names = [vm_name for vm_name in nbrhosts.keys() if vm_name.endswith('T0')]
+        # Use a fixed number of downstream neighbors as the remote side. This count
+        # becomes step in the test's range(0, 64, step) loop, so
+        # MAX_DOWNSTREAM_REMOTE_RECEIVERS is a divisor of 64 to keep every DSCP value
+        # covered exactly once with no value > 63 generated.
+        exabgp_port_list = exabgp_port_list[:MAX_DOWNSTREAM_REMOTE_RECEIVERS]
+        remote_vm_names = downstream_vm_names[:MAX_DOWNSTREAM_REMOTE_RECEIVERS]
 
-    for i in range(upstream_vm_num):
-        logger.info(f"{ANNOUNCE} {inner_dst_ip_list[i] + '/32'} from upstream VMs")
+    if not exabgp_port_list:
+        pytest.skip("No BGP-speaking remote neighbors available to announce inner routes from")
+
+    remote_vm_num = len(exabgp_port_list)
+    inner_dst_ip_list = [INNER_DST_IP_PREFIX + str(i + 1) for i in range(remote_vm_num)]
+
+    for i in range(remote_vm_num):
+        logger.info(f"{ANNOUNCE} {inner_dst_ip_list[i] + '/32'} from {remote_side} VMs")
         announce_route(ptfip=ptf_ip,
                        route=inner_dst_ip_list[i] + '/32',
-                       port=upstream_exabgp_port_list[i])
+                       port=exabgp_port_list[i])
 
-    yield inner_dst_ip_list
+    yield {
+        "inner_dst_ip_list": inner_dst_ip_list,
+        "remote_side": remote_side,
+        "remote_vm_names": remote_vm_names,
+    }
 
-    for i in range(upstream_vm_num):
-        logger.info(f"{WITHDRAW} {inner_dst_ip_list[i] + '/32'} from upstream VMs")
+    for i in range(remote_vm_num):
+        logger.info(f"{WITHDRAW} {inner_dst_ip_list[i] + '/32'} from {remote_side} VMs")
         announce_route(ptfip=ptf_ip,
                        route=inner_dst_ip_list[i] + '/32',
-                       port=upstream_exabgp_port_list[i],
+                       port=exabgp_port_list[i],
                        action=WITHDRAW)
 
 
@@ -140,8 +164,8 @@ def dscp_config_pipe(rand_selected_dut, loganalyzer):
     if asic_type != 'broadcom':
         # TODO: Remove this skip for other vendors/platforms that want to validate
         # pipe mode DSCP preservation without queue mapping verification.
-        pytest.skip(f"{asic_type} pipe mode DSCP-only check not needed:"
-                    " covered by test_dscp_to_queue_mapping[pipe]")
+        pytest.skip(f"{asic_type} pipe mode DSCP-only check not needed: "
+                    "covered by test_dscp_to_queue_mapping[pipe]")
 
     apply_dscp_cfg_setup(duthost, "pipe", loganalyzer)
     yield
@@ -278,6 +302,8 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
                            tbinfo,
                            downstream_links,  # noqa F811
                            upstream_links,  # noqa F811
+                           remote_side="upstream",
+                           remote_vm_names=None
                            ):
         """
         Set up test parameters for the DSCP to Queue mapping test for IP-IP packets.
@@ -289,13 +315,30 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
             duthost (fixture): DUT fixture
             downstream_links (fixture): Dictionary of downstream links info for DUT
             upstream_links (fixture): Dictionary of upstream links info for DUT
+            remote_side (str): "upstream" (canonical) or "downstream" (isolated T1 fallback).
+                Selects which neighbor tier provides the egress ports to verify.
+            remote_vm_names (list): For the downstream fallback, the names of the downstream
+                neighbors that announced the inner routes (used as egress, kept disjoint from
+                the injection source).
         """
-        links = {**downstream_links, **upstream_links}
+        remote_vm_names = remote_vm_names or []
 
         loopback_ip = get_ipv4_loopback_ip(duthost)
         pytest_assert(loopback_ip is not None, "No loopback IP found")
 
-        src_link = select_random_link(links)
+        if remote_side == "downstream":
+            egress_links = {intf: link for intf, link in downstream_links.items()
+                            if link.get("name") in remote_vm_names}
+            source_links = {intf: link for intf, link in downstream_links.items()
+                            if link.get("name") not in remote_vm_names}
+            pytest_assert(egress_links,
+                          "No downstream egress links found for remote VMs {}".format(remote_vm_names))
+            pytest_assert(source_links,
+                          "No downstream link available as an injection source disjoint from egress")
+            src_link = select_random_link(source_links)
+        else:
+            egress_links = {**downstream_links, **upstream_links}
+            src_link = select_random_link(egress_links)
         pytest_assert(src_link is not None, "src_link is None")
 
         ptf_src_port_id = src_link.get("ptf_port_id")
@@ -316,7 +359,7 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
 
         pytest_assert(dst_mac is not None, "No router/vlan MAC found")
 
-        ptf_dst_port_ids = get_stream_ptf_ports(links)
+        ptf_dst_port_ids = get_stream_ptf_ports(egress_links)
         pytest_assert(ptf_dst_port_ids, f"ptf_dst_port_ids is {ptf_dst_port_ids}")
 
         if ptf_src_port_id in ptf_dst_port_ids:
@@ -380,7 +423,7 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
             pytest_assert(dscp_mode == real_dscp_mode, "Wrong DSCP mode configured")
 
         def check_ip_route(duthost, step):
-            ip_route_list = [f"{INNER_DST_IP_PREFIX}{i}/32" for i in range(1, step)]
+            ip_route_list = [f"{INNER_DST_IP_PREFIX}{i}/32" for i in range(1, step + 1)]
             for route in ip_route_list:
                 output = duthost.shell(f"show ip route {route}")["stdout"]
                 if route not in output:
@@ -537,10 +580,13 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
             Test QoS SAI DSCP to queue mapping for IP-IP packets in DSCP "uniform" and "pipe" mode
         """
         duthost = rand_selected_dut
-        inner_dst_ip_list = route_config
+        inner_dst_ip_list = route_config["inner_dst_ip_list"]
+        remote_side = route_config["remote_side"]
+        remote_vm_names = route_config["remote_vm_names"]
 
         with allure.step("Prepare test parameter"):
-            test_params = self._setup_test_params(duthost, tbinfo, downstream_links, upstream_links)
+            test_params = self._setup_test_params(duthost, tbinfo, downstream_links, upstream_links,
+                                                  remote_side=remote_side, remote_vm_names=remote_vm_names)
 
         with allure.step("Run test"):
             self._run_test(ptfadapter, duthost, tbinfo, test_params, inner_dst_ip_list, dut_qos_maps_module, dscp_mode)
@@ -585,11 +631,14 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
         if asic_type == 'vs':
             pytest.skip("Skipping DSCP preservation check for VS platform")
 
-        inner_dst_ip_list = route_config
+        inner_dst_ip_list = route_config["inner_dst_ip_list"]
+        remote_side = route_config["remote_side"]
+        remote_vm_names = route_config["remote_vm_names"]
         step = len(inner_dst_ip_list)
 
         with allure.step("Prepare test parameters"):
-            test_params = self._setup_test_params(duthost, tbinfo, downstream_links, upstream_links)
+            test_params = self._setup_test_params(duthost, tbinfo, downstream_links, upstream_links,
+                                                  remote_side=remote_side, remote_vm_names=remote_vm_names)
 
         dst_mac = test_params['dst_mac']
         ptf_src_port_id = test_params['ptf_src_port_id']
@@ -660,7 +709,7 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
                         logger.info(f"SUCCESS: Inner DSCP {cur_dscp} preserved in decapsulated packet")
                         output_table.append([cur_dscp, "SUCCESS - DSCP PRESERVED"])
                     else:
-                        logger.info(f"FAILURE: Inner DSCP {cur_dscp} not found in decapsulated packet")
+                        logger.info(f"FAILURE: Inner DSCP {cur_dscp} missing from decapsulated packet")
                         output_table.append([cur_dscp, "FAILURE - DSCP NOT PRESERVED"])
                         failed_once = True
 


### PR DESCRIPTION
### Description of PR

Summary:
Enables `qos/test_qos_dscp_mapping.py` to run on T1 topologies (e.g. `t1-isolated-d32`, `t1-isolated-d128`, `t1-isolated-v6-d128`) where the DUT has only downstream T0 neighbors and no upstream T2 tier.

The test is marked `topology('t0', 't1')`, so it is selected on isolated T1, but its traffic-path setup was hard-wired to the **upstream** tier. On an isolated T1 there are no upstream VMs, so `route_config` produced an empty `inner_dst_ip_list`, `step` became `0`, and the test hard-crashed during preparation:

```
File "tests/qos/test_qos_dscp_mapping.py", in _run_test
    for rotating_dscp in range(0, 64, step):
ValueError: range() arg 3 must not be zero
```

This PR generalizes the test's notion of a "remote side" (the neighbor tier used to announce inner-destination routes and to verify egress queues) so that it falls back to the **downstream T0** neighbors when no upstream tier exists. IP-in-IP decap matches on `outer-dst == loopback` regardless of ingress port, and DSCP->TC->queue is a per-egress-port property, so a `down -> DUT -> down` path is a valid way to exercise the same mapping.

Fixes # (link the isolated-T1 enablement issue/work item)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Provide IP-in-IP DSCP -> queue mapping coverage on isolated-T1 testbeds, which were previously unrunnable for this test (it crashed with `ValueError` instead of testing or skipping cleanly). The fix must not regress the canonical T0 and T1-with-T2 paths.

#### How did you do it?
- `tests/qos/qos_helpers.py`: added `get_downstream_vm_offset()` and `get_downstream_exabgp_port()`, mirroring the existing upstream helpers but filtering downstream `T0` neighbors on a `t1` DUT.
- `route_config` is now topology-aware: it tries the upstream tier first and, only when it is empty, falls back to the downstream tier. It yields a dict `{inner_dst_ip_list, remote_side, remote_vm_names}`. If neither tier has BGP-speaking neighbors, it `pytest.skip`s instead of crashing.
- `MAX_DOWNSTREAM_REMOTE_RECEIVERS = 4`: the downstream fallback uses a fixed number of receivers. This count becomes `step` in `range(0, 64, step)`, so it is a divisor of 64, guaranteeing every DSCP value 0–63 is covered exactly once
  with no value > 63 generated. The remaining downstream neighbors stay free to serve as a disjoint injection source.
- `_setup_test_params` is remote-side aware: for the downstream path it selects egress ports from the announcing neighbors and the injection source from the disjoint complement (source and egress never overlap). The upstream path is
  unchanged.

The upstream path (canonical T0 / T1-with-T2) is a strict no-op fallback and behaves exactly as before.

#### How did you verify/test it?
Ran on an isolated-T1 testbed (Arista-7060X6-64PE-B-O128, Broadcom, SONiC 202511):

- Logs confirm the downstream fallback was exercised (`announce 10.10.10.{1..4}/32 from downstream VMs`), `step = 4`, full DSCP 0–63 sweep, **64 SUCCESS / 0 FAILURE**.
- No `ValueError`; the original crash is gone.

#### Any platform specific information?
No platform-specific logic added. Behavior differences observed are pre-existing: Broadcom skips the `pipe` parametrization (hardware uses outer DSCP for egress queue selection), which is unrelated to this change.

#### Supported testbed topology if it's a new test case?
This extends an existing test to additionally support isolated-T1 topologies (`t1-isolated-d32`, `t1-isolated-d128`,
`t1-isolated-v6-d128`) in addition to the existing `t0` / `t1` (with upstream) coverage.

### Documentation
N/A 