### PR TITLE
Repair test_bgp_bounce + Unskip test

### DIFF
--- a/tests/bgp/test_bgp_bounce.py
+++ b/tests/bgp/test_bgp_bounce.py
@@ -2,12 +2,11 @@
 Test bgp no-export community in SONiC.
 """
 
-import random
 import pytest
-import time
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import is_ipv6_only_topology
+from tests.common.helpers.constants import DOWNSTREAM_ALL_NEIGHBOR_MAP
+from tests.common.utilities import is_ipv6_only_topology, wait_until
 from bgp_helpers import apply_bgp_config
 from bgp_helpers import get_no_export_output
 from bgp_helpers import BGP_ANNOUNCE_TIME
@@ -15,6 +14,27 @@ from bgp_helpers import BGP_ANNOUNCE_TIME
 pytestmark = [
     pytest.mark.topology('t1')
 ]
+
+
+def get_downstream_vm(duthost, nbrhosts, tbinfo):
+    downstream_type = [t.upper() for t in DOWNSTREAM_ALL_NEIGHBOR_MAP[tbinfo["topo"]["type"]]]
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    connected_neighbors = set(neigh['name'] for neigh in list(mg_facts['minigraph_neighbors'].values()))
+    downstream_neighbors = sorted(
+        [vm_name for vm_name in list(nbrhosts.keys())
+         if vm_name in connected_neighbors and vm_name.upper().endswith(tuple(downstream_type))]
+    )
+    pytest_assert(downstream_neighbors, "No downstream BGP neighbor found for topology {}".format(tbinfo["topo"]["type"]))
+    return nbrhosts[downstream_neighbors[0]]['host']
+
+
+def check_no_export_routes(vm_host, is_v6_topo, expected):
+    def _no_export_state_matches():
+        routes = get_no_export_output(vm_host, ipv6=is_v6_topo)
+        return bool(routes) == expected
+
+    pytest_assert(wait_until(BGP_ANNOUNCE_TIME, 5, 0, _no_export_state_matches),
+                  "No-export route state did not become {}".format("present" if expected else "absent"))
 
 
 def test_bgp_bounce(duthost, nbrhosts, tbinfo, deploy_plain_bgp_config, deploy_no_export_bgp_config,
@@ -39,9 +59,8 @@ def test_bgp_bounce(duthost, nbrhosts, tbinfo, deploy_plain_bgp_config, deploy_n
     # Check if this is an IPv6-only topology
     is_v6_topo = is_ipv6_only_topology(tbinfo)
 
-    # Get random ToR VM
-    vm_name = random.choice([vm_name for vm_name in list(nbrhosts.keys()) if vm_name.endswith('T0')])
-    vm_host = nbrhosts[vm_name]['host']
+    # Get downstream VM
+    vm_host = get_downstream_vm(duthost, nbrhosts, tbinfo)
 
     # Start all bgp sessions
     duthost.shell('config bgp startup all')
@@ -49,19 +68,11 @@ def test_bgp_bounce(duthost, nbrhosts, tbinfo, deploy_plain_bgp_config, deploy_n
     # Apply bgp plain config
     apply_bgp_config(duthost, bgp_plain_config)
 
-    # Give additional delay for routes to be propagated
-    time.sleep(BGP_ANNOUNCE_TIME)
-
     # Take action on one of the ToR VM
-    no_export_route_num = get_no_export_output(vm_host, ipv6=is_v6_topo)
-    pytest_assert(not no_export_route_num, "Routes has no_export attribute")
+    check_no_export_routes(vm_host, is_v6_topo, expected=False)
 
     # Apply bgp no export config
     apply_bgp_config(duthost, bgp_no_export_config)
 
-    # Give additional delay for routes to be propagated
-    time.sleep(BGP_ANNOUNCE_TIME)
-
     # Take action on one of the ToR VM
-    no_export_route_num = get_no_export_output(vm_host, ipv6=is_v6_topo)
-    pytest_assert(no_export_route_num, "Routes received on T1 are no-export")
+    check_no_export_routes(vm_host, is_v6_topo, expected=True)

--- a/tests/bgp/test_bgp_bounce.py
+++ b/tests/bgp/test_bgp_bounce.py
@@ -25,6 +25,7 @@ def get_downstream_vm(duthost, nbrhosts, tbinfo):
          if vm_name in connected_neighbors and vm_name.upper().endswith(tuple(downstream_type))]
     )
     pytest_assert(downstream_neighbors, "No downstream neighbor found for topology {}".format(tbinfo["topo"]["type"]))
+    # Pick deterministically so failures are reproducible.
     return nbrhosts[downstream_neighbors[0]]['host']
 
 
@@ -37,7 +38,7 @@ def check_no_export_routes(vm_host, is_v6_topo, expected):
                   "No-export route state did not become {}".format("present" if expected else "absent"))
 
 
-@pytest.mark.disable_loganalyzer
+@pytest.mark.disable_loganalyzer  # apply_bgp_config restarts BGP and can log expected transient errors.
 def test_bgp_bounce(duthost, nbrhosts, tbinfo, deploy_plain_bgp_config, deploy_no_export_bgp_config,
                     backup_bgp_config):
     """
