### PR TITLE
[bgp]: Disable mcast_tunnel_enabled for cisco-8000 VNET scale decap test

### DIFF
--- a/tests/bgp/test_bgp_vnet_scale.py
+++ b/tests/bgp/test_bgp_vnet_scale.py
@@ -22,6 +22,7 @@ PORTCHANNEL_NAME_FMT = "PortChannel{}"
 PORTCHANNEL_SHORT_NAME_FMT = "Po{}"
 VXLAN_PORT = 4789
 VNI_BASE = 10000
+CISCO_8000_ASIC = "cisco-8000"
 
 pytestmark = [
     pytest.mark.topology("t0"),
@@ -34,6 +35,51 @@ pytestmark = [
 
 def get_cfg_facts(duthost):
     return json.loads(duthost.shell("sonic-cfggen -d --print-data")["stdout"])
+
+
+def _mcast_tunnel_cfg_files(duthost):
+    """Cisco-8000 SAI init files that carry the mcast_tunnel_enabled device property.
+
+    asic_cfg.json is the live SAI_INIT_CONFIG_FILE read by syncd at init;
+    platform_npu_cfg.yaml is its cold-boot source. Both are updated so the
+    setting survives either a config reload or a reboot.
+    """
+    base = "/usr/share/sonic/device/{}/{}".format(
+        duthost.facts["platform"], duthost.facts["hwsku"]
+    )
+    return [
+        "{}/asic_cfg.json".format(base),
+        "{}/platform_npu_cfg.yaml".format(base),
+    ]
+
+
+def is_mcast_tunnel_enabled(duthost):
+    """Return True if mcast_tunnel_enabled is currently set true in the SAI init config."""
+    for path in _mcast_tunnel_cfg_files(duthost):
+        res = duthost.shell(
+            "grep -Eq 'mcast_tunnel_enabled\"?[[:space:]]*:[[:space:]]*true' {}".format(path),
+            module_ignore_errors=True,
+        )
+        if res["rc"] == 0:
+            return True
+    return False
+
+
+def set_mcast_tunnel_enabled(duthost, enabled):
+    """Toggle mcast_tunnel_enabled in the Cisco-8000 SAI init files (asic_cfg.json + npu yaml).
+
+    Cisco-8000 only terminates VXLAN whose outer SIP is a known remote VTEP while
+    this property is enabled; disabling it lets the ASIC decap from arbitrary SIPs.
+    A config reload is required afterwards for syncd to re-read the value.
+    """
+    new_val = "true" if enabled else "false"
+    for path in _mcast_tunnel_cfg_files(duthost):
+        duthost.shell(
+            "sudo sed -i -E "
+            "'s/(mcast_tunnel_enabled\"?[[:space:]]*:[[:space:]]*)(true|false)/\\1{}/' "
+            "{}".format(new_val, path),
+            module_ignore_errors=True,
+        )
 
 
 def calculate_wait_time(total_sessions):
@@ -429,12 +475,23 @@ def vnet_bgp_setup(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, vnet_count,
     t1_ptf_port_index = None
 
     duthost = None
+    mcast_tunnel_disabled = False
 
     try:
         ecmp_utils.Constants["KEEP_TEMP_FILES"] = False
         ecmp_utils.Constants["DEBUG"] = True
         duthost = duthosts[rand_one_dut_hostname]
         dut_index = tbinfo["duts"].index(rand_one_dut_hostname)
+
+        # Cisco-8000 terminates VXLAN only from known remote VTEPs while the
+        # mcast_tunnel_enabled ASIC property is set, so scale decap validation
+        # that sources traffic from arbitrary outer SIPs fails. Disable it for
+        # the duration of the test (only when currently enabled) and restore it
+        # in teardown. A config reload is needed for syncd to pick up the change.
+        if duthost.facts["asic_type"] == CISCO_8000_ASIC and is_mcast_tunnel_enabled(duthost):
+            set_mcast_tunnel_enabled(duthost, False)
+            mcast_tunnel_disabled = True
+            config_reload(duthost, safe_reload=True, yang_validate=False)
 
         cfg_facts = get_cfg_facts(duthost)
         config_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
@@ -484,6 +541,8 @@ def vnet_bgp_setup(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, vnet_count,
         logger.error(json.dumps(traceback.format_exception(*sys.exc_info()), indent=2))
         cleanup_ptf_config(ptfhost, ptf_ports)
         if duthost is not None:
+            if mcast_tunnel_disabled:
+                set_mcast_tunnel_enabled(duthost, True)
             config_reload(duthost, safe_reload=True, yang_validate=False)
         pytest.fail("Vnet testing setup failed")
 
@@ -498,6 +557,8 @@ def vnet_bgp_setup(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, vnet_count,
     }
 
     cleanup_ptf_config(ptfhost, ptf_ports)
+    if mcast_tunnel_disabled:
+        set_mcast_tunnel_enabled(duthost, True)
     config_reload(duthost, safe_reload=True, yang_validate=False)
 
 

--- a/tests/bgp/test_bgp_vnet_scale.py
+++ b/tests/bgp/test_bgp_vnet_scale.py
@@ -74,12 +74,23 @@ def set_mcast_tunnel_enabled(duthost, enabled):
     """
     new_val = "true" if enabled else "false"
     for path in _mcast_tunnel_cfg_files(duthost):
-        duthost.shell(
+        result = duthost.shell(
             "sudo sed -i -E "
             "'s/(mcast_tunnel_enabled\"?[[:space:]]*:[[:space:]]*)(true|false)/\\1{}/' "
             "{}".format(new_val, path),
-            module_ignore_errors=True,
         )
+        pytest_assert(
+            result["rc"] == 0,
+            "sed failed updating mcast_tunnel_enabled in {}".format(path),
+        )
+
+    currently_enabled = is_mcast_tunnel_enabled(duthost)
+    pytest_assert(
+        currently_enabled == enabled,
+        "Failed to set mcast_tunnel_enabled={} in SAI init config (currently {})".format(
+            new_val, "enabled" if currently_enabled else "disabled"
+        ),
+    )
 
 
 def calculate_wait_time(total_sessions):

--- a/tests/bgp/test_bgp_vnet_scale.py
+++ b/tests/bgp/test_bgp_vnet_scale.py
@@ -37,12 +37,21 @@ def get_cfg_facts(duthost):
     return json.loads(duthost.shell("sonic-cfggen -d --print-data")["stdout"])
 
 
+# The key and its boolean value may each be quoted or unquoted across hwskus,
+# e.g. `mcast_tunnel_enabled: true`, `"mcast_tunnel_enabled": true`, or
+# `"mcast_tunnel_enabled": "true"`. This ERE matches up to (but not including)
+# the boolean literal, capturing any leading quote so it can be preserved.
+MCAST_TUNNEL_KEY_RE = r'mcast_tunnel_enabled"?[[:space:]]*:[[:space:]]*"?'
+MCAST_TUNNEL_BACKUP_SUFFIX = ".mcast_tunnel_bak"
+
+
 def _mcast_tunnel_cfg_files(duthost):
-    """Cisco-8000 SAI init files that carry the mcast_tunnel_enabled device property.
+    """Cisco-8000 SAI init files that may carry the mcast_tunnel_enabled device property.
 
     asic_cfg.json is the live SAI_INIT_CONFIG_FILE read by syncd at init;
     platform_npu_cfg.yaml is its cold-boot source. Both are updated so the
-    setting survives either a config reload or a reboot.
+    setting survives either a config reload or a reboot. Not every hwsku ships
+    both files, so callers must tolerate missing paths.
     """
     base = "/usr/share/sonic/device/{}/{}".format(
         duthost.facts["platform"], duthost.facts["hwsku"]
@@ -53,44 +62,77 @@ def _mcast_tunnel_cfg_files(duthost):
     ]
 
 
-def is_mcast_tunnel_enabled(duthost):
-    """Return True if mcast_tunnel_enabled is currently set true in the SAI init config."""
-    for path in _mcast_tunnel_cfg_files(duthost):
-        res = duthost.shell(
-            "grep -Eq 'mcast_tunnel_enabled\"?[[:space:]]*:[[:space:]]*true' {}".format(path),
-            module_ignore_errors=True,
-        )
-        if res["rc"] == 0:
-            return True
-    return False
+def _file_exists(duthost, path):
+    return duthost.stat(path=path).get("stat", {}).get("exists", False)
 
 
-def set_mcast_tunnel_enabled(duthost, enabled):
-    """Toggle mcast_tunnel_enabled in the Cisco-8000 SAI init files (asic_cfg.json + npu yaml).
+def _file_mcast_tunnel_enabled(duthost, path):
+    """Return True if mcast_tunnel_enabled is set true in the given SAI init file."""
+    res = duthost.shell(
+        "grep -Eq '{}true' {}".format(MCAST_TUNNEL_KEY_RE, path),
+        module_ignore_errors=True,
+    )
+    return res["rc"] == 0
+
+
+def mcast_tunnel_enabled_files(duthost):
+    """Return the SAI init files that exist and currently enable mcast_tunnel_enabled."""
+    return [
+        path
+        for path in _mcast_tunnel_cfg_files(duthost)
+        if _file_exists(duthost, path) and _file_mcast_tunnel_enabled(duthost, path)
+    ]
+
+
+def disable_mcast_tunnel(duthost, paths):
+    """Back up and disable mcast_tunnel_enabled in the given Cisco-8000 SAI init files.
 
     Cisco-8000 only terminates VXLAN whose outer SIP is a known remote VTEP while
     this property is enabled; disabling it lets the ASIC decap from arbitrary SIPs.
     A config reload is required afterwards for syncd to re-read the value.
+
+    Each file is copied to a per-file backup first so teardown can restore the
+    exact original bytes (and thus the original per-file value) rather than
+    blindly rewriting the property. This assumes the key already exists in the
+    file: callers pass only files that matched the enabled pattern, and the sed
+    below rewrites the value in place -- it does not insert a missing key.
+
+    Returns the list of (path, backup_path) pairs that were modified so the
+    caller can restore them on teardown/failure.
     """
-    new_val = "true" if enabled else "false"
-    for path in _mcast_tunnel_cfg_files(duthost):
+    backups = []
+    for path in paths:
+        backup = path + MCAST_TUNNEL_BACKUP_SUFFIX
+        duthost.shell("sudo cp -p {} {}".format(path, backup))
+        backups.append((path, backup))
         result = duthost.shell(
-            "sudo sed -i -E "
-            "'s/(mcast_tunnel_enabled\"?[[:space:]]*:[[:space:]]*)(true|false)/\\1{}/' "
-            "{}".format(new_val, path),
+            "sudo sed -i -E 's/({})true/\\1false/' {}".format(MCAST_TUNNEL_KEY_RE, path),
         )
         pytest_assert(
             result["rc"] == 0,
-            "sed failed updating mcast_tunnel_enabled in {}".format(path),
+            "sed failed disabling mcast_tunnel_enabled in {}".format(path),
         )
+        pytest_assert(
+            not _file_mcast_tunnel_enabled(duthost, path),
+            "Failed to disable mcast_tunnel_enabled in {}".format(path),
+        )
+    return backups
 
-    currently_enabled = is_mcast_tunnel_enabled(duthost)
-    pytest_assert(
-        currently_enabled == enabled,
-        "Failed to set mcast_tunnel_enabled={} in SAI init config (currently {})".format(
-            new_val, "enabled" if currently_enabled else "disabled"
-        ),
-    )
+
+def restore_mcast_tunnel(duthost, backups):
+    """Restore the SAI init files backed up by disable_mcast_tunnel.
+
+    Runs on the teardown/failure path and must never raise so the caller always
+    reaches the subsequent config_reload; per-file failures are logged and the
+    remaining files are still restored.
+    """
+    for path, backup in backups:
+        res = duthost.shell("sudo mv -f {} {}".format(backup, path), module_ignore_errors=True)
+        if res["rc"] != 0:
+            logger.error(
+                "Failed to restore mcast_tunnel_enabled file %s from %s: %s",
+                path, backup, res.get("stderr"),
+            )
 
 
 def calculate_wait_time(total_sessions):
@@ -486,7 +528,7 @@ def vnet_bgp_setup(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, vnet_count,
     t1_ptf_port_index = None
 
     duthost = None
-    mcast_tunnel_disabled = False
+    mcast_tunnel_backups = []
 
     try:
         ecmp_utils.Constants["KEEP_TEMP_FILES"] = False
@@ -497,12 +539,14 @@ def vnet_bgp_setup(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, vnet_count,
         # Cisco-8000 terminates VXLAN only from known remote VTEPs while the
         # mcast_tunnel_enabled ASIC property is set, so scale decap validation
         # that sources traffic from arbitrary outer SIPs fails. Disable it for
-        # the duration of the test (only when currently enabled) and restore it
-        # in teardown. A config reload is needed for syncd to pick up the change.
-        if duthost.facts["asic_type"] == CISCO_8000_ASIC and is_mcast_tunnel_enabled(duthost):
-            set_mcast_tunnel_enabled(duthost, False)
-            mcast_tunnel_disabled = True
-            config_reload(duthost, safe_reload=True, yang_validate=False)
+        # the duration of the test (only in the files that currently enable it)
+        # and restore the original files in teardown. A config reload is needed
+        # for syncd to pick up the change.
+        if duthost.facts["asic_type"] == CISCO_8000_ASIC:
+            enabled_files = mcast_tunnel_enabled_files(duthost)
+            if enabled_files:
+                mcast_tunnel_backups = disable_mcast_tunnel(duthost, enabled_files)
+                config_reload(duthost, safe_reload=True, yang_validate=False)
 
         cfg_facts = get_cfg_facts(duthost)
         config_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
@@ -552,8 +596,7 @@ def vnet_bgp_setup(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, vnet_count,
         logger.error(json.dumps(traceback.format_exception(*sys.exc_info()), indent=2))
         cleanup_ptf_config(ptfhost, ptf_ports)
         if duthost is not None:
-            if mcast_tunnel_disabled:
-                set_mcast_tunnel_enabled(duthost, True)
+            restore_mcast_tunnel(duthost, mcast_tunnel_backups)
             config_reload(duthost, safe_reload=True, yang_validate=False)
         pytest.fail("Vnet testing setup failed")
 
@@ -568,8 +611,7 @@ def vnet_bgp_setup(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, vnet_count,
     }
 
     cleanup_ptf_config(ptfhost, ptf_ports)
-    if mcast_tunnel_disabled:
-        set_mcast_tunnel_enabled(duthost, True)
+    restore_mcast_tunnel(duthost, mcast_tunnel_backups)
     config_reload(duthost, safe_reload=True, yang_validate=False)
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Fix VNET BGP scale dataplane decap validation on cisco-8000 when `mcast_tunnel_enabled` is set in the SAI init config. On this platform, VXLAN decaps are limited to known remote VTEP outer SIPs while that property is enabled. The existing scale test injects decap traffic with arbitrary outer SIPs, so packets are dropped and the dataplane check fails.
This change scopes a cisco-8000-only workaround in the `vnet_bgp_setup` module fixture: if `mcast_tunnel_enabled` is currently `true`, disable it in the SAI init files (`asic_cfg.json` and `platform_npu_cfg.yaml`), reload config so syncd picks up the change, and restore the original value on teardown and on setup failure.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
The VNET BGP scale test (`test_bgp_vnet_scale.py`) validates BGP scale and VXLAN decap dataplane behavior. On cisco-8000, when `mcast_tunnel_enabled` is `true`, the ASIC only terminates VXLAN packets whose outer source IP matches a known remote VTEP. The test's PTF dataplane validation uses arbitrary outer SIPs for decap traffic, which does not satisfy that constraint and causes the test to fail even when BGP/VXLAN configuration is correct.

#### How did you do it?
- Added helpers to locate and read/update `mcast_tunnel_enabled` in cisco-8000 SAI init files (`asic_cfg.json` and `platform_npu_cfg.yaml`).
- In `vnet_bgp_setup`, before test configuration: on cisco-8000 only, if the property is enabled, disable it, set a tracking flag, and `config_reload` so syncd re-reads the SAI init config.
- On setup failure and in fixture teardown: if the property was disabled for the test, restore it to `true` before the existing `config_reload`.
No changes to test logic, topology, or non-cisco-8000 platforms.

#### How did you verify/test it?
- Reviewed the change against cisco-8000 VXLAN decap behavior with `mcast_tunnel_enabled` set.
- Intended validation: run the VNET BGP scale test on a cisco-8000 `t0` physical testbed with `mcast_tunnel_enabled` enabled in platform SAI init config.

#### Any platform specific information?
**cisco-8000 only.** The workaround is gated on `duthost.facts["asic_type"] == "cisco-8000"`. The test module is already marked with `pytest.mark.asic("cisco-8000")`.


#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
