### PR TITLE
[dut_utils] fall back to get_vars when ansible-core _hostvars is None

### DIFF
--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -598,8 +598,16 @@ def create_duthost_console(duthost, localhost, conn_graph_facts, creds):  # noqa
         console_menu_type = console_type
 
     # console password and sonic_password are lists, which may contain more than one password
-    sonicadmin_alt_password = localhost.host.options['variable_manager']._hostvars[dut_hostname].get(
-        "ansible_altpassword")
+    # ansible-core >= 2.21: variable_manager._hostvars is None outside of a play run (it stays
+    # None in the pytest-ansible adhoc context). Fall back to the public get_vars() API, which
+    # resolves inventory + group + host vars for the target host.
+    _vm = localhost.host.options['variable_manager']
+    if _vm._hostvars is not None:
+        _host_vars = _vm._hostvars[dut_hostname]
+    else:
+        _host_obj = localhost.host.options['inventory_manager'].get_host(dut_hostname)
+        _host_vars = _vm.get_vars(host=_host_obj) if _host_obj is not None else {}
+    sonicadmin_alt_password = _host_vars.get("ansible_altpassword")
     sonic_password = [creds['sonicadmin_password'], sonicadmin_alt_password]
 
     if console_type in creds["console_password"]:
@@ -676,7 +684,15 @@ def creds_on_dut(duthost):
         "docker_registry_password",
         "public_docker_registry_host"
     ]
-    hostvars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]
+    # ansible-core >= 2.21: variable_manager._hostvars is None outside of a play run (it stays
+    # None in the pytest-ansible adhoc context). Fall back to the public get_vars() API, which
+    # resolves inventory + group + host vars for the target host.
+    _vm = duthost.host.options['variable_manager']
+    if _vm._hostvars is not None:
+        hostvars = _vm._hostvars[duthost.hostname]
+    else:
+        _host_obj = duthost.host.options['inventory_manager'].get_host(duthost.hostname)
+        hostvars = _vm.get_vars(host=_host_obj) if _host_obj is not None else {}
     for cred_var in cred_vars:
         if cred_var in creds:
             creds[cred_var] = jinja2.Template(creds[cred_var]).render(**hostvars)  # nosemgrep: direct-use-of-jinja2


### PR DESCRIPTION
### Description of PR

Summary:
Fix two ansible-core >= 2.21 compatibility issues causing test setup failures in the new sonic-mgmt docker (build 1145279).

Fixes issues introduced by ansible-core version bump in the docker image.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [x] 202605

### Approach

#### What is the motivation for this PR?

Two separate failures observed after the ansible-core version bump in the latest sonic-mgmt docker:

**Issue 1 — `conftest.py` (tests: telemetry, ip_packet, mgmt_ipv6)**

`dut.shell("free -h")` and `dut.shell("df -h")` in the `core_dump_and_config_check` fixture fail with:
`Task failed: [Errno 9] Bad file descriptor`
with warning: `Unhandled error in Python interpreter discovery: [Errno 32] Broken pipe`

These are **diagnostic-only** logging calls (not assertions). In ansible-core >= 2.21, Python interpreter discovery uses subprocess pipes that can produce broken-pipe errors in non-main thread contexts. The failure aborts test setup unnecessarily.

**Issue 2 — `dut_utils.py` (test: macsec)**

`variable_manager._hostvars[hostname]` raises:
`TypeError: 'NoneType' object is not subscriptable`

In ansible-core >= 2.21, the private attribute `_hostvars` on `VariableManager` is no longer pre-populated (returns `None`). The code relied on this internal attribute at two locations in `dut_utils.py`.

#### How did you do it?

**Issue 1:** Add `module_ignore_errors=True` to the four diagnostic `dut.shell("free -h")` / `dut.shell("df -h")` calls (before-test and after-test). These calls only log system stats and should never block test execution.

**Issue 2:** Add a fallback for `_hostvars is None`: use `inventory_manager.get_host(hostname).get_vars()` to retrieve host variables via the public inventory API. Applied at both usages in `create_duthost_console` (line ~601) and `creds_on_dut` (line ~679).

Also adds `# noqa` suppression comments for 5 pre-existing flake8 6.0.0 false positives in `conftest.py` (E713/E702/E231 inside f-string literals).

#### How did you verify/test it?

- Pre-commit checks pass locally (trim whitespace, check python ast, flake8 — all Passed)
- Root causes confirmed via log analysis of ADO build [1145279](https://dev.azure.com/mssonic/build/_build/results?buildId=1145279)
- Both fixes are backward-compatible: they have no effect when ansible-core provides `_hostvars` or when `free -h` succeeds

#### Any platform specific information?

N/A — framework-level fix.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A