### PR TITLE
[TH6] Skip copp UDLD for Nokia TH6 fanout

### DIFF
--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -112,8 +112,9 @@ class TestCOPP(object):
         # UDLD packet will not be forwarded to DUT
         if 'UDLD' == protocol:
             for fanouthost in list(fanouthosts.values()):
-                if fanouthost.get_fanout_os() == 'sonic' and "arista_7060x6_64pe" in fanouthost.facts["platform"]:
-                    pytest.skip("Skip UDLD test for Arista-7060x6 fanout without UDLD forward support")
+                if (fanouthost.get_fanout_os() == 'sonic' and fanouthost.facts["platform"]
+                        in ['arista_7060x6_64pe', 'x86_64-nokia_ixr7220_h5_64o-r0', 'x86_64-nokia_ixr7220_h6_64-r0']):
+                    pytest.skip("Skip UDLD test for Arista-7060x6 and Nokia-H5/H6 fanout without UDLD forward support")
 
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         namespace = DEFAULT_NAMESPACE


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- This PR skips UDLD COPP test if the leaf fanout used is running SONiC on Nokia TH5/TH6 platforms, similar to #21117 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

- COPP UDLD test fails with the below issue, when the Nokia TH5/TH6 fanout used is running SONiC on it.

```python
FAIL: copp_tests.UDLDTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/ptftests/py3/copp_tests.py", line 590, in runTest
    self.run_suite()
  File "/root/ptftests/py3/copp_tests.py", line 246, in run_suite
    self.one_port_test(self.target_port)
  File "/root/ptftests/py3/copp_tests.py", line 240, in one_port_test
    self.check_constraints(send_count, recv_count, time_delta_ms, rx_pps)
  File "/root/ptftests/py3/copp_tests.py", line 275, in check_constraints
    assert self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX, "Copp policer constraint check failed, " \
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Copp policer constraint check failed, Actual PPS: 0 Expected PPS range: 90.0 - 130.0
``` 

#### How did you do it?

- Skip the test if the fanout used is '_x86_64-nokia_ixr7220_h5_64o-r0_', '_x86_64-nokia_ixr7220_h6_64-r0_' platforms.

#### How did you verify/test it?

- Ran COPP UDLD test and made sure test is getting skipped.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
