### PR TITLE
Skip config gen via minigraph when init_cfg_profile is defined

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -930,7 +930,7 @@
           console_ports: "{{ device_serial_link[inventory_hostname] | default(omit) if 'c0' in topo else omit }}"
           enabled_dpu_indices: "{{ (testbed_facts.enabled_dpus[inventory_hostname] | map(attribute='dpu_index') | list) if (testbed_facts.enabled_dpus is defined and inventory_hostname in testbed_facts.enabled_dpus) else omit }}"
         become: true
-        when: enable_macsec is not defined
+        when: enable_macsec is not defined and init_cfg_profile is not defined
 
       - name: Copy macsec profile json to dut
         copy: src=../tests/common/macsec/profile.json
@@ -1178,7 +1178,7 @@
             become: true
             command: chronyc makestep
 
-        when: chrony_service.status.LoadState != "not-found"
+        when: chrony_service.status.LoadState != "not-found" and init_cfg_profile is not defined
 
       - name: Check if "config bmp" is supported
         shell: "config -h | grep 'BMP-related configuration'"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

For the topologies using init_cfg_profile , the full config_db json would be provided. We would not be able to use minigraph to generate configurations 

The following commits adds a check which doesn't exclude init_cfg_profile  in use case. 

https://github.com/sonic-net/sonic-mgmt/commit/54453e2c4e96b6a3e8b23a81d37dbffad6fbdc90#diff-14746e4d601d9af215ae97cc54b6cc5f0ff351e1a7810e105e78e92c08ebcb76R889

which leads testbed bring up faile. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Test topology vms-kvm-force10-7nodes with sonic vs image. Test case is srv6/test_srv6_basic_sanity.py



#### How did you do it?
Test topology vms-kvm-force10-7nodes with sonic vs image. Test case is srv6/test_srv6_basic_sanity.py

#### How did you verify/test it?
Test topology vms-kvm-force10-7nodes with sonic vs image. Test case is srv6/test_srv6_basic_sanity.py

#### Any platform specific information?
vms-kvm-force10-7nodes
vms-kvm-ciscovs-7nodes
vms-kvm-ciscovs-5nodes

These three test topologies are using  init_cfg_profile to provide configurations to all test nodes.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