@@ -69,11 +70,11 @@ def test_bgp_bounce(duthost, nbrhosts, tbinfo, deploy_plain_bgp_config, deploy_n
     # Apply bgp plain config
     apply_bgp_config(duthost, bgp_plain_config)
 
-    # Take action on one of the ToR VM
+    # Verify downstream VM has no no-export routes yet
     check_no_export_routes(vm_host, is_v6_topo, expected=False)
 
     # Apply bgp no export config
     apply_bgp_config(duthost, bgp_no_export_config)
 
-    # Take action on one of the ToR VM
+    # Verify downstream VM now sees the no-export community
     check_no_export_routes(vm_host, is_v6_topo, expected=True)

--- a/tests/bgp/test_bgp_bounce.py
+++ b/tests/bgp/test_bgp_bounce.py
@@ -37,6 +37,7 @@ def check_no_export_routes(vm_host, is_v6_topo, expected):
                   "No-export route state did not become {}".format("present" if expected else "absent"))
 
 
+@pytest.mark.disable_loganalyzer
 def test_bgp_bounce(duthost, nbrhosts, tbinfo, deploy_plain_bgp_config, deploy_no_export_bgp_config,
                     backup_bgp_config):
     """

--- a/tests/bgp/test_bgp_bounce.py
+++ b/tests/bgp/test_bgp_bounce.py
@@ -24,7 +24,7 @@ def get_downstream_vm(duthost, nbrhosts, tbinfo):
         [vm_name for vm_name in list(nbrhosts.keys())
          if vm_name in connected_neighbors and vm_name.upper().endswith(tuple(downstream_type))]
     )
-    pytest_assert(downstream_neighbors, "No downstream BGP neighbor found for topology {}".format(tbinfo["topo"]["type"]))
+    pytest_assert(downstream_neighbors, "No downstream neighbor found for topology {}".format(tbinfo["topo"]["type"]))
     return nbrhosts[downstream_neighbors[0]]['host']
 
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t1_multiasic.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t1_multiasic.yaml
@@ -18,11 +18,6 @@ bgp/test_bgp_allow_list.py:
     conditions:
     - asic_type in ['vs'] and 't1-8-lag' in topo_name
     reason: This test case either cannot pass or should be skipped on virtual chassis
-bgp/test_bgp_bbr_default_state.py:
-  skip:
-    conditions:
-    - asic_type in ['vs'] and 't1-8-lag' in topo_name
-    reason: This test case either cannot pass or should be skipped on virtual chassis
 bgp/test_bgp_command.py:
   skip:
     conditions:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t1_multiasic.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t1_multiasic.yaml
@@ -23,11 +23,6 @@ bgp/test_bgp_bbr_default_state.py:
     conditions:
     - asic_type in ['vs'] and 't1-8-lag' in topo_name
     reason: This test case either cannot pass or should be skipped on virtual chassis
-bgp/test_bgp_bounce.py:
-  skip:
-    conditions:
-    - asic_type in ['vs'] and 't1-8-lag' in topo_name
-    reason: This test case either cannot pass or should be skipped on virtual chassis
 bgp/test_bgp_command.py:
   skip:
     conditions:


### PR DESCRIPTION
### Description of PR
Summary:
Fix 'test_bgp_bounce' so it correctly validates BGP no-export community behavior on T1 topology. This test was originally written with assumptions of a T0 topology. This PR updates the test to rely on the topology metadata to select a downstream neighbor, so on T1 it is able to validate the correct downstream T0 neighbor rather than relying on hardcoded name matching. It also replaces fixed sleeps with polling for the no-export state. 

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
test_bgp_bounce verifies that the routes advertised from a T1 DUT to downstream ToR neighbors are tagged with the 'no-export' community when the no-export BGP config is applied. The test is marked for T1, but its original logic for neighbor selection was still based on T0, making the test not fully compatible for a T1 topology. 

#### How did you do it?
- Replaced hardcoded T0 VM selection with downstream neighbor selection based on the downstream neighbor map and the DUT minigraph. 
- Ensured the selected neighbor is actually connected to the DUT. 
- Replaced fixed sleeps with polling for the condition (no-export condition after certain BGP configs)

#### How did you verify/test it?
- Verified the updated test logic selects correct downstream neighbor for T1. 
- Verified no linter errors.
- Github PR Checker validates others and above. 
- Marked test with `disable_loganalyzer` because it intentionally applies custom BGP configs, which restarts the BGP service. During these BGP restarts, transient syslog errors can be picked up by loganalyzer, resulting in an error during checks, even though the test behavior is correct, so loganalyzer is disabled. 

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
