### PR TITLE
[ansible]: Add M2-W6940 port alias and PFC support

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -212,6 +212,9 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
                         cur_idx += 4
             port_alias_to_name_map['etp25a'] = "Ethernet512"
             port_alias_to_name_map['etp25b'] = "Ethernet513"
+        elif hwsku == "M2-W6940-64X1-FR4":
+            for i in range(1, 65):
+                port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % ((i - 1) * 8)
         elif hwsku == "Arista-7050QX32S-Q32":
             for i in range(5, 29):
                 port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 5) * 4)

--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -32,6 +32,7 @@ def get_chip_name_if_asic_pfc_storm_supported(fanout):
         "Arista DCS-7260CX3": "Tomahawk2",
         "Arista-7260CX3": "Tomahawk2",
         "Arista-7260QX3": "Tomahawk2",
+        "M2-W6940-64X1-FR4": "Tomahawk5",
         "Nokia-IXR7220": "Tomahawk6",
         }
 


### PR DESCRIPTION
### Description of PR

Summary:
Add M2-W6940-64X1-FR4 port alias mapping and PFC storm ASIC mapping.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Add support for the M2-W6940-64X1-FR4 platform.

#### How did you do it?

Added a 64-port alias mapping for M2-W6940-64X1-FR4 in `ansible/module_utils/port_utils.py` and mapped the HWSKU to Tomahawk5 in `tests/common/helpers/pfc_storm.py`.

#### How did you verify/test it?

#### Any platform specific information?

M2-W6940-64X1-FR4.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.
