### PR TITLE
[Mellanox] Validate Spectrum-6 egress ACL mirroring behavior

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -479,9 +479,6 @@ r, ".*ERR systemd\[1\]: Failed to listen on systemd-networkd.socket - Network Se
 # Ignore syncd error when switching global packet trimming mode
 r, ".*ERR .* SAI_API_SWITCH:brcm_sai_switch_pkt_trim_qos_tc_egr_entries_create:.* Egress qos map with idx .* entries are already present.*"
 
-# Ignore SPC6 Egress mirroring not supported failures on SPC6 mellanox platform
-r, ".*ERR syncd#SDK: \[SAI_PORT.ERR\] .*mlnx_sai_port.c\[.*\]- mlnx_port_samplepacket_session_get: Egress mirroring is not supported on SPC6.*"
-
 # Ignore the error when the sysfs was accessed too soon, before sys creation has been completed.
 r, ".*ERR sfputil: Failed to read from file /sys/module/sx_core/asic\d+/module\d+/present - FileNotFoundError.*"
 

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -482,9 +482,6 @@ r, ".*ERR systemd\[1\]: Failed to listen on systemd-networkd.socket - Network Se
 # Ignore syncd error when switching global packet trimming mode
 r, ".*ERR .* SAI_API_SWITCH:brcm_sai_switch_pkt_trim_qos_tc_egr_entries_create:.* Egress qos map with idx .* entries are already present.*"
 
