### PR TITLE
[system_health] honor skip_modules PSUs in test_service_checker

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -1390,3 +1390,31 @@ def reboot_dpu_and_wait_for_start_up(duthost, dpuhost_name, dpu_index):
         return False
 
     return True
+
+
+def get_skip_mod_list(duthost, mod_key=None):
+    """
+    Return list of modules/peripherals absent in the chassis per the inventory's skip_modules.
+
+    inventory example:
+    DUTHOST:
+      skip_modules:
+        'psus':
+          - PSU4
+          - PSU5
+
+    Returns an empty list if skip_modules is not defined for the host.
+    """
+    skip_mod_list = []
+    dut_vars = duthost.host.options['variable_manager'].get_vars()['hostvars'][duthost.hostname]
+    if 'skip_modules' in dut_vars:
+        if mod_key is None:
+            for mod_type in list(dut_vars['skip_modules'].keys()):
+                for mod_id in dut_vars['skip_modules'][mod_type]:
+                    skip_mod_list.append(mod_id)
+        else:
+            for mod_type in mod_key:
+                if mod_type in list(dut_vars['skip_modules'].keys()):
+                    for mod_id in dut_vars['skip_modules'][mod_type]:
+                        skip_mod_list.append(mod_id)
+    return skip_mod_list

--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -1229,14 +1229,14 @@ def add_platform_api_server_port_nat_for_dpu(
         npu_host = create_npu_host_based_on_dpu_info(ansible_adhoc, tbinfo, request, duthost)
         npu_host.command(
             f'sudo iptables -t nat -A PREROUTING -i eth0 -p tcp --dport \
-            {SERVER_PORT} -j DNAT --to-destination {dpu_ip}:{SERVER_PORT}')
+            {SERVER_PORT} -j DNAT --to-destination {dpu_ip}:{SERVER_PORT}')  # noqa: E231
 
     yield
 
     if duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_dpu"):
         npu_host.command(
             f'sudo iptables -t nat -D PREROUTING -i eth0 -p tcp --dport \
-                {SERVER_PORT} -j DNAT --to-destination {dpu_ip}:{SERVER_PORT}')
+                {SERVER_PORT} -j DNAT --to-destination {dpu_ip}:{SERVER_PORT}')  # noqa: E231
 
 
 def get_ansible_ssh_port(duthost, ansible_adhoc):  # noqa: F811

--- a/tests/platform_tests/cli/util.py
+++ b/tests/platform_tests/cli/util.py
@@ -4,6 +4,7 @@ util.py
 Utility functions for testing SONiC CLI
 """
 import six
+from tests.common.platform.device_utils import get_skip_mod_list  # noqa: F401
 
 
 def parse_colon_speparated_lines(lines):
@@ -66,43 +67,6 @@ def get_fields(line, field_ranges):
         fields.append(field.strip())
 
     return fields
-
-
-def get_skip_mod_list(duthost, mod_key=None):
-    """
-    @summary: utility function returns list of modules / peripherals absent in chassis
-    by default if no keyword passed it will return all from inventory file
-    provides a list under skip_modules: in inventory file for each dut
-    returns a empty list if skip_modules not defined under host in inventory
-    inventory example:
-    DUTHOST:
-    skip_modules:
-        'line-cards':
-          - LINE-CARD0
-          - LINE-CARD2
-        'fabric-cards':
-          - FABRIC-CARD3
-        'psus':
-          - PSU4
-          - PSU5
-        'thermals':
-          - TEMPERATURE_INFO_2
-    @return a list of modules/peripherals to be skipped in check for platform test
-    """
-
-    skip_mod_list = []
-    dut_vars = duthost.host.options['variable_manager'].get_vars()['hostvars'][duthost.hostname]
-    if 'skip_modules' in dut_vars:
-        if mod_key is None:
-            for mod_type in list(dut_vars['skip_modules'].keys()):
-                for mod_id in dut_vars['skip_modules'][mod_type]:
-                    skip_mod_list.append(mod_id)
-        else:
-            for mod_type in mod_key:
-                if mod_type in list(dut_vars['skip_modules'].keys()):
-                    for mod_id in dut_vars['skip_modules'][mod_type]:
-                        skip_mod_list.append(mod_id)
-    return skip_mod_list
 
 
 def get_skip_logical_module_list(duthost, mod_key=None):

--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -15,7 +15,7 @@ from tests.common.helpers.thermal_control_test_helper import disable_thermal_pol
 from .device_mocker import device_mocker_factory        # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.duthost_utils import is_support_mock_asic, is_support_fan, is_support_psu    # noqa F401
-from tests.platform_tests.cli.util import get_skip_mod_list
+from tests.common.platform.device_utils import get_skip_mod_list
 
 pytestmark = [
     pytest.mark.topology('any'),

--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -15,6 +15,7 @@ from tests.common.helpers.thermal_control_test_helper import disable_thermal_pol
 from .device_mocker import device_mocker_factory        # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.duthost_utils import is_support_mock_asic, is_support_fan, is_support_psu    # noqa F401
+from tests.platform_tests.cli.util import get_skip_mod_list
 
 pytestmark = [
     pytest.mark.topology('any'),
@@ -105,7 +106,18 @@ def test_service_checker(duthosts, enum_rand_one_per_hwsku_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     wait_system_health_boot_up(duthost)
     check_system_health_led_info(duthost)
+    skip_psus = get_skip_mod_list(duthost, ['psus'])
     with ConfigFileContext(duthost, os.path.join(FILES_DIR, IGNORE_DEVICE_CHECK_CONFIG_FILE)):
+        # A bare 'psu' ignore doesn't suppress the per-PSU presence check (only
+        # ignoring both 'psu' and 'pdb' does, see hardware_checker._check_psu_status).
+        # The bypass keys off the PSU name, so add each PSU absent via skip_modules
+        # to devices_to_ignore by name; healthd reloads and the summary recovers to OK.
+        if skip_psus:
+            config_path = DUT_CONFIG_FILE.format(duthost.facts['platform'])
+            config = json.loads(duthost.shell('cat {}'.format(config_path))['stdout'])
+            ignore_list = config.setdefault('devices_to_ignore', [])
+            ignore_list.extend(psu for psu in skip_psus if psu not in ignore_list)
+            duthost.copy(content=json.dumps(config, indent=4), dest=config_path)
         processes_status = duthost.all_critical_process_status()
         expect_error_dict = {}
         for container_name, processes in list(processes_status.items()):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Fixes `test_service_checker` (system_health) reporting "Not OK" / timing out on devices that intentionally run with a PSU removed.

When a device runs with a PSU physically absent, that PSU is listed under `skip_modules` in the inventory. `test_service_checker` applies `ignore_device_check.json` (`devices_to_ignore: [asic, fan, psu]`), but the bare `psu` category does **not** suppress the per-PSU *presence* check — that is only short-circuited when both `psu` and `pdb` are ignored (see `health_checker/hardware_checker.py::_check_psu_status`). So an absent PSU keeps the summary at "Not OK" and the test times out.

The per-PSU bypass keys off the PSU *name*, so this change adds each absent PSU's name (from `skip_modules['psus']`) to `devices_to_ignore` in the applied config. healthd reloads on mtime change and rewrites `SYSTEM_HEALTH_INFO` every poll, so the summary recovers to OK once the absent PSU is name-ignored. No-op on devices with no skipped PSUs.

Summary:
Fixes #25638 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
test_service_checker fails on devices intentionally running with a PSU removed. The ignore config's bare `psu` entry does not bypass the per-PSU presence check, so the absent PSU pins the summary to "Not OK" until the test times out.

#### How did you do it?
After the ignore config is applied, look up PSUs in the inventory `skip_modules` via `get_skip_mod_list(duthost, ['psus'])` and append each absent PSU name to `devices_to_ignore` in the on-DUT config. healthd reloads on the mtime change and recomputes a clean summary.

#### How did you verify/test it?
Ran on a unit with no PSU — `test_service_checker` passes (the PSU presence check no longer pins the summary to "Not OK"):

#### Any platform specific information?
Only affects testbeds that list PSUs under `skip_modules`; a no-op everywhere else (empty skip list → block is skipped).

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
