### PR TITLE
[bgp] Fix test_bgp_router_id router-id read for cSONiC neighbors

### DIFF
--- a/tests/bgp/test_bgp_router_id.py
+++ b/tests/bgp/test_bgp_router_id.py
@@ -20,7 +20,16 @@ CUSTOMIZED_BGP_ROUTER_ID = "8.8.8.8"
 
 
 def verify_bgp_peer(neighbor_type, nbrhost, localip, expected_bgp_router_id, is_v6_topo, vrf="default"):
-    if neighbor_type in ("sonic", "csonic"):
+    if neighbor_type == "csonic":
+        # cSONiC (docker-sonic-vs) neighbors: the `show ip[ v6] bgp neighbors`
+        # click CLI wrapper is not reliably available, so query FRR directly via
+        # vtysh. The vtysh output uses the same
+        # "BGP version 4, remote router ID <x>" line that the regex below expects.
+        if is_v6_topo:
+            cmd = "vtysh -c \"show bgp ipv6 neighbor {}\"".format(localip)
+        else:
+            cmd = "vtysh -c \"show ip bgp neighbor {}\"".format(localip)
+    elif neighbor_type == "sonic":
         if is_v6_topo:
             cmd = "show ipv6 bgp neighbors {}".format(localip)
         else:


### PR DESCRIPTION
### Description of PR

`tests/bgp/test_bgp_router_id.py::verify_bgp_peer` reads each neighbor's BGP remote router ID by running a CLI command and matching the line `BGP version 4, remote router ID <x>`.

For **cSONiC** (docker-sonic-vs) neighbors it previously reused the SONiC click path (`show ip[ v6] bgp neighbors`). On docker-sonic-vs that click CLI wrapper returns empty output, so the regex never matches and the test fails with `Cannot get ... router id`.

This PR routes cSONiC neighbors through `vtysh` directly:
- v4: `vtysh -c "show ip bgp neighbor <ip>"`
- v6: `vtysh -c "show bgp ipv6 neighbor <ip>"`

vtysh emits the same `BGP version 4, remote router ID` line the existing regex expects, so only the command selection changes for cSONiC. `sonic` / `eos` neighbor handling is unchanged.

Fixes #25518

### Type of change
- [x] Bug fix

### Approach
**What is the motivation for this PR?**
Make the bgp_router_id tests pass on a cSONiC (docker-sonic-vs neighbor) testbed; the EOS/click command path returns no output there.

**How did you do it?**
Split the cSONiC case out of the shared `sonic`/`csonic` branch and query FRR via vtysh, which is always available on docker-sonic-vs neighbors and prints the expected router-id line.

**How did you verify/test it?**
Ran the full module on a `vms-kvm-t0-csonic` testbed:
```
4 passed, 269 warnings in 408.72s
```
All four cases (default, set, set_ipv6, set_without_loopback) PASS; tr.xml reports errors=0 failures=0.

### Documentation
N/A