### PR TITLE
[tgen] Add dRH tgen route convergence topology and fix TSB for RH topos

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -1352,10 +1352,10 @@
 
         when: "'dualtor-mixed' in topo or 'dualtor-aa' in topo"
 
-      - name: execute "TSB" on T2 DUTs
+      - name: execute "TSB" on T2/RH DUTs
         become: True
         shell: "TSB"
-        when: "'t2' in topo"
+        when: "'t2' in topo or 'rh' in topo"
 
       - name: execute cli "config save -y" to save current minigraph as startup-config
         become: true

--- a/ansible/vars/topo_drh_tgen_route_conv.yml
+++ b/ansible/vars/topo_drh_tgen_route_conv.yml
@@ -1,0 +1,449 @@
+topology:
+  # dRH (Disaggregated Regional Hub) tgen route convergence topology
+  # 1 DUT (LowerRegionalHub) with 16 uplink ports to IXIA/tgen
+  # IXIA emulates UpperRegionalHub neighbors via PortChannels
+  #
+  # No downlink ports (FRH/LT2 not included in this topo)
+
+  dut_num: 1
+  VMs:
+    # Uplink ports - via Fanout to Ixia (T3/Spine emulation)
+    Snappi_URH_1:
+      vlans:
+        - 32
+      vm_offset: 0
+    Snappi_URH_2:
+      vlans:
+        - 33
+      vm_offset: 1
+    Snappi_URH_3:
+      vlans:
+        - 34
+      vm_offset: 2
+    Snappi_URH_4:
+      vlans:
+        - 35
+      vm_offset: 3
+    Snappi_URH_5:
+      vlans:
+        - 36
+      vm_offset: 4
+    Snappi_URH_6:
+      vlans:
+        - 37
+      vm_offset: 5
+    Snappi_URH_7:
+      vlans:
+        - 38
+      vm_offset: 6
+    Snappi_URH_8:
+      vlans:
+        - 39
+      vm_offset: 7
+    Snappi_URH_9:
+      vlans:
+        - 40
+      vm_offset: 8
+    Snappi_URH_10:
+      vlans:
+        - 41
+      vm_offset: 9
+    Snappi_URH_11:
+      vlans:
+        - 42
+      vm_offset: 10
+    Snappi_URH_12:
+      vlans:
+        - 43
+      vm_offset: 11
+    Snappi_URH_13:
+      vlans:
+        - 44
+      vm_offset: 12
+    Snappi_URH_14:
+      vlans:
+        - 45
+      vm_offset: 13
+    Snappi_URH_15:
+      vlans:
+        - 46
+      vm_offset: 14
+    Snappi_URH_16:
+      vlans:
+        - 47
+      vm_offset: 15
+
+  DUT:
+    loopback:
+      ipv4:
+        - 10.1.0.1/32
+      ipv6:
+        - FC00:10::1/128
+
+configuration_properties:
+  common:
+    podset_number: 400
+    tor_number: 16
+    tor_subnet_number: 8
+    max_tor_subnet_number: 32
+    tor_subnet_size: 128
+    dut_asn: 65100
+    dut_type: LowerRegionalHub
+    nhipv4: 10.10.246.254
+    nhipv6: FC0A::FF
+  core:
+    swrole: core
+
+configuration:
+  Snappi_URH_1:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.3.1.0
+          - 2000:1:1:1::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 20.3.1.1/31
+        ipv6: 2000:1:1:1::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_URH_2:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.4.1.0
+          - 2000:1:1:2::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.2/32
+        ipv6: 2064:100::2/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 20.4.1.1/31
+        ipv6: 2000:1:1:2::2/126
+    bp_interface:
+      ipv4: 10.10.246.2/24
+      ipv6: fc0a::3/64
+  Snappi_URH_3:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.5.1.0
+          - 2000:1:1:3::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.3/32
+        ipv6: 2064:100::3/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 20.5.1.1/31
+        ipv6: 2000:1:1:3::2/126
+    bp_interface:
+      ipv4: 10.10.246.3/24
+      ipv6: fc0a::4/64
+  Snappi_URH_4:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.6.1.0
+          - 2000:1:1:4::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.4/32
+        ipv6: 2064:100::4/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 20.6.1.1/31
+        ipv6: 2000:1:1:4::2/126
+    bp_interface:
+      ipv4: 10.10.246.4/24
+      ipv6: fc0a::5/64
+  Snappi_URH_5:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.7.1.0
+          - 2000:1:1:5::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.5/32
+        ipv6: 2064:100::5/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 20.7.1.1/31
+        ipv6: 2000:1:1:5::2/126
+    bp_interface:
+      ipv4: 10.10.246.5/24
+      ipv6: fc0a::6/64
+  Snappi_URH_6:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.8.1.0
+          - 2000:1:1:6::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.6/32
+        ipv6: 2064:100::6/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 20.8.1.1/31
+        ipv6: 2000:1:1:6::2/126
+    bp_interface:
+      ipv4: 10.10.246.6/24
+      ipv6: fc0a::7/64
+  Snappi_URH_7:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.9.1.0
+          - 2000:1:1:7::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.7/32
+        ipv6: 2064:100::7/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 20.9.1.1/31
+        ipv6: 2000:1:1:7::2/126
+    bp_interface:
+      ipv4: 10.10.246.7/24
+      ipv6: fc0a::8/64
+  Snappi_URH_8:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.10.1.0
+          - 2000:1:1:8::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.8/32
+        ipv6: 2064:100::8/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 20.10.1.1/31
+        ipv6: 2000:1:1:8::2/126
+    bp_interface:
+      ipv4: 10.10.246.8/24
+      ipv6: fc0a::9/64
+  Snappi_URH_9:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.11.1.0
+          - 2000:1:1:9::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.9/32
+        ipv6: 2064:100::9/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 20.11.1.1/31
+        ipv6: 2000:1:1:9::2/126
+    bp_interface:
+      ipv4: 10.10.246.9/24
+      ipv6: fc0a::a/64
+  Snappi_URH_10:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.12.1.0
+          - 2000:1:1:a::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.10/32
+        ipv6: 2064:100::a/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 20.12.1.1/31
+        ipv6: 2000:1:1:a::2/126
+    bp_interface:
+      ipv4: 10.10.246.10/24
+      ipv6: fc0a::b/64
+  Snappi_URH_11:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.13.1.0
+          - 2000:1:1:b::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.11/32
+        ipv6: 2064:100::b/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 20.13.1.1/31
+        ipv6: 2000:1:1:b::2/126
+    bp_interface:
+      ipv4: 10.10.246.11/24
+      ipv6: fc0a::c/64
+  Snappi_URH_12:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.14.1.0
+          - 2000:1:1:c::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.12/32
+        ipv6: 2064:100::c/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 20.14.1.1/31
+        ipv6: 2000:1:1:c::2/126
+    bp_interface:
+      ipv4: 10.10.246.12/24
+      ipv6: fc0a::d/64
+  Snappi_URH_13:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.15.1.0
+          - 2000:1:1:d::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.13/32
+        ipv6: 2064:100::d/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 20.15.1.1/31
+        ipv6: 2000:1:1:d::2/126
+    bp_interface:
+      ipv4: 10.10.246.13/24
+      ipv6: fc0a::e/64
+  Snappi_URH_14:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.16.1.0
+          - 2000:1:1:e::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.14/32
+        ipv6: 2064:100::e/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 20.16.1.1/31
+        ipv6: 2000:1:1:e::2/126
+    bp_interface:
+      ipv4: 10.10.246.14/24
+      ipv6: fc0a::f/64
+  Snappi_URH_15:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.17.1.0
+          - 2000:1:1:f::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.15/32
+        ipv6: 2064:100::f/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 20.17.1.1/31
+        ipv6: 2000:1:1:f::2/126
+    bp_interface:
+      ipv4: 10.10.246.15/24
+      ipv6: fc0a::10/64
+  Snappi_URH_16:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.18.1.0
+          - 2000:1:1:10::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.16/32
+        ipv6: 2064:100::10/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 20.18.1.1/31
+        ipv6: 2000:1:1:10::2/126
+    bp_interface:
+      ipv4: 10.10.246.16/24
+      ipv6: fc0a::11/64


