### PR TITLE
[transceiver][framework] Add expected_pid_changes fixture for additive per-test PID-change opt-in

### DIFF
--- a/docs/testplan/transceiver/system_test_plan.md
+++ b/docs/testplan/transceiver/system_test_plan.md
@@ -203,7 +203,7 @@ The following tests aim to validate the link status and stability of transceiver
 
 ### Process and Service Restart Test Cases
 
-**Subcategory setup/teardown**: Disruptive — intentionally restarts services or daemons. Note: this subcategory marks the restarted process as expected to change PID (by adding it to the `expected_pid_changes` fixture, typically via an autouse fixture in the subcategory's conftest) so the framework's per-test PID check treats the restart as expected rather than a regression; the parent health check still verifies the process comes back `RUNNING`. Additional teardown: if a service fails to restart or remains down after the test, manually restart it (e.g., `sudo systemctl restart pmon`) before proceeding to the next test case.
+**Subcategory setup/teardown**: Disruptive — intentionally restarts services or daemons. Note: because the per-test PID check evaluates only the monitored processes listed in `DEFAULT_MONITORED_PROCESSES` (`tests/transceiver/common/health_checks.py`, currently only `xcvrd`), this subcategory adds the name of the *monitored* process whose restart is expected (today only `"xcvrd"`) — not the name of the restarted service — to the `expected_pid_changes` fixture, typically via an autouse fixture in the subcategory's conftest. The framework's per-test PID check then treats the PID change as expected rather than a regression; the parent health check still verifies the monitored process comes back `RUNNING`. Additional teardown: if a service fails to restart or remains down after the test, manually restart it (e.g., `sudo systemctl restart pmon`) before proceeding to the next test case.
 
 | TC No. | Test | Steps | Expected Results |
 |------|------|------|------------------|

--- a/docs/testplan/transceiver/system_test_plan.md
+++ b/docs/testplan/transceiver/system_test_plan.md
@@ -203,7 +203,7 @@ The following tests aim to validate the link status and stability of transceiver
 
 ### Process and Service Restart Test Cases
 
-**Subcategory setup/teardown**: Disruptive — intentionally restarts services or daemons. Note: the framework's PID check is overridden in this subcategory's conftest since service restarts are the subject of the test; instead, verify that each restarted service comes back up and is running before the test is considered complete. Additional teardown: if a service fails to restart or remains down after the test, manually restart it (e.g., `sudo systemctl restart pmon`) before proceeding to the next test case.
+**Subcategory setup/teardown**: Disruptive — intentionally restarts services or daemons. Note: this subcategory marks the restarted process as expected to change PID (by adding it to the `expected_pid_changes` fixture, typically via an autouse fixture in the subcategory's conftest) so the framework's per-test PID check treats the restart as expected rather than a regression; the parent health check still verifies the process comes back `RUNNING`. Additional teardown: if a service fails to restart or remains down after the test, manually restart it (e.g., `sudo systemctl restart pmon`) before proceeding to the next test case.
 
 | TC No. | Test | Steps | Expected Results |
 |------|------|------|------------------|

--- a/tests/transceiver/conftest.py
+++ b/tests/transceiver/conftest.py
@@ -326,8 +326,29 @@ def links_verified(duthost, port_attributes_dict):
 # ──────────────────────────────────────────────────────────────────────
 
 
+@pytest.fixture
+def expected_pid_changes():
+    """Per-test set of monitored-process names allowed to change PID.
+
+    Empty by default, so any monitored-process restart is treated as a
+    regression by the post-test health check — the strict behavior every
+    existing test relies on, unchanged.
+
+    A test (or a subcategory conftest) that intentionally restarts a daemon
+    adds the process name to this set so the parent ``_per_test_health_check``
+    treats the PID change as expected instead of a failure. The set is mutable
+    and shared with the parent fixture for the duration of the test, so it can
+    be populated at runtime — e.g. a test whose conftest determines that the
+    restart it triggers will propagate to ``xcvrd`` adds ``"xcvrd"`` only in
+    that conditional branch. This is additive: the parent fixture remains the
+    single owner of the xcvrd/core check; subcategories feed it intent rather
+    than overriding it.
+    """
+    return set()
+
+
 @pytest.fixture(autouse=True)
-def _per_test_health_check(request, duthost):
+def _per_test_health_check(request, duthost, expected_pid_changes):
     """Capture health baseline before each test; verify before and after."""
     baseline = capture_baseline(duthost)
     logger.debug("Health baseline captured for %s", request.node.name)
@@ -341,7 +362,7 @@ def _per_test_health_check(request, duthost):
 
     yield
 
-    result = verify_health(duthost, baseline)
+    result = verify_health(duthost, baseline, expect_pid_change=expected_pid_changes)
     post_checks = [
         ("system_health", result["passed"], "; ".join(result["failures"])),
     ]

--- a/tests/transceiver/conftest.py
+++ b/tests/transceiver/conftest.py
@@ -338,9 +338,9 @@ def expected_pid_changes():
     adds the process name to this set so the parent ``_per_test_health_check``
     treats the PID change as expected instead of a failure. The set is mutable
     and shared with the parent fixture for the duration of the test, so it can
-    be populated at runtime — e.g. a test whose conftest determines that the
-    restart it triggers will propagate to ``xcvrd`` adds ``"xcvrd"`` only in
-    that conditional branch. This is additive: the parent fixture remains the
+    be populated at runtime — e.g. a test that restarts ``pmon`` (which forces
+    an ``xcvrd`` restart) calls ``expected_pid_changes.add("xcvrd")`` before
+    issuing the restart. This is additive: the parent fixture remains the
     single owner of the xcvrd/core check; subcategories feed it intent rather
     than overriding it.
     """


### PR DESCRIPTION
### Description of PR
Summary:
Add an additive `expected_pid_changes` fixture so a test (or a subcategory conftest) can declare that a monitored process is expected to restart, without overriding or replacing the cross-category `_per_test_health_check` autouse fixture in `tests/transceiver/conftest.py`. Required to land the upcoming `tests/transceiver/system/process_restart/` test cases (xcvrd / pmon / swss / syncd restart impact), which intentionally restart `xcvrd` and would otherwise trip the framework's default "PID change ⇒ `pytest.exit`" behavior.

Fixes # (issue)
MSFT ADO - 38556873

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The autouse `_per_test_health_check` fixture (`tests/transceiver/conftest.py`) captures monitored-process PIDs before each test (today `xcvrd` in `pmon`) and asserts they are unchanged afterwards via `verify_health(duthost, baseline)`. Any PID change is treated as an unexpected restart and the default post-test action is `pytest.exit`, which aborts the whole session.

Per the parent's "in addition, never instead" rule (see `docs/testplan/transceiver/test_plan.md`, "Cross-Category Prerequisite Tests and Health Checks"), a category-level autouse fixture must run *additionally* — it cannot suppress the parent. The forthcoming `system/process_restart/` test cases intentionally restart `xcvrd`, so the framework needs an additive way to say "this restart is expected" instead of requiring the subcategory to bypass the parent.

#### How did you do it?
1. **`tests/transceiver/conftest.py`**
   - Added a function-scoped `expected_pid_changes` fixture returning an empty `set()`. Empty by default → strict behavior is unchanged for every existing test.
   - Made the autouse `_per_test_health_check` depend on `expected_pid_changes`, and changed the post-yield call from `verify_health(duthost, baseline)` to `verify_health(duthost, baseline, expect_pid_change=expected_pid_changes)`. The set is mutable and shared with the parent fixture for the duration of the test, so a test (or subcategory conftest) can populate it at runtime:
     ```python
     def test_xcvrd_daemon_restart_impact(duthost, expected_pid_changes, ...):
         expected_pid_changes.add("xcvrd")
         duthost.shell("docker exec pmon supervisorctl restart xcvrd")
         ...
     ```
2. **`docs/testplan/transceiver/system_test_plan.md`**
   - Reworded the "Process and Service Restart Test Cases" subcategory note to describe the additive `expected_pid_changes` mechanism (previous wording said the framework's PID check is "overridden ... instead", which contradicted the parent's "in addition, never instead" rule).
3. No changes to `verify_health` itself — the helper already accepted `expect_pid_change=None`, which had no caller until now.
4. The `system/process_restart/` test cases that consume the new fixture are not part of this PR; they are tracked in a follow-up work item.

#### How did you verify/test it?
Smoke-tested end-to-end on a SONiC switch with a temporary `tests/transceiver/eeprom/test_tmp_expected_pid_changes_smoke.py` that:
- restarted `xcvrd` via `docker exec pmon supervisorctl restart xcvrd` and waited for the new PID,
- ran one variant that called `expected_pid_changes.add("xcvrd")` and one that did not (the latter marked `@pytest.mark.xcvr_post_test_failure_action("warn")` so the post-check would record-and-continue instead of aborting the session).

Result:
- Positive variant (with `.add`): PASSED, no entry in the terminal `Health Check Summary`.
- Negative variant (without `.add`): post-check correctly emitted `[post-test action=warn] ... system_health: Process xcvrd PID changed: <old-pid> -> <new-pid> (unexpected restart)`.

The temporary smoke file has been removed; only the framework + doc changes ship.

#### Any platform specific information?
None. `DEFAULT_MONITORED_PROCESSES` in `tests/transceiver/common/health_checks.py` currently lists only `xcvrd` / `pmon`, which is platform-agnostic. The fixture's empty default preserves prior behavior for any platform-specific tests that do not opt in.

#### Supported testbed topology if it's a new test case?
N/A — framework-only change. No new test cases.

### Documentation
- `docs/testplan/transceiver/system_test_plan.md` (one-line reword in the "Process and Service Restart Test Cases" subcategory note).
