### PR TITLE
[template]: Clarify backport issue requirement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,10 @@ Please provide following information to help code review process a bit easier:
 
 Summary:
 Fixes # (issue)
+<!--
+If you request a backport/cherry-pick below, link the GitHub issue or ADO work
+item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
+-->
 
 ### Type of change
 
@@ -30,6 +34,13 @@ Fixes # (issue)
 
 
 ### Back port request
+<!--
+Only check a release or feature branch when the PR links a GitHub issue or ADO
+work item above. The linked tracker should explain the failure in detail,
+including whether it is a day-one issue or a regression, the affected
+branch/image/platform/test, and why this branch needs the fix. Backport or
+cherry-pick requests without a linked issue/work item may not be favored.
+-->
 - [ ] 202311
 - [ ] 202405
 - [ ] 202411
@@ -37,6 +48,9 @@ Fixes # (issue)
 - [ ] 202511
 - [ ] 202512
 - [ ] 202605
+
+Tracking issue/work item for backport/cherry-pick request:
+Failure type: <!-- day-one issue / regression / other -->
 
 ### Approach
 #### What is the motivation for this PR?


### PR DESCRIPTION
### Description of PR
Summary: Clarify the PR template requirements for backport/cherry-pick requests so authors link a GitHub issue or ADO work item with failure details.
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: N/A
Failure type: N/A

### Approach
#### What is the motivation for this PR?
Backport/cherry-pick requests should include enough context for maintainers to understand whether the request is for a day-one issue or a regression and why the target branch needs the fix.

#### How did you do it?
Added guidance under the PR template's Back port request section requiring a linked GitHub issue or ADO work item with failure details.

#### How did you verify/test it?
Ran `git diff --check`.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A