### PR TITLE
[test_pretest] Fix saithrift switch_sai_thrift import on Trixie (py3.13) PTF

### DIFF
--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -524,13 +524,30 @@ def test_update_saithrift_ptf(request, ptfhost, duthosts, enum_dut_hostname):
     if result["failed"] or "OK" not in result["msg"]:
         pytest.fail("Download failed/error while installing python saithrift package: {}".format(py_saithrift_url))
     ptfhost.shell("dpkg -i {}".format(os.path.join("/root", pkg_name)))
-    # In 202405 branch, the switch_sai_thrift package is inside saithrift-0.9-py3.11.egg
-    # We need to move it out to the correct location
-    PY_PATH = "/usr/lib/python3/dist-packages/"
-    SRC_PATH = PY_PATH + "saithrift-0.9-py3.11.egg/switch_sai_thrift"
-    DST_PATH = PY_PATH + "switch_sai_thrift"
-    if ptfhost.stat(path=SRC_PATH)['stat']['exists'] and not ptfhost.stat(path=DST_PATH)['stat']['exists']:
-        ptfhost.copy(src=SRC_PATH, dest=PY_PATH, remote_src=True)
+    # The saithrift deb installs switch_sai_thrift inside an egg dir named for the
+    # Python version it was built against (e.g. saithrift-0.9-py3.11.egg on
+    # bookworm/OS12, saithrift-0.9-py3.13.egg on trixie/OS13). The PTF runs from its
+    # own virtualenv (/root/env-python3) whose sys.path references that egg dir via
+    # easy-install.pth; dpkg does NOT update the .pth when the egg version changes,
+    # so switch_sai_thrift becomes unimportable when the image's Python version
+    # differs from the PTF's (e.g. a trixie/py3.13 deb on a bookworm/py3.11 PTF).
+    # Locate the actual egg (any py3.x) and copy switch_sai_thrift into the PTF
+    # virtualenv's site-packages, which is always on the runner's sys.path.
+    PY_PATH = "/usr/lib/python3/dist-packages"
+    egg_switch_sai = ptfhost.shell(
+        "ls -d {}/saithrift-0.9-py3.*.egg/switch_sai_thrift 2>/dev/null | head -1".format(PY_PATH),
+        module_ignore_errors=True,
+    )["stdout"].strip()
+    if egg_switch_sai:
+        # Prefer the PTF virtualenv site-packages (always on the ptf_runner sys.path);
+        # fall back to the system dist-packages if the virtualenv is absent.
+        site_dir = ptfhost.shell(
+            "/root/env-python3/bin/python -c "
+            "'import sysconfig; print(sysconfig.get_paths()[\"purelib\"])'",
+            module_ignore_errors=True,
+        )["stdout"].strip() or PY_PATH
+        ptfhost.shell("rm -rf {}/switch_sai_thrift".format(site_dir), module_ignore_errors=True)
+        ptfhost.copy(src=egg_switch_sai, dest=site_dir + "/", remote_src=True)
     logging.info("Python saithrift package installed successfully")
 
 


### PR DESCRIPTION
### Description of PR

Summary:
Fix `test_update_saithrift_ptf` so the `switch_sai_thrift` PTF bindings remain importable on Debian 13 (Trixie / OS13) images, where every `qos/test_qos_sai.py` (and `qos/test_qos_probe.py`) case currently errors out at setup with `ModuleNotFoundError: No module named 'switch_sai_thrift'`.

Fixes # (N/A)

ADO: https://msazure.visualstudio.com/One/_workitems/edit/38477068

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

After `dpkg -i` of the `python-saithrift` deb, `test_update_saithrift_ptf` relocated `switch_sai_thrift` out of an egg dir whose name was **hardcoded to `saithrift-0.9-py3.11.egg`**, and copied it to the bare `/usr/lib/python3/dist-packages`.

The egg dir name encodes the Python version the deb was built against. The PTF (`docker-ptf`) is still Debian 12 Bookworm (python **3.11**), but SONiC images moved to Debian 13 Trixie (python **3.13**), so the Trixie saithrift deb installs `saithrift-0.9-py3.13.egg` and `dpkg` removes the old `py3.11` egg that the PTF virtualenv's `easy-install.pth` references. Two problems result:

1. the hardcoded `py3.11` egg path no longer exists (it's `py3.13`), so the relocation is skipped; and
2. the copy target (`/usr/lib/python3/dist-packages`) is **not** on the PTF virtualenv (`/root/env-python3`) `sys.path` — only the specific egg dir is, via `easy-install.pth`.

Net effect: `import switch_sai_thrift` fails inside the PTF runner, so all saithrift-RPC qos tests (`ReleaseAllPorts` fixture) error at setup on every Trixie/OS13 image.

#### How did you do it?

- Glob the **actual** installed egg (`saithrift-0.9-py3.*.egg`) instead of hardcoding `py3.11`, so it works for `py3.13` (Trixie) and any future Python version.
- Copy `switch_sai_thrift` into the PTF virtualenv's **site-packages** (resolved dynamically via `sysconfig`), which is always on the `ptf_runner` `sys.path`; fall back to the system `dist-packages` if the virtualenv is absent.
- `rm -rf` the destination first so re-runs replace stale bindings cleanly.

The `switch_sai_thrift` thrift bindings are pure Python (no compiled extension), so a py3.11 PTF imports the py3.13-built modules without issue.

#### How did you verify/test it?

- Reproduced the failure and the fix end-to-end inside the exact `docker-ptf` image: `dpkg -i` of the Trixie py3.13 deb broke `import switch_sai_thrift`; after the new relocation it imports successfully (`switch_sai_rpc`, `ttypes`, `constants`, `sai_headers`).
- Verified backward compatibility on a Bookworm/py3.11 PTF: the `py3.*` glob matches the `py3.11` egg and the import still works.
- Ran `qos` on real Arista 7060CX hardware with this change: `qos/test_qos_sai.py` (16 passed / 0 failed) and `qos/test_qos_probe.py` (8 passed / 0 failed) both pass, where they previously errored with 27 / 14 `switch_sai_thrift` setup errors respectively.
- `flake8` clean, `py_compile` OK.

#### Any platform specific information?

Affects any Debian 13 (Trixie / OS13) image whose saithrift deb is built for a different Python version than the `docker-ptf` (currently Bookworm / py3.11). No platform-specific code; the relocation is version-agnostic.

#### Supported testbed topology if it's a new test case?

N/A — bug fix to an existing pretest helper.

### Documentation

N/A