### PR TITLE
xfail test_bgp_route_with_suppress vrf testing for TH6

### DIFF
--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -1038,8 +1038,8 @@ def test_bgp_route_with_suppress(duthosts, enum_downstream_dut_hostname, enum_up
                                  request, loganalyzer):
     duthost = duthosts[enum_upstream_dut_hostname]
     asic_name = duthost.get_asic_name()
-    if vrf_type == USER_DEFINED_VRF and asic_name == 'th5':
-        pytest.xfail("vrf testing not supported on TH5")
+    if vrf_type == USER_DEFINED_VRF and asic_name in ("th5", "th6"):
+        pytest.xfail("vrf testing not supported on TH5/6")
 
     duthost_down = duthosts[enum_downstream_dut_hostname]
     duthost_up = duthosts[enum_upstream_dut_hostname]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Same as for TH5, xfailing the test while support is under development for TH6 chips. Note that this is contingent the asic matching that is added in https://github.com/sonic-net/sonic-mgmt/pull/23633 


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Same as for TH5, xfailing the test while support is under development for TH6 chips

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
