### PR TITLE
[TH6-P] Fix test speed change tests to only allow valid speed changes

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -1101,15 +1101,29 @@ class TestShowVlan():
 @pytest.mark.topology('t1', 'lt2', 'ft2')
 class TestConfigInterface():
     def check_speed_change(self, duthost, asic_index, interface, change_speed):
-        db_cmd = 'sudo {} CONFIG_DB HGET "PORT|{}" speed'\
-            .format(duthost.asic_instance(asic_index).sonic_db_cli,
-                    interface)
-        speed = duthost.shell('SONIC_CLI_IFACE_MODE={}'.format(db_cmd))['stdout']
+        sonic_db_cli = duthost.asic_instance(asic_index).sonic_db_cli
+
+        def _port_field(field):
+            db_cmd = 'sudo {} CONFIG_DB HGET "PORT|{}" {}'.format(sonic_db_cli, interface, field)
+            return duthost.shell('SONIC_CLI_IFACE_MODE={}'.format(db_cmd))['stdout'].strip()
+
+        speed = _port_field('speed')
         hwsku = duthost.facts['hwsku']
         if hwsku in ["Cisco-88-LC0-36FH-M-O36", "Cisco-88-LC0-36FH-O36"]:
             if (
                 (int(speed) == 400000 and int(change_speed) <= 100000) or
                 (int(speed) == 100000 and int(change_speed) > 200000)
+            ):
+                return False
+            return True
+
+        if "NH-4210" in hwsku:
+            # TH6-P: on a 4-lane port 100G is NRZ while >=200G is PAM4, and the port
+            # macro's shared VCO cannot cross that boundary at runtime.
+            num_lanes = len(_port_field('lanes').split(','))
+            if num_lanes == 4 and (
+                (int(speed) >= 200000 and int(change_speed) == 100000) or
+                (int(speed) == 100000 and int(change_speed) >= 200000)
             ):
                 return False
         return True
@@ -1286,9 +1300,9 @@ class TestConfigInterface():
 
         if not self.check_speed_change(duthost, asic_index, interface, configure_speed):
             pytest.skip(
-                "Cisco-88-LC0-36FH-M-O36 and Cisco-88-LC0-36FH-O36 \
+                "{} \
                     currently does not support\
-                    speed change from 100G to 400G and vice versa on runtime"
+                    speed change from 100G to 400G and vice versa on runtime".format(duthost.facts['hwsku'])
             )
 
         db_cmd = 'sudo {} CONFIG_DB HGET "PORT|{}" speed'\


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

`test_iface_namingmode::TestConfigInterface::test_config_interface_speed` is failing on TH6-P chips when ports are configured in 2x400G because the test is attempting to change the interface speed which is incompatible with settings of the other lanes.

`2x400G` <-> `2x100G`. While the speed change is technically supported, 2x100G requires NRZ whereas 2x200G and 2x400G use PAM4. Every lane in a port macro shares the same VCO meaning that lanes must be either PAM4 or NRZ.

This was producing fallout in the following tests because some of the interfaces were not appropriate recovered when the speed change was unsuccessful.

#### How did you do it?

Added Nexthop TH6-P specific logic to look at available breakout modes and validate whether the resulting breakout mode from the speed change would be valid.

#### How did you verify/test it?

**Recreated the issue identically without the changes**
```
TESTS RUN RESULTS:BEG
+-------------------------------------------------+---------------------------------------+--------+----------+-----------------------------------------------+
| Test                                            | Description                           | Result | Duration | Error                                         |
+-------------------------------------------------+---------------------------------------+--------+----------+-----------------------------------------------+
| tests/iface_namingmode/test_iface_namingmode.py | skipped 41 errors 5 failed 2 total 67 | FAIL   | 3427.73  | Native speed is not 100G or 40G, it is 400000 |
+-------------------------------------------------+---------------------------------------+--------+----------+-----------------------------------------------+
TESTS RUN RESULTS:END
```

Following the changes:

```
+-------------------------------------------------+---------------------------------------+-----------+----------+-----------------------------------------------+
| Test                                            | Description                           | Result    | Duration | Error                                         |
+-------------------------------------------------+---------------------------------------+-----------+----------+-----------------------------------------------+
| tests/iface_namingmode/test_iface_namingmode.py | skipped 43 errors 0 failed 0 total 63 | SKIP_PASS | 3366.81  | Native speed is not 100G or 40G, it is 400000 |
+-------------------------------------------------+---------------------------------------+-----------+----------+-----------------------------------------------+
TESTS RUN RESULTS:END

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
