### PR TITLE
Fix KeyError: 'failed' by normalizing ansible result in AnsibleHostBase._run

### DIFF
--- a/tests/common/devices/base.py
+++ b/tests/common/devices/base.py
@@ -247,6 +247,12 @@ class AnsibleHostBase(object):
         if (hostname_res.is_failed or 'exception' in hostname_res) and not module_ignore_errors:
             raise RunAnsibleModuleFail("run module {} failed".format(module_name), hostname_res)
 
+        # Ensure 'failed' key is always present for compatibility with code that checks rc['failed'].
+        # The _IGNORE hack above is no longer effective in ansible-core >= 2.21 which changed
+        # how task results are post-processed. Normalizing here is a robust fallback.
+        if 'failed' not in hostname_res:
+            hostname_res['failed'] = hostname_res.is_failed
+
         return hostname_res
 
 


### PR DESCRIPTION
## Why I did it

The existing _IGNORE hack in ase.py (which prevents ansible from stripping the 'failed' key from task results) no longer works in **ansible-core >= 2.21**. The post-processing behavior changed in the new ansible-core version shipped in the latest sonic-mgmt docker, causing 'failed' to be absent from successful command results.

This broke multiple test modules when they access `rc['failed']` after calling `self.shell()` or `self.command()`:

| Module | File | Error |
|---|---|---|
| tacacs | `common/helpers/tacacs/tacacs_helper.py:366` | `if nss_config_attribute['failed']:` → `KeyError: 'failed'` |
| dualtor_io | `common/dualtor/dual_tor_io.py:591` | `if not output['failed']:` → `KeyError: 'failed'` |
| bgp | `bgp/route_checker.py:121` | `if res['failed'] and cmd_backup != "":` → `KeyError: 'failed'` |
| macsec | `macsec/test_dataplane.py:117` | `...["failed"]` → `KeyError: 'failed'` |

## How I did it

Normalize the result in `_run()` to always include the `'failed'` key, based on `hostname_res.is_failed`, before returning. This is a single fix that covers all call sites and is robust across ansible-core versions.

`python
# Ensure 'failed' key is always present for compatibility with code that checks rc['failed'].
# The _IGNORE hack above is no longer effective in ansible-core >= 2.21 which changed
# how task results are post-processed. Normalizing here is a robust fallback.
if 'failed' not in hostname_res:
    hostname_res['failed'] = hostname_res.is_failed
`

Note: A previous PR (#25443) fixed two specific call sites in `sonic.py` (`ping_v4`/`ping_v6`). This PR fixes the root cause in `base.py` so all remaining call sites are covered.

## How to verify it

Run any of the following tests with the latest sonic-mgmt docker:
- `tacacs/test_authorization.py`
- `tacacs/test_ro_user.py`
- `dualtor_io/test_link_failure.py`
- `bgp/test_traffic_shift.py`
- `macsec/test_dataplane.py`

The `KeyError: 'failed'` should no longer occur.