### PR TITLE
[arp][ip][everflow] Tolerate 'N/A' port counters instead of crashing

### DIFF
--- a/tests/arp/test_unknown_mac.py
+++ b/tests/arp/test_unknown_mac.py
@@ -341,6 +341,12 @@ class TrafficSendVerify(object):
         stats = self._parseCntrs()
         for key, value in list(self.pkt_map.items()):
             intf = value[1]
+            # Counters read as 'N/A' until the counters poller has populated
+            # COUNTERS_DB (e.g. right after `sonic-clear counters`). Treat that
+            # as "not ready yet" so the wait_until wrappers keep polling instead
+            # of crashing with `int('N/A')`.
+            if stats[intf]['RX_DRP'] == 'N/A':
+                return False
             if pretest:
                 self.pre_rx_drops[intf] = int(stats[intf]['RX_DRP'])
             else:
@@ -366,7 +372,11 @@ class TrafficSendVerify(object):
         if asic_type != "vs":
             time.sleep(1)
             logger.info("Collect drop counters before test run")
-            self._verifyIntfCounters(pretest=True)
+            # Counters can read 'N/A' right after `sonic-clear counters` until the
+            # poller repopulates COUNTERS_DB; wait for them to be ready and fail
+            # loudly if they never are (rather than crashing on `int('N/A')`).
+            pytest_assert(wait_until(10, 2, 0, self._verifyIntfCounters, True),
+                          "Drop counters not ready (still 'N/A') before test run")
             for pkt, exp_pkt in zip(self.pkts, self.exp_pkts):
                 self.ptfadapter.dataplane.flush()
                 out_intf = self.pkt_map[str(pkt)][0]

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -384,6 +384,14 @@ def assert_no_tx_drops_on_mirror_port(duthost, mirror_port):
         duthost: DUT fixture
         mirror_port: The mirror port to check for tx drops
     """
+    def _mirror_port_counter_ready():
+        portstat = json.loads(duthost.get_port_counters(in_json=True))
+        # Counters read as 'N/A' until the poller has populated COUNTERS_DB;
+        # wait for the mirror port to appear with a numeric TX_DRP.
+        return mirror_port in portstat and portstat[mirror_port]["TX_DRP"].replace(',', '') != 'N/A'
+
+    pytest_assert(wait_until(30, 5, 0, _mirror_port_counter_ready),
+                  "TX_DRP counter on mirror port {} not ready (still 'N/A')".format(mirror_port))
     portstat = json.loads(duthost.get_port_counters(in_json=True))
     pytest_assert(mirror_port in portstat, "Mirror port {} not found in port counters".format(mirror_port))
     tx_drops = int(portstat[mirror_port]["TX_DRP"].replace(',', ''))

--- a/tests/ip/test_ip_packet.py
+++ b/tests/ip/test_ip_packet.py
@@ -40,7 +40,12 @@ class TestIPPacket(object):
     def check_rx_ok(duthost, ingress_iface, pkt_num_min):
         """Check if the ingress port has received enough packets."""
         portstat_out = parse_portstat(duthost.command("portstat")["stdout_lines"])
-        rx_ok = int(portstat_out[ingress_iface]["rx_ok"].replace(",", ""))
+        rx_ok_raw = portstat_out[ingress_iface]["rx_ok"].replace(",", "")
+        # Counters read as 'N/A' until the poller has populated COUNTERS_DB;
+        # treat that as "not ready yet" so the wait_until caller keeps polling.
+        if rx_ok_raw == "N/A":
+            return False
+        rx_ok = int(rx_ok_raw)
         return rx_ok >= pkt_num_min
 
     @staticmethod


### PR DESCRIPTION
### Description of PR

Summary:
Fixes counter-based tests crashing with `ValueError: invalid literal for int() with base 10: 'N/A'`.

`portstat` / `show interfaces counters` report `N/A` until the counters poller has populated
COUNTERS_DB — e.g. for a short window right after `sonic-clear counters` / `portstat -c`. Several
tests call `int(<counter>)` directly on that value and abort the whole test (and, for class-scoped
setups, every case under them). Observed across many modules on a Broadcom 7260CX3 dualtor-120
nightly (arp/test_unknown_mac, ip/test_ip_packet, everflow/test_everflow_testbed, ...).

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

### Approach
#### What is the motivation for this PR?

* Microsoft ADO (number only): 38502283

Make counter reads robust to a transient `N/A` so tests do not crash with an opaque `int('N/A')`
ValueError when counters are momentarily unavailable.

Assisted-by: Stuart 🍌 (Hermes Agent, model claude-opus-4.8)
Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Wait for a numeric counter value instead of crashing on `N/A`, mirroring the existing convention in
`tests/common/helpers/drop_counters/drop_counters.py`:
- `arp/test_unknown_mac.py`: `_verifyIntfCounters` returns False (not ready) when RX_DRP is `N/A`
  so the existing `wait_until` wrappers keep polling, and the pretest collection is wrapped in
  `wait_until`.
- `ip/test_ip_packet.py`: `check_rx_ok` returns False on `N/A` so its existing `wait_until(30, ...)`
  keeps polling.
- `everflow/everflow_test_utilities.py`: `assert_no_tx_drops_on_mirror_port` waits for the mirror
  port's TX_DRP to become numeric before asserting.

This only hardens against a **transient** `N/A`. If a counter never becomes ready the test still
fails (assertion / `wait_until` timeout), so a genuine counters-infra regression is **not masked**.

#### How did you verify/test it?
- `flake8 --max-line-length=120` clean on all changed files; AST/syntax check passes.
- Logic preserves existing behavior once counters are numeric; only adds a not-ready/poll path.
- A hardware run on a testbed exhibiting the transient `N/A` is still pending.

#### Any platform specific information?
None — platform-agnostic counter handling.
