### PR TITLE
[bgp] test_bgp_establish_combo: update combo neighbor lists and restart BGP after GCU rollback

### DIFF
--- a/tests/bgp/test_bgp_establish_combo.py
+++ b/tests/bgp/test_bgp_establish_combo.py
@@ -27,12 +27,22 @@ def setup_teardown(duthost):
     # Restore the config via config_reload may cost too much time.
     # So we leverage GCU for the config update. Setup checkpoint before the test
     # and rollback to it after the test.
+    # Capture the original BGP neighbor set so we can verify the post-rollback state.
+    original_neighbors = set(duthost.get_bgp_neighbors().keys())
     create_checkpoint(duthost)
 
     yield
 
     try:
         rollback_or_reload(duthost, fail_on_rollback_error=False)
+        # GCU rollback restores CONFIG_DB, but bgpcfgd may not push the reverse
+        # of the "move + rename" patches cleanly down to FRR. Force a BGP restart
+        # so FRR re-reads CONFIG_DB, and wait until all original neighbors are
+        # visible again before letting the next test run.
+        duthost.shell("systemctl reset-failed bgp", module_ignore_errors=True)
+        duthost.shell("sudo systemctl restart bgp", module_ignore_errors=True)
+        wait_until(180, 10, 30,
+                   lambda: original_neighbors.issubset(set(duthost.get_bgp_neighbors().keys())))
     finally:
         delete_checkpoint(duthost)
 
@@ -81,8 +91,10 @@ def verify_bgp_session_established(duthost, neighbors):
     # entry: [DUT type, [BGP neighbor types]]
     ["MgmtSpineRouter", ['MgmtAggregator', 'CoreTs', 'MgmtToRRouter', 'SpineTs']],
     ["MgmtAccessRouter", ['MgmtAggregator', 'CoreTs', 'MgmtToRRouter', 'SpineTs']],
-    ["LowerMgmtAggregator", ["CoreTs", "MgmtToRRouter", "UpperMgmtAggregator", "CoreRouter"]],
-    ["UpperMgmtAggregator", ["CoreTs", "MgmtToRRouter", "LowerMgmtAggregator", "CoreRouter"]],
+    ["LowerMgmtAggregator", ["MgmtSpineRouter", "MgmtAccessRouter", "UpperMgmtAggregator",
+                             "CoreTs", "CoreMgmtRouter"]],
+    ["UpperMgmtAggregator", ["MgmtLeafRouter", "LowerMgmtAggregator", "CoreTs", "CoreRouter", "CoreMgmtRouter",
+                             "ConsoleServer"]],
 ])
 def test_bgp_establish_combo(duthost, ip_version, combo):
     target_dut_type, target_neigh_types = combo


### PR DESCRIPTION
### Description of PR

This PR contains two related fixes for `tests/bgp/test_bgp_establish_combo.py`:

**Fix 1: Align combo parametrization with the real scenario**

The original `LowerMgmtAggregator` and `UpperMgmtAggregator` combos used a 4-peer placeholder list (`CoreTs, MgmtToRRouter, <peer>, CoreRouter`) that does not match the actual BGP peer-type set those DUT roles see in production. This PR updates them to better-aligned peer-type lists:

- `LowerMgmtAggregator` → `MgmtSpineRouter, MgmtAccessRouter, UpperMgmtAggregator, CoreTs, CoreMgmtRouter` (5 types)
- `UpperMgmtAggregator` → `MgmtLeafRouter, LowerMgmtAggregator, CoreTs, CoreRouter, CoreMgmtRouter, ConsoleServer` (6 types)

**Fix 2: Restart BGP after rollback in teardown**

The test mutates `BGP_NEIGHBOR` / `DEVICE_NEIGHBOR_METADATA` via GCU and then runs `systemctl restart bgp`. The teardown only calls `rollback_or_reload`, which restores `CONFIG_DB` but relies on `bgpcfgd` to push the reverse of the `move + rename` patches down to FRR. In practice that does not happen cleanly — FRR keeps the stale view from the prior restart, so the next combo sees only a small subset of the original BGP neighbors instead of the full set. With smaller combos (4–5 peer types) it happens to pass; with larger combos like the updated `UpperMgmtAggregator` it raises `IndexError: list index out of range` at `bgp_neigh_ips[i]`.

The teardown is hardened to:

* Capture the original neighbor set in `setup_teardown` before yielding.
* After `rollback_or_reload`, force a `systemctl restart bgp` so FRR re-reads `CONFIG_DB`.
* Wait until FRR sees the original neighbor set again before releasing control to the next test.

Summary:
Fixes flaky failure / `IndexError` in `tests/bgp/test_bgp_establish_combo.py` on topology `m1`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

1. The `LowerMgmtAggregator`/`UpperMgmtAggregator` combos used a synthetic 4-peer list that did not reflect the real peer-type set those DUT roles see in deployment, so the test was not exercising the actual scenario.
2. After expanding the combos to match reality, the test reliably reproduced an `IndexError` driven by stale FRR state left over from the previous combo's GCU patch + bgp restart. The default GCU rollback path does not bring FRR back in sync.

#### How did you do it?

1. Replaced the two combo entries with updated peer-type lists for the two DUT roles.
2. Updated `setup_teardown`:
   - Snapshot `duthost.get_bgp_neighbors()` keys before each test.
   - After `rollback_or_reload`, run `systemctl reset-failed bgp` and `systemctl restart bgp`.
   - `wait_until(180, 10, 30, ...)` for the original neighbor set to be a subset of the post-restart neighbor set.

#### How did you verify/test it?

Ran `tests/bgp/test_bgp_establish_combo.py` end-to-end on a physical `m1-128` testbed (Arista-7050CX3-32C-S128, SONiC.20260310.13):

- Before fix #2 (combos updated only): 6 passed, 2 failed (`combo3-4`, `combo3-6` — `IndexError`).
- After both fixes: **8 passed, 0 failed** in 3652s.

#### Any platform specific information?

None.

#### Supported testbed topology if it's a new test case?

Existing test, topology `m1` (unchanged).

### Documentation
N/A.
