### PR TITLE
[qos] testQosSaiDscpEcn: enable on q3d and make the test robust

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4485,8 +4485,10 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pQueueMapping:
 qos/test_qos_sai.py::TestQosSai::testQosSaiDscpEcn:
   skip:
     reason: "Unsupported testbed type"
+    conditions_logical_operator: and
     conditions:
       - "platform not in ['x86_64-nokia_ixr7250e_36x400g-r0']"
+      - "asic_gen not in ['q3d']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping:
   skip:

--- a/tests/qos/files/qos_params.q3d.yaml
+++ b/tests/qos/files/qos_params.q3d.yaml
@@ -1,6 +1,67 @@
 qos_params:
     q3d:
         topo-t2_single_node_min: &topo-t2_single_node_min
+            # ecn_1: non-ECT drop sanity on the lossless queue.
+            ecn_1:
+                dscp: 3
+                ecn: 0
+                num_of_pkts: 1500
+                limit: 1500
+                min_limit: 1200
+                cell_size: 4096
+                packet_size: 3950
+            # ecn_2: ECT below green_min ⇒ no marking expected.
+            ecn_2:
+                dscp: 3
+                ecn: 1
+                num_of_pkts: 1500
+                limit: 1500
+                min_limit: 2000
+                cell_size: 4096
+                packet_size: 3950
+            # ecn_3, ecn_4: ECN-capable bursts driven past green_max so WRED
+            # marking saturates and is deterministic: a fixed unmarked fill
+            # prefix (~1.3k pkts to reach green_max) then ~100% marking, so
+            # marked ~= num - fill_prefix (measured ~6705-6707 at num=8000).
+            ecn_3:
+                dscp: 3
+                ecn: 2
+                num_of_pkts: 8000
+                limit: 1200
+                min_limit: 1000
+                marked_pkts_min: 6500
+                marked_pkts_max: 6900
+                cell_size: 4096
+                packet_size: 3950
+            ecn_4:
+                dscp: 4
+                ecn: 1
+                num_of_pkts: 8000
+                limit: 1200
+                min_limit: 1000
+                marked_pkts_min: 6500
+                marked_pkts_max: 6900
+                cell_size: 4096
+                packet_size: 3950
+            # ecn_5: dscp=0 → lossy queue (q0) on Q3D, no WRED/ECN profile
+            # attached.
+            ecn_5:
+                dscp: 0
+                ecn: 1
+                num_of_pkts: 3500
+                limit: 1500
+                min_limit: 4000
+                cell_size: 4096
+                packet_size: 3950
+            # wred_drop: Q3D-specific non-ECT drop test.
+            wred_drop:
+                dscp: 3
+                ecn: 0
+                num_of_pkts: 2800
+                limit: 2800
+                min_limit: 2500
+                cell_size: 4096
+                packet_size: 3950
             400000_2000m:
                 hdrm_pool_size:
                     dscps:

--- a/tests/qos/files/qos_params.q3d.yaml
+++ b/tests/qos/files/qos_params.q3d.yaml
@@ -10,6 +10,7 @@ qos_params:
                 min_limit: 1200
                 cell_size: 4096
                 packet_size: 3950
+                egress_shaper_rate: 125000000
             # ecn_2: ECT below green_min ⇒ no marking expected.
             ecn_2:
                 dscp: 3
@@ -19,6 +20,7 @@ qos_params:
                 min_limit: 2000
                 cell_size: 4096
                 packet_size: 3950
+                egress_shaper_rate: 125000000
             # ecn_3, ecn_4: ECN-capable bursts driven past green_max so WRED
             # marking saturates and is deterministic: a fixed unmarked fill
             # prefix (~1.3k pkts to reach green_max) then ~100% marking, so
@@ -33,6 +35,7 @@ qos_params:
                 marked_pkts_max: 6900
                 cell_size: 4096
                 packet_size: 3950
+                egress_shaper_rate: 125000000
             ecn_4:
                 dscp: 4
                 ecn: 1
@@ -43,6 +46,7 @@ qos_params:
                 marked_pkts_max: 6900
                 cell_size: 4096
                 packet_size: 3950
+                egress_shaper_rate: 125000000
             # ecn_5: dscp=0 → lossy queue (q0) on Q3D, no WRED/ECN profile
             # attached.
             ecn_5:
@@ -53,6 +57,7 @@ qos_params:
                 min_limit: 4000
                 cell_size: 4096
                 packet_size: 3950
+                egress_shaper_rate: 125000000
             # wred_drop: Q3D-specific non-ECT drop test.
             wred_drop:
                 dscp: 3
@@ -62,6 +67,7 @@ qos_params:
                 min_limit: 2500
                 cell_size: 4096
                 packet_size: 3950
+                egress_shaper_rate: 125000000
             400000_2000m:
                 hdrm_pool_size:
                     dscps:

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -2684,7 +2684,7 @@ class TestQosSai(QosSaiBase):
             ptfhost, testCase="sai_qos_tests.XonHysteresisTest",
             testParams=test_params)
 
