### PR TITLE
Compute pmon uptime from container StartedAt and widen the pmon-ready wait timeout

### DIFF
--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -12,14 +12,13 @@ from tests.common.utilities import wait_until, get_plt_reboot_ctrl
 logger = logging.getLogger(__name__)
 
 
-# Computes pmon's uptime in whole seconds from its container start time, entirely
-# on the DUT so there is no test-host/DUT clock skew. Prints nothing when pmon is
-# absent or not running. Reading State.StartedAt avoids parsing the localized,
-# rounded "Up ..." text that `docker ps` renders for display.
+# Runs on the DUT to avoid clock skew; uses State.StartedAt (not `docker ps` text) for precision.
 _PMON_UPTIME_SECONDS_CMD = (
+    '{% raw %}'
     'if [ "$(docker inspect -f \'{{.State.Running}}\' pmon 2>/dev/null)" = "true" ]; then '
     'echo $(( $(date -u +%s) - $(date -u -d "$(docker inspect -f \'{{.State.StartedAt}}\' pmon)" +%s) )); '
     'fi'
+    '{% endraw %}'
 )
 
 

--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -14,11 +14,9 @@ logger = logging.getLogger(__name__)
 
 # Runs on the DUT to avoid clock skew; uses State.StartedAt (not `docker ps` text) for precision.
 _PMON_UPTIME_SECONDS_CMD = (
-    '{% raw %}'
-    'if [ "$(docker inspect -f \'{{.State.Running}}\' pmon 2>/dev/null)" = "true" ]; then '
-    'echo $(( $(date -u +%s) - $(date -u -d "$(docker inspect -f \'{{.State.StartedAt}}\' pmon)" +%s) )); '
+    'if [ "$(docker inspect -f \\{\\{.State.Running\\}\\} pmon 2>/dev/null)" = "true" ]; then '
+    'echo $(( $(date -u +%s) - $(date -u -d "$(docker inspect -f \\{\\{.State.StartedAt\\}\\} pmon)" +%s) )); '
     'fi'
-    '{% endraw %}'
 )
 
 

--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -19,8 +19,13 @@ _PMON_UPTIME_SECONDS_CMD = (
     'fi'
 )
 
+PMON_MIN_UPTIME_MINUTES = 6
+# Wait budget must exceed the uptime threshold, else a pmon that (re)started just before
+# the test can never accrue PMON_MIN_UPTIME_MINUTES within the window and the wait times out.
+PMON_READY_TIMEOUT_SECS = PMON_MIN_UPTIME_MINUTES * 60 + 120
 
-def check_pmon_uptime_minutes(duthost, minimal_runtime_minutes=6):
+
+def check_pmon_uptime_minutes(duthost, minimal_runtime_minutes=PMON_MIN_UPTIME_MINUTES):
     """
     @summary: Check whether the pmon container has been running for at least
               minimal_runtime_minutes, computed from its docker start time.

--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -5,7 +5,6 @@ This script contains re-usable functions for checking status of critical service
 """
 import logging
 import time
-import re
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until, get_plt_reboot_ctrl
@@ -13,23 +12,28 @@ from tests.common.utilities import wait_until, get_plt_reboot_ctrl
 logger = logging.getLogger(__name__)
 
 
-def check_pmon_uptime_minutes(duthost, minimal_runtime=6):
+# Computes pmon's uptime in whole seconds from its container start time, entirely
+# on the DUT so there is no test-host/DUT clock skew. Prints nothing when pmon is
+# absent or not running. Reading State.StartedAt avoids parsing the localized,
+# rounded "Up ..." text that `docker ps` renders for display.
+_PMON_UPTIME_SECONDS_CMD = (
+    'if [ "$(docker inspect -f \'{{.State.Running}}\' pmon 2>/dev/null)" = "true" ]; then '
+    'echo $(( $(date -u +%s) - $(date -u -d "$(docker inspect -f \'{{.State.StartedAt}}\' pmon)" +%s) )); '
+    'fi'
+)
+
+
+def check_pmon_uptime_minutes(duthost, minimal_runtime_minutes=6):
     """
-    @summary: This function checks if pmon uptime is at least the minimal_runtime
-    @return: True pmon has been running at least the minimal_runtime, False for otherwise
+    @summary: Check whether the pmon container has been running for at least
+              minimal_runtime_minutes, computed from its docker start time.
+    @return: True if pmon's uptime is at least minimal_runtime_minutes, False otherwise.
     """
