### PR TITLE
[cacl] Add BFD rules to expected iptables

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -608,6 +608,10 @@ def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expecte
     iptables_rules.append("-A INPUT ! -i eth0 -p tcp -m tcp --dport 179 -j ACCEPT")
     ip6tables_rules.append("-A INPUT ! -i eth0 -p tcp -m tcp --dport 179 -j ACCEPT")
 
+    # Allow BFD single-hop and multi-hop sessions programmed by caclmgrd.
+    iptables_rules.append("-A INPUT ! -i eth0 -p udp -m multiport --dports 3784,4784 -j ACCEPT")
+    ip6tables_rules.append("-A INPUT ! -i eth0 -p udp -m multiport --dports 3784,4784 -j ACCEPT")
+
     extra_rule_branches = ['201911', '202012', '202111']
     if any(branch in duthost.os_version for branch in extra_rule_branches):
         iptables_rules.append("-A INPUT -p tcp -m tcp --sport 179 -j ACCEPT")


### PR DESCRIPTION
### Description of PR

Summary:
The CACL application test builds an expected iptables/ip6tables rule set and compares it with the rules programmed by caclmgrd. caclmgrd intentionally programs BFD single-hop/multi-hop UDP accept rules for ports 3784 and 4784, but the test's expected rule list did not include them, causing nightly failures with an unexpected iptables rule.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
caclmgrd programs BFD UDP accept rules (ports 3784/4784) that were missing from the test's expected rule set, causing a consistent test failure.

#### How did you do it?
Added IPv4 and IPv6 BFD accept rules to `generate_expected_rules()` so the expected list matches caclmgrd behavior.

#### How did you verify/test it?
`python -m py_compile tests/cacl/test_cacl_application.py`

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A

Related ADO PBI: 38518988