### PR TITLE
Wait for FDB ping-pong LRU counter target

### DIFF
--- a/tests/fdb/test_fdb_churn.py
+++ b/tests/fdb/test_fdb_churn.py
@@ -509,7 +509,7 @@ def test_fdb_mac_ping_pong(
 
     after = wait_for_stat_increase(
         duthost, FDBORCH_STATS_KEY, "lru_pushed",
-        before["lru_pushed"], timeout=STATS_PUBLISH_SEC + 60,
+        before["lru_pushed"] + cycles - 1, timeout=STATS_PUBLISH_SEC + 60,
     )
     pushed = after["lru_pushed"] - before["lru_pushed"]
     hits = after["lru_dedup_hits"] - before["lru_dedup_hits"]


### PR DESCRIPTION
### Description of PR
Fixes `tests/fdb/test_fdb_churn.py::test_fdb_mac_ping_pong` so it waits for the published `lru_pushed` counter to reach the test target before asserting.

The notification consumer stats are published on a timer. The existing code returned as soon as `lru_pushed` increased by any amount, so the test could read a partial publication such as 3 pushes and fail before the 50-cycle ping-pong count was visible.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): 
Failure type: regression

### Tested branch
<!-- Select each branch where the change was tested. -->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result
N/A - validated by code inspection / log analysis; see Approach > "How did you verify/test it?".

### Approach
#### What is the motivation for this PR?
Nightly runs failed with `Expected at least 50 LRU pushes; got pushed=3, hits=0` even though the test had only waited for any `lru_pushed` increase after the ping-pong traffic.

#### How did you do it?
Use the existing `wait_for_stat_increase` helper with a baseline of `before["lru_pushed"] + cycles - 1`, matching the later assertion requirement of at least `cycles` pushes.

#### How did you verify/test it?
Ran `python -m py_compile tests\fdb\test_fdb_churn.py`.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
