### PR TITLE
[202511 backport PR24610] Fix the names of the qos-capable topologies

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -28,9 +28,9 @@ MARK_CONDITIONS_CONSTANTS = {
                      't1-lag', 't1-28-lag', 't1-48-lag', 't1-64-lag', 't1-56-lag',
                      't1-backend', 't1-isolated-d128', 't1-isolated-d32',
                      't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic',
-                     'lt2-p32o64', 'lt2-o128', 'ft2-64', 't2-single-node-min',
+                     'lt2-p32o64', 'lt2-o128', 'ft2-64', 't2-single-node-min', 't2_single_node_min',
                      't2_single_node_max', 't2_single_node_max_64p', 't2-single-node-max-64p',
-                     'topo_t2_single_node_max_64p_v2']
+                     't2_single_node_max_64p_v2']
 }
 
 


### PR DESCRIPTION
Backport https://github.com/sonic-net/sonic-mgmt/pull/24610 to 202511

[202511 backport PR24610] Fix the names of the qos-capable topologies to prevent skipping tests

Add t2_single_node_min
Replace topo_t2_single_node_max_64p_v2 -> t2_single_node_max_64p_v2