### PR TITLE
Ignoring `Invalid VRF name` errors in VxLAN tests

### DIFF
--- a/tests/vxlan/conftest.py
+++ b/tests/vxlan/conftest.py
@@ -354,3 +354,16 @@ def restore_config_by_config_reload(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     logger.info("Restore config after running tests")
     config_reload(duthost, safe_reload=True)
+
+
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exception(duthost, loganalyzer):
+    if loganalyzer:
+        # The following error sometimes happens after removing the VNET during fixture_setUp teardown.
+        # It is a harmless error and does not affect the test results.
+        # The root cause is a race condition that is fixed by https://github.com/sonic-net/sonic-swss/pull/4499.
+        # Since the PR is not merged yet, we need to ignore this error for now.
+        ignore_regex_list = [
+            ".*ERR bgp#fpmsyncd:.*onRouteMsg: Invalid VRF name.*"
+        ]
+        loganalyzer[duthost.hostname].ignore_regex.extend(ignore_regex_list)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR tells loganalyzer to ignore syslog errors matching `.*ERR bgp#fpmsyncd:.*onRouteMsg: Invalid VRF name.*` that are sometimes seen during VxLAN tests.

Summary:
Microsoft ADO ID: 36841610
Ignoring `Invalid VRF name` errors in VxLAN tests

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
There is a known issue that after deleting the VNET during the teardown of `fixture_setUp` fixture in VxLAN tests, a race condition might happen that will cause a log similar to the following to be added to syslog:
```
ERR bgp#fpmsyncd: :- onRouteMsg: Invalid VRF name  (ifindex 1158)
```
Please see this issue for more details: https://github.com/sonic-net/sonic-buildimage/issues/12259
The SWSS fix is available, but it is not merged yet: https://github.com/sonic-net/sonic-swss/pull/4499
This error does not indicate any functional issues and is safe to ignore. However, the loganalyzer catches and reports this error (even though the test itself passed). Therefore, this PR tells loganalyzer to ignore this error pattern.

#### How did you do it?
For all VxLAN tests, added an error pattern to the loganalyzer's `ignore_regex` list.

#### How did you verify/test it?
I verified that after this change, the following test passed without any loganalyzer errors:
```
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_bgp_removal_before_ep[v6_in_v4-BFD-initially_down]
```
**Note:** I also used the following command on the DUT during the test to add the error log to syslog:
```
logger -p ERR -t "bgp#fpmsyncd" ":- onRouteMsg: Invalid VRF name  (ifindex 1158)"
```

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A