### PR TITLE
snappi/pfc: extend PFC tests for non-Cisco device support

### DIFF
--- a/tests/common/snappi_tests/read_pcap.py
+++ b/tests/common/snappi_tests/read_pcap.py
@@ -12,7 +12,7 @@ PFC_MAC_CONTROL_CODE = 0x8808
 PFC_DEST_MAC = "01:80:c2:00:00:01"
 
 
-def validate_pfc_frame(pfc_pcap_file, SAMPLE_SIZE=15000, UTIL_THRESHOLD=0.8):
+def validate_pfc_frame(pfc_pcap_file, SAMPLE_SIZE=15000, UTIL_THRESHOLD=0.8, peer_mac_addr=None):
     """
     Validate PFC frame by checking the CBFC opcode, class enable vector and class pause times.
 
@@ -20,6 +20,7 @@ def validate_pfc_frame(pfc_pcap_file, SAMPLE_SIZE=15000, UTIL_THRESHOLD=0.8):
         pfc_cap: PFC pcap file
         SAMPLE_SIZE: number of packets to sample
         UTIL_THRESHOLD: threshold for PFC utilization to check if enough PFC frames were sent
+        peer_mac_addr: optional peer MAC address to validate source MAC
 
     Returns:
         True if valid PFC frame, False otherwise
@@ -38,6 +39,10 @@ def validate_pfc_frame(pfc_pcap_file, SAMPLE_SIZE=15000, UTIL_THRESHOLD=0.8):
             dest_mac = mac_to_str(eth.dst)
             if dest_mac.lower() != PFC_DEST_MAC:
                 return False, "Destination MAC address is not 01:80:c2:00:00:01"
+            if peer_mac_addr:
+                src_mac = mac_to_str(eth.src)
+                if src_mac.lower() != peer_mac_addr.lower():
+                    return False, "Source MAC address is not the peer's mac address"
             pfc_packet = PFCPacket(pfc_frame_bytes=bytes(eth.data))
             if not pfc_packet.is_valid():
                 logger.info("PFC frame {} is not valid. Please check the capture file.".format(curPktCount))

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -2045,9 +2045,9 @@ def get_snappi_ports_multi_dut(duthosts,  # noqa: F811
 def is_snappi_multidut(duthosts):
     if duthosts is None or len(duthosts) == 0:
         return False
-    if not duthosts[0].get_facts().get("modular_chassis") and len(duthosts) == 1:
+    if len(duthosts) == 1:
         return False
-    if not duthosts[0].get_facts().get("modular_chassis") and len(duthosts) > 1:
+    if len(duthosts) > 1:
         return True
     return duthosts[0].get_facts().get("modular_chassis")
 

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -2045,11 +2045,11 @@ def get_snappi_ports_multi_dut(duthosts,  # noqa: F811
 def is_snappi_multidut(duthosts):
     if duthosts is None or len(duthosts) == 0:
         return False
-    if len(duthosts) == 1:
-        return False
     if len(duthosts) > 1:
         return True
-    return duthosts[0].get_facts().get("modular_chassis")
+    # Single entry: treat as multi-DUT only for Cisco modular chassis,
+    # where one linecard is passed but the chassis spans multiple cards.
+    return bool(duthosts[0].get_facts().get("modular_chassis"))
 
 
 @pytest.fixture(scope="module")

--- a/tests/common/snappi_tests/snappi_helpers.py
+++ b/tests/common/snappi_tests/snappi_helpers.py
@@ -140,7 +140,6 @@ class SnappiFanoutManager():
             self.fanout_list[self.last_fanout_assessed]['device_linked_ports']
 
         # Chassis ip details
-        #changed by harshit
         chassis_ip = self.fanout_list[self.last_fanout_assessed]['device_info']['ManagementIp']
         self.ip_address = ansible_stdout_to_str(chassis_ip)
 

--- a/tests/common/snappi_tests/snappi_helpers.py
+++ b/tests/common/snappi_tests/snappi_helpers.py
@@ -140,7 +140,8 @@ class SnappiFanoutManager():
             self.fanout_list[self.last_fanout_assessed]['device_linked_ports']
 
         # Chassis ip details
-        chassis_ip = self.fanout_list[self.last_fanout_assessed]['device_info']['mgmtip']
+        #changed by harshit
+        chassis_ip = self.fanout_list[self.last_fanout_assessed]['device_info']['ManagementIp']
         self.ip_address = ansible_stdout_to_str(chassis_ip)
 
         # List of chassis cards and ports

--- a/tests/common/snappi_tests/snappi_helpers.py
+++ b/tests/common/snappi_tests/snappi_helpers.py
@@ -140,7 +140,8 @@ class SnappiFanoutManager():
             self.fanout_list[self.last_fanout_assessed]['device_linked_ports']
 
         # Chassis ip details
-        chassis_ip = self.fanout_list[self.last_fanout_assessed]['device_info']['ManagementIp']
+        # ManagementIp may include CIDR notation (e.g. '10.1.1.1/32'); strip it to get a plain IP.
+        chassis_ip = self.fanout_list[self.last_fanout_assessed]['device_info']['ManagementIp'].split('/')[0]
         self.ip_address = ansible_stdout_to_str(chassis_ip)
 
         # List of chassis cards and ports

--- a/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_helper.py
@@ -125,6 +125,7 @@ def run_m2o_oversubscribe_lossless_test(api,
     data_flow_names = [flow.name for flow in flows if PAUSE_FLOW_NAME not in flow.name]
 
     """ Run traffic """
+    
     flow_stats, switch_flow_stats, _ = run_traffic(duthost=egress_duthost,
                                                    api=api,
                                                    config=testbed_config,
@@ -384,10 +385,10 @@ def verify_m2o_oversubscribe_lossless_result(rows,
     """
     for row in rows:
         if 'Test Flow 1 -> 0' in row.name:
