### PR TITLE
[process_monitoring] Wait for redis before config_reload in DB recovery

### DIFF
--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -665,8 +665,12 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
 
         # After a dirty reboot (SysRq/PDU), /var/run/redis/sonic-db/database_config.json
         # (on tmpfs) may not exist yet -- even "config reload -h" crashes without it.
-        # Wait for database_config.json first, then use config_reload for a clean
-        # recovery that also waits for BGP sessions to re-establish.
+        # The file appearing is necessary but NOT sufficient: it lands on tmpfs before
+        # redis-server is actually accepting connections, so "config reload" (which
+        # connects to redis even for "config reload -h") can still crash with
+        # "Unable to connect to redis - Connection refused".  Wait for both the config
+        # files AND redis connectivity before running config_reload, which also waits
+        # for BGP sessions to re-establish.
         db_config_timeout = 120
         if duthost.facts.get("modular_chassis"):
             db_config_timeout = max(db_config_timeout, 600)
@@ -692,12 +696,20 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
                         "test -f {}".format(db_config_file),
                         module_ignore_errors=True)["rc"] != 0:
                     return False
+            # database_config.json on tmpfs can appear before redis-server is actually
+            # accepting connections.  Probe redis directly so the subsequent
+            # config_reload (which runs "config reload -h" against redis) does not crash
+            # with "Unable to connect to redis - Connection refused".
+            redis_ping = duthost.shell("sonic-db-cli PING", module_ignore_errors=True)
+            if redis_ping["rc"] != 0 or "PONG" not in redis_ping["stdout"]:
+                return False
             return True
 
         db_config_ready = wait_until(db_config_timeout, 5, 0, _all_db_configs_ready)
         if not db_config_ready:
             # Fail fast here to protect subsequent tests from a sick DUT.
-            pytest.fail("database_config.json not ready after %ds -- DUT recovery incomplete" % db_config_timeout)
+            pytest.fail("database_config.json / redis not ready after %ds -- DUT recovery incomplete"
+                        % db_config_timeout)
 
         logger.info("Database config ready, performing config reload for clean recovery...")
         config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)


### PR DESCRIPTION
### Description of PR

Summary: Fix flaky `process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical_processes`. The test intentionally kills critical processes (including the `database`/redis container) and recovers the DUT in the `recover_critical_processes` teardown — on single-ASIC KVM via a SysRq reboot followed by `config_reload(wait_for_bgp=True)`.

After the dirty reboot, the recovery waits only for `/var/run/redis/sonic-db/database_config.json` to **exist** (`test -f`) before calling `config_reload`. That file lands on tmpfs **before redis-server is accepting connections**, so the gate passes too early. `config_reload` then calls `config_force_option_supported()`, which runs `config reload -h`; because the SONiC `config` CLI eagerly builds `Db()` and connects to redis even for `-h`, it crashes with `RuntimeError: Unable to connect to redis - Connection refused`, aborting the recovery `config_reload` and failing teardown. The existing code comment already anticipated this ("even `config reload -h` crashes without it") but guarded the **file**, not **redis connectivity**.

This PR strengthens the readiness gate in `_all_db_configs_ready` to also require redis to answer `PING` (`PONG`) before running `config_reload`.

Originating flaky signal (elastictest PR run): https://elastictest.org/scheduler/testplan/6a35e08f77f1abdf7c8f32f8

Fixes # (N/A — flaky test triage)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

`test_monitoring_critical_processes` is a recurring PR flake. Every failure signature is a teardown/recovery race — the recovery touches a subsystem (redis, BGP, critical processes) before the DUT has finished recovering from the deliberate `database`-container kill + reboot. The most direct, deterministic instance is `config reload -h` crashing on a not-yet-listening redis.

#### How did you do it?

In `recover_critical_processes` (`_all_db_configs_ready`), besides checking the `database_config.json` files exist, probe redis directly and require a `PONG`:

```python
redis_ping = duthost.shell("sonic-db-cli PING", module_ignore_errors=True)
if redis_ping["rc"] != 0 or "PONG" not in redis_ping["stdout"]:
    return False
```

`config_reload` now runs only once redis actually answers, so `config reload -h` (and the rest of the reload) no longer crashes.

#### How did you verify/test it?

Reproduced deterministically and verified on a KVM dev testbed (`vms-kvm-t1-lag`, DUT `vlab-03`) — same test, same testbed, only the fix differs.

Before the fix — teardown ERROR:

```
common/config_reload.py:275: in config_reload
    if config_force_option_supported(sonic_host):
common/config_reload.py:70: in config_force_option_supported
    out = duthost.shell("config reload -h", executable="/bin/bash")
E   cmd = config reload -h
E   RuntimeError: Unable to connect to redis - Connection refused(1): Cannot assign requested address
E   tests.common.errors.RunAnsibleModuleFail: run module shell failed
============= 1 passed, 240 warnings, 1 error in 473.93s (0:07:53) =============
```

Originating elastictest testplan error message (same recovery teardown path):

```
ERROR at teardown of test_monitoring_critical_processes
E   Failed: Post-check failed after testing the process monitoring!
```

After the fix — clean pass:

```
test_critical_process_monitoring.py:691 Waiting for database_config.json to be ready ...
test_critical_process_monitoring.py:714 Database config ready, performing config reload for clean recovery...
test_critical_process_monitoring.py:719 DUT recovered successfully after power cycle!
test_critical_process_monitoring.py:213 Post-checking status of critical processes and BGP sessions...
test_critical_process_monitoring.py:730 Post-checking status of critical processes and BGP sessions was done!
conftest.py:3371 Core dump and config check passed for test_critical_process_monitoring.py
================= 1 passed, 309 warnings in 725.62s (0:12:05) ==================
```

| Scenario (same test, same testbed) | Before fix | After fix |
|---|---|---|
| db-container kill -> SysRq reboot -> recovery | 1 passed, 1 error (`config reload -h` -> `Unable to connect to redis`) | 1 passed, 0 error (recovery clean, post-check passed) |

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?

N/A — not a new test case.

### Documentation

N/A.
