### PR TITLE
Preserve auto-techsupport decimal limit values

### DIFF
--- a/tests/show_techsupport/test_auto_techsupport.py
+++ b/tests/show_techsupport/test_auto_techsupport.py
@@ -6,6 +6,7 @@ import random
 import copy
 import os
 import re
+from decimal import Decimal
 
 from tests.common.config_reload import config_reload
 from tests.common.errors import RunAnsibleModuleFail
@@ -32,9 +33,9 @@ max_limit_test_modes_list = ['techsupport', 'core']
 DEFAULT_STATE = 'enabled'
 DEFAULT_RATE_LIMIT_GLOBAL = 180
 DEFAULT_RATE_LIMIT_FEATURE = 600
-DEFAULT_MAX_TECHSUPPORT_LIMIT = 10
+DEFAULT_MAX_TECHSUPPORT_LIMIT = 10.0
 DEFAULT_AVAILABLE_MEM_THRESHOLD = 10.0
-DEFAULT_MAX_CORE_LIMIT = 5
+DEFAULT_MAX_CORE_LIMIT = 5.0
 DEFAULT_SINCE = '2 days ago'
 
 KB_SIZE = 1000  # We use 1000 to have the same value as in shutil.disk_usage() method which used in SONiC code
@@ -863,14 +864,18 @@ def validate_auto_techsupport_global_config(dut_cli, state=None, rate_limit_inte
             assert str(current_rate_limit_interval) == str(rate_limit_interval), \
                 'Wrong configuration for rate_limit_interval: {} expected: {}'.format(current_rate_limit_interval,
                                                                                       rate_limit_interval)
+    # max_techsupport_limit / max_core_size are decimal64; `show auto-techsupport global`
+    # renders them via tabulate's default floatfmt="g", which drops trailing zeros
+    # ("10.0" -> "10"). Compare as Decimal so a display-only format difference does not
+    # fail the assertion.
     if max_techsupport_limit:
         with allure.step('Checking global max techsupport limit'):
-            assert str(current_max_techsupport_limit) == str(max_techsupport_limit), \
+            assert Decimal(str(current_max_techsupport_limit)) == Decimal(str(max_techsupport_limit)), \
                 'Wrong configuration for max_techsupport_limit: {} expected: {}'.format(current_max_techsupport_limit,
                                                                                         max_techsupport_limit)
     if max_core_size:
         with allure.step('Checking global max core size'):
-            assert str(current_max_core_size) == str(max_core_size), \
+            assert Decimal(str(current_max_core_size)) == Decimal(str(max_core_size)), \
                 'Wrong configuration for max_core_size: {} expected: {}'.format(current_max_core_size, max_core_size)
     if since:
         with allure.step('Checking global since'):


### PR DESCRIPTION
### Description of PR

Summary: Fix `AUTO_TECHSUPPORT` limit handling so `show_techsupport` tests don't introduce CONFIG_DB drift, and compare limit values numerically.

`max_techsupport_limit` and `max_core_limit` are `decimal64` in the YANG model, so their image defaults are stored in CONFIG_DB as `"10.0"` / `"5.0"`. This caused two related test-side problems on 720DT.

**1. CONFIG_DB drift after default restore.** The test changes a limit, then restores the default from `DEFAULT_MAX_TECHSUPPORT_LIMIT` / `DEFAULT_MAX_CORE_LIMIT`. Those constants were Python `int`s (`10`, `5`), so the restore ran `config auto-techsupport global max-techsupport-limit 10`. The `config` CLI argument is untyped and written to CONFIG_DB verbatim, so CONFIG_DB held `"10"` while the golden value was `"10.0"`. Post-test config sanity then reported drift:

```
AUTO_TECHSUPPORT|GLOBAL|max_techsupport_limit: 10.0 -> 10
AUTO_TECHSUPPORT|GLOBAL|max_core_limit:        5.0  -> 5
```

Keeping the defaults as decimals makes the restore write `"10.0"` / `"5.0"`, matching golden — no drift.

**2. Limit assertion must compare numerically.** `validate_auto_techsupport_global_config` compares the value parsed from `show auto-techsupport global` against the expected default. Although CONFIG_DB stores `"10.0"`, the CLI displays `10`, so the parser returns `"10"`. With the default now `10.0` (`str(10.0) == "10.0"`), a literal string compare `"10" == "10.0"` fails; `Decimal("10") == Decimal("10.0")` is numerically correct and independent of display formatting.

Why the CLI drops the trailing zero — verified in the image CLI code (`/usr/local/lib/python3.13/dist-packages/show/plugins/auto_techsupport.py`, SONiC.20251110.35):

```python
table = db.cfgdb.get_table("AUTO_TECHSUPPORT")   # {'max_techsupport_limit': '10.0', ...}
...
def format_attr_value(entry, attr):
    return entry.get(attr["name"], "N/A")         # returns '10.0' unchanged
...
click.echo(tabulate.tabulate(body, header, numalign="left"))
```

The value reaches `tabulate` as `"10.0"`; tabulate's default `floatfmt="g"` reformats numeric cells, and `format(10.0, "g") == "10"`. Demonstrated on the DUT:

```
>>> format(10.0, "g")
'10'
>>> tabulate.tabulate([["10.0", "5.0"]], ["MAX TS LIMIT", "MAX CORE LIMIT"], numalign="left")
MAX TS LIMIT    MAX CORE LIMIT
10              5
```

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Stop `show_techsupport` tests from leaving `AUTO_TECHSUPPORT` decimal limit fields drifted to `int`, and from failing the limit assertion due to CLI display formatting.

#### How did you do it?

- Keep `DEFAULT_MAX_TECHSUPPORT_LIMIT` and `DEFAULT_MAX_CORE_LIMIT` as decimals (`10.0` / `5.0`) so the default restore writes decimal values back to CONFIG_DB.
- Compare `max_techsupport_limit` / `max_core_size` with `Decimal(...)` instead of `str(...)`, so the assertion is independent of whether the CLI renders `10` or `10.0`.

#### How did you verify/test it?

```bash
python3 -m py_compile tests/show_techsupport/test_auto_techsupport.py
```

Verified on a 720DT DUT (SONiC.20251110.35) that CONFIG_DB holds `'10.0'` / `'5.0'` while `show auto-techsupport global` displays `10` / `5`, and that the truncation is produced by `tabulate`'s default `floatfmt="g"` in the image show plugin (shown above).

#### Any platform specific information?

Observed during 720DT show_techsupport RCA, but the YANG decimal typing and the CLI formatting apply generally to AUTO_TECHSUPPORT decimal limit fields.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A

##### Work item tracking
- Microsoft ADO (number only): 38699917
