### PR TITLE
[iface_namingmode] Increase LLDP repopulation timeout for SONiC/cSONiC neighbors

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -18,7 +18,13 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 PORT_TOGGLE_TIMEOUT = 30
-ESTABLISH_LLDP_NEIGHBOR_TIMEOUT = 90
+# Allow enough time for the neighbor's lldpd to re-advertise after a port toggle.
+# SONiC/cSONiC (docker-sonic-vs) neighbors run lldpd with a 30s transmit delay and
+# a transmit hold of 4 (120s TTL), so re-population after a port flap can take well
+# over 90s (slower than EOS). 180s covers the worst-case stale-TTL expiry plus a
+# couple of transmit cycles. This is a wait_until ceiling, so fast neighbors (EOS)
+# are unaffected.
+ESTABLISH_LLDP_NEIGHBOR_TIMEOUT = 180
 
 QUEUE_COUNTERS_RE_FMT = r'{}\s+[U|M]C|ALL\d\s+\S+\s+\S+\s+\S+\s+\S+'
 


### PR DESCRIPTION
#### Why I did it

`tests/iface_namingmode/test_iface_namingmode.py::test_config_interface_state` toggles a DUT port and then waits for the neighbor's LLDP entry to be repopulated:

```python
ESTABLISH_LLDP_NEIGHBOR_TIMEOUT = 90
...
pytest_assert(wait_until(ESTABLISH_LLDP_NEIGHBOR_TIMEOUT, 2, 0, _lldp_exists, True),
              "LLDP neighbor should exist for interface {}".format(test_intf))
```

On a `vms-kvm-t0-csonic` testbed the neighbor is a `CsonicHost` (docker-sonic-vs). Its lldpd is configured with a **30s transmit delay** and **transmit hold 4** (120s TTL):

```
Transmit delay: 30
Transmit hold: 4
```

After a port flap the worst-case re-advertisement (next tx cycle plus expiry of the stale entry) can exceed the hard-coded 90s — slower than EOS — so `test_config_interface_state[default]` / `[alias]` can fail even though LLDP eventually recovers.

Fixes #25520.

#### How I did it

Raised `ESTABLISH_LLDP_NEIGHBOR_TIMEOUT` from 90 to 180. The check is already a `wait_until` poll, so this only raises the ceiling: fast neighbors (EOS) return as soon as LLDP reappears and are unaffected; only the slow cSONiC worst case gets the extra headroom. 180s comfortably covers the documented 30s tx-delay + 120s TTL worst case.

#### How to verify it

Run on a `vms-kvm-t0-csonic` testbed:
```
pytest tests/iface_namingmode/test_iface_namingmode.py -k test_config_interface_state
```

Manual verification on a live testbed: toggled a DUT port (`config interface shutdown/startup Ethernet112`) and timed LLDP repopulation for the cSONiC neighbor. In a fast run it returned in ~27s; the lldpd config (`Transmit delay: 30`, `Transmit hold: 4` → 120s TTL) shows the worst case can approach/exceed 90s, which the new 180s ceiling absorbs without slowing the fast path.

#### Description for the changelog

Increase the LLDP-repopulation timeout in `test_config_interface_state` from 90s to 180s so SONiC/cSONiC neighbors (30s lldpd tx-delay, 120s TTL) have enough time to re-advertise after a port toggle; the change is a `wait_until` ceiling and does not slow down faster neighbors.
