### PR TITLE
Increase auto-techsupport wait for Arista-720DT

### DIFF
--- a/tests/show_techsupport/test_auto_techsupport.py
+++ b/tests/show_techsupport/test_auto_techsupport.py
@@ -948,8 +948,12 @@ def validate_techsupport_generation(duthost, dut_cli, is_techsupport_expected, e
 
         platform = duthost.facts["platform"]
 
-        if platform in ["armhf-nokia_ixs7215_52x-r0"]:
-            # For this platform, techsupport takes more time, so increase waiting time
+        slow_techsupport_platforms = [
+            "armhf-nokia_ixs7215_52x-r0",
+            "x86_64-arista_720dt_48s",
+        ]
+        if platform in slow_techsupport_platforms:
+            # These platforms need more time to finish techsupport collection and publish the tarball.
             wait = 900
         else:
             # For other platforms, fall back to default 600 seconds


### PR DESCRIPTION
#### Why I did it
Fixes #25079.

`test_auto_techsupport` is flaky on slow platforms because the test waits for a new techsupport tarball after triggering auto-techsupport. For Arista-720DT, recent 202511 nightly failures hit the same signature described in #25079:

```
AssertionError: New expected techsupport file was not generated
```

Evidence checked while investigating 720DT nightlies:

- Public issue #25079 already tracks this failure class and lists Arista-720DT as affected.
- Kusto showed 720DT m0 failures on `SONiC.20251110.35` for:
  - `test_rate_limit_interval`
  - `test_max_limit[techsupport]`
- The failing and passing 720DT runs used the same image commit (`9d5a100af0`), so this is not explained by an image update.
- We also checked mgmt commits in the fail/pass window and did not find a show_techsupport/loganalyzer/sanity change that would explain the difference.
- After `deploy-mg`, the two target 720DT cases passed 10x locally, so the issue remains flaky/state-dependent rather than always reproducible.

This PR follows the existing Nokia slow-platform handling by adding Arista-720DT to the slow techsupport platform list.

#### How I did it
Add `x86_64-arista_720dt_48s` to the platforms that use a 900s wait for the techsupport tarball to appear.

The default remains 600s for other platforms.

#### How to verify it
Ran syntax check:

```bash
python3 -m py_compile tests/show_techsupport/test_auto_techsupport.py
```

Manual 720DT validation during investigation:

```bash
./run_tests.sh -n testbed-bjw2-can-720dt-6 -i ../ansible/veos,../ansible/bjw2 -u -x -a False -t m0,any \
  -c "show_techsupport/test_auto_techsupport.py::TestAutoTechSupport::test_rate_limit_interval" \
  -c "show_techsupport/test_auto_techsupport.py::TestAutoTechSupport::test_max_limit[techsupport]"
```

Result after `deploy-mg`: 10 consecutive runs passed for the two target cases (20 test executions).

#### Description for the changelog
Increase auto-techsupport tarball wait time for Arista-720DT platforms.
