### PR TITLE
Check for divergence in fec-stats

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -304,6 +304,60 @@ def get_fec_eligible_interfaces(duthost, supported_speeds):
     return interfaces
 
 
+def verify_fec_counters_not_diverging(duthost, interfaces, num_snapshots=3, interval=5):
+    """
+    Verify that fec_correctable and fec_symbol counters are not diverging.
+
+    SAI does not guarantee symbol >= correctable on each individual read because
+    counters are not read atomically. This method helps take multiple snapshots and
+    fails if for any interface the difference (fec_corr - fec_symbol) is positive and
+    monotonically increasing across all snapshots, indicating real divergence.
+
+    Returns list of (intf_name, diffs) for failing interfaces, empty list if all pass.
+    """
+    interfaces_set = set(interfaces)
+    snapshots = []
+
+    for i in range(num_snapshots):
+        if i > 0:
+            time.sleep(interval)
+
+        intf_status = duthost.show_and_parse("show interfaces counters fec-stats")
+        snapshot = {}
+        for intf in intf_status:
+            intf_name = intf['iface']
+            if intf_name not in interfaces_set:
+                continue
+
+            fec_corr_str = intf.get('fec_corr', '0').replace(',', '').lower()
+            fec_symbol_str = intf.get('fec_symbol_err', '0').replace(',', '').lower()
+            try:
+                fec_corr = int(fec_corr_str)
+                fec_symbol = int(fec_symbol_str)
+            except ValueError:
+                logging.warning("Non-integer FEC counters for %s: fec_corr=%s fec_symbol_err=%s",
+                                intf_name, fec_corr_str, fec_symbol_str)
+                continue
+
+            snapshot[intf_name] = fec_corr - fec_symbol
+
+        snapshots.append(snapshot)
+        positive = {k: v for k, v in snapshot.items() if v > 0}
+        if positive:
+            logging.info("FEC divergence check snapshot %d, interfaces with corr > symbol: %s",
+                         i + 1, positive)
+
+    failing = []
+    for intf_name in sorted(interfaces_set):
+        diffs = [s[intf_name] for s in snapshots if intf_name in s]
+        if len(diffs) < num_snapshots:
+            continue
+        if all(d > 0 for d in diffs) and all(diffs[i] < diffs[i + 1] for i in range(len(diffs) - 1)):
+            failing.append((intf_name, diffs))
+
+    return failing
+
+
 def clear_interface_counters_and_wait(duthost, wait_time=60):
     """
     Clear SONiC interface counters and wait before validating them.

--- a/tests/layer1/test_fec_error.py
+++ b/tests/layer1/test_fec_error.py
@@ -2,7 +2,11 @@ import logging
 import pytest
 import re
 
-from tests.common.platform.interface_utils import clear_interface_counters_and_wait, get_fec_eligible_interfaces
+from tests.common.platform.interface_utils import (
+    clear_interface_counters_and_wait,
+    get_fec_eligible_interfaces,
+    verify_fec_counters_not_diverging,
+)
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
@@ -114,9 +118,7 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
         fec_symbol_err = intf.get('fec_symbol_err', '').replace(',', '').lower()
         # Check if fec_corr, fec_uncorr, and fec_symbol_err are valid integers
         try:
-            fec_corr_int = int(fec_corr)
             fec_uncorr_int = int(fec_uncorr)
-            fec_symbol_err_int = int(fec_symbol_err)
         except ValueError:
             pytest.fail("FEC stat counters are not valid integers for interface {}, \
                         fec_corr: {} fec_uncorr: {} fec_symbol_err: {}"
@@ -126,11 +128,6 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
         if fec_uncorr_int > 0:
             pytest.fail("FEC uncorrectable errors are non-zero for interface {}: {}"
                         .format(intf_name, fec_uncorr_int))
-
-        # FEC correctable codeword errors should always be less than actual FEC symbol errors, check it
-        if fec_corr_int > 0 and fec_corr_int > fec_symbol_err_int:
-            pytest.fail("FEC symbol errors:{} are higher than FEC correctable errors:{} for interface {}"
-                        .format(fec_symbol_err_int, fec_corr_int, intf_name))
 
         # Test for observed flr
         if not skip_fec_flr_counters_test(intf):
@@ -151,3 +148,9 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
             except ValueError:
                 pytest.fail("predicted_flr is not a valid float for interface {}, \
                             flr(p): {}".format(intf_name, fec_flr_predicted))
+
+    # Check that fec_correctable and fec_symbol counters are not diverging
+    failing = verify_fec_counters_not_diverging(duthost, interfaces)
+    if failing:
+        pytest.fail("FEC correctable-symbol difference is positive and monotonically increasing \
+                    for interfaces: {}".format(failing))

--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -4,7 +4,11 @@ import time
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import skip_release, wait_until
-from tests.common.platform.interface_utils import clear_interface_counters_and_wait, get_fec_eligible_interfaces
+from tests.common.platform.interface_utils import (
+    clear_interface_counters_and_wait,
+    get_fec_eligible_interfaces,
+    verify_fec_counters_not_diverging,
+)
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
@@ -169,9 +173,7 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
         fec_symbol_err = intf.get('fec_symbol_err', '').replace(',', '').lower()
         # Check if fec_corr, fec_uncorr, and fec_symbol_err are valid integers
         try:
-            fec_corr_int = int(fec_corr)
             fec_uncorr_int = int(fec_uncorr)
-            fec_symbol_err_int = int(fec_symbol_err)
         except ValueError:
             pytest.fail("FEC stat counters are not valid integers for interface {}, \
                         fec_corr: {} fec_uncorr: {} fec_symbol_err: {}"
@@ -181,11 +183,6 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
         if fec_uncorr_int > 0:
             pytest.fail("FEC uncorrectable errors are non-zero for interface {}: {}"
                         .format(intf_name, fec_uncorr_int))
-
-        # FEC correctable codeword errors should always be less than actual FEC symbol errors, check it
-        if fec_corr_int > 0 and fec_corr_int > fec_symbol_err_int:
-            pytest.fail("FEC symbol errors:{} are higher than FEC correctable errors:{} for interface {}"
-                        .format(fec_symbol_err_int, fec_corr_int, intf_name))
 
         if skip_ber_counters_test(intf):
             continue
@@ -200,6 +197,12 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
             pytest.fail("Pre-FEC and Post-FEC BER are not valid floats for interface {}, \
                     fec_pre_ber: {} fec_post_ber: {}"
                         .format(intf_name, fec_pre_ber, fec_post_ber))
+
+    # Check that fec_correctable and fec_symbol counters are not diverging
+    failing = verify_fec_counters_not_diverging(duthost, interfaces)
+    if failing:
+        pytest.fail("FEC correctable-symbol difference is positive and monotonically increasing \
+                    for interfaces: {}".format(failing))
 
 
 def get_fec_histogram(duthost, intf_name):


### PR DESCRIPTION
The current fec stats check for fec correctable code words < fec symbol errors is causing intermittent failures. The FEC CORR and FEC SYMBOL ERR are read in a sequential manner and there can be momentary irregularity where correctable is greater than symbol errors.

Instead we should check for continuous divergence over time and assert if corr errors are monotonically diverging from symbol errors.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #25455

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Add verify_fec_counters_not_diverging to check for monotonic divergence between FEC_CORR > FEC_SYMBOL_ERR

#### How did you do it?
- Removed the single-snapshot fec_corr > fec_symbol_err check from both test_intf_fec.py and test_fec_error.py. That check was flaky because SAI does not guarantee symbol >= correctable on any individual read, the counters are not read
atomically.

- Added a new helper verify_fec_counters_not_diverging in tests/common/platform/interface_utils.py that takes multiple snapshots (default 3, spaced 5 seconds apart) and computes fec_corr - fec_symbol for each interface at each snapshot.
It only flags an interface as failing if the difference is positive and monotonically increasing across all snapshots, indicating real divergence rather than a transient read-ordering mismatch.

- Called the new helper at the end of test_verify_fec_stats_counters in both tests/platform_tests/test_intf_fec.py and tests/layer1/test_fec_error.py.

#### How did you verify/test it?
Ran both tests multiple times.

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
