### PR TITLE
[hft] Parse Msg/s without rate validation

### DIFF
--- a/tests/high_frequency_telemetry/utilities.py
+++ b/tests/high_frequency_telemetry/utilities.py
@@ -962,14 +962,14 @@ def validate_enabled_stream_output(
             f"Successfully verified {len(counter_matches)} counter values "
             f"are > {min_counter_value}")
 
-    # Validate Msg/s if poll_interval is provided
+    # Always parse Msg/s so callers that only need to detect active streams can
+    # inspect the values without requesting strict rate validation.
     msg_per_sec_matches = []
     msg_validation_result = None
+    msg_pattern = r'Msg/s:\s+(\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)'
+    msg_per_sec_matches = re.findall(msg_pattern, stable_output)
 
     if expected_poll_interval:
-        msg_pattern = r'Msg/s:\s+(\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)'
-        msg_per_sec_matches = re.findall(msg_pattern, stable_output)
-
         if msg_per_sec_matches:
             msg_values = [float(m) for m in msg_per_sec_matches]
 


### PR DESCRIPTION
## Description of PR
Summary:
Fix HFT config transition validation after #22975 by parsing Msg/s values even when strict poll-interval based rate validation is disabled.

Fixes #24907

## Type of change
- Bug fix
- Test case improvement

## Approach
### What is the motivation for this PR?
#22975 intentionally passes expected_poll_interval=None for config transition validation so the test does not fail on cumulative average Msg/s drift caused by config application latency.

However, validate_enabled_stream_output only parsed Msg/s inside the expected_poll_interval branch. As a result, config create/re-create phases received actual_msg_per_sec=[] and has_active_msgs=False even when countersyncd output contained non-zero Msg/s values.

### How did you do it?
- Always parse Msg/s values from stable countersyncd reports.
- Keep strict Msg/s range validation gated by expected_poll_interval.

### How did you verify/test it?
- python -m py_compile tests/high_frequency_telemetry/utilities.py
- Reviewed the validation flow to confirm create/re-create phases can detect active Msg/s values while strict rate validation remains disabled when expected_poll_interval=None.
-
```
high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_port_counters[str4-sn5640-3] PASSED [  7%]
high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_full_queue_counters[str4-sn5640-3] PASSED [ 14%]
high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_full_ingress_priority_group_counters[str4-sn5640-3] PASSED [ 21%]
high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_full_buffer_pool_counters[str4-sn5640-3] SKIPPED [ 28%]
high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_full_counters[str4-sn5640-3] SKIPPED [ 35%]
high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_full_port_counters[str4-sn5640-3] PASSED [ 42%]
high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_disabled_stream[str4-sn5640-3] PASSED [ 50%]
high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_config_deletion_stream[str4-sn5640-3] 
-------------------------------- live log setup --------------------------------
10:29:29 conftest.get_swss_uptime_seconds         L0064 WARNING| Failed to parse status line: c7774a4fa085   docker-orchagent:latest   "/usr/bin/docker-ini…"   About an hour ago   Up About an hour             swss
10:29:29 conftest.ensure_swss_ready               L0080 WARNING| swss container is not running, attempting to start...
PASSED                                                                   [ 57%]
high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_poll_interval_validation[str4-sn5640-3-1000-1000] SKIPPED [ 64%]
high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_poll_interval_validation[str4-sn5640-3-10000-100] SKIPPED [ 71%]
high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_poll_interval_validation[str4-sn5640-3-100000-10] SKIPPED [ 78%]
high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_poll_interval_validation[str4-sn5640-3-1000000-1] SKIPPED [ 85%]
high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_poll_interval_validation[str4-sn5640-3-10000000-0.1] SKIPPED [ 92%]
high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_port_shutdown_stream[str4-sn5640-3] PASSED [100%]
```

## Any platform specific information?
No platform-specific behavior introduced.