### PR TITLE
[fib] Skip ip-proto hash test for single-node VoQ topologies

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -375,51 +375,62 @@ def get_vlan_untag_ports(duthosts, duts_running_config_facts):
 
 @pytest.fixture(scope="module")
 def hash_keys(duthost, tbinfo):
-    asic_type = duthost.facts['asic_type']
-    platform = duthost.facts['platform']
-    topo_name = tbinfo['topo']['name']
-
-    # Keys to drop from the global list for this platform/topology combination
-    keys_to_remove = {'dst-mac'}
+    # Copy from global var to avoid side effects of multiple iterations
+    hash_keys = HASH_KEYS[:]
+    if 'dst-mac' in hash_keys:
+        hash_keys.remove('dst-mac')
 
     # do not test load balancing on L4 port on vs platform as kernel 4.9
     # can only do load balance base on L3
-    if asic_type == "vs":
-        keys_to_remove.update(['src-port', 'dst-port'])
-
-    # ASICs/platforms that don't support ip-proto as a hash key
-    # (removing ip-proto from hash_keys not supported by Marvell SAI for nokia ixs7215)
-    if asic_type in ["vpp", "mellanox", "barefoot", "marvell-teralynx", "cisco-8000"] \
-            or platform == 'armhf-nokia_ixs7215_52x-r0':
-        keys_to_remove.add('ip-proto')
-
-    # ASICs/platforms that don't support ingress-port as a hash key
-    if asic_type in ["vpp", "barefoot"] or platform == 'armhf-nokia_ixs7215_52x-r0':
-        keys_to_remove.add('ingress-port')
-
-    # ft2 fabric topos don't have enough entropy in the 8-bit ip-proto field
-    # to evenly distribute packets across all egress ports
-    if 'ft2' in topo_name:
-        keys_to_remove.add('ip-proto')
-
-    # Single-node VoQ topologies (ut2) also lack enough ip-proto entropy to hit
-    # all egress ports. These are identified by an "Upper" dut_type
-    # (UpperSpineRouter, UpperRegionalHub) in the topology definition.
+    if duthost.facts['asic_type'] in ["vs"]:
+        if 'src-port' in hash_keys:
+            hash_keys.remove('src-port')
+        if 'dst-port' in hash_keys:
+            hash_keys.remove('dst-port')
+    if duthost.facts['asic_type'] in ["vpp"]:
+        if 'ip-proto' in hash_keys:
+            hash_keys.remove('ip-proto')
+        if 'ingress-port' in hash_keys:
+            hash_keys.remove('ingress-port')
+    if duthost.facts['asic_type'] in ["mellanox"]:
+        if 'ip-proto' in hash_keys:
+            hash_keys.remove('ip-proto')
+    if duthost.facts['asic_type'] in ["barefoot"]:
+        if 'ingress-port' in hash_keys:
+            hash_keys.remove('ingress-port')
+        if 'ip-proto' in hash_keys:
+            hash_keys.remove('ip-proto')
+    # removing ingress-port and ip-proto from hash_keys not supported by Marvell SAI
+    if duthost.facts['platform'] in ['armhf-nokia_ixs7215_52x-r0']:
+        if 'ip-proto' in hash_keys:
+            hash_keys.remove('ip-proto')
+        if 'ingress-port' in hash_keys:
+            hash_keys.remove('ingress-port')
+    if duthost.facts['asic_type'] in ["marvell-teralynx", "cisco-8000"]:
+        if 'ip-proto' in hash_keys:
+            hash_keys.remove('ip-proto')
+    if 'ft2' in tbinfo['topo']['name']:
+        #  Remove ip-proto from hash_keys for FT2 as there is not enough entropy in ip-proto
+        #  to ensure packets are evenly distributed to all 64 egress ports
+        if 'ip-proto' in hash_keys:
+            hash_keys.remove('ip-proto')
+    # Single-node VoQ (ut2) topologies don't have enough entropy in the 8-bit
+    # ip-proto field to get a good distribution across all egress ports. These
+    # are identified by an "Upper" dut_type (UpperSpineRouter, UpperRegionalHub).
     dut_type = tbinfo['topo'].get('properties', {}) \
         .get('configuration_properties', {}).get('common', {}).get('dut_type', '')
     if dut_type.startswith('Upper'):
