### PR TITLE
[syslog] Wait for expected logs to be forwarded instead of fixed sleep in test_syslog_rate_limit

### DIFF
--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -3,10 +3,11 @@ import logging
 import os
 import pytest
 import random
+import re
 import time
 
 from tests.common.config_reload import config_reload
-from tests.common.utilities import skip_release
+from tests.common.utilities import skip_release, wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.helpers.sonic_db import SonicDbCli
@@ -15,6 +16,8 @@ logger = logging.getLogger(__name__)
 
 RATE_LIMIT_BURST = 100
 RATE_LIMIT_INTERVAL = 10
+SYSLOG_FORWARD_TIMEOUT = 60
+SYSLOG_FORWARD_INTERVAL = 2
 # Generate 101 packets in tests/syslog/log_generator.py, so that 1 log message will be dropped by rsyslogd
 LOG_MESSAGE_GENERATE_COUNT = 101
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -271,6 +274,35 @@ def verify_config_rate_limit_fail(duthost, service_name):
     pytest_assert('Error' in output, 'Error: config syslog rate limit for {}: {}'.format(service_name, output))
 
 
+def _wait_expected_logs_forwarded(duthost, start_marker, expect_log_regex, additional_files):
+    """Wait until every expected message has been forwarded into the host log files for
+    this LogAnalyzer window before the window is closed.
+
+    The log generator runs inside a container; its messages are forwarded to the host
+    syslog asynchronously. A fixed sleep races that forwarding: under load the messages
+    can arrive after the LogAnalyzer end marker, so the window is captured empty and the
+    test fails intermittently. Poll the host log files, scoped to this window's unique
+    start marker (the test reuses a marker prefix across config_reload, so an earlier
+    window's identical logs must not be matched), until the expected messages appear.
+
+    The scoping pattern is the bare marker (``<prefix>.<timestamp>``) rather than the full
+    ``start-LogAnalyzer-<marker>`` line: this shell command is itself echoed into syslog,
+    so matching the full marker string would inject a second ``start-LogAnalyzer-<marker>``
+    line and corrupt the window LogAnalyzer extracts on exit.
+    """
+    log_files = ['/var/log/syslog'] + list(additional_files or {})
+
+    def _all_expected_present():
+        escaped_marker = re.escape(start_marker).replace('/', r'\/')
+        captured = ''
+        for log_file in log_files:
+            captured += duthost.shell("sudo awk '/{}/,0' {}".format(escaped_marker, log_file),
+                                      module_ignore_errors=True)['stdout']
+        return all(re.search(regex, captured) for regex in expect_log_regex)
+
+    return wait_until(SYSLOG_FORWARD_TIMEOUT, SYSLOG_FORWARD_INTERVAL, 0, _all_expected_present)
+
+
 def verify_rate_limit_with_log_generator(duthost, service_name, log_marker, expect_log_regex, expect_log_matches,
                                          is_host=False, additional_files=None):
     """Generator syslog with a script and verify that syslog rate limit reached
@@ -296,10 +328,12 @@ def verify_rate_limit_with_log_generator(duthost, service_name, log_marker, expe
 
     with loganalyzer:
         duthost.command(run_generator_cmd)
-        # Wait for rsyslogd to forward the rate-limiting notification from the container
-        # to the host syslog. Without this, the notification may arrive after the
-        # LogAnalyzer end marker, causing intermittent test failures.
-        time.sleep(5)
+        # The log generator runs inside a container; its messages are forwarded to the
+        # host syslog asynchronously. Wait until the expected messages have actually been
+        # forwarded (scoped to this window's unique start marker) before LogAnalyzer closes
+        # and verifies the window, instead of racing that forwarding with a fixed sleep.
+        # LogAnalyzer itself asserts the messages on exit, so this is only a wait.
+        _wait_expected_logs_forwarded(duthost, loganalyzer._markers[-1], expect_log_regex, additional_files)
 
 
 def get_loganalyzer_additional_files(service_name):


### PR DESCRIPTION
### Description of PR

Summary: Fix the flaky `syslog/test_syslog_rate_limit.py::test_syslog_rate_limit`.

The test floods 101 log messages into a container and uses `LogAnalyzer` to assert that
the rate-limit notification (`begin to drop messages due to rate-limiting`) and the test
log line appear in the host syslog **within the LogAnalyzer marker window**. The container's
messages are forwarded to the host syslog **asynchronously** by rsyslogd. The old code waited
for that forwarding with a fixed `time.sleep(5)`. Under load the forwarding can take longer
than 5s, so the expected messages land **after** the LogAnalyzer end marker is placed, the
window is captured empty, and the test fails intermittently with:

```
LogAnalyzerError: match: 0
expected_match: 0
expected_missing_match: 2

Expected Messages that are missing:
.*begin to drop messages due to rate-limiting.*
.*database#rate-limit-test: This is a test log:.*
```
Fixes the intermittent failure observed in Elastictest test plan

(https://elastictest.org/scheduler/testplan/6a305e2d03b7f75ed1c2301f).

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

`test_syslog_rate_limit` is one of the top PR-gate flaky tests. Over the last 14 days the
dominant signature was `LogAnalyzerError ... Expected Messages that are missing:
.*begin to drop messages due to rate-limiting.*` (342 hits / 283 distinct PRs / 116 in the
last 14 days). A representative failure is Elastictest plan `6a305e2d03b7f75ed1c2301f`
(attempt 0 FAILED, attempt 1 PASSED — classic flake).

#### How did you do it?

Replaced the fixed `time.sleep(5)` in `verify_rate_limit_with_log_generator` with a bounded
poll, `_wait_expected_logs_forwarded`, that keeps the LogAnalyzer window open until every
expected message has actually been forwarded into the host log files for **this** window,
driven by the existing `wait_until` helper (`SYSLOG_FORWARD_TIMEOUT=60s`,
`SYSLOG_FORWARD_INTERVAL=2s`). `LogAnalyzer` still performs the assertions on `__exit__`;
this change is purely a wait, so it cannot mask a real failure (a genuine >60s forwarding
outage still fails the test, fast).

Two subtleties handled:
- The poll is scoped to **this window's unique start marker** (`loganalyzer._markers[-1]`,
  i.e. `<prefix>.<timestamp>`). The test reuses a marker *prefix* across `config_reload`, so
  scoping by prefix alone would match an earlier window's identical logs (false positive).
- The poll matches the **bare** marker (`<prefix>.<timestamp>`) rather than the full
  `start-LogAnalyzer-<marker>` string. The poll command text is itself echoed into syslog,
  so matching the full string would inject a second `start-LogAnalyzer-<marker>` line and
  corrupt the window LogAnalyzer extracts on exit.

#### How did you verify/test it?

Reproduced and verified on a KVM dev-VM (DUT `vlab-03`, testbed `vms-kvm-t1-lag`).

**1. Production failure (before fix) — Elastictest plan `6a305e2d03b7f75ed1c2301f`:**
```
syslog/test_syslog_rate_limit.py::test_syslog_rate_limit FAILED
LogAnalyzerError: match: 0
expected_match: 0
expected_missing_match: 2
Expected Messages that are missing:
.*begin to drop messages due to rate-limiting.*
.*database#rate-limit-test: This is a test log:.*
1 failed in ...
```

**2. Mechanism proof (deterministic micro-harness against the new helper on vlab-03)** —
proves the new wait *holds* the window when logs are absent (the old `sleep(5)` could not)
and *releases* immediately once they appear:
```
PHASE_A logs absent  -> wait returned False after 13.3s  (held the full window; sleep(5) would have closed it early)
PHASE_B logs present -> wait returned True  after  1.3s  (detected + released immediately)
```

**3. Full test runs (after fix) on vms-kvm-t1-lag / vlab-03:**
```
# natural run
1 passed, 239 warnings in 373.01s (0:06:13)
# under an induced container->host rsyslogd forwarding stall (the exact condition that
# produced the empty window before the fix)
1 passed, 244 warnings in 364.03s (0:06:04)
1 passed, 241 warnings in 363.01s (0:06:03)
```

#### Any platform specific information?

None.

#### Supported testbed topology if it's a new test case?

N/A — existing test (`t1`, `any`).

### Documentation

N/A — no behavior/feature change; internal test reliability fix.
