### PR TITLE
[ip][test_ip_packet] Wait for rx drop counter to settle before asserting

### DIFF
--- a/tests/ip/test_ip_packet.py
+++ b/tests/ip/test_ip_packet.py
@@ -44,6 +44,20 @@ class TestIPPacket(object):
         return rx_ok >= pkt_num_min
 
     @staticmethod
+    def check_rx_drop(duthost, ingress_iface, rif_support, rif_rx_ifaces, pkt_num_min):
+        """Check if the ingress drop counter (rx_drp / rif rx_err) has caught up.
+        On some ASICs the drop counter updates a few seconds after rx_ok, so reading
+        it immediately yields a flaky 0. Poll until it settles."""
+        portstat_out = parse_portstat(duthost.command("portstat")["stdout_lines"])
+        rx_drp = int(portstat_out[ingress_iface]["rx_drp"].replace(",", ""))
+        rx_err = 0
+        if rif_support:
+            rif_counter_out = parse_rif_counters(
+                duthost.command("show interfaces counters rif")["stdout_lines"])
+            rx_err = int(rif_counter_out[rif_rx_ifaces]["rx_err"].replace(",", ""))
+        return max(rx_drp, rx_err) >= pkt_num_min
+
+    @staticmethod
     def send_packets(duthost, ptfadapter, ptf_port_idx, pkt, count):
         """Send packets, using chunked sends on VPP/KVM to avoid virtio TX ring overflow."""
         platform = duthost.facts.get("platform", "")
@@ -632,6 +646,15 @@ class TestIPPacket(object):
         # Wait for port counters to update (non-asserting, real checks follow below)
         if not wait_until(30, 1, 0, self.check_rx_ok, duthost, peer_ip_ifaces_pair[0][1][0], self.PKT_NUM_MIN):
             logger.warning("Port counter polling timed out for %s", peer_ip_ifaces_pair[0][1][0])
+
+        # The drop counter (rx_drp / rif rx_err) can lag rx_ok by a few seconds on some
+        # ASICs, producing a flaky 0 read. Wait for it to settle before asserting.
+        # Platforms that tolerate/forward the packet (marvell) never drop it, so they
+        # are excluded to avoid an unnecessary 30s timeout.
+        if asic_type not in ["marvell", "marvell-prestera"]:
+            if not wait_until(30, 1, 0, self.check_rx_drop, duthost, peer_ip_ifaces_pair[0][1][0],
+                              rif_support, rif_rx_ifaces, self.PKT_NUM_MIN):
+                logger.warning("Drop counter polling timed out for %s", peer_ip_ifaces_pair[0][1][0])
 
         portstat_out = parse_portstat(duthost.command("portstat")["stdout_lines"])
         if rif_support:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

`test_drop_ip_packet_with_wrong_0xffff_chksum` is intermittently failing with
`Failed: Dropped 0 packets in rx, not in expected range`. The DUT *does* drop the
IP packet with a `0xffff` checksum in hardware, but on some ASICs the ingress drop
counter (`rx_drp` / rif `rx_err`) updates a few seconds after `rx_ok`. The test
read the drop counter immediately after waiting only for `rx_ok`, so it occasionally
sampled the drop counter before it had settled and saw `0` drops.
This PR makes the test poll the drop counter (mirroring the existing `rx_ok` wait)
until it settles before asserting. There is no change to assertion behavior — every
platform is still validated; we only remove the race on reading the counter.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605


### Test result
* 202605 : PASSED
 
### Approach
#### What is the motivation for this PR?
Remove a flaky failure in `test_drop_ip_packet_with_wrong_0xffff_chksum`. The test
asserted on the ingress drop counter immediately after the packets were sent, but
the L2/L3 drop counters can lag the `rx_ok` counter by a few seconds on some ASICs.
This produced intermittent `Dropped 0 packets in rx, not in expected range`
failures even though the hardware was correctly dropping the packets.

#### How did you do it?
- Added a `check_rx_drop` static helper that reads `rx_drp` (portstat) and, when
  RIF counters are supported, `rx_err` (`show interfaces counters rif`), returning
  `True` once `max(rx_drp, rx_err) >= PKT_NUM_MIN`.
- After the existing `wait_until(check_rx_ok, ...)`, added a
  `wait_until(check_rx_drop, ...)` (30s timeout, 1s interval) so the drop counter is
  allowed to settle before the assertion reads it.
- Gated the new wait on drop-expecting platforms only: `marvell` / `marvell-prestera`
  tolerate/forward the packet and never drop it, so they are excluded to avoid a
  needless 30s timeout.
- No assertion logic was changed; the existing `marvell` carve-out on the drop
  assertion is untouched.

#### How did you verify/test it?
- Ran the test 5x with `pytest --count=5` on a Cisco 8000 T0 testbed:
  **5/5 passed**. The new `check_rx_drop` poll returned `True` after ~3s in every
  iteration, with zero `Drop counter polling timed out` warnings.
- Independently reproduced the underlying behavior: injected `0xffff`-checksum IP
  packets via scapy from the PTF docker and captured on the DUT with `tcpdump` —
  confirmed the packets are dropped in hardware (not forwarded, not punted to CPU).
- Confirmed the counters this assertion reads update at a 1s cadence
  (`counterpoll show`: `PORT_STAT` and `RIF_STAT` = `1000 ms`), so a 30s timeout
  with a 1s poll interval gives ample margin (and `wait_until` exits early).

#### Any platform specific information?
The flake was observed on Cisco 8000 (the drop counter lags `rx_ok` by ~1-3s). The
fix is platform-agnostic — it simply waits for the counter to settle on any
drop-expecting platform and leaves the `marvell`/`marvell-prestera` forward behavior
exclusion as-is.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
