### PR TITLE
Support multiple Vendor Extension (0xFD) fields in syseeprom cli test

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -195,19 +195,39 @@ def test_show_platform_syseeprom(duthosts, enum_rand_one_per_hwsku_hostname, dut
         parsed_syseeprom = {}
         # Can't use util.get_fields as the values go beyond the last set of '---' in the hearder line.
         regex_int = re.compile(r'([\S\s]+)(0x[A-F0-9]+)\s+([\d]+)\s+([\S\s]*)')
+        # TLV codes that can appear more than once in syseeprom output.
+        # Currently only 0xFD (Vendor Extension) can have multiple values.
+        multi_value_tlv_codes = ["0xfd"]
         for line in syseeprom_output_lines[6:]:
             t1 = regex_int.match(line)
             if t1:
                 tlv_code_lower_case = t1.group(2).strip().lower()
-                parsed_syseeprom[tlv_code_lower_case] = t1.group(4).strip()
+                new_value = t1.group(4).strip()
+                if tlv_code_lower_case in parsed_syseeprom and tlv_code_lower_case in multi_value_tlv_codes:
+                    existing_value = parsed_syseeprom[tlv_code_lower_case]
+                    if isinstance(existing_value, list):
+                        existing_value.append(new_value)
+                    else:
+                        parsed_syseeprom[tlv_code_lower_case] = [existing_value, new_value]
+                else:
+                    parsed_syseeprom[tlv_code_lower_case] = new_value
 
         for field in expected_syseeprom_info_dict:
             pytest_assert(field.lower() in parsed_syseeprom, "Expected field '{}' not present in syseeprom on '{}'".
                           format(field, duthost.hostname))
-            pytest_assert(parsed_syseeprom[field.lower()] == expected_syseeprom_info_dict[field],
-                          "System EEPROM info is incorrect - for '{}', rcvd '{}', expected '{}' on '{}'".
-                          format(field, parsed_syseeprom[field.lower()], expected_syseeprom_info_dict[field],
-                                 duthost.hostname))
+            expected_value = expected_syseeprom_info_dict[field]
+            actual_value = parsed_syseeprom[field.lower()]
+            if field.lower() in multi_value_tlv_codes:
+                expected_list = expected_value if isinstance(expected_value, list) else [expected_value]
+                actual_list = actual_value if isinstance(actual_value, list) else [actual_value]
+                for expected_item in expected_list:
+                    pytest_assert(expected_item in actual_list,
+                                  "System EEPROM info is incorrect - for '{}', expected '{}' not found in '{}' on '{}'".
+                                  format(field, expected_item, actual_list, duthost.hostname))
+            else:
+                pytest_assert(actual_value == expected_value,
+                              "System EEPROM info is incorrect - for '{}', rcvd '{}', expected '{}' on '{}'".
+                              format(field, actual_value, expected_value, duthost.hostname))
 
     if duthost.facts["asic_type"] in ["mellanox"]:
         # Define the expected fields that should be present in the syseeprom output


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

This PR enhances `test_show_platform_syseeprom` to support multiple 0xFD (Vendor Extension) fields.


Summary: 
The syseeprom parser previously overwrote repeated TLV codes, keeping only the last occurrence. This caused test_show_platform_syseeprom to fail on platforms with multiple Vendor Extension (0xFD) entries. This PR accumulates multi-value TLV codes into a list and use list-aware assertion logic for validation.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605


#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

- 202511: 20251110.42 :
- 202605: 20260510.07 :

Before Changes :
```

>               pytest_assert(parsed_syseeprom[field.lower()] == expected_syseeprom_info_dict[field],
                              "System EEPROM info is incorrect - for '{}', rcvd '{}', expected '{}' on '{}'".
                              format(field, parsed_syseeprom[field.lower()], expected_syseeprom_info_dict[field],
                                     duthost.hostname))

FAILED platform_tests/cli/test_show_platform.py::test_show_platform_syseeprom[dut-name] - Failed: System EEPROM info is incorrect - for '0xFD', rcvd '0x00 0x00 0x00 0x10 0x00 0x00 0x00 0x20 0x00 0x30 0x00 0x40 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00', expected '['0x00 0x00 0x00 0x10 0x00 0x00 0x00 0x20 0x00 0x30 0x00 0x40 0x00..., 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00, 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00]
```
Note : EEPROM data pasted above is modified to not share exact info/data of device

After Changes :
```
platform_tests/cli/test_show_platform.py::test_show_platform_syseeprom[dut-name] PASSED                                                                                                                                    [100%]

```



#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

### Approach
#### What is the motivation for this PR?
The ONIE TLV standard allows certain TLV codes to appear more than once in syseeprom output. The existing regex parser used a simple dict assignment `parsed_syseeprom[code] = value`  which silently overwrote earlier entries, keeping only the last one. When the inventory defined the expected value as a list, the comparison always failed because the parsed side was always a single string.

#### How did you do it?
Introduced a `multi_value_tlv_codes` list (currently containing only `"0xfd"`). When the parser encounters a TLV code that already exists in the dict and is in this list, it accumulates values into a list rather than overwriting. First occurrence stores a string, second converts to a 2-element list, subsequent occurrences append.

For fields in `multi_value_tlv_codes`, both expected and actual values are normalized to lists. The assertion then verifies that every expected item is present in the actual list (order-independent containment check). Non-multi-value fields continue to use exact equality.

#### How did you verify/test it?
Ran the test on a platform with multiple vendor extension fields and confirmed all entries are parsed and validated correctly.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
