### PR TITLE
[memory utilization] Add SN6600 t0 and t1 HWSKUs to memory utilization dependence

### DIFF
--- a/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
@@ -8,7 +8,7 @@
     "Arista-7260CX3": ["Arista-7260CX3-C64", "Arista-7260CX3-D108C8", "Arista-7260CX3-D108C10"],
     "Nokia-IXR7220": ["Nokia-IXR7220-H6-O256"],
     "Cisco-C8220TG": ["Cisco-C8220TG-48A-O", "Cisco-C8220TG-G1S2"],
-    "Mellanox-SN6600":["Mellanox-SN6600_LD-V512C2", "Mellanox-SN6600_LD-V448P16C2"]
+    "Mellanox-SN6600":["Mellanox-SN6600_LD-V512C2", "Mellanox-SN6600_LD-V448P16C2", "Mellanox-SN6600_LD-P64O128C2", "Mellanox-SN6600_LD-P128C2"]
   },
   "COMMON": [
     {


### PR DESCRIPTION
…n dependence

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Added missed t0 and t1 HWSKU of SN6600 to memory utilization dependence, to use the specified system thresholds and not the default.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605

### Approach
#### What is the motivation for this PR?
Stable tests on SN6600

#### How did you verify/test it?
Test passed

#### Any platform specific information?
SN6600

