### PR TITLE
Fix test_cacl_application_nondualtor for BMC

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer globally
-    pytest.mark.topology('any', 'bmc-shared-mgmt', 'bmc-dual-mgmt')
+    pytest.mark.topology('any', 'bmc')
 ]
 
 

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer globally
-    pytest.mark.topology('any')
+    pytest.mark.topology('any', 'bmc-shared-mgmt', 'bmc-dual-mgmt')
 ]
 
 
@@ -518,8 +518,8 @@ def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expecte
     if asic_index is None:
         # Allow Communication among docker containers
         for k, v in list(docker_network['container'].items()):
-            # network mode for dhcp_server container is bridge, but this rule is not expected to be seen
-            if k == "dhcp_server":
+            # network mode for dhcp_server and redfish containers is bridge, but this rule is not expected to be seen
+            if k in ("dhcp_server", "redfish"):
                 continue
             iptables_rules.append("-A INPUT -s {}/32 -d {}/32 -j ACCEPT"
                                   .format(docker_network['bridge']['IPv4Address'],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
`test_cacl_application_nondualtor` fails on BMC devices. The redfish container runs in docker bridge-network mode, so the test's docker_network fixture (which enumerates everything attached to the docker bridge) synthesizes an expected inter-container ACCEPT rule for it. However, caclmgrd only emits these inter-container bridge rules for the per-ASIC database* containers, it never emits one for bridge-mode service containers like redfish or dhcp_server, regardless of ASIC count. The synthesized rule therefore has no matching iptables rule on the DUT, so redfish must be excluded from the expected set - the same situation as the existing dhcp_server skip.


This PR also adds the BMC topologies (`bmc`, per docs/testplan/bmc/BMC-high-level-test-plan.md) to the topology marks so the CACL tests run on BMC testbeds.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
Since redfish is a bridge-network container, the docker-bridge iptables rule is not expected for it.

#### What is the motivation for this PR?
Enable `tests/cacl/` on BMC topologies and fix `test_cacl_application_nondualtor` failing there.

#### How did you do it?
- Added `redfish` to the existing `dhcp_server` skip in the docker-container loop of `generate_expected_rules()`.
- Added `bmc` to the module topology marks.

#### How did you verify/test it?
Ran `cacl/test_cacl_application.py` on a BMC testbed the testcase passes. No behavior change for non-BMC topologies.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
