### PR TITLE
Auto-select cSONiC neighbor type for cSONiC testbeds

### DIFF
--- a/tests/common/test_csonic_neighbor_type.py
+++ b/tests/common/test_csonic_neighbor_type.py
@@ -1,0 +1,31 @@
+import pytest
+
+from tests.conftest import _neighbor_type_option_provided, _resolve_neighbor_type_for_testbed
+
+
+@pytest.mark.parametrize(
+    "requested,testbed_name,provided,expected",
+    [
+        ("eos", "vms-kvm-t0", False, "eos"),
+        ("eos", "vms-kvm-t0-csonic", False, "csonic"),
+        ("eos", "vms-kvm-t0-csonic", True, "eos"),
+        ("csonic", "vms-kvm-t0-csonic", True, "csonic"),
+        ("sonic", "vms-kvm-t0-csonic", True, "sonic"),
+    ],
+)
+def test_resolve_neighbor_type_for_csonic_testbed(requested, testbed_name, provided, expected):
+    tbinfo = {"conf-name": testbed_name}
+
+    assert _resolve_neighbor_type_for_testbed(requested, tbinfo, provided) == expected
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        (["bgp/test_bgp_session.py"], False),
+        (["--neighbor_type", "csonic"], True),
+        (["--neighbor_type=csonic"], True),
+    ],
+)
+def test_neighbor_type_option_provided(args, expected):
+    assert _neighbor_type_option_provided(args) == expected

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1079,6 +1079,24 @@ def k8scluster(k8smasters):
     return k8s_master_cluster
 
 
+def _neighbor_type_option_provided(args):
+    """Return True if pytest was invoked with --neighbor_type."""
+    return any(arg == "--neighbor_type" or arg.startswith("--neighbor_type=") for arg in args)
+
+
+def _resolve_neighbor_type_for_testbed(neighbor_type, tbinfo, neighbor_type_provided=False):
+    """Return the neighbor type that matches the testbed metadata.
+
+    Keep the historical pytest default (eos) for regular testbeds, but avoid
+    silently constructing EosHost objects for cSONiC testbeds when callers omit
+    --neighbor_type. Explicit --neighbor_type values still win.
+    """
+    testbed_name = tbinfo.get('conf-name', '')
+    if not neighbor_type_provided and neighbor_type == "eos" and "csonic" in testbed_name:
+        return "csonic"
+    return neighbor_type
+
+
 @pytest.fixture(scope="session")
 def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request):
     """
@@ -1092,7 +1110,19 @@ def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request):
         logger.info("No VMs exist for this topology: {}".format(tbinfo['topo']['name']))
         return devices
 
-    neighbor_type = request.config.getoption("--neighbor_type")
+    requested_neighbor_type = request.config.getoption("--neighbor_type")
+    neighbor_type = _resolve_neighbor_type_for_testbed(
+        requested_neighbor_type,
+        tbinfo,
+        _neighbor_type_option_provided(request.config.invocation_params.args)
+    )
+    if neighbor_type != requested_neighbor_type:
+        logger.info(
+            "Auto-selecting %s neighbor type for testbed %s; "
+            "pass --neighbor_type explicitly to override",
+            neighbor_type,
+            tbinfo.get('conf-name', '')
+        )
     if 'VMs' not in tbinfo['topo']['properties']['topology']:
         logger.info("No VMs exist for this topology: {}".format(
             tbinfo['topo']['properties']['topology']))


### PR DESCRIPTION
## Summary
- Auto-select `neighbor_type=csonic` when the selected testbed name contains `csonic` and the caller omitted `--neighbor_type`.
- Preserve explicit `--neighbor_type` values, including explicit `--neighbor_type=eos`.
- Add unit coverage for omitted-vs-explicit neighbor type resolution.

## Motivation
A cSONiC validation smoke run omitted `--neighbor_type=csonic`, so pytest used the historical default `eos`. The `nbrhosts` fixture then built `EosHost VM0100`, and neighbor-side link injection called `eos_config` against the cSONiC neighbor management IP instead of using `CsonicHost.shutdown()` / `no_shutdown()`.

This makes cSONiC testbeds robust to that omission while keeping existing EOS/default behavior for non-cSONiC testbeds.

## Verification
- `python3 -m py_compile tests/conftest.py tests/common/test_csonic_neighbor_type.py`
- Direct helper sanity checks for:
  - omitted neighbor type on regular testbed remains `eos`
  - omitted neighbor type on `vms-kvm-t0-csonic` becomes `csonic`
  - explicit `--neighbor_type=eos` remains `eos`
  - explicit `csonic` / `sonic` values are preserved
- `git diff --check`

Related: securely1g/csonic-validation#1
