### PR TITLE
Added assertions for Arista devices to test_warmboot_data_consistency checker test

### DIFF
--- a/tests/common/db_comparison.py
+++ b/tests/common/db_comparison.py
@@ -13,6 +13,7 @@ Main features:
 """
 
 from enum import Enum
+import fnmatch
 import json
 import logging
 import os
@@ -89,14 +90,45 @@ class DBType(Enum):
     STATE = 6
 
 
+# Top-level keys that are always dropped from a snapshot before comparison due
+# to their volatile nature. Patterns are fnmatch-style globs matched against
+# the full top-level key (e.g. `FOO|*` drops every `FOO|<suffix>` entry,
+# `FOO|bar` matches only that exact row).
+VOLATILE_TOP_LEVEL_KEYS = {
+    DBType.STATE: {
+        # Summary row with only 'lastupdate'; no per-container content.
+        "DOCKER_STATS|LastUpdateTime",
+        # Per-port transceiver status flag tables flip presence and
+        # timestamps every snapshot; diffing them is not useful.
+        "TRANSCEIVER_STATUS_FLAG|*",
+        "TRANSCEIVER_STATUS_FLAG_SET_TIME|*",
+        "TRANSCEIVER_STATUS_FLAG_CLEAR_TIME|*",
+        "TRANSCEIVER_STATUS_FLAG_CHANGE_COUNT|*",
+    },
+}
+
+
+def _matches_any_glob(key: str, patterns) -> bool:
+    """Return True if `key` matches any fnmatch-style glob in `patterns`."""
+    for pattern in patterns:
+        if fnmatch.fnmatchcase(key, pattern):
+            return True
+    return False
+
+
 # These are the keys/fields that are always ignored during comparison due to their volatile nature
 VOLATILE_VALUES = {
     DBType.APPL: {
         "expireat",
         "ttl",
         "last_up_time",
+        "last_down_time",
         # These are below the 'LLDP_ENTRY_TABLE:*' top-level keys
         "lldp_rem_time_mark",
+        # lldp_rem_index is a per-session counter assigned by lldpd; it is
+        # reset and re-incremented on each daemon start, so two snapshots
+        # can pick up different indices for the same neighbor.
+        "lldp_rem_index",
     },
     DBType.CONFIG: {
         "expireat",
@@ -133,6 +165,8 @@ VOLATILE_VALUES = {
         "MEM_BYTES",
         "MEM%",
         "CPU%",
+        "BLOCK_IN_BYTES",
+        "BLOCK_OUT_BYTES",
         # These are below 'TEMPERATURE_INFO|*' top-level keys
         "temperature",
         "maximum_temperature",
@@ -147,6 +181,23 @@ VOLATILE_VALUES = {
         # These are below 'FAN_INFO|*' top-level keys
         "speed",
         "speed_target",
+        # These are below 'TRANSCEIVER_DOM_SENSOR|*' top-level keys.
+        # Per-channel optical/electrical sensor readings (tx/rx bias and
+        # power) drift between snapshot moments on real hardware
+        # (e.g. tx4bias "37.136" vs "37.142"); voltage/temperature on the
+        # same row are already covered above by the shared field names.
+        "tx1bias",
+        "tx2bias",
+        "tx3bias",
+        "tx4bias",
+        "tx1power",
+        "tx2power",
+        "tx3power",
+        "tx4power",
+        "rx1power",
+        "rx2power",
+        "rx3power",
+        "rx4power",
     }
 }
 
@@ -299,7 +350,10 @@ class SnapshotDiff:
         self._label_a = label_a
         self._label_b = label_b
 
-        # Start building metrics on snapshot
+        # Start building metrics from the raw snapshots. Volatile top-level
+        # keys (VOLATILE_TOP_LEVEL_KEYS) still count toward total_keys and the
+        # _incl_volatile value totals; they are excluded only from the
+        # _excl_volatile totals and from the diff itself.
         self._metrics = DbComparisonMetrics()
         self._metrics.total_a_keys = len(self._snapshot_a)
         self._metrics.total_a_values_incl_volatile, self._metrics.total_a_values_excl_volatile = \
@@ -308,14 +362,23 @@ class SnapshotDiff:
         self._metrics.total_b_values_incl_volatile, self._metrics.total_b_values_excl_volatile = \
             _sum_total_values(db_type, self._snapshot_b)
 
+        # Drop volatile top-level keys from both snapshots before diffing so
+        # their contents are not reported as mismatches.
+        self._snapshot_a = _drop_volatile_top_level_keys(db_type, self._snapshot_a)
+        self._snapshot_b = _drop_volatile_top_level_keys(db_type, self._snapshot_b)
+
         # Build the diff
         if db_type == DBType.STATE:
-            state_db_diff = self._diff_state_db_process_stats(self._snapshot_a, self._snapshot_b)
+            process_stats_diff = self._diff_state_db_process_stats(self._snapshot_a, self._snapshot_b)
             # Remove all 'PROCESS_STATS|*' keys from the dbs since they've already been diffed
             self._snapshot_a = {k: v for k, v in self._snapshot_a.items() if not k.startswith("PROCESS_STATS|")}
             self._snapshot_b = {k: v for k, v in self._snapshot_b.items() if not k.startswith("PROCESS_STATS|")}
+            docker_stats_diff = self._diff_state_db_docker_stats(self._snapshot_a, self._snapshot_b)
+            # Remove all 'DOCKER_STATS|*' keys from the dbs since they've already been diffed
+            self._snapshot_a = {k: v for k, v in self._snapshot_a.items() if not k.startswith("DOCKER_STATS|")}
+            self._snapshot_b = {k: v for k, v in self._snapshot_b.items() if not k.startswith("DOCKER_STATS|")}
             remaining_diff = self._diff_dict(db_type, self._snapshot_a, self._snapshot_b)
-            self._diff = {**state_db_diff, **remaining_diff}
+            self._diff = {**process_stats_diff, **docker_stats_diff, **remaining_diff}
         else:
             self._diff = self._diff_dict(db_type, self._snapshot_a, self._snapshot_b)
 
@@ -332,13 +395,26 @@ class SnapshotDiff:
 
     def _diff_state_db_process_stats(self, state_db_a: dict, state_db_b: dict) -> dict:
         """Between reboots or process restarts the PID can change but there is an
-        equivalent process running. This pairs up the PROCESS_STATS entries and diffs
-        based on the process running vs not.
+        equivalent process running. This pairs up the PROCESS_STATS entries and
+        emits one synthesized top-level diff entry per unmatched CMD.
 
