### PR TITLE
Handle CsonicHost in BGP GR helper setup

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -28,6 +28,7 @@ from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common import constants
 from tests.common.devices.eos import EosHost
 from tests.common.devices.sonic import SonicHost
+from tests.common.devices.csonic import CsonicHost
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +108,7 @@ def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo
                         parents=['router bgp {}'.format(asn), 'address-family ipv6'],
                         module_ignore_errors=True)
                     )
-        elif isinstance(node['host'], SonicHost):
+        elif isinstance(node['host'], (SonicHost, CsonicHost)):
             node_results.append(node['host'].config(
                 lines=['bgp graceful-restart', 'bgp graceful-restart restart-time 300'],
                 parents=['router bgp {}'.format(asn)],
@@ -180,7 +181,7 @@ def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo
                         parents=['router bgp {}'.format(asn), 'address-family ipv6'],
                         module_ignore_errors=True)
                     )
-        elif isinstance(node['host'], SonicHost):
+        elif isinstance(node['host'], (SonicHost, CsonicHost)):
             node_results.append(node['host'].config(
                 lines=['no bgp graceful-restart', 'no bgp graceful-restart restart-time 300'],
                 parents=['router bgp {}'.format(asn)],

--- a/tests/common/devices/csonic.py
+++ b/tests/common/devices/csonic.py
@@ -146,7 +146,7 @@ class CsonicHost(NeighborDevice):
                 return result['stdout']
         return {}
 
-    def config(self, lines=None, parents=None):
+    def config(self, lines=None, parents=None, **kwargs):
         """
         Configure via vtysh (loose compatibility with EOS config style).
         Translates config lines to vtysh commands.
@@ -164,7 +164,11 @@ class CsonicHost(NeighborDevice):
         for c in cmds:
             vtysh_cmd += " -c '{}'".format(c)
 
-        return self._docker_exec(vtysh_cmd)
+        return self._docker_exec(vtysh_cmd, **kwargs)
+
+    def start_bgpd(self):
+        """Start the BGP daemon inside the cSONiC container."""
+        return self._docker_exec("supervisorctl start bgpd", module_ignore_errors=True)
 
     def fetch(self, src=None, dest=None, **kwargs):
         """


### PR DESCRIPTION
## Summary

Fixes cSONiC validation issue securely1g/csonic-validation#3 by allowing BGP graceful-restart helper setup/restore to configure `CsonicHost` neighbors using the existing SONiC/FRR command path.

Changes:

- Treat `CsonicHost` like `SonicHost` in `tests/bgp/conftest.py` for GR enable/restore.
- Extend `CsonicHost.config()` to accept/pass through `**kwargs`, matching the call pattern used by the GR helper (`module_ignore_errors=True`).
- Add `CsonicHost.start_bgpd()` so the restore path can restart bgpd on cSONiC containers like other neighbor host classes.

## Validation

Local/static:

- `python3 -m py_compile tests/bgp/conftest.py tests/common/devices/csonic.py`
- `git diff --check`

Focused local cSONiC pytest was not run yet because the local KVM/cSONiC testbed is not currently deployed: no running `sonic-mgmt`/cSONiC containers or `virsh` domains were present, and the required `/data/sonic-buildimage/target/docker-sonic-vs.gz` and `target/sonic-vs.img.gz` artifacts were absent.

Planned focused validation once the testbed is available:

```bash
tests/run_tests.sh \
  -n vms-kvm-t0-csonic \
  -t t0 \
  -c bgp/test_bgp_gr_helper.py::test_bgp_gr_helper_routes_perserved \
  -e "--neighbor_type=csonic"
```

Fixes securely1g/csonic-validation#3
