### PR TITLE
[smartswitch]: disable loganalyzer for test_dpu_status_post_switch_reboot

### DIFF
--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -416,6 +416,7 @@ def test_cold_reboot_dpus(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname,
                          pre_boot_times=pre_boot_times)
 
 
+@pytest.mark.disable_loganalyzer
 def test_cold_reboot_switch(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname,
                             platform_api_conn, num_dpu_modules, localhost):  # noqa: F811, E501
     """

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -69,6 +69,7 @@ def ensure_dpus_up_after_test(duthosts,
         logging.warning("DPU recovery in teardown failed (non-fatal): %s", e)
 
 
+@pytest.mark.disable_loganalyzer
 def test_dpu_status_post_switch_reboot(duthosts, dpuhosts,
                                        enum_rand_one_per_hwsku_hostname,
                                        localhost,


### PR DESCRIPTION
### Description of PR

Summary:
Add `@pytest.mark.disable_loganalyzer` to `test_dpu_status_post_switch_reboot` to prevent false failures from expected boot-time syslog messages.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
`test_dpu_status_post_switch_reboot` performs a cold reboot of the NPU (switch), which generates many expected syslog messages during boot:
- Kernel messages (SGX disabled, sysctl table check failed, spi-nor JEDEC id errors, mei\_me init failures, lm75 probe errors, cisco-fpga errors)
- `sonic-db-cli` errors about missing database config (before Redis starts)
- `syncd#syncd` logEventData messages
- `xcvrd` optics deinit messages

The log analyzer was flagging these 89 expected messages as test failures.

#### How did you do it?
Added `@pytest.mark.disable_loganalyzer` to `test_dpu_status_post_switch_reboot`. All other reboot tests in `tests/smartswitch/platform_tests/test_reload_dpu.py` already have this marker, and `tests/platform_tests/test_reboot.py` disables it at the module level — this change makes `test_dpu_status_post_switch_reboot` consistent with the rest of the reboot tests in the repo.

#### How did you verify/test it?
Ran `test_dpu_status_post_switch_reboot` smartswitch

#### Any platform specific information?
smartswitch

#### Supported testbed topology if it's a new test case?
N/A — improvement to existing test case.

### Documentation
N/A