### PR TITLE
[gnmi/test_gnoi_smartswitch]: route DPU gNOI via PtfGnoi headers; drop direct-to-DPU path

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -1305,32 +1305,6 @@ def get_dpu_ip(duthost, dpu_index):
     return ip.split('/')[0]
 
 
-def get_dpu_port(duthost, dpu_index):
-    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
-    if not config_facts:
-        logger.error("Failed to retrieve config_facts from DUT")
-        return None
-
-    dpu_section = config_facts.get('DPU', {})
-    if not dpu_section:
-        logger.error("DPU section not found in config_facts")
-        return None
-
-    dpu_key = 'dpu{}'.format(dpu_index)
-    # Check if the DPU exists in the configuration
-    if dpu_key not in dpu_section:
-        logger.error("DPU '{}' not found in config_facts. Available DPUs: {}".format(
-            dpu_key, list(dpu_section.keys())))
-        return None
-
-    dpu_config = dpu_section[dpu_key]
-    port = dpu_config.get('gnmi_port', None)
-    if port is None:
-        logger.error("gnmi_port not found in config_facts for dpu_index {}".format(dpu_index))
-        return None
-    return port
-
-
 def get_configured_dpu_names(duthost):
     """
     Return DPU names configured in the DUT running config (e.g. ["dpu0","dpu1"]).

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -3,7 +3,6 @@ import logging
 import pytest
 import json
 from tests.common.utilities import wait_until
-from tests.common.platform.device_utils import get_dpu_ip, get_dpu_port
 from tests.common.helpers.gnmi_utils import GNMIEnvironment, add_gnmi_client_common_name, del_gnmi_client_common_name, \
                                             dump_gnmi_log, dump_system_status
 from tests.common.helpers.gnmi_utils import gnmi_container   # noqa: F401
@@ -513,29 +512,3 @@ def is_reboot_inactive(duthost, localhost):
         return False
     status = extract_gnoi_response(msg)
     return status and not status.get("active", True)
-
-
-def gnoi_request_dpu(duthost, localhost, dpu_index, module, rpc, request_json_data):
-    env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
-
-    ip = get_dpu_ip(duthost, dpu_index)
-    if ip is None:
-        return -1, "Failed to get DPU IP address"
-
-    port = get_dpu_port(duthost, dpu_index)
-    if port is None:
-        return -1, "Failed to get DPU gNMI port"
-
-    cmd = "docker exec %s gnoi_client -target %s:%s " % (env.gnmi_container, ip, port)
-    cmd += "-cert /etc/sonic/telemetry/gnmiclient.crt "
-    cmd += "-key /etc/sonic/telemetry/gnmiclient.key "
-    cmd += "-ca /etc/sonic/telemetry/gnmiCA.pem "
-    cmd += "-insecure "
-    cmd += "-logtostderr -module {} -rpc {} ".format(module, rpc)
-    cmd += f'-jsonin \'{request_json_data}\''
-    output = duthost.shell(cmd, module_ignore_errors=True)
-    if output['stderr']:
-        logging.error(output['stderr'])
-        return -1, output['stderr']
-    else:
-        return 0, output['stdout']

--- a/tests/gnmi/test_gnoi_smartswitch.py
+++ b/tests/gnmi/test_gnoi_smartswitch.py
@@ -6,7 +6,7 @@ import logging
 import pytest
 
 from tests.common.fixtures.grpc_fixtures import (  # noqa: F401
-    gnmi_tls, ptf_grpc, ptf_gnoi, setup_gnoi_tls_server, reprovision_gnoi_tls
+    gnmi_tls, ptf_grpc, ptf_gnoi, setup_gnoi_tls_server
 )
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.ptf_gnoi import PtfGnoi

--- a/tests/gnmi/test_gnoi_smartswitch.py
+++ b/tests/gnmi/test_gnoi_smartswitch.py
@@ -1,12 +1,15 @@
 """
 This module contains gNOI tests specific to SmartSwitch/DPU platforms.
 """
-import pytest
 import logging
-import json
 
-from .helper import gnoi_request_dpu, extract_gnoi_response, is_reboot_inactive
+import pytest
+
+from tests.common.fixtures.grpc_fixtures import (  # noqa: F401
+    gnmi_tls, ptf_grpc, ptf_gnoi, setup_gnoi_tls_server, reprovision_gnoi_tls
+)
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.ptf_gnoi import PtfGnoi
 from tests.common.utilities import wait_until
 from tests.conftest import get_specified_dpus
 from tests.common.platform.device_utils import reboot_dpu_and_wait_for_start_up
@@ -15,100 +18,87 @@ from tests.common.platform.device_utils import reboot_dpu_and_wait_for_start_up
 pytestmark = [
     pytest.mark.topology('any'),
     pytest.mark.disable_loganalyzer,
-    pytest.mark.usefixtures("setup_gnmi_ntp_client_server", "setup_gnmi_server",
-                            "setup_gnmi_rotated_server", "check_dut_timestamp")
+    pytest.mark.usefixtures("setup_gnoi_tls_server"),
 ]
 
 
-# Enum mapping for RebootMethod for readability
-RebootMethod = {
-    "UNKNOWN": 0,
-    "COLD": 1,
-    "POWERDOWN": 2,
-    "HALT": 3,
-    "WARM": 4,
-    "NSF": 5,
-    # 6 is reserved
-    "POWERUP": 7
-}
-
 REBOOT_MESSAGE = "gnoi test reboot"
 
+# How long to wait for a DPU's gNOI server to answer System.Time after a reboot.
+DPU_REBOOT_READY_TIMEOUT = 600
 
-def check_dpu_reboot_status(duthost, localhost, dpu_index, expected_active, expected_reason, expected_method):
+
+def get_npu_duthost(duthosts):
     """
