### PR TITLE
Auto-derive nbrhosts neighbor_type from testbed vm_type (fix cSONiC neighbor tests using EOS module)

### DIFF
--- a/ansible/vtestbed.yaml
+++ b/ansible/vtestbed.yaml
@@ -25,6 +25,7 @@
   ptf_ipv6: fec0::ffff:afa:2/64
   server: server_1
   vm_base: VM0100
+  vm_type: csonic
   dut:
     - vlab-01
   inv_name: veos_vtb

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1093,20 +1093,23 @@ def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request):
         return devices
 
     neighbor_type = request.config.getoption("--neighbor_type")
-    # Auto-derive the neighbor type from the testbed's ``vm_type`` field when the
-    # ``--neighbor_type`` flag was left at its default ("eos"). This lets non-EOS
-    # testbeds (e.g. cSONiC, vsonic) resolve the correct neighbor host class
-    # (CsonicHost/SonicHost) without every caller (run_tests.sh, CI, ad-hoc pytest)
-    # having to remember to pass ``--neighbor_type``. An explicitly-provided flag
-    # always wins over the testbed default.
-    if neighbor_type == "eos":
+    neighbor_type_overridden = any(
+        arg == "--neighbor_type" or arg.startswith("--neighbor_type=")
+        for arg in request.config.invocation_params.args
+    )
+    # Auto-derive the neighbor type from the testbed's ``vm_type`` field only
+    # when no ``--neighbor_type`` override was provided on the pytest command
+    # line. This lets non-EOS testbeds (e.g. cSONiC, vsonic) resolve the correct
+    # neighbor host class (CsonicHost/SonicHost) while preserving explicit CLI
+    # overrides.
+    if not neighbor_type_overridden:
         tb_vm_type = tbinfo.get("vm_type")
         valid_vm_types = ("eos", "sonic", "cisco", "csonic", "vsonic", "ceos")
         if tb_vm_type and tb_vm_type in valid_vm_types:
             if tb_vm_type != neighbor_type:
                 logger.info(
                     "nbrhosts: deriving neighbor_type='%s' from testbed vm_type "
-                    "(--neighbor_type was left at default)", tb_vm_type)
+                    "(--neighbor_type was not provided)", tb_vm_type)
             neighbor_type = tb_vm_type
         elif tb_vm_type:
             logger.warning(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1093,6 +1093,25 @@ def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request):
         return devices
 
     neighbor_type = request.config.getoption("--neighbor_type")
+    # Auto-derive the neighbor type from the testbed's ``vm_type`` field when the
+    # ``--neighbor_type`` flag was left at its default ("eos"). This lets non-EOS
+    # testbeds (e.g. cSONiC, vsonic) resolve the correct neighbor host class
+    # (CsonicHost/SonicHost) without every caller (run_tests.sh, CI, ad-hoc pytest)
+    # having to remember to pass ``--neighbor_type``. An explicitly-provided flag
+    # always wins over the testbed default.
+    if neighbor_type == "eos":
+        tb_vm_type = tbinfo.get("vm_type")
+        valid_vm_types = ("eos", "sonic", "cisco", "csonic", "vsonic", "ceos")
+        if tb_vm_type and tb_vm_type in valid_vm_types:
+            if tb_vm_type != neighbor_type:
+                logger.info(
+                    "nbrhosts: deriving neighbor_type='%s' from testbed vm_type "
+                    "(--neighbor_type was left at default)", tb_vm_type)
+            neighbor_type = tb_vm_type
+        elif tb_vm_type:
+            logger.warning(
+                "nbrhosts: testbed vm_type='%s' is not a recognized neighbor type; "
+                "falling back to neighbor_type='%s'", tb_vm_type, neighbor_type)
     if 'VMs' not in tbinfo['topo']['properties']['topology']:
         logger.info("No VMs exist for this topology: {}".format(
             tbinfo['topo']['properties']['topology']))


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md
-->

#### Description of PR

The `nbrhosts` fixture only constructed the correct neighbor host class (e.g. `CsonicHost` for cSONiC neighbors) when `--neighbor_type` was **explicitly** passed. That option defaults to `eos` and is not wired into `run_tests.sh` (or the PR-CI invocation), so a cSONiC testbed silently fell back to `EosHost` for its neighbors.

Any test that drives a neighbor over its device API then ran the **EOS** Ansible module against a **SONiC** neighbor and errored. Concretely, `bgp/test_bgp_session.py::test_bgp_session_interface_down[neighbor-*]` calls `nbrhosts[nbr]['host'].shutdown(port)`, which dispatched to `eos_config` and failed with:

```
tests.common.errors.RunAnsibleModuleFail: run module eos_config failed
msg = Task failed: [Errno None] Unable to connect to port 22 on 10.250.0.51
```

This PR makes the neighbor type **auto-derive from the testbed `vm_type` field** when `--neighbor_type` is left at its default, mirroring the existing `vm_type: vsonic` precedent in `ansible/testbed_ocs.yaml`. An explicitly-provided `--neighbor_type` still takes precedence. The `vms-kvm-t0-csonic` testbed is tagged with `vm_type: csonic` so cSONiC neighbor tests resolve to `CsonicHost` with no extra flag (and no `run_tests.sh`/CI change required).

#### Summary:
Fixes neighbor-side fixtures running EOS modules against cSONiC (SONiC) neighbors.

#### Type of change

- [x] Bug fix
- [ ] Testbed and Framework (new/improvement)
- [ ] New Test case
- [ ] Test case improvement
- [ ] Skipped for non-supported platforms

#### Back port request

- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Approach
#### What is the motivation for this PR?

Enable the cSONiC T0 testbed to run neighbor-side test logic (BGP session interface-down via the neighbor, etc.) without manually passing `--neighbor_type csonic`, which is easy to forget and is not plumbed through `run_tests.sh`/CI. This is a prerequisite for the cSONiC PR-CI t0 parity effort.

#### How did you do it?

- In `tests/conftest.py` (`nbrhosts`): when `--neighbor_type` is at its default (`eos`), read `tbinfo['vm_type']` and use it as the neighbor type if it is a recognized value (`eos`, `sonic`, `cisco`, `csonic`, `vsonic`, `ceos`). Explicit `--neighbor_type` always wins; an unrecognized `vm_type` logs a warning and falls back to the default.
- In `ansible/vtestbed.yaml`: add `vm_type: csonic` to the `vms-kvm-t0-csonic` entry.

#### How did you verify/test it?

On a local KVM T0 cSONiC testbed (`vms-kvm-t0-csonic`, 4 cSONiC neighbors), running `bgp/test_bgp_session.py` via `run_tests.sh` **without** `--neighbor_type`:

- Before: `test_bgp_session_interface_down[neighbor-bgp_docker]` and `[neighbor-swss_docker]` → **ERROR** (`eos_config` could not connect to the neighbor mgmt IP).
- After: both → **PASSED** (neighbor type auto-derived as `csonic`, dispatched to `CsonicHost.shutdown()` which shuts the neighbor's `Ethernet1` and the DUT correctly observes the session going down/up). No `eos_config` failures.

#### Any platform specific information?

Affects only how neighbor host objects are constructed; default behavior (EOS neighbors) is unchanged when `vm_type` is absent or `eos`.