-    result = duthost.command("docker ps | grep pmon", _uses_shell=True)
-    if result["stdout"]:
-        match = re.search(r'Up (\d+) (minutes|hours)', result["stdout"])
-        if match:
-            if match.group(2) == "hours":
-                return int(match.group(1))*60 >= minimal_runtime
-            else:
-                return int(match.group(1)) >= minimal_runtime
-        match = re.search(r'Up About an hour', result["stdout"])
-        if match:
-            return 60 >= minimal_runtime
-    return False
+    uptime_seconds = duthost.command(_PMON_UPTIME_SECONDS_CMD, _uses_shell=True)["stdout"].strip()
+    try:
+        return int(uptime_seconds) >= minimal_runtime_minutes * 60
+    except ValueError:
+        return False
 
 
 def reset_timeout(duthost):

--- a/tests/common/unit_tests/platform/unit_test_processes_utils.py
+++ b/tests/common/unit_tests/platform/unit_test_processes_utils.py
@@ -68,3 +68,16 @@ def test_check_pmon_uptime_minutes(processes_utils, uptime_seconds, expected):
     invoked_cmd = duthost.command.call_args[0][0]
     assert "docker inspect" in invoked_cmd
     assert "State.StartedAt" in invoked_cmd
+
+
+def test_pmon_uptime_cmd_survives_ansible_jinja2_templating(processes_utils):
+    """Go-template braces in _PMON_UPTIME_SECONDS_CMD must survive Ansible Jinja2 templating."""
+    jinja2 = pytest.importorskip("jinja2")
+    cmd = processes_utils._PMON_UPTIME_SECONDS_CMD
+
+    try:
+        rendered = jinja2.Environment().from_string(cmd).render()
+        assert "{{.State.Running}}" in rendered
+        assert "{{.State.StartedAt}}" in rendered
+    except jinja2.exceptions.TemplateError as exc:
+        pytest.fail("_PMON_UPTIME_SECONDS_CMD is not Jinja2-safe: {}".format(exc))

--- a/tests/common/unit_tests/platform/unit_test_processes_utils.py
+++ b/tests/common/unit_tests/platform/unit_test_processes_utils.py
@@ -71,13 +71,14 @@ def test_check_pmon_uptime_minutes(processes_utils, uptime_seconds, expected):
 
 
 def test_pmon_uptime_cmd_survives_ansible_jinja2_templating(processes_utils):
-    """Go-template braces in _PMON_UPTIME_SECONDS_CMD must survive Ansible Jinja2 templating."""
+    """Escaped Go-template braces in _PMON_UPTIME_SECONDS_CMD must pass through Ansible Jinja2 templating unchanged."""
     jinja2 = pytest.importorskip("jinja2")
     cmd = processes_utils._PMON_UPTIME_SECONDS_CMD
 
     try:
         rendered = jinja2.Environment().from_string(cmd).render()
-        assert "{{.State.Running}}" in rendered
-        assert "{{.State.StartedAt}}" in rendered
+        assert rendered == cmd
+        assert r"\{\{.State.Running\}\}" in rendered
+        assert r"\{\{.State.StartedAt\}\}" in rendered
     except jinja2.exceptions.TemplateError as exc:
         pytest.fail("_PMON_UPTIME_SECONDS_CMD is not Jinja2-safe: {}".format(exc))

