### PR TITLE
test_console_driver: tolerate extra ttys for unwired physical lines

### DIFF
--- a/tests/console/test_console_driver.py
+++ b/tests/console/test_console_driver.py
@@ -15,8 +15,10 @@ def test_console_driver(duthost, conn_graph_facts):  # noqa: F811
 
     For each line recorded for this DUT in ``ansible/files/*_serial_links.csv``
     (exposed via the ``conn_graph_facts`` fixture), assert that a tty device
-    with a matching line-number suffix exists on the DUT, and that no extra
-    tty devices with the same prefix are present.
+    with a matching line-number suffix exists on the DUT. Extra tty devices
+    that the platform driver creates for unwired physical lines are tolerated
+    -- the inventory documents only the lines wired to a peer, while the
+    console driver exposes one tty per physical line on the chassis.
     """
     dut_serial_links = conn_graph_facts.get('device_serial_link', {}).get(duthost.hostname, {})
     pytest_assert(
@@ -35,9 +37,8 @@ def test_console_driver(duthost, conn_graph_facts):  # noqa: F811
 
     expected_ttys = {"{}{}".format(device_prefix, line_number) for line_number in dut_serial_links.keys()}
     missing_ttys = sorted(expected_ttys - existing_ttys)
-    extra_ttys = sorted(existing_ttys - expected_ttys)
     pytest_assert(
-        not missing_ttys and not extra_ttys,
-        "tty device set does not match the serial-link inventory: missing={}, extra={}".format(
-            missing_ttys, extra_ttys),
+        not missing_ttys,
+        "Console driver did not expose tty devices for wired serial-link inventory entries on DUT '{}': missing={}".format(
+            duthost.hostname, missing_ttys),
     )

--- a/tests/console/test_console_driver.py
+++ b/tests/console/test_console_driver.py
@@ -39,6 +39,6 @@ def test_console_driver(duthost, conn_graph_facts):  # noqa: F811
     missing_ttys = sorted(expected_ttys - existing_ttys)
     pytest_assert(
         not missing_ttys,
-        "Console driver did not expose tty devices for wired serial-link inventory entries on DUT '{}': missing={}".format(
-            duthost.hostname, missing_ttys),
+        "Console driver did not expose tty devices for wired serial-link inventory entries on DUT '{}': "
+        "missing={}".format(duthost.hostname, missing_ttys),
     )


### PR DESCRIPTION
The console driver exposes one tty per physical line on the chassis (e.g., 48 ttys on a 48-port Cisco c8220tg). The serial-link inventory CSV, by design, lists only the lines actually wired to a peer device. The previous strict set-equality between the kernel's tty set and the CSV inventory treated every unwired physical line as a failure.

Relax the assertion to a subset check: every line recorded in ansible/files/*_serial_links.csv must still exist as a tty on the DUT, but extra ttys for unwired lines are no longer a failure.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
