### PR TITLE
Clean stale auto-techsupport handlers before tests

### DIFF
--- a/tests/show_techsupport/test_auto_techsupport.py
+++ b/tests/show_techsupport/test_auto_techsupport.py
@@ -94,10 +94,13 @@ class TestAutoTechSupport:
         self.set_test_dockers_list()
 
         logger.info('Waiting until existing(if exist) techsupport processes finish')
-        wait_until(300, 10, 0, is_techsupport_generation_in_expected_state, self.duthost, False)
+        if not wait_until(300, 10, 0, is_techsupport_generation_in_expected_state, self.duthost, False):
+            logger.warning('Existing techsupport generation processes did not finish; cleaning them up')
+            clear_techsupport_generation_processes(self.duthost)
 
         clear_auto_techsupport_history(self.duthost)
         self.duthost.shell('sudo mkdir /var/dump/', module_ignore_errors=True)
+        clear_techsupport_generation_processes(self.duthost)
         clear_folders(self.duthost)
 
         create_core_file_generator_script(self.duthost)
@@ -105,6 +108,7 @@ class TestAutoTechSupport:
         yield
 
         clear_auto_techsupport_history(self.duthost)
+        clear_techsupport_generation_processes(self.duthost)
         clear_folders(self.duthost)
 
     @pytest.fixture(autouse=True, scope='class')
@@ -687,15 +691,10 @@ def is_techsupport_generation_in_expected_state(duthost, expected_in_progress=Tr
     :return: True in case when techsupport generation in progress
     """
     with allure.step('Checking techsupport generation process'):
-        techsupport_in_progress = False
-        processes_to_be_ignored = 2
-        get_running_tech_procs_cmd = 'ps -aux | grep "coredump_gen_handler"'
-        # Need to ignore 2 lines: one line with "grep...", another line with ansible module which call "grep..."
-        num_of_process = len(duthost.shell(get_running_tech_procs_cmd)['stdout_lines']) - processes_to_be_ignored
+        running_processes = get_running_techsupport_generation_processes(duthost)
+        num_of_process = len(running_processes)
         logger.info('Number of running autotechsupport processes: {}'.format(num_of_process))
-
-        if num_of_process >= 1:
-            techsupport_in_progress = True
+        techsupport_in_progress = num_of_process >= 1
 
         is_in_expected_state = False
         if expected_in_progress:
@@ -706,6 +705,34 @@ def is_techsupport_generation_in_expected_state(duthost, expected_in_progress=Tr
                 is_in_expected_state = True
 
         return is_in_expected_state
+
+
+def get_running_techsupport_generation_processes(duthost):
+    """
+    Get coredump handler PIDs. These handlers own auto-techsupport generation.
+    :param duthost: duthost object
+    :return: list of PIDs as strings
+    """
+    cmd = "ps -eo pid=,cmd= | awk '/[c]oredump_gen_handler.py/ {print $1}'"
+    output = duthost.shell(cmd, module_ignore_errors=True)['stdout_lines']
+    return [line.strip() for line in output if line.strip().isdigit()]
+
+
+def clear_techsupport_generation_processes(duthost):
+    """
+    Stop stale coredump handlers so a previous failed run cannot block the next one.
+    :param duthost: duthost object
+    """
+    pids = get_running_techsupport_generation_processes(duthost)
+    if not pids:
+        return
+
+    logger.warning('Stopping stale auto-techsupport generation processes: {}'.format(', '.join(pids)))
+    duthost.shell('sudo kill {}'.format(' '.join(pids)), module_ignore_errors=True)
+    if not wait_until(30, 2, 0, is_techsupport_generation_in_expected_state, duthost, False):
+        pids = get_running_techsupport_generation_processes(duthost)
+        if pids:
+            duthost.shell('sudo kill -9 {}'.format(' '.join(pids)), module_ignore_errors=True)
 
 
 def validate_core_files_inside_techsupport(duthost, techsupport_folder, expected_core_files_list):


### PR DESCRIPTION
### Description of PR

Summary:
Clean stale auto-techsupport generation handlers before running show_techsupport tests.

During 720DT show_techsupport RCA, the tarball timeout was reproduced even after increasing the wait to 900s. The failed run showed that `/var/dump` had an incomplete new `sonic_dump_...tar` and directory that never became `.tar.gz`. The DUT also had stale `coredump_gen_handler.py` processes from previous runs, including processes more than 20 hours old. Those handlers made the test's generation-state checks unreliable and could block later auto-techsupport generation.

This PR is scoped to `show_techsupport/test_auto_techsupport.py`: it uses precise PID detection for `coredump_gen_handler.py` and clears stale handlers in the test fixture before/after the test instead of relying on a grep-line count.

Fixes #

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Prevent stale auto-techsupport handler processes from previous failed/interrupted runs from blocking or confusing subsequent `show_techsupport` tests. This addresses the remaining 720DT failure mode after the simple timeout extension was disproved.

#### How did you do it?

- Replace `ps | grep` line-counting with exact PID extraction using an awk pattern that does not match itself.
- If existing handler processes do not finish within the existing 300s pre-test wait, stop them before continuing.
- Also clear handlers before folder cleanup and during teardown so failed runs do not leave stale processes for the next run.
- Keep the cleanup limited to `coredump_gen_handler.py`, which is the process this test already uses as the auto-techsupport generation signal.

#### How did you verify/test it?

```bash
python3 -m py_compile tests/show_techsupport/test_auto_techsupport.py
```

Manual validation on locked 720DT m0 `testbed-bjw-can-720dt-3`, image `SONiC.20251110.35`, platform `x86_64-arista_720dt_48s`:

- Injected fake stale `coredump_gen_handler.py`-named processes.
- Ran `test_max_limit[techsupport]` with this patch.
- Result: `1 passed` in 1058.51s, and log showed `Stopping stale auto-techsupport generation processes: ...` before the test proceeded.

A 10x pair validation for `test_max_limit[techsupport]` + `test_rate_limit_interval` is running separately on the same locked testbed.

#### Any platform specific information?

Observed Arista-720DT during 202511 nightly RCA, but this cleanup is limited to the show_techsupport test fixture and its own handler process.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