-    @pytest.mark.parametrize("ecn", ["ecn_1", "ecn_2", "ecn_3", "ecn_4", "ecn_5"])
+    @pytest.mark.parametrize("ecn", ["ecn_1", "ecn_2", "ecn_3", "ecn_4", "ecn_5", "wred_drop"])
     def testQosSaiDscpEcn(
         self, ecn, duthosts, get_src_dst_asic_and_duts,
         ptfhost, dutTestParams, dutConfig, dutQosConfig, ecnLosslessProfile, enableECN,
@@ -2714,6 +2714,11 @@ class TestQosSai(QosSaiBase):
         if dutTestParams['hwsku'] in self.BREAKOUT_SKUS and 'backend' not in dutTestParams['topo']:
             qosConfig = dutQosConfig["param"][portSpeedCableLength]["breakout"]
         else:
+            # Some ECN variants (e.g. wred_drop) are only defined for certain
+            # platforms; skip the variant when this platform's params omit it
+            # instead of failing with a KeyError.
+            if ecn not in dutQosConfig["param"]:
+                pytest.skip("'{}' params not defined for this platform".format(ecn))
             qosConfig = dutQosConfig["param"][ecn]
 
         self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
@@ -2733,8 +2738,18 @@ class TestQosSai(QosSaiBase):
             "limit": qosConfig["limit"],
             "min_limit": qosConfig["min_limit"],
             "cell_size": qosConfig["cell_size"],
-            "hwsku": dutTestParams['hwsku']
+            "hwsku": dutTestParams['hwsku'],
         })
+        if "packet_size" in qosConfig:
+            testParams["packet_size"] = qosConfig["packet_size"]
+        for opt in ("marked_pkts_min", "marked_pkts_max", "egress_shaper_rate"):
+            if opt in qosConfig:
+                testParams[opt] = qosConfig[opt]
+        # Preserve the '-n asicX' namespace flag for the wredcounter reads on
+        # multi-ASIC DNX (mirrors populateArpEntries_T2); single-ASIC -> False.
+        testParams["dst_is_multi_asic"] = get_src_dst_asic_and_duts['dst_dut'].sonichost.is_multi_asic
+        if ecn == "wred_drop":
+            testParams["verify_wred_drops"] = True
 
         if "platform_asic" in dutTestParams["basicParams"]:
             testParams["platform_asic"] = dutTestParams["basicParams"]["platform_asic"]

--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -234,6 +234,21 @@ class ThriftInterface(BaseTest):
             return '-n asic{} '.format(dst_asic_index)
         return ''
 
+    def _read_dut_value(self, cmd):
+        """Run cmd on the dst DUT and return its first stdout line, stripped.
+
+        Returns '' when the command produced no output, which is what
+        'sonic-db-cli ... hget' yields for an unset field -- so callers must not
+        index into the result unconditionally.
+        """
+        stdOut, stdErr, retValue = self.exec_cmd_on_dut(
+            self.dst_server_ip, self.test_params['dut_username'],
+            self.test_params['dut_password'], cmd)
+        if stdErr:
+            print("_read_dut_value: command failed (retValue={}, stdErr={}): {}".format(
+                retValue, stdErr, cmd))
+        return stdOut[0].strip() if stdOut else ''
+
     def _run_shaper_cmds(self, cmds, caller):
         """Run the shaper's CONFIG_DB writes, logging any that fail."""
         for cmd in cmds:
