### PR TITLE
[test_nbr_health] Recognize CsonicHost neighbors in health check

### DIFF
--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -5,6 +5,7 @@ import logging
 from .common.helpers.assertions import pytest_assert
 from .common.devices.eos import EosHost
 from .common.devices.sonic import SonicHost
+from .common.devices.csonic import CsonicHost
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +95,20 @@ def check_sonic_bgp_facts(hostname, host):
         return "neighbor {} bgp not configured correctly".format(hostname)
 
 
+def check_csonic_health(hostname, host):
+    """Health check for a cSONiC (docker-sonic-vs) neighbor container.
+
+    A cSONiC neighbor is reached via 'docker exec' rather than SSH/SNMP, so it
+    has no SNMP mgmt-address path. Verify the container is reachable and that
+    BGP is configured/up via vtysh, mirroring the SONiC BGP health check.
+    """
+    logger.info("Check cSONiC neighbor {} health".format(hostname))
+    reach = host.command('true')
+    if reach.get('rc', 1) != 0:
+        return "cSONiC neighbor {} container is not reachable".format(hostname)
+    return check_sonic_bgp_facts(hostname, host)
+
+
 def test_neighbors_health(duthosts, localhost, nbrhosts, eos, sonic, enum_frontend_dut_hostname):
     """Check each neighbor device health"""
 
@@ -129,6 +144,14 @@ def test_neighbors_health(duthosts, localhost, nbrhosts, eos, sonic, enum_fronte
                 fails.append(failmsg)
 
             failmsg = check_eos_bgp_facts(k, nbrhost)
+            if failmsg:
+                fails.append(failmsg)
+
+        elif isinstance(nbrhost, CsonicHost):
+            # cSONiC neighbors are docker-sonic-vs containers accessed via
+            # 'docker exec' (no SSH/SNMP mgmt path). Check container reachability
+            # and BGP health rather than SNMP/mgmt facts.
+            failmsg = check_csonic_health(k, nbrhost)
             if failmsg:
                 fails.append(failmsg)
 


### PR DESCRIPTION
#### Why I did it

`tests/test_nbr_health.py::test_neighbors_health` dispatches neighbor health checks only on `EosHost` and `SonicHost`:

```python
if isinstance(nbrhost, EosHost):
    ...
elif isinstance(nbrhost, SonicHost):
    ...
else:
    failmsg = "neighbor type {} is unknown".format(k)
    fails.append(failmsg)
```

A cSONiC (`docker-sonic-vs`) neighbor is a `CsonicHost`, which extends `NeighborDevice` and is **not** a `SonicHost` subclass. So on a `vms-kvm-t0-csonic` testbed every cSONiC neighbor falls through to the `else` branch and the test fails with "neighbor type ... is unknown", even when the neighbor is perfectly healthy.

Fixes #25523.

#### How I did it

Added a `CsonicHost` branch before the `SonicHost` branch. cSONiC neighbors are reached via `docker exec` (no SSH/SNMP mgmt path), so the new `check_csonic_health()`:
- verifies the container is reachable through the `CsonicHost` shell interface, and
- reuses `check_sonic_bgp_facts()` to confirm BGP is up via `vtysh -c "show ip bgp sum"`.

The SNMP and mgmt-facts checks used for EOS/SONiC are intentionally not run for cSONiC, because those neighbors have no SNMP/mgmt-IP surface.

#### How to verify it

Run on a `vms-kvm-t0-csonic` testbed:
```
pytest tests/test_nbr_health.py::test_neighbors_health
```

Manual verification of the health logic against a live testbed (4 cSONiC neighbors) — each returns healthy where it previously reported "unknown":
```
csonic_vms6-1_VM0100: HEALTHY
csonic_vms6-1_VM0101: HEALTHY
csonic_vms6-1_VM0102: HEALTHY
csonic_vms6-1_VM0103: HEALTHY
```

#### Description for the changelog

Recognize cSONiC (`docker-sonic-vs`) neighbors in `test_neighbors_health` by adding a `CsonicHost` branch that checks container reachability and BGP health, instead of reporting them as an unknown neighbor type.
