### PR TITLE
Handle missing rc in GCU rollback failure

### DIFF
--- a/tests/common/gu_utils.py
+++ b/tests/common/gu_utils.py
@@ -365,7 +365,7 @@ def rollback_or_reload(duthost, cp=DEFAULT_CHECKPOINT_NAME):
     """
     output = rollback(duthost, cp)
 
-    if output['rc'] or "Config rolled back successfully" not in output['stdout']:
+    if output.get('rc', 1) or "Config rolled back successfully" not in output.get('stdout', ''):
         config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
         pytest.fail("config rollback failed. Restored by config_reload")
 


### PR DESCRIPTION
### Description of PR

Summary:
`rollback_or_reload()` in `tests/common/gu_utils.py` assumes `config rollback` always returns an Ansible result containing `rc` and `stdout`. When privilege escalation times out, Ansible can return only `failed/msg/_ansible_no_log`; teardown then raises `KeyError: 'rc'` and hides the intended recovery path.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
When Ansible privilege escalation times out during `config rollback`, the result dict lacks `rc` and `stdout`, causing `KeyError: 'rc'` in teardown and hiding the `config_reload()` recovery path.

#### How did you do it?
Use defensive `dict.get()` access for `rc` and `stdout`, treating a missing `rc` as rollback failure so the existing `config_reload()` recovery and pytest failure path runs instead of crashing with `KeyError`.

#### How did you verify/test it?
`python -m py_compile tests/common/gu_utils.py`

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A

Related ADO PBI: 38518990