-# Ignore SPC6 Egress mirroring not supported failures on SPC6 mellanox platform
-r, ".*ERR syncd#SDK: \[SAI_PORT.ERR\] .*mlnx_sai_port.c\[.*\]- mlnx_port_samplepacket_session_get: Egress mirroring is not supported on SPC6.*"
-
 # Ignore the error when the sysfs was accessed too soon, before sys creation has been completed.
 r, ".*ERR sfputil: Failed to read from file /sys/module/sx_core/asic\d+/module\d+/present - FileNotFoundError.*"
 r, ".*ERR sfputil.*message repeated \d+ times.*Failed to read from file \/sys\/module\/sx_core\/asic\d+\/module\d+\/present.*FileNotFoundError.*"

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -1375,8 +1375,8 @@ class BaseEverflowTest(object):
         """
         if ip_version == 4:
             pytest.skip("IP_TYPE Matching test has not been written for IPv4")
-        else:
-            rule_file = IP_TYPE_RULE_V6
+            return
+        rule_file = IP_TYPE_RULE_V6
         table_name = "EVERFLOWV6" if self.acl_stage() == "ingress" else "EVERFLOW_EGRESSV6"
         action = "MIRROR_INGRESS_ACTION" if self.acl_stage() == "ingress" else "MIRROR_EGRESS_ACTION"
         extra_vars = {

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -24,6 +24,7 @@ from tests.common.utilities import wait_until, check_msg_in_syslog, get_plt_wait
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.utilities import find_duthost_on_role
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
+from tests.common.mellanox_data import get_chip_type
 from tests.common.macsec.macsec_helper import MACSEC_INFO
 from tests.common.dualtor.dual_tor_common import mux_config              # noqa: F401
 from tests.common.helpers.sonic_db import AsicDbCli
@@ -856,7 +857,6 @@ class BaseEverflowTest(object):
         duthost_set = BaseEverflowTest.get_duthost_set(setup_info)
 
         session_info = None
-
         for duthost in duthost_set:
             if not session_info:
                 session_info = BaseEverflowTest.mirror_session_info("test_session_1", duthost.facts["asic_type"])
@@ -870,7 +870,7 @@ class BaseEverflowTest(object):
             # Default to "false" when keys are absent — this matches the CLI behavior in
             # sonic-utilities (config/main.py is_port_mirror_capability_supported) which
             # reads STATE_DB directly and rejects when keys are missing.
-            if config_method == CONFIG_MODE_CLI:
+            if config_method == CONFIG_MODE_CLI and not self.egress_mirror_payload_unchanged(duthost):
                 switch_caps = everflow_capabilities.get(duthost.hostname, {})
                 ingress_capable = switch_caps.get("PORT_INGRESS_MIRROR_CAPABLE", "false")
                 egress_capable = switch_caps.get("PORT_EGRESS_MIRROR_CAPABLE", "false")
@@ -884,7 +884,8 @@ class BaseEverflowTest(object):
 
             BaseEverflowTest.apply_mirror_config(
                 duthost, session_info, config_method,
-                erspan_ip_ver=erspan_ip_ver, direction=self.mirror_type())
+                erspan_ip_ver=erspan_ip_ver, direction=self.mirror_type(),
+                prefer_directional_cli=self.egress_mirror_payload_unchanged(duthost))
 
         yield session_info
 
@@ -947,7 +948,8 @@ class BaseEverflowTest(object):
         Args:
             session_info: Mirror session parameters dict.
             queue_num: Optional queue number.
-            direction: Optional mirror direction (ingress/egress/both).
+            direction: Optional Everflow mirror direction (ingress/egress)
+                or CLI direction (rx/tx/both).
             policer: Optional policer name.
             use_erspan_subcmd: If True, use 'config mirror_session erspan add'
                 (supports direction as positional arg). If False, use the
@@ -965,6 +967,9 @@ class BaseEverflowTest(object):
         if use_erspan_subcmd:
             # New syntax: config mirror_session erspan add <name> <src> <dst>
             #     <dscp> <ttl> [gre_type] [queue] [src_port] [direction]
+            # CLI direction values are rx/tx/both; Everflow uses ingress/egress
+            # to describe the mirror action under test.
+            cli_direction = {"ingress": "rx", "egress": "tx"}.get(direction, direction)
             command = (
                 f"config mirror_session erspan add"
                 f" {session_info['session_name']}"
@@ -973,14 +978,16 @@ class BaseEverflowTest(object):
                 f" {session_info['session_ttl']}"
                 f" {session_info['session_gre']}"
             )
-            if queue_num:
+            if queue_num is not None:
                 command += f" {queue_num}"
+            elif direction:
+                command += " 0"
             else:
                 command += " ''"
             # src_port placeholder (not used for ERSPAN without SPAN src)
             command += " ''"
-            if direction:
-                command += f" {direction}"
+            if cli_direction:
+                command += f" {cli_direction}"
             if policer:
                 command += f" --policer {policer}"
         else:
@@ -1002,10 +1009,56 @@ class BaseEverflowTest(object):
         return command
 
     @staticmethod
+    def _build_mirror_db_command(session_info, policer=None, erspan_ip_ver=4):
+        """Build a sonic-db-cli command to write mirror session directly to CONFIG_DB.
+
+        CLI commands (both legacy and erspan cmd) do not support IPv6
+        addresses, so we bypass the CLI and write to the database directly.
+        """
+        src_ip = session_info['session_src_ip'] if erspan_ip_ver == 4 \
+            else session_info['session_src_ipv6']
+        dst_ip = session_info['session_dst_ip'] if erspan_ip_ver == 4 \
+            else session_info['session_dst_ipv6']
+
+        command = (
+            f"sonic-db-cli CONFIG_DB HSET"
+            f" 'MIRROR_SESSION|{session_info['session_name']}'"
+            f" 'dscp' '{session_info['session_dscp']}'"
+            f" 'dst_ip' '{dst_ip}'"
+            f" 'gre_type' '{session_info['session_gre']}'"
+            f" 'src_ip' '{src_ip}'"
+            f" 'ttl' '{session_info['session_ttl']}'"
+        )
+        if policer:
+            command += f" 'policer' '{policer}'"
+        return command
+
+    @staticmethod
     def apply_mirror_config(duthost, session_info, config_method=CONFIG_MODE_CLI, policer=None,
-                            erspan_ip_ver=4, queue_num=None, direction=None):
+                            erspan_ip_ver=4, queue_num=None, direction=None, prefer_directional_cli=False):
         if config_method == CONFIG_MODE_CLI:
-            if direction:
+            if erspan_ip_ver == 6:
+                command = BaseEverflowTest._build_mirror_db_command(
+                    session_info, policer=policer, erspan_ip_ver=erspan_ip_ver
+                )
+                duthost.command(command)
+            elif direction:
+                if prefer_directional_cli:
+                    erspan_cmd = BaseEverflowTest._build_erspan_cli_command(
+                        session_info, queue_num=queue_num,
+                        direction=direction, policer=policer,
+                        use_erspan_subcmd=True,
+                        erspan_ip_ver=erspan_ip_ver
+                    )
+                    result2 = duthost.command(erspan_cmd, module_ignore_errors=True)
+                    if result2["rc"] == 0:
+                        return
+                    pytest.skip(
+                        "Cannot create mirror session with direction. "
+                        "ERSPAN error: {}. Legacy CLI does not configure "
+                        "mirror direction.".format(result2.get("stderr", "").strip())
+                    )
+
                 # Try legacy command first (without direction since it
                 # does not support it), then fall back to erspan subcmd.
                 # sonic-utilities PR #4089 added capability checks but
@@ -1332,6 +1385,86 @@ class BaseEverflowTest(object):
         }
         self.apply_non_openconfig_acl_rule(duthost, extra_vars, rule_file, table_name)
 
+    def egress_mirror_payload_unchanged(self, duthost):
+        if self.acl_stage() != "egress" or self.mirror_type() != "egress":
+            return False
+        if duthost.facts["asic_type"] != "mellanox":
+            return False
+        try:
+            return get_chip_type(duthost) == "spectrum6"
+        except KeyError:
+            return False
+
+    @staticmethod
+    def _get_interface_mtu(duthost, interface):
+        interface_status = duthost.show_and_parse(f"show interface status {interface}")
+        pytest_assert(interface_status, f"Failed to read MTU for interface {interface}")
+        return int(interface_status[0]["mtu"])
+
+    def _set_interface_mtu(self, duthost, interface, mtu):
+        duthost.command(f"config interface mtu {interface} {mtu}")
+        pytest_assert(
+            wait_until(30, 5, 0, lambda: self._get_interface_mtu(duthost, interface) == mtu),
+            f"Failed to update MTU {mtu} on interface {interface}"
+        )
+
+    @staticmethod
+    def _get_acl_packets_count(duthost, table_name, rule_name):
+        acl_counters = duthost.show_and_parse("aclshow -a")
+        pytest_assert(acl_counters, f"Failed to read ACL counters for {table_name}|{rule_name}")
+
+        for rule in acl_counters:
+            if rule["table name"] == table_name and rule["rule name"] == rule_name:
+                packets_count = rule["packets count"]
+                pytest_assert(
+                    packets_count != "N/A",
+                    f"ACL counter is not ready for {table_name}|{rule_name}"
+                )
+                return int(packets_count)
+
+        pytest.fail(f"ACL counter entry not found for {table_name}|{rule_name}")
+
+    @staticmethod
+    def _select_tx_port_not_in(port_info, excluded_ptf_ids, purpose):
+        for port, ptf_id in zip(port_info["dest_port"], port_info["dest_port_ptf_id"]):
+            ptf_ids = BaseEverflowTest._get_tx_port_id_list([ptf_id])
+            if not set(ptf_ids).intersection(excluded_ptf_ids):
+                return port, ptf_ids
+        pytest.skip(f"Skip test as there is no available {purpose} port.")
+
+    @staticmethod
+    def _select_route_ready_tx_port(remote_dut, port_info, tbinfo, session_prefix, namespace, ip_version,
+                                    route_timeout=60, route_interval=10):
+        attempts = []
+
+        for port, ptf_id in zip(port_info["dest_port"], port_info["dest_port_ptf_id"]):
+            peer_ip = get_neighbor_info(remote_dut, port, tbinfo, ip_version=ip_version)
+            attempts.append(f"{port}->{peer_ip}")
+            logging.info(
+                "Probe mirror session route candidate: prefix=%s port=%s peer_ip=%s namespace=%s",
+                session_prefix,
+                port,
+                peer_ip,
+                namespace
+            )
+
+            add_route(remote_dut, session_prefix, peer_ip, namespace)
+            if wait_until(route_timeout, route_interval, 0, validate_asic_route, remote_dut, session_prefix):
+                return port, BaseEverflowTest._get_tx_port_id_list([ptf_id]), peer_ip
+
+            logging.info(
+                "Mirror session route candidate did not reach ASIC: prefix=%s port=%s peer_ip=%s",
+                session_prefix,
+                port,
+                peer_ip
+            )
+            remove_route(remote_dut, session_prefix, peer_ip, namespace)
+
+        pytest.fail(
+            f"Failed to install mirror session route {session_prefix} into ASIC for all candidates: "
+            f"{', '.join(attempts)}"
+        )
+
     def send_and_check_mirror_packets(self,
                                       setup,
                                       mirror_session,
@@ -1425,7 +1558,9 @@ class BaseEverflowTest(object):
 
                 inner_packet = Mask(inner_packet)
 
-                # For egress mirroring, we expect the DUT to have modified the packet
+                # Spectrum-6 mirrors the original eACL egress payload without rewriting it.
+                #
+                # For egress mirroring, we expect older platforms to have modified the packet
                 # before forwarding it. Specifically:
                 #
                 # - In L2 the SMAC and DMAC will change.
@@ -1434,7 +1569,7 @@ class BaseEverflowTest(object):
                 # We know what the TTL and SMAC should be after going through the pipeline,
                 # but DMAC and checksum are trickier. For now, update the TTL and SMAC, and
                 # mask off the DMAC and IP Checksum to verify the packet contents.
-                if self.mirror_type() == "egress":
+                if self.mirror_type() == "egress" and not self.egress_mirror_payload_unchanged(duthost):
                     inner_packet.set_do_not_care_scapy(packet.Ether, "dst")
 
                     if self.acl_ip_version() == 4:

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -1396,43 +1396,6 @@ class BaseEverflowTest(object):
             return False
 
     @staticmethod
-    def _get_interface_mtu(duthost, interface):
-        interface_status = duthost.show_and_parse(f"show interface status {interface}")
-        pytest_assert(interface_status, f"Failed to read MTU for interface {interface}")
-        return int(interface_status[0]["mtu"])
-
-    def _set_interface_mtu(self, duthost, interface, mtu):
-        duthost.command(f"config interface mtu {interface} {mtu}")
-        pytest_assert(
-            wait_until(30, 5, 0, lambda: self._get_interface_mtu(duthost, interface) == mtu),
-            f"Failed to update MTU {mtu} on interface {interface}"
-        )
-
-    @staticmethod
-    def _get_acl_packets_count(duthost, table_name, rule_name):
-        acl_counters = duthost.show_and_parse("aclshow -a")
-        pytest_assert(acl_counters, f"Failed to read ACL counters for {table_name}|{rule_name}")
-
-        for rule in acl_counters:
-            if rule["table name"] == table_name and rule["rule name"] == rule_name:
-                packets_count = rule["packets count"]
-                pytest_assert(
-                    packets_count != "N/A",
-                    f"ACL counter is not ready for {table_name}|{rule_name}"
-                )
-                return int(packets_count)
-
-        pytest.fail(f"ACL counter entry not found for {table_name}|{rule_name}")
-
-    @staticmethod
-    def _select_tx_port_not_in(port_info, excluded_ptf_ids, purpose):
-        for port, ptf_id in zip(port_info["dest_port"], port_info["dest_port_ptf_id"]):
-            ptf_ids = BaseEverflowTest._get_tx_port_id_list([ptf_id])
-            if not set(ptf_ids).intersection(excluded_ptf_ids):
-                return port, ptf_ids
-        pytest.skip(f"Skip test as there is no available {purpose} port.")
-
-    @staticmethod
     def _select_route_ready_tx_port(remote_dut, port_info, tbinfo, session_prefix, namespace, ip_version,
                                     route_timeout=60, route_interval=10):
         attempts = []

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -1417,43 +1417,6 @@ class BaseEverflowTest(object):
             return False
 
     @staticmethod
-    def _get_interface_mtu(duthost, interface):
-        interface_status = duthost.show_and_parse(f"show interface status {interface}")
-        pytest_assert(interface_status, f"Failed to read MTU for interface {interface}")
-        return int(interface_status[0]["mtu"])
-
-    def _set_interface_mtu(self, duthost, interface, mtu):
-        duthost.command(f"config interface mtu {interface} {mtu}")
-        pytest_assert(
-            wait_until(30, 5, 0, lambda: self._get_interface_mtu(duthost, interface) == mtu),
-            f"Failed to update MTU {mtu} on interface {interface}"
-        )
-
-    @staticmethod
-    def _get_acl_packets_count(duthost, table_name, rule_name):
-        acl_counters = duthost.show_and_parse("aclshow -a")
-        pytest_assert(acl_counters, f"Failed to read ACL counters for {table_name}|{rule_name}")
-
-        for rule in acl_counters:
-            if rule["table name"] == table_name and rule["rule name"] == rule_name:
-                packets_count = rule["packets count"]
-                pytest_assert(
-                    packets_count != "N/A",
-                    f"ACL counter is not ready for {table_name}|{rule_name}"
-                )
-                return int(packets_count)
-
-        pytest.fail(f"ACL counter entry not found for {table_name}|{rule_name}")
-
-    @staticmethod
-    def _select_tx_port_not_in(port_info, excluded_ptf_ids, purpose):
-        for port, ptf_id in zip(port_info["dest_port"], port_info["dest_port_ptf_id"]):
-            ptf_ids = BaseEverflowTest._get_tx_port_id_list([ptf_id])
-            if not set(ptf_ids).intersection(excluded_ptf_ids):
-                return port, ptf_ids
-        pytest.skip(f"Skip test as there is no available {purpose} port.")
-
-    @staticmethod
     def _select_route_ready_tx_port(remote_dut, port_info, tbinfo, session_prefix, namespace, ip_version,
                                     route_timeout=60, route_interval=10):
         attempts = []

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -1396,8 +1396,8 @@ class BaseEverflowTest(object):
         """
         if ip_version == 4:
             pytest.skip("IP_TYPE Matching test has not been written for IPv4")