--- a/tests/common/unit_tests/platform/unit_test_processes_utils.py
+++ b/tests/common/unit_tests/platform/unit_test_processes_utils.py
@@ -1,0 +1,70 @@
+"""Unit tests for tests/common/platform/processes_utils.py.
+
+Run (from the repository root):
+    python3 -m pytest --noconftest tests/common/unit_tests/platform/unit_test_processes_utils.py -v
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+MODULE_PATH = (Path(__file__).resolve().parents[3] /
+               "common/platform/processes_utils.py")
+
+MINUTE = 60
+HOUR = 60 * MINUTE
+DAY = 24 * HOUR
+WEEK = 7 * DAY
+MONTH = 30 * DAY
+
+
+def _load_target_module():
+    """Load processes_utils.py in isolation, stubbing its intra-repo imports."""
+    for name, attrs in {
+        "tests.common.helpers.assertions": {"pytest_assert": lambda *a, **k: None},
+        "tests.common.utilities": {"wait_until": None,
+                                   "get_plt_reboot_ctrl": lambda *a, **k: None},
+    }.items():
+        module = types.ModuleType(name)
+        for attr, value in attrs.items():
+            setattr(module, attr, value)
+        sys.modules[name] = module
+
+    spec = importlib.util.spec_from_file_location(
+        "unit_target_processes_utils", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def processes_utils():
+    return _load_target_module()
+
+
+@pytest.mark.parametrize("uptime_seconds, expected", [
+    (str(2 * MONTH), True),         # "Up 2 months"  -- the original failing case
+    (str(3 * WEEK), True),          # "Up 3 weeks"
+    (str(4 * DAY), True),           # "Up 4 days"
+    (str(HOUR), True),              # "Up About an hour"
+    (str(7 * MINUTE), True),        # "Up 7 minutes"
+    (str(6 * MINUTE), True),        # exactly at the threshold
+    (str(6 * MINUTE - 1), False),   # one second below the threshold
+    (str(MINUTE), False),           # "Up About a minute"
+    ("30", False),                  # "Up 30 seconds"
+    ("0", False),                   # just started
+    ("-5", False),                  # clock skew / negative elapsed
+    ("", False),                    # pmon absent or not running
+])
+def test_check_pmon_uptime_minutes(processes_utils, uptime_seconds, expected):
+    duthost = MagicMock()
+    duthost.command.return_value = {"stdout": uptime_seconds}
+    assert processes_utils.check_pmon_uptime_minutes(duthost) is expected
+    # Verify it reads structured docker state, not the rendered "docker ps" text.
+    invoked_cmd = duthost.command.call_args[0][0]
+    assert "docker inspect" in invoked_cmd
+    assert "State.StartedAt" in invoked_cmd

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -3,7 +3,6 @@ import json
 import pytest
 import os
 import logging
-import re
 import tempfile
 from tests.common.mellanox_data import is_mellanox_device
 from .args.counterpoll_cpu_usage_args import add_counterpoll_cpu_usage_args
@@ -161,25 +160,6 @@ def thermal_manager_enabled(duthosts, enum_rand_one_per_hwsku_hostname):
             "chassis").get("thermal_manager", True)
     if not thermal_manager_available:
         pytest.skip("skipped as thermal manager is not available")
-
-
-def check_pmon_uptime_minutes(duthost, minimal_runtime=6):
-    """
-    @summary: This function checks if pmon uptime is at least the minimal_runtime
-    @return: True pmon has been running at least the minimal_runtime, False for otherwise
-    """
-    result = duthost.command("docker ps | grep pmon", _uses_shell=True)
-    if result["stdout"]:
-        match = re.search(r'Up (\d+) (minutes|hours)', result["stdout"])
-        if match:
-            if match.group(2) == "hours":
-                return int(match.group(1))*60 >= minimal_runtime
-            else:
-                return int(match.group(1)) >= minimal_runtime
-        match = re.search(r'Up About an hour', result["stdout"])
-        if match:
-            return 60 >= minimal_runtime
-    return False
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/platform_tests/mellanox/test_check_sfp_eeprom.py
+++ b/tests/platform_tests/mellanox/test_check_sfp_eeprom.py
@@ -6,7 +6,7 @@ from .util import check_sfp_eeprom_info
 from tests.common.platform.transceiver_utils import parse_sfp_eeprom_infos
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.platform.processes_utils import check_pmon_uptime_minutes
+from tests.common.platform.processes_utils import check_pmon_uptime_minutes, PMON_READY_TIMEOUT_SECS
 from tests.platform_tests.mellanox.conftest import CPO_PORT_TYPE
 import logging
 
@@ -57,7 +57,7 @@ def test_check_sfp_eeprom_with_option_dom(duthosts, rand_one_dut_hostname, show_
     """
     duthost = duthosts[rand_one_dut_hostname]
 
