### PR TITLE
[Chassis] Extend fabric capacity test for isolated links and isolate …

### DIFF
--- a/tests/voq/test_voq_fabric_capacity.py
+++ b/tests/voq/test_voq_fabric_capacity.py
@@ -15,15 +15,15 @@ pytestmark = [
 # on a linecard. It is designed to run on a modular chassis.
 
 
-def test_fabric_capacity(duthosts, enum_frontend_dut_hostname):
+def test_fabric_capacity(duthosts, enum_rand_one_per_hwsku_hostname):
     """Checks if the fabric capacity monitor works"""
 
     # get a start state from system
     # by running "show fabric monitor capcity" command
-    duthost = duthosts[enum_frontend_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     asic = 0
     if duthost.is_multi_asic:
-        asic = random.randint(0, duthost.num_asics())
+        asic = random.choice(duthost.facts['asics_present'])
     asicName = "asic{}".format(asic)
     logger.info(asicName)
 
@@ -35,10 +35,11 @@ def test_fabric_capacity(duthosts, enum_frontend_dut_hostname):
     # # show fabric monitor capacity
     # Monitored fabric capacity threshold:  100%
     #
-    #   ASIC    Operating     Total #    %    Last Event    Last Time
-    #               Links    of Links
-    # ------  -----------  ----------  ---  ------------  -----------
-    #  asic0          112         112  100          None        Never
+    #  ASIC    Operating    Isolated     Total #    % Operating    Last Event     Last Time
+    #              Links       Links    of Links          Links
+    # ------  -----------  ----------  ----------  -------------  ------------  ------------
+    # asic0          111           1         112        36.9792         Lower  19:16:42 ago
+
     cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
     operating_links = 0
     for line in cmd_output:
@@ -48,15 +49,17 @@ def test_fabric_capacity(duthosts, enum_frontend_dut_hostname):
         if token[0].startswith("asic"):
             operating_links = int(token[1])
 
+
     # get list of up/unisolated links by running "show fabric isolation" with Isolated=0
     # example output:
     # # show fabric isolation -n asic0
     #
+
     # asic0
-    #   Local Link    Auto Isolated    Manual Isolated    Isolated
-    # ------------  ---------------  -----------------  ----------
-    #           20                0                  0           0
-    #           21                0                  0           0
+    #   Local Link    Auto Isolated    Manual Isolated    Isolated    Isolate Reason
+    # ------------  ---------------  -----------------  ----------  ----------------
+    #           20                0                  1           1      config
+    #           21                0                  0           0        none
     up_link_list = []
     if duthost.is_multi_asic:
         cmd = "show fabric isolation -n asic{}".format(asic)
@@ -94,9 +97,12 @@ def test_fabric_capacity(duthosts, enum_frontend_dut_hostname):
         # check the output of "show fabric monitor capcity" command
         exp_links = operating_links - 1
         pytest_assert(wait_until(180, 30, 0, check_operational_link,
-                                 duthost, asic, exp_links),
-                      "The number of opertional links should be {}".format(exp_links))
+                                 duthost, asic, exp_links, 1),
+                  "The number of opertional links should be {} and Isolated links should be {}".format(exp_links, 1))
 
+        pytest_assert(wait_until(180, 30, 0, check_isolated_link,
+                                 duthost, asic, shutlink, 'config'),
+                      "The Port Isolate Reason is not 'config'")
         # unisolate the link so the capacity is back
         cmd = "sudo config fabric port unisolate {} {}".format(shutlink, asicName)
         cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
@@ -104,35 +110,76 @@ def test_fabric_capacity(duthosts, enum_frontend_dut_hostname):
         # check the output of "show fabric monitor capcity" command
         exp_links = operating_links
         pytest_assert(wait_until(180, 30, 0, check_operational_link,
-                                 duthost, asic, exp_links),
-                      "The number of opertional links should be {}".format(exp_links))
+                                 duthost, asic, exp_links, 0),
+                  "The number of opertional links should be {} and Isolated links should be {}".format(exp_links, 0))
+
+        pytest_assert(not wait_until(180, 30, 0, check_isolated_link,
+                                 duthost, asic, shutlink, 'config'),
+                      "The Port Isolate Reason is not removed")
     finally:
         # clean up the test
         cmd = "sudo config fabric port unisolate {} {}".format(shutlink, asicName)
         cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
 
 
-def check_operational_link(host, asic, op_links):
-    if host.is_multi_asic:
+def check_operational_link(duthost, asic, op_links, iso_links):
+    if duthost.is_multi_asic:
         cmd = "show fabric monitor capacity -n asic{}".format(asic)
     else:
         cmd = "show fabric monitor capacity"
     # Example output is:
     # # show fabric monitor capacity
     #
