### PR TITLE
test_watchdog: add Nokia IXR-7220-H6 watchdog config

### DIFF
--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -132,6 +132,13 @@ x86_64-nokia_ixr7220_d4-r0:
     greater_timeout: 170
     too_big_timeout: 341
 
+# Nokia IXR-7220-H6 watchdog (max timeout 340s enforced in arm())
+x86_64-nokia_ixr7220_h6_128-r0:
+  default:
+    valid_timeout: 30
+    greater_timeout: 170
+    too_big_timeout: 341
+
 # Cisco-8000 watchdog
 x86_64-8102_64h_o-r0:
   default:


### PR DESCRIPTION
### Description of PR
**Summary:** Add platform-specific watchdog configuration for Nokia IXR-7220-H6-O256 (`x86_64-nokia_ixr7220_h6_128-r0`) to `watchdog.yml`.

Fixes #(issue)

### Type of change
- [x] Bug fix
- [x] Test case improvement

### Approach
#### What is the motivation for this PR?
The Nokia IXR-7220-H6-O256 platform was missing from `watchdog.yml`, so `test_arm_too_big_timeout` fell back to the default config with `too_big_timeout: 100`. The Nokia TH6 watchdog `arm()` implementation enforces `seconds > 340` rejection, so 100s is accepted and the test fails unexpectedly.

#### How did you do it?
Added a platform entry for `x86_64-nokia_ixr7220_h6_128-r0` with `valid_timeout: 30`, `greater_timeout: 170`, and `too_big_timeout: 341`. This matches the IXR-7220-D4 which shares the same watchdog hardware with a 340s maximum.

#### How did you verify/test it?
`test_arm_too_big_timeout` verified passing on Nokia IXR7220-H6-O256 testbed (`vms13-lt2-nokia-th6-1`) with this change.

#### Any platform specific information?
Nokia IXR-7220-H6-O256, platform string `x86_64-nokia_ixr7220_h6_128-r0`, SONiC 202511.

### Documentation
N/A