### PR TITLE
[platform_tests] Skip PSU on/off test when all PSUs share one PDU outlet to avoid rebooting the DUT

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -347,6 +347,24 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_h
 
     # Group outlets/PDUs by PSU and toggle PDUs by PSU
     psu_to_pdus = get_grouped_pdus_by_psu(pdu_ctrl)
+    # Safety check: there must be at least 2 distinct PDU outlets across all PSUs, so that
+    # turning one PSU's outlet off still leaves another PSU powered. If every PSU hangs off
+    # a single shared outlet (e.g. both PSUs of a 2-PSU DUT on one outlet, as seen when the
+    # PDU connection graph maps PSU1 and PSU2 to the same outlet), turning it off removes
+    # all power from the DUT and reboots it
+    distinct_outlets = set()
+    for outlets in psu_to_pdus.values():
+        for outlet in outlets:
+            distinct_outlets.add("{}/{}".format(outlet.get('pdu_name'), outlet.get('outlet_id')))
+    if len(distinct_outlets) < 2:
+        logging.warning(
+            "All PSUs on %s share a single PDU outlet %s; turning it off would power off the "
+            "whole DUT. Please fix the PDU cabling/connection graph so each PSU has its own "
+            "outlet.", duthost.hostname, sorted(distinct_outlets))
+    pytest_require(
+        len(distinct_outlets) >= 2,
+        "Skip the test: all PSUs on {} share PDU outlet(s) {}; toggling would power off the "
+        "whole DUT.".format(duthost.hostname, sorted(distinct_outlets)))
 
     # Get list of PSUs to skip from inventory configuration
     skip_psu_list = get_skip_mod_list(duthost, ['psus'])


### PR DESCRIPTION
### Description of PR

Summary:
`test_turn_on_off_psu_and_check_psustatus` powers off each PSU's PDU outlet to verify the PSU reports `NOT OK` while the DUT stays up on its remaining PSU(s). When the PDU connection graph maps **every** PSU of a DUT to the **same** outlet, turning it off cuts all power and reboots the DUT — surfacing as a misleading `Timeout (62s) waiting for privilege escalation` failure plus a cascade of `container pmon is not running` errors in later platform tests (not real SONiC bugs).

This PR adds a pre-toggle safety check requiring **≥2 distinct PDU outlets** across all PSUs. If all PSUs share one outlet, it logs a warning and skips (via `pytest_require`) **before** powering anything off. DUTs with independent per-PSU outlets are unaffected and run all existing assertions.

> **Action required for testbed owners:** this is a PDU cabling/connection-graph issue, not a DUT/SONiC bug. Please cable each PSU to its **own independent** PDU outlet and update the corresponding `*_pdu_links.csv` (matching healthy peers in the same pod). Until fixed, the test will skip on these DUTs, and PSU on/off coverage will not run.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Prevent the test from blacking out a DUT (and producing misleading SONiC-looking failures) when all of its PSUs are cabled to a single PDU outlet.

#### How did you do it?
After `get_grouped_pdus_by_psu`, collect the distinct `(pdu_name, outlet_id)` outlets. If fewer than 2, log a warning naming the DUT and shared outlet and `pytest_require`-skip before any `turn_off_outlet`. No existing assertion is relaxed.

#### How did you verify/test it?
- now skips with the warning instead of rebooting the DUT.
- Correctly-cabled DUT (distinct outlets): check is a no-op; full flow runs as before.

#### Any platform specific information?
None 

#### Supported testbed topology if it's a new test case?
N/A 

### Documentation
N/A 