### PR TITLE
[lldp]: Enable test_lldp_syncd.py on sonic-vpp t1-lag

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -691,6 +691,7 @@ t1-lag-vpp:
   - ipfwd/test_mtu.py
   - ipfwd/test_dip_sip.py
   - lldp/test_lldp.py
+  - lldp/test_lldp_syncd.py
   - log_fidelity/test_bgp_shutdown.py
   - pc/test_po_voq.py
   - pc/test_lag_member.py


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enable `lldp/test_lldp_syncd.py` on the sonic-vpp `t1-lag-vpp` PR test group

Fixes # (issue)
https://github.com/sonic-net/sonic-buildimage/issues/25770

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
`lldp/test_lldp_syncd.py` checks that the LLDP `LLDP_ENTRY_TABLE` in APPL_DB stays
consistent with `show lldp table` / `lldpctl` across interface flaps, service
restarts and reboot. It already runs on `t0` and `t1-lag` but was never enabled
on the sonic-vpp testbed; this adds the same coverage to `t1-lag-vpp`.

#### How did you do it?
- Added `lldp/test_lldp_syncd.py` to the `t1-lag-vpp` group in
  `.azure-pipelines/pr_test_scripts.yaml`.

#### How did you verify/test it?
The related tests got passed in the regression test:
<img width="1801" height="253" alt="image" src="https://github.com/user-attachments/assets/9c01985d-da9c-48a9-ba24-844678d86fb4" />

<img width="817" height="58" alt="image" src="https://github.com/user-attachments/assets/94ed4cae-df7d-40cc-9a06-f2243930a3a5" />

#### Any platform specific information?
VPP

#### Supported testbed topology if it's a new test case?
t1-lag-vpp

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
