### PR TITLE
Fix flaky YANG validation: apply empty patch from file, not stdin pipe

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -972,7 +972,12 @@ class MultiAsicSonicHost(object):
         """
         Validate yang over running config
         """
-        output = self.shell("echo '[]' | sudo config apply-patch /dev/stdin", module_ignore_errors=True)
+        empty_patch_file = self.shell("mktemp")["stdout"]
+        try:
+            self.copy(content="[]", dest=empty_patch_file)
+            output = self.shell(f"sudo config apply-patch {empty_patch_file}", module_ignore_errors=True)
+        finally:
+            self.file(path=empty_patch_file, state="absent")
         if output['rc'] != 0:
             return False
         if strict_yang_validation:

--- a/tests/common/helpers/yang_utils.py
+++ b/tests/common/helpers/yang_utils.py
@@ -16,10 +16,15 @@ def run_yang_validation(duthost, stage="validation"):
     """
     logger.info(f"Running YANG validation on {duthost.hostname} ({stage})")
     try:
-        result = duthost.shell(
-            'echo "[]" | sudo config apply-patch /dev/stdin',
-            module_ignore_errors=True
-        )
+        empty_patch_file = duthost.shell("mktemp")["stdout"]
+        try:
+            duthost.copy(content="[]", dest=empty_patch_file)
+            result = duthost.shell(
+                f"sudo config apply-patch {empty_patch_file}",
+                module_ignore_errors=True
+            )
+        finally:
+            duthost.file(path=empty_patch_file, state="absent")
 
         if result['rc'] != 0:
             error = result.get('stderr', result.get('stdout', 'Unknown error'))


### PR DESCRIPTION
### Description of PR

Summary:
Tests that run YANG validation (e.g. `pc/test_lag_member_forwarding`) intermittently fail/error with `Failed to apply patch due to: Expecting value: line 1 column 1 (char 0)`. The empty-patch YANG probe pipes its payload via `echo '[]' | sudo config apply-patch /dev/stdin`. On the DUT, `generic_config_updater/main.py` does `json.loads(open(path).read())` on `/dev/stdin` as its first operation, with no empty-input guard. Under load the pipe is read back empty (0 bytes) before the data lands, so `json.loads('')` raises the error above, before YANG validation even runs. This replaces the pipe with a durable file (`config apply-patch <file>`), matching the existing race-free convention in `tests/common/gu_utils.py` (`apply_patch`).

Fixes # (no linked issue; flaky-test fix)

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Intermittent `Expecting value: line 1 column 1 (char 0)` failures in the YANG-validation step cause flaky PR failures. It surfaces both in the test body (`config_reload` -> `MultiAsicSonicHost.yang_validate`) and in teardown (`conftest` -> `yang_utils.run_yang_validation`). The root cause is reading an empty `/dev/stdin` pipe, not an actual config/YANG problem.

#### How did you do it?
Replaced `echo '[]' | sudo config apply-patch /dev/stdin` with a durable file at both probe sites (`tests/common/devices/multi_asic.py::yang_validate` and `tests/common/helpers/yang_utils.py::run_yang_validation`): copy `[]` to `/tmp/yang_validation_empty_patch.json`, run `sudo config apply-patch <file>`, then remove it. A file on disk always contains `[]`, so the empty-read race is structurally impossible. This mirrors the `gu_utils.apply_patch` pattern already used throughout the repo.

#### How did you verify/test it?
- Reproduced deterministically on a KVM t1-lag testbed (DUT vlab-03, SONiC.202605): forcing an empty stdin pipe (`printf '' | sudo config apply-patch /dev/stdin`) yields the exact error (`rc=2`, `Expecting value: line 1 column 1 (char 0)`); the file-based form returns `rc=0 Patch applied successfully`.
- DUT-side instrumentation confirmed the patched probe always reads the file, never `/dev/stdin`.
- Re-ran `test_lag_member_forwarding_packets[vlab-03]` with the patched framework: green; all probes read the file.
- `flake8` clean (120-char CI limit).

#### Any platform specific information?
None

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
No documentation changes required.