### PR TITLE
Do not fail auto-techsupport cleanup on debug listing

### DIFF
--- a/tests/show_techsupport/test_auto_techsupport.py
+++ b/tests/show_techsupport/test_auto_techsupport.py
@@ -1308,8 +1308,8 @@ def clear_folders(duthost):
     :param duthost: duthost object
     """
     # print into logs folders content(for debug purpose) before remove
-    duthost.shell('sudo ls -lh /var/core/')
-    duthost.shell('sudo ls -lh /var/dump/')
+    duthost.shell('sudo ls -lh /var/core/', module_ignore_errors=True)
+    duthost.shell('sudo ls -lh /var/dump/', module_ignore_errors=True)
 
     duthost.shell('sudo rm -rf /var/core/*')
     duthost.shell('sudo rm -rf /var/dump/*')


### PR DESCRIPTION
### Description of PR

Summary:
Do not fail auto-techsupport cleanup when debug-only directory listing fails.

During 720DT show_techsupport repeated-run RCA, one failure subtype was an Ansible module failure/`rc=-9` while `clear_folders()` was only trying to log `ls -lh /var/core/` before cleanup. Those listing commands are for debug visibility only; failing there prevents the real cleanup from running and turns transient DUT command failures into test failures.

This PR keeps the actual cleanup commands strict, but makes the pre-cleanup debug listings non-fatal.

Fixes #

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Limit the blast radius of transient failures in logging-only cleanup diagnostics. The `ls -lh` output is useful for debugging, but it is not required for cleanup correctness.

#### How did you do it?

Set `module_ignore_errors=True` only on the two debug `ls -lh` calls in `clear_folders()`. The following `rm -rf /var/core/*` and `rm -rf /var/dump/*` cleanup commands still fail the test if they fail.

#### How did you verify/test it?

```bash
python3 -m py_compile tests/show_techsupport/test_auto_techsupport.py
```

This addresses only the cleanup debug-listing failure subtype. It does not claim to fix other `rc=-9`/facts failures or the techsupport tarball timeout.

#### Any platform specific information?

Observed during 720DT show_techsupport repeated-run RCA, but the change is limited to show_techsupport cleanup debug logging.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
