### PR TITLE
Fix loganalyzer to ignore port attr errors with any exit code

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -507,7 +507,7 @@ r, ".* ERR swss\d*#orchagent:.*getPortLinkTrainingFailure: Failed to get LT fail
 # https://github.com/sonic-net/sonic-mgmt/issues/24023
 r, ".* ERR syncd\d*#syncd:.*SAI_API_PORT:brcm_sai_get_port_attribute_cmn:\d+ RX signal detect status get \d+ attrib \d+ failed with error Feature unavailable \(0xfffffff0\).*"
 r, ".* ERR syncd\d*#syncd:.*SAI_API_PORT:brcm_sai_get_port_attribute_cmn:\d+ bcm_port_phy_control_get rx snr failed with error Feature unavailable \(0xfffffff0\).*"
-r, ".* ERR syncd\d*#syncd: :- collectData: Failed to get port attr for VID 0x[0-9a-fA-F]+, RID:0x[0-9a-fA-F]+: -2.*"
+r, ".* ERR syncd\d*#syncd: :- collectData: Failed to get port attr for VID 0x[0-9a-fA-F]+, RID:0x[0-9a-fA-F]+: -\d+.*"
 
 # https://github.com/sonic-net/sonic-mgmt/issues/19347
 r, ".* ERR auditd.*: queue to plugins is full - dropping event"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The existing ignore pattern only matched 'Failed to get port attr' errors with exit code -2. Other negative exit codes (e.g., -6) from syncd were still flagged as test failures. Generalize the pattern to match any negative exit code (-\d+).
The `qos.test_qos_sai.TestQosSai.testParameter` test consistently fails on teardown on Arista-7060X6-64PE-P32O64 (LT2 topology) because the loganalyzer catches syncd  errors like:


 ERR syncd#syncd: :- collectData: Failed to get port attr for VID 0x100000000000b, RID:0x100000055: -8


 An ignore rule already exists in `loganalyzer_common_ignore.txt` but it only matches exit code `-2`. On this platform, syncd returns `-8`, causing 16 spurious matches  per run and a 0% pass rate on LT2 topology across all OS versions (20251110.23 through 20251110.30).



Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
The existing ignore pattern only matched 'Failed to get port attr' errors with exit code -2. Other negative exit codes (e.g., -6) from syncd were still flagged as test failures.

#### How did you do it?
Changed the regex in `loganalyzer_common_ignore.txt` from:

 r, ".* ERR syncd\d*#syncd: :- collectData: Failed to get port attr for VID 0x[0-9a-fA-F]+, RID:0x[0-9a-fA-F]+: -2.*"

 to:

 r, ".* ERR syncd\d*#syncd: :- collectData: Failed to get port attr for VID 0x[0-9a-fA-F]+, RID:0x[0-9a-fA-F]+: -\d+.*"


 This matches any negative return code from `collectData`, which is a benign platform-specific log message that does not indicate a real test failure.

#### How did you verify/test it?
Verified the updated regex matches the actual syslog lines from the failing test runs:
 bash
 echo 'ERR syncd#syncd: :- collectData: Failed to get port attr for VID 0x100000000000b, RID:0x100000055:  -8' | grep -P 'collectData: Failed to get port attr for VID 0x[0-9a-fA-F]+, RID:0x[0-9a-fA-F]+: -\d+'

#### Any platform specific information?
Consistently reproduced on Arista-7060X6-64PE-P32O64 (Broadcom ASIC, LT2 topology). The  -8  return code  appears specific to this hardware SKU.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->