-        NOTE: That some PROCESS_STATS entries have a CMD: "" i.e. empty but there is still
-              a non-zero PPID. In reality these entries form a tree and should be assembled
-              into a tree structure and the trees of each compared. For now, this is simply
-              a count of process matches. So far this has been adequate.
+        Each unmatched CMD becomes a presence-style top-level key in the same
+        shape `_diff_dict` would produce for an a-only / b-only row::
+
+            "PROCESS_STATS|<seq>": {
+                self._label_a: {"value": {"CMD": "<cmd>"}},
+                self._label_b: None,
+            }
+
+        The sequence number is a single counter across both sides so keys are
+        unique without leaking which side a row came from into the key string
+        (the side is encoded by which label has the non-null payload).
+
+        NOTE: Some PROCESS_STATS entries have a CMD: "" i.e. empty but there is
+              still a non-zero PPID. In reality these entries form a tree and
+              should be assembled into a tree structure and the trees of each
+              compared. For now, this is simply a count of process matches. So
+              far this has been adequate.
         """
 
         # Extract all the CMD entries out of the DB's
@@ -359,19 +435,45 @@ class SnapshotDiff:
         if len(db_a_only_processes) == 0 and len(db_b_only_processes) == 0:
             return {}
 
-        value_dict = {}
-        # Insert the a only processes first ...
-        for i, cmd in enumerate(db_a_only_processes):
-            value_dict[f"CMD{i}"] = {self._label_a: cmd, self._label_b: None}
-        # ... followed by db_b only processes
-        for i, cmd in enumerate(db_b_only_processes, start=len(value_dict)):
-            value_dict[f"CMD{i}"] = {self._label_a: None, self._label_b: cmd}
-
-        return {
-            "PROCESS_STATS|*": {
-                "value": value_dict
+        result = {}
+        seq = 0
+        for cmd in db_a_only_processes:
+            result[f"PROCESS_STATS|{seq}"] = {
+                self._label_a: {"value": {"CMD": cmd}},
+                self._label_b: None,
             }
-        }
+            seq += 1
+        for cmd in db_b_only_processes:
+            result[f"PROCESS_STATS|{seq}"] = {
+                self._label_a: None,
+                self._label_b: {"value": {"CMD": cmd}},
+            }
+            seq += 1
+        return result
+
+    def _diff_state_db_docker_stats(self, state_db_a: dict, state_db_b: dict) -> dict:
+        """Between reboots Docker container IDs change, but NAME is stable. This
+        rekeys `DOCKER_STATS|<id>` entries to `DOCKER_STATS|<NAME>` on both
+        sides and diffs the rekeyed dicts so the ephemeral container id does not
+        masquerade as a diff.
+
+        Returns a diff dict in the same shape as `_diff_dict` output. Caller
+        is responsible for stripping `DOCKER_STATS|*` from the snapshots after
+        this runs so the generic diff pass does not re-process them.
+        """
+
+        rekeyed_a = {}
+        rekeyed_b = {}
+        for rekeyed, state_db in [(rekeyed_a, state_db_a), (rekeyed_b, state_db_b)]:
+            for key, content in state_db.items():
+                if not key.startswith("DOCKER_STATS|"):
+                    continue
+                assert "value" in content and "NAME" in content["value"], \
+                    f"Unexpected DOCKER_STATS entry: {key} : {content}"
+                name = content["value"]["NAME"]
+                rekeyed[f"DOCKER_STATS|{name}"] = content
+
+        return self._diff_dict(DBType.STATE, rekeyed_a, rekeyed_b)
 
     def _diff_dict(self, db_type: DBType, dict_a: dict, dict_b: dict) -> dict:
 
@@ -467,6 +569,7 @@ class SnapshotDiff:
             # This top level key only exists in one of the snapshots
             label_a_content = contents[self._label_a]
             label_b_content = contents[self._label_b]
+            self._metrics.num_overall_differing_keys -= 1
             if label_a_content is not None:
                 self._metrics.num_differing_keys_a -= 1
                 a_content_key_count = len(label_a_content["value"])
@@ -500,6 +603,20 @@ class SnapshotDiff:
         del self._diff[top_level_key]
 
 
+def _drop_volatile_top_level_keys(db_type: DBType, snapshot: dict) -> dict:
+    """Return a shallow copy of `snapshot` with volatile top-level keys removed.
+
+    Patterns from `VOLATILE_TOP_LEVEL_KEYS[db_type]` are fnmatch-style globs
+    matched against each top-level key, so `"DOCKER_STATS|LastUpdateTime"`
+    drops only that exact row while `"TRANSCEIVER_STATUS_FLAG|*"` drops
+    every key with that prefix.
+    """
+    patterns = VOLATILE_TOP_LEVEL_KEYS.get(db_type)
+    if not patterns:
+        return snapshot
+    return {k: v for k, v in snapshot.items() if not _matches_any_glob(k, patterns)}
+
+
 def _recursively_remove_keys_matching_pattern(d_for_removal, patterns):
     """
     Recursively remove keys from a dictionary that match any pattern in the given set.
@@ -521,15 +638,25 @@ def _recursively_remove_keys_matching_pattern(d_for_removal, patterns):
 
 
 def _sum_total_values(db_type: DBType, db_dump: dict) -> Tuple[int, int]:
-    """Summarize the number of total values in the DB dump."""
+    """Summarize the number of total values in the DB dump.
+
+    Returned tuple is `(incl_volatile, excl_volatile)`. Values under
+    volatile top-level keys (`VOLATILE_TOP_LEVEL_KEYS`) and values whose
+    field name is in `VOLATILE_VALUES` are counted toward `(incl_volatile)`
+    but excluded from `(excl_volatile)`.
+    """
     total_incl_volatile = 0
     total_excl_volatile = 0
     always_ignore_keys = VOLATILE_VALUES.get(db_type, [])
+    volatile_tl_patterns = VOLATILE_TOP_LEVEL_KEYS.get(db_type, set())
     for tl_key, content in db_dump.items():
         assert "value" in content, f"Unexpected entry in {db_type.name} DB: {tl_key} : {content}"
         value_dict = content["value"]
+        tl_is_volatile = _matches_any_glob(tl_key, volatile_tl_patterns) if volatile_tl_patterns else False
         for key in value_dict:
             total_incl_volatile += 1
+            if tl_is_volatile:
+                continue
             if key not in always_ignore_keys:
                 total_excl_volatile += 1
     return total_incl_volatile, total_excl_volatile