-    #   ASIC    Operating     Total #    %    Last Event    Last Time
-    #               Links    of Links
-    # ------  -----------  ----------  ---  ------------  -----------
-    #  asic0          112         112  100          None        Never
-    cmd_output = host.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
+    #  ASIC    Operating    Isolated     Total #    % Operating    Last Event     Last Time
+    #              Links       Links    of Links          Links
+    # ------  -----------  ----------  ----------  -------------  ------------  ------------
+    # asic0          111           1         112        36.9792         Lower  19:16:42 ago
+
+    cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
     operating_links = 0
+    isolated_links = 0
     for line in cmd_output:
         if not line:
             continue
         token = line.split()
         if token[0].startswith("asic"):
             operating_links = int(token[1])
-    if operating_links == op_links:
+            isolated_links = int(token[2])
+    if operating_links == op_links and isolated_links == iso_links:
+        return True
+    else:
+        return False
+
+
+def check_isolated_link(duthost, asic, port, iso_reason):
+    if duthost.is_multi_asic:
+        cmd = "show fabric isolation -n asic{} -nz".format(asic)
+    else:
+        cmd = "show fabric isolation -nz"
+    # Example output is:
+    # # show fabric isolation
+    #
+    # asic0
+    #   Local Link    Auto Isolated    Manual Isolated    Isolated    Isolate Reason
+    # ------------  ---------------  -----------------  ----------  ----------------
+    #           20                0                  1           1      config
+    #           21                0                  0           0        none
+
+    cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
+    isolate_state = "0"
+    isolate_reason = "unknown"
+    for line in cmd_output:
+        if not line:
+            continue
+        token = line.split()
+        if not token[0].isdigit():
+            continue
+        localPort = token[0]
+        if localPort == port:
+            isolate_state = token[3]
+            isolate_reason = token[4]
+            break
+    if isolate_state == "1" and isolate_reason == iso_reason:
         return True
     else:
         return False

--- a/tests/voq/test_voq_fabric_capacity.py
+++ b/tests/voq/test_voq_fabric_capacity.py
@@ -49,7 +49,6 @@ def test_fabric_capacity(duthosts, enum_rand_one_per_hwsku_hostname):
         if token[0].startswith("asic"):
             operating_links = int(token[1])
 
-
     # get list of up/unisolated links by running "show fabric isolation" with Isolated=0
     # example output:
     # # show fabric isolation -n asic0
@@ -98,7 +97,8 @@ def test_fabric_capacity(duthosts, enum_rand_one_per_hwsku_hostname):
         exp_links = operating_links - 1
         pytest_assert(wait_until(180, 30, 0, check_operational_link,
                                  duthost, asic, exp_links, 1),
-                  "The number of opertional links should be {} and Isolated links should be {}".format(exp_links, 1))
+                      "The number of opertional links should be {} and Isolated links should be {}".
+                      format(exp_links, 1))
 
         pytest_assert(wait_until(180, 30, 0, check_isolated_link,
                                  duthost, asic, shutlink, 'config'),
@@ -111,11 +111,12 @@ def test_fabric_capacity(duthosts, enum_rand_one_per_hwsku_hostname):
         exp_links = operating_links
         pytest_assert(wait_until(180, 30, 0, check_operational_link,
                                  duthost, asic, exp_links, 0),
-                  "The number of opertional links should be {} and Isolated links should be {}".format(exp_links, 0))
+                      "The number of opertional links should be {} and Isolated links should be {}".
+                      format(exp_links, 0))
 
-        pytest_assert(not wait_until(180, 30, 0, check_isolated_link,
-                                 duthost, asic, shutlink, 'config'),
-                      "The Port Isolate Reason is not removed")
+        pytest_assert(not wait_until(180, 30, 0, check_isolated_link, duthost, asic,
+                                     shutlink, 'config'), "The Port Isolate Reason is not removed")
+
     finally:
         # clean up the test
         cmd = "sudo config fabric port unisolate {} {}".format(shutlink, asicName)


### PR DESCRIPTION
### Description of PR
Update test_voq_fabric_capacity to match the expanded fabric capacity
CLI (Isolated Links column) and new ISOLATE_REASON field in fabric
isolation output.

This PR depends on sonic-swss and sonic-utilities changes and should be merged after they get merged
sonic-swss PR https://github.com/sonic-net/sonic-swss/pull/4704
sonic-utilities PR : https://github.com/sonic-net/sonic-utilities/pull/4641

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
To update test_voq_fabric_capacity to match the expanded fabric capacity
CLI (Isolated Links column) and new ISOLATE_REASON field in fabric
isolation output.

#### How did you do it?
Validate both operating_links and isolated_links after config isolate
and unisolate, and verify the isolated port reports isolate reason
"config" via "show fabric isolation -nz".

Run on fabric cards using enum_rand_one_per_hwsku_hostname, pick ASICs
from asics_present

#### How did you verify/test it?
Tested on a multi Asics multi LCS chassis platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
