### PR TITLE
[ssh/test_ssh_limit] Retry admin SSH login to survive AAA/PAM re-render race

### DIFF
--- a/tests/ssh/test_ssh_limit.py
+++ b/tests/ssh/test_ssh_limit.py
@@ -5,7 +5,7 @@ import time
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.fixtures.tacacs import tacacs_creds     # noqa F401
 from tests.common.helpers.tacacs.tacacs_helper import setup_local_user
-from tests.common.utilities import paramiko_ssh
+from tests.common.utilities import paramiko_ssh, wait_until
 from tests.common.fixtures.tacacs import get_aaa_sub_options_value
 
 pytestmark = [
@@ -67,10 +67,23 @@ def modify_templates(duthost, tacacs_creds, creds):     # noqa F811
 
     sonic_admin_alt_password = duthost.host.options['variable_manager']._hostvars[duthost.hostname].get(
         "ansible_altpassword")
-    # Duthost shell not support run command with J2 template in command text.
-    admin_session = paramiko_ssh(ip_address=dut_ip, username=creds['sonicadmin_user'],
-                                 passwords=[creds['sonicadmin_password'], sonic_admin_alt_password]
-                                 + creds["ansible_altpasswords"])
+    # Connect over SSH as admin (duthost.shell can't run commands containing J2 templates).
+    # Retry the login for up to 1 minute instead of once, because the AAA config change above is
+    # applied asynchronously and may take a little time to take effect, during which the admin
+    # login can be transiently rejected.
+    admin_session_holder = {}
+
+    def _open_admin_session():
+        admin_session_holder['session'] = paramiko_ssh(
+            ip_address=dut_ip, username=creds['sonicadmin_user'],
+            passwords=[creds['sonicadmin_password'], sonic_admin_alt_password]
+            + creds["ansible_altpasswords"])
+        return True
+
+    pytest_assert(
+        wait_until(60, 5, 0, _open_admin_session),
+        "Failed to establish admin SSH session to {} after AAA change".format(dut_ip))
+    admin_session = admin_session_holder['session']
 
     # Backup and change /usr/share/sonic/templates/pam_limits.j2
     additional_content = "session  required  pam_limits.so"


### PR DESCRIPTION
### Description of PR

Summary:
`tests/ssh/test_ssh_limit.py::setup_limit` can fail intermittently during setup with an `AuthenticationException` when the admin SSH login is transiently rejected right after an AAA login change.

When `setup_limit` detects that `login` is set to `tacacs+`, it runs `config aaa authentication login default` and then, ~6s later, `modify_templates` opens an admin SSH session via `paramiko_ssh`. The AAA change triggers an asynchronous hostcfgd PAM re-render; during that brief window the admin SSH login is transiently rejected. `paramiko_ssh` tries each candidate password only once and immediately raises `AuthenticationException`, failing the whole module's setup.

This was observed in the 720DT nightly (m0/mx, 202511): admin auth succeeded just before the AAA change, then was rejected for ~6-12s immediately after `config aaa authentication login default` ran — exactly when `modify_templates` attempted to connect.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Make `test_ssh_limit` setup robust to the transient admin SSH auth rejection that occurs during the asynchronous PAM re-render triggered by disabling AAA `tacacs+` login. Today a single transient rejection fails the entire module's setup.

#### How did you do it?
Wrapped the admin `paramiko_ssh` connect in `modify_templates` with `wait_until(60, 5, 0, ...)`, which retries the login (every 5s, up to 60s) and rides out the re-render window. `wait_until` swallows the `AuthenticationException` and keeps polling until the login succeeds. No behavior change on the happy path (the first attempt succeeds immediately); if the login genuinely cannot be established within 60s, a clear `pytest_assert` message is raised instead of the opaque `AuthenticationException`.

#### How did you verify/test it?
- Deterministic mechanism test against a live DUT using the repo's real `paramiko_ssh` and `wait_until`: simulated the observed ~8s reject window by monkeypatching `SSHClient.connect`. The old one-shot path raised `AuthenticationException` immediately; the new retry path recovered after ~10s.
- Ran `tests/ssh/test_ssh_limit.py` end-to-end on a 720DT mx testbed with `login=tacacs+` (the exact nightly precondition, so `setup_limit` takes the disable->retry branch): `test_ssh_limits PASSED` (1 passed in ~252s), no regression.

#### Any platform specific information?
None. The change is in the test framework path only.

#### Supported testbed topology if it's a new test case?
N/A (existing test).

### Documentation
N/A

##### Work item tracking
- Microsoft ADO (number only): 38699916
