### PR TITLE
[everflow] Add /128 prefix to DST_IPV6 in IPv6 ip_type test rules

### DIFF
--- a/tests/everflow/files/test_rules_ip_type_v6.json
+++ b/tests/everflow/files/test_rules_ip_type_v6.json
@@ -4,19 +4,19 @@
             "PRIORITY": "999",
             "IP_TYPE": "ANY",
             "{{ action }}": "test_session_1",
-            "DST_IPV6": "2002:0225:7c6b:a982:d48b:230e:f271:0011"
+            "DST_IPV6": "2002:0225:7c6b:a982:d48b:230e:f271:0011/128"
         },
         "{{ table_name }}|rule_998": {
             "PRIORITY": "998",
             "IP_TYPE": "IP",
             "{{ action }}": "test_session_1",
-            "DST_IPV6": "2002:0225:7c6b:a982:d48b:230e:f271:0012"
+            "DST_IPV6": "2002:0225:7c6b:a982:d48b:230e:f271:0012/128"
         },
         "{{ table_name }}|rule_997": {
             "PRIORITY": "997",
             "IP_TYPE": "IPV6ANY",
             "{{ action }}": "test_session_1",
-            "DST_IPV6": "2002:0225:7c6b:a982:d48b:230e:f271:0013"
+            "DST_IPV6": "2002:0225:7c6b:a982:d48b:230e:f271:0013/128"
         }
     }
 }


### PR DESCRIPTION
### Description of PR

`rule_997/998/999` in `tests/everflow/files/test_rules_ip_type_v6.json` set `DST_IPV6` to a bare IPv6 address with no prefix length. The sonic-acl YANG model requires `DST_IPV6` to be an `ipv6-prefix`, so config validation in the teardown config-db check fails.

Summary:
- Append `/128` to the `DST_IPV6` of `rule_997/998/999` so each is a valid host prefix.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202605

### Approach

#### What is the motivation for this PR?

* Microsoft ADO (number only): 38475482

While triaging `test_everflow_ipv6` on a Broadcom dualtor nightly, the teardown `core_dump_and_config_check` reported a config-db validation failure:

```
failed to parse data tree: Unsatisfied pattern -
'2002:0225:7c6b:a982:d48b:230e:f271:0013' does not conform to <ipv6-prefix>
Data path: .../ACL_RULE_LIST[ACL_TABLE_NAME='EVERFLOWV6'][RULE_NAME='rule_997']/DST_IPV6
```

The three ip-type rules (`rule_997/998/999`) carry a bare IPv6 address in `DST_IPV6`, which does not satisfy the sonic-acl YANG `ipv6-prefix` pattern (it requires a prefix length). The other EVERFLOWV6 rules in `ipv6_test_rules.yaml` already use the `/NNN` form.

#### How did you do it?

Append `/128` to the `DST_IPV6` value of `rule_997`, `rule_998`, and `rule_999` in `test_rules_ip_type_v6.json`.

#### How did you verify/test it?

```
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_src_ipv6_mirroring[erspan_ipv4-cli-default] PASSED [  1%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_dst_ipv6_mirroring[erspan_ipv4-cli-default] PASSED [  2%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_next_header_mirroring[erspan_ipv4-cli-default] PASSED [  3%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_src_port_mirroring[erspan_ipv4-cli-default] PASSED [  4%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_dst_port_mirroring[erspan_ipv4-cli-default] PASSED [  5%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_src_port_range_mirroring[erspan_ipv4-cli-default] PASSED [  6%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_dst_port_range_mirroring[erspan_ipv4-cli-default] PASSED [  7%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_tcp_flags_mirroring[erspan_ipv4-cli-default] PASSED [  8%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_dscp_mirroring[erspan_ipv4-cli-default] PASSED [  9%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_range_mirroring[erspan_ipv4-cli-default] PASSED [ 10%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_tcp_response_mirroring[erspan_ipv4-cli-default] PASSED [ 11%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_tcp_application_mirroring[erspan_ipv4-cli-default] PASSED [ 12%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_udp_application_mirroring[erspan_ipv4-cli-default] PASSED [ 13%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_any_protocol[erspan_ipv4-cli-default] PASSED [ 14%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_any_transport_protocol[erspan_ipv4-cli-default] PASSED [ 15%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_invalid_tcp_rule[erspan_ipv4-cli-default] PASSED [ 16%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_source_subnet[erspan_ipv4-cli-default] PASSED [ 17%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_dest_subnet[erspan_ipv4-cli-default] PASSED [ 18%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_both_subnets[erspan_ipv4-cli-default] PASSED [ 19%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_fuzzy_subnets[erspan_ipv4-cli-default] PASSED [ 20%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_icmpv6_type[erspan_ipv4-cli-default] PASSED [ 21%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_icmpv6_code[erspan_ipv4-cli-default] PASSED [ 22%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_ip_type_any[erspan_ipv4-cli-default] PASSED [ 23%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_ip_type_ip[erspan_ipv4-cli-default] PASSED [ 24%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_ip_type_ipv6any[erspan_ipv4-cli-default] PASSED [ 25%]
```

Assisted-by: Stuart (Hermes Agent, model claude-opus-4.8)
Signed-off-by: Longxiang Lyu <lolv@microsoft.com>
