### PR TITLE
test_continous_pfc: add polling and retry for counter check

### DIFF
--- a/tests/common/helpers/pfc_counters.py
+++ b/tests/common/helpers/pfc_counters.py
@@ -168,6 +168,12 @@ def run_test(fanouthosts, duthost, conn_graph_facts, enum_fanout_graph_facts, le
             ).format(len(failures))
 
     else:
+        """ Poll interval and timeout for waiting on counter updates """
+        POLL_INTERVAL = 0.5
+        POLL_TIMEOUT = 10
+        """ Retry sending frames once if the counter does not update in time """
+        MAX_RETRIES = 2
+
         for intf in active_phy_intfs:
             """only check priority 3 and 4: lossless priorities"""
             for priority in range(3, 5):
@@ -196,16 +202,38 @@ def run_test(fanouthosts, duthost, conn_graph_facts, enum_fanout_graph_facts, le
                         cmd = 'docker exec %s "python %s -i %s -p %d -t %d -n %d"' % (
                             onyx_pfc_container_name, PFC_GEN_FILE_ABSOLUTE_PATH,
                             peer_port_name, 2 ** priority, pause_time, PKT_COUNT)
-                        peerdev_ans.host.config(cmd)
+                        send_frames = lambda: peerdev_ans.host.config(cmd)  # noqa: E731
                     else:
                         cmd = "sudo python %s -i %s -p %d -t %d -n %d" % (
                             PFC_GEN_FILE_DEST, peer_port_name, 2 ** priority, pause_time, PKT_COUNT)
-                        peerdev_ans.host.command(cmd)
+                        send_frames = lambda: peerdev_ans.host.command(cmd)  # noqa: E731
 
-                time.sleep(5)
+                    send_frames()
 
-                pfc_rx = duthost.sonic_pfc_counters(
-                    method="get")['ansible_facts']
+                    pfc_rx = {}
+                    for attempt in range(1, MAX_RETRIES + 1):
+                        """ Poll until counter reaches PKT_COUNT or timeout """
+                        deadline = time.time() + POLL_TIMEOUT
+                        pfc_rx = duthost.sonic_pfc_counters(method="get")['ansible_facts']
+                        while pfc_rx[intf]['Rx'][priority] != str(PKT_COUNT) and time.time() < deadline:
+                            time.sleep(POLL_INTERVAL)
+                            pfc_rx = duthost.sonic_pfc_counters(method="get")['ansible_facts']
+
+                        if pfc_rx[intf]['Rx'][priority] == str(PKT_COUNT):
+                            break
+
+                        if attempt < MAX_RETRIES:
+                            logger.warning(
+                                "Attempt %d: PFC counter not updated for interface %s priority %d "
+                                "(got %s), retrying send", attempt, intf, priority,
+                                pfc_rx[intf]['Rx'][priority])
+                            duthost.sonic_pfc_counters(method="clear")
+                            send_frames()
+
+                else:
+                    time.sleep(5)
+                    pfc_rx = duthost.sonic_pfc_counters(method="get")['ansible_facts']
+
                 if asic_type != 'vs':
                     """check pfc Rx frame count on particular priority are increased"""
                     assert pfc_rx[intf]['Rx'][priority] == str(PKT_COUNT), (


### PR DESCRIPTION
### Description of PR
Summary:
Stabilize `test_continous_pfc` by replacing the fixed 5-second sleep with a polling loop and adding a retry when the PFC counter does not update.

### Type of change
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

`test_continous_pfc` iterates over ~256 ports × 2 priorities and sends PFC frames from the fanout for each pair. With a fixed 5-second sleep between sending and reading, a single transient SSH connection failure to the fanout causes pfc_gen.py to not actually send frames, making the counter stay at 0 and the test fail — even though the DUT PFC counter is working correctly.

Observed on Nokia IXR7220-H6-128 (256-port TH6): ~1 out of 300 iterations fails intermittently. The counter hardware works correctly (frames arrive within < 1s), but the test infrastructure is not resilient to SSH blips over the 60-minute test run.

#### How did you do it?

1. **Polling instead of fixed sleep**: after sending PFC frames, poll `pfcstat` every 0.5s for up to 10s, stopping as soon as the counter reaches `PKT_COUNT`. On fast hardware this exits in ~1s instead of always waiting 5s.

2. **Retry on failure**: if the counter does not reach `PKT_COUNT` within the polling window, log a warning, re-clear counters, and re-send PFC frames once before the final assertion. This recovers from transient fanout SSH failures without masking genuine SAI counter bugs.

#### How did you verify/test it?

Ran `test_continous_pfc` on Nokia IXR7220-H6-128 testbed `vms13-lt2-nokia-th6-1` with the fix applied:

```
1 passed in 3761.23s (1:02:41)
```

The previous run without the fix failed at `Ethernet396 priority 3` (got 0, expected 10).

Also verified the counter works correctly in isolation:
```
Run 1: base=20 after=30 diff=10 pfcstat_pfc3=10  ✅
Run 2: base=30 after=40 diff=10 pfcstat_pfc3=10  ✅
Run 3: base=40 after=50 diff=10 pfcstat_pfc3=10  ✅
Run 4: base=50 after=60 diff=10 pfcstat_pfc3=10  ✅
Run 5: base=60 after=70 diff=10 pfcstat_pfc3=10  ✅
```

#### Any platform specific information?

The issue is most visible on high-port-count platforms (256 ports) where the test makes 300+ fanout SSH connections in a single run. The fix benefits all platforms.

#### Supported testbed topology if its a new test case?

Not a new test case — improvement to existing `test_continous_pfc`.

### Documentation