### PR TITLE
[TH6] multi-vrf EOS config support for test_4-byte_asn_community test

### DIFF
--- a/tests/bgp/test_4-byte_asn_community.py
+++ b/tests/bgp/test_4-byte_asn_community.py
@@ -13,6 +13,7 @@ import pytest
 import time
 import textfsm
 import re
+from tests.bgp.bgp_helpers import eos_bgp_neighbor_config_parents
 from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
@@ -23,6 +24,8 @@ dut_4byte_asn = 400003
 neighbor_4byte_asn = 400001
 bgp_sleep = 120
 bgp_id_textfsm = "./bgp/templates/bgp_id.template"
+# Full startup-config backup for converged multi-VRF cEOS
+EOS_NEIGH_BACKUP_CONFIG_FILE = "/tmp/bgp_4byte_asn_community_eos_backup_{}"
 
 pytestmark = [
     pytest.mark.topology('t2', 'lrh', 'urh')
@@ -110,41 +113,75 @@ class SonicBGPRouter(BGPRouter):
 
 
 class EosBGPRouter(BGPRouter):
-    def __init__(self, host, asn):
+    def __init__(self, host, asn, eos_bgp_summary_vrf=None, eos_bgp_parents=None, dut_peer_addrs=None,
+                 eos_restore_backup_path=None):
         super().__init__(host, asn)
         self.os_type = 'eos'
+        # Converged multi-VRF cEOS: default VRF "show ip bgp summary" can be empty; use vrf <logical_peer>.
+        self.eos_bgp_summary_vrf = eos_bgp_summary_vrf
+        self.eos_bgp_parents = eos_bgp_parents
+        self.dut_peer_addrs = dut_peer_addrs
+        self.eos_restore_backup_path = eos_restore_backup_path
+
+    def _ip_bgp_summary_cmd(self):
+        cmd = "show ip bgp summary"
+        if self.eos_bgp_summary_vrf:
+            cmd += " vrf {}".format(self.eos_bgp_summary_vrf)
+        return cmd
+
+    def _ipv6_bgp_summary_cmd(self):
+        cmd = "show ipv6 bgp summary"
+        if self.eos_bgp_summary_vrf:
+            cmd += " vrf {}".format(self.eos_bgp_summary_vrf)
+        return cmd
 
     def get_router_id(self):
-        neigh_ip_bgp_sum = self.get_command_output("show ip bgp summary")
-        neigh_ip_bgp_sum = neigh_ip_bgp_sum.split("\n")
-        # Use regular expression to find the router identifier
-        match = re.search(r'Router identifier (\d+\.\d+\.\d+\.\d+)', neigh_ip_bgp_sum[1])
-        if match:
-            router_id = match.group(1)
-        else:
-            pytest_assert(router_id is not None, f"Failed to get BGP ID {self.host}")
-        return router_id
+        neigh_ip_bgp_sum = self.get_command_output(self._ip_bgp_summary_cmd())
+        # Classic EOS: "Router identifier ..."; SONiC/FRR-style: "BGP router identifier ..."
+        match = re.search(
+            r'(?:BGP\s+router\s+identifier|Router\s+identifier)\s+(\d+\.\d+\.\d+\.\d+)',
+            neigh_ip_bgp_sum,
+            re.IGNORECASE,
+        )
+        pytest_assert(
+            match,
+            "Failed to get BGP router ID from [{}] on {}".format(neigh_ip_bgp_sum, self.host),
+        )
+        return match.group(1)
 
     def get_current_bgp_asn(self):
         current_bgp_asn = self.get_command_output("show run section bgp | sec router bgp")
         match = re.search(r'router bgp (\d+)', current_bgp_asn)
-        if match:
-            current_asn = match.group(1)
-        else:
-            pytest_assert(current_asn is not None, f"Failed to get BGP ASN {self.host}")
-        return current_asn
+        pytest_assert(match, "Failed to get BGP ASN from [{}] on {}".format(current_bgp_asn, self.host))
+        return match.group(1)
 
     def save_bgp_config(self):
         self.saved_bgp_config = self.get_command_output("show run section bgp")
 
     def remove_bgp_config(self, asn=None):
+        # Converged multi-VRF: do not run "no router bgp <primary_asn>" on a shared cEOS VM.
+        if self.eos_bgp_parents and self.dut_peer_addrs:
+            cv4, cv6 = self.dut_peer_addrs
+            cleanup = [
+                "no neighbor {}".format(cv4),
+                "no neighbor {}".format(cv6),
+            ]
+            self.host.eos_config(
+                lines=cleanup, parents=self.eos_bgp_parents)
+            return
         if asn is None:
             asn = self.get_current_bgp_asn()
         self.host.eos_config(
             lines=["no router bgp {}".format(asn)])
 
     def restore_bgp_config(self, asn_to_be_removed):
-        self.remove_bgp_config(asn=asn_to_be_removed)
+        if self.eos_restore_backup_path:
+            self.host.load_configuration(self.eos_restore_backup_path)
+            return
+        if self.eos_bgp_parents and self.dut_peer_addrs:
+            self.remove_bgp_config()
+        else:
+            self.remove_bgp_config(asn=asn_to_be_removed)
         self.host.eos_config(lines=list(self.saved_bgp_config.split("\n")))
 
     def get_bgp_config(self):
@@ -154,23 +191,36 @@ class EosBGPRouter(BGPRouter):
     def get_originated_ipv4_networks(self):
         ipv4_af_output = self.get_command_output("show run section bgp | sec address-family ipv4")
         match = re.search(r'network (\d+\.\d+\.\d+\.\d+/\d+)', ipv4_af_output)
-        if match:
-            self_ipv4_network = match.group(1)
-        else:
-            pytest_assert(self_ipv4_network is not None, f"Failed to get IPv4 network {self.host}")
-        return self_ipv4_network
+        pytest_assert(match, "Failed to get IPv4 network from [{}] on {}".format(ipv4_af_output, self.host))
+        return match.group(1)
 
     def get_originated_ipv6_networks(self):
         ipv6_af_network = self.get_command_output("show run section bgp | sec address-family ipv6")
         match = re.search(r'network ([a-fA-F0-9:]+/\d+)', ipv6_af_network)
-        if match:
-            self_ipv6_network = match.group(1)
-        else:
-            pytest_assert(self_ipv6_network is not None, f"Failed to get IPv6 network {self.host}")
-        return self_ipv6_network
+        pytest_assert(match, "Failed to get IPv6 network from [{}] on {}".format(ipv6_af_network, self.host))
+        return match.group(1)
 
     def get_command_output(self, command):
-        return self.host.eos_command(commands=[command])['stdout'][0]
+        out = self.host.eos_command(commands=[command])['stdout']
+        if not out:
+            return ''
+        # Ansible may return one string per screen line; join for reliable parsing.
+        if len(out) == 1:
+            return out[0]
+        return '\n'.join(out)
+
+    def eos_bgp_summary_include_cmd(self, ip, ipv6=False):
+        base = self._ipv6_bgp_summary_cmd() if ipv6 else self._ip_bgp_summary_cmd()
+        return "{} | include {}".format(base, ip)
+
+    def eos_bgp_neighbor_routes_cmd(self, nbr_ip, ipv6=False):
+        if ipv6:
+            base = "show ipv6 bgp peers {} routes".format(nbr_ip)
+        else:
+            base = "show ip bgp neighbors {} routes".format(nbr_ip)
+        if self.eos_bgp_summary_vrf:
+            base += " vrf {}".format(self.eos_bgp_summary_vrf)
+        return base
 
 
 def check_bgp_neighbor(duthost, bgp_neighbors):
@@ -196,6 +246,29 @@ def setup_ceos(tbinfo, nbrhosts, duthosts, enum_frontend_dut_hostname, enum_rand
     confed_asn = duthost.get_bgp_confed_asn()
 
     neighbors = dict()
+
+    def _all_ebgp_neighbors_established():
+        """Same peer filter as the setup loop below: every non-INTERNAL / non-VOQ_CHASSIS session must be up."""
+        facts = duthost.bgp_facts(instance_id=asic_index)['ansible_facts']
+        for _k, v in facts['bgp_neighbors'].items():
+            if "INTERNAL" in v["peer group"] or "VOQ_CHASSIS" in v["peer group"]:
+                continue
+            if v['state'] != 'established':
+                return False
+        return True
+
+    # If a prior run failed before fixture teardown, the DUT can still be on 4-byte test BGP while neighbors are not
+    # teardown (restore + config_reload) never ran because yield was not reached. Recover once.
+    if not wait_until(120, 10, 0, _all_ebgp_neighbors_established):
+        logger.warning(
+            "eBGP not fully established before 4-byte ASN community setup; reloading DUT to clear stale state"
+        )
+        config_reload(duthost, safe_reload=True, wait_for_bgp=True)
+    pytest_assert(
+        wait_until(300, 10, 0, _all_ebgp_neighbors_established),
+        "eBGP sessions are not all established after optional config_reload; fix topology or neighbor VMs",
+    )
+
     bgp_facts = duthost.bgp_facts(instance_id=asic_index)['ansible_facts']
     ceosNeighbors = [v['description'] for v in bgp_facts['bgp_neighbors'].values()
                      if 'asic' not in v['description'].lower()]
@@ -232,7 +305,23 @@ def setup_ceos(tbinfo, nbrhosts, duthosts, enum_frontend_dut_hostname, enum_rand
 
     dut_ip_bgp_sum = duthost.shell('show ip bgp summary')['stdout']
 
-    bgp_neigh = EosBGPRouter(nbrhosts[neigh]["host"], neigh_asn[neigh])
+    nbr_ent = nbrhosts[neigh]
+    neigh_eos_bgp_parents = eos_bgp_neighbor_config_parents(tbinfo, nbrhosts, neigh, neigh_asn[neigh])
+    multi_vrf = bool(nbr_ent.get("is_multi_vrf_peer"))
+    vrf_name = nbr_ent.get("multi_vrf_data", {}).get("vrf") if multi_vrf else None
+    dut_peer_addrs = (dut_ip_v4, dut_ip_v6) if multi_vrf else None
+    eos_parents_for_cleanup = neigh_eos_bgp_parents if multi_vrf else None
+    neigh_eos_restore_backup = (
+        EOS_NEIGH_BACKUP_CONFIG_FILE.format(neighbors[neigh].hostname) if multi_vrf else None)
+
+    bgp_neigh = EosBGPRouter(
+        nbrhosts[neigh]["host"],
+        neigh_asn[neigh],
+        eos_bgp_summary_vrf=vrf_name,
+        eos_bgp_parents=eos_parents_for_cleanup,
+        dut_peer_addrs=dut_peer_addrs,
+        eos_restore_backup_path=neigh_eos_restore_backup,
+    )
     neigh_bgp_id = bgp_neigh.get_router_id()
     with open(bgp_id_textfsm) as template:
         fsm = textfsm.TextFSM(template)
@@ -267,12 +356,18 @@ def setup_ceos(tbinfo, nbrhosts, duthosts, enum_frontend_dut_hostname, enum_rand
         'dut_ipv6_network': dut_ipv6_network,
         'neigh_ipv4_network': neigh_ipv4_network,
         'neigh_ipv6_network': neigh_ipv6_network,
+        'neigh_eos_bgp_parents': neigh_eos_bgp_parents if multi_vrf else None,
     }
 
     logger.debug("DUT BGP Config: {}".format(duthost.shell("show run bgp", module_ignore_errors=True)['stdout']))
     logger.debug("Neighbor BGP Config: {}".format(bgp_neigh.get_bgp_config()))
     logger.debug('Setup_info: {}'.format(setup_info))
     bgp_neigh.save_bgp_config()
+    if neigh_eos_restore_backup:
+        neighbors[neigh].eos_config(
+            backup=True,
+            backup_options={'filename': neigh_eos_restore_backup},
+        )
 
     yield setup_info
 
@@ -338,7 +433,9 @@ def setup(tbinfo, nbrhosts, duthosts, enum_frontend_dut_hostname, enum_rand_one_
     with open(bgp_id_textfsm) as template:
         fsm = textfsm.TextFSM(template)
         dut_bgp_id = fsm.ParseText(dut_ip_bgp_sum)[0][0]
-        neigh_bgp_id = fsm.ParseText(neigh_ip_bgp_sum)[1][0]
+        neigh_parsed = fsm.ParseText(neigh_ip_bgp_sum)
+        pytest_assert(neigh_parsed, "Failed to parse BGP router id from neighbor summary")
+        neigh_bgp_id = neigh_parsed[-1][0]
 
     dut_ipv4_network = duthost.shell("show run bgp | grep 'ip prefix-list PL_Loopback'")['stdout'].split()[6]
     dut_ipv6_network = duthost.shell("show run bgp | grep 'ipv6 prefix-list PL_Loopback'")['stdout'].split()[6]
@@ -528,10 +625,8 @@ def run_bgp_4_byte_asn_community_eos(setup):
     config_dut_4_byte_asn_dut(setup)
 
     bgp_neigh = setup['bgp_neigh']
-    bgp_neigh.remove_bgp_config()
-    # configure BGP with 4-byte ASN using the standard T2 config and existing route-maps on neighbor device
-    cmd = [
-        "router bgp {}".format(neighbor_4byte_asn),
+    parents = setup.get('neigh_eos_bgp_parents')
+    vrf_neighbor_lines = [
         "router-id {}".format(setup['neigh_bgp_id']),
         "neighbor {} remote-as {}".format(setup['dut_ip_v4'], dut_4byte_asn),
         "neighbor {} description {}".format(setup['dut_ip_v4'], 'DUT'),
@@ -539,17 +634,51 @@ def run_bgp_4_byte_asn_community_eos(setup):
         "neighbor {} remote-as {}".format(setup['dut_ip_v6'], dut_4byte_asn),
         "neighbor {} description {}".format(setup['dut_ip_v6'], 'DUT'),
         "neighbor {} maximum-routes 0".format(setup['dut_ip_v6']),
-        "!",
-        "address-family ipv4",
-        "neighbor {} activate".format(setup['dut_ip_v4']),
-        "network {}".format(setup['neigh_ipv4_network']),
-        "!",
-        "address-family ipv6",
-        "neighbor {} activate".format(setup['dut_ip_v6']),
-        "network {}".format(setup['neigh_ipv6_network'])
     ]
-
-    logger.debug(bgp_neigh.host.eos_config(lines=cmd))
+    # Converged multi-VRF: BGP process stays "router bgp <primary> vrf …" so the real local ASN is still the
+    # primary ASN. The DUT is renumbered to router bgp 400003 and expects the peer as remote-as 400001 — match
+    # that with local-as … no-prepend replace-as on the neighbor toward the DUT (only EOS requires those modifiers).
+    if parents:
+        # EOS requires modifiers after local-as (bare "local-as <asn>" is % Incomplete command).
+        vrf_neighbor_lines.extend([
+            "neighbor {} local-as {} no-prepend replace-as".format(setup['dut_ip_v4'], neighbor_4byte_asn),
+            "neighbor {} local-as {} no-prepend replace-as".format(setup['dut_ip_v6'], neighbor_4byte_asn),
+        ])
+    bgp_neigh.remove_bgp_config()
+    # configure BGP with 4-byte ASN using the standard T2 config and existing route-maps on neighbor device
+    if parents:
+        # Ansible eos_config only applies 'lines' under the fixed 'parents' context. It does NOT treat
+        # "address-family …" lines as a new nesting level, so neighbor activate/network must be pushed
+        # with full parent paths including each address-family.
+        host = bgp_neigh.host
+        logger.debug(host.eos_config(lines=vrf_neighbor_lines, parents=parents))
+        logger.debug(host.eos_config(
+            lines=["network {}".format(setup['neigh_ipv4_network'])],
+            parents=parents + ["address-family ipv4"],
+        ))
+        logger.debug(host.eos_config(
+            lines=[
+                "neighbor {} activate".format(setup['dut_ip_v6']),
+                "network {}".format(setup['neigh_ipv6_network']),
+            ],
+            parents=parents + ["address-family ipv6"],
+        ))
+    else:
+        bgp_lines = (
+            ["router bgp {}".format(neighbor_4byte_asn)]
+            + vrf_neighbor_lines
+            + [
+                "!",
+                "address-family ipv4",
+                "neighbor {} activate".format(setup['dut_ip_v4']),
+                "network {}".format(setup['neigh_ipv4_network']),
+                "!",
+                "address-family ipv6",
+                "neighbor {} activate".format(setup['dut_ip_v6']),
+                "network {}".format(setup['neigh_ipv6_network']),
+            ]
+        )
+        logger.debug(bgp_neigh.host.eos_config(lines=bgp_lines))
 
     logger.debug("DUT BGP Config: {}".format(setup['duthost'].shell("show run bgp")['stdout']))
     logger.debug("Neighbor BGP Config: {}".format(bgp_neigh.get_bgp_config()))
@@ -571,13 +700,15 @@ def run_bgp_4_byte_asn_community_eos(setup):
     assert (str(neighbor_4byte_asn) in str(output.split('\n')[9]) or
            str(neighbor_4byte_asn) in str(output.split('\n')[10]))
 
-    output = bgp_neigh.get_command_output("show ip bgp summary | include {}".format(setup['dut_ip_v4']))
-    assert str(dut_4byte_asn) in output.split()[3]
-    output = bgp_neigh.get_command_output("show ipv6 bgp summary | include {}".format(setup['dut_ip_v6'].lower()))
-    assert str(dut_4byte_asn) in output.split()[3]
-    output = bgp_neigh.get_command_output("show ip bgp neighbors {} routes".format(setup['dut_ip_v4']))
+    output = bgp_neigh.get_command_output(bgp_neigh.eos_bgp_summary_include_cmd(setup['dut_ip_v4']))
+    assert str(dut_4byte_asn) in output
+    output = bgp_neigh.get_command_output(
+        bgp_neigh.eos_bgp_summary_include_cmd(setup['dut_ip_v6'].lower(), ipv6=True))
+    assert str(dut_4byte_asn) in output
+    output = bgp_neigh.get_command_output(bgp_neigh.eos_bgp_neighbor_routes_cmd(setup['dut_ip_v4'], ipv6=False))
     assert str(dut_4byte_asn) in str(output.split('\n')[-1])
-    output = bgp_neigh.get_command_output("show ipv6 bgp peers {} routes".format(setup['dut_ip_v6'].lower()))
+    output = bgp_neigh.get_command_output(
+        bgp_neigh.eos_bgp_neighbor_routes_cmd(setup['dut_ip_v6'].lower(), ipv6=True))
     assert str(dut_4byte_asn) in str(output.split('\n')[-1]) or str(dut_4byte_asn) in str(output.split('\n')[-2])
 
 

--- a/tests/bgp/test_4-byte_asn_community.py
+++ b/tests/bgp/test_4-byte_asn_community.py
@@ -653,7 +653,10 @@ def run_bgp_4_byte_asn_community_eos(setup):
         host = bgp_neigh.host
         logger.debug(host.eos_config(lines=vrf_neighbor_lines, parents=parents))
         logger.debug(host.eos_config(
-            lines=["network {}".format(setup['neigh_ipv4_network'])],
+            lines=[
+                "neighbor {} activate".format(setup['dut_ip_v4']),
+                "network {}".format(setup['neigh_ipv4_network']),
+            ],
             parents=parents + ["address-family ipv4"],
         ))
         logger.debug(host.eos_config(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is similar to the **multi-vrf** EOS config support fix https://github.com/sonic-net/sonic-mgmt/pull/24667. In this PR, we are fixing _test_4-byte_asn_community_ test.

- Extend _tests/bgp/test_4-byte_asn_community.py_ so that EOS neighbor (cEOS) configuration and checks work on multi-VRF topologies, reusing the same _eos_bgp_neighbor_config_parents_ pattern introduced for other BGP tests in [#24667](https://github.com/sonic-net/sonic-mgmt/pull/24667).
- And also added VRF-aware BGP summary / neighbor CLI with safe cleanup. 
- Added full startup-config backup/restore, and recovery when a prior failed run leaves the DUT in a bad BGP state.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

- [#24667](https://github.com/sonic-net/sonic-mgmt/pull/24667) fixed _test_passive_peering, test_bgp_authentication, and test_ipv6_nlri_over_ipv4_ for this class of topologies; _test_4-byte_asn_community_ was still using the old code and could fail or leave bad state.

#### How did you do it?

- Align _test_4-byte_asn_community_ with multi-VRF topologies on cEOS neighbors using the same _eos_bgp_neighbor_config_parents_ / VRF-aware CLI pattern as #24667, plus safer neighbor teardown and recovery when sessions are left inconsistent after a failed run.
- Non-multi-vrf code path is **same** as before. 

#### How did you verify/test it?

- Ran _test_4-byte_asn_community_ test with the new changes and made sure tests is passing without any issues.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
[test_4-byte_asn_community.zip](https://github.com/user-attachments/files/28882415/test_4-byte_asn_community.zip)

