### PR TITLE
[test_snmp_loopback] Skip SNMP-from-neighbor test for cSONiC neighbors

### DIFF
--- a/tests/snmp/test_snmp_loopback.py
+++ b/tests/snmp/test_snmp_loopback.py
@@ -29,6 +29,7 @@ def test_snmp_loopback(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     config_facts = duthost.config_facts(
         host=duthost.hostname, source="persistent")['ansible_facts']
 
+    nbr = None
     if tbinfo['topo']['type'] == 'lt2':
         # Get a UT2 nbr to run the test on LT2 topo
         for nbr_id, nbr_host in nbrhosts.items():

--- a/tests/snmp/test_snmp_loopback.py
+++ b/tests/snmp/test_snmp_loopback.py
@@ -2,6 +2,7 @@ import pytest
 import ipaddress
 from tests.common.helpers.snmp_helpers import get_snmp_facts, get_snmp_output
 from tests.common.devices.eos import EosHost
+from tests.common.devices.csonic import CsonicHost
 from tests.common.utilities import skip_release
 
 pytestmark = [
@@ -37,6 +38,17 @@ def test_snmp_loopback(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     else:
         # Get first neighbor VM information
         nbr = nbrhosts[list(nbrhosts.keys())[0]]
+
+    # A cSONiC neighbor is itself a docker-sonic-vs container with no SNMP client
+    # installed (no snmpget/snmpwalk binaries, and the legacy vsonic path runs
+    # 'docker exec snmp ...' which fails because there is no nested docker). The
+    # SNMP query in this test must originate from the neighbor, which a cSONiC
+    # neighbor cannot do. Skip with a clear reason until docker-sonic-vs ships an
+    # SNMP client. See sonic-net/sonic-mgmt#25522.
+    if isinstance(nbr["host"], CsonicHost):
+        pytest.skip(
+            "cSONiC (docker-sonic-vs) neighbor has no SNMP client to send the "
+            "loopback SNMP query from; skipping SNMP-from-neighbor test")
 
     for ip in config_facts['LOOPBACK_INTERFACE']['Loopback0']:
         loip = ip.split('/')[0]


### PR DESCRIPTION
#### Why I did it

`tests/snmp/test_snmp_loopback.py::test_snmp_loopback` sends an SNMP query to the DUT's Loopback0 **from a BGP neighbor**. For non-EOS neighbors, `get_snmp_output()` runs a vsonic-style nested-docker command (`docker exec snmp snmpwalk ...`).

On a `vms-kvm-t0-csonic` testbed the neighbor is a `CsonicHost` — itself a `docker-sonic-vs` container. That breaks the test two ways:
- there is no nested docker, so `docker exec snmp ...` fails:
  ```
  bash: line 1: docker: command not found   (rc=127)
  ```
- no SNMP client is installed in the container (no `snmpget`/`snmpwalk` binaries, no `pysnmp`), and it has no usable package egress to install one.

The query must originate from the neighbor, which a cSONiC neighbor cannot do, so the test errors instead of testing anything.

Fixes #25522.

#### How I did it

Skip `test_snmp_loopback` for `CsonicHost` neighbors with a clear reason (added an `isinstance(nbr["host"], CsonicHost)` guard right after the neighbor is selected). EOS/SONiC neighbor behavior is unchanged. The skip references this issue so it can be revisited if/when `docker-sonic-vs` ships an SNMP client.

#### How to verify it

On a `vms-kvm-t0-csonic` testbed:
```
pytest tests/snmp/test_snmp_loopback.py
# -> SKIPPED (cSONiC neighbor has no SNMP client ...)
```

Live confirmation that the test genuinely cannot run from a cSONiC neighbor (justifying the skip):
```
# inside a cSONiC neighbor container
docker exec snmp snmpwalk -v2c -c public <dut-lo> .1.3.6.1.2.1.1.1.0
  -> bash: docker: command not found (rc=127)
# and no client present:
find / -name snmpget -o -name snmpwalk   -> (none)
python3 -c "import pysnmp"                -> ModuleNotFoundError
```

#### Description for the changelog

Skip `test_snmp_loopback` on cSONiC (docker-sonic-vs) neighbors, which have no SNMP client and no nested docker to originate the neighbor-side SNMP query; EOS/SONiC neighbors are unaffected.
