### PR TITLE
Improve logrotate test isolation and cleanup

### DIFF
--- a/tests/syslog/test_logrotate.py
+++ b/tests/syslog/test_logrotate.py
@@ -65,14 +65,14 @@ def simulate_small_var_log_partition(rand_selected_dut, localhost):
             duthost.shell('sudo losetup -P  /dev/loop2 log-new-partition')
             duthost.shell('sudo mkfs.ext4 /dev/loop2')
             duthost.shell('sudo mount /dev/loop2 /var/log')
-            duthost.shell('sudo cp -f {} /var/log/syslog'.format(SYSLOG_BACKUP_FILE), module_ignore_errors=True)
+            duthost.shell('sudo cp -f {} /var/log/syslog'.format(SYSLOG_BACKUP_FILE))
             duthost.shell('sudo rm -f {}'.format(LOGROTATE_TEST_STATE_FILE), module_ignore_errors=True)
 
             config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
-            setup_finished = True
 
             logger.info('Start logrotate-config service')
             duthost.shell('sudo service logrotate-config restart')
+            setup_finished = True
 
         yield
     finally:
@@ -187,6 +187,16 @@ def run_logrotate(duthost, force=False):
     return result
 
 
+def assert_logrotate_success(duthost, result):
+    if result.get('rc') != 0:
+        state = collect_syslog_rotate_state(duthost)
+        pytest.fail(
+            'Logrotate command failed unexpectedly. rc={}, stdout={}, stderr={}, state={}'.format(
+                result.get('rc'), result.get('stdout', ''), result.get('stderr', ''), state
+            )
+        )
+
+
 def multiply_with_unit(logrotate_threshold, num):
     """
     Multiply logrotate_threshold with number, and return the value
@@ -205,7 +215,8 @@ def validate_logrotate_function(duthost, logrotate_threshold, small_size):
     :param logrotate_threshold: logrotate threshold, such as 16M or 1024K
     """
     with allure.step('Run logrotate with force option to prepare clean syslog environment'):
-        run_logrotate(duthost, force=True)
+        logrotate_result = run_logrotate(duthost, force=True)
+        assert_logrotate_success(duthost, logrotate_result)
 
     with allure.step('There should be no logrotate process when rsyslog size is smaller than threshold {}'.format(
             logrotate_threshold)):
@@ -218,6 +229,7 @@ def validate_logrotate_function(duthost, logrotate_threshold, small_size):
 
         oldest_checksum_before_rotate = get_oldest_syslog_checksum(duthost)
         logrotate_result = run_logrotate(duthost)
+        assert_logrotate_success(duthost, logrotate_result)
         syslog_number_no_rotate = get_syslog_file_count(duthost)
         logger.info('There are {} syslog gz files after running logrotate'.format(syslog_number_no_rotate))
         # For no rotation happen, both two conditions has to be satisfied
@@ -241,6 +253,7 @@ def validate_logrotate_function(duthost, logrotate_threshold, small_size):
         create_temp_syslog_file(duthost, multiply_with_unit(logrotate_threshold, 1.1))
         oldest_checksum_before_rotate = get_oldest_syslog_checksum(duthost)
         logrotate_result = run_logrotate(duthost)
+        assert_logrotate_success(duthost, logrotate_result)
         syslog_number_with_rotate = get_syslog_file_count(duthost)
         logger.info('There are {} syslog gz files after running logrotate'.format(syslog_number_with_rotate))
         oldest_checksum_after_rotate = get_oldest_syslog_checksum(duthost)
@@ -248,17 +261,17 @@ def validate_logrotate_function(duthost, logrotate_threshold, small_size):
         # 1. If the number of syslog file the same, the oldest log file checksum has to be different
         #    This is the corner case that number of log files reach the rotate limit.
         # 2. Otherwise, number of log file has to increase by 1
