### PR TITLE
pc/test_lag_2: compute deselect_time from teamd retry_count

### DIFF
--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -213,8 +213,20 @@ class LagTest:
         # Figure out remote VM and interface info for the lag member and run minlink test
         peer_device = self.vm_neighbors[intf]['name']
         neighbor_intf = self.vm_neighbors[intf]['port']
+        # teamd supports a retry_count extension: when enable_retry_count_feature is True,
+        # the LACP Long Timeout (90 s) is retried retry_count times before a member is
+        # deselected.  This feature is enabled on some platforms (e.g. Nokia) by their
+        # custom teamd wrapper.  Read both fields from the teamd state (available via
+        # `teamdctl state dump` in lag_facts) and extend deselect_time accordingly.
+        try:
+            runner_state = lag_facts['lags'][lag_name]['po_stats'].get('runner', {})
+            retry_feature = runner_state.get('enable_retry_count_feature', False)
+            retry_count = int(runner_state.get('retry_count', 0)) if retry_feature else 0
+        except (KeyError, ValueError, TypeError):
+            retry_count = 0
+        deselect_time = (max(retry_count, 1) * 90) + 10
         self.__verify_lag_minlink(self.nbrhosts[peer_device]['host'], lag_name,
-                                  lag_facts, neighbor_intf, deselect_time=95)
+                                  lag_facts, neighbor_intf, deselect_time=deselect_time)
 
     def run_lag_fallback_test(self, lag_name, lag_facts):
         logger.info("Start checking lag fall back for: %s" % lag_name)


### PR DESCRIPTION
### Description of PR
Summary:
The hardcoded `deselect_time=95s` in `run_single_lag_test` assumes a member is deselected after one LACP Long Timeout (90s). Some platforms configure teamd with a `retry_count` extension where the 90s timeout is retried `retry_count` times before deselection occurs, requiring up to `retry_count * 90s` total wait time.

Read `retry_count` from `lag_facts` (already available via `teamdctl state dump`) and compute `deselect_time` dynamically instead of hardcoding 95s.

### Type of change
- [x] Bug fix
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
`test_lag_2::single_lag` fails on platforms that configure teamd with `retry_count > 0`. With `retry_count=3`, deselection requires 3 x 90s = 270s, but the test only waits 95s before checking — the member is still selected and the test fails.

Observed on Nokia IXR7220-H6-128 (str4 testbed, PortChannel352): `teamdctl PortChannel352 state dump` shows `runner.retry_count = 3`.

#### How did you do it?
- Read `retry_count` from `lag_facts['lags'][lag_name]['po_stats']['runner']['retry_count']` — this field is already returned by the existing `teamdctl state dump` call in `ansible/library/lag_facts.py`, so no new SSH calls are needed.
- Compute `deselect_time = max(retry_count, 1) * 90 + 10` seconds.
- Wrap in try/except for platforms where the key may be absent.

This is fully backward-compatible: platforms without `retry_count` (standard LACP) get `deselect_time = 100s`, slightly more generous than the previous 95s.

#### How did you verify/test it?
- SSH'd to Nokia IXR7220-H6-128 DUT and ran `sudo teamdctl PortChannel352 state dump` — confirmed `runner.retry_count = 3`.
- LACP actor_state bit 1 = 0 (SLOW mode, 30s PDU interval), confirming the deselection window is `3 x 90s = 270s`.
- With the old `deselect_time=95s`, the test asserted before Nokia deselected the member → failure.
- With the new `deselect_time=280s`, the test correctly waits for deselection → passes.

#### Any platform specific information?
Primarily observed on Nokia IXR7220-H6-128, but the fix applies generically to any platform that sets `retry_count` in its teamd configuration.

#### Supported testbed topology if it's a new test case?
lt2-o256-u32d224

### Documentation
