### PR TITLE
[bgp]: Fix PTF port index mapping in test_bgp_vnet_route_forwarding

### DIFF
--- a/tests/bgp/test_bgp_vnet.py
+++ b/tests/bgp/test_bgp_vnet.py
@@ -449,14 +449,7 @@ def _check_vnet2_all_dynamic_peers_established(duthost):
         return False
 
 
-def get_ptf_port_index(interface_name):
-    """
-    Convert Ethernet interface name to PTF port index (Ethernet112 → 28).
-    """
-    return int(interface_name.replace("Ethernet", "")) // 4
-
-
-def get_expected_unexpected_ptf_ports(cfg_facts, vnet_expected, vnet_unexpected):
+def get_expected_unexpected_ptf_ports(cfg_facts, mg_facts, vnet_expected, vnet_unexpected):
     """
     Return two lists of unique PTF port indices:
     - expected_ptf_ports: ports belonging to vnet_expected
@@ -464,6 +457,7 @@ def get_expected_unexpected_ptf_ports(cfg_facts, vnet_expected, vnet_unexpected)
     """
     portchannel_interfaces = cfg_facts.get("PORTCHANNEL_INTERFACE", {})
     portchannel_members = cfg_facts.get("PORTCHANNEL_MEMBER", {})
+    ptf_indices = mg_facts["minigraph_ptf_indices"]
 
     expected_portchannels = set()
     unexpected_portchannels = set()
@@ -486,8 +480,8 @@ def get_expected_unexpected_ptf_ports(cfg_facts, vnet_expected, vnet_unexpected)
             except ValueError:
                 # Malformed key (should be pc|member)
                 continue
-            if pc in portchannels:
-                ptf_ports.add(get_ptf_port_index(iface))
+            if pc in portchannels and iface in ptf_indices:
+                ptf_ports.add(ptf_indices[iface])
         return sorted(ptf_ports)
 
     expected_ptf_ports = collect_ptf_ports(expected_portchannels)
@@ -558,7 +552,7 @@ def test_dynamic_peer_vnet(duthosts, rand_one_dut_hostname, cfg_facts):
         pytest.fail("Vnet testing setup failed: {}".format(repr(e)))
 
 
