### PR TITLE
[202511] Backport: cryptography-based gnmi/telemetry cert generation with notBefore backdate (#24607, #15770)

### DIFF
--- a/tests/common/cert_utils.py
+++ b/tests/common/cert_utils.py
@@ -163,6 +163,13 @@ class TlsCertificateGenerator:
                 ),
                 critical=True,
             )
+            # SubjectKeyIdentifier matches what `openssl req -x509` adds by
+            # default. Required so the CRL flow (which sets
+            # authorityKeyIdentifier=keyid:always) can resolve.
+            .add_extension(
+                x509.SubjectKeyIdentifier.from_public_key(key.public_key()),
+                critical=False,
+            )
             .sign(key, hashes.SHA256())
         )
 

--- a/tests/common/gnmi_setup.py
+++ b/tests/common/gnmi_setup.py
@@ -15,6 +15,7 @@ import time
 
 import tests.common.gu_utils as gu_utils
 
+from tests.common.cert_utils import TlsCertificateGenerator
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
 from tests.common.utilities import wait_until
 from tests.common.helpers.ntp_helper import NtpDaemon, get_ntp_daemon_in_use   # noqa: F401
@@ -175,9 +176,17 @@ def recover_cert_config(duthost):
 
 def create_certificates(localhost, duthost_mgmt_ip, cert_path: Path):
     """
-    Create GNMI CA, server and client certificates
-    :param localhost: localhost fixture
-    :param duthost_mgmt_ip: DUT management IP
+    Create GNMI CA, server and client certificates.
+
+    Builds the test PKI in-process via cryptography (not openssl shell) so
+    that notBefore can be backdated by 7 days. This absorbs clock skew
+    between the sonic-mgmt runner, the DUT, and the PTF docker; otherwise
+    the TLS handshake fails with "certificate is not yet valid". The
+    openssl 3.0.x runtime on Ubuntu 24.04 has no CLI flag to set
+    notBefore on `req -x509` or `x509 -req` (added only in 3.5).
+
+    :param localhost: localhost fixture (unused; kept for backward compat)
+    :param duthost_mgmt_ip: DUT management IP (included in server cert SAN)
     :param cert_path: Path to store the certificates
     :return: True if successful, False otherwise
     """
@@ -200,105 +209,24 @@ def create_certificates(localhost, duthost_mgmt_ip, cert_path: Path):
         logger.error(f"Failed to create directory {dest_dir}: {e}")
         raise Exception(f"Failed to create directory {dest_dir}: {e}")
 
