### PR TITLE
conditional_mark: skip test_loopback_filter and test_acl_egress_drop on Nokia IXR7220-H6-128

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1296,6 +1296,10 @@ drop_packets/test_drop_counters.py::test_acl_egress_drop:
     reason: "xfail for IPv6-only topologies, issue with valid_ipv4"
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/19921 and '-v6-' in topo_name"
+  skip:
+    reason: "Egress ACL bind to LAG is not implemented on Nokia IXR7220-H6-128 SAI"
+    conditions:
+      - "platform in ['x86_64-nokia_ixr7220_h6_128-r0']"
 
 drop_packets/test_drop_counters.py::test_broken_ip_header:
    xfail:
@@ -1308,6 +1312,12 @@ drop_packets/test_drop_counters.py::test_ip_is_zero_addr:
     reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
     conditions:
       - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
+
+drop_packets/test_drop_counters.py::test_loopback_filter:
+  skip:
+    reason: "Loopback filter drop is not implemented on Nokia IXR7220-H6-128 SAI"
+    conditions:
+      - "platform in ['x86_64-nokia_ixr7220_h6_128-r0']"
 
 drop_packets/test_drop_counters.py::test_no_egress_drop_on_down_link:
   xfail:


### PR DESCRIPTION
### Description of PR
Summary:
Add explicit Nokia IXR7220-H6-128 skip conditions for two drop_packets tests that fail on Nokia hardware due to SAI limitations:

1. **test_loopback_filter**: Nokia SAI does not implement loopback filter drop. When a packet arrives on interface X and the route to the destination also exits on interface X, Nokia forwards the packet instead of dropping it. Test sends 1000 packets expecting `RX_DRP` to increment, but Nokia keeps it at 0 (rif_members) or 1 (port_channel_members). Note: `tests_mark_conditions_drop_packets.yaml` already has an unconditional skip for this test for all platforms — this PR adds a Nokia-specific explicit entry for documentation clarity.

2. **test_acl_egress_drop**: Nokia TH6 uses a Broadcom ASIC internally, and SAI logs `Egress ACL Bind to LAG is not implemented yet` causing the test setup to fail. `tests_mark_conditions_drop_packets.yaml` already skips this for `asic_type in ['broadcom']` which covers Nokia. This PR adds a Nokia-platform-specific entry as explicit documentation.

Also fixes a pre-existing alphabetical sort violation in the `dhcp_relay` section (moved `dhcp_relay/.*\[.*sonic-relay-agent` to its correct position).

### Type of change
- [x] Bug fix

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Nokia IXR7220-H6-128 nightly tests on testbed `vms13-lt2-nokia-th6-1` produce failures and errors for these two test cases due to SAI limitations.

#### How did you do it?
Added platform-specific skip conditions for `x86_64-nokia_ixr7220_h6_128-r0` in `tests_mark_conditions.yaml`.

#### How did you verify/test it?
Ran `drop_packets/test_drop_counters.py` on testbed `vms13-lt2-nokia-th6-1`. Before this fix: 40 passed, 58 skipped, 2 failed (`test_loopback_filter`), 6 errors (`test_acl_egress_drop` ×4 setup/teardown + 2 unrelated teardown monitoring false positives).

#### Any platform specific information?
Nokia IXR7220-H6-128 only.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A