### PR TITLE
[telemetry]: Skip BGP event tests when no BGP neighbors exist

### DIFF
--- a/tests/telemetry/events/bgp_events.py
+++ b/tests/telemetry/events/bgp_events.py
@@ -4,6 +4,8 @@ import logging
 import time
 import ipaddress
 
+import pytest
+
 from run_events_test import run_test
 from tests.common.utilities import is_ipv6_only_topology
 
@@ -12,6 +14,8 @@ tag = "sonic-events-bgp"
 
 
 def test_event(duthost, tbinfo, gnxi_path, ptfhost, ptfadapter, data_dir, validate_yang):
+    if len(duthost.get_bgp_neighbors()) == 0:
+        pytest.skip("Skipping BGP telemetry events: no BGP neighbors configured")
     run_test(duthost, tbinfo, gnxi_path, ptfhost, data_dir, validate_yang, drop_tcp_packets,
              "bgp_notification.json", "sonic-events-bgp:notification", tag)
     run_test(duthost, tbinfo, gnxi_path, ptfhost, data_dir, validate_yang, shutdown_bgp_neighbors,


### PR DESCRIPTION
### Description of PR

Summary:
Skip the BGP telemetry events test (`telemetry/test_events.py` -> `events/bgp_events.py`) on topologies that have no BGP neighbors configured. Previously `test_event` indexed into `duthost.get_bgp_neighbors()` unconditionally, raising `IndexError: list index out of range` on testbeds without any BGP neighbors, which also blocked the remaining telemetry event plugins from running. This adds a guard that `pytest.skip`s the BGP event plugin when no BGP neighbors are present.

Fixes #25504

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
On topologies without BGP neighbors, the telemetry BGP event test crashes with an `IndexError` instead of being cleanly skipped, which also prevents the other telemetry event plugins from running.

#### How did you do it?
Added a check at the start of `test_event`: if `len(duthost.get_bgp_neighbors()) == 0`, call `pytest.skip(...)`. The dispatcher in `test_events.py` catches `pytest.skip.Exception`, so the remaining event plugins still run.

#### How did you verify/test it?
Ran `telemetry/test_events.py` on a testbed with no BGP neighbors: the BGP plugin is skipped (log shows "Skipping test file: bgp_events.py ...") and the run passes instead of erroring. Confirmed flake8 clean (`--max-line-length=120`).

#### Any platform specific information?
None.

#### Supported testbed topology if it's a new test case?
N/A (bug fix to existing test).

### Documentation
N/A