### PR TITLE
Fix acl outer vlan counter lookup with zero timeout

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -305,8 +305,8 @@ def get_acl_counter(duthost, table_name, rule_name, timeout=ACL_COUNTERS_UPDATE_
                 return True
         return False
 
-    # Wait for orchagent to update the ACL counters
-    if not wait_until(timeout, 2, 0, _check_acl_counter):
+    # Wait for orchagent to update the ACL counters when requested.
+    if timeout > 0 and not wait_until(timeout, 2, 0, _check_acl_counter):
         pytest.fail("Failed to retrieve acl counter for {}|{}".format(table_name, rule_name))
 
     result = duthost.show_and_parse('aclshow -a')


### PR DESCRIPTION
### Description of PR
Summary:
`test_acl_outer_vlan` calls `get_acl_counter(..., timeout=0)` to read the baseline counter immediately after ACL rule setup. `get_acl_counter` still passed that zero timeout into `wait_until`, which can return without checking and caused all ingress cases to fail with `Failed to retrieve acl counter for DATAACL_ingress_*|rule_1`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://dev.azure.com/msazure/One/_workitems/edit/38502280
Failure type: regression

### Tested branch
<!-- Select each branch where the change was tested. -->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result
N/A - validated by code inspection / log analysis; see Approach > "How did you verify/test it?".

### Approach
#### What is the motivation for this PR?
`get_acl_counter` passed `timeout=0` into `wait_until`, which can return without checking, causing ingress ACL counter baseline reads to fail consistently.

#### How did you do it?
Skip the wait loop only when the caller explicitly passes `timeout=0`, then perform the existing `aclshow -a` parse once. Positive timeouts keep the existing wait behavior.

#### How did you verify/test it?
Reviewed the failing nightly log from PBI 38502280 and the test code path. Matches the helper pattern used by `tests/acl/test_src_mac_rewrite.py` for immediate counter reads.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A

Related ADO PBI: 38502280
