### PR TITLE
[ha][yang]: Avoid writing test GNMI certs to CONFIG_DB

### DIFF
--- a/tests/ha/gnmi_utils.py
+++ b/tests/ha/gnmi_utils.py
@@ -205,29 +205,6 @@ def apply_gnmi_cert(my_duthost, ptfhost):
     ptfhost.copy(src=env.work_dir+env.gnmi_client_cert, dest=my_dest)
     ptfhost.copy(src=env.work_dir+env.gnmi_client_key, dest=my_dest)
     _set_gnmi_client_cert_role(my_duthost)
-    certs_table = "{}|certs".format(env.gnmi_config_table)
-    my_duthost.shell(
-        'sudo sonic-db-cli CONFIG_DB hset "{}" ca_crt "{}{}"'.format(
-            certs_table, env.gnmi_cert_path, env.gnmi_ca_cert
-        ),
-        module_ignore_errors=True,
-    )
-    my_duthost.shell(
-        'sudo sonic-db-cli CONFIG_DB hset "{}" server_crt "{}{}"'.format(
-            certs_table, env.gnmi_cert_path, env.gnmi_server_cert
-        ),
-        module_ignore_errors=True,
-    )
-    my_duthost.shell(
-        'sudo sonic-db-cli CONFIG_DB hset "{}" server_key "{}{}"'.format(
-            certs_table, env.gnmi_cert_path, env.gnmi_server_key
-        ),
-        module_ignore_errors=True,
-    )
-    my_duthost.shell(
-        'sudo sonic-db-cli CONFIG_DB hset "{}|gnmi" client_auth true'.format(env.gnmi_config_table),
-        module_ignore_errors=True,
-    )
     port = env.gnmi_port
     assert int(port) > 0, "Invalid GNMI port"
     dut_command = "docker exec %s supervisorctl stop %s" % (env.gnmi_container, env.gnmi_program)


### PR DESCRIPTION
### Description
Avoid writing HA test-generated gNMI certificate paths into `GNMI|certs` in CONFIG_DB.

The HA helper starts telemetry with explicit test certificate arguments for the generated cert chain. Writing those generated `.pem`/`.crt` paths into CONFIG_DB can leave runtime config that fails GNMI YANG validation, while the deployed/default cert paths remain YANG-compatible.

### Changes
- Keep HA gNMI client certificate role setup.
- Continue launching telemetry with explicit generated cert arguments.
- Stop updating CONFIG_DB `GNMI|certs` and `GNMI|gnmi client_auth` for the test certs.

### Validation
- `python3 -m py_compile tests/ha/gnmi_utils.py`
- Representative SmartSwitch HA test passed with YANG validation enabled:
  - `ha/test_ha_steady_state_pl.py::test_privatelink_basic_transform[vxlan]`
  - Pre-test and post-test YANG validation passed on both DUTs.