-        else:
-            rule_file = IP_TYPE_RULE_V6
+            return
+        rule_file = IP_TYPE_RULE_V6
         table_name = "EVERFLOWV6" if self.acl_stage() == "ingress" else "EVERFLOW_EGRESSV6"
         action = "MIRROR_INGRESS_ACTION" if self.acl_stage() == "ingress" else "MIRROR_EGRESS_ACTION"
         extra_vars = {

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -24,6 +24,7 @@ from tests.common.utilities import wait_until, check_msg_in_syslog, get_plt_wait
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.utilities import find_duthost_on_role
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
+from tests.common.mellanox_data import get_chip_type
 from tests.common.macsec.macsec_helper import MACSEC_INFO
 from tests.common.dualtor.dual_tor_common import mux_config              # noqa: F401
 from tests.common.helpers.sonic_db import AsicDbCli
@@ -929,7 +930,6 @@ class BaseEverflowTest(object):
         duthost_set = BaseEverflowTest.get_duthost_set(setup_info)
 
         session_info = None
-
         for duthost in duthost_set:
             if not session_info:
                 session_info = BaseEverflowTest.mirror_session_info("test_session_1", duthost.facts["asic_type"])
@@ -937,7 +937,12 @@ class BaseEverflowTest(object):
             if duthost.facts['platform'] in ('x86_64-arista_7260cx3_64', 'x86_64-arista_7060_cx32s') and erspan_ip_ver == 6:  # noqa E501
                 pytest.skip("Skip IPv6 mirror session on unsupported platforms")
 
-            BaseEverflowTest.apply_mirror_config(duthost, session_info, config_method, erspan_ip_ver=erspan_ip_ver)
+            prefer_directional_cli = self.egress_mirror_payload_unchanged(duthost)
+            BaseEverflowTest.apply_mirror_config(
+                duthost, session_info, config_method,
+                erspan_ip_ver=erspan_ip_ver,
+                direction=self.mirror_type() if prefer_directional_cli else None,
+                prefer_directional_cli=prefer_directional_cli)
 
         yield session_info
 
@@ -1008,26 +1013,109 @@ class BaseEverflowTest(object):
         return command
 
     @staticmethod
-    def apply_mirror_config(duthost, session_info, config_method=CONFIG_MODE_CLI, policer=None,
-                            erspan_ip_ver=4, queue_num=None):
-        commands_list = list()
-        if config_method == CONFIG_MODE_CLI:
-            if erspan_ip_ver == 4:
-                command = f"config mirror_session add {session_info['session_name']} \
-                            {session_info['session_src_ip']} {session_info['session_dst_ip']} \
-                            {session_info['session_dscp']} {session_info['session_ttl']} \
-                            {session_info['session_gre']}"
-                if queue_num:
-                    command += f" {queue_num}"
-                if policer:
-                    command += f" --policer {policer}"
-                commands_list.append(command)
+    def _build_erspan_cli_command(session_info, queue_num=None,
+                                  direction=None, policer=None,
+                                  use_erspan_subcmd=False,
+                                  erspan_ip_ver=4):
+        """Build the CLI command string for adding an ERSPAN mirror session.
+
+        Args:
+            session_info: Mirror session parameters dict.
+            queue_num: Optional queue number.
+            direction: Optional Everflow mirror direction (ingress/egress)
+                or CLI direction (rx/tx/both).
+            policer: Optional policer name.
+            use_erspan_subcmd: If True, use 'config mirror_session erspan add'
+                (supports direction as positional arg). If False, use the
+                legacy 'config mirror_session add'.
+            erspan_ip_ver: IP version (4 or 6).
+
+        Returns:
+            str: The CLI command string.
+        """
+        src_ip = session_info['session_src_ip'] if erspan_ip_ver == 4 \
+            else session_info['session_src_ipv6']
+        dst_ip = session_info['session_dst_ip'] if erspan_ip_ver == 4 \
+            else session_info['session_dst_ipv6']
+
+        if use_erspan_subcmd:
+            # New syntax: config mirror_session erspan add <name> <src> <dst>
+            #     <dscp> <ttl> [gre_type] [queue] [src_port] [direction]
+            # CLI direction values are rx/tx/both; Everflow uses ingress/egress
+            # to describe the mirror action under test.
+            cli_direction = {"ingress": "rx", "egress": "tx"}.get(direction, direction)
+            command = (
+                f"config mirror_session erspan add"
+                f" {session_info['session_name']}"
+                f" {src_ip} {dst_ip}"
+                f" {session_info['session_dscp']}"
+                f" {session_info['session_ttl']}"
+                f" {session_info['session_gre']}"
+            )
+            if queue_num is not None:
+                command += f" {queue_num}"
+            elif direction:
+                command += " 0"
             else:
+                command += " ''"
+            # src_port placeholder (not used for ERSPAN without SPAN src)
+            command += " ''"
+            if cli_direction:
+                command += f" {cli_direction}"
+            if policer:
+                command += f" --policer {policer}"
+        else:
+            # Legacy syntax: config mirror_session add <name> <src> <dst>
+            #     <dscp> <ttl> [gre_type] [queue]
+            # No direction support in this command.
+            command = (
+                f"config mirror_session add"
+                f" {session_info['session_name']}"
+                f" {src_ip} {dst_ip}"
+                f" {session_info['session_dscp']}"
+                f" {session_info['session_ttl']}"
+                f" {session_info['session_gre']}"
+            )
+            if queue_num:
+                command += f" {queue_num}"
+            if policer:
+                command += f" --policer {policer}"
+        return command
+
+    @staticmethod
+    def apply_mirror_config(duthost, session_info, config_method=CONFIG_MODE_CLI, policer=None,
+                            erspan_ip_ver=4, queue_num=None, direction=None, prefer_directional_cli=False):
+        commands_list = []
+        if config_method == CONFIG_MODE_CLI:
+            if erspan_ip_ver == 6:
                 commands_list = [
-                        BaseEverflowTest._build_v6_erspan_asic_command(session_info, asic_index=asic_index,
-                                                                       queue_num=queue_num, policer=policer)
-                        for asic_index in duthost.get_frontend_asic_ids()
+                    BaseEverflowTest._build_v6_erspan_asic_command(
+                        session_info, asic_index=asic_index,
+                        queue_num=queue_num, policer=policer
+                    )
+                    for asic_index in duthost.get_frontend_asic_ids()
                 ]
+            elif prefer_directional_cli and direction:
+                command = BaseEverflowTest._build_erspan_cli_command(
+                    session_info, queue_num=queue_num,
+                    direction=direction, policer=policer,
+                    use_erspan_subcmd=True,
+                    erspan_ip_ver=erspan_ip_ver
+                )
+                result = duthost.command(command, module_ignore_errors=True)
+                if result["rc"] != 0:
+                    pytest.skip(
+                        "Cannot create mirror session with direction. "
+                        "ERSPAN error: {}. Legacy CLI does not configure "
+                        "mirror direction.".format(result.get("stderr", "").strip())
+                    )
+            else:
+                command = BaseEverflowTest._build_erspan_cli_command(
+                    session_info, queue_num=queue_num,
+                    policer=policer, use_erspan_subcmd=False,
+                    erspan_ip_ver=erspan_ip_ver
+                )
+                commands_list.append(command)
 
         elif config_method == CONFIG_MODE_CONFIGLET:
             pass
@@ -1318,6 +1406,86 @@ class BaseEverflowTest(object):
         }
         self.apply_non_openconfig_acl_rule(duthost, extra_vars, rule_file, table_name)
 
