### PR TITLE
[snappi] Fix IPv4 config skipped when pfcQueueGroupSize == 8 in generate_background_flows

### DIFF
--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -389,12 +389,12 @@ def generate_background_flows(testbed_config,
             else:
                 eth.pfc_queue.value = pfcQueueValueDict[prio]
 
-                ipv4.src.value = base_flow_config["tx_port_config"].ip
-                ipv4.dst.value = gen_data_flow_dest_ip(base_flow_config["rx_port_config"].ip)
-                ipv4.priority.choice = ipv4.priority.DSCP
-                ipv4.priority.dscp.phb.values = prio_dscp_map[prio]
-                ipv4.priority.dscp.ecn.value = (
-                    ipv4.priority.dscp.ecn.CAPABLE_TRANSPORT_1)
+            ipv4.src.value = base_flow_config["tx_port_config"].ip
+            ipv4.dst.value = gen_data_flow_dest_ip(base_flow_config["rx_port_config"].ip)
+            ipv4.priority.choice = ipv4.priority.DSCP
+            ipv4.priority.dscp.phb.values = prio_dscp_map[prio]
+            ipv4.priority.dscp.ecn.value = (
+                ipv4.priority.dscp.ecn.CAPABLE_TRANSPORT_1)
 
         bg_flow.size.fixed = bg_flow_config["flow_pkt_size"]
         bg_flow.rate.percentage = bg_flow_config["flow_rate_percent"]


### PR DESCRIPTION
### Description of PR

Fix a bug in `generate_background_flows` where IPv4 header configuration was incorrectly placed inside the `pfcQueueGroupSize != 8` else branch. As a result, when `pfcQueueGroupSize == 8`, the background flow packets were generated without IPv4 src/dst addresses and DSCP/ECN priority settings, causing traffic generation failures or incorrect packet classification.

No issue filed. The root cause is an indentation error introduced during a previous refactor.

### Type of change

- [x] Bug fix

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach

#### What is the motivation for this PR?

In `traffic_generation.py`, the `generate_background_flows` function sets `eth.pfc_queue.value` conditionally based on `pfcQueueGroupSize`, but the subsequent IPv4 field assignments (`src`, `dst`, `priority.dscp`, `ecn`) were accidentally indented inside the `else` branch. This means they were only applied when `pfcQueueGroupSize != 8`, skipping IPv4 configuration for the standard 8-queue case.

#### How did you do it?

Moved the IPv4 header configuration block out of the `if/else` block so it executes unconditionally after the `pfc_queue` assignment.

#### How did you verify/test it?

Code inspection. The fix is a pure indentation correction with no logic change.

#### Any platform specific information?

Affects all platforms using `pfcQueueGroupSize == 8` (the default 8-priority PFC queue configuration).

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
