### PR TITLE
[route/test_duplicate_route]: Skip unsupported IP family instead of erroring

### DIFF
--- a/tests/route/test_duplicate_route.py
+++ b/tests/route/test_duplicate_route.py
@@ -139,19 +139,17 @@ def setup_routes(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     if interface_types == 'Loopback':
         # Get loopback ips
         intf_ips = get_intf_ips('Loopback', cfg_facts)
-        pytest_require((len(intf_ips['ipv4']) + len(intf_ips['ipv6'])) > 0, "No IP configured on Loopback0")
     else:
         # Get vlan ips
         intf_ips = get_intf_ips('Vlan', cfg_facts)
-        pytest_require((len(intf_ips['ipv4']) + len(intf_ips['ipv6'])) > 0, "No IP configured on any Vlan")
+
+    ip_key = 'ipv4' if ip_versions == 4 else 'ipv6'
+    pytest_require(len(intf_ips[ip_key]) > 0, "No {} configured on {}".format(ip_key, interface_types))
 
     # Generate interfaces and neighbors
     intf_neighs, str_intf_nexthop = generate_intf_neigh(
         asichost, 1, ip_versions)
-    if ip_versions == 4:
-        prefixes.append(str(random.choice(intf_ips['ipv4'])).split("/")[0])
-    else:
-        prefixes.append(str(random.choice(intf_ips['ipv6'])).split("/")[0])
+    prefixes.append(str(random.choice(intf_ips[ip_key])).split("/")[0])
 
     # Setup interface IPs and neighbors
     prepare_dut(asichost, intf_neighs)


### PR DESCRIPTION
### Description of PR

Summary:
`route/test_duplicate_route.py::test_duplicate_routes` raises `IndexError: Cannot choose from an empty sequence` on testbeds where the Vlan (or Loopback) interface is configured with only a single IP address family.

The `setup_routes` fixture is parametrized over `ip_versions = [4, 6]` and `interface_types = ['Loopback', 'Vlan']`, but it only verified that the interface had at least one IP across **both** families combined:

```python
pytest_require((len(intf_ips['ipv4']) + len(intf_ips['ipv6'])) > 0, "No IP configured on any Vlan")
...
else:
    prefixes.append(str(random.choice(intf_ips['ipv6'])).split("/")[0])
```

It then unconditionally called `random.choice()` on the family selected by `ip_versions`. On testbeds that configure only one family on the interface — e.g. a SmartSwitch where `Vlan55` is IPv4-only (`20.0.200.254/24`) — the `ip_versions=6` + `interface_types='Vlan'` combination calls `random.choice([])` and errors out.

Fixes # (no GitHub issue filed yet)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Make the test robust on any testbed where an interface only has a single address family, instead of crashing with an unhandled `IndexError`. This was observed on SmartSwitch testbeds, where `Vlan55` is provisioned IPv4-only — see [`smartswitch_vlan_config`](https://github.com/sonic-net/sonic-mgmt/blob/995861eb21720d63da5a4916e9fbeb51fa1f7e12/ansible/module_utils/smartswitch_utils.py#L35-L50). The fix itself is generic.

#### How did you do it?
Check the **specific** address family under test (`ipv4` or `ipv6`) before selecting a prefix. When the requested family is not configured on the interface, the case is skipped via `pytest_require` instead of erroring. This also removes the duplicated `if ip_versions == 4 / else` selection logic.

#### How did you verify/test it?
- Verified the failing combination (`ip_versions=6`, `interface_types='Vlan'`) on a SmartSwitch testbed (Vlan55 IPv4-only) now skips cleanly instead of raising `IndexError`.
- Verified the supported combinations (v4-Vlan, v4/v6-Loopback) still run as before.

#### Any platform specific information?
Observed on SmartSwitch (`t1-28-lag`, light mode) where `Vlan55` is configured IPv4-only. The change is platform-agnostic.

#### Supported testbed topology if it's a new test case?
N/A — existing test case.
