### PR TITLE
[snappi/pfc]: Dynamically compute the total drop expectation in m2o test

### DIFF
--- a/tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py
@@ -150,6 +150,31 @@ def get_expected_bg_loss_percent(egress_duthost,
     return sum(losses) / len(losses)
 
 
+def get_expected_total_drop_percent(test_flow_rate_percent,
+                                    bg_prio_list,
+                                    bg_flow_rate_percent,
+                                    expected_bg_loss_percent):
+    """Compute expected overall drop percent from offered-load mix.
+
+    The total drop is background-offered-share multiplied by the expected
+    background loss percent, normalized by total offered load.
+    """
+    pytest_assert(bg_flow_rate_percent, "FAIL: bg_flow_rate_percent must be non-empty")
+    pytest_assert(
+        len(set(bg_flow_rate_percent)) == 1,
+        "FAIL: bg_flow_rate_percent entries must be equal, got {}".format(bg_flow_rate_percent))
+
+    bg_flow_count = len(bg_prio_list)
+    bg_rate_per_flow = bg_flow_rate_percent[0]
+    total_bg_offered_percent = bg_flow_count * bg_rate_per_flow
+    total_test_offered_percent = sum(test_flow_rate_percent)
+    total_offered_percent = total_bg_offered_percent + total_test_offered_percent
+    pytest_assert(total_offered_percent > 0,
+                  "FAIL: total offered percent must be > 0 (got {})".format(total_offered_percent))
+
+    return total_bg_offered_percent * expected_bg_loss_percent / total_offered_percent
+
+
 def run_m2o_fluctuating_lossless_test(api,
                                       testbed_config,
                                       port_config_list,
@@ -277,8 +302,6 @@ def run_m2o_fluctuating_lossless_test(api,
         pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[egress_duthost.hostname][dut_tx_port]['tx_drp']
         drop_percentage = (100 * pkt_drop) / total_rx_pkts
 
-    pytest_assert(abs(drop_percentage - 8) < 1, 'FAIL: Drop packets must be around 8 percent')
-
     expected_bg_loss_percent = get_expected_bg_loss_percent(
         egress_duthost=egress_duthost,
         test_prio_list=test_prio_list,
@@ -287,6 +310,18 @@ def run_m2o_fluctuating_lossless_test(api,
         bg_flow_rate_percent=BG_FLOW_AGGR_RATE_PERCENT,
         asic_value=rx_port.get('asic_value'),
         port=dut_tx_port)
+
+    expected_drop_percentage = get_expected_total_drop_percent(
+        test_flow_rate_percent=TEST_FLOW_AGGR_RATE_PERCENT,
+        bg_prio_list=bg_prio_list,
+        bg_flow_rate_percent=BG_FLOW_AGGR_RATE_PERCENT,
+        expected_bg_loss_percent=expected_bg_loss_percent)
+
+    pytest_assert(
+        abs(drop_percentage - expected_drop_percentage) < 1,
+        'FAIL: Drop packets must be around {:.2f}% (got {:.2f}%)'.format(
+            expected_drop_percentage, drop_percentage))
+
     logger.info('Expected per-Background-Flow loss: {:.2f}% (tolerance +/- {}%)'.format(
         expected_bg_loss_percent, BG_LOSS_TOLERANCE_PERCENT))
 

--- a/tests/snappi_tests/unit_tests/pfc/unit_test_m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/unit_tests/pfc/unit_test_m2o_fluctuating_lossless_helper.py
@@ -37,7 +37,10 @@ import pytest
 MODULE_PATH = (Path(__file__).resolve().parents[3] /
                "snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py")
 
-FUNCTION_NAMES = ("get_expected_bg_loss_percent",)
+FUNCTION_NAMES = (
+    "get_expected_bg_loss_percent",
+    "get_expected_total_drop_percent",
+)
 
 
 def _load_functions(names):
@@ -174,3 +177,28 @@ def test_expected_bg_loss_matches_analytical_dwrr_split(
     )
 
     assert result == pytest.approx(expected_loss, abs=0.01)
+
+
+@pytest.mark.parametrize(
+    "test_rate,bg_prio,bg_rates,bg_loss,expected_total_drop",
+    [
+        # m2o fluctuating-lossless default: total offered = 110%,
+        # bg offered = 80%, bg loss ~= 11.2676% => total drop ~= 8.1946%
+        ([20, 10], [0, 1, 2, 5], [20, 20, 20, 20], 11.2676, 8.1946),
+        # Uniform-weight reference: bg loss = 10% => total drop ~= 7.2727%
+        ([20, 10], [0, 1, 2, 5], [20, 20, 20, 20], 10.0, 7.2727),
+        # Mix-weight from Cisco-8102: bg_prio_list=[2,1,5,6]
+        ([20, 10], [2, 1, 5, 6], [20, 20, 20, 20], 11.2676, 8.1946),
+    ],
+)
+def test_expected_total_drop_percent_matches_weighted_formula(
+        helper_ns, test_rate, bg_prio, bg_rates, bg_loss, expected_total_drop):
+    """Overall drop must equal weighted BG-loss contribution over total load."""
+    result = helper_ns["get_expected_total_drop_percent"](
+        test_flow_rate_percent=test_rate,
+        bg_prio_list=bg_prio,
+        bg_flow_rate_percent=bg_rates,
+        expected_bg_loss_percent=bg_loss,
+    )
+
+    assert result == pytest.approx(expected_total_drop, abs=0.01)


### PR DESCRIPTION
### Description of PR

Summary:  
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/25426

This PR removes a brittle fixed drop gate in the m2o fluctuating-lossless Snappi test and replaces it with a dynamic expected total drop calculation derived from:
- configured offered load split (test flows + background flows), and
- computed per-background-flow loss from egress DWRR scheduler weights.

It also adds unit coverage for the new total-drop helper and for the Cisco-8102 priority mix regression case.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
The previous assertion used a hardcoded expected drop value (~8%), which can fail depending on selected lossy priorities and scheduler weight distribution. A dynamic expectation is required to make validation accurate and stable across platforms/topologies.

#### How did you do it?
- Added a helper to compute expected total drop percentage from:
  - test offered rates,
  - background offered rates/priorities,
  - expected background loss percentage.
- Updated m2o fluctuating-lossless verification to compare measured drop with this dynamic expected drop (same tolerance as before).
- Added unit tests for:
  - expected total drop formula (multiple scenarios),
  - Cisco-8102 regression priority mix case.

#### How did you verify/test it?
- Ran targeted unit tests:
  - python3 -m pytest --noconftest unit_test_m2o_fluctuating_lossless_helper.py -v
- Result: all tests passed.

#### Any platform specific information?
No platform-specific code path introduced. Logic uses existing scheduler/queue mapping and applies to current supported behavior in this test.

#### Supported testbed topology if it's a new test case?
Not a new test case. Existing m2o fluctuating-lossless test behavior is improved.

### Documentation
No documentation update required (no new feature/test case introduced).