### PR TITLE
[fib] Skip test_ipinip_hash_negative[ipv6] on Nokia physical platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2413,6 +2413,12 @@ fib/test_fib.py::test_ipinip_hash_negative[ipv4:
     conditions:
       - "'-v6-' in topo_name"
 
+fib/test_fib.py::test_ipinip_hash_negative[ipv6:
+  skip:
+    reason: "Nokia physical platforms do not forward IPv4 packets with IP protocol 41 (IPv6-in-IPv4). On non-v6 topologies the test sends IPv4-outer/IPv6-inner (protocol 41) which Nokia TH6 drops."
+    conditions:
+      - "'nokia' in platform"
+
 fib/test_fib.py::test_nvgre_hash:
   skip:
     reason: 'Nvgre hash test is not fully supported on VS and Broadcom platform; Not supported on M* and cisco-8122, cisco-8223 platforms. Skip on t1-isolated-d32/128 topos'


### PR DESCRIPTION
### Description of PR
Summary:
Nokia TH6 physical hardware does not forward IPv4 packets with IP protocol 41 (IPv6-in-IPv4 / 6in4 tunneling). On non-IPv6-only topologies, `test_ipinip_hash_negative[ipv6]` creates IPv4-outer packets encapsulating IPv6-inner (IP protocol 41). Nokia TH6 silently drops these packets, causing the test to fail with:
```
AssertionError: Did not receive expected packet on any of ports [90, 91, ..., 121]
```
Note: `test_ipinip_hash_negative[ipv4]` already has a skip for IPv6-only topologies. This PR adds a complementary skip for Nokia physical platforms on the `[ipv6]` variant.

### Type of change
- [x] Bug fix

### Back port request
- [x] 202511

### Approach
#### What is the motivation for this PR?
Nokia TH6 (platform `x86_64-nokia_ixr7220_h6_128-r0`) drops IPv4 packets with IP protocol 41. On non-v6 topologies, `test_ipinip_hash_negative[ipv6]` creates such packets (IPv4 outer containing IPv6 inner) — Nokia TH6 drops them silently, causing the test to report no packets received.

#### How did you do it?
Added a skip condition in `tests_mark_conditions.yaml` for `fib/test_fib.py::test_ipinip_hash_negative[ipv6` when `nokia` appears in the platform string.

#### How did you verify/test it?
Confirmed from nightly failure logs that Nokia TH6 drops IPv4/proto-41 packets. Verified the platform string contains `nokia` (`x86_64-nokia_ixr7220_h6_128-r0`).

#### Any platform specific information?
Nokia TH6 (`Nokia-IXR7220-H6-O256`, platform `x86_64-nokia_ixr7220_h6_128-r0`).

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A