### PR TITLE
[bgp] Support BGP confederation in test_passive_peering

### DIFF
--- a/tests/bgp/test_passive_peering.py
+++ b/tests/bgp/test_passive_peering.py
@@ -35,6 +35,7 @@ def setup(tbinfo, nbrhosts, duthosts, rand_one_dut_front_end_hostname, request):
 
     duthost = duthosts[rand_one_dut_front_end_hostname]
     dut_asn = tbinfo['topo']['properties']['configuration_properties']['common']['dut_asn']
+    confed_asn = duthost.get_bgp_confed_asn()
 
     lldp_table = duthost.shell("show lldp table")['stdout'].split("\n")[3].split()
     neigh_name = lldp_table[1]
@@ -69,8 +70,17 @@ def setup(tbinfo, nbrhosts, duthosts, rand_one_dut_front_end_hostname, request):
                     assert v['state'] == 'established'
             neigh_asn[v['description']] = v['remote AS']
 
-    dut_ip_v4 = tbinfo['topo']['properties']['configuration'][neigh_name]['bgp']['peers'][dut_asn][0]
-    dut_ip_v6 = tbinfo['topo']['properties']['configuration'][neigh_name]['bgp']['peers'][dut_asn][1]
+    # On confederation topologies the peer is configured under the confed ASN, so
+    # use it for the topo peer/IP lookup. The DUT-side vtysh 'router bgp' commands
+    # still use dut_asn (the original FRR member ASN).
+    neigh_bgp_config = tbinfo['topo']['properties']['configuration'][neigh_name]['bgp']
+    peer_in_bgp_confed = neigh_bgp_config.get('peer_in_bgp_confed', False)
+    if peer_in_bgp_confed:
+        asn = int(confed_asn)
+    else:
+        asn = int(dut_asn)
+    dut_ip_v4 = tbinfo['topo']['properties']['configuration'][neigh_name]['bgp']['peers'][asn][0]
+    dut_ip_v6 = tbinfo['topo']['properties']['configuration'][neigh_name]['bgp']['peers'][asn][1]
 
     # EOS/cEOS converged: eos_config parents (nbrhosts flag or tbinfo convergence_data fallback)
     if is_sonic:


### PR DESCRIPTION
### Description of PR

Summary:
Make `test_passive_peering` BGP-confederation aware so it passes on UT2 testbeds where the DUT participates in a BGP confederation.

This test assumes the DUT advertises routes using its own `dut_asn`. On testbeds where the DUT is in a BGP confederation, the eBGP sessions to the T3 neighbors are established with the configured confederation ASN, not the member ASN. As a result `test_passive_peering` looked up peer IPs under the wrong ASN key, causing spurious failures on confederation topologies. This PR makes the test confederation-aware while leaving non-confederation behavior unchanged.

> Note: `test_ipv6_nlri_over_ipv4` was originally part of this PR but has been removed to reduce scope — that fix is covered by #25221.

Fixes # (N/A)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

On confederation UT2 testbeds, the DUT peers with its T3 neighbors using the confederation ASN rather than its member `dut_asn`. `test_passive_peering` hard-coded `dut_asn`, so peer-IP lookups used the wrong ASN and failed even though BGP was healthy.

#### How did you do it?

- `tests/bgp/test_passive_peering.py`
  - Query `duthost.get_bgp_confed_asn()` and the neighbor's `peer_in_bgp_confed` topology property; resolve the neighbor's peer IPv4/IPv6 under the confederation ASN when the neighbor peers via confederation, otherwise under `dut_asn`. The DUT-side `router bgp <dut_asn>` commands are left unchanged.

Non-confederation behavior is preserved by construction: `get_bgp_confed_asn()` returns `None` when no confederation is configured, the new logic is gated on `peer_in_bgp_confed` (defaults to `False`), and the non-confed code path is identical to the previous behavior.

#### How did you verify/test it?

Ran `tests/bgp/test_passive_peering.py` on a confederation UT2 testbed (topology `t2_single_node_max_64p`, `dut_confed_asn` configured): **PASSED**.

#### Any platform specific information?

No platform-specific code. The change only takes effect on topologies that configure a BGP confederation (`dut_confed_asn` / neighbors with `peer_in_bgp_confed: true`); all other topologies retain the original behavior.

#### Supported testbed topology if it's a new test case?

Not a new test case. Existing `ut2` topology coverage is unchanged; the fix additionally makes the test work on confederation `ut2` topologies.

### Documentation

No documentation changes required.