### PR TITLE
Fix Cisco fwutil component update argument order

### DIFF
--- a/tests/platform_tests/cisco/test_fwutil_cisco.py
+++ b/tests/platform_tests/cisco/test_fwutil_cisco.py
@@ -68,7 +68,7 @@ def test_fwutil_component_update(request, duthost, localhost, pdu_controller,
 
     logging.info("Cold rebooting after firmware update")
     current = duthost.shell('sonic-installer list | grep Current | cut -f2 -d " "')['stdout']
-    complete_install(duthost, localhost, "cold", res, pdu_controller, False, current)
+    complete_install(duthost, localhost, "cold", res, pdu_controller, component, False, current)
 
     logging.info(f"Checking the status after {component} firmware upgrade")
     output_fwutil_status = duthost.shell(f'fwutil show updates | grep {component}')


### PR DESCRIPTION
### Description of PR

Summary:
Fixes Cisco fwutil component update test failure where the `component` argument is accidentally passed as `False` to `complete_install()`.

The current call shifts arguments positionally:
- `component=False`
- `auto_reboot=<current image string>`

This causes `complete_install()` to evaluate `'CPLD' in component` / `'FPGA' in component` with a boolean and raise `TypeError: argument of type 'bool' is not iterable`.

This change passes the parametrized component name before `auto_reboot=False`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
`complete_install()` signature expects `component` as the 5th positional argument, but the call was passing `False` (the `auto_reboot` value) in that slot, corrupting both arguments.

#### How did you do it?
Added the missing `component` argument before `auto_reboot=False` in the `complete_install()` call.

#### How did you verify/test it?
Code review — the fix aligns the call with the function signature. The 202605 backport is tracked in #25478.

#### Any platform specific information?
Cisco platform only (`test_fwutil_cisco.py`).

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A

Related ADO PBI: 38475459