### PR TITLE
[smartswitch]: move ensure_all_dpus_ready to platform_tests conftest

### DIFF
--- a/tests/smartswitch/platform_tests/conftest.py
+++ b/tests/smartswitch/platform_tests/conftest.py
@@ -1,0 +1,63 @@
+"""
+Pytest fixtures for SmartSwitch platform tests.
+"""
+import logging
+import pytest
+from pytest_ansible.errors import AnsibleConnectionFailure
+from tests.common.platform.processes_utils import wait_critical_processes
+from tests.common.reboot import wait_for_startup
+from tests.smartswitch.common.device_utils_dpu import (  # noqa: F401
+    dpus_startup_and_check, SWITCH_MAX_DELAY, SWITCH_MAX_TIMEOUT, num_dpu_modules
+)
+from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service  # noqa: F401
+
+
+@pytest.fixture(autouse=True)
+def ensure_all_dpus_ready(duthosts,
+                          enum_rand_one_per_hwsku_hostname,
+                          localhost,
+                          num_dpu_modules):  # noqa: F811
+    """
+    Teardown fixture: after each test case, ensure all DPUs are back online.
+    If any DPU is found offline at the end of a test, it will be started up
+    before the next test begins.
+    """
+    yield
+
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dpu_names = ["DPU{}".format(i) for i in range(num_dpu_modules)]
+
+    def _get_offline_dpus():
+        """Single shell call to find all offline DPUs."""
+        output = duthost.shell("show chassis module status")["stdout"]
+        return [
+            dpu for dpu in dpu_names
+            if any(dpu in line and "offline" in line.lower()
+                   for line in output.splitlines())
+        ]
+
+    def _do_dpu_recovery():
+        offline = _get_offline_dpus()
+        if offline:
+            logging.info("DPUs found offline after test: %s. Bringing them back UP...", offline)
+            dpus_startup_and_check(duthost, offline, num_dpu_modules)
+            logging.info("All DPUs are back online after recovery.")
+        else:
+            logging.info("All DPUs are online after test. No recovery needed.")
+
+    try:
+        _do_dpu_recovery()
+    except AnsibleConnectionFailure:
+        logging.warning(
+            "DUT %s unreachable in teardown (still rebooting?); waiting for it to come back up",
+            duthost.hostname
+        )
+        try:
+            wait_for_startup(duthost, localhost, SWITCH_MAX_DELAY, SWITCH_MAX_TIMEOUT)
+            wait_critical_processes(duthost)
+            logging.info("DUT %s is back up; retrying DPU recovery", duthost.hostname)
+            _do_dpu_recovery()
+        except Exception as e:
+            logging.warning("DPU recovery after DUT reboot wait failed (non-fatal): %s", e)
+    except Exception as e:
+        logging.warning("DPU recovery in teardown failed (non-fatal): %s", e)

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -41,34 +41,6 @@ def invocation_type(request):
     return request.param
 
 
-@pytest.fixture(autouse=True)
-def ensure_dpus_up_after_test(duthosts,
-                              enum_rand_one_per_hwsku_hostname,
-                              num_dpu_modules):  # noqa: F811
-    """
-    Teardown fixture: after each test case, ensure all DPUs are back online.
-    If any DPU is found offline at the end of a test, it will be started up
-    before the next test begins.
-    """
-    yield
-
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    dpu_names = ["DPU{}".format(i) for i in range(num_dpu_modules)]
-    try:
-        offline_dpus = [
-            dpu for dpu in dpu_names
-            if not check_dpu_module_status(duthost, "on", dpu)
-        ]
-        if offline_dpus:
-            logging.info("DPUs found offline after test: %s. Bringing them back UP...", offline_dpus)
-            dpus_startup_and_check(duthost, offline_dpus, num_dpu_modules)
-            logging.info("All DPUs are back online after recovery.")
-        else:
-            logging.info("All DPUs are online after test. No recovery needed.")
-    except Exception as e:
-        logging.warning("DPU recovery in teardown failed (non-fatal): %s", e)
-
-
 @pytest.mark.disable_loganalyzer
 def test_dpu_status_post_switch_reboot(duthosts, dpuhosts,
                                        enum_rand_one_per_hwsku_hostname,


### PR DESCRIPTION
### Description of PR

Summary:
Move the `ensure_all_dpus_ready` teardown fixture (previously `ensure_dpus_up_after_test` in `test_reload_dpu.py`) into a new `tests/smartswitch/platform_tests/conftest.py` so it is automatically applied to all tests in the `platform_tests` directory.

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
The `ensure_all_dpus_ready` teardown fixture was only present in `test_reload_dpu.py`, but `test_platform_dpu.py` also shuts down DPUs mid-test and can leave them offline if a test fails. Moving the fixture to `conftest.py` ensures all platform tests benefit from the same DPU recovery safety net without duplicating code.

#### How did you do it?
- Created `tests/smartswitch/platform_tests/conftest.py` with the `ensure_all_dpus_ready` fixture (`autouse=True`) and all required imports.
- Removed the fixture definition and its now-unused imports (`AnsibleConnectionFailure`, `wait_for_startup`, `SWITCH_MAX_DELAY`, `SWITCH_MAX_TIMEOUT`) from `test_reload_dpu.py`.
- Additionally, fix `ensure_all_dpus_ready` will now check if DUT is reachable and waits for startup, if not.

#### How did you verify/test it?
Tested on SmartSwitch testbed.

#### Any platform specific information?
SmartSwitch only.

#### Supported testbed topology if it's a new test case?
N/A — this is a framework improvement, not a new test case.

### Documentation