### PR TITLE
[bgp/test_bgp_vnet]: Corrected the PTF index get call

### DIFF
--- a/tests/bgp/test_bgp_vnet.py
+++ b/tests/bgp/test_bgp_vnet.py
@@ -449,14 +449,14 @@ def _check_vnet2_all_dynamic_peers_established(duthost):
         return False
 
 
-def get_ptf_port_index(interface_name):
+def get_ptf_port_index(interface_name, mg_facts):
     """
-    Convert Ethernet interface name to PTF port index (Ethernet112 → 28).
+    Convert Ethernet interface name to PTF port index using the minigraph port map.
     """
-    return int(interface_name.replace("Ethernet", "")) // 4
+    return mg_facts['minigraph_ptf_indices'][interface_name]
 
 
-def get_expected_unexpected_ptf_ports(cfg_facts, vnet_expected, vnet_unexpected):
+def get_expected_unexpected_ptf_ports(cfg_facts, vnet_expected, vnet_unexpected, mg_facts):
     """
     Return two lists of unique PTF port indices:
     - expected_ptf_ports: ports belonging to vnet_expected
@@ -487,7 +487,7 @@ def get_expected_unexpected_ptf_ports(cfg_facts, vnet_expected, vnet_unexpected)
                 # Malformed key (should be pc|member)
                 continue
             if pc in portchannels:
-                ptf_ports.add(get_ptf_port_index(iface))
+                ptf_ports.add(get_ptf_port_index(iface, mg_facts))
         return sorted(ptf_ports)
 
     expected_ptf_ports = collect_ptf_ports(expected_portchannels)
@@ -558,7 +558,7 @@ def test_dynamic_peer_vnet(duthosts, rand_one_dut_hostname, cfg_facts):
         pytest.fail("Vnet testing setup failed: {}".format(repr(e)))
 
 
-def test_bgp_vnet_route_forwarding(ptfadapter, duthosts, rand_one_dut_hostname, cfg_facts):
+def test_bgp_vnet_route_forwarding(ptfadapter, duthosts, rand_one_dut_hostname, cfg_facts, mg_facts):
     '''
     Verify that the traffic to the peer in Vnet1 is forwarded correctly.
     Send a UDP packet to with the destination as one of the routes learned via bgp in Vnet1
@@ -584,7 +584,7 @@ def test_bgp_vnet_route_forwarding(ptfadapter, duthosts, rand_one_dut_hostname, 
         # Discover the destination IP from the live FIB so the test is not
         # tied to a topology-specific hardcoded address.
         dst_ip = _get_vnet1_bgp_dst_ip(duthost)
-        expected_ports, unexpected_ports = get_expected_unexpected_ptf_ports(cfg_facts, "Vnet1", "Vnet2")
+        expected_ports, unexpected_ports = get_expected_unexpected_ptf_ports(cfg_facts, "Vnet1", "Vnet2", mg_facts)
         assert expected_ports, \
             "No PTF ports found for Vnet1; check PORTCHANNEL_INTERFACE vnet_name in cfg_facts"
         assert unexpected_ports, \

--- a/tests/bgp/test_bgp_vnet.py
+++ b/tests/bgp/test_bgp_vnet.py
@@ -294,7 +294,7 @@ def validate_dynamic_peer_established(bgp_summary, template):
         ), f"BGP peer {dyn_peer1} not in Established state or missing from summary"
         assert (
             dyn_peer2 not in bgp_summary['ipv4Unicast']['peers']
-        ), f"BGP peer {dyn_peer2} should not be in show bgp summary output"
+        ), f"BGP peer {dyn_peer2} should be absent from show bgp summary output"
 
 
 def modify_dynamic_peer_cfg(duthost, template):


### PR DESCRIPTION
… agnostic

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
get_ptf_port_index API was using hardcoded /4 to get the PTF index from interface name. This creates issue if the DUT has interfaces with stride of 8. Corrected the call using mg_facts and made the API platform agnostic

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Verified on Cisco 8223 platform.
[test_bgp_vnet.py::test_bgp_vnet_route_forwarding_2026-06-24-01-03-23.log](https://github.com/user-attachments/files/29280578/test_bgp_vnet.py.test_bgp_vnet_route_forwarding_2026-06-24-01-03-23.log)


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
