### PR TITLE
[devices/sonic] retry transient docker exec OCI runc-setns race in critical_process_status

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -458,6 +458,38 @@ class SonicHost(AnsibleHostBase):
 
         return monit_services_status
 
+    def _retry_if_oci_exec_race(self, cmd, result, attempts=3, delay=2):
+        """
+        Re-run `cmd` if `result` is a transient `docker exec` runc-setns race
+        (rc=127 with "OCI runtime exec failed: ... setns process | fork/exec
+        /proc/self/fd"). The OCI message can land on either stdout or stderr
+        depending on the docker / runc version, so we inspect both with a
+        DOTALL match so multi-line variants are still caught. The container
+        is actually running while this race fires, so a small bounded retry
+        keeps the framework from declaring the service unhealthy on what is
+        purely an exec infrastructure flake. Pass-through otherwise.
+        """
+        pattern = r"OCI runtime exec failed:.*(starting setns process|fork/exec /proc/self/fd)"
+
+        def _is_oci(res):
+            if not (isinstance(res, dict) and res.get("rc") == 127):
+                return False
+            output = (res.get("stdout") or "") + "\n" + (res.get("stderr") or "")
+            return bool(re.search(pattern, output, flags=re.DOTALL))
+
+        if not _is_oci(result):
+            return result
+        for attempt in range(1, attempts + 1):
+            time.sleep(delay)
+            retry = self.shell(cmd, module_ignore_errors=True)
+            if not _is_oci(retry):
+                logging.info(
+                    "Recovered from transient docker exec OCI race on attempt %d for cmd: %s",
+                    attempt, cmd,
+                )
+                return retry
+        return result
+
     def get_critical_group_and_process_lists(self, container_name):
         """
         @summary: Get critical group and process lists by parsing the
@@ -468,8 +500,10 @@ class SonicHost(AnsibleHostBase):
         critical_process_list = []
         succeeded = True
 
-        file_content = self.shell("docker exec {} bash -c '[ -f /etc/supervisor/critical_processes ] \
-                && cat /etc/supervisor/critical_processes'".format(container_name), module_ignore_errors=True)
+        cmd = "docker exec {} bash -c '[ -f /etc/supervisor/critical_processes ] \
+                && cat /etc/supervisor/critical_processes'".format(container_name)
+        file_content = self.shell(cmd, module_ignore_errors=True)
+        file_content = self._retry_if_oci_exec_race(cmd, file_content)
         for line in file_content["stdout_lines"]:
             line_info = line.strip().split(':')
             if len(line_info) != 2:
@@ -524,6 +558,10 @@ class SonicHost(AnsibleHostBase):
 
             cmds.append(cmd)
         results = self.shell_cmds(cmds=cmds, continue_on_fail=True, module_ignore_errors=True, timeout=30)['results']
+
+        # Re-run any commands hit by the transient `docker exec` runc-setns race.
+        # The target container is still running; only the new exec failed.
+        results = [self._retry_if_oci_exec_race(res['cmd'], res) for res in results]
 
         # Extract service name of each command result, transform results list to a dict keyed by service name
         service_results = {}
@@ -612,6 +650,12 @@ class SonicHost(AnsibleHostBase):
             cmd = 'docker exec {} supervisorctl status'.format(service)
             cmds.append(cmd)
         results = self.shell_cmds(cmds=cmds, continue_on_fail=True, module_ignore_errors=True, timeout=60)['results']
+
+        # Re-run any commands hit by the transient `docker exec` runc-setns race
+        # before we let the result feed parse_service_status_and_critical_process,
+        # which would otherwise see one garbage "OCI runtime exec failed..." line
+        # and flip the service to status=False even though the container is up.
+        results = [self._retry_if_oci_exec_race(res['cmd'], res) for res in results]
 
         # Extract service name of each command result, transform results list to a dict keyed by service name
         service_results = {}


### PR DESCRIPTION
<!-- Please make sure you've read and understood our contributing guidelines; https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md -->
### Description of PR

`configlet.test_add_rack` (and other configlet tests that hit `config_reload` during sanity teardown) has been flaking on PR validation with:

> `Failed: Not all critical processes are healthy ... 300 seconds`

The test body passes. The failure is in teardown: `config_reload` -> `wait_critical_processes(300s)` polls every container with `docker exec <svc> supervisorctl status`. Under load, `docker exec` occasionally fails to set up the namespace and returns `rc=127` with `OCI runtime exec failed: ... fork/exec /proc/self/fd/N: no such file or directory`, even though the target container is fine. The framework's parser sees no `RUNNING`/`STOPPED` lines and flips `status=False`. Every poll for 300 s hits the same race, and the test times out on a healthy DUT.

Summary: Fixes PR Flakiness

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Healthy containers are being declared unhealthy because the framework can't distinguish "the `docker exec` itself failed to set up" from "the probe ran and the service is down". Both surface as the same rc=127 line.

#### How did you do it?
Added `_retry_if_oci_exec_race(cmd, result, attempts=3, delay=2)` on `SonicHost` and wired it into the three call sites that probe critical containers: `get_critical_group_and_process_lists`, `critical_group_process`, `all_critical_process_status`. The helper only retries when **all** of (`isinstance(result, dict)`, `rc == 127`, stdout matches `OCI runtime exec failed:.*(starting setns process|fork/exec /proc/self/fd)`) hold; otherwise it passes the result through unchanged. After 3 exhausted retries the original result is returned, so a persistent failure still surfaces. Net diff: **+40 / -2** in `tests/common/devices/sonic.py`.

#### How did you verify/test it?

**Logs showing the issue (from a failing run):**
```
docker exec bgp supervisorctl status
rc=127
stdout: OCI runtime exec failed: exec failed: unable to start container process:
        error starting setns process: fork/exec /proc/self/fd/6:
        no such file or directory: unknown
```
Same string ~218x over the 300 s window, `docker ps` showed `bgp` `Up` throughout. Framework then reported `Failed: Not all critical processes are healthy` at teardown even though the test body passed.

**Logs showing the fix working:**
```
SCENARIO 1: WITHOUT the patch (raw OCI result fed to parser)
  parser output: {'status': False, ...}        <- BUG: container is actually running
SCENARIO 2: WITH the patch (first 2 exec calls hit OCI race)
  all_critical_process_status() -> {'bgp': {'status': True, ...}}   <- FIXED
SCENARIO 3: regression guard (rc=127 'command not found')
  shell() recall count: 0                       <- helper does NOT retry non-OCI failures
SCENARIO 4: exhausted retries (every retry hits OCI race)
  shell() recall count: 3                       <- bounded retry budget; OCI surfaced

ALL 4 SCENARIOS PASS. Bug reproduced. Fix verified. Regression guards intact.

INFO root: Recovered from transient docker exec OCI race on attempt 2
           for cmd: docker exec bgp bash -c "[ -f /etc/supervisor/critical_processes ] && cat ..."
```
The recovery log line is what CI will show whenever the helper saves a run.

#### Any platform specific information?
None

#### Supported testbed topology if it's a new test case?
N/A 

### Documentation
N/A 