### PR TITLE
Use ocs cross-connect CLI in Python module for L1 deploy instead of patch and reload 

### DIFF
--- a/ansible/library/ocs_cross_connect.py
+++ b/ansible/library/ocs_cross_connect.py
@@ -1,0 +1,335 @@
+#!/usr/bin/python
+# Configure OCS cross-connects on an L1 (FanoutL1Sonic) switch using the OCS CLI,
+# instead of building a JSON patch and reloading the config.
+#
+# All of the parsing and set math is implemented in Python here so the playbook task is
+# a single, declarative module invocation.
+#
+# Algorithm (mirrors templates/config_patch/l1/ocs_xconnect.json.j2 for the desired set):
+#   1. Read the current configured cross-connects ("show ocs cross-connect config")
+#      and the live hardware status ("show ocs cross-connect status").
+#   2. Compute the desired cross-connects from the cross_connects mapping. Each
+#      (a, b) entry maps to two directed cross-connects: {a}A-{b}B and {b}A-{a}B.
+#   3. Clear "stale" cross-connects that exist in hardware status but not in config
+#      and that block a desired port. A status-only entry cannot be deleted directly,
+#      so it is cleared by an add-then-delete sequence.
+#   4. Remove current cross-connects that conflict (occupy an A or B side a still
+#      missing desired cross-connect needs) so the new ones can be added.
+#   5. Add the desired cross-connects that are not already present.
+#   6. Optionally verify the operational status ("show ocs cross-connect status")
+#      reports "tuned" on both sides for every desired cross-connect.
+#
+# The operation is idempotent: when every desired A-B connection already exists the
+# add/remove/clear lists are all empty and nothing is changed.
+
+import re
+import time
+
+from ansible.module_utils.basic import AnsibleModule
+
+DOCUMENTATION = r'''
+---
+module: ocs_cross_connect
+version_added: "1.0"
+short_description: Configure OCS cross-connects on an L1 (FanoutL1Sonic) switch via live CLI.
+description:
+    - Configure the OCS cross-connects on an L1 switch to match a desired mapping using
+      the "config ocs cross-connect" CLI, instead of building a JSON patch and reloading.
+    - The OCS CLI persists changes automatically, so no "config save" is required.
+    - The operation is idempotent. When every desired cross-connect already exists nothing
+      is changed.
+options:
+    cross_connects:
+        description:
+            - Mapping of bare A-side port number to bare B-side port number for this device,
+              e.g. device_l1_cross_connects[inventory_hostname].
+                        - Each (a, b) entry expands to two directed cross-connects {a}A-{b}B and {b}A-{a}B.
+        required: True
+        type: dict
+    clear_stale:
+        description: Clear status-only entries that block a desired port via add-then-delete.
+        required: False
+        type: bool
+        default: True
+    verify:
+        description: Verify status is "tuned" on both sides for every desired cross-connect.
+        required: False
+        type: bool
+        default: True
+    verify_retries:
+        description: Number of times to poll the status table while verifying.
+        required: False
+        type: int
+        default: 12
+    verify_delay:
+        description: Seconds to wait between status polls while verifying.
+        required: False
+        type: int
+        default: 5
+notes:
+    - Run with become so the "config ocs cross-connect" commands have the required privileges.
+    - Supports check mode, in which the planned changes are computed and returned but not applied.
+'''
+
+EXAMPLES = r'''
+- name: deploy L1 OCS cross-connects via live CLI
+  become: true
+  ocs_cross_connect:
+    cross_connects: "{{ device_l1_cross_connects[inventory_hostname] | default({}) }}"
+    clear_stale: true
+    verify: true
+  register: ocs_reconcile
+'''
+
+RETURN = r'''
+added:
+    description: Ids of cross-connects that were (or would be, in check mode) added.
+    returned: always
+    type: list
+removed:
+    description: Ids of conflicting cross-connects that were (or would be) removed.
+    returned: always
+    type: list
+cleared_stale:
+    description: Ids of stale status-only cross-connects that were (or would be) cleared.
+    returned: always
+    type: list
+desired:
+    description: Ids of all desired cross-connects.
+    returned: always
+    type: list
+'''
+
+# A cross-connect id looks like "<num>A-<num>B", e.g. "29A-1B".
+XCONN_ID_RE = re.compile(r'^[0-9]+[AB]-[0-9]+[AB]$')
+NUMERIC_PORT_RE = re.compile(r'^[0-9]+$')
+SHOW_CONFIG_CMD = 'show ocs cross-connect config'
+SHOW_STATUS_CMD = 'show ocs cross-connect status'
+ADD_CMD_TMPL = 'config ocs cross-connect add {id} update'
+DEL_CMD_TMPL = 'config ocs cross-connect delete {id}'
+
+
+def build_desired(cross_connects):
+    """Expand the bare a->b mapping into the list of directed cross-connects.
+
+    Each (a, b) entry yields {a}A-{b}B and {b}A-{a}B.
+    """
+    desired = []
+    for a, b in cross_connects.items():
+        a = str(a)
+        b = str(b)
+        desired.append({'id': '{}A-{}B'.format(a, b), 'a_side': '{}A'.format(a), 'b_side': '{}B'.format(b)})
+        desired.append({'id': '{}A-{}B'.format(b, a), 'a_side': '{}A'.format(b), 'b_side': '{}B'.format(a)})
+    return desired
+
+
+def get_invalid_desired_ids(desired):
+    """Return derived desired IDs that do not match the expected xconn format."""
+    return [x['id'] for x in desired if not XCONN_ID_RE.match(x['id'])]
+
+
+def get_invalid_cross_connect_pairs(cross_connects):
+    """Return (a, b) entries whose ports are not bare numeric values."""
+    invalid = []
+    for a, b in cross_connects.items():
+        sa = str(a)
+        sb = str(b)
+        if not NUMERIC_PORT_RE.match(sa) or not NUMERIC_PORT_RE.match(sb):
+            invalid.append({'a': sa, 'b': sb})
+    return invalid
+
+
+def parse_config(stdout):
+    """Parse "show ocs cross-connect config" output.
+
+    Table format: "id  a_side  b_side". Skip the header ("a_side") and separator ("---") rows.
+    """
+    xconns = []
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        if 'a_side' in line or '---' in line:
+            continue
+        cols = line.split()
+        if len(cols) < 3 or not XCONN_ID_RE.match(cols[0]):
+            continue
+        xconns.append({'id': cols[0], 'a_side': cols[1], 'b_side': cols[2]})
+    return xconns
+
+
+def parse_status_ids(stdout):
+    """Parse the cross-connect ids (first column) from "show ocs cross-connect status".
+
+    Status table format: "id  a_side  b_side  a_side_status  b_side_status".
+    """
+    ids = []
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        if 'a_side' in line or '---' in line:
+            continue
+        cols = line.split()
+        if not cols or not XCONN_ID_RE.match(cols[0]):
+            continue
+        ids.append(cols[0])
+    return ids
+
+
+def parse_tuned_ids(stdout):
+    """Return the ids whose status row reports "tuned" on both sides."""
+    tuned = []
+    for line in stdout.splitlines():
+        norm = ' '.join(line.split())
+        if norm.endswith('tuned tuned'):
+            tuned.append(norm.split(' ', 1)[0])
+    return tuned
+
+
+def compute_changes(desired, current, status_ids):
+    """Compute the stale-to-clear, conflicts-to-remove and to-add sets.
+
+    Returns (stale_to_clear, to_remove, to_add).
+    """
+    def _port_num(side):
+        return side[:-1] if side and side[-1] in ('A', 'B') else side
+
+    desired_ids = [x['id'] for x in desired]
+    current_ids = [x['id'] for x in current]
+    desired_port_nums = set([_port_num(x['a_side']) for x in desired] + [_port_num(x['b_side']) for x in desired])
+
+    # Add = desired cross-connects not already present in config. Computed up front so
+    # that stale/conflict removals are computed independently from add operations.
+    to_add = [x for x in desired if x['id'] not in current_ids]
+
+    # Stale = id present in hardware status but absent from config. Keep only those whose
+    # A or B port number blocks a port number a desired connect uses.
+    stale_to_clear = []
+    for sid in status_ids:
+        if sid in current_ids or not XCONN_ID_RE.match(sid):
+            continue
+        parts = sid.split('-')
+        if _port_num(parts[0]) in desired_port_nums or _port_num(parts[1]) in desired_port_nums:
+            if sid not in stale_to_clear:
+                stale_to_clear.append(sid)
+
+    # Conflict = a currently configured cross-connect that is not a desired pairing but
+    # occupies a port number (A side or B side) that a desired cross-connect uses.
+    to_remove = []
+    seen_remove = set()
+    for x in current:
+        if x['id'] in desired_ids:
+            continue
+        if _port_num(x['a_side']) in desired_port_nums or _port_num(x['b_side']) in desired_port_nums:
+            if x['id'] not in seen_remove:
+                seen_remove.add(x['id'])
+                to_remove.append(x)
+
+    return stale_to_clear, to_remove, to_add
+
+
+def run_or_fail(module, cmd, failed_cmds):
+    """Run a command, recording it on non-zero return code."""
+    rc, out, err = module.run_command(cmd, use_unsafe_shell=True)
+    if rc != 0:
+        failed_cmds.append({'cmd': cmd, 'rc': rc, 'stderr': err.strip()})
+    return rc, out, err
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            cross_connects=dict(required=True, type='dict'),
+            clear_stale=dict(required=False, type='bool', default=True),
+            verify=dict(required=False, type='bool', default=True),
+            verify_retries=dict(required=False, type='int', default=12),
+            verify_delay=dict(required=False, type='int', default=5),
+        ),
+        supports_check_mode=True,
+    )
+    p = module.params
+
+    invalid_pairs = get_invalid_cross_connect_pairs(p['cross_connects'])
+    if invalid_pairs:
+        module.fail_json(
+            msg="Invalid cross_connects mapping; expected bare numeric ports for both sides.",
+            invalid_pairs=invalid_pairs)
+
+    desired = build_desired(p['cross_connects'])
+    invalid = get_invalid_desired_ids(desired)
+    if invalid:
+        module.fail_json(
+            msg="Invalid cross-connect mapping; expected bare numeric ports. Invalid id(s): {}".format(invalid),
+            invalid=invalid)
+    desired_ids = [x['id'] for x in desired]
+
+    # Read current config and live status.
+    rc, config_out, err = module.run_command(SHOW_CONFIG_CMD, use_unsafe_shell=True)
+    if rc != 0:
+        module.fail_json(msg="Failed to read OCS cross-connect config: {}".format(err.strip()))
+    rc, status_out, err = module.run_command(SHOW_STATUS_CMD, use_unsafe_shell=True)
+    if rc != 0:
+        module.fail_json(msg="Failed to read OCS cross-connect status: {}".format(err.strip()))
+
+    current = parse_config(config_out)
+    status_ids = parse_status_ids(status_out)
+
+    stale_to_clear, to_remove, to_add = compute_changes(desired, current, status_ids)
+    remove_ids = [x['id'] for x in to_remove]
+    add_ids = [x['id'] for x in to_add]
+
+    result = dict(
+        desired=desired_ids,
+        cleared_stale=stale_to_clear,
+        removed=remove_ids,
+        added=add_ids,
+    )
+
+    changed = bool(stale_to_clear or to_remove or to_add)
+
+    if module.check_mode:
+        module.exit_json(changed=changed, **result)
+
+    add_tmpl = ADD_CMD_TMPL
+    del_tmpl = DEL_CMD_TMPL
+    failed_cmds = []
+
+    # A status-only ("stale") entry cannot be deleted directly; adding it to config first
+    # lets the subsequent delete clear it from hardware status. Run before removing config
+    # conflicts and adding the desired connects so the blocked ports are freed first.
+    if p['clear_stale']:
+        for xid in stale_to_clear:
+            run_or_fail(module, add_tmpl.replace('{id}', xid), failed_cmds)
+            run_or_fail(module, del_tmpl.replace('{id}', xid), failed_cmds)
+
+    for xid in remove_ids:
+        run_or_fail(module, del_tmpl.replace('{id}', xid), failed_cmds)
+
+    for xid in add_ids:
+        run_or_fail(module, add_tmpl.replace('{id}', xid), failed_cmds)
+
+    if failed_cmds:
+        module.fail_json(msg="One or more OCS cross-connect commands failed",
+                         failed_cmds=failed_cmds, **result)
+
+    # Operational status: a healthy cross-connect reports "tuned" for both status columns.
+    # Poll until every desired cross-connect is tuned on both sides.
+    if p['verify'] and desired_ids:
+        pending = list(desired_ids)
+        for attempt in range(p['verify_retries']):
+            rc, status_out, err = module.run_command(SHOW_STATUS_CMD, use_unsafe_shell=True)
+            tuned = parse_tuned_ids(status_out)
+            pending = [d for d in desired_ids if d not in tuned]
+            if not pending:
+                break
+            if attempt < p['verify_retries'] - 1:
+                time.sleep(p['verify_delay'])
+        if pending:
+            module.fail_json(
+                msg="OCS cross-connects not tuned after {} retries: {}".format(p['verify_retries'], pending),
+                pending=pending, **result)
+
+    module.exit_json(changed=changed, **result)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/roles/testbed/nut/tasks/l1_apply_cross_connects.yml
+++ b/ansible/roles/testbed/nut/tasks/l1_apply_cross_connects.yml
@@ -1,0 +1,47 @@
+---
+# Reconcile OCS cross-connects on an L1 (FanoutL1Sonic) switch using the live CLI,
+# instead of building a JSON patch and reloading the config.
+#
+# All of the parsing and set math lives in the ocs_cross_connect Python module
+# (ansible/library/ocs_cross_connect.py); this task is a single declarative call.
+# The reconcile is idempotent. A "config save" step is run after successful changes
+# so cross-connect updates are explicitly written to config DB.
+#
+# Tunables (override with -e):
+#   l1_xconnect_dry_run     (default false): only compute the planned changes, do not apply.
+#   l1_xconnect_clear_stale (default true):  clear status-only entries that block a desired port.
+#   l1_xconnect_verify      (default true):  verify status is "tuned" after applying.
+#   l1_xconnect_save_config (default true):  run "config save -y" after applying changes.
+#   l1_xconnect_verify_retries / l1_xconnect_verify_delay: status polling controls.
+#   ocs_xconn_show_config_cmd / ocs_xconn_show_status_cmd: show command overrides.
+#   ocs_xconn_add_cmd / ocs_xconn_del_cmd: command templates with an "{id}" placeholder.
+
+- name: configure OCS cross-connects via live CLI
+  become: true
+  check_mode: "{{ l1_xconnect_dry_run | default(false) | bool }}"
+  ocs_cross_connect:
+    cross_connects: "{{ device_l1_cross_connects[inventory_hostname] | default({}) }}"
+    clear_stale: "{{ l1_xconnect_clear_stale | default(true) | bool }}"
+    verify: "{{ l1_xconnect_verify | default(true) | bool }}"
+    verify_retries: "{{ l1_xconnect_verify_retries | default(12) | int }}"
+    verify_delay: "{{ l1_xconnect_verify_delay | default(5) | int }}"
+  register: ocs_reconcile
+
+- name: show OCS cross-connect progress
+  debug:
+    msg:
+      - "desired={{ ocs_reconcile.desired | default([]) | length }}"
+      - "cleared_stale={{ ocs_reconcile.cleared_stale | default([]) | length }}"
+      - "removed={{ ocs_reconcile.removed | default([]) | length }}"
+      - "added={{ ocs_reconcile.added | default([]) | length }}"
+      - "cleared_stale_ids: {{ ocs_reconcile.cleared_stale | default([]) }}"
+      - "removed_ids: {{ ocs_reconcile.removed | default([]) }}"
+      - "added_ids: {{ ocs_reconcile.added | default([]) }}"
+
+- name: save config DB after OCS cross-connect apply
+  become: true
+  command: config save -y
+  when:
+    - ocs_reconcile is changed
+    - l1_xconnect_save_config | default(true) | bool
+    - not (l1_xconnect_dry_run | default(false) | bool)

