### PR TITLE
Fix ENI counter test for CT aging interval change

### DIFF
--- a/tests/dash/dash_eni_counter_utils.py
+++ b/tests/dash/dash_eni_counter_utils.py
@@ -8,6 +8,7 @@ import re
 logger = logging.getLogger(__name__)
 ENI_COUNTER_POLL_INTERVAL = 1000  # 1 second
 ENI_COUNTER_READY_MAX_TIME = 10  # 10 seconds
+CT_AGING_TEST_INTERVAL = 1  # 1 second aging interval for test
 
 
 def get_eni_counter_status(dpuhost):
@@ -43,6 +44,43 @@ def get_eni_counters(dpuhost, eni_counter_oid):
     dash_counter_dict = dpuhost.shell(cmd_get_eni_counter)['stdout']
     dash_counter_dict = ast.literal_eval(dash_counter_dict)
     return dash_counter_dict
+
+
+def get_ct_aging_interval(dpuhost, use_udp=False):
+    """Get the current CT aging interval from sai.profile via nasa-cli-helper.
+
+    Args:
+        dpuhost: DPU host object
+        use_udp: If True, get UDP aging interval; otherwise get TCP aging interval
+
+    Returns:
+        int: Current aging interval in seconds, or None if not supported
+    """
+    cmd = "nasa-cli-helper.py get_aging_interval"
+    if use_udp:
+        cmd += " -u"
+    result = dpuhost.shell(cmd)
+    if not result['stdout'].strip().isdigit():
+        return None
+    return int(result['stdout'].strip())
+
+
+def set_ct_aging_interval(dpuhost, seconds, use_udp=False):
+    """Set the CT aging interval in sai.profile via nasa-cli-helper.
+
+    Note: Requires syncd restart or config reload to take effect.
+
+    Args:
+        dpuhost: DPU host object
+        seconds: Aging interval in seconds
+        use_udp: If True, set UDP aging interval; otherwise set TCP aging interval
+    """
+    cmd = f"nasa-cli-helper.py set_aging_interval {seconds}"
+    if use_udp:
+        cmd += " -u"
+    protocol = "UDP" if use_udp else "TCP"
+    logger.info(f"Setting CT {protocol} aging interval to {seconds}s")
+    dpuhost.shell(cmd)
 
 
 def verify_eni_counter(eni_counter_check_point_dict, eni_counter_before_sending_pkt, eni_counter_after_sending_pkt):
@@ -102,7 +140,7 @@ def eni_counter_setup(dpuhost):
     set_eni_counter_interval(dpuhost, original_eni_counter_status.get('POLL_INTERVAL'))
 
     if original_eni_counter_status.get("FLEX_COUNTER_STATUS") != "enable":
-        logger.info("enable eni counter")
+        logger.info("restoring original disabled state")
         set_eni_counter_status(dpuhost, "disable")
 
 

--- a/tests/dash/test_dash_eni_counter.py
+++ b/tests/dash/test_dash_eni_counter.py
@@ -16,7 +16,8 @@ from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until
 from tests.common.dash_utils import apply_dash_configs, apply_swssconfig_file
 from dash_eni_counter_utils import get_eni_counters, get_eni_counter_oid, verify_eni_counter, \
-    eni_counter_setup, partition_supported_counters, ENI_COUNTER_READY_MAX_TIME  # noqa: F401
+    eni_counter_setup, partition_supported_counters, ENI_COUNTER_READY_MAX_TIME, \
+    CT_AGING_TEST_INTERVAL, get_ct_aging_interval, set_ct_aging_interval  # noqa: F401
 
 
 logger = logging.getLogger(__name__)