-    # Create CA key and certificate
-    logger.info("Creating CA key and certificate.")
-    key_file = str(dest_dir / 'gnmiCA.key')
-    out_file = str(dest_dir / 'gnmiCA.pem')
-    logger.debug(f"CA key file: {key_file}, CA certificate file: {out_file}")
-    local_command = f"openssl genrsa -out {key_file} 2048"
-    localhost.shell(local_command)
-    local_command = (
-        f"openssl req -x509 -new -nodes -key {key_file} "
-        f"-sha256 -days 1825 -subj '/CN=test.gnmi.sonic' "
-        f"-out {out_file}"
-    )
-    out = localhost.shell(local_command)
-    if out['rc'] != 0:
-        logger.error(f"Failed to create CA certificate {out['stderr']}")
-        return False
-
-    # Create server key
-    logger.info("Creating server key.")
-    key_file = str(dest_dir / 'gnmiserver.key')
-    logger.debug(f"Server key file: {key_file}")
-    local_command = f"openssl genrsa -out {key_file} 2048"
-    out = localhost.shell(local_command)
-    if out['rc'] != 0:
-        logger.error(f"Failed to create server key {out['stderr']}")
-        return False
-
-    # Create server CSR
-    logger.info("Creating server CSR.")
-    out_file = str(dest_dir / 'gnmiserver.csr')
-    logger.debug(f"Server CSR file: {out_file}")
-    local_command = (
-        f"openssl req -new -key {key_file} "
-        f"-subj '/CN=test.server.gnmi.sonic' -out {out_file}"
-    )
-    localhost.shell(local_command)
-    if out['rc'] != 0:
-        logger.error(f"Failed to create server CSR {out['stderr']}")
-        return False
-
-    # Sign server certificate
-    logger.info("Signing server certificate.")
-    extfile_path = str(dest_dir / 'extfile.cnf')
-    logger.debug(f"Extension file path: {extfile_path}")
-    create_ext_conf(duthost_mgmt_ip, extfile_path)
-    ca_key = str(dest_dir / 'gnmiCA.key')
-    ca_pem = str(dest_dir / 'gnmiCA.pem')
-    in_file = str(dest_dir / 'gnmiserver.csr')
-    out_file = str(dest_dir / 'gnmiserver.crt')
-    logger.debug(f"CA key: {ca_key}, CA PEM: {ca_pem}, Input CSR: {in_file}, Output CRT: {out_file}")
-    local_command = (
-        f"openssl x509 -req -in {in_file} "
-        f"-CA {ca_pem} -CAkey {ca_key} -CAcreateserial "
-        f"-out {out_file} -days 825 -sha256 "
-        f"-extensions req_ext -extfile {extfile_path}"
-    )
-    out = localhost.shell(local_command)
-    if out['rc'] != 0:
-        logger.error(f"Failed to sign server certificate {out['stderr']}")
-        return False
-
-    # Create client key
-    logger.info("Creating client key.")
-    key_file = str(dest_dir / 'gnmiclient.key')
-    logger.debug(f"Client key file: {key_file}")
-    local_command = f"openssl genrsa -out {key_file} 2048"
-    out = localhost.shell(local_command)
-    if out['rc'] != 0:
-        logger.error(f"Failed to create client key {out['stderr']}")
-        return False
-
-    # Create client CSR
-    logger.info("Creating client CSR.")
-    out_file = str(dest_dir / 'gnmiclient.csr')
-    logger.debug(f"Client CSR file: {out_file}")
-    local_command = (
-        f"openssl req -new -key {key_file} "
-        f"-subj '/CN=test.client.gnmi.sonic' -out {out_file}"
-    )
-    out = localhost.shell(local_command)
-    if out['rc'] != 0:
-        logger.error(f"Failed to create client CSR {out['stderr']}")
-        return False
-
-    # Sign client certificate
-    logger.info("Signing client certificate.")
-    in_file = str(dest_dir / 'gnmiclient.csr')
-    ca_pem = str(dest_dir / 'gnmiCA.pem')
-    ca_key = str(dest_dir / 'gnmiCA.key')
-    out_file = str(dest_dir / 'gnmiclient.crt')
-    logger.debug(f"CA key: {ca_key}, CA PEM: {ca_pem}, Input CSR: {in_file}, Output CRT: {out_file}")
-    local_command = (
-        f"openssl x509 -req -in {in_file} "
-        f"-CA {ca_pem} -CAkey {ca_key} "
-        f"-CAcreateserial -out {out_file} -days 825 -sha256"
-    )
-    out = localhost.shell(local_command)
-    if out['rc'] != 0:
-        logger.error(f"Failed to sign client certificate {out['stderr']}")
+    try:
+        generator = TlsCertificateGenerator(
+            server_ip=duthost_mgmt_ip,
+            backdate_days=7,
+            dns_names=["hostname.com"],
+            ca_cn="test.gnmi.sonic",
+            server_cn="test.server.gnmi.sonic",
+            client_cn="test.client.gnmi.sonic",
+            ca_cert_name="gnmiCA.pem",
+            ca_key_name="gnmiCA.key",
+            server_cert_name="gnmiserver.crt",
+            server_key_name="gnmiserver.key",
+            client_cert_name="gnmiclient.crt",
+            client_key_name="gnmiclient.key",
+        )
+        generator.write_all(str(dest_dir))
+    except Exception as e:
+        logger.error(f"Failed to generate GNMI certificates: {e}")
         return False
 
     logger.info("Certificate creation process completed successfully.")

--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -4,6 +4,7 @@ logger = logging.getLogger(__name__)
 
 
 GNMI_CERT_NAME = "test.client.gnmi.sonic"
+REVOKED_GNMICERT_NAME = "test.client.revoked.gnmi.sonic"
 TELEMETRY_CONTAINER = "telemetry"
 
 
@@ -188,34 +189,16 @@ def get_ptf_crl_server_ip(duthost, ptfhost):
 
 
 def create_revoked_cert_and_crl(localhost, ptfhost, duthost=None):
