### PR TITLE
Skip console tests when console link is missing

### DIFF
--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -579,6 +579,8 @@ def create_linecard_console(supervisor, linecard_duthost, inv_files, creds):
 
 def create_duthost_console(duthost, localhost, conn_graph_facts, creds):  # noqa: F811
     dut_hostname = duthost.hostname
+    if "ManagementIp" not in conn_graph_facts['device_console_info'][dut_hostname]:
+        pytest.skip("Console port does not exist in console_links.csv file. Skipping {}".format(dut_hostname))
     console_host = conn_graph_facts['device_console_info'][dut_hostname]['ManagementIp']
     if "/" in console_host:
         console_host = console_host.split("/")[0]


### PR DESCRIPTION
### Description of PR
Fix console stress setup failures when the selected DUT does not have console server ManagementIp data in the connection graph. This matches the existing skip behavior used by dut_console/test_console_baud_rate.py and avoids a fixture KeyError before the test can report unsupported console topology.

Fixes ADO PBI 38538188.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://dev.azure.com/msazure/One/_workitems/edit/38538188
Failure type: regression

### Tested branch
<!-- Select each branch where the change was tested. -->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result
N/A - validated by code inspection / log analysis; see Approach > "How did you verify/test it?".

### Approach
#### What is the motivation for this PR?
Nightly dut_console.test_console_stress failed during duthost_console fixture setup with KeyError: 'ManagementIp' when conn_graph_facts contained an empty console info entry for a DUT.

#### How did you do it?
Check for missing ManagementIp before accessing it and skip the test with a clear unsupported-console message, consistent with test_console_baud_rate.py.

#### How did you verify/test it?
Ran python -m py_compile on tests/common/helpers/dut_utils.py.

#### Any platform specific information?
Observed on Cisco-8101C01-C32 dualtor-aa testbed vms26-dual-t0-8101c1-02.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
