### PR TITLE
telemetry: set idle_conn_duration=30 on Nokia before starting telemetry

### DIFF
--- a/tests/common/helpers/telemetry_helper.py
+++ b/tests/common/helpers/telemetry_helper.py
@@ -85,12 +85,36 @@ def setup_streaming_telemetry_context(is_ipv6, duthost, localhost, ptfhost, gnxi
     """
     @summary: Post setting up the streaming telemetry before running the test.
     """
+    original_idle_conn_duration = None
     try:
         has_gnmi_config = check_gnmi_config(duthost)
         if not has_gnmi_config:
             create_gnmi_config(duthost)
         env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
+
+        # Nokia IXR7220 telemetry server defaults to a 5-minute idle connection timeout
+        # (--idle_conn_duration 5).  EVENTS streaming tests can take more than 5 minutes,
+        # causing DEADLINE_EXCEEDED failures.  Set idle_conn_duration to 30 minutes before
+        # starting the telemetry container so the gRPC stream stays alive for the full test.
+        if 'Nokia' in duthost.facts.get('hwsku', ''):
+            orig = duthost.shell(
+                'sonic-db-cli CONFIG_DB HGET "%s|gnmi" idle_conn_duration' % env.gnmi_config_table,
+                module_ignore_errors=True)['stdout'].strip()
+            if orig != '30':
+                original_idle_conn_duration = orig  # '' means key was absent
+                duthost.shell(
+                    'sonic-db-cli CONFIG_DB HSET "%s|gnmi" idle_conn_duration 30' % env.gnmi_config_table)
+
         default_client_auth = setup_telemetry_forpyclient(duthost)
+
+        # If idle_conn_duration was changed but setup_telemetry_forpyclient did not restart
+        # the container (client_auth was already false), force a restart now so the new
+        # idle_conn_duration value is picked up by the telemetry startup script.
+        if original_idle_conn_duration is not None and default_client_auth != "true":
+            duthost.shell("systemctl reset-failed %s" % env.gnmi_container)
+            duthost.service(name=env.gnmi_container, state="restarted")
+            py_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, env.gnmi_container),
+                      "%s not started after idle_conn_duration change." % env.gnmi_container)
 
         # Wait until the TCP port was opened
         dut_ip = duthost.mgmt_ip
@@ -113,5 +137,15 @@ def setup_streaming_telemetry_context(is_ipv6, duthost, localhost, ptfhost, gnxi
 
     yield
     restore_telemetry_forpyclient(duthost, default_client_auth)
+    # Restore Nokia idle_conn_duration to its original value if it was changed
+    if original_idle_conn_duration is not None:
+        env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
+        if original_idle_conn_duration:
+            duthost.shell(
+                'sonic-db-cli CONFIG_DB HSET "%s|gnmi" idle_conn_duration %s'
+                % (env.gnmi_config_table, original_idle_conn_duration))
+        else:
+            duthost.shell(
+                'sonic-db-cli CONFIG_DB HDEL "%s|gnmi" idle_conn_duration' % env.gnmi_config_table)
     if not has_gnmi_config:
         delete_gnmi_config(duthost)


### PR DESCRIPTION
### Description of PR
Summary:
Nokia IXR7220 telemetry server defaults to --idle_conn_duration 5 (5 minutes). The EVENTS streaming test takes ~18 minutes, causing DEADLINE_EXCEEDED failures after 5 minutes of gRPC stream idle time.

### Type of change
- [x] Bug fix
- [x] Testbed and Framework(new/improvement)

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Nokia IXR7220-H6-128 nightly test_events.py fails with gRPC DEADLINE_EXCEEDED for later event modules. Root cause: Nokia telemetry server closes idle gRPC streams after 5 minutes by default, but the test runs ~18 minutes total.

#### How did you do it?
In setup_streaming_telemetry_context, before starting the telemetry container on Nokia, write idle_conn_duration=30 to TELEMETRY|gnmi in ConfigDB. The Nokia telemetry startup script reads this key and passes it as --idle_conn_duration 30, keeping the gRPC stream alive for the full test duration.

If the telemetry container is not restarted by setup_telemetry_forpyclient (client_auth was already false), force a restart so the new setting takes effect. Restore the original value in teardown.

#### How did you verify/test it?
Confirmed on Nokia IXR7220-H6-128: ConfigDB TELEMETRY|gnmi has no idle_conn_duration key by default, so telemetry defaults to 5 minutes. With this fix the key is set to 30 before the test and cleaned up after.

#### Any platform specific information?
Nokia IXR7220-H6-128 only.

#### Supported testbed topology if it's a new test case?
lt2-o256-u32d224

### Documentation