### PR TITLE
test_bgp_bbr_default_state test - Repair for T1 topology

### DIFF
--- a/tests/bgp/test_bgp_bbr_default_state.py
+++ b/tests/bgp/test_bgp_bbr_default_state.py
@@ -5,7 +5,6 @@ import logging
 import time
 import pytest
 from jinja2 import Template
-from natsort import natsorted
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.utilities import delete_running_config
@@ -117,7 +116,7 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo, nbrhosts):
     for dut_port, neigh in list(mg_facts['minigraph_neighbors'].items()):
         if neigh['name'] in nbrhosts:
             tor1 = neigh['name']
-            tor1_namespace = neigh.get('namespace',DEFAULT_NAMESPACE)
+            tor1_namespace = neigh.get('namespace', DEFAULT_NAMESPACE)
             break
 
     pytest_assert(tor1 is not None, "Could not find a valid BGP neighbor in the minigraph")

--- a/tests/bgp/test_bgp_bbr_default_state.py
+++ b/tests/bgp/test_bgp_bbr_default_state.py
@@ -5,6 +5,7 @@ import logging
 import time
 import pytest
 from jinja2 import Template
+from natsort import natsorted
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.utilities import delete_running_config
@@ -12,6 +13,7 @@ from tests.common.gu_utils import apply_patch, expect_op_success
 from tests.common.gu_utils import generate_tmpfile, delete_tmpfile
 from tests.common.gu_utils import format_json_patch_for_multiasic
 from tests.common.config_reload import config_reload
