### PR TITLE
Fix CRM route polling for single-route case

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -728,7 +728,7 @@ def test_crm_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
 
     # Make sure CRM counters updated - use polling to wait for route counter to update
     logger.info(f"Waiting for route counters to update after adding {total_routes} routes...")
-    expected_min_used = crm_stats_route_used + total_routes - CRM_COUNTER_TOLERANCE
+    expected_min_used = crm_stats_route_used + max(1, total_routes - CRM_COUNTER_TOLERANCE)
 
     def check_route_added():
         return get_route_used() >= expected_min_used
@@ -771,7 +771,7 @@ def test_crm_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
 
     # Make sure CRM counters updated - use polling to wait for route counter to update
     logger.info(f"Waiting for route counters to update after deleting {total_routes} routes...")
-    expected_max_used = crm_stats_route_used + CRM_COUNTER_TOLERANCE
+    expected_max_used = crm_stats_route_used + min(total_routes - 1, CRM_COUNTER_TOLERANCE)
 
     def check_route_deleted():
         return get_route_used() <= expected_max_used


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
#22132 added polling with counter tolerance, but when total_routes is 1 the tolerance let the wait pass before the CRM counter actually moved. Require at least one route worth of movement on add, and tighten delete polling back to baseline for the single-route case.
Fixes #25661

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
crm/test_crm.py::test_crm_route is flaky on platforms that use total_routes = 1

#### How did you do it?
Consider total_routes = 1 when calculating expected_min_used/expected_max_used.

#### How did you verify/test it?
The test case passed consistently during overnight test 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
