### PR TITLE
[dualtor][vpp] Fix dualtor vpp vtestbeds

### DIFF
--- a/ansible/roles/eos/templates/dualtor-aa-vpp-leaf.j2
+++ b/ansible/roles/eos/templates/dualtor-aa-vpp-leaf.j2
@@ -1,0 +1,1 @@
+dualtor-aa-leaf.j2

--- a/ansible/roles/eos/templates/dualtor-vpp-leaf.j2
+++ b/ansible/roles/eos/templates/dualtor-vpp-leaf.j2
@@ -1,0 +1,1 @@
+dualtor-leaf.j2

--- a/ansible/vars/topo_dualtor-aa-vpp.yml
+++ b/ansible/vars/topo_dualtor-aa-vpp.yml
@@ -1,0 +1,1 @@
+topo_dualtor-aa.yml

--- a/ansible/vars/topo_dualtor-vpp.yml
+++ b/ansible/vars/topo_dualtor-vpp.yml
@@ -1,0 +1,1 @@
+topo_dualtor.yml

--- a/ansible/veos_vtb
+++ b/ansible/veos_vtb
@@ -421,8 +421,8 @@ vm_host_1:
   hosts:
     STR-ACS-VSERV-01:
       ansible_host: 172.17.0.1
-      ansible_user: lolv
-      vm_host_user: lolv
+      ansible_user: "{{ lookup('env', 'SONIC_MGMT_VM_HOST_USER') | default('use_own_value', true) }}"
+      vm_host_user: "{{ lookup('env', 'SONIC_MGMT_VM_HOST_USER') | default('use_own_value', true) }}"
 
 vms_1:
   hosts:

--- a/ansible/veos_vtb
+++ b/ansible/veos_vtb
@@ -38,6 +38,7 @@ all:
           - t0-backend
           - t0-88-o8c80
           - dualtor
+          - dualtor-vpp
           - dualtor-56
           - dualtor-120
           - t2
@@ -53,6 +54,7 @@ all:
           - dualtor-mixed-56
           - dualtor-mixed-120
           - dualtor-aa
+          - dualtor-aa-vpp
           - dualtor-aa-56
           - dualtor-aa-64
           - dualtor-aa-120
@@ -358,7 +360,7 @@ all:
           type: kvm
           hwsku: Force10-S6000
           asic_type: vpp
-          serial_port: 9001
+          serial_port: 9008
           ansible_password: password
           ansible_user: admin
         vlab-vpp-02:
@@ -367,7 +369,7 @@ all:
           type: kvm
           hwsku: Force10-S6000
           asic_type: vpp
-          serial_port: 9001
+          serial_port: 9091
           ansible_password: password
           ansible_user: admin
         vlab-vpp-03:
@@ -419,8 +421,8 @@ vm_host_1:
   hosts:
     STR-ACS-VSERV-01:
       ansible_host: 172.17.0.1
-      ansible_user: "{{ lookup('env', 'SONIC_MGMT_VM_HOST_USER') | default('use_own_value', true) }}"
-      vm_host_user: "{{ lookup('env', 'SONIC_MGMT_VM_HOST_USER') | default('use_own_value', true) }}"
+      ansible_user: lolv
+      vm_host_user: lolv
 
 vms_1:
   hosts:

--- a/ansible/vtestbed.yaml
+++ b/ansible/vtestbed.yaml
@@ -572,7 +572,7 @@
 
 - conf-name: vms-kvm-dual-vpp-t0-1
   group-name: vms6-9
-  topo: dualtor
+  topo: dualtor-vpp
   ptf_image_name: docker-ptf
   ptf: ptf-09
   ptf_ip: 10.250.0.120/24
@@ -584,12 +584,12 @@
     - vlab-vpp-04
   inv_name: veos_vtb
   auto_recover: 'False'
-  use_converged_peers: True
+  use_converged_peers: False
   comment: Dual-TOR VPP testbed
 
 - conf-name: vms-kvm-dual-vpp-t0-2
   group-name: vms6-10
-  topo: dualtor-aa
+  topo: dualtor-aa-vpp
   ptf_image_name: docker-ptf
   ptf: ptf-10
   ptf_ip: 10.250.0.121/24
@@ -602,5 +602,5 @@
     - vlab-vpp-06
   inv_name: veos_vtb
   auto_recover: 'False'
-  use_converged_peers: True
+  use_converged_peers: False
   comment: Active-Active Dual-TOR VPP testbed


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

* Microsoft ADO (number only): 38615500

The VPP dual-ToR KVM testbeds (vms-kvm-dual-vpp-t0-1, vms-kvm-dual-vpp-t0-2) reused the stock dualtor / dualtor-aa topology names. VPP detection in tests/common/testbed.py keys off the -vpp topo-name suffix to set is_vpp=True, so these two testbeds were inconsistently treated as non-VPP, unlike every other VPP testbed (t0-vpp, t1-lag-vpp, …). They also could not be brought up reliably: with use_converged_peers: True, deploy hit failures during cEOS neighbor config.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?

- ansible/vtestbed.yaml — renamed the topologies to dualtor-vpp / dualtor-aa-vpp, and set use_converged_peers: False for both.
- ansible/veos_vtb — registered dualtor-vpp / dualtor-aa-vpp in the topologies list (and gave vlab-vpp-01 / vlab-vpp-02 unique serial_ports, fixing a 9001 collision).
- ansible/vars/topo_dualtor-vpp.yml, ansible/vars/topo_dualtor-aa-vpp.yml — added as symlinks to the base topo_dualtor.yml / topo_dualtor-aa.yml (definitions are identical to stock dualtor, so a symlink avoids a duplicate that would drift out of sync).
- ansible/roles/eos/templates/dualtor-vpp-leaf.j2, dualtor-aa-vpp-leaf.j2 — added as symlinks to the base dualtor-leaf.j2 / dualtor-aa-leaf.j2 cEOS startup-config templates, required by add-topo.

#### How did you verify/test it?

Ran add-topo for vms-kvm-dual-vpp-t0-1 (-t vtestbed.yaml -m veos_vtb -k ceos): PLAY RECAP failed=0 on the host; all 4 cEOS neighbors (VM0144–VM0147) plus net_* and ptf_vms6-9 containers come up.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
