### PR TITLE
Ignore error when stopping portchannels services on PTF in renumber_topo

### DIFF
--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -32,6 +32,7 @@
     vars:
       ptf_portchannel_action: stop
     when: "'bmc' not in topo"
+    ignore_errors: yes
 
   - name: Kill exabgp and ptf_nn_agent processes in PTF container
     ptf_control:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This PR is to ignore the error when stopping portchannels services on PTF in renumber_topo.
The error could happen if the ptf container was created with an old sonic-mgmt branch. The error message is as below
```
 FAILED! => {"changed": false, "module_stderr": "OpenSSH_9.6p1 Ubuntu-3ubuntu13.16, OpenSSL 3.0.13 30 Jan 2024\r\ndebug1: Reading configuration data /etc/ssh/ssh_config\r\ndebug1: /etc/ssh/ssh_config line 19: include /etc/ssh/ssh_config.d/*.conf matched no files\r\ndebug1: /etc/ssh/ssh_config line 21: Applying options for *\r\ndebug2: resolve_canonicalize: hostname  is address\r\ndebug1: auto-mux: Trying existing master at '/home/AzDevOps/.ansible/cp/1c90b0574f'\r\ndebug2: fd 3 setting O_NONBLOCK\r\ndebug2: mux_client_hello_exchange: master version 4\r\ndebug1: mux_client_request_session: master session id: 2\r\nTraceback (most recent call last):\n  File \"<stdin>\", line 107, in <module>\n  File \"<stdin>\", line 99, in _ansiballz_main\n  File \"<stdin>\", line 44, in invoke_module\n  File \"/tmp/ansible_ptf_portchannel_payload_ccYvyT/ansible_ptf_portchannel_payload.zip/ansible/module_utils/basic.py\", line 17\n    msg=f\"ansible-core requires a minimum of Python version {'.'.join(map(str, _PY_MIN))}. Current version: {''.join(sys.version.splitlines())}\",\n                                                                                                                                               ^\nSyntaxError: invalid syntax\ndebug2: Received exit status from master 1\r\n", "module_stdout": "", "msg": "MODULE FAILURE: No start of json char found\nSee stdout/stderr for the exact error", "rc": 1}

```
It's safe to ignore as the ptf container is going to be removed.

Summary:
Ignore error when stopping portchannels services on PTF in renumber_topo

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
This PR is to improve the implementation of `restart-ptf`.

#### How did you do it?
Ignore error when stopping portchannels services on PTF in renumber_topo.

#### How did you verify/test it?
The change is verified by running `restart-topo` on a physical testbed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
