### PR TITLE
[telemetry] Skip pfc-storm events test for Nokia physical hardware

### DIFF
--- a/tests/common/nokia_data.py
+++ b/tests/common/nokia_data.py
@@ -2,4 +2,4 @@ def is_nokia_device(dut):
     return ('nokia' in dut.facts["hwsku"].lower())
 
 
-NO_QOS_HWSKUS = ['Nokia-7215-C1']
+NO_QOS_HWSKUS = ['Nokia-7215-C1', 'Nokia-IXR7220-H6-O256']

--- a/tests/telemetry/events/swss_events.py
+++ b/tests/telemetry/events/swss_events.py
@@ -40,7 +40,12 @@ def test_event(duthost, tbinfo, gnxi_path, ptfhost, ptfadapter, data_dir, valida
              "if_state.json", "sonic-events-swss:if-state", tag)
 
     asic_type = duthost.facts["asic_type"]
-    if asic_type == "mellanox":
+    hwsku = duthost.facts["hwsku"]
+    if 'nokia' in hwsku.lower():
+        # Check Nokia by HWSKU first: Nokia physical devices report asic_type="broadcom"
+        # because the underlying chip vendor is Broadcom, so asic_type alone is insufficient.
+        skip_pfc_hwskus = NOKIA_NO_QOS_HWSKUS
+    elif asic_type == "mellanox":
         skip_pfc_hwskus = [*MELLANOX_LOSSY_ONLY_HWSKUS, *MELLANOX_NO_QOS_HWSKUS]
     elif asic_type == "broadcom":
         skip_pfc_hwskus = [*BROADCOM_LOSSY_ONLY_HWSKUS, *BROADCOM_NO_QOS_HWSKUS]


### PR DESCRIPTION
### Description of PR
Summary:
Nokia TH6 physical hardware has `platform_asic` set to `"broadcom"`, so `duthost.facts["asic_type"]` returns `"broadcom"` for Nokia TH6 (not `"nokia-vs"`). This causes `swss_events.py` to fall into the broadcom ASIC branch and attempt to test pfc-storm events, which Nokia TH6 does not publish.

The test then fails with `DEADLINE_EXCEEDED` waiting for a pfc-storm event that never arrives.

This PR:
1. Adds `Nokia-IXR7220-H6-O256` to `NOKIA_NO_QOS_HWSKUS` in `tests/common/nokia_data.py`
2. Checks Nokia HW by HWSKU **first** (before the `asic_type` check) in `swss_events.py` so Nokia physical hardware correctly skips the pfc-storm test

### Type of change
- [x] Bug fix

### Back port request
- [x] 202511

### Approach
#### What is the motivation for this PR?
Nokia TH6 physical HW reports `asic_type=broadcom` (from `platform_asic` file), which causes `swss_events.py` to run pfc-storm events test — but Nokia TH6 does not publish pfc-storm events, causing DEADLINE_EXCEEDED timeout.

#### How did you do it?
Moved Nokia HWSKU check before asic_type check in the if-elif chain so Nokia physical hardware is detected first. Added `Nokia-IXR7220-H6-O256` to `NOKIA_NO_QOS_HWSKUS`.

#### How did you verify/test it?
Ran `test_events` on Nokia TH6 testbed (SONiC 202511). Test PASSED.

#### Any platform specific information?
Nokia TH6 (`Nokia-IXR7220-H6-O256`): `platform_asic` = `"broadcom"`, so `asic_type` = `"broadcom"`.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A