-    Call gNOI System.RebootStatus for DPU and assert the fields and values of the response.
+    Return the NPU (non-DPU) host on a SmartSwitch testbed.
+
+    ``duthosts`` can include the individual DPU SONiC instances in addition to
+    the NPU. The NPU runs the gNOI server that handles/forwards DPU-targeted RPCs
+    and performs the DPU bring-up, so it must be selected explicitly rather than
+    picked at random.
     """
-    ret, msg = gnoi_request_dpu(duthost, localhost, dpu_index, "System", "RebootStatus", "")
-    pytest_assert(ret == 0,
-                  "System.RebootStatus API reported failure (rc = {}) with message: {}".format(ret, msg))
-    logging.info("System.RebootStatus API returned msg: {}".format(msg))
-
-    status = extract_gnoi_response(msg)
-    pytest_assert(status is not None, "Failed to extract JSON from gNOI response")
-
-    pytest_assert("active" in status, "Missing 'active' in RebootStatus")
-    pytest_assert("when" in status, "Missing 'when' in RebootStatus")
-    pytest_assert("reason" in status, "Missing 'reason' in RebootStatus")
-    pytest_assert("count" in status, "Missing 'count' in RebootStatus")
-    pytest_assert("method" in status, "Missing 'method' in RebootStatus")
-    pytest_assert(status["active"] is expected_active,
-                  "'active' should be {} after reboot".format(expected_active))
-    pytest_assert(status["reason"] == expected_reason,
-                  "'reason' should be '{}'".format(expected_reason))
-    pytest_assert(status["method"] == expected_method,
-                  "'method' should be {}".format(expected_method))
-    pytest_assert(isinstance(status["when"], int) and status["when"] > 0,
-                  "'when' should be a positive integer")
-    pytest_assert(isinstance(status["count"], int) and status["count"] >= 1,
-                  "'count' should be >= 1")
+    npu_duthost = next(
+        (dut for dut in duthosts
+         if not dut.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_dpu")),
+        None)
+    pytest_assert(npu_duthost is not None, "No NPU (non-DPU) host found in duthosts")
+    return npu_duthost
 
 
-def test_gnoi_system_reboot_halt_dpus(duthosts, rand_one_dut_hostname, localhost, request):
+def _dpu_gnoi_time_ok(dpu_gnoi):
+    """Return True iff the DPU's gNOI server answers System.Time."""
+    try:
+        dpu_gnoi.system_time()
+        return True
+    except Exception as exc:
+        logging.debug("DPU gNOI System.Time not ready yet: %s", exc)
+        return False
+
+
+def test_gnoi_system_reboot_halt_dpus(duthosts, ptfhost, request, ptf_gnoi):  # noqa: F811
     """
-    Test gNOI System.Reboot API with HALT method for DPUs.
+    Test gNOI System.Reboot (HALT) for SmartSwitch DPUs.
 
-    Verifies that the reboot is triggered, RebootStatus is correct before reboot,
-    and the DPU recovers properly.
+    For each specified DPU, route a gNOI System.Reboot to the DPU through the
+    NPU's gNOI server (SmartSwitch DPU routing headers), bring the DPU back up
+    from the NPU, and verify recovery by polling the DPU's gNOI System.Time.
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    npu_duthost = get_npu_duthost(duthosts)
 
     dpuhost_names = get_specified_dpus(request)
-    if dpuhost_names:
-        logging.info("dpuhost_names: {}".format(dpuhost_names))
-    else:
-        pytest.skip("No DPUs specified, skipping HALT reboot test.")
-
-    reboot_args = {
-        "message": REBOOT_MESSAGE,
-        "method": RebootMethod["HALT"]
-    }
+    if not dpuhost_names:
+        pytest.skip("No DPUs specified (-H/--dpu-pattern), skipping HALT reboot test.")
+    logging.info("dpuhost_names: %s", dpuhost_names)
 
     for dpuhost_name in dpuhost_names:
-        # Extract the last number from the duthost name
+        # The DPU index is the trailing number of the DPU host name.
         dpu_index = int(dpuhost_name.split('-')[-1])
+        pytest_assert(0 <= dpu_index <= 8,
+                      "Invalid dpu_index {}, must be between 0 and 8".format(dpu_index))
 
-        # Validate dpu_index and log error if out of range
-        if not (0 <= dpu_index <= 8):
-            pytest.fail("Invalid dpu_index {}, must be between 0 and 8".format(dpu_index))
+        # gNOI client that routes RPCs to this DPU through the NPU gNOI server.
+        dpu_gnoi = PtfGnoi(ptf_gnoi.grpc_client.with_ss_target("dpu", dpu_index))
 
-        ret, msg = gnoi_request_dpu(duthost, localhost, dpu_index, "System", "Reboot", json.dumps(reboot_args))
-        pytest_assert(ret == 0,
-                      "System.Reboot API reported failure (rc = {}) with message: {}".format(ret, msg))
-        logging.info("System.Reboot API returned msg: {}".format(msg))
+        # Sanity: the DPU's gNOI server is reachable before we reboot it.
+        pytest_assert(wait_until(60, 5, 0, _dpu_gnoi_time_ok, dpu_gnoi),
+                      "DPU {} gNOI server is not reachable before reboot".format(dpu_index))
 
-        check_dpu_reboot_status(
-            duthost, localhost, dpu_index,
-            expected_active=True,
-            expected_reason=REBOOT_MESSAGE,
-            expected_method=RebootMethod["HALT"]
-        )
+        # Trigger the HALT reboot. System.Reboot may tear down the channel as the
+        # DPU goes down, so a transport error here is expected, not a failure.
+        try:
+            dpu_gnoi.system_reboot(method="HALT", message=REBOOT_MESSAGE)
+            logging.info("System.Reboot(HALT) request sent for DPU %s", dpu_index)
+        except Exception as exc:
+            logging.info("System.Reboot(HALT) returned a transport error "
+                         "(expected as the DPU goes down): %s", exc)
 
-        wait_until(120, 10, 0, is_reboot_inactive, duthost, localhost)
-        logging.info("HALT reboot is completed")
+        # Bring the DPU back up from the NPU and wait for midplane reachability.
+        pytest_assert(reboot_dpu_and_wait_for_start_up(npu_duthost, dpuhost_name, dpu_index),
+                      "DPU {} (index {}) failed to reboot/come back".format(dpuhost_name, dpu_index))
 
-        dpu_reboot_status = reboot_dpu_and_wait_for_start_up(duthost, dpuhost_name, dpu_index)
-        if not dpu_reboot_status:
-            pytest.fail("DPU {} (DPU index: {}) failed to reboot properly".format(dpuhost_name, dpu_index))
+        # Confirm recovery at the gNOI layer: the DPU answers System.Time again.
+        pytest_assert(
+            wait_until(DPU_REBOOT_READY_TIMEOUT, 10, 0, _dpu_gnoi_time_ok, dpu_gnoi),
+            "DPU {} gNOI server did not come back (System.Time) after reboot".format(dpu_index))
 
-        logging.info("DPU {} (DPU index: {}) rebooted successfully".format(dpuhost_name, dpu_index))
+        logging.info("DPU %s (index %s) rebooted and recovered", dpuhost_name, dpu_index)


### PR DESCRIPTION
### Description of PR

Summary:
Rework `tests/gnmi/test_gnoi_smartswitch.py::test_gnoi_system_reboot_halt_dpus`
to drive DPU gNOI through the NPU's gNOI server using the `PtfGnoi`/grpcurl client
with SmartSwitch DPU routing headers (`x-sonic-ss-target-type` / `x-sonic-ss-target-index`),
the same mechanism already used by `tests/upgrade_path/test_upgrade_smart_switch_gnoi.py`,
`tests/common/ptf_grpc.py` (`with_ss_target`), and `tests/common/platform/reboot_utils.py`.

This supersedes #25434. That PR adjusted `get_dpu_port` to default to `8080`, but
the underlying approach — `docker exec gnmi gnoi_client -target <dpu_midplane_ip>:<port>`
straight to the DPU — is the wrong model for SmartSwitch DPU gNOI:

- It requires the DPU's gNOI port and midplane IP (`get_dpu_port` / `get_dpu_ip`),
  which vary by image and CONFIG_DB key format.
- It assumes the DPU's gNOI endpoint is reachable with the same TLS expectations
  as the NPU. On at least one image the per-DPU gNOI server is plaintext while the
  client still negotiates TLS, so the RPC fails the handshake regardless of port.
- The test also picked the DUT via `rand_one_dut_hostname`, which on a SmartSwitch
  can select a DPU host instead of the NPU.

Routing through the NPU avoids all of this: the client talks to the NPU's gNMI/gNOI
endpoint and the NPU forwards the RPC to the requested DPU, so no DPU IP/port and no
per-DPU TLS assumptions are needed. As a result `get_dpu_port` (in
`tests/common/platform/device_utils.py`) and `gnoi_request_dpu` (in
`tests/gnmi/helper.py`) become unused and are removed. `get_dpu_ip` is kept — it is
still used by `check_dpu_reachable_from_npu`.

Fixes # (n/a)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

`test_gnoi_system_reboot_halt_dpus` could not exercise the DPU reboot path on real
SmartSwitch hardware: it selected a DPU (not the NPU) as the DUT, and it issued the
gNOI RPC directly to the DPU midplane, which failed on a TLS-vs-plaintext mismatch
before any reboot was attempted. The repository already has a proven pattern for
DPU gNOI (routing headers via the NPU); this aligns the test with it.

#### How did you do it?

- Select the NPU (non-DPU) host from `duthosts` via `dut_basic_facts` `is_dpu`.
- Build a DPU-scoped gNOI client with `PtfGnoi(ptf_gnoi.grpc_client.with_ss_target("dpu", dpu_index))`.
- Sanity-check the DPU is reachable (gNOI `System.Time`), trigger `System.Reboot`
  with method `HALT` (transport errors as the DPU goes down are tolerated), bring
  the DPU back up from the NPU, and confirm recovery by polling gNOI `System.Time`.
- Use the existing `gnmi_tls` / `setup_gnoi_tls_server` fixtures for cert/grpcurl
  setup, matching `test_upgrade_smart_switch_gnoi.py`.
- Remove the now-unused `get_dpu_port` and `gnoi_request_dpu`; keep `get_dpu_ip`.

#### How did you verify/test it?

Ran on a physical SmartSwitch testbed (8-DPU platform), targeting one DPU:

```
./run_tests.sh -n <smartswitch_testbed> -c gnmi/test_gnoi_smartswitch.py \
  -i ../ansible/<inv>,../ansible/veos -H <dut>-dpu-0 -u -e "--skip_sanity"
```

The test passed: `System.Time` and `System.Reboot(HALT)` were routed to the DPU via
the `x-sonic-ss-target-*` headers, the DPU was rebooted and recovered, and the test
reported `rebooted and recovered`. (A teardown-only `memory_utilization` monit alarm,
unrelated to this change, was observed on the NPU.)

`flake8 --max-line-length=120` passes on all three changed files.

#### Any platform specific information?

SmartSwitch / DPU platforms only. The test is marked `topology('any')` and skips
when no DPUs are specified (`-H` / `--dpu-pattern`).

#### Supported testbed topology if it's a new test case?

Not a new test case — improvement to an existing SmartSwitch gNOI test.

### Documentation

No documentation changes.
