### PR TITLE
test: xfail BGP prefix GCU across 202605 platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2576,6 +2576,10 @@ generic_config_updater/test_bgp_prefix.py::test_bgp_prefix_tc1_suite:
       - "platform in ['x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/18445"
       - "'isolated' in topo_name"
+  xfail:
+    reason: "Cisco-8102-C64 fails BGP allowed-prefix GCU validation, tracked by https://github.com/sonic-net/sonic-mgmt/issues/25549"
+    conditions:
+      - "hwsku in ['Cisco-8102-C64'] and https://github.com/sonic-net/sonic-mgmt/issues/25549"
 
 generic_config_updater/test_bgp_speaker.py::test_bgp_speaker_tc1_test_config:
   xfail:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2577,9 +2577,9 @@ generic_config_updater/test_bgp_prefix.py::test_bgp_prefix_tc1_suite:
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/18445"
       - "'isolated' in topo_name"
   xfail:
-    reason: "Cisco-8102-C64 fails BGP allowed-prefix GCU validation, tracked by https://github.com/sonic-net/sonic-mgmt/issues/25549"
+    reason: "BGP allowed-prefix GCU validation fails across platforms, tracked by https://github.com/sonic-net/sonic-mgmt/issues/25549"
     conditions:
-      - "hwsku in ['Cisco-8102-C64'] and https://github.com/sonic-net/sonic-mgmt/issues/25549"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/25549"
 
 generic_config_updater/test_bgp_speaker.py::test_bgp_speaker_tc1_test_config:
   xfail:


### PR DESCRIPTION
### Description of PR

Summary:
Add a conditional xfail for `generic_config_updater/test_bgp_prefix.py::test_bgp_prefix_tc1_suite` while the known 202605 BGP allowed-prefix GCU failure is tracked. Kusto data shows the case fails across multiple platforms/HWSKUs.

Related issue: #25549

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202605
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Kusto query over the last 30 days shows `generic_config_updater.test_bgp_prefix.test_bgp_prefix_tc1_suite` failing on 202605 across multiple platforms/topologies
The failures include both parametrizations:

```text
generic_config_updater.test_bgp_prefix.test_bgp_prefix_tc1_suite[None-empty]
generic_config_updater.test_bgp_prefix.test_bgp_prefix_tc1_suite[None-1010:1010]
```

The issue is tracked in #25549.

#### How did you do it?

Added a conditional xfail in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` for the whole `test_bgp_prefix_tc1_suite`, tied to #25549 so the mark remains active while the issue is open.

#### How did you verify/test it?

- Updated GitHub issue #25549 with the broader all-platform scope.
- Parsed `tests_mark_conditions.yaml` with PyYAML successfully.
- Verified the issue-gated condition is converted to `True` while the issue is open.
- Ran `git diff --check` successfully.

Note: full conditional-mark unittest cannot run in this native Windows environment because the test package imports `fcntl`.

#### Any platform specific information?


#### Supported testbed topology if it's a new test case?

N/A - no new test case.

### Documentation

N/A