### PR TITLE
[everflow] Fix test_everflow_ipv6 ACL rule check: compare CONFIG_DB/ASIC_DB count deltas

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -594,27 +594,28 @@ def validate_acl_rule_rids(duthost):
     return True
 
 
-def validate_acl_rules_in_asic_db(duthost):
+def get_acl_rule_counts(duthost):
     """
-    Validate that the number of ACL rules in ASIC DB is the same as the number of ACL rules in CONFIG DB.
-    Also check that the ACL rule RIDs are not empty.
-    For multi-ASIC DUTs, validates ACL rules in each frontend ASIC's ASIC_DB and CONFIG_DB.
+    Snapshot the number of ACL rules in CONFIG DB and ASIC DB, per frontend ASIC.
+
+    Returns a list with one (config_count, asic_count) tuple per frontend ASIC
+    (a single tuple for single-ASIC DUTs). Use this to capture a baseline before
+    applying ACL rules so the readiness check can compare deltas (see
+    validate_acl_rules_in_asic_db).
 
     Args:
         duthost: DUT host object
 
     Returns:
-        bool: True if ACL rules count matches and RIDs are valid in all frontend ASICs, False otherwise
+        list[tuple[int, int]]: [(config_count, asic_count), ...] indexed by frontend ASIC
     """
-    # Get all frontend ASIC instances
     if duthost.is_multi_asic:
         asic_instances = [duthost.asic_instance(asic_id) for asic_id in duthost.get_frontend_asic_ids()]
     else:
         asic_instances = [duthost]
 
-    # Validate ACL rules in each ASIC
+    counts = []
     for asic in asic_instances:
-        # Get namespace-specific command prefix
         if duthost.is_multi_asic:
             namespace = asic.get_asic_namespace()
             config_cmd = "sonic-db-cli -n {} CONFIG_DB KEYS *ACL_RULE*".format(namespace)
@@ -623,32 +624,90 @@ def validate_acl_rules_in_asic_db(duthost):
             config_cmd = "sonic-db-cli CONFIG_DB KEYS *ACL_RULE*"
             asic_cmd = "sonic-db-cli ASIC_DB KEYS *SAI_OBJECT_TYPE_ACL_ENTRY*"
 
-        config_rules = asic.shell(config_cmd)['stdout_lines']
-        asic_rules = asic.shell(asic_cmd)['stdout_lines']
+        config_count = len(asic.shell(config_cmd)['stdout_lines'])
+        asic_count = len(asic.shell(asic_cmd)['stdout_lines'])
+        counts.append((config_count, asic_count))
 
-        if len(config_rules) != len(asic_rules):
-            logging.warning("ACL rules count mismatch in ASIC {}: CONFIG_DB={}, ASIC_DB={}".format(
-                asic.asic_index if duthost.is_multi_asic else "single",
-                len(config_rules), len(asic_rules)))
+    return counts
+
+
+def validate_acl_rules_in_asic_db(duthost, baseline_counts=None):
+    """
+    Validate that the ACL rules added since a baseline have all been programmed into ASIC DB.
+    Also check that the ACL rule RIDs are not empty.
+    For multi-ASIC DUTs, validates ACL rules in each frontend ASIC's ASIC_DB and CONFIG_DB.
+
+    The check compares the CHANGE in entry counts rather than absolute counts: the
+    number of new ASIC_DB ACL entries must be at least the number of new CONFIG_DB
+    ACL rules since `baseline_counts` was captured. This cancels any constant,
+    pre-existing offset between the two DBs caused by ASIC ACL entries that have no
+    CONFIG_DB ACL_RULE key.
+
+    On dualtor, the standby ToR carries exactly such an entry: MuxOrch programs a
+    DROP-all-ingress-ports ACL (matching IN_PORTS + traffic-class) directly into the
+    ASIC -- not via CONFIG_DB ACL_RULE/ACL_TABLE -- to black-hole server traffic on
+    the standby side. So on the standby ToR ASIC_DB has one more ACL entry than
+    CONFIG_DB, and the old absolute-equality check spun until timeout (observed on
+    Broadcom dualtor: a stable CONFIG_DB=28, ASIC_DB=29 on the standby ToR on every
+    retry).
+
+    Args:
+        duthost: DUT host object
+        baseline_counts: optional list of (config_count, asic_count) tuples captured
+            by get_acl_rule_counts() BEFORE the rules under test were applied. When
+            None, a zero baseline is assumed, which requires ASIC_DB >= CONFIG_DB
+            (every configured rule is programmed) without assuming the two counts
+            are exactly equal.
+
+    Returns:
+        bool: True if the per-ASIC ACL delta matches and RIDs are valid in all
+        frontend ASICs, False otherwise
+    """
+    # Get all frontend ASIC instances
+    if duthost.is_multi_asic:
+        asic_instances = [duthost.asic_instance(asic_id) for asic_id in duthost.get_frontend_asic_ids()]
+    else:
+        asic_instances = [duthost]
+
+    if baseline_counts is None:
+        baseline_counts = [(0, 0)] * len(asic_instances)
+
+    current_counts = get_acl_rule_counts(duthost)
+
+    # Validate ACL rules in each ASIC by comparing deltas against the baseline
+    for index, asic in enumerate(asic_instances):
+        config_now, asic_now = current_counts[index]
+        config_base, asic_base = baseline_counts[index]
+        config_delta = config_now - config_base
+        asic_delta = asic_now - asic_base
+
+        if asic_delta < config_delta:
+            logging.warning("Not all ACL rules are programmed in ASIC {}: "
+                            "CONFIG_DB delta={}, ASIC_DB delta={} (CONFIG_DB={}, ASIC_DB={})".format(
+                                asic.asic_index if duthost.is_multi_asic else "single",
+                                config_delta, asic_delta, config_now, asic_now))
             return False
 
     # Validate ACL rule RIDs across all ASICs
     return validate_acl_rule_rids(duthost)
 
 