-        keys_to_remove.add('ip-proto')
-
+        if 'ip-proto' in hash_keys:
+            hash_keys.remove('ip-proto')
     # remove the ingress port from multi asic platform
     # In multi asic platform each asic has different hash seed,
     # the same packet coming in different asic
     # could egress out of different port
     # the hash_test condition for hash_key == ingress_port will fail
     if duthost.sonichost.is_multi_asic:
-        keys_to_remove.add('ingress-port')
+        hash_keys.remove('ingress-port')
 
-    # Copy from global var to avoid side effects of multiple iterations
-    return [key for key in HASH_KEYS if key not in keys_to_remove]
+    return hash_keys
 
 
 def configure_vlan(duthost, ports):

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -375,59 +375,51 @@ def get_vlan_untag_ports(duthosts, duts_running_config_facts):
 
 @pytest.fixture(scope="module")
 def hash_keys(duthost, tbinfo):
-    # Copy from global var to avoid side effects of multiple iterations
-    hash_keys = HASH_KEYS[:]
-    if 'dst-mac' in hash_keys:
-        hash_keys.remove('dst-mac')
+    asic_type = duthost.facts['asic_type']
+    platform = duthost.facts['platform']
+    topo_name = tbinfo['topo']['name']
+
+    # Keys to drop from the global list for this platform/topology combination
+    keys_to_remove = {'dst-mac'}
 
     # do not test load balancing on L4 port on vs platform as kernel 4.9
     # can only do load balance base on L3
-    if duthost.facts['asic_type'] in ["vs"]:
-        if 'src-port' in hash_keys:
-            hash_keys.remove('src-port')
-        if 'dst-port' in hash_keys:
-            hash_keys.remove('dst-port')
-    if duthost.facts['asic_type'] in ["vpp"]:
-        if 'ip-proto' in hash_keys:
-            hash_keys.remove('ip-proto')
-        if 'ingress-port' in hash_keys:
-            hash_keys.remove('ingress-port')
-    if duthost.facts['asic_type'] in ["mellanox"]:
-        if 'ip-proto' in hash_keys:
-            hash_keys.remove('ip-proto')
-    if duthost.facts['asic_type'] in ["barefoot"]:
-        if 'ingress-port' in hash_keys:
-            hash_keys.remove('ingress-port')
-        if 'ip-proto' in hash_keys:
-            hash_keys.remove('ip-proto')
-    # removing ingress-port and ip-proto from hash_keys not supported by Marvell SAI
-    if duthost.facts['platform'] in ['armhf-nokia_ixs7215_52x-r0']:
-        if 'ip-proto' in hash_keys:
-            hash_keys.remove('ip-proto')
-        if 'ingress-port' in hash_keys:
-            hash_keys.remove('ingress-port')
-    if duthost.facts['asic_type'] in ["marvell-teralynx", "cisco-8000"]:
-        if 'ip-proto' in hash_keys:
-            hash_keys.remove('ip-proto')
-    if 'ft2' in tbinfo['topo']['name']:
-        #  Remove ip-proto from hash_keys for FT2 as there is not enough entropy in ip-proto
-        #  to ensure packets are evenly distributed to all 64 egress ports
-        if 'ip-proto' in hash_keys:
-            hash_keys.remove('ip-proto')
-    if tbinfo['topo']['name'] in ['t2_single_node_max_64p', 't2_single_node_max_64p_v2']:
-        # Remove ip-proto on topos that have 64 ports as there isn't enough entropy in
-        # the ip-proto field (8-bits) to get a good distribution across that many ports
-        if 'ip-proto' in hash_keys:
-            hash_keys.remove('ip-proto')
+    if asic_type == "vs":
+        keys_to_remove.update(['src-port', 'dst-port'])
+
+    # ASICs/platforms that don't support ip-proto as a hash key
+    # (removing ip-proto from hash_keys not supported by Marvell SAI for nokia ixs7215)
+    if asic_type in ["vpp", "mellanox", "barefoot", "marvell-teralynx", "cisco-8000"] \
+            or platform == 'armhf-nokia_ixs7215_52x-r0':
+        keys_to_remove.add('ip-proto')
+
+    # ASICs/platforms that don't support ingress-port as a hash key
+    if asic_type in ["vpp", "barefoot"] or platform == 'armhf-nokia_ixs7215_52x-r0':
+        keys_to_remove.add('ingress-port')
+
+    # ft2 fabric topos don't have enough entropy in the 8-bit ip-proto field
+    # to evenly distribute packets across all egress ports
+    if 'ft2' in topo_name:
+        keys_to_remove.add('ip-proto')
+
+    # Single-node VoQ topologies (ut2) also lack enough ip-proto entropy to hit
+    # all egress ports. These are identified by an "Upper" dut_type
+    # (UpperSpineRouter, UpperRegionalHub) in the topology definition.
+    dut_type = tbinfo['topo'].get('properties', {}) \
+        .get('configuration_properties', {}).get('common', {}).get('dut_type', '')
+    if dut_type.startswith('Upper'):
+        keys_to_remove.add('ip-proto')
+
     # remove the ingress port from multi asic platform
     # In multi asic platform each asic has different hash seed,
     # the same packet coming in different asic
     # could egress out of different port
     # the hash_test condition for hash_key == ingress_port will fail
     if duthost.sonichost.is_multi_asic:
