### PR TITLE
[pc]: add lacp_rate_dut testcase

### DIFF
--- a/ansible/roles/test/files/acstests/py3/lag_test.py
+++ b/ansible/roles/test/files/acstests/py3/lag_test.py
@@ -148,11 +148,16 @@ class LacpTimingTest(BaseTest, RouterUtility):
         # Flush packets in dataplane
         self.dataplane.flush()
 
+        # tolerance is configurable; default 0.1s for existing tests
+        self.tolerance = float(self.test_params.get('tolerance', 0.1))
+
         # Check that packet timing matches the expected value.
         current_pkt_timing = self.getMedianInterval(masked_exp_pkt)
-        self.assertTrue(abs(current_pkt_timing - float(self.packet_timing)) < 0.1, "Bad packet timing: \
-                        %.2f seconds while expected timing is %d seconds from port %s out of %d intervals" %
-                        (current_pkt_timing, self.packet_timing, self.exp_iface, self.interval_count))
+        self.assertTrue(abs(current_pkt_timing - float(self.packet_timing)) < self.tolerance,
+                        "Bad packet timing: %.2f seconds while expected timing is %d seconds "
+                        "from port %s out of %d intervals (tolerance=%.2f)" %
+                        (current_pkt_timing, self.packet_timing, self.exp_iface,
+                         self.interval_count, self.tolerance))
 
 
 class LagMemberTrafficTest(BaseTest, RouterUtility):

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -109,7 +109,7 @@ class LagTest:
         neighbor_intf = self.__resolve_vm_neighbor_intf(peer_device, neighbor_intf)
         return vm_host, neighbor_intf, peer_device
 
-    def __verify_lag_lacp_timing(self, lacp_timer, exp_iface):
+    def __verify_lag_lacp_timing(self, lacp_timer, exp_iface, tolerance=0.1):
         if exp_iface is None:
             return
 
@@ -120,10 +120,106 @@ class LagTest:
             'packet_timing': lacp_timer,
             'ether_type': 0x8809,
             'interval_count': 3,
-            'kvm_support': True
+            'kvm_support': True,
+            'tolerance': tolerance
         }
         ptf_runner(self.ptfhost, 'acstests', "lag_test.LacpTimingTest",
                    '/root/ptftests', params=params, is_python3=True)
