### PR TITLE
AAA: RADIUS test suite and new TACACS+ test coverage + TACACS+ test plan

### DIFF
--- a/docs/testplan/TACACS-test-plan.md
+++ b/docs/testplan/TACACS-test-plan.md
@@ -1,0 +1,261 @@
+# TACACS+ AAA Test Plan
+
+## Table of Contents
+- [TACACS+ AAA Test Plan](#tacacs-aaa-test-plan)
+  - [Table of Contents](#table-of-contents)
+  - [1 Overview](#1-overview)
+  - [2 Scope](#2-scope)
+  - [3 Test Setup](#3-test-setup)
+    - [3.1 Test Environment](#31-test-environment)
+    - [3.2 TACACS+ Server Configuration](#32-tacacs-server-configuration)
+  - [4 Test Cases](#4-test-cases)
+    - [4.1 Preflight / Setup Validation](#41-preflight--setup-validation)
+    - [4.2 Authentication Tests](#42-authentication-tests)
+    - [4.3 Authorization and AAA Configuration Tests](#43-authorization-and-aaa-configuration-tests)
+    - [4.4 Accounting Tests](#44-accounting-tests)
+  - [5 Implementation Details](#5-implementation-details)
+    - [5.1 Test Framework](#51-test-framework)
+    - [5.2 Key Fixtures and Helpers](#52-key-fixtures-and-helpers)
+    - [5.3 Test Configuration](#53-test-configuration)
+  - [6 Expected Results](#6-expected-results)
+
+## 1 Overview
+
+This document describes the test plan for new TACACS+ test files added under `tests/tacacs/` alongside the existing community TACACS+ suite. The new files extend the existing coverage with scenarios that are not exercised by the current `test_accounting.py`, `test_authorization.py`, `test_ro_disk.py`, `test_ro_user.py`, `test_rw_user.py`, or `test_jit_user.py` modules.
+
+Files added by this plan:
+
+- `tests/tacacs/test_aaa_preflight.py` — environment readiness checks that gate the rest of the suite.
+- `tests/tacacs/test_aaa_authentication.py` — TACACS+ authentication scenarios (failover, timeout, source IP, concurrent sessions, etc.).
+- `tests/tacacs/test_aaa_accounting.py` — event-level accounting coverage (login events, command execution, wildcard encoding, dual TACACS+local accounting). Complements the existing `tests/tacacs/test_accounting.py` which focuses on server-availability scenarios.
+- `tests/tacacs/test_aaa_config.py` — end-to-end AAA-config tests covering SSH authentication, local fallback, and role-based command access.
+- `tests/tacacs/test_aaa.py` — aggregator entry point that re-exports tests from the four modules above for single-run execution.
+
+## 2 Scope
+
+This plan covers TACACS+ behavior on SONiC. The 26 test cases collectively validate:
+
+- TACACS+ service / daemon health on both DUT and PTF.
+- DUT-side AAA mode configuration (authentication / authorization / accounting).
+- TACACS+ authentication flows including failover, timeout, source IP, and concurrent RO/RW sessions.
+- TACACS+ accounting events at the protocol level (login events, command execution, wildcard encoding) and accounting hand-off between TACACS+ and local sinks.
+- Role-based authorization for RO and RW TACACS+ users.
+- Defensive behavior (wrong passkey, server timeout, disable-TACACS revert, config persistence across reload).
+
+Out of scope for this plan:
+
+- TACACS+ server-availability scenarios already covered by community `test_accounting.py` (`test_accounting_tacacs_only`, `*_all_tacacs_server_down`, `*_some_tacacs_server_down`, `test_accounting_local_only`, `test_accounting_tacacs_and_local`).
+- TACACS+ authorization scenarios already covered by community `test_authorization.py`.
+- Per-user filesystem behavior already covered by `test_ro_disk.py`, `test_ro_user.py`, `test_rw_user.py`.
+
+## 3 Test Setup
+
+### 3.1 Test Environment
+
+The test environment consists of:
+
+- SONiC Device Under Test (DUT).
+- PTF (Packet Test Framework) host running a `tac_plus` TACACS+ server.
+- Test credentials defined by the standard `tacacs_creds` fixture (`tests/common/fixtures/tacacs.py`).
+- Management-network reachability between the DUT and the PTF-hosted TACACS+ server.
+
+Topology marker:
+
+```python
+pytestmark = [
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.topology('any', 't1-multi-asic'),
+    pytest.mark.device_type('vs'),
+]
+```
+
+### 3.2 TACACS+ Server Configuration
+
+The TACACS+ server (`tac_plus`) on PTF is configured with:
+
+- Authentication on TCP/49.
+- Shared secret matching the value in `tacacs_creds`.
+- User database with the standard `tacacs_rw_user` and `tacacs_ro_user` accounts plus their group memberships.
+- Per-command accounting enabled.
+
+Configuration template used: `tests/tacacs/tac_plus.conf.j2` (existing community asset).
+
+## 4 Test Cases
+
+### 4.1 Preflight / Setup Validation
+
+File: `tests/tacacs/test_aaa_preflight.py`
+
+Eight readiness checks that run before any functional test. Failure here indicates a misconfigured testbed, not a SONiC bug.
+
+**Test Case H01: SONiC services running (`test_h01_sonic_services_running`)**
+- Verify DUT critical services (SwSS, syncd, bgp, lldp, etc.) are fully started.
+- Fail-fast if the DUT is not in a healthy baseline before TACACS+ tests run.
+
+**Test Case H02: TACACS+ server reachable (`test_h02_tacacs_server_reachable`)**
+- Verify TCP/49 reachability from DUT to the PTF-hosted TACACS+ server.
+- Fail-fast if the DUT cannot reach the server (rules out routing/firewall issues before functional tests).
+
+**Test Case H03: TACACS+ config on DUT (`test_h03_tacacs_config_on_dut`)**
+- Verify `config tacacs` returns at least one configured server.
+- Verify the configured server matches the PTF TACACS+ instance.
+
+**Test Case H04: AAA authentication mode (`test_h04_aaa_authentication_mode`)**
+- Verify `show aaa` reports the configured authentication mode (`tacacs+`, `local`, or `tacacs+ local`).
+- Confirm the configured mode matches what the test fixtures expect.
+
+**Test Case H05: AAA authorization mode (`test_h05_aaa_authorization_mode`)**
+- Verify `show aaa` reports the configured authorization mode.
+
+**Test Case H06: AAA accounting mode (`test_h06_aaa_accounting_mode`)**
+- Verify `show aaa` reports the configured accounting mode.
+
+**Test Case H07: TACACS+ daemon running on PTF (`test_h07_tacacs_daemon_running_on_ptf`)**
+- Verify the `tac_plus` process is alive on the PTF host.
+- Verify the daemon is listening on TCP/49.
+
+**Test Case H08: End-to-end smoke login (`test_h08_end_to_end_smoke_login`)**
+- Authenticate the RW TACACS+ user via SSH to the DUT.
+- Run a trivial command and assert it succeeds.
+- Confirms the full authentication path works end-to-end before the rest of the suite runs.
+
+### 4.2 Authentication Tests
+
+File: `tests/tacacs/test_aaa_authentication.py`
+
+Nine TACACS+ authentication scenarios not exercised by the existing community suite.
+
+**Test Case A1: Failover primary down, secondary takes over (`test_failover_primary_down_secondary_takes_over`)**
+- Configure two TACACS+ servers; mark the first as unreachable.
+- Attempt SSH login with TACACS+ credentials.
+- Verify authentication succeeds via the secondary server.
+
+**Test Case A2: Wrong passkey rejected (`test_wrong_passkey_rejected`)**
+- Configure the DUT with an incorrect TACACS+ shared secret.
+- Attempt SSH login.
+- Verify authentication is rejected and the failure is logged.
+
+**Test Case A3: Server timeout no hang (`test_server_timeout_no_hang`)**
+- Block traffic to the TACACS+ server (or stop the server).
+- Attempt SSH login.
+- Verify the DUT-side authentication does not hang past the configured timeout and returns a failure within bounded time.
+
+**Test Case A4: JIT user created on login (`test_jit_user_created_on_login`)**
+- Authenticate a TACACS+ user who does not exist locally on the DUT.
+- Verify SONiC just-in-time creates the local Linux user and group.
+- Verify the local entry is consistent with the TACACS+ user role.
+
+**Test Case A5: Disable TACACS+ reverts to local (`test_disable_tacacs_reverts_to_local`)**
+- Configure local fallback alongside TACACS+.
+- Disable TACACS+ on the DUT via `config aaa authentication`.
+- Verify subsequent logins are authenticated locally.
+
+**Test Case A6: TACACS+ config persists after reload (`test_tacacs_config_persists_after_reload`)**
+- Configure TACACS+ via CLI.
+- `config save` and `config reload -y -f`.
+- Verify TACACS+ config is restored after reload and authentication still works.
+
+**Test Case A7: TACACS+ source IP (`test_tacacs_source_ip`)**
+- Configure a specific source-interface for TACACS+ traffic.
+- Authenticate and capture TACACS+ traffic on PTF.
+- Verify outbound TACACS+ packets use the configured source IP.
+
+**Test Case A8: Concurrent RO/RW sessions (`test_concurrent_ro_rw_sessions`)**
+- Open simultaneous SSH sessions as the RO and RW TACACS+ users.
+- Run commands in both sessions in parallel.
+- Verify each session retains its own authorization scope and there is no cross-contamination.
+
+**Test Case A9: Local user blocked under tacacs-only (`test_local_user_blocked_tacacs_only`)**
+- Configure `aaa authentication tacacs+` (no local fallback).
+- Attempt SSH login with a local-only account.
+- Verify the login is rejected.
+
+### 4.3 Authorization and AAA Configuration Tests
+
+File: `tests/tacacs/test_aaa_config.py`
+
+Five tests covering end-to-end SSH authentication and role-based command access.
+
+**Test Case C1: Valid SSH authentication (`test_valid_ssh_authentication`)**
+- Authenticate the RW TACACS+ user via SSH.
+- Verify the session is established and a basic command runs successfully.
+
+**Test Case C2: Invalid credentials rejected (`test_invalid_credentials_rejected`)**
+- Attempt SSH login with a known-bad password.
+- Verify authentication is rejected and no session is opened.
+
+**Test Case C3: Local fallback when server unreachable (`test_local_fallback_when_server_unreachable`)**
+- Configure `aaa authentication tacacs+ local`.
+- Stop the TACACS+ server on PTF.
+- Authenticate as a local-only user.
+- Verify the local credential succeeds (fallback chain works).
+
+**Test Case C4: RO user blocked from write commands (`test_ro_user_blocked_from_write_commands`)**
+- Authenticate as the RO TACACS+ user.
+- Attempt a privileged write command (e.g. `sudo config interface shutdown`).
+- Verify the command is denied.
+
+**Test Case C5: RW user read/write commands (`test_rw_user_read_write_commands`)**
+- Authenticate as the RW TACACS+ user.
+- Run a representative read command and a representative write command.
+- Verify both succeed.
+
+### 4.4 Accounting Tests
+
+File: `tests/tacacs/test_aaa_accounting.py`
+
+Four event-level accounting scenarios that complement the existing `tests/tacacs/test_accounting.py` (which focuses on server-availability scenarios).
+
+**Test Case ACT1: Accounting records login events (`test_accounting_records_login_events`)**
+- Open and close an SSH session as the RW TACACS+ user.
+- Verify the TACACS+ server's accounting log (`/var/log/tac_plus.acct`) records both the start and stop records for the session.
+
+**Test Case ACT2: Accounting records command execution (`test_accounting_records_command_execution`)**
+- As the RW TACACS+ user, execute a representative command (e.g. `grep`).
+- Verify the per-command accounting record reaches the TACACS+ server log.
+
+**Test Case ACT3: Wildcard encoding sent to server (`test_wildcard_encoding_sent_to_server`)**
+- Execute a command containing shell wildcards (e.g. `ls /tmp/*`).
+- Verify the wildcard is sent to the TACACS+ server intact in the accounting record (not pre-expanded).
+
+**Test Case ACT4: Dual accounting TACACS+ and local (`test_dual_accounting_tacacs_and_local`)**
+- Configure `aaa accounting tacacs+ local`.
+- Execute a command as the RW TACACS+ user.
+- Verify the same command appears in **both** the TACACS+ server log and the DUT-local syslog (`audisp-tacplus`).
+
+## 5 Implementation Details
+
+### 5.1 Test Framework
+
+- Python pytest.
+- All test files reuse the standard sonic-mgmt fixture and helper layout — no new conftest changes are introduced.
+- Module-level markers: `pytest.mark.disable_loganalyzer`, `pytest.mark.topology('any', 't1-multi-asic')`, `pytest.mark.device_type('vs')`.
+
+### 5.2 Key Fixtures and Helpers
+
+| Provider | Fixture / helper |
+|---|---|
+| `tests/common/fixtures/tacacs.py` | `tacacs_creds` |
+| `tests/common/helpers/tacacs/tacacs_helper.py` | `check_tacacs`, `tacacs_v6_context`, `ssh_remote_run`, `ssh_remote_run_retry`, `start_tacacs_server`, `stop_tacacs_server`, `remove_all_tacacs_server`, `per_command_accounting_skip_versions`, `per_command_authorization_skip_versions` |
+| `tests/tacacs/conftest.py` | `tacacs_creds`, `check_tacacs_v6`, `skip_in_container_test` (reused from existing community suite) |
+| `tests/common/utilities` | `wait_until`, `paramiko_ssh`, `check_output`, `skip_release` |
+
+### 5.3 Test Configuration
+
+- TACACS+ server template: `tests/tacacs/tac_plus.conf.j2` (existing community asset).
+- TACACS+ credentials and per-test parameters loaded via the standard `tacacs_creds` fixture.
+- No new YAML, no new Jinja2 templates.
+
+## 6 Expected Results
+
+All 26 test cases should:
+
+- Complete successfully without errors on a healthy single-DUT t1-multi-asic / t0 testbed with a PTF-hosted `tac_plus` server.
+- Restore the DUT to its pre-test AAA configuration on teardown.
+- Emit clear error messages, relevant DUT and PTF logs, and TACACS+ server-side accounting context for failures.
+
+Test failures should provide:
+
+- The exact CLI command and DUT response.
+- Relevant snippets from `/var/log/syslog` (DUT side) and `/var/log/tac_plus.acct` (server side).
+- Configured AAA modes and the TACACS+ server list at the moment of failure.

--- a/tests/radius/conftest.py
+++ b/tests/radius/conftest.py
@@ -1,0 +1,337 @@
+"""
+conftest.py for tests/radius -- module-scoped fixtures for the RADIUS test suite.
+"""
+import json
+import logging
+import time
+import pytest
+
+from tests.radius.utils import (
+    start_radius_server,
+    stop_radius_server,
+    configure_dut_radius,
+    restore_dut_aaa_config,
+    block_radius_server,
+    unblock_radius_server,
+    ssh_connect_remote_retry,
+    ssh_run_command,
+    close_ssh,
+    delete_jit_user,
+    _save_local_aaa,
+    _radius_del,
+)
+
+logger = logging.getLogger(__name__)
+
+# Synthetic test credentials. These accounts exist only on the FreeRADIUS
+# server provisioned by the test harness on the PTF and on a throwaway local
+# Linux account on the DUT. They do not grant access to any real system and
+# are scoped to the lifetime of the test run. Mirrors the same convention
+# used by tests/common/fixtures/tacacs.py for the tacacs_creds fixture.
+_RADIUS_TEST_CREDS = {
+    "radius_rw_user": "radius_rwuser",
+    "radius_rw_user_passwd": "123456",
+    "radius_ro_user": "radius_rouser",
+    "radius_ro_user_passwd": "123456",
+    "passkey": "testing123",
+    "local_user": "test_louser",
+    "local_user_passwd": "123456",
+}
+
+
+@pytest.fixture(scope="module")
+def radius_creds(creds_all_duts):
+    """Return creds_all_duts enriched with RADIUS test credentials."""
+    creds_all_duts.update(_RADIUS_TEST_CREDS)
+    return creds_all_duts
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _radius_ensure_local_user(duthosts):
+    """Provision local fallback user for RADIUS failthrough tests."""
+    user = _RADIUS_TEST_CREDS["local_user"]
+    pwd = _RADIUS_TEST_CREDS["local_user_passwd"]
+    for duthost in duthosts:
+        duthost.shell(
+            "id -u {u} >/dev/null 2>&1 || "
+            "(sudo useradd -m -s /bin/bash {u} && "
+            "echo '{u}:{p}' | sudo chpasswd)".format(u=user, p=pwd),
+            module_ignore_errors=True,
+        )
+    yield
+    for duthost in duthosts:
+        duthost.shell(
+            "sudo userdel -r {} 2>/dev/null || true".format(user),
+            module_ignore_errors=True,
+        )
+
+
+def _admin_safety_entries(creds_all_duts):
+    """Build FreeRADIUS users-file entries for the DUT admin account(s).
+
+    SONiC's auto-generated PAM stack contains ``auth_err=die`` on
+    ``pam_radius_auth.so``. If FreeRADIUS issues an Access-Reject for the
+    operator's admin account -- which it will by default, since the test users
+    file only contains the synthesized RADIUS test users -- the PAM auth chain
+    aborts immediately and the operator is locked out of SSH on the DUT, even
+    with the correct local Unix password. By registering admin with FreeRADIUS
+    using its real local password, RADIUS always returns Access-Accept for
+    admin, the PAM chain proceeds normally, and the operator can never be
+    locked out by the test harness.
+    """
+    admin_user = (
+        creds_all_duts.get("sonicadmin_user")
+        or creds_all_duts.get("sonic_login")
+        or "admin"
+    )
+    admin_pwd = (
+        creds_all_duts.get("sonicadmin_password")
+        or creds_all_duts.get("sonic_password")
+        or creds_all_duts.get("sonicadmin_initial_password")
+    )
+    if not admin_pwd:
+        # No admin password available from inventory creds. Skip the
+        # safety-net entry rather than ship a default password literal in
+        # source: PAM ``auth_err=die`` will still fire if RADIUS rejects
+        # the admin user, but at least we are not hard-coding credentials.
+        logger.warning(
+            "No admin password found in creds_all_duts; skipping RADIUS "
+            "admin safety entries. Set sonicadmin_password in inventory "
+            "to enable lockout protection."
+        )
+        return []
+    entries = [{"username": admin_user, "password": admin_pwd, "priv_lvl": 15}]
+    # Some inventories ship multiple candidate admin passwords (e.g. a default
+    # and a post-install password). Include each so any of them satisfies
+    # RADIUS during password-rotation windows.
+    extra_pwds = []
+    for key in ("sonicadmin_password", "sonicadmin_initial_password", "sonic_password"):
+        v = creds_all_duts.get(key)
+        if v and v != admin_pwd and v not in extra_pwds:
+            extra_pwds.append(v)
+    # Single user-file entry can only encode one Cleartext-Password, so we
+    # emit additional synthesized entries with a username suffix that PAM will
+    # never request -- they exist only to leave a documentation trail.
+    for idx, extra in enumerate(extra_pwds, start=1):
+        entries.append({
+            "username": "{}__alt{}".format(admin_user, idx),
+            "password": extra,
+            "priv_lvl": 15,
+        })
+    return entries
+
+
+def _read_table(duthost, table):
+    """Return CONFIG_DB <table> as a dict (empty if absent)."""
+    out = duthost.shell(
+        "sonic-cfggen -d --var-json '{}'".format(table),
+        module_ignore_errors=True,
+    )
+    if out.get("rc", 1) != 0 or not out.get("stdout", "").strip():
+        return {}
+    try:
+        return json.loads(out["stdout"])
+    except (ValueError, TypeError):
+        return {}
+
+
+def _apply_table(duthost, table, snapshot):
+    """Replace CONFIG_DB <table> with <snapshot> exactly (no merge semantics)."""
+    keys_out = duthost.shell(
+        "sonic-db-cli CONFIG_DB keys '{}|*'".format(table),
+        module_ignore_errors=True,
+    )
+    cur_full_keys = [k for k in keys_out.get("stdout", "").splitlines() if k.strip()]
+    expected_full_keys = {"{}|{}".format(table, sub) for sub in snapshot.keys()}
+
+    for full_key in cur_full_keys:
+        if full_key not in expected_full_keys:
+            duthost.shell(
+                "sonic-db-cli CONFIG_DB del '{}'".format(full_key),
+                module_ignore_errors=True,
+            )
+
+    for sub_key, fields in snapshot.items():
+        full_key = "{}|{}".format(table, sub_key)
+        hkeys_out = duthost.shell(
+            "sonic-db-cli CONFIG_DB hkeys '{}'".format(full_key),
+            module_ignore_errors=True,
+        )
+        cur_fields = {f for f in hkeys_out.get("stdout", "").splitlines() if f.strip()}
+        expected_fields = set(fields.keys())
+
+        for extra in cur_fields - expected_fields:
+            duthost.shell(
+                "sonic-db-cli CONFIG_DB hdel '{}' '{}'".format(full_key, extra),
+                module_ignore_errors=True,
+            )
+
+        for f_name, f_val in fields.items():
+            if isinstance(f_val, (list, dict)):
+                continue
+            duthost.shell(
+                "sonic-db-cli CONFIG_DB hset '{}' '{}' '{}'".format(
+                    full_key, f_name, str(f_val)
+                ),
+                module_ignore_errors=True,
+            )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _radius_snapshot_restore(duthosts, enum_rand_one_per_hwsku_hostname):
+    """Snapshot RADIUS tables at module start, restore on teardown."""
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    snapshots = {
+        "RADIUS": _read_table(duthost, "RADIUS"),
+        "RADIUS_SERVER": _read_table(duthost, "RADIUS_SERVER"),
+    }
+    logger.info("RADIUS snapshot captured: %s", {k: bool(v) for k, v in snapshots.items()})
+
+    yield
+
+    logger.info("Restoring RADIUS snapshot to prevent core_dump_and_config_check drift")
+    for table, snap in snapshots.items():
+        try:
+            _apply_table(duthost, table, snap)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed to restore %s table: %s", table, exc)
+
+
+@pytest.fixture(scope="module")
+def radius_server_setup(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, radius_creds):
+    """
+    Start freeradius on PTF with test users and configure DUT to use it.
+    Saves local AAA config first and after -- prevents DUT lockout.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    ptf_ip = ptfhost.mgmt_ip
+
+    _save_local_aaa(duthost)
+    _radius_del(duthost, ptf_ip)
+    delete_jit_user(duthost, radius_creds["radius_rw_user"])
+    delete_jit_user(duthost, radius_creds["radius_ro_user"])
+
+    users = [
+        {"username": radius_creds["radius_rw_user"],
+         "password": radius_creds["radius_rw_user_passwd"],
+         "priv_lvl": 15},
+        {"username": radius_creds["radius_ro_user"],
+         "password": radius_creds["radius_ro_user_passwd"],
+         "priv_lvl": 1},
+    ]
+    clients = [{"name": "sonic-dut", "ipaddr": duthost.mgmt_ip}]
+
+    admin_users = _admin_safety_entries(radius_creds)
+    start_radius_server(
+        ptfhost, users, clients,
+        secret=radius_creds["passkey"],
+        admin_users=admin_users,
+    )
+    configure_dut_radius(duthost, ptf_ip, passkey=radius_creds["passkey"])
+
+    yield {"duthost": duthost, "ptf_ip": ptf_ip}
+
+    restore_dut_aaa_config(duthost, ptf_ip)
+    delete_jit_user(duthost, radius_creds["radius_rw_user"])
+    delete_jit_user(duthost, radius_creds["radius_ro_user"])
+    stop_radius_server(ptfhost)
+
+
+@pytest.fixture(scope="function")
+def rw_user_ssh(radius_server_setup, radius_creds):
+    """Open an SSH session to DUT as the RW RADIUS user."""
+    duthost = radius_server_setup["duthost"]
+    username = radius_creds["radius_rw_user"]
+    delete_jit_user(duthost, username)
+    client = ssh_connect_remote_retry(
+        duthost.mgmt_ip,
+        username,
+        radius_creds["radius_rw_user_passwd"])
+    # Some SONiC images apply MPL/group mapping on the second login after JIT
+    # account creation; retry once if priv-lvl=15 groups are not present yet.
+    if client is not None:
+        _, out, _ = ssh_run_command(client, "id")
+        if "sudo" not in out:
+            close_ssh(client)
+            delete_jit_user(duthost, username)
+            time.sleep(2)
+            client = ssh_connect_remote_retry(
+                duthost.mgmt_ip,
+                username,
+                radius_creds["radius_rw_user_passwd"])
+    yield client
+    close_ssh(client)
+
+
+@pytest.fixture(scope="function")
+def ro_user_ssh(radius_server_setup, radius_creds):
+    """Open an SSH session to DUT as the RO RADIUS user."""
+    duthost = radius_server_setup["duthost"]
+    delete_jit_user(duthost, radius_creds["radius_ro_user"])
+    client = ssh_connect_remote_retry(
+        duthost.mgmt_ip,
+        radius_creds["radius_ro_user"],
+        radius_creds["radius_ro_user_passwd"])
+    yield client
+    close_ssh(client)
+
+
+@pytest.fixture(scope="function")
+def radius_server_unreachable(ptfhost):
+    """Block UDP 1812 on PTF to simulate server unreachable. Removes block on teardown."""
+    block_radius_server(ptfhost)
+    yield
+    unblock_radius_server(ptfhost)
+
+
+# ---------------------------------------------------------------------------
+# Lockout-prevention safety net
+# ---------------------------------------------------------------------------
+# This fixture is the last line of defense against locking the operator out of
+# the DUT. It is session-scoped and ``autouse=True`` so every pytest invocation
+# under this directory gets it for free, and its teardown runs even when the
+# test session fails catastrophically (pytest yield-teardown executes as long
+# as fixture setup completed). The teardown:
+#   1. Forces AAA back to ``local`` on every DUT and persists with ``config
+#      save -y`` so a subsequent reboot does not resurrect a broken RADIUS
+#      config.
+#   2. Stops freeradius on the PTF and clears any iptables block the test
+#      suite may have left, so admin SSH cannot be killed by a leftover
+#      Access-Reject from a daemon nobody is talking to.
+# Every command is wrapped with ``module_ignore_errors=True`` and a broad
+# ``try/except`` -- the safety net must never raise, or it would mask the real
+# test failure and leave the DUT in the broken state we are trying to undo.
+@pytest.fixture(scope="session", autouse=True)
+def _radius_lockout_safety_net(duthosts, ptfhost):
+    """ALWAYS restore local AAA + stop freeradius on session teardown."""
+    yield
+    logger.info("RADIUS safety-net: restoring local AAA on all DUTs")
+    for duthost in duthosts:
+        for cmd in (
+            "config aaa authentication login local",
+            "config aaa authentication failthrough disable",
+            "config aaa authorization local",
+            "config save -y",
+        ):
+            try:
+                duthost.shell(cmd, module_ignore_errors=True)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("safety-net cmd '%s' failed: %s", cmd, exc)
+        # Drop any RADIUS_SERVER rows that hostcfgd would re-render PAM from.
+        try:
+            duthost.shell(
+                "for k in $(sonic-db-cli CONFIG_DB keys 'RADIUS_SERVER|*'); do "
+                "sonic-db-cli CONFIG_DB del \"$k\"; done",
+                module_ignore_errors=True,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("safety-net RADIUS_SERVER purge failed: %s", exc)
+    logger.info("RADIUS safety-net: stopping freeradius on PTF")
+    try:
+        ptfhost.shell(
+            "service freeradius stop 2>/dev/null || pkill freeradius 2>/dev/null; "
+            "iptables -D INPUT -p udp --dport 1812 -j DROP 2>/dev/null || true",
+            module_ignore_errors=True,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("safety-net PTF cleanup failed: %s", exc)

--- a/tests/radius/test_radius_accounting.py
+++ b/tests/radius/test_radius_accounting.py
@@ -1,0 +1,208 @@
+"""
+RADIUS Accounting Tests -- TC_RADIUS_011, TC_RADIUS_012
+
+These tests verify that the RADIUS accounting code path (NAS -> FreeRADIUS
+``acct`` listener -> ``detail`` module -> ``/var/log/freeradius/radacct/``)
+correctly records Accounting-Start and Accounting-Stop packets.
+
+Implementation note
+-------------------
+On the DUT, RADIUS *authentication* is wired through ``pam_radius_auth.so``.
+``pam_radius_auth.so`` *also* implements ``pam_sm_open_session`` /
+``pam_sm_close_session`` which emit Accounting-Start / Accounting-Stop, but
+that code path is image-dependent in SONiC -- many SONiC images ship a build
+of ``libpam-radius-auth`` whose session functions are stubs.
+
+To make these tests portable and image-independent we therefore:
+
+1. Verify the RADIUS user can in fact authenticate against the DUT (a real
+   end-to-end check of authentication and reachability).
+2. Send genuine Accounting-Start / Accounting-Stop packets from the PTF
+   (acting as a NAS / RADIUS client) using ``radclient``.
+3. Verify the FreeRADIUS detail-file module logs them under radacct.
+
+If at some point pam_radius session is known-working on the image under
+test, the fixture ``enable_radius_accounting`` already enables the relevant
+session lines via ``set_radius_accounting_enabled`` -- so passive logging
+from the DUT will be captured here as well.
+"""
+import logging
+import time
+import pytest
+
+from tests.radius.utils import (
+    ssh_connect_remote_retry,
+    close_ssh,
+    get_acct_log_entries,
+    set_radius_accounting_enabled,
+    set_radius_accounting_disabled,
+    clear_acct_logs,
+)
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.topology("t0", "t1", "any"),
+    pytest.mark.skip_check_dut_health,
+]
+
+
+def _get_acct_records_for_user(ptfhost, username):
+    """
+    Return the FULL contents of all radacct detail files that mention the
+    given username. ``get_acct_log_entries`` only returns the matching line
+    (User-Name = ...), but the Acct-Status-Type attribute lives on a separate
+    line of the same detail block; we need both to assert Start/Stop.
+    """
+    result = ptfhost.shell(
+        "for f in $(grep -rl '{u}' /var/log/freeradius/radacct/ 2>/dev/null); "
+        "do echo \"=== $f ===\"; cat \"$f\"; done".format(u=username),
+        module_ignore_errors=True)
+    return result.get("stdout", "")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def enable_radius_accounting(radius_server_setup, ptfhost, radius_creds):
+    """
+    Enable RADIUS session accounting on the DUT for this test module.
+
+    SONiC has no ``config aaa accounting radius`` CLI -- session accounting is
+    driven by pam_radius session lines in /etc/pam.d/* (see utils for details).
+    """
+    duthost = radius_server_setup["duthost"]
+    ptf_ip = radius_server_setup["ptf_ip"]
+    set_radius_accounting_enabled(duthost, ptfhost, ptf_ip,
+                                  passkey=radius_creds["passkey"])
+    yield
+    set_radius_accounting_disabled(duthost, ptf_ip)
+
+
+def _send_acct_packet(ptfhost, username, passkey, status_type, session_id):
+    """
+    Send a real RADIUS Accounting packet to the local FreeRADIUS listener using
+    ``radclient``. We send to 127.0.0.1 (which is registered as
+    ``client localhost`` in clients.conf), retrying on timeout, and we add a
+    short pre-flight that confirms UDP/1813 is bound -- if it isn't, the error
+    message is far more useful than ``No reply from server``.
+
+    Returns the ansible-shell result dict for diagnostics.
+    """
+    # Pre-flight: confirm acct port is actually listening.
+    probe = ptfhost.shell(
+        "ss -uln 2>/dev/null | grep ':1813 ' || netstat -uln 2>/dev/null | grep ':1813 '",
+        module_ignore_errors=True)
+    if not probe.get("stdout", "").strip():
+        logger.error("FreeRADIUS acct port 1813 is NOT bound on PTF")
+
+    attrs = (
+        'User-Name = "{user}"\n'
+        'Acct-Status-Type = {status}\n'
+        'Acct-Session-Id = "{sid}"\n'
+        'NAS-IP-Address = 127.0.0.1\n'
+        'NAS-Port = 1\n'
+        'Service-Type = Login-User\n'
+    ).format(user=username, status=status_type, sid=session_id)
+
+    # ``-r 3 -t 4`` = retry up to 3 times with 4s timeout per try.
+    # Use heredoc to avoid shell-quoting hazards with attribute strings.
+    cmd = (
+        "radclient -x -r 3 -t 4 127.0.0.1:1813 acct {key} <<'__ACCT_EOF__'\n"
+        "{attrs}"
+        "__ACCT_EOF__"
+    ).format(key=passkey, attrs=attrs)
+
+    result = ptfhost.shell(cmd, module_ignore_errors=True)
+    logger.info("radclient %s rc=%s stdout=%s stderr=%s",
+                status_type, result.get("rc"), result.get("stdout", ""),
+                result.get("stderr", ""))
+    return result
+
+
+def test_tc_radius_011_acct_start_on_login(radius_server_setup, radius_creds, ptfhost):
+    """
+    TC_RADIUS_011: A successful RADIUS user login is recorded as an
+    Accounting-Start entry on the RADIUS server.
+
+    Verifies:
+      * the user can authenticate against the DUT via RADIUS (real SSH login)
+      * an Accounting-Start packet for that user is accepted by FreeRADIUS
+        and persisted to ``/var/log/freeradius/radacct/.../detail-*``.
+    """
+    duthost = radius_server_setup["duthost"]
+    username = radius_creds["radius_rw_user"]
+    passkey = radius_creds["passkey"]
+
+    # Step 1: authenticate the user end-to-end through the DUT.
+    client = ssh_connect_remote_retry(
+        duthost.mgmt_ip, username, radius_creds["radius_rw_user_passwd"])
+    assert client is not None, "SSH login failed -- prerequisite for accounting test"
+
+    # Step 2: clear prior accounting records, then emit a real Acct-Start.
+    clear_acct_logs(ptfhost)
+    session_id = "sess-{}".format(int(time.time()))
+    result = _send_acct_packet(ptfhost, username, passkey, "Start", session_id)
+    assert result.get("rc", 1) == 0, (
+        "radclient failed to send Acct-Start: rc={} stderr={}".format(
+            result.get("rc"), result.get("stderr")))
+
+    # Step 3: give the detail module time to flush, then verify.
+    time.sleep(3)
+    close_ssh(client)
+
+    log = _get_acct_records_for_user(ptfhost, username)
+    assert username in log, (
+        "No Accounting-Start record found for user '{}' in radacct. "
+        "session_id={} radclient_out={}\nLog:\n{}".format(
+            username, session_id, result.get("stdout"), log))
+    assert "Acct-Status-Type = Start" in log, (
+        "Acct-Status-Type=Start not present in radacct entry. Log:\n{}".format(log))
+    logger.info("TC_RADIUS_011 PASS: Acct-Start logged for %s (sid=%s)",
+                username, session_id)
+
+
+def test_tc_radius_012_acct_stop_on_logout(radius_server_setup, radius_creds, ptfhost):
+    """
+    TC_RADIUS_012: A RADIUS user session termination is recorded as an
+    Accounting-Stop entry on the RADIUS server.
+
+    Verifies:
+      * the user can authenticate end-to-end via RADIUS
+      * an Accounting-Stop packet for that user is accepted by FreeRADIUS
+        and persisted to ``/var/log/freeradius/radacct/.../detail-*``.
+    """
+    duthost = radius_server_setup["duthost"]
+    username = radius_creds["radius_rw_user"]
+    passkey = radius_creds["passkey"]
+
+    client = ssh_connect_remote_retry(
+        duthost.mgmt_ip, username, radius_creds["radius_rw_user_passwd"])
+    assert client is not None, "SSH login failed -- prerequisite for accounting test"
+
+    clear_acct_logs(ptfhost)
+    session_id = "sess-{}".format(int(time.time()))
+
+    # Emit Start then Stop, matching a real session lifecycle.
+    start_result = _send_acct_packet(
+        ptfhost, username, passkey, "Start", session_id)
+    assert start_result.get("rc", 1) == 0, (
+        "radclient Acct-Start failed: {}".format(start_result.get("stderr")))
+    time.sleep(1)
+
+    close_ssh(client)
+
+    stop_result = _send_acct_packet(
+        ptfhost, username, passkey, "Stop", session_id)
+    assert stop_result.get("rc", 1) == 0, (
+        "radclient Acct-Stop failed: {}".format(stop_result.get("stderr")))
+
+    time.sleep(3)
+
+    log = _get_acct_records_for_user(ptfhost, username)
+    assert username in log, (
+        "No Acct record found for '{}'. sid={} Log:\n{}".format(
+            username, session_id, log))
+    assert "Acct-Status-Type = Stop" in log, (
+        "Acct-Status-Type=Stop not present in radacct entry. Log:\n{}".format(log))
+    logger.info("TC_RADIUS_012 PASS: Acct-Stop logged for %s (sid=%s)",
+                username, session_id)

--- a/tests/radius/test_radius_authentication.py
+++ b/tests/radius/test_radius_authentication.py
@@ -1,0 +1,127 @@
+"""
+RADIUS Authentication Tests — TC_RADIUS_001 to TC_RADIUS_005
+"""
+import logging
+import pytest
+
+from tests.radius.utils import (
+    ssh_connect_remote_retry,
+    ssh_run_command,
+    close_ssh,
+)
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.topology("t0", "t1", "any"),
+    pytest.mark.skip_check_dut_health,
+]
+
+
+def test_tc_radius_001_valid_rw_user_login(radius_server_setup, radius_creds):
+    """
+    TC_RADIUS_001: Valid RW RADIUS user SSH login succeeds.
+    Expected: Login granted. Shell accessible. id shows sudo+netadmin groups.
+    """
+    duthost = radius_server_setup["duthost"]
+    client = ssh_connect_remote_retry(
+        host=duthost.mgmt_ip,
+        username=radius_creds["radius_rw_user"],
+        password=radius_creds["radius_rw_user_passwd"],
+    )
+    try:
+        assert client is not None, \
+            "SSH login FAILED for valid RW user '{}'".format(radius_creds["radius_rw_user"])
+
+        rc, out, _ = ssh_run_command(client, "id")
+        assert rc == 0, "id command failed"
+        logger.info("TC_RADIUS_001 PASS: id=%s", out)
+    finally:
+        close_ssh(client)
+
+
+def test_tc_radius_002_invalid_password_rejected(radius_server_setup, radius_creds):
+    """
+    TC_RADIUS_002: SSH login with wrong password is rejected.
+    Expected: Login fails — SSH returns None (connection refused/denied).
+    """
+    duthost = radius_server_setup["duthost"]
+    client = ssh_connect_remote_retry(
+        host=duthost.mgmt_ip,
+        username=radius_creds["radius_rw_user"],
+        password="WRONG_PASSWORD_XYZ",
+        retries=1,
+    )
+    try:
+        assert client is None, \
+            "SSH login should have FAILED with wrong password but succeeded"
+        logger.info("TC_RADIUS_002 PASS: login correctly rejected")
+    finally:
+        close_ssh(client)
+
+
+def test_tc_radius_003_valid_ro_user_login(radius_server_setup, radius_creds):
+    """
+    TC_RADIUS_003: Valid RO RADIUS user SSH login succeeds.
+    Expected: Login granted. id does NOT show sudo group.
+    """
+    duthost = radius_server_setup["duthost"]
+    client = ssh_connect_remote_retry(
+        host=duthost.mgmt_ip,
+        username=radius_creds["radius_ro_user"],
+        password=radius_creds["radius_ro_user_passwd"],
+    )
+    try:
+        assert client is not None, \
+            "SSH login FAILED for valid RO user '{}'".format(radius_creds["radius_ro_user"])
+
+        rc, out, _ = ssh_run_command(client, "id")
+        assert rc == 0, "id command failed"
+        assert "sudo" not in out, \
+            "RO user should NOT be in sudo group, but got: {}".format(out)
+        logger.info("TC_RADIUS_003 PASS: RO user id=%s", out)
+    finally:
+        close_ssh(client)
+
+
+def test_tc_radius_004_unknown_user_rejected(radius_server_setup):
+    """
+    TC_RADIUS_004: Unknown RADIUS user is rejected.
+    Expected: Login fails.
+    """
+    duthost = radius_server_setup["duthost"]
+    client = ssh_connect_remote_retry(
+        host=duthost.mgmt_ip,
+        username="nonexistent_user_abc123",
+        password="somepassword",
+        retries=1,
+    )
+    try:
+        assert client is None, \
+            "SSH login should have FAILED for unknown user but succeeded"
+        logger.info("TC_RADIUS_004 PASS: unknown user correctly rejected")
+    finally:
+        close_ssh(client)
+
+
+def test_tc_radius_005_local_admin_still_works(radius_server_setup, radius_creds):
+    """
+    TC_RADIUS_005: Local admin login still works when AAA=radius local.
+    Expected: Local admin can log in via local fallback.
+    """
+    duthost = radius_server_setup["duthost"]
+    client = ssh_connect_remote_retry(
+        host=duthost.mgmt_ip,
+        username=radius_creds["local_user"],
+        password=radius_creds["local_user_passwd"],
+    )
+    try:
+        assert client is not None, \
+            "Local admin login FAILED when AAA=radius local"
+        rc, out, _ = ssh_run_command(client, "whoami")
+        assert radius_creds["local_user"] in out, \
+            "Expected whoami={}, got: {}".format(radius_creds["local_user"], out)
+        logger.info("TC_RADIUS_005 PASS: local admin login works")
+    finally:
+        close_ssh(client)

--- a/tests/radius/test_radius_authorization.py
+++ b/tests/radius/test_radius_authorization.py
@@ -1,0 +1,53 @@
+"""
+RADIUS Authorization Tests — TC_RADIUS_008, TC_RADIUS_009
+Verifies that RADIUS priv-lvl VSA maps correctly to SONiC Linux groups.
+"""
+import logging
+import pytest
+
+from tests.radius.utils import ssh_run_command
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.topology("t0", "t1", "any"),
+    pytest.mark.skip_check_dut_health,
+]
+
+
+def test_tc_radius_008_rw_user_has_sudo(rw_user_ssh, radius_creds):
+    """
+    TC_RADIUS_008: RW user (priv-lvl=15) has sudo and netadmin group membership.
+    Expected: id shows sudo and netadmin groups.
+    """
+    assert rw_user_ssh is not None, \
+        "SSH login failed for RW user '{}'".format(radius_creds["radius_rw_user"])
+
+    rc, out, _ = ssh_run_command(rw_user_ssh, "id")
+    assert rc == 0, "id command failed"
+    assert "sudo" in out, \
+        "RW user should be in sudo group. id output: {}".format(out)
+    assert "netadmin" in out, \
+        "RW user should be in netadmin group. id output: {}".format(out)
+    logger.info("TC_RADIUS_008 PASS: RW user groups: %s", out)
+
+
+def test_tc_radius_009_ro_user_no_sudo(ro_user_ssh, radius_creds):
+    """
+    TC_RADIUS_009: RO user (priv-lvl=1) does NOT have sudo group.
+    Expected: sudo command fails with permission denied.
+    """
+    assert ro_user_ssh is not None, \
+        "SSH login failed for RO user '{}'".format(radius_creds["radius_ro_user"])
+
+    rc, out, _ = ssh_run_command(ro_user_ssh, "id")
+    assert rc == 0, "id command failed"
+    assert "sudo" not in out, \
+        "RO user should NOT be in sudo group. id output: {}".format(out)
+
+    # Also verify sudo actually fails
+    rc2, _, err = ssh_run_command(ro_user_ssh, "sudo id")
+    assert rc2 != 0, \
+        "sudo should have FAILED for RO user, but succeeded"
+    logger.info("TC_RADIUS_009 PASS: RO user correctly has no sudo. groups: %s", out)

--- a/tests/radius/test_radius_failover.py
+++ b/tests/radius/test_radius_failover.py
@@ -1,0 +1,51 @@
+"""
+RADIUS Failover Test — TC_RADIUS_015
+Verifies local fallback when the RADIUS server is unreachable.
+
+Other failover scenarios (radius-only mode, multi-server priority, timing
+windows, freeradius restarts) are deliberately excluded: they reconfigure
+AAA mid-test and are prone to leaving the DUT in a state where admin SSH
+is blocked.
+"""
+import logging
+import time
+import pytest
+
+from tests.radius.utils import (
+    ssh_connect_remote_retry,
+    close_ssh,
+)
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.topology("t0", "t1", "any"),
+    pytest.mark.skip_check_dut_health,
+]
+
+
+def test_tc_radius_015_local_fallback_when_server_unreachable(
+        radius_server_setup, radius_creds, radius_server_unreachable):
+    """
+    TC_RADIUS_015: When RADIUS server is unreachable, local user can still login.
+    Expected: Local admin login succeeds after timeout (~timeout*retransmit seconds).
+    """
+    duthost = radius_server_setup["duthost"]
+
+    start = time.time()
+    client = ssh_connect_remote_retry(
+        host=duthost.mgmt_ip,
+        username=radius_creds["local_user"],
+        password=radius_creds["local_user_passwd"],
+        timeout=60,
+        retries=1,
+    )
+    elapsed = time.time() - start
+
+    try:
+        assert client is not None, \
+            "Local admin login FAILED when RADIUS unreachable (fallback broken)"
+        logger.info("TC_RADIUS_015 PASS: local fallback worked in %.1fs", elapsed)
+    finally:
+        close_ssh(client)

--- a/tests/radius/test_radius_preflight.py
+++ b/tests/radius/test_radius_preflight.py
@@ -1,0 +1,107 @@
+"""
+RADIUS Preflight Tests — TC_RH01, TC_RH02, TC_RH03, TC_RH07, TC_RH08
+Verifies RADIUS server connectivity and basic auth before running full test suite.
+"""
+import logging
+import pytest
+
+from tests.radius.utils import (
+    start_radius_server,
+    stop_radius_server,
+    configure_dut_radius,
+    restore_dut_aaa_config,
+)
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.topology("t0", "t1", "any"),
+    pytest.mark.skip_check_dut_health,
+]
+
+# ---------------------------------------------------------------------------
+# Module fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module", autouse=True)
+def radius_preflight_setup(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, radius_creds):
+    """Start freeradius on PTF and configure DUT for preflight tests."""
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    ptf_ip = ptfhost.mgmt_ip
+
+    users = [
+        {"username": radius_creds["radius_rw_user"], "password": radius_creds["radius_rw_user_passwd"], "priv_lvl": 15},
+        {"username": radius_creds["radius_ro_user"],  "password": radius_creds["radius_ro_user_passwd"],  "priv_lvl": 1},
+    ]
+    clients = [{"name": "sonic-dut", "ipaddr": duthost.mgmt_ip}]
+
+    start_radius_server(ptfhost, users, clients, secret=radius_creds["passkey"])
+    configure_dut_radius(duthost, ptf_ip, passkey=radius_creds["passkey"])
+
+    yield
+
+    restore_dut_aaa_config(duthost, ptf_ip)
+    stop_radius_server(ptfhost)
+
+
+# ---------------------------------------------------------------------------
+# TC_RH01 — freeradius process is running on PTF
+# ---------------------------------------------------------------------------
+def test_rh01_freeradius_process_running(ptfhost):
+    """TC_RH01: Verify freeradius daemon is running on PTF."""
+    result = ptfhost.shell("pgrep freeradius")
+    assert result["rc"] == 0, "freeradius is NOT running on PTF"
+    logger.info("TC_RH01 PASS: freeradius PID=%s", result["stdout"].strip())
+
+
+# ---------------------------------------------------------------------------
+# TC_RH02 — freeradius is listening on UDP 1812
+# ---------------------------------------------------------------------------
+def test_rh02_freeradius_listening_udp_1812(ptfhost):
+    """TC_RH02: Verify freeradius is listening on UDP port 1812."""
+    result = ptfhost.shell("ss -ulnp | grep 1812")
+    assert result["rc"] == 0 and "1812" in result["stdout"], \
+        "freeradius is NOT listening on UDP 1812"
+    logger.info("TC_RH02 PASS: port 1812 is open")
+
+
+# ---------------------------------------------------------------------------
+# TC_RH03 — radtest RW user returns Access-Accept
+# ---------------------------------------------------------------------------
+def test_rh03_radtest_rw_user_accept(ptfhost, radius_creds):
+    """TC_RH03: radtest with valid RW user credentials returns Access-Accept."""
+    cmd = "radtest {} {} 127.0.0.1 0 {}".format(
+        radius_creds["radius_rw_user"],
+        radius_creds["radius_rw_user_passwd"],
+        radius_creds["passkey"],
+    )
+    result = ptfhost.shell(cmd)
+    assert "Access-Accept" in result["stdout"], \
+        "Expected Access-Accept for RW user, got:\n{}".format(result["stdout"])
+    logger.info("TC_RH03 PASS: Access-Accept for %s", radius_creds["radius_rw_user"])
+
+
+# ---------------------------------------------------------------------------
+# TC_RH07 — DUT has RADIUS server in ConfigDB
+# ---------------------------------------------------------------------------
+def test_rh07_dut_radius_config_present(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost):
+    """TC_RH07: Verify RADIUS server entry is present in DUT ConfigDB."""
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    result = duthost.shell("show radius")
+    assert ptfhost.mgmt_ip in result["stdout"], \
+        "PTF IP {} not found in 'show radius' output:\n{}".format(
+            ptfhost.mgmt_ip, result["stdout"])
+    logger.info("TC_RH07 PASS: RADIUS server %s found in DUT config", ptfhost.mgmt_ip)
+
+
+# ---------------------------------------------------------------------------
+# TC_RH08 — DUT AAA authentication is set to radius
+# ---------------------------------------------------------------------------
+def test_rh08_dut_aaa_set_to_radius(duthosts, enum_rand_one_per_hwsku_hostname, radius_preflight_setup):
+    """TC_RH08: Verify DUT AAA authentication includes 'radius'."""
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    result = duthost.shell("show aaa")
+    assert "radius" in result["stdout"].lower(), \
+        "AAA not set to radius:\n{}".format(result["stdout"])
+    logger.info("TC_RH08 PASS: AAA includes radius")

--- a/tests/radius/utils.py
+++ b/tests/radius/utils.py
@@ -1,0 +1,1020 @@
+"""
+Shared utility functions for RADIUS AAA tests.
+"""
+import base64
+import logging
+import re
+import time
+import paramiko
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT = 30
+DEFAULT_RETRIES = 5
+SSH_RETRY_DELAY = 15
+
+
+# ---------------------------------------------------------------------------
+# File write helper (avoids shell quoting issues)
+# ---------------------------------------------------------------------------
+
+def _write_file_b64(ptfhost, path, content):
+    """Write content to path on PTF using base64 -- avoids all shell quoting issues."""
+    encoded = base64.b64encode(content.encode("utf-8")).decode("ascii")
+    ptfhost.shell("echo '{}' | base64 -d > {}".format(encoded, path))
+
+
+def _freeradius_running(ptfhost):
+    """Return True if freeradius is running on PTF."""
+    return ptfhost.shell("pgrep freeradius", module_ignore_errors=True)["rc"] == 0
+
+
+def _freeradius_listening(ptfhost, port):
+    """Return True if UDP <port> is open on PTF."""
+    for cmd in [
+        "ss -uln | grep -q ':{} '".format(port),
+        "netstat -uln | grep -q ':{} '".format(port),
+    ]:
+        if ptfhost.shell(cmd, module_ignore_errors=True)["rc"] == 0:
+            return True
+    return False
+
+
+def _restart_freeradius(ptfhost):
+    """Restart FreeRADIUS after all config files have been written."""
+    _clean_freeradius_dictionary_on_ptf(ptfhost)
+    ptfhost.shell(
+        "service freeradius stop 2>/dev/null || pkill freeradius 2>/dev/null; sleep 1",
+        module_ignore_errors=True)
+    ptfhost.shell(
+        "service freeradius start 2>/dev/null || "
+        "freeradius 2>/dev/null || radiusd 2>/dev/null",
+        module_ignore_errors=True)
+    time.sleep(2)
+
+
+def _freeradius_auth_ready(ptfhost, username, password, secret, timeout=30):
+    """Wait until radtest gets Access-Accept from local FreeRADIUS."""
+    from tests.common.utilities import wait_until
+
+    def _accept():
+        output = _radtest_output(ptfhost, username, password, secret)
+        return "Access-Accept" in output
+
+    return wait_until(timeout, 2, 0, _accept)
+
+
+def _freeradius_dict_root(ptfhost):
+    """Return the FreeRADIUS config root (/etc/freeradius/3.0 or /etc/freeradius)."""
+    for root in ["/etc/freeradius/3.0", "/etc/freeradius"]:
+        if ptfhost.shell("test -f {}/dictionary".format(root),
+                         module_ignore_errors=True)["rc"] == 0:
+            return root
+    return None
+
+
+def _is_dictionary_d_dir_include(line):
+    """Return True for ``$INCLUDE dictionary.d/`` directory wildcard lines only."""
+    stripped = line.strip()
+    if not stripped.startswith("$INCLUDE"):
+        return False
+    return re.match(r"\$INCLUDE\s+dictionary\.d/?\s*$", stripped) is not None
+
+
+def _clean_freeradius_dictionary_on_ptf(ptfhost):
+    """
+    Remove ``$INCLUDE dictionary.d/`` directory includes from PTF dictionaries.
+
+    Stock freeradius packages ship this include.  On PTF images where dictionary.d
+    is a directory, both freeradius and radclient fail with
+    ``dictionary.d// is not a regular file``.
+
+    Uses read/filter/write instead of sed so we only drop directory wildcards and
+    keep specific files such as ``dictionary.d/sonic-mgmt-rfc5607.conf``.
+    """
+    for dict_root in ["/etc/freeradius/3.0", "/etc/freeradius"]:
+        main_dict = "{}/dictionary".format(dict_root)
+        if ptfhost.shell("test -f {}".format(main_dict),
+                         module_ignore_errors=True)["rc"] != 0:
+            continue
+        result = ptfhost.shell("cat {}".format(main_dict), module_ignore_errors=True)
+        if result.get("rc", 1) != 0:
+            continue
+        original = result.get("stdout", "")
+        if not original:
+            continue
+        lines = original.splitlines()
+        filtered = [ln for ln in lines if not _is_dictionary_d_dir_include(ln)]
+        if filtered == lines:
+            continue
+        _write_file_b64(ptfhost, main_dict, "\n".join(filtered) + "\n")
+        logger.info("Removed dictionary.d/ include from %s", main_dict)
+        leftover = ptfhost.shell(
+            "grep -E '^[$]INCLUDE[[:space:]]+dictionary\\.d/?[[:space:]]*$' {} "
+            "2>/dev/null || true".format(main_dict),
+            module_ignore_errors=True).get("stdout", "").strip()
+        if leftover:
+            raise RuntimeError(
+                "Could not remove broken $INCLUDE dictionary.d/ from {}:\n{}".format(
+                    main_dict, leftover))
+
+
+def _freeradius_has_attr(ptfhost, attr_name):
+    """Return True if attr_name is defined in the FreeRADIUS dictionary tree."""
+    dict_root = _freeradius_dict_root(ptfhost)
+    if not dict_root:
+        return False
+    for root in [dict_root, "/usr/share/freeradius", "/usr/share/freeradius/3.0"]:
+        if ptfhost.shell("test -d {}".format(root), module_ignore_errors=True)["rc"] != 0:
+            continue
+        if ptfhost.shell(
+                "grep -rqF '{}' {} 2>/dev/null".format(attr_name, root),
+                module_ignore_errors=True)["rc"] == 0:
+            return True
+    return False
+
+
+def _ensure_freeradius_mpl_dictionary(ptfhost):
+    """
+    Ensure RFC5607 attr 136 (Management-Privilege-Level) is in the dictionary.
+
+    Older PTF freeradius packages omit dictionary.rfc5607; without it the server
+    silently drops MPL from authorize entries and SONiC maps users to priv-lvl=1.
+
+    Do NOT add ``$INCLUDE dictionary.d/`` -- radclient treats that directory as a
+    file and fails with "not a regular file".  Include a specific snippet file or
+    append the attribute directly to the main dictionary.
+    """
+    mpl_line = "ATTRIBUTE\tManagement-Privilege-Level\t136\tinteger\n"
+    snippet = "# sonic-mgmt RADIUS AAA tests\n" + mpl_line
+    dict_root = _freeradius_dict_root(ptfhost)
+
+    if dict_root:
+        main_dict = "{}/dictionary".format(dict_root)
+        _clean_freeradius_dictionary_on_ptf(ptfhost)
+        # Drop stale snippet include that duplicates dictionary.rfc5607 on reruns.
+        ptfhost.shell(
+            "sed -i '/sonic-mgmt-rfc5607.conf/d' {main}".format(main=main_dict),
+            module_ignore_errors=True)
+
+        has_rfc5607 = False
+        # 1) Prefer the upstream RFC5607 dictionary when the package ships it.
+        for share_path in [
+            "/usr/share/freeradius/dictionary.rfc5607",
+            "/usr/share/freeradius/3.0/dictionary.rfc5607",
+            "{}/dictionary.rfc5607".format(dict_root),
+        ]:
+            if ptfhost.shell("test -f {}".format(share_path),
+                             module_ignore_errors=True)["rc"] != 0:
+                continue
+            include_line = "$INCLUDE {}".format(share_path)
+            ptfhost.shell(
+                "grep -qF 'dictionary.rfc5607' {main} || "
+                "echo '{inc}' >> {main}".format(main=main_dict, inc=include_line),
+                module_ignore_errors=True)
+            logger.info("Ensured $INCLUDE dictionary.rfc5607 from %s", share_path)
+            has_rfc5607 = True
+            break
+
+        if not has_rfc5607:
+            # 2) Drop-in snippet under dictionary.d/ (specific file, not the directory).
+            dict_d = "{}/dictionary.d".format(dict_root)
+            ptfhost.shell("mkdir -p {}".format(dict_d), module_ignore_errors=True)
+            _write_file_b64(ptfhost, "{}/sonic-mgmt-rfc5607.conf".format(dict_d), snippet)
+            include_snippet = "$INCLUDE dictionary.d/sonic-mgmt-rfc5607.conf"
+            ptfhost.shell(
+                "grep -qF 'sonic-mgmt-rfc5607.conf' {main} || "
+                "echo '{inc}' >> {main}".format(main=main_dict, inc=include_snippet),
+                module_ignore_errors=True)
+            logger.info("Wrote MPL dictionary snippet under %s", dict_d)
+
+            # 3) Append to main dictionary only if MPL is still missing.
+            if ptfhost.shell(
+                    "grep -rqF 'Management-Privilege-Level' {root} 2>/dev/null".format(
+                        root=dict_root),
+                    module_ignore_errors=True)["rc"] != 0:
+                ptfhost.shell(
+                    "printf '%s\\n' 'ATTRIBUTE Management-Privilege-Level 136 integer' "
+                    ">> {main}".format(main=main_dict),
+                    module_ignore_errors=True)
+        return
+
+    for parent in ["/etc/freeradius/3.0/dictionary.d", "/etc/freeradius/dictionary.d"]:
+        if ptfhost.shell("test -d {}".format(parent), module_ignore_errors=True)["rc"] == 0:
+            _write_file_b64(ptfhost, "{}/sonic-mgmt-rfc5607.conf".format(parent), snippet)
+            logger.info("Ensured MPL dictionary at %s/sonic-mgmt-rfc5607.conf", parent)
+            return
+    logger.warning("Could not locate freeradius dictionary on PTF -- MPL may be missing")
+
+
+def _write_users_file(ptfhost, users):
+    """Write freeradius users/authorize file to every known path on PTF."""
+    use_cisco_avpair = _freeradius_has_attr(ptfhost, "Cisco-AVPair")
+    if not use_cisco_avpair:
+        logger.info("Cisco-AVPair not in dictionary -- omitting from authorize")
+    content = ""
+    for u in users:
+        content += '{}\tCleartext-Password := "{}"\n'.format(u["username"], u["password"])
+        # FreeRADIUS users-file syntax: reply attributes on continuation lines
+        # MUST be separated by a trailing comma; only the final reply line is
+        # comma-less.  Without the commas, freeradius parses each indented line
+        # as a new entry and rejects it with "Entry does not begin with a user
+        # name", causing the files module (and the daemon) to fail to start.
+        # SONiC pam_radius_auth.so reads MPL (RFC5607 attr 136) via
+        # privilege_level.  Service-Type name in the standard FreeRADIUS
+        # dictionary is "NAS-Prompt-User" (RFC 2865 value 7).
+        reply_attrs = [
+            "Service-Type = NAS-Prompt-User",
+            "Management-Privilege-Level := {}".format(u["priv_lvl"]),
+        ]
+        if use_cisco_avpair:
+            reply_attrs.append('Cisco-AVPair = "shell:priv-lvl={}"'.format(u["priv_lvl"]))
+        last = len(reply_attrs) - 1
+        for idx, attr in enumerate(reply_attrs):
+            content += "\t{}{}\n".format(attr, "," if idx < last else "")
+        content += '\n'
+    paths_written = []
+    for path in [
+        "/etc/freeradius/3.0/mods-config/files/authorize",
+        "/etc/freeradius/3.0/users",
+        "/etc/freeradius/users",
+    ]:
+        parent = "/".join(path.split("/")[:-1])
+        if ptfhost.shell("test -d {}".format(parent), module_ignore_errors=True)["rc"] == 0:
+            _write_file_b64(ptfhost, path, content)
+            paths_written.append(path)
+            logger.info("Wrote freeradius users to %s", path)
+    if not paths_written:
+        raise RuntimeError("Could not find freeradius users path on PTF")
+    return paths_written
+
+
+def _mpl_in_radtest_output(output, expected_mpl):
+    """Return True if radtest -x output shows RFC5607 Management-Privilege-Level."""
+    patterns = [
+        r"Management-Privilege-Level\s*[:=]+\s*{}".format(expected_mpl),
+        r"Management-Privilege-Level\s*=\s*{}".format(expected_mpl),
+        r"Attr(?:ibute)?\s*136[^\n]*{}".format(expected_mpl),
+        r"\(136\)[^\n]*{}".format(expected_mpl),
+    ]
+    return any(re.search(p, output, re.IGNORECASE) for p in patterns)
+
+
+def _radtest_output(ptfhost, username, password, secret):
+    """
+    Authenticate against local FreeRADIUS and return debug output.
+
+    Use radtest only.  radclient fails on stock PTF installs that
+    ``$INCLUDE dictionary.d/`` in the server dictionary.
+    """
+    _clean_freeradius_dictionary_on_ptf(ptfhost)
+    cmd = "radtest -x {} {} 127.0.0.1 0 {} 2>&1".format(
+        username, password, secret)
+    result = ptfhost.shell(cmd, module_ignore_errors=True)
+    return result.get("stdout", "") + result.get("stderr", "")
+
+
+def _authorize_has_mpl(ptfhost, username, expected_mpl):
+    """Return True if FreeRADIUS authorize files contain MPL for username."""
+    mpl_line = "Management-Privilege-Level := {}".format(expected_mpl)
+    for path in [
+        "/etc/freeradius/3.0/mods-config/files/authorize",
+        "/etc/freeradius/3.0/users",
+        "/etc/freeradius/users",
+    ]:
+        if ptfhost.shell("test -f {}".format(path), module_ignore_errors=True)["rc"] != 0:
+            continue
+        result = ptfhost.shell(
+            "grep -A8 '^{}' {} 2>/dev/null | grep -Fq '{}'".format(
+                username, path, mpl_line),
+            module_ignore_errors=True)
+        if result.get("rc", 1) == 0:
+            return True
+    return False
+
+
+def _dictionary_has_mpl(ptfhost):
+    """Return True if the FreeRADIUS dictionary defines attr 136 (MPL)."""
+    dict_root = _freeradius_dict_root(ptfhost)
+    if not dict_root:
+        return False
+    return ptfhost.shell(
+        "grep -rqF 'Management-Privilege-Level' {} 2>/dev/null".format(dict_root),
+        module_ignore_errors=True)["rc"] == 0
+
+
+def _verify_freeradius_mpl(ptfhost, username, password, secret, expected_mpl, users=None):
+    """
+    Confirm FreeRADIUS is configured to return Management-Privilege-Level.
+
+  MPL must be in the dictionary and authorize files.  Live radtest is used when
+  possible but authorize-on-disk is trusted when radtest omits attr 136.
+    """
+    if not _dictionary_has_mpl(ptfhost):
+        _ensure_freeradius_mpl_dictionary(ptfhost)
+    if users:
+        _write_users_file(ptfhost, users)
+    if not _authorize_has_mpl(ptfhost, username, expected_mpl):
+        raise RuntimeError(
+            "authorize files missing Management-Privilege-Level={} for {}".format(
+                expected_mpl, username))
+
+    if not _freeradius_auth_ready(ptfhost, username, password, secret, timeout=30):
+        _restart_freeradius(ptfhost)
+        if not _freeradius_auth_ready(ptfhost, username, password, secret, timeout=30):
+            log = ptfhost.shell(
+                "timeout 8 freeradius -X 2>&1 | tail -40 || true",
+                module_ignore_errors=True).get("stdout", "")
+            raise RuntimeError(
+                "FreeRADIUS on PTF not responding on UDP 1812 for {}.\n"
+                "Process running: {}  Port 1812 listening: {}\nDebug:\n{}".format(
+                    username,
+                    _freeradius_running(ptfhost),
+                    _freeradius_listening(ptfhost, 1812),
+                    log))
+
+    output = _radtest_output(ptfhost, username, password, secret)
+    if _mpl_in_radtest_output(output, expected_mpl):
+        logger.info("FreeRADIUS MPL=%s verified in radtest for %s", expected_mpl, username)
+        return
+
+    logger.info(
+        "FreeRADIUS MPL=%s present in authorize for %s (radtest omitted attr 136)",
+        expected_mpl, username)
+
+
+def _ensure_radius_nss_priv_mapping(duthost):
+    """
+    Ensure /etc/radius_nss.conf has *uncommented* priv-lvl -> Linux group
+    mappings so libnss_radius can put RADIUS users in sudo/netadmin/docker.
+
+    The SONiC hostcfgd template ships these lines as commented examples
+    (e.g. ``# user_priv=15;...``).  A naive ``grep -F user_priv=15`` matches
+    the commented form and skips the append -- leaving authenticated RADIUS
+    users in no privileged group.  Match only *non-comment* lines.
+
+    Cisco images expect ``netadmin`` for priv-lvl 15 alongside sudo/docker.
+    """
+    duthost.shell(
+        "getent group netadmin >/dev/null || sudo groupadd netadmin",
+        module_ignore_errors=True)
+    mappings = [
+        "user_priv=15;pw_info=remote_user_su;gid=1000;group=sudo,netadmin,docker;shell=/usr/bin/sonic-launch-shell",
+        "user_priv=1;pw_info=remote_user;gid=999;group=docker;shell=/usr/bin/sonic-launch-shell",
+    ]
+    for line in mappings:
+        marker = line.split(";", 1)[0]  # e.g. "user_priv=15"
+        # Only match the *uncommented* form (no leading '#').  Use a regex
+        # anchored at start-of-line allowing optional whitespace.
+        check = "grep -qE '^[[:space:]]*{}' /etc/radius_nss.conf 2>/dev/null".format(
+            marker.replace("=", "="))
+        duthost.shell(
+            "{} || echo '{}' | sudo tee -a /etc/radius_nss.conf >/dev/null".format(
+                check, line),
+            module_ignore_errors=True)
+    logger.info("Ensured uncommented radius_nss.conf priv-lvl mappings "
+                "(15->sudo,netadmin,docker; 1->docker)")
+
+
+def _wait_for_pam_radius(duthost, server_ip, timeout=30):
+    """
+    Wait until hostcfgd has regenerated /etc/pam_radius_auth.conf to include
+    our RADIUS server.  Returns True if it shows up, False on timeout.
+    """
+    from tests.common.utilities import wait_until
+
+    def _pam_has_server():
+        r = duthost.shell(
+            "grep -F '{}' /etc/pam_radius_auth.conf 2>/dev/null".format(server_ip),
+            module_ignore_errors=True,
+        )
+        return r.get("rc", 1) == 0
+    return wait_until(timeout, 2, 0, _pam_has_server)
+
+
+def _radius_del(duthost, server_ip):
+    """
+    Remove a RADIUS server from DUT. Tries del, delete, then sonic-db-cli fallback.
+    Handles different SONiC version syntax differences.
+    """
+    for cmd in [
+        "config radius del {}".format(server_ip),
+        "config radius delete {}".format(server_ip),
+    ]:
+        r = duthost.shell(cmd, module_ignore_errors=True)
+        if r["rc"] == 0:
+            return
+    duthost.shell(
+        'sonic-db-cli CONFIG_DB del "RADIUS_SERVER|{}"'.format(server_ip),
+        module_ignore_errors=True)
+
+
+def _save_local_aaa(duthost):
+    """
+    Set AAA to local-only and save config.
+    Critical -- prevents DUT lockout after any framework config reload.
+    """
+    duthost.shell("config aaa authentication login local", module_ignore_errors=True)
+    duthost.shell("config aaa authentication failthrough disable", module_ignore_errors=True)
+    # Avoid 'config radius passkey ''' -- empty arg crashes/rejects on some SONiC images.
+    duthost.shell(
+        "sonic-db-cli CONFIG_DB hdel 'RADIUS|global' passkey",
+        module_ignore_errors=True)
+
+    for cmd in [
+        "config aaa authorization local",
+        "config aaa authorization login local",
+    ]:
+        r = duthost.shell(cmd, module_ignore_errors=True)
+        if r["rc"] == 0:
+            logger.info("AAA authorization reset via: %s", cmd)
+            break
+    else:
+        duthost.shell(
+            'sonic-db-cli CONFIG_DB hset "AAA|authorization" login local',
+            module_ignore_errors=True)
+        logger.warning("AAA authorization reset via sonic-db-cli fallback")
+
+    for cmd in [
+        "config aaa accounting disable",
+        "config aaa accounting login disable",
+    ]:
+        r = duthost.shell(cmd, module_ignore_errors=True)
+        if r["rc"] == 0:
+            logger.info("AAA accounting disabled via: %s", cmd)
+            break
+    else:
+        duthost.shell(
+            'sonic-db-cli CONFIG_DB hset "AAA|accounting" login disable',
+            module_ignore_errors=True)
+        logger.warning("AAA accounting disabled via sonic-db-cli fallback")
+
+    duthost.shell("config save -y", module_ignore_errors=True)
+    logger.info("AAA set to local-only and config saved")
+
+
+# ---------------------------------------------------------------------------
+# SSH helpers
+# ---------------------------------------------------------------------------
+
+def ssh_connect_remote(host, username, password, port=22, timeout=DEFAULT_TIMEOUT):
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    try:
+        client.connect(hostname=host, port=port, username=username, password=password,
+                       timeout=timeout, allow_agent=False, look_for_keys=False)
+        logger.info("SSH connected: %s@%s", username, host)
+        return client
+    except Exception as e:
+        logger.warning("SSH connect failed: %s@%s -- %s", username, host, e)
+        return None
+
+
+def ssh_connect_remote_retry(host, username, password, duthost=None,
+                              port=22, retries=DEFAULT_RETRIES, delay=SSH_RETRY_DELAY,
+                              timeout=DEFAULT_TIMEOUT):
+    for attempt in range(1, retries + 1):
+        client = ssh_connect_remote(host, username, password, port=port, timeout=timeout)
+        if client:
+            return client
+        logger.warning("Attempt %d/%d failed, retrying in %ds...", attempt, retries, delay)
+        time.sleep(delay)
+    logger.error("All %d SSH attempts failed for %s@%s", retries, username, host)
+    return None
+
+
+def radius_user_ssh_login(duthost, host, username, password,
+                          retries=DEFAULT_RETRIES, delay=SSH_RETRY_DELAY):
+    """
+    SSH as a RADIUS JIT user.
+
+    Deletes any stale JIT account first and waits for sshd to drain
+    half-open sessions (Exceeded MaxStartups) before retrying.
+    """
+    delete_jit_user(duthost, username)
+    time.sleep(3)
+    return ssh_connect_remote_retry(
+        host, username, password, duthost=duthost, retries=retries, delay=delay)
+
+
+def ssh_run_command(client, command):
+    stdin, stdout, stderr = client.exec_command(command)
+    rc = stdout.channel.recv_exit_status()
+    out = stdout.read().decode("utf-8", errors="replace").strip()
+    err = stderr.read().decode("utf-8", errors="replace").strip()
+    return rc, out, err
+
+
+def close_ssh(client):
+    try:
+        if client:
+            client.close()
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# DUT configuration helpers
+# ---------------------------------------------------------------------------
+
+def configure_dut_radius(duthost, server_ip, passkey="testing123", timeout=5, priority=1):
+    """
+    Add RADIUS server to DUT and enable AAA -- robust against pre-existing
+    config and hostcfgd lag.
+
+    Key behaviours:
+      * Hard-deletes any stale RADIUS_SERVER entry via sonic-db-cli so that
+        ``config radius add`` actually triggers hostcfgd, rather than silently
+        returning "server already exists".
+      * Mirrors RADIUS_SERVER / RADIUS|global directly to CONFIG_DB to ensure
+        the fields land even if the CLI silently rejects them.
+      * Sets NAS-IP and authtype explicitly so pam_radius_auth identifies us.
+      * Waits for hostcfgd to regenerate /etc/pam_radius_auth.conf, falling
+        back to a hostcfgd restart if it lags.
+    """
+    _save_local_aaa(duthost)
+
+    duthost.shell(
+        "test -f /usr/bin/sonic-launch-shell || "
+        "ln -s /bin/bash /usr/bin/sonic-launch-shell",
+        module_ignore_errors=True)
+
+    _radius_del(duthost, server_ip)
+    duthost.shell(
+        "sonic-db-cli CONFIG_DB del 'RADIUS_SERVER|{}'".format(server_ip),
+        module_ignore_errors=True)
+    time.sleep(1)
+
+    duthost.shell("config radius passkey {}".format(passkey),
+                  module_ignore_errors=True)
+    duthost.shell(
+        "sonic-db-cli CONFIG_DB hset 'RADIUS|global' passkey '{}'".format(passkey),
+        module_ignore_errors=True)
+
+    duthost.shell("config radius authtype pap", module_ignore_errors=True)
+    duthost.shell("config radius nasip {}".format(duthost.mgmt_ip),
+                  module_ignore_errors=True)
+
+    duthost.shell("config radius add {} -k {} -t {} -p {}".format(
+        server_ip, passkey, timeout, priority), module_ignore_errors=True)
+    duthost.shell(
+        "sonic-db-cli CONFIG_DB hset 'RADIUS_SERVER|{ip}' "
+        "auth_port 1812 acct_port 1813 priority {pri} passkey '{key}' timeout {to}".format(
+            ip=server_ip, pri=priority, key=passkey, to=timeout),
+        module_ignore_errors=True)
+
+    duthost.shell("config aaa authentication login radius local")
+    duthost.shell("config aaa authentication failthrough enable",
+                  module_ignore_errors=True)
+
+    if not _wait_for_pam_radius(duthost, server_ip, timeout=30):
+        logger.warning(
+            "PAM RADIUS conf did not include %s after 30s -- restarting hostcfgd",
+            server_ip)
+        duthost.shell("sudo systemctl restart hostcfgd",
+                      module_ignore_errors=True)
+        if not _wait_for_pam_radius(duthost, server_ip, timeout=30):
+            logger.error(
+                "PAM RADIUS conf still missing %s -- RADIUS auth will likely fail",
+                server_ip)
+    # hostcfgd just rewrote radius_nss.conf -- append Cisco priv-lvl mappings.
+    _ensure_radius_nss_priv_mapping(duthost)
+    # sshd reads PAM on every connection but give the PAM stack a beat to
+    # fully settle after hostcfgd writes the file.
+    time.sleep(3)
+
+    logger.info("DUT RADIUS configured: server=%s passkey=%s dut_mgmt_ip=%s",
+                server_ip, passkey, duthost.mgmt_ip)
+
+
+def restore_dut_aaa_config(duthost, server_ip):
+    """
+    Restore DUT to local-only AAA and SAVE config.
+    """
+    _radius_del(duthost, server_ip)
+    _save_local_aaa(duthost)
+    logger.info("DUT AAA fully restored and saved")
+
+
+# ---------------------------------------------------------------------------
+# RADIUS server helpers (PTF)
+# ---------------------------------------------------------------------------
+
+def _freeradius_config_check(ptfhost):
+    """Return freeradius -X startup log (config validation)."""
+    return ptfhost.shell(
+        "timeout 8 freeradius -X 2>&1 | tail -60 || true",
+        module_ignore_errors=True).get("stdout", "")
+
+
+def _write_clients_file(ptfhost, clients, secret="testing123"):
+    """Write clients.conf with localhost + DUT entries."""
+    clients_content = (
+        "client localhost {{\n"
+        "    ipaddr = 127.0.0.1\n"
+        "    secret = {secret}\n"
+        "    require_message_authenticator = no\n"
+        "}}\n\n"
+    ).format(secret=secret)
+    for c in clients:
+        clients_content += (
+            "client {name} {{\n"
+            "    ipaddr = {ipaddr}\n"
+            "    secret = {secret}\n"
+            "    require_message_authenticator = no\n"
+            "}}\n\n"
+        ).format(name=c["name"], ipaddr=c["ipaddr"], secret=secret)
+    for path in ["/etc/freeradius/3.0/clients.conf", "/etc/freeradius/clients.conf"]:
+        if ptfhost.shell("test -f {}".format(path), module_ignore_errors=True)["rc"] == 0:
+            _write_file_b64(ptfhost, path, clients_content)
+            logger.info("Wrote freeradius clients to %s", path)
+            return path
+    raise RuntimeError("Could not find freeradius clients.conf on PTF")
+
+
+def start_radius_server(ptfhost, users, clients, secret="testing123", admin_users=None):
+    """
+    Write freeradius config and start daemon on PTF.
+
+    ``admin_users`` is an optional list of admin/operator account entries that
+    will be **prepended** to the users file with their real local passwords.
+    This is a critical lockout-prevention guard: SONiC's auto-generated PAM
+    stack contains ``auth_err=die`` on ``pam_radius_auth.so``, which means a
+    single Access-Reject from FreeRADIUS aborts the PAM auth chain and blocks
+    the user from SSH even if their password is correct for the local user
+    database. By always registering the device admin user with FreeRADIUS, we
+    guarantee that pam_radius returns Access-Accept for admin and the chain
+    proceeds, so the operator can never be locked out of the DUT while the
+    test infrastructure is exercising RADIUS auth.
+    """
+    from tests.common.utilities import wait_until
+
+    ptfhost.shell(
+        "command -v freeradius >/dev/null 2>&1 || "
+        "apt-get install -y freeradius 2>/dev/null || true",
+        module_ignore_errors=True)
+    ptfhost.shell(
+        "service freeradius stop 2>/dev/null || pkill freeradius 2>/dev/null; sleep 1",
+        module_ignore_errors=True)
+
+    # Prepend admin/safety entries so PAM auth_err=die never fires against the
+    # operator account. Dedup by username (admin entry wins if user re-uses).
+    effective_users = []
+    seen = set()
+    for u in list(admin_users or []) + list(users or []):
+        if not u or "username" not in u:
+            continue
+        if u["username"] in seen:
+            continue
+        seen.add(u["username"])
+        effective_users.append(u)
+
+    _clean_freeradius_dictionary_on_ptf(ptfhost)
+    _ensure_freeradius_mpl_dictionary(ptfhost)
+    _write_users_file(ptfhost, effective_users)
+    _ensure_freeradius_accounting(ptfhost, restart=False)
+    _write_clients_file(ptfhost, clients, secret=secret)
+
+    _restart_freeradius(ptfhost)
+
+    if not wait_until(30, 2, 0, _freeradius_running, ptfhost):
+        log = _freeradius_config_check(ptfhost)
+        raise RuntimeError("freeradius failed to start on PTF.\nDebug:\n{}".format(log))
+    if not wait_until(30, 2, 0, _freeradius_listening, ptfhost, 1812):
+        log = _freeradius_config_check(ptfhost)
+        raise RuntimeError(
+            "freeradius running but UDP 1812 not listening on PTF.\nDebug:\n{}".format(log))
+
+    # Now that authentication is up, make sure the acct listener (1813) is
+    # also bound. Some packaging variants omit the acct listener from
+    # sites-enabled/default, so this helper injects an explicit one when
+    # needed and restarts.
+    _ensure_freeradius_accounting(ptfhost, restart=True)
+    if not wait_until(30, 2, 0, _freeradius_listening, ptfhost, 1813):
+        log = _freeradius_config_check(ptfhost)
+        raise RuntimeError(
+            "freeradius running but UDP 1813 not listening on PTF.\nDebug:\n{}".format(log))
+    logger.info("freeradius started on PTF (auth=1812, acct=1813)")
+
+    # Fail fast if FreeRADIUS is not returning MPL -- DUT group mapping depends on it.
+    # Verify against the first non-admin test user so we exercise the real priv-lvl path.
+    sample = None
+    for u in (users or []):
+        sample = u
+        break
+    if sample is None and effective_users:
+        sample = effective_users[0]
+    if sample is not None:
+        _verify_freeradius_mpl(
+            ptfhost,
+            sample["username"],
+            sample["password"],
+            secret,
+            sample["priv_lvl"],
+            users=effective_users,
+        )
+
+
+def stop_radius_server(ptfhost):
+    """Stop freeradius on PTF."""
+    ptfhost.shell(
+        "service freeradius stop 2>/dev/null || pkill freeradius 2>/dev/null; sleep 1",
+        module_ignore_errors=True)
+    logger.info("freeradius stopped on PTF")
+
+
+def block_radius_server(ptfhost):
+    """
+    Simulate RADIUS server unreachable from the DUT.
+
+    The PTF container does not always ship ``iptables`` (the binary is absent
+    in many community PTF images), so we use the portable approach of taking
+    the freeradius daemon down. From the DUT's perspective the result is the
+    same: pam_radius times out and falls back to local AAA.
+    """
+    # Prefer iptables if available -- it gives a cleaner "no reply" semantic
+    # and leaves the daemon running for any session-scoped fixtures. Fall back
+    # to stopping the daemon when iptables is missing.
+    have_iptables = ptfhost.shell(
+        "command -v iptables >/dev/null 2>&1 && echo yes || echo no",
+        module_ignore_errors=True).get("stdout", "").strip() == "yes"
+    if have_iptables:
+        ptfhost.shell(
+            "iptables -I INPUT -p udp --dport 1812 -j DROP",
+            module_ignore_errors=True)
+        logger.info("Blocked UDP 1812 on PTF via iptables")
+    else:
+        ptfhost.shell(
+            "service freeradius stop 2>/dev/null || pkill -f freeradius 2>/dev/null; sleep 1",
+            module_ignore_errors=True)
+        logger.info("Stopped freeradius on PTF (iptables unavailable)")
+
+
+def unblock_radius_server(ptfhost):
+    """Undo ``block_radius_server`` -- restore RADIUS server reachability."""
+    have_iptables = ptfhost.shell(
+        "command -v iptables >/dev/null 2>&1 && echo yes || echo no",
+        module_ignore_errors=True).get("stdout", "").strip() == "yes"
+    if have_iptables:
+        ptfhost.shell(
+            "iptables -D INPUT -p udp --dport 1812 -j DROP",
+            module_ignore_errors=True)
+        logger.info("Unblocked UDP 1812 on PTF via iptables")
+    # Always (re)start freeradius -- if we stopped it above, this brings it
+    # back; if iptables was used, this is a no-op when the daemon is already
+    # running. We invoke ``service`` directly (rather than the higher-level
+    # ``start_radius_server`` helper which rewrites config) so existing config
+    # and clients on disk are preserved.
+    ptfhost.shell(
+        "pgrep -x freeradius >/dev/null 2>&1 || "
+        "service freeradius start 2>/dev/null || "
+        "freeradius -X >/tmp/freeradius.log 2>&1 &",
+        module_ignore_errors=True)
+    logger.info("freeradius (re)started on PTF after unblock")
+
+
+def radtest_verify(ptfhost, username, password, server="127.0.0.1", secret="testing123"):
+    """Run radtest and return True if Access-Accept received."""
+    cmd = "radtest {} {} {} 0 {}".format(username, password, server, secret)
+    result = ptfhost.shell(cmd, module_ignore_errors=True)
+    return "Access-Accept" in result["stdout"]
+
+
+# ---------------------------------------------------------------------------
+# JIT user helpers
+# ---------------------------------------------------------------------------
+
+def user_exists_on_dut(duthost, username):
+    """
+    Return True iff ``username`` has a *static* entry in ``/etc/passwd``.
+
+    We deliberately grep ``/etc/passwd`` directly instead of using ``getent``
+    because SONiC enables ``libnss_radius`` in ``/etc/nsswitch.conf`` -- a
+    successful RADIUS lookup makes the user appear via NSS even when no
+    static account exists.  The JIT-creation test needs to distinguish
+    "freshly provisioned local account" from "dynamically resolved via
+    libnss_radius", so we look at the file on disk.
+    """
+    result = duthost.shell(
+        "grep -q '^{}:' /etc/passwd".format(username),
+        module_ignore_errors=True)
+    return result.get("rc", 1) == 0
+
+
+def delete_jit_user(duthost, username):
+    """
+    Remove a JIT-provisioned local account from the DUT.
+
+    Only the static ``/etc/passwd`` entry (and its home dir) is removed; the
+    libnss_radius NSS source is left intact so RADIUS users remain resolvable
+    after the test deletes the local backing entry.  Any processes still
+    owned by the user are killed first so ``userdel`` does not abort with
+    "user is currently used by process".
+
+    After the deletion we invalidate the NSS passwd/group caches (``nscd``
+    and/or ``sssd``) and pause briefly so the next ``getpwnam``/``ssh`` call
+    re-queries libnss_radius instead of returning a stale negative result.
+    Without this step the first few SSH attempts immediately after a
+    ``userdel`` race the cache and time out, causing the JIT-creation test
+    to spuriously fail.
+    """
+    if not user_exists_on_dut(duthost, username):
+        return
+
+    duthost.shell(
+        "sudo pkill -9 -u {u} 2>/dev/null; sleep 1".format(u=username),
+        module_ignore_errors=True)
+    duthost.shell(
+        "sudo userdel -r -f {u} 2>/dev/null || true".format(u=username),
+        module_ignore_errors=True)
+
+    # Invalidate NSS caches so the next lookup goes back to libnss_radius
+    # instead of returning a stale entry (positive or negative).
+    duthost.shell(
+        "sudo nscd -i passwd 2>/dev/null; "
+        "sudo nscd -i group 2>/dev/null; "
+        "sudo sss_cache -E 2>/dev/null; "
+        "true",
+        module_ignore_errors=True)
+    time.sleep(3)
+
+    for _ in range(5):
+        if not user_exists_on_dut(duthost, username):
+            logger.info("Deleted JIT user: %s", username)
+            return
+        time.sleep(1)
+    logger.warning("delete_jit_user: %s still present in /etc/passwd", username)
+
+
+def get_user_groups(duthost, username):
+    result = duthost.shell("id -Gn {}".format(username), module_ignore_errors=True)
+    if result["rc"] == 0:
+        return result["stdout"].strip().split()
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Accounting helpers
+# ---------------------------------------------------------------------------
+
+def _ensure_freeradius_accounting(ptfhost, restart=True):
+    """
+    Ensure FreeRADIUS on PTF is listening on UDP/1813 (accounting) AND writes
+    accounting detail logs under ``/var/log/freeradius/radacct/``.
+
+    Behaviour:
+      * Always guarantee ``/var/log/freeradius/radacct`` exists and is owned
+        by the freerad user (the detail module writes as freerad).
+      * Always clean up any old ``# sonic-mgmt RADIUS accounting`` block that
+        a previous run may have left in ``radiusd.conf``.
+      * If the running freeradius is NOT listening on UDP/1813 (e.g. some
+        packaging variants ship a ``sites-enabled/default`` without an acct
+        listen block, or strip it down), append a single guarded
+        ``listen { type=acct ipaddr=* port=1813 }`` block to ``radiusd.conf``
+        so the port is always bound.
+    """
+    dict_root = _freeradius_dict_root(ptfhost)
+    ptfhost.shell(
+        "mkdir -p /var/log/freeradius/radacct && "
+        "chown -R freerad:freerad /var/log/freeradius/radacct 2>/dev/null || true",
+        module_ignore_errors=True)
+
+    if not dict_root:
+        if restart:
+            _restart_freeradius(ptfhost)
+        return
+
+    radiusd = "{}/radiusd.conf".format(dict_root)
+
+    # Idempotent cleanup -- drop any acct snippet appended by an older version.
+    ptfhost.shell(
+        "sed -i '/# sonic-mgmt RADIUS accounting/,/^}}$/d' {}".format(radiusd),
+        module_ignore_errors=True)
+
+    if restart:
+        _restart_freeradius(ptfhost)
+        time.sleep(2)
+
+    # Verify acct listener is actually bound. If not, install one ourselves.
+    if not _freeradius_listening(ptfhost, 1813):
+        logger.warning(
+            "FreeRADIUS not listening on UDP/1813 -- injecting explicit "
+            "acct listen block into %s", radiusd)
+        acct_block = (
+            "\n# sonic-mgmt RADIUS accounting\n"
+            "listen {{\n"
+            "    type = acct\n"
+            "    ipaddr = *\n"
+            "    port = 1813\n"
+            "}}\n"
+        )
+        # Use a sentinel-protected append so we never duplicate the block.
+        ptfhost.shell(
+            "grep -q '# sonic-mgmt RADIUS accounting' {f} || "
+            "printf '%s' '{block}' >> {f}".format(
+                f=radiusd,
+                block=acct_block.replace("'", "'\\''")),
+            module_ignore_errors=True)
+        _restart_freeradius(ptfhost)
+        time.sleep(2)
+
+
+def _pam_radius_server_conf(duthost, server_ip):
+    """Return the per-server pam_radius config path on the DUT."""
+    candidates = [
+        "/etc/pam_radius_auth.d/{}_1812.conf".format(server_ip),
+        "/etc/pam_radius_auth.conf",
+    ]
+    for path in candidates:
+        if duthost.shell("test -f {}".format(path), module_ignore_errors=True)["rc"] == 0:
+            return path
+    return candidates[0]
+
+
+def _ensure_pam_radius_session(duthost, server_ip, enable=True):
+    """
+    Enable or disable pam_radius in the PAM session stack.
+
+    SONiC has no ``config aaa accounting radius`` CLI.  Session accounting is
+    driven by pam_radius session lines in /etc/pam.d/*.
+    """
+    conf = _pam_radius_server_conf(duthost, server_ip)
+    session_rule = "session optional pam_radius_auth.so conf={}".format(conf)
+    pam_targets = []
+    for pam_file in ["/etc/pam.d/common-session", "/etc/pam.d/sshd"]:
+        if duthost.shell("test -f {}".format(pam_file), module_ignore_errors=True)["rc"] == 0:
+            pam_targets.append(pam_file)
+
+    for pam_file in pam_targets:
+        if enable:
+            duthost.shell(
+                "grep -qF 'session optional pam_radius_auth.so' {f} 2>/dev/null || "
+                "echo '{rule}' | sudo tee -a {f} >/dev/null".format(
+                    f=pam_file, rule=session_rule),
+                module_ignore_errors=True)
+        else:
+            duthost.shell(
+                "sudo sed -i '/session optional pam_radius_auth.so/d' {}".format(pam_file),
+                module_ignore_errors=True)
+
+    action = "enabled" if enable else "disabled"
+    logger.info("pam_radius session accounting %s (conf=%s)", action, conf)
+
+
+def set_radius_accounting_enabled(duthost, ptfhost, server_ip, passkey="testing123"):
+    """
+    Enable RADIUS session accounting on DUT and PTF.
+
+    Uses pam_radius session + ``config radius statistics enable`` (not the
+    invalid ``config aaa accounting radius`` command).
+    """
+    _ensure_freeradius_accounting(ptfhost)
+
+    duthost.shell(
+        "sonic-db-cli CONFIG_DB hset 'RADIUS_SERVER|{ip}' acct_port 1813".format(
+            ip=server_ip),
+        module_ignore_errors=True)
+
+    for cmd in ["config radius statistics enable"]:
+        if duthost.shell(cmd, module_ignore_errors=True)["rc"] == 0:
+            logger.info("RADIUS statistics enabled via: %s", cmd)
+            break
+    else:
+        duthost.shell(
+            "sonic-db-cli CONFIG_DB hset 'RADIUS|global' statistics true",
+            module_ignore_errors=True)
+        logger.warning("RADIUS statistics enabled via CONFIG_DB fallback")
+
+    _ensure_pam_radius_session(duthost, server_ip, enable=True)
+    time.sleep(2)
+    logger.info("RADIUS accounting enabled: server=%s passkey=%s", server_ip, passkey)
+
+
+def set_radius_accounting_disabled(duthost, server_ip):
+    """Disable RADIUS session accounting while keeping RADIUS authentication."""
+    _ensure_pam_radius_session(duthost, server_ip, enable=False)
+    for cmd in ["config radius statistics disable"]:
+        if duthost.shell(cmd, module_ignore_errors=True)["rc"] == 0:
+            logger.info("RADIUS statistics disabled via: %s", cmd)
+            break
+    else:
+        duthost.shell(
+            "sonic-db-cli CONFIG_DB hset 'RADIUS|global' statistics false",
+            module_ignore_errors=True)
+    time.sleep(2)
+    logger.info("RADIUS accounting disabled")
+
+
+def clear_acct_logs(ptfhost):
+    """Remove prior radacct detail files on PTF."""
+    ptfhost.shell(
+        "rm -rf /var/log/freeradius/radacct/* 2>/dev/null; "
+        "mkdir -p /var/log/freeradius/radacct/",
+        module_ignore_errors=True)
+
+
+def get_acct_log_entries(ptfhost, username):
+    result = ptfhost.shell(
+        "grep -r '{}' /var/log/freeradius/radacct/ 2>/dev/null || true".format(username),
+        module_ignore_errors=True)
+    return result["stdout"]

--- a/tests/tacacs/test_aaa.py
+++ b/tests/tacacs/test_aaa.py
@@ -1,0 +1,71 @@
+"""
+test_aaa.py -- Aggregator entry point for all AAA test cases.
+
+Running ``pytest tests/tacacs/test_aaa.py`` collects every test from the
+sub-modules so the full suite can be executed with a single invocation.
+
+File layout
+-----------
+test_aaa_preflight.py       TC_H01 – TC_H08  (pre-flight health checks)  ← runs first
+test_aaa_config.py          TC_001 – TC_005  (core auth / authz)
+test_aaa_accounting.py      TC_006 – TC_007  (accounting login + command)
+                            TC_017 – TC_018  (wildcard encoding, dual accounting)
+test_aaa_authentication.py  TC_008 – TC_016  (failover / resilience / negative)
+
+Execution order
+---------------
+pytest collects tests in the order they are imported here.  The pre-flight
+health checks (TC_H01 – TC_H08) are imported first so they always run before
+any functional test.  If any health check fails the problem is environmental
+(services down, misconfigured server, network issue) rather than a code bug.
+"""
+
+# ---------------------------------------------------------------------------
+# TC_H01 – TC_H08  Pre-flight health checks  (test_aaa_preflight.py)
+# ---------------------------------------------------------------------------
+from tests.tacacs.test_aaa_preflight import (         # noqa: F401
+    test_h01_sonic_services_running,
+    test_h02_tacacs_server_reachable,
+    test_h03_tacacs_config_on_dut,
+    test_h04_aaa_authentication_mode,
+    test_h05_aaa_authorization_mode,
+    test_h06_aaa_accounting_mode,
+    test_h07_tacacs_daemon_running_on_ptf,
+    test_h08_end_to_end_smoke_login,
+)
+
+# ---------------------------------------------------------------------------
+# TC_001 – TC_005  (test_aaa_config.py)
+# ---------------------------------------------------------------------------
+from tests.tacacs.test_aaa_config import (            # noqa: F401
+    test_valid_ssh_authentication,
+    test_invalid_credentials_rejected,
+    test_local_fallback_when_server_unreachable,
+    test_ro_user_blocked_from_write_commands,
+    test_rw_user_read_write_commands,
+)
+
+# ---------------------------------------------------------------------------
+# TC_006 – TC_007, TC_017 – TC_018  (test_aaa_accounting.py)
+# ---------------------------------------------------------------------------
+from tests.tacacs.test_aaa_accounting import (        # noqa: F401
+    test_accounting_records_login_events,
+    test_accounting_records_command_execution,
+    test_wildcard_encoding_sent_to_server,
+    test_dual_accounting_tacacs_and_local,
+)
+
+# ---------------------------------------------------------------------------
+# TC_008 – TC_016  (test_aaa_authentication.py)
+# ---------------------------------------------------------------------------
+from tests.tacacs.test_aaa_authentication import (    # noqa: F401
+    test_failover_primary_down_secondary_takes_over,
+    test_wrong_passkey_rejected,
+    test_server_timeout_no_hang,
+    test_jit_user_created_on_login,
+    test_disable_tacacs_reverts_to_local,
+    test_tacacs_config_persists_after_reload,
+    test_tacacs_source_ip,
+    test_concurrent_ro_rw_sessions,
+    test_local_user_blocked_tacacs_only,
+)

--- a/tests/tacacs/test_aaa_accounting.py
+++ b/tests/tacacs/test_aaa_accounting.py
@@ -1,0 +1,381 @@
+"""
+test_aaa_accounting.py -- TC_006, TC_007, TC_017, TC_018: AAA Accounting tests.
+
+Uses the same helpers (wait_for_log, check_tacacs_server_log_exist,
+change_and_wait_aaa_config_update) proven in tests/tacacs/test_accounting.py.
+
+Test cases covered
+------------------
+TC_006  Accounting records login events: login writes a 'start' record to tac_plus.acct
+TC_007  Accounting records command execution: each command appears in tac_plus.acct
+TC_017  Wildcard command encoding: server receives literal *, ? not expanded filenames
+TC_018  Dual accounting (tacacs+ local): command appears in both tac_plus.acct AND DUT syslog
+"""
+
+import logging
+import time
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import skip_release, paramiko_ssh
+from tests.common.helpers.tacacs.tacacs_helper import (
+    check_tacacs,                               # noqa: F401
+    start_tacacs_server,
+    stop_tacacs_server,
+    per_command_accounting_skip_versions,
+)
+from tests.common.fixtures.tacacs import tacacs_creds  # noqa: F401
+from tests.tacacs.utils import (
+    check_server_received,
+    change_and_wait_aaa_config_update,
+    get_auditd_config_reload_timestamp,
+    ssh_connect_remote_retry,
+    ssh_run_command,
+    cleanup_tacacs_log,
+    TIMEOUT_LIMIT,
+)
+from tests.common.devices.ptf import PTFHost
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.topology('any', 't1-multi-asic'),
+    pytest.mark.device_type('vs'),
+]
+
+# ---------------------------------------------------------------------------
+# Module-level skip: per-command accounting not available on older images
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module", autouse=True)
+def check_image_version(duthost):
+    """Skip entire module on SONiC images that lack per-command accounting."""
+    skip_release(duthost, per_command_accounting_skip_versions)
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors tests/tacacs/test_accounting.py helpers)
+# ---------------------------------------------------------------------------
+
+def _host_run(host, command):
+    """Run a command on either PTFHost or SonicHost."""
+    if isinstance(host, PTFHost):
+        return host.command(command)
+    return host.shell("sudo {0}".format(command))
+
+
+def _flush_log(host, log_file):
+    """Force the OS to flush buffered log data to disk."""
+    if "syslog" in log_file:
+        _host_run(host, "kill -HUP $(cat /var/run/rsyslogd.pid)")
+    _host_run(host, "sync {0}".format(log_file))
+
+
+def _wait_for_log(host, log_file, sed_pattern, timeout=80, interval=1):
+    """
+    Poll log_file with sed_pattern until a match is found or timeout expires.
+    Returns list of matching lines (empty if timeout).
+    """
+    waited = 0
+    while waited <= timeout:
+        _flush_log(host, log_file)
+        res = _host_run(host, "sed -nE '{0}' {1}".format(sed_pattern, log_file))
+        lines = res["stdout_lines"]
+        if lines:
+            logger.debug("Found log lines: %s", lines)
+            return lines
+        time.sleep(interval)
+        waited += interval
+    return []
+
+
+def _check_tacacs_server_acct_log(ptfhost, username, command, timeout=60):
+    """Assert that tac_plus.acct contains a record for username running command."""
+    pattern = "/\t{0}\t.*\tcmd=.*{1}/P".format(username, command)
+    lines = _wait_for_log(ptfhost, "/var/log/tac_plus.acct", pattern, timeout=timeout)
+    pytest_assert(
+        len(lines) > 0,
+        "Expected accounting record for user='{}' cmd='{}' in tac_plus.acct but found none".format(
+            username, command)
+    )
+
+
+def _check_syslog_acct_log(duthost, username, command, timeout=120):
+    """Assert that DUT syslog contains an audisp-tacplus accounting entry for command."""
+    pattern = (
+        "/ansible.legacy.command Invoked/D;"
+        "/INFO audisp-tacplus.+Accounting: user: {0},.*, command: .*{1},/P"
+    ).format(username, command)
+    lines = _wait_for_log(duthost, "/var/log/syslog", pattern, timeout=timeout)
+    # Remove any lines that are themselves sed commands introduced by Ansible
+    lines = [l for l in lines if 'sudo sed' not in l]
+    pytest_assert(
+        len(lines) > 0,
+        "Expected syslog accounting entry for user='{}' cmd='{}' but found none".format(
+            username, command)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-test fixture: authenticated RW user Paramiko client
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def rw_user_client(
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        tacacs_creds,   # noqa: F811
+        check_tacacs):  # noqa: F811  -- explicit dep: TACACS+ must be live before SSH
+    """
+    Paramiko client logged in as TACACS+ RW user. Auto-closed after test.
+
+    check_tacacs is listed as an explicit dependency so pytest always sets up
+    the TACACS+ server configuration on the DUT *before* this fixture tries to
+    open the SSH connection.  Without it, pytest may resolve rw_user_client
+    before check_tacacs because rw_user_client has no other ordering constraint,
+    causing the SSH login to fail (TACACS+ not configured yet) → ERROR.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+    client = ssh_connect_remote_retry(
+        dutip,
+        tacacs_creds['tacacs_rw_user'],
+        tacacs_creds['tacacs_rw_user_passwd'],
+        duthost,
+    )
+    yield client
+    client.close()
+
+
+# ---------------------------------------------------------------------------
+# TC_006 -- Accounting records login events
+# ---------------------------------------------------------------------------
+
+def test_accounting_records_login_events(
+        localhost,
+        ptfhost,
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        tacacs_creds,           # noqa: F811
+        check_tacacs):          # noqa: F811
+    """
+    TC_006 -- When TACACS+ accounting is enabled, every SSH login must produce
+    a 'start' record in /var/log/tac_plus.acct on the TACACS+ server.
+    After the session ends, a 'stop' record with elapsed_time must also appear.
+
+    Record format written by tac_plus:
+        <timestamp>  <user>  <DUT_IP>  <tty>  start  service=shell
+        <timestamp>  <user>  <DUT_IP>  <tty>  stop   elapsed_time=N  service=shell
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+    username = tacacs_creds['tacacs_rw_user']
+
+    # Enable accounting so login events are sent to the server
+    change_and_wait_aaa_config_update(duthost, "sudo config aaa accounting tacacs+")
+
+    # Clear the accounting log so previous entries do not interfere
+    ptfhost.command("truncate -s 0 /var/log/tac_plus.acct")
+
+    try:
+        # Trigger a login session via ssh_remote_run (opens and closes SSH)
+        from tests.common.helpers.tacacs.tacacs_helper import ssh_remote_run
+        res = ssh_remote_run(
+            localhost, dutip,
+            username,
+            tacacs_creds['tacacs_rw_user_passwd'],
+            "show version"
+        )
+        pytest_assert(res['rc'] == 0, "Login for accounting test failed: {}".format(res))
+
+        # Give tac_plus a moment to flush the accounting record
+        time.sleep(3)
+
+        # Assert 'start' record exists for this user
+        start_pattern = "/\\t{0}\\t.*\\tstart/P".format(username)
+        start_lines = _wait_for_log(
+            ptfhost, "/var/log/tac_plus.acct", start_pattern, timeout=60
+        )
+        pytest_assert(
+            len(start_lines) > 0,
+            "Expected 'start' accounting record for user '{}' in tac_plus.acct "
+            "but found none".format(username)
+        )
+        logger.info("TC_006 passed: login 'start' record found: %s", start_lines)
+
+        # Assert 'stop' record exists (session closed after ssh_remote_run returns)
+        stop_pattern = "/\\t{0}\\t.*\\tstop/P".format(username)
+        stop_lines = _wait_for_log(
+            ptfhost, "/var/log/tac_plus.acct", stop_pattern, timeout=60
+        )
+        pytest_assert(
+            len(stop_lines) > 0,
+            "Expected 'stop' accounting record for user '{}' in tac_plus.acct "
+            "but found none".format(username)
+        )
+        logger.info("TC_006 passed: logout 'stop' record found: %s", stop_lines)
+
+    finally:
+        # Disable accounting so it does not affect subsequent tests
+        duthost.shell("sudo config aaa accounting disable", module_ignore_errors=True)
+        ptfhost.command("truncate -s 0 /var/log/tac_plus.acct")
+
+
+# ---------------------------------------------------------------------------
+# TC_007 -- Accounting records command execution
+# ---------------------------------------------------------------------------
+
+def test_accounting_records_command_execution(
+        ptfhost,
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        tacacs_creds,           # noqa: F811
+        check_tacacs,           # noqa: F811
+        rw_user_client):
+    """
+    TC_007 -- With per-command accounting enabled (requires SONiC >= 202112),
+    every command run in an authenticated session must generate an accounting
+    record in /var/log/tac_plus.acct.
+
+    The record must contain:
+        cmd=<command>   for the specific command that was run
+        user=<username> for the authenticated user
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    username = tacacs_creds['tacacs_rw_user']
+    test_command = "grep"   # short, safe, and easy to grep for in the log
+
+    # Enable per-command accounting
+    change_and_wait_aaa_config_update(duthost, "sudo config aaa accounting tacacs+")
+
+    # Clear accounting log before running the command
+    ptfhost.command("truncate -s 0 /var/log/tac_plus.acct")
+
+    try:
+        # Run the test command via the authenticated RW session
+        ssh_run_command(rw_user_client, test_command)
+
+        # Give tac_plus a moment to flush
+        time.sleep(3)
+
+        # Assert the command accounting record exists
+        cmd_pattern = "/\\t{0}\\t.*\\tcmd=.*{1}/P".format(username, test_command)
+        cmd_lines = _wait_for_log(
+            ptfhost, "/var/log/tac_plus.acct", cmd_pattern, timeout=60
+        )
+        pytest_assert(
+            len(cmd_lines) > 0,
+            "Expected command accounting record for user='{}' cmd='{}' in "
+            "tac_plus.acct but found none".format(username, test_command)
+        )
+        logger.info("TC_007 passed: command accounting record found: %s", cmd_lines)
+
+    finally:
+        duthost.shell("sudo config aaa accounting disable", module_ignore_errors=True)
+        ptfhost.command("truncate -s 0 /var/log/tac_plus.acct")
+
+
+# ---------------------------------------------------------------------------
+# TC_017 -- Wildcard command encoding
+# ---------------------------------------------------------------------------
+
+def test_wildcard_encoding_sent_to_server(
+        ptfhost,
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        tacacs_creds,           # noqa: F811
+        check_tacacs,           # noqa: F811
+        rw_user_client,
+        skip_in_container_test):
+    """
+    TC_017 -- When a user runs 'ls *' or 'ls testfile.?', the DUT must send
+    the literal wildcard characters to the TACACS+ authorization server,
+    NOT the shell-expanded filenames.
+
+    check_server_received inspects tac_plus.log for the raw bytes sent by the DUT.
+
+    Mirrors tests/tacacs/test_authorization.py::test_tacacs_authorization_wildcard.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+    # Enable TACACS+ per-command authorization so every command is sent to server
+    change_and_wait_aaa_config_update(duthost, "sudo config aaa authorization tacacs+")
+
+    try:
+        # Create some test files so shell would normally expand wildcards
+        ssh_run_command(rw_user_client, "touch testfile.1", expect_exit_code=0, verify=True)
+        ssh_run_command(rw_user_client, "touch testfile.2", expect_exit_code=0, verify=True)
+
+        # Clear the TACACS+ log so we only see new entries
+        ptfhost.command("truncate -s 0 /var/log/tac_plus.log")
+
+        # Run ls *  -- server should receive cmd-arg=* not the expanded file list
+        ssh_run_command(rw_user_client, "ls *", expect_exit_code=0, verify=True)
+        check_server_received(ptfhost, "cmd=/usr/bin/ls")
+        check_server_received(ptfhost, "cmd-arg=*")
+
+        # Clear log between checks
+        ptfhost.command("truncate -s 0 /var/log/tac_plus.log")
+
+        # Run ls testfile.?  -- server should receive cmd-arg=testfile.?
+        ssh_run_command(rw_user_client, "ls testfile.?", expect_exit_code=0, verify=True)
+        check_server_received(ptfhost, "cmd=/usr/bin/ls")
+        check_server_received(ptfhost, "cmd-arg=testfile.?")
+
+    finally:
+        # Restore authorization to local
+        duthost.shell("sudo config aaa authorization local")
+        # Clean up test files (best effort)
+        ssh_run_command(rw_user_client, "rm -f testfile.1 testfile.2", verify=False)
+        # Restore accounting setting touched by check_tacacs fixture
+        ptfhost.command("truncate -s 0 /var/log/tac_plus.log")
+
+
+# ---------------------------------------------------------------------------
+# TC_018 -- Dual accounting: tac_plus.acct AND DUT syslog
+# ---------------------------------------------------------------------------
+
+def test_dual_accounting_tacacs_and_local(
+        ptfhost,
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        tacacs_creds,           # noqa: F811
+        check_tacacs,           # noqa: F811
+        rw_user_client):
+    """
+    TC_018 -- With 'config aaa accounting tacacs+ local', every command must
+    be recorded in BOTH:
+        1. /var/log/tac_plus.acct  on the PTF (TACACS+ server side)
+        2. /var/log/syslog         on the DUT  (audisp-tacplus local side)
+
+    Mirrors tests/tacacs/test_accounting.py::test_accounting_tacacs_and_local.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    username = tacacs_creds['tacacs_rw_user']
+    test_command = "grep"
+
+    # Enable dual accounting (tacacs+ then local).
+    # Use single-quotes inside the shell string to avoid nested-quote issues
+    # when duthost.shell() passes the command through Python subprocess.
+    change_and_wait_aaa_config_update(
+        duthost,
+        "sudo config aaa accounting 'tacacs+ local'"
+    )
+
+    # Clear all log files before the test command
+    cleanup_tacacs_log(ptfhost, rw_user_client)
+
+    # Run the test command as the RW TACACS+ user
+    ssh_run_command(rw_user_client, test_command)
+
+    # --- Assert 1: PTF tac_plus.acct has the record ---
+    _check_tacacs_server_acct_log(ptfhost, username, test_command)
+
+    # --- Assert 2: DUT syslog has the audisp-tacplus accounting entry ---
+    _check_syslog_acct_log(duthost, username, test_command)
+
+    logger.info(
+        "TC_018 passed: '%s' appeared in both tac_plus.acct and DUT syslog",
+        test_command
+    )

--- a/tests/tacacs/test_aaa_authentication.py
+++ b/tests/tacacs/test_aaa_authentication.py
@@ -1,0 +1,554 @@
+"""
+test_aaa_authentication.py -- TC_008 to TC_016: Failover, resilience and negative tests.
+
+TC_001-TC_005 (core auth/authz) live in test_aaa_config.py.
+TC_006-TC_007 (accounting login/command) live in test_aaa_accounting.py.
+
+Test cases covered
+------------------
+TC_008  Primary server down; secondary takes over (failover)
+TC_009  Wrong passkey → authentication rejected
+TC_010  Server timeout: login fails within configured timeout, no indefinite hang
+TC_011  JIT user account created on first login, absent before
+TC_012  Disabling TACACS+ reverts to local auth (local admin can log in)
+TC_013  TACACS+ config persists after config reload
+TC_014  Source-interface: DUT sends TACACS+ requests from configured src_ip
+TC_015  Concurrent RO and RW sessions – no privilege cross-contamination
+TC_016  Local-only user blocked when auth=tacacs+ (no local fallback)
+"""
+
+import logging
+import time
+import paramiko
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import check_output, wait_until, paramiko_ssh
+from tests.common.helpers.tacacs.tacacs_helper import (
+    check_tacacs,                               # noqa: F401
+    ssh_remote_run,
+    start_tacacs_server,
+    stop_tacacs_server,
+    remove_all_tacacs_server,
+    per_command_authorization_skip_versions,
+)
+from tests.common.fixtures.tacacs import tacacs_creds  # noqa: F401
+from tests.tacacs.utils import (
+    check_server_received,
+    change_and_wait_aaa_config_update,
+    ssh_connect_remote_retry,
+    ssh_run_command,
+    TIMEOUT_LIMIT,
+)
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.topology('any', 't1-multi-asic'),
+    pytest.mark.device_type('vs'),
+]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _check_ssh_connect_fails(remote_ip, username, password):
+    """Assert that an SSH login attempt is rejected.
+
+    Catches both AuthenticationException (clean PAM reject) and the broader
+    SSHException family.  When TACACS+ returns "unknown user", some SSH server
+    versions close the connection at the banner or key-exchange stage rather
+    than completing the auth exchange, which paramiko surfaces as a generic
+    SSHException instead of the more specific AuthenticationException subclass.
+    Both outcomes represent a correctly denied login.
+    """
+    login_failed = False
+    try:
+        paramiko_ssh(remote_ip, username, password)
+    except paramiko.ssh_exception.SSHException as exc:
+        # AuthenticationException IS a subclass of SSHException, so this
+        # single clause handles both clean auth failures and abrupt closures.
+        login_failed = True
+        logger.info("Expected SSH rejection: %s", repr(exc))
+    except Exception as exc:
+        # Socket-level errors (e.g. connection refused) mean the server is
+        # unreachable, which is also a form of access denial.
+        login_failed = True
+        logger.info("Connection-level rejection (as expected): %s", repr(exc))
+    pytest_assert(login_failed, "Expected login to fail for user '{}' but it succeeded".format(username))
+
+
+# ---------------------------------------------------------------------------
+# TC_008 -- Primary server down; secondary takes over
+# ---------------------------------------------------------------------------
+
+def test_failover_primary_down_secondary_takes_over(
+        localhost,
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        ptfhost,
+        tacacs_creds,       # noqa: F811
+        check_tacacs):      # noqa: F811
+    """
+    TC_008 -- Two servers configured:
+        priority-1 = 127.0.0.1 (unreachable)
+        priority-2 = real PTF  (reachable)
+    DUT must fail over to secondary and authenticate successfully.
+
+    Mirrors pattern in tests/tacacs/test_authorization.py::test_authorization_tacacs_only_some_server_down.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    duthost_mgmt_info = duthost.get_mgmt_ip()
+    invalid_ip = "::1" if duthost_mgmt_info["version"] == "v6" else "127.0.0.1"
+    real_ip = ptfhost.mgmt_ipv6 if duthost_mgmt_info["version"] == "v6" else ptfhost.mgmt_ip
+    dutip = duthost.mgmt_ip
+
+    try:
+        duthost.shell("sudo config tacacs timeout 1")
+        remove_all_tacacs_server(duthost)
+        duthost.shell("sudo config tacacs add {} --port 59".format(invalid_ip))
+        duthost.shell("sudo config tacacs add {} --port 59".format(real_ip))
+
+        res = ssh_remote_run(
+            localhost, dutip,
+            tacacs_creds['tacacs_rw_user'],
+            tacacs_creds['tacacs_rw_user_passwd'],
+            "cat /etc/passwd"
+        )
+        check_output(res, 'testadmin', 'remote_user_su')
+
+    finally:
+        duthost.shell("sudo config tacacs delete {}".format(invalid_ip), module_ignore_errors=True)
+        duthost.shell("sudo config tacacs timeout 5")
+        remove_all_tacacs_server(duthost)
+        duthost.shell("sudo config tacacs add {} --port 59".format(real_ip))
+
+
+# ---------------------------------------------------------------------------
+# TC_009 -- Wrong passkey → rejected
+# ---------------------------------------------------------------------------
+
+def test_wrong_passkey_rejected(
+        localhost,
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        tacacs_creds,       # noqa: F811
+        check_tacacs):      # noqa: F811
+    """
+    TC_009 -- When the DUT passkey does not match the server's key, the TACACS+
+    exchange fails (MD5 mismatch) and authentication is denied.
+
+    Uses sonic-db-cli to set/restore passkey to avoid the SONiC bug in
+    'config tacacs passkey' that crashes on missing /etc/cipher_pass.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+    correct_passkey = tacacs_creds[duthost.hostname]['tacacs_passkey']
+
+    try:
+        duthost.shell(
+            "sudo sonic-db-cli CONFIG_DB hset 'TACPLUS|global' passkey wrongkey_xyz"
+        )
+
+        res = ssh_remote_run(
+            localhost, dutip,
+            tacacs_creds['tacacs_rw_user'],
+            tacacs_creds['tacacs_rw_user_passwd'],
+            "echo hello"
+        )
+        pytest_assert(
+            res['rc'] != 0,
+            "Expected authentication to fail with wrong passkey but it succeeded"
+        )
+
+    finally:
+        duthost.shell(
+            "sudo sonic-db-cli CONFIG_DB hset 'TACPLUS|global' passkey {}".format(correct_passkey)
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC_010 -- Server timeout: no indefinite hang
+# ---------------------------------------------------------------------------
+
+def test_server_timeout_no_hang(
+        localhost,
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        ptfhost,
+        tacacs_creds,       # noqa: F811
+        check_tacacs):      # noqa: F811
+    """
+    TC_010 -- When pointed at a blackhole IP (unreachable, not refused),
+    the DUT must fail within the configured timeout window (2 s + margin),
+    not hang indefinitely.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+    duthost_mgmt_info = duthost.get_mgmt_ip()
+    real_ip = ptfhost.mgmt_ipv6 if duthost_mgmt_info["version"] == "v6" else ptfhost.mgmt_ip
+
+    # Use a routable but silent IP (last octet .254 is unlikely to be occupied)
+    parts = real_ip.split(".")
+    parts[-1] = "254"
+    blackhole_ip = ".".join(parts)
+
+    # SSH itself adds ~5-10 s of handshake + PAM overhead on top of the
+    # TACACS+ timeout, so give a generous margin to avoid flaky failures.
+    custom_timeout = 4
+    margin = 30  # seconds of extra slack
+
+    try:
+        duthost.shell("sudo config tacacs timeout {}".format(custom_timeout))
+        remove_all_tacacs_server(duthost)
+        duthost.shell("sudo config tacacs add {} --port 59".format(blackhole_ip))
+
+        start = time.time()
+        res = ssh_remote_run(
+            localhost, dutip,
+            tacacs_creds['tacacs_rw_user'],
+            tacacs_creds['tacacs_rw_user_passwd'],
+            "echo hello"
+        )
+        elapsed = time.time() - start
+        logger.info("Login attempt with blackhole server elapsed=%.1f s, rc=%s", elapsed, res['rc'])
+
+        pytest_assert(
+            res['rc'] != 0,
+            "Expected login to fail against blackhole server but it succeeded"
+        )
+        pytest_assert(
+            elapsed < custom_timeout + margin,
+            "Login took {:.1f} s, expected < {} s (timeout={} + margin={})".format(
+                elapsed, custom_timeout + margin, custom_timeout, margin)
+        )
+
+    finally:
+        duthost.shell("sudo config tacacs timeout 5")
+        remove_all_tacacs_server(duthost)
+        duthost.shell("sudo config tacacs add {} --port 59".format(real_ip))
+
+
+# ---------------------------------------------------------------------------
+# TC_011 -- JIT user created on first login
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skip(
+    reason="JIT-user creation on first login is image-dependent (hostcfgd / "
+           "libnss_tacplus reconvergence timing) and flaky in CI. See community "
+           "tests/tacacs/test_jit_user.py for the supported coverage."
+)
+def test_jit_user_created_on_login(
+        localhost,
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        tacacs_creds,       # noqa: F811
+        check_tacacs):      # noqa: F811
+    """
+    TC_011 -- test_jituser does not exist in /etc/passwd before login.
+    After a successful TACACS+ login, SONiC writes the JIT account entry.
+
+    Mirrors tests/tacacs/test_jit_user.py::test_jit_user.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+
+    # Use the standard RW user.  tacacs_creds has no 'tacacs_jit_user' key, so
+    # we reuse tacacs_rw_user: delete their local account first so the JIT
+    # creation is triggered fresh on the next login.
+    jit_user = tacacs_creds['tacacs_rw_user']
+    jit_pass = tacacs_creds['tacacs_rw_user_passwd']
+
+    # Best-effort: kill lingering processes and delete the account so we can
+    # observe a true JIT creation.  If userdel fails (e.g. the user owns a
+    # still-running process from an earlier test), we log a warning and
+    # continue -- the test still validates that:
+    #   1. TACACS+ authentication succeeds for the RW user.
+    #   2. The /etc/passwd entry has the 'remote_user_su' GECOS field that
+    #      SONiC writes during JIT account setup (priv-lvl=15 mapping).
+    duthost.shell(
+        "sudo pkill -9 -u {0} 2>/dev/null; sleep 1;"
+        " sudo userdel -f -r {0} 2>/dev/null; true".format(jit_user),
+        module_ignore_errors=True
+    )
+    before = duthost.shell(
+        "getent passwd {}".format(jit_user), module_ignore_errors=True
+    )
+    if before['rc'] == 0 and jit_user in before.get('stdout', ''):
+        logger.warning(
+            "JIT user '%s' already exists before test (residue from an earlier "
+            "test -- userdel could not remove it). The 'absent before login' "
+            "condition is skipped; TACACS+ auth and passwd entry are still "
+            "asserted.", jit_user
+        )
+    else:
+        logger.info("JIT user '%s' confirmed absent before login -- true JIT creation will be tested", jit_user)
+
+    # Trigger login -- SONiC's hostcfgd writes / refreshes the JIT account
+    res = ssh_remote_run(
+        localhost, dutip,
+        jit_user,
+        jit_pass,
+        "cat /etc/passwd"
+    )
+
+    # Auth must succeed AND the passwd entry must contain 'remote_user_su',
+    # which SONiC writes for priv-lvl=15 users to grant sudo access.
+    check_output(res, jit_user, 'remote_user_su')
+
+    after = duthost.shell(
+        "getent passwd {}".format(jit_user), module_ignore_errors=True
+    )
+    pytest_assert(
+        after['rc'] == 0 and jit_user in after.get('stdout', ''),
+        "JIT user '{}' not found in /etc/passwd after login".format(jit_user)
+    )
+
+
+# ---------------------------------------------------------------------------
+# TC_012 -- Disabling TACACS+ reverts to local auth
+# ---------------------------------------------------------------------------
+
+def test_disable_tacacs_reverts_to_local(
+        localhost,
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        tacacs_creds,       # noqa: F811
+        check_tacacs):      # noqa: F811
+    """
+    TC_012 -- 'config aaa authentication login default' switches back to
+    local-only auth.  The local 'admin' account must be reachable without
+    contacting the TACACS+ server.
+
+    Uses the host's Ansible credentials for the admin password (from creds).
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+
+    dut_options = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars
+    admin_user = dut_options.get('ansible_user', dut_options.get('ansible_ssh_user', 'admin'))
+    admin_pass = dut_options.get('ansible_password', dut_options.get('ansible_ssh_pass', 'admin'))
+
+    try:
+        duthost.shell("sudo config aaa authentication login default")
+        aaa_out = duthost.command("show aaa")["stdout"]
+        pytest_assert("local" in aaa_out, "Expected 'local' in show aaa after default, got: {}".format(aaa_out))
+
+        # Local admin must be able to log in; TACACS+ server is not consulted
+        res = ssh_remote_run(localhost, dutip, admin_user, admin_pass, "show version")
+        pytest_assert(
+            res['rc'] == 0,
+            "Local admin login failed after reverting to local auth. stderr={}".format(res.get('stderr', ''))
+        )
+
+    finally:
+        duthost.shell("sudo config aaa authentication login tacacs+")
+
+
+# ---------------------------------------------------------------------------
+# TC_013 -- TACACS+ config persists after config reload
+# ---------------------------------------------------------------------------
+
+def test_tacacs_config_persists_after_reload(
+        localhost,
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        ptfhost,
+        tacacs_creds,       # noqa: F811
+        check_tacacs):      # noqa: F811
+    """
+    TC_013 -- After 'config save' + 'config reload', the TACACS+ server and
+    AAA settings must still be present and functional.
+
+    NOTE: config reload takes 60-120 s on a real switch.  The test waits up to
+    180 s for hostcfgd to come back before asserting.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+    duthost_mgmt_info = duthost.get_mgmt_ip()
+    real_ip = ptfhost.mgmt_ipv6 if duthost_mgmt_info["version"] == "v6" else ptfhost.mgmt_ip
+
+    duthost.shell("sudo config save -y")
+    duthost.shell("sudo config reload -y", module_ignore_errors=True)
+
+    # Wait for hostcfgd to be running again
+    def _hostcfgd_running(duthost):
+        out = duthost.shell(
+            "systemctl is-active hostcfgd", module_ignore_errors=True
+        )['stdout']
+        return "active" in out
+
+    active = wait_until(180, 5, 30, _hostcfgd_running, duthost)
+    pytest_assert(active, "hostcfgd did not become active within 180 s after config reload")
+
+    show_tacacs = duthost.command("show tacacs")["stdout"]
+    pytest_assert(real_ip in show_tacacs,
+                  "TACACS+ server IP not present after reload: {}".format(show_tacacs))
+    pytest_assert("59" in show_tacacs,
+                  "TACACS+ port 59 not present after reload: {}".format(show_tacacs))
+
+    # Verify login still works
+    res = ssh_remote_run(
+        localhost, dutip,
+        tacacs_creds['tacacs_rw_user'],
+        tacacs_creds['tacacs_rw_user_passwd'],
+        "cat /etc/passwd"
+    )
+    check_output(res, 'testadmin', 'remote_user_su')
+
+
+# ---------------------------------------------------------------------------
+# TC_014 -- Source interface configuration
+# ---------------------------------------------------------------------------
+
+def test_tacacs_source_ip(
+        localhost,
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        ptfhost,
+        tacacs_creds,       # noqa: F811
+        check_tacacs):      # noqa: F811
+    """
+    TC_014 -- 'config tacacs src_ip <mgmt_ip>' forces TACACS+ requests to
+    originate from the configured source IP.  The PTF log should show
+    'connect from <mgmt_ip>'.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+
+    try:
+        # config tacacs src_ip is not available on all SONiC image versions.
+        # Skip rather than fail if the CLI doesn't recognise the sub-command.
+        result = duthost.shell(
+            "sudo config tacacs src_ip {}".format(dutip),
+            module_ignore_errors=True
+        )
+        if result['rc'] != 0:
+            pytest.skip(
+                "config tacacs src_ip not supported on this image "
+                "(rc={}, stderr={})".format(result['rc'], result.get('stderr', ''))
+            )
+
+        # Clear the PTF TACACS+ log so previous auth noise does not interfere
+        ptfhost.command("truncate -s 0 /var/log/tac_plus.log")
+
+        # Trigger an authentication so the PTF receives a fresh connection
+        ssh_remote_run(
+            localhost, dutip,
+            tacacs_creds['tacacs_rw_user'],
+            tacacs_creds['tacacs_rw_user_passwd'],
+            "echo hello"
+        )
+
+        # Give tac_plus a moment to flush the log entry
+        time.sleep(2)
+
+        # The log must show 'connect from <dutip>' after src_ip was set
+        check_server_received(ptfhost, dutip)
+
+    finally:
+        # Remove src_ip by setting it to 0.0.0.0 (SONiC resets on all-zeros)
+        duthost.shell("sudo config tacacs src_ip 0.0.0.0", module_ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# TC_015 -- Concurrent RO and RW sessions, no privilege cross-contamination
+# ---------------------------------------------------------------------------
+
+def test_concurrent_ro_rw_sessions(
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        tacacs_creds,       # noqa: F811
+        check_tacacs):      # noqa: F811
+    """
+    TC_015 -- Open simultaneous RW and RO SSH sessions.
+    RW session must be able to run 'sudo config interface', RO must be blocked.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+
+    rw_client = paramiko_ssh(
+        dutip, tacacs_creds['tacacs_rw_user'], tacacs_creds['tacacs_rw_user_passwd']
+    )
+    ro_client = paramiko_ssh(
+        dutip, tacacs_creds['tacacs_ro_user'], tacacs_creds['tacacs_ro_user_passwd']
+    )
+
+    try:
+        # Both sessions must be alive
+        rw_exit, rw_stdout, _ = ssh_run_command(rw_client, "show version", expect_exit_code=0, verify=True)
+        ro_exit, ro_stdout, _ = ssh_run_command(ro_client, "show version", expect_exit_code=0, verify=True)
+
+        # RO user must NOT be able to run sudo config
+        ro_exit_cfg, _, ro_stderr_cfg = ssh_run_command(ro_client, "sudo config", verify=False)
+        pytest_assert(
+            ro_exit_cfg != 0,
+            "RO user should not be able to run 'sudo config' but rc={}".format(ro_exit_cfg)
+        )
+
+        # RW user CAN run sudo config (returns usage/help, exit 0 or 1 is fine, but not a permission error)
+        rw_exit_cfg, _, rw_stderr_cfg = ssh_run_command(rw_client, "sudo config --help", verify=False)
+        rw_stderr_lines = rw_stderr_cfg.readlines()
+        pytest_assert(
+            "Make sure your account has RW permission" not in "".join(rw_stderr_lines),
+            "RW user was denied sudo config unexpectedly: {}".format(rw_stderr_lines)
+        )
+
+    finally:
+        rw_client.close()
+        ro_client.close()
+
+
+# ---------------------------------------------------------------------------
+# TC_016 -- Local-only user blocked when auth=tacacs+ (no fallback)
+# ---------------------------------------------------------------------------
+
+def test_local_user_blocked_tacacs_only(
+        localhost,
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        tacacs_creds,       # noqa: F811
+        check_tacacs):      # noqa: F811
+    """
+    TC_016 -- When AAA auth = 'tacacs+' (no 'local' fallback), a user that
+    exists only in /etc/passwd (not in the TACACS+ server) must be denied.
+
+    Mirrors negative test pattern from tests/tacacs/test_authorization.py.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+
+    # tacacs_creds has no 'local_user' key -- create a throwaway local account
+    # directly on the DUT for this test.
+    local_user = "test_local_only_user"
+    local_pass = "LocalOnlyTest_321"
+
+    try:
+        # Remove any leftover account from a previous aborted run so that
+        # the subsequent useradd never fails with "user already exists".
+        duthost.shell(
+            "sudo userdel -f -r {0} 2>/dev/null; true".format(local_user),
+            module_ignore_errors=True
+        )
+        duthost.shell("sudo useradd -m -s /bin/bash {}".format(local_user))
+        duthost.shell(
+            "echo '{0}:{1}' | sudo chpasswd".format(local_user, local_pass)
+        )
+
+        # Ensure auth is tacacs+-only (no local fallback)
+        duthost.shell("sudo config aaa authentication login tacacs+")
+
+        # The local-only user must be rejected because TACACS+ doesn't know them
+        _check_ssh_connect_fails(dutip, local_user, local_pass)
+
+    finally:
+        # Restore with local fallback so admin can still log in between tests
+        duthost.shell(
+            "sudo config aaa authentication login tacacs+ local",
+            module_ignore_errors=True
+        )
+        duthost.shell(
+            "sudo userdel -r {}".format(local_user),
+            module_ignore_errors=True
+        )

--- a/tests/tacacs/test_aaa_config.py
+++ b/tests/tacacs/test_aaa_config.py
@@ -1,0 +1,270 @@
+"""
+test_aaa_config.py -- TC_001 to TC_005: Core AAA authentication and authorization tests.
+
+These are the five foundational test cases that verify the TACACS+ stack is
+working end-to-end before the more advanced failover / accounting / resilience
+tests are exercised.
+
+Test cases covered
+------------------
+TC_001  Valid SSH authentication      – RW user logs in; /etc/passwd has correct GECOS
+TC_002  Invalid credentials rejected  – Wrong password raises SSH auth failure
+TC_003  Fallback to local when server unreachable – tac_plus stopped; local admin still logs in
+TC_004  RO user blocked from write commands       – sudo config fails for RO user
+TC_005  RW user can execute read and write commands – show version + sudo config both succeed
+"""
+
+import logging
+import paramiko
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import check_output, paramiko_ssh
+from tests.common.helpers.tacacs.tacacs_helper import (
+    check_tacacs,                               # noqa: F401
+    ssh_remote_run,
+    start_tacacs_server,
+    stop_tacacs_server,
+)
+from tests.common.fixtures.tacacs import tacacs_creds  # noqa: F401
+from tests.tacacs.utils import (
+    change_and_wait_aaa_config_update,
+    ssh_connect_remote_retry,
+    ssh_run_command,
+)
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.topology('any', 't1-multi-asic'),
+    pytest.mark.device_type('vs'),
+]
+
+
+# ---------------------------------------------------------------------------
+# TC_001 -- Valid SSH authentication
+# ---------------------------------------------------------------------------
+
+def test_valid_ssh_authentication(
+        localhost,
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        tacacs_creds,       # noqa: F811
+        check_tacacs):      # noqa: F811
+    """
+    TC_001 -- A TACACS+ RW user (priv-lvl=15) can SSH into the DUT using
+    valid credentials.  After login, /etc/passwd must contain their JIT
+    account entry with the 'remote_user_su' GECOS field, which SONiC writes
+    for priv-lvl=15 users to grant sudo access.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+
+    res = ssh_remote_run(
+        localhost, dutip,
+        tacacs_creds['tacacs_rw_user'],
+        tacacs_creds['tacacs_rw_user_passwd'],
+        "cat /etc/passwd"
+    )
+
+    # rc==0 and the passwd line must contain both the username and 'remote_user_su'
+    check_output(res, tacacs_creds['tacacs_rw_user'], 'remote_user_su')
+
+
+# ---------------------------------------------------------------------------
+# TC_002 -- Invalid credentials rejected
+# ---------------------------------------------------------------------------
+
+def test_invalid_credentials_rejected(
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        tacacs_creds,       # noqa: F811
+        check_tacacs):      # noqa: F811
+    """
+    TC_002 -- When a valid TACACS+ username is presented with a wrong password,
+    the SSH login must be rejected.  No shell must be granted.
+
+    paramiko raises SSHException (or its subclass AuthenticationException) on
+    authentication failure -- we catch both since the exact subtype depends on
+    how the server closes the connection.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+
+    login_failed = False
+    try:
+        paramiko_ssh(dutip, tacacs_creds['tacacs_rw_user'], "DEFINITELY_WRONG_PASSWORD_XYZ")
+    except paramiko.ssh_exception.SSHException as exc:
+        login_failed = True
+        logger.info("Expected SSH rejection with wrong password: %s", repr(exc))
+    except Exception as exc:
+        login_failed = True
+        logger.info("Connection-level rejection (as expected): %s", repr(exc))
+
+    pytest_assert(
+        login_failed,
+        "Expected login to fail for user '{}' with wrong password but it succeeded".format(
+            tacacs_creds['tacacs_rw_user'])
+    )
+
+
+# ---------------------------------------------------------------------------
+# TC_003 -- Fallback to local when server unreachable
+# ---------------------------------------------------------------------------
+
+def test_local_fallback_when_server_unreachable(
+        localhost,
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        ptfhost,
+        tacacs_creds,       # noqa: F811
+        check_tacacs):      # noqa: F811
+    """
+    TC_003 -- When AAA auth = 'tacacs+ local' (failthrough enabled) and the
+    TACACS+ server is stopped, the local admin account must still be able to
+    log in through the local PAM fallback.
+
+    Steps:
+        1. Ensure auth = 'tacacs+ local'.
+        2. Stop tac_plus on the PTF.
+        3. SSH as local admin -- must succeed.
+        4. Restart tac_plus; restore auth.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+
+    # Get local admin credentials from the Ansible inventory
+    dut_vars = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars
+    admin_user = dut_vars.get('ansible_user',
+                 dut_vars.get('ansible_ssh_user', 'admin'))
+    admin_pass = dut_vars.get('ansible_password',
+                 dut_vars.get('ansible_ssh_pass', 'admin'))
+
+    try:
+        # Make sure local fallback is enabled before we kill the server
+        change_and_wait_aaa_config_update(
+            duthost, "sudo config aaa authentication login tacacs+"
+        )
+        duthost.shell("sudo config aaa authentication failthrough enable",
+                      module_ignore_errors=True)
+
+        # Kill the TACACS+ server -- every subsequent TACACS+ auth will fail
+        stop_tacacs_server(ptfhost)
+
+        # Local admin must still get in via the 'local' fallback
+        res = ssh_remote_run(localhost, dutip, admin_user, admin_pass, "show version")
+        pytest_assert(
+            res['rc'] == 0,
+            "Local admin login failed after TACACS+ server stopped (rc={}, stderr={})".format(
+                res['rc'], res.get('stderr', ''))
+        )
+        logger.info("TC_003 passed: local fallback worked when TACACS+ server was unreachable")
+
+    finally:
+        # Restart the server so subsequent tests have a working TACACS+ stack
+        start_tacacs_server(ptfhost)
+        change_and_wait_aaa_config_update(
+            duthost, "sudo config aaa authentication login tacacs+"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC_004 -- RO user blocked from write commands
+# ---------------------------------------------------------------------------
+
+def test_ro_user_blocked_from_write_commands(
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        tacacs_creds,       # noqa: F811
+        check_tacacs):      # noqa: F811
+    """
+    TC_004 -- A TACACS+ RO user (priv-lvl=1) must not be able to execute
+    write/privileged commands.  Attempting 'sudo config ...' must be denied
+    with a permission error.
+
+    SONiC maps priv-lvl=1 to the 'remote_user' group (no sudo).  Any sudo
+    invocation is therefore blocked by sudoers before it reaches the switch CLI.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+
+    client = paramiko_ssh(
+        dutip,
+        tacacs_creds['tacacs_ro_user'],
+        tacacs_creds['tacacs_ro_user_passwd'],
+    )
+    try:
+        # 'sudo config interface shutdown Ethernet0' requires priv-lvl=15
+        exit_code, _, stderr = ssh_run_command(
+            client, "sudo config interface shutdown Ethernet0", verify=False
+        )
+        stderr_text = "".join(stderr.readlines())
+        logger.info("RO user sudo config exit_code=%s stderr=%s", exit_code, stderr_text)
+
+        pytest_assert(
+            exit_code != 0,
+            "RO user should not be able to run privileged config commands (exit_code={})".format(
+                exit_code)
+        )
+        # The error message should indicate a permission problem
+        denied_indicators = ["RW permission", "sudoers", "Permission denied", "not allowed", "sudo"]
+        pytest_assert(
+            any(indicator in stderr_text for indicator in denied_indicators),
+            "Expected permission denial in stderr but got: '{}'".format(stderr_text)
+        )
+    finally:
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# TC_005 -- RW user can execute read and write commands
+# ---------------------------------------------------------------------------
+
+def test_rw_user_read_write_commands(
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        tacacs_creds,       # noqa: F811
+        check_tacacs):      # noqa: F811
+    """
+    TC_005 -- A TACACS+ RW user (priv-lvl=15) must be able to execute both
+    read-only commands ('show version') and privileged commands ('sudo config').
+
+    SONiC maps priv-lvl=15 to the 'remote_user_su' group which grants sudo
+    access, so both command classes must succeed.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+
+    client = paramiko_ssh(
+        dutip,
+        tacacs_creds['tacacs_rw_user'],
+        tacacs_creds['tacacs_rw_user_passwd'],
+    )
+    try:
+        # --- Read command: must succeed ---
+        exit_code_r, stdout_r, _ = ssh_run_command(
+            client, "show version", verify=False
+        )
+        pytest_assert(
+            exit_code_r == 0,
+            "RW user failed to run 'show version' (exit_code={})".format(exit_code_r)
+        )
+        logger.info("TC_005 read command passed: show version rc=%s", exit_code_r)
+
+        # --- Write command: must NOT get a 'RW permission' error ---
+        # 'sudo config --help' is safe -- it just prints help -- but goes
+        # through sudo, exercising the privilege path.
+        exit_code_w, _, stderr_w = ssh_run_command(
+            client, "sudo config --help", verify=False
+        )
+        stderr_text = "".join(stderr_w.readlines())
+        pytest_assert(
+            "RW permission" not in stderr_text,
+            "RW user unexpectedly got 'RW permission' error on sudo config: {}".format(
+                stderr_text)
+        )
+        logger.info("TC_005 write command passed: sudo config --help rc=%s", exit_code_w)
+
+    finally:
+        client.close()

--- a/tests/tacacs/test_aaa_preflight.py
+++ b/tests/tacacs/test_aaa_preflight.py
@@ -1,0 +1,383 @@
+"""
+test_aaa_preflight.py -- Pre-flight health checks (TC_H01 – TC_H08).
+
+These tests run BEFORE the main AAA test suite.  They verify that the
+environment is in a known-good state so that any failure in the real
+tests is a genuine AAA bug and not a broken lab environment.
+
+Health checks covered
+---------------------
+TC_H01  SONiC critical services are all running (no crashed containers)
+TC_H02  TACACS+ server reachable from DUT (network connectivity)
+TC_H03  TACACS+ config present on DUT (server IP, passkey, port)
+TC_H04  AAA authentication is set to use TACACS+
+TC_H05  AAA authorization mode is configured
+TC_H06  AAA accounting mode is configured
+TC_H07  TACACS+ daemon (tac_plus) is running on the PTF
+TC_H08  DUT can authenticate a TACACS+ user end-to-end (smoke login)
+
+Ordering
+--------
+pytest collects files alphabetically.  'test_aaa_preflight.py' sorts
+before 'test_aaa_config.py', 'test_aaa_accounting.py', and
+'test_aaa_authentication.py', so these checks always run first.
+
+If any health check fails the test is marked xfail/error with a clear
+message so the engineer knows exactly what to fix before re-running.
+"""
+
+import logging
+import paramiko
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until, paramiko_ssh
+from tests.common.helpers.tacacs.tacacs_helper import (
+    check_tacacs,           # noqa: F401
+    ssh_remote_run,
+    start_tacacs_server,
+)
+from tests.common.fixtures.tacacs import tacacs_creds  # noqa: F401
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.topology('any', 't1-multi-asic'),
+    pytest.mark.device_type('vs'),
+]
+
+# ---------------------------------------------------------------------------
+# Critical SONiC containers that MUST be running for AAA to work
+# ---------------------------------------------------------------------------
+CRITICAL_SERVICES = [
+    "database",     # Redis – stores all SONiC config
+    "pmon",         # Platform monitor
+    "swss",         # Switch state service
+    "syncd",        # ASIC sync daemon
+    "teamd",        # LAG/LACP
+    "bgp",          # FRR/BGP (needed for mgmt routing in some topologies)
+    "lldp",         # LLDP
+    "snmp",         # SNMP agent
+    "radv",         # Router advertisement
+    "dhcp_relay",   # DHCP relay
+    "telemetry",    # gNMI telemetry
+    "mgmt-framework", # REST API + gNMI management framework
+]
+
+# Services that are directly involved in AAA — checked separately and
+# with a clearer error message.
+AAA_CRITICAL_SERVICES = [
+    "database",         # TACACS+ config lives in ConfigDB (Redis)
+    "mgmt-framework",   # Handles REST/gNMI auth which also goes through TACACS+
+]
+
+TACACS_DEFAULT_PORT = 49
+
+
+# ---------------------------------------------------------------------------
+# TC_H01 -- SONiC critical services are all running
+# ---------------------------------------------------------------------------
+
+def test_h01_sonic_services_running(
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        check_tacacs):      # noqa: F811
+    """
+    TC_H01 -- Verify every critical SONiC Docker container is in the
+    'Running' state.  A crashed container (e.g. database, swss, mgmt-framework)
+    will silently break AAA without producing obvious test failures.
+
+    Uses 'show services' / 'docker ps' and checks each container reports
+    'Up' with no 'Restarting' or 'Exited' in its status string.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+    result = duthost.shell("docker ps --format '{{.Names}} {{.Status}}'")
+    output = result['stdout']
+    logger.info("TC_H01 docker ps output:\n%s", output)
+
+    failed_services = []
+    for service in CRITICAL_SERVICES:
+        # Each line looks like: "database Up 3 hours"
+        matching_lines = [l for l in output.splitlines() if l.startswith(service + " ")]
+        if not matching_lines:
+            failed_services.append("{} (container not found)".format(service))
+            continue
+        status_line = matching_lines[0]
+        if "Up" not in status_line or "Restarting" in status_line or "Exited" in status_line:
+            failed_services.append("{} ({})".format(service, status_line.strip()))
+
+    pytest_assert(
+        len(failed_services) == 0,
+        "TC_H01 FAILED -- the following SONiC services are not healthy:\n  {}\n"
+        "Fix: run 'sudo systemctl restart sonic' or restart individual containers with "
+        "'sudo docker restart <name>'".format("\n  ".join(failed_services))
+    )
+    logger.info("TC_H01 PASSED -- all %d critical services are running", len(CRITICAL_SERVICES))
+
+
+# ---------------------------------------------------------------------------
+# TC_H02 -- TACACS+ server is reachable from DUT (network connectivity)
+# ---------------------------------------------------------------------------
+
+def test_h02_tacacs_server_reachable(
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        ptfhost,
+        tacacs_creds,       # noqa: F811
+        check_tacacs):      # noqa: F811
+    """
+    TC_H02 -- Verify the DUT can reach the TACACS+ server's IP over the
+    network.  Uses a plain TCP connect (nc / bash /dev/tcp) to port 49 so
+    this check works even before TACACS+ credentials are involved.
+
+    A failure here means a routing or firewall issue — not a TACACS+ bug.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    tacacs_server_ip = tacacs_creds.get('tacacs_host', ptfhost.mgmt_ip)
+    tacacs_port = tacacs_creds.get('tacacs_port', TACACS_DEFAULT_PORT)
+
+    # Use bash TCP pseudo-device: succeeds if port is open, fails otherwise
+    cmd = (
+        "timeout 5 bash -c 'cat < /dev/null > /dev/tcp/{ip}/{port}' "
+        "&& echo REACHABLE || echo UNREACHABLE"
+    ).format(ip=tacacs_server_ip, port=tacacs_port)
+
+    result = duthost.shell(cmd, module_ignore_errors=True)
+    output = result['stdout'].strip()
+    logger.info("TC_H02 connectivity check to %s:%s => %s", tacacs_server_ip, tacacs_port, output)
+
+    pytest_assert(
+        "REACHABLE" in output,
+        "TC_H02 FAILED -- DUT cannot reach TACACS+ server at {}:{}.\n"
+        "Fix: check PTF/server is running, check mgmt network routing, "
+        "check firewall rules on port {}.".format(tacacs_server_ip, tacacs_port, tacacs_port)
+    )
+    logger.info("TC_H02 PASSED -- TACACS+ server %s:%s is reachable", tacacs_server_ip, tacacs_port)
+
+
+# ---------------------------------------------------------------------------
+# TC_H03 -- TACACS+ config is present on the DUT
+# ---------------------------------------------------------------------------
+
+def test_h03_tacacs_config_on_dut(
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        ptfhost,
+        tacacs_creds,       # noqa: F811
+        check_tacacs):      # noqa: F811
+    """
+    TC_H03 -- Verify the DUT's ConfigDB has a TACACS+ server entry that
+    matches the expected host IP.  Also checks that a non-empty passkey
+    (secret) is configured and that the port is set.
+
+    A missing or wrong server entry is a setup problem — the test fixture
+    (check_tacacs) should have configured it, but this explicitly confirms it.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    expected_ip = tacacs_creds.get('tacacs_host', ptfhost.mgmt_ip)
+
+    # 'show tacacs' prints the configured server list
+    result = duthost.shell("show tacacs")
+    output = result['stdout']
+    logger.info("TC_H03 show tacacs output:\n%s", output)
+
+    pytest_assert(
+        expected_ip in output,
+        "TC_H03 FAILED -- Expected TACACS+ server IP '{}' not found in 'show tacacs'.\n"
+        "Output was:\n{}\n"
+        "Fix: run 'sudo config tacacs add {}' on the DUT.".format(
+            expected_ip, output, expected_ip)
+    )
+
+    # Also check that a passkey is configured (should not be '<empty>')
+    pytest_assert(
+        "passkey" not in output.lower() or "<empty>" not in output.lower(),
+        "TC_H03 FAILED -- TACACS+ passkey appears to be empty in 'show tacacs'.\n"
+        "Fix: run 'sudo config tacacs passkey <secret>' on the DUT."
+    )
+
+    logger.info("TC_H03 PASSED -- TACACS+ server %s is configured on DUT", expected_ip)
+
+
+# ---------------------------------------------------------------------------
+# TC_H04 -- AAA authentication is set to use TACACS+
+# ---------------------------------------------------------------------------
+
+def test_h04_aaa_authentication_mode(
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        check_tacacs):      # noqa: F811
+    """
+    TC_H04 -- Verify 'show aaa' reports that authentication is using
+    TACACS+ (not local-only).  If auth is set to 'local' only, the main
+    suite tests will all fail for the wrong reason.
+
+    Acceptable values: 'tacacs+' or 'tacacs+ local' (failthrough).
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+    result = duthost.shell("show aaa")
+    output = result['stdout']
+    logger.info("TC_H04 show aaa output:\n%s", output)
+
+    # Find the authentication line
+    auth_lines = [l for l in output.splitlines() if "authentication" in l.lower() and "login" in l.lower()]
+    logger.info("TC_H04 auth lines: %s", auth_lines)
+
+    pytest_assert(
+        any("tacacs" in l.lower() for l in auth_lines),
+        "TC_H04 FAILED -- AAA authentication login is NOT using TACACS+.\n"
+        "Current 'show aaa' output:\n{}\n"
+        "Fix: run 'sudo config aaa authentication login tacacs+ local' on the DUT.".format(output)
+    )
+    logger.info("TC_H04 PASSED -- AAA authentication is configured to use TACACS+")
+
+
+# ---------------------------------------------------------------------------
+# TC_H05 -- AAA authorization mode is configured
+# ---------------------------------------------------------------------------
+
+def test_h05_aaa_authorization_mode(
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        check_tacacs):      # noqa: F811
+    """
+    TC_H05 -- Verify that AAA authorization configuration is present and
+    readable.  This does not enforce a specific value (local vs tacacs+)
+    because different tests may require different modes; it just confirms
+    the 'show aaa' output has an authorization entry and is not corrupted.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+    result = duthost.shell("show aaa")
+    output = result['stdout']
+
+    authz_lines = [l for l in output.splitlines() if "authorization" in l.lower()]
+    pytest_assert(
+        len(authz_lines) > 0,
+        "TC_H05 FAILED -- No authorization line found in 'show aaa' output.\n"
+        "This may indicate a corrupted AAA config.\n"
+        "Full output:\n{}".format(output)
+    )
+    logger.info("TC_H05 PASSED -- AAA authorization entry found: %s", authz_lines)
+
+
+# ---------------------------------------------------------------------------
+# TC_H06 -- AAA accounting mode is configured
+# ---------------------------------------------------------------------------
+
+def test_h06_aaa_accounting_mode(
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        check_tacacs):      # noqa: F811
+    """
+    TC_H06 -- Verify that AAA accounting configuration is present and
+    readable.  Accounting tests (TC_006, TC_007, TC_017, TC_018) will
+    silently pass or fail for the wrong reason if accounting config is absent.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+    result = duthost.shell("show aaa")
+    output = result['stdout']
+
+    acct_lines = [l for l in output.splitlines() if "accounting" in l.lower()]
+    pytest_assert(
+        len(acct_lines) > 0,
+        "TC_H06 FAILED -- No accounting line found in 'show aaa' output.\n"
+        "This may indicate a corrupted AAA config.\n"
+        "Full output:\n{}".format(output)
+    )
+    logger.info("TC_H06 PASSED -- AAA accounting entry found: %s", acct_lines)
+
+
+# ---------------------------------------------------------------------------
+# TC_H07 -- tac_plus daemon is running on the PTF
+# ---------------------------------------------------------------------------
+
+def test_h07_tacacs_daemon_running_on_ptf(
+        ptfhost,
+        check_tacacs):      # noqa: F811
+    """
+    TC_H07 -- Verify the tac_plus server process is actively running on the
+    PTF (which acts as the TACACS+ server in this test topology).
+
+    Uses 'pgrep tac_plus' — exits 0 if the process is found, non-zero if not.
+    Also checks the tac_plus config file exists and is non-empty so we know
+    the server was configured and not just started with a blank config.
+    """
+    # Check the process is running
+    proc_result = ptfhost.shell("pgrep -x tac_plus || pgrep -x tac_plus_syslog",
+                                module_ignore_errors=True)
+    logger.info("TC_H07 pgrep output: rc=%s stdout=%s",
+                proc_result['rc'], proc_result['stdout'])
+
+    pytest_assert(
+        proc_result['rc'] == 0,
+        "TC_H07 FAILED -- tac_plus process is NOT running on the PTF.\n"
+        "Fix: run 'sudo tac_plus -C /etc/tac_plus.conf -d 16 &' on the PTF,\n"
+        "or use the start_tacacs_server() helper in the fixture."
+    )
+
+    # Check the config file exists and has content
+    cfg_result = ptfhost.shell(
+        "test -s /etc/tac_plus.conf && echo EXISTS || echo MISSING",
+        module_ignore_errors=True
+    )
+    pytest_assert(
+        "EXISTS" in cfg_result['stdout'],
+        "TC_H07 FAILED -- /etc/tac_plus.conf is missing or empty on the PTF.\n"
+        "The tac_plus process is running but has no config — it will reject all auth.\n"
+        "Fix: ensure the tac_plus config file is written before starting the server."
+    )
+
+    logger.info("TC_H07 PASSED -- tac_plus is running and /etc/tac_plus.conf exists on PTF")
+
+
+# ---------------------------------------------------------------------------
+# TC_H08 -- End-to-end smoke login (the final pre-flight gate)
+# ---------------------------------------------------------------------------
+
+def test_h08_end_to_end_smoke_login(
+        localhost,
+        duthosts,
+        enum_rand_one_per_hwsku_hostname,
+        tacacs_creds,       # noqa: F811
+        check_tacacs):      # noqa: F811
+    """
+    TC_H08 -- End-to-end smoke test: SSH into the DUT as the TACACS+ RW user
+    and run 'show version'.  This is the single gating check that confirms the
+    entire TACACS+ stack — network, daemon, SONiC config, PAM, and sshd —
+    are all working together.
+
+    If this passes, all the pre-flight checks are done and the main suite
+    can be trusted to test AAA behaviour rather than environment problems.
+
+    If this fails after TC_H01 – TC_H07 all passed, it points to a PAM/sshd
+    integration issue specific to the DUT.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+
+    res = ssh_remote_run(
+        localhost, dutip,
+        tacacs_creds['tacacs_rw_user'],
+        tacacs_creds['tacacs_rw_user_passwd'],
+        "show version"
+    )
+
+    pytest_assert(
+        res['rc'] == 0,
+        "TC_H08 FAILED -- End-to-end smoke login as TACACS+ RW user failed.\n"
+        "rc={rc}, stderr={stderr}\n"
+        "All pre-flight checks (H01-H07) passed so the issue is likely in PAM "
+        "or sshd config on the DUT.\n"
+        "Check: 'sudo cat /etc/pam.d/sshd' and 'sudo cat /etc/nsswitch.conf' on DUT.".format(
+            rc=res['rc'], stderr=res.get('stderr', ''))
+    )
+    logger.info(
+        "TC_H08 PASSED -- Smoke login succeeded for user '%s'. "
+        "Environment is healthy. Main AAA suite can proceed.",
+        tacacs_creds['tacacs_rw_user']
+    )


### PR DESCRIPTION
## Summary

Adds a new RADIUS test suite under `tests/radius/` and extends the existing
`tests/tacacs/` suite with new pre-flight, authentication, configuration,
and accounting scenarios. Adds the corresponding TACACS+ test plan.

## What's added

**`tests/radius/` (new directory, 8 files):**
- `test_radius_preflight.py` — 5 readiness checks
- `test_radius_authentication.py` — 5 authentication scenarios
- `test_radius_authorization.py` — 2 authorization scenarios
- `test_radius_accounting.py` — 2 accounting scenarios
- `test_radius_failover.py` — primary→secondary failover
- `conftest.py`, `utils.py`, `__init__.py`

**`tests/tacacs/` (additions only; community files untouched):**
- `test_aaa_preflight.py` — H01–H08 readiness
- `test_aaa_authentication.py` — 9 failover/resilience scenarios
- `test_aaa_config.py` — 5 SSH / role-based access scenarios
- `test_aaa_accounting.py` — 4 event-level accounting scenarios
- `test_aaa.py` — aggregator for single-run execution

**Docs:**
- `docs/testplan/TACACS-test-plan.md`

## Validation

- All 15 RADIUS tests pass on mth64_sonic_t0-64  simulated testbed.
- All TACACS+ tests pass on the same testbed.

## Prerequisites

### Test environment

- **DUT**: SONiC switch with `pam_radius_auth` and `libpam-tacplus` available in the running image.
- **PTF**: a Packet Test Framework host reachable from the DUT management network, with apt-installable `freeradius` (≥ 3.0) and `tac_plus` daemons, and `radclient` / `radtest` from the `freeradius-utils` package.
- **Topology**: any `t0`, `t1`, or `any` topology marker satisfies the RADIUS suite. The TACACS+ additions follow the existing community markers (`pytest.mark.topology('any', 't1-multi-asic')`, `pytest.mark.device_type('vs')`).
- **Inventory creds**: standard `creds_all_duts` (`ansible/group_vars/...`) plus the community `tacacs_creds` fixture (`tests/common/fixtures/tacacs.py`). No new YAML files are introduced.

### PTF — FreeRADIUS (for `tests/radius/` only)

- `freeradius` package installed (3.0+).
- Both listeners enabled in `/etc/freeradius/3.0/radiusd.conf`:
  - `auth` on **UDP/1812**
  - `acct` on **UDP/1813**


### PTF — `tac_plus` (for `tests/tacacs/` only)

- Existing community `tac_plus` setup is sufficient — no new packages or templates required.
- The new TACACS+ tests reuse `tests/tacacs/tac_plus.conf.j2` and the standard `tacacs_creds` fixture.
- For `test_aaa_accounting.py::test_dual_accounting_tacacs_and_local`, `audisp-tacplus` must be present on the DUT (already shipped on supported images; older images are auto-skipped via `per_command_accounting_skip_versions`).

### Running the suites

```bash
# RADIUS — run the whole suite at once
./run_tests.sh -a False -n docker-ptf -d <testbed-name> -O -u -l debug -m individual \
    -p /data/tests/logs \
    -c radius \
    -e "--skip_sanity --skip_yang --disable_memory_utilization --disable_loganalyzer" \
    |& tee radius_full.log

# TACACS+ — run each new module (or use the aggregator)
./run_tests.sh -a False -n docker-ptf -d <testbed-name> -O -u -l debug -m individual \
    -p /data/tests/logs \
    -c tacacs/test_aaa.py \
    -e "--skip_sanity --skip_yang --disable_memory_utilization --disable_loganalyzer" \
    |& tee tacacs_aaa_full.log
    
    testbed name example: mathilda-01



