### PR TITLE
fix: skip SRv6 static config on unsupported devices

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5356,12 +5356,12 @@ srv6/test_srv6_dataplane.py::TestSRv6DataPlaneBase::test_srv6_full_func:
 
 srv6/test_srv6_static_config.py:
   skip:
-    reason: "Only target mellanox SPC4+ platform with 202412 or 202511+ image. Requires particular image support (202412 or 202511+). SRv6 is not supported on older ASICs (Broadcom TH/TH2/TD3; Mellanox SPC1-3). Skip for non Arista-7060X6-64PE-B-* TH5 SKUs. Skip for t0-isolated-d96u32, t1-isolated-d32/128"
+    reason: "Only target Mellanox SPC4+, VPP, and SRv6-capable Broadcom platforms with 202412 or 202511+ image. Requires particular image support (202412 or 202511+). SRv6 is not supported on older ASICs (Broadcom TH/TH2/TD3; Mellanox SPC1-3). Skip for non Arista-7060X6-64PE-B-* TH5 SKUs. Skip for t0-isolated-d96u32, t1-isolated-d32/128"
     conditions_logical_operator: or
     conditions:
-      - "(release != 'master' and release != '202412' and release < '202511') and asic_type not in ['vpp']"
+      - "asic_type not in ['mellanox', 'broadcom', 'vpp'] or (release != 'master' and release != '202412' and release < '202511')"
       - "asic_type == 'mellanox' and asic_gen in ['spc1', 'spc2', 'spc3']"
-      - "'Arista-7060X6-64PE' in hwsku and 'Arista-7060X6-64PE-B' not in hwsku"
+      - "asic_type == 'broadcom' and 'Arista-7060X6-64PE-B' not in hwsku"
       - "topo_name in ['t0-isolated-d96u32s2', 't1-isolated-d128', 't1-isolated-d32']"
       - "asic_type == 'broadcom' and asic_gen not in ['th5', 'th6', 'q3d']"
 


### PR DESCRIPTION
### Description of PR

Summary:
Update the conditional mark for `srv6/test_srv6_static_config.py` so the test is skipped on devices that do not support SRv6. This aligns the static-config test with the existing SRv6 dataplane support matrix and prevents it from running on old/unsupported ASICs.

Fixes # (issue)
N/A

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

`test_srv6_static_config.py` should not run on old or unsupported devices that do not support SRv6. The existing skip rule already excludes old Mellanox/Broadcom ASIC generations, but it did not skip unsupported non-Mellanox/non-Broadcom ASIC types and was less strict for Broadcom TH5 SKUs than adjacent SRv6 tests.

#### How did you do it?

Updated `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` for `srv6/test_srv6_static_config.py` to:

- skip ASIC types outside the supported SRv6 static-config matrix (`mellanox`, `broadcom`, `vpp`)
- keep the image release gate for 202412 / 202511+ / master
- skip old Mellanox generations (`spc1`, `spc2`, `spc3`)
- skip Broadcom devices except SRv6-capable `Arista-7060X6-64PE-B` SKUs
- preserve existing unsupported topology skips

#### How did you verify/test it?

- Parsed `tests_mark_conditions.yaml` with PyYAML successfully.
- Evaluated representative conditional-mark contexts:
  - unsupported Cisco master: skipped
  - old Broadcom TD3 master: skipped
  - supported Broadcom TH5 Arista-7060X6-64PE-B: not skipped
  - supported Mellanox SPC4: not skipped
  - old Mellanox SPC3: skipped
- Ran `git diff --check` successfully.

Note: the conditional-mark unit test imports `fcntl` through the common test package and cannot run in my native Windows environment.

#### Any platform specific information?

Affects SRv6 static-config test selection. Unsupported old devices are skipped; supported Mellanox SPC4+, VPP, and SRv6-capable Broadcom platforms remain eligible.

#### Supported testbed topology if it's a new test case?

N/A - no new test case.

### Documentation

N/A