### PR TITLE
system_health: wait for LED to converge before checking consistency

### DIFF
--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -522,10 +522,14 @@ def check_system_health_led_info(duthost):
 
     # Cache the consistent snapshot captured inside the closure to avoid a
     # re-fetch that could observe a different value on a flapping LED.
+    # last_observed is always updated so assertion messages show real state on timeout.
     consistent_snapshot = {}
+    last_observed = {}
 
     def _led_consistent():
         led, status_dict = _fetch_led_and_status(duthost)
+        last_observed['led'] = led
+        last_observed['status_dict'] = status_dict
         all_ok = all(status == "OK" for status in status_dict.values())
         if led == expected_normal if all_ok else led in not_normal:
             consistent_snapshot['led'] = led
@@ -536,8 +540,8 @@ def check_system_health_led_info(duthost):
     # LED update by system-health daemon is asynchronous; wait for it to reflect current status
     result = wait_until(WAIT_TIMEOUT, 10, 0, _led_consistent)
 
-    system_led_status = consistent_snapshot.get('led', '')
-    status_dict = consistent_snapshot.get('status_dict', {})
+    system_led_status = consistent_snapshot.get('led', last_observed.get('led', ''))
+    status_dict = consistent_snapshot.get('status_dict', last_observed.get('status_dict', {}))
     logger.info(f"System status LED is {system_led_status}")
     logger.info(f"Status dict is {status_dict}")
 

--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -504,32 +504,48 @@ def check_health_field_not_equal(duthost, field, unexpected):
     return not value or value != unexpected
 
 
-def check_system_health_led_info(duthost):
-    system_health_summary = duthost.shell('show system-health summary')['stdout']
-
-    "System status LED  red"
-    system_led_res = re.findall(r"System status LED\s+(\w+)", system_health_summary)
-    if system_led_res:
-        system_led_status = system_led_res[0].strip()
-    logger.info(f"System status LED is {system_led_status}")
-
-    # Regex to find all status names and values
-    status_data = re.findall(r"(\w+):\s+Status:\s+(\w+)", system_health_summary)
+def _fetch_led_and_status(duthost):
+    """Fetch system health summary and return (led_color_lower, status_dict)."""
+    summary = duthost.shell('show system-health summary')['stdout']
+    # Use [\w ]+ to capture multi-word colors like "blinking green"
+    led_res = re.findall(r"System status LED\s+([\w ]+)", summary)
+    led_status = led_res[0].strip().lower() if led_res else ""
+    status_data = re.findall(r"(\w+):\s+Status:\s+(\w+)", summary)
     status_dict = {name: status for name, status in status_data}
+    return led_status, status_dict
+
+
+def check_system_health_led_info(duthost):
+    led_cfg = get_system_health_config(duthost, "led_color", DEFAULT_LED_CONFIG)
+    expected_normal = led_cfg["normal"].lower()
+    not_normal = {color.lower() for key, color in led_cfg.items() if key != "normal"}
+
+    # Cache the consistent snapshot captured inside the closure to avoid a
+    # re-fetch that could observe a different value on a flapping LED.
+    consistent_snapshot = {}
+
+    def _led_consistent():
+        led, status_dict = _fetch_led_and_status(duthost)
+        all_ok = all(status == "OK" for status in status_dict.values())
+        if led == expected_normal if all_ok else led in not_normal:
+            consistent_snapshot['led'] = led
+            consistent_snapshot['status_dict'] = status_dict
+            return True
+        return False
+
+    # LED update by system-health daemon is asynchronous; wait for it to reflect current status
+    result = wait_until(WAIT_TIMEOUT, 10, 0, _led_consistent)
+
+    system_led_status = consistent_snapshot.get('led', '')
+    status_dict = consistent_snapshot.get('status_dict', {})
+    logger.info(f"System status LED is {system_led_status}")
     logger.info(f"Status dict is {status_dict}")
 
-    led_cfg = get_system_health_config(duthost, "led_color", DEFAULT_LED_CONFIG)
-
-    system_status_lower = system_led_status.lower()
     if all(status == "OK" for status in status_dict.values()):
-        # Logic for healthy system: must match the 'normal' key value
-        expected_normal = led_cfg["normal"].lower()
-        assert system_status_lower == expected_normal, \
+        assert result and system_led_status == expected_normal, \
             f"System status LED is not the configured 'normal' color ({expected_normal}), but it is {system_led_status}"
     else:
-        # Logic for faulted system: Iterate through led_cfg to find a match among non-normal keys
-        not_normal = {color for key, color in led_cfg.items() if key != "normal"}
-        assert system_status_lower in not_normal, \
+        assert result and system_led_status in not_normal, \
             f"System status LED '{system_led_status}' does not match any colors defined in config: {not_normal}"
 
     return True


### PR DESCRIPTION
### Description of PR
Summary:
The system-health daemon updates the LED asynchronously. After a service fault is detected, the STATE_DB health table is updated immediately but the physical LED may take a cycle (up to ~60s) to be updated. This causes `test_service_checker` to fail intermittently: `show system-health summary` already reports `Services: Not OK` but the LED is still showing `green`.

Additionally, on platforms where the LED color is a multi-word string like `blinking green`, the existing regex `(\w+)` only captures the first word (`blinking`), causing incorrect matching.

### Type of change
- [x] Bug fix

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Flaky `test_service_checker` failures due to LED update latency and incorrect multi-word color regex.

#### How did you do it?
1. Refactored `check_system_health_led_info()` to extract `_fetch_led_and_status()` helper.
2. Added `wait_until(180s, 10s interval)` loop waiting for the LED color to be consistent with the aggregated service status, instead of assuming immediate consistency.
3. Cache the consistent snapshot inside the `wait_until` closure to avoid a re-fetch that could observe a different value on a flapping LED.
4. Fixed LED color regex from `(\w+)` to `([\w ]+)` to correctly capture multi-word colors like `blinking green`.

#### How did you verify/test it?
Ran `test_service_checker` 3 times on a Nokia IXR7220-H6-O256 (TH6) DUT that had a service in non-OK state. All 3 runs passed with the fix (previously 2 of 3 failed).

#### Any platform specific information?
Observed on Nokia IXR7220-H6-O256 platform (SONiC 202512). The LED flaps between `green` and `amber` while the system-health daemon converges.

### Documentation
N/A