+from bgp_bbr_helpers import get_bbr_default_state
 
 
 pytestmark = [
@@ -96,6 +98,33 @@ def disable_bbr(duthost, namespace):
         config_bbr_by_gcu(duthost, "disabled")
 
 
+def get_bbr_status_from_config_db(duthost, namespace):
+    namespace_prefix = '-n ' + namespace if namespace else ''
+    return duthost.shell(
+        'sonic-db-cli {} CONFIG_DB HGET "BGP_BBR|all" "status"'.format(namespace_prefix)
+    )['stdout'].strip().strip('"')
+
+
+def get_external_allowas_lines(duthost, namespace):
+    bgp_cmd = 'vtysh -c "show running-configuration bgp"'
+    cmd = duthost.get_vtysh_cmd_for_namespace(bgp_cmd, namespace)
+    output = duthost.shell(cmd, module_ignore_errors=True)['stdout']
+    return [
+        line.strip() for line in output.splitlines()
+        if 'allowas' in line and 'INTERNAL_PEER' not in line
+    ]
+
+
+def verify_bbr_disabled(duthost, namespace):
+    bbr_status = get_bbr_status_from_config_db(duthost, namespace)
+    pytest_assert(bbr_status == 'disabled',
+                  "BGP_BBR status is '{}', expected 'disabled'".format(bbr_status))
+
+    external_allowas = get_external_allowas_lines(duthost, namespace)
+    pytest_assert(not external_allowas,
+                  "BBR allowas-in found on external peers: {}".format(external_allowas))
+
+
 @pytest.fixture
 def config_bbr_disabled(duthosts, setup, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
@@ -108,20 +137,27 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo, nbrhosts):
     constants_stat = duthost.stat(path=CONSTANTS_FILE)
     if not constants_stat['stat']['exists']:
         pytest.skip('No file {} on DUT, BBR is not supported')
-    bbr_default_state = 'disabled'
-    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
-    tor1 = None
+    bbr_supported, bbr_default_state = get_bbr_default_state(duthost)
+    if not bbr_supported:
+        pytest.skip('BGP BBR is not supported')
+    if bbr_default_state != 'disabled':
+        pytest.skip('Test only applies when constants.yml BBR default is disabled')
+
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    tor_neighbors = natsorted([neighbor for neighbor in list(nbrhosts.keys()) if neighbor.endswith('T0')])
+    pytest_assert(tor_neighbors, 'No T0 neighbor found in topology')
+    tor1 = tor_neighbors[0]
+
     tor1_namespace = DEFAULT_NAMESPACE
-    for dut_port, neigh in list(mg_facts['minigraph_neighbors'].items()):
-        if neigh['name'] in nbrhosts:
-            tor1 = neigh['name']
+    for _, neigh in list(mg_facts['minigraph_neighbors'].items()):
+        if tor1 == neigh['name']:
             tor1_namespace = neigh.get('namespace', DEFAULT_NAMESPACE)
             break
 
-    pytest_assert(tor1 is not None, "Could not find a valid BGP neighbor in the minigraph")
     setup_info = {
         'bbr_default_state': bbr_default_state,
+        'tor1': tor1,
         'tor1_namespace': tor1_namespace,
     }
     if not setup_info['tor1_namespace']:
@@ -136,5 +172,4 @@ def test_bbr_disabled_constants_yml_default(duthosts, rand_one_dut_hostname, set
     duthost = duthosts[rand_one_dut_hostname]
     duthost.shell("sudo config save -y")
     config_reload(duthost, safe_reload=True)
-    is_bbr_enabled = duthost.shell("show runningconfiguration bgp | grep allowas", module_ignore_errors=True)['stdout']
-    pytest_assert(is_bbr_enabled == "", "BBR is not disabled when it should be.")
+    verify_bbr_disabled(duthost, setup['tor1_namespace'])

--- a/tests/bgp/test_bgp_bbr_default_state.py
+++ b/tests/bgp/test_bgp_bbr_default_state.py
@@ -111,13 +111,16 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo, nbrhosts):
         pytest.skip('No file {} on DUT, BBR is not supported')
     bbr_default_state = 'disabled'
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-    tor_neighbors = natsorted([neighbor for neighbor in list(nbrhosts.keys()) if neighbor.endswith('T0')])
-    tor1 = tor_neighbors[0]
+
+    tor1 = None
     tor1_namespace = DEFAULT_NAMESPACE
     for dut_port, neigh in list(mg_facts['minigraph_neighbors'].items()):
-        if tor1 == neigh['name']:
-            tor1_namespace = neigh['namespace']
+        if neigh['name'] in nbrhosts:
+            tor1 = neigh['name']
+            tor1_namespace = neigh.get('namespace',DEFAULT_NAMESPACE)
             break
+
+    pytest_assert(tor1 is not None, "Could not find a valid BGP neighbor in the minigraph")
     setup_info = {
         'bbr_default_state': bbr_default_state,
         'tor1_namespace': tor1_namespace,

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t1_multiasic.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t1_multiasic.yaml
@@ -18,11 +18,6 @@ bgp/test_bgp_allow_list.py:
     conditions:
     - asic_type in ['vs'] and 't1-8-lag' in topo_name
     reason: This test case either cannot pass or should be skipped on virtual chassis
-bgp/test_bgp_bbr_default_state.py:
-  skip:
-    conditions:
-    - asic_type in ['vs'] and 't1-8-lag' in topo_name
-    reason: This test case either cannot pass or should be skipped on virtual chassis
 bgp/test_bgp_bounce.py:
   skip:
     conditions:


### PR DESCRIPTION
Skipped test, repair for validity in T1 topology testing.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The test_bgp_bbr_default_state test previously verified BBR disabled state by checking that "grep allowas" returned nothing in the running config. This didn't apply to the T1 topology, so this test was marked to skip, as for this multi-ASIC setup, BGP always configures allowas-in on internal inter-ASIC peer groups. The test falsely reported that BBR is not disabled, on a T1 topology. 

This PR updates the verification to be correct for T1. "BGP_BBR|all" status is disabled, and there is no allowas-in on external (T0) peers. It also picks a T0 downstream neighbor and its namespace and does not hardcode the BBR default (aligning the setup with test_bgp_bbr). 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Previously, this test was written for T0 and was skipped on T1. On T1 multi-ASIC, it failed even when BBR was correctly disabled. The test falsely reported BBR as enabled for T1. 

#### How did you do it?
- After reload, verify that BBR is disabled using the correct ASIC namespace on multi-ASIC. 
- Check the running config for allowas-in on external peers only. 
- Select the downstream T0 neighbor from minigraph
- Read BBR default from constants.yml rather than hardcoding it. 

#### How did you verify/test it?
- Ran on T1 testbed.
- Confirmed test no longer fails on internal config
- Removed the test from skipped tests list for T1. 

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A
