### PR TITLE
fix(snappi): OTG/TestCenter backend compatibility fixes for snappi tests

### DIFF
--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -1596,6 +1596,11 @@ def tgen_curr_stats(traf_metrics, flow_metrics, data_flow_names):
         stats[metric_name+'_avg_latency_ns'] = metric.latency.average_ns
         stats[metric_name+'_max_latency_ns'] = metric.latency.maximum_ns
         stats[metric_name+'_min_latency_ns'] = metric.latency.minimum_ns
+        # Populate rate stats for STC/OTG backends where traf_metrics is empty.
+        # traf_metrics (IXIA-only) already sets _rxrate_Gbps; don't override it.
+        if metric_name+'_rxrate_Gbps' not in stats:
+            stats[metric_name+'_rxrate_Gbps'] = round(metric.rx_l1_rate_bps / 1e9, 2)
+            stats[metric_name+'_txrate_Gbps'] = round(metric.tx_l1_rate_bps / 1e9, 2)
     return stats
 
 

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -1099,6 +1099,7 @@ def run_basic_traffic(
         request = api.capture_request()
         request.port_name = snappi_extra_params.packet_capture_ports[0]
         cs = api.control_state()
+        cs.port.capture.port_names = snappi_extra_params.packet_capture_ports
         cs.port.capture.state = cs.port.capture.STOP
         api.set_control_state(cs)
         logger.info(
@@ -1667,11 +1668,10 @@ def run_traffic_and_collect_stats(rx_duthost,
         cs.port.capture.state = cs.port.capture.START
         api.set_control_state(cs)
 
-    # Returns the rest API object for features not present in Snappi
-    ixnet_rest_api = api._ixnetwork
-
     # If imix flag is set, IMIX packet-profile is enabled.
     if (imix):
+        # Returns the rest API object for features not present in Snappi (IxNetwork only)
+        ixnet_rest_api = api._ixnetwork
         logger.info('Test packet-profile setting to IMIX')
         for traff_item in ixnet_rest_api.Traffic.TrafficItem.find():
             config_ele = traff_item.ConfigElement.find()[0].FrameSize
@@ -1726,7 +1726,7 @@ def run_traffic_and_collect_stats(rx_duthost,
         logger.info('----------- Collecting Stats for Iteration : {} ------------'.format(m+1))
         f_stats[m] = {'Date': datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}
         flow_metrics = fetch_snappi_flow_metrics(api, data_flow_names)
-        traf_metrics = StatViewAssistant(ixnet_rest_api, 'Traffic Item Statistics').Rows
+        traf_metrics = StatViewAssistant(ixnet_rest_api, 'Traffic Item Statistics').Rows if imix else []
         tx_frame = sum([metric.frames_tx for metric in flow_metrics if metric.name in data_flow_names])
         f_stats[m]['tgen_tx_frames'] = tx_frame
         rx_frame = sum([metric.frames_rx for metric in flow_metrics if metric.name in data_flow_names])
@@ -1791,6 +1791,7 @@ def run_traffic_and_collect_stats(rx_duthost,
         request = api.capture_request()
         request.port_name = snappi_extra_params.packet_capture_ports[0]
         cs = api.control_state()
+        cs.port.capture.port_names = snappi_extra_params.packet_capture_ports
         cs.port.capture.state = cs.port.capture.STOP
         api.set_control_state(cs)
         logger.info("Retrieving and saving packet capture to {}.pcapng".format(snappi_extra_params.packet_capture_file))
@@ -1822,7 +1823,7 @@ def run_traffic_and_collect_stats(rx_duthost,
     m = iter_count
     f_stats[m] = {'Date': datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}
     flow_metrics = fetch_snappi_flow_metrics(api, data_flow_names)
-    traf_metrics = StatViewAssistant(ixnet_rest_api, 'Traffic Item Statistics').Rows
+    traf_metrics = StatViewAssistant(ixnet_rest_api, 'Traffic Item Statistics').Rows if imix else []
     tx_frame = sum([metric.frames_tx for metric in flow_metrics if metric.name in data_flow_names])
     rx_frame = sum([metric.frames_rx for metric in flow_metrics if metric.name in data_flow_names])
     f_stats[m]['tgen_tx_frames'] = tx_frame

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -1099,7 +1099,6 @@ def run_basic_traffic(
         request = api.capture_request()
         request.port_name = snappi_extra_params.packet_capture_ports[0]
         cs = api.control_state()
-        cs.port.capture.port_names = snappi_extra_params.packet_capture_ports
         cs.port.capture.state = cs.port.capture.STOP
         api.set_control_state(cs)
         logger.info(
@@ -1796,7 +1795,6 @@ def run_traffic_and_collect_stats(rx_duthost,
         request = api.capture_request()
         request.port_name = snappi_extra_params.packet_capture_ports[0]
         cs = api.control_state()
-        cs.port.capture.port_names = snappi_extra_params.packet_capture_ports
         cs.port.capture.state = cs.port.capture.STOP
         api.set_control_state(cs)
         logger.info("Retrieving and saving packet capture to {}.pcapng".format(snappi_extra_params.packet_capture_file))

--- a/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
@@ -361,7 +361,7 @@ def __tgen_bgp_config(snappi_api,
 
     def create_v4_topo():
         eth = config.devices[0].ethernets.add()
-        eth.connection.port_name = config.lags[0].name
+        eth.connection.lag_name = config.lags[0].name
         eth.name = 'Ethernet 1'
         eth.mac = "00:00:00:00:00:01"
         ipv4 = eth.ipv4_addresses.add()
@@ -379,7 +379,7 @@ def __tgen_bgp_config(snappi_api,
                 m = hex(i).split('0x')[1]
 
             ethernet_stack = config.devices[i-1].ethernets.add()
-            ethernet_stack.connection.port_name = config.lags[i-1].name
+            ethernet_stack.connection.lag_name = config.lags[i-1].name
             ethernet_stack.name = 'Ethernet %d' % i
             ethernet_stack.mac = "00:00:00:00:00:%s" % m
             ipv4_stack = ethernet_stack.ipv4_addresses.add()
@@ -410,7 +410,7 @@ def __tgen_bgp_config(snappi_api,
 
     def create_v6_topo():
         eth = config.devices[0].ethernets.add()
-        eth.connection.port_name = config.lags[0].name
+        eth.connection.lag_name = config.lags[0].name
         eth.name = 'Ethernet 1'
         eth.mac = "00:00:00:00:00:01"
         ipv6 = eth.ipv6_addresses.add()
@@ -427,7 +427,7 @@ def __tgen_bgp_config(snappi_api,
             else:
                 m = hex(i).split('0x')[1]
             ethernet_stack = config.devices[i-1].ethernets.add()
-            ethernet_stack.connection.port_name = config.lags[i-1].name
+            ethernet_stack.connection.lag_name = config.lags[i-1].name
             ethernet_stack.name = 'Ethernet %d' % i
             ethernet_stack.mac = "00:00:00:00:00:%s" % m
             ipv6_stack = ethernet_stack.ipv6_addresses.add()
@@ -561,6 +561,11 @@ def __tgen_bgp_config(snappi_api,
         createTrafficItem("IPv6 Traffic", v6_tx_flow, v6_rx_flow, 50)
     else:
         raise Exception('Invalid route type given')
+    flow.tx_rx.device.tx_names = [config.devices[0].ethernets[0].name]
+    flow.tx_rx.device.rx_names = rx_flows
+    flow.size.fixed = 1024
+    flow.rate.percentage = 100
+    flow.metrics.enable = True
     return config
 
 
@@ -950,7 +955,7 @@ def get_RIB_IN_capacity(snappi_api,
 
         def create_v4_topo():
             eth = config.devices[0].ethernets.add()
-            eth.connection.port_name = config.lags[0].name
+            eth.connection.lag_name = config.lags[0].name
             eth.name = 'Ethernet 1'
             eth.mac = "00:00:00:00:00:01"
             ipv4 = eth.ipv4_addresses.add()
@@ -965,7 +970,7 @@ def get_RIB_IN_capacity(snappi_api,
                 else:
                     m = hex(i).split('0x')[1]
                 ethernet_stack = config.devices[i-1].ethernets.add()
-                ethernet_stack.connection.port_name = config.lags[i-1].name
+                ethernet_stack.connection.lag_name = config.lags[i-1].name
                 ethernet_stack.name = 'Ethernet %d' % i
                 ethernet_stack.mac = "00:00:00:00:00:%s" % m
                 ipv4_stack = ethernet_stack.ipv4_addresses.add()
@@ -995,7 +1000,7 @@ def get_RIB_IN_capacity(snappi_api,
 
         def create_v6_topo():
             eth = config.devices[0].ethernets.add()
-            eth.connection.port_name = config.lags[0].name
+            eth.connection.lag_name = config.lags[0].name
             eth.name = 'Ethernet 1'
             eth.mac = "00:00:00:00:00:01"
             ipv6 = eth.ipv6_addresses.add()
@@ -1010,7 +1015,7 @@ def get_RIB_IN_capacity(snappi_api,
                 else:
                     m = hex(i).split('0x')[1]
                 ethernet_stack = config.devices[i-1].ethernets.add()
-                ethernet_stack.connection.port_name = config.lags[i-1].name
+                ethernet_stack.connection.lag_name = config.lags[i-1].name
                 ethernet_stack.name = 'Ethernet %d' % i
                 ethernet_stack.mac = "00:00:00:00:00:%s" % m
                 ipv6_stack = ethernet_stack.ipv6_addresses.add()
@@ -1046,7 +1051,7 @@ def get_RIB_IN_capacity(snappi_api,
             flow = config.flows.flow(name='IPv6_Traffic_%d' % routes)[-1]
         else:
             raise Exception('Invalid route type given')
-        flow.tx_rx.device.tx_names = [config.devices[0].name]
+        flow.tx_rx.device.tx_names = [config.devices[0].ethernets[0].name]
         flow.tx_rx.device.rx_names = rx_flows
         flow.size.fixed = 1024
         flow.rate.percentage = 100

--- a/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
@@ -561,11 +561,6 @@ def __tgen_bgp_config(snappi_api,
         createTrafficItem("IPv6 Traffic", v6_tx_flow, v6_rx_flow, 50)
     else:
         raise Exception('Invalid route type given')
-    flow.tx_rx.device.tx_names = [config.devices[0].ethernets[0].name]
-    flow.tx_rx.device.rx_names = rx_flows
-    flow.size.fixed = 1024
-    flow.rate.percentage = 100
-    flow.metrics.enable = True
     return config
 
 

--- a/tests/snappi_tests/bgp/files/bgp_outbound_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_outbound_helper.py
@@ -500,7 +500,7 @@ def __snappi_bgp_config(api,
 
         device = config.devices.device(name="T3 Device {}".format(lag_count))[-1]
         eth = device.ethernets.add()
-        eth.connection.port_name = lag.name
+        eth.connection.lag_name = lag.name
         eth.name = 'T3_Ethernet_%d' % lag_count
         eth.mac = "00:00:00:00:00:%s" % m
 

--- a/tests/snappi_tests/bgp/files/bgp_test_gap_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_test_gap_helper.py
@@ -240,7 +240,7 @@ def __tgen_bgp_config(snappi_api,
     # Source
     config.devices.device(name='Tx')
     eth_1 = config.devices[0].ethernets.add()
-    eth_1.connection.port_name = lag1.name
+    eth_1.connection.lag_name = lag1.name
     eth_1.name = 'Ethernet 1'
     eth_1.mac = "00:14:0a:00:00:01"
     ipv4_1 = eth_1.ipv4_addresses.add()
@@ -256,7 +256,7 @@ def __tgen_bgp_config(snappi_api,
     # Destination
     config.devices.device(name="Rx")
     eth_2 = config.devices[1].ethernets.add()
-    eth_2.connection.port_name = lag2.name
+    eth_2.connection.lag_name = lag2.name
     eth_2.name = 'Ethernet 2'
     eth_2.mac = "00:14:01:00:00:01"
     ipv4_2 = eth_2.ipv4_addresses.add()
@@ -377,7 +377,7 @@ def get_convergence_for_remote_link_failover(snappi_api,
 
         def create_v4_topo():
             eth = config.devices[0].ethernets.add()
-            eth.connection.port_name = config.lags[0].name
+            eth.connection.lag_name = config.lags[0].name
             eth.name = 'Ethernet 1'
             eth.mac = "00:00:00:00:00:01"
             ipv4 = eth.ipv4_addresses.add()
@@ -394,7 +394,7 @@ def get_convergence_for_remote_link_failover(snappi_api,
                     m = hex(i).split('0x')[1]
 
                 ethernet_stack = config.devices[i - 1].ethernets.add()
-                ethernet_stack.connection.port_name = config.lags[i - 1].name
+                ethernet_stack.connection.lag_name = config.lags[i - 1].name
                 ethernet_stack.name = 'Ethernet %d' % i
                 ethernet_stack.mac = "00:00:00:00:00:%s" % m
                 ipv4_stack = ethernet_stack.ipv4_addresses.add()
@@ -422,7 +422,7 @@ def get_convergence_for_remote_link_failover(snappi_api,
 
         def create_v6_topo():
             eth = config.devices[0].ethernets.add()
-            eth.connection.port_name = config.lags[0].name
+            eth.connection.lag_name = config.lags[0].name
             eth.name = 'Ethernet 1'
             eth.mac = "00:00:00:00:00:01"
             ipv6 = eth.ipv6_addresses.add()
@@ -438,7 +438,7 @@ def get_convergence_for_remote_link_failover(snappi_api,
                 else:
                     m = hex(i).split('0x')[1]
                 ethernet_stack = config.devices[i - 1].ethernets.add()
-                ethernet_stack.connection.port_name = config.lags[i - 1].name
+                ethernet_stack.connection.lag_name = config.lags[i - 1].name
                 ethernet_stack.name = 'Ethernet %d' % i
                 ethernet_stack.mac = "00:00:00:00:00:%s" % m
                 ipv6_stack = ethernet_stack.ipv6_addresses.add()
@@ -475,7 +475,7 @@ def get_convergence_for_remote_link_failover(snappi_api,
             flow = config.flows.flow(name='IPv6_Traffic_%d' % routes)[-1]
         else:
             raise Exception('Invalid route type given')
-        flow.tx_rx.device.tx_names = [config.devices[0].name]
+        flow.tx_rx.device.tx_names = [config.devices[0].ethernets[0].name]
         flow.tx_rx.device.rx_names = rx_flows
         flow.size.fixed = 1024
         flow.rate.percentage = 100

--- a/tests/snappi_tests/bgp/files/bgp_test_gap_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_test_gap_helper.py
@@ -209,7 +209,8 @@ def __tgen_bgp_config(snappi_api,
         dual_stack_flag: notation for dual or single stack
     """
     config = snappi_api.config()
-    snappi_api.enable_scaling(True)
+    if hasattr(snappi_api, 'enable_scaling'):
+        snappi_api.enable_scaling(True)
     p1, p2 = (
         config.ports.port(name="Source", location=temp_tg_port[0]['location'])
         .port(name="Destination", location=temp_tg_port[1]['location'])

--- a/tests/snappi_tests/lacp/files/lacp_dut_helper.py
+++ b/tests/snappi_tests/lacp/files/lacp_dut_helper.py
@@ -166,7 +166,7 @@ def __tgen_bgp_config(snappi_api,
     # Source
     config.devices.device(name='Tx')
     eth_1 = config.devices[0].ethernets.add()
-    eth_1.connection.port_name = lag0.name
+    eth_1.connection.lag_name = lag0.name
     eth_1.name = 'Ethernet 1'
     eth_1.mac = "00:14:0a:00:00:01"
     ipv4_1 = eth_1.ipv4_addresses.add()
@@ -183,7 +183,7 @@ def __tgen_bgp_config(snappi_api,
     # Destination
     config.devices.device(name="Rx")
     eth_2 = config.devices[1].ethernets.add()
-    eth_2.connection.port_name = lag1.name
+    eth_2.connection.lag_name = lag1.name
     eth_2.name = 'Ethernet 2'
     eth_2.mac = "00:14:01:00:00:01"
     ipv4_2 = eth_2.ipv4_addresses.add()

--- a/tests/snappi_tests/lacp/files/lacp_physical_helper.py
+++ b/tests/snappi_tests/lacp/files/lacp_physical_helper.py
@@ -229,7 +229,7 @@ def __tgen_bgp_config(snappi_api,
     # Source
     config.devices.device(name='Tx')
     eth_1 = config.devices[0].ethernets.add()
-    eth_1.connection.port_name = lag0.name
+    eth_1.connection.lag_name = lag0.name
     eth_1.name = 'Ethernet 1'
     eth_1.mac = "00:14:0a:00:00:01"
     ipv4_1 = eth_1.ipv4_addresses.add()
@@ -246,7 +246,7 @@ def __tgen_bgp_config(snappi_api,
     # Destination
     config.devices.device(name="Rx")
     eth_2 = config.devices[1].ethernets.add()
-    eth_2.connection.port_name = lag1.name
+    eth_2.connection.lag_name = lag1.name
     eth_2.name = 'Ethernet 2'
     eth_2.mac = "00:14:01:00:00:01"
     ipv4_2 = eth_2.ipv4_addresses.add()

--- a/tests/snappi_tests/reboot/files/reboot_helper.py
+++ b/tests/snappi_tests/reboot/files/reboot_helper.py
@@ -229,7 +229,8 @@ def __tgen_bgp_config(snappi_api, ):
         snappi_api (pytest fixture): snappi API
     """
     config = snappi_api.config()
-    snappi_api.enable_scaling(True)
+    if hasattr(snappi_api, 'enable_scaling'):
+        snappi_api.enable_scaling(True)
 
     p1, p2, p3 = (
         config.ports.port(name="t1", location=temp_tg_port[0]['location'])

--- a/tests/snappi_tests/reboot/files/reboot_helper.py
+++ b/tests/snappi_tests/reboot/files/reboot_helper.py
@@ -300,7 +300,7 @@ def __tgen_bgp_config(snappi_api, ):
     # T1
     d3 = config.devices.device(name="T1")[-1]
     eth_3 = d3.ethernets.add()
-    eth_3.connection.port_name = lag3.name
+    eth_3.connection.lag_name = lag3.name
     eth_3.name = 'Ethernet 3'
     eth_3.mac = "00:14:01:00:00:01"
     ipv4_3 = eth_3.ipv4_addresses.add()


### PR DESCRIPTION
### Description of PR

Summary:
Fix OTG/TestCenter backend compatibility in snappi test infrastructure. Several code paths
assumed IxNetwork-specific APIs (`_ixnetwork`, `StatViewAssistant`, `enable_scaling`)
or used incorrect OTG connection attributes (`port_name` instead of `lag_name` for LAG
devices), causing `AttributeError` / silent misconfiguration when running with
non-IxNetwork backends (e.g., VIAVI TestCenter via OTG/gRPC).

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach

#### What is the motivation for this PR?

The snappi test helpers were written assuming IxNetwork as the only backend. Running
the same tests with an OTG-compatible backend (TestCenter/GrpcApi) hit three classes of
failures:

1. `api._ixnetwork` and `StatViewAssistant` are IxNetwork-only; accessing them outside
   the `imix` code path raises `AttributeError` on any other backend.
2. LAG ethernet connection was set via `eth.connection.port_name = lag.name`, which is
   incorrect per the OTG API spec; the correct attribute is `eth.connection.lag_name`.
3. `snappi_api.enable_scaling()` does not exist on TestCenter/GrpcApi, causing `AttributeError`.

#### How did you do it?

**`tests/common/snappi_tests/traffic_generation.py`**
- Moved `ixnet_rest_api = api._ixnetwork` inside the `if imix:` block so it is only
  accessed when IxNetwork IMIX is actually in use.
- Changed `traf_metrics = StatViewAssistant(...).Rows` to `... if imix else []` at both
  collection sites, so non-IxNetwork runs receive an empty list and skip IxNet-only
  stat paths.
- Added fallback rate-stat population from OTG `flow_metrics` (`rx_l1_rate_bps` /
  `tx_l1_rate_bps`) when `traf_metrics` is empty, so downstream assertions on
  `_rxrate_Gbps` / `_txrate_Gbps` remain valid for all backends.

**LAG ethernet connection (bgp/lacp/reboot helpers)**
- Replaced `eth.connection.port_name = lag.name` with `eth.connection.lag_name = lag.name`
  across all six affected helper files.
- Fixed `flow.tx_rx.device.tx_names` to reference the ethernet interface name
  (`config.devices[0].ethernets[0].name`) instead of the device name, per OTG spec.

**`enable_scaling()` guard (bgp_test_gap_helper, reboot_helper)**
- Wrapped `snappi_api.enable_scaling(True)` with `if hasattr(snappi_api, 'enable_scaling'):`
  so TestCenter/GrpcApi backends skip the call gracefully.

#### How did you verify/test it?

Ran BGP convergence and LACP snappi test cases end-to-end against a VIAVI TestCenter testbed
using the OTG/gRPC API. Tests that previously aborted with `AttributeError` now
complete successfully. Existing IxNetwork behavior is unchanged (all guards are
additive no-ops for IxNetwork).

#### Any platform specific information?

Changes are backend-agnostic. IxNetwork path is unaffected; fixes only activate when
`api._ixnetwork` / `enable_scaling` are absent.

#### Supported testbed topology if it's a new test case?

N/A — these are fixes to existing test cases.

### Documentation

N/A
