### PR TITLE
[snappi][reboot] Fix ping result comparison and add ASIC forwarding readiness check

### DIFF
--- a/tests/snappi_tests/files/helper.py
+++ b/tests/snappi_tests/files/helper.py
@@ -4,7 +4,7 @@ import pytest
 import json
 from itertools import cycle
 from tests.common.broadcom_data import is_broadcom_device
-from tests.common.helpers.assertions import pytest_require
+from tests.common.helpers.assertions import pytest_require, pytest_assert
 from tests.common.cisco_data import is_cisco_device
 from tests.common.nokia_data import is_nokia_device
 from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
@@ -446,6 +446,12 @@ def get_npu_voq_queue_counters(duthost, interface, priority, clear=False):
     return dict_output
 
 
+def _dut_can_reach(duthost, ip):
+    """Return True if DUT can ping the given IP (used to verify ASIC forwarding readiness)."""
+    result = duthost.shell("ping -c 1 -W 2 {}".format(ip), module_ignore_errors=True)
+    return result.get('rc', 1) == 0
+
+
 @pytest.fixture(params=['warm', 'cold', 'fast'])
 def reboot_duts_and_disable_wd(tgen_port_info, localhost, request):
     '''
@@ -470,6 +476,21 @@ def reboot_duts_and_disable_wd(tgen_port_info, localhost, request):
     # Convert the list of duthosts into a list of tuples as required for parallel func.
     args = set((snappi_ports[0]['duthost'], snappi_ports[1]['duthost']))
     parallel_run(save_config_and_reboot, {}, {}, list(args), timeout=900)
+
+    # Warm/fast reboot completes the control plane quickly, but the ASIC forwarding
+    # plane may still be initializing (orchagent syncing routes/ARP to ASIC).
+    # Verify that each DUT can actually reach the TGEN test IP before the test starts,
+    # so traffic doesn't begin before end-to-end forwarding is ready.
+    if reboot_type in ('warm', 'fast'):
+        logger.info("Verifying L3 forwarding plane is ready after {} reboot ...".format(reboot_type))
+        for port in snappi_ports:
+            tgen_ip = port['ip']
+            duthost = port['duthost']
+            pytest_assert(
+                wait_until(120, 5, 0, _dut_can_reach, duthost, tgen_ip),
+                "DUT {} cannot reach TGEN {} after {} reboot — "
+                "forwarding plane not ready".format(duthost.hostname, tgen_ip, reboot_type)
+            )
 
     pfcwd_value = {}
 

--- a/tests/snappi_tests/reboot/files/reboot_helper.py
+++ b/tests/snappi_tests/reboot/files/reboot_helper.py
@@ -412,7 +412,7 @@ def wait_for_bgp_and_lb_soft(snappi_api, ping_req, ):
     found_lb_state = False
     while True:
         responses = ping_loopback_if(snappi_api, ping_req)
-        if not found_lb_state and not responses[-1].result == "succeeded":
+        if not found_lb_state and responses[-1].result != "succeeded":
             loopback_down_start_timer = time.time()
             found_lb_state = True
             logger.info('!!!!!!! 1. loopback timer started {} !!!!!!'.format(
@@ -460,13 +460,13 @@ def wait_for_bgp_and_lb(snappi_api, ping_req, ):
             found_bgp_state = True
             logger.info('!!! 1. bgp is down time started {} !!!'.format(
                 bgp_down_start_timer))
-        if not found_lb_state and not responses[-1].result == "succeeded":
+        if not found_lb_state and responses[-1].result != "succeeded":
             loopback_down_start_timer = time.time()
             found_lb_state = True
             logger.info('!!! 1. loopback timer started {} !!!'.format(
                 loopback_down_start_timer))
-        if bgpv4_metrics[-1].session_state in "down" and not \
-                responses[-1].result == "succeeded" and found_bgp_state and \
+        if bgpv4_metrics[-1].session_state in "down" and \
+                responses[-1].result != "succeeded" and found_bgp_state and \
                 found_lb_state:
             logger.info('BGP Control And LoopBack I/F Down')
             break
@@ -490,8 +490,8 @@ def wait_for_bgp_and_lb(snappi_api, ping_req, ):
             logger.info(' ')
             logger.info('2. loopback up end time {} !!!'.format(
                 loopback_up_start_timer))
-        if bgpv4_metrics[-1].session_state in "up" and responses[-1].result == "succeeded" \
-                and found_bgp_state and found_lb_state:
+        if bgpv4_metrics[-1].session_state in "up" and \
+                responses[-1].result == "succeeded" and found_bgp_state and found_lb_state:
             logger.info('BGP Control And LoopBack I/F Up')
             break
 

--- a/tests/snappi_tests/reboot/files/reboot_helper.py
+++ b/tests/snappi_tests/reboot/files/reboot_helper.py
@@ -549,6 +549,10 @@ def get_convergence_for_reboot_test(duthost,
     ping_req = snappi_api.control_action()
     ping_req.protocol.ipv4.ping.requests.add(src_name='IPv4 3', dst_ip="1.1.1.1")
 
+    for i in range(3):
+        responses = ping_loopback_if(snappi_api, ping_req)
+        logger.info("Ping {} response: {}".format(i + 1, responses))
+
     logger.info("Issuing a {} reboot on the dut {}".format(
         reboot_type, duthost.hostname))
     Thread(target=reboot, args=([duthost, localhost, reboot_type])).start()


### PR DESCRIPTION
### Description of PR

Summary:

Fix two issues in snappi reboot convergence tests:

1. **Ping result string comparison** (`reboot_helper.py`): `responses[-1].result`
   returns OTG enum strings `"succeeded"` / `"failed"`. The original code used
   `not x == y` which is ambiguous; replaced with explicit `!= "succeeded"` comparisons.

2. **ASIC forwarding plane readiness** (`helper.py`): after warm/fast reboot,
   the control plane (BGP, critical services) recovers in ~30 s but `orchagent`
   may still be programming routes/ARP/FIB to the ASIC. The test was starting
   traffic before end-to-end forwarding was ready, causing `rx=0` on all flows
   and a misleading assertion failure. Added a ping-based readiness poll
   (every 5 s, up to 120 s) for each DUT after warm/fast reboot.

### Type of change

- [x] Bug fix
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach

#### What is the motivation for this PR?

The reboot convergence tests produced intermittent `rx=0` failures on
warm/fast reboot runs. Root cause: the fixture only waited for control-plane
recovery (BGP up, services healthy) before starting traffic, but the ASIC
forwarding plane was still initializing.

#### How did you do it?

- Added `_dut_can_reach(duthost, ip)` helper that runs a single ping from the
  DUT to the TGEN test IP.
- In `reboot_duts_and_disable_wd()`, after warm/fast reboot completes, call
  `wait_until(120, 5, 0, _dut_can_reach, duthost, tgen_ip)` for each DUT.
  A successful ping confirms ARP is resolved and ASIC FIB is programmed.
- Cold reboot is excluded — it is slow enough that the ASIC is always fully
  ready before the fixture exits.
- Also corrected `not x == y` → `x != y` in three conditions in
  `wait_for_bgp_and_lb` / `wait_for_bgp_and_lb_soft`.

#### How did you verify/test it?

Ran the snappi reboot convergence tests (`test_reboot_convergence`) on a
multi-DUT testbed with warm and fast reboot types. The ASIC readiness check
correctly delayed traffic start until forwarding was confirmed, eliminating
the intermittent `rx=0` failures.

#### Any platform specific information?

No. The fix applies to all platforms that use the `reboot_duts_and_disable_wd`
fixture.

#### Supported testbed topology if it's a new test case?

N/A (existing test case improvement). Topology: multi-DUT with snappi/TGEN.

### Documentation

N/A
