### PR TITLE
Fix Nokia IXR7220 TH6 nightly test failures with proper platform fixes

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -16,7 +16,8 @@ from tests.common.helpers.dut_utils import get_disabled_container_list
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.disable_memory_utilization
 ]
 
 CONTAINER_CHECK_INTERVAL_SECS = 1
@@ -460,8 +461,14 @@ def postcheck_critical_processes_status(duthost, feature_autorestart_states, up_
             if is_hiting_start_limit(duthost, feature_name):
                 clear_failed_flag_and_restart(duthost, feature_name, feature_name)
 
-    post_check_threshold = POST_CHECK_THRESHOLD_SECS_T2 if duthost.get_facts().get("modular_chassis") \
-        else POST_CHECK_THRESHOLD_SECS
+    # Nokia IXR7220 has 252 PortChannels all using slow LACP (30 s PDU interval) and
+    # retry_count=3, so LACP re-establishment after teamd restart takes up to 270 s.
+    # Combined with BGP reconvergence for 252 sessions, 360 s is often not sufficient.
+    # Use the T2-chassis threshold (600 s) for Nokia.
+    if duthost.get_facts().get("modular_chassis") or 'Nokia' in duthost.facts.get('hwsku', ''):
+        post_check_threshold = POST_CHECK_THRESHOLD_SECS_T2
+    else:
+        post_check_threshold = POST_CHECK_THRESHOLD_SECS
 
     critical_proceses = wait_until(
         post_check_threshold, POST_CHECK_INTERVAL_SECS, 0,
@@ -496,6 +503,8 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
     skip_condition = disabled_containers[:]
     skip_condition.append("database")
     skip_condition.append("acms")
+    skip_condition.append("dummyk8s")
+    skip_condition.append("otel")
     if tbinfo["topo"]["type"] != "t0":
         skip_condition.append("radv")
     if "202412" in duthost.os_version:
@@ -553,14 +562,26 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
     critical_proceses, bgp_check = postcheck_critical_processes_status(
         duthost, feature_autorestart_states, up_bgp_neighbors
     )
+    if not critical_proceses:
+        processes_status = duthost.all_critical_process_status()
+        for cname, procs in list(processes_status.items()):
+            if procs["status"] is False or len(procs["exited_critical_process"]) > 0:
+                logger.info("Post-check: container '{}' has exited critical processes: {}"
+                            .format(cname, procs["exited_critical_process"]))
+    if not bgp_check:
+        bgp_neigh = duthost.get_bgp_neighbors()
+        down_sessions = {ip: info['state'] for ip, info in list(bgp_neigh.items()) if info['state'] != 'established'}
+        logger.info("Post-check: BGP sessions not established: {}".format(down_sessions))
     if not (critical_proceses and bgp_check):
-        config_reload(duthost, safe_reload=True)
-        # after config reload, the feature autorestart config is reset,
-        # so, before next test, enable again
-        enable_autorestart(duthost)
-
+        # Capture diagnostic state BEFORE config_reload, otherwise all sessions
+        # will appear established in the error message after recovery.
         failed_check = "[Critical Process] " if not critical_proceses else ""
         failed_check += "[BGP] " if not bgp_check else ""
+        bgp_failures = [
+            {x: v['state']}
+            for x, v in list(duthost.get_bgp_neighbors().items())
+            if v['state'] != 'established'
+        ]
         processes_status = duthost.all_critical_process_status()
         pstatus = [
             {
@@ -572,6 +593,11 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
                 "status"
             ] is False and len(v["exited_critical_process"]) > 0
         ]
+
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+        # after config reload, the feature autorestart config is reset,
+        # so, before next test, enable again
+        enable_autorestart(duthost)
 
         if (duthost.get_facts().get("modular_chassis") and
                 duthost.facts["asic_type"] == "cisco-8000" and
@@ -589,11 +615,7 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
                 ("{}check failed, testing feature {}, \nBGP:{}, \nNeighbors:{}"
                  "\nProcess status {}").format(
                     failed_check, container_name,
-                    [
-                        {x: v['state']}
-                        for x, v in list(duthost.get_bgp_neighbors().items())
-                        if v['state'] != 'established'
-                    ],
+                    bgp_failures,
                     up_bgp_neighbors, pstatus
                 )
             )

--- a/tests/bgp/route_checker.py
+++ b/tests/bgp/route_checker.py
@@ -63,7 +63,7 @@ def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver, exp_community=[]):
     """
     mg_facts = dut_host.minigraph_facts(
         host=dut_host.hostname)['ansible_facts']
-    asn = mg_facts['minigraph_bgp_asn']
+    confed_asn = dut_host.get_bgp_confed_asn()
     all_routes = {}
     BGP_ENTRY_HEADING = r"BGP routing table entry for "
     BGP_COMMUNITY_HEADING = r"Community: "
@@ -80,9 +80,17 @@ def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver, exp_community=[]):
         :param neigh_host_item: tuple of hostname and host_conf dict
         :return: no return value
         """
-        # get hostname('ARISTA11T0') by VM name('VM0122')
-        hostname = host_name_map[node['host'].hostname]
+        multi_vrf_peer = node.get('is_multi_vrf_peer', False)
+        if multi_vrf_peer:
+            hostname = node['multi_vrf_data']['vrf']
+        else:
+            # get hostname('ARISTA11T0') by VM name('VM0122')
+            hostname = host_name_map[node['host'].hostname]
         host = node['host']
+        peer_in_bgp_confed = node['conf']['bgp'].get('peer_in_bgp_confed', False)
+        asn = mg_facts['minigraph_bgp_asn']
+        if peer_in_bgp_confed:
+            asn = int(confed_asn)
         peer_ips = node['conf']['bgp']['peers'][asn]
         for ip in peer_ips:
             if ipaddress.IPNetwork(ip).version == 4:
@@ -91,16 +99,23 @@ def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver, exp_community=[]):
                 peer_ip_v6 = ip
         # The json formatter on EOS consumes too much time (over 40 seconds).
         # So we have to parse the raw output instead json.
