### PR TITLE
[TH6] test_syslog_rate_limit rsyslogd fix

### DIFF
--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -22,10 +22,15 @@ LOCAL_LOG_GENERATOR_FILE = os.path.join(BASE_DIR, 'log_generator.py')
 REMOTE_LOG_GENERATOR_FILE = os.path.join('/tmp', 'log_generator.py')
 DOCKER_LOG_GENERATOR_FILE = '/log_generator.py'
 STP_LOG_FILE = '/var/log/stpd.log'
+# Container: expect the imuxsock per-socket line only. Do not also match
+# rsyslogd[internal_messages] here — on busy DUTs both lines can appear in the same marker
+# window and LogAnalyzer counts every matching line toward expected_matches_target (101),
+# which would fail if the internal_messages summary matched too.
+LOG_EXPECT_SYSLOG_RATE_LIMIT_CONTAINER = (
+    r'.*rate-limit-test>: begin to drop messages due to rate-limiting.*'
+)
 # Log pattern for tests/syslog/log_generator.py
 LOG_EXPECT_LAST_MESSAGE = '.*{}rate-limit-test: This is a test log:.*'
-# rsyslogd emits this when container rate-limit starts dropping messages.
-LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED = '.*begin to drop messages due to rate-limiting.*'
 
 pytestmark = [
     pytest.mark.topology("any")
@@ -176,7 +181,7 @@ def verify_container_rate_limit(rand_selected_dut, ignore_containers=[]):
             expect_log_regex = [LOG_EXPECT_LAST_MESSAGE.format(container_name + '#')]
             expect_log_matches = 0
         else:
-            expect_log_regex = [LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED,
+            expect_log_regex = [LOG_EXPECT_SYSLOG_RATE_LIMIT_CONTAINER,
                                 LOG_EXPECT_LAST_MESSAGE.format(container_name + '#')]
             expect_log_matches = RATE_LIMIT_BURST + 1
 
@@ -211,6 +216,23 @@ def verify_container_rate_limit(rand_selected_dut, ignore_containers=[]):
         break  # we only randomly test 1 container to reduce test time
 
 
+# Host: count only application test lines in LogAnalyzer (burst+1). rsyslogd may also
+# emit one or more internal_messages summaries in the same window; those must not be
+# included in expect_regex or expected_matches_target will exceed burst+1.
+def assert_host_syslog_shows_rate_limit(duthost):
+    """Confirm host rsyslog reported rate limiting (imuxsock and/or internal_messages)."""
+    cmd = (
+        "sudo grep -E 'begin to drop messages due to rate-limiting|messages lost due to rate-limiting' "
+        "/var/log/syslog 2>/dev/null | tail -n 20"
+    )
+    out = duthost.shell(cmd, module_ignore_errors=True)['stdout']
+    pytest_assert(
+        out.strip(),
+        'Expected host syslog rate-limit notice (imuxsock begin-to-drop or internal_messages summary); '
+        'grep returned empty',
+    )
+
+
 def verify_host_rate_limit(rand_selected_dut):
     """Config syslog rate limit for host and verify it works. Basic flow:
         1. Config syslog rate limit
@@ -234,6 +256,8 @@ def verify_host_rate_limit(rand_selected_dut):
     pytest_assert(rate_limit_data[0]['burst'] == str(RATE_LIMIT_BURST),
                   'Expect rate limit burst {}, actual {}'.format(RATE_LIMIT_BURST, rate_limit_data[0]['burst']))
 
+    # Host syslog: burst B allows B application lines through; the (B+1)th is dropped, so only
+    # B lines match LOG_EXPECT_LAST_MESSAGE here.
     verify_rate_limit_with_log_generator(rand_selected_dut,
                                          'host',
                                          'syslog_rate_limit_host_interval_{}_burst_{}'.format(RATE_LIMIT_INTERVAL,
@@ -241,6 +265,7 @@ def verify_host_rate_limit(rand_selected_dut):
                                          [LOG_EXPECT_LAST_MESSAGE.format('')],
                                          RATE_LIMIT_BURST,
                                          is_host=True)
+    assert_host_syslog_shows_rate_limit(rand_selected_dut)
 
     with expect_host_rsyslog_restart(rand_selected_dut):
         rand_selected_dut.command('config syslog rate-limit-host -b {} -i {}'.format(0, 0))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR fixes "_test_syslog_rate_limit_" failure failures on busy platforms (e.g. TH6/H6) when rsyslogd emits  multiple rate-limit lines and LogAnalyzer over-counts matches.

When rate limiting triggers, rsyslogd can log more than one line in the same window:

**Per-socket (imuxsock):** rate-limit-test>: begin to drop messages due to rate-limiting
**Internal summary:** N messages lost due to rate-limiting (M allowed within K seconds)

Both are valid rsyslogd rate-limit messages. The test treated them as a single expected line and counted every matching line toward expected_matches_target, so on busy DUTs the total could exceed the expected count and the test failed even though rate limiting was working.

This PR change separates what LogAnalyzer counts from how we confirm rate limiting happened.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
_test_syslog_rate_limit_ failed because LogAnalyzer expected a fixed number of matches, but rsyslogd could emit both the imuxsock “begin to drop” line and the internal_messages summary in the same marker window. Each match counted toward the target (e.g. 101), so the test failed on loaded systems like TH6/H6.

```python
E               Expected Messages that are missing:
E               .*rate-limit-test>: begin to drop messages due to rate-limiting.*

result     = {'expect_messages': {'/tmp/syslog.2026-05-05-07:18:20': ['2026 May  5 07:18:26.709642 INFO rate-...g.H6-128-WTC.2026-05-05-07:18:20': []}, 'total': {'expected_match': 100, 'expected_missing_match': 1, 'match': 0}, ...}
result_str = 'match: 0\nexpected_match: 100\nexpected_missing_match: 1\n\nExpected Messages:\n2026 May  5 07:18:26.709642 ...est log: 100\n\nExpected Messages that are missing:\n.*rate-limit-test>: begin to drop messages due to rate-limiting.*'
self       = <tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzer object at 0x764c5eca4dd0>

common/plugins/loganalyzer/loganalyzer.py:153: LogAnalyzerError
``` 

#### How did you do it?

- The test was counting too many syslog lines. When rate limiting kicked in, rsyslogd sometimes printed more than one “we’re rate limiting” message, and the test treated each as a separate hit and failed.

- We stopped doing that. LogAnalyzer now only counts the test messages we send on purpose. To confirm rate limiting actually happened, we separately check syslog with grep for a rate-limit notice — without letting those extra rsyslog lines affect the count.

#### How did you verify/test it?

- Ran _test_syslog_rate_limit_  and made sure test is passing without any issues.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
