### PR TITLE
[smartswitch]: Populate DPU table in golden config

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -754,6 +754,7 @@ class GenerateGoldenConfigDBModule(object):
             "VLAN_MEMBER": copy.deepcopy(ori_config_db["VLAN_MEMBER"]),
             "CHASSIS_MODULE": copy.deepcopy(ori_config_db["CHASSIS_MODULE"]),
             "DPUS": copy.deepcopy(ori_config_db["DPUS"]),
+            "DPU": self._generate_dpu_config(dpu_num, enabled_dpu_set),
             "DHCP_SERVER_IPV4_PORT": copy.deepcopy(ori_config_db["DHCP_SERVER_IPV4_PORT"]),
             "MID_PLANE_BRIDGE": copy.deepcopy(ori_config_db["MID_PLANE_BRIDGE"]),
             "DHCP_SERVER_IPV4": copy.deepcopy(ori_config_db["DHCP_SERVER_IPV4"])
@@ -763,7 +764,7 @@ class GenerateGoldenConfigDBModule(object):
         if self.topo_name == "t1-smartswitch-ha":
             gold_config_db["DEVICE_METADATA"]["localhost"]["cluster"] = "cluster1"
             gold_config_db["DEVICE_METADATA"]["localhost"]["region"] = "west"
-            ha_config = self._generate_ha_config(dpu_num, enabled_dpu_set)
+            ha_config = self._generate_ha_config(dpu_num)
             # Merge FEATURE dict so we don't overwrite existing features
             if "FEATURE" in ha_config and "FEATURE" in gold_config_db:
                 gold_config_db["FEATURE"].update(ha_config.pop("FEATURE"))
@@ -776,20 +777,47 @@ class GenerateGoldenConfigDBModule(object):
         gold_config_db.update(smartswitch_config_obj)
         return json.dumps(gold_config_db, indent=4)
 