+    def egress_mirror_payload_unchanged(self, duthost):
+        if self.acl_stage() != "egress" or self.mirror_type() != "egress":
+            return False
+        if duthost.facts["asic_type"] != "mellanox":
+            return False
+        try:
+            return get_chip_type(duthost) == "spectrum6"
+        except KeyError:
+            return False
+
+    @staticmethod
+    def _get_interface_mtu(duthost, interface):
+        interface_status = duthost.show_and_parse(f"show interface status {interface}")
+        pytest_assert(interface_status, f"Failed to read MTU for interface {interface}")
+        return int(interface_status[0]["mtu"])
+
+    def _set_interface_mtu(self, duthost, interface, mtu):
+        duthost.command(f"config interface mtu {interface} {mtu}")
+        pytest_assert(
+            wait_until(30, 5, 0, lambda: self._get_interface_mtu(duthost, interface) == mtu),
+            f"Failed to update MTU {mtu} on interface {interface}"
+        )
+
+    @staticmethod
+    def _get_acl_packets_count(duthost, table_name, rule_name):
+        acl_counters = duthost.show_and_parse("aclshow -a")
+        pytest_assert(acl_counters, f"Failed to read ACL counters for {table_name}|{rule_name}")
+
+        for rule in acl_counters:
+            if rule["table name"] == table_name and rule["rule name"] == rule_name:
+                packets_count = rule["packets count"]
+                pytest_assert(
+                    packets_count != "N/A",
+                    f"ACL counter is not ready for {table_name}|{rule_name}"
+                )
+                return int(packets_count)
+
+        pytest.fail(f"ACL counter entry not found for {table_name}|{rule_name}")
+
+    @staticmethod
+    def _select_tx_port_not_in(port_info, excluded_ptf_ids, purpose):
+        for port, ptf_id in zip(port_info["dest_port"], port_info["dest_port_ptf_id"]):
+            ptf_ids = BaseEverflowTest._get_tx_port_id_list([ptf_id])
+            if not set(ptf_ids).intersection(excluded_ptf_ids):
+                return port, ptf_ids
+        pytest.skip(f"Skip test as there is no available {purpose} port.")
+
+    @staticmethod
+    def _select_route_ready_tx_port(remote_dut, port_info, tbinfo, session_prefix, namespace, ip_version,
+                                    route_timeout=60, route_interval=10):
+        attempts = []
+
+        for port, ptf_id in zip(port_info["dest_port"], port_info["dest_port_ptf_id"]):
+            peer_ip = get_neighbor_info(remote_dut, port, tbinfo, ip_version=ip_version)
+            attempts.append(f"{port}->{peer_ip}")
+            logging.info(
+                "Probe mirror session route candidate: prefix=%s port=%s peer_ip=%s namespace=%s",
+                session_prefix,
+                port,
+                peer_ip,
+                namespace
+            )
+
+            add_route(remote_dut, session_prefix, peer_ip, namespace)
+            if wait_until(route_timeout, route_interval, 0, validate_asic_route, remote_dut, session_prefix):
+                return port, BaseEverflowTest._get_tx_port_id_list([ptf_id]), peer_ip
+
+            logging.info(
+                "Mirror session route candidate did not reach ASIC: prefix=%s port=%s peer_ip=%s",
+                session_prefix,
+                port,
+                peer_ip
+            )
+            remove_route(remote_dut, session_prefix, peer_ip, namespace)
+
+        pytest.fail(
+            f"Failed to install mirror session route {session_prefix} into ASIC for all candidates: "
+            f"{', '.join(attempts)}"
+        )
+
     def send_and_check_mirror_packets(self,
                                       setup,
                                       mirror_session,
@@ -1412,7 +1580,9 @@ class BaseEverflowTest(object):
 
                 inner_packet = Mask(inner_packet)
 
-                # For egress mirroring, we expect the DUT to have modified the packet
+                # Spectrum-6 mirrors the original eACL egress payload without rewriting it.
+                #
+                # For egress mirroring, we expect older platforms to have modified the packet
                 # before forwarding it. Specifically:
                 #
                 # - In L2 the SMAC and DMAC will change.
@@ -1421,7 +1591,7 @@ class BaseEverflowTest(object):
                 # We know what the TTL and SMAC should be after going through the pipeline,
                 # but DMAC and checksum are trickier. For now, update the TTL and SMAC, and
                 # mask off the DMAC and IP Checksum to verify the packet contents.
-                if self.mirror_type() == "egress":
+                if self.mirror_type() == "egress" and not self.egress_mirror_payload_unchanged(duthost):
                     inner_packet.set_do_not_care_scapy(packet.Ether, "dst")
 
                     if self.acl_ip_version() == 4:

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -8,6 +8,8 @@ from ptf.mask import Mask
 import ptf.packet as scapy
 from . import everflow_test_utilities as everflow_utils
 from .everflow_test_utilities import BaseEverflowTest, DOWN_STREAM, UP_STREAM, erspan_ip_ver              # noqa: F401
+from tests.common.utilities import wait_until
+from common.helpers.assertions import pytest_assert
 import random
 # Module-level fixtures
 from .everflow_test_utilities import setup_info, skip_ipv6_everflow_tests                                 # noqa: F401
@@ -53,19 +55,26 @@ class EverflowIPv6Tests(BaseEverflowTest):
         ip = "ipv4" if erspan_ip_ver == 4 else "ipv6"
         # On T0 testbed, the collector IP is routed to T1
         namespace = setup_info[dest_port_type]['remote_namespace']
-        tx_port = setup_info[dest_port_type]["dest_port"][0]
-        dest_port_ptf_id_list = [setup_info[dest_port_type]["dest_port_ptf_id"][0]]
         remote_dut = setup_info[dest_port_type]['remote_dut']
         rx_port_id = setup_info[dest_port_type]["src_port_ptf_id"]
         remote_dut.shell(remote_dut.get_vtysh_cmd_for_namespace(
             f"vtysh -c \"config\" -c \"router bgp\" -c \"address-family {ip}\" -c \"redistribute static\"", namespace))
-        peer_ip = everflow_utils.get_neighbor_info(remote_dut, tx_port, tbinfo, ip_version=erspan_ip_ver)
         session_prefixes = setup_mirror_session["session_prefixes"] if erspan_ip_ver == 4 \
             else setup_mirror_session["session_prefixes_ipv6"]
-        everflow_utils.add_route(remote_dut, session_prefixes[0], peer_ip, namespace)
-        EverflowIPv6Tests.tx_port_ids = BaseEverflowTest._get_tx_port_id_list(dest_port_ptf_id_list)
+        _, dest_port_ptf_id_list, peer_ip = self._select_route_ready_tx_port(
+            remote_dut,
+            setup_info[dest_port_type],
+            tbinfo,
+            session_prefixes[0],
+            namespace,
+            erspan_ip_ver,
+            route_timeout=60,
+            route_interval=10
+        )
+        pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_mirror_session_up,
+                                 remote_dut, setup_mirror_session["session_name"]))
+        EverflowIPv6Tests.tx_port_ids = dest_port_ptf_id_list
         EverflowIPv6Tests.rx_port_ptf_id = rx_port_id
