### PR TITLE
[vxlan][dualtor] Fix test_vnet_decap on active-active dualtor

### DIFF
--- a/tests/vxlan/test_vnet_decap.py
+++ b/tests/vxlan/test_vnet_decap.py
@@ -7,6 +7,13 @@ import ptf.packet as packet
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
 from tests.common.helpers.assertions import pytest_assert
 from ptf.mask import Mask
+# On dualtor, the upstream IP-in-IP packet from PTF is handled by the active ToR for the
+# server-facing mux port. These fixtures force the randomly selected ToR (the one this test
+# configures the VNET tunnel/route on) to be the active side, so the packet is processed by
+# the configured ToR. They are no-ops on non-dualtor topologies and for the irrelevant cable
+# type, so t0/t1 behavior is unchanged.
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m  # noqa: F401
+from tests.common.dualtor.dual_tor_utils import setup_standby_ports_on_rand_unselected_tor  # noqa: F401
 
 
 pytestmark = [
@@ -56,13 +63,13 @@ def outer_ip_version(request):
 
 
 @pytest.fixture
-def setup(request, duthosts, rand_one_dut_hostname, tbinfo, inner_ip_version, outer_ip_version):
+def setup(request, duthosts, rand_selected_dut, tbinfo, inner_ip_version, outer_ip_version):
     """
     Creates a VXLAN tunnel, a VNET, and one VNET route (with a single endpoint). Also finds an appropriate
     Ethernet port for sending the IP-in-IP packet to the DUT.
     Yields test configuration and data.
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = rand_selected_dut
     asic_type = duthost.facts["asic_type"]
     if asic_type not in ["cisco-8000", "mellanox"]:
         pytest.skip("The VNET decap test will only run on Cisco-8000 and Mellanox ASICs.")
@@ -235,7 +242,9 @@ def extract_inner_ip_pkt(outer_pkt, inner_ip_version, outer_ip_version):
         return packet.IPv6(outer_pkt_bytes[outer_ip_header_size:])
 
 
-def test_vnet_decap(setup, ptfadapter):
+def test_vnet_decap(setup, ptfadapter,
+                    toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa: F811
+                    setup_standby_ports_on_rand_unselected_tor):        # noqa: F811
     """
     We send an IP-in-IP packet to the DUT:
         Outer IP packet is from an arbitrary address to the VXLAN tunnel's src IP.


### PR DESCRIPTION
### Description of PR

Summary:
Fixes `test_vnet_decap` failing on active-active dualtor (e.g. `dualtor-aa-64-breakout`).

`vxlan/test_vnet_decap.py` is marked `topology("t0", ...)`, so it also runs on dualtor
testbeds. On **active-active** dualtor it fails **deterministically on every retry** (4/4),
across multiple ASIC vendors (Mellanox-SN4700-V64 and Cisco-8101), while passing on plain
t0/t1. Verified from the test logs: the DUT produces **no VXLAN packet on any watched port**
(captures contain only background BGP/LLDP traffic) — i.e. the configured ToR never decaps
the packet.

Root cause: the test sends an upstream IP-in-IP packet from a server-facing (mux) PTF port.
On active-active dualtor the smart NIC ECMPs that fixed-5-tuple flow to **one** ToR. The test
configures the VXLAN tunnel + VNET route on a single randomly selected ToR but does nothing
to ensure that ToR is the one the packet lands on, so the expected re-encapsulated VXLAN
packet is never produced. This is a test/topology-adaptation gap, not an image regression.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Make `test_vnet_decap` pass on active-active dualtor by ensuring the upstream test packet is
processed by the ToR the test actually configures. Currently it fails 100% on dualtor-aa.

#### How did you do it?
Pin the randomly selected ToR (the one the test configures) to be the **active** side so the
upstream packet deterministically reaches it:
- Switch the `setup` fixture to use `rand_selected_dut` (equivalent to
  `duthosts[rand_one_dut_hostname]` on non-dualtor).
- Add `toggle_all_simulator_ports_to_rand_selected_tor_m` (active-standby) and
  `setup_standby_ports_on_rand_unselected_tor` (active-active) to force the selected ToR
  active for the mux ports.

Both fixtures are no-ops on non-dualtor topologies and for the irrelevant cable type, so
t0/t1 behavior is unchanged. This mirrors the existing pattern in
`tests/decap/test_subnet_decap.py`.

#### How did you verify/test it?
- `flake8 --max-line-length=120` clean; `check-ast` passes.
- Behavior on t0/t1 is unchanged (the added fixtures self-skip on non-dualtor).
- Pending: a run on a `dualtor-aa` testbed to confirm the four encap combinations now pass
  (I will attach results / would appreciate a pipeline run on dualtor-aa).

#### Any platform specific information?
The test already runs only on Cisco-8000 and Mellanox ASICs (existing skip). The fix targets
the active-active dualtor topology specifically.

#### Supported testbed topology if it's a new test case?
N/A (existing test). Restores correct behavior on dualtor / dualtor-aa.
