### PR TITLE
Make auto-techsupport cron cleanup fixture idempotent

### DIFF
--- a/tests/show_techsupport/test_auto_techsupport.py
+++ b/tests/show_techsupport/test_auto_techsupport.py
@@ -112,11 +112,11 @@ class TestAutoTechSupport:
         self.duthost = duthosts[rand_one_dut_hostname]
         tmp_path = '/tmp/core_cleanup'
         cron_d_path = '/etc/cron.d/core_cleanup'
-        self.duthost.shell('sudo mv {} {}'.format(cron_d_path, tmp_path))
+        self.duthost.shell('sudo mv {} {}'.format(cron_d_path, tmp_path), module_ignore_errors=True)
 
         yield
 
-        self.duthost.shell('sudo mv {} {}'.format(tmp_path, cron_d_path))
+        self.duthost.shell('sudo mv {} {}'.format(tmp_path, cron_d_path), module_ignore_errors=True)
 
     @pytest.fixture()
     def global_rate_limit_zero(self):


### PR DESCRIPTION
### Description of PR

Summary:
Make the auto-techsupport core cleanup cron fixture idempotent.

During 720DT show_techsupport repeated-run RCA, an interrupted run left `/etc/cron.d/core_cleanup` moved to `/tmp/core_cleanup`. The next run then failed during class setup with:

```text
mv: cannot stat '/etc/cron.d/core_cleanup': No such file or directory
```

This is a test fixture cleanup robustness issue and is separate from the techsupport tarball timeout and stale handler issues.

Fixes #

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Avoid setup/teardown failures when a previous show_techsupport run was interrupted after moving `/etc/cron.d/core_cleanup` but before restoring it.

#### How did you do it?

- Run the setup and teardown `mv` with `module_ignore_errors=True`, so a missing source (e.g. `/etc/cron.d/core_cleanup` already moved by an interrupted prior run) is tolerated instead of failing the fixture.
- The ignored error is still logged, so a genuine failure is not silently masked.

#### How did you verify/test it?

```bash
python3 -m py_compile tests/show_techsupport/test_auto_techsupport.py
```

Also restored a 720DT DUT manually from this exact interrupted state and confirmed `/etc/cron.d/core_cleanup` was present again.

#### Any platform specific information?

Observed on 720DT during show_techsupport repeated-run RCA, but the fixture is common to this test class.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A

