### PR TITLE
Optimize ip/test_mgmt_ipv6_only.py to reduce runtime by ~85%

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -92,6 +92,43 @@ def backup_and_restore_config_db_session(duthosts):
         yield func
 
 
+@pytest.fixture(scope="module")
+def backup_and_restore_ansible_hosts(duthosts):
+    """
+    Back up the current ansible_host config for each duthost and restore it on
+    cleanup and reloads config_db
+    """
+    original_ansible_hosts = get_ansible_hosts(duthosts)
+    logger.info("Backup ansible hosts: {}".format(original_ansible_hosts))
+
+    yield
+
+    # Reload to bring IPv4 mgmt back and then restore the ansible host to IPv4
+    current_ansible_hosts = get_ansible_hosts(duthosts)
+
+    def reload_config_and_addr(duthost, ip_address):
+        try:
+            config_reload(duthost, safe_reload=True, wait_for_bgp=True)
+        except AnsibleConnectionFailure as e:
+            logger.warning(f'Exception after config reload: {e}')
+        finally:
+            host = duthost.host.options['inventory_manager'].get_host(duthost.hostname)
+            host.vars['ansible_host'] = ip_address
+
+    restoring_ansible = False
+    with SafeThreadPoolExecutor(max_workers=8) as executor:
+        for duthost in duthosts.nodes:
+            original_ip = original_ansible_hosts[duthost.hostname]
+            current_ip = current_ansible_hosts[duthost.hostname]
+            if current_ip != original_ip:
+                executor.submit(reload_config_and_addr, duthost, original_ip)
+                restoring_ansible = True
+
+    if restoring_ansible:
+        logger.info("Restore ansible_hosts from {} to {}"
+                    .format(current_ansible_hosts, original_ansible_hosts))
+
+
 def _is_route_checker_in_status(duthost, expected_status_substrings):
     """
     Check if routeCheck service status contains any expected substring.
@@ -767,8 +804,23 @@ def wait_bgp_sessions(duthost, timeout=120):
     )
 
 
+def get_ansible_hosts(duthosts):
+    ansible_hosts = {}
+    for duthost in duthosts.nodes:
+        host = duthost.host.options['inventory_manager'].get_host(duthost.hostname)
+        ansible_hosts[duthost.hostname] = host.vars['ansible_host']
+    return ansible_hosts
+
+
+def set_ansible_hosts(duthosts, ip_address):
+    for duthost in duthosts.nodes:
+        host = duthost.host.options['inventory_manager'].get_host(duthost.hostname)
+        addr = ip_address[duthost.hostname]
+        host.vars['ansible_host'] = addr[0] if isinstance(addr, list) else addr
+
+
 @pytest.fixture(scope="module")
-def duthosts_ipv6_mgmt_only(duthosts, backup_and_restore_config_db_on_duts):
+def duthosts_ipv6_mgmt_only(duthosts, backup_and_restore_ansible_hosts, backup_and_restore_config_db_on_duts):
     """Convert the DUTs mgmt-ip to IPv6 only
 
     Since the change commands is distributed by IPv4 mgmt-ip,
@@ -818,7 +870,7 @@ def duthosts_ipv6_mgmt_only(duthosts, backup_and_restore_config_db_on_duts):
         # "RuntimeError: dictionary changed size during iteration" error
         ssh_client = paramiko.SSHClient()
         ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        has_available_ipv6_addr = False
+        has_ipv6_config = False
         for key in list(mgmt_interface):
             ip_addr = key.split("|")[1]
             ip_addr_without_mask = ip_addr.split('/')[0]
@@ -826,7 +878,7 @@ def duthosts_ipv6_mgmt_only(duthosts, backup_and_restore_config_db_on_duts):
                 is_ipv6 = valid_ipv6(ip_addr_without_mask)
                 if is_ipv6:
                     logger.info(f"Host[{duthost.hostname}] IPv6[{ip_addr}]")
-                    ipv6_address[duthost.hostname].append(ip_addr_without_mask)
+                    has_ipv6_config = True
                     try:
                         # Add a temporary debug log to see if the DUT is reachable via IPv6 mgmt-ip. Will remove later
                         duthost_interface = duthost.shell("sudo ifconfig eth0")['stdout']
@@ -835,16 +887,16 @@ def duthosts_ipv6_mgmt_only(duthosts, backup_and_restore_config_db_on_duts):
                                            username="WRONG_USER", password="WRONG_PWD", timeout=15)
                     except AuthenticationException:
                         logger.info(f"Host[{duthost.hostname}] IPv6[{ip_addr_without_mask}] mgmt-ip is available")
