### PR TITLE
snmp: fix test_snmp_loopback for LT2 topo when UT2 BGP not established

### DIFF
--- a/tests/snmp/test_snmp_loopback.py
+++ b/tests/snmp/test_snmp_loopback.py
@@ -1,8 +1,11 @@
+import logging
 import pytest
 import ipaddress
 from tests.common.helpers.snmp_helpers import get_snmp_facts, get_snmp_output
 from tests.common.devices.eos import EosHost
 from tests.common.utilities import skip_release
+
+logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('t0', 't1', 't2', 'lrh', 'urh', 'm0', 'mx', 'm1', 't1-multi-asic', 'lt2', 'ft2', 'c0'),
@@ -29,11 +32,25 @@ def test_snmp_loopback(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
         host=duthost.hostname, source="persistent")['ansible_facts']
 
     if tbinfo['topo']['type'] == 'lt2':
-        # Get a UT2 nbr to run the test on LT2 topo
+        # For LT2 topo, prefer a UT2 (uplink) neighbor for multi-hop loopback reachability test.
+        # Fall back to a T1 neighbor if no UT2 has BGP established (e.g. UT2 VMs not deployed).
+        nbr = None
+        bgp_neighbors = duthost.bgp_facts()['ansible_facts']['bgp_neighbors']
+        established = {v.get('description', '') for v in bgp_neighbors.values()
+                       if v.get('state', '').lower() == 'established'}
         for nbr_id, nbr_host in nbrhosts.items():
-            if "UT2" in nbr_id:
+            if "UT2" in nbr_id and nbr_id in established:
+                logger.info("Using UT2 neighbor {} for LT2 SNMP loopback test".format(nbr_id))
                 nbr = nbr_host
                 break
+        if nbr is None:
+            logger.info("No established UT2 neighbor found, falling back to first T1 neighbor")
+            for nbr_id, nbr_host in nbrhosts.items():
+                if "T1" in nbr_id and nbr_id in established:
+                    nbr = nbr_host
+                    break
+        if nbr is None:
+            pytest.skip("No neighbor with established BGP found to run SNMP loopback test")
     else:
         # Get first neighbor VM information
         nbr = nbrhosts[list(nbrhosts.keys())[0]]


### PR DESCRIPTION
### Description of PR
Summary:
Fix `test_snmp_loopback` failure on LT2 topology testbeds where UT2 (uplink T2) neighbor VMs are not deployed or their BGP sessions are not established.

**Root cause:** The original LT2 code path always selected the first UT2 neighbor without checking if its BGP session is established. If no UT2 VM is reachable, the SNMP query from that VM times out (no route to the loopback IP), causing the assertion to fail. Additionally, if no UT2 neighbor exists in `nbrhosts` at all, the code raises a `NameError` (variable `nbr` never assigned).

**Fix:**
- Query `bgp_facts()` to get the set of BGP neighbors with `state == established`
- Prefer an established UT2 neighbor (multi-hop test, original intent)
- Fall back to an established T1 neighbor if no UT2 is available
- Skip the test if no neighbor with established BGP is found

Fixes # (issue)

### Type of change
- [x] Bug fix

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202405
- [x] 202505
- [x] 202511
- [x] 202512

### Approach
#### What is the motivation for this PR?
Nightly test failure on Nokia TH6 LT2 testbed: SNMP loopback test failed because UT2 VMs BGP sessions were not established, so there was no route from UT2 to the DUT loopback IP.

#### How did you do it?
Query `duthost.bgp_facts()` to build the set of established BGP neighbor descriptions, then only select a UT2 neighbor if its BGP is up. Fall back to T1 if needed.

#### How did you verify/test it?
Code review — testbed currently occupied. The fix correctly handles both the "UT2 not deployed" and "UT2 BGP down" cases.

#### Any platform specific information?
Observed on Nokia IXR7220-H6 (TH6) with LT2 topology (`lt2-o256-u32d224`).

#### Supported testbed topology if it's a new test case?
Existing test — lt2 topology

### Documentation
N/A