### PR TITLE
Fix vxlan decap PTF test spec

### DIFF
--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -222,7 +222,7 @@ def test_vxlan_decap(setup, vxlan_status, duthosts, rand_one_dut_hostname, tbinf
 
     ptf_runner(ptfhost,
                "ptftests",
-               "vxlan-decap.Vxlan",
+               "vxlan-decap",
                platform_dir="ptftests",
                params={"vxlan_enabled": vxlan_enabled,
                        "config_file": '/tmp/vxlan_decap.json',


### PR DESCRIPTION
### Description of PR
Fix `test_vxlan_decap` PTF invocation to use the module-level test spec `vxlan-decap` instead of `vxlan-decap.Vxlan`. Newer PTF fails to match the hyphenated module plus class selector and exits with `test-spec element vxlan-decap.Vxlan did not match any tests`.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [x] 202605
- [ ] 202511
- [ ] 202405

### Approach
#### What is the motivation for this PR?
SONiC nightly PBI 38538187 shows all `test_vxlan_decap` scenarios failing before dataplane validation because PTF cannot resolve the requested test spec.

#### How did you do it?
Pass `vxlan-decap` to `ptf_runner`, matching the invocation documented in `ansible/roles/test/files/ptftests/py3/vxlan-decap.py` and allowing PTF to discover the `Vxlan` test class from that file.

#### How did you verify/test it?
Verified from nightly ElasticTest logs that failure occurs during PTF test discovery with `test-spec element vxlan-decap.Vxlan did not match any tests`; verified source file contains `class Vxlan` and its documented invocation uses `vxlan-decap`.

#### Any platform specific information?
Observed on Cisco-8101C01-C32 DUALTOR in 202605 nightly.

#### Supported testbed topology if it's a new test case?
Existing test; no new topology.

### Documentation
N/A