### PR TITLE
[utilities] Update DoW selection to shuffle and seed 

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1738,7 +1738,8 @@ def get_day_of_week_distributed_ports_from_buckets(ports: list, num_buckets: int
     # Get DoW
     day_of_week = datetime.now().weekday()
     logger.info("Day of Week: {} (0=Mon, 6=Sun) - used for port selection".format(day_of_week))
-    random.seed(day_of_week)  # Seed random with DoW for consistent selection across runs on the same day
+    day_index = datetime.now().toordinal()
+    rng = random.Random(day_index)  # Local RNG: reproducible per day, no global side effects
 
     bucket_size = len(ports) // num_buckets
     remainder = len(ports) % num_buckets
@@ -1752,7 +1753,7 @@ def get_day_of_week_distributed_ports_from_buckets(ports: list, num_buckets: int
             break
         end_idx = start_idx + current_bucket_size
         bucket_ports = ports[start_idx:end_idx]
-        random.shuffle(bucket_ports)
+        rng.shuffle(bucket_ports)
         # Select port based on DoW index (wrapping if bucket is smaller than 7)
         port_index = day_of_week % len(bucket_ports)
         selected_ports.append(bucket_ports[port_index])

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1738,11 +1738,10 @@ def get_day_of_week_distributed_ports_from_buckets(ports: list, num_buckets: int
     # Get DoW
     day_of_week = datetime.now().weekday()
     logger.info("Day of Week: {} (0=Mon, 6=Sun) - used for port selection".format(day_of_week))
+    random.seed(day_of_week)  # Seed random with DoW for consistent selection across runs on the same day
 
     bucket_size = len(ports) // num_buckets
     remainder = len(ports) % num_buckets
-    shuffled_ports = list(ports)
-    random.shuffle(shuffled_ports)
     selected_ports = []
     start_idx = 0
 
@@ -1752,7 +1751,8 @@ def get_day_of_week_distributed_ports_from_buckets(ports: list, num_buckets: int
         if current_bucket_size == 0:
             break
         end_idx = start_idx + current_bucket_size
-        bucket_ports = shuffled_ports[start_idx:end_idx]
+        bucket_ports = ports[start_idx:end_idx]
+        random.shuffle(bucket_ports)
         # Select port based on DoW index (wrapping if bucket is smaller than 7)
         port_index = day_of_week % len(bucket_ports)
         selected_ports.append(bucket_ports[port_index])


### PR DESCRIPTION
### Description of PR

Summary:
Updates `get_day_of_week_distributed_ports_from_buckets` in utilities.py to make its port selection deterministic for a given day. The random shuffle within each bucket is now seeded with the day-of-week, so all runs on the same day select the same set of ports, while the selection still rotates across the week to spread coverage over different ports over time.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ x ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Port selection should be reproducible within a single day so that reruns and parallel jobs exercise the same ports, making results comparable and debuggable, while still rotating the chosen ports day-to-day for broader coverage over time.

#### How did you do it?
Seeded the per-bucket shuffle with the current day-of-week (`random.seed(day_of_week)`) once before iterating the buckets, so selection is consistent across runs on the same day and varies predictably across the week.

#### How did you verify/test it?
Verified that repeated calls on the same day return identical selections, that the function returns exactly `num_buckets` distinct ports for bucket counts spanning typical sizes (28/32/64/128), and that the early-return cases (empty input, `len <= num_buckets`) behave as expected.

#### Any platform specific information?
None

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A 