### PR TITLE
Fix AnsibleHostBase._run: normalize 'failed' key for ansible-core >= 2.21

### DIFF
--- a/tests/common/devices/base.py
+++ b/tests/common/devices/base.py
@@ -247,6 +247,14 @@ class AnsibleHostBase(object):
         if (hostname_res.is_failed or 'exception' in hostname_res) and not module_ignore_errors:
             raise RunAnsibleModuleFail("run module {} failed".format(module_name), hostname_res)
 
+        # Ensure 'failed' key is always present for backward compatibility with code that
+        # accesses rc['failed'] directly. The _IGNORE hack above is no longer effective in
+        # ansible-core >= 2.21 where the post-processing behavior changed so that 'failed'
+        # is absent from successful command results. Normalizing here is a single robust fix
+        # that covers all call sites without requiring per-file changes.
+        if 'failed' not in hostname_res:
+            hostname_res['failed'] = hostname_res.is_failed
+
         return hostname_res
 
 


### PR DESCRIPTION
### Description of PR

Summary:
Fix KeyError: 'failed' in AnsibleHostBase._run caused by ansible-core >= 2.21 changing how task results are post-processed.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [x] 202605

### Approach

#### What is the motivation for this PR?

The existing _IGNORE hack in base.py prevents ansible from stripping 'failed' from task results. This hack no longer works in **ansible-core >= 2.21**, which changed post-processing so that 'failed' is absent from successful command results.

Multiple test modules hit KeyError: 'failed' when they access 
c['failed'] after a successful self.shell() or self.command() call, observed when running with the latest sonic-mgmt docker:

| Module | Location |
|---|---|
| tacacs | common/helpers/tacacs/tacacs_helper.py:366 — if nss_config_attribute['failed']: |
| dualtor_io | common/dualtor/dual_tor_io.py:591 — if not output['failed']: |
| bgp | bgp/route_checker.py:121 — if res['failed'] and cmd_backup != "": |
| macsec | macsec/test_dataplane.py:117 — ...["failed"] |

#### How did you do it?

Normalize hostname_res in _run() to always include 'failed' (based on hostname_res.is_failed) before returning. This is a **single-point fix** that covers all call sites without requiring per-file changes.

`python
if 'failed' not in hostname_res:
    hostname_res['failed'] = hostname_res.is_failed
`

This approach is backward-compatible — it has no effect when ansible-core already includes 'failed' in the result.

#### How did you verify/test it?

- Pre-commit checks passed locally
- Observed failures in ADO build [1142845](https://dev.azure.com/mssonic/build/_build/results?buildId=1142845) are all caused by this root issue
- The fix aligns with the original intent of the _IGNORE hack — ensuring callers always have access to 
c['failed']

#### Any platform specific information?

N/A — this is a framework-level fix affecting all platforms.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A