-        time.sleep(5)
 
         yield
 
@@ -852,8 +861,10 @@ class EverflowIPv6Tests(BaseEverflowTest):
                            dscp=None,
                            sport=2020,
                            dport=8080,
-                           flags=0x10):
+                           flags=0x10,
+                           pktlen=100):
         pkt = testutils.simple_tcpv6_packet(
+            pktlen=pktlen,
             eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
             eth_dst=setup[direction]["ingress_router_mac"],
             ipv6_src=src_ip,

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -861,10 +861,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                            dscp=None,
                            sport=2020,
                            dport=8080,
-                           flags=0x10,
-                           pktlen=100):
+                           flags=0x10):
         pkt = testutils.simple_tcpv6_packet(
-            pktlen=pktlen,
             eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
             eth_dst=setup[direction]["ingress_router_mac"],
             ipv6_src=src_ip,

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -8,6 +8,8 @@ from ptf.mask import Mask
 import ptf.packet as scapy
 from . import everflow_test_utilities as everflow_utils
 from .everflow_test_utilities import BaseEverflowTest, DOWN_STREAM, UP_STREAM, erspan_ip_ver              # noqa: F401
+from tests.common.utilities import wait_until
+from common.helpers.assertions import pytest_assert
 import random
 # Module-level fixtures
 from .everflow_test_utilities import setup_info, skip_ipv6_everflow_tests                                 # noqa: F401
@@ -53,19 +55,26 @@ class EverflowIPv6Tests(BaseEverflowTest):
         ip = "ipv4" if erspan_ip_ver == 4 else "ipv6"
         # On T0 testbed, the collector IP is routed to T1
         namespace = setup_info[dest_port_type]['remote_namespace']
-        tx_port = setup_info[dest_port_type]["dest_port"][0]
-        dest_port_ptf_id_list = [setup_info[dest_port_type]["dest_port_ptf_id"][0]]
         remote_dut = setup_info[dest_port_type]['remote_dut']
         rx_port_id = setup_info[dest_port_type]["src_port_ptf_id"]
         remote_dut.shell(remote_dut.get_vtysh_cmd_for_namespace(
             f"vtysh -c \"config\" -c \"router bgp\" -c \"address-family {ip}\" -c \"redistribute static\"", namespace))
-        peer_ip = everflow_utils.get_neighbor_info(remote_dut, tx_port, tbinfo, ip_version=erspan_ip_ver)
         session_prefixes = setup_mirror_session["session_prefixes"] if erspan_ip_ver == 4 \
             else setup_mirror_session["session_prefixes_ipv6"]
-        everflow_utils.add_route(remote_dut, session_prefixes[0], peer_ip, namespace)
-        EverflowIPv6Tests.tx_port_ids = BaseEverflowTest._get_tx_port_id_list(dest_port_ptf_id_list)
+        _, dest_port_ptf_id_list, peer_ip = self._select_route_ready_tx_port(
+            remote_dut,
+            setup_info[dest_port_type],
+            tbinfo,
+            session_prefixes[0],
+            namespace,
+            erspan_ip_ver,
+            route_timeout=60,
+            route_interval=10
+        )
+        pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_mirror_session_up,
+                                 remote_dut, setup_mirror_session["session_name"]))
+        EverflowIPv6Tests.tx_port_ids = dest_port_ptf_id_list
         EverflowIPv6Tests.rx_port_ptf_id = rx_port_id