@@ -128,45 +129,65 @@ def common_setup_teardown(
         return
     dpuhost = dpuhosts[dpu_index]
 
-    # ``INBOUND_VNI_ROUTE_RULE_CONFIG`` is only programmed on Bluefield DPUs;
-    # on other platforms ROUTE_RULE entries are skipped at the source.
-    bluefield_route_rule_configs = []
-    if 'bluefield' in dpuhost.facts['asic_type']:
-        bluefield_route_rule_configs = [pl.INBOUND_VNI_ROUTE_RULE_CONFIG]
+    try:
+        is_nvidia_dpu = 'bluefield' in dpuhost.facts['asic_type']
+        if is_nvidia_dpu:
+            original_tcp_aging = get_ct_aging_interval(dpuhost, use_udp=False)
+            original_udp_aging = get_ct_aging_interval(dpuhost, use_udp=True)
+            logger.info(f"Original CT aging intervals - TCP: {original_tcp_aging}s, UDP: {original_udp_aging}s")
 
-    config_dicts = [
-        pl.APPLIANCE_CONFIG,
-        pl.ROUTING_TYPE_PL_CONFIG,
-        pl.VNET_CONFIG,
-        pl.ROUTE_GROUP1_CONFIG,
-        pl.METER_POLICY_V4_CONFIG,
-        pl.PE_VNET_MAPPING_CONFIG,
-        pl.PE_SUBNET_ROUTE_CONFIG,
-        pl.VM_SUBNET_ROUTE_CONFIG,
-        *bluefield_route_rule_configs,
-        pl.METER_RULE1_V4_CONFIG,
-        pl.METER_RULE2_V4_CONFIG,
-        pl.ENI_CONFIG,
-        pl.ENI_ROUTE_GROUP1_CONFIG,
-    ]
+            set_ct_aging_interval(dpuhost, CT_AGING_TEST_INTERVAL, use_udp=False)
+            set_ct_aging_interval(dpuhost, CT_AGING_TEST_INTERVAL, use_udp=True)
+            logger.info(f"Set CT aging intervals to {CT_AGING_TEST_INTERVAL}s, config reloadto apply")
 
-    # ``apply_dash_configs`` buckets entries by DASH table name and applies them in
-    # dependency order (see ``DashPhase`` in ``tests/common/dash_utils.py``):
-    # GROUP_1 (APPLIANCE) -> GROUP_2 (ROUTING_TYPE/METER_POLICY/VNET) ->
-    # GROUP_3 (METER_RULE) -> GROUP_4 (ENI/ROUTE_GROUP) ->
-    # GROUP_5 (ROUTE_RULE/ROUTE/VNET_MAPPING) -> GROUP_6 (ENI_ROUTE).
-    #
-    # This fixture is module-scoped: the DASH config is programmed once and shared by every
-    # test. Tests must not leak flow state between each other -- each is assigned a unique
-    # inner 5-tuple (see ``flow_port_offset``) so flows never collide.
-    apply_dash_configs(localhost, duthost, ptfhost, dpuhost.dpu_index, *config_dicts)
+            config_reload(dpuhost, safe_reload=True)
 
-    yield
+        # ``INBOUND_VNI_ROUTE_RULE_CONFIG`` is only programmed on Bluefield DPUs;
+        # on other platforms ROUTE_RULE entries are skipped at the source.
+        bluefield_route_rule_configs = []
+        if 'bluefield' in dpuhost.facts['asic_type']:
+            bluefield_route_rule_configs = [pl.INBOUND_VNI_ROUTE_RULE_CONFIG]
 
-    # Explicit delete (rather than ``config_reload``) preserves the runtime
-    # ``counterpoll eni`` enable/interval configured by ``eni_counter_setup``.
-    if not skip_cleanup:
-        apply_dash_configs(localhost, duthost, ptfhost, dpuhost.dpu_index, *config_dicts, set_db=False)
+        config_dicts = [
+            pl.APPLIANCE_CONFIG,
+            pl.ROUTING_TYPE_PL_CONFIG,
+            pl.VNET_CONFIG,
+            pl.ROUTE_GROUP1_CONFIG,
+            pl.METER_POLICY_V4_CONFIG,
+            pl.PE_VNET_MAPPING_CONFIG,
+            pl.PE_SUBNET_ROUTE_CONFIG,
+            pl.VM_SUBNET_ROUTE_CONFIG,
+            *bluefield_route_rule_configs,
+            pl.METER_RULE1_V4_CONFIG,
+            pl.METER_RULE2_V4_CONFIG,
+            pl.ENI_CONFIG,
+            pl.ENI_ROUTE_GROUP1_CONFIG,
+        ]
+
+        # ``apply_dash_configs`` buckets entries by DASH table name and applies them in
+        # dependency order (see ``DashPhase`` in ``tests/common/dash_utils.py``):
+        # GROUP_1 (APPLIANCE) -> GROUP_2 (ROUTING_TYPE/METER_POLICY/VNET) ->
+        # GROUP_3 (METER_RULE) -> GROUP_4 (ENI/ROUTE_GROUP) ->
+        # GROUP_5 (ROUTE_RULE/ROUTE/VNET_MAPPING) -> GROUP_6 (ENI_ROUTE).
+        #
+        # This fixture is module-scoped: the DASH config is programmed once and shared by every
+        # test. Tests must not leak flow state between each other -- each is assigned a unique
+        # inner 5-tuple (see ``flow_port_offset``) so flows never collide.
+        apply_dash_configs(localhost, duthost, ptfhost, dpuhost.dpu_index, *config_dicts)
+
+        yield
+    finally:
+        if is_nvidia_dpu:
+            logger.info(f"Restoring CT aging intervals - TCP: {original_tcp_aging}s, UDP: {original_udp_aging}s")
+            set_ct_aging_interval(dpuhost, original_tcp_aging, use_udp=False)
+            set_ct_aging_interval(dpuhost, original_udp_aging, use_udp=True)
+            config_reload(dpuhost, safe_reload=True)
+            skip_cleanup = True
+
+        # Explicit delete (rather than ``config_reload``) preserves the runtime
+        # ``counterpoll eni`` enable/interval configured by ``eni_counter_setup``.
+        if not skip_cleanup:
+            apply_dash_configs(localhost, duthost, ptfhost, dpuhost.dpu_index, *config_dicts, set_db=False)
 
 
 @pytest.fixture(scope="function", params=["vxlan", "gre"])


### PR DESCRIPTION

### Description of PR

Summary:
Adapt test_dash_eni_counter.py for the CT aging interval change introduced by sonic-buildimage [PR #25869](https://github.com/sonic-net/sonic-buildimage/pull/25869). The default aging interval was increased from 1s to TCP: 300s, UDP 120s, causing SAI_ENI_STAT_FLOW_AGED counter checks to time out within the 10s test wait window.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
The upstream PR sonic-net/sonic-buildimage#25869 (https://github.com/sonic-net/sonic-buildimage/pull/25869) introduced configurable Connection Tracking (CT) aging intervals for TCP and UDP flows on NVIDIA BlueField DPUs. Previously, the CT aging interval was hardcoded to 1 second. After this change, the default aging intervals were increased to 60 seconds (and will be further increased to TCP=300s, UDP=120s).
This caused test_dash_eni_counter.py to fail on all test cases that verify the SAI_ENI_STAT_FLOW_AGED counter. The test expects the FLOW_AGED counter to increment within a 10-second polling window (ENI_COUNTER_READY_MAX_TIME), but with the new 60s default aging interval, flows are no longer aged within that window.
#### How did you do it?
1. Added helper functions in dash_eni_counter_utils.py to get/set CT aging intervals via the new nasa-cli-helper.py CLI introduced by the buildimage PR:
   - get_ct_aging_interval(dpuhost, use_udp) — reads current TCP or UDP aging from sai.profile
   - set_ct_aging_interval(dpuhost, seconds, use_udp) — writes aging interval to sai.profile
   - Added CT_AGING_TEST_INTERVAL = 1 constant for the test-time aging value
2. Updated the common_setup_teardown module fixture in test_dash_eni_counter.py:
   - Setup: Saves original TCP/UDP aging intervals, sets both to 1 second, then performs a config_reload to apply the sai.profile changes (syncd picks up new aging on restart). DASH config is applied via gNMI after the reload.
   - Teardown: Restores original aging intervals and performs config_reload to apply them.
#### How did you verify/test it?
Test suite passed
#### Any platform specific information?
This change only affects SmartSwitch (eg. NVIDIA SN4280) platforms with BlueField DPUs.
- Requires the nasa-cli-helper.py CLI tool to be present on the DPU image (introduced by sonic-buildimage#25869)
- The config_reload in setup adds approximately 60-90 seconds to the module setup time, but is necessary because sai.profile changes only take effect after syncd restart.
#### Supported testbed topology if it's a new test case?
Any
### Documentation
NA
