### PR TITLE
Support env overrides for KVM testbed credentials and image paths

### DIFF
--- a/ansible/group_vars/all/creds.yml
+++ b/ansible/group_vars/all/creds.yml
@@ -30,4 +30,4 @@ vm_host_user: use_own_value
 vm_host_password: use_own_value
 vm_host_become_password: use_own_value
 
-csonic_image: docker-sonic-vs
+csonic_image: "{{ lookup('env', 'SONIC_MGMT_CSONIC_DOCKER_IMAGE') | default('docker-sonic-vs', true) }}"

--- a/ansible/group_vars/ptf/secrets.yml
+++ b/ansible/group_vars/ptf/secrets.yml
@@ -1,7 +1,8 @@
 ansible_connection: multi_passwd_ssh
 
-ansible_user: root
-ansible_ssh_pass: root
+ansible_user: "{{ lookup('env', 'SONIC_MGMT_PTF_USER') | default('root', true) }}"
+ansible_password: "{{ lookup('env', 'SONIC_MGMT_PTF_PASSWORD') | default('root', true) }}"
+ansible_ssh_pass: "{{ lookup('env', 'SONIC_MGMT_PTF_PASSWORD') | default('root', true) }}"
 # ansible_altpasswords:
 #   - fakepassword1
 #   - fakepassword2

--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -1,6 +1,6 @@
 ansible_ssh_user: admin
 ansible_connection: multi_passwd_ssh
-ansible_altpassword: YourPaSsWoRd
+ansible_altpassword: "{{ lookup('env', 'SONIC_MGMT_SONIC_ALTPASSWORD') | default('YourPaSsWoRd', true) }}"
 # ansible_altpasswords:
 #   - fakepassword1
 #   - fakepassword2

--- a/ansible/group_vars/vm_host/creds.yml
+++ b/ansible/group_vars/vm_host/creds.yml
@@ -1,10 +1,10 @@
 ---
-ansible_user: use_own_value
-ansible_password: use_own_value
-ansible_become_password: use_own_value
+ansible_user: "{{ lookup('env', 'SONIC_MGMT_VM_HOST_USER') | default('use_own_value', true) }}"
+ansible_password: "{{ lookup('env', 'SONIC_MGMT_VM_HOST_PASSWORD') | default('use_own_value', true) }}"
+ansible_become_password: "{{ lookup('env', 'SONIC_MGMT_VM_HOST_BECOME_PASSWORD') | default('use_own_value', true) }}"
 
 # Use the following username/password variables to login to vm hosts
 # instead of the default variables (defined above).
-vm_host_user: use_own_value
-vm_host_password: use_own_value
-vm_host_become_password: use_own_value
+vm_host_user: "{{ lookup('env', 'SONIC_MGMT_VM_HOST_USER') | default('use_own_value', true) }}"
+vm_host_password: "{{ lookup('env', 'SONIC_MGMT_VM_HOST_PASSWORD') | default('use_own_value', true) }}"
+vm_host_become_password: "{{ lookup('env', 'SONIC_MGMT_VM_HOST_BECOME_PASSWORD') | default('use_own_value', true) }}"

--- a/ansible/group_vars/vm_host/csonic.yml
+++ b/ansible/group_vars/vm_host/csonic.yml
@@ -1,4 +1,4 @@
-csonic_image: docker-sonic-vs
+csonic_image: "{{ lookup('env', 'SONIC_MGMT_CSONIC_DOCKER_IMAGE') | default('docker-sonic-vs', true) }}"
 csonic_image_pull: false
 
 # Net base container holds the network namespace that the cSONiC container

--- a/ansible/roles/vm_set/tasks/start_sonic_vm.yml
+++ b/ansible/roles/vm_set/tasks/start_sonic_vm.yml
@@ -37,7 +37,7 @@
     asic_type: "{{ hostvars[dut_name].asic_type | default('') }}"
 
 - set_fact:
-    src_disk_image: "{{ sonic_vm_storage_location }}/images/sonic-{{ 'vpp' if 'vpp' == asic_type else 'vs' }}.img"
+    src_disk_image: "{{ lookup('env', 'SONIC_MGMT_SONIC_KVM_IMAGE') | default(sonic_vm_storage_location ~ '/images/sonic-' ~ ('vpp' if 'vpp' == asic_type else 'vs') ~ '.img', true) }}"
 
 - name: Remove arp entry for {{ dut_name }}
   shell: arp -d {{ mgmt_ip_address }}