@@ -270,6 +285,12 @@ class ThriftInterface(BaseTest):
             burst = max(max_rate // 100, 8192)
         sched_name = "egress_shaper_{}".format(dut_port)
         ns_opt = self._dst_ns_opt()
+        # Remember any pre-existing port-level scheduler binding so cleanup can
+        # restore it.
+        saved = self._read_dut_value(
+            'sudo sonic-db-cli {}CONFIG_DB hget "PORT_QOS_MAP|{}" scheduler'.format(
+                ns_opt, dut_port))
+        self.saved_port_scheduler = '' if saved == sched_name else saved
         cmds = [
             'sudo sonic-db-cli {}CONFIG_DB hset "SCHEDULER|{}" meter_type bytes pir {} pbs {}'.format(
                 ns_opt, sched_name, int(max_rate), int(burst)),
@@ -281,15 +302,23 @@ class ThriftInterface(BaseTest):
         time.sleep(3)
 
     def clear_egress_shaper(self, dut_port, max_rate):
-        """Remove the shaper applied by apply_egress_shaper(). No-op when max_rate
+        """Remove the shaper applied by apply_egress_shaper(), putting back any
+        port-level scheduler binding that was there before. No-op when max_rate
         is falsy or the platform is not Broadcom, mirroring apply_egress_shaper()
         so it is safe to call unconditionally in a finally block."""
         if not max_rate or self.test_params.get('sonic_asic_type') != 'broadcom':
             return
         sched_name = "egress_shaper_{}".format(dut_port)
         ns_opt = self._dst_ns_opt()
+        saved = getattr(self, 'saved_port_scheduler', '')
+        if saved:
+            unbind_cmd = 'sudo sonic-db-cli {}CONFIG_DB hset "PORT_QOS_MAP|{}" scheduler {}'.format(
+                ns_opt, dut_port, saved)
+        else:
+            unbind_cmd = 'sudo sonic-db-cli {}CONFIG_DB hdel "PORT_QOS_MAP|{}" scheduler'.format(
+                ns_opt, dut_port)
         cmds = [
-            'sudo sonic-db-cli {}CONFIG_DB hdel "PORT_QOS_MAP|{}" scheduler'.format(ns_opt, dut_port),
+            unbind_cmd,
             'sudo sonic-db-cli {}CONFIG_DB del "SCHEDULER|{}"'.format(ns_opt, sched_name),
         ]
         self._run_shaper_cmds(cmds, 'clear_egress_shaper')

--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -226,6 +226,57 @@ class ThriftInterface(BaseTest):
         else:
             sai_thrift_port_tx_disable(client, asic_type, port_list, target=target)
 
+    def apply_egress_shaper(self, dut_port, max_rate, burst=0):
+        """Program a port-level egress shaper on the DUT via CONFIG_DB so a
+        high-speed port does not overrun the fanout->PTF path when a queued
+        burst is released.
+
+        Creates a SCHEDULER (meter_type=bytes, pir=max_rate, pbs=burst) and binds
+        it to dut_port via PORT_QOS_MAP; orchagent programs the port scheduler
+        profile (SAI_PORT_ATTR_QOS_SCHEDULER_PROFILE_ID), leaving the per-queue
+        schedulers untouched. Applied while the port is up so the rate limiter is
+        armed before traffic is released.
+
+        No-op when max_rate is falsy or the platform is not Broadcom (the shaper
+        is validated only on Broadcom XGS/DNX; other vendors manage the port
+        scheduler differently). Rate/burst are bytes/sec and bytes; burst
+        defaults to ~1% of the rate. Pair with clear_egress_shaper() in a finally
+        block."""
+        if not max_rate:
+            return
+        if self.test_params.get('sonic_asic_type') != 'broadcom':
+            print("apply_egress_shaper: egress shaper is only supported on Broadcom; "
+                  "skipping on asic_type={}".format(self.test_params.get('sonic_asic_type')))
+            return
+        if not burst:
+            burst = max(max_rate // 100, 8192)
+        sched_name = "egress_shaper_{}".format(dut_port)
+        cmds = [
+            'sudo sonic-db-cli CONFIG_DB hset "SCHEDULER|{}" meter_type bytes pir {} pbs {}'.format(
+                sched_name, int(max_rate), int(burst)),
+            'sudo sonic-db-cli CONFIG_DB hset "PORT_QOS_MAP|{}" scheduler {}'.format(dut_port, sched_name),
+        ]
+        for cmd in cmds:
+            self.exec_cmd_on_dut(self.dst_server_ip, self.test_params['dut_username'],
+                                 self.test_params['dut_password'], cmd)
+        # Let orchagent program the port scheduler profile before traffic is released.
+        time.sleep(3)
+
+    def clear_egress_shaper(self, dut_port, max_rate):
+        """Remove the shaper applied by apply_egress_shaper(). No-op when max_rate
+        is falsy or the platform is not Broadcom, mirroring apply_egress_shaper()
+        so it is safe to call unconditionally in a finally block."""
+        if not max_rate or self.test_params.get('sonic_asic_type') != 'broadcom':
+            return
+        sched_name = "egress_shaper_{}".format(dut_port)
+        cmds = [
+            'sudo sonic-db-cli CONFIG_DB hdel "PORT_QOS_MAP|{}" scheduler'.format(dut_port),
+            'sudo sonic-db-cli CONFIG_DB del "SCHEDULER|{}"'.format(sched_name),
+        ]
+        for cmd in cmds:
+            self.exec_cmd_on_dut(self.dst_server_ip, self.test_params['dut_username'],
+                                 self.test_params['dut_password'], cmd)
+
     def get_dut_port(self, ptf_port):
         for port_group in interface_to_front_mapping.keys():
             if str(ptf_port) in interface_to_front_mapping[port_group].keys():

--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -226,6 +226,24 @@ class ThriftInterface(BaseTest):
         else:
             sai_thrift_port_tx_disable(client, asic_type, port_list, target=target)
 
+    def _dst_ns_opt(self):
+        """'-n asic<idx> ' for the dst port's namespace on a multi-ASIC DUT, else ''."""
+        # dst_asic_index is only assigned on the 'port_map_file' setUp path.
+        dst_asic_index = getattr(self, 'dst_asic_index', None)
+        if self.test_params.get('dst_is_multi_asic', False) and dst_asic_index is not None:
+            return '-n asic{} '.format(dst_asic_index)
+        return ''
+
+    def _run_shaper_cmds(self, cmds, caller):
+        """Run the shaper's CONFIG_DB writes, logging any that fail."""
+        for cmd in cmds:
+            _, stdErr, retValue = self.exec_cmd_on_dut(
+                self.dst_server_ip, self.test_params['dut_username'],
+                self.test_params['dut_password'], cmd)
+            if retValue != 0 or stdErr:
+                print("{}: command failed (retValue={}, stdErr={}): {}".format(
+                    caller, retValue, stdErr, cmd))
+
     def apply_egress_shaper(self, dut_port, max_rate, burst=0):
         """Program a port-level egress shaper on the DUT via CONFIG_DB so a
         high-speed port does not overrun the fanout->PTF path when a queued
@@ -251,14 +269,14 @@ class ThriftInterface(BaseTest):
         if not burst:
             burst = max(max_rate // 100, 8192)
         sched_name = "egress_shaper_{}".format(dut_port)
+        ns_opt = self._dst_ns_opt()
         cmds = [
-            'sudo sonic-db-cli CONFIG_DB hset "SCHEDULER|{}" meter_type bytes pir {} pbs {}'.format(
-                sched_name, int(max_rate), int(burst)),
-            'sudo sonic-db-cli CONFIG_DB hset "PORT_QOS_MAP|{}" scheduler {}'.format(dut_port, sched_name),
+            'sudo sonic-db-cli {}CONFIG_DB hset "SCHEDULER|{}" meter_type bytes pir {} pbs {}'.format(
+                ns_opt, sched_name, int(max_rate), int(burst)),
+            'sudo sonic-db-cli {}CONFIG_DB hset "PORT_QOS_MAP|{}" scheduler {}'.format(
+                ns_opt, dut_port, sched_name),
         ]
-        for cmd in cmds:
-            self.exec_cmd_on_dut(self.dst_server_ip, self.test_params['dut_username'],
-                                 self.test_params['dut_password'], cmd)
+        self._run_shaper_cmds(cmds, 'apply_egress_shaper')
         # Let orchagent program the port scheduler profile before traffic is released.
         time.sleep(3)
 
@@ -269,13 +287,12 @@ class ThriftInterface(BaseTest):
         if not max_rate or self.test_params.get('sonic_asic_type') != 'broadcom':
             return
         sched_name = "egress_shaper_{}".format(dut_port)
+        ns_opt = self._dst_ns_opt()
         cmds = [
-            'sudo sonic-db-cli CONFIG_DB hdel "PORT_QOS_MAP|{}" scheduler'.format(dut_port),
-            'sudo sonic-db-cli CONFIG_DB del "SCHEDULER|{}"'.format(sched_name),
+            'sudo sonic-db-cli {}CONFIG_DB hdel "PORT_QOS_MAP|{}" scheduler'.format(ns_opt, dut_port),
+            'sudo sonic-db-cli {}CONFIG_DB del "SCHEDULER|{}"'.format(ns_opt, sched_name),
         ]
-        for cmd in cmds:
-            self.exec_cmd_on_dut(self.dst_server_ip, self.test_params['dut_username'],
-                                 self.test_params['dut_password'], cmd)
+        self._run_shaper_cmds(cmds, 'clear_egress_shaper')
 
     def get_dut_port(self, ptf_port):
         for port_group in interface_to_front_mapping.keys():

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4493,6 +4493,44 @@ class SharedResSizeTest(sai_base_test.ThriftInterfaceDataPlane):
 
 
 class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
+    def _read_wred_drop_pkts(self, dut_port, dscp, ns_opt, voq):
+        """Read SAI_QUEUE_STAT_WRED_DROPPED_PACKETS (the WredDrp/pkts column of
+        'show queue wredcounters'): the ingress VOQ<dscp> (with --voq) on DNX,
+        or the egress unicast queue UC<dscp> on XGS, depending on `voq`.
+
+        Returns the int counter, or None if the row is missing or shows N/A.
+        Raises RuntimeError if the underlying CLI fails (stderr non-empty).
+        """
+        voq_flag = '--voq ' if voq else ''
+        cmd = 'show queue wredcounters {}{}| grep -w {}'.format(voq_flag, ns_opt, dut_port)
+        stdOut, stdErr, retValue = self.exec_cmd_on_dut(
+            self.dst_server_ip, self.test_params['dut_username'],
+            self.test_params['dut_password'], cmd)
+        if stdErr:
+            raise RuntimeError(
+                "show queue wredcounters failed: stdErr={}, retValue={}"
+                .format(stdErr, retValue))
+        label = ('VOQ' if voq else 'UC') + str(dscp)
+        for line in stdOut:
+            fields = line.split()
+            # DNX VOQ chassis row: <host>|<asic>|<port>  VOQ<idx>  WredDrp/pkts ...
+            # XGS row:             <port>                UC<idx>   WredDrp/pkts ...
+            port_match = fields[0].endswith(dut_port) if voq else fields[0] == dut_port
+            if len(fields) >= 3 and port_match and fields[1] == label:
+                value = fields[2]
+                if value == 'N/A':
+                    return None
+                return int(value.replace(',', ''))
+        return None
+
+    def _poll_until(self, fn, ok, timeout=20, interval=2):
+        val = fn()
+        deadline = time.time() + timeout
+        while not ok(val) and time.time() < deadline:
+            time.sleep(interval)
+            val = fn()
+        return val
+
     def runTest(self):
         switch_init(self.clients)
 
@@ -4509,6 +4547,10 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
         src_port_ip = self.test_params['src_port_ip']
         src_port_mac = self.dataplane.get_mac(0, src_port_id)
         num_of_pkts = self.test_params['num_of_pkts']
+        # Egress shaper (bytes/sec) on the dst port, applied by default to pace
+        # the release so a high-speed port does not overrun the fanout->PTF path.
+        # The base-class helper no-ops on non-Broadcom platforms; 0 disables it.
+        egress_shaper_rate = int(self.test_params.get('egress_shaper_rate', 125000000))
         cell_size = self.test_params['cell_size']
         pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
         src_port_vlan = self.test_params['src_port_vlan']
@@ -4538,21 +4580,44 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
         )
         log_message("actual dst_port_id: {}".format(dst_port_id), to_stderr=True)
 
+        # Cache the dst DUT port name and per-asic namespace flag once, so the
+        # pre/post-test wredcounter blocks below can share them.
+        dut_port = self.get_dut_port(dst_port_id)
+        dst_is_multi_asic = self.test_params.get('dst_is_multi_asic', False)
+        ns_opt = ("-n asic{} ".format(self.dst_asic_index)
+                  if dst_is_multi_asic and self.dst_asic_index is not None
+                  else "")
+        verify_wred_drops = self.test_params.get('verify_wred_drops', False)
+
         # Get a snapshot of counter values
         port_counters_base, queue_counters_base = sai_thrift_read_port_counters(
             self.dst_client, asic_type, port_list['dst'][dst_port_id])
         print(port_counters_base)
         print(queue_counters_base)
+        # Pace egress on the dst port so the release does not overrun the
+        # fanout->PTF path. Applied while the port is still up; broadcom-only
+        # (no-op otherwise). Per-queue WRED/scheduling is untouched.
+        self.apply_egress_shaper(dut_port, egress_shaper_rate)
         self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
-        # Clear wred counters
-        if platform_asic and platform_asic == "broadcom-dnx":
-            stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.dst_server_ip, self.test_params['dut_username'],
-                                                            self.test_params['dut_password'],
-                                                            'sonic-clear queue wredcounters')
+        # Clear WRED counter caches so the post-test 'show queue wredcounters'
+        # reads are per-run deltas. 'sonic-clear queue wredcounters' resets
+        # the egress-queue cache (XGS, and DNX's egress UC rows). On DNX
+        # the VOQ cache is separate and only matters for the wred_drop
+        # variant (verify_wred_drops + ecn==0) — clear it via
+        # 'wredstat -c -V' there.
+        clear_cmds = []
+        if platform_asic and platform_asic in ("broadcom-dnx", "broadcom"):
+            clear_cmds.append('sonic-clear queue wredcounters')
+            if platform_asic == "broadcom-dnx" and verify_wred_drops and ecn == 0:
+                clear_cmds.append('wredstat -c -V')
+        for clear_cmd in clear_cmds:
+            stdOut, stdErr, retValue = self.exec_cmd_on_dut(
+                self.dst_server_ip, self.test_params['dut_username'],
+                self.test_params['dut_password'], clear_cmd)
             if stdErr and retValue != 0:
                 raise RuntimeError("Command might have failed in the DUT.Error:{}".format(stdErr))
             else:
-                print("---------Wredcounter queue counters reset------------")
+                print("---------Wredcounter cache reset via '{}'------------".format(clear_cmd))
 
         # send packets
         try:
@@ -4589,11 +4654,11 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
             # if (ecn == 1) - capture and parse all incoming packets
             marked_cnt = 0
             not_marked_cnt = 0
+            total_recv_cnt = 0
             if (ecn != 0):
                 print("")
                 print(
                     "ECN capable packets generated, releasing dst_port and analyzing traffic -")
-                total_recv_cnt = 0
                 pkts = []
                 while total_recv_cnt < num_of_pkts:
                     result = self.dataplane.poll(
@@ -4623,45 +4688,89 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
                 print("    ECN marked pkts:     " + str(marked_cnt))
                 print("")
 
-            dut_port = self.get_dut_port(dst_port_id)
             if platform_asic and platform_asic == "broadcom-dnx":
-                time.sleep(8)
-                stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.dst_server_ip, self.test_params['dut_username'],
-                                                                self.test_params['dut_password'],
-                                                                'show queue wredcounters -n asic{}| grep {}| grep UC{}'
-                                                                .format(self.dst_asic_index, dut_port, dscp))
-                if stdErr and retValue != 0:
-                    raise RuntimeError("Command might have failed in the DUT.Error:{}".format(stdErr))
-                else:
-                    print("----Queue WredCounters on DUT----")
-                    print("ECNMarked pkts: {}  ECNMarked bytes: {}".format(stdOut[0].split()[4],
-                                                                           stdOut[0].split()[5]))
-                # the output number format is comma seperated value,remove comma if expected marked_pkts > 999
+                def read_ecn_marked():
+                    out, err, ret = self.exec_cmd_on_dut(
+                        self.dst_server_ip, self.test_params['dut_username'],
+                        self.test_params['dut_password'],
+                        'show queue wredcounters {}| grep -w {} | grep -w UC{}'.format(ns_opt, dut_port, dscp))
+                    if err:
+                        raise RuntimeError(
+                            "show queue wredcounters failed: stdErr={}, retValue={}".format(err, ret))
+                    f = out[0].split() if out else []
+                    return f[4] if len(f) > 5 else None
                 if ecn_queue_status == 'off':
                     assert (marked_cnt == 0)
                     limit = 0
-                assert (int(stdOut[0].split()[4]) == marked_cnt)
+                ecn_marked_pkts = self._poll_until(
+                    read_ecn_marked,
+                    lambda v: v is None or v == 'N/A' or int(v.replace(',', '')) == marked_cnt)
+                print("ECNMarked pkts: {}".format(ecn_marked_pkts))
+                if ecn_marked_pkts is not None and ecn_marked_pkts != 'N/A':
+                    assert (int(ecn_marked_pkts.replace(',', '')) == marked_cnt)
+                else:
+                    print("Skipping wred counter assertion: counter unavailable (stdOut={})".format(ecn_marked_pkts))
 
-            assert (port_counters[TRANSMITTED_PKTS] - port_counters_base[TRANSMITTED_PKTS] >= num_of_pkts)
+            transmitted_pkts = port_counters[TRANSMITTED_PKTS] - port_counters_base[TRANSMITTED_PKTS]
+
+            # WRED-drop counter cross-check (verify_wred_drops, non-ECT only).
+            # The drop counter is on the ingress VOQ on DNX and on the egress
+            # queue on XGS; both caches were cleared before the send, so the
+            # read is a per-run delta. It should track the port-level drop count
+            # (num_of_pkts - transmitted), within a slack of 5 pkts or 10% to
+            # absorb background traffic on the same VOQ/queue.
+            if ecn == 0 and verify_wred_drops and platform_asic in ("broadcom-dnx", "broadcom"):
+                voq = platform_asic == "broadcom-dnx"
+                counter_id = ("VOQ" if voq else "UC") + str(dscp)
+                port_drops_this_run = num_of_pkts - transmitted_pkts
+                assert port_drops_this_run > 0, \
+                    "no port-level drops observed (num_of_pkts={}, transmitted={})".format(
+                        num_of_pkts, transmitted_pkts)
+                allowed_slack = max(5, int(port_drops_this_run * 0.1))
+                drop_delta = self._poll_until(
+                    lambda: self._read_wred_drop_pkts(dut_port, dscp, ns_opt, voq),
+                    lambda v: v is not None and abs(v - port_drops_this_run) <= allowed_slack)
+                print("----WredCounters on DUT (port={}, {}): WredDrp/pkts={}----"
+                      .format(dut_port, counter_id, drop_delta))
+                assert drop_delta is not None, \
+                    "WredDrp/pkts row unavailable for port={} {}".format(dut_port, counter_id)
+                assert abs(drop_delta - port_drops_this_run) <= allowed_slack, \
+                    "WRED drop delta ({}) differs from port drops ({}) by more than {}".format(
+                        drop_delta, port_drops_this_run, allowed_slack)
             if ecn == 0:
+                # ecn==0 -> non-ECT flow; WRED drops above threshold, so
+                # transmitted_pkts < num_of_pkts is expected. Bound by queue limit instead.
                 assert (marked_cnt == 0)
-                transmitted_data = ((port_counters[TRANSMITTED_PKTS] - port_counters_base[TRANSMITTED_PKTS])
-                                    * cell_occupancy)
+                transmitted_data = transmitted_pkts * cell_occupancy
                 assert (min_limit <= transmitted_data <= limit * 1.05)
             else:
+                # ECN-capable flow: packets are marked, not dropped, so all
+                # should egress (the egress shaper paces the release so the
+                # full burst reaches the PTF without loss).
+                assert (transmitted_pkts >= num_of_pkts)
                 non_marked_data = not_marked_cnt * cell_occupancy
                 assert (limit * 0.95 <= non_marked_data)
                 # If the number of packets in the queue is below the minimum threshold
                 # then the packets will not be marked
                 if num_of_pkts > min_limit:
-                    assert (limit * 0.03 <= marked_cnt <= limit * 0.07)
+                    marked_min = self.test_params.get('marked_pkts_min')
+                    marked_max = self.test_params.get('marked_pkts_max')
+                    if (marked_min is not None and marked_max is not None
+                            and ecn_queue_status != 'off'):
+                        assert (marked_min <= marked_cnt <= marked_max)
+                    else:
+                        assert (limit * 0.03 <= marked_cnt <= limit * 0.07)
                     assert (marked_cnt >= (num_of_pkts - not_marked_cnt))
 
+                # Tolerate small background drift (e.g. IPv6 NS/RA neighbors
+                # leaking a few packets into the ingress drop counter); a
+                # strict equality is too brittle.
                 for cntr in ingress_counters:
-                    assert (port_counters[cntr] == port_counters_base[cntr])
+                    assert (port_counters[cntr] <= port_counters_base[cntr] + COUNTER_MARGIN)
         finally:
             # RELEASE PORT
             self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
+            self.clear_egress_shaper(dut_port, egress_shaper_rate)
             print("END OF TEST")
 
 

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4513,6 +4513,11 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
         label = ('VOQ' if voq else 'UC') + str(dscp)
         for line in stdOut:
             fields = line.split()
+            # Column order is fixed by sonic-utilities scripts/wredstat:
+            # port, <queuetype><idx>, WredDrp/pkts, WredDrp/bytes,
+            # EcnMarked/pkts, EcnMarked/bytes -- so the drop count is always
+            # fields[2] and the ECN count fields[4]. The port column is a
+            # single token in both layouts:
             # DNX VOQ chassis row: <host>|<asic>|<port>  VOQ<idx>  WredDrp/pkts ...
             # XGS row:             <port>                UC<idx>   WredDrp/pkts ...
             if len(fields) < 3:
@@ -4701,6 +4706,13 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
                     if err:
                         raise RuntimeError(
                             "show queue wredcounters failed: stdErr={}, retValue={}".format(err, ret))
+                    # wredstat always prints a 6-column row per queue, so a
+                    # matched row yields a value: the literal 'N/A' when the
+                    # counter is not in COUNTERS_DB (flex counters not polled,
+                    # or no WRED/ECN counter support on the platform), which is
+                    # the case this cross-check is skipped for. None means no
+                    # row matched at all -- a wrong namespace or queue-type
+                    # label -- which is a genuine failure, not 'unsupported'.
                     f = out[0].split() if out else []
                     return f[4] if len(f) > 5 else None
                 if ecn_queue_status == 'off':
@@ -4708,14 +4720,24 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
                     limit = 0
                 ecn_marked_pkts = self._poll_until(
                     read_ecn_marked,
-                    lambda v: v is None or v == 'N/A' or int(v.replace(',', '')) == marked_cnt)
+                    lambda v: v == 'N/A' or (v is not None and int(v.replace(',', '')) == marked_cnt))
                 print("ECNMarked pkts: {}".format(ecn_marked_pkts))
-                if ecn_marked_pkts is not None and ecn_marked_pkts != 'N/A':
-                    assert (int(ecn_marked_pkts.replace(',', '')) == marked_cnt)
+                if ecn_marked_pkts == 'N/A':
+                    print("Skipping wred counter assertion: ECN counters unavailable on this "
+                          "platform (flex counters not polled, or unsupported)")
                 else:
-                    print("Skipping wred counter assertion: counter unavailable (stdOut={})".format(ecn_marked_pkts))
+                    assert ecn_marked_pkts is not None, \
+                        "no 'show queue wredcounters' row matched port={} UC{}".format(dut_port, dscp)
+                    assert (int(ecn_marked_pkts.replace(',', '')) == marked_cnt)
 
             transmitted_pkts = port_counters[TRANSMITTED_PKTS] - port_counters_base[TRANSMITTED_PKTS]
+
+            # The full burst is expected to egress on every variant except the
+            # one that deliberately overruns the WRED drop threshold. Scoped to
+            # 'verify_wred_drops' rather than to 'ecn != 0' so the non-ECT
+            # variants keep this bound as well.
+            if not verify_wred_drops:
+                assert (transmitted_pkts >= num_of_pkts)
 
             # Tuned for q3d: assumes num_of_pkts exceeds the platform's WRED
             # drop threshold by a small, bounded margin. Retune before enabling
@@ -4754,8 +4776,8 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
             else:
                 # ECN-capable flow: packets are marked, not dropped, so all
                 # should egress (the egress shaper paces the release so the
-                # full burst reaches the PTF without loss).
-                assert (transmitted_pkts >= num_of_pkts)
+                # full burst reaches the PTF without loss). The full-burst
+                # assertion is made above, for the non-ECT variants too.
                 non_marked_data = not_marked_cnt * cell_occupancy
                 assert (limit * 0.95 <= non_marked_data)
                 # If the number of packets in the queue is below the minimum threshold

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4554,11 +4554,12 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
         src_port_ip = self.test_params['src_port_ip']
         src_port_mac = self.dataplane.get_mac(0, src_port_id)
         num_of_pkts = self.test_params['num_of_pkts']
-        # Egress shaper (bytes/sec) on the dst port, applied by default to pace
-        # the release so a high-speed port does not overrun the fanout->PTF path.
-        # The base-class helper no-ops on non-Broadcom platforms; 0 disables it.
-        egress_shaper_rate = int(self.test_params.get('egress_shaper_rate', 125000000))
-        cell_size = self.test_params['cell_size']
+        # Egress shaper (bytes/sec) on the dst port, to pace the release so a
+        # high-speed port does not overrun the fanout->PTF path. Opt-in per
+        # platform via 'egress_shaper_rate' in that platform's qos_params: it
+        # defaults to 0 (disabled) so a platform that does not need it is left
+        # untouched. The base-class helper also no-ops on non-Broadcom.
+        egress_shaper_rate = int(self.test_params.get('egress_shaper_rate', 0))
         pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
         src_port_vlan = self.test_params['src_port_vlan']
         limit = self.test_params['limit']

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4515,8 +4515,10 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
             fields = line.split()
             # DNX VOQ chassis row: <host>|<asic>|<port>  VOQ<idx>  WredDrp/pkts ...
             # XGS row:             <port>                UC<idx>   WredDrp/pkts ...
+            if len(fields) < 3:
+                continue
             port_match = fields[0].endswith(dut_port) if voq else fields[0] == dut_port
-            if len(fields) >= 3 and port_match and fields[1] == label:
+            if port_match and fields[1] == label:
                 value = fields[2]
                 if value == 'N/A':
                     return None
@@ -4594,33 +4596,35 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
             self.dst_client, asic_type, port_list['dst'][dst_port_id])
         print(port_counters_base)
         print(queue_counters_base)
-        # Pace egress on the dst port so the release does not overrun the
-        # fanout->PTF path. Applied while the port is still up; broadcom-only
-        # (no-op otherwise). Per-queue WRED/scheduling is untouched.
-        self.apply_egress_shaper(dut_port, egress_shaper_rate)
-        self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
-        # Clear WRED counter caches so the post-test 'show queue wredcounters'
-        # reads are per-run deltas. 'sonic-clear queue wredcounters' resets
-        # the egress-queue cache (XGS, and DNX's egress UC rows). On DNX
-        # the VOQ cache is separate and only matters for the wred_drop
-        # variant (verify_wred_drops + ecn==0) — clear it via
-        # 'wredstat -c -V' there.
-        clear_cmds = []
-        if platform_asic and platform_asic in ("broadcom-dnx", "broadcom"):
-            clear_cmds.append('sonic-clear queue wredcounters')
-            if platform_asic == "broadcom-dnx" and verify_wred_drops and ecn == 0:
-                clear_cmds.append('wredstat -c -V')
-        for clear_cmd in clear_cmds:
-            stdOut, stdErr, retValue = self.exec_cmd_on_dut(
-                self.dst_server_ip, self.test_params['dut_username'],
-                self.test_params['dut_password'], clear_cmd)
-            if stdErr and retValue != 0:
-                raise RuntimeError("Command might have failed in the DUT.Error:{}".format(stdErr))
-            else:
-                print("---------Wredcounter cache reset via '{}'------------".format(clear_cmd))
-
-        # send packets
+        # Shaper and tx-disable are inside the try so the finally always undoes
+        # them; both they and the clear_cmds loop below can raise.
         try:
+            # Pace egress on the dst port so the release does not overrun the
+            # fanout->PTF path. Applied while the port is still up; broadcom-only
+            # (no-op otherwise). Per-queue WRED/scheduling is untouched.
+            self.apply_egress_shaper(dut_port, egress_shaper_rate)
+            self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
+            # Clear WRED counter caches so the post-test 'show queue wredcounters'
+            # reads are per-run deltas. 'sonic-clear queue wredcounters' resets
+            # the egress-queue cache (XGS, and DNX's egress UC rows). On DNX
+            # the VOQ cache is separate and only matters for the wred_drop
+            # variant (verify_wred_drops + ecn==0) — clear it via
+            # 'wredstat -c -V' there.
+            clear_cmds = []
+            if platform_asic and platform_asic in ("broadcom-dnx", "broadcom"):
+                clear_cmds.append('sonic-clear queue wredcounters')
+                if platform_asic == "broadcom-dnx" and verify_wred_drops and ecn == 0:
+                    clear_cmds.append('wredstat -c -V')
+            for clear_cmd in clear_cmds:
+                stdOut, stdErr, retValue = self.exec_cmd_on_dut(
+                    self.dst_server_ip, self.test_params['dut_username'],
+                    self.test_params['dut_password'], clear_cmd)
+                if stdErr and retValue != 0:
+                    raise RuntimeError("Command might have failed in the DUT.Error:{}".format(stdErr))
+                else:
+                    print("---------Wredcounter cache reset via '{}'------------".format(clear_cmd))
+
+            # send packets
             tos = dscp << 2
             tos |= ecn
 
@@ -4713,6 +4717,10 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
 
             transmitted_pkts = port_counters[TRANSMITTED_PKTS] - port_counters_base[TRANSMITTED_PKTS]
 
+            # Tuned for q3d: assumes num_of_pkts exceeds the platform's WRED
+            # drop threshold by a small, bounded margin. Retune before enabling
+            # 'wred_drop' on another asic.
+            #
             # WRED-drop counter cross-check (verify_wred_drops, non-ECT only).
             # The drop counter is on the ingress VOQ on DNX and on the egress
             # queue on XGS; both caches were cleared before the send, so the


### PR DESCRIPTION
### Description of PR

`testQosSaiDscpEcn` is currently skipped on every platform except the Nokia ixr7250e (#20544, #23317). This PR enables it on the **q3d** asic generation as well, and hardens the test so it runs reliably on high-speed DNX ports without regressing existing ones.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Test case improvement

### Approach

#### conditional_mark
Run `testQosSaiDscpEcn` on `asic_gen == 'q3d'` in addition to the Nokia platform (q3d hwskus are already registered under `broadcom_q3d_hwskus`). Nokia coverage is preserved.

#### sai_base_test.py
- **Port egress shaper** (`apply_egress_shaper` / `clear_egress_shaper`): programs a CONFIG_DB `SCHEDULER` (`meter_type=bytes`, `pir`, `pbs`) and binds it to the dst port via `PORT_QOS_MAP`, so orchagent sets `SAI_PORT_ATTR_QOS_SCHEDULER_PROFILE_ID` on the port. Per-queue WRED/DWRR schedulers are untouched. Broadcom-only; a no-op elsewhere and when the rate is 0.

#### test_qos_sai.py / sai_qos_tests.py (DscpEcnSend)
- **Pace the release with the egress shaper** so a high-speed port does not overrun the fanout->PTF path when the queued burst is released. This is what lets the ECN cases run at the DUT's real WRED thresholds and keeps the receive/transmit assertions strict (the full burst is expected to reach PTF).
- **Skip undefined ecn variants gracefully**: a parametrized variant (e.g. `wred_drop`) is skipped when the platform's `qos_params` don't define it, instead of failing with a `KeyError`. This keeps the shared parametrize list safe for platforms that don't define every variant (e.g. Nokia/j2c has no `wred_drop`).
- **Absolute ECN-marked-count bounds** (`marked_pkts_min`/`marked_pkts_max`): the default `limit*[0.03, 0.07]` window is a fixed 2.33x upper/lower ratio that can't bracket the marked count once the queue is driven into saturation; when supplied, absolute bounds are used, otherwise the original window.
- **WRED-drop counter cross-check** for `wred_drop` (`verify_wred_drops`): reads the per-run WRED drop delta from the ingress VOQ on DNX / egress queue on XGS and checks it tracks the port-level drop count (slack of 5 pkts or 10%). This cross-check is tuned for q3d and needs per-platform tuning before `wred_drop` is enabled on another asic.

#### qos_params.q3d.yaml
Add `ecn_1..ecn_5` and `wred_drop` for q3d, sized for the platform's real WRED thresholds. `ecn_3` (dscp 3) and `ecn_4` (dscp 4) cover both lossless queues and both ECN codepoints.

#### How did you verify/test it?
Ran `testQosSaiDscpEcn` on a q3d (NH-5010) testbed: all 6 variants pass (`ecn_1`, `ecn_2`, `ecn_3`, `ecn_4`, `ecn_5`, `wred_drop`); the non-applicable multi-asic/multi-dut port combinations skip on this single-asic testbed. `wred_drop` exercises the WRED drop counter cross-check. On platforms without a `wred_drop` param block, that variant skips cleanly instead of erroring.

#### Which release branch to backport (provide reason below if selected)
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605
