### PR TITLE
test_monitor_config: skip policer for Nokia TH6 in is_policer_supported

### DIFF
--- a/tests/generic_config_updater/test_monitor_config.py
+++ b/tests/generic_config_updater/test_monitor_config.py
@@ -30,6 +30,8 @@ def is_policer_supported(duthost):
     platform = duthost.facts.get('platform', '')
     if platform.startswith("x86_64-arista_7060x6"):
         return False
+    if platform.startswith("x86_64-nokia_ixr7220"):
+        return False
     return True
 
 


### PR DESCRIPTION
### Description of PR
Summary:
Nokia TH6 (`x86_64-nokia_ixr7220_h6_128-r0`) SAI does not support `SAI_MIRROR_SESSION_ATTR_POLICER`. The `is_policer_supported()` function already excludes Arista 7060x6 for the same reason. This PR extends that logic to also exclude Nokia TH6 platforms.

Fixes Nokia-ION/nokia-th6#12

### Type of change
- [x] Bug fix

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Nokia TH6 `test_monitor_config_tc1_suite` passes the test body but fails at teardown because loganalyzer catches SAI_MIRROR_SESSION_ATTR_POLICER not supported ERR logs.

#### How did you do it?
Added `if platform.startswith("x86_64-nokia_ixr7220"): return False` to `is_policer_supported()`, mirroring the existing Arista exclusion.

#### How did you verify/test it?
Ran on testbed vms13-lt2-nokia-th6-1 (DUT: str4-Nokia-7220-Th6p-1, platform: x86_64-nokia_ixr7220_h6_128-r0).

#### Any platform specific information?
Affects all Nokia IXR7220 platforms (x86_64-nokia_ixr7220*).

#### Supported testbed topology if it is a new test case?
N/A

### Documentation
N/A