### PR TITLE
Provide IP version to fix v6 test case for test_pfcwd_no_traffic

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -1446,6 +1446,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         setup_info = setup_pfc_test
         setup_dut_info = setup_dut_test_params
+        ip_version = setup_info["ip_version"]
         self.fanout_info = enum_fanout_graph_facts
         self.ptf = ptfhost
         self.dut = duthost
@@ -1473,7 +1474,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         for idx, port in enumerate(self.ports):
             logger.info("")
             logger.info("--- Testing non-Trafific Pfcwd actions on {} ---".format(port))
-            self.setup_test_params(port, setup_info['vlan'], init=not idx)
+            self.setup_test_params(port, setup_info['vlan'], init=not idx, ip_version=ip_version)
 
             pfc_wd_restore_time_large = request.config.getoption("--restore-time")
             # wait time before we check the logs for the 'restore' signature. 'pfc_wd_restore_time_large' is in ms.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Seeing this failure for T0 Cisco-series router in internal testing: 
```
        if (res.is_failed or 'exception' in res) and not module_ignore_errors:                                                                                                                                                                                                         
>           raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)                                                                                                                                                                                           
E           tests.common.errors.RunAnsibleModuleFail: run module command failed, Ansible Results =>                                                                                                                                                                                    
E           failed = True                                                                                                                                                                                                                                                              
E           changed = True                                                                                                                                                                                                                                                             
E           rc = 1                                                                                                                                                                                                                                                                     
E           cmd = ['ifconfig', 'eth8', 'fc02:1000::2']                                                                                                                                                                                                                                 
E           start = 2026-06-16 16:40:43.600960                                                                                                                                                                                                                                         
E           end = 2026-06-16 16:40:43.613972                                                                                                                                                                                                                                           
E           delta = 0:00:00.013012                                                                                                                                                                                                                                                     
E           msg = non-zero return code                                                                                                                                                                                                                                                 
E           invocation = {'module_args': {'_raw_params': 'ifconfig eth8 fc02:1000::2', '_uses_shell': False, 'warn': False, 'stdin_add_newline': True, 'strip_empty_ends': True, 'argv': None, 'chdir': None, 'executable': None, 'creates': None, 'removes': None, 'stdin': None}}    
E           _ansible_no_log = None                                                                                                                                                                                                                                                     
E           stdout =                                                                                                                                                                                                                                                                   
E           stderr =                                                                                                                                                                                                                                                                   
E           fc02:1000::2: Unknown host                                                                                                                                                                                                                                                 
E           ifconfig: `--help' gives usage information.                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                       
complex_args = {}                                                                                                                                                                                                                                                                      
filename   = '/data/tests/pfcwd/test_pfcwd_function.py'                                                                                                                                                                                                                                
function_name = 'resolve_arp'                                                                                                                                                                                                                                                          
index      = 0                                                                                                                                                                                                                                                                         
line_number = 450                                                                                                                                                                                                                                                                      
lines      = ['                self.ptf.command("ifconfig {} {}".format(ptf_port, self.pfc_wd[\'test_neighbor_addr\']))\n']                                                                                                                                                            
module_args = ['ifconfig eth8 fc02:1000::2']                                                                                                                                                                                                                                           
module_async = False                                                                                                                                                                                                                                                                   
module_ignore_errors = False                                                                                                                                                                                                                                                           
previous_frame = <frame at 0x7f99c5207640, file '/data/tests/pfcwd/test_pfcwd_function.py', line 450, code resolve_arp>                                                                                                                                                                
res        = {'failed': True, 'changed': True, 'stdout': '', 'stderr': "fc02:1000::2: Unknown host\nifconfig: `--help' gives usage ...'stderr_lines': ['fc02:1000::2: Unknown host', "ifconfig: `--help' gives usage information."], '_ansible_no_log': None}                          
self       = <tests.common.devices.ptf.PTFHost object at 0x7f99c5032640>                                                                                                                                                                                                               
verbose    = True                                                                                                                                                                                                                                                                      
```

Is fixed by adding IP versioned support for the test case. 

Appears that this test was missed out when adding IPv6 support for PFC-WD, possibly due to the T0 requirement. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Bug fix. 

#### How did you do it?

#### How did you verify/test it?
Tested on Cisco internal T0 device. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