--- a/ansible/roles/testbed/nut/tasks/main.yml
+++ b/ansible/roles/testbed/nut/tasks/main.yml
@@ -6,17 +6,23 @@
         device_info[inventory_hostname] is defined and
         device_info[inventory_hostname].Type == 'FanoutL1Sonic'
   block:
-  - import_tasks: l1_create_config_patch.yml
-  - import_tasks: device_prepare_config.yml
-  - import_tasks: device_apply_config.yml
-    when: deploy is defined and deploy|bool == true
+    - name: deploy L1 config via patch and reload
+      when: not (use_l1_ocs_cli | default(false) | bool)
+      block:
+        - import_tasks: l1_create_config_patch.yml
+        - import_tasks: device_prepare_config.yml
+        - import_tasks: device_apply_config.yml
+          when: deploy is defined and deploy|bool == true
+    - name: deploy L1 OCS cross-connects via live CLI
+      import_tasks: l1_apply_cross_connects.yml
+      when: use_l1_ocs_cli | default(false) | bool
 
 - name: config duts
   when: (config_duts is not defined or config_duts|bool == true) and
         device_info[inventory_hostname] is defined and
         device_info[inventory_hostname].Type != 'FanoutL1Sonic'
   block:
-  - import_tasks: dut_create_config_patch.yml
-  - import_tasks: device_prepare_config.yml
-  - import_tasks: device_apply_config.yml
-    when: deploy is defined and deploy|bool == true
+    - import_tasks: dut_create_config_patch.yml
+    - import_tasks: device_prepare_config.yml
+    - import_tasks: device_apply_config.yml
+      when: deploy is defined and deploy|bool == true

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -32,6 +32,7 @@ function usage
   echo "    $0 [options] (create-master | destroy-master) <k8s-server-name> <vault-password-file>"
   echo "    $0 [options] restart-ptf <testbed-name> <vault-password-file>"
   echo "    $0 [options] set-l2 <testbed-name> <vault-password-file>"