-        hash_keys.remove('ingress-port')
+        keys_to_remove.add('ingress-port')
 
-    return hash_keys
+    # Copy from global var to avoid side effects of multiple iterations
+    return [key for key in HASH_KEYS if key not in keys_to_remove]
 
 
 def configure_vlan(duthost, ports):


### PR DESCRIPTION
### Description of PR

Summary:
`test_hash[ipv4]` fails on single-node VoQ (ut2) topologies because the
8-bit `ip-proto` field doesn't carry enough entropy to spread ECMP traffic
evenly across all egress ports (the IPv6 variant passes because the 128-bit
addresses provide plenty of entropy). This change removes `ip-proto` from the
set of hash keys exercised on these topologies.

Previously this was handled by hardcoding individual topology names
(`t2_single_node_max_64p`, `t2_single_node_max_64p_v2`). This PR instead keys
off the `dut_type` field in the topology definition: single-node VoQ topos use
an "Upper" dut_type (`UpperSpineRouter`, `UpperRegionalHub`), so all current
and future variants are covered without maintaining a topology-name list.

Fixes # (N/A)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ x] 202511
- [ x] 202512
- [ x] 202605

### Approach
#### What is the motivation for this PR?
`test_hash[ipv4]` was failing on single-node VoQ (ut2) topologies. The 8-bit
`ip-proto` field (effectively constant, e.g. TCP=6) has too little entropy to
achieve an even ECMP distribution across the large number of egress ports on
these topologies, so the load-balancing assertion fails. IPv6 is unaffected
because its 128-bit addresses supply enough entropy.

#### How did you do it?
In the `hash_keys` fixture in `tests/fib/test_fib.py`, replaced the hardcoded
list of single-node topology names with a check on the topology's `dut_type`:

```python
dut_type = tbinfo['topo'].get('properties', {}) \
    .get('configuration_properties', {}).get('common', {}).get('dut_type', '')
if dut_type.startswith('Upper'):
    if 'ip-proto' in hash_keys:
        hash_keys.remove('ip-proto')
```

Single-node VoQ topologies (`t2_single_node_*`, `urh_min*`) all declare an
"Upper" dut_type, so this covers them generically. The existing `ft2` handling
is unchanged.

#### How did you verify/test it?
Validated the fixture logic against the actual topology definitions in
`ansible/vars/topo_*.yml`. Confirmed that `ip-proto` is removed for the
single-node VoQ topologies (`UpperSpineRouter` / `UpperRegionalHub`) and the
existing `ft2` case, while it is retained for regular `t0`/`t1`/`t2`
(`ToRRouter` / `LeafRouter` / `SpineRouter`) topologies.

#### Any platform specific information?
Applies to single-node VoQ (ut2) topologies. Detection is purely via the
topology `dut_type`, so no platform/ASIC/hwsku-specific data is referenced.

#### Supported testbed topology if it's a new test case?
N/A (not a new test case).

### Documentation
N/A