### PR DESCRIPTION
### Description of PR
Summary:
Add `topo_drh_tgen_route_conv.yml` for disaggregated Regional Hub (dRH) BGP route convergence testing with IXIA/tgen, and fix the TSB step in deploy-mg for Regional Hub topologies.

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

1. **New topology**: The dRH (disaggregated Regional Hub) architecture introduces new device roles (`LowerRegionalHub`, `UpperRegionalHub`, `FabricRegionalHub`). A tgen route convergence topology is needed to test BGP RIB-IN performance on these roles using IXIA/snappi.

2. **TSB bug fix**: The `deploy-mg` playbook runs TSB only for topos containing `t2` in the name. Regional Hub topos (`drh_*`, `lrh_*`, `urh_*`) were missed, leaving devices in TSA mode with all BGP neighbors shutdown after deploy-mg.

#### How did you do it?

1. Added `ansible/vars/topo_drh_tgen_route_conv.yml`:
   - DUT type: `LowerRegionalHub` (single-ASIC)
   - 16 uplink ports (Ethernet128-188, stride 4) connected to IXIA via PortChannels
   - IXIA emulates 16 `UpperRegionalHub` neighbors (ASN 65400)

2. Fixed TSB condition in `ansible/config_sonic_basedon_testbed.yml`:
   - Changed `when: "t2 in topo"` to `when: "t2 in topo or rh in topo"`
   - Covers all Regional Hub topos: `drh_*`, `lrh_*`, `urh_*`

#### How did you verify/test it?

- Topology tested on physical hardware with IXIA chassis
- TSB fix verified: BGP neighbors come up after deploy-mg on dRH testbed
- Without fix: device stays in TSA, all neighbors remain shutdown

#### Any platform specific information?

Topology is platform-agnostic.

#### Supported testbed topology if it is a new test case?

Not a test case — this is a topology definition file + framework fix.

### Documentation
N/A