+  echo "    $0 [options] deploy-l1 <testbed-name> <inventory> <vault-password-file>"
   echo "    $0 [options] install-image <testbed-name> <inventory> <image-url>"
   echo "    $0 [options] install-dpu-image <testbed-name> <inventory> <image-url> [<dpu-index>]"
   echo "    $0 [options] collect-show-tech <testbed-name> <inventory> <vault-password-file>"
@@ -95,6 +96,7 @@ function usage
   echo "To destroy Kubernetes master on a server: $0 -m k8s_ubuntu destroy-master 'k8s-server-name' ~/.password"
   echo "To restart ptf of specified testbed: $0 restart-ptf 'testbed-name' ~/.password"
   echo "To set DUT of specified testbed to l2 switch mode: $0 set-l2 'testbed-name' ~/.password"
+  echo "To deploy L1 (OCS) config for a testbed: $0 deploy-l1 'testbed-name' 'inventory' ~/.password"
   echo "To install an image on all DUTs in a testbed: $0 install-image 'testbed-name' 'inventory' 'image-url'"
   echo "To install an image on DPUs of a testbed: $0 install-dpu-image 'testbed-name' 'inventory' 'image-url' [dpu-index]"
   echo "    Optional argument for install-dpu-image:"
@@ -936,7 +938,20 @@ function deploy_l1
   echo "Devices to generate config for: $devices"
   echo ""
 
