### PR TITLE
fix test_bgp_facts_ipv6_only on modular with different linecards

### DIFF
--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -109,7 +109,7 @@ def test_bgp_facts_ipv6_only(duthosts_ipv6_mgmt_only):  # noqa: F411, F811
     log_eth0_interface_info(duthosts_ipv6_mgmt_only)
 
     def verify_bgp_facts(dut):
-        if duthost.is_multi_asic:
+        if dut.is_multi_asic:
             for asic in dut.asics:
                 run_bgp_facts(dut, asic.asic_index)
         else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

The test incorrectly uses `duthost` to check if the current front end host is multi-asic or not. When the thread starts for each front end host `duthost`` will have been defined by the loop but it will not necessarily be the correct host when verify_bgp_facts is called.

The test fails on a modular where the linecards have different numbers of asics because containers on a multi-asic LC are not the same as containers on a single-asic LC. The loop re-assigns duthost each iteration but each thread is sharing that same object.

Fix is to use the passed `dut` object.

Summary:
Fixes #26479 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

### Approach
#### What is the motivation for this PR?
Fix test failure seen on modular chassis. 

#### How did you do it?
Fix is to use the passed `dut` object instead of `duthost` object defined by the loop.

#### How did you verify/test it?
ran `ip/test_mgmt_ipv6_only.py` with the change.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] msft-202601
- [x] 202605


#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] msft-202601
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result
The correct duthost is selected

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->