-    pytest_assert(wait_until(360, 10, 0, check_pmon_uptime_minutes, duthost),
+    pytest_assert(wait_until(PMON_READY_TIMEOUT_SECS, 10, 0, check_pmon_uptime_minutes, duthost),
                   "Pmon docker is not ready for test")
 
     with allure.step("Run: {} to get transceiver eeprom info".format(show_eeprom_cmd)):

--- a/tests/platform_tests/test_xcvr_info_in_db.py
+++ b/tests/platform_tests/test_xcvr_info_in_db.py
@@ -11,7 +11,7 @@ from tests.common.platform.interface_utils import get_port_map, get_lport_to_fir
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts     # noqa F401
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.platform.processes_utils import check_pmon_uptime_minutes
+from tests.common.platform.processes_utils import check_pmon_uptime_minutes, PMON_READY_TIMEOUT_SECS
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -26,7 +26,7 @@ def test_xcvr_info_in_db(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
-    pytest_assert(wait_until(360, 10, 0, check_pmon_uptime_minutes, duthost),
+    pytest_assert(wait_until(PMON_READY_TIMEOUT_SECS, 10, 0, check_pmon_uptime_minutes, duthost),
                   "Pmon docker is not ready for test")
 
     logging.info("Check transceiver status")

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -3,7 +3,7 @@ import pytest
 
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.platform.processes_utils import check_pmon_uptime_minutes
+from tests.common.platform.processes_utils import check_pmon_uptime_minutes, PMON_READY_TIMEOUT_SECS
 
 pytestmark = [
     pytest.mark.topology('any', 't1-multi-asic'),
@@ -16,7 +16,7 @@ def test_interfaces(duthosts, enum_frontend_dut_hostname, tbinfo, enum_asic_inde
 
     duthost = duthosts[enum_frontend_dut_hostname]
 
-    pytest_assert(wait_until(360, 10, 0, check_pmon_uptime_minutes, duthost),
+    pytest_assert(wait_until(PMON_READY_TIMEOUT_SECS, 10, 0, check_pmon_uptime_minutes, duthost),
                   "Pmon docker is not ready for test")
 
     asic_host = duthost.asic_instance(enum_asic_index)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

`check_pmon_uptime_minutes` previously derived uptime by parsing the localized, rounded "Up ..." text that `docker ps` renders. 
This PR replaces that with an exact computation on the DUT: 
read `docker inspect -f '{{.State.StartedAt}}' pmon` and subtract from the DUT's current time, avoiding both text-format fragility and test-host/DUT clock skew. 
Returns False when pmon is absent or not running.

It also fixes the pmon-ready waits in `test_xcvr_info_in_db`, `test_interfaces`, and `test_check_sfp_eeprom` (Mellanox)
These waited up to 360s for pmon to reach 360s of uptime.
Since there was zero margin a pmon that (re)started just before the test, which happens following a reboot test, will never satisfy the wait. 

Updated the threshold (`PMON_MIN_UPTIME_MINUTES`) and wait budget (`PMON_READY_TIMEOUT_SECS`, threshold + 120s) to be named constants in `processes_utils.py` so they cannot drift apart again.

Unit tests for `check_pmon_uptime_minutes` are added under `tests/common/unit_tests/platform/`.


Fixes # (issue) 
Fails when pmon container up for a long time: https://github.com/sonic-net/sonic-mgmt/issues/25606 
Fails when pmon container restarts at time of test start: https://github.com/sonic-net/sonic-mgmt/issues/26238

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Backports requested for all active branches to prevent this bug from causing intermittent failures.

### Approach
#### What is the motivation for this PR?

test_xcvr_info_in_db, test_interfaces, and test_check_sfp_eeprom (Mellanox) wait up to 360s for pmon to reach 360s (6 minutes) of uptime — a budget equal to the threshold, with zero margin. If pmon (re)started shortly before the test (e.g. right after a preceding reboot test), the wait times out even though pmon is healthy.

Previously, platform_tests.test_xcvr_info_in_db failed at the setup readiness gate with Failed: Pmon docker is not ready for test. The run log showed all 35 polls during the 360s wait returned Up 2 months for the pmon container — pmon was healthy and stable, not crash-looping or recently restarted. The failure is purely in the test helper's parsing of docker's uptime string. It latently affects every consumer of the helper (test_xcvr_info_in_db, test_interfaces, mellanox/test_check_sfp_eeprom) and surfaces intermittently across the fleet because it depends only on how long since the box was last reimaged.
This was fixed in https://github.com/sonic-net/sonic-mgmt/pull/26534 however this PR further improves it by calculating uptime on the dut rather than using text parsing.


#### How did you do it?

- Compute pmon uptime in whole seconds on the DUT from `State.StartedAt` via `docker inspect`, instead of parsing `docker ps` status text.
- Name the uptime threshold (`PMON_MIN_UPTIME_MINUTES`) and derive the wait budget from it (`PMON_READY_TIMEOUT_SECS = threshold + 120s`); use these in the three affected tests.
- Rename the parameter to `minimal_runtime_minutes` so its units are explicit.
- Add unit tests for `check_pmon_uptime_minutes`.

#### How did you verify/test it?
  Reimaging would reset pmon uptime to seconds and destroy the reproduction condition, so the fix was validated by running the edited helper against the exact Up 2 months string captured in the failing run plus boundary cases:
  
```
  ┌──────────────────────────────────────────────────┬───────┬───────┬───────────┐
  │                  docker STATUS                   │  old  │  new  │ correct?  │
  ├──────────────────────────────────────────────────┼───────┼───────┼───────────┤
  │ Up 2 months (real failing string)                │ False │ True  │ ready     │
  ├──────────────────────────────────────────────────┼───────┼───────┼───────────┤
  │ Up 3 weeks / Up 4 days / Up 1 year               │ False │ True  │ ready     │
  ├──────────────────────────────────────────────────┼───────┼───────┼───────────┤
  │ Up 3 hours / Up 6 minutes                        │ True  │ True  │ ready     │
  ├──────────────────────────────────────────────────┼───────┼───────┼───────────┤
  │ Up 5 minutes / Up About a minute / Up 30 seconds │ False │ False │ not ready │
  ├──────────────────────────────────────────────────┼───────┼───────┼───────────┤
  │ <no pmon>                                        │ False │ False │ not ready │
  └──────────────────────────────────────────────────┴───────┴───────┴───────────┘
```

For the wait-budget fix: reproduced on hardware — fresh pmon restart + old 360s budget fails at 352s uptime; same scenario + new budget passes at 361s; a stable, long-running pmon still passes immediately (no regression). The Mellanox test was updated for correctness/consistency with the other two callers but not exercised on hardware.

#### Any platform specific information?

None

#### Supported testbed topology if it's a new test case?

N/A - bug fix not a new test case

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

N/A - bug fix not a new test case