-  ansible-playbook -i "$inventory" deploy_config_on_testbed.yml --vault-password-file="$passfile" -l "$devices" -e testbed_name="$testbed_name" -e testbed_file=$tbfile -e deploy=true -e save=true -e config_duts=false -e reset_previous_connection=false$@
+  # Toggle the OCS cross-connect CLI path. When true, reconcile
+  # cross-connects via the CLI and clear stale entries (the CLI persists
+  # automatically, no "config save" needed; l1_xconnect_clear_stale defaults
+  # to true). When false, fall back to the patch and reload path (gated by
+  # deploy=true) and reset previous connections. The CLI path and deploy=true
+  # are mutually exclusive.
+  use_l1_ocs_cli="${use_l1_ocs_cli:-true}"
+  if [[ "$use_l1_ocs_cli" == "true" ]]; then
+    ocs_options="-e use_l1_ocs_cli=true"
+  else
+    ocs_options="-e use_l1_ocs_cli=false -e deploy=true -e save=true -e reset_previous_connection=false"
+  fi
+
+  ansible-playbook -i "$inventory" deploy_config_on_testbed.yml --vault-password-file="$passfile" -l "$devices" -e testbed_name="$testbed_name" -e testbed_file=$tbfile -e config_duts=false $ocs_options "$@"
 
   echo Done
 }


