### PR TITLE
[sanity_check] Skip pseudo filesystems in disk_usage pretest check

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -1395,6 +1395,18 @@ def check_disk_usage(duthosts):
 
     DISK_USAGE_THRESHOLD = 90  # percentage - aligned with monit resource limit
 
+    # Pseudo/virtual filesystems are not backed by real storage, are not
+    # monitored by monit, and routinely report misleading usage. For example
+    # efivarfs (mounted at /sys/firmware/efi/efivars) exposes a tiny UEFI
+    # variable store that frequently sits at ~99% and is unrelated to disk
+    # health. Skip these filesystem types to avoid false-positive failures.
+    SKIP_FSTYPES = frozenset([
+        "efivarfs", "tmpfs", "devtmpfs", "devpts", "sysfs", "proc",
+        "cgroup", "cgroup2", "overlay", "squashfs", "ramfs", "debugfs",
+        "tracefs", "securityfs", "pstore", "mqueue", "hugetlbfs",
+        "configfs", "fusectl", "bpf", "autofs", "binfmt_misc",
+    ])
+
     def _check(*args, **kwargs):
         init_result = {"failed": False, "check_item": "disk_usage"}
         result = parallel_run(_check_disk_usage_on_dut, args, kwargs, duthosts,
@@ -1408,7 +1420,7 @@ def check_disk_usage(duthosts):
         logger.info("Checking disk usage on %s..." % dut.hostname)
         check_result = {"failed": False, "check_item": "disk_usage", "host": dut.hostname}
 
-        res = dut.shell("df --output=pcent,target,source", module_ignore_errors=True)
+        res = dut.shell("df --output=pcent,target,source,fstype", module_ignore_errors=True)
         if res["rc"] != 0:
             logger.error("Failed to get disk usage on %s: %s" % (dut.hostname, res.get("stderr", "")))
             check_result["failed"] = True
@@ -1420,9 +1432,9 @@ def check_disk_usage(duthosts):
             line = line.strip()
             if not line:
                 continue
-            # Format: "Use% Mounted on Filesystem" e.g. " 92% /     /dev/sda3"
-            parts = line.split(None, 2)
-            if len(parts) < 2:
+            # Format: "Use% Mounted on Filesystem Type" e.g. " 92% /     /dev/sda3 ext4"
+            parts = line.split(None, 3)
+            if len(parts) < 3:
                 continue
             usage_str = parts[0].rstrip('%')
             try:
@@ -1430,7 +1442,12 @@ def check_disk_usage(duthosts):
             except ValueError:
                 continue
             mount_point = parts[1]
-            filesystem = parts[2] if len(parts) > 2 else ""
+            filesystem = parts[2]
+            fstype = parts[3] if len(parts) > 3 else ""
+            # Skip pseudo/virtual filesystems (e.g. efivarfs, tmpfs) that are
+            # not real storage and would otherwise cause false positives.
+            if fstype in SKIP_FSTYPES:
+                continue
             if usage_pct >= DISK_USAGE_THRESHOLD:
                 over_threshold.append({
                     "mount": mount_point,


### PR DESCRIPTION
### Description of PR

Summary:
The `disk_usage` pre-test sanity check (`check_disk_usage` in
`tests/common/plugins/sanity_check/checks.py`) flagged **every** mount
returned by `df` whose usage was `>= 90%`, **including pseudo/virtual
filesystems**. On many DUTs, `efivarfs` (mounted at
`/sys/firmware/efi/efivars`) exposes a tiny UEFI variable store that
routinely sits at ~99% and is unrelated to real disk health. This caused
a false-positive pre-test sanity failure, which in turn **errored out
every `test_pretest.py` case** (and any other test that runs pre-sanity)
on the affected testbed.

Example: on a Cisco-8102 t1 nightly run, all 14 `test_pretest.py` tests
errored at setup with:
```
Pre-test sanity check failed:
[ { "check_item": "disk_usage", "failed": true, "host": "...",
    "over_threshold": [ { "mount": "/sys/firmware/efi/efivars",
                          "use_pct": 99, "filesystem": "efivarfs" } ] } ]
```
No real filesystem (`/`, `/var/log`, `/host`) was over threshold.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Stop the `disk_usage` sanity check from producing false-positive failures
on pseudo/virtual filesystems (notably `efivarfs`), which were erroring
out unrelated test modules (e.g. all of `test_pretest.py`) and kicking
otherwise-healthy testbeds out of nightly test plans.

#### How did you do it?
- Query the filesystem type by adding `fstype` to the `df` output
  (`df --output=pcent,target,source,fstype`).
- Skip a denylist of known pseudo/virtual filesystem types (`efivarfs`,
  `tmpfs`, `devtmpfs`, `sysfs`, `proc`, `cgroup`/`cgroup2`, `overlay`,
  `squashfs`, etc.) so only real, monit-monitored storage is evaluated
  against the 90% threshold.
- The reported `filesystem` (source device) field in `over_threshold` is
  unchanged, preserving existing output semantics for real filesystems.

#### How did you verify/test it?
- `python -m py_compile` and `flake8 --max-line-length=120` pass on the
  changed file.
- Verified parsing logic against representative `df --output=...,fstype`
  output: `efivarfs` / `tmpfs` lines are now skipped while real
  partitions (e.g. `ext4` `/`, `/host`, `/var/log`) are still evaluated
  and would still fail when genuinely `>= 90%`.

#### Any platform specific information?
The false positive was observed on Cisco-8102 (cisco-8000) DUTs with a
nearly-full EFI variable store, but the fix is platform-agnostic — it
applies to any DUT that mounts pseudo filesystems (i.e. all of them).

#### Supported testbed topology if it's a new test case?
N/A - not a new test case; this is a framework/sanity-check bug fix.

### Documentation
N/A
