### PR TITLE
Handle CsonicHost in BGP neighbor route learning test

### DIFF
--- a/tests/bgp/test_bgp_route_neigh_learning.py
+++ b/tests/bgp/test_bgp_route_neigh_learning.py
@@ -4,6 +4,7 @@ import logging
 from tests.common.helpers.assertions import pytest_assert as py_assert
 from tests.common.devices.eos import EosHost
 from tests.common.devices.sonic import SonicHost
+from tests.common.devices.csonic import CsonicHost
 from tests.common.utilities import wait_until
 pytestmark = [
     pytest.mark.topology('t0'),
@@ -118,7 +119,7 @@ def fixture_setUp(nbrhosts, duthosts, enum_frontend_dut_hostname, ip_version):
         # remove the route in the neighbor T1 eos device
         if isinstance(nbrhost, EosHost):
             rm_route_from_nbr(data, name, prefix, mask, afi_cfg["afi_cmd_eos"])
-        elif isinstance(nbrhost, SonicHost):
+        elif isinstance(nbrhost, (SonicHost, CsonicHost)):
             cmd = "sudo vtysh -c 'configure terminal' " \
                   f"-c 'router bgp {bgp_as_num}' " \
                   f"-c \"{afi_cfg['afi_cmd_sonic']}\" " \
@@ -156,7 +157,7 @@ def run_bgp_neighbor_route_learning(duthosts, enum_frontend_dut_hostname, data):
         # add a route in the neighbor T1 eos device
         if isinstance(nbrhost, EosHost):
             add_route_to_nbr(data, name, prefix, mask, afi_cfg["afi_cmd_eos"], afi_cfg["loopback_cmd_eos"])
-        elif isinstance(nbrhost, SonicHost):
+        elif isinstance(nbrhost, (SonicHost, CsonicHost)):
             # Create and configure loopback interface
             cmd = f"sudo config interface ip add Loopback1 {prefix}/{mask}"
             result = nbrhost.shell(cmd)

--- a/tests/bgp/test_bgp_route_neigh_learning.py
+++ b/tests/bgp/test_bgp_route_neigh_learning.py
@@ -175,7 +175,7 @@ def run_bgp_neighbor_route_learning(duthosts, enum_frontend_dut_hostname, data):
 
     duthost = duthosts[enum_frontend_dut_hostname]
     Logger.info("checking  DUT for route %s", prefix)
-    is_route_propagated = wait_until(10, 2, 0, lambda: _check_route_propagation(duthost, data))
+    is_route_propagated = wait_until(60, 5, 0, lambda: _check_route_propagation(duthost, data))
     py_assert(is_route_propagated, "Route did not propagate to the DUT")
 
 


### PR DESCRIPTION
## Summary

Fixes cSONiC validation issue securely1g/csonic-validation#2 by treating `CsonicHost` like `SonicHost` in `bgp/test_bgp_route_neigh_learning.py`.

The test already has SONiC-compatible commands for adding/removing the Loopback1 route and BGP network. cSONiC neighbors expose the same `shell()` interface and run SONiC/FRR inside the container, but `CsonicHost` does not subclass `SonicHost`, so the old type check fell through to `ValueError("Unsupported neighbor type")`.

This updates both the setup path and cleanup path to use the SONiC command path for `CsonicHost`.

## Validation

Local/static:

- `python3 -m py_compile tests/bgp/test_bgp_route_neigh_learning.py`
- `git diff --check`

Focused local cSONiC pytest was not run yet because the local KVM/cSONiC testbed is not currently deployed: no running `sonic-mgmt`/cSONiC containers or `virsh` domains were present, and the required `/data/sonic-buildimage/target/docker-sonic-vs.gz` and `target/sonic-vs.img.gz` artifacts were absent.

Planned focused validation once the testbed is available:

```bash
cd /data/sonic-mgmt/tests
pytest bgp/test_bgp_route_neigh_learning.py \
  --neighbor_type csonic \
  --inventory ../ansible/veos_vtb \
  --host-pattern vlab-01 \
  --module-path ../ansible/library \
  --testbed vms-kvm-t0-csonic \
  --testbed_file ../ansible/vtestbed.yaml
```

Fixes securely1g/csonic-validation#2
