### PR TITLE
[tacacs]: Fix ssh_run_command hang on large Paramiko SSH output

### DIFF
--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -1,4 +1,5 @@
 import binascii
+import io
 import logging
 import pytest
 import paramiko
@@ -100,21 +101,47 @@ def change_and_wait_aaa_config_update(duthost, command, last_timestamp=None, tim
     pytest_assert(exist, "Not found aaa config update log: {}".format(command))
 
 
-def ssh_run_command(ssh_client, command, expect_exit_code=0, verify=False):
-    stdin, stdout, stderr = ssh_client.exec_command(command, timeout=TIMEOUT_LIMIT)
-    exit_code = stdout.channel.recv_exit_status()
+def ssh_run_command(ssh_client, command, expect_exit_code=0, verify=False, timeout=TIMEOUT_LIMIT):
+    stdin, stdout, stderr = ssh_client.exec_command(command, timeout=timeout)
+    channel = stdout.channel
+    out_chunks = []
+    err_chunks = []
+    deadline = time.monotonic() + timeout
+    exit_code = None
+
+    def drain_streams():
+        while channel.recv_ready():
+            out_chunks.append(channel.recv(65535))
+        while channel.recv_stderr_ready():
+            err_chunks.append(channel.recv_stderr(65535))
+
+    def time_left():
+        return max(0.0, deadline - time.monotonic())
+
+    def command_complete():
+        nonlocal exit_code
+        drain_streams()
+        if exit_code is None and channel.exit_status_ready():
+            exit_code = channel.recv_exit_status()
+        return exit_code is not None and not channel.recv_ready() and not channel.recv_stderr_ready()
+
+    if not wait_until(time_left(), 0.1, 0, command_complete):
+        channel.close()
+        pytest.fail("Command timed out after {}s: {}".format(timeout, command))
+
+    channel.close()
+
+    out_data = b"".join(out_chunks)
+    err_data = b"".join(err_chunks)
     if verify is True:
-        if exit_code != expect_exit_code:
-            # This if-block is here so that stdout.readlines() and
-            # stderr.readlines() get evaluated if and only if the exit code
-            # doesn't match the expected exit code. If they do match, and they
-            # do get evaluated, then the state of the object will be different,
-            # which will cause issues for other functions that use those
-            # objects.
-            pytest.fail(
-                f"Command: '{command}' failed with exit code: {exit_code}, "
-                f"stdout: {stdout.readlines()}, stderr: {stderr.readlines()}")
-    return exit_code, stdout, stderr
+        pytest_assert(
+            exit_code == expect_exit_code,
+            "Command: '{}' failed with exit code: {}, stdout: {}, stderr: {}".format(
+                command, exit_code,
+                out_data.decode('utf-8', errors='replace'),
+                err_data.decode('utf-8', errors='replace')))
+    return exit_code, io.StringIO(out_data.decode('utf-8', errors='replace')), \
+        io.StringIO(err_data.decode('utf-8', errors='replace'))
 
 
 def ssh_connect_remote_retry(remote_ip, remote_username, remote_password, duthost):
@@ -131,6 +158,9 @@ def ssh_connect_remote_retry(remote_ip, remote_username, remote_password, duthos
 
         time.sleep(1)
         retry_count -= 1
+
+    raise paramiko.ssh_exception.AuthenticationException(
+        "Failed to connect to {} as {} after retries".format(remote_ip, remote_username))
 
 
 def duthost_shell_with_unreachable_retry(duthost, command):


### PR DESCRIPTION
### Description of PR
Summary: Fix TACACS ssh_run_command() hang when Paramiko SSH commands produce large output (e.g. sudo zgrep pfcwd /var/log/syslog* on a DUT with thousands of rotated syslog files). 
Enforce TIMEOUT_LIMIT as a real wall-clock timeout, drain stdout/stderr to avoid channel deadlock, and fail clearly instead of blocking indefinitely.

Fixes # https://github.com/sonic-net/sonic-mgmt/issues/25512

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
TACACS tests use ssh_run_command() in tests/tacacs/utils.py to run commands on the DUT over Paramiko SSH. The helper sets TIMEOUT_LIMIT = 120 but does not enforce a wall-clock limit on command execution. It calls stdout.channel.recv_exit_status(), which blocks until the remote command exits.

Two problems combine on real testbeds:

No execution timeout — exec_command(timeout=120) only bounds initial channel setup, not command runtime ([paramiko#1815](https://github.com/paramiko/paramiko/issues/1815)).
Paramiko channel deadlock — Without draining stdout/stderr while waiting, large output (e.g. ~3.5 MB from zgrep over 2300+ files) fills the SSH channel window. The remote process blocks on write, the client blocks on recv_exit_status(), and the test hangs until Jenkins or an operator kills it.
This was seen in full regression on test_tacacs_authorization_wildcard when the DUT had 1000+ rotated syslog files.

#### How did you do it?
Updated ssh_run_command() in tests/tacacs/utils.py:

Call exec_command(command, timeout=timeout) for channel-level I/O timeout.
Use a single time.monotonic() deadline shared across the whole command.
Poll with wait_until() and a command_complete() callback that:
Drains stdout/stderr in while recv_ready() / while recv_stderr_ready() loops each poll (not one chunk per second).
Collects exit status when exit_status_ready(), then keeps draining until both streams are idle.
Avoid blocking stdout.read() / stderr.read() after exit status.
On timeout: channel.close() and pytest.fail() with a clear message.
Return decoded io.StringIO streams so readlines() callers (e.g. check_ssh_output_any_of()) still work.
Raise AuthenticationException from ssh_connect_remote_retry() after retries instead of returning None.

#### How did you verify/test it?
Repro: On mth-t0-64, created 2300 extra rotated syslog files (syslog.100.gz … syslog.2399.gz). Without the fix, pytest tacacs/test_authorization.py::test_tacacs_authorization_wildcard hung indefinitely on sudo zgrep pfcwd /var/log/syslog*.

With fix: All 13 tests in tacacs/test_authorization.py passed; the wildcard zgrep case completed in ~8s on the DUT (hang was in Paramiko I/O, not slow DUT execution).

Timeout behavior: Slow or stuck commands now fail at 120s with Command timed out after 120s: <command> instead of hanging the job.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
