### PR TITLE
[lldp] Skip neighbor LLDP-over-SNMP verification for cSONiC neighbors

### DIFF
--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -140,6 +140,14 @@ def _neighbor_has_lldp_entry(localhost, hostip, snmp_community, neighbor_interfa
 def check_lldp_neighbor(duthost, localhost, eos, sonic, collect_techsupport_all_duts,
                         enum_rand_one_frontend_asic_index, tbinfo, request):
     """ verify LLDP information on neighbors """
+    # cSONiC (docker-sonic-vs) neighbors do not run an SNMP agent (no snmpd /
+    # FEATURE|snmp), and the neighbor advertises an IPv6 mgmt-ip that Ansible's
+    # lldp_facts (pysnmp, IPv4/UDP transport only) cannot query. The neighbor-side
+    # LLDP verification below relies on SNMP, so skip it for cSONiC neighbors. The
+    # DUT-side LLDP coverage (test_lldp / test_lldp_interfaces) still runs.
+    if request.config.getoption("--neighbor_type") == 'csonic':
+        pytest.skip("SNMP not served on docker-sonic-vs (cSONiC) neighbor; "
+                    "neighbor-side LLDP-over-SNMP verification is not applicable")
     asic = enum_rand_one_frontend_asic_index
 
     res = duthost.shell(


### PR DESCRIPTION
### What I did
Skip the neighbor-side LLDP-over-SNMP verification (`check_lldp_neighbor`) when the testbed uses cSONiC (docker-sonic-vs) neighbors, i.e. `--neighbor_type csonic`. This affects two test cases: `test_lldp_neighbor` and `test_lldp_neighbor_post_swss_reboot`.

### Why
On a cSONiC testbed the LLDP neighbor checks cannot work, for two independent reasons (ref: issue sonic-net/sonic-mgmt#25706):

1. **No SNMP agent on the neighbor.** `docker-sonic-vs` (cSONiC) neighbors do not run snmpd / have no `FEATURE|snmp`, so there is nothing to answer the SNMP queries that the neighbor-side verification relies on.
2. **IPv6 mgmt-ip breaks the SNMP transport.** The cSONiC neighbor advertises an IPv6 management IP, but Ansible's `lldp_facts` is built on pysnmp's IPv4/UDP transport only, so it cannot query the neighbor even if SNMP were served.

Both make the SNMP-based neighbor verification not applicable for cSONiC neighbors, so the cleanest fix is to skip those two cases with a clear reason.

### Scope / impact
- The **3 DUT-side LLDP tests still run and pass** on cSONiC: `test_lldp`, `test_lldp_interfaces`, `test_lldp_interfaces_config_reload`.
- Only the **2 SNMP-based neighbor tests are skipped** on cSONiC: `test_lldp_neighbor`, `test_lldp_neighbor_post_swss_reboot`.
- Non-cSONiC testbeds (EOS / SONiC VM neighbors) are unaffected.

### Verification
Verified on a live `vms-kvm-t0-csonic` testbed running `lldp/test_lldp.py`:

```
============ 3 passed, 2 skipped, 204 warnings in 415.64s (0:06:55) ============
SKIPPED [2] lldp/test_lldp.py:149: SNMP not served on docker-sonic-vs (cSONiC) neighbor;
            neighbor-side LLDP-over-SNMP verification is not applicable
```

The two skips are exactly `test_lldp_neighbor` and `test_lldp_neighbor_post_swss_reboot`; the three DUT-side tests passed.

Fixes / relates to sonic-net/sonic-mgmt#25706.
