### PR TITLE
[conditional_mark] Scope bgp/test_bgp_suppress_fib VS skip to the runnable cases

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -616,10 +616,8 @@ bgp/test_bgp_stress_link_flap.py::test_bgp_stress_link_flap[all]:
 bgp/test_bgp_suppress_fib.py:
   skip:
     reason: "Not supported before release 202411."
-    conditions_logical_operator: or
     conditions:
-      - "release in ['201811', '201911', '202012', '202205', '202211', '202305', '202311', '202405', 'master']"
-      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/14449"
+      - "release in ['201811', '201911', '202012', '202205', '202211', '202305', '202311', '202405']"
   xfail:
     reason: "xfail for IPv6-only topologies, issue https://github.com/sonic-net/sonic-mgmt/issues/20756 or Mellanox platform due to https://github.com/sonic-net/sonic-buildimage/issues/24679"
     conditions_logical_operator: or
@@ -627,11 +625,51 @@ bgp/test_bgp_suppress_fib.py:
       - "https://github.com/sonic-net/sonic-mgmt/issues/20756 and '-v6-' in topo_name"
       - "https://github.com/sonic-net/sonic-buildimage/issues/24679 and asic_type in ['mellanox', 'nvidia']"
 
+bgp/test_bgp_suppress_fib.py::test_bgp_route_with_suppress:
+  skip:
+    reason: "On VS the forwarding plane is the Linux kernel FIB (not the ASIC). zebra installs a route
+             into the kernel immediately, independent of offload, so a suppress-fib-pending route the
+             kernel has installed is still forwarded and the DROP assertion (verify_no_packet) cannot
+             hold on VS. See https://github.com/sonic-net/sonic-mgmt/issues/14449"
+    conditions:
+      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/14449"
+
+bgp/test_bgp_suppress_fib.py::test_bgp_route_with_suppress_negative_operation:
+  skip:
+    reason: "On VS the forwarding plane is the Linux kernel FIB (not the ASIC). zebra installs a route
+             into the kernel immediately, independent of offload, so a suppress-fib-pending route the
+             kernel has installed is still forwarded and the DROP assertion (verify_no_packet) cannot
+             hold on VS. See https://github.com/sonic-net/sonic-mgmt/issues/14449"
+    conditions:
+      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/14449"
+
 bgp/test_bgp_suppress_fib.py::test_bgp_route_without_suppress:
   xfail:
     reason: "Testcase ignored due to https://github.com/sonic-net/sonic-buildimage/issues/24679"
     conditions:
       - "https://github.com/sonic-net/sonic-buildimage/issues/24679 and asic_type in ['mellanox', 'nvidia']"
+
+bgp/test_bgp_suppress_fib.py::test_credit_loop:
+  skip:
+    reason: "On VS the forwarding plane is the Linux kernel FIB (not the ASIC), so the dataplane
+             credit-loop behavior cannot be reproduced: zebra installs routes into the kernel
+             immediately and traffic is forwarded regardless of offload state, so the loop_back /
+             verify_no_packet traffic assertions cannot hold on VS. See
+             https://github.com/sonic-net/sonic-mgmt/issues/14449"
+    conditions:
+      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/14449"
+
+bgp/test_bgp_suppress_fib.py::test_suppress_fib_performance:
+  skip:
+    reason: "Skip for KVM/VS due to low performance (bulk 512+512 route relay-timing measurement)."
+    conditions:
+      - "asic_type in ['vs']"
+
+bgp/test_bgp_suppress_fib.py::test_suppress_fib_stress:
+  skip:
+    reason: "Skip for KVM/VS due to low performance (bulk route-flap stress over 512+512 routes)."
+    conditions:
+      - "asic_type in ['vs']"
 
 bgp/test_bgp_update_replication.py:
   xfail:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
@@ -63,6 +63,11 @@ bgp/test_bgp_port_disable.py:
     conditions:
     - asic_type in ['vs'] and 't2' in topo_name
     reason: This test case either cannot pass or should be skipped on virtual chassis
+bgp/test_bgp_suppress_fib.py:
+  skip:
+    conditions:
+    - asic_type in ['vs'] and 't2' in topo_name
+    reason: This test case either cannot pass or should be skipped on virtual chassis
 bgp/test_bgp_update_timer.py:
   skip:
     conditions:


### PR DESCRIPTION
### Description of PR

Summary: Fixes https://github.com/sonic-net/sonic-mgmt/issues/14449

