### PR TITLE
[ha]: Xfail Cisco 8102 SmartSwitch HA tests

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5730,6 +5730,18 @@ test_vs_chassis_setup.py:
       - "asic_type not in ['vs']"
       - *lossyTopos
 
+tests/ha/test_ha_bfd_pin.py:
+  xfail:
+    reason: "BFD pin test is expected to fail on Cisco 8102 SmartSwitch with SONiC 202511"
+    conditions:
+      - "is_smartswitch == True and platform in ['x86_64-8102_28fh_dpu_o-r0'] and branch in ['202511', 'internal-202511']"
+
+tests/ha/test_ha_repairing_dpu.py:
+  xfail:
+    reason: "HA repairing DPU test is expected to fail on Cisco 8102 SmartSwitch with SONiC 202511"
+    conditions:
+      - "is_smartswitch == True and platform in ['x86_64-8102_28fh_dpu_o-r0'] and branch in ['202511', 'internal-202511']"
+
 #######################################
 #####         upgrade_path        #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add conditional xfail marks for the HA BFD pin and HA repairing DPU tests on Cisco 8102 SmartSwitch with SONiC 202511.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

The HA BFD pin and HA repairing DPU tests are known to fail on Cisco 8102 SmartSwitch with SONiC 202511. Marking these cases as expected failures keeps the test result aligned with the known platform/release behavior while preserving execution coverage.

#### How did you do it?

Added conditional xfail entries in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` for:
- `tests/ha/test_ha_bfd_pin.py`
- `tests/ha/test_ha_repairing_dpu.py`

The condition is scoped to SmartSwitch, Cisco 8102 platform `x86_64-8102_28fh_dpu_o-r0`, and branch `202511` / `internal-202511`.

#### How did you verify/test it?

- Validated YAML syntax with `python3 -c "import yaml; yaml.safe_load(open('tests/common/plugins/conditional_mark/tests_mark_conditions.yaml'))"`.
- Ran HA BFD pin validation on 8102 HA testbed `vms25-t1-smartswitch-ha-8102-01`; confirmed the first parametrized case reported `XFAIL`.
- Ran HA repairing DPU validation on the same 8102 HA testbed with enabled DPUs `str2-8102-smartswitch-03-dpu-0,str2-8102-smartswitch-04-dpu-0,str2-8102-smartswitch-04-dpu-1`; confirmed the first parametrized case reported `XFAIL`.

#### Any platform specific information?

Cisco 8102 SmartSwitch, platform `x86_64-8102_28fh_dpu_o-r0`, SONiC 202511.

#### Supported testbed topology if it's a new test case?

N/A. This is not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

N/A.