+        grepCmd = 'grep -E "{}|{}"'.format(BGP_ENTRY_HEADING, BGP_COMMUNITY_HEADING)
         if 4 == ip_ver:
-            cmd = "show ip bgp neighbors {} received-routes detail | grep -E \"{}|{}\""\
-                  .format(peer_ip_v4, BGP_ENTRY_HEADING, BGP_COMMUNITY_HEADING)
+            cmd = "show ip bgp neighbors {} received-routes detail".format(peer_ip_v4)
+            if multi_vrf_peer:
+                cmd = "{} vrf {}".format(cmd, hostname)
+            cmd = "{} | {}".format(cmd, grepCmd)
             cmd_backup = ""
         else:
-            cmd = "show ipv6 bgp peers {} received-routes detail | grep -E \"{}|{}\""\
-                  .format(peer_ip_v6, BGP_ENTRY_HEADING, BGP_COMMUNITY_HEADING)
+            cmd = "show ipv6 bgp peers {} received-routes detail".format(peer_ip_v6)
+            if multi_vrf_peer:
+                cmd = "{} vrf {}".format(cmd, hostname)
+            cmd = "{} | {}".format(cmd, grepCmd)
             # For compatibility on EOS of old version
-            cmd_backup = "show ipv6 bgp neighbors {} received-routes detail | grep -E \"{}|{}\""\
-                         .format(peer_ip_v6, BGP_ENTRY_HEADING, BGP_COMMUNITY_HEADING)
+            cmd_backup = "show ipv6 bgp neighbors {} received-routes detail".format(peer_ip_v6)
+            if multi_vrf_peer:
+                cmd_backup = "{} vrf {}".format(cmd_backup, hostname)
+            cmd_backup = "{} | {}".format(cmd_backup, grepCmd)
         res = host.eos_command(commands=[cmd], module_ignore_errors=True)
         if res['failed'] and cmd_backup != "":
             res = host.eos_command(
@@ -154,7 +169,7 @@ def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver, exp_community=[]):
 def parse_routes_on_vsonic(dut_host, neigh_hosts, ip_ver):
     mg_facts = dut_host.minigraph_facts(
         host=dut_host.hostname)['ansible_facts']
-    asn = mg_facts['minigraph_bgp_asn']
+    confed_asn = dut_host.get_bgp_confed_asn()
     all_routes = {}
 
     host_name_map = {}
@@ -164,6 +179,10 @@ def parse_routes_on_vsonic(dut_host, neigh_hosts, ip_ver):
     def parse_routes_process_vsonic(node=None, results=None):
         hostname = host_name_map[node['host'].hostname]
         host = node['host']
+        peer_in_bgp_confed = node['conf']['bgp'].get('peer_in_bgp_confed', False)
+        asn = mg_facts['minigraph_bgp_asn']
+        if peer_in_bgp_confed:
+            asn = int(confed_asn)
         peer_ips = node['conf']['bgp']['peers'][asn]
 
         for ip in peer_ips:
@@ -198,23 +217,23 @@ def parse_routes_on_vsonic(dut_host, neigh_hosts, ip_ver):
     return all_routes
 
 
-def verify_only_loopback_routes_are_announced_to_neighs(dut_hosts, duthost, neigh_hosts, community):
+def verify_only_loopback_routes_are_announced_to_neighs(dut_hosts, duthost, neigh_hosts, community, is_v6_topo=False):
     """
     Verify only loopback routes with certain community are announced to neighs in TSA
     """
-    return verify_loopback_route_with_community(dut_hosts, duthost, neigh_hosts, 4, community) and \
+    return (is_v6_topo or verify_loopback_route_with_community(dut_hosts, duthost, neigh_hosts, 4, community)) and \
         verify_loopback_route_with_community(
             dut_hosts, duthost, neigh_hosts, 6, community)
 
 
 def assert_only_loopback_routes_announced_to_neighs(dut_hosts, duthost, neigh_hosts, community,
-                                                    error_msg=""):
+                                                    error_msg="", is_v6_topo=False, timeout=180):
     if not error_msg:
         error_msg = "Failed to verify only loopback routes are announced to neighbours"
 
     pytest_assert(
-        wait_until(180, 10, 5, verify_only_loopback_routes_are_announced_to_neighs,
-                   dut_hosts, duthost, neigh_hosts, community),
+        wait_until(timeout, 10, 5, verify_only_loopback_routes_are_announced_to_neighs,
+                   dut_hosts, duthost, neigh_hosts, community, is_v6_topo),
         error_msg
     )
 

--- a/tests/bgp/test_seq_idf_isolation.py
+++ b/tests/bgp/test_seq_idf_isolation.py
@@ -63,11 +63,11 @@ def check_idf_isolation_support(duthost):
     return True
 
 
-def dut_nbrs(duthost, nbrhosts):
+def dut_t1_nbrs(duthost, nbrhosts):
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
     nbrs_to_dut = {}
     for host in list(nbrhosts.keys()):
-        if host in mg_facts['minigraph_devices']:
+        if host in mg_facts['minigraph_devices'] and host.endswith('T1'):
             new_nbrhost = {host: nbrhosts[host]}
             nbrs_to_dut.update(new_nbrhost)
     return nbrs_to_dut
