### PR TITLE
[ansible/vm_set]: Bootstrap uv and venv in renumber-topo flow

### DIFF
--- a/ansible/testbed_renumber_vm_topology.yml
+++ b/ansible/testbed_renumber_vm_topology.yml
@@ -83,6 +83,17 @@
     set_fact:
       package_installation: false
 
+  # Defensive bootstrap: even though we set package_installation=false to skip
+  # heavy host setup (apt, sysctl, docker), we still need `uv` and the persistent
+  # venv at {{ sonic_testbed_venv }} because the renumber flow calls into
+  # control_mux_simulator.yml / control_nic_simulator.yml which `uv pip install`
+  # Flask/Werkzeug unconditionally. ensure_python_env.yml is idempotent: it
+  # checks for `uv` and the venv first and only installs what is missing.
+  - name: Ensure uv and Python venv exist on the host
+    include_role:
+      name: vm_set
+      tasks_from: ensure_python_env.yml
+
   - name: Load topo variables
     include_vars: "vars/topo_{{ topo }}.yml"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

* Microsoft ADO (number only): 38615522

Fix:

```
TASK [vm_set : Check installed Flask and Werkzeug versions] ********************
task path: /var/src/sonic-mgmt_testbed-bjw3-can-dual-t0-7260-1/ansible/roles/vm_set/tasks/control_mux_simulator.yml:19
ok: [BJW3-CAN-SERV-1] => {"changed": false, "cmd": "/opt/sonic-testbed/venv/bin/python -c 'import flask, werkzeug; print(flask.__version__); print(werkzeug.__version__)'", "failed_when_result": false, "msg": "[Errno 2] No such file or directory: b'/opt/sonic-testbed/venv/bin/python'", "rc": 2, "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [vm_set : Install Flask and Werkzeug in venv] *****************************
task path: /var/src/sonic-mgmt_testbed-bjw3-can-dual-t0-7260-1/ansible/roles/vm_set/tasks/control_mux_simulator.yml:27
fatal: [BJW3-CAN-SERV-1]: FAILED! => {"changed": false, "cmd": "uv pip install --python /opt/sonic-testbed/venv/bin/python flask==2.3.3 werkzeug==2.3.7", "msg": "[Errno 2] No such file or directory: b'uv'", "rc": 2, "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

PLAY RECAP *********************************************************************
BJW3-CAN-SERV-1            : ok=124  changed=24   unreachable=0    failed=1    skipped=77   rescued=0    ignored=1   
```

#### How did you do it?
Added a defensive bootstrap step to `testbed_renumber_vm_topology.yml`
that explicitly includes `ensure_python_env.yml` from the `vm_set` role
right after `package_installation` is set to `false`. The included task
is idempotent — it checks for `uv` and the venv first and only installs
what is missing — so it adds no measurable overhead on already-provisioned
hosts. The `package_installation=false` flag still skips the heavy
host_setup tasks (apt packages, Docker repo, sysctl, br_netfilter); only
the lightweight `uv` + venv bootstrap is forced.


#### How did you verify/test it?
run restart-ptf, no error

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
