### PR TITLE
Clarify DHCP counter tolerance defaults

### DIFF
--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -91,14 +91,14 @@ def query_and_sum_dhcpmon_counters(duthost, vlan_name, interface_name_list, is_v
 
 
 def compare_dhcp_counters_with_warning(actual_counter, expected_counter, warning_msg,
-                                       error_in_percentage=0.0, is_v6=False):
+                                       error_in_percentage=0, is_v6=False):
     compare_result = compare_dhcp_counters(
         actual_counter, expected_counter, error_in_percentage, is_v6)
     while msg := next(compare_result, False):
         logger.warning(warning_msg + ": " + str(msg))
 
 
-def compare_dhcp_counters(actual_counter, expected_counter, error_in_percentage=0.0, is_v6=False):
+def compare_dhcp_counters(actual_counter, expected_counter, error_in_percentage=0, is_v6=False):
     """Compare the DHCP counter (could come from relay or dhcpmon or anywhere) value with the expected counter."""
     for dir in SUPPORTED_DIR:
         for dhcp_type in SUPPORTED_DHCPV6_TYPE if is_v6 else SUPPORTED_DHCPV4_TYPE:
@@ -117,7 +117,7 @@ def compare_dhcp_counters(actual_counter, expected_counter, error_in_percentage=
 
 
 def validate_dhcpmon_counters(dhcp_relay, duthost, expected_uplink_counter,
-                              expected_downlink_counter, error_in_percentage=0.0, is_v6=False):
+                              expected_downlink_counter, error_in_percentage=0, is_v6=False):
     """Validate the dhcpmon counters against the expected counters."""
     logger.info("Expected uplink counters: {}, expected downlink counters: {}, error in percentage: {}%".format(
         expected_uplink_counter, expected_downlink_counter, error_in_percentage))
@@ -237,7 +237,7 @@ def calculate_counters_per_pkts(pkts, is_v6=False):
 
 
 def validate_counters_and_pkts_consistency(dhcp_relay, duthost, pkts, interface_name_index_mapping,
-                                           error_in_percentage=0.0, is_v6=False):
+                                           error_in_percentage=0, is_v6=False):
     """Validate the dhcpmon counters and packets consistence"""
     downlink_vlan_iface = dhcp_relay['downlink_vlan_iface']['name']
     # it can be portchannel or interface, it depends on the topology

--- a/tests/dhcp_relay/test_dhcp_counter_stress.py
+++ b/tests/dhcp_relay/test_dhcp_counter_stress.py
@@ -104,7 +104,7 @@ def test_dhcpmon_relay_counters_stress(ptfhost, relay_agent, enable_sonic_dhcpv4
                                                    error_in_percentage=error_margin)
             if testing_mode == DUAL_TOR_MODE:
                 validate_dhcpmon_counters(dhcp_relay, standby_duthost,
-                                          {}, {}, 0)
+                                          {}, {})
 
         def get_ip_link_result(duthost):
             # Get the output of 'ip link' command and parse it to a dictionary of index: name


### PR DESCRIPTION
### Description of PR
Summary:
Clarify DHCP counter helper tolerance defaults by using `0` instead of `0.0` for `error_in_percentage` defaults, and remove an explicit `0` argument where the default already applies.

The helper interprets `error_in_percentage` as a 0-100 percentage value. Using `0.0` as the default can imply a unit-fraction convention, which is not how the helper is used.

Microsoft ADO: 38725627

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Make the tolerance convention explicit: `error_in_percentage` is a percentage value, not a unit fraction.

#### How did you do it?
- Changed helper defaults from `error_in_percentage=0.0` to `error_in_percentage=0`.
- Removed the explicit `0` passed by the dualtor standby path in `test_dhcp_counter_stress.py`, leaving it to use the default.

#### How did you verify/test it?
Compiled the touched Python files with `python3 -m py_compile`.

#### Any platform specific information?
N/A.

#### Supported testbed topology if it's a new test case?
N/A.

### Documentation
N/A.

