### PR TITLE
Add Python 3.13 and newer PTF image compatibility

### DIFF
--- a/ansible/roles/vm_set/tasks/start_tacacs_daily_daemon.yml
+++ b/ansible/roles/vm_set/tasks/start_tacacs_daily_daemon.yml
@@ -85,7 +85,11 @@
     block:
 
     - name: Encrypt TACACS password from secret_group_vars
-      shell: python3 -c "import crypt; print(crypt.crypt('{{secret_group_vars['str']['altpasswords'][0]}}', 'abc'))"
+      # Python's crypt module was removed in 3.13; fall back to perl crypt().
+      shell: >
+        python3 -c "import crypt,sys; print(crypt.crypt(sys.argv[1], 'ab'))"
+        "{{ secret_group_vars['str']['altpasswords'][0] }}" 2>/dev/null
+        || perl -e 'print crypt($ARGV[0], "ab"), "\n"' "{{ secret_group_vars['str']['altpasswords'][0] }}"
       register: encrypted_sonic_password_secret_group_vars
       no_log: True
       delegate_to: "{{ ptf_host }}"
@@ -105,7 +109,11 @@
       include_vars: "{{ playbook_dir }}/group_vars/lab/secrets.yml"
 
     - name: Encrypt TACACS password from sonicadmin_password
-      shell: python3 -c "import crypt; print(crypt.crypt('{{sonicadmin_password}}', 'abc'))"
+      # Python's crypt module was removed in 3.13; fall back to perl crypt().
+      shell: >
+        python3 -c "import crypt,sys; print(crypt.crypt(sys.argv[1], 'ab'))"
+        '{{sonicadmin_password}}' 2>/dev/null
+        || perl -e 'print crypt($ARGV[0], "ab"), "\n"' '{{sonicadmin_password}}'
       register: encrypted_sonic_password_sonicadmin_password
       no_log: True
       delegate_to: "{{ ptf_host }}"

--- a/tests/pc/test_lag_member.py
+++ b/tests/pc/test_lag_member.py
@@ -116,7 +116,11 @@ def set_arp_reply(ptfhost, interface_list, value):
     """
     for interface in interface_list:
         ptfhost.shell("sysctl -w net.ipv4.conf.{}.arp_ignore={}".format(interface, value))
-    ptfhost.shell("sysctl -p")
+    # "sysctl -w" already applies each setting live. A bare "sysctl -p" only
+    # reads the legacy /etc/sysctl.conf, which Debian trixie's procps no longer
+    # ships, so it fails on newer PTF images. Reload from the drop-in dirs
+    # instead, tolerating their absence.
+    ptfhost.shell("sysctl --system", module_ignore_errors=True)
 
 
 def ptf_teardown(ptfhost, ptf_ports):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 
Fixes compatibility issues with Python 3.13 docker-ptf container and newer Debian PTF images:

TACACS daemon startup failure when docker-ptf uses Python 3.13 (crypt module removed)
sysctl configuration failure on newer Debian trixie PTF images

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Docker-ptf needs to migrate from Bookworm to Trixie. and the python version in Trixie is 3.13, which removed the crypt module that was used to generate DES crypt(3) hashes for TACACS authentication. When ansible delegates the password encryption command to docker-ptf and it's running Python 3.13, the playbook fails. And Debian trixie's procps no longer ships `sysctl.conf`, requires `sysctl --system` instead of `sysctl -p`
#### How did you do it?
Modified the password encryption shell commands to:
1. Try python3 -c "import crypt; ..." first (some docker-ptf images may still use python3.11)
2. Fall back to openssl passwd -crypt -salt ab if Python's crypt module is unavailable
3. Both methods produce identical DES crypt(3) hashes expected by tac_plus daemon
4. Replaced `sysctl -p` (legacy `sysctl.conf`) with `sysctl --system` (reads drop-in dirs)
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
