### PR TITLE
[DASH] Use specific import

### DIFF
--- a/tests/dash/test_dash_privatelink_redirect.py
+++ b/tests/dash/test_dash_privatelink_redirect.py
@@ -14,7 +14,7 @@ from constants import (
     VXLAN_UDP_BASE_SRC_PORT,
     VXLAN_UDP_SRC_PORT_MASK
 )
-from conftest import get_interface_ip
+from tests.dash.conftest import get_interface_ip
 from configs.privatelink_config import TUNNEL1_ENDPOINT_IP
 import configs.privatelink_config as pl
 from tests.common.dash_utils import apply_swssconfig_file


### PR DESCRIPTION
Update test_dash_privatelink_redirect.py to import the correct conftest to use.

### Description of PR

The tests were failing to start because test_dash_privatelink_redirect.py was picking up the wrong conftest.py. It probably depended on what conftest was found when python traversed the various imports so it may have been picking up the right one in some cases.

Summary:
Fixes #25327

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Tested branch
- [x] master: PASS
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 20251: PASS
- [ ] 202512
- [X] 202605: PASS

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Make test_dash_privatelink_redirect.py use `from tests.dash.conftest import get_interface_ip` the same as the other dash tests.