### PR TITLE
Fix legacy percentage memory threshold alarms to report % not MB

### DIFF
--- a/tests/common/plugins/memory_utilization/memory_utilization.py
+++ b/tests/common/plugins/memory_utilization/memory_utilization.py
@@ -230,8 +230,14 @@ class MemoryMonitor:
                 else:
                     # Legacy single-tier mode: threshold acts as fail level
                     if increase > increase_threshold:
+                        # If threshold type is percentage, express increase as percentage for logging
+                        # (matches sonic-mgmt #22718 behavior on branches without two-tier thresholds).
+                        increase_report = increase
+                        if (isinstance(increase_threshold_raw, dict)
+                                and increase_threshold_raw.get("type") == "percentage"):
+                            increase_report = (increase * 100) / current_value
                         self._handle_memory_threshold_exceeded(
-                            name, mem_item, increase, increase_threshold_raw,
+                            name, mem_item, increase_report, increase_threshold_raw,
                             previous_values, current_values, is_increase=True
                         )
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Fix inconsistent memory-increase reporting in the memory utilization plugin when memory_increase_threshold is configured as a percentage threshold.

Fixes # (issue)
The memory utilization plugin compares pre-test vs post-test memory usage against configured thresholds. Thresholds can be absolute (type: value, MB) or relative (type: percentage, e.g. "10%").

After two-tier thresholds were introduced (memory_increase_threshold = warning, memory_increase_fail_threshold = fail), percentage-to-display conversion was added only on the fail path (increase > increase_fail_threshold). The legacy single-tier path (when only memory_increase_threshold is configured and acts as the fail level) still passed the raw MB delta into _handle_memory_threshold_exceeded().

That produced misleading messages such as:

`[ALARM]: frr_bgp:used memory usage increased by 45.2, exceeds increase threshold 10%`
The threshold is in percent, but the reported increase was in MB, which makes triage harder and inconsistent with percentage-based configs (e.g. frr_bgp / frr_zebra in memory_utilization_dependence.json).

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
### What is the motivation for this PR?
Memory utilization checks run on many tests by default. When thresholds are percentage-based, failure and warning logs must use the same units as the threshold. Without this fix, percentage thresholds in legacy single-tier mode report MB deltas, which is confusing and inconsistent with the two-tier fail path and with upstream #22718 behavior.

This was observed during internal CACL scale testing and memory utilization validation on Cisco platforms using percentage-based FRR memory thresholds.

### How did you do it?
In check_memory_thresholds(), inside the legacy single-tier branch (memory_increase_fail_threshold is not set), when increase > increase_threshold:

1. Keep the raw MB delta in increase for threshold comparison (unchanged).
2. If memory_increase_threshold is percentage-typed, compute increase_report = (increase * 100) / current_value.
3. Pass increase_report (instead of raw increase) to _handle_memory_threshold_exceeded() so alarm text uses percentage units aligned with the threshold.

This mirrors the percentage conversion already present on the two-tier fail path and aligns legacy mode with sonic-mgmt #22718.


### How did you verify/test it?

- Reviewed threshold handling for type: percentage vs type: value and confirmed comparison logic is unchanged (still uses parsed MB threshold from _parse_threshold()).
- Verified alarm formatting via _handle_memory_threshold_exceeded() shows increase and threshold in consistent units for percentage configs.
- Internal validation: ran tests that exercise memory utilization with percentage thresholds (e.g. FRR/BGP-related cases using memory_utilization_dependence.json configs) and confirmed alarm/warning messages report percentage increase instead of raw MB when threshold type is percentage.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