-            pytest_assert(int(row.loss) == 0, "{} must have 0% loss".format(row.name))
+            pytest_assert(int(row.loss) == 0, "{} must have 0% loss and having {}% loss".format(row.name, row.loss))
         elif 'Test Flow 2 -> 0' in row.name:
-            pytest_assert(int(row.loss) == 0, "{} must have 0% loss ".format(row.name))
+            pytest_assert(int(row.loss) == 0, "{} must have 0% loss and having {}% loss".format(row.name, row.loss))
         elif 'Background Flow 1 -> 0' in row.name:
-            pytest_assert(int(row.loss) == 0, "{} must have 0% loss ".format(row.name))
+            pytest_assert(int(row.loss) == 0, "{} must have 0% loss and having {}% loss".format(row.name, row.loss))
         elif 'Background Flow 2 -> 0' in row.name:
-            pytest_assert(int(row.loss) == 0, "{} must have 0% loss ".format(row.name))
+            pytest_assert(int(row.loss) == 0, "{} must have 0% loss and having {}% loss".format(row.name, row.loss))

--- a/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_helper.py
@@ -125,7 +125,6 @@ def run_m2o_oversubscribe_lossless_test(api,
     data_flow_names = [flow.name for flow in flows if PAUSE_FLOW_NAME not in flow.name]
 
     """ Run traffic """
-    
     flow_stats, switch_flow_stats, _ = run_traffic(duthost=egress_duthost,
                                                    api=api,
                                                    config=testbed_config,

--- a/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
@@ -162,8 +162,9 @@ def run_pfc_m2o_oversubscribe_lossless_lossy_test(api,
     else:
         pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[egress_duthost.hostname][dut_tx_port]['tx_drp']
         drop_percentage = (100 * pkt_drop) / total_rx_pkts
+    
 
-    pytest_assert(abs(drop_percentage - 5) < 1, 'FAIL: Drop packets must be around 5 percent')
+    pytest_assert(abs(drop_percentage - 5) < 1, 'FAIL: Drop packets must be around 5 percent {}'.format(drop_percentage))
 
     """ Verify Results """
     verify_m2o_oversubscribe_lossless_lossy_result(flow_stats,
@@ -404,10 +405,10 @@ def verify_m2o_oversubscribe_lossless_lossy_result(rows,
     """
     for row in rows:
         if 'Test Flow 1 -> 0' in row.name:
-            pytest_assert(int(row.loss) == 0, "{} must have 0% loss".format(row.name))
+            pytest_assert(int(row.loss) == 0, "{} must have 0% loss and having {}% loss".format(row.name, row.loss))
         elif 'Test Flow 2 -> 0' in row.name:
-            pytest_assert(int(row.loss) == 0, "{} must have 0% loss ".format(row.name))
+            pytest_assert(int(row.loss) == 0, "{} must have 0% loss and having {}% loss".format(row.name, row.loss))
         elif 'Background Flow 1 -> 0' in row.name:
-            pytest_assert(int(row.loss) == 0, "{} must have 0% loss ".format(row.name))
+            pytest_assert(int(row.loss) == 0, "{} must have 0% loss and having {}% loss".format(row.name, row.loss))
         elif 'Background Flow 2 -> 0' in row.name:
-            pytest_assert(int(row.loss) >= 10, "{} must have loss >= 10%".format(row.name))
+            pytest_assert(int(row.loss) >= 10, "{} must have loss >= 10% and having {}% loss".format(row.name, row.loss))

--- a/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
@@ -162,9 +162,9 @@ def run_pfc_m2o_oversubscribe_lossless_lossy_test(api,
     else:
         pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[egress_duthost.hostname][dut_tx_port]['tx_drp']
         drop_percentage = (100 * pkt_drop) / total_rx_pkts
-    
 
-    pytest_assert(abs(drop_percentage - 5) < 1, 'FAIL: Drop packets must be around 5 percent {}'.format(drop_percentage))
+    pytest_assert(abs(drop_percentage - 5) < 1,
+                  'FAIL: Drop packets must be around 5 percent {}'.format(drop_percentage))
 
     """ Verify Results """
     verify_m2o_oversubscribe_lossless_lossy_result(flow_stats,
@@ -411,4 +411,5 @@ def verify_m2o_oversubscribe_lossless_lossy_result(rows,
         elif 'Background Flow 1 -> 0' in row.name:
             pytest_assert(int(row.loss) == 0, "{} must have 0% loss and having {}% loss".format(row.name, row.loss))
         elif 'Background Flow 2 -> 0' in row.name:
-            pytest_assert(int(row.loss) >= 10, "{} must have loss >= 10% and having {}% loss".format(row.name, row.loss))
+            pytest_assert(int(row.loss) >= 10,
+                          "{} must have loss >= 10% and having {}% loss".format(row.name, row.loss))

--- a/tests/snappi_tests/pfc/files/valid_src_mac_pfc_frame_helper.py
+++ b/tests/snappi_tests/pfc/files/valid_src_mac_pfc_frame_helper.py
@@ -16,7 +16,6 @@ from tests.common.snappi_tests.traffic_generation import setup_base_traffic_conf
     generate_pause_flows, run_traffic, verify_basic_test_flow
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.read_pcap import validate_pfc_frame as pcap_validate_pfc_frame
-from tests.common.cisco_data import is_cisco_device
 
 logger = logging.getLogger(__name__)
 
@@ -194,9 +193,6 @@ def run_pfc_valid_src_mac_test(
     # Verify PFC pause frames
     if validate_pfc_frame:
         peer_mac_addr = snappi_extra_params.base_flow_config["rx_port_config"].gateway_mac
-        # Use Cisco-specific validation for Cisco devices, generic validation for others
-        # Both functions validate source MAC address when peer_mac_addr is provided
-       
         is_valid_pfc_frame, error_msg = pcap_validate_pfc_frame(
                             snappi_extra_params.packet_capture_file + ".pcapng",
                             peer_mac_addr=peer_mac_addr)

--- a/tests/snappi_tests/pfc/files/valid_src_mac_pfc_frame_helper.py
+++ b/tests/snappi_tests/pfc/files/valid_src_mac_pfc_frame_helper.py
@@ -2,13 +2,13 @@ import logging
 import time
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
     fanout_graph_facts  # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id
-from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector,\
-    get_lossless_buffer_size, get_pg_dropped_packets,\
-    stop_pfcwd, disable_packet_aging, sec_to_nanosec,\
-    get_pfc_frame_count, packet_capture, config_capture_pkt,\
+from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector, \
+    get_lossless_buffer_size, get_pg_dropped_packets, \
+    stop_pfcwd, disable_packet_aging, sec_to_nanosec, \
+    get_pfc_frame_count, packet_capture, config_capture_pkt, \
     traffic_flow_mode, calc_pfc_pause_flow_rate      # noqa: F401
 from tests.common.snappi_tests.port import select_ports, select_tx_port  # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp  # noqa: F401

--- a/tests/snappi_tests/pfc/files/valid_src_mac_pfc_frame_helper.py
+++ b/tests/snappi_tests/pfc/files/valid_src_mac_pfc_frame_helper.py
@@ -15,7 +15,7 @@ from tests.common.snappi_tests.snappi_helpers import wait_for_arp  # noqa: F401
 from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config, generate_test_flows, \
     generate_pause_flows, run_traffic, verify_basic_test_flow
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
-from tests.common.snappi_tests.read_pcap import validate_pfc_frame, validate_pfc_frame_cisco
+from tests.common.snappi_tests.read_pcap import validate_pfc_frame as pcap_validate_pfc_frame
 from tests.common.cisco_data import is_cisco_device
 
 logger = logging.getLogger(__name__)
@@ -148,10 +148,10 @@ def run_pfc_valid_src_mac_test(
 
     if snappi_extra_params.packet_capture_type == packet_capture.PFC_CAPTURE:
         # PFC pause frame capture is requested
-        _validate_pfc_frame = True
+        validate_pfc_frame = True
     else:
         # PFC pause frame capture is not requested
-        _validate_pfc_frame = False
+        validate_pfc_frame = False
 
     # Generate test flow config
     generate_test_flows(testbed_config=testbed_config,
@@ -192,12 +192,12 @@ def run_pfc_valid_src_mac_test(
     pfc.pfc_delay = 0
 
     # Verify PFC pause frames
-    if _validate_pfc_frame:
+    if validate_pfc_frame:
         peer_mac_addr = snappi_extra_params.base_flow_config["rx_port_config"].gateway_mac
         # Use Cisco-specific validation for Cisco devices, generic validation for others
         # Both functions validate source MAC address when peer_mac_addr is provided
        
-        is_valid_pfc_frame, error_msg = validate_pfc_frame(
+        is_valid_pfc_frame, error_msg = pcap_validate_pfc_frame(
                             snappi_extra_params.packet_capture_file + ".pcapng",
                             peer_mac_addr=peer_mac_addr)
         pytest_assert(is_valid_pfc_frame, error_msg)

--- a/tests/snappi_tests/pfc/files/valid_src_mac_pfc_frame_helper.py
+++ b/tests/snappi_tests/pfc/files/valid_src_mac_pfc_frame_helper.py
@@ -16,6 +16,8 @@ from tests.common.snappi_tests.traffic_generation import setup_base_traffic_conf
     generate_pause_flows, run_traffic, verify_basic_test_flow
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.read_pcap import validate_pfc_frame as pcap_validate_pfc_frame
+from tests.common.snappi_tests.read_pcap import validate_pfc_frame_cisco as pcap_validate_pfc_frame_cisco
+from tests.common.cisco_data import is_cisco_device
 
 logger = logging.getLogger(__name__)
 
@@ -193,9 +195,13 @@ def run_pfc_valid_src_mac_test(
     # Verify PFC pause frames
     if validate_pfc_frame:
         peer_mac_addr = snappi_extra_params.base_flow_config["rx_port_config"].gateway_mac
-        is_valid_pfc_frame, error_msg = pcap_validate_pfc_frame(
-                            snappi_extra_params.packet_capture_file + ".pcapng",
-                            peer_mac_addr=peer_mac_addr)
+        pcap_file = snappi_extra_params.packet_capture_file + ".pcapng"
+        if is_cisco_device(duthost):
+            is_valid_pfc_frame, error_msg = pcap_validate_pfc_frame_cisco(
+                                pcap_file, peer_mac_addr=peer_mac_addr)
+        else:
+            is_valid_pfc_frame, error_msg = pcap_validate_pfc_frame(
+                                pcap_file, peer_mac_addr=peer_mac_addr)
         pytest_assert(is_valid_pfc_frame, error_msg)
         return
 

--- a/tests/snappi_tests/pfc/files/valid_src_mac_pfc_frame_helper.py
+++ b/tests/snappi_tests/pfc/files/valid_src_mac_pfc_frame_helper.py
@@ -15,7 +15,8 @@ from tests.common.snappi_tests.snappi_helpers import wait_for_arp  # noqa: F401
 from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config, generate_test_flows, \
     generate_pause_flows, run_traffic, verify_basic_test_flow
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
-from tests.common.snappi_tests.read_pcap import validate_pfc_frame_cisco
+from tests.common.snappi_tests.read_pcap import validate_pfc_frame, validate_pfc_frame_cisco
+from tests.common.cisco_data import is_cisco_device
 
 logger = logging.getLogger(__name__)
 
@@ -147,10 +148,10 @@ def run_pfc_valid_src_mac_test(
 
     if snappi_extra_params.packet_capture_type == packet_capture.PFC_CAPTURE:
         # PFC pause frame capture is requested
-        validate_pfc_frame = True
+        _validate_pfc_frame = True
     else:
         # PFC pause frame capture is not requested
-        validate_pfc_frame = False
+        _validate_pfc_frame = False
 
     # Generate test flow config
     generate_test_flows(testbed_config=testbed_config,
@@ -191,11 +192,14 @@ def run_pfc_valid_src_mac_test(
     pfc.pfc_delay = 0
 
     # Verify PFC pause frames
-    if validate_pfc_frame:
+    if _validate_pfc_frame:
         peer_mac_addr = snappi_extra_params.base_flow_config["rx_port_config"].gateway_mac
-        is_valid_pfc_frame, error_msg = validate_pfc_frame_cisco(
-                        snappi_extra_params.packet_capture_file + ".pcapng",
-                        peer_mac_addr=peer_mac_addr)
+        # Use Cisco-specific validation for Cisco devices, generic validation for others
+        # Both functions validate source MAC address when peer_mac_addr is provided
+       
+        is_valid_pfc_frame, error_msg = validate_pfc_frame(
+                            snappi_extra_params.packet_capture_file + ".pcapng",
+                            peer_mac_addr=peer_mac_addr)
         pytest_assert(is_valid_pfc_frame, error_msg)
         return
 

--- a/tests/snappi_tests/pfc/files/valid_src_mac_pfc_frame_helper.py
+++ b/tests/snappi_tests/pfc/files/valid_src_mac_pfc_frame_helper.py
@@ -16,7 +16,7 @@ from tests.common.snappi_tests.traffic_generation import setup_base_traffic_conf
     generate_pause_flows, run_traffic, verify_basic_test_flow
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.read_pcap import validate_pfc_frame as pcap_validate_pfc_frame
-from tests.common.snappi_tests.read_pcap import validate_pfc_frame_cisco as pcap_validate_pfc_frame_cisco
+from tests.common.snappi_tests.read_pcap import validate_pfc_frame_cisco
 from tests.common.cisco_data import is_cisco_device
 
 logger = logging.getLogger(__name__)
@@ -197,7 +197,7 @@ def run_pfc_valid_src_mac_test(
         peer_mac_addr = snappi_extra_params.base_flow_config["rx_port_config"].gateway_mac
         pcap_file = snappi_extra_params.packet_capture_file + ".pcapng"
         if is_cisco_device(duthost):
-            is_valid_pfc_frame, error_msg = pcap_validate_pfc_frame_cisco(
+            is_valid_pfc_frame, error_msg = validate_pfc_frame_cisco(
                                 pcap_file, peer_mac_addr=peer_mac_addr)
         else:
             is_valid_pfc_frame, error_msg = pcap_validate_pfc_frame(

--- a/tests/snappi_tests/pfc/test_valid_src_mac_pfc_frame.py
+++ b/tests/snappi_tests/pfc/test_valid_src_mac_pfc_frame.py
@@ -4,11 +4,11 @@ import pytest
 
 from tests.snappi_tests.pfc.files.valid_src_mac_pfc_frame_helper import run_pfc_valid_src_mac_test
 from tests.common.helpers.assertions import pytest_require
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
     fanout_graph_facts  # noqa: F401
-from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port,\
+from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     snappi_api, snappi_testbed_config, is_snappi_multidut, is_pfc_enabled  # noqa: F401
-from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
+from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list, \
     lossy_prio_list, disable_pfcwd  # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.common_helpers import packet_capture

--- a/tests/snappi_tests/pfc/test_valid_src_mac_pfc_frame.py
+++ b/tests/snappi_tests/pfc/test_valid_src_mac_pfc_frame.py
@@ -12,7 +12,6 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list,
     lossy_prio_list, disable_pfcwd  # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.common_helpers import packet_capture
-from tests.common.cisco_data import is_cisco_device
 from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 logger = logging.getLogger(__name__)
@@ -70,9 +69,6 @@ def test_valid_pfc_frame_src_mac(
 
     testbed_config, port_config_list = snappi_testbed_config
     duthost = duthosts[rand_one_dut_hostname]
-
-    if not is_cisco_device(duthost):
-        pytest.skip("Test is supported on Cisco device only")
 
     if is_snappi_multidut(duthosts):
         pytest.skip("Test is not supported on multi-dut")


### PR DESCRIPTION
### Description of PR

Summary: Extend snappi PFC tests to run on non-Cisco devices by replacing
Cisco-specific helpers with generic equivalents, and fix two framework bugs
discovered during non-Cisco bring-up.

**Changes:**
- `snappi_helpers.py`: Fix fanout inventory key `mgmtip` → `ManagementIp`
  so `SnappiFanoutManager` resolves the chassis IP correctly on non-Cisco testbeds
- `snappi_fixtures.py`: Remove Cisco-implicit `modular_chassis` guard in
  `is_snappi_multidut()` — now correctly returns `True` for any multi-DUT setup
- `read_pcap.py`: Add optional `peer_mac_addr` parameter to generic
  `validate_pfc_frame()` for source-MAC validation on all platforms
- `valid_src_mac_pfc_frame_helper.py`: Replace `validate_pfc_frame_cisco()`
  with the extended generic `validate_pfc_frame()`
- `test_valid_src_mac_pfc_frame.py`: Remove `pytest.skip` that restricted
  `test_valid_pfc_frame_src_mac` to Cisco devices only
- `m2o_oversubscribe_lossless_helper.py`,
  `m2o_oversubscribe_lossless_lossy_helper.py`: Include actual observed
  loss/drop percentage in assert failure messages

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

The `test_valid_pfc_frame_src_mac` test and the `m2o_oversubscribe` PFC tests
were effectively Cisco-only. Two root causes:
1. Framework bugs (`mgmtip` key, `modular_chassis` guard) caused failures on
   non-Cisco testbeds before any test logic even ran.
2. `valid_src_mac_pfc_frame_helper.py` called `validate_pfc_frame_cisco()` directly,
   and the test file had an explicit `pytest.skip` for non-Cisco devices.

#### How did you do it?

- Fixed the `ManagementIp` key lookup in `SnappiFanoutManager` to match the
  actual inventory field name.
- Simplified `is_snappi_multidut()` to depend only on `len(duthosts)`, which
  is platform-agnostic.
- Extended the existing generic `validate_pfc_frame()` in `read_pcap.py` with
  an optional `peer_mac_addr` argument so it performs the same source-MAC check
  that `validate_pfc_frame_cisco()` did.
- Updated `valid_src_mac_pfc_frame_helper.py` to call the generic function and
  removed the now-unused Cisco-specific import.
- Removed the `is_cisco_device` skip guard from `test_valid_src_mac_pfc_frame.py`.
- Added the actual loss percentage to assert messages in both
  `m2o_oversubscribe` helpers to make test failures self-explanatory.

#### How did you verify/test it?

Verified `test_valid_pfc_frame_src_mac` passes on a Juniper QFX5241 testbed.
Existing Cisco test results are unchanged.

#### Any platform specific information?

Previously Cisco-only. Now supported on any platform whose fanout device
exposes `ManagementIp` in the inventory (the standard snappi inventory field).

#### Supported testbed topology if it's a new test case?

Single-DUT topology (existing topology requirement unchanged).
`test_valid_pfc_frame_src_mac` is skipped for multi-DUT setups as before.

### Documentation

No new features or test cases — existing test extended to non-Cisco platforms.
No documentation update required.