-        time.sleep(5)
 
         yield
 
@@ -861,8 +870,10 @@ class EverflowIPv6Tests(BaseEverflowTest):
                            dscp=None,
                            sport=2020,
                            dport=8080,
-                           flags=0x10):
+                           flags=0x10,
+                           pktlen=100):
         pkt = testutils.simple_tcpv6_packet(
+            pktlen=pktlen,
             eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
             eth_dst=setup[direction]["ingress_router_mac"],
             ipv6_src=src_ip,

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -870,10 +870,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                            dscp=None,
                            sport=2020,
                            dport=8080,
-                           flags=0x10,
-                           pktlen=100):
+                           flags=0x10):
         pkt = testutils.simple_tcpv6_packet(
-            pktlen=pktlen,
             eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
             eth_dst=setup[direction]["ingress_router_mac"],
             ipv6_src=src_ip,

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -1233,9 +1233,12 @@ class EverflowIPv4Tests(BaseEverflowTest):
         dscp=None,
         sport=0x1234,
         dport=0x50,
-        flags=0x10
+        flags=0x10,
+        pktlen=100,
+        ip_flags=0
     ):
         pkt = testutils.simple_tcp_packet(
+            pktlen=pktlen,
             eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
             eth_dst=router_mac,
             ip_src=src_ip,
@@ -1246,6 +1249,9 @@ class EverflowIPv4Tests(BaseEverflowTest):
             tcp_dport=dport,
             tcp_flags=flags
         )
