### PR TITLE
[ansible] Fix conn_graph_facts 'No module named module_utils' under ansible-core 2.21

### DIFF
--- a/ansible/module_utils/debug_utils.py
+++ b/ansible/module_utils/debug_utils.py
@@ -1,7 +1,7 @@
 import os
 import re
 import logging
-from ansible.module_utils.basic import datetime
+import datetime
 
 MAX_LOG_FILES_PER_MODULE = 10
 


### PR DESCRIPTION
### Description of PR

Summary:
Fixes the testbed preparation failure `Read duts minigraph` -> `ADD_TOPOLOGY_FAILED` that appears once `docker-sonic-mgmt` uses an unpinned ansible (ansible-core 2.21).

The `conn_graph_facts` ansible module (used by `ansible/testbed_add_vm_topology.yml`) imports `config_module_logging` from `ansible/module_utils/debug_utils.py`, which does:

```python
from ansible.module_utils.basic import datetime
```

`datetime` is not a real attribute of `ansible.module_utils.basic` - it was only exposed via a deprecated `__getattr__` compatibility shim (deprecation `version="2.21"`) that exists in ansible-core 2.18/2.19/2.20 but was **removed in ansible-core 2.21**.

Under ansible-core 2.21 this import raises `ImportError`, so `conn_graph_facts.py` and `graph_utils.py` fall through to their `except ImportError` fallback (`from module_utils... import`, intended only for running the file standalone outside ansible). Inside the AnsiballZ payload there is no top-level `module_utils` package, so it fails with:

```
[ERROR]: Task failed: Module failed: No module named 'module_utils'
```

Fix: import the standard-library `datetime` module directly. This is version-independent and does not rely on any ansible re-export, so it works on every ansible-core version (no ansible/ansible-core version pin required).

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
`docker-sonic-mgmt` recently unpinned ansible (PR sonic-net/sonic-buildimage#27301), so the image now installs ansible-core 2.21. The removed `ansible.module_utils.basic` re-export of `datetime` breaks testbed preparation (`conn_graph_facts`), failing kvm `Prepare Testbed` with `No module named 'module_utils'`.

#### How did you do it?
Changed `ansible/module_utils/debug_utils.py` to `import datetime` (stdlib) instead of `from ansible.module_utils.basic import datetime`. A repo-wide scan confirmed this is the only place relying on the removed shim.

#### How did you verify/test it?
- Verified against ansible-core 2.21 in a clean venv: the old import is no longer available, while the patched module imports cleanly and `datetime.datetime.now().isoformat()` (the only usage in `config_module_logging`) works.
- Confirmed by source inspection that the `__getattr__` shim exposing `datetime` is present in ansible stable-2.18/2.19/2.20 and absent in 2.21.

#### Any platform specific information?
None. Pure ansible module-utils fix; no platform dependency.

#### Supported testbed topology if it's a new test case?
N/A
