### PR TITLE
[smartswitch]: Harden DPU startup/shutdown retries

### DIFF
--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -253,6 +253,17 @@ def check_dpu_module_status(duthost, power_status, dpu_name):
             return False
 
 
+def _wait_for_dpu_status(duthost, dpu_name, expected_status, action):
+    """
+    Poll until the DPU module reaches *expected_status* ('on' or 'off').
+    """
+    pytest_assert(
+        wait_until(DPU_MAX_ONLINE_TIMEOUT, DPU_TIME_INT, 0,
+                   check_dpu_module_status, duthost, expected_status, dpu_name),
+        f"DPU {dpu_name} is not {expected_status} after '{action}'"
+    )
+
+
 def check_dpus_module_status(duthost, dpu_list, power_status, wait_timeout=30):
     """
     Check module status of given DPU list
@@ -789,34 +800,28 @@ def dpus_shutdown_and_check(duthost, dpu_list, num_dpu_modules):
                 duthost.shell,
                 f"sudo config chassis modules shutdown {dpu_name}"
             )
-            executor.submit(
-                wait_until, DPU_MAX_ONLINE_TIMEOUT, DPU_TIME_INT, 0,
-                check_dpu_module_status, duthost, "off", dpu_name
-            )
+            executor.submit(_wait_for_dpu_status, duthost, dpu_name, "off", "shutdown")
 
 
 def dpus_startup_and_check(duthost, dpu_list, num_dpu_modules):
     """
-    Parallely Execute DPU startup for given DPU list
+    Serialize DPU startup for given DPU list
     Waits and checks parallely whether DPU is actually UP
     Args:
        duthost: Host handle
        dpu_list: List of DPUs to be startup
-
+       num_dpu_modules: number of dpu modules
     Returns:
        Returns Nothing
     """
+    logging.info("Dispatching startup commands for DPUs serially")
+    for dpu_name in dpu_list:
+        duthost.shell(f"sudo config chassis modules startup {dpu_name}")
+
     with SafeThreadPoolExecutor(max_workers=num_dpu_modules) as executor:
         logging.info("Check startup of DPUs in parallel")
         for dpu_name in dpu_list:
-            executor.submit(
-                duthost.shell,
-                f"sudo config chassis modules startup {dpu_name}"
-            )
-            executor.submit(
-                wait_until, DPU_MAX_ONLINE_TIMEOUT, DPU_TIME_INT, 0,
-                check_dpu_module_status, duthost, "on", dpu_name
-            )
+            executor.submit(_wait_for_dpu_status, duthost, dpu_name, "on", "startup")
 
 
 def check_midplane_status(duthost, dpu_ip, expected_status):


### PR DESCRIPTION
### Description of PR
Summary:
Fix transient SSH connection failures during mass DPU startup by serializing command dispatch and parallelizing status polling. Addresses sshd MaxStartups limit (default 10:30:100) that randomly drops unauthenticated sessions when too many are opened simultaneously.
Fixes # (issue): N/A

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
During mass DPU startup, `SafeThreadPoolExecutor` submits startup commands in parallel, each opening a new SSH connection. When too many unauthenticated sessions are in-flight simultaneously, sshd's MaxStartups limit causes it to randomly drop connections, triggering transient `pytest_ansible.errors.AnsibleConnectionFailure` ("Host unreachable in the inventory").

#### How did you do it?

- Added `_wait_for_dpu_status()` helper to encapsulate the repeated wait_until(`check_dpu_module_status`) pattern for module state polling.
- Refactored `dpus_startup_and_check()` to split work into two phases:
- Serial dispatch: Startup commands sent one at a time in a plain for loop (at most one SSH session open at a time).
- Parallel wait: Status checks submitted to `SafeThreadPoolExecutor`, preserving parallelism for the slow polling phase.
- Updated `dpus_shutdown_and_check()` to use the `_wait_for_dpu_status()` helper.

#### How did you verify/test it?
- Verified the test by running tests/smartswitch/platform_tests/test_reload_dpu.py::test_dpu_status_post_dpu_kernel_panic on a smartswitch

#### Any platform specific information?
This change targets SmartSwitch DPU platform tests where multiple DPUs are transitioned in parallel.

#### Supported testbed topology if it's a new test case?
N/A (not a new test case).

### Documentation
No documentation update required (test helper robustness change only).