### PR TITLE
[route][dualtor] Skip test_static_route warm reboot cases on dualtor

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4943,9 +4943,9 @@ route/test_static_route.py::test_static_route_ecmp_ipv6:
 
 route/test_static_route.py::test_static_route_ecmp_warmboot:
   skip:
-    reason: "Dualtor topology doesn't support warm reboot on mellanox platform"
+    reason: "Warm reboot is not supported on dualtor topology"
     conditions:
-      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout'] and asic_type in ['mellanox', 'nvidia']"
+      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
 
 route/test_static_route.py::test_static_route_ipv6:
   xfail:
@@ -4955,9 +4955,15 @@ route/test_static_route.py::test_static_route_ipv6:
 
 route/test_static_route.py::test_static_route_ipv6_warmboot:
   skip:
-    reason: "Dualtor topology doesn't support warm reboot on mellanox platform"
+    reason: "Warm reboot is not supported on dualtor topology"
     conditions:
-      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout'] and asic_type in ['mellanox', 'nvidia']"
+      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
+
+route/test_static_route.py::test_static_route_warmboot:
+  skip:
+    reason: "Warm reboot is not supported on dualtor topology"
+    conditions:
+      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
 
 #######################################
 #####           sai_qualify       #####


### PR DESCRIPTION
### Description of PR

Summary:
Skip the static route warmboot tests on dualtor topologies via conditional marks.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202605

### Approach
#### What is the motivation for this PR?

* Microsoft ADO (number only): 38475461

The static route warmboot tests fail on dualtor topologies because the warm-reboot
RESTARTCHECK cannot probe the PortChannel peer devices. Observed on `7260cx3.dualtor-120`
(Broadcom):

```
warm-reboot rc=10
ERROR: There are port channels/peer devices that failed the probe:
['PortChannel104', 'PortChannel103', 'PortChannel102', 'PortChannel101']
RESTARTCHECK failed
```

This is a dualtor warm-reboot limitation independent of the ASIC vendor.

Assisted-by: Stuart 🍌 (Hermes Agent, model claude-opus-4.8)
Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
In `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`:
- Add a `skip` entry for `test_static_route_warmboot`, which was missing one.
- For `test_static_route_ecmp_warmboot` and `test_static_route_ipv6_warmboot`, drop the
  `asic_type in ['mellanox', 'nvidia']` gate so warm reboot is skipped generically on dualtor,
  and align the skip reason.

All three now skip on the dualtor `topo_name` list
(`dualtor`, `dualtor-56`, `dualtor-120`, `dualtor-aa`, `dualtor-aa-56`, `dualtor-aa-64-breakout`)
across all ASICs.

#### How did you verify/test it?
- YAML parses cleanly (`yaml.safe_load`, 801 keys); no duplicate keys.
- The conditions reuse the existing proven dualtor `topo_name` syntax in the same file.

#### Any platform specific information?
The failure is a dualtor warm-reboot limitation (RESTARTCHECK PortChannel peer probe), so the
skips are keyed on topology only. The previous mellanox/nvidia gate missed Broadcom dualtor
testbeds (e.g. 7260CX3), which exhibit the same failure.