+
+        if ip_flags:
+            pkt["IP"].flags = ip_flags
 
         if ip_protocol:
             pkt["IP"].proto = ip_protocol

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -1237,9 +1237,12 @@ class EverflowIPv4Tests(BaseEverflowTest):
         dscp=None,
         sport=0x1234,
         dport=0x50,
-        flags=0x10
+        flags=0x10,
+        pktlen=100,
+        ip_flags=0
     ):
         pkt = testutils.simple_tcp_packet(
+            pktlen=pktlen,
             eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
             eth_dst=router_mac,
             ip_src=src_ip,
@@ -1250,6 +1253,9 @@ class EverflowIPv4Tests(BaseEverflowTest):
             tcp_dport=dport,
             tcp_flags=flags
         )
+
+        if ip_flags:
+            pkt["IP"].flags = ip_flags
 
         if ip_protocol:
             pkt["IP"].proto = ip_protocol

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -1233,12 +1233,9 @@ class EverflowIPv4Tests(BaseEverflowTest):
         dscp=None,
         sport=0x1234,
         dport=0x50,
-        flags=0x10,
-        pktlen=100,
-        ip_flags=0
+        flags=0x10
     ):
         pkt = testutils.simple_tcp_packet(
-            pktlen=pktlen,
             eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
             eth_dst=router_mac,
             ip_src=src_ip,
@@ -1249,9 +1246,6 @@ class EverflowIPv4Tests(BaseEverflowTest):
             tcp_dport=dport,
             tcp_flags=flags
         )
