### PR TITLE
[bgp]: Retry empty BGP summary read in test_bgp_update_replication

### DIFF
--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -19,6 +19,8 @@ logger = logging.getLogger(__name__)
 # Fixture params
 PEER_COUNT = 16
 WAIT_TIMEOUT = 120
+STATS_COLLECT_TIMEOUT = 30
+STATS_COLLECT_INTERVAL = 5
 
 pytestmark = [
     pytest.mark.topology('t0', 't1', 't2', 'lrh', 'urh', 'lt2', 'ft2'),
@@ -50,6 +52,31 @@ def generate_routes(num_routes, nexthop, is_ipv6=False):
             }
 
 
+def _read_parsed_stats(dut, cmd, template_path):
+    '''
+    Run a stats command on the DUT and TextFSM-parse its output, retrying while the DUT
+    returns empty/unparseable output. Under the heavy route churn this test drives, the DUT
+    management plane can momentarily return empty output for "show ip bgp summary", which
+    would otherwise crash the caller with an IndexError when indexing the empty parse.
+    '''
+    parsed = []
+
+    def _parsed_ready():
+        nonlocal parsed
+        output = dut.shell(cmd, module_ignore_errors=True)['stdout']
+        with open(template_path) as template:
+            parsed = textfsm.TextFSM(template).ParseTextToDicts(output)
+        if not parsed:
+            logger.warning("Empty parse for '%s', retrying; output=%r", cmd, output)
+        return bool(parsed)
+
+    pytest_assert(
+        wait_until(STATS_COLLECT_TIMEOUT, STATS_COLLECT_INTERVAL, 0, _parsed_ready),
+        f"DUT did not return parseable output for '{cmd}' within {STATS_COLLECT_TIMEOUT} sec"
+    )
+    return parsed
+
+
 def measure_stats(dut, is_ipv6=False):
     '''
     Validates that the provided DUT is responsive during test, and that device stats do not
@@ -64,11 +91,11 @@ def measure_stats(dut, is_ipv6=False):
 
     time_before_cmd = time.process_time()
 
-    proc_cpu = dut.shell("show processes cpu | head -n 10", module_ignore_errors=True)['stdout']
+    parsed_proc = _read_parsed_stats(dut, "show processes cpu | head -n 10", PROC_TEMPLATE)
     time_first_cmd = time.process_time()
 
     bgp_cmd = f"show ip{'v6' if is_ipv6 else ''} bgp summary | grep memory"
-    bgp_sum = dut.shell(bgp_cmd, module_ignore_errors=True)['stdout']
+    parsed_bgp_sum = _read_parsed_stats(dut, bgp_cmd, BGP_SUM_TEMPLATE)
     time_second_cmd = time.process_time()
 
     num_cores = dut.shell('cat /proc/cpuinfo | grep "cpu cores" | uniq', module_ignore_errors=True)['stdout']
@@ -86,14 +113,6 @@ def measure_stats(dut, is_ipv6=False):
         responsive_threshold > average_response_time,
         f"SSH session took longer than average of {responsive_threshold} sec to respond"
     )
-
-    with open(PROC_TEMPLATE) as template:
-        fsm = textfsm.TextFSM(template)
-        parsed_proc = fsm.ParseTextToDicts(proc_cpu)
-
-    with open(BGP_SUM_TEMPLATE) as template:
-        fsm = textfsm.TextFSM(template)
-        parsed_bgp_sum = fsm.ParseTextToDicts(bgp_sum)
 
     stats: dict[str, Any] = {"timestamp": datetime.datetime.now().time()}
     stats.update(parsed_proc[0])


### PR DESCRIPTION
### Description of PR

Summary:
`bgp/test_bgp_update_replication.py` is intermittently failing (flaky) with `IndexError: list index out of range` in `measure_stats()`. Under the heavy route churn this test drives (inject/withdraw 10,000 routes x120), the DUT management plane momentarily returns **empty** output for `show ip bgp summary | grep memory`; TextFSM parses that empty string to `[]`, and `measure_stats` does `parsed_bgp_sum[0]` on the empty list -> `IndexError`, failing the whole ~46-min run.

This PR makes the per-call CPU / BGP-summary reads resilient: it retries the read+parse (via the repo's standard `wait_until` helper) until the DUT returns parseable output, instead of indexing a single, possibly-empty read.



Scope (Kusto, last 45 days): the `IndexError` signature hit **153 distinct PRs** across master / 202511 / 202512 / 202605, ~6% fail rate, still occurring.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Remove a high-volume PR-gate flake. The failure is a timing race independent of the code under test - it has failed 153 distinct, unrelated PRs, forcing needless reruns.

#### How did you do it?
Added a small module-level helper `_read_parsed_stats(dut, cmd, template_path)` that runs the existing command and TextFSM-parses it, **retrying while the DUT returns empty/unparseable output**, using the already-imported `wait_until` + `pytest_assert` (the same idiom used elsewhere in this file, e.g. `_check_rib_routes_received`). `measure_stats` now routes its two reads through this helper. The commands, TextFSM templates, parsing, function signature, return value and all 6 call sites are unchanged; on a genuine outage it now fails with a clear message instead of a bare `IndexError`. Diff: +29 / -10, one file.

#### How did you verify/test it?

`--showlocals` dump at the crash:
```
tests/bgp/test_bgp_update_replication.py:328: in test_bgp_update_replication
    results.append(measure_stats(duthost, is_ipv6))
tests/bgp/test_bgp_update_replication.py:100: in measure_stats
    stats.update(parsed_bgp_sum[0])
E   IndexError: list index out of range

bgp_cmd        = 'show ip bgp summary | grep memory'
bgp_sum        = ''                 # DUT returned empty
parsed_bgp_sum = []
parsed_proc    = [{'av1': '4.15', ...}]
proc_cpu       = 'top - ... load average: 4.15, 4.47, 4.14 ...'   # DUT under load, 2 vCPUs
```

**2) Deterministic local reproduction + fix verification** (`vms-kvm-t1-lag`, vlab-03, running the real `measure_stats`). Forced the exact trigger by stopping bgpd so `show ip bgp summary | grep memory` returns empty.

Before fix (master) reproduces the crash:
```
dut.shell('show ip bgp summary | grep memory') -> stdout=''
File ".../test_bgp_update_replication.py", line 100, in measure_stats
IndexError: list index out of range
```

After fix, same forced break:

| Scenario | Before (master) | After (fix) |
|---|---|---|
| bgpd healthy | SUCCESS num_rib=12851 | SUCCESS num_rib=12851 (unchanged) |
| empty, recovers mid-run (the real transient) | IndexError | **1 retry -> SUCCESS** |
| empty, stays down | IndexError | 5 retries -> clean `Failed: DUT did not return parseable output for 'show ip bgp summary \| grep memory' within 30 sec` |

#### Any platform specific information?
None. Topology-agnostic; observed on t1-lag KVM.

#### Supported testbed topology if it's a new test case?
N/A - existing test, no topology change.

### Documentation
N/A
