### PR TITLE
Fix edit of parameter skip_xcvrd_cmis_mgr for fanout

### DIFF
--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202311.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202311.yml
@@ -52,8 +52,9 @@
     - name: Skip transceiver cmis manager
       lineinfile:
         path: /usr/share/sonic/device/{{ fanout_platform }}/{{ fanout_hwsku }}/pmon_daemon_control.json
-        regexp: '"skip_xcvrd_cmis_mgr": false'
-        line: '    "skip_xcvrd_cmis_mgr": true'
+        regexp: '^(\s*"skip_xcvrd_cmis_mgr"\s*:\s*)(?:true|false)(,?)\s*$'
+        line: '\1true\2'
+        backrefs: yes
       when: pmon_daemon_control_json.stat.exists
 
     - name: Remove media setting file

--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202405.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202405.yml
@@ -52,8 +52,9 @@
     - name: Skip transceiver cmis manager
       lineinfile:
         path: /usr/share/sonic/device/{{ fanout_platform }}/{{ fanout_hwsku }}/pmon_daemon_control.json
-        regexp: '"skip_xcvrd_cmis_mgr": false'
-        line: '    "skip_xcvrd_cmis_mgr": true'
+        regexp: '^(\s*"skip_xcvrd_cmis_mgr"\s*:\s*)(?:true|false)(,?)\s*$'
+        line: '\1true\2'
+        backrefs: yes
       when: pmon_daemon_control_json.stat.exists
 
     - name: Remove media setting file

--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202505.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202505.yml
@@ -67,8 +67,9 @@
     - name: Skip transceiver cmis manager
       lineinfile:
         path: /usr/share/sonic/device/{{ fanout_platform }}/{{ fanout_hwsku }}/pmon_daemon_control.json
-        regexp: '"skip_xcvrd_cmis_mgr": false'
-        line: '    "skip_xcvrd_cmis_mgr": true'
+        regexp: '^(\s*"skip_xcvrd_cmis_mgr"\s*:\s*)(?:true|false)(,?)\s*$'
+        line: '\1true\2'
+        backrefs: yes
       when: pmon_daemon_control_json.stat.exists
 
     - name: Remove media setting file

--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202511.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202511.yml
@@ -67,8 +67,9 @@
     - name: Skip transceiver cmis manager
       lineinfile:
         path: /usr/share/sonic/device/{{ fanout_platform }}/{{ fanout_hwsku }}/pmon_daemon_control.json
-        regexp: '"skip_xcvrd_cmis_mgr": false'
-        line: '    "skip_xcvrd_cmis_mgr": true'
+        regexp: '^(\s*"skip_xcvrd_cmis_mgr"\s*:\s*)(?:true|false)(,?)\s*$'
+        line: '\1true\2'
+        backrefs: yes
       when: pmon_daemon_control_json.stat.exists
 
     - name: Remove media setting file


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Part of ansible-playbook fanout.yml, updates file on fanout `pmon_daemon_control.json`.
The parameter changed from "false" to "true".

Old implementation works only when parameter exist and the value is `false`.

New implementation works in the cases when:
value is `true`/`false` with/without `,` at the end of the line.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Stabilize the fanout after deployment

#### How did you do it?
changed regex and used backrefs

#### How did you verify/test it?
Fanout dockers and interfaces are Up




