### PR TITLE
[vm_set]: Skip data-plane binding tasks for bmc topology

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -234,10 +234,10 @@
   - debug: msg="{{ duts_mgmt_port }}"
 
   - include_tasks: add_ceos_list.yml
-    when: vm_type is defined and vm_type == "ceos"
+    when: vm_type is defined and vm_type == "ceos" and 'bmc' not in topo
 
   - include_tasks: add_csonic_list.yml
-    when: vm_type is defined and (vm_type == "csonic")
+    when: vm_type is defined and (vm_type == "csonic") and 'bmc' not in topo
 
   - name: Bind topology {{ topo }} to VMs. base vm = {{ VM_base }}
     vm_topology:
@@ -270,7 +270,12 @@
       topo_config: "{{ configuration | default({}) }}"
       is_vs_chassis: "{{ is_vs_chassis | default(false) }}"
     become: yes
-    when: not enable_async and "bmc" not in topo
+    # For bmc portless topo: the PTF container only needs its mgmt interface. On servers that use
+    # the Docker network mode (ptf_use_docker_network) the PTF gets mgmt directly from the docker
+    # network, so bind is skipped. On servers with a Linux mgmt bridge (default), bind must run so
+    # add_mgmt_port_to_docker attaches a veth from the bridge into the PTF netns (vms_exists is
+    # False here, so all VM/port binding inside bind is skipped — only mgmt setup happens).
+    when: not enable_async and ("bmc" not in topo or not (ptf_use_docker_network | default(false)))
 
   - name: Bind topology {{ topo }} to VMs. base vm = {{ VM_base }} (async mode)
     loop: "{{ VM_targets|flatten(levels=1) }}"

--- a/ansible/roles/vm_set/tasks/ptf_change_mac.yml
+++ b/ansible/roles/vm_set/tasks/ptf_change_mac.yml
@@ -34,3 +34,6 @@
 - name: Change PTF interface MAC addresses
   script: change_mac.sh
   delegate_to: "{{ ptf_host }}"
+  # change_mac.sh re-MACs the PTF data-plane ethN interfaces. A portless topo (e.g. bmc)
+  # has only the mgmt interface and no data-plane ports, so there is nothing to re-MAC.
+  when: "'bmc' not in topo"


### PR DESCRIPTION
Summary: Skip data-plane binding tasks for bmc topology
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [] 202605

### Approach
#### What is the motivation for this PR?
For the portless `bmc` topology there are no neighbor VMs and no data-plane `ethN` interfaces on the PTF container, so the following tasks are either unnecessary or fail:
- `add_ceos_list` / `add_csonic_list` neighbor VM list builds
- PTF interface MAC re-assignment (`change_mac.sh`), which re-MACs the data-plane `ethN` interfaces

The synchronous PTF bind must still run for the `bmc` topo when a Linux mgmt bridge is used (i.e. `ptf_use_docker_network` is false), so that `add_mgmt_port_to_docker` attaches a veth from the bridge into the PTF netns. When the Docker network mode is used the PTF gets its mgmt directly from the docker network, so the bind can be skipped.

#### How did you do it?
- `add_topo.yml`: gate `add_ceos_list` / `add_csonic_list` on `'bmc' not in topo`, and adjust the synchronous bind `when` condition so it still runs for `bmc` topo when a Linux mgmt bridge is used.
- `ptf_change_mac.yml`: skip the MAC re-assignment task for `bmc` topo.

#### How did you verify/test it?
Deploy bmc success

#### Any platform specific information?
BMC

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A