### PR TITLE
Fix test_ha_dpu_process_crash.py for NPU-driven HA

### DIFF
--- a/tests/ha/ha_utils.py
+++ b/tests/ha/ha_utils.py
@@ -174,14 +174,16 @@ def verify_ha_state(
     expected_state,
     timeout=120,
     interval=5,
+    ack=True
 ):
     """
     Wait until HA reaches the expected state by querying STATE_DB.
     """
     def _check_ha_state():
         db_key = "DASH_HA_SCOPE_STATE|" + scope_key.replace(":", "|")
+        var = "local_acked_asic_ha_state" if ack else "local_ha_state"
         res = duthost.shell(
-            f'sonic-db-cli STATE_DB HGET "{db_key}" local_acked_asic_ha_state'
+            f'sonic-db-cli STATE_DB HGET "{db_key}" {var}'
         )
         state = res["stdout"].strip()
         return state == expected_state

--- a/tests/ha/test_ha_dpu_process_crash.py
+++ b/tests/ha/test_ha_dpu_process_crash.py
@@ -47,6 +47,7 @@ MAX_TRAFFIC_LOSS_PCT = 5.0
 DPU_CRITICAL_PROCESSES = [
     pytest.param("syncd", "syncd", id="syncd"),
     pytest.param("bgpd", "bgp", id="bgp"),
+    pytest.param("orchagent", "swss", id="swss"),
 ]
 
 
@@ -77,6 +78,7 @@ def verify_ha_state_converged(duthost, scope_key, expected_state):
         expected_state=expected_state,
         timeout=HA_CONVERGENCE_TIMEOUT,
         interval=HA_CHECK_INTERVAL,
+        ack=False
     ), (
         f"{duthost.hostname}: HA scope '{scope_key}' did not reach "
         f"'{expected_state}' within {HA_CONVERGENCE_TIMEOUT}s"
@@ -143,6 +145,11 @@ def standby_dpuhost(dpuhosts):
 
 
 class TestDpuProcessCrash:
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, ha_owner):
+        self.expected_ha_state_after_crash = "active" if ha_owner == "dpu" else "HA_STATE_STANDBY"
+        self.expected_ha_state_verify = "active" if ha_owner == "dpu" else "HA_STATE_STANDALONE"
 
     def _run(
         self, process_name, container,
@@ -225,10 +232,10 @@ class TestDpuProcessCrash:
             process_name=process_name, container=container,
             crash_dpuhost=primary_dpuhost, crash_duthost=primary_dut,
             crash_scope_key=primary_vdpu_key,
-            expected_ha_state_after_crash="active",
+            expected_ha_state_after_crash=self.expected_ha_state_after_crash,
             verify_duthost=standby_dut,
             verify_scope_key=standby_vdpu_key,
-            expected_ha_state_verify="active",
+            expected_ha_state_verify=self.expected_ha_state_verify,
             ptfadapter=ptfadapter, dash_pl_config=dash_pl_config,
             traffic_dut_index=0,
         )
@@ -245,10 +252,10 @@ class TestDpuProcessCrash:
             process_name=process_name, container=container,
             crash_dpuhost=primary_dpuhost, crash_duthost=primary_dut,
             crash_scope_key=primary_vdpu_key,
-            expected_ha_state_after_crash="active",
+            expected_ha_state_after_crash=self.expected_ha_state_after_crash,
             verify_duthost=standby_dut,
             verify_scope_key=standby_vdpu_key,
-            expected_ha_state_verify="active",
+            expected_ha_state_verify=self.expected_ha_state_verify,
             ptfadapter=ptfadapter, dash_pl_config=dash_pl_config,
             traffic_dut_index=1,
         )
@@ -265,10 +272,10 @@ class TestDpuProcessCrash:
             process_name=process_name, container=container,
             crash_dpuhost=standby_dpuhost, crash_duthost=standby_dut,
             crash_scope_key=standby_vdpu_key,
-            expected_ha_state_after_crash="active",
+            expected_ha_state_after_crash=self.expected_ha_state_after_crash,
             verify_duthost=primary_dut,
             verify_scope_key=primary_vdpu_key,
-            expected_ha_state_verify="active",
+            expected_ha_state_verify=self.expected_ha_state_verify,
             ptfadapter=ptfadapter, dash_pl_config=dash_pl_config,
             traffic_dut_index=0,
         )
@@ -285,10 +292,10 @@ class TestDpuProcessCrash:
             process_name=process_name, container=container,
             crash_dpuhost=standby_dpuhost, crash_duthost=standby_dut,
             crash_scope_key=standby_vdpu_key,
-            expected_ha_state_after_crash="active",
+            expected_ha_state_after_crash=self.expected_ha_state_after_crash,
             verify_duthost=primary_dut,
             verify_scope_key=primary_vdpu_key,
-            expected_ha_state_verify="active",
+            expected_ha_state_verify=self.expected_ha_state_verify,
             ptfadapter=ptfadapter, dash_pl_config=dash_pl_config,
             traffic_dut_index=1,
         )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix test_ha_dpu_process_crash.py for NPU-driven HA
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
`test_ha_dpu_process_crash.py` assumed HA was always DPU-owned and asserted a fixed `"active"` state from the DPU-acked STATE_DB field. On NPU-driven (`ha_owner != "dpu"`) setups the expected post-crash and verification states differ (`HA_STATE_STANDBY` / `HA_STATE_STANDALONE`), so the test reported false failures. The state also needs to be read from `local_ha_state` rather than the DPU-acked field in this case.

#### How did you do it?
- `tests/ha/ha_utils.py`: Added an `ack` parameter to `verify_ha_state` so the caller can choose which STATE_DB field to query — `local_acked_asic_ha_state` (ack=True, default) or `local_ha_state` (ack=False).
- `tests/ha/test_ha_dpu_process_crash.py`:
  - Added an autouse `_setup` fixture that derives the expected post-crash and verify states from the `ha_owner` fixture (`"active"` for DPU-owned, otherwise `HA_STATE_STANDBY` / `HA_STATE_STANDALONE`).
  - Replaced the hard-coded `"active"` expectations across all four crash scenarios with the owner-derived values.
  - Set `ack=False` in `verify_ha_state_converged` to read `local_ha_state`.
  - Added `orchagent`/`swss` to `DPU_CRITICAL_PROCESSES` to extend crash coverage.

#### How did you verify/test it?
Ran `test_ha_dpu_process_crash.py` on a SmartSwitch HA testbed for NPU-driven HA configurations, covering the syncd, bgp, and swss critical processes.

#### Any platform specific information?
SmartSwitch / DPU platforms with DASH HA enabled.

#### Supported testbed topology if it's a new test case?
N/A (existing SmartSwitch HA test).

### Documentation
N/A