### PR TITLE
[test] Accept valid CMIS partial states for Mellanox OSFP modules

### DIFF
--- a/tests/common/platform/transceiver_utils.py
+++ b/tests/common/platform/transceiver_utils.py
@@ -451,6 +451,15 @@ def get_port_expected_error_state_for_mellanox_device_on_sw_control_enabled(
     return expected_state
 
 
+# Valid CMIS module states for Mellanox sw_control-enabled ports where not all
+# data paths (sub-lanes) of an OSFP module are activated. An 8-lane OSFP module
+# reports "OK" only when all data paths are active. When partial sub-lanes are
+# used (e.g., 1 of 8 in the topology), the module reports "DataPathInitialized".
+# "ConfigUndefined" is a transient state after module reset (e.g., lpmode toggle)
+# before xcvrd re-applies configuration.
+MLNX_VALID_CMIS_PARTIAL_STATES = ['DataPathInitialized', 'ConfigUndefined']
+
+
 def is_sw_control_enabled(duthost, port_index):
     """
     @summary: This method is for checking if software control SAI attribute set to 1 in sai.profile

--- a/tests/common/platform/transceiver_utils.py
+++ b/tests/common/platform/transceiver_utils.py
@@ -457,7 +457,7 @@ def get_port_expected_error_state_for_mellanox_device_on_sw_control_enabled(
 # used (e.g., 1 of 8 in the topology), the module reports "DataPathInitialized".
 # "ConfigUndefined" is a transient state after module reset (e.g., lpmode toggle)
 # before xcvrd re-applies configuration.
-MLNX_VALID_CMIS_PARTIAL_STATES = ['DataPathInitialized', 'ConfigUndefined']
+MLNX_VALID_CMIS_PARTIAL_STATES = ('DataPathInitialized', 'ConfigUndefined')
 
 
 def is_sw_control_enabled(duthost, port_index):

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -15,9 +15,11 @@ from tests.common.utilities import wait_until
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts     # noqa: F401
 from tests.common.fixtures.duthost_utils import shutdown_ebgp           # noqa: F401
 from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service    # noqa: F401
-from tests.common.platform.transceiver_utils import is_sw_control_enabled,\
-    get_port_expected_error_state_for_mellanox_device_on_sw_control_enabled,\
-    MLNX_VALID_CMIS_PARTIAL_STATES
+from tests.common.platform.transceiver_utils import (
+    is_sw_control_enabled,
+    get_port_expected_error_state_for_mellanox_device_on_sw_control_enabled,
+    MLNX_VALID_CMIS_PARTIAL_STATES,
+)
 from tests.common.mellanox_data import is_mellanox_device
 from collections import defaultdict
 from tests.platform_tests.mellanox.conftest import is_sw_control_feature_enabled  # noqa: F401

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -16,7 +16,8 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts     # noqa: 
 from tests.common.fixtures.duthost_utils import shutdown_ebgp           # noqa: F401
 from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service    # noqa: F401
 from tests.common.platform.transceiver_utils import is_sw_control_enabled,\
-    get_port_expected_error_state_for_mellanox_device_on_sw_control_enabled
+    get_port_expected_error_state_for_mellanox_device_on_sw_control_enabled,\
+    MLNX_VALID_CMIS_PARTIAL_STATES
 from tests.common.mellanox_data import is_mellanox_device
 from collections import defaultdict
 from tests.platform_tests.mellanox.conftest import is_sw_control_feature_enabled  # noqa: F401
@@ -1025,6 +1026,11 @@ class TestSfpApi(PlatformApiTestBase):
                     intf = self.sfp_setup["index_physical_port_map"][i][0]
                     expected_state = get_port_expected_error_state_for_mellanox_device_on_sw_control_enabled(
                         intf, passive_cable_ports[duthost.hostname], cmis_cable_ports_and_ver[duthost.hostname])
+                    if error_description in MLNX_VALID_CMIS_PARTIAL_STATES:
+                        logger.info("test_get_error_description: Transceiver {} state is '{}' "
+                                    "(valid CMIS state for partially-used OSFP module), skipping".format(
+                                        i, error_description))
+                        continue
                 elif "Not supported" in error_description:
                     logger.warning("test_get_error_description: Skipping transceiver {} as error description not "
                                    "supported on this port)".format(i))

--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -19,9 +19,11 @@ from tests.common.port_toggle import default_port_toggle_wait_time
 from tests.common.platform.transceiver_utils import I2C_WAIT_TIME_AFTER_SFP_RESET
 from tests.common.platform.interface_utils import get_physical_port_indices
 from tests.common.mellanox_data import is_mellanox_device
-from tests.common.platform.transceiver_utils import is_sw_control_enabled, \
-    get_port_expected_error_state_for_mellanox_device_on_sw_control_enabled, \
-    MLNX_VALID_CMIS_PARTIAL_STATES
+from tests.common.platform.transceiver_utils import (
+    is_sw_control_enabled,
+    get_port_expected_error_state_for_mellanox_device_on_sw_control_enabled,
+    MLNX_VALID_CMIS_PARTIAL_STATES,
+)
 
 
 cmd_sfp_presence = "sudo sfputil show presence"

--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -20,7 +20,8 @@ from tests.common.platform.transceiver_utils import I2C_WAIT_TIME_AFTER_SFP_RESE
 from tests.common.platform.interface_utils import get_physical_port_indices
 from tests.common.mellanox_data import is_mellanox_device
 from tests.common.platform.transceiver_utils import is_sw_control_enabled, \
-    get_port_expected_error_state_for_mellanox_device_on_sw_control_enabled
+    get_port_expected_error_state_for_mellanox_device_on_sw_control_enabled, \
+    MLNX_VALID_CMIS_PARTIAL_STATES
 
 
 cmd_sfp_presence = "sudo sfputil show presence"
@@ -406,6 +407,11 @@ def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_h
                     continue
                 expected_state = get_port_expected_error_state_for_mellanox_device_on_sw_control_enabled(
                     intf, passive_cable_ports[duthost.hostname], cmis_cable_ports_and_ver[duthost.hostname])
+                if intf in parsed_presence and parsed_presence[intf] in MLNX_VALID_CMIS_PARTIAL_STATES:
+                    logger.info("test_check_sfputil_error_status: Interface {} state is '{}' "
+                                "(valid CMIS state for partially-used OSFP module), skipping".format(
+                                    intf, parsed_presence[intf]))
+                    continue
             elif "Not supported" in sfp_error_status['stdout']:
                 logger.warning("test_check_sfputil_error_status: Skipping transceiver {} as error status "
                                "not supported on this port)".format(intf))


### PR DESCRIPTION
On SN5640 with sw_control enabled, an 8-lane OSFP module reports "OK" only when all data paths are activated. When partial sub-lanes are used in the topology (e.g., 1 of 8 admin up), the module reports "DataPathInitialized". After a module reset (e.g., lpmode toggle), the transient state is "ConfigUndefined" before xcvrd re-applies config.

Both are valid CMIS operational states — the port itself is fully functional. Update the test to skip these transceivers instead of failing.

Affected DUTs: SN5640 with shared fanout connections where only partial OSFP sub-lanes are used.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