-
-        if ip_flags:
-            pkt["IP"].flags = ip_flags
 
         if ip_protocol:
             pkt["IP"].proto = ip_protocol

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -1237,12 +1237,9 @@ class EverflowIPv4Tests(BaseEverflowTest):
         dscp=None,
         sport=0x1234,
         dport=0x50,
-        flags=0x10,
-        pktlen=100,
-        ip_flags=0
+        flags=0x10
     ):
         pkt = testutils.simple_tcp_packet(
-            pktlen=pktlen,
             eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
             eth_dst=router_mac,
             ip_src=src_ip,
@@ -1253,9 +1250,6 @@ class EverflowIPv4Tests(BaseEverflowTest):
             tcp_dport=dport,
             tcp_flags=flags
         )
-
-        if ip_flags:
-            pkt["IP"].flags = ip_flags
 
         if ip_protocol:
             pkt["IP"].proto = ip_protocol


### PR DESCRIPTION
### Description of PR

Summary:
Update Everflow mirror setup to use directional CLI behavior for Spectrum-6, where egress mirrored payloads remain unchanged. Remove the obsolete Spectrum-6 egress mirroring log ignore and make IPv6 mirror route setup select a route-ready transmit port before validation.

Fixes #27756

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #27756
Failure type: other

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

### Approach
#### What is the motivation for this PR?

Spectrum-6 egress ACL mirroring behavior is supported, but the Everflow test setup still treated it like unsupported or legacy egress mirroring behavior. This caused stale log analyzer ignores and incorrect assumptions about egress mirrored packet payload changes.

#### How did you do it?

Updated Everflow mirror session setup to use directional CLI behavior for Spectrum-6, adjusted packet validation, improved IPv6 mirror route setup to select a route-ready transmit port, and removed the obsolete log ignore.

#### How did you verify/test it?

Confirmed the public PR CI passed, including static analysis, test-case validation, and all reported impacted-area jobs.

#### Any platform specific information?

The changed egress behavior applies to Spectrum-6.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

No documentation change is required.