--- a/tests/common/db_comparison.py
+++ b/tests/common/db_comparison.py
@@ -160,6 +160,14 @@ VOLATILE_VALUES = {
         "UID",
         # These are below 'LAG_TABLE|*' top-level keys
         "setup.pid",
+        # Kernel interface index of the PortChannel netdev, published by
+        # tlm_teamd. It is a monotonically increasing per-netns counter
+        # assigned at netdev creation, so its absolute value is
+        # non-deterministic across boot cycles and has no functional meaning.
+        "team_device.ifinfo.ifindex",
+        # Per-member kernel interface index below 'LAG_MEMBER_TABLE|*'; same
+        # non-determinism as the PortChannel ifindex above.
+        "ifinfo.ifindex",
         # These are below 'DOCKER_STATS|*' top-level keys
         "PIDS",
         "MEM_BYTES",

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -97,6 +97,22 @@ def check_container_state(duthost, container_name, should_be_running):
     return is_running == should_be_running
 
 
+def wait_for_container_running(duthost, container_name, timeout=120, check_interval=5):
+    """Wait until `container_name` is in the running state on `duthost`.
+
+    Polls `is_container_running` every `check_interval` seconds, up to
+    `timeout` seconds total. Raises an Exception if the container is still
+    not running when the timeout expires.
+    """
+    logger.info("Waiting for container %s to be running on %s", container_name, duthost.hostname)
+    if not wait_until(timeout, check_interval, 0, is_container_running, duthost, container_name):
+        raise TimeoutError(
+            "Container {} is not running on {} after {} seconds".format(
+                container_name, duthost.hostname, timeout
+            )
+        )
+
+
 def is_hitting_start_limit(duthost, container_name):
     """Checks whether the container can not be restarted is due to start-limit-hit.
     @param duthost: Host DUT.

--- a/tests/common/helpers/snapshot_warm_vs_cold_boot_helpers.py
+++ b/tests/common/helpers/snapshot_warm_vs_cold_boot_helpers.py
@@ -3,8 +3,10 @@
 import json
 import logging
 import os
+import time
 from typing import Dict
 from tests.common.db_comparison import DBType, SnapshotDiff
+from tests.common.helpers.dut_utils import wait_for_container_running
 from tests.common.platform.device_utils import check_neighbors, check_services, get_current_sonic_version, \
     verify_no_coredumps
 
@@ -29,9 +31,19 @@ def run_presnapshot_checks(duthost, tbinfo):
         - Core dump detection (expecting zero core dumps)
     """
 
-    check_services(duthost)
+    check_services(duthost)  # NOTE: Only checks critical services
     check_neighbors(duthost, tbinfo)
     verify_no_coredumps(duthost, 0)
+    # Telemetry container is typically the last container to start, so waiting for it is a good proxy for
+    # all containers being up
+    wait_for_container_running(duthost, "telemetry", timeout=300)
+
+    # NOTE: There are some late running processes such as xcvrd that may still be starting up and causing
+    # Redis keys to be changing in the background. FIXME: We should replace this with a clear finish
+    # signal. For now, we will just take a blunt approach and sleep for a bit to let the system settle
+    # before taking the snapshot.
+    settle_seconds = 300
+    time.sleep(settle_seconds)
 
 
 def record_diff(pytest_request, diff: Dict[DBType, SnapshotDiff], base_dir: str, diff_name: str):

--- a/tests/common/snapshot_comparison/warm_vs_cold.py
+++ b/tests/common/snapshot_comparison/warm_vs_cold.py
@@ -1,10 +1,21 @@
 """Utilities specific for warm vs cold boot snapshots"""
 
+import json
+import logging
+import re
 from typing import Dict, List, Tuple
 from tests.common.db_comparison import DBType, SnapshotDiff
+from tests.common.snapshot_comparison.warm_vs_cold_assertion_mask import (
+    KeyMatchMode,
+    TopLevelKeyBothValueDiffExpectation,
+    TopLevelKeyOneSideExpectation,
+    ValueSpecMode,
+    resolve_warm_cold_diff_mask,
+)
 
 AFTER_WARMBOOT = "after_warmboot"
 AFTER_COLDBOOT = "after_coldboot"
+logger = logging.getLogger(__name__)
 
 
 def process_state_db_warm_restart_table_diff(state_db_snapshot_diff: SnapshotDiff) -> Tuple[List[str], List[str]]:
@@ -60,6 +71,9 @@ def process_state_db_warm_restart_table_diff(state_db_snapshot_diff: SnapshotDif
             "restore_count": {"after_warmboot": "1", "after_coldboot": "0"},
         },
         "gearsyncd": {
+            # gearsyncd may restart multiple times during the warm-boot sequence,
+            # so any restore_count >= 1 is acceptable on the warm side. The
+            # comparison below special-cases this leaf.
             "restore_count": {"after_warmboot": "1", "after_coldboot": "0"},
         },
         "tunnelmgrd": {
@@ -106,12 +120,161 @@ def process_state_db_warm_restart_table_diff(state_db_snapshot_diff: SnapshotDif
             "state": {"after_warmboot": "reconciled", "after_coldboot": "disabled"},
             "restore_count": {"after_warmboot": "1", "after_coldboot": "0"},
         },
-        "xcvrd": {"after_warmboot": {"restore_count": "0"}}
     }
 
-    if processed_warm_restart_table != EXPECTED_WARM_RESTART_TABLE:
-        errors.append(f"WARM_RESTART_TABLE mismatch: expected {EXPECTED_WARM_RESTART_TABLE}, "
-                      f"found {processed_warm_restart_table}")
+    # Compare processed_warm_restart_table against EXPECTED_WARM_RESTART_TABLE
+    # and produce one mismatch line per diverging leaf so the first failure can
+    # be located without parsing the entire nested dict.
+    mismatches: List[str] = []
+
+    def _walk(expected, actual, path: str):
+        # gearsyncd is a one-shot config loader (not a daemon), so its
+        # restore_count tracks supervisord spawns. A timing race in
+        # supervisord-dependent-startup can fire a second startProcess RPC,
+        # producing restore_count >= 2. Accept any int >= 1 here.
+        # NOTE: If more such exceptions are needed, consider refactoring into a per-path
+        #       validator table.
+        if path == "gearsyncd.restore_count.after_warmboot":
+            try:
+                ok = actual is not None and int(actual) >= 1
+            except (TypeError, ValueError):
+                ok = False
+            if not ok:
+                mismatches.append(f"{path}: expected int >= 1, got {actual!r}")
+            return
+        if isinstance(expected, dict) and isinstance(actual, dict):
+            for k in sorted(set(expected) | set(actual), key=str):
+                sub_path = f"{path}.{k}" if path else str(k)
+                if k not in expected:
+                    mismatches.append(f"{sub_path}: unexpected key (actual={actual[k]!r})")
+                elif k not in actual:
+                    mismatches.append(f"{sub_path}: missing key (expected={expected[k]!r})")
+                else:
+                    _walk(expected[k], actual[k], sub_path)
+            return
+        if expected != actual:
+            mismatches.append(f"{path}: expected={expected!r}, got={actual!r}")
+
+    _walk(EXPECTED_WARM_RESTART_TABLE, processed_warm_restart_table, "")
+    if mismatches:
+        errors.append("WARM_RESTART_TABLE mismatch:\n  " + "\n  ".join(mismatches))
+
+    return processed_keys, errors
+
+
+def process_process_stats_table_diff(state_db_snapshot_diff: SnapshotDiff) -> Tuple[List[str], List[str]]:
+    """Process expected PROCESS_STATS|* differences between warm and cold boot snapshots.
+
+    PROCESS_STATS rows are pre-paired in :meth:`SnapshotDiff._diff_state_db_process_stats`
+    into synthesized `PROCESS_STATS|<seq>` presence-style entries where exactly one of
+    `AFTER_WARMBOOT` / `AFTER_COLDBOOT` carries `{"value": {"CMD": ...}}` and the
+    other side is `None`.
+
+    Currently handles:
+
+    - `teamd`: warmboot starts `teamd` with `-w -o` while coldboot uses `-r`;
+      otherwise the command lines are identical. We pair warm-only and cold-only teamd
+      entries by the `-t PortChannelNNN` argument and verify the rest of the command
+      line is unchanged once those flags are normalized. Matched pairs are added to
+      `processed_keys` so the caller can remove them; mismatches are reported as errors.
+    - `finalize-warmboot.sh`: warmboot has a `/bin/bash /usr/local/bin/finalize-warmboot.sh`
+      process that coldboot does not. The warm-only entry is added to `processed_keys`;
+      a cold-only entry or both/neither sides present is reported as an error.
+
+    Returns:
+        (processed_keys, errors)
+    """
+    diff = state_db_snapshot_diff.diff
+    processed_keys: List[str] = []
+    errors: List[str] = []
+
+    # Group warm-only and cold-only teamd PROCESS_STATS entries by their PortChannel
+    # target so they can be paired and validated.
+    teamd_re = re.compile(r"(?:^|/)teamd\s.*\s-t\s+(PortChannel\d+)\b")
+    teamd_warm: Dict[str, Tuple[str, str]] = {}  # PortChannel -> (diff_key, cmd)
+    teamd_cold: Dict[str, Tuple[str, str]] = {}
+    finalize_warmboot_re = re.compile(r"/bin/bash\s+/usr/local/bin/finalize-warmboot\.sh\b")
+    finalize_warmboot_warm: List[Tuple[str, str]] = []  # (diff_key, cmd)
+    finalize_warmboot_cold: List[Tuple[str, str]] = []
+    for key, content in diff.items():
+        if not key.startswith("PROCESS_STATS|"):
+            continue
+        if AFTER_WARMBOOT not in content or AFTER_COLDBOOT not in content:
+            errors.append(f"PROCESS_STATS diff entry {key} should have both warmboot and coldboot sides: {content}")
+            continue
+        warm_content = content[AFTER_WARMBOOT]
+        cold_content = content[AFTER_COLDBOOT]
+        if warm_content is not None and cold_content is None:
+            cmd = warm_content["value"]["CMD"]
+            side = "warm"
+        elif cold_content is not None and warm_content is None:
+            cmd = cold_content["value"]["CMD"]
+            side = "cold"
+        else:
+            # Only one side should have the entry, never both or neither
+            errors.append(
+                f"Unexpected PROCESS_STATS diff entry {key} with "
+                f"warm_content={warm_content} and cold_content={cold_content}"
+            )
+            continue
+
+        if finalize_warmboot_re.search(cmd):
+            (finalize_warmboot_warm if side == "warm" else finalize_warmboot_cold).append((key, cmd))
+            continue
+
+        match = teamd_re.search(cmd)
+        if not match:
+            # Not a process this function is responsible for; leave it in the diff for
+            # downstream handlers (e.g. assertion mask / regression reporting).
+            continue
+        portchannel = match.group(1)
+        store = teamd_warm if side == "warm" else teamd_cold
+        if portchannel in store:
+            errors.append(f"Multiple teamd PROCESS_STATS entries for {portchannel} on the same side")
+            continue
+        store[portchannel] = (key, cmd)
+
+    for portchannel in sorted(set(teamd_warm) | set(teamd_cold)):
+        warm_entry = teamd_warm.get(portchannel)
+        cold_entry = teamd_cold.get(portchannel)
+        if warm_entry is None:
+            errors.append(
+                f"teamd PROCESS_STATS for {portchannel} present in coldboot but not warmboot: "
+                f"{cold_entry[1]}"
+            )
+            continue
+        if cold_entry is None:
+            errors.append(
+                f"teamd PROCESS_STATS for {portchannel} present in warmboot but not coldboot: "
+                f"{warm_entry[1]}"
+            )
+            continue
+        warm_key, warm_cmd = warm_entry
+        cold_key, cold_cmd = cold_entry
+        # Warmboot uses '-w -o' where coldboot uses '-r'; normalize the warm command and
+        # verify the rest of the command line is identical.
+        normalized_warm = warm_cmd.replace(" -w -o ", " -r ", 1)
+        if normalized_warm != cold_cmd:
+            errors.append(
+                f"Unexpected teamd warm/cold cmd diff for {portchannel}.\n"
+                f"  warm: {warm_cmd}\n"
+                f"  cold: {cold_cmd}"
+            )
+            continue
+        processed_keys.append(warm_key)
+        processed_keys.append(cold_key)
+
+    # finalize-warmboot.sh should appear only on the warm side.
+    for cold_key, cold_cmd in finalize_warmboot_cold:
+        errors.append(f"Unexpected finalize-warmboot.sh PROCESS_STATS entry on coldboot side: {cold_cmd}")
+    if len(finalize_warmboot_warm) > 1:
+        errors.append(
+            f"Expected at most one finalize-warmboot.sh PROCESS_STATS entry on warmboot side, "
+            f"found {len(finalize_warmboot_warm)}: {[c for _, c in finalize_warmboot_warm]}"
+        )
+    elif len(finalize_warmboot_warm) == 1 and not finalize_warmboot_cold:
+        warm_key, _ = finalize_warmboot_warm[0]
+        processed_keys.append(warm_key)
 
     return processed_keys, errors
 
@@ -174,7 +337,9 @@ def prune_expected_from_diff_state_db(state_db_snapshot_diff: SnapshotDiff):
     # Process the WARM_RESTART_TABLE
     warm_restart_table_processed_keys, warm_restart_table_errors = process_state_db_warm_restart_table_diff(
         state_db_snapshot_diff)
-    assert len(warm_restart_table_errors) == 0, f"WARM_RESTART_TABLE processing errors: {warm_restart_table_errors}"
+    assert len(warm_restart_table_errors) == 0, (
+        "WARM_RESTART_TABLE processing errors:\n" + "\n".join(warm_restart_table_errors)
+    )
     processed_keys.extend(warm_restart_table_processed_keys)
 
     # Process the NEIGH_RESTORE_TABLE
@@ -185,6 +350,13 @@ def prune_expected_from_diff_state_db(state_db_snapshot_diff: SnapshotDiff):
     assert state_db_diff[neigh_restore_table_flags].get(AFTER_COLDBOOT) is None, \
         "NEIGH_RESTORE_TABLE|Flags after_coldboot should be missing"
     processed_keys.append(neigh_restore_table_flags)
+
+    # Process the PROCESS_STATS|* table
+    process_stats_processed_keys, process_stats_errors = process_process_stats_table_diff(state_db_snapshot_diff)
+    assert len(process_stats_errors) == 0, (
+        "PROCESS_STATS processing errors:\n" + "\n".join(process_stats_errors)
+    )
+    processed_keys.extend(process_stats_processed_keys)
 
     for key in processed_keys:
         # These keys have been processed so they can now be removed
@@ -203,3 +375,193 @@ def prune_expected_from_diff(diff: Dict[DBType, SnapshotDiff]):
         if db_type == DBType.STATE:
             prune_expected_from_diff_state_db(snapshot_diff)
             continue
+
+
+def is_assertion_mask_supported_for_platform(platform: str) -> bool:
+    """Returns True if there is an assertion mask for the given platform, False otherwise."""
+    mask = resolve_warm_cold_diff_mask(platform)
+    return mask is not None
+
+
+def apply_diff_assertion_mask(diff: Dict[DBType, SnapshotDiff], platform: str):
+    """Apply assertion mask after metrics are recorded to detect regressions.
+
+    This function is intentionally separate from prune_expected_from_diff() so
+    "known expected" pruning behavior is unchanged, and so callers can first
+    record post-prune metrics before any mask-driven removals.
+
+    For every diff entry that matches a mask expectation, the entry is removed
+    from the per-DB `SnapshotDiff` via `remove_top_level_key` (which also
+    updates SnapshotDiff's diff metrics but it is not recorded after this point
+    so it is not an issue). Any entries remaining in the diff afterwards
+    are surfaced as regressions by the caller's post-mask inspection of `diff`.
+
+    If the platform has no mask registered, a warning is logged and the diff is
+    left unchanged. Callers should gate this with
+    :func:`is_assertion_mask_supported_for_platform` if they want to skip
+    regression assertions for unsupported platforms.
+    """
+    mask = resolve_warm_cold_diff_mask(platform)
+    if mask is None:
+        logger.warning(
+            f"No warm-vs-cold assertion mask found for platform={platform!r}; "
+            "regression assertions are skipped for this DUT."
+        )
+        return
+
+    for db_type, snapshot_diff in diff.items():
+        expectations = mask.get(db_type, [])
+        unused = _apply_expectations_to_snapshot(snapshot_diff, expectations, db_type)
+        if unused:
+            logger.warning(
+                f"{len(unused)} {db_type.name} mask expectation(s) did not match any "
+                f"diff entry; the underlying difference may have been fixed and the "
+                f"mask can likely be reduced. Unused expectations:\n"
+                + "\n".join(f"  - {e}" for e in unused)
+            )
+
+
+def assert_no_unmasked_regressions(diff: Dict[DBType, SnapshotDiff], platform: str):
+    """Apply the platform's assertion mask and assert no unmasked regressions remain.
+
+    This is the single entry point for the post-prune regression check used by
+    the warm-vs-cold consistency tests. It:
+
+    1. Resolves the platform's assertion mask. If none exists, the remaining
+       diff is logged as a warning and the function returns without asserting
+       (the platform needs a mask added before regressions can be enforced).
+    2. Applies the mask via :func:`apply_diff_assertion_mask`, removing
+       expected-difference entries from each per-DB `SnapshotDiff`.
+    3. Logs any per-DB residual diff and asserts that none remain; any
+       residual entry is a regression not covered by the mask.
+    """
+    if not is_assertion_mask_supported_for_platform(platform):
+        logger.warning(
+            f"No warm-vs-cold assertion mask found for platform={platform!r}; "
+            "regression assertions are skipped for this DUT."
+        )
+        if diff:
+            pretty_diff = json.dumps(
+                {db_type.name: db_snapshot.diff for db_type, db_snapshot in diff.items()},
+                indent=4,
+            )
+            logger.warning(
+                "Differences found in snapshots after warm vs cold boot "
+                f"(no assertion mask applied):\n{pretty_diff}"
+            )
+        # Don't fail the test; this platform needs an assertion mask added in future.
+        return
+
+    apply_diff_assertion_mask(diff, platform)
+
+    # Report per-DB residual diffs and collect any regressions for the final assertion.
+    all_unexpected = []
+    for db_type, db_snapshot in diff.items():
+        if db_snapshot.diff:
+            pretty_diff = json.dumps(db_snapshot.diff, indent=4)
+            logger.warning(f"Differences found in {db_type.name} DB after pruning:\n{pretty_diff}")
+            all_unexpected.append((db_type.name, db_snapshot.diff))
+        else:
+            logger.info(f"No unmasked differences found in {db_type.name} DB")
+
+    assert not all_unexpected, (
+        f"Unexpected diffs found after applying assertion mask (potential regression). "
+        f"Unexpected diffs: {all_unexpected}"
+    )
+
+
+def _key_matches(key_match, candidate: str) -> bool:
+    if key_match.mode == KeyMatchMode.EXACT:
+        return candidate == key_match.pattern
+    if key_match.mode == KeyMatchMode.PREFIX:
+        return candidate.startswith(key_match.pattern)
+    if key_match.mode == KeyMatchMode.REGEX:
+        return re.fullmatch(key_match.pattern, candidate) is not None
+    return False
+
+
+def _value_matches(value_spec, actual) -> bool:
+    if value_spec.mode == ValueSpecMode.ANY:
+        return True
+    if value_spec.mode == ValueSpecMode.NULL:
+        return actual is None
+    if value_spec.mode == ValueSpecMode.LITERAL:
+        return actual == value_spec.value
+    if value_spec.mode == ValueSpecMode.REGEX:
+        return actual is not None and re.fullmatch(value_spec.value, str(actual)) is not None
+    if value_spec.mode == ValueSpecMode.ONE_OF:
+        return actual in value_spec.value
+    return False
+
+
+def _entry_matches_expectation(expectation, content) -> bool:
+    """True if a diff entry's content matches the given expectation's shape/values."""
+    if isinstance(expectation, TopLevelKeyOneSideExpectation):
+        # Presence diff: content has AFTER_WARMBOOT / AFTER_COLDBOOT at top level.
+        if AFTER_WARMBOOT not in content or AFTER_COLDBOOT not in content:
+            return False
+        warm_present = content[AFTER_WARMBOOT] is not None
+        cold_present = content[AFTER_COLDBOOT] is not None
+        if (warm_present != expectation.after_warmboot_present
+                or cold_present != expectation.after_coldboot_present):
+            return False
+
+        # Optional per-field shape check on the present side.
+        specs = expectation.present_side_value_specs
+        if not specs:
+            return True
+        present_content = content[AFTER_WARMBOOT] if warm_present else content[AFTER_COLDBOOT]
+        if not isinstance(present_content, dict) or "value" not in present_content:
+            return False
+        fields = present_content["value"]
+        if not isinstance(fields, dict):
+            return False
+        if set(fields.keys()) != set(specs.keys()):
+            return False
+        return all(_value_matches(specs[name], fields[name]) for name in specs)
+
+    if isinstance(expectation, TopLevelKeyBothValueDiffExpectation):
+        # Field-level diff: content["value"] maps field name -> {warm, cold}.
+        if "value" not in content:
+            return False
+        fields = content["value"]
+        if not fields:
+            return False
+        for field_name, field_diff in fields.items():
+            if not isinstance(field_diff, dict):
+                return False
+            warm_actual = field_diff.get(AFTER_WARMBOOT)
+            cold_actual = field_diff.get(AFTER_COLDBOOT)
+            covered = any(
+                _key_matches(fe.field_match, field_name)
+                and _value_matches(fe.after_warmboot, warm_actual)
+                and _value_matches(fe.after_coldboot, cold_actual)
+                for fe in expectation.fields
+            )
+            if not covered:
+                return False
+        return True
+
+    return False
+
+
+def _apply_expectations_to_snapshot(snapshot_diff: SnapshotDiff, expectations, db_type: DBType):
+    """For each expectation, remove matching top-level keys from the snapshot_diff.
+
+    Returns the list of expectations that did not match any diff entry, so the
+    caller can surface them as candidates for mask reduction.
+    """
+    unused = []
+    for expectation in expectations:
+        matched_keys = []
+        for key, content in snapshot_diff.diff.items():
+            if not _key_matches(expectation.key_match, key):
+                continue
+            if _entry_matches_expectation(expectation, content):
+                matched_keys.append(key)
+        if not matched_keys:
+            unused.append(expectation)
+            continue
+        for key in matched_keys:
+            snapshot_diff.remove_top_level_key(key)
+    return unused

--- a/tests/common/snapshot_comparison/warm_vs_cold_assertion_mask.py
+++ b/tests/common/snapshot_comparison/warm_vs_cold_assertion_mask.py
@@ -1,0 +1,280 @@
+"""Warm-vs-cold assertion mask.
+
+Declarative mask of post-prune diffs that are currently expected on a given
+platform for a given base->target upgrade path. Entries here represent
+residual, known-acceptable diffs after prune_expected_from_diff() has run.
+
+Semantics (applied in apply_diff_assertion_mask):
+- Matching diff entries are masked out and do NOT count as regressions.
+- Any remaining diffs after masking should be asserted as regressions by the caller.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Union
+
+from tests.common.db_comparison import DBType
+
+
+# -------- Expectation builders ---------------------------------------------
+#
+# The classes below describe how a mask entry should match a post-prune
+# SnapshotDiff. The matcher in apply_diff_assertion_mask() walks each DB
+# section's list of expectation instances and, for each one, decides which
+# entries of the actual diff are "expected" so they can be subtracted before
+# the final assertion.
+
+
+class KeyMatchMode(Enum):
+    """How a key/field pattern is compared against a candidate string."""
+
+    # Pattern must equal the candidate string.
+    EXACT = "exact"
+    # Pattern must be a prefix of the candidate string (used for family
+    # matches like "ROUTE_TABLE:" or "TRANSCEIVER_STATUS_FLAG|").
+    PREFIX = "prefix"
+    # Pattern is a regex fully matched against the candidate.
+    REGEX = "regex"
+
+
+class ValueSpecMode(Enum):
+    """How an expected value on one side of a warm/cold pair is evaluated."""
+
+    # Value must equal `value` exactly.
+    LITERAL = "literal"
+    # Field must be absent / None on this side of the diff.
+    NULL = "null"
+    # Any value (including absent) is accepted on this side.
+    ANY = "any"
+    # `value` is a regex fully matched against the actual stringified value.
+    REGEX = "regex"
+    # `value` is a tuple of accepted literals.
+    ONE_OF = "one_of"
+
+
+@dataclass(frozen=True)
+class KeyMatch:
+    """How to match a diff key (top-level table key or a field name)."""
+
+    mode: KeyMatchMode
+    pattern: str
+
+    def __str__(self) -> str:
+        return f"{self.mode.value}:{self.pattern!r}"
+
+
+@dataclass(frozen=True)
+class ValueSpec:
+    """Expected value on one side of a warm/cold pair.
+
+    Use the `literal`/`null`/`any_`/`regex`/`one_of` classmethod
+    factories to build instances so mode/value stay consistent.
+    """
+
+    mode: ValueSpecMode
+    value: Any = None
+
+    @classmethod
+    def literal(cls, v: Any) -> "ValueSpec":
+        return cls(ValueSpecMode.LITERAL, v)
+
+    @classmethod
+    def null(cls) -> "ValueSpec":
+        return cls(ValueSpecMode.NULL)
+
+    @classmethod
+    def any_(cls) -> "ValueSpec":
+        return cls(ValueSpecMode.ANY)
+
+    @classmethod
+    def regex(cls, pattern: str) -> "ValueSpec":
+        return cls(ValueSpecMode.REGEX, pattern)
+
+    @classmethod
+    def one_of(cls, values) -> "ValueSpec":
+        # Frozen dataclass requires a hashable default, so store as a tuple.
+        return cls(ValueSpecMode.ONE_OF, tuple(values))
+
+    def __str__(self) -> str:
+        if self.mode in (ValueSpecMode.LITERAL, ValueSpecMode.REGEX, ValueSpecMode.ONE_OF):
+            return f"{self.mode.value}:{self.value!r}"
+        return self.mode.value
+
+
+@dataclass(frozen=True)
+class FieldExpectation:
+    """Describes an expected per-field diff inside a top-level key.
+
+    Applies when a diff entry is nested under a "value" sub-dict (i.e. the
+    top-level key is present in BOTH snapshots and individual fields differ).
+
+    `field_match` picks which field name(s) this expectation covers.
+    `after_warmboot` / `after_coldboot` describe what the diff's warm and
+    cold sides should look like for the expectation to apply.
+    """
+
+    field_match: KeyMatch
+    after_warmboot: ValueSpec
+    after_coldboot: ValueSpec
+
+
+@dataclass
+class TopLevelKeyOneSideExpectation:
+    """Top-level key is expected to appear on only one side of the diff.
+
+    Example: "NEIGH_TABLE:eth0:*" appears only in the warm snapshot because
+    management-interface neighbor state is repopulated fresh after cold boot.
+
+    `after_warmboot_present` / `after_coldboot_present` encode which
+    side(s) the key is expected to be observed on.
+
+    Optional `present_side_value_specs` validates the field shape of the
+    present side's `value` dict: keys are field names, values are
+    :class:`ValueSpec` instances. When non-empty the present side must
+    contain exactly these field names (no extras, no missing) and each
+    field's value must satisfy its spec. Useful when the row's *presence*
+    on one side is expected but its values still need a format check (e.g.
+    PSU_INFO serial/model strings).
+    """
+
+    key_match: KeyMatch
+    after_warmboot_present: bool
+    after_coldboot_present: bool
+    present_side_value_specs: Dict[str, ValueSpec] = field(default_factory=dict)
+
+    def __str__(self) -> str:
+        """Render a short identifier for warning messages, e.g.::
+
+            TopLevelKeyOneSideExpectation(key=prefix:'NEIGH_TABLE:eth0:' present=warm)
+            TopLevelKeyOneSideExpectation(key=exact:'DOCKER_STATS|gnmi' present=cold \
+specs={NAME=literal:'gnmi', BLOCK_IN_BYTES=literal:'0'})
+        """
+        sides = []
+        if self.after_warmboot_present:
+            sides.append("warm")
+        if self.after_coldboot_present:
+            sides.append("cold")
+        extra = f" present={'+'.join(sides) or 'neither'}"
+        if self.present_side_value_specs:
+            spec_strs = [f"{name}={vs}" for name, vs in self.present_side_value_specs.items()]
+            extra += " specs={" + ", ".join(spec_strs) + "}"
+        return f"{type(self).__name__}(key={self.key_match}{extra})"
+
+
+@dataclass
+class TopLevelKeyBothValueDiffExpectation:
+    """Top-level key present in both snapshots, with expected field-level diffs.
+
+    `fields` is the ordered list of per-field expectations. The matcher
+    applies them to the "value" sub-dict of the diff entry; for an expectation
+    to mask the entry, every field-level diff observed must be covered by one
+    of the FieldExpectations here.
+    """
+
+    key_match: KeyMatch
+    fields: List[FieldExpectation] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        return f"{type(self).__name__}(key={self.key_match})"
+
+
+# Union alias used by the matcher to iterate a section's entries.
+Expectation = Union[TopLevelKeyOneSideExpectation, TopLevelKeyBothValueDiffExpectation]
+
+
+# -------- Arista mask -------------------------------------------------------
+
+_ARISTA_ASSERTION_MASK = {
+    DBType.APPL: [
+        # IPv4/IPv6 ECMP routes warm-only 'weight' field.
+        # Warm has a weight string ("1,1,1,1" for 4-member ECMP, "1" for single),
+        # cold has no weight field.
+        TopLevelKeyBothValueDiffExpectation(
+            key_match=KeyMatch(mode=KeyMatchMode.PREFIX, pattern="ROUTE_TABLE:"),
+            fields=[
+                FieldExpectation(
+                    field_match=KeyMatch(mode=KeyMatchMode.EXACT, pattern="weight"),
+                    after_warmboot=ValueSpec.one_of(["1,1,1,1", "1"]),
+                    after_coldboot=ValueSpec.null(),
+                ),
+            ],
+        ),
+        # PortChannel tpid appears only after cold boot.
+        TopLevelKeyBothValueDiffExpectation(
+            key_match=KeyMatch(mode=KeyMatchMode.PREFIX, pattern="LAG_TABLE:PortChannel"),
+            fields=[
+                FieldExpectation(
+                    field_match=KeyMatch(mode=KeyMatchMode.EXACT, pattern="tpid"),
+                    after_warmboot=ValueSpec.null(),
+                    after_coldboot=ValueSpec.literal("0x8100"),
+                ),
+            ],
+        ),
+        # Management interface neighbor entries present only in warmboot.
+        TopLevelKeyOneSideExpectation(
+            key_match=KeyMatch(mode=KeyMatchMode.PREFIX, pattern="NEIGH_TABLE:eth0:"),
+            after_warmboot_present=True,
+            after_coldboot_present=False,
+        ),
+    ],
+    DBType.STATE: [
+        # PROCESS_STATS|<seq> entries are synthesized by
+        # _diff_state_db_process_stats: every PID-paired CMD that exists on
+        # only one side becomes its own one-sided top-level diff. CMD-string
+        # value matching proved too flakey (sleep durations, container IDs,
+        # neighbor counts, etc. change run-to-run), so we mask all of it out.
+        # TODO: Investigate a more robust way to match
+        TopLevelKeyOneSideExpectation(
+            key_match=KeyMatch(mode=KeyMatchMode.REGEX, pattern=r"PROCESS_STATS\|\d+"),
+            after_warmboot_present=True,
+            after_coldboot_present=False,
+        ),
+        TopLevelKeyOneSideExpectation(
+            key_match=KeyMatch(mode=KeyMatchMode.REGEX, pattern=r"PROCESS_STATS\|\d+"),
+            after_warmboot_present=False,
+            after_coldboot_present=True,
+        ),
+        # Fast restart enable flag set during warm boot sequence; the whole
+        # FAST_RESTART_ENABLE_TABLE|system row is present only on the warm
+        # side (hash {"enable": "false"}) and absent after cold boot.
+        TopLevelKeyOneSideExpectation(
+            key_match=KeyMatch(mode=KeyMatchMode.EXACT, pattern="FAST_RESTART_ENABLE_TABLE|system"),
+            after_warmboot_present=True,
+            after_coldboot_present=False,
+        ),
+    ],
+    DBType.CONFIG: [
+        # No residual config_db diffs known or expected
+    ],
+    DBType.ASIC: [
+        # Intentionally empty: ASIC_DB comparison not implemented yet.
+    ],
+}
+
+# -------- Top-level mask ----------------------------------------------------
+#
+# Platform masks keyed by a platform prefix. The resolver picks the first
+# entry whose key is a prefix of duthost.facts["platform"].
+
+
+PLATFORM_MASKS = {
+    # Matched as prefix against duthost.facts["platform"].
+    "x86_64-arista_7260": _ARISTA_ASSERTION_MASK,
+    "x86_64-arista_7060": _ARISTA_ASSERTION_MASK,
+    "x86_64-arista_7050cx3": _ARISTA_ASSERTION_MASK,
+}
+
+
+def resolve_warm_cold_diff_mask(platform: str):
+    """Return the mask sections for the first platform prefix that matches.
+
+    Returns None if no prefix matches; callers should warn in that case.
+    The returned dict is the shared module-level structure and must not be
+    mutated by callers.
+    """
+    if not platform:
+        return None
+    for platform_prefix, sections in PLATFORM_MASKS.items():
+        if platform.startswith(platform_prefix):
+            return sections
+    return None

--- a/tests/common/snapshot_comparison/warm_vs_cold_assertion_mask.py
+++ b/tests/common/snapshot_comparison/warm_vs_cold_assertion_mask.py
@@ -187,14 +187,14 @@ Expectation = Union[TopLevelKeyOneSideExpectation, TopLevelKeyBothValueDiffExpec
 _ARISTA_ASSERTION_MASK = {
     DBType.APPL: [
         # IPv4/IPv6 ECMP routes warm-only 'weight' field.
-        # Warm has a weight string ("1,1,1,1" for 4-member ECMP, "1" for single),
+        # Warm has one all-ones weight per next hop ("1", "1,1", "1,1,1,1", ...),
         # cold has no weight field.
         TopLevelKeyBothValueDiffExpectation(
             key_match=KeyMatch(mode=KeyMatchMode.PREFIX, pattern="ROUTE_TABLE:"),
             fields=[
                 FieldExpectation(
                     field_match=KeyMatch(mode=KeyMatchMode.EXACT, pattern="weight"),
-                    after_warmboot=ValueSpec.one_of(["1,1,1,1", "1"]),
+                    after_warmboot=ValueSpec.regex(r"1(,1)*"),
                     after_coldboot=ValueSpec.null(),
                 ),
             ],

--- a/tests/upgrade_path/test_warmboot_data_consistency.py
+++ b/tests/upgrade_path/test_warmboot_data_consistency.py
@@ -1,10 +1,14 @@
-import json
 import os
 import pytest
 import logging
 from tests.common.helpers.snapshot_warm_vs_cold_boot_helpers import backup_device_logs, record_diff, \
     run_presnapshot_checks, write_upgrade_path_summary
-from tests.common.snapshot_comparison.warm_vs_cold import AFTER_COLDBOOT, AFTER_WARMBOOT, prune_expected_from_diff
+from tests.common.snapshot_comparison.warm_vs_cold import (
+    AFTER_COLDBOOT,
+    AFTER_WARMBOOT,
+    assert_no_unmasked_regressions,
+    prune_expected_from_diff,
+)
 from tests.upgrade_path.utilities import boot_into_base_image, cleanup_prev_images
 from tests.common.db_comparison import SonicRedisDBSnapshotter, DBType
 from tests.common import reboot
@@ -140,10 +144,5 @@ def test_warmboot_data_consistency(localhost, duthosts, rand_one_dut_hostname, t
     # Write metrics to custom message and dump snapshots to disk after pruning
     record_diff(request, diff, data_dir, "post_prune")
 
-    # Log warn any diffs after pruning
-    for db_type, db_snapshot in diff.items():
-        if db_snapshot.diff:
-            pretty_diff = json.dumps(db_snapshot.diff, indent=4)
-            logger.warning(f"Differences found in {db_type.name} DB:\n{pretty_diff}")
-        else:
-            logger.info(f"No differences found in {db_type.name} DB")
+    # Apply assertion mask and assert no unmasked regressions remain.
+    assert_no_unmasked_regressions(diff, duthost.facts["platform"])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #21226
MSFT ADO: 38503975

Added assertions and an assertion mask framework for the warmboot data consistency test to validate Arista devices automatically. This enables detection of unexpected differences during warm-vs-cold boot comparisons.

Note the assertion mask is currently set to cold 202511.29 vs 202505.30--wb-->202511.29 Arista mask. Any failures on 202605 will be handled in follow-up PRs. 

For platforms without an assertion mask, those tests continue to pass and require manual review of differences to assess if there is an issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Without this change the test doesn't have any assertions and requires manual effort to look through the diff which is time consuming. With this change, now for the 3 Arista platforms, their changes are assessed against a set of vetted and known diffs. If a new diff is found the test will fail and only at that point will the manual effort be required.

#### How did you do it?
1. Created a new `warm_vs_cold_assertion_mask.py` module that provides a declarative framework for masking expected post-prune diffs on a per-platform, per-upgrade-path basis
2. Enhanced `db_comparison.py` with expanded comparison logic and utilities
3. Extended `snapshot_warm_vs_cold_boot_helpers.py` to support the new assertion framework
4. Updated `warm_vs_cold.py` with assertion mask application logic
5. Modified `test_warmboot_data_consistency.py` to apply the assertion mask and assert no unmasked regressions remain
6. Added helper utilities in `dut_utils.py` to support the test improvements

#### How did you verify/test it?
**202605 sonic-mgmt branch**
Tested cold 202511.29 vs 202505.30--wb-->202511.29 on Arista:
- Arista-7050CX3-32S-C32
- Arista-7260CX3-D108C8
- Arista-7060CX-32S-D48C8

#### Any platform specific information?
This lays the assertion framework but only enables it for the following platforms:
- x86_64-arista_7260
- x86_64-arista_7060
- x86_64-arista_7050cx3

Other platforms continue to have their current functionality

#### Supported testbed topology if it's a new test case?
Still T0*

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