-    # Create client key
-    local_command = "openssl genrsa -out gnmiclient.revoked.key 2048"
-    localhost.shell(local_command)
+    create_client_key(localhost, revoke=True)
 
-    # Create client CSR
-    local_command = "openssl req \
-                        -new \
-                        -key gnmiclient.revoked.key \
-                        -subj '/CN=test.client.revoked.gnmi.sonic' \
-                        -out gnmiclient.revoked.csr"
-    localhost.shell(local_command)
+    create_client_csr(localhost, revoke=True)
 
     # Sign client certificate
     # Get appropriate PTF IP address based on DUT management IP type
     ptf_ip = get_ptf_crl_server_ip(duthost, ptfhost) if duthost else ptfhost.mgmt_ip
     crl_url = "http://{}:1234/crl".format(ptf_ip)
     create_ca_conf(crl_url, "crlext.cnf")
-    local_command = "openssl x509 \
-                        -req \
-                        -in gnmiclient.revoked.csr \
-                        -CA gnmiCA.pem \
-                        -CAkey gnmiCA.key \
-                        -CAcreateserial \
-                        -out gnmiclient.revoked.crt \
-                        -days 825 \
-                        -sha256 \
-                        -extensions req_ext -extfile crlext.cnf"
-    localhost.shell(local_command)
+    sign_client_certificate(localhost, revoke=True, extension_file="crlext.cnf")
 
     # create crl config file
     local_command = "rm -f gnmi/crl/index.txt"
@@ -264,80 +247,121 @@ def create_gnmi_certs(duthost, localhost, ptfhost):
     '''
     Create GNMI client certificates
     '''
-    # Create Root key
+    prepare_root_cert(localhost)
+    prepare_server_cert(duthost, localhost)
+    prepare_client_cert(localhost)
+    create_revoked_cert_and_crl(localhost, ptfhost)
+    copy_certificate_to_dut(duthost)
+    copy_certificate_to_ptf(ptfhost)
+
+
+def prepare_root_cert(localhost, days="1825"):
+    create_root_key(localhost)
+    create_root_cert(localhost, days)
+
+
+def create_root_key(localhost):
     local_command = "openssl genrsa -out gnmiCA.key 2048"
     localhost.shell(local_command)
 
-    # Create Root cert
+
+def create_root_cert(localhost, days):
     local_command = "openssl req \
-                        -x509 \
-                        -new \
-                        -nodes \
-                        -key gnmiCA.key \
-                        -sha256 \
-                        -days 1825 \
-                        -subj '/CN=test.gnmi.sonic' \
-                        -out gnmiCA.pem"
+                            -x509 \
+                            -new \
+                            -nodes \
+                            -key gnmiCA.key \
+                            -sha256 \
+                            -days {} \
+                            -subj '/CN=test.gnmi.sonic' \
+                            -out gnmiCA.pem".format(days)
     localhost.shell(local_command)
 
-    # Create server key
+
+def prepare_server_cert(duthost, localhost, days="825"):
+    create_server_key(localhost)
+    create_server_csr(localhost)
+    sign_server_certificate(duthost, localhost, days)
+
+
+def create_server_key(localhost):
     local_command = "openssl genrsa -out gnmiserver.key 2048"
     localhost.shell(local_command)
 
-    # Create server CSR
+
+def create_server_csr(localhost):
     local_command = "openssl req \
-                        -new \
-                        -key gnmiserver.key \
-                        -subj '/CN=test.server.gnmi.sonic' \
-                        -out gnmiserver.csr"
+                            -new \
+                            -key gnmiserver.key \
+                            -subj '/CN=test.server.gnmi.sonic' \
+                            -out gnmiserver.csr"
     localhost.shell(local_command)
 
-    # Sign server certificate
+
+def sign_server_certificate(duthost, localhost, days):
     create_ext_conf(duthost.mgmt_ip, "extfile.cnf")
     local_command = "openssl x509 \
-                        -req \
-                        -in gnmiserver.csr \
-                        -CA gnmiCA.pem \
-                        -CAkey gnmiCA.key \
-                        -CAcreateserial \
-                        -out gnmiserver.crt \
-                        -days 825 \
-                        -sha256 \
-                        -extensions req_ext -extfile extfile.cnf"
+                            -req \
+                            -in gnmiserver.csr \
+                            -CA gnmiCA.pem \
+                            -CAkey gnmiCA.key \
+                            -CAcreateserial \
+                            -out gnmiserver.crt \
+                            -days {} \
+                            -sha256 \
+                            -extensions req_ext \
+                            -extfile extfile.cnf".format(days)
     localhost.shell(local_command)
 
