### PR TITLE
[sflow] testDelAgent: wait for hsflowd to rewrite hsflowd.auto after agent-id del

### DIFF
--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -666,9 +666,15 @@ class TestAgentId():
 
     def testDelAgent(self, duthosts, rand_one_dut_hostname, partial_ptf_runner):
         duthost = duthosts[rand_one_dut_hostname]
+        read_agent_cmd = "docker exec sflow grep -w 'agentIP' /etc/hsflowd.auto 2>/dev/null | cut -d '=' -f 2"
+        previous_agent_ip = duthost.shell(read_agent_cmd, module_ignore_errors=True)['stdout'].strip()
         duthost.shell(" config sflow agent-id del")
         verify_show_sflow(duthost, status='up', agent_id='default')
         wait_until(30, 5, 0, verify_sflow_config_apply, duthost)
+        # Wait for hsflowd to rewrite /etc/hsflowd.auto with the new agentIP,
+        # otherwise get_default_agent below reads the stale previous value.
+        wait_until(60, 2, 0, lambda: duthost.shell(
+            read_agent_cmd, module_ignore_errors=True)['stdout'].strip() not in ('', previous_agent_ip))
         agent_ip = get_default_agent(duthost)
         # Verify  whether the samples are received with previously configured agent ip
         partial_ptf_runner(


### PR DESCRIPTION
### Description of PR

Summary:
Fix the `sflow.test_sflow::TestAgentId.testDelAgent` flaky test by waiting for `hsflowd` to rewrite `/etc/hsflowd.auto` with the new agent IP before reading it back.

Per Kusto telemetry, this test signature has hit **128 distinct PRs over the last 30 days** on both `master` and `202605` branches with the exact same converging assertion:

```
AssertionError: Agent id in Sampled packet is not expected . Expected : <stale> , received : <new>
  at ansible/roles/test/files/ptftests/py3/sflow_test.py:217 (analyze_counter_sample)
```

Fixes the race between hsflowd's runtime selection of a new agent IP (fast) and its asynchronous rewrite of `/etc/hsflowd.auto` (slow) after `config sflow agent-id del`.

Fixes # 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

`testDelAgent` reads `/etc/hsflowd.auto` via `get_default_agent(duthost)` immediately after `config sflow agent-id del`, then hands that value to PTF as the expected `agent_id`. PTF parses the agent IP out of the actual sFlow CounterSample packets it captures on the wire.

The existing gate, `wait_until(verify_sflow_config_apply)`, only checks that `*SAMPLEPACKET*` redis keys exist — which they already do from the prior test in the class — so it returns immediately on the first poll and provides no synchronization against `hsflowd`.

After `config sflow agent-id del`, hsflowd:
1. notices the CONFIG_DB change,
2. picks a new agent interface and **starts emitting samples with the new agent IP** (fast — sub-second),
3. **asynchronously rewrites `/etc/hsflowd.auto`** with the new `agentIP=` line (slow — tens to hundreds of milliseconds, longer under load).

If `get_default_agent` reads the file between steps 2 and 3, it gets the **stale** agent IP from the previous test (`testNonDefaultAgent` left `Loopback0`'s IP there). PTF then compares the stale expected value against the new actually-emitted value and asserts. This is why only `testDelAgent` flakes — the other two methods in `TestAgentId` pass hard-coded IPs and don't read `hsflowd.auto`.

#### How did you do it?

Snapshot the pre-del `agentIP=` line from `/etc/hsflowd.auto` directly via `duthost.shell(..., module_ignore_errors=True)` (rather than `get_default_agent`, which `pytest.fail`s on transient empty states). After `verify_sflow_config_apply`, poll the same file until its `agentIP=` line is non-empty and not equal to the snapshotted previous value — that is, until hsflowd has finished its asynchronous rewrite. Then proceed to `get_default_agent`.

The fix is 6 lines, contained entirely in `testDelAgent`, with no new module-level helpers. It mirrors the existing `wait_until_hsflowd_ready` precedent at `tests/sflow/test_sflow.py:282` which solves the analogous race for *startup*.

#### How did you verify/test it?

- Reproduced the full testbed on a local dev-vm (vlab-01, `vms-kvm-t0`).

```
___________________________ TestAgentId.testDelAgent ___________________________
    def testDelAgent(self, duthosts, rand_one_dut_hostname, partial_ptf_runner):
        ...
>       partial_ptf_runner(
            polling_int=20,
            agent_id=agent_ip,
            active_collectors="['collector0','collector1']")
                                                                                  tests/sflow/test_sflow.py:674

E   tests.common.errors.RunAnsibleModuleFail: run module shell failed
E   cmd = /root/env-python3/bin/ptf ... sflow_test ... agent_id='10.1.0.32' ...
E
E   The following tests failed:
E   AssertionError: False is not true : Agent id in Sampled packet is not expected .
E                   Expected :  10.1.0.32 , received : 20.1.1.1
E
E   Ran 1 test in 29.210s
E   FAILED (failures=1)

common/devices/base.py:248: RunAnsibleModuleFail
FAILED sflow/test_sflow.py::TestAgentId::testDelAgent - tests.common.errors.R...
============ 1 failed, 9 passed, 670 warnings in 1598.15s (0:26:38) ============
```
- Ran the `TestAgentId` class end-to-end three times: against the final `+6/-0` version. 

Same topology (`vms-kvm-t0`, `vlab-01`), same pytest invocation, after applying this PR:

```
sflow/test_sflow.py::TestAgentId::testNonDefaultAgent PASSED             [ 33%]
sflow/test_sflow.py::TestAgentId::testDelAgent       PASSED              [ 66%]
sflow/test_sflow.py::TestAgentId::testAddAgent       PASSED              [100%]
================= 3 passed, 241 warnings in 860.34s (0:14:20) ==================
```

#### Any platform specific information?

None — fix lives entirely in test code.

#### Supported testbed topology if it's a new test case?

Not a new test case; existing test is t0/t1-only and remains so.

### Documentation

No documentation changes required.
