### PR TITLE
[telemetry] Support both libyang1 and libyang3 in validate_yang_events.py

### DIFF
--- a/tests/telemetry/validate_yang_events.py
+++ b/tests/telemetry/validate_yang_events.py
@@ -1,4 +1,11 @@
-import libyang as ly
+try:
+    # libyang3 Python bindings (preferred; present in SONiC 202512+)
+    import libyang as ly
+    _LY3 = True
+except ImportError:
+    # libyang1 Python bindings (python3-yang; present in SONiC ≤ 202511)
+    import yang as ly
+    _LY3 = False
 import sys
 import json
 import argparse
@@ -30,7 +37,10 @@ class YangValidator:
         try:
             yangFiles = glob(YANG_DIR + "/*.yang")
             for file in yangFiles:
-                module = self.ctx.parse_module(file, ly.IOType.FILEPATH, "yang")
+                if _LY3:
+                    module = self.ctx.parse_module(file, ly.IOType.FILEPATH, "yang")
+                else:
+                    module = self.ctx.parse_module_path(file, ly.LYS_IN_YANG)
                 if module is None:
                     logging.info("Could not load module from file {}".format(file))
                     raise Exception(INVALID_YANG_ERROR)
@@ -57,9 +67,13 @@ class YangValidator:
             data_json = "{\"" + self.yangModule + ":" + self.yangModule + "\":" + data_json + "}"
 
             try:
-                self.ctx.parse_data_mem(data_json, "json",
-                                        no_state=True, strict=True,
-                                        json_string_datatypes=True)
+                if _LY3:
+                    self.ctx.parse_data_mem(data_json, "json",
+                                            no_state=True, strict=True,
+                                            json_string_datatypes=True)
+                else:
+                    self.ctx.parse_data_mem(data_json, ly.LYD_JSON,
+                                            ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
             except Exception as e:
                 logging.info("Exception thrown: {}".format(e))
                 raise e


### PR DESCRIPTION
### Description of PR
Summary:
On SONiC 202511 and earlier, the DUT has libyang1 (Python module `yang`, package `python3-yang` via SWIG binding). Starting with SONiC 202512+, libyang3 (Python module `libyang`) will be available. `validate_yang_events.py` was written for libyang3 and fails with `ModuleNotFoundError: No module named libyang` on 202511 DUTs.

This PR adds a try/except fallback so the script works with either libyang version. The libyang1 API uses `yang.Context` with `ctx.parse_module_path()` and `ctx.parse_data_mem()`, while libyang3 uses `libyang.Context` with `ctx.parse_module()` and `ctx.parse_data()`. Both paths are now supported.

Fixes failing `test_events` on Nokia TH6 (SONiC 202511) and other platforms running SONiC ≤202511.

### Type of change
- [x] Bug fix

### Back port request
- [x] 202511
- [x] 202505

### Approach
#### What is the motivation for this PR?
`validate_yang_events.py` uses libyang3 Python API but SONiC 202511 DUTs only have libyang1. This causes `test_events` to fail with `ModuleNotFoundError: No module named libyang`.

#### How did you do it?
Added a try/except import block: try `import libyang` (libyang3), fall back to `import yang as libyang` (libyang1). Added an `_LY3` boolean flag to branch the API calls that differ between libyang1 and libyang3.

#### How did you verify/test it?
Ran `test_events` on Nokia TH6 testbed (SONiC 202511/Debian 13). Test PASSED.

#### Any platform specific information?
Affects all platforms running SONiC ≤202511 with libyang1.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A