-def wait_for_acl_rules_in_asic_db(duthost):
+def wait_for_acl_rules_in_asic_db(duthost, baseline_counts=None):
     """
-    Wait until the ACL rules in ASIC DB match CONFIG DB and RIDs are valid.
+    Wait until the ACL rules added since a baseline are programmed in ASIC DB and RIDs are valid.
 
     Uses the platform-specific wait time from get_plt_wait_time (key "everflow"),
     defaulting to 120 seconds if not configured.
 
     Args:
         duthost: DUT host object
+        baseline_counts: optional ACL-count baseline from get_acl_rule_counts(),
+            captured before the rules under test were applied. Passed through to
+            validate_acl_rules_in_asic_db so the readiness check compares deltas.
     """
     acl_rule_wait_time = get_plt_wait_time(duthost, "everflow").get("wait", 120)
     pytest_assert(
-        wait_until(acl_rule_wait_time, 10, 0, validate_acl_rules_in_asic_db, duthost),
+        wait_until(acl_rule_wait_time, 10, 0, validate_acl_rules_in_asic_db, duthost, baseline_counts),
         "ACL rules in ASIC DB did not match CONFIG DB within {} seconds".format(acl_rule_wait_time)
     )
     logging.info("Successfully validated ACL rules")

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -222,11 +222,18 @@ class EverflowIPv6Tests(BaseEverflowTest):
                     self.apply_acl_table_config(duthost, table_name, "MIRRORV6", config_method,
                                                 bind_namespace=getattr(inst, 'namespace', None))
 
+            # Snapshot the ACL rule counts BEFORE applying the everflow rules so the
+            # readiness check can compare deltas instead of absolute counts. On dualtor
+            # the standby ToR already carries a MuxOrch-installed DROP-all-ingress ACL
+            # entry in ASIC_DB that has no CONFIG_DB ACL_RULE key; capturing the baseline
+            # here folds that constant offset into the baseline so it cancels out.
+            baseline_counts = everflow_utils.get_acl_rule_counts(duthost)
+
             self.apply_acl_rule_config(duthost, table_name, setup_mirror_session["session_name"],
                                        config_method, rules=EVERFLOW_V6_RULES)
             self.apply_ip_type_rule(duthost, 6)
             # Wait for ACL rules to be programmed
-            everflow_utils.wait_for_acl_rules_in_asic_db(duthost)
+            everflow_utils.wait_for_acl_rules_in_asic_db(duthost, baseline_counts)
 
         everflow_utils.wait_for_acl_rules_in_asic_db(everflow_dut)
 


### PR DESCRIPTION
### Description of PR

`test_everflow_ipv6` errors out **every** test case in setup on dualtor because the ACL-rule readiness check requires CONFIG_DB and ASIC_DB ACL counts to be **exactly equal**, which never holds on the standby ToR.

Summary:
- Compare the **change** in ACL counts (delta since a baseline), not absolute counts, in `validate_acl_rules_in_asic_db()`.

> Note: a separate, related teardown config-check failure (malformed `DST_IPV6` in the ip-type rules) is fixed in #25588.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202605

### Approach

#### What is the motivation for this PR?

* Microsoft ADO (number only): 38475482

On a Broadcom 7260CX3 `dualtor-120` 202605 nightly, all 26 `TestIngressEverflowIPv6` cases errored at setup:

```
Failed: ACL rules in ASIC DB did not match CONFIG DB within 120 seconds
```

The underlying reason, logged on **every** retry for the full window (persistent, not a timing flake):

```
ACL rules count mismatch in ASIC single: CONFIG_DB=28, ASIC_DB=29
```

`validate_acl_rules_in_asic_db()` compared the **global, absolute** count of `CONFIG_DB *ACL_RULE*` keys against `ASIC_DB *SAI_OBJECT_TYPE_ACL_ENTRY*` keys and required them to be **equal**.

