### PR TITLE
 Ignore wred profiles with wred green disabled in gcu ecn test

### DIFF
--- a/tests/generic_config_updater/test_ecn_config_update.py
+++ b/tests/generic_config_updater/test_ecn_config_update.py
@@ -165,7 +165,10 @@ def determine_delta_values(ecn_data, fields, wred_green_enabled):
     max_threshold = int(ecn_data["green_max_threshold"])
     assert 0 <= min_threshold <= max_threshold, \
         f"Invalid thresholds: green_min_threshold={min_threshold}, green_max_threshold={max_threshold}"
-    if "green_min_threshold" in fields and "green_max_threshold" in fields:
+    if ecn_data.get("wred_green_enable", "true") == "false" or ecn_data.get("green_enable", "true") == "false":
+        # Ignore this profile as it's not being used
+        return delta
+    elif "green_min_threshold" in fields and "green_max_threshold" in fields:
         # Both fields are being updated.
         if min_threshold > 0:
             delta["green_min_threshold"] = -1
@@ -240,6 +243,9 @@ def test_ecn_config_updates(duthost, ensure_dut_readiness, configdb_field, opera
         if not wred_green_enabled:
             logger.info(f"Not modifying the WRED profile {wred_profile} since 'wred_green_enable' is false.")
         delta = determine_delta_values(ecn_data, fields, wred_green_enabled)
+        if all(delta[f] == 0 for f in fields):
+            logger.info(f"Skipping WRED profile {wred_profile}: all deltas are 0, no real value change possible.")
+            continue
         new_values[wred_profile] = {}
         for field in fields:
             value = int(ecn_data[field])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #26163 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
We are seeing failures in `generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[None-replace-green_min_threshold,green_max_threshold,green_drop_probability]`

```
2026 May 28 22:08:54.591950 qspf204 ERR syncd#syncd: [none] SAI_API_PORT:_brcm_sai_cosq_gport_discard_set:7062 cosq gport discard set failed with error Invalid parameter (0xfffffffc).
2026 May 28 22:08:54.591950 qspf204 ERR syncd#syncd: [none] SAI_API_QUEUE:_brcm_sai_qos_queue_wred_set:1769 sai cosq gport discard set failed with error -5.
2026 May 28 22:08:54.591950 qspf204 ERR syncd#syncd: [none] SAI_API_WRED:_brcm_xgs_sai_reapply_wred_profile:882 Apply queue config failed with error -5.
```
#### How did you do it?
There are a number of dummy wred profiles configured with wred green disabled. We came to the conclusion that updating these profiles in a wred green configuration test was invalid. Fixed by adding logic to the test that ignores wred profiles with wred green disabled.
#### How did you verify/test it?
Verified by running the test manually. Passes with the change.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