@@ -103,7 +103,7 @@ def test_idf_isolated_no_export(rand_one_downlink_duthost,
 
     pytest_assert(IDF_UNISOLATED == get_idf_isolation_state(duthost),
                   "DUT is not in unisolated state")
-    nbrs = dut_nbrs(duthost, nbrhosts)
+    nbrs = dut_t1_nbrs(duthost, nbrhosts)
     orig_v4_routes = parse_routes_on_neighbors(duthost, nbrs, 4)
     orig_v6_routes = parse_routes_on_neighbors(duthost, nbrs, 6)
     try:
@@ -156,9 +156,13 @@ def test_idf_isolated_withdraw_all(duthosts, rand_one_downlink_duthost,
 
     pytest_assert(IDF_UNISOLATED == get_idf_isolation_state(duthost),
                   "DUT is not in unisolated state")
-    nbrs = dut_nbrs(duthost, nbrhosts)
+    nbrs = dut_t1_nbrs(duthost, nbrhosts)
     orig_v4_routes = parse_routes_on_neighbors(duthost, nbrs, 4)
     orig_v6_routes = parse_routes_on_neighbors(duthost, nbrs, 6)
+    # Nokia IXR7220 has 252 BGP neighbors; route withdrawal and re-advertisement
+    # take longer than the defaults (180 s / 300 s) on this platform.
+    route_timeout = 360 if 'Nokia' in duthost.facts.get('hwsku', '') else 180
+    converge_timeout = 600 if 'Nokia' in duthost.facts.get('hwsku', '') else 300
     try:
         # Issue command to isolate by withdrawing all routes
         duthost.shell("sudo idf_isolation isolated_withdraw_all")
@@ -167,7 +171,8 @@ def test_idf_isolated_withdraw_all(duthosts, rand_one_downlink_duthost,
                       "DUT is not in isolated_withdraw_all state")
         assert_only_loopback_routes_announced_to_neighs(duthosts, duthost, nbrs, traffic_shift_community,
                                                         "Failed to verify only loopback route \
-                                                            in isolated_withdraw_all state")
+                                                            in isolated_withdraw_all state",
+                                                        timeout=route_timeout)
     finally:
         # Recover to unisolated state
         duthost.shell("sudo idf_isolation unisolated")
@@ -176,12 +181,12 @@ def test_idf_isolated_withdraw_all(duthosts, rand_one_downlink_duthost,
         cur_v4_routes = {}
         cur_v6_routes = {}
         # Verify that all routes advertised to neighbor at the start of the test
-        if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
+        if not wait_until(converge_timeout, 3, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrs, orig_v4_routes, cur_v4_routes, 4):
             if not check_and_log_routes_diff(duthost, nbrs, orig_v4_routes, cur_v4_routes, 4):
                 pytest.fail("Not all ipv4 routes are announced to neighbors")
 
-        if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
+        if not wait_until(converge_timeout, 3, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrs, orig_v6_routes, cur_v6_routes, 6):
             if not check_and_log_routes_diff(duthost, nbrs, orig_v6_routes, cur_v6_routes, 6):
                 pytest.fail("Not all ipv6 routes are announced to neighbors")
@@ -201,9 +206,12 @@ def test_idf_isolation_no_export_with_config_reload(rand_one_downlink_duthost,
     # Ensure that the DUT is not in maintenance already before start of the test
     pytest_assert(IDF_UNISOLATED == get_idf_isolation_state(duthost),
                   "DUT is not in normal state")
-    nbrs = dut_nbrs(duthost, nbrhosts)
+    nbrs = dut_t1_nbrs(duthost, nbrhosts)
     orig_v4_routes = parse_routes_on_neighbors(duthost, nbrs, 4)
     orig_v6_routes = parse_routes_on_neighbors(duthost, nbrs, 6)
+    # Nokia IXR7220 has 252 BGP neighbors; IPv6 route re-advertisement after
+    # config_reload takes longer than the 600 s default on this large-scale platform.
+    converge_timeout = 900 if 'Nokia' in duthost.facts.get('hwsku', '') else 600
     try:
         # Issue command to isolate with no export community on DUT
         duthost.shell("sudo idf_isolation isolated_no_export")
@@ -217,12 +225,12 @@ def test_idf_isolation_no_export_with_config_reload(rand_one_downlink_duthost,
         cur_v4_routes = {}
         cur_v6_routes = {}
         # Verify that all routes advertised to neighbor at the start of the test
-        if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
+        if not wait_until(converge_timeout, 3, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrs, orig_v4_routes, cur_v4_routes, 4, exp_community):
             if not check_and_log_routes_diff(duthost, nbrs, orig_v4_routes, cur_v4_routes, 4):
                 pytest.fail("Not all ipv4 routes are announced to neighbors")
 
-        if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
+        if not wait_until(converge_timeout, 3, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrs, orig_v6_routes, cur_v6_routes, 6, exp_community):
             if not check_and_log_routes_diff(duthost, nbrs, orig_v6_routes, cur_v6_routes, 6):
                 pytest.fail("Not all ipv6 routes are announced to neighbors")
@@ -240,12 +248,12 @@ def test_idf_isolation_no_export_with_config_reload(rand_one_downlink_duthost,
         cur_v4_routes = {}
         cur_v6_routes = {}
         # Verify that all routes seen at the start of the test are re-advertised to neighbors
-        if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
+        if not wait_until(converge_timeout, 3, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrs, orig_v4_routes, cur_v4_routes, 4):
             if not check_and_log_routes_diff(duthost, nbrs, orig_v4_routes, cur_v4_routes, 4):
                 pytest.fail("Not all ipv4 routes are announced to neighbors")
 
-        if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
+        if not wait_until(converge_timeout, 3, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrs, orig_v6_routes, cur_v6_routes, 6):
             if not check_and_log_routes_diff(duthost, nbrs, orig_v6_routes, cur_v6_routes, 6):
                 pytest.fail("Not all ipv6 routes are announced to neighbors")
@@ -265,7 +273,7 @@ def test_idf_isolation_withdraw_all_with_config_reload(duthosts, rand_one_downli
     # Ensure that the DUT is not in maintenance already before start of the test
     pytest_assert(IDF_UNISOLATED == get_idf_isolation_state(duthost),
                   "DUT is not in normal state")
-    nbrs = dut_nbrs(duthost, nbrhosts)
+    nbrs = dut_t1_nbrs(duthost, nbrhosts)
     try:
         # Get all routes on neighbors before doing TSA
         orig_v4_routes = parse_routes_on_neighbors(duthost, nbrs, 4)
@@ -295,12 +303,12 @@ def test_idf_isolation_withdraw_all_with_config_reload(duthosts, rand_one_downli
         cur_v4_routes = {}
         cur_v6_routes = {}
         # Verify that all routes advertised to neighbor at the start of the test
-        if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
+        if not wait_until(600, 3, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrs, orig_v4_routes, cur_v4_routes, 4):
             if not check_and_log_routes_diff(duthost, nbrhosts, orig_v4_routes, cur_v4_routes, 4):
                 pytest.fail("Not all ipv4 routes are announced to neighbors")
 
-        if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
+        if not wait_until(600, 3, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrs, orig_v6_routes, cur_v6_routes, 6):
             if not check_and_log_routes_diff(duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
                 pytest.fail("Not all ipv6 routes are announced to neighbors")

--- a/tests/common/helpers/platform_api/fan_discrete_speed_helper.py
+++ b/tests/common/helpers/platform_api/fan_discrete_speed_helper.py
@@ -1,0 +1,90 @@
+"""
+Shared helpers for chassis / fan-drawer fan tests on platforms with discrete PWM steps
+from `chassis.fans.supported_speeds` in platform.json (via `duthost.facts`).
+"""
+
+import logging
+import random
+
+from tests.common.helpers.platform_api import fan, fan_drawer_fan
+
+logger = logging.getLogger(__name__)
+
+# Fan - for these SKUs; use `chassis.fans.supported_speeds` in platform.json
+FAN_SPEED_DISCRETE_PLATFORMS = (
+    "x86_64-nokia_ixr7220_h6_128-r0",
+    "x86_64-nokia_ixr7220_h6_64-r0",
+)
+
+
+def fan_speed_uses_platform_discrete_list(duthost):
+    return duthost.facts.get("platform") in FAN_SPEED_DISCRETE_PLATFORMS
+
+
+def parse_supported_speeds_csv(raw, log_ctx):
+    """Parse comma-separated integer speeds from platform.json."""
+    if raw is None:
+        return None
+    text = raw if isinstance(raw, str) else str(raw)
+    out = []
+    for part in text.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            out.append(int(part))
+        except ValueError:
+            logger.warning(
+                "Ignoring non-integer supported_speeds token %r (%s)",
+                part,
+                log_ctx,
+            )
+    return out or None
+
+
+def get_chassis_fans_supported_speeds(duthost):
+    """
+    Read the common discrete fan table from `chassis.fans.supported_speeds` in platform.json (via duthost.facts).
+    """
+    chassis = duthost.facts.get("chassis") or {}
+    fans = chassis.get("fans")
+    if not fans or not isinstance(fans, list):
+        return None
+    for entry in fans:
+        if not isinstance(entry, dict):
+            continue
+        raw = entry.get("supported_speeds")
+        if raw is not None:
+            return parse_supported_speeds_csv(raw, "chassis.fans supported_speeds")
+    return None
+
+
+def pick_initial_discrete_target_speed(num_fans, chassis_speeds, is_controllable, get_smin, get_smax):
+    """
+    Pick one discrete speed using the first controllable fan index for min/max bounds.
+    """
+    if not chassis_speeds:
+        return None
+    for probe in range(num_fans):
+        if not is_controllable(probe):
+            continue
+        smin = get_smin(probe)
+        smax = get_smax(probe)
+        in_range = [s for s in chassis_speeds if smin <= s <= smax]
+        pick_from = in_range if in_range else chassis_speeds
+        return random.choice(pick_from)
+    return None
+
+
+def fan_drawer_speed_within_tolerance(platform_api_conn, j, i):
+    """True when fan-drawer fan speed is within platform API under/over tolerance for target."""
+    under = fan_drawer_fan.is_under_speed(platform_api_conn, j, i)
+    over = fan_drawer_fan.is_over_speed(platform_api_conn, j, i)
+    return not under and not over
+
+
+def chassis_fan_speed_within_tolerance(platform_api_conn, i):
+    """True when chassis fan speed is within platform API under/over tolerance for target."""
+    under = fan.is_under_speed(platform_api_conn, i)
+    over = fan.is_over_speed(platform_api_conn, i)
+    return not under and not over

--- a/tests/common/helpers/telemetry_helper.py
+++ b/tests/common/helpers/telemetry_helper.py
@@ -85,12 +85,35 @@ def setup_streaming_telemetry_context(is_ipv6, duthost, localhost, ptfhost, gnxi
     """
     @summary: Post setting up the streaming telemetry before running the test.
     """
+    original_idle_conn_duration = None
     try:
         has_gnmi_config = check_gnmi_config(duthost)
         if not has_gnmi_config:
             create_gnmi_config(duthost)
         env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
+
+        # Nokia IXR7220 telemetry server defaults to a 5-minute idle connection timeout
+        # (--idle_conn_duration 5).  EVENTS streaming tests can take more than 5 minutes,
+        # causing DEADLINE_EXCEEDED failures.  Set idle_conn_duration to 30 minutes before
+        # starting the telemetry container so the gRPC stream stays alive for the full test.
+        if 'Nokia' in duthost.facts.get('hwsku', ''):
+            orig = duthost.shell(
+                'sonic-db-cli CONFIG_DB HGET "%s|gnmi" idle_conn_duration' % env.gnmi_config_table,
+                module_ignore_errors=True)['stdout'].strip()
+            if orig != '30':
+                original_idle_conn_duration = orig  # '' means key was absent
+                duthost.shell(
+                    'sonic-db-cli CONFIG_DB HSET "%s|gnmi" idle_conn_duration 30' % env.gnmi_config_table)
+
         default_client_auth = setup_telemetry_forpyclient(duthost)
+
+        # If idle_conn_duration was changed but setup_telemetry_forpyclient did not restart
+        # the container (client_auth was already false), force a restart now.
+        if original_idle_conn_duration is not None and default_client_auth != "true":
+            duthost.shell("systemctl reset-failed %s" % env.gnmi_container)
+            duthost.service(name=env.gnmi_container, state="restarted")
+            py_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, env.gnmi_container),
+                      "%s not started after idle_conn_duration change." % env.gnmi_container)
 
         # Wait until the TCP port was opened
         dut_ip = duthost.mgmt_ip
@@ -113,5 +136,15 @@ def setup_streaming_telemetry_context(is_ipv6, duthost, localhost, ptfhost, gnxi
 
     yield
     restore_telemetry_forpyclient(duthost, default_client_auth)
+    # Restore Nokia idle_conn_duration if it was changed
+    if original_idle_conn_duration is not None:
+        env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
+        if original_idle_conn_duration:
+            duthost.shell(
+                'sonic-db-cli CONFIG_DB HSET "%s|gnmi" idle_conn_duration %s'
+                % (env.gnmi_config_table, original_idle_conn_duration))
+        else:
+            duthost.shell(
+                'sonic-db-cli CONFIG_DB HDEL "%s|gnmi" idle_conn_duration' % env.gnmi_config_table)
     if not has_gnmi_config:
         delete_gnmi_config(duthost)

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -213,8 +213,18 @@ class LagTest:
         # Figure out remote VM and interface info for the lag member and run minlink test
         peer_device = self.vm_neighbors[intf]['name']
         neighbor_intf = self.vm_neighbors[intf]['port']
+        # Nokia IXR7220 teamd uses retry_count > 1: each LACP Long Timeout (90 s) is retried
+        # before the member is deselected.  Read retry_count from the teamd state and compute
+        # the deselect_time accordingly so we wait long enough before checking member state.
+        try:
+            retry_count = int(lag_facts['lags'][lag_name]['po_stats']
+                              .get('runner', {}).get('retry_count', 0))
+        except (KeyError, ValueError, TypeError):
+            retry_count = 0
+        lacp_long_timeout_secs = 90
+        deselect_time = (max(retry_count, 1) * lacp_long_timeout_secs) + 10
         self.__verify_lag_minlink(self.nbrhosts[peer_device]['host'], lag_name,
-                                  lag_facts, neighbor_intf, deselect_time=95)
+                                  lag_facts, neighbor_intf, deselect_time=deselect_time)
 
     def run_lag_fallback_test(self, lag_name, lag_facts):
         logger.info("Start checking lag fall back for: %s" % lag_name)
@@ -288,6 +298,12 @@ def test_lag(common_setup_teardown, duthosts, tbinfo, nbrhosts, fanouthosts,
     if testcase == "lacp_rate":
         if request.config.getoption("--neighbor_type") == 'sonic':
             pytest.skip("lacp_rate is not supported in vsonic")
+        # Nokia IXR7220 does not support dynamic LACP rate negotiation: the DUT always
+        # transmits slow PDUs (30 s) regardless of the partner's Short_Timeout preference,
+        # and the SONiC CLI has no 'config portchannel lacp-rate' command on this platform.
+        for duthost in duthosts:
+            if 'Nokia' in duthost.facts.get('hwsku', ''):
+                pytest.skip("lacp_rate is not supported on Nokia IXR7220 platform")
 
     ptfhost = common_setup_teardown
 

--- a/tests/platform_tests/api/test_chassis_fans.py
+++ b/tests/platform_tests/api/test_chassis_fans.py
@@ -4,9 +4,16 @@ import time
 import pytest
 
 from tests.common.helpers.platform_api import chassis, fan
+from tests.common.helpers.platform_api.fan_discrete_speed_helper import (
+    chassis_fan_speed_within_tolerance,
+    fan_speed_uses_platform_discrete_list,
+    get_chassis_fans_supported_speeds,
+    pick_initial_discrete_target_speed,
+)
 from .platform_api_test_base import PlatformApiTestBase
 from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service    # noqa: F401
 from tests.common.helpers.thermal_control_test_helper import start_thermal_control_daemon, stop_thermal_control_daemon
+from tests.common.utilities import wait_until
 
 ###################################################
 # TODO: Remove this after we transition to Python 3
@@ -190,10 +197,26 @@ class TestChassisFans(PlatformApiTestBase):
                                    localhost, platform_api_conn):   # noqa: F811
 
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        use_discrete = fan_speed_uses_platform_discrete_list(duthost)
+        chassis_discrete_speeds = get_chassis_fans_supported_speeds(duthost) if use_discrete else None
         fans_skipped = 0
 
         for i in range(self.num_fans):
-            speed_target_val = 25
+            if use_discrete:
+                speed_target_val = pick_initial_discrete_target_speed(
+                    self.num_fans,
+                    chassis_discrete_speeds,
+                    lambda p: self.get_fan_facts(duthost, p, True, "speed", "controllable"),
+                    lambda p: self.get_fan_facts(duthost, p, 1, "speed", "minimum"),
+                    lambda p: self.get_fan_facts(duthost, p, 100, "speed", "maximum"),
+                )
+                if speed_target_val is None:
+                    pytest.fail(
+                        "Chassis fans: no controllable fan for discrete speed pick (platform {})".format(
+                            duthost.facts.get("platform"))
+                    )
+            else:
+                speed_target_val = 25
             speed_controllable = self.get_fan_facts(duthost, i, True, "speed", "controllable")
             if not speed_controllable:
                 logger.info("test_get_fans_target_speed: Skipping chassis fan {} (speed not controllable)"
@@ -204,7 +227,8 @@ class TestChassisFans(PlatformApiTestBase):
             speed_minimum = self.get_fan_facts(duthost, i, 25, "speed", "minimum")
             speed_maximum = self.get_fan_facts(duthost, i, 100, "speed", "maximum")
             if speed_minimum > speed_target_val or speed_maximum < speed_target_val:
-                speed_target_val = random.randint(speed_minimum, speed_maximum)
+                speed_target_val = self.get_fan_facts(duthost, i, random.randint(speed_minimum, speed_maximum),
+                                                      "speed", "default")
 
             speed_set = fan.set_speed(platform_api_conn, i, speed_target_val)       # noqa: F841
             target_speed = fan.get_target_speed(platform_api_conn, i)
@@ -229,8 +253,29 @@ class TestChassisFans(PlatformApiTestBase):
 
         fans_skipped = 0
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        use_discrete = fan_speed_uses_platform_discrete_list(duthost)
+        chassis_discrete_speeds = get_chassis_fans_supported_speeds(duthost) if use_discrete else None
+        if use_discrete and not chassis_discrete_speeds:
+            pytest.fail(
+                "Discrete fan speed platforms require a `supported_speeds` field on an entry under "
+                "`chassis.fans` in platform.json (platform {})".format(duthost.facts.get("platform"))
+            )
+
         if duthost.facts["asic_type"] in ["cisco-8000"]:
             target_speed = random.randint(40, 60)
+        elif use_discrete:
+            target_speed = pick_initial_discrete_target_speed(
+                self.num_fans,
+                chassis_discrete_speeds,
+                lambda p: self.get_fan_facts(duthost, p, True, "speed", "controllable"),
+                lambda p: self.get_fan_facts(duthost, p, 1, "speed", "minimum"),
+                lambda p: self.get_fan_facts(duthost, p, 100, "speed", "maximum"),
+            )
+            if target_speed is None:
+                pytest.fail(
+                    "Chassis fans: no controllable fan for discrete speed pick (platform {})".format(
+                        duthost.facts.get("platform"))
+                )
         else:
             target_speed = random.randint(1, 100)
 
@@ -243,24 +288,48 @@ class TestChassisFans(PlatformApiTestBase):
 
             speed_minimum = self.get_fan_facts(duthost, i, 1, "speed", "minimum")
             speed_maximum = self.get_fan_facts(duthost, i, 100, "speed", "maximum")
-            if speed_minimum > target_speed or speed_maximum < target_speed:
-                target_speed = random.randint(speed_minimum, speed_maximum)
+            if use_discrete:
+                in_range = [s for s in chassis_discrete_speeds if speed_minimum <= s <= speed_maximum]
+                pick_from = in_range if in_range else chassis_discrete_speeds
+                if target_speed not in pick_from:
+                    target_speed = random.choice(pick_from)
+            else:
+                if speed_minimum > target_speed or speed_maximum < target_speed:
+                    target_speed = random.randint(speed_minimum, speed_maximum)
 
             speed = fan.get_speed(platform_api_conn, i)
             speed_delta = abs(speed-target_speed)
 
             speed_set = fan.set_speed(platform_api_conn, i, target_speed)       # noqa: F841
-            time_wait = 10 if speed_delta > 40 else 5
-            time.sleep(self.get_fan_facts(duthost, i, time_wait, "speed", "delay"))
+            if use_discrete:
+                settled = wait_until(
+                    10, 2, 0,
+                    chassis_fan_speed_within_tolerance,
+                    platform_api_conn, i,
+                )
+                act_speed = fan.get_speed(platform_api_conn, i)
+                self.expect(
+                    settled,
+                    "Chassis fan {} speed change from {} to {} did not settle within tolerance "
+                    "within 10s (2s poll), actual speed {}".format(i, speed, target_speed, act_speed),
+                )
+            else:
+                time_wait = 10 if speed_delta > 40 else 5
+                time.sleep(self.get_fan_facts(duthost, i, time_wait, "speed", "delay"))
 
-            act_speed = fan.get_speed(platform_api_conn, i)
-            under_speed = fan.is_under_speed(platform_api_conn, i)
-            over_speed = fan.is_over_speed(platform_api_conn, i)
-            self.expect(not under_speed and not over_speed,
-                        "Fan {} speed change from {} to {} is not within tolerance, actual speed {}"
-                        .format(i, speed, target_speed, act_speed))
+                act_speed = fan.get_speed(platform_api_conn, i)
+                under_speed = fan.is_under_speed(platform_api_conn, i)
+                over_speed = fan.is_over_speed(platform_api_conn, i)
+                self.expect(not under_speed and not over_speed,
+                            "Fan {} speed change from {} to {} is not within tolerance, actual speed {}"
+                            .format(i, speed, target_speed, act_speed))
 
         if fans_skipped == self.num_fans:
+            if use_discrete:
+                pytest.skip(
+                    "skipped as every chassis fan was skipped (not controllable, or no controllable fan "
+                    "for discrete speed pick)"
+                )
             pytest.skip("skipped as all chassis fans' speed is not controllable")
 
         self.assert_expectations()

--- a/tests/platform_tests/api/test_fan_drawer_fans.py
+++ b/tests/platform_tests/api/test_fan_drawer_fans.py
@@ -5,7 +5,14 @@ import time
 import pytest
 
 from tests.common.helpers.platform_api import chassis, fan_drawer, fan_drawer_fan
+from tests.common.helpers.platform_api.fan_discrete_speed_helper import (
+    fan_drawer_speed_within_tolerance,
+    fan_speed_uses_platform_discrete_list,
+    get_chassis_fans_supported_speeds,
+    pick_initial_discrete_target_speed,
+)
 from tests.common.helpers.thermal_control_test_helper import start_thermal_control_daemon, stop_thermal_control_daemon
+from tests.common.utilities import wait_until
 from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service    # noqa: F401
 from .platform_api_test_base import PlatformApiTestBase
 
@@ -243,6 +250,8 @@ class TestFanDrawerFans(PlatformApiTestBase):
                                    platform_api_conn, suspend_and_resume_hw_tc_on_mellanox_device):        # noqa: F811
 
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        use_discrete = fan_speed_uses_platform_discrete_list(duthost)
+        chassis_discrete_speeds = get_chassis_fans_supported_speeds(duthost) if use_discrete else None
         fan_drawers_skipped = 0
 
         for j in range(self.num_fan_drawers):
@@ -250,7 +259,21 @@ class TestFanDrawerFans(PlatformApiTestBase):
             fans_skipped = 0
 
             for i in range(num_fans):
-                speed_target_val = 25
+                if use_discrete:
+                    speed_target_val = pick_initial_discrete_target_speed(
+                        num_fans,
+                        chassis_discrete_speeds,
+                        lambda p: self.get_fan_facts(duthost, j, p, True, "speed", "controllable"),
+                        lambda p: self.get_fan_facts(duthost, j, p, 1, "speed", "minimum"),
+                        lambda p: self.get_fan_facts(duthost, j, p, 100, "speed", "maximum"),
+                    )
+                    if speed_target_val is None:
+                        pytest.fail(
+                            "Chassis fans: no controllable fan for discrete speed pick (platform {})".format(
+                                duthost.facts.get("platform"))
+                        )
+                else:
+                    speed_target_val = 25
                 speed_controllable = self.get_fan_facts(duthost, j, i, True, "speed", "controllable")
                 if not speed_controllable:
                     logger.info("test_get_fans_target_speed: Skipping fandrawer {} fan {} (speed not controllable)"
@@ -261,7 +284,8 @@ class TestFanDrawerFans(PlatformApiTestBase):
                 speed_minimum = self.get_fan_facts(duthost, j, i, 25, "speed", "minimum")
                 speed_maximum = self.get_fan_facts(duthost, j, i, 100, "speed", "maximum")
                 if speed_minimum > speed_target_val or speed_maximum < speed_target_val:
-                    speed_target_val = random.randint(speed_minimum, speed_maximum)
+                    speed_target_val = self.get_fan_facts(duthost, j, i, random.randint(speed_minimum, speed_maximum),
+                                                          "speed", "default")
 
                 speed_set = fan_drawer_fan.set_speed(platform_api_conn, j, i, speed_target_val)     # noqa: F841
                 target_speed = fan_drawer_fan.get_target_speed(platform_api_conn, j, i)
@@ -292,11 +316,33 @@ class TestFanDrawerFans(PlatformApiTestBase):
 
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         fan_drawers_skipped = 0
+        use_discrete = fan_speed_uses_platform_discrete_list(duthost)
+        chassis_discrete_speeds = get_chassis_fans_supported_speeds(duthost) if use_discrete else None
+        if use_discrete and not chassis_discrete_speeds:
+            pytest.fail(
+                "Discrete fan speed platforms require a `supported_speeds` field on an entry under "
+                "`chassis.fans` in platform.json (platform {})".format(duthost.facts.get("platform"))
+            )
 
         for j in range(self.num_fan_drawers):
-            target_speed = random.randint(1, 100)
             num_fans = fan_drawer.get_num_fans(platform_api_conn, j)
             fans_skipped = 0
+
+            if use_discrete:
+                target_speed = pick_initial_discrete_target_speed(
+                    num_fans,
+                    chassis_discrete_speeds,
+                    lambda p: self.get_fan_facts(duthost, j, p, True, "speed", "controllable"),
+                    lambda p: self.get_fan_facts(duthost, j, p, 1, "speed", "minimum"),
+                    lambda p: self.get_fan_facts(duthost, j, p, 100, "speed", "maximum"),
+                )
+                if target_speed is None:
+                    pytest.fail(
+                        "Fan drawer {}: no controllable fan for discrete speed pick (platform {})".format(
+                            j, duthost.facts.get("platform"))
+                    )
+            else:
+                target_speed = random.randint(1, 100)
 
             for i in range(num_fans):
                 speed_controllable = self.get_fan_facts(duthost, j, i, True, "speed", "controllable")
@@ -308,27 +354,52 @@ class TestFanDrawerFans(PlatformApiTestBase):
 
                 speed_minimum = self.get_fan_facts(duthost, j, i, 1, "speed", "minimum")
                 speed_maximum = self.get_fan_facts(duthost, j, i, 100, "speed", "maximum")
-                if speed_minimum > target_speed or speed_maximum < target_speed:
-                    target_speed = random.randint(speed_minimum, speed_maximum)
+                if use_discrete:
+                    in_range = [s for s in chassis_discrete_speeds if speed_minimum <= s <= speed_maximum]
+                    pick_from = in_range if in_range else chassis_discrete_speeds
+                    if target_speed not in pick_from:
+                        target_speed = random.choice(pick_from)
+                else:
+                    if speed_minimum > target_speed or speed_maximum < target_speed:
+                        target_speed = random.randint(speed_minimum, speed_maximum)
 
                 speed = fan_drawer_fan.get_speed(platform_api_conn, j, i)
                 speed_delta = abs(speed-target_speed)
 
                 speed_set = fan_drawer_fan.set_speed(platform_api_conn, j, i, target_speed)     # noqa: F841
-                time_wait = 10 if speed_delta > 40 else 5
-                time.sleep(self.get_fan_facts(duthost, j, i, time_wait, "speed", "delay"))
+                if use_discrete:
+                    # Large steps can take longer than a fixed sleep; poll tolerance.
+                    settled = wait_until(
+                        10, 2, 0,
+                        fan_drawer_speed_within_tolerance,
+                        platform_api_conn, j, i,
+                    )
+                    act_speed = fan_drawer_fan.get_speed(platform_api_conn, j, i)
+                    self.expect(
+                        settled,
+                        "Fan drawer {} fan {} speed change from {} to {} did not settle within tolerance "
+                        "within 10s (2s poll), actual speed {}".format(j, i, speed, target_speed, act_speed),
+                    )
+                else:
+                    time_wait = 10 if speed_delta > 40 else 5
+                    time.sleep(self.get_fan_facts(duthost, j, i, time_wait, "speed", "delay"))
 
-                act_speed = fan_drawer_fan.get_speed(platform_api_conn, j, i)
-                under_speed = fan_drawer_fan.is_under_speed(platform_api_conn, j, i)
-                over_speed = fan_drawer_fan.is_over_speed(platform_api_conn, j, i)
-                self.expect(not under_speed and not over_speed,
-                            "Fan drawer {} fan {} speed change from {} to {} is not within tolerance, actual speed {}"
-                            .format(j, i, speed, target_speed, act_speed))
+                    act_speed = fan_drawer_fan.get_speed(platform_api_conn, j, i)
+                    under_speed = fan_drawer_fan.is_under_speed(platform_api_conn, j, i)
+                    over_speed = fan_drawer_fan.is_over_speed(platform_api_conn, j, i)
+                    self.expect(not under_speed and not over_speed,
+                                "Fan drawer {} fan {} speed change from {} to {} is not within tolerance, "
+                                "actual speed {}".format(j, i, speed, target_speed, act_speed))
 
             if fans_skipped == num_fans:
                 fan_drawers_skipped += 1
 
         if fan_drawers_skipped == self.num_fan_drawers:
+            if use_discrete:
+                pytest.skip(
+                    "skipped as every fan drawer fan was skipped (not controllable, or no controllable fan "
+                    "in a drawer for discrete speed pick)"
+                )
             pytest.skip("skipped as all fandrawer fans' speed is not controllable")
 
         self.assert_expectations()

--- a/tests/qos/test_pfc_counters.py
+++ b/tests/qos/test_pfc_counters.py
@@ -85,11 +85,12 @@ def run_test(fanouthosts, duthost, conn_graph_facts, enum_fanout_graph_facts, le
     onyx_pfc_container_name = 'storm'
     int_status = asic.show_interface(command="status")[
         'ansible_facts']['int_status']
-    """ We only test active physical interfaces """
+    """ We only test active physical interfaces that have connection graph entries """
     active_phy_intfs = [intf for intf in int_status if
                         intf.startswith('Ethernet') and
                         int_status[intf]['admin_state'] == 'up' and
-                        int_status[intf]['oper_state'] == 'up']
+                        int_status[intf]['oper_state'] == 'up' and
+                        intf in conn_facts]
     only_lossless_rx_counters = "Cisco-8122" in asic.sonichost.facts["hwsku"]
     no_xon_counters = "Cisco-8122" in asic.sonichost.facts["hwsku"]
     if only_lossless_rx_counters and asic_type != 'vs':
@@ -195,16 +196,43 @@ def run_test(fanouthosts, duthost, conn_graph_facts, enum_fanout_graph_facts, le
                         cmd = 'docker exec %s "python %s -i %s -p %d -t %d -n %d"' % (
                             onyx_pfc_container_name, PFC_GEN_FILE_ABSOLUTE_PATH,
                             peer_port_name, 2 ** priority, pause_time, PKT_COUNT)
-                        peerdev_ans.host.config(cmd)
+                        send_frames = lambda: peerdev_ans.host.config(cmd)  # noqa: E731
                     else:
                         cmd = "sudo python %s -i %s -p %d -t %d -n %d" % (
                             PFC_GEN_FILE_DEST, peer_port_name, 2 ** priority, pause_time, PKT_COUNT)
-                        peerdev_ans.host.command(cmd)
+                        send_frames = lambda: peerdev_ans.host.command(cmd)  # noqa: E731
 
-                time.sleep(5)
+                    send_frames()
 
-                pfc_rx = duthost.sonic_pfc_counters(
-                    method="get")['ansible_facts']
+                    """ Poll interval and timeout for waiting on counter updates """
+                    POLL_INTERVAL = 0.5
+                    POLL_TIMEOUT = 30
+                    """ Retry sending frames up to MAX_RETRIES times if the counter does not update """
+                    MAX_RETRIES = 3
+
+                    pfc_rx = {}
+                    for attempt in range(1, MAX_RETRIES + 1):
+                        """ Poll until counter reaches PKT_COUNT or timeout """
+                        deadline = time.time() + POLL_TIMEOUT
+                        pfc_rx = duthost.sonic_pfc_counters(method="get")['ansible_facts']
+                        while pfc_rx[intf]['Rx'][priority] != str(PKT_COUNT) and time.time() < deadline:
+                            time.sleep(POLL_INTERVAL)
+                            pfc_rx = duthost.sonic_pfc_counters(method="get")['ansible_facts']
+
+                        if pfc_rx[intf]['Rx'][priority] == str(PKT_COUNT):
+                            break
+
+                        if attempt < MAX_RETRIES:
+                            logger.warning(
+                                "Attempt %d: PFC counter not updated for interface %s priority %d "
+                                "(got %s), retrying send", attempt, intf, priority,
+                                pfc_rx[intf]['Rx'][priority])
+                            duthost.sonic_pfc_counters(method="clear")
+                            send_frames()
+
+                else:
+                    time.sleep(5)
+                    pfc_rx = duthost.sonic_pfc_counters(method="get")['ansible_facts']
                 if asic_type != 'vs':
                     """check pfc Rx frame count on particular priority are increased"""
                     assert pfc_rx[intf]['Rx'][priority] == str(PKT_COUNT), (

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -36,8 +36,9 @@ def validate_yang(duthost, op_file="", yang_file=""):
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 @pytest.mark.disable_loganalyzer
-def test_events(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, ptfadapter, setup_streaming_telemetry, gnxi_path,
-                test_eventd_healthy, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_host_m,  # noqa: F811
+def test_events(duthosts, tbinfo, enum_rand_one_per_hwsku_hostname, ptfhost, ptfadapter,
+                setup_streaming_telemetry, gnxi_path, test_eventd_healthy,
+                toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_host_m,  # noqa: F811
                 setup_standby_ports_on_non_enum_rand_one_per_hwsku_host_m):  # noqa: F811
     """ Run series of events inside duthost and validate that output is correct
     and conforms to YANG schema"""
@@ -51,7 +52,7 @@ def test_events(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, ptfadapter,
         if file.endswith("_events.py") and not file.endswith("eventd_events.py"):
             module = __import__(file[:len(file)-3])
             try:
-                module.test_event(duthost, gnxi_path, ptfhost, ptfadapter, DATA_DIR, validate_yang)
+                module.test_event(duthost, tbinfo, gnxi_path, ptfhost, ptfadapter, DATA_DIR, validate_yang)
             except pytest.skip.Exception as e:
                 logger.info("Skipping test file: {} due to {}".format(file, e))
                 continue


### PR DESCRIPTION
Superseded by separate PRs:
- #25399 (fan speed)
- #25400 (LAG retry_count)
- #25401 (telemetry idle_conn_duration)
- #25316 (PFC counters, existing PR)

BGP IDF and autorestart fixes were already merged to master.