### PR TITLE
[platform_tests] Skip unavailable SFP thermal thresholds

### DIFF
--- a/tests/platform_tests/test_sfp_thermal_state_db.py
+++ b/tests/platform_tests/test_sfp_thermal_state_db.py
@@ -59,8 +59,9 @@ class TestSfpThermalStateDb:
                 'sonic-db-cli STATE_DB HGET "TRANSCEIVER_DOM_THRESHOLD|{}" {}'.format(port, field),
                 module_ignore_errors=True
             )
-            if result["rc"] == 0 and result["stdout"].strip():
-                thresholds[field] = result["stdout"].strip()
+            value = result["stdout"].strip() if result["rc"] == 0 else ""
+            if value and value.upper() != "N/A":
+                thresholds[field] = value
             else:
                 thresholds[field] = None
         return thresholds


### PR DESCRIPTION
### Description of PR

Summary:
The SFP thermal threshold test treats N/A values in `TRANSCEIVER_DOM_THRESHOLD` as available threshold data. On platforms where xcvrd publishes threshold keys but all threshold fields are N/A, the test compares zero numeric rows and fails with `Only 0/0 SFP rows had thresholds matching TRANSCEIVER_DOM_THRESHOLD`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Platforms where xcvrd publishes threshold keys but all values are N/A should be treated as "no threshold data available" and skipped, rather than failing with a 0/0 comparison.

#### How did you do it?
Normalize N/A threshold field values to missing data in `_get_dom_threshold_data`, allowing the existing "No TRANSCEIVER_DOM_THRESHOLD data available" skip path when no numeric thresholds exist.

#### How did you verify/test it?
`python -m py_compile tests/platform_tests/test_sfp_thermal_state_db.py`

#### Any platform specific information?
Affects platforms where xcvrd reports N/A for all threshold fields.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A

Related ADO PBI: 38502254