### PR TITLE
Skip test_buffer_profile_create_remove_rollback due to sonic-mgmt issue #25395

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2726,6 +2726,12 @@ generic_config_updater/test_incremental_qos.py:
     conditions:
       - "'dualtor' in topo_name"
 
+generic_config_updater/test_incremental_qos.py::test_buffer_profile_create_remove_rollback:
+  skip:
+    reason: "Skipped due to test issue: https://github.com/sonic-net/sonic-mgmt/issues/25395"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/25395 and asic_type in ['mellanox']"
+
 generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates:
   skip:
     reason: "This test is not run on this hwsku/asic type or version or topology currently"


### PR DESCRIPTION
### Description of PR

Summary:
Add the skip of test test_buffer_profile_create_remove_rollback due to https://github.com/sonic-net/sonic-mgmt/issues/25395.
This should be a generic issue but we don't know for other vendors whether the buffer profile config is valid or not, so skip only on Mellanox platforms.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Add the skip of test test_buffer_profile_create_remove_rollback due to https://github.com/sonic-net/sonic-mgmt/issues/25395.
#### How did you do it?
Add the skip in tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
#### How did you verify/test it?
Run the test on SN5640 testbed, it's skipped.
#### Any platform specific information?
Currently the skip is only for Mellanox platforms
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A
