### PR TITLE
[ha]: Update FNIC planned shutdown flow checks

### DIFF
--- a/tests/ha/test_ha_planned_shutdown_fnic.py
+++ b/tests/ha/test_ha_planned_shutdown_fnic.py
@@ -13,10 +13,16 @@ from constants import LOCAL_PTF_INTF, REMOTE_PTF_RECV_INTF
 from gnmi_utils import apply_messages
 from packets import outbound_pl_packets
 from tests.common.config_reload import config_reload
+from ha_dash_flow_utils import compare_flow_tables, compare_flow_tables_pdsctl
 from ha_utils import activate_primary_dash_ha, activate_secondary_dash_ha, \
          verify_ha_state, set_dash_ha_scope, set_dead_dash_ha_scope
 
 logger = logging.getLogger(__name__)
+
+# Distinct inner UDP ports used only after standby shutdown to create a new
+# flow on the standalone primary and verify it is bulk-synced to the standby.
+POST_SHUTDOWN_INNER_SPORT = 50001
+POST_SHUTDOWN_INNER_DPORT = 50002
 
 pytestmark = [
     pytest.mark.topology('t1-smartswitch-ha'),
@@ -119,57 +125,61 @@ def test_ha_planned_shutdown(
 
     rcv_outbound_pl_ports = dash_pl_config[0][REMOTE_PTF_RECV_INTF] + dash_pl_config[1][REMOTE_PTF_RECV_INTF]
 
-    packet_sending_flag = queue.Queue(1)
+    if ha_owner == "dpu":
+        # shutdown active HA Scope is only applicable to DPU-driven HA
+        packet_sending_flag = queue.Queue(1)
 
-    def primary_ha_action():
-        # wait for packets sending started, then set primary to dead
-        while packet_sending_flag.empty() or (not packet_sending_flag.get()):
-            time.sleep(0.2)
-        logging.info("HA: Set primary to dead")
-        set_dead_dash_ha_scope(localhost, duthosts[0], ptfhost, primary_vdpu_key)
+        def primary_ha_action():
+            # wait for packets sending started, then set primary to dead
+            while packet_sending_flag.empty() or (not packet_sending_flag.get()):
+                time.sleep(0.2)
+            logging.info("HA: Set primary to dead")
+            set_dead_dash_ha_scope(localhost, duthosts[0], ptfhost, primary_vdpu_key, ha_owner)
 
-    t = threading.Thread(target=primary_ha_action, name="primary_ha_action_thread")
-    t.start()
-    t_max = time.time() + 60
-    # Calculate the delay between packets based on the desired rate
-    reached_max_time = False
-    ptfadapter.dataplane.flush()
-    time.sleep(1)
-    send_count = 0
-    while not reached_max_time:
-        sport = random.randint(49152, 65535)
-        dport = random.randint(49152, 65535)
-        vm_to_dpu_pkt, exp_dpu_to_pe_pkt = outbound_pl_packets(
-            dash_pl_config[0], encap_proto, floating_nic=True,
-            inner_sport=sport, inner_dport=dport, vni=pl.ENI_TRUSTED_VNI
-        )
-        testutils.send(ptfadapter, dash_pl_config[0][LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
-        testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, rcv_outbound_pl_ports)
-        if send_count == 0:
-            logger.info("HA: First packet received")
-        send_count += 1
-        # After we send initial_send_count packets, awake perform_ha_action thread
-        if send_count == initial_send_count:
-            logging.info("HA: awake action thread")
-            packet_sending_flag.put(True)
+        t = threading.Thread(target=primary_ha_action, name="primary_ha_action_thread")
+        t.start()
+        t_max = time.time() + 60
+        # Calculate the delay between packets based on the desired rate
+        reached_max_time = False
+        ptfadapter.dataplane.flush()
+        time.sleep(1)
+        send_count = 0
+        while not reached_max_time:
+            sport = random.randint(49152, 65535)
+            dport = random.randint(49152, 65535)
+            vm_to_dpu_pkt, exp_dpu_to_pe_pkt = outbound_pl_packets(
+                dash_pl_config[0], encap_proto, floating_nic=True,
+                inner_sport=sport, inner_dport=dport, vni=pl.ENI_TRUSTED_VNI
+            )
+            testutils.send(ptfadapter, dash_pl_config[0][LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
+            testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, rcv_outbound_pl_ports)
+            if send_count == 0:
+                logger.info("HA: First packet received - compare flows")
+                flow_op = compare_flow_tables_pdsctl(dpuhosts[0], dpuhosts[1])
+                pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
+            send_count += 1
+            # After we send initial_send_count packets, awake perform_ha_action thread
+            if send_count == initial_send_count:
+                logging.info("HA: awake action thread")
+                packet_sending_flag.put(True)
 
-        time.sleep(delay)
-        reached_max_time = time.time() > t_max
+            time.sleep(delay)
+            reached_max_time = time.time() > t_max
 
-    t.join()
-    time.sleep(2)
+        t.join()
+        time.sleep(2)
 
-    pytest_assert(verify_ha_state(duthosts[0], primary_vdpu_key, "dead"),
-                  "Primary HA state is not dead")
-    pytest_assert(verify_ha_state(duthosts[1], standby_vdpu_key, "standalone"),
-                  "Standby HA state is not standalone")
+        pytest_assert(verify_ha_state(duthosts[0], primary_vdpu_key, "dead"),
+                      "Primary HA state is not dead")
+        pytest_assert(verify_ha_state(duthosts[1], standby_vdpu_key, "standalone"),
+                      "Standby HA state is not standalone")
 
-    logging.info(f"HA: Primary shutdown all {send_count} packets received")
+        logging.info(f"HA: Primary shutdown all {send_count} packets received")
 
-    # Re-activate primary
-    set_dash_ha_scope(localhost, duthosts[0], ptfhost, primary_vdpu_key, "dead", ha_owner, disabled=True)
-    pytest_assert(activate_primary_dash_ha(localhost, duthosts[0], ptfhost, primary_vdpu_key, "activate_role"),
-                  "Failed to re-activate HA on primary")
+        # Re-activate primary
+        set_dash_ha_scope(localhost, duthosts[0], ptfhost, primary_vdpu_key, "dead", ha_owner, disabled=True)
+        pytest_assert(activate_primary_dash_ha(localhost, duthosts[0], ptfhost, primary_vdpu_key, "activate_role"),
+                      "Failed to re-activate HA on primary")
 
     packet_sending_flag = queue.Queue(1)
 
@@ -178,7 +188,7 @@ def test_ha_planned_shutdown(
         while packet_sending_flag.empty() or (not packet_sending_flag.get()):
             time.sleep(0.2)
         logging.info("HA: Set standby to dead")
-        set_dead_dash_ha_scope(localhost, duthosts[1], ptfhost, standby_vdpu_key)
+        set_dead_dash_ha_scope(localhost, duthosts[1], ptfhost, standby_vdpu_key, ha_owner)
 
     t = threading.Thread(target=standby_ha_action, name="standby_ha_action_thread")
     t.start()
@@ -198,7 +208,9 @@ def test_ha_planned_shutdown(
         testutils.send(ptfadapter, dash_pl_config[0][LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
         testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, rcv_outbound_pl_ports)
         if send_count == 0:
-            logger.info("HA: First packet received")
+            logger.info("HA: First packet received - compare flows")
+            flow_op = compare_flow_tables(dpuhosts[0], dpuhosts[1])
+            pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
         send_count += 1
         # After we send initial_send_count packets, awake perform_ha_action thread
         if send_count == initial_send_count:
@@ -217,7 +229,26 @@ def test_ha_planned_shutdown(
 
     logging.info(f"HA: standby shutdown all {send_count} packets received")
 
+    logger.info(
+        "HA: Post-shutdown - send outbound packet with inner_sport=%s then compare flow tables",
+        POST_SHUTDOWN_INNER_SPORT,
+    )
+    ptfadapter.dataplane.flush()
+    time.sleep(1)
+    vm_post_sd, exp_post_sd = outbound_pl_packets(
+        dash_pl_config[0], encap_proto, floating_nic=True,
+        inner_sport=POST_SHUTDOWN_INNER_SPORT, inner_dport=POST_SHUTDOWN_INNER_DPORT,
+        vni=pl.ENI_TRUSTED_VNI
+    )
+    testutils.send(ptfadapter, dash_pl_config[0][LOCAL_PTF_INTF], vm_post_sd, 1)
+    testutils.verify_packet_any_port(ptfadapter, exp_post_sd, rcv_outbound_pl_ports)
+
     # Re-activate standby
     set_dash_ha_scope(localhost, duthosts[1], ptfhost, standby_vdpu_key, "dead", ha_owner, disabled=True)
     pytest_assert(activate_secondary_dash_ha(localhost, duthosts[1], ptfhost, standby_vdpu_key, "activate_role",
                                              owner=ha_owner), "Failed to re-activate HA on standby")
+
+    flow_post = compare_flow_tables(
+        dpuhosts[0], dpuhosts[1], verbose=True, flow_state=True
+    )
+    pytest_assert(flow_post, "Expected identical flow tables after launch from standalone (bulk sync)")


### PR DESCRIPTION
### Description of PR
Summary:
Update HA FNIC planned-shutdown coverage to validate flow synchronization around standalone/bulk-sync behavior.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

The HA FNIC planned-shutdown flow should verify that flow state is synchronized between primary and standby DPUs before and after a standalone-primary packet is launched, so planned shutdown coverage can catch flow-sync regressions.

#### How did you do it?

- Gate active-primary shutdown behavior to DPU-owned HA, where shutdown of the active HA scope is applicable.
- Compare flow tables after the first received packet to verify initial flow synchronization.
- Send a distinct post-standby-shutdown outbound packet and compare flow tables with flow state after reactivating standby.

#### How did you verify/test it?
```
- generated xml file: /var/src/sonic-mgmt-int/tests/logs/ha/test_ha_planned_shutdown_fnic.py::test_ha_planned_shutdown.xml -
---------------------------- live log sessionfinish ----------------------------
INFO     root:__init__.py:67 Can not get Allure report URL. Please check logs
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_ha_planned_shutdown>
DEBUG:root:[Parallel Fixture] Terminate parallel manager after teardown
INFO:root:[Parallel Fixture] Terminating parallel fixture manager
DEBUG:root:[Parallel Fixture] Running tasks to be terminated: []
DEBUG:root:[Parallel Fixture] Current worker threads: []
DEBUG:root:[Parallel Fixture] Current worker threads: []
DEBUG:root:[Parallel Fixture] The fixture manager is terminated:
stopped tasks [],
canceled tasks [],
pending tasks [],
done tasks [].
INFO:root:Can not get Allure report URL. Please check logs
================= 1 passed, 544 warnings in 1017.86s (0:16:57) =================
```

#### Any platform specific information?

N/A.

#### Supported testbed topology if it's a new test case?

N/A. This updates an existing HA FNIC planned-shutdown test.

### Documentation

N/A.