### PR TITLE
[tests/ansible]: Register new SN5640 HWSKUs across test and config files

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -380,7 +380,7 @@
 
   - name: gather hwsku that supports ComputeAI deployment
     set_fact:
-      hwsku_list_compute_ai: "['Cisco-8111-O64', 'Cisco-8111-O32', 'Cisco-8122-O64', 'Cisco-8122-O64S2', 'Cisco-8122-O128']"
+      hwsku_list_compute_ai: ['Cisco-8111-O64', 'Cisco-8111-O32', 'Cisco-8122-O64', 'Cisco-8122-O64S2', 'Cisco-8122-O128', 'Mellanox-SN5640-C508O1X2', 'Mellanox-SN5640-C512X2', 'Mellanox-SN5640-O128X2']
 
   - name: enable ComputeAI deployment
     set_fact:

--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -28,7 +28,7 @@ mellanox_spc2_hwskus: [ 'ACS-MSN3700', 'ACS-MSN3700C', 'ACS-MSN3800', 'Mellanox-
 mellanox_spc3_hwskus: [ 'ACS-MSN4700', 'Mellanox-SN4700-O28', 'Mellanox-SN4700-O32', 'ACS-MSN4600', 'ACS-MSN4600C', 'ACS-MSN4410', 'Mellanox-SN4600C-D112C8', 'Mellanox-SN4600C-C64', 'Mellanox-SN4700-O8C48', 'Mellanox-SN4700-O8V48', 'ACS-SN4280', 'Mellanox-SN4280-O28', 'Mellanox-SN4280-O8C40', 'Mellanox-SN4280-C48', 'Mellanox-SN4280-O8V40', 'Mellanox-SN4280-O8C80', 'Mellanox-SN4700-V64', 'Mellanox-SN4700-O32']
 mellanox_spc4_hwskus: [ 'ACS-SN5600' , 'Mellanox-SN5600-V256', 'Mellanox-SN5600-C256S1', 'Mellanox-SN5600-C224O8',
                         'Mellanox-SN5610N-C256S2', 'Mellanox-SN5610N-C224O8']
-mellanox_spc5_hwskus: [ 'Mellanox-SN5640-C512S2', 'Mellanox-SN5640-C448O16']
+mellanox_spc5_hwskus: [ 'Mellanox-SN5640-C512S2', 'Mellanox-SN5640-C448O16', 'Mellanox-SN5640-C508O1X2', 'Mellanox-SN5640-C512X2', 'Mellanox-SN5640-O128X2']
 mellanox_hwskus: "{{ mellanox_spc1_hwskus + mellanox_spc2_hwskus + mellanox_spc3_hwskus + mellanox_spc4_hwskus + mellanox_spc5_hwskus }}"
 mellanox_dualtor_hwskus: [ 'Mellanox-SN4700-V64' ]
 

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -44,6 +44,8 @@ LOSSY_HWSKU = frozenset({'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8
                          'Mellanox-SN5600-C256S1', 'Mellanox-SN5600-C224O8',
                          'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16',
                          'Mellanox-SN5640-C512S2', 'Mellanox-SN5640-C448O16',
+                         'Mellanox-SN5640-C508O1X2',
+                         'Mellanox-SN5640-C512X2', 'Mellanox-SN5640-O128X2',
                          "Mellanox-SN6600_LD-P64O128C2", "Mellanox-SN6600_LD-P128C2"})
 
 

--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -13,12 +13,14 @@ SPC3_HWSKUS = ["ACS-MSN4700", "Mellanox-SN4700-O28", "ACS-MSN4600C", "ACS-MSN441
                "Mellanox-SN4280-O8C40", "Mellanox-SN4280-C48", "Mellanox-SN4280-O8V40", "Mellanox-SN4280-O8C80"]
 SPC4_HWSKUS = ["ACS-SN5600", "Mellanox-SN5600-V256", "Mellanox-SN5600-C256S1", "Mellanox-SN5600-C224O8",
                'Mellanox-SN5610N-C256S2', 'Mellanox-SN5610N-C224O8']
-SPC5_HWSKUS = ["Mellanox-SN5640-C512S2", "Mellanox-SN5640-C448O16"]
+SPC5_HWSKUS = ["Mellanox-SN5640-C512S2", "Mellanox-SN5640-C448O16", "Mellanox-SN5640-C508O1X2",
+               "Mellanox-SN5640-C512X2", "Mellanox-SN5640-O128X2"]
 SPC6_HWSKUS = ["ACS-SN6600", "ACS-SN6600_LD", "Mellanox-SN6600_LD-V512C2", "Mellanox-SN6600_LD-V448P16C2"]
 SWITCH_HWSKUS = SPC1_HWSKUS + SPC2_HWSKUS + SPC3_HWSKUS + SPC4_HWSKUS + SPC5_HWSKUS + SPC6_HWSKUS
 
 LOSSY_ONLY_HWSKUS = ['Mellanox-SN5600-C256S1', 'Mellanox-SN5600-C224O8', 'Mellanox-SN5640-C512S2',
-                     'Mellanox-SN5640-C448O16']
+                     'Mellanox-SN5640-C448O16', 'Mellanox-SN5640-C508O1X2',
+                     'Mellanox-SN5640-C512X2', 'Mellanox-SN5640-O128X2']
 NO_QOS_HWSKUS = []
 
 PSU_CAPABILITIES = [

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1204,7 +1204,7 @@ platform_tests/sfp/test_sfputil.py::test_check_sfputil_error_status:
     reason: "Per lane interface status is not supported on SP4/SP5 platform."
     conditions_logical_operator: or
     conditions:
-    - hwsku in ['Mellanox-SN5600-C224O8', 'Mellanox-SN5600-C256S1', 'Mellanox-SN5640-C448O16', 'Mellanox-SN5640-C512S2']
+      - "hwsku in ['Mellanox-SN5600-C224O8', 'Mellanox-SN5600-C256S1', 'Mellanox-SN5640-C448O16', 'Mellanox-SN5640-C512S2', 'Mellanox-SN5640-C508O1X2', 'Mellanox-SN5640-C512X2', 'Mellanox-SN5640-O128X2']"
 
 platform_tests/sfp/test_sfputil.py::test_check_sfputil_low_power_mode:
   skip:

--- a/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
@@ -3,7 +3,7 @@
     "Arista-7050QX": ["Arista-7050-QX-32S", "Arista-7050-QX32", "Arista-7050QX-32S-S4Q31", "Arista-7050QX32S-Q32"],
     "Mellanox-SN4600C": ["Mellanox-SN4600C-C64"],
     "Arista-7060X6": ["Arista-7060X6-64PE-B-C512S2", "Arista-7060X6-64PE-B-C448O16", "Arista-7060X6-16PE-384C-B-O128S2", "Arista-7060X6-64PE-B-O128"],
-    "Mellanox-SN5640": ["Mellanox-SN5640-C448O16", "Mellanox-SN5640-C512S2"],
+    "Mellanox-SN5640": ["Mellanox-SN5640-C448O16", "Mellanox-SN5640-C512S2", "Mellanox-SN5640-C508O1X2", "Mellanox-SN5640-C512X2", "Mellanox-SN5640-O128X2"],
     "Arista-7060CX": ["Arista-7060CX-32S-C32", "Arista-7060CX-32S-D48C8"],
     "Arista-7260CX3": ["Arista-7260CX3-C64", "Arista-7260CX3-D108C8", "Arista-7260CX3-D108C10"],
     "Nokia-IXR7220": ["Nokia-IXR7220-H6-O256"],

--- a/tests/common/snappi_tests/packet_trim_helpers.py
+++ b/tests/common/snappi_tests/packet_trim_helpers.py
@@ -87,7 +87,8 @@ def get_max_supported_trim_ratio(duthost):
     if not hwsku:
         return None
     hwsku_upper = hwsku.upper()
-    sn5640_hwskus = {"MELLANOX-SN5640-C512S2", "MELLANOX-SN5640-C448O16"}
+    sn5640_hwskus = {"MELLANOX-SN5640-C512S2", "MELLANOX-SN5640-C448O16", "MELLANOX-SN5640-C508O1X2",
+                     "MELLANOX-SN5640-C512X2", "MELLANOX-SN5640-O128X2"}
     if hwsku_upper in sn5640_hwskus:
         return 8
     return None

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -3787,6 +3787,8 @@ def set_queue_pir(interface, queue, rate):
     @pytest.fixture(scope='class', autouse=True)
     def is_supported_per_dir(self, get_src_dst_asic_and_duts, tbinfo):  # noqa F811
         supported_per_dir_platform = ["Mellanox-SN5640-C448O16", "Mellanox-SN5640-C512S2",
+                                      "Mellanox-SN5640-C508O1X2",
+                                      "Mellanox-SN5640-C512X2", "Mellanox-SN5640-O128X2",
                                       "Mellanox-SN5600-C224O8", "Mellanox-SN5600-C256S1",
                                       "Arista-7060X6-16PE-384C-B-O128S2"]
         is_supported_per_dir = \


### PR DESCRIPTION
 - Add Mellanox-SN5640-C508O1X2, Mellanox-SN5640-C512X2, and Mellanox-SN5640-O128X2 to SPC5/lossy/compute-ai HWSKU lists
 - Update mellanox_data, variables, golden config, QoS, packet trim, conditional mark, and memory utilization files

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