`bgp/test_bgp_suppress_fib.py` is currently skipped at the **whole-file** level on VS (`asic_type == vs`, [issue 14449](https://github.com/sonic-net/sonic-mgmt/issues/14449)) and on master (the "not supported before 202411" release list still contains `'master'`). That over-broad scope hides perfectly healthy cases — most importantly `test_bgp_update_relay_latency`, which detects the FRR full-RIB re-download regression class tracked in [sonic-buildimage issue 28026](https://github.com/sonic-net/sonic-buildimage/issues/28026) ([fix PR 28043](https://github.com/sonic-net/sonic-buildimage/pull/28043)) but never runs on the VS PR checker, so that regression merged unblocked.

Only the cases that depend on the ASIC being the forwarding plane are genuinely un-runnable on VS, and for a structural reason (see below). This PR re-scopes the skips so the runnable control-plane cases execute on single-ASIC VS / the PR checker, while keeping the legitimate skips in place. VS enablement is **single-ASIC only**; multi-ASIC virtual chassis stay skipped at the whole-module level.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

The blanket file-level VS skip is over-broad. On VS the forwarding plane is the **Linux kernel FIB**, not the ASIC: zebra installs a route into the kernel immediately (via netlink), independent of offload state (`syncd`/`libsaivs` is a non-forwarding model). `bgp suppress-fib-pending` is a control-plane *advertisement* gate only — it does not remove the kernel route or gate forwarding.

So the **data-plane** cases — the two DROP tests (`test_bgp_route_with_suppress`, `test_bgp_route_with_suppress_negative_operation`) and the traffic-loopback test (`test_credit_loop`) — which `SIGSTOP` orchagent and then assert traffic is dropped / not looped (`verify_no_packet`, `loop_back`) cannot pass on VS: even with orchagent suspended and the route absent from `ASIC_DB`, the kernel still forwards it. This is a permanent VS data-plane modeling limitation, re-confirmed on current master, not a SONiC bug. The control-plane cases (route-offload-state and update-relay-timing) do not rely on ASIC-gated forwarding and run fine on single-ASIC VS.

#### How did you do it?

In `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`:

- Moved the `asic_type in ['vs'] and .../issues/14449` skip from the whole file to the data-plane cases only — the two DROP cases (`test_bgp_route_with_suppress`, `test_bgp_route_with_suppress_negative_operation`) and `test_credit_loop` — each with a reason explaining the kernel-FIB forwarding limitation.
- Kept `test_suppress_fib_stress` and `test_suppress_fib_performance` skipped on VS for low KVM performance (they push 512 IPv4 + 512 IPv6 bulk routes with route-flap loops), following the established per-testcase pattern used for other heavy tests (e.g. `dhcp_relay/test_dhcp_relay_stress`, `bfd/test_bfd_scale`, `bgp/test_bgp_stress_link_flap`).
- Removed `'master'` from the "not supported before 202411" release list — the feature is GA on master — so the module runs on the newest line.

In `tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml`:

- Added the symmetric **whole-module** skip on t2, mirroring the existing entry in `tests_mark_conditions_vs_t1_multiasic.yaml`. Both multi-ASIC virtual-chassis topologies (t1-8-lag, t2) thus skip the entire module — the control-plane cases that pass on single-ASIC VS do not pass on multi-ASIC virtual chassis (the route stays in a non-offloaded `queued` state under the all-orchagents-suspended path). Scoping VS enablement to single-ASIC keeps the PR focused on the 28026 gate; the multi-ASIC virtual-chassis behavior is a separate follow-up.

Net effect: on **single-ASIC VS** / the PR checker, `test_bgp_route_without_suppress` and `test_bgp_update_relay_latency` now run; the two DROP cases, `test_credit_loop`, and the two stress/perf cases remain skipped. On **multi-ASIC virtual chassis** (t1-8-lag, t2) the whole module remains skipped.

#### How did you verify/test it?

- Ran the data-plane cases on a live single-ASIC `vms-kvm-t1-lag` VS testbed (SONiC master, FRR 10.5.4) with the skip bypassed: the two DROP cases and `test_credit_loop` all fail with `verify_no_packet` ("Received packet that we expected not to receive") — confirming the limitation is real and permanent, so the per-case VS skips are correct.
- A controlled repro (static route injected while orchagent was suspended) captured, at the same instant: kernel FIB has the route (`ip route get` forwards via it), zebra `Status: Queued` (not `Offloaded`), and `ASIC_DB` has no `ROUTE_ENTRY` — i.e. kernel-has and ASIC-lacks the route simultaneously.
- `test_bgp_route_without_suppress` and `test_bgp_update_relay_latency` were run on the same single-ASIC VS testbed (with a fixed image) and **pass** — i.e. the control-plane cases are green on a good build, and `test_bgp_update_relay_latency` is red on the regressed one, so it is a valid pre-merge gate and is not too slow for the PR checker.
- The PR checker surfaced that on multi-ASIC virtual chassis `test_bgp_route_without_suppress` fails (the route remains in a non-offloaded `queued` state), which is why the whole module stays skipped there — matching the pre-existing t1-8-lag skip.
- `python3 .hooks/pre_commit_hooks/check_conditional_mark_sort.py` passes for both files; the YAML parses; the entries keep alphabetical key order.

#### Any platform specific information?

The data-plane-case skips are specific to `asic_type == vs` (KVM). On real ASIC platforms the DROP cases and `test_credit_loop` continue to run and pass (the ASIC is the forwarding plane and is gated by orchagent). The stress/perf skips are also VS-only. The whole-module multi-ASIC virtual-chassis skips are scoped to `asic_type == vs` with the t1-8-lag / t2 topologies.

#### Supported testbed topology if it's a new test case?

N/A — no new test case; this only adjusts skip scoping for the existing `bgp/test_bgp_suppress_fib.py` module.

### Documentation
N/A
