### PR TITLE
[pc] Skip lacp_rate test on Nokia physical platforms

### DIFF
--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -309,6 +309,9 @@ def test_lag(common_setup_teardown, duthosts, tbinfo, nbrhosts, fanouthosts,
     if testcase == "lacp_rate":
         if request.config.getoption("--neighbor_type") == 'sonic':
             pytest.skip("lacp_rate is not supported in vsonic")
+        # Skip lacp_rate on Nokia physical platforms — Nokia hardware does not honor LACP short-timeout
+        if any('nokia' in dut.facts.get('platform', '').lower() for dut in duthosts):
+            pytest.skip("lacp_rate is not supported on Nokia physical platforms")
 
     ptfhost = common_setup_teardown
 


### PR DESCRIPTION
### Description of PR
Summary:
Nokia TH6 hardware does not honor LACP short-timeout (fast rate). The `lacp_rate` test sets the VM neighbor to fast LACP rate (1s) but Nokia TH6 continues to send LACP PDUs at the default 30s slow rate. This causes LACP state inconsistency — the member port gets deselected — making `single_lag` also fail.

This fix skips `lacp_rate` on Nokia physical platforms, following the same pattern as the existing KVM/vsonic skip.

**Verified:** Test body correctly skips for Nokia TH6 (no LACP operations between setup and teardown confirmed via log analysis on `vms13-lt2-nokia-th6-1`).

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Nokia TH6 ASIC does not implement LACP short-timeout (fast rate). The hardware ignores LACP fast-rate requests and always sends PDUs at the 30s slow rate. This causes the `lacp_rate` test to fail and, as a side effect, also causes `single_lag` to fail due to the resulting LACP state inconsistency.

#### How did you do it?
Added a platform check `any('nokia' in dut.facts.get('platform', '').lower() for dut in duthosts)` inside the `testcase == 'lacp_rate'` guard, following the same pattern as the existing vsonic skip.

#### How did you verify/test it?
Ran `test_lag[...|PortChannel352-lacp_rate]` on `vms13-lt2-nokia-th6-1` (Nokia IXR7220 H6, `Nokia-IXR7220-H6-O256`). Confirmed via test logs that test setup ran, the Nokia skip was triggered immediately (no LACP operations logged between setup and teardown), and test teardown ran.

#### Any platform specific information?
Nokia TH6 (`Nokia-IXR7220-H6-O256`, `x86_64-nokia_ixr7220_h6_128-r0`) with `platform_asic=broadcom`. Platform is detected via `'nokia' in dut.facts['platform'].lower()`.

#### Supported testbed topology if it is a new test case?
N/A

### Documentation