-    # Create client key
-    local_command = "openssl genrsa -out gnmiclient.key 2048"
+
+def prepare_client_cert(localhost, days="825"):
+    create_client_key(localhost)
+    create_client_csr(localhost)
+    sign_client_certificate(localhost, days)
+
+
+def create_client_key(localhost, revoke=False):
+    revoke_suffix = "revoked." if revoke else ""
+    local_command = "openssl genrsa -out gnmiclient.{}key 2048".format(revoke_suffix)
     localhost.shell(local_command)
 
-    # Create client CSR
+
+def create_client_csr(localhost, revoke=False):
+    revoke_suffix = "revoked." if revoke else ""
+    cn = REVOKED_GNMICERT_NAME if revoke else GNMI_CERT_NAME
     local_command = "openssl req \
-                        -new \
-                        -key gnmiclient.key \
-                        -subj '/CN={}' \
-                        -out gnmiclient.csr".format(GNMI_CERT_NAME)
+                            -new \
+                            -key gnmiclient.{}key \
+                            -subj '/CN={}' \
+                            -out gnmiclient.{}csr".format(revoke_suffix, cn, revoke_suffix)
     localhost.shell(local_command)
 
-    # Sign client certificate
+
+def sign_client_certificate(localhost, days="825", revoke=False, extension_file=None):
+    revoke_suffix = "revoked." if revoke else ""
+    extensions = "-extensions req_ext -extfile {}".format(extension_file) if extension_file else ""
     local_command = "openssl x509 \
-                        -req \
-                        -in gnmiclient.csr \
-                        -CA gnmiCA.pem \
-                        -CAkey gnmiCA.key \
-                        -CAcreateserial \
-                        -out gnmiclient.crt \
-                        -days 825 \
-                        -sha256"
+                            -req \
+                            -in gnmiclient.{}csr \
+                            -CA gnmiCA.pem \
+                            -CAkey gnmiCA.key \
+                            -CAcreateserial \
+                            -out gnmiclient.{}crt \
+                            -days {} \
+                            -sha256 {}".format(revoke_suffix, revoke_suffix, days, extensions)
     localhost.shell(local_command)
 
-    create_revoked_cert_and_crl(localhost, ptfhost)
 
+def copy_certificate_to_dut(duthost):
     # Copy CA certificate, server certificate and client certificate over to the DUT
     duthost.copy(src='gnmiCA.pem', dest='/etc/sonic/telemetry/')
     duthost.copy(src='gnmiserver.crt', dest='/etc/sonic/telemetry/')
     duthost.copy(src='gnmiserver.key', dest='/etc/sonic/telemetry/')
     duthost.copy(src='gnmiclient.crt', dest='/etc/sonic/telemetry/')
     duthost.copy(src='gnmiclient.key', dest='/etc/sonic/telemetry/')
+
+
+def copy_certificate_to_ptf(ptfhost):
     # Copy CA certificate and client certificate over to the PTF
     ptfhost.copy(src='gnmiCA.pem', dest='/root/')
     ptfhost.copy(src='gnmiclient.crt', dest='/root/')

--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -1,4 +1,11 @@
+import ipaddress
 import logging
+import re
+from datetime import datetime, timedelta, timezone
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.x509.oid import NameOID
 
 logger = logging.getLogger(__name__)
 
@@ -6,6 +13,50 @@ logger = logging.getLogger(__name__)
 GNMI_CERT_NAME = "test.client.gnmi.sonic"
 REVOKED_GNMICERT_NAME = "test.client.revoked.gnmi.sonic"
 TELEMETRY_CONTAINER = "telemetry"
