### PR TITLE
Fix enable_sonic_dhcpv4_relay_agent targeting wrong DUT in dualtor

### DIFF
--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -409,13 +409,15 @@ def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
 
 
 @pytest.fixture()
-def enable_sonic_dhcpv4_relay_agent(duthost, request):
+def enable_sonic_dhcpv4_relay_agent(rand_selected_dut, request):
     """
     Fixture to enable the DHCP relay feature flag and restart the service.
     """
     if "skip_config_dhcpv4_relay_agent" in request.keywords:
         yield
         return
+
+    duthost = rand_selected_dut
 
     if "dut_dhcp_relay_data" in request.fixturenames:
         dut_dhcp_relay_data = request.getfixturevalue("dut_dhcp_relay_data")


### PR DESCRIPTION
The fixture used duthost which always resolves to duthosts[0]. In dualtor, rand_selected_dut may differ, causing the daemon to be enabled on the wrong TOR.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The fixture enable_sonic_dhcpv4_relay_agent in tests/common/dhcp_relay_utils.py accepts duthost as its parameter. In the sonic-mgmt pytest framework, duthost always resolves to duthosts[0] — the first DUT in inventory — regardless of which DUT the test is actually targeting. test_dhcp_counter_stress.py uses rand_selected_dut as its active DUT (unpacked from testing_config). In a dualtor topology these two fixtures can resolve to different hosts. When they do, the fixture enables the sonic-dhcpv4-relay-agent daemon on the wrong TOR while traffic is sent to the other TOR which remains in ISC relay mode, producing an invalid test run.


Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/25392

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
This issue was identified while debugging another issue. test was always running on duthosts[0] irrespective of which is selected as active in a dualtor topo. 

#### What is the motivation for this PR?
The fixture enable_sonic_dhcpv4_relay_agent in tests/common/dhcp_relay_utils.py accepts duthost as its parameter. In the sonic-mgmt pytest framework, duthost always resolves to duthosts[0] — the first DUT in inventory — regardless of which DUT the test is actually targeting. test_dhcp_counter_stress.py uses rand_selected_dut as its active DUT (unpacked from testing_config). In a dualtor topology these two fixtures can resolve to different hosts. When they do, the fixture enables the sonic-dhcpv4-relay-agent daemon on the wrong TOR while traffic is sent to the other TOR which remains in ISC relay mode, producing an invalid test run.
#### How did you do it?
Added a fix in the fixture to use rand_selected_dut as duthost

#### How did you verify/test it?
ran test_dhcp_counter_stress testcase in both dtAA and t0 topologies

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA 
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