-    def _generate_ha_config(self, dpu_num, enabled_dpu_set):
+    def _generate_dpu_config(self, dpu_num, enabled_dpu_set):
+        switch_id = self.npu_index
+        hostname = self.duts_list[switch_id] if self.duts_list and switch_id < len(self.duts_list) else "dpu"
+
+        pa_prefix = "20.0.20{}.".format(switch_id)
+        vip_prefix = "3.2.1."
+        midplane_prefix = "169.254.200."
+        swbus_start = 23606
+
+        dpu_table = {}
+        for idx in range(dpu_num):
+            dpu_key = self._format_dpu_key(hostname, idx)
+            dpu_table[dpu_key] = {
+                "dpu_id": str(idx),
+                "gnmi_port": "50052",
+                "local_port": "8080",
+                "orchagent_zmq_port": "8100",
+                "pa_ipv4": "{}{}".format(pa_prefix, idx + 1),
+                "state": "up" if idx in enabled_dpu_set else "down",
+                "swbus_port": str(swbus_start + idx),
+                "vdpu_id": "vdpu{}_{}".format(switch_id, idx),
+                "vip_ipv4": "{}{}".format(vip_prefix, idx),
+                "midplane_ipv4": "{}{}".format(midplane_prefix, idx + 1),
+            }
+
+        return dpu_table
+
+    def _format_dpu_key(self, hostname, dpu_index):
+        return "{}-dpu{}".format(hostname, dpu_index)
+
+    def _generate_ha_config(self, dpu_num):
         """
-        Generate DASH-HA configuration tables (DPU, REMOTE_DPU, VDPU,
+        Generate DASH-HA configuration tables (REMOTE_DPU, VDPU,
         DASH_HA_GLOBAL_CONFIG, FEATURE, VNET, VXLAN_TUNNEL) for the
         t1-smartswitch-ha topology.
 
         Entries are emitted for every DPU supported by the hwsku
-        (0..dpu_num-1). Only the DPU table's `state` field reflects whether
-        the DPU is enabled for this testbed; disabled DPUs are recorded with
-        state="down" so the config schema stays consistent across NPUs.
+        (0..dpu_num-1) so the config schema stays consistent across NPUs.
 
         Args:
             dpu_num: Total number of DPUs supported by the hwsku.
-            enabled_dpu_set: Set of DPU indices that should be admin-up.
 
         Requires self.duts_list (ordered list of DUT hostnames) and
         self.dut_loopbacks (dict with 'ipv4' and 'ipv6' lists from topology).
@@ -820,33 +848,13 @@ class GenerateGoldenConfigDBModule(object):
         vxlan_src_ip = loopback_ip.split("/")[0]
         peer_npu_ip = peer_loopback_ip.split("/")[0]
 
-        # --- Local DPU table ---
-        pa_prefix = "20.0.20{}.".format(switch_id)
-        vip_prefix = "3.2.1."
-        midplane_prefix = "169.254.200."
         swbus_start = 23606
-
-        dpu_table = {}
-        for idx in range(dpu_num):
-            dpu_key = "{}-dpu-{}".format(hostname, idx)
-            dpu_table[dpu_key] = {
-                "dpu_id": str(idx),
-                "gnmi_port": "50052",
-                "local_port": "8080",
-                "orchagent_zmq_port": "8100",
-                "pa_ipv4": "{}{}".format(pa_prefix, idx + 1),
-                "state": "up" if idx in enabled_dpu_set else "down",
-                "swbus_port": str(swbus_start + idx),
-                "vdpu_id": "vdpu{}_{}".format(switch_id, idx),
-                "vip_ipv4": "{}{}".format(vip_prefix, idx),
-                "midplane_ipv4": "{}{}".format(midplane_prefix, idx + 1),
-            }
 
         # --- Remote DPU table ---
         remote_pa_prefix = "20.0.20{}.".format(peer_switch_id)
         remote_dpu_table = {}
         for idx in range(dpu_num):
-            dpu_key = "{}-dpu-{}".format(peer_hostname, idx)
+            dpu_key = self._format_dpu_key(peer_hostname, idx)
             remote_dpu_table[dpu_key] = {
                 "dpu_id": str(idx),
                 "npu_ipv4": peer_npu_ip,
@@ -867,15 +875,14 @@ class GenerateGoldenConfigDBModule(object):
         '''
         for idx in range(dpu_num):
             vdpu_table["vdpu0_{}".format(idx)] = {
-                "main_dpu_ids": "{}-dpu-{}".format(hostname_0, idx)
+                "main_dpu_ids": self._format_dpu_key(hostname_0, idx)
             }
         for idx in range(dpu_num):
             vdpu_table["vdpu1_{}".format(idx)] = {
-                "main_dpu_ids": "{}-dpu-{}".format(hostname_1, idx)
+                "main_dpu_ids": self._format_dpu_key(hostname_1, idx)
             }
 
         ha_config = {
-            "DPU": dpu_table,
             "REMOTE_DPU": remote_dpu_table,
             "VDPU": vdpu_table,
             "DASH_HA_GLOBAL_CONFIG": {


### PR DESCRIPTION
### Description of PR
Summary:
Populate the `DPU` table for SmartSwitch golden config generation outside of the HA-only table merge path.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
SmartSwitch DUTs need the `DPU` table populated in `CONFIG_DB`, but the local DPU table was previously generated only as part of the DASH HA topology configuration.

#### How did you do it?
Extracted the local DPU table creation into a shared helper and added it to the common SmartSwitch golden config output. The HA-specific helper now only returns HA-specific peer/global tables.

DPU table keys are generated with a separator before the DPU suffix and no separator before the index, for example `DPU|<hostname>-dpu0`. HA `REMOTE_DPU` keys and `VDPU.main_dpu_ids` use the same key format.

#### How did you verify/test it?
- Ran `python3 -m py_compile ansible/library/generate_golden_config_db.py`.
- Validated on a Cisco 8102 SmartSwitch testbed that generated `golden_config_db.json` contains 8 `DPU` entries.
- Validated on the DUT that `CONFIG_DB` contains `DPU|<hostname>-dpu0` through `DPU|<hostname>-dpu7`, and inspected one populated DPU entry including `dpu_id`, `pa_ipv4`, `midplane_ipv4`, `state`, `vdpu_id`, and ports.
- Validated on a Cisco 8102 SmartSwitch HA testbed that `deploy-mg` completed successfully, including `Generate golden_config_db.json`, `config load_minigraph --override_config -y`, and `Load DPU config in smartswitch`.
- Validated on both HA NPUs that `CONFIG_DB` contains 8 local `DPU|<hostname>-dpuN` entries, 8 peer `REMOTE_DPU|<peer-hostname>-dpuN` entries, and `VDPU.main_dpu_ids` references the DPU key format consistently.
- Scanned HA tests and did not find dependencies on the previous local `DPU` table key format. Matches for `-dpu-` are command names/comments or Ansible inventory hostname matching, not CONFIG_DB DPU keys.
- Attempted a representative HA pytest after deploy; it collected and entered setup, but was blocked before the test body by lab credential authentication in the shared HA setup fixture.

#### Any platform specific information?
Validated on Cisco 8102 SmartSwitch and Cisco 8102 SmartSwitch HA topologies. The change also applies to supported 4280 SmartSwitch HWSKUs through the shared SmartSwitch HWSKU config path.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A