+
+# Backdate notBefore on test certs to absorb clock skew between the
+# sonic-mgmt runner, the DUT, and the PTF docker. Without this, even a
+# few minutes of drift produces TLS handshake failures with
+# "certificate is not yet valid". We do the signing in-process via
+# cryptography because the openssl 3.0.x CLI on the runner has no flag
+# to set notBefore on `req -x509` / `x509 -req` (added only in 3.5).
+_CERT_BACKDATE_DAYS = 7
+
+
+def _cert_validity_period(days):
+    """notBefore is backdated by _CERT_BACKDATE_DAYS; notAfter is `days` from now."""
+    now = datetime.now(timezone.utc)
+    not_before = now - timedelta(days=_CERT_BACKDATE_DAYS)
+    not_after = now + timedelta(days=int(days))
+    return not_before, not_after
+
+
+def _load_pem_private_key(path):
+    with open(path, "rb") as f:
+        return serialization.load_pem_private_key(f.read(), password=None)
+
+
+def _load_pem_certificate(path):
+    with open(path, "rb") as f:
+        return x509.load_pem_x509_certificate(f.read())
+
+
+def _load_pem_csr(path):
+    with open(path, "rb") as f:
+        return x509.load_pem_x509_csr(f.read())
+
+
+def _write_pem_certificate(path, cert):
+    with open(path, "wb") as f:
+        f.write(cert.public_bytes(serialization.Encoding.PEM))
+
+
+def _parse_crl_dp_uri(extension_file):
+    """Extract the CRL distribution point URI written by create_ca_conf."""
+    with open(extension_file, "r") as f:
+        text = f.read()
+    match = re.search(r"crlDistributionPoints\s*=\s*URI:(\S+)", text)
+    return match.group(1) if match else None
 
 
 class GNMIEnvironment(object):
@@ -266,16 +317,37 @@ def create_root_key(localhost):
 
 
 def create_root_cert(localhost, days):
-    local_command = "openssl req \
-                            -x509 \
-                            -new \
-                            -nodes \
-                            -key gnmiCA.key \
-                            -sha256 \
-                            -days {} \
-                            -subj '/CN=test.gnmi.sonic' \
-                            -out gnmiCA.pem".format(days)
-    localhost.shell(local_command)
+    """Self-signed CA cert, backdated by _CERT_BACKDATE_DAYS.
+
+    Includes SubjectKeyIdentifier to match what `openssl req -x509`
+    used to add for free via the system openssl.cnf [v3_ca] section.
+    The CRL flow in create_revoked_cert_and_crl needs SKI here so its
+    `authorityKeyIdentifier=keyid:always` extension can resolve.
+    """
+    ca_key = _load_pem_private_key("gnmiCA.key")
+    subject = issuer = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, "test.gnmi.sonic"),
+    ])
+    not_before, not_after = _cert_validity_period(days)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=None),
+            critical=True,
+        )
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(ca_key.public_key()),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+    _write_pem_certificate("gnmiCA.pem", cert)
 
 
 def prepare_server_cert(duthost, localhost, days="825"):
@@ -299,19 +371,30 @@ def create_server_csr(localhost):
 
 
 def sign_server_certificate(duthost, localhost, days):
