### PR TITLE
Relax DHCP counter stress tolerance

### DIFF
--- a/tests/dhcp_relay/test_dhcp_counter_stress.py
+++ b/tests/dhcp_relay/test_dhcp_counter_stress.py
@@ -54,7 +54,7 @@ def test_dhcpmon_relay_counters_stress(ptfhost, relay_agent, enable_sonic_dhcpv4
     '''
     testing_mode, duthost = testing_config
     packets_send_duration = 120
-    error_margin = 0.01
+    error_margin = 1
     dut_hwsku = duthost.facts["hwsku"]
     client_packets_per_sec = PACKET_RATE_PER_SEC_MAP.get(dut_hwsku, DEFAULT_PACKET_RATE_PER_SEC) \
         if request.config.option.max_packets_per_sec is None else request.config.option.max_packets_per_sec


### PR DESCRIPTION
### Description of PR
Summary:
Relax the DHCP counter stress-test tolerance from `0.01` to `1` percent.

`test_dhcpmon_relay_counters_stress` passes this value to helpers as `error_in_percentage`. The helper interprets it as a 0-100 percentage value and computes the allowed delta as `int(expected * error_in_percentage / 100)`. With the current `0.01` value and about 3000 stress packets, the effective allowed delta is 0 packets.

Even though the effective margin is currently 0 packets, failures are still very rare. Recent failures are small off-by-one counter/capture mismatches that pass on retry, so this change gives the stress test the intended small tolerance without masking sustained packet loss.

Microsoft ADO: [38317570](https://msazure.visualstudio.com/One/_workitems/edit/38317570)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
The existing `0.01` value is interpreted as 0.01%, which rounds down to 0 allowed packet difference for the packet counts used by this stress test.

#### How did you do it?
Changed the stress-test margin from `0.01` to `1`.

#### How did you verify/test it?
All subcases passed.

#### Any platform specific information?
Observed on 720dt m0 nightly runs.

#### Supported testbed topology if it's a new test case?
N/A.

### Documentation
N/A.

