### PR TITLE
[ha]: Parallelize DPU config reload cleanup

### DIFF
--- a/tests/ha/conftest.py
+++ b/tests/ha/conftest.py
@@ -27,12 +27,12 @@ from tests.common.dash_utils import render_template_to_host, apply_swssconfig_fi
 from tests.common.helpers.smartswitch_util import correlate_dpu_info_with_dpuhost, get_data_port_on_dpu, get_dpu_dataplane_port # noqa F401
 from tests.ha.gnmi_utils import generate_gnmi_cert, apply_gnmi_cert, recover_gnmi_cert, apply_gnmi_file, apply_messages
 from tests.ha.ha_gnmi import apply_ha_messages, ha_scope_config, ha_set_config
-from tests.common import config_reload
 import configs.privatelink_config as pl
 from tests.common.helpers.assertions import pytest_require as pt_require
 from tests.common.helpers.assertions import pytest_assert as pt_assert
 from tests.common.utilities import wait_until
 from tests.ha.ha_utils import (
+    parallel_config_reload_dpuhosts,
     wait_for_pending_operation_id,
     verify_ha_state,
     set_dash_ha_scope
@@ -500,10 +500,12 @@ def set_vxlan_udp_sport_range(dpuhosts):
     """
     _apply_vxlan_udp_sport_range(dpuhosts)
     yield
+    dpuhosts_to_reload = []
     for dpuhost in dpuhosts:
         if str(VXLAN_UDP_BASE_SRC_PORT) in dpuhost.shell("redis-cli -n 0"
                                                          " hget SWITCH_TABLE:switch vxlan_sport")['stdout']:
-            config_reload(dpuhost, safe_reload=True, yang_validate=False)
+            dpuhosts_to_reload.append(dpuhost)
+    parallel_config_reload_dpuhosts(dpuhosts_to_reload)
 
 
 @pytest.fixture(scope="function")
@@ -956,8 +958,7 @@ def setup_dash_pl_pipeline(
     apply_dash_pl_pipeline_config(localhost, duthosts, dpuhosts, ptfhost)
     yield
     logger.info("setup_dash_pl_pipeline: cleanup.")
-    for dpuhost in dpuhosts:
-        config_reload(dpuhost, safe_reload=True, yang_validate=False)
+    parallel_config_reload_dpuhosts(dpuhosts)
 
 
 @pytest.fixture(scope="module")
@@ -971,5 +972,4 @@ def setup_dash_pl_pipeline_module_scope(
     apply_dash_pl_pipeline_config(localhost, duthosts, dpuhosts, ptfhost)
     yield
     logger.info("setup_dash_pl_pipeline: cleanup.")
-    for dpuhost in dpuhosts:
-        config_reload(dpuhost, safe_reload=True, yang_validate=False)
+    parallel_config_reload_dpuhosts(dpuhosts)

--- a/tests/ha/ha_utils.py
+++ b/tests/ha/ha_utils.py
@@ -1,13 +1,29 @@
 import logging
 import json
 import os
+from concurrent.futures import ThreadPoolExecutor
 
 import configs.privatelink_config as pl
+from tests.common.config_reload import config_reload
 from tests.common.utilities import wait_until
 from tests.ha.ha_gnmi import apply_ha_messages, ha_scope_config, ha_set_config
 from gnmi_utils import apply_messages
 
 logger = logging.getLogger(__name__)
+
+
+def _config_reload_dpuhost(dpuhost):
+    logger.info(f"config reload on {dpuhost.hostname}")
+    config_reload(dpuhost, safe_reload=True, yang_validate=False)
+
+
+def parallel_config_reload_dpuhosts(dpuhosts):
+    dpuhosts = list(dpuhosts)
+    if not dpuhosts:
+        return
+
+    with ThreadPoolExecutor(max_workers=len(dpuhosts)) as executor:
+        list(executor.map(_config_reload_dpuhost, dpuhosts))
 
 
 def build_dash_ha_scope_args(fields):

--- a/tests/ha/test_ha_bfd_pin.py
+++ b/tests/ha/test_ha_bfd_pin.py
@@ -10,11 +10,16 @@ from constants import (
     REMOTE_PTF_RECV_INTF
 )
 from packets import outbound_pl_packets
-from tests.common.config_reload import config_reload
 from tests.ha.conftest import apply_dash_pl_pipeline_config
 from tests.common.helpers.assertions import pytest_assert
 from ha_dash_flow_utils import compare_flow_tables_pdsctl
-from ha_utils import bfd_pin_primary, bfd_unpin_primary, bfd_pin_both_sides, bfd_unpin_both_sides
+from ha_utils import (
+    bfd_pin_primary,
+    bfd_unpin_primary,
+    bfd_pin_both_sides,
+    bfd_unpin_both_sides,
+    parallel_config_reload_dpuhosts,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -46,9 +51,7 @@ def common_setup_teardown(
     apply_dash_pl_pipeline_config(localhost, duthosts, dpuhosts, ptfhost)
 
     yield
-    for dpuhost in dpuhosts:
-        logger.info(f"config reload on {dpuhost.hostname}")
-        config_reload(dpuhost, safe_reload=True, yang_validate=False)
+    parallel_config_reload_dpuhosts(dpuhosts)
 
 
 """

--- a/tests/ha/test_ha_bgp_down.py
+++ b/tests/ha/test_ha_bgp_down.py
@@ -10,11 +10,11 @@ from constants import (
     REMOTE_PTF_RECV_INTF
 )
 from packets import outbound_pl_packets
-from tests.common.config_reload import config_reload
 from tests.ha.conftest import apply_dash_pl_pipeline_config
 from tests.common.helpers.assertions import pytest_assert
 from ha_dash_flow_utils import compare_flow_tables_pdsctl
 from ha_bgp_utils import ha_bgp_shutdown, ha_bgp_start
+from ha_utils import parallel_config_reload_dpuhosts
 
 logger = logging.getLogger(__name__)
 
@@ -46,9 +46,7 @@ def common_setup_teardown(
     apply_dash_pl_pipeline_config(localhost, duthosts, dpuhosts, ptfhost)
 
     yield
-    for dpuhost in dpuhosts:
-        logger.info(f"config reload on {dpuhost.hostname}")
-        config_reload(dpuhost, safe_reload=True, yang_validate=False)
+    parallel_config_reload_dpuhosts(dpuhosts)
 
 
 """

--- a/tests/ha/test_ha_config_reload.py
+++ b/tests/ha/test_ha_config_reload.py
@@ -14,6 +14,7 @@ from tests.common.config_reload import config_reload
 from tests.ha.conftest import apply_dash_pl_pipeline_config
 from tests.common.helpers.assertions import pytest_assert
 from ha_dash_flow_utils import compare_flow_tables_pdsctl
+from ha_utils import parallel_config_reload_dpuhosts
 
 logger = logging.getLogger(__name__)
 
@@ -45,9 +46,7 @@ def common_setup_teardown(
     apply_dash_pl_pipeline_config(localhost, duthosts, dpuhosts, ptfhost)
 
     yield
-    for dpuhost in dpuhosts:
-        logger.info(f"config reload on {dpuhost.hostname}")
-        config_reload(dpuhost, safe_reload=True, yang_validate=False)
+    parallel_config_reload_dpuhosts(dpuhosts)
 
 
 """

--- a/tests/ha/test_ha_dpu_power_down.py
+++ b/tests/ha/test_ha_dpu_power_down.py
@@ -4,17 +4,16 @@ import ptf.testutils as testutils
 import pytest
 import time
 import threading
-import concurrent.futures
 from constants import (
     LOCAL_PTF_INTF,
     REMOTE_PTF_RECV_INTF
 )
 from packets import outbound_pl_packets
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.config_reload import config_reload
 from tests.ha.conftest import apply_dash_pl_pipeline_config
 from ha_dash_flow_utils import compare_flow_tables
 from ha_dpu_utils import dpu_power_off_for_index, dpu_power_on_for_index
+from ha_utils import parallel_config_reload_dpuhosts
 
 logger = logging.getLogger(__name__)
 
@@ -27,11 +26,6 @@ pytestmark = [
 TRAFFIC_LOSS_DURATION_CAP = 2.0
 RATE_PPS = 20
 INITIAL_SEND_COUNT = 100
-
-
-def reload_config_for_host(dpuhost):
-    logger.info(f"config reload on {dpuhost.hostname}")
-    config_reload(dpuhost, safe_reload=True, yang_validate=False)
 
 
 @pytest.fixture(autouse=True, scope="function")
@@ -54,9 +48,7 @@ def common_setup_teardown(
     apply_dash_pl_pipeline_config(localhost, duthosts, dpuhosts, ptfhost)
 
     yield
-    with concurrent.futures.ThreadPoolExecutor(max_workers=len(dpuhosts)) as executor:
-        # Map the reload_config_for_host function to the dpuhosts list
-        executor.map(reload_config_for_host, dpuhosts)
+    parallel_config_reload_dpuhosts(dpuhosts)
 
 
 """

--- a/tests/ha/test_ha_eni_out_of_order.py
+++ b/tests/ha/test_ha_eni_out_of_order.py
@@ -1,9 +1,7 @@
 import logging
-import concurrent.futures
 
 import pytest
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.config_reload import config_reload
 from tests.ha.conftest import (
     apply_dash_pl_pipeline_config,
     setup_dash_ha_from_json_util,
@@ -11,18 +9,13 @@ from tests.ha.conftest import (
     activate_dash_ha_from_json_util,
     deactivate_dash_ha_from_json_util
 )
-from ha_utils import verify_ha_state
+from ha_utils import parallel_config_reload_dpuhosts, verify_ha_state
 
 logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('t1-smartswitch-ha')
 ]
-
-
-def reload_config_for_host(dpuhost):
-    logger.info(f"config reload on {dpuhost.hostname}")
-    config_reload(dpuhost, safe_reload=True, yang_validate=False)
 
 
 def test_ha_eni_out_of_order(
@@ -57,8 +50,7 @@ def test_ha_eni_out_of_order(
         deactivate_dash_ha_from_json_util(duthosts, dpuhosts, localhost, ptfhost, setup_gnmi_server, ha_owner)
         remove_setup_dash_ha_from_json_util(duthosts, dpuhosts, localhost, ptfhost, setup_gnmi_server, ha_owner)
         # cleanup the ENI
-        with concurrent.futures.ThreadPoolExecutor(max_workers=len(dpuhosts)) as executor:
-            executor.map(reload_config_for_host, dpuhosts)
+        parallel_config_reload_dpuhosts(dpuhosts)
 
         logger.info("HA: reprogram HA and ENI")
         setup_dash_ha_from_json_util(duthosts, dpuhosts, localhost, ptfhost, setup_gnmi_server, ha_owner)
@@ -71,6 +63,5 @@ def test_ha_eni_out_of_order(
                       "Standby HA state is not active")
     finally:
         deactivate_dash_ha_from_json_util(duthosts, dpuhosts, localhost, ptfhost, setup_gnmi_server, ha_owner)
-        with concurrent.futures.ThreadPoolExecutor(max_workers=len(dpuhosts)) as executor:
-            executor.map(reload_config_for_host, dpuhosts)
+        parallel_config_reload_dpuhosts(dpuhosts)
         remove_setup_dash_ha_from_json_util(duthosts, dpuhosts, localhost, ptfhost, setup_gnmi_server, ha_owner)

--- a/tests/ha/test_ha_npu_reboot.py
+++ b/tests/ha/test_ha_npu_reboot.py
@@ -1,6 +1,5 @@
 import logging
 from multiprocessing.pool import ThreadPool
-import concurrent.futures
 
 import configs.privatelink_config as pl
 import ptf.testutils as testutils
@@ -20,7 +19,6 @@ from gnmi_utils import (
 )
 from packets import outbound_pl_packets
 from tests.common.utilities import wait_until
-from tests.common.config_reload import config_reload
 from tests.ha.conftest import apply_dash_pl_pipeline_config
 from tests.common.helpers.assertions import pytest_assert, pytest_require as pt_require
 from tests.common.platform.processes_utils import wait_critical_processes
@@ -28,6 +26,7 @@ from ha_dash_flow_utils import compare_flow_tables_pdsctl
 from tests.common.reboot import reboot_smartswitch, wait_for_startup
 from tests.ha.conftest import get_interface_ip
 from tests.ha.ha_dpu_utils import CHECK_DPU_STATE_TIMEOUT, CHECK_DPU_STATE_TIME_INT, check_dpu_up_state
+from ha_utils import parallel_config_reload_dpuhosts
 
 
 logger = logging.getLogger(__name__)
@@ -41,11 +40,6 @@ pytestmark = [
 THRESHOLD_LOSS_PERCENT = 2.0
 RATE_PPS = 20
 INITIAL_SEND_COUNT = 100
-
-
-def reload_config_for_host(dpuhost):
-    logger.info(f"config reload on {dpuhost.hostname}")
-    config_reload(dpuhost, safe_reload=True, yang_validate=False)
 
 
 @pytest.fixture(scope="function")
@@ -127,9 +121,7 @@ def common_setup_teardown(
     apply_dash_pl_pipeline_config(localhost, duthosts, dpuhosts, ptfhost)
 
     yield
-    with concurrent.futures.ThreadPoolExecutor(max_workers=len(dpuhosts)) as executor:
-        # Map the reload_config_for_host function to the dpuhosts list
-        executor.map(reload_config_for_host, dpuhosts)
+    parallel_config_reload_dpuhosts(dpuhosts)
 
 
 """

--- a/tests/ha/test_ha_planned_shutdown_fnic.py
+++ b/tests/ha/test_ha_planned_shutdown_fnic.py
@@ -1,5 +1,4 @@
 import logging
-import concurrent.futures
 import random
 
 import configs.privatelink_config as pl
@@ -11,11 +10,16 @@ import queue
 from tests.common.helpers.assertions import pytest_assert
 from constants import LOCAL_PTF_INTF, REMOTE_PTF_RECV_INTF
 from packets import outbound_pl_packets
-from tests.common.config_reload import config_reload
 from tests.ha.conftest import apply_dash_pl_pipeline_config
 from ha_dash_flow_utils import compare_flow_tables, compare_flow_tables_pdsctl
-from ha_utils import activate_primary_dash_ha, activate_secondary_dash_ha, \
-         verify_ha_state, set_dash_ha_scope, set_dead_dash_ha_scope
+from ha_utils import (
+    activate_primary_dash_ha,
+    activate_secondary_dash_ha,
+    verify_ha_state,
+    set_dash_ha_scope,
+    set_dead_dash_ha_scope,
+    parallel_config_reload_dpuhosts,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -28,11 +32,6 @@ pytestmark = [
     pytest.mark.topology('t1-smartswitch-ha'),
     pytest.mark.skip_check_dut_health
 ]
-
-
-def reload_config_for_host(dpuhost):
-    logger.info(f"config reload on {dpuhost.hostname}")
-    config_reload(dpuhost, safe_reload=True, yang_validate=False)
 
 
 @pytest.fixture(autouse=True, scope="function")
@@ -56,8 +55,7 @@ def common_setup_teardown(
 
     yield
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=len(dpuhosts)) as executor:
-        executor.map(reload_config_for_host, dpuhosts)
+    parallel_config_reload_dpuhosts(dpuhosts)
 
 
 def test_ha_planned_shutdown(

--- a/tests/ha/test_ha_planned_swo.py
+++ b/tests/ha/test_ha_planned_swo.py
@@ -1,4 +1,3 @@
-import concurrent.futures
 import logging
 import queue
 import random
@@ -8,7 +7,6 @@ import time
 import ptf.testutils as testutils
 import pytest
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.config_reload import config_reload
 from tests.ha.conftest import apply_dash_pl_pipeline_config
 from constants import (
     LOCAL_PTF_INTF,
@@ -18,7 +16,7 @@ from constants import (
 )
 from packets import outbound_pl_packets
 from ha_dash_flow_utils import compare_flow_tables
-from ha_utils import verify_ha_state, set_dash_ha_scope
+from ha_utils import verify_ha_state, set_dash_ha_scope, parallel_config_reload_dpuhosts
 
 logger = logging.getLogger(__name__)
 
@@ -53,13 +51,7 @@ def common_setup_teardown(
     apply_dash_pl_pipeline_config(localhost, duthosts, dpuhosts, ptfhost)
 
     yield
-
-    def _reload(host):
-        logger.info(f"config reload on {host.hostname}")
-        config_reload(host, safe_reload=True, yang_validate=False)
-
-    with concurrent.futures.ThreadPoolExecutor(max_workers=len(dpuhosts)) as executor:
-        list(executor.map(_reload, dpuhosts))
+    parallel_config_reload_dpuhosts(dpuhosts)
 
 
 def _planned_swo_phase(

--- a/tests/ha/test_ha_repairing_dpu.py
+++ b/tests/ha/test_ha_repairing_dpu.py
@@ -15,7 +15,6 @@ from constants import (
 )
 from packets import outbound_pl_packets
 from tests.common.devices.duthosts import DutHosts
-from tests.common.config_reload import config_reload
 from tests.common.dash_utils import apply_swssconfig_file
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import InterruptableThread
@@ -23,6 +22,7 @@ from tests.conftest import get_specified_dpus, get_target_hostname, is_parallel_
 from tests.ha.conftest import apply_dash_pl_pipeline_config
 from ha_gnmi import apply_ha_messages, ha_scope_config, ha_set_config
 from ha_utils import (
+    parallel_config_reload_dpuhosts,
     program_eni_pl_on_dpu,
     set_dash_ha_scope,
     verify_ha_state,
@@ -487,9 +487,7 @@ def common_setup_teardown(
                     set_db=False,
                 )
     finally:
-        for dpuhost in selected_dpuhosts:
-            logger.info(f"config reload on {dpuhost.hostname}")
-            config_reload(dpuhost, safe_reload=True, yang_validate=False)
+        parallel_config_reload_dpuhosts(selected_dpuhosts)
 
 
 def _update_ha_set_with_replacement_dpu(

--- a/tests/ha/test_ha_steady_state_fnic.py
+++ b/tests/ha/test_ha_steady_state_fnic.py
@@ -1,6 +1,5 @@
 import logging
 import random
-import concurrent.futures
 
 import configs.privatelink_config as pl
 import ptf.packet as scapy
@@ -9,10 +8,10 @@ import pytest
 from tests.common.helpers.assertions import pytest_assert
 from constants import LOCAL_PTF_INTF, REMOTE_PTF_RECV_INTF, REMOTE_PTF_SEND_INTF
 from packets import inbound_pl_packets, outbound_pl_packets
-from tests.common.config_reload import config_reload
 from tests.ha.conftest import apply_dash_pl_pipeline_config
 from tests.common.dash_utils import verify_tunnel_packets
 from ha_dash_flow_utils import compare_flow_tables_pdsctl
+from ha_utils import parallel_config_reload_dpuhosts
 
 logger = logging.getLogger(__name__)
 
@@ -23,11 +22,6 @@ pytestmark = [
 
 
 NUM_PACKETS = 5
-
-
-def reload_config_for_host(dpuhost):
-    logger.info(f"config reload on {dpuhost.hostname}")
-    config_reload(dpuhost, safe_reload=True, yang_validate=False)
 
 
 def _build_fnic_pkt_set(config, encap_proto, ptfadapter):
@@ -69,8 +63,7 @@ def common_setup_teardown(
     apply_dash_pl_pipeline_config(localhost, duthosts, dpuhosts, ptfhost, floating_nic=True)
 
     yield
-    with concurrent.futures.ThreadPoolExecutor(max_workers=len(dpuhosts)) as executor:
-        executor.map(reload_config_for_host, dpuhosts)
+    parallel_config_reload_dpuhosts(dpuhosts)
 
 
 @pytest.mark.parametrize("encap_proto", ["vxlan", "gre"])

--- a/tests/ha/test_ha_steady_state_pl.py
+++ b/tests/ha/test_ha_steady_state_pl.py
@@ -2,15 +2,14 @@ import logging
 
 import ptf.testutils as testutils
 import pytest
-import concurrent.futures
 from configs.privatelink_config import APPLIANCE_VIP
 from tests.common.helpers.assertions import pytest_assert
 from constants import LOCAL_PTF_INTF, REMOTE_PTF_RECV_INTF, REMOTE_PTF_SEND_INTF
 from packets import outbound_pl_packets, inbound_pl_packets
-from tests.common.config_reload import config_reload
 from tests.ha.conftest import apply_dash_pl_pipeline_config
 from ha_bgp_utils import check_vip_advertised_to_t2
 from ha_dash_flow_utils import compare_flow_tables
+from ha_utils import parallel_config_reload_dpuhosts
 
 logger = logging.getLogger(__name__)
 
@@ -23,11 +22,6 @@ pytestmark = [
 Test prerequisites:
 - Assign IPs to DPU-NPU dataplane interfaces
 """
-
-
-def reload_config_for_host(dpuhost):
-    logger.info(f"config reload on {dpuhost.hostname}")
-    config_reload(dpuhost, safe_reload=True, yang_validate=False)
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -50,9 +44,7 @@ def common_setup_teardown(
     apply_dash_pl_pipeline_config(localhost, duthosts, dpuhosts, ptfhost)
 
     yield
-    with concurrent.futures.ThreadPoolExecutor(max_workers=len(dpuhosts)) as executor:
-        # Map the reload_config_for_host function to the dpuhosts list
-        executor.map(reload_config_for_host, dpuhosts)
+    parallel_config_reload_dpuhosts(dpuhosts)
 
 
 @pytest.mark.parametrize("encap_proto", ["vxlan", "gre"])


### PR DESCRIPTION
### Description of PR
Summary:
Parallelize HA DPU config reload cleanup so multiple DPUs are restored concurrently after HA tests instead of sequentially.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

HA tests reload DPU config during cleanup. When multiple DPUs are selected, running those reloads sequentially extends test runtime unnecessarily.

#### How did you do it?

Added a shared HA helper that runs DPU `config_reload` calls through a `ThreadPoolExecutor`, then replaced sequential cleanup loops and duplicated local thread-pool helpers with the shared helper.

#### How did you verify/test it?

- `python3 -m py_compile` for all touched HA files
- `git diff --check`
- Focused live SmartSwitch HA validation with two selected DPUs: both DPU reloads entered `config_reload` concurrently and the validation passed (`1 passed`)

#### Any platform specific information?

Validated on a SmartSwitch HA setup with two selected DPUs.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A