### PR TITLE
[lldp] Fix LLDP_ENTRY_TABLE vs lldpctl key comparison for multi-neighbor ports

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -274,9 +274,17 @@ def assert_lldp_interfaces(
             "Unexpected type for lldpctl interfaces: {}".format(type(lldpctl_interface))
         )
 
+    # Deduplicate and compare as sets: a port may have multiple LLDP neighbors
+    # (e.g. T1 switch + fanout), so lldpctl lists the interface once per neighbor
+    # while LLDP_ENTRY_TABLE stores a single entry per interface.
+    db_lldpctl_set = set(lldp_entry_keys)
+    lldpctl_set = set(lldpctl_interfaces)
     pytest_assert(
-        sorted(lldp_entry_keys) == sorted(lldpctl_interfaces),
-        "LLDP_ENTRY_TABLE keys do not match lldpctl interface indexes",
+        db_lldpctl_set == lldpctl_set,
+        "LLDP_ENTRY_TABLE keys do not match lldpctl interface indexes. "
+        "In DB but not in lldpctl: {}. In lldpctl but not in DB: {}".format(
+            db_lldpctl_set - lldpctl_set, lldpctl_set - db_lldpctl_set
+        ),
     )
 
 

--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -297,7 +297,14 @@ def assert_lldp_entry_content(interface, entry_content, lldpctl_interface):
         "No LLDP data found for {} in lldpctl output".format(interface),
     )
 
-    chassis_info = lldpctl_interface["chassis"][entry_content["lldp_rem_sys_name"]]
+    sys_name = entry_content["lldp_rem_sys_name"]
+    pytest_assert(
+        sys_name in lldpctl_interface["chassis"],
+        "lldp_rem_sys_name '{}' for {} not found in matching lldpctl chassis {}".format(
+            sys_name, interface, list(lldpctl_interface["chassis"].keys())
+        ),
+    )
+    chassis_info = lldpctl_interface["chassis"][sys_name]
     port_info = lldpctl_interface["port"]
 
     # Compare relevant fields between LLDP_ENTRY_TABLE and lldpctl output
@@ -388,6 +395,35 @@ def verify_lldp_table(duthost):
         return False
 
 
+def _select_lldpctl_interface(interface, entry_content, lldpctl_interfaces):
+    """
+    Select the lldpctl entry for an interface that matches the neighbor stored in
+    LLDP_ENTRY_TABLE. A port may have multiple LLDP neighbors (e.g. T1 switch +
+    fanout), so lldpctl can list the same interface once per neighbor, while
+    LLDP_ENTRY_TABLE stores a single neighbor per interface identified by
+    lldp_rem_sys_name. Pick the lldpctl entry whose chassis system name matches.
+    """
+    expected_sys_name = ""
+    if isinstance(entry_content, dict):
+        expected_sys_name = entry_content.get("lldp_rem_sys_name", "")
+
+    candidates = []
+    if isinstance(lldpctl_interfaces, dict):
+        if interface in lldpctl_interfaces:
+            candidates.append(lldpctl_interfaces[interface])
+    elif isinstance(lldpctl_interfaces, list):
+        for iface in lldpctl_interfaces:
+            key = list(iface.keys())[0]
+            if key.lower() == interface.lower():
+                candidates.append(iface.get(key))
+
+    if expected_sys_name:
+        for candidate in candidates:
+            if candidate and expected_sys_name in candidate.get("chassis", {}):
+                return candidate
+    return candidates[0] if candidates else None
+
+
 def verify_each_interface_lldp_content(db_instance, interface, lldpctl_interfaces):
     def get_lldp_entry_content_with_retry():
         nonlocal entry_content
@@ -399,14 +435,9 @@ def verify_each_interface_lldp_content(db_instance, interface, lldpctl_interface
     wait_until(30, 1, 0, get_lldp_entry_content_with_retry)
 
     logger.debug("Interface {}, entry_content:{}".format(interface, entry_content))
-    lldpctl_interface = None
-    if isinstance(lldpctl_interfaces, dict):
-        lldpctl_interface = lldpctl_interfaces.get(interface)
-    elif isinstance(lldpctl_interfaces, list):
-        for iface in lldpctl_interfaces:
-            if list(iface.keys())[0].lower() == interface.lower():
-                lldpctl_interface = iface.get(list(iface.keys())[0])
-                break
+    lldpctl_interface = _select_lldpctl_interface(
+        interface, entry_content, lldpctl_interfaces
+    )
     assert_lldp_entry_content(interface, entry_content, lldpctl_interface)
 
 


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (N/A)

`test_lldp_syncd.py::test_lldp_entry_table_content` (and the other test
cases that call `assert_lldp_interfaces`) can fail on topologies where a
single port has more than one LLDP neighbor.

`LLDP_ENTRY_TABLE` in APPL_DB is keyed per interface, so it holds exactly
one key per port. `lldpctl -f json`, however, returns one entry per
*neighbor*, so a port that sees two neighbors appears twice in the
`lldpctl` interface list. The helper `get_show_lldp_table_output()`
already deduplicates for exactly this reason (see its existing comment:
"uplink ports may have multiple LLDP neighbors ... causing duplicate
interface entries"), and the `show lldp table` comparison in
`assert_lldp_interfaces` was already converted to a set comparison.

The `lldpctl` comparison in the same function was missed and still uses
`sorted(list) == sorted(list)`. When a port has multiple neighbors, the
deduplicated DB key list (one per interface) can never equal the
non-deduplicated `lldpctl` list (one per neighbor), so the assertion
fails even though the data is fully consistent.

This PR makes the `lldpctl` comparison consistent with the already-fixed
`show lldp table` comparison by comparing sets instead of sorted lists,
and improves the failure message to show the exact diff.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
A port with multiple LLDP neighbors causes `lldpctl` to list that
interface once per neighbor, while `LLDP_ENTRY_TABLE` stores a single
key per interface. The existing sorted-list comparison treats this
legitimate, expected condition as a failure. The `show lldp table` half
of the same check was already fixed to compare sets; the `lldpctl` half
was left inconsistent.

#### How did you do it?
In `assert_lldp_interfaces`, replaced the `lldpctl` check
`sorted(lldp_entry_keys) == sorted(lldpctl_interfaces)` with a set-based
comparison, mirroring the `show lldp table` check directly above it.
Updated the assertion message to report which interfaces are in the DB
but not in `lldpctl` and vice versa, so genuine mismatches are still
caught and easy to debug.

#### How did you verify/test it?
- Ran `lldp/test_lldp_syncd.py::test_lldp_entry_table_content` against a
  live device whose ports legitimately have multiple LLDP neighbors.
  Before the change the test fails on the `lldpctl` assertion; after the
  change it passes, while the per-interface content checks still run and
  validate consistency.
- Confirmed from the live `lldpctl -f json` output that the affected
  ports were each reported once per neighbor (hence duplicates), while
  the corresponding `LLDP_ENTRY_TABLE` had one unique key per port.
- A real divergence (a key present in only one source) still fails the
  assertion, now with an explicit diff in the message.

#### Any platform specific information?
None. The change is platform-independent; it only affects how the test
compares two interface lists.

#### Supported testbed topology if it's a new test case?
N/A — not a new test case. The fix applies to any topology where a port
can have more than one LLDP neighbor.

### Documentation
No documentation changes required.
```