-def test_bgp_vnet_route_forwarding(ptfadapter, duthosts, rand_one_dut_hostname, cfg_facts):
+def test_bgp_vnet_route_forwarding(ptfadapter, duthosts, rand_one_dut_hostname, cfg_facts, mg_facts):
     '''
     Verify that the traffic to the peer in Vnet1 is forwarded correctly.
     Send a UDP packet to with the destination as one of the routes learned via bgp in Vnet1
@@ -584,7 +578,7 @@ def test_bgp_vnet_route_forwarding(ptfadapter, duthosts, rand_one_dut_hostname, 
         # Discover the destination IP from the live FIB so the test is not
         # tied to a topology-specific hardcoded address.
         dst_ip = _get_vnet1_bgp_dst_ip(duthost)
-        expected_ports, unexpected_ports = get_expected_unexpected_ptf_ports(cfg_facts, "Vnet1", "Vnet2")
+        expected_ports, unexpected_ports = get_expected_unexpected_ptf_ports(cfg_facts, mg_facts, "Vnet1", "Vnet2")
         assert expected_ports, \
             "No PTF ports found for Vnet1; check PORTCHANNEL_INTERFACE vnet_name in cfg_facts"
         assert unexpected_ports, \

--- a/tests/bgp/test_bgp_vnet.py
+++ b/tests/bgp/test_bgp_vnet.py
@@ -449,14 +449,7 @@ def _check_vnet2_all_dynamic_peers_established(duthost):
         return False
 
 
-def get_ptf_port_index(interface_name, mg_facts):
-    """
-    Convert Ethernet interface name to PTF port index using the minigraph port map.
-    """
-    return mg_facts['minigraph_ptf_indices'][interface_name]
-
-
-def get_expected_unexpected_ptf_ports(cfg_facts, vnet_expected, vnet_unexpected, mg_facts):
+def get_expected_unexpected_ptf_ports(cfg_facts, mg_facts, vnet_expected, vnet_unexpected):
     """
     Return two lists of unique PTF port indices:
     - expected_ptf_ports: ports belonging to vnet_expected
@@ -464,6 +457,7 @@ def get_expected_unexpected_ptf_ports(cfg_facts, vnet_expected, vnet_unexpected,
     """
     portchannel_interfaces = cfg_facts.get("PORTCHANNEL_INTERFACE", {})
     portchannel_members = cfg_facts.get("PORTCHANNEL_MEMBER", {})
+    ptf_indices = mg_facts["minigraph_ptf_indices"]
 
     expected_portchannels = set()
     unexpected_portchannels = set()
@@ -486,8 +480,8 @@ def get_expected_unexpected_ptf_ports(cfg_facts, vnet_expected, vnet_unexpected,
             except ValueError:
                 # Malformed key (should be pc|member)
                 continue
-            if pc in portchannels:
-                ptf_ports.add(get_ptf_port_index(iface, mg_facts))
+            if pc in portchannels and iface in ptf_indices:
+                ptf_ports.add(ptf_indices[iface])
         return sorted(ptf_ports)
 
     expected_ptf_ports = collect_ptf_ports(expected_portchannels)
@@ -584,7 +578,7 @@ def test_bgp_vnet_route_forwarding(ptfadapter, duthosts, rand_one_dut_hostname, 
         # Discover the destination IP from the live FIB so the test is not
         # tied to a topology-specific hardcoded address.
         dst_ip = _get_vnet1_bgp_dst_ip(duthost)
-        expected_ports, unexpected_ports = get_expected_unexpected_ptf_ports(cfg_facts, "Vnet1", "Vnet2", mg_facts)
+        expected_ports, unexpected_ports = get_expected_unexpected_ptf_ports(cfg_facts, mg_facts, "Vnet1", "Vnet2")
         assert expected_ports, \
             "No PTF ports found for Vnet1; check PORTCHANNEL_INTERFACE vnet_name in cfg_facts"
         assert unexpected_ports, \


### PR DESCRIPTION
## Description of PR

Fixes `KeyError: (0, 56)` in `test_bgp_vnet_route_forwarding` on platforms with non-stride-4 port numbering (e.g. `8101_32FH_O`).

`get_expected_unexpected_ptf_ports` derived PTF port indices from DUT interface names using a hardcoded stride-4 formula:

```python
int(interface_name.replace("Ethernet", "")) // 4
```

This assumes ports are numbered `Ethernet0, 4, 8, ...`. On `8101_32FH_O`, ports use stride-8 (`Ethernet0, 8, 16, ... 224, 232, 240, 248`), so PortChannel members such as `Ethernet224/232/240/248` computed PTF indices `56/58/60/62`, which do not exist in the PTF dataplane, raising `KeyError: (0, 56)`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework (new/improvement)
- [ ] New Test case
- [ ] Test case enhancement
- [ ] Skipped for non-supported platforms

## Approach

### What is the motivation for this PR?

The test fails on `8101_32FH_O` (t0-64) because the hardcoded `// 4` formula does not match the platform's stride-8 port numbering.

### How did you do it?

- Use the authoritative DUT-to-PTF mapping from `mg_facts['minigraph_ptf_indices']` instead of arithmetic derivation. This matches the established convention in `test_bgp_speaker.py`, `test_bgpmon.py`, `test_bgpmon_v6.py`, `bgp_helpers.py`, etc.
- Remove the now-unused `get_ptf_port_index()` helper (only referenced in this file).
- Add the existing `mg_facts` fixture as a parameter to `test_bgp_vnet_route_forwarding` and pass it through.
- Add a guard to skip interfaces not present in the PTF index mapping.

### How did you verify/test it?

- `python -m py_compile` passes; lines within flake8 `max-line-length=120`.
- Should be run on a stride-4 t0 platform (regression) and on `8101_32FH_O` (t0-64) where the original `KeyError` reproduced.

## Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202511