### PR TITLE
Fix test_bgp_speaker IPv6 nexthop ping6 failure due to NDP DAD race condition

### DIFF
--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -135,6 +135,13 @@ def common_setup_teardown(duthosts, rand_one_dut_hostname, ptfhost, localhost, t
     for i in [0, 1, 2]:
         ptfhost.shell("ip -6 addr add %s dev %s:%d" % (nexthops_ipv6[i], ptf_ports[0], i))
 
+    # Wait for DAD to complete on PTF, then flush any INCOMPLETE/FAILED NDP entries
+    # on the DUT that were created when the DUT received DAD NS packets from PTF.
+    # Without this, the DUT can have a FAILED NDP entry for a nexthop address right
+    # when ping6 starts, causing an immediate "Address unreachable" failure.
+    time.sleep(3)
+    duthost.shell("ip -6 neigh flush dev %s" % vlan_if_name)
+
     # Issue a ping command to populate entry for next_hop
     for nh in nexthops_ipv6:
         duthost.shell("ping6 %s -c 3" % nh.ip)


### PR DESCRIPTION
test_bgp_speaker_announce_routes_v6 fails intermittently with "Address unreachable" when ping6 is run against IPv6 nexthops in common_setup_teardown. ping6 to IPv6 nexthops in common_setup_teardown fails immediately with EHOSTUNREACH. The DUT already has a i FAILED NDP entry for the nexthop by the time ping6 starts, so the kernel returns an error without even attempting NDP resolution.

Root Cause
When PTF runs ip -6 addr add, the kernel immediately sends a DAD Neighbor Solicitation with source ::, which the DUT receives and uses to create an INCOMPLETE NDP entry. The PTF address stays TENTATIVE for ~1 second and doesn't respond to the DUT's 3 NDP probes, causing the entry to go FAILED (~3 seconds after creation). The ping6 starts only 38 ms after the entry goes FAILED and fails instantly.

Fix
Insert a dealy after the addr add loop to allow all PTF addresses to complete DAD and become VALID. Then flush the DUT's NDP table to remove any INCOMPLETE/FAILED entries created by the DAD NS packets. The existing ping6 loop then runs against a clean NDP table with VALID PTF addresses and succeeds reliably.

Test result:
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

generated xml file: /data/tests/logs/bgp/test_bgp_speaker_2026-06-15-04-54-47.xml - ---------------------------- live log sessionfinish ---------------------------- 15/06/2026 05:19:34 init.pytest_terminal_summary L0067 INFO | Can not get Allure report URL. Please check logs =================== 3 passed, 1 warning in 154.23s (0:02:34) ===================

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
