### PR TITLE
Fix check_sonic_facts due to comparing CIDR vs bare-IP

### DIFF
--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -58,7 +58,7 @@ def check_sonic_facts(hostname, mgmt_addr, host):
     if len(mgmt_addrs) == 0:
         return "there is no management interface in neighbor {}".format(hostname)
     for addr in mgmt_addrs:
-        if addr == mgmt_addr:
+        if addr.split('/')[0] == mgmt_addr:
             return
     return "neighbor {} has no management address {}".format(hostname, mgmt_addr)
 


### PR DESCRIPTION
### Description of PR

Strip ip address before comparing in https://github.com/sonic-net/sonic-mgmt/blob/024594564f61cf5243969484e95653999fe529e7/tests/test_nbr_health.py#L61

Previously, the mgmt interface IP doesn't have the suffix https://github.com/sonic-net/sonic-mgmt/blob/7c82be0a3eaeb5dc13d04269dec5c86140395486/tests/common/devices/sonic.py#L270

Since https://github.com/sonic-net/sonic-mgmt/pull/21442 ,  `facts['mgmt_interface']` stores addresses in CIDR notation (e.g. "10.250.58.10/24") as parsed from the MGMT_INTERFACE config_db table ([ref](https://github.com/sonic-net/sonic-mgmt/blob/024594564f61cf5243969484e95653999fe529e7/ansible/library/sonic_basic_facts.py#L445-L447)), but `mgmt_addr` from DEVICE_NEIGHBOR_METADATA is a bare IP (e.g. "10.250.58.10") ([ref](https://github.com/sonic-net/sonic-mgmt/blob/024594564f61cf5243969484e95653999fe529e7/tests/test_nbr_health.py#L103-L104)). The direct equality check always failed, causing all SonicHost neighbors to report "has no management address".

Summary:
Resolves #25596

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Testing

Tested on 202605 (sonic-buildimage commit `3d22ec91f` , sonic-mgmt commit (without / with fix) `4aebf5059` / `61c66e8862` . Without the fix, all 8 SonicHost neighbors `has no management address` (issue #25596 signature). Test passed with the fix. 

Pre-fix failure on 202605:
```
  E       Failed: neighbor ... has no management address 10.250.30.14
```

### Approach
#### What is the motivation for this PR?

Fix the ip address comparison in `check_sonic_facts` https://github.com/sonic-net/sonic-mgmt/blob/master/tests/test_nbr_health.py

#### How did you do it?

Strip the ip address before comparing

#### How did you verify/test it?

Run the test case.

Add debug log to verify (not in PR)

```
20/06/2026 03:11:30 test_nbr_health.check_sonic_facts        L0061 INFO   | DEBUG addr='10.250.12.12/24'  addr.split('/')[0]='10.250.12.12'  mgmt_addr
='10.250.12.12'
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
