### PR TITLE
platform/device_utils: default get_dpu_port to 8080 on miss

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -1264,6 +1264,10 @@ def create_npu_host_based_on_dpu_info(ansible_adhoc, tbinfo, request, duthost): 
     return npu_host
 
 
+# Default gNMI port for SmartSwitch DPUs.
+DEFAULT_DPU_GNMI_PORT = "8080"
+
+
 def get_dpu_ip(duthost, dpu_index):
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     if not config_facts:
@@ -1299,26 +1303,18 @@ def get_dpu_ip(duthost, dpu_index):
 def get_dpu_port(duthost, dpu_index):
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     if not config_facts:
-        logger.error("Failed to retrieve config_facts from DUT")
-        return None
+        logger.warning("Failed to retrieve config_facts from DUT; using default DPU gNMI port %s",
+                       DEFAULT_DPU_GNMI_PORT)
+        return DEFAULT_DPU_GNMI_PORT
 
     dpu_section = config_facts.get('DPU', {})
-    if not dpu_section:
-        logger.error("DPU section not found in config_facts")
-        return None
-
     dpu_key = 'dpu{}'.format(dpu_index)
-    # Check if the DPU exists in the configuration
-    if dpu_key not in dpu_section:
-        logger.error("DPU '{}' not found in config_facts. Available DPUs: {}".format(
-            dpu_key, list(dpu_section.keys())))
-        return None
-
-    dpu_config = dpu_section[dpu_key]
-    port = dpu_config.get('gnmi_port', None)
+    dpu_config = dpu_section.get(dpu_key, {}) if dpu_section else {}
+    port = dpu_config.get('gnmi_port')
     if port is None:
-        logger.error("gnmi_port not found in config_facts for dpu_index {}".format(dpu_index))
-        return None
+        logger.info("gnmi_port not set in CONFIG_DB for %s; using default %s",
+                    dpu_key, DEFAULT_DPU_GNMI_PORT)
+        return DEFAULT_DPU_GNMI_PORT
     return port
 
 


### PR DESCRIPTION
### Description of PR

`tests/common/platform/device_utils.py::get_dpu_port` currently returns `None` when any of the CONFIG_DB DPU lookup steps fail, which makes the only caller (`tests/gnmi/helper.py::gnoi_request_dpu`) raise `"Failed to get DPU gNMI port"`. That branch fires on real SmartSwitch DUTs because the singular `DPU` table is not populated:

- `device/mellanox/x86_64-nvidia_sn4280-r0/platform.json` exposes `DPUS` (plural), not `DPU`.
- `src/sonic-config-engine/smartswitch_config.py` copies `DPUS` through as-is and never derives a `DPU` table.
- `[redacted]`'s `ansible/golden_config_db/smartswitch_t1.json` doesn't push a `DPU` table either.
- No `hset 'DPU|...'` calls exist in production code anywhere under `sonic-buildimage/src/`.

The production gNOI shutdown daemon (`src/sonic-host-services/scripts/gnoi_shutdown_daemon.py::get_dpu_gnmi_port`) is the only other consumer of this field and it already handles the absence by defaulting to `8080`:

```python
DEFAULT_GNMI_PORT = "8080"  # Default GNMI port for DPU
```

So the test helper was stricter than the production daemon for no obvious reason. This change mirrors the daemon's fallback: keep reading the field if it's there, otherwise return `"8080"`.

### Surfaced by

[redacted] (`gnmi.test_gnoi_system_reboot.test_gnoi_system_reboot_halt_dpus` on `Nvidia-bf3-com-dpu` / [redacted] / [redacted]). Confirmed via live DUT inspection on [redacted] (image [redacted], three weeks newer than the failing [redacted]):

```
admin@[redacted]:$ sudo sonic-db-cli CONFIG_DB keys 'DPU|*'
                          # empty
admin@[redacted]:$ sudo sonic-db-cli CONFIG_DB hgetall 'DPU|dpu0'
                          {}
```

Net behavior change: `test_gnoi_system_reboot_halt_dpus` stops failing on SmartSwitch DUTs where the DPU table happens to be empty.

### Type of change

- [x] Bug fix

### Caller compatibility

The only caller is `tests/gnmi/helper.py::gnoi_request_dpu`, which after the change still works exactly as before. Its existing `if port is None: return -1, "Failed to get DPU gNMI port"` branch becomes dead code (port can no longer be `None`); harmless and intentionally left in place rather than touched in this PR.

### Local checks

- `python -m py_compile tests/common/platform/device_utils.py` ✓
- `flake8 --max-line-length=120 tests/common/platform/device_utils.py` ✓

### Follow-ups (out of scope here, intentionally)

- Schema cleanup: `gnmi_port` arguably belongs in `DPUS` (plural, the table that's actually populated by `smartswitch_config.py`) rather than `DPU` (singular). Tracking that as a separate decision so this PR can stay minimal.