### PR DESCRIPTION
### Description of PR

Switch the L1 (OCS) deploy path to reconcile cross-connects through the live OCS CLI instead of generating a config patch and reloading the switch.  This makes deployment idempotent and removes stale or conflicting entries that block desired links.

Summary:  
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/25382

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms (only applicable for a new test case)
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach

#### What is the motivation for this PR?

The previous L1 flow relied on patch generation and reload, which is disruptive and not a true reconciliation flow.  
It could also leave stale cross-connect state that blocks required A/B ports.

#### How did you do it?

- Added a custom Ansible module, ansible/library/ocs_cross_connect.py, to perform live reconciliation using config ocs cross-connect add/delete.
- Added l1_apply_cross_connects.yml as a thin declarative call to the module.
- Updated main.yml to gate paths with use_l1_ocs_cli:
- When true, run live OCS CLI reconciliation.
- When false, keep the existing patch and reload flow.
- Updated deploy_l1 in testbed-cli.sh to default to the live CLI path (use_l1_ocs_cli=true), while retaining patch-path fallback logic.
- Steps:
  - Expands desired mappings from device_l1_cross_connects into directed pairs.
  - Removes conflicting configured entries that occupy ports needed by missing desired pairs.
  - Clears stale status-only entries that block desired ports.
  - Adds only missing desired entries.
  - No config save is issued, because OCS CLI changes are already persistent.
  - Supports verification that expected cross-connects are tuned after apply.

#### How did you verify/test it?

- Validated YAML/Python/Bash syntax for updated files.
- Ran deploy-l1 on a real FanoutL1Sonic OCS target with stale reverse-direction entries.
- Confirmed stale/conflicting entries were reconciled and desired cross-connects were programmed.
- Re-ran deploy-l1 and confirmed no-op behavior when state already matched (idempotent).

#### Any platform specific information?

Applies to FanoutL1Sonic (OCS) L1 devices.

#### Supported testbed topology if it's a new test case?

N/A. This is a testbed framework/tooling change, not a new test case.

### Documentation

No documentation or wiki updates are required.