### PR TITLE
platform_tests: skip PSU on/off test when a PDU outlet is shared by multiple PSUs (breakout cable)

### DIFF
--- a/tests/common/helpers/psu_helpers.py
+++ b/tests/common/helpers/psu_helpers.py
@@ -58,3 +58,32 @@ def get_grouped_pdus_by_psu(pdu_controller):
             psu_to_pdus[outlet['psu_name']].append(outlet)
 
     return psu_to_pdus
+
+
+def get_psus_sharing_outlets(pdu_controller):
+    """Find physical PDU outlets that feed more than one PSU of the DUT.
+
+    On some testbeds a single switchable PDU outlet powers more than one PSU of
+    the DUT (for example when a breakout/Y power cable is used, so pdu_links.csv
+    maps PSU1 and PSU2 to the same pdu/outlet). Turning such an outlet off to
+    test one PSU would also power off the other PSU(s) sharing it and reboot the
+    whole DUT, so a single PSU cannot be turned off in isolation on these
+    testbeds.
+
+    A physical outlet is identified by the pair (pdu_name, outlet_id).
+
+    Args:
+        pdu_controller (BasePduController): Instance of PDU controller
+
+    Returns:
+        dict: {(pdu_name, outlet_id): sorted list of psu_name} for every
+              physical outlet that is associated with more than one PSU.
+              Returns an empty dict when no outlet is shared.
+    """
+    outlet_status = pdu_controller.get_outlet_status()
+    outlet_to_psus = {}
+    for outlet in outlet_status:
+        identity = (outlet.get('pdu_name'), outlet.get('outlet_id'))
+        outlet_to_psus.setdefault(identity, set()).add(outlet.get('psu_name'))
+
+    return {identity: sorted(psus) for identity, psus in outlet_to_psus.items() if len(psus) > 1}

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -11,7 +11,7 @@ import pytest
 
 from retry.api import retry_call
 from tests.common.helpers.assertions import pytest_assert, pytest_require
-from tests.common.helpers.psu_helpers import turn_on_all_outlets, get_grouped_pdus_by_psu
+from tests.common.helpers.psu_helpers import turn_on_all_outlets, get_grouped_pdus_by_psu, get_psus_sharing_outlets
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.utilities import wait_until, get_sup_node_or_random_node
 from tests.common.platform.device_utils import get_dut_psu_line_pattern
@@ -347,6 +347,20 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_h
 
     # Group outlets/PDUs by PSU and toggle PDUs by PSU
     psu_to_pdus = get_grouped_pdus_by_psu(pdu_ctrl)
+
+    # On testbeds that use a breakout/Y power cable, a single switchable PDU
+    # outlet feeds more than one PSU. Turning that outlet off to test one PSU
+    # would also power off the PSU(s) sharing it and reboot the whole DUT, so a
+    # single PSU cannot be turned off in isolation. Skip the test in that case.
+    shared_outlets = get_psus_sharing_outlets(pdu_ctrl)
+    if shared_outlets:
+        shared_desc = "; ".join(
+            "outlet {} on {} feeds PSUs {}".format(outlet_id, pdu_name, psus)
+            for (pdu_name, outlet_id), psus in shared_outlets.items())
+        pytest.skip(
+            "Skip the test because one or more PDU outlets are shared by multiple PSUs "
+            "(e.g. breakout cable); a single PSU cannot be powered off without rebooting "
+            "the DUT: {}".format(shared_desc))
 
     # Get list of PSUs to skip from inventory configuration
     skip_psu_list = get_skip_mod_list(duthost, ['psus'])


### PR DESCRIPTION
### Description of PR

platform_tests/test_platform_info.py::test_turn_on_off_psu_and_check_psustatus assumes every PSU is fed by its **own, independently switchable** PDU outlet. The test turns off the outlet(s) of one PSU and expects the rest of the DUT to stay powered.

On testbeds wired with a **breakout / Y power cable**, a single switchable PDU outlet feeds **more than one PSU** (e.g. pdu_links.csv maps PSU1 and PSU2 to the same pdu/outlet). Turning that outlet off to test one PSU also powers off the PSU sharing it, which **reboots the whole DUT**. The test then fails with `Timeout (62s) waiting for privilege escalation prompt` on the next `show platform psustatus` command, and the subsequent thermal/fan cases in the module fail/err as collateral (`There should be at least 1 thermalctld process`, lost syslog markers, etc.).

#### How did you verify/test it?

- Added get_psus_sharing_outlets() which detects physical outlets — identified by (pdu_name, outlet_id) — associated with more than one PSU.
- 	est_turn_on_off_psu_and_check_psustatus now skips with a descriptive message when any shared outlet is detected, instead of bricking the DUT and cascading failures across the module.
- Behavior is unchanged on normal testbeds (no shared outlets -> empty dict -> no skip).
- lake8 --max-line-length=120 clean on both changed files; `python -m py_compile` passes.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202012 / 202205 / 202305 / 202311 / 202405 / 202411 / 202505 (maintainers to advise)

#### Description for the changelog

Skip `test_turn_on_off_psu_and_check_psustatus` on testbeds where a PDU outlet is shared by multiple PSUs (breakout cable), since a single PSU cannot be powered off in isolation.
