### PR TITLE
[dns/static_dns]: Restart host rsyslog after teardown config_reload to clear stale imrelp clients

### DIFF
--- a/tests/dns/static_dns/conftest.py
+++ b/tests/dns/static_dns/conftest.py
@@ -71,6 +71,9 @@ def static_dns_setup(duthost):
     with allure.step("Config reload to recover the original state"):
         config_reload(duthost, safe_reload=True)
 
+    with allure.step("Restart host rsyslog to clear stale imrelp client connections"):
+        duthost.shell("systemctl restart rsyslog")
+
 
 @pytest.fixture(autouse=False)
 def static_dns_clean(duthost):


### PR DESCRIPTION
### Description of PR

Summary: `dns/static_dns/test_static_dns.py::test_static_dns_negative` leaves host `rsyslog` half-restarted at teardown, breaking `omrelp` log forwarding from every SONiC container for ~20 min and producing ~47 LogAnalyzer false-positives across 18 containers in downstream tests. Fix closes the window in the offending fixture's own teardown.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

`static_dns_setup` blanks `/etc/resolv.conf` in every running container, then calls `config_reload(safe_reload=True)` at teardown. That reload only `SIGHUP`s host `rsyslog.service` — never a full Stop+Start. SIGHUP doesn't reset the `imrelp` listener's per-client state, so container `omrelp` clients get stuck retrying with `librelp error 10014` until a later unrelated test happens to fully restart `rsyslog`. Representative plan: https://elastictest.org/scheduler/testplan/6a03c0c1686444e666af82fc — `test_static_dns` ran 00:47-01:07; container logs from `01:02-01:05` only surfaced at `01:21:29` after `config syslog del` incidentally restarted `rsyslog`.

#### How did you do it?

Added one `systemctl restart rsyslog` after the existing `config_reload` in the fixture teardown (`tests/dns/static_dns/conftest.py`). Produces the same Stop+Start that recovered the cited plan, but inside this fixture's own teardown — recovery window = 0s instead of ~14 min.

#### How did you verify/test it?

Local dev-VM, SONiC `202605-27718.1134779`, 14-container vlab-08 + 9-container single-asic vlab. Forced-race script mimicking the exact teardown sequence:

```
Pre-fix:  host rsyslog PID unchanged (only "Sending signal SIGHUP" in journal, 0 Stopped/Started events)
Post-fix: host rsyslog PID changes, "Stopped rsyslog.service" + "Started rsyslog.service" appear
```

Same lifecycle events as the `01:21:29` recovery in the cited plan. Note: local vlabs had too few containers to trip the actual `omrelp` race; post-merge Kusto signature count is the production ground-truth.

#### Any platform specific information?

None. `rsyslog.service` is standard systemd on every SONiC platform.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

None required.