-    create_ext_conf(duthost.mgmt_ip, "extfile.cnf")
-    local_command = "openssl x509 \
-                            -req \
-                            -in gnmiserver.csr \
-                            -CA gnmiCA.pem \
-                            -CAkey gnmiCA.key \
-                            -CAcreateserial \
-                            -out gnmiserver.crt \
-                            -days {} \
-                            -sha256 \
-                            -extensions req_ext \
-                            -extfile extfile.cnf".format(days)
-    localhost.shell(local_command)
+    """Sign gnmiserver.csr with the CA, backdated, with SAN (hostname.com + DUT mgmt IP)."""
+    ca_cert = _load_pem_certificate("gnmiCA.pem")
+    ca_key = _load_pem_private_key("gnmiCA.key")
+    csr = _load_pem_csr("gnmiserver.csr")
+    not_before, not_after = _cert_validity_period(days)
+    san_entries = [
+        x509.DNSName("hostname.com"),
+        x509.IPAddress(ipaddress.ip_address(duthost.mgmt_ip)),
+    ]
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(csr.subject)
+        .issuer_name(ca_cert.subject)
+        .public_key(csr.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .add_extension(
+            x509.SubjectAlternativeName(san_entries),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+    _write_pem_certificate("gnmiserver.crt", cert)
 
 
 def prepare_client_cert(localhost, days="825"):
@@ -338,18 +421,44 @@ def create_client_csr(localhost, revoke=False):
 
 
 def sign_client_certificate(localhost, days="825", revoke=False, extension_file=None):
+    """Sign a (regular or revoked) client CSR with the CA, backdated.
+
+    `extension_file` is the cnf written by create_ca_conf when caller wants
+    a CRL Distribution Points extension on the cert; we parse the URI out
+    of it and add the extension via cryptography (we no longer hand the
+    file to openssl).
+    """
     revoke_suffix = "revoked." if revoke else ""
-    extensions = "-extensions req_ext -extfile {}".format(extension_file) if extension_file else ""
-    local_command = "openssl x509 \
-                            -req \
-                            -in gnmiclient.{}csr \
-                            -CA gnmiCA.pem \
-                            -CAkey gnmiCA.key \
-                            -CAcreateserial \
-                            -out gnmiclient.{}crt \
-                            -days {} \
-                            -sha256 {}".format(revoke_suffix, revoke_suffix, days, extensions)
-    localhost.shell(local_command)
+    csr_path = "gnmiclient.{}csr".format(revoke_suffix)
+    out_path = "gnmiclient.{}crt".format(revoke_suffix)
+    ca_cert = _load_pem_certificate("gnmiCA.pem")
+    ca_key = _load_pem_private_key("gnmiCA.key")
+    csr = _load_pem_csr(csr_path)
+    not_before, not_after = _cert_validity_period(days)
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(csr.subject)
+        .issuer_name(ca_cert.subject)
+        .public_key(csr.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+    )
+    if extension_file:
+        crl_uri = _parse_crl_dp_uri(extension_file)
+        if crl_uri:
+            dp = x509.DistributionPoint(
+                full_name=[x509.UniformResourceIdentifier(crl_uri)],
+                relative_name=None,
+                reasons=None,
+                crl_issuer=None,
+            )
+            builder = builder.add_extension(
+                x509.CRLDistributionPoints([dp]),
+                critical=False,
+            )
+    cert = builder.sign(ca_key, hashes.SHA256())
+    _write_pem_certificate(out_path, cert)
 
 
 def copy_certificate_to_dut(duthost):
@@ -372,7 +481,9 @@ def delete_gnmi_certs(localhost):
     '''
     Delete GNMI client certificates
     '''
-    local_command = "rm \
+    # -f because extfile.cnf is no longer always created on disk
+    # (sign_server_certificate now sets SAN in-process).
+    local_command = "rm -f \
                         extfile.cnf \
                         gnmiCA.* \
                         gnmiserver.* \

--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -6,7 +6,9 @@ from tests.common.helpers.dut_utils import check_container_state
 from tests.gnmi.helper import gnmi_container, apply_cert_config, recover_cert_config
 from tests.gnmi.helper import GNMI_SERVER_START_WAIT_TIME, check_ntp_sync_status
 from tests.common.gu_utils import create_checkpoint, rollback
-from tests.common.helpers.gnmi_utils import create_gnmi_certs, delete_gnmi_certs
+from tests.common.helpers.gnmi_utils import GNMIEnvironment, create_revoked_cert_and_crl, create_gnmi_certs, \
+    delete_gnmi_certs, prepare_root_cert, prepare_server_cert, prepare_client_cert, copy_certificate_to_dut, \
+    copy_certificate_to_ptf
 from tests.common.helpers.ntp_helper import setup_ntp_context
 
 
@@ -76,7 +78,12 @@ def setup_gnmi_rotated_server(duthosts, rand_one_dut_hostname, localhost, ptfhos
         check_container_state(duthost, gnmi_container(duthost), should_be_running=True),
         "Test was not supported on devices which do not support GNMI!"
     )
-    create_gnmi_certs(duthost, localhost, ptfhost)
+    prepare_root_cert(localhost)
+    prepare_server_cert(duthost, localhost)
+    prepare_client_cert(localhost)
+    copy_certificate_to_ptf(ptfhost)
+    create_revoked_cert_and_crl(localhost, ptfhost)
+    copy_certificate_to_dut(duthost)
 
 
 @pytest.fixture(scope="module")

--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -6,7 +6,7 @@ from tests.common.helpers.dut_utils import check_container_state
 from tests.gnmi.helper import gnmi_container, apply_cert_config, recover_cert_config
 from tests.gnmi.helper import GNMI_SERVER_START_WAIT_TIME, check_ntp_sync_status
 from tests.common.gu_utils import create_checkpoint, rollback
-from tests.common.helpers.gnmi_utils import GNMIEnvironment, create_revoked_cert_and_crl, create_gnmi_certs, \
+from tests.common.helpers.gnmi_utils import create_revoked_cert_and_crl, create_gnmi_certs, \
     delete_gnmi_certs, prepare_root_cert, prepare_server_cert, prepare_client_cert, copy_certificate_to_dut, \
     copy_certificate_to_ptf
 from tests.common.helpers.ntp_helper import setup_ntp_context

--- a/tests/gnmi/test_gnmi_2038.py
+++ b/tests/gnmi/test_gnmi_2038.py
@@ -1,0 +1,66 @@
+import pytest
+import logging
+import re
+from datetime import datetime, timezone
+from dateutil import parser
+
+from tests.common.helpers.gnmi_utils import gnmi_capabilities, prepare_root_cert, prepare_server_cert, \
+    prepare_client_cert, copy_certificate_to_dut, copy_certificate_to_ptf
+from .helper import apply_cert_config
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.disable_loganalyzer
+]
+
+ROOT_CERT_DAYS = 4850
+SERVER_CERT_DAYS = 4800
+CLIENT_CERT_DAYS = 4800
+
+
+def test_gnmi_capabilities_2038(duthosts, rand_one_dut_hostname, localhost, ptfhost):
+    '''
+    Verify certificate after 2038 year problem
+    '''
+    duthost = duthosts[rand_one_dut_hostname]
+
+    prepare_root_cert(localhost, days=ROOT_CERT_DAYS)
+    prepare_server_cert(duthost, localhost, days=SERVER_CERT_DAYS)
+    prepare_client_cert(localhost, days=CLIENT_CERT_DAYS)
+
+    copy_certificate_to_dut(duthost)
+    copy_certificate_to_ptf(ptfhost)
+
+    apply_cert_config(duthost)
+
+    # Verify certificate date on DUT
+    check_cert_date_on_dut(duthost)
+
+    # Verify GNMI capabilities to validate functionality
+    ret, msg = gnmi_capabilities(duthost, localhost)
+    assert ret == 0, msg
+    assert "sonic-db" in msg, msg
+    assert "JSON_IETF" in msg, msg
+
+
+def check_cert_date_on_dut(duthost):
+    cmd = "openssl x509 -in /etc/sonic/telemetry/gnmiCA.pem -text"
+    output = duthost.shell(cmd, module_ignore_errors=True)
+    not_after_line = re.search(r"Not After\s*:\s*(.*)", output['stdout'])
+    if not_after_line:
+        not_after_date_str = not_after_line.group(1).strip()
+        # Convert the date string to a datetime object
+        expiry_date = parser.parse(not_after_date_str)
+        if expiry_date.tzinfo is None:
+            expiry_date = expiry_date.replace(tzinfo=timezone.utc)
+        # comparison date is January 20, 2038, after the 2038 problem
+        after_2038_problem_date = datetime(2038, 1, 20, tzinfo=timezone.utc)
+
+        if expiry_date < after_2038_problem_date:
+            raise Exception("The expiry date {} is not after 2038 problem date".format(expiry_date))
+        else:
+            logger.info("The expiry date {} is after January 20, 2038.".format(expiry_date))
+    else:
+        raise Exception("The 'Not After' line with expiry date was not found")

--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -2,12 +2,25 @@ import logging
 import pytest
 import json
 import re
+from datetime import datetime, timedelta, timezone
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
 
 from pkg_resources import parse_version
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
 
 logger = logging.getLogger(__name__)
+
+# Backdate rotated telemetry cert notBefore so it survives clock skew
+# between the sonic-mgmt runner and the DUT. Cryptography lib here
+# instead of openssl shell because openssl 3.0.x has no CLI flag to
+# set notBefore on `req -x509` (added only in 3.5).
+_TELEMETRY_CERT_BACKDATE_DAYS = 7
+_TELEMETRY_CERT_VALIDITY_DAYS = 365
 
 METHOD_GET = "get"
 METHOD_SUBSCRIBE = "subscribe"
@@ -173,27 +186,43 @@ def archive_telemetry_certs(duthost):
             duthost.shell(cmd)
 
 
+def _mint_self_signed_telemetry_cert(common_name, cert_path, key_path):
+    """Generate a backdated self-signed leaf cert + key on the sonic-mgmt runner."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    now = datetime.now(timezone.utc)
+    not_before = now - timedelta(days=_TELEMETRY_CERT_BACKDATE_DAYS)
+    not_after = now + timedelta(days=_TELEMETRY_CERT_VALIDITY_DAYS)
+    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .sign(key, hashes.SHA256())
+    )
+    with open(key_path, "wb") as f:
+        f.write(key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        ))
+    with open(cert_path, "wb") as f:
+        f.write(cert.public_bytes(serialization.Encoding.PEM))
+
+
 def rotate_telemetry_certs(duthost, localhost):
     path = "/etc/sonic/telemetry/"
-    # Create new certs to rotate
-    cmd = "openssl req \
-              -x509 \
-              -sha256 \
-              -nodes \
-              -newkey rsa:2048 \
-              -keyout streamingtelemetryserver.key \
-              -subj '/CN=ndastreamingservertest' \
-              -out streamingtelemetryserver.cer"
-    localhost.shell(cmd)
-    cmd = "openssl req \
-              -x509 \
-              -sha256 \
-              -nodes \
-              -newkey rsa:2048 \
-              -keyout dsmsroot.key \
-              -subj '/CN=ndastreamingclienttest' \
-              -out dsmsroot.cer"
-    localhost.shell(cmd)
+    # Mint fresh self-signed certs locally with a backdate so the rotated
+    # PKI survives clock skew between the sonic-mgmt runner and the DUT.
+    _mint_self_signed_telemetry_cert(
+        "ndastreamingservertest", "streamingtelemetryserver.cer", "streamingtelemetryserver.key",
+    )
+    _mint_self_signed_telemetry_cert(
+        "ndastreamingclienttest", "dsmsroot.cer", "dsmsroot.key",
+    )
 
     # Rotate certs
     duthost.copy(src="streamingtelemetryserver.cer", dest=path)


### PR DESCRIPTION
### Description of PR
202511 backport of #24607 ("Use cryptography library to add buffer for notBefore field to gnmi/telemetry certs"), which is the structural fix for the cert-not-yet-valid clock-skew family of nightly failures.

#24607 is already merged on master (commit `b951195c6`). The auto-cherry-pick bot did not open a backport PR because of conflicts in `tests/common/helpers/gnmi_utils.py` and `tests/telemetry/telemetry_utils.py`.

### Why a clean cherry-pick wasn't possible

202511 was missing the prerequisite refactor #15770 ("[gnmi] add test to use gnmi certificate after 2038 year problem", merged to master 2025-12-18), which extracted the inline `openssl` shell calls inside `create_gnmi_certs` into separate `prepare_root_cert` / `sign_server_certificate` / `sign_client_certificate` helpers. Without that refactor, #24607 has nothing to convert. So this PR is two clean cherry-picks plus a one-line lint fix:

1. `4f95e85c7` — cherry-pick #15770. Conflict in `tests/gnmi/conftest.py` resolved by taking the post-refactor import list. Also brings `tests/gnmi/test_gnmi_2038.py`.
2. `c89ea4bca` — cherry-pick #24607. Conflict in `tests/telemetry/telemetry_utils.py::rotate_telemetry_certs` resolved by taking the new `_mint_self_signed_telemetry_cert` calls.
3. `4e2d1381b` — drop the unused `GNMIEnvironment` import from `tests/gnmi/conftest.py` (master fixed this same lint issue later in #22553, which we are not pulling).

### What this fixes (after merge)

The cert-not-yet-valid family of PBIs — every cert-skew failure currently filed against `internal-202511` / `20251110.*` builds:

- 38147607, 38147626, 38147616, 38023433, 37940586, 37924369, 38330763, 36656668, plus sibling 37430686 (Cisco-8101).

After this lands, the next nightly off `internal-202511.20251110.NN` should green up these tests; the underlying TLS handshake will no longer fail with "certificate is not yet valid" because notBefore is backdated 7 days in the test PKI.

### Local checks

- `python -m py_compile` on every touched file ✓
- `flake8 --max-line-length=120` on every touched file ✓
- All three commits are clean cherry-picks (`-x` annotated) plus one targeted lint fix.

### Type of change

- [x] Bug fix
