### PR TITLE
[202511] Enable and fix test_buffer_traditional.py for Broadcom platforms (#22155)

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3738,11 +3738,12 @@ qos/test_buffer.py::test_buffer_model_test:
 
 qos/test_buffer_traditional.py:
   skip:
-    reason: "Buffer traditional test is only supported 201911 branch / M* topo does not support qos"
+    reason: "Buffer traditional test is supported on Mellanox and Broadcom platforms only / M* topo does not support qos"
     conditions_logical_operator: or
     conditions:
-      - "release not in ['201911']"
-      - "topo_type in ['m0', 'mx', 'm1']"
+      - "asic_type not in ['mellanox', 'broadcom']"
+      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+
 
 qos/test_ecn_config.py:
   skip:


### PR DESCRIPTION
#### Why I did it
Backport of #22155 ("Enable test_buffer_traditional.py for Broadcom platforms") to the **202511** release branch.

`test_buffer_traditional.py` was previously gated to the 201911 branch only. #22155 enabled and fixed it for Broadcom platforms (in addition to Mellanox) on `master`; this brings the same coverage to 202511.

#### How I did it
- `tests/qos/test_buffer_traditional.py`: enable/fix the test for Broadcom platforms (cherry-picked from #22155).
- `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`: update the skip condition from "release in 201911" to "asic_type in ['mellanox', 'broadcom']" and extend the unsupported `m*` topo list.
- The `tests/drop_packets/combined_drop_counters.yml` change from #22155 is **already present** on 202511 (the `x86_64-nexthop.*` entry under `l2_l3` already exists), so it is intentionally omitted.

#### How did you verify/test it?
Cherry-pick applies cleanly on 202511 (one trivially-already-present hunk dropped). YAML parses and the Python file compiles. Same functional change validated upstream in #22155.

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

This PR itself targets the 202511 branch (backport of the master change in #22155).