-                        has_available_ipv6_addr = True
+                        ipv6_address[duthost.hostname].append(ip_addr_without_mask)
                     except BaseException as e:
                         logger.info(f"Host[{duthost.hostname}] IPv6[{ip_addr_without_mask}] mgmt-ip is unavailable, "
                                     f"exception[{type(e)}], msg[{str(e)}]")
                     finally:
                         ssh_client.close()
 
-        if not ipv6_address[duthost.hostname]:
+        if not has_ipv6_config:
             pytest.skip(f"{duthost.hostname} doesn't have IPv6 Management IP address")
-        if not has_available_ipv6_addr:
+        if not ipv6_address[duthost.hostname]:
             pytest.skip(f"{duthost.hostname} doesn't have available IPv6 Management IP address")
 
     # Remove IPv4 mgmt-ip
@@ -903,11 +955,13 @@ def duthosts_ipv6_mgmt_only(duthosts, backup_and_restore_config_db_on_duts):
                 # Then 'duthost' will lost IPV4 connection and throw exception
                 logger.warning(f'Exception after config reload: {e}')
 
+    set_ansible_hosts(duthosts, ipv6_address)
     with SafeThreadPoolExecutor(max_workers=8) as executor:
         for duthost in duthosts.nodes:
             executor.submit(config_reload_if_modified, duthost)
 
     duthosts.reset()
+    set_ansible_hosts(duthosts, ipv6_address)
 
     def wait_for_processes_and_bgp(dut):
         if config_db_modified[dut.hostname]:


### PR DESCRIPTION
Right now, `ip/test_mgmt_ipv6_only.py` takes 2 to 2.5 hours to run. The test is so slow because every ansible connection times out after removing the ipv4 mgmt interface address. The new tested runtime is about 22 minutes, which is 6x to 7x faster.

We need to update the ansible host to be aware of the correct IPv6 address it should now be using. Previously this test still passed because every ansible ssh connection would fall back to using the IPv6 address, it just took a very long time to do so.

 The fix is to set the default address to the IPv6 as soon as we remove the IPv4 configuration.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Speed up `ip/test_mgmt_ipv6_only.py` up to 7 times faster.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Right now ip/test_mgmt_ipv6_only.py takes an excessively long time to run, I am fixing it and speeding it up.

#### How did you do it?
As-is the test "worked" and tested the IPv6 address on the management interface, just in a roundabout way since it relied on IPv4 timing out and falling back to IPv6. I added a new function to update this address on the ansible host after it is found.

The new `set_ansible_host` function is called twice: once before config reload and once after `duthosts.reset()` This is intentional, to speed up the config reload which will and then to speed up the tests after `duthosts.reset` wipes out the `ansible_host` ip address setting update.

#### How did you verify/test it?
I ran `ip/test_mgmt_ipv6_only.py` several times without then with my change.
Without my change on a max topology T2 device this test would take as long as 2 hours and 40 minutes.
With my change this test file took between 20 and 30 minutes.

`9 passed, 1 skipped, 531 warnings in 1323.60s (0:22:03)`

I also verified that this change did not affect the tests running before and after it:

```shell
[ ip/test_mgmt_ipv6_only.py runs ]
------- live log setup -------
19/06/2026 17:14:55 duthost_utils.log_ansible_host           L0781 WARNING| PBAILEY [BEFORE duthosts_ipv6_mgmt_only] HOSTNAME ansible_host=<an IPv4 address>
19/06/2026 17:23:09 duthost_utils.log_ansible_host           L0781 WARNING| PBAILEY [AFTER duthosts_ipv6_mgmt_only] HOSTNAME ansible_host=<an IPv6 Address>
[ all ip/test_mgmt_ipv6_only.py tests pass ]

[ ipfwd/ tests run ]
------- live log setup -------
19/06/2026 17:36:56 duthost_utils.log_ansible_host           L0781 WARNING| PBAILEY [BEFORE ipfwd/test_dip_sip lldp_setup] HOSTNAME ansible_host=<the original IPv4 address>

[ all ipfwd tests pass]
```


### Tested branch

- [x] 202605

### 202605 physical test result

Validated the #25501 change on physical testbed `testbed-bjw2-can-t0-7260-1` (topology `t0-116`, DUT `bjw2-can-7260-1`) using image `SONiC.20260510.09` (commit `ed7a797580`). The DUT had IPv6 management address `2404:f801:10:2200::a96:161f/52`, so the test ran without capability skips.

Command:
`./run_tests.sh -n testbed-bjw2-can-t0-7260-1 -c ip/test_mgmt_ipv6_only.py -i ../ansible/veos,../ansible/bjw2 -t any -u -x -a False -p /home/xichenlin/logs/mgmt-ipv6-only-t0-20260804T1918Z`

Result: **10 passed, 0 failed, 0 skipped** in **1569.22s (0:26:09)**.