### PR TITLE
[elastictest] Plumb DPU_IMAGE_URL through to the test plan image config

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -85,6 +85,10 @@ parameters:
     type: string
     default: ""
 
+  - name: DPU_IMAGE_URL
+    type: string
+    default: ""
+
   - name: UPGRADE_IMAGE_PARAM
     type: string
     default: ""
@@ -304,6 +308,7 @@ steps:
       --ptf_image_tag ${{ parameters.PTF_IMAGE_TAG }} \
       --ptf-modified ${{ parameters.PTF_MODIFIED }} \
       --image_url ${{ parameters.IMAGE_URL }} \
+      --dpu_image_url ${{ parameters.DPU_IMAGE_URL }} \
       --upgrade-image-param="${{ parameters.UPGRADE_IMAGE_PARAM }}" \
       --hwsku ${{ parameters.HWSKU }} \
       --test-plan-type ${{ parameters.TEST_PLAN_TYPE }} \

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -370,6 +370,7 @@ class TestPlanManager(object):
                 "ptf_modified": ptf_modified,
                 "image": {
                     "url": image_url,
+                    "dpu_url": kwargs.get("dpu_image_url", None),
                     "upgrade_image_param": kwargs.get("upgrade_image_param", None),
                     "release": "",
                     "kvm_image_build_id": kvm_image_build_id,
@@ -870,6 +871,16 @@ if __name__ == "__main__":
         help="Image url"
     )
     parser_create.add_argument(
+        "--dpu_image_url",
+        type=str,
+        dest="dpu_image_url",
+        nargs='?',
+        const=None,
+        default=None,
+        required=False,
+        help="SONiC image url for DPU upgrade on SmartSwitch testbeds"
+    )
+    parser_create.add_argument(
         "--upgrade-image-param",
         type=str,
         dest="upgrade_image_param",
@@ -1220,6 +1231,7 @@ if __name__ == "__main__":
                     ptf_image_tag=args.ptf_image_tag,
                     ptf_modified=args.ptf_modified,
                     image_url=args.image_url,
+                    dpu_image_url=args.dpu_image_url,
                     upgrade_image_param=args.upgrade_image_param,
                     hwsku=args.hwsku,
                     test_plan_type=args.test_plan_type,


### PR DESCRIPTION
### Description of PR

Summary:
Plumb a new `DPU_IMAGE_URL` parameter through the Elastictest nightly flow so that SmartSwitch DPU images can be upgraded during nightly tests. This is the test-plan-creation counterpart to #23915, which added the `--dpu-url` argument to `.azure-pipelines/upgrade_image.py`.

The Elastictest scheduler reads `test_option.image.dpu_url` from the test plan and, when present, passes it to `upgrade_image.py --dpu-url` (the scheduler additionally guards on whether the checked-out `upgrade_image.py` supports the argument). This PR wires the value from the pipeline parameter down into the test plan `image` block.

Changes:
- `.azure-pipelines/test_plan.py`: add a `--dpu_url` argument and include `image.dpu_url` in the generated test plan JSON (mirrors the existing `--image_url`/`image.url`).
- `.azure-pipelines/run-test-elastictest-template.yml`: add a `DPU_IMAGE_URL` template parameter and pass it to `test_plan.py create` via `--dpu_url`.

When `DPU_IMAGE_URL` is not set, behavior is unchanged (the argument resolves to its `nargs='?'` `const`, exactly like `IMAGE_URL`).

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
SmartSwitch testbeds run independent SONiC instances on their DPUs. #23915 added the ability for `upgrade_image.py` to upgrade DPU images via `--dpu-url`, but there was no way to supply that URL through the Elastictest nightly pipeline. This PR adds that plumbing.

#### How did you do it?
Added a `--dpu_url` arg to `test_plan.py` and a `DPU_IMAGE_URL` parameter to the nightly Elastictest template, carrying the value into the test plan `image.dpu_url` field consumed by the scheduler.

#### How did you verify/test it?
- `python3 -m py_compile .azure-pipelines/test_plan.py`
- `python3 .azure-pipelines/test_plan.py create --help` shows the new `--dpu_url` argument.
- Confirmed the generated test plan `image` block includes `dpu_url`.

#### Any platform specific information?
Only affects SmartSwitch testbeds that set `DPU_IMAGE_URL`. No change in behavior when the parameter is empty.

### Documentation
N/A
