### PR TITLE
Fix pktgen port selection for counters

### DIFF
--- a/tests/test_pktgen.py
+++ b/tests/test_pktgen.py
@@ -43,7 +43,8 @@ PKTGEN_CMDS = [
 
 def get_port_list(duthost, tbinfo):
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-    return list(mg_facts["minigraph_ports"].keys())
+    int_counters = duthost.show_interface(command="counter")['ansible_facts']['int_counter']
+    return [port for port in mg_facts["minigraph_ports"] if port in int_counters]
 
 
 @pytest.fixture(scope='function', autouse='True')


### PR DESCRIPTION
### Description of PR
Summary:
Fix `test_pktgen` on topologies where `minigraph_ports` includes ports that are not present in `show interface counter` output. The test randomly selected such a port and then raised `KeyError` while indexing `int_counter[port]`.

### Type of change
- [x] Bug fix

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

SONiC nightly reports **consistent** `test_pktgen` failures across multiple Arista-7260CX3 testbeds and topologies — e.g. `Arista-7260CX3-C64` (`t1-64-lag`, `dualtor-aa-56`), `Arista-7260CX3-D108C8` (`dualtor-120`) and `Arista-7260CX3-D108C10` (`t0-118`) — on both `master` and `20260510.02` nightly builds (PBI 38502282).

`get_port_list()` returns every `minigraph_ports` key, but on these testbeds `minigraph_ports` is a superset of the ports reported by `show interface counter`. When `random.choice(port_list)` picks a port that is absent from `int_counter`, the interface-counter verification step raises `KeyError`:

```
tests/test_pktgen.py:119: in test_pktgen
    interf_counters = duthost.show_interface(command="counter")['ansible_facts']['int_counter'][port]['TX_OK']
E   KeyError: 'Ethernet252'
```

Because the port is chosen at random, the offending interface differs per run (observed `Ethernet252`, `Ethernet212`, `Ethernet204`, `Ethernet72`, `Ethernet56`, `Ethernet40`, `Ethernet24`, ...).
#### How did you do it?
Filter the packet-generation candidate port list to ports present in `duthost.show_interface(command="counter")['ansible_facts']['int_counter']` before selecting a random port. The existing no-port skip remains effective if no counter-backed data ports are available.

#### How did you verify/test it?
- `python -m py_compile tests/test_pktgen.py`
- Verified against the failure stack: the failing line indexes `int_counter[port]`, so selecting only keys present in `int_counter` prevents the observed `KeyError` while preserving the counter verification.

#### Any platform specific information?
Observed on Arista-7260CX3-D108C8 dualtor master nightly.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A