### PR TITLE
[test_vlan_ping] Use correct PortChannel netdev name for SONiC/cSONiC neighbors

### DIFF
--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -7,6 +7,7 @@ import ptf.packet as scapy
 from ptf.mask import Mask
 import six
 from tests.common.helpers.assertions import pytest_assert as py_assert
+from tests.common.devices.eos import EosHost
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m   # noqa: F401
 from tests.common.dualtor.dual_tor_utils import lower_tor_host   # noqa: F401
 from tests.vlan.test_vlan import populate_mac_table   # noqa: F401
@@ -47,6 +48,19 @@ def static_neighbor_entry(duthost, dic, oper, ip_version="both"):
             logger.debug("unknown IP version")
 
 
+def _portchannel_netdev_name(nbr_host, index):
+    """Return the neighbor's PortChannel kernel netdev name for a given index.
+
+    EOS names the LAG netdev ``po<N>`` (e.g. ``po1``); SONiC/cSONiC teamd names
+    it ``PortChannel<N>`` (e.g. ``PortChannel1``). The topology config interface
+    is always ``Port-Channel<N>``; this maps it to the right netdev so commands
+    like ``ip addr show dev <name>`` work on the neighbor regardless of type.
+    """
+    if isinstance(nbr_host, EosHost):
+        return 'po{}'.format(index)
+    return 'PortChannel{}'.format(index)
+
+
 @pytest.fixture(scope='module')
 def vlan_ping_setup(duthosts, rand_one_dut_hostname, ptfhost, nbrhosts, tbinfo, lower_tor_host):   # noqa: F811
     """
@@ -72,14 +86,14 @@ def vlan_ping_setup(duthosts, rand_one_dut_hostname, ptfhost, nbrhosts, tbinfo, 
     else:
         if 'Port-Channel1' in vm_info['conf']['interfaces']:
             interface_name = 'Port-Channel1'
-            dev_name = 'po1'
+            dev_name = _portchannel_netdev_name(vm_info['host'], 1)
         else:
             interface_name = 'Ethernet1'
             dev_name = 'eth1'
         # in case of lower tor host we need to use the next portchannel
         if "dualtor-aa" in tbinfo["topo"]["name"] and rand_one_dut_hostname == lower_tor_host.hostname:
             interface_name = 'Port-Channel2'
-            dev_name = 'po2'
+            dev_name = _portchannel_netdev_name(vm_info['host'], 2)
 
     # Get IPv4 and IPv6 addresses if available
     vm_interface = vm_info['conf']['interfaces'][interface_name]


### PR DESCRIPTION
#### Why I did it

`tests/vlan/test_vlan_ping.py::vlan_ping_setup` resolves the neighbor PortChannel to the EOS netdev name and queries it:

```python
interface_name = 'Port-Channel1'
dev_name = 'po1'
...
output = vm_info['host'].command("ip addr show dev {}".format(dev_name))
vm_host_info["mac"] = output['stdout_lines'][1].split()[1]
```

On a `vms-kvm-t0-csonic` testbed the neighbor is a `CsonicHost` (docker-sonic-vs). SONiC teamd names the LAG netdev `PortChannel1`, not `po1`, so `ip addr show dev po1` returns nothing and `output['stdout_lines'][1]` raises:

```
IndexError: list index out of range
```

Fixes #25524.

#### How I did it

Added a small helper that maps the topology config interface `Port-Channel<N>` to the correct kernel netdev name per neighbor type:
- EOS: `po<N>`
- SONiC/cSONiC: `PortChannel<N>`

and used it for both the `Port-Channel1` and dualtor-aa `Port-Channel2` cases. EOS behavior is unchanged.

#### How to verify it

Run on a `vms-kvm-t0-csonic` testbed:
```
pytest tests/vlan/test_vlan_ping.py
```

Manual verification against a live cSONiC neighbor:
```
# new path
ip addr show dev PortChannel1   -> 8 lines, MAC da:8e:8b:d9:66:53 extracted (no IndexError)
# old path
ip addr show dev po1            -> "Device po1 does not exist" -> 0 lines -> IndexError on [1]
```

#### Description for the changelog

Fix `test_vlan_ping` setup on SONiC/cSONiC neighbors by deriving the PortChannel kernel netdev name per neighbor type (`PortChannel<N>` vs EOS `po<N>`), preventing an IndexError when the EOS-style `po1` device does not exist.
