### PR TITLE
[ha]: Update FNIC steady-state flow checks

### DIFF
--- a/tests/ha/test_ha_steady_state_fnic.py
+++ b/tests/ha/test_ha_steady_state_fnic.py
@@ -10,7 +10,7 @@ from constants import LOCAL_PTF_INTF, REMOTE_PTF_RECV_INTF, REMOTE_PTF_SEND_INTF
 from packets import inbound_pl_packets, outbound_pl_packets
 from tests.ha.conftest import apply_dash_pl_pipeline_config
 from tests.common.dash_utils import verify_tunnel_packets
-from ha_dash_flow_utils import compare_flow_tables_pdsctl
+from ha_dash_flow_utils import compare_flow_tables
 from ha_utils import parallel_config_reload_dpuhosts
 
 logger = logging.getLogger(__name__)
@@ -96,7 +96,7 @@ def test_fnic_basic_transform(
 
     pytest_assert(sum(tunnel_endpoint_counts.values()) == NUM_PACKETS, "Expected active return-path packets")
 
-    flow_op = compare_flow_tables_pdsctl(dpuhosts[0], dpuhosts[1])
+    flow_op = compare_flow_tables(dpuhosts[0], dpuhosts[1])
     pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
 
     # traffic to standby DPU (forwarded through active for processing)
@@ -116,5 +116,5 @@ def test_fnic_basic_transform(
 
     pytest_assert(sum(tunnel_endpoint_counts.values()) == NUM_PACKETS, "Expected standby return-path packets")
 
-    flow_op = compare_flow_tables_pdsctl(dpuhosts[0], dpuhosts[1])
+    flow_op = compare_flow_tables(dpuhosts[0], dpuhosts[1])
     pytest_assert(flow_op, "Expected identical flow tables on primary and standby")


### PR DESCRIPTION
### Description of PR

Summary:
Update the FNIC steady-state HA test to use the generic DASH flow-table comparison helper.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

The FNIC steady-state test should use the common DASH flow comparison wrapper, consistent with the newer flow dump selection logic.

#### How did you do it?

Replaced direct `compare_flow_tables_pdsctl` usage with `compare_flow_tables` in the active and standby FNIC steady-state flow checks.

#### How did you verify/test it?


#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