+
+    def __check_portchannel_up(self, lag_name):
+        lag_facts = self.__get_lag_facts()
+        return lag_facts['lags'].get(lag_name, {}).get('po_intf_stat') == 'Up'
+
+    def run_single_lag_lacp_rate_dut_test(self, lag_name, lag_facts):
+        logger.info("Start checking DUT-side lacp fast rate config for: %s" % lag_name)
+
+        intf, po_interfaces = self.__get_lag_intf_info(lag_facts, lag_name)
+        peer_device = self.vm_neighbors[intf]['name']
+        namespace_id = self.__get_lag_intf_namespace_id(lag_facts, lag_name)
+        if namespace_id and str(namespace_id).isdigit():
+            namespace_id = 'asic{}'.format(namespace_id)
+        ns_opt = '-n {}'.format(namespace_id) if namespace_id else ''
+
+        # Collect PTF interfaces and neighbor LAG interfaces for this LAG
+        iface_behind_lag_member = []
+        for neighbor_intf in list(self.vm_neighbors.keys()):
+            if peer_device == self.vm_neighbors[neighbor_intf]['name']:
+                iface_behind_lag_member.append(self.mg_facts['minigraph_ptf_indices'][neighbor_intf])
+
+        neighbor_lag_intfs = [
+            self.__resolve_vm_neighbor_intf(peer_device, self.vm_neighbors[po_intf]['port'])
+            for po_intf in po_interfaces
+        ]
+        vm_host = self.nbrhosts[peer_device]['host']
+
+        # Snapshot PortChannel config for full restoration
+        runner_cfg = lag_facts['lags'][lag_name]['po_config']['runner']
+        min_links = runner_cfg.get('min_ports', 1)
+        fallback = runner_cfg.get('fallback', False)
+        pc_ips = [n['subnet'] for n in self.mg_facts['minigraph_portchannel_interfaces']
+                  if n['attachto'] == lag_name]
+
+        portchannel_mutated = False
+        neighbor_rate_mutated = False
+        try:
+            # Remove members before deleting PortChannel
+            for po_intf in list(po_interfaces.keys()):
+                self.duthost.shell("sudo config portchannel {} member del {} {}"
+                                   .format(ns_opt, lag_name, po_intf))
+            self.duthost.shell("sudo config portchannel {} del {}".format(ns_opt, lag_name))
+            portchannel_mutated = True
+
+            # Recreate with --fast-rate=true, preserving min-links and fallback
+            self.duthost.shell(
+                "sudo config portchannel {} add {} --fast-rate=true --min-links={} {}"
+                .format(ns_opt, lag_name, min_links, '--fallback=true' if fallback else ''))
+            for po_intf in list(po_interfaces.keys()):
+                self.duthost.shell("sudo config portchannel {} member add {} {}"
+                                   .format(ns_opt, lag_name, po_intf))
+            for ip in pc_ips:
+                self.duthost.shell("sudo config interface {} ip add {} {}".format(ns_opt, lag_name, ip))
+
+            # Wait for LAG to re-establish before verifying timing
+            pytest_assert(wait_until(30, 1, 5, self.__check_portchannel_up, lag_name),
+                          "PortChannel {} did not come up after fast-rate reconfiguration".format(lag_name))
+
+            # Also set neighbor to fast mode so DUT's teamd switches TX to 1s.
+            # In KVM/vs, teamd only switches TX interval to 1s when the partner
+            # also sends Short_Timeout=1, even though DUT has fast_rate=true configured.
+            # This verifies: DUT fast_rate config causes the neighbor to auto-adapt
+            # (Short_Timeout=1 propagated via LACP PDU), and with both sides in fast
+            # mode the session operates at 1s end-to-end.
+            for neighbor_lag_intf in neighbor_lag_intfs:
+                logger.info("Changing lacp rate to fast for %s in %s" % (neighbor_lag_intf, peer_device))
+                vm_host.set_interface_lacp_rate_mode(neighbor_lag_intf, 'fast')
+            neighbor_rate_mutated = True
+            time.sleep(5)
+
+            # Verify LACP PDUs at 1-second intervals (0.5s tolerance for post-reconvergence transient)
+            for iface_behind_lag in iface_behind_lag_member:
+                self.__verify_lag_lacp_timing(1, iface_behind_lag, tolerance=0.5)
+
+        finally:
+            # Restore neighbor rate first, then DUT portchannel config
+            if neighbor_rate_mutated:
+                for neighbor_lag_intf in neighbor_lag_intfs:
+                    logger.info("Changing lacp rate to normal for %s in %s" % (neighbor_lag_intf, peer_device))
+                    vm_host.set_interface_lacp_rate_mode(neighbor_lag_intf, 'normal')
+            if portchannel_mutated:
+                for po_intf in list(po_interfaces.keys()):
+                    self.duthost.shell("sudo config portchannel {} member del {} {}"
+                                       .format(ns_opt, lag_name, po_intf),
+                                       module_ignore_errors=True)
+                self.duthost.shell("sudo config portchannel {} del {}"
+                                   .format(ns_opt, lag_name), module_ignore_errors=True)
+                self.duthost.shell(
+                    "sudo config portchannel {} add {} --min-links={} {}"
+                    .format(ns_opt, lag_name, min_links, '--fallback=true' if fallback else ''))
+                for po_intf in list(po_interfaces.keys()):
+                    self.duthost.shell("sudo config portchannel {} member add {} {}"
+                                       .format(ns_opt, lag_name, po_intf))
+                for ip in pc_ips:
+                    self.duthost.shell("sudo config interface {} ip add {} {}".format(ns_opt, lag_name, ip))
 
     def __verify_lag_minlink(self, host, lag_name, lag_facts,
                              neighbor_intf, deselect_time, wait_timeout=30):
@@ -296,9 +392,11 @@ def skip_if_no_lags(duthosts):
 
 @pytest.mark.parametrize("testcase", ["single_lag",
                                       "lacp_rate",
+                                      "lacp_rate_dut",
                                       "fallback"])
 def test_lag(common_setup_teardown, duthosts, tbinfo, nbrhosts, fanouthosts,
-             conn_graph_facts, enum_dut_portchannel_with_completeness_level, testcase, request):     # noqa: F811
+             conn_graph_facts, enum_dut_portchannel_with_completeness_level, testcase, request,  # noqa: F811
+             ignore_expected_loganalyzer_exceptions_lag):
     if 'PortChannel201' in enum_dut_portchannel_with_completeness_level:
         pytest.skip("PortChannel201 is a specific configuration of t0-56-po2vlan topo, which is not supported by test")
 