-        if (syslog_number_origin == syslog_number_with_rotate and
-                oldest_checksum_before_rotate == oldest_checksum_after_rotate):
-            state = collect_syslog_rotate_state(duthost)
-            pytest.fail(
-                'No logrotate happens, both syslog file number and timestamp are the same. '
-                'origin={}, after={}, checksum_before={}, checksum_after={}, rc={}, state={}'.format(
-                    syslog_number_origin, syslog_number_with_rotate,
-                    oldest_checksum_before_rotate, oldest_checksum_after_rotate,
-                    logrotate_result.get('rc'), state
+        if syslog_number_origin == syslog_number_with_rotate:
+            if oldest_checksum_before_rotate == oldest_checksum_after_rotate:
+                state = collect_syslog_rotate_state(duthost)
+                pytest.fail(
+                    'No logrotate happens, both syslog file number and timestamp are the same. '
+                    'origin={}, after={}, checksum_before={}, checksum_after={}, rc={}, state={}'.format(
+                        syslog_number_origin, syslog_number_with_rotate,
+                        oldest_checksum_before_rotate, oldest_checksum_after_rotate,
+                        logrotate_result.get('rc'), state
+                    )
                 )
-            )
         elif syslog_number_origin + 1 != syslog_number_with_rotate:
             state = collect_syslog_rotate_state(duthost)
             pytest.fail(

--- a/tests/syslog/test_logrotate.py
+++ b/tests/syslog/test_logrotate.py
@@ -19,6 +19,8 @@ LOG_FOLDER = '/var/log'
 SMALL_VAR_LOG_PARTITION_SIZE = '300M'
 FAKE_IP = '10.20.30.40'
 FAKE_MAC = 'aa:bb:cc:dd:11:22'
+SYSLOG_BACKUP_FILE = '/tmp/syslog_bk'
+LOGROTATE_TEST_STATE_FILE = '/tmp/logrotate-test.status'
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -34,13 +36,15 @@ def backup_syslog(rand_selected_dut):
     :param rand_selected_dut: The fixture returns a randomly selected DUT
     """
     duthost = rand_selected_dut
-    logger.info('Backup syslog file to syslog_bk')
-    duthost.shell('sudo cp -f /var/log/syslog /var/log/syslog_bk')
+    logger.info('Backup syslog file to {}'.format(SYSLOG_BACKUP_FILE))
+    duthost.shell('sudo cp -f /var/log/syslog {}'.format(SYSLOG_BACKUP_FILE))
+    duthost.shell('sudo rm -f {}'.format(LOGROTATE_TEST_STATE_FILE), module_ignore_errors=True)
 
     yield
 
     logger.info('Recover syslog file to syslog')
-    duthost.shell('sudo mv /var/log/syslog_bk /var/log/syslog')
+    duthost.shell('sudo mv {} /var/log/syslog'.format(SYSLOG_BACKUP_FILE), module_ignore_errors=True)
+    duthost.shell('sudo rm -f {}'.format(LOGROTATE_TEST_STATE_FILE), module_ignore_errors=True)
 
     logger.info('Restart rsyslog service')
     duthost.shell('sudo service rsyslog restart')
@@ -53,32 +57,43 @@ def simulate_small_var_log_partition(rand_selected_dut, localhost):
     :param rand_selected_dut: The fixture returns a randomly selected DUT
     """
     duthost = rand_selected_dut
-    with allure.step('Create a small var log partition with size of {}'.format(SMALL_VAR_LOG_PARTITION_SIZE)):
-        logger.info('Create a small var log partition with size of {}'.format(SMALL_VAR_LOG_PARTITION_SIZE))
-        duthost.shell('sudo fallocate -l {} log-new-partition'.format(SMALL_VAR_LOG_PARTITION_SIZE))
-        duthost.shell('sudo losetup -P  /dev/loop2 log-new-partition')
-        duthost.shell('sudo mkfs.ext4 /dev/loop2')
-        duthost.shell('sudo mount /dev/loop2 /var/log')
+    setup_finished = False
+    try:
+        with allure.step('Create a small var log partition with size of {}'.format(SMALL_VAR_LOG_PARTITION_SIZE)):
+            logger.info('Create a small var log partition with size of {}'.format(SMALL_VAR_LOG_PARTITION_SIZE))
+            duthost.shell('sudo fallocate -l {} log-new-partition'.format(SMALL_VAR_LOG_PARTITION_SIZE))
+            duthost.shell('sudo losetup -P  /dev/loop2 log-new-partition')
+            duthost.shell('sudo mkfs.ext4 /dev/loop2')
+            duthost.shell('sudo mount /dev/loop2 /var/log')
+            duthost.shell('sudo cp -f {} /var/log/syslog'.format(SYSLOG_BACKUP_FILE), module_ignore_errors=True)
+            duthost.shell('sudo rm -f {}'.format(LOGROTATE_TEST_STATE_FILE), module_ignore_errors=True)
 
-        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+            config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+            setup_finished = True
 
-        logger.info('Start logrotate-config service')
-        duthost.shell('sudo service logrotate-config restart')
+            logger.info('Start logrotate-config service')
+            duthost.shell('sudo service logrotate-config restart')
 
-    yield
+        yield
+    finally:
+        with allure.step('Recovery var log'):
+            logger.info('Umount and unload the small var log partition')
+            duthost.shell('sudo umount -l /dev/loop2', module_ignore_errors=True)
+            duthost.shell('sudo losetup -d /dev/loop2', module_ignore_errors=True)
 
-    with allure.step('Recovery var log'):
-        logger.info('Umount and unload the small var log partition')
-        duthost.shell('sudo umount -l /dev/loop2')
-        duthost.shell('sudo losetup -d /dev/loop2')
+            logger.info('Remove the small var log partition')
+            duthost.shell('sudo rm -f log-new-partition', module_ignore_errors=True)
 
-        logger.info('Remove the small var log partition')
-        duthost.shell('sudo rm -f log-new-partition')
+            if setup_finished:
+                config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+            else:
+                try:
+                    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+                except Exception:
+                    logger.exception('Failed to recover config after small var log setup failure')
 
-        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
-
-        logger.info('Restart logrotate-config service')
-        duthost.shell('sudo service logrotate-config restart')
+            logger.info('Restart logrotate-config service')
+            duthost.shell('sudo service logrotate-config restart', module_ignore_errors=not setup_finished)
 
 
 def get_var_log_size(duthost):
@@ -114,6 +129,21 @@ def create_temp_syslog_file(duthost, size):
     duthost.shell('sudo fallocate -l {} /var/log/syslog'.format(size))
 
 
+def collect_syslog_rotate_state(duthost):
+    """Collect logrotate state useful for debugging intermittent failures."""
+    cmds = [
+        'ls -l /var/log/syslog* || true',
+        'du -k /var/log/syslog || true',
+        'cat {} || true'.format(LOGROTATE_TEST_STATE_FILE),
+        'cat /var/lib/logrotate/status || true',
+    ]
+    result = duthost.shell('sudo sh -c {}'.format(repr(' ; '.join(cmds))), module_ignore_errors=True)
+    logger.info('Syslog/logrotate state:\nstdout:\n{}\nstderr:\n{}'.format(
+        result.get('stdout', ''), result.get('stderr', '')
+    ))
+    return result.get('stdout', '')
+
+
 def get_oldest_syslog_checksum(duthost):
     checksum = "0"
 
@@ -144,19 +174,17 @@ def run_logrotate(duthost, force=False):
     """
     if force:
         logger.debug('Make sure there is no big /var/log/syslog exist by forcing execute logrotate')
-        cmd = 'sudo /usr/sbin/logrotate -f /etc/logrotate.conf'
+        cmd = 'sudo /usr/sbin/logrotate -s {} -f /etc/logrotate.conf'.format(LOGROTATE_TEST_STATE_FILE)
     else:
-        cmd = 'sudo /usr/sbin/logrotate /etc/logrotate.conf'
+        cmd = 'sudo /usr/sbin/logrotate -s {} /etc/logrotate.conf'.format(LOGROTATE_TEST_STATE_FILE)
     logger.info('Run logrotate command: {}'.format(cmd))
     result = duthost.shell(cmd, module_ignore_errors=True)
-    if result.get('rc', 1) != 0:
-        logger.warning(
-            'Logrotate returned non-zero rc={} (stdout: {}, stderr: {})'.format(
-                result.get('rc'),
-                result.get('stdout', ''),
-                result.get('stderr', '')
-            )
+    logger.info(
+        'Logrotate result rc={} stdout={} stderr={}'.format(
+            result.get('rc'), result.get('stdout', ''), result.get('stderr', '')
         )
+    )
+    return result
 
 
 def multiply_with_unit(logrotate_threshold, num):
@@ -189,36 +217,58 @@ def validate_logrotate_function(duthost, logrotate_threshold, small_size):
             create_temp_syslog_file(duthost, multiply_with_unit(logrotate_threshold, 0.9))
 
         oldest_checksum_before_rotate = get_oldest_syslog_checksum(duthost)
-        run_logrotate(duthost)
+        logrotate_result = run_logrotate(duthost)
         syslog_number_no_rotate = get_syslog_file_count(duthost)
         logger.info('There are {} syslog gz files after running logrotate'.format(syslog_number_no_rotate))
         # For no rotation happen, both two conditions has to be satisfied
         # 1. the number of syslog files keep the same
         # 2. the oldest log file's checksum keep the same
-        assert syslog_number_origin == syslog_number_no_rotate, \
-            'Unexpected logrotate happens, there should be no logrotate executed'
         oldest_checksum_after_rotate = get_oldest_syslog_checksum(duthost)
-        assert oldest_checksum_before_rotate == oldest_checksum_after_rotate, \
-            'Unexpected logrotate happens, there should be no logrotate executed'
+        if (syslog_number_origin != syslog_number_no_rotate or
+                oldest_checksum_before_rotate != oldest_checksum_after_rotate):
+            state = collect_syslog_rotate_state(duthost)
+            pytest.fail(
+                'Unexpected logrotate happens, there should be no logrotate executed. '
+                'origin={}, after={}, checksum_before={}, checksum_after={}, rc={}, state={}'.format(
+                    syslog_number_origin, syslog_number_no_rotate,
+                    oldest_checksum_before_rotate, oldest_checksum_after_rotate,
+                    logrotate_result.get('rc'), state
+                )
+            )
 
     with allure.step('There will be logrotate process when rsyslog size is larger than threshold {}'.format(
             logrotate_threshold)):
         create_temp_syslog_file(duthost, multiply_with_unit(logrotate_threshold, 1.1))
         oldest_checksum_before_rotate = get_oldest_syslog_checksum(duthost)
-        run_logrotate(duthost)
+        logrotate_result = run_logrotate(duthost)
         syslog_number_with_rotate = get_syslog_file_count(duthost)
         logger.info('There are {} syslog gz files after running logrotate'.format(syslog_number_with_rotate))
         oldest_checksum_after_rotate = get_oldest_syslog_checksum(duthost)
         # For rotation happen,
         # 1. If the number of syslog file the same, the oldest log file checksum has to be different
-        #    This is the corner case that number of syslog files reach the rotate limit.
+        #    This is the corner case that number of log files reach the rotate limit.
         # 2. Otherwise, number of log file has to increase by 1
-        if syslog_number_origin == syslog_number_with_rotate:
-            assert oldest_checksum_before_rotate != oldest_checksum_after_rotate, \
-                'No logrotate happens, both syslog file number and timestamp are the same'
-        else:
-            assert syslog_number_origin + 1 == syslog_number_with_rotate, \
-                'No logrotate happens, the number of syslog files does not increase by 1'
+        if (syslog_number_origin == syslog_number_with_rotate and
+                oldest_checksum_before_rotate == oldest_checksum_after_rotate):
+            state = collect_syslog_rotate_state(duthost)
+            pytest.fail(
+                'No logrotate happens, both syslog file number and timestamp are the same. '
+                'origin={}, after={}, checksum_before={}, checksum_after={}, rc={}, state={}'.format(
+                    syslog_number_origin, syslog_number_with_rotate,
+                    oldest_checksum_before_rotate, oldest_checksum_after_rotate,
+                    logrotate_result.get('rc'), state
+                )
+            )
+        elif syslog_number_origin + 1 != syslog_number_with_rotate:
+            state = collect_syslog_rotate_state(duthost)
+            pytest.fail(
+                'No logrotate happens, the number of syslog files does not increase by 1. '
+                'origin={}, after={}, checksum_before={}, checksum_after={}, rc={}, state={}'.format(
+                    syslog_number_origin, syslog_number_with_rotate,
+                    oldest_checksum_before_rotate, oldest_checksum_after_rotate,
+                    logrotate_result.get('rc'), state
+                )
+            )
 
 
 def get_threshold_based_on_memory(duthost):


### PR DESCRIPTION
## Description

Improve `tests/syslog/test_logrotate.py` isolation and cleanup for the intermittent Elastictest failures tracked in #25353 and #25360.

Changes:
- Store the module-level syslog backup outside `/var/log`, so it is not hidden/lost when `test_logrotate_small_size` mounts a temporary filesystem on `/var/log`.
- Make the small `/var/log` fixture cleanup run from `finally`, including when setup fails before `yield`.
- Make cleanup best-effort after setup failure so cleanup errors do not hide the original `config_reload`/BGP setup failure.
- Use a test-specific logrotate state file (`/tmp/logrotate-test.status`) so the test is isolated from the DUT's normal `/var/lib/logrotate/status` state.
- Log logrotate return code/stdout/stderr and collect syslog/logrotate state on assertion failures.

## Motivation and Context

In Elastictest plan `6a2e403f729d944bd21ca1ce`, `syslog/test_logrotate.py` failed in two different ways:

1. `test_logrotate_small_size` failed during setup after remounting `/var/log`, then teardown failed with:
   ```text
   mv: cannot stat '/var/log/syslog_bk': No such file or directory
   ```
   because the backup lived under `/var/log` and the fixture cleanup did not run when setup failed before `yield`.

2. Retry runs of `test_logrotate_normal_size` failed with:
   ```text
   AssertionError: No logrotate happens, both syslog file number and timestamp are the same
   ```
   but the test did not capture enough state to explain why logrotate skipped rotation.

## Testing

- `python3 -m py_compile tests/syslog/test_logrotate.py`
- `git diff --check`

Full behavioral validation requires a SONiC KVM/t2 Elastictest run.

Fixes #25353
Fixes #25360
