### PR TITLE
[pfc_storm] Add Nokia IXR7220 (Tomahawk6) support for PFC storm

### DIFF
--- a/tests/common/helpers/pfc_gen_brcm_xgs.py
+++ b/tests/common/helpers/pfc_gen_brcm_xgs.py
@@ -97,7 +97,7 @@ class FanoutPfcStorm():
         intfTolPort = {}
         lPortToIntf = {}
 
-        if self.switchChip.startswith(("Tomahawk5", "Tomahawk4")):
+        if self.switchChip.startswith(("Tomahawk6", "Tomahawk5", "Tomahawk4")):
             output = self._bcmltshellCmd('knet netif info')
             for info in output.split("Network interface Info:"):
                 mo = re.search(r"Name: (?P<intf>Ethernet\d+)[\s\S]{1,100}Port: (?P<lport>\d+)", info)
@@ -143,7 +143,7 @@ class FanoutPfcStorm():
         '''
         mmuPort = self.intfToMmuPort[intf]
         port = self.intfToPort[intf]
-        if self.switchChip.startswith(("Tomahawk5", "Tomahawk4")):
+        if self.switchChip.startswith(("Tomahawk6", "Tomahawk5", "Tomahawk4")):
             self._bcmltshellCmd(f"pt MMU_INTFO_XPORT_BKP_HW_UPDATE_DISr set BCMLT_PT_PORT={mmuPort} PAUSE_PFC_BKP=0")
             self._bcmltshellCmd(f"pt MMU_INTFO_TO_XPORT_BKPr set BCMLT_PT_PORT={mmuPort} PAUSE_PFC_BKP=0")
         else:
@@ -175,7 +175,7 @@ class FanoutPfcStorm():
                 if (1 << prio) & self.priority:
                     self._cliCmd(f"en\nconf\n\nint {intf}\npriority-flow-control priority {prio} no-drop")
 
-        if self.switchChip.startswith(("Tomahawk5", "Tomahawk4")):
+        if self.switchChip.startswith(("Tomahawk6", "Tomahawk5", "Tomahawk4")):
             self._bcmltshellCmd(f"pt MMU_INTFO_XPORT_BKP_HW_UPDATE_DISr set BCMLT_PT_PORT={mmuPort} PAUSE_PFC_BKP=1")
             self._bcmltshellCmd(f"pt MMU_INTFO_TO_XPORT_BKPr set BCMLT_PT_PORT={mmuPort} PAUSE_PFC_BKP={self.priority}")
         else:

--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -32,6 +32,7 @@ def get_chip_name_if_asic_pfc_storm_supported(fanout):
         "Arista DCS-7260CX3": "Tomahawk2",
         "Arista-7260CX3": "Tomahawk2",
         "Arista-7260QX3": "Tomahawk2",
+        "Nokia-IXR7220": "Tomahawk6",
         }
 
     for sku, chip in hwSkuInfo.items():


### PR DESCRIPTION
### Description of PR
Summary:
Fix `test_all_port_storm_restore` (and related PFCWD tests) on Nokia IXR7220 (Tomahawk6 ASIC) by adding support for the platform in the PFC storm generation infrastructure.

### Type of change
- [x] Bug fix

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512

### Approach
#### What is the motivation for this PR?
Nokia IXR7220 uses Broadcom Tomahawk6 ASIC. Without this change, `get_chip_name_if_asic_pfc_storm_supported` returns `None` for Nokia devices, causing `test_all_port_storm_restore` to skip or fail.

#### How did you do it?
1. Added `"Nokia-IXR7220": "Tomahawk6"` to the `hwSkuInfo` map in `pfc_storm.py` so Nokia IXR7220 is recognized as a supported platform.
2. Extended the three `startswith(("Tomahawk5", "Tomahawk4"))` checks in `pfc_gen_brcm_xgs.py` to also match `"Tomahawk6"`, enabling the correct BCM LTSH shell commands for PFC backpressure configuration on this ASIC.

#### How did you verify/test it?
Verified on Nokia IXR7220-H6-O256 testbed (lt2 topology).

#### Any platform specific information?
Nokia IXR7220-H6-O256 uses Broadcom Tomahawk6 (BCM56990).

#### Supported testbed topology if it's a new test case?
N/A — existing test case.

### Documentation