@@ -306,6 +404,11 @@ def test_lag(common_setup_teardown, duthosts, tbinfo, nbrhosts, fanouthosts,
     if testcase == "lacp_rate":
         if request.config.getoption("--neighbor_type") == 'sonic':
             pytest.skip("lacp_rate is not supported in vsonic")
+
+    # Skip lacp_rate_dut on vsonic neighbors — PTF timing verification requires EOS
+    if testcase == "lacp_rate_dut":
+        if request.config.getoption("--neighbor_type") == 'sonic':
+            pytest.skip("lacp_rate_dut is not supported in vsonic")
 
     ptfhost = common_setup_teardown
 
@@ -330,7 +433,7 @@ def test_lag(common_setup_teardown, duthosts, tbinfo, nbrhosts, fanouthosts,
                 # specific LAG interface from t0-56-po2vlan topo, which can't be tested
                 if lag_name == 'PortChannel201':
                     continue
-                if testcase in ["single_lag",  "lacp_rate"]:
+                if testcase in ["single_lag", "lacp_rate", "lacp_rate_dut"]:
                     try:
                         lag_facts['lags'][lag_name]['po_config']['runner']['min_ports']
                     except KeyError:
@@ -342,6 +445,8 @@ def test_lag(common_setup_teardown, duthosts, tbinfo, nbrhosts, fanouthosts,
                         some_test_ran = True
                         if testcase == "single_lag":
                             test_instance.run_single_lag_test(lag_name, lag_facts)
+                        elif testcase == "lacp_rate_dut":
+                            test_instance.run_single_lag_lacp_rate_dut_test(lag_name, lag_facts)
                         else:
                             test_instance.run_single_lag_lacp_rate_test(lag_name, lag_facts)
                 else:   # fallback testcase

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -1,5 +1,6 @@
 import pytest
 
+import json
 import time
 import logging
 
@@ -136,9 +137,11 @@ class LagTest:
         intf, po_interfaces = self.__get_lag_intf_info(lag_facts, lag_name)
         peer_device = self.vm_neighbors[intf]['name']
         namespace_id = self.__get_lag_intf_namespace_id(lag_facts, lag_name)
-        if namespace_id and str(namespace_id).isdigit():
+        raw_namespace_id = namespace_id  # preserve numeric id for teamdctl
+        if namespace_id is not None and str(namespace_id).isdigit():
             namespace_id = 'asic{}'.format(namespace_id)
         ns_opt = '-n {}'.format(namespace_id) if namespace_id else ''
+        teamd_ns_opt = ('-n ' + str(raw_namespace_id)) if str(raw_namespace_id).isdigit() else ''
 
         # Collect PTF interfaces and neighbor LAG interfaces for this LAG
         iface_behind_lag_member = []
@@ -152,10 +155,14 @@ class LagTest:
         ]
         vm_host = self.nbrhosts[peer_device]['host']
 
-        # Snapshot PortChannel config for full restoration
+        # Snapshot the PortChannel attributes this test mutates (min_links, fallback,
+        # fast_rate) and the member IPs (pc_ips, below), so they can be restored in
+        # the finally block. This does not capture every possible PortChannel
+        # attribute (e.g. MTU, description) -- only what this test itself changes.
         runner_cfg = lag_facts['lags'][lag_name]['po_config']['runner']
         min_links = runner_cfg.get('min_ports', 1)
         fallback = runner_cfg.get('fallback', False)
+        original_fast_rate = runner_cfg.get('fast_rate', False)
         pc_ips = [n['subnet'] for n in self.mg_facts['minigraph_portchannel_interfaces']
                   if n['attachto'] == lag_name]
 
@@ -183,17 +190,28 @@ class LagTest:
             pytest_assert(wait_until(30, 1, 5, self.__check_portchannel_up, lag_name),
                           "PortChannel {} did not come up after fast-rate reconfiguration".format(lag_name))
 
-            # Also set neighbor to fast mode so DUT's teamd switches TX to 1s.
-            # In KVM/vs, teamd only switches TX interval to 1s when the partner
-            # also sends Short_Timeout=1, even though DUT has fast_rate=true configured.
-            # This verifies: DUT fast_rate config causes the neighbor to auto-adapt
-            # (Short_Timeout=1 propagated via LACP PDU), and with both sides in fast
-            # mode the session operates at 1s end-to-end.
+            # Verify DUT-side fast_rate is actually applied before invoking neighbor
+            teamdctl_out = self.duthost.shell(
+                'sudo teamdctl {} {} state dump'.format(teamd_ns_opt, lag_name))['stdout']
+            teamd_state = json.loads(teamdctl_out)
+            pytest_assert(
+                teamd_state.get('runner', {}).get('fast_rate') is True,
+                "DUT fast_rate not applied to {} — teamd runner.fast_rate={}".format(
+                    lag_name, teamd_state.get('runner', {}).get('fast_rate')))
+
+            # Also set neighbor to fast mode so both sides operate at 1s intervals.
+            # DUT already advertises Short_Timeout=1 via LACP PDUs; this confirms
+            # end-to-end fast-rate session at 1s.
             for neighbor_lag_intf in neighbor_lag_intfs:
                 logger.info("Changing lacp rate to fast for %s in %s" % (neighbor_lag_intf, peer_device))
                 vm_host.set_interface_lacp_rate_mode(neighbor_lag_intf, 'fast')
             neighbor_rate_mutated = True
-            time.sleep(5)
+
+            # Setting neighbor to fast mode causes a brief LACP renegotiation on physical DUTs,
+            # during which the PortChannel may go down for up to ~30 seconds before reconverging.
+            # Wait up to 60s to allow LACP state machine to complete reconvergence.
+            pytest_assert(wait_until(60, 1, 3, self.__check_portchannel_up, lag_name),
+                          "PortChannel {} did not recover after setting neighbor to fast rate".format(lag_name))
 
             # Verify LACP PDUs at 1-second intervals (0.5s tolerance for post-reconvergence transient)
             for iface_behind_lag in iface_behind_lag_member:
@@ -212,14 +230,26 @@ class LagTest:
                                        module_ignore_errors=True)
                 self.duthost.shell("sudo config portchannel {} del {}"
                                    .format(ns_opt, lag_name), module_ignore_errors=True)
+                # module_ignore_errors=True on every re-add step so a single transient
+                # failure doesn't abort the finally block and leave later re-adds (and
+                # thus the PortChannel) partially restored for downstream tests.
                 self.duthost.shell(
-                    "sudo config portchannel {} add {} --min-links={} {}"
-                    .format(ns_opt, lag_name, min_links, '--fallback=true' if fallback else ''))
+                    "sudo config portchannel {} add {} --min-links={} {} {}"
+                    .format(ns_opt, lag_name, min_links,
+                            '--fallback=true' if fallback else '',
+                            '--fast-rate=true' if original_fast_rate else ''),
+                    module_ignore_errors=True)
                 for po_intf in list(po_interfaces.keys()):
                     self.duthost.shell("sudo config portchannel {} member add {} {}"
-                                       .format(ns_opt, lag_name, po_intf))
+                                       .format(ns_opt, lag_name, po_intf),
+                                       module_ignore_errors=True)
                 for ip in pc_ips:
-                    self.duthost.shell("sudo config interface {} ip add {} {}".format(ns_opt, lag_name, ip))
+                    self.duthost.shell("sudo config interface {} ip add {} {}".format(ns_opt, lag_name, ip),
+                                       module_ignore_errors=True)
+                # Explicit post-condition check: confirm the PortChannel actually came
+                # back up after restoration instead of assuming the re-add steps worked.
+                if not wait_until(30, 1, 3, self.__check_portchannel_up, lag_name):
+                    logger.error("PortChannel %s did not come back up after restore", lag_name)
 
     def __verify_lag_minlink(self, host, lag_name, lag_facts,
                              neighbor_intf, deselect_time, wait_timeout=30):
@@ -408,7 +438,7 @@ def test_lag(common_setup_teardown, duthosts, tbinfo, nbrhosts, fanouthosts,
     # Skip lacp_rate_dut on vsonic neighbors — PTF timing verification requires EOS
     if testcase == "lacp_rate_dut":
         if request.config.getoption("--neighbor_type") == 'sonic':
-            pytest.skip("lacp_rate_dut is not supported in vsonic")
+            pytest.skip("lacp_rate_dut requires EOS neighbor for set_interface_lacp_rate_mode; vsonic not supported")
 
     ptfhost = common_setup_teardown
 

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -163,7 +163,13 @@ class LagTest:
         min_links = runner_cfg.get('min_ports', 1)
         fallback = runner_cfg.get('fallback', False)
         original_fast_rate = runner_cfg.get('fast_rate', False)
-        pc_ips = [n['subnet'] for n in self.mg_facts['minigraph_portchannel_interfaces']
+        # Use the interface's actual host address (addr/prefixlen), not the network
+        # address (subnet). For IPv6 /126 links these differ (subnet is the network
+        # address, e.g. fc00::18/126, while addr is the DUT's real host IP, e.g.
+        # fc00::19); re-adding the subnet value creates a duplicate/overlapping
+        # address alongside the pre-existing one and stalls LAG reconvergence.
+        pc_ips = ['{}/{}'.format(n['addr'], n['prefixlen'])
+                  for n in self.mg_facts['minigraph_portchannel_interfaces']
                   if n['attachto'] == lag_name]
 
         portchannel_mutated = False

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -186,8 +186,10 @@ class LagTest:
             for ip in pc_ips:
                 self.duthost.shell("sudo config interface {} ip add {} {}".format(ns_opt, lag_name, ip))
 
-            # Wait for LAG to re-establish before verifying timing
-            pytest_assert(wait_until(30, 1, 5, self.__check_portchannel_up, lag_name),
+            # Wait for LAG to re-establish before verifying timing. Physical DUTs can take
+            # longer than KVM to reconverge after delete/recreate + member re-add, so use
+            # the same 60s window as the neighbor-side reconvergence wait below.
+            pytest_assert(wait_until(60, 1, 3, self.__check_portchannel_up, lag_name),
                           "PortChannel {} did not come up after fast-rate reconfiguration".format(lag_name))
 
             # Verify DUT-side fast_rate is actually applied before invoking neighbor


### PR DESCRIPTION
### Description of PR

Adds a new `lacp_rate_dut` testcase to `tests/pc/test_lag_2.py` that validates DUT-side LACP fast-rate configuration across all topologies.

The existing `lacp_rate` test only verifies neighbor-side rate changes. `lacp_rate_dut` specifically tests that configuring `--fast-rate=true` on the DUT PortChannel causes LACP PDUs to be exchanged at 1-second intervals.

### Type of change
- [x] New Test case

### Changes

**`tests/pc/test_lag_2.py`**
- Added `run_single_lag_lacp_rate_dut_test`: deletes/recreates PortChannel with `--fast-rate=true`, sets EOS neighbor to fast rate, verifies LACP PDUs at 1s intervals via PTF, fully restores config in teardown
- Added `lacp_rate_dut` to parametrize list with vsonic skip guard
- Made `tolerance` configurable in `__verify_lag_lacp_timing` (default 0.1s); `lacp_rate_dut` uses 0.5s to handle post-reconvergence transient
- Uses `__resolve_vm_neighbor_intf` for converged topology compatibility
- Proper namespace handling for multi-ASIC devices

**`ansible/roles/test/files/acstests/py3/lag_test.py`**
- Made timing tolerance configurable via `test_params` (default 0.1s, backward compatible)
- Improved error message to include tolerance value

### Update: fixes from AI code review + physical DUT validation

Added 3 follow-up commits addressing AI review feedback and a real issue found during physical testbed validation:

1. **`[pc]: address AI code review feedback for lacp_rate_dut test`**
   - Added a direct DUT-side `teamdctl` state-dump assertion that `fast_rate` is actually applied, before relying on the timing check as the only signal.
   - Snapshot/restore now preserves the PortChannel's original `fast_rate` value instead of silently downgrading it after the test.
   - Fixed a namespace-id predicate that dropped `asic0` (falsy check on `0`).
   - Replaced a blind `time.sleep(5)` with `wait_until` on observable LACP state; added `module_ignore_errors=True` plus a post-restore `wait_until` check to the config-restore path so a transient failure can't skip remaining re-adds; reworded an inaccurate snapshot-scope comment and skip message.

2. **`test_lag_2: increase DUT-side reconvergence wait to 60s`**
   - Widened the wait_until window (30s/5s -> 60s/3s) after PortChannel delete/recreate to match the already-fixed neighbor-side wait.

3. **`test_lag_2: use minigraph host addr/prefixlen instead of subnet for pc_ips`**
   - Restoring PortChannel IPs previously re-added the network `subnet` value, which can differ from the DUT's actual assigned host `addr`. On real hardware (IPv6 /126 links) this created a duplicate/overlapping address and caused `orchagent` to repeatedly fail `removeLag`, stalling reconvergence indefinitely. This was the actual root cause of the physical DUT failure below (the 60s wait bump alone was not sufficient). Now uses the DUT's actual `addr`/`prefixlen` from minigraph facts.

### Testing
- KVM virtual testbed (`vlab-01`, `vms-kvm-t0`, `PortChannel104`): `lacp_rate_dut` **PASS**, including full teardown/restore path (module_ignore_errors + post-restore check)
- Physical testbed (`svcstr-nh5010-ut2-7`, `PortChannel106`): `lacp_rate_dut` **PASS** (`1 passed, 3 deselected` in 523s), after root-causing and fixing the `subnet`/`addr` bug above

### Known gaps / testing needed
- Converged/multi-VRF topology validation
- Multi-DUT chassis topology validation

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