**Root cause (the extra ASIC entry is the dualtor standby drop ACL).** On dualtor, MuxOrch programs a DROP-all-ingress-ports ACL directly into the ASIC on whichever ToR is **standby**, to black-hole server traffic on the standby side. Inspecting ASIC_DB on the failing (standby) ToR:

```
SAI_OBJECT_TYPE_ACL_ENTRY oid:0x800000000184e
  SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION = SAI_PACKET_ACTION_DROP
  SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS       = 56 ports (all front-panel ports)
  SAI_ACL_ENTRY_ATTR_PRIORITY             = 999
  SAI_ACL_ENTRY_ATTR_TABLE_ID             = oid:0x700000000168d  (BIND_POINT PORT+LAG, STAGE INGRESS)
```

This table/entry is programmed straight into the ASIC by MuxOrch and has **no CONFIG_DB ACL_RULE/ACL_TABLE counterpart** (`show acl table` lists only DATAACL/EVERFLOW/EVERFLOWV6). So on the standby ToR, ASIC_DB carries exactly one more ACL entry than CONFIG_DB has rules -- hence the stable `CONFIG_DB=28, ASIC_DB=29` -- and the absolute-equality check can never balance.

The debug `test.log` confirms all **28** CONFIG_DB EVERFLOWV6 rules were programmed; the **29th** ASIC entry is the standby drop ACL. This also explains why it was absent when the DUT was active/auto (the drop ACL is only present while standby) and why an earlier run showed a different oid (it is dynamically (re)programmed on each transition to standby). The symptom is not specific to one ASIC vendor -- it appears across Broadcom and Mellanox dualtor in nightly history.

#### How did you do it?

Compare the **change** in counts rather than absolutes, which cancels the constant standby-side offset:

1. Add `get_acl_rule_counts()` to snapshot `(config_count, asic_count)` per frontend ASIC.
2. `validate_acl_rules_in_asic_db()` / `wait_for_acl_rules_in_asic_db()` take an optional `baseline_counts`. The check now requires the **ASIC_DB delta >= CONFIG_DB delta** since the baseline (every newly-configured rule was programmed). With no baseline it falls back to `ASIC_DB >= CONFIG_DB`.
3. `test_everflow_ipv6` `setup_acl_table` captures the baseline **before** applying the everflow rules. The standby drop ACL is already present at that point, so it is folded into the baseline `(0, 1)` and cancels: after 28 rules the standby ToR reads `(28, 29)` -> `config_delta = asic_delta = 28` -> passes. The active ToR baseline `(0, 0)` -> `(28, 28)` -> passes.

Rule **identity/correctness** is still enforced by the existing `validate_acl_rule_rids()` call, which verifies each mirror ACL entry has a valid RID -- so a genuinely-missing or unprogrammed rule is still caught.

#### How did you verify/test it?

```
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_src_ipv6_mirroring[erspan_ipv4-cli-default] PASSED [  1%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_dst_ipv6_mirroring[erspan_ipv4-cli-default] PASSED [  2%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_next_header_mirroring[erspan_ipv4-cli-default] PASSED [  3%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_src_port_mirroring[erspan_ipv4-cli-default] PASSED [  4%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_dst_port_mirroring[erspan_ipv4-cli-default] PASSED [  5%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_src_port_range_mirroring[erspan_ipv4-cli-default] PASSED [  6%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_dst_port_range_mirroring[erspan_ipv4-cli-default] PASSED [  7%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_tcp_flags_mirroring[erspan_ipv4-cli-default] PASSED [  8%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_dscp_mirroring[erspan_ipv4-cli-default] PASSED [  9%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_range_mirroring[erspan_ipv4-cli-default] PASSED [ 10%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_tcp_response_mirroring[erspan_ipv4-cli-default] PASSED [ 11%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_tcp_application_mirroring[erspan_ipv4-cli-default] PASSED [ 12%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_udp_application_mirroring[erspan_ipv4-cli-default] PASSED [ 13%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_any_protocol[erspan_ipv4-cli-default] PASSED [ 14%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_any_transport_protocol[erspan_ipv4-cli-default] PASSED [ 15%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_invalid_tcp_rule[erspan_ipv4-cli-default] PASSED [ 16%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_source_subnet[erspan_ipv4-cli-default] PASSED [ 17%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_dest_subnet[erspan_ipv4-cli-default] PASSED [ 18%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_both_subnets[erspan_ipv4-cli-default] PASSED [ 19%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_fuzzy_subnets[erspan_ipv4-cli-default] PASSED [ 20%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_icmpv6_type[erspan_ipv4-cli-default] PASSED [ 21%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_icmpv6_code[erspan_ipv4-cli-default] PASSED [ 22%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_ip_type_any[erspan_ipv4-cli-default] PASSED [ 23%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_ip_type_ip[erspan_ipv4-cli-default] PASSED [ 24%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_ip_type_ipv6any[erspan_ipv4-cli-default] PASSED [ 25%]
```

Assisted-by: Stuart (Hermes Agent, model claude-opus-4.8)
Signed-off-by: Longxiang Lyu <lolv@microsoft.com>