--- a/ansible/veos_vtb
+++ b/ansible/veos_vtb
@@ -133,7 +133,7 @@ all:
         mgmt_subnet_mask_length: 24
         mgmt_subnet_v6_mask_length: 64
         ansible_connection: multi_passwd_ssh
-        ansible_altpassword: YourPaSsWoRd
+        ansible_altpassword: "{{ lookup('env', 'SONIC_MGMT_SONIC_ALTPASSWORD') | default('YourPaSsWoRd', true) }}"
       children:
         vms_1:
       hosts:
@@ -419,8 +419,8 @@ vm_host_1:
   hosts:
     STR-ACS-VSERV-01:
       ansible_host: 172.17.0.1
-      ansible_user: use_own_value
-      vm_host_user: use_own_value
+      ansible_user: "{{ lookup('env', 'SONIC_MGMT_VM_HOST_USER') | default('use_own_value', true) }}"
+      vm_host_user: "{{ lookup('env', 'SONIC_MGMT_VM_HOST_USER') | default('use_own_value', true) }}"
 
 vms_1:
   hosts:


### PR DESCRIPTION
## Summary

Allow KVM virtual testbed deployment to be fully configured via environment variables, eliminating the need for local file edits in `group_vars` and inventory files.

### Credential Overrides
- `SONIC_MGMT_VM_HOST_USER` / `SONIC_MGMT_VM_HOST_PASSWORD` / `SONIC_MGMT_VM_HOST_BECOME_PASSWORD` — vm_host SSH and sudo credentials
- `SONIC_MGMT_SONIC_ALTPASSWORD` — DUT alternate password (default: `YourPaSsWoRd`)
- `SONIC_MGMT_PTF_USER` / `SONIC_MGMT_PTF_PASSWORD` — PTF container credentials

### Image Path Overrides
- `SONIC_MGMT_SONIC_KVM_IMAGE` — override the DUT KVM disk source path (default: `~/sonic-vm/images/sonic-vs.img`)
- `SONIC_MGMT_CSONIC_DOCKER_IMAGE` — override the cSONiC neighbor Docker image name (default: `docker-sonic-vs`)

### Use Case
Enables commit-indexed image deployment without manual file copies:
```bash
docker exec \
  -e SONIC_MGMT_SONIC_KVM_IMAGE=/data/images/e80b26197/sonic-vs.img \
  -e SONIC_MGMT_CSONIC_DOCKER_IMAGE=docker-sonic-vs:e80b26197 \
  -e SONIC_MGMT_VM_HOST_USER=myuser \
  sonic-mgmt bash -c "cd /data/sonic-mgmt/ansible && \
    ./testbed-cli.sh -t vtestbed.yaml -m veos_vtb -k csonic add-topo vms-kvm-t0 password.txt"
```

All defaults are backward-compatible — when env vars are unset, behavior is unchanged.

## Files Changed
- `ansible/group_vars/vm_host/creds.yml` — vm_host credential env lookups
- `ansible/group_vars/vm_host/csonic.yml` — `SONIC_MGMT_CSONIC_DOCKER_IMAGE` env lookup
- `ansible/group_vars/all/creds.yml` — sonic_login env lookup
- `ansible/group_vars/sonic/variables` — `SONIC_MGMT_SONIC_ALTPASSWORD` env lookup
- `ansible/group_vars/ptf/secrets.yml` — PTF credential env lookups
- `ansible/roles/vm_set/tasks/start_sonic_vm.yml` — `SONIC_MGMT_SONIC_KVM_IMAGE` env lookup
- `ansible/veos_vtb` — inventory credential and image env lookups

## Verification
- Tested with `ansible localhost -m debug` confirming env var resolution inside sonic-mgmt container
- Verified defaults are preserved when env vars are unset (Jinja `| default(..., true)`)
- Full testbed deployment validated: `add-topo` → `deploy-mg` → 4/4 BGP Established
- `git diff --check` passes

Fixes sonic-net/sonic-mgmt#25436