### PR TITLE
[snappi] SRv6 NUT test case

### DIFF
--- a/tests/snappi_tests/dataplane/files/helper.py
+++ b/tests/snappi_tests/dataplane/files/helper.py
@@ -385,7 +385,8 @@ def create_snappi_config(snappi_api, get_snappi_ports):
     def _create_snappi_config(snappi_extra_params):
         config = create_snappi_l1config(snappi_api, get_snappi_ports, snappi_extra_params)
         pytest_assert(snappi_extra_params.protocol_config, "No protocol configuration provided in snappi_extra_params")
-        snappi_obj_handles = {k: {"ip": [], "ipv4_address": [], "ipv6_address": [], "port_name": [], "network_group": []} for k in snappi_extra_params.protocol_config}
+        snappi_obj_handles = {k: {"ip": [], "ipv4_address": [], "ipv6_address": [],
+                                  "port_name": [], "network_group": []} for k in snappi_extra_params.protocol_config}
         count = 0
         for role, pconfig in snappi_extra_params.protocol_config.items():
             is_ipv4 = True if pconfig['subnet_type'] == 'IPv4' else False

--- a/tests/snappi_tests/dataplane/files/helper.py
+++ b/tests/snappi_tests/dataplane/files/helper.py
@@ -385,10 +385,11 @@ def create_snappi_config(snappi_api, get_snappi_ports):
     def _create_snappi_config(snappi_extra_params):
         config = create_snappi_l1config(snappi_api, get_snappi_ports, snappi_extra_params)
         pytest_assert(snappi_extra_params.protocol_config, "No protocol configuration provided in snappi_extra_params")
-        snappi_obj_handles = {k: {"ip": [], "network_group": []} for k in snappi_extra_params.protocol_config}
+        snappi_obj_handles = {k: {"ip": [], "ipv4_address": [], "ipv6_address": [], "port_name": [], "network_group": []} for k in snappi_extra_params.protocol_config}
         count = 0
         for role, pconfig in snappi_extra_params.protocol_config.items():
             is_ipv4 = True if pconfig['subnet_type'] == 'IPv4' else False
+
             for index, port_data in enumerate(pconfig['ports']):
                 device = config.devices.device(name=f"{role} Topology {index}")[-1]
                 eth = device.ethernets.add(name=f"{role} Ethernet_{index}", mac=port_data["src_mac_address"])
@@ -401,6 +402,12 @@ def create_snappi_config(snappi_api, get_snappi_ports):
                     prefix=int(port_data["prefix"])
                 )
                 snappi_obj_handles[role]["ip"].append(ip_layer.name)
+
+                snappi_obj_handles[role]["port_name"].append(f"Port_{port_data['port_id']}")
+                if is_ipv4:
+                    snappi_obj_handles[role]["ipv4_address"].append(port_data["ipAddress"])
+                else:
+                    snappi_obj_handles[role]["ipv6_address"].append(port_data["ipAddress"])
 
                 if pconfig.get("protocol_type", False) and pconfig['protocol_type'] == "bgp":
                     bgp = device.bgp

--- a/tests/snappi_tests/dataplane/srv6/files/srv6_helper.py
+++ b/tests/snappi_tests/dataplane/srv6/files/srv6_helper.py
@@ -1,0 +1,802 @@
+import collections
+import re
+import logging
+# from rich import print as pr
+
+logger = logging.getLogger(__name__)
+
+
+class Multi_Tier_Map:
+    """
+    Reads conn_graph_facts to get understand how DUTs and TGEN are connected
+    and create a full NUT tree.
+
+    Usage:
+        topo = MultiTierMap(conn_graph_facts)
+
+        # shortest tgen -> tgen
+        topo.shortest_path('snappi-sonic', 'snappi-sonic2')
+        # -> ['snappi-sonic', 'switch-t0-1', 'switch-t0-2', 'snappi-sonic2']        (direct T0<->T0)
+        # -> ['snappi-sonic', 'switch-t0-1', 'switch-t1-1', 'switch-t0-2', 'snappi-sonic2']  (via spine)
+
+        # every path (e.g. both spines)
+        for p in topo.all_paths('snappi-sonic', 'snappi-sonic2'):
+            print("  ->  ".join(p))
+
+        # port-level view of the chosen path
+        for a, pa, pb, b in topo.path_with_ports(topo.shortest_path('snappi-sonic', 'snappi-sonic2')):
+            print(f"{a}:{pa}  -->  {b}:{pb}")
+    """
+    TIER_RANK = {'tgen': 0, 't0': 1, 't1': 2, 't2': 3}
+
+    def __init__(self, conn_graph_facts):
+        self.graph = self._build_graph(conn_graph_facts)
+
+    def _build_graph(self, conn_graph_facts):
+        graph = {}
+        for section in ('device_conn', 'device_linked_ports'):
+            for dut, ports in conn_graph_facts.get(section, {}).items():
+                for local_port, props in ports.items():
+                    peer, peer_port = props['peerdevice'], props['peerport']
+                    graph.setdefault(dut, {}).setdefault(peer, []).append((local_port, peer_port))
+                    graph.setdefault(peer, {}).setdefault(dut, []).append((peer_port, local_port))
+
+        return graph
+
+    @staticmethod
+    def tier_of(name):
+        m = re.search(r'[-_](t[012])', name)
+        if m:
+            return m.group(1)
+
+        if re.search(r'snappi|tgen|ixia', name, re.IGNORECASE):
+            return 'tgen'
+
+        return None
+
+    def _transitable(self, node, src, dst):
+        """tgens are only allowed as the path's own endpoints, never transit."""
+        return self.tier_of(node) != 'tgen' or node in (src, dst)
+
+    def shortest_path(self, src, dst):
+        """
+        Fewest-hop device path from src to dst (both can be tgens or switches).
+        Returns [] if unreachable.  BFS => first path found is shortest.
+        """
+        if src == dst:
+            return [src]
+
+        queue = collections.deque([[src]])
+        seen = {src}
+        while queue:
+            path = queue.popleft()
+            node = path[-1]
+            for neighbor in self.graph.get(node, {}):
+                if neighbor in seen or not self._transitable(neighbor, src, dst):
+                    continue
+
+                if neighbor == dst:
+                    return path + [neighbor]
+
+                seen.add(neighbor)
+                queue.append(path + [neighbor])
+
+        return []
+
+    def all_paths(self, src, dst, max_hops=8):
+        """
+        Every loop-free device path from src to dst, up to max_hops edges.
+        Shorter paths come first (BFS-ordered).
+        """
+        paths = []
+        queue = collections.deque([[src]])
+        while queue:
+            path = queue.popleft()
+            node = path[-1]
+            if node == dst and len(path) > 1:
+                paths.append(path)
+                continue
+
+            if len(path) - 1 >= max_hops:
+                continue
+
+            for neighbor in self.graph.get(node, {}):
+                if neighbor in path or not self._transitable(neighbor, src, dst):
+                    continue
+
+                queue.append(path + [neighbor])
+
+        return paths
+
+    # ---- port-level detail for a resolved path ------------------------------
+    def path_with_ports(self, path):
+        """
+        Annotate a device path with the ports used on each hop:
+            [(dev_a, port_a, port_b, dev_b), ...]
+        Picks the first available link per hop.
+        """
+        hops = []
+        for a, b in zip(path, path[1:]):
+            local_port, peer_port = self.graph[a][b][0]      # first parallel link
+            hops.append((a, local_port, peer_port, b))
+
+        return hops
+
+    # ---- endpoint discovery (no params needed) ------------------------------
+    def tgens(self):
+        """All traffic-generator devices in the graph, sorted by name."""
+        return sorted(d for d in self.graph if self.tier_of(d) == 'tgen')
+
+    def edge_t0s(self):
+        """All t0 (leaf) switches, sorted — the ingress/egress edge of the fabric."""
+        return sorted(d for d in self.graph if self.tier_of(d) == 't0')
+
+    def full_path(self, src=None, dst=None):
+        """
+        Return the full tgen -> ... -> tgen path with NO required parameters.
+
+        Auto-picks endpoints when not given:
+          - src = first tgen (lowest name)
+          - dst = first tgen attached to a DIFFERENT t0 than src
+        Falls back to the longest discoverable path if the simple pick fails.
+        """
+        tgens = self.tgens()
+        if len(tgens) < 2:
+            return tgens[:]                     # 0 or 1 tgen: nothing to traverse
+
+        if src is None:
+            src = tgens[0]
+
+        if dst is None:
+            dst = self._other_edge_tgen(src, tgens)
+
+        path = self.shortest_path(src, dst)
+        if path:
+            return path
+
+        # fallback: the longest path among all tgen pairs (most complete traversal)
+        return self._longest_tgen_path()
+
+    def _other_edge_tgen(self, src, tgens):
+        """First tgen that hangs off a different t0 than `src` (so the path crosses the fabric)."""
+        src_t0 = self._attached_t0(src)
+        for t in tgens:
+            if t != src and self._attached_t0(t) != src_t0:
+                return t
+
+        # no distinct t0: just take the next tgen
+        return tgens[1]
+
+    def _attached_t0(self, tgen):
+        """The t0 switch a tgen is wired to (first one found)."""
+        for neighbor in self.graph.get(tgen, {}):
+            if self.tier_of(neighbor) == 't0':
+                return neighbor
+        return None
+
+    def _longest_tgen_path(self):
+        """Longest shortest-path between any two tgens — the most complete traversal."""
+        tgens = self.tgens()
+        best = []
+        for i, a in enumerate(tgens):
+            for b in tgens[i + 1:]:
+                p = self.shortest_path(a, b)
+                if len(p) > len(best):
+                    best = p
+        return best
+
+
+class Create_Tier:
+    def __init__(self, name, type):
+        '''
+        name: t0|t1|t2
+        type: core|spine|leaf|tgen
+        '''
+        self.name = name
+        self.type = type
+        self.connections = []
+
+    def add_connection(self, other_switch):
+        self.connections.append(other_switch)
+        other_switch.connections.append(self)
+
+
+def display_topology(data, conn_graph_facts, Common_vars):
+    """
+    Core: switch-t2-1
+            Spine: switch-t1-1:
+                Leaf: switch-t0-1
+                    - 10.36.84.36/1.1 (tgen)
+                    - 10.36.84.36/1.3 (tgen)
+                    - 10.36.84.36/1.5 (tgen)
+                    - 10.36.84.36/1.7 (tgen)
+                    - 10.36.84.36/1.2 (tgen)
+                    - 10.36.84.36/1.4 (tgen)
+                    - 10.36.84.36/1.6 (tgen)
+                    - 10.36.84.36/1.8 (tgen)
+
+            Spine: switch-t1-2:
+                Leaf: switch-t0-2
+                    - 10.36.84.37/3.1 (tgen)
+                    - 10.36.84.37/3.3 (tgen)
+                    - 10.36.84.37/3.5 (tgen)
+                    - 10.36.84.37/3.7 (tgen)
+                    - 10.36.84.37/3.2 (tgen)
+                    - 10.36.84.37/3.4 (tgen)
+                    - 10.36.84.37/3.6 (tgen)
+                    - 10.36.84.37/3.8 (tgen)
+    """
+    cores = [c for c in data['cores'] if c is not None]
+    spines = data["spines"]
+
+    # --- Cores (if exist) ---
+    for core in cores:
+        logger.info(f'\nCore: {core.name}')
+        logger.info(f'\t- My-SIDs: {Common_vars.config_data[core.name]["my_sids"]}')
+
+        # Get links to spine
+        logger.info('\t- Links to spines:')
+        for link_to_spine, properties in conn_graph_facts['device_linked_ports'][core.name].items():
+            # 'Ethernet128': {'peerdevice': 'switch-t0-1', 'peerport': 'Ethernet128',
+            # 'speed': '100000', 'fec_disable': False}
+
+            logger.info(f'\t    - {link_to_spine} -> {properties["peerdevice"]} interface:{properties["peerport"]}')
+
+    # --- Spines (if exist) ---
+    if spines:
+        for spine in spines:
+            logger.info('\n')
+            logger.info(f"\tSpine: {spine.name}:")
+            logger.info(f'\t   - My-SIDs: {Common_vars.config_data[spine.name]["my_sids"]}')
+
+            # Get links to Core
+            display_leaves(data, spine.connections)
+    else:
+        # no spines: show every leaf directly
+        display_leaves(data, None)
+
+
+def display_leaves(data, connections, Common_vars):
+    logger.info('\n')
+    for leaf in data["leaves"]:
+        # connections is None  -> no spine Common_vars.tier, show every leaf
+        # connections is a set -> only leaves wired to that spine
+        if connections is None or leaf in connections:
+            logger.info(f"\t    Leaf: {leaf.name}")
+            logger.info(f'\t       - My-SIDs: {Common_vars.config_data[leaf.name]["my_sids"]}')
+
+            display_tgen(data, leaf)
+
+
+def display_tgen(data, leaf):
+    logger.info('\t       - TGEN')
+    for tgen in data["tgen"]:
+        if tgen in leaf.connections:
+            logger.info(f"\t\t     - {tgen.name} ({tgen.type})")
+
+
+def assign_sid_on_tgen_ports(conn_graph_facts, snappi_ports, Common_vars):
+    # Assign TGEN ports to the DUT in config_data
+    # Assign SID to each snappi port
+    for dut_name in conn_graph_facts['device_conn'].keys():
+        look_once_only = False
+
+        if conn_graph_facts['device_conn'][dut_name]:
+            # These are the tgen ports connected to this current t0 DUT
+            for snappi_port in snappi_ports:
+                # 'Ethernet71': {'peerdevice': 'snappi-sonic', 'peerport': 'Port1.8'3256,
+                #                'speed': '100000', 'fec_disable': False},
+                # 'Ethernet128': {'peerdevice': 'switch-t0-2', 'peerport': 'Ethernet128',
+                #                 'speed': '100000', 'fec_disable': False},
+                if snappi_port['peer_device'] == dut_name:
+                    # Assign a SID to snappi ports
+                    # This is for creating static route on the DUT where the tgen snappi host resides using its SID
+                    snappi_port.update({'tgen_endpoint_sid': Common_vars.tgen_endpoint_sid_start})
+                    Common_vars.tgen_endpoint_sid_start += 1
+
+                    if look_once_only is False:
+                        Common_vars.config_data[dut_name].update(
+                            {'router_mac_address': snappi_port['router_mac_address']})
+                        look_once_only = True
+
+                    # All ports will be transmitting bi-directionally. So all ports are Tx and Rx ports.
+                    Common_vars.config_data[dut_name]['tgen_ports'].append(snappi_port)
+
+
+def assign_sid_to_duts(Common_vars):
+    """
+    Mark every dut with a starting SID number (201, 301, 301 ...)
+    For configuring my-sids, locators and static routes
+
+    The total tgen ports on each dut is total SIDs because the test assigns
+    each tgen port a SID. This total is also total SIDs on the DUT and
+    total links connecting to adjacent DUTs and static routes.
+    """
+    for dut in Common_vars.dut_list:
+        if Common_vars.config_data[dut]['tier_level'] == 't0':
+            sid = Common_vars.t0_sid_start
+
+            for x in range(0, len(Common_vars.config_data[dut]['tgen_ports'])):
+                Common_vars.config_data[dut]['my_sids'].append(sid)
+                sid += 1
+
+            Common_vars.t0_sid_start = increment_first_digit(Common_vars.t0_sid_start)
+
+        else:
+            total_sids_per_device = len(Common_vars.config_data[dut]['tgen_ports'])
+            sid = Common_vars.t1_sid_start
+
+            for x in range(0, total_sids_per_device):
+                Common_vars.config_data[dut]['my_sids'].append(sid)
+                sid += 1
+
+            Common_vars.t1_sid_start = increment_first_digit(Common_vars.t1_sid_start)
+
+
+def create_snappi_flows(conn_graph_facts, tx_ports, rx_ports, Common_vars):
+    """
+    Create tx-ports flows
+
+    tx/rx ports
+    {'ip': '10.36.84.36',
+      'port_id': '1',
+      'peer_port': 'Ethernet64', <---
+      'peer_device': 'switch-t0-1', <---
+      'speed': '100000',
+      'location': '10.36.84.36/1.1',
+      'intf_config_changed': False,
+      'api_server_ip': '10.36.84.36',
+      'asic_type': 'broadcom',
+      'duthost': None,
+      'snappi_speed_type': 'speed_100_gbps',
+      'asic_value': None,
+      'autoneg': False,
+      'fec': True,
+      'ipAddress': 'fc0a::2',
+      'ipGateway': 'fc0a::1',
+      'prefix': '126',
+      'router_mac_address': '8c:01:9d:fa:40:cc',
+      'src_mac_address': '10:17:00:00:00:11',
+      'subnet': 'fc0a::1/126'
+    }
+    """
+    for index, port in enumerate(tx_ports):
+        sid_full_path = get_complete_srv6_path(conn_graph_facts, starting_t0_dut=port['peer_device'],
+                                               ending_t0_dut=rx_ports[index]['peer_device'],
+                                               get_dut_sid_index=index, Common_vars=Common_vars)
+        # switch-t0-1
+        dut = port['peer_device']
+
+        sid_full_path = f'{sid_full_path}:{rx_ports[index]["tgen_endpoint_sid"]}'
+        if len(sid_full_path.split(":")) < 8:
+            sid_full_path = f'{sid_full_path}::'
+
+        # This is for understanding the full path for tx-port to rx-port for getting all
+        # DUt port statistic counters.
+        #
+        # Get the tx-port's snappi device -> in this example: peerdevice == "snappi-sonic"
+        # Have to get the rx-port peerdevice too.
+        # conn_graph_facts = {
+        # 'device_conn': {
+        #     'switch-t0-1': {
+        #         'Ethernet64': {'peerdevice': 'snappi-sonic', 'peerport': 'Port1.1',
+        #                        'speed': '100000', 'fec_disable': False}
+        tx_port_snappi_device = conn_graph_facts['device_conn'][port['peer_device']][port['peer_port']]['peerdevice']
+        rx_port_peer_port = rx_ports[index]['peer_port']  # 'peer_port': 'Ethernet80'
+        rx_port_peer_device = rx_ports[index]['peer_device']  # 'peer_device': 'switch-t0-2'
+        rx_port_snappi_device = conn_graph_facts['device_conn'][rx_port_peer_device][rx_port_peer_port]['peerdevice']
+
+        Common_vars.config_data[dut]['tx_ports'].append({
+            'my_snappi_port': port['location'],
+            'my_snappi_device_name': tx_port_snappi_device,
+            'my_dut_port': port['peer_port'],
+            'my_dut_sid_to_use': Common_vars.config_data[dut]['my_sids'][index],
+            'my_src_ip': port['ipAddress'],
+            'my_src_ip_prefix': port['prefix'],
+            'my_src_mac': port['src_mac_address'],
+            'my dest_mac': port['router_mac_address'],
+            'my_ipv6_srv6_dest': sid_full_path,
+            'rx_port': rx_ports[index]['location'],
+            'rx_port_ip_address': rx_ports[index]['ipAddress'],
+            'rx_port_snappi_device_name': rx_port_snappi_device
+            })
+
+
+def get_complete_srv6_path(conn_graph_facts, starting_t0_dut, ending_t0_dut, get_dut_sid_index, Common_vars):
+    """
+    Construct full sid path for tgen port IPv6 dest IP
+    """
+    # t0_duts = []
+    topo = Multi_Tier_Map(conn_graph_facts)
+
+    # snappi-sonic  ->  switch-t0-1  ->  switch-t1-1  ->  switch-t2-1  ->  switch-t1-2
+    # ->  switch-t0-2  ->  snappi-sonic2
+    srv6_sid_path = []
+
+    # fcbb:bbbb:201:
+    srv6_dest_sid_path = []
+
+    logger.info((f'\nget_complete_srv6_path: index:{get_dut_sid_index} '
+                 f'starting_dut:{starting_t0_dut} -> {ending_t0_dut}\n'))
+
+    if starting_t0_dut == ending_t0_dut:
+        # Single DUT
+        sid = Common_vars.config_data[starting_t0_dut]['my_sids'][get_dut_sid_index]
+        srv6_dest_sid_path.append(str(sid))
+        logger.info(f'SRv6 on a single DUT.  SID: {sid}')
+    else:
+        # Multiple DUTs
+        for dut_path_list in topo.all_paths(starting_t0_dut, ending_t0_dut):
+            # dut_path_list: ['switch-t0-1', 'switch-t1-1', 'switch-t2-1', 'switch-t1-2', 'switch-t0-2']
+            for dut in dut_path_list:
+                sid = Common_vars.config_data[dut]['my_sids'][get_dut_sid_index]
+                srv6_sid_path.append(f'{dut}: SID={sid}')
+                srv6_dest_sid_path.append(str(sid))
+
+            # switch-t0-1: SID=204  ->  switch-t1-1: SID=1004  ->  switch-t2-1: SID=3004
+            # ->  switch-t1-2: SID=2004  ->  switch-t0-2: SID=304
+            logger.info("  ->  ".join(srv6_sid_path))
+
+    # Returns a complete srv6 sid path minus the tgen snappi sid
+    # 206:1006:3006:2006:306  <-- This does not include the tgen endpoint SID.
+    #                             Added in create_snappi_flows() when this function returns
+    dut_sid_path = ':'.join(srv6_dest_sid_path)
+    srv6_full_sid_path = f'fcbb:bbbb:{dut_sid_path}'
+
+    logger.info(srv6_full_sid_path)
+    return srv6_full_sid_path
+
+
+def get_dut_list(conn_graph_facts, Common_vars):
+    for dut_name in conn_graph_facts['device_conn'].keys():
+        if conn_graph_facts['device_conn'][dut_name]:
+            Common_vars.dut_list.append(dut_name)
+
+    if conn_graph_facts.get('device_linked_ports', None):
+        for dut_name in conn_graph_facts['device_linked_ports'].keys():
+            if conn_graph_facts['device_linked_ports'][dut_name]:
+                if dut_name not in Common_vars.dut_list:
+                    Common_vars.dut_list.append(dut_name)
+
+
+def set_dut_tier_level(Common_vars):
+    """
+    Mark each dut as t0, t1, t2
+
+    core1 = Create_Tier("core1", "core")
+
+    # Add spine switches
+    spine1 = Create_Tier(name="T1-1", type="spine")
+    spine2 = Create_Tier(name="T1-2", type="spine")
+
+    # Add leaf switches
+    leaf1 = Create_Tier(name="T0-1", type="leaf")
+    leaf2 = Create_Tier(name="T0-2", type="leaf")
+
+    # leaf1.add_connection(spine2)
+    # leaf2.add_connection(spine2)
+
+    # Data representation
+    #     "cores": [core1, core2],
+    network_data = {
+        #"cores": [None],
+        "cores": [core1],
+        "spines": [spine1, spine2],
+        "leaves": [leaf1, leaf2]
+    }
+
+    display_topology(network_data)
+    """
+    # Get all DUTs and its Common_vars.tier type
+    for dut in Common_vars.dut_list:
+        match = re.search('.*-t0|_t0', dut)
+        if match:
+            dut_tier = 't0'
+            Common_vars.tier[dut] = Create_Tier(name=dut, type="Leaf")
+            Common_vars.leaf_list.append(Common_vars.tier[dut])
+
+        match = re.search('.*-t1|_t1', dut)
+        if match:
+            dut_tier = 't1'
+            Common_vars.tier[dut] = Create_Tier(name=dut, type="Spine")
+            Common_vars.spine_list.append(Common_vars.tier[dut])
+
+        match = re.search('.*-t2|_t2', dut)
+        if match:
+            dut_tier = 't2'
+            Common_vars.tier[dut] = Create_Tier(name=dut, type="Core")
+            Common_vars.core_list.append(Common_vars.tier[dut])
+
+        Common_vars.config_data[dut]['tier_level'] = dut_tier
+
+
+def get_t0_duts(conn_graph_facts, Common_vars):
+    """
+    T0 DUTs are from links.csv file
+    """
+    t0_duts = []
+    for dut in conn_graph_facts['device_conn'].keys():
+        if len(conn_graph_facts['device_conn'][dut]) == 0:
+            continue
+
+        if Common_vars.config_data[dut]['tier_level'] == 't0':
+            t0_duts.append(dut)
+
+    return t0_duts
+
+
+def get_pairings(path):
+    """
+    Return consecutive pairs: [a,b,c,d] -> [(a,b), (b,c), (c,d)]
+    [('switch-t0-1', 'switch-t1-1'), ('switch-t1-1', 'switch-t2-1'),
+    ('switch-t2-1', 'switch-t1-2'), ('switch-t1-2', 'switch-t0-2')]
+    """
+    return list(zip(path, path[1:]))
+
+
+def increment_hex(hex_str, by=1, width=2, prefix=False, upper=False):
+    value = int(hex_str, 16) + by
+    fmt = f'0{width}{"X" if upper else "x"}'   # e.g. '02x'
+    out = format(value, fmt)
+    return ('0x' if prefix else '') + out
+
+
+def increment_first_digit(n):
+    s = str(n)
+    return int(str(int(s[0]) + 1) + s[1:])
+
+
+def snappi_port_name_mapper(snappi_obj_handles, Common_vars):
+    """
+    For RAW traffic and be able to select custom src and dst endpoints, have to use port_names
+    as tgen endpoints generated in snappi_obj_handles.
+    This is a helper function to get the port_name from snappi_obj_handle when sending
+    bi-directional traffic or if having mixed traffic patterns.
+    Creating a port mapper to solve the problem.
+
+    # The helper.py function create_snappi_config() now returns only ['ip', 'network_group'] per role, but the
+    # it also need port_name for raw packet endpoint selection, as well as ipv4/ipv6 and mac address alignments
+    # for indexing. Below code could do this from protocol_config (the same ports the config was built from in
+    # create_snappi_config()); the order matches create_snappi_config()'s iteration so they stay index-aligned.
+    # Keeping this code here in case the PR is rejected.
+    for role, pconfig in snappi_extra_params.protocol_config.items():
+        is_ipv4 = pconfig['subnet_type'] == 'IPv4'
+        snappi_obj_handles[role]['port_name'] = [f"Port_{p['port_id']}" for p in pconfig['ports']]
+        snappi_obj_handles[role]['ethernet_mac'] = [p['src_mac_address'] for p in pconfig['ports']]
+        snappi_obj_handles[role]['ipv4_address' if is_ipv4 else 'ipv6_address'] = \
+            [p['ipAddress'] for p in pconfig['ports']]
+        snappi_obj_handles[role]['ipv4_gateway' if is_ipv4 else 'ipv6_gateway'] = \
+            [p['ipGateway'] for p in pconfig['ports']]
+    """
+    for dut in Common_vars.dut_hosts:
+        for port in Common_vars.config_data[dut.hostname]['tgen_ports']:
+            # Look in snappi_obj_handle for the port that matches the ip address to get the port_name
+            for x_type in ['Tx', 'Rx']:
+                addresses = snappi_obj_handles[x_type].get('ipv6_address', [])
+                port_names = snappi_obj_handles[x_type].get('port_name', [])
+                if port['ipAddress'] in addresses:
+                    index = addresses.index(port['ipAddress'])
+                    port_name = port_names[index]
+                    Common_vars.port_name_mapper[port['location']] = port_name
+                    break
+
+
+def _num(v):
+    """
+    For tracing SRv6 DUT path end-to-end for ingress and egress stats
+
+    '8,276,951,808' -> 8276951808 ; non-numeric -> None.
+    """
+    v = v.replace(',', '')
+    return int(v) if v.lstrip('-').isdigit() else None
+
+
+def _dut_counters(all_stats, dut):
+    """
+    For tracing SRv6 DUT path end-to-end for ingress and egress stats
+
+    Parse a portstat text table -> {iface: {'RX_OK': int, 'TX_OK': int}}.
+    """
+    c = all_stats[dut]
+    if isinstance(c, dict):
+        return c
+
+    rows = {}
+    for line in c.splitlines():
+        parts = line.split()
+        # skip blanks, header, and the dashed divider
+        if len(parts) < 10 or parts[0] == 'IFACE' or set(parts[0]) <= {'-'}:
+            continue
+        if not parts[0].startswith('Ethernet'):
+            continue
+        rows[parts[0]] = {'RX_OK': _num(parts[2]), 'TX_OK': _num(parts[9])}
+    return rows
+
+
+def _tgen_facing_port(cfg, dut, index):
+    """
+    For tracing SRv6 DUT path end-to-end for ingress and egress stats
+
+    The t0's tgen-facing Ethernet port at this index (None if out of range).
+    """
+    tgen_ports = cfg[dut].get('tgen_ports', [])
+    if index < len(tgen_ports):
+        return tgen_ports[index]['peer_port']      # DUT-side port facing the tgen
+    return None
+
+
+def get_ingress_egress_stats(full_path_duts, Common_vars):
+    """
+    For tracing SRv6 DUT path end-to-end for ingress and egress stats
+    """
+    cfg = Common_vars.config_data
+
+    parsed = {dut: _dut_counters(Common_vars.dut_stats, dut) for dut in full_path_duts}
+
+    link_counts = [len(cfg[a]['dut_link_port_connections'][b])
+                   for a, b in zip(full_path_duts, full_path_duts[1:])]
+    n = min(link_counts)
+    if len(set(link_counts)) > 1:
+        logger.info(f"WARNING: hop link counts differ {link_counts}; aligning on min={n}")
+
+    last = len(full_path_duts) - 1
+
+    aligned = []
+    for index in range(n):
+        chain = []
+        for pos, dut in enumerate(full_path_duts):
+            prev_dut = full_path_duts[pos - 1] if pos > 0 else None
+            next_dut = full_path_duts[pos + 1] if pos < last else None
+
+            # ingress: from previous DUT, OR the tgen-facing port on the first t0
+            if prev_dut:
+                ingress = cfg[dut]['dut_link_port_connections'][prev_dut][index]
+            else:
+                ingress = _tgen_facing_port(cfg, dut, index)     # entry t0 <- tgen
+
+            # egress: to next DUT, OR the tgen-facing port on the last t0
+            if next_dut:
+                egress = cfg[dut]['dut_link_port_connections'][next_dut][index]
+            else:
+                egress = _tgen_facing_port(cfg, dut, index)      # exit t0 -> tgen
+
+            counters = parsed[dut]
+            chain.append({'dut': dut,
+                          'tier': Multi_Tier_Map.tier_of(dut),
+                          'ingress_port': ingress,
+                          'egress_port': egress,
+                          'ingress_stats': counters.get(ingress, {}) if ingress else {},
+                          'egress_stats': counters.get(egress, {}) if egress else {}
+                          })
+        aligned.append({'index': index, 'chain': chain})
+
+    return aligned
+
+
+def verify_nut_stats(aligned, snappi_stats):
+    """
+    For tracing SRv6 DUT path end-to-end to verify ingress and egress stats
+    are equal or more than the tx-port's transmitted packets
+
+    snappi stats:
+        bytes_rx: '560736539008'
+        bytes_tx: '0'
+        frames_rx: '260068189'
+        frames_rx_rate: 0.0
+        frames_tx: '260068189'
+        frames_tx_rate: 0.0
+        latency: {}
+        loss: 0.0
+        name: 10.36.84.36/1.1:Port_1 -> 10.36.84.37/3.1:Port_9
+        port_rx: Port_9
+        port_tx: Port_1
+        rx_l1_rate_bps: 0.0
+        rx_rate_bps: 0.0
+        rx_rate_bytes: 0.0
+        rx_rate_kbps: 0.0
+        rx_rate_mbps: 0.0
+        transmit: stopped
+        tx_l1_rate_bps: 0.0
+        tx_rate_bps: 0.0
+        tx_rate_bytes: 0.0
+        tx_rate_kbps: 0.0
+        tx_rate_mbps: 0.0
+
+    === link index 0 ===
+    t0  switch-t0-1    in Ethernet64  (RX_OK=260068189)  ->  out Ethernet128 (TX_OK=260068307)
+    t0  switch-t0-2    in Ethernet128 (RX_OK=260068310)  ->  out Ethernet80  (TX_OK=260068193)
+    """
+    result = True  # PASSED
+
+    for row in aligned:
+        logger.info(f"\n=== link index {row['index']} ===")
+        snappi_tx_frames = snappi_stats[row['index']].frames_tx
+
+        for hop in row['chain']:
+            ig, eg = hop['ingress_port'], hop['egress_port']
+            ig_rx = hop['ingress_stats'].get('RX_OK', '-')
+            eg_tx = hop['egress_stats'].get('TX_OK', '-')
+            logger.info(f"  {hop['tier']:3} {hop['dut']:14} "
+                        f"in {str(ig):12}(RX_OK={ig_rx})  ->  out {str(eg):12}(TX_OK={eg_tx})")
+
+            # The DUT counter RX/TX stats must be equal or more than the TX-port transmitted packets.
+            # It is ok for DUT link ports to have a little more packets from periodic protocol packets.
+            if int(ig_rx) < int(snappi_tx_frames) or int(eg_tx) < int(snappi_tx_frames):
+                logger.warning('FAILED: DUT counter stats shows less packets than transmitted packets')
+                result = False
+
+    return result
+
+
+def build_dut_iface_stats(aligned):
+    """
+    For tracing SRv6 DUT path end-to-end for ingress and egress stats
+
+    Collapse the index-aligned chain into per-DUT interface stats:
+
+        {
+          'switch-t0-1': {'Ethernet128': {'rx_ok': 123, 'tx_ok': 456}, ...},
+          'switch-t1-1': {'Ethernet0':   {'rx_ok': ...,  'tx_ok': ...}, ...},
+          ...
+        }
+    """
+    dut_stats = {}
+
+    for row in aligned:
+        for hop in row['chain']:
+            dut = hop['dut']
+            ifaces = dut_stats.setdefault(dut, {})
+
+            # both ingress and egress ports of this hop
+            for port, stats in ((hop['ingress_port'], hop['ingress_stats']),
+                                (hop['egress_port'],  hop['egress_stats'])):
+                if not port:
+                    continue                          # endpoint side has no ingress/egress
+                ifaces[port] = {
+                    'rx_ok': stats.get('RX_OK'),
+                    'tx_ok': stats.get('TX_OK'),
+                }
+
+    return dut_stats
+
+
+def remove_srv6_config(Common_vars):
+    for dut in Common_vars.dut_hosts:
+        count = 1
+        for sid in Common_vars.config_data[dut.hostname]['my_sids']:
+            logger.info(f'Removing SRv6 loc{count} sid fcbb:bbbb:{sid}::/48 and locator on {dut.hostname} ...')
+            dut.shell(f'sudo sonic-db-cli CONFIG_DB DEL "SRV6_MY_LOCATORS|loc{count}"')
+            dut.shell(f'sudo sonic-db-cli CONFIG_DB DEL "SRV6_MY_SIDS|loc{count}|fcbb:bbbb:{sid}::/48"')
+            count += 1
+
+    # Configure static routes on DUTs
+    for dut in Common_vars.dut_hosts:
+        for static_route in Common_vars.config_data[dut.hostname]['static_routes']:
+            logger.info(f'DUT:{dut.hostname} -> sudo {static_route.replace("hset", "del")}')
+
+            # Common_vars.dut_hosts[0].shell(f'sonic-db-cli CONFIG_DB del "STATIC_ROUTE|{route_lookup}"
+            # nexthop {nexthop} ifname {ifname}')
+            dut.shell(f'sudo {static_route.replace("hset", "del")}')
+
+    # Remove configured DUT links in between DUTs
+    for dut in Common_vars.dut_hosts:
+        # 'dut_link_ip_addresses': {
+        #     'switch-t1-1': ['5010::2/64', '5011::2/64', '5012::2/64', '5013::2/64',
+        #                     '5014::2/64', '5015::2/64', '5016::2/64', '5017::2/64'],
+        #     'switch-t1-2': ['5018::2/64', '5019::2/64', '501a::2/64', '501b::2/64',
+        #                     '501c::2/64', '501d::2/64', '501e::2/64', '501f::2/64']
+        # }
+        # 'dut_link_port_connections': {
+        #     'switch-t1-1': ['Ethernet128', 'Ethernet129', 'Ethernet130', 'Ethernet131',
+        #                     'Ethernet132', 'Ethernet133', 'Ethernet134', 'Ethernet135'],
+        #     'switch-t1-2': ['Ethernet100', 'Ethernet101', 'Ethernet102', 'Ethernet103',
+        #                     'Ethernet104', 'Ethernet105', 'Ethernet106', 'Ethernet107']
+        # }
+        for adjacent_dut, dut_ports in Common_vars.config_data[dut.hostname]['dut_link_port_connections'].items():
+            for index, port in enumerate(dut_ports):
+                ip_address = Common_vars.config_data[dut.hostname]['dut_link_ip_addresses'][adjacent_dut][index]
+
+                # {'dut': 'switch-t0-1', 'ip_address': '5010::1/64', 'local_dut_port': 'Ethernet128',
+                #  'port': 'Ethernet128'}
+                logger.info(f'DUT:{dut.hostname}: sudo config int ip remove {port} {ip_address}')
+                dut.shell(f'sudo config int ip remove {port} {ip_address}')

--- a/tests/snappi_tests/dataplane/srv6/files/srv6_helper.py
+++ b/tests/snappi_tests/dataplane/srv6/files/srv6_helper.py
@@ -140,6 +140,10 @@ class Multi_Tier_Map:
           - dst = first tgen attached to a DIFFERENT t0 than src
         Falls back to the longest discoverable path if the simple pick fails.
         """
+        edge_t0s = self.edge_t0s()
+        if len(edge_t0s) == 1:
+            return edge_t0s[:]                  # only one t0: that's the whole path
+
         tgens = self.tgens()
         if len(tgens) < 2:
             return tgens[:]                     # 0 or 1 tgen: nothing to traverse
@@ -625,6 +629,32 @@ def _tgen_facing_port(cfg, dut, index):
     return None
 
 
+def _single_dut_stats(dut, cfg, parsed):
+    """
+    Single-t0 fabric: traffic enters on a tgen-facing tx port and leaves on a
+    different tgen-facing rx port of the SAME dut, so there are no inter-dut
+    hops to walk -- trace the dut's own tx_ports records instead.
+    """
+    counters = parsed[dut]
+    # snappi location ('10.36.84.36/1.1') -> dut-side ethernet port ('Ethernet64')
+    loc_to_port = {p['location']: p['peer_port'] for p in cfg[dut].get('tgen_ports', [])}
+
+    aligned = []
+    for index, flow in enumerate(cfg[dut].get('tx_ports', [])):
+        ingress = flow['my_dut_port']                 # tgen -> t0  (RX_OK)
+        egress = loc_to_port.get(flow['rx_port'])     # t0 -> tgen  (TX_OK)
+        chain = [{'dut': dut,
+                  'tier': Multi_Tier_Map.tier_of(dut),
+                  'ingress_port': ingress,
+                  'egress_port': egress,
+                  'ingress_stats': counters.get(ingress, {}) if ingress else {},
+                  'egress_stats': counters.get(egress, {}) if egress else {}
+                  }]
+        aligned.append({'index': index, 'chain': chain})
+
+    return aligned
+
+
 def get_ingress_egress_stats(full_path_duts, Common_vars):
     """
     For tracing SRv6 DUT path end-to-end for ingress and egress stats
@@ -632,6 +662,10 @@ def get_ingress_egress_stats(full_path_duts, Common_vars):
     cfg = Common_vars.config_data
 
     parsed = {dut: _dut_counters(Common_vars.dut_stats, dut) for dut in full_path_duts}
+
+    # Single-t0 fabric: no inter-dut hops, ingress/egress are both on the one dut.
+    if len(full_path_duts) == 1:
+        return _single_dut_stats(full_path_duts[0], cfg, parsed)
 
     link_counts = [len(cfg[a]['dut_link_port_connections'][b])
                    for a, b in zip(full_path_duts, full_path_duts[1:])]
@@ -709,7 +743,7 @@ def verify_nut_stats(aligned, snappi_stats):
     result = True  # PASSED
 
     for row in aligned:
-        logger.info(f"\n=== link index {row['index']} ===")
+        logger.info(f"\n=== Link port index {row['index']} ===")
         snappi_tx_frames = snappi_stats[row['index']].frames_tx
 
         for hop in row['chain']:

--- a/tests/snappi_tests/dataplane/srv6/files/srv6_telemetry.py
+++ b/tests/snappi_tests/dataplane/srv6/files/srv6_telemetry.py
@@ -1,0 +1,650 @@
+"""
+Self-contained telemetry collection for the SRv6 performance test.
+
+This module is the entire on-DUT telemetry pipeline for the SRv6 test in one
+file. It reuses the existing ``tests.common.telemetry`` *primitives* (metric
+classes, label constants, base ``MetricCollection``) but does **not modify
+any code outside** ``tests/snappi_tests/srv6/``.
+
+================================================================================
+WHY A LOCAL POLLER (instead of reusing test_switch_capacity.py's poll_stats)
+================================================================================
+
+The neighboring ``test_switch_capacity.py`` has a private ``poll_stats``
+function that collects port/queue/PSU/temperature counters. The SRv6 test
+needs the same counters PLUS the new ``show srv6 stat --json`` data. To keep
+this test fully self-contained (per project requirement: only modify files
+under ``srv6/``) we re-implement the loop here and add the SRv6 MY_SID
+collection alongside.
+
+================================================================================
+WHAT GETS COLLECTED
+================================================================================
+
+Every ``interval_sec`` seconds, for each DUT in ``dut_tg_port_map``, we run:
+
+    +-----------------------+--------------------------------------------+
+    | DUT command           | Metrics emitted                            |
+    +-----------------------+--------------------------------------------+
+    | show queue watermark  | queue.watermark.bytes per port/queue       |
+    |   unicast --json      |                                            |
+    | show platform psu     | psu.voltage/current/power/status/led       |
+    |   --json              |                                            |
+    | show platform         | temperature.reading/high_th/low_th/...     |
+    |   temperature --json  |                                            |
+    | portstat -i <ports>   | port.rx/tx.bps/util/ok/err/drop/overrun    |
+    |   -j                  |                                            |
+    | show srv6 stat --json | srv6.my_sid.rx.bytes / srv6.my_sid.rx.     |
+    |   (NEW per testplan)  |   packets, labelled with device.srv6.my_sid|
+    +-----------------------+--------------------------------------------+
+
+Each emit goes through ``db_reporter``, which is the standard sonic-mgmt
+telemetry sink (typically a metrics database / time-series backend).
+
+================================================================================
+INTERNAL ARCHITECTURE
+================================================================================
+
+::
+
+    poll_srv6_perf_stats(...)                  -- outer loop, sleeps interval_sec
+        get_dut_stats(dut_tg_port_map)         -- runs all show commands per DUT
+            _flatten_srv6_mysid(raw)           -- normalize SRv6 JSON shape
+        for each stat_type in configs:
+            record_metrics(...)                -- generic label/field dispatcher
+                metric_obj.<method>.record(value, labels)
+
+The ``configs`` dict is the heart of the dispatcher: each entry says
+"for this command's parsed output, here's how to derive labels and here's
+how to map JSON fields to metric methods on the metric object." Adding a
+new on-box command becomes a matter of adding one more entry.
+"""
+import json
+import logging
+import time
+from typing import Dict, List, Optional
+
+# We import from the existing telemetry framework (read-only) so the SRv6
+# metrics flow through the same DB reporter and use the same label/unit
+# conventions as the rest of sonic-mgmt.
+from tests.common.telemetry import (
+    METRIC_LABEL_DEVICE_ID,
+    METRIC_LABEL_DEVICE_PORT_ID,
+    METRIC_LABEL_DEVICE_PSU_ID,
+    METRIC_LABEL_DEVICE_QUEUE_ID,
+    METRIC_LABEL_DEVICE_SENSOR_ID,
+)
+from tests.common.telemetry.base import MetricCollection, MetricDefinition, Reporter
+from tests.common.telemetry.constants import (
+    METRIC_LABEL_DEVICE_PSU_MODEL,
+    METRIC_LABEL_DEVICE_PSU_SERIAL,
+    METRIC_LABEL_DEVICE_PSU_HW_REV,
+    METRIC_LABEL_DEVICE_QUEUE_CAST,
+    UNIT_BYTES,
+    UNIT_COUNT,
+)
+from tests.common.telemetry.metrics.device import (
+    DevicePortMetrics,
+    DevicePSUMetrics,
+    DeviceQueueMetrics,
+    DeviceTemperatureMetrics,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+# ===========================================================================
+# Local SRv6 MY_SID metric definitions
+#
+# We declare the new label name + metric names locally rather than amending
+# tests/common/telemetry/constants.py. If/when this gets promoted to the
+# shared module, search for these three constants and delete this block.
+# ===========================================================================
+METRIC_LABEL_DEVICE_SRV6_MY_SID = "device.srv6.my_sid"
+METRIC_NAME_SRV6_MY_SID_BYTES = "srv6.my_sid.rx.bytes"
+METRIC_NAME_SRV6_MY_SID_PACKETS = "srv6.my_sid.rx.packets"
+
+
+class DeviceSRv6Metrics(MetricCollection):
+    """Per-SID receive counters reported via ``show srv6 stat``.
+
+    Conforms to the same ``MetricCollection`` pattern as
+    ``DevicePortMetrics`` / ``DevicePSUMetrics``: declare a class-level
+    ``METRICS_DEFINITIONS`` list, and the base class wires up each entry
+    as an attribute (e.g. ``self.rx_bytes`` becomes a GaugeMetric you can
+    call ``.record(value, labels)`` on).
+
+    Labels expected on each record:
+      * ``device.id`` - DUT hostname.
+      * ``device.srv6.my_sid`` - the SID prefix, e.g. ``fcbb:bbbb:1::/48``.
+    """
+
+    METRICS_DEFINITIONS: List[MetricDefinition] = [
+        MetricDefinition(
+            "rx_bytes",
+            METRIC_NAME_SRV6_MY_SID_BYTES,
+            "SRv6 MY_SID RX bytes",
+            UNIT_BYTES,
+        ),
+        MetricDefinition(
+            "rx_packets",
+            METRIC_NAME_SRV6_MY_SID_PACKETS,
+            "SRv6 MY_SID RX packets",
+            UNIT_COUNT,
+        ),
+    ]
+
+    def __init__(self, reporter: Reporter, labels: Optional[Dict[str, str]] = None):
+        super().__init__(reporter, labels)
+
+
+# ===========================================================================
+# PSU field decoders
+# ===========================================================================
+# ``show platform psu --json`` reports ``status`` and ``led_status`` as plain
+# strings (e.g. "OK", "green"), so we map them to the numeric codes the PSU
+# metrics expect. Older/alternate schemas occasionally nest the value as
+# ``{"value": <n>}``; we still honor that form for robustness.
+def _psu_status_value(record):
+    """Decode PSU ``status`` to 0=error, 1=ok."""
+    status = record.get("status", 0)
+    if isinstance(status, dict):
+        return status.get("value", 0)
+    if isinstance(status, str):
+        return 1 if status.strip().upper() == "OK" else 0
+    return status
+
+
+def _psu_led_value(record):
+    """Decode PSU LED color to 0=off, 1=green, 2=amber, 3=red."""
+    led = record.get("led_status", record.get("led", 0))
+    if isinstance(led, dict):
+        return led.get("value", 0)
+    if isinstance(led, str):
+        return {"off": 0, "green": 1, "amber": 2, "red": 3}.get(led.strip().lower(), 0)
+    return led
+
+
+# ===========================================================================
+# Raw stats collection from DUTs
+# ===========================================================================
+def _flatten_srv6_mysid(raw):
+    """Normalize the output of ``show srv6 stat --json``.
+
+    SONiC's CLI sometimes returns this command's JSON as a dict (``{sid:
+    {packets, bytes}}``) and sometimes as a list of records. To keep
+    ``record_metrics`` simple, we flatten both forms into one canonical
+    list:
+
+        ``[{"sid": <prefix>, "packets_count": <int>, "packets_bytes": <int>}, ...]``
+
+    Unknown keys are tolerated (``.get(...) or 0``) so we still emit
+    something useful on future schema variations.
+    """
+    records = []
+    if isinstance(raw, dict):
+        for sid, stats in raw.items():
+            if not isinstance(stats, dict):
+                continue
+            records.append({
+                "sid": sid,
+                "packets_count": stats.get("packets", stats.get("packets_count", 0)),
+                "packets_bytes": stats.get("bytes", stats.get("packets_bytes", 0)),
+            })
+    elif isinstance(raw, list):
+        for r in raw:
+            if not isinstance(r, dict):
+                continue
+            records.append({
+                "sid": r.get("sid") or r.get("my_sid") or "",
+                "packets_count": r.get("packets") or r.get("packets_count") or 0,
+                "packets_bytes": r.get("bytes") or r.get("packets_bytes") or 0,
+            })
+    return records
+
+
+def get_dut_stats(dut_tg_port_map):
+    """Run every telemetry command on every DUT and parse the JSON output.
+
+    Args:
+        dut_tg_port_map: ``{duthost: {peer_port: tg_port_name, ...}}`` -
+                         which DUT-side interfaces this poll should look
+                         at. Used to (a) target ``portstat -i <ports>`` and
+                         (b) filter queue records down to the test's ports.
+
+    Returns:
+        ``{duthostname: {command_name: parsed_output}}``. ``parsed_output``
+        is ``None`` if the command failed; for ``srv6_mysid`` an empty list
+        is returned on empty/failed output so the downstream record_metrics
+        is a no-op rather than an exception.
+    """
+    commands = {
+        "queue":      "show queue watermark unicast --json",
+        "psu":        "show platform psu --json",
+        "temp":       "show platform temperature --json",
+        "portstat":   "portstat -i {} -j",   # {} is replaced per-DUT below
+        "srv6_mysid": "show srv6 stat --json",
+    }
+
+    result = {}
+    for duthost, interfaces in dut_tg_port_map.items():
+        duthostname = duthost.hostname
+        logger.info(f"Collecting stats from {duthostname}")
+        result[duthostname] = {}
+
+        for command_name, command in commands.items():
+            # portstat needs the explicit comma-separated interface list.
+            if command_name == "portstat":
+                command = command.format(",".join(interfaces.keys()))
+            try:
+                # module_ignore_errors=True so a transient stderr (e.g. the
+                # command not yet being available on the DUT image) is not
+                # fatal to the whole poll loop.
+                raw_output = duthost.command(command, module_ignore_errors=True)["stdout"]
+                if not raw_output or not raw_output.strip():
+                    # Empty output: treat as no-records-this-poll. Use [] for
+                    # srv6_mysid (list-shaped) and None for the others.
+                    result[duthostname][command_name] = [] if command_name == "srv6_mysid" else None
+                    continue
+                json_output = json.loads(raw_output)
+
+                # Per-command shape normalization.
+                if command_name == "queue":
+                    # Flatten {Port, UC0, UC1, ...} dicts into
+                    # one record per (Port, queue_id, watermark_byte).
+                    # Filter down to ports we asked about so the metric set
+                    # stays focused on the test's interfaces.
+                    json_output = [
+                        {"Port": d["Port"], "queue_id": key, "watermark_byte": d[key]}
+                        for d in json_output
+                        for key in d.keys()
+                        if d["Port"] in interfaces.keys() and (key.startswith("UC") or key.startswith("MC"))
+                    ]
+                elif command_name == "srv6_mysid":
+                    json_output = _flatten_srv6_mysid(json_output)
+
+                result[duthostname][command_name] = json_output
+            except Exception as e:
+                # Catch-all on purpose: telemetry must never crash the test.
+                logger.error(f"[{duthostname}] Failed to run '{command}': {e}")
+                result[duthostname][command_name] = None
+    return result
+
+
+# ===========================================================================
+# Generic record -> metric writer
+# ===========================================================================
+def record_metrics(metric_obj, records, duthostname, label_template, label_map, field_map):
+    """Emit one set of metrics from a list/dict of telemetry records.
+
+    Args:
+        metric_obj:     a ``MetricCollection`` instance (e.g.
+                        ``DeviceSRv6Metrics``). Each metric definition on
+                        it is an attribute we call ``.record(value, labels)``
+                        on.
+        records:        the parsed JSON output for one command on one DUT.
+                        Dict-shaped records (e.g. portstat: ``{port: stats}``)
+                        and list-shaped records (e.g. PSU list) are both
+                        accepted.
+        duthostname:    hostname string used as the ``device.id`` label.
+        label_template: starting dict of static labels (keys are label
+                        constants, values are filled in below per-record).
+        label_map:      ``{label_const: <source>}`` - the source can be
+                        either a string key (looked up in the record) or
+                        a callable ``(record, key) -> value`` for custom
+                        derivation.
+        field_map:      ``{metric_method: <source>}`` - same source rules
+                        as label_map but the value goes into a metric.
+
+    Returns:
+        None. The metric_obj writes via its reporter as a side effect.
+    """
+    if not records:
+        return
+    # Both shapes iterate uniformly with .items() / enumerate() yielding (k, v).
+    items = records.items() if isinstance(records, dict) else enumerate(records)
+    for key, record in items:
+        # Copy so we don't mutate the caller's template.
+        labels = label_template.copy()
+        labels[METRIC_LABEL_DEVICE_ID] = duthostname
+
+        # Resolve each label - either lookup or computed.
+        for label_key, src in label_map.items():
+            if callable(src):
+                labels[label_key] = src(record, key)
+            else:
+                labels[label_key] = record.get(src, "Unknown") if isinstance(record, dict) else "Unknown"
+
+        # Resolve each metric value and record it with the labels.
+        for method_name, field in field_map.items():
+            if callable(field):
+                value = field(record)
+            else:
+                value = record.get(field, 0) if isinstance(record, dict) else 0
+            getattr(metric_obj, method_name).record(value, labels)
+
+
+# ===========================================================================
+# Main poll loop
+# ===========================================================================
+def poll_srv6_perf_stats(dut_tg_port_map, duration_sec, interval_sec, db_reporter):
+    """Drive the telemetry collection loop for ``duration_sec`` seconds.
+
+    Args:
+        dut_tg_port_map: ``{duthost: {peer_port: tg_port_name}}`` -
+                         the universe of DUTs/ports to poll.
+        duration_sec:    total run time in seconds (matches
+                         ``test_duration`` from the parametrize matrix).
+        interval_sec:    sleep between polls. The loop subtracts the time
+                         spent doing the actual poll so it does not drift.
+        db_reporter:     telemetry sink that backs every metric object.
+
+    Returns:
+        None. Metrics are appended to db_reporter throughout the run; the
+        caller is responsible for ``db_reporter.report()`` to flush them.
+    """
+    # ---- Static label templates per stat type ----
+    # These set the *keys* that should appear on every record of each kind.
+    # ``device.id`` is filled in inside record_metrics; the rest are filled
+    # in per-record by label_map.
+    label_templates = {
+        "portstat":   {METRIC_LABEL_DEVICE_ID: None, METRIC_LABEL_DEVICE_PORT_ID: None},
+        "psu":        {
+            METRIC_LABEL_DEVICE_ID: None,
+            METRIC_LABEL_DEVICE_PSU_ID: None,
+            METRIC_LABEL_DEVICE_PSU_MODEL: None,
+            METRIC_LABEL_DEVICE_PSU_SERIAL: None,
+            METRIC_LABEL_DEVICE_PSU_HW_REV: None,
+        },
+        "queue":      {
+            METRIC_LABEL_DEVICE_ID: None,
+            METRIC_LABEL_DEVICE_PORT_ID: None,
+            METRIC_LABEL_DEVICE_QUEUE_ID: None,
+            METRIC_LABEL_DEVICE_QUEUE_CAST: "unicast",
+        },
+        "temp":       {METRIC_LABEL_DEVICE_ID: None, METRIC_LABEL_DEVICE_SENSOR_ID: None},
+        "srv6_mysid": {METRIC_LABEL_DEVICE_ID: None, METRIC_LABEL_DEVICE_SRV6_MY_SID: None},
+    }
+
+    # ---- Metric objects (instantiated once, reused every poll). ----
+    metrics = {
+        "portstat":   DevicePortMetrics(reporter=db_reporter),
+        "psu":        DevicePSUMetrics(reporter=db_reporter),
+        "queue":      DeviceQueueMetrics(reporter=db_reporter),
+        "temp":       DeviceTemperatureMetrics(reporter=db_reporter),
+        "srv6_mysid": DeviceSRv6Metrics(reporter=db_reporter),
+    }
+
+    # ---- Dispatcher map ----
+    # For each stat type, declare:
+    #   * metric_obj      -- where the values go
+    #   * label_template  -- which label keys we expect on each record
+    #   * label_map       -- how to fill those label values from the record
+    #   * field_map       -- which record field -> which metric method
+    # To add a new on-box command, also add a new entry here.
+    configs = {
+        # Queue watermarks. Records come pre-flattened by get_dut_stats.
+        "queue": dict(
+            metric_obj=metrics["queue"],
+            label_template=label_templates["queue"],
+            label_map={
+                METRIC_LABEL_DEVICE_PORT_ID:    "Port",
+                METRIC_LABEL_DEVICE_QUEUE_ID:   "queue_id",
+                METRIC_LABEL_DEVICE_QUEUE_CAST: lambda r, _: "unicast",
+            },
+            field_map={"watermark_bytes": "watermark_byte"},
+        ),
+        # PSU readings. PSU JSON reports "status"/"led_status" as plain
+        # strings, so we decode them to numeric codes via callables.
+        "psu": dict(
+            metric_obj=metrics["psu"],
+            label_template=label_templates["psu"],
+            label_map={
+                METRIC_LABEL_DEVICE_PSU_ID:     "name",
+                METRIC_LABEL_DEVICE_PSU_MODEL:  "model",
+                METRIC_LABEL_DEVICE_PSU_SERIAL: "serial",
+                METRIC_LABEL_DEVICE_PSU_HW_REV: "revision",
+            },
+            field_map={
+                "voltage": "voltage",
+                "current": "current",
+                "power":   "power",
+                "status":  _psu_status_value,
+                "led":     _psu_led_value,
+            },
+        ),
+        # Per-sensor temperatures + thresholds.
+        "temp": dict(
+            metric_obj=metrics["temp"],
+            label_template=label_templates["temp"],
+            label_map={METRIC_LABEL_DEVICE_SENSOR_ID: "Sensor"},
+            field_map={
+                "reading":      "Temperature",
+                "high_th":      "High_TH",
+                "low_th":       "Low_TH",
+                "crit_high_th": "Crit_High_TH",
+                "crit_low_th":  "Crit_Low_TH",
+                "warning":      "Warning",
+            },
+        ),
+        # portstat: the outer JSON is a dict {port: stats}, so the label
+        # callable receives the dict-key as `k` (the port name) directly.
+        "portstat": dict(
+            metric_obj=metrics["portstat"],
+            label_template=label_templates["portstat"],
+            label_map={METRIC_LABEL_DEVICE_PORT_ID: lambda _, k: k},
+            field_map={
+                "rx_bps":     "RX_BPS",
+                "tx_bps":     "TX_BPS",
+                "rx_util":    "RX_UTIL",
+                "tx_util":    "TX_UTIL",
+                "rx_ok":      "RX_OK",
+                "tx_ok":      "TX_OK",
+                "rx_err":     "RX_ERR",
+                "tx_err":     "TX_ERR",
+                "rx_drop":    "RX_DRP",
+                "tx_drop":    "TX_DRP",
+                "rx_overrun": "RX_OVR",
+                "tx_overrun": "TX_OVR",
+            },
+        ),
+        # SRv6 MY_SID counters (NEW per testplan). Records are the flat
+        # list produced by _flatten_srv6_mysid.
+        "srv6_mysid": dict(
+            metric_obj=metrics["srv6_mysid"],
+            label_template=label_templates["srv6_mysid"],
+            label_map={METRIC_LABEL_DEVICE_SRV6_MY_SID: "sid"},
+            field_map={
+                "rx_bytes":   "packets_bytes",
+                "rx_packets": "packets_count",
+            },
+        ),
+    }
+
+    end_time = time.time() + duration_sec
+    logger.info(f"Started polling every {interval_sec:.2f}s for {duration_sec}s")
+
+    while time.time() < end_time:
+        poll_start = time.time()
+        results = get_dut_stats(dut_tg_port_map)
+
+        # Walk every DUT's results through every dispatcher entry.
+        for duthostname, outputs in results.items():
+            logger.info(f"Stats from {duthostname}: {outputs}")
+            for stat_type, cfg in configs.items():
+                record_metrics(
+                    cfg["metric_obj"],
+                    outputs.get(stat_type),
+                    duthostname,
+                    cfg["label_template"],
+                    cfg["label_map"],
+                    cfg["field_map"],
+                )
+
+        # Sleep the remainder of the interval - this guards against drift
+        # when the poll itself takes a non-trivial amount of time.
+        time.sleep(max(0, interval_sec - (time.time() - poll_start)))
+
+    logger.info(f"Finished polling after {duration_sec}s.")
+
+
+def poll_srv6_perf_stats_backup(dut_tg_port_map, duration_sec, interval_sec, db_reporter):
+    """Drive the telemetry collection loop for ``duration_sec`` seconds.
+
+    Args:
+        dut_tg_port_map: ``{duthost: {peer_port: tg_port_name}}`` -
+                         the universe of DUTs/ports to poll.
+        duration_sec:    total run time in seconds (matches
+                         ``test_duration`` from the parametrize matrix).
+        interval_sec:    sleep between polls. The loop subtracts the time
+                         spent doing the actual poll so it does not drift.
+        db_reporter:     telemetry sink that backs every metric object.
+
+    Returns:
+        None. Metrics are appended to db_reporter throughout the run; the
+        caller is responsible for ``db_reporter.report()`` to flush them.
+    """
+    # ---- Static label templates per stat type ----
+    # These set the *keys* that should appear on every record of each kind.
+    # ``device.id`` is filled in inside record_metrics; the rest are filled
+    # in per-record by label_map.
+    label_templates = {
+        "portstat":   {METRIC_LABEL_DEVICE_ID: None, METRIC_LABEL_DEVICE_PORT_ID: None},
+        "psu":        {
+            METRIC_LABEL_DEVICE_ID: None,
+            METRIC_LABEL_DEVICE_PSU_ID: None,
+            METRIC_LABEL_DEVICE_PSU_MODEL: None,
+            METRIC_LABEL_DEVICE_PSU_SERIAL: None,
+            METRIC_LABEL_DEVICE_PSU_HW_REV: None,
+        },
+        "queue":      {
+            METRIC_LABEL_DEVICE_ID: None,
+            METRIC_LABEL_DEVICE_PORT_ID: None,
+            METRIC_LABEL_DEVICE_QUEUE_ID: None,
+            METRIC_LABEL_DEVICE_QUEUE_CAST: "unicast",
+        },
+        "temp":       {METRIC_LABEL_DEVICE_ID: None, METRIC_LABEL_DEVICE_SENSOR_ID: None},
+        "srv6_mysid": {METRIC_LABEL_DEVICE_ID: None, METRIC_LABEL_DEVICE_SRV6_MY_SID: None},
+    }
+
+    # ---- Metric objects (instantiated once, reused every poll). ----
+    metrics = {
+        "portstat":   DevicePortMetrics(reporter=db_reporter),
+        "psu":        DevicePSUMetrics(reporter=db_reporter),
+        "queue":      DeviceQueueMetrics(reporter=db_reporter),
+        "temp":       DeviceTemperatureMetrics(reporter=db_reporter),
+        "srv6_mysid": DeviceSRv6Metrics(reporter=db_reporter),
+    }
+
+    # ---- Dispatcher map ----
+    # For each stat type, declare:
+    #   * metric_obj      -- where the values go
+    #   * label_template  -- which label keys we expect on each record
+    #   * label_map       -- how to fill those label values from the record
+    #   * field_map       -- which record field -> which metric method
+    # To add a new on-box command, also add a new entry here.
+    configs = {
+        # Queue watermarks. Records come pre-flattened by get_dut_stats.
+        "queue": dict(
+            metric_obj=metrics["queue"],
+            label_template=label_templates["queue"],
+            label_map={
+                METRIC_LABEL_DEVICE_PORT_ID:    "Port",
+                METRIC_LABEL_DEVICE_QUEUE_ID:   "queue_id",
+                METRIC_LABEL_DEVICE_QUEUE_CAST: lambda r, _: "unicast",
+            },
+            field_map={"watermark_bytes": "watermark_byte"},
+        ),
+        # PSU readings. PSU JSON reports "status"/"led_status" as plain
+        # strings, so we decode them to numeric codes via callables.
+        "psu": dict(
+            metric_obj=metrics["psu"],
+            label_template=label_templates["psu"],
+            label_map={
+                METRIC_LABEL_DEVICE_PSU_ID:     "name",
+                METRIC_LABEL_DEVICE_PSU_MODEL:  "model",
+                METRIC_LABEL_DEVICE_PSU_SERIAL: "serial",
+                METRIC_LABEL_DEVICE_PSU_HW_REV: "revision",
+            },
+            field_map={
+                "voltage": "voltage",
+                "current": "current",
+                "power":   "power",
+                "status":  _psu_status_value,
+                "led":     _psu_led_value,
+            },
+        ),
+        # Per-sensor temperatures + thresholds.
+        "temp": dict(
+            metric_obj=metrics["temp"],
+            label_template=label_templates["temp"],
+            label_map={METRIC_LABEL_DEVICE_SENSOR_ID: "Sensor"},
+            field_map={
+                "reading":      "Temperature",
+                "high_th":      "High_TH",
+                "low_th":       "Low_TH",
+                "crit_high_th": "Crit_High_TH",
+                "crit_low_th":  "Crit_Low_TH",
+                "warning":      "Warning",
+            },
+        ),
+        # portstat: the outer JSON is a dict {port: stats}, so the label
+        # callable receives the dict-key as `k` (the port name) directly.
+        "portstat": dict(
+            metric_obj=metrics["portstat"],
+            label_template=label_templates["portstat"],
+            label_map={METRIC_LABEL_DEVICE_PORT_ID: lambda _, k: k},
+            field_map={
+                "rx_bps":     "RX_BPS",
+                "tx_bps":     "TX_BPS",
+                "rx_util":    "RX_UTIL",
+                "tx_util":    "TX_UTIL",
+                "rx_ok":      "RX_OK",
+                "tx_ok":      "TX_OK",
+                "rx_err":     "RX_ERR",
+                "tx_err":     "TX_ERR",
+                "rx_drop":    "RX_DRP",
+                "tx_drop":    "TX_DRP",
+                "rx_overrun": "RX_OVR",
+                "tx_overrun": "TX_OVR",
+            },
+        ),
+        # SRv6 MY_SID counters (NEW per testplan). Records are the flat
+        # list produced by _flatten_srv6_mysid.
+        "srv6_mysid": dict(
+            metric_obj=metrics["srv6_mysid"],
+            label_template=label_templates["srv6_mysid"],
+            label_map={METRIC_LABEL_DEVICE_SRV6_MY_SID: "sid"},
+            field_map={
+                "rx_bytes":   "packets_bytes",
+                "rx_packets": "packets_count",
+            },
+        ),
+    }
+
+    end_time = time.time() + duration_sec
+    logger.info(f"Started polling every {interval_sec:.2f}s for {duration_sec}s")
+
+    while time.time() < end_time:
+        poll_start = time.time()
+        results = get_dut_stats(dut_tg_port_map)
+
+        # Walk every DUT's results through every dispatcher entry.
+        for duthostname, outputs in results.items():
+            logger.info(f"Stats from {duthostname}: {outputs}")
+            for stat_type, cfg in configs.items():
+                record_metrics(
+                    cfg["metric_obj"],
+                    outputs.get(stat_type),
+                    duthostname,
+                    cfg["label_template"],
+                    cfg["label_map"],
+                    cfg["field_map"],
+                )
+
+        # Sleep the remainder of the interval - this guards against drift
+        # when the poll itself takes a non-trivial amount of time.
+        time.sleep(max(0, interval_sec - (time.time() - poll_start)))
+
+    logger.info(f"Finished polling after {duration_sec}s.")

--- a/tests/snappi_tests/dataplane/srv6/test_srv6.py
+++ b/tests/snappi_tests/dataplane/srv6/test_srv6.py
@@ -6,7 +6,6 @@ from itertools import product
 # from rich import print as pr
 import collections
 
-from tests.snappi_tests.dataplane.srv6.files.srv6_telemetry import poll_srv6_perf_stats
 from snappi_tests.dataplane.files.helper import create_traffic_items, start_stop, get_stats
 
 from tests.common.helpers.assertions import pytest_assert
@@ -20,6 +19,7 @@ from tests.snappi_tests.dataplane.files.helper import set_primary_chassis, creat
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp
 
+from tests.snappi_tests.dataplane.srv6.files.srv6_telemetry import poll_srv6_perf_stats
 from tests.snappi_tests.dataplane.srv6.files.srv6_helper import Multi_Tier_Map, assign_sid_on_tgen_ports, \
     assign_sid_to_duts, create_snappi_flows, get_dut_list, set_dut_tier_level, get_t0_duts, get_pairings, \
     increment_hex, snappi_port_name_mapper, get_ingress_egress_stats, verify_nut_stats, remove_srv6_config
@@ -450,7 +450,6 @@ def test_srv6_nut_test(snappi_api,                 # noqa F811
         # Snappi doesn't support custom mix packet sizes yet
         # Using restpy to make the imix packets
         for flow in snappi_api._ixnetwork.Traffic.TrafficItem.find():
-            logger.info(f'flow mixed packets: {flow.Name}')
             flow.ConfigElement.find()[0].FrameSize.PresetDistribution = 'cisco'
             flow.ConfigElement.find()[0].FrameSize.Type = 'weightedPairs'
             flow.ConfigElement.find()[0].FrameSize.WeightedPairs = [128, 1, 256, 98, 4096, 98]
@@ -490,18 +489,24 @@ def test_srv6_nut_test(snappi_api,                 # noqa F811
 
     start_stop(snappi_api, operation="stop", op_type="traffic")
 
-    stats = get_stats(api=snappi_api,
-                      stat_name="Traffic Item Statistics",
-                      columns=["frames_tx", "frames_rx", "loss"],
-                      return_type='stat_obj')
-    logger.info(f"\nTraffic Item Statistics: {stats}\n")
+    snappi_stats = get_stats(api=snappi_api,
+                             stat_name="Traffic Item Statistics",
+                             columns=["frames_tx", "frames_rx", "loss"],
+                             return_type='stat_obj')
+    logger.info(f"\nTraffic Item Statistics: {snappi_stats}\n")
 
     # --------------- Trace SRv6 DUT paths for ingress/egress stats -----------------
     topo = Multi_Tier_Map(conn_graph_facts)
+
     # ['switch-t0-1', 'switch-t1-1', 'switch-t2-1', 'switch-t1-2', 'switch-t0-2']
     full_path_duts = topo.full_path()
-    full_path_duts.pop(0)
-    full_path_duts.pop(-1)
+
+    if len(full_path_duts) > 1:
+        # Remove snappi tgen devices from full_path_duts
+        # 2+ DUTS:  ['snappi-sonic', 'switch-t0-1', 'switch-t0-2', 'snappi-sonic2'] ->  ['switch-t0-1', 'switch-t0-2']
+        # 1 DUT:    ['switch-t0-1']
+        full_path_duts.pop(0)
+        full_path_duts.pop(-1)
 
     for dut in Common_vars.dut_hosts:
         # 'dut_link_port_connections': {'switch-t1-2': ['Ethernet128', 'Ethernet129', 'Ethernet130', 'Ethernet131',
@@ -524,22 +529,30 @@ def test_srv6_nut_test(snappi_api,                 # noqa F811
         Common_vars.dut_stats[dut.hostname] = dut_stats
         logger.info(dut_stats)
 
-    half_of_snappi_stats = len(stats) // 2
-    from_t0_1_stats = stats[:half_of_snappi_stats]
-    from_t0_2_stats = stats[half_of_snappi_stats: 2 * half_of_snappi_stats]
-
-    # Now check DUT stats the other direction from t0-2 to t0-1
-    aligned = get_ingress_egress_stats(full_path_duts, Common_vars)
-    t0_1_stat_result = verify_nut_stats(aligned, from_t0_1_stats)
-    full_path_duts.reverse()
+    half_of_snappi_stats = len(snappi_stats) // 2
+    from_t0_1_stats = snappi_stats[:half_of_snappi_stats]
+    from_t0_2_stats = snappi_stats[half_of_snappi_stats: 2 * half_of_snappi_stats]
 
     aligned = get_ingress_egress_stats(full_path_duts, Common_vars)
-    t0_2_stat_result = verify_nut_stats(aligned, from_t0_2_stats)
+
+    if len(Common_vars.dut_list) > 1:
+        # Two t0s: each carries one direction's flows -> verify each half separately.
+        t0_1_stat_result = verify_nut_stats(aligned, from_t0_1_stats)
+        # Now check DUT stats the other direction from t0-2 to t0-1
+        full_path_duts.reverse()
+        aligned = get_ingress_egress_stats(full_path_duts, Common_vars)
+        t0_2_stat_result = verify_nut_stats(aligned, from_t0_2_stats)
+    else:
+        # Single t0: the one dut carries all bidirectional flows. aligned already has
+        # one row per flow (ingress/egress swap naturally for the reverse-direction
+        # flows), so verify against the full snappi_stats -- no half-split, no reverse.
+        t0_1_stat_result = verify_nut_stats(aligned, snappi_stats)
+        t0_2_stat_result = True
 
     # ------------------------------------------------------------------------------
 
     test_failed = False
-    for index, flow_stat in enumerate(stats):
+    for index, flow_stat in enumerate(snappi_stats):
         flow_name = flow_stat.name
         frames_tx = flow_stat.frames_tx
         frames_rx = flow_stat.frames_rx

--- a/tests/snappi_tests/dataplane/srv6/test_srv6.py
+++ b/tests/snappi_tests/dataplane/srv6/test_srv6.py
@@ -20,7 +20,7 @@ from tests.snappi_tests.dataplane.files.helper import set_primary_chassis, creat
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp
 
-from tests.snappi_tests.srv6.files.srv6_helper import Multi_Tier_Map, assign_sid_on_tgen_ports, \
+from tests.snappi_tests.dataplane.srv6.files.srv6_helper import Multi_Tier_Map, assign_sid_on_tgen_ports, \
     assign_sid_to_duts, create_snappi_flows, get_dut_list, set_dut_tier_level, get_t0_duts, get_pairings, \
     increment_hex, snappi_port_name_mapper, get_ingress_egress_stats, verify_nut_stats, remove_srv6_config
 

--- a/tests/snappi_tests/dataplane/srv6/test_srv6.py
+++ b/tests/snappi_tests/dataplane/srv6/test_srv6.py
@@ -1,0 +1,563 @@
+
+import logging
+import pytest
+import re
+from itertools import product
+from rich import print as pr
+import collections
+
+from tests.snappi_tests.srv6.files.srv6_telemetry import poll_srv6_perf_stats
+from snappi_tests.dataplane.files.helper import create_traffic_items, start_stop, get_stats
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts # noqa F401
+from tests.common.fixtures.conn_graph_facts import fanout_graph_facts, fanout_graph_facts_multidut # noqa F401
+from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port # noqa F401
+from tests.common.snappi_tests.snappi_fixtures import snappi_api, get_snappi_ports, get_snappi_ports_single_dut # noqa F401
+from tests.common.snappi_tests.snappi_fixtures import get_snappi_ports_multi_dut, snappi_testbed_config # noqa F401
+from tests.snappi_tests.dataplane.files.helper import get_duthost_interface_details
+from tests.snappi_tests.dataplane.files.helper import set_primary_chassis, create_snappi_config # noqa F401
+from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.common.snappi_tests.snappi_helpers import wait_for_arp
+
+from tests.snappi_tests.srv6.files.srv6_helper import Multi_Tier_Map, assign_sid_on_tgen_ports, \
+    assign_sid_to_duts, create_snappi_flows, get_dut_list, set_dut_tier_level, get_t0_duts, get_pairings, \
+    increment_hex, snappi_port_name_mapper, get_ingress_egress_stats, verify_nut_stats, remove_srv6_config
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.topology("nut")]
+
+
+class Common_vars:
+    dut_hosts = []
+    sid_list = []
+    dut_tier = {}
+    # This dict contains a blueprint of all DUTS, TGENs and how
+    # they are connected.
+    config_data = {}
+    static_route_subnet_start = '5000'
+    tgen_endpoint_sid_start = 100
+    t0_sid_start = 200
+    t1_sid_start = 1000
+    ixia_src_ipv6_prefix_start = 'fc0a'
+    dut_list = []
+    port_name_mapper = {}
+    tier = {}
+    core_list = []
+    spine_list = []
+    leaf_list = []
+    tgen_list = []
+    # A dict containing all DUT ingress/egress stats to trace SRv6 path
+    dut_stats = {}
+
+
+@pytest.fixture(scope="session")
+def local_script_setup_and_teardown():
+    logger.info("Setup before ALL test cases")
+    yield
+    logger.info("Remove all SRv6 and SRv6 static routes ...")
+    remove_srv6_config(Common_vars)
+
+
+srv6_param_values = {
+    "subnet_type":     ["IPv6"],
+    # "test_duration":    [1 * 60, 5 * 60, 15 * 60, 60 * 60, 24 * 60 * 60, 2 * 24 * 60 * 60],
+    "test_duration":    [10],
+    "packet_size":      [128, 'mix'],
+    "collect_interval": [30],
+    "topology":         ["nut-2tiers"],
+}
+
+srv6_param_names = ",".join(srv6_param_values.keys())
+srv6_param_product = list(product(*srv6_param_values.values()))
+
+
+@pytest.mark.parametrize(srv6_param_names, srv6_param_product)
+def test_srv6_single_dut(snappi_api,                 # noqa F811
+                         conn_graph_facts,           # noqa F811
+                         fanout_graph_facts_multidut, # noqa F811
+                         duthosts,
+                         set_primary_chassis, # noqa F811
+                         rand_one_dut_hostname,
+                         rand_one_dut_portname_oper_up,
+                         get_snappi_ports, # noqa F811
+                         subnet_type, # noqa F811
+                         packet_size, # noqa F811
+                         test_duration, # noqa F811
+                         collect_interval, # noqa F811
+                         create_snappi_config, # noqa F811
+                         topology,
+                         db_reporter,
+                         local_script_setup_and_teardown
+                         ):
+    Common_vars.dut_hosts = duthosts
+    snappi_extra_params = SnappiTestParams()
+
+    snappi_ports = get_duthost_interface_details(duthosts, get_snappi_ports,
+                                                 subnet_type, protocol_type='ip')
+
+    # ['switch-t0-1', 'switch-t0-2', 'switch-t1-1', 'switch-t1-2']
+    get_dut_list(conn_graph_facts, Common_vars)
+
+    for index, dut in enumerate(duthosts):
+        if dut.hostname not in Common_vars.dut_list:
+            duthosts.pop(index)
+
+    # Sort the snappi_port list in numerical natural order
+    snappi_ports.sort(key=lambda p: [int(n) for n in re.findall(r'\d+', p['location'])])
+
+    if len(snappi_ports) % 2 == 1:
+        # If there are odd number of ports, then remove the last port
+        del snappi_ports[-1]
+
+    # Split ports in half
+    half_of_total_ports = len(snappi_ports) // 2
+    tx_ports = snappi_ports[:half_of_total_ports]
+    rx_ports = snappi_ports[half_of_total_ports: 2 * half_of_total_ports]
+
+    snappi_extra_params.protocol_config = {
+        "Tx": {"protocol_type": "ip", "ports": tx_ports, "subnet_type": subnet_type},
+        "Rx": {"protocol_type": "ip", "ports": rx_ports, "subnet_type": subnet_type}
+    }
+
+    # For poll_srv6_perf_stats()
+    dut_tg_port_map = collections.defaultdict(list)
+    for intf in tx_ports + rx_ports:
+        dut_tg_port_map[intf["duthost"]].append((intf["peer_port"], f"Port_{intf['port_id']}"))
+    dut_tg_port_map = {duthost: dict(ports) for duthost, ports in dut_tg_port_map.items()}
+
+    snappi_config, snappi_obj_handles = create_snappi_config(snappi_extra_params)
+    snappi_extra_params.traffic_flow_config = []
+
+    # ====== SRv6 code begins =========
+
+    # Initialize properties
+    for dut_name in Common_vars.dut_list:
+        Common_vars.config_data[dut_name] = {'dut_mac_address': None,
+                                             'tier_level': None,
+                                             'tgen_ports': [],
+                                             'tx_ports': [],
+                                             'dut_link_ip_addresses': {},
+                                             'dut_link_port_connections': {},
+                                             'static_routes': [],
+                                             'my_sids': []}
+
+    assign_sid_on_tgen_ports(conn_graph_facts, snappi_ports, Common_vars)
+    set_dut_tier_level(Common_vars)
+    assign_sid_to_duts(Common_vars)
+    snappi_port_name_mapper(snappi_obj_handles, Common_vars)
+
+    # ['switch-t0-1', 'switch-t0-2']
+    t0_duts = get_t0_duts(conn_graph_facts, Common_vars)
+
+    # For creating static routes. Need to pair up the DUT-to-DUT adjacencies
+    # to create the port link ip addresses and static routes between the two DUTs.
+    dut_connection_parings = []
+    if len(t0_duts) > 1:
+        topo = Multi_Tier_Map(conn_graph_facts)
+        # ['switch-t0-1', 'switch-t1-1', 'switch-t2-1', 'switch-t1-2', 'switch-t0-2']
+        topology_map = topo.all_paths(t0_duts[0], t0_duts[1])
+        # [('switch-t0-1', 'switch-t1-1'), ('switch-t1-1', 'switch-t2-1'), ('switch-t2-1',
+        # 'switch-t1-2'), ('switch-t1-2', 'switch-t0-2')]
+        dut_connection_parings = get_pairings(topology_map[0])
+
+    # Get all dut-to-dut links
+    if conn_graph_facts.get('device_linked_ports', None):
+        for dut, properties in conn_graph_facts['device_linked_ports'].items():
+            # Get all the adjacent DUT links Ethernet port names
+            # 'device_linked_ports': {'switch-t0-1': {}, 'switch-t0-2': {}}
+            #                        {'switch-t0-1': {'Ethernet128': {'peerdevice': 'switch-t0-2',
+            #                                                         'peerport': 'Ethernet128'}}
+            if len(properties) == 0:
+                continue
+
+            # dut, properties:
+            # dut -> switch-t0-1:
+            # properties -> {'Ethernet128': {'peerdevice': 'switch-t1-1', 'peerport': 'Ethernet100',
+            #                                'speed': '100000', 'fec_disable': False},
+            # For each local dut port and attributes on who it's connected to
+            for index, (dut_port, attributes) in enumerate(properties.items()):
+                if len(attributes) == 0:
+                    continue
+
+                # DUT-to_DUT link IP addresses
+                local_dut_link_ip = f'{Common_vars.static_route_subnet_start}::1/64'
+                next_hop_ip = f'{Common_vars.static_route_subnet_start}::2/64'
+
+                # Initialize dut_link_ip_addresses with dut dict() on current DUT and the adjacent DUT
+                if attributes['peerdevice'] not in Common_vars.config_data[dut]['dut_link_ip_addresses']:
+                    Common_vars.config_data[dut]['dut_link_ip_addresses'].update({attributes['peerdevice']: []})
+
+                if dut not in Common_vars.config_data[attributes['peerdevice']]['dut_link_ip_addresses']:
+                    Common_vars.config_data[attributes['peerdevice']]['dut_link_ip_addresses'].update({dut: []})
+
+                # Add link port connections and its IP addresses
+                if attributes['peerdevice'] not in Common_vars.config_data[dut]['dut_link_port_connections']:
+                    Common_vars.config_data[dut]['dut_link_port_connections'].update({attributes['peerdevice']: []})
+
+                if attributes['peerdevice'] in Common_vars.dut_list:
+                    if dut_port not in (
+                        Common_vars.config_data[dut]['dut_link_port_connections'][attributes['peerdevice']]
+                    ):
+                        Common_vars.config_data[dut]['dut_link_port_connections'][attributes['peerdevice']]\
+                            .append(dut_port)
+
+                        # Add IP address
+                        Common_vars.config_data[dut]['dut_link_ip_addresses'][attributes['peerdevice']]\
+                            .append(local_dut_link_ip)
+
+                # REVERSE: Adding link connection on adjacent DUT
+                # {'peerdevice': 'switch-t1-1', 'peerport': 'Ethernet100', 'speed': '100000', 'fec_disable': False}
+                # To the peerdevice as dut
+                if dut not in Common_vars.config_data[attributes['peerdevice']]['dut_link_port_connections']:
+                    Common_vars.config_data[attributes['peerdevice']]['dut_link_port_connections'].update({dut: []})
+
+                if attributes['peerport'] not in (
+                    Common_vars.config_data[attributes['peerdevice']]['dut_link_port_connections'][dut]
+                ):
+                    (
+                        Common_vars.config_data[attributes['peerdevice']]['dut_link_port_connections']
+                        [dut].append(attributes['peerport'])
+                    )
+
+                    # Add IP addresses on link connections between 2 DUTs
+                    Common_vars.config_data[attributes['peerdevice']]['dut_link_ip_addresses'][dut].append(next_hop_ip)
+
+                Common_vars.static_route_subnet_start = increment_hex(str(Common_vars.static_route_subnet_start))
+
+    # Create static routes from t0 DUT to tgen hosts
+    for dut, properties in conn_graph_facts['device_conn'].items():
+        # 'Ethernet128': {'peerdevice': 'switch-t1-1', 'peerport': 'Ethernet100',
+        # 'speed': '100000', 'fec_disable': False},
+        if len(conn_graph_facts['device_conn'][dut]) == 0:
+            continue
+
+        # Create static-routes from t0 to tgen hosts
+        for index, dut_link_port_name in enumerate(Common_vars.config_data[dut]['tgen_ports']):
+            # Create a static route for each tgen snappi host
+            snappi_sid = Common_vars.config_data[dut]['tgen_ports'][index]['tgen_endpoint_sid']
+            snappi_dest_host_ip = Common_vars.config_data[dut]['tgen_ports'][index]['ipAddress']
+            snappi_dest_port = Common_vars.config_data[dut]['tgen_ports'][index]['peer_port']
+
+            static_route = (f'sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:{snappi_sid}::/48" '
+                            f'nexthop {snappi_dest_host_ip} ifname {snappi_dest_port}')
+
+            Common_vars.config_data[dut]['static_routes'].append(static_route)
+            Common_vars.static_route_subnet_start = increment_hex(str(Common_vars.static_route_subnet_start))
+
+    # Execute twice to make bi-directional traffic
+    create_snappi_flows(conn_graph_facts, tx_ports, rx_ports, Common_vars)
+    create_snappi_flows(conn_graph_facts, rx_ports, tx_ports, Common_vars)
+
+    # Static routes for topologies with more than 1 DUT
+    for dut_connection_pair in dut_connection_parings:
+        # dut_connection: ('switch-t0-1', 'switch-t1-1')
+        # [('switch-t0-1', 'switch-t1-1'), ('switch-t1-1', 'switch-t2-1'),
+        #  ('switch-t2-1', 'switch-t1-2'), ('switch-t1-2', 'switch-t0-2')]
+
+        for dut in dut_connection_pair:
+            # Assign IP address to each port
+            # 'dut_link_ip_addresses': {'switch-t0-1': ['5000::2/64', '5000::2/64', '5000::2/64', '5000::2/64',
+            #                                           '5000::2/64', '5000::2/64', '5000::2/64', '5000::2/64']}
+            for adjacent_dut, local_dut_ip_list in Common_vars.config_data[dut]['dut_link_port_connections'].items():
+                for index, each_ip in enumerate(local_dut_ip_list):
+                    adjacent_dut_sid = Common_vars.config_data[adjacent_dut]['my_sids'][index]
+
+                    # 'dut_link_port_connections': {'switch-t0-1': ['Ethernet128', 'Ethernet129', 'Ethernet130',
+                    # 'Ethernet131', 'Ethernet132', 'Ethernet133', 'Ethernet134', 'Ethernet135']}
+                    # next_hop_local_dut_port = (Common_vars.config_data[dut]['dut_link_port_connections']
+                    #                            [adjacent_dut][index])
+                    next_hop_local_dut_port = (
+                        Common_vars.config_data[dut]['dut_link_port_connections'][adjacent_dut][index]
+                    )
+
+                    next_hop_ip = (
+                        Common_vars.config_data[adjacent_dut]['dut_link_ip_addresses'][dut][index].split("/")[0]
+                    )
+
+                    to_route = f'fcbb:bbbb:{adjacent_dut_sid}::/48'
+                    static_route = (f'sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|{to_route}" '
+                                    f'nexthop {next_hop_ip} ifname {next_hop_local_dut_port}')
+
+                    if static_route not in Common_vars.config_data[dut]['static_routes']:
+                        Common_vars.config_data[dut]['static_routes'].append(static_route)
+
+    logger.info('--- MY-SIDS and SID-LOCATORS---')
+    # Configure MY-SIDS on DUTs
+    for dut in duthosts:
+        count = 1
+        for sid in Common_vars.config_data[dut.hostname]['my_sids']:
+            logger.info(f'Configuring {dut.hostname}: sonic-db-cli CONFIG_DB hset '
+                        f'"SRV6_MY_LOCATORS|loc{count}" prefix "fcbb:bbbb:{sid}::" func_len 0')
+
+            dut.shell((f'sonic-db-cli CONFIG_DB hset "SRV6_MY_LOCATORS|loc{count}" '
+                       f'prefix "fcbb:bbbb:{sid}::" func_len 0'))
+
+            logger.info((f'    sonic-db-cli CONFIG_DB hset "SRV6_MY_SIDS|loc{count}|fcbb:bbbb:{sid}::/48" '
+                         f'action uN decap_dscp_mode pipe'))
+
+            dut.shell(f'sonic-db-cli CONFIG_DB hset "SRV6_MY_SIDS|loc{count}|fcbb:bbbb:{sid}::/48" '
+                      f'action uN decap_dscp_mode pipe')
+            count += 1
+
+    logger.info('--- DUT-to-DUT interface IP addresses ---')
+    # Configure DUT links in between DUTs
+    for dut in duthosts:
+        # 'dut_link_ip_addresses': {
+        #     'switch-t1-1': ['5010::2/64', '5011::2/64', '5012::2/64', '5013::2/64',
+        #                     '5014::2/64', '5015::2/64', '5016::2/64', '5017::2/64'],
+        #     'switch-t1-2': ['5018::2/64', '5019::2/64', '501a::2/64', '501b::2/64',
+        #                     '501c::2/64', '501d::2/64', '501e::2/64', '501f::2/64']
+        # }
+        # 'dut_link_port_connections': {
+        #     'switch-t1-1': ['Ethernet128', 'Ethernet129', 'Ethernet130', 'Ethernet131',
+        #                     'Ethernet132', 'Ethernet133', 'Ethernet134', 'Ethernet135'],
+        #     'switch-t1-2': ['Ethernet100', 'Ethernet101', 'Ethernet102', 'Ethernet103',
+        #                     'Ethernet104', 'Ethernet105', 'Ethernet106', 'Ethernet107']
+        # }
+        for adjacent_dut, dut_ports in Common_vars.config_data[dut.hostname]['dut_link_port_connections'].items():
+            for index, port in enumerate(dut_ports):
+                ip_address = Common_vars.config_data[dut.hostname]['dut_link_ip_addresses'][adjacent_dut][index]
+
+                # {'dut': 'switch-t0-1', 'ip_address': '5010::1/64', 'local_dut_port': 'Ethernet128',
+                #  'port': 'Ethernet128'}
+                logger.info(f'DUT:{dut.hostname}: sudo config int ip add {port} {ip_address}')
+                dut.shell(f'sudo config int ip add {port} {ip_address}')
+
+    # At this point, all DUTs are interconnected with links and IP addresses.
+    # On each DUT, ping the adjacent link IP for the DUTs to learn ARPs.
+    for dut in duthosts:
+        for adjacent_dut, dut_ports in Common_vars.config_data[dut.hostname]['dut_link_port_connections'].items():
+            for index, link in enumerate(dut_ports):
+                adjacent_dut_link_ip = (
+                    Common_vars.config_data[adjacent_dut]['dut_link_ip_addresses'][dut.hostname][index].split('/')[0]
+                )
+
+                logger.info((f'Ping adjacent DUT to learn ARP: {dut.hostname} -> {adjacent_dut}  '
+                             f'pinging {adjacent_dut_link_ip}'))
+
+                dut.shell(f'ping {adjacent_dut_link_ip} -c 2')
+
+    logger.info('--- STATIC ROUTES FOR TGEN PORTS ---')
+    # Configure static routes on DUTs
+    # All static routes cli commands are created in a list already
+    # 'sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:1000::/48" nexthop 5010::1 ifname Ethernet128'
+    for dut in duthosts:
+        for static_route in Common_vars.config_data[dut.hostname]['static_routes']:
+            logger.info(f'DUT:{dut.hostname} -> {static_route}')
+            dut.shell(f'{static_route}')
+
+    if packet_size == 'mix':
+        # Temporarily use 64 for all flows until we implement the logic to support mixed
+        # packet sizes in a single test run.
+        # Use restpy to configure IMIX
+        pket_size = 64
+    else:
+        pket_size = packet_size
+
+    """
+        Common_vars.config_data[dut.hostname]['tx_ports']
+            {
+                'my_snappi_port': '10.36.84.36/1.1',
+                'my_dut_port': 'Ethernet64',
+                'my_dut_sid_to_use': 200,
+                'my_src_ip': 'fc0a::2',
+                'my_src_ip_prefix': '126',
+                'my_src_mac': '10:17:00:00:00:11',
+                'my dest_mac': '8c:01:9d:fa:40:cc',
+                'my_ipv6_srv6_dest': 'fcbb:bbbb:200:1000:3000:2000:300:108',
+                'rx_port': '10.36.84.37/3.1',
+                'rx_port_ip_address': 'fc2a::2'
+            }
+
+        'tgen_ports': [
+            {
+                'ip': '10.36.84.37',
+                'port_id': '9',
+                'peer_port': 'Ethernet80',
+                'peer_device': 'switch-t0-2',
+                'speed': '100000',
+                'location': '10.36.84.37/3.1',
+                'intf_config_changed': False,
+                'api_server_ip': '10.36.84.36',
+                'asic_type': 'broadcom',
+                'duthost': 'switch-t0-2',
+                'snappi_speed_type': 'speed_100_gbps',
+                'asic_value': None,
+                'autoneg': False,
+                'fec': False,
+                'ipAddress': 'fc2a::2',
+                'ipGateway': 'fc2a::1',
+                'prefix': '126',
+                'router_mac_address': '8c:01:9d:fa:4b:10',
+                'src_mac_address': '10:17:00:00:00:19',
+                'subnet': 'fc2a::1/126',
+                'tgen_endpoint_sid': 108
+            }
+    """
+
+    snappi_config = create_traffic_items(snappi_config, snappi_extra_params)
+
+    index = 0
+    for dut in duthosts:
+        for flow in Common_vars.config_data[dut.hostname]['tx_ports']:
+            tx_snappi_port_name_for_raw_pkts = Common_vars.port_name_mapper[flow['my_snappi_port']]
+            rx_snappi_port_name_for_raw_pkts = Common_vars.port_name_mapper[flow['rx_port']]
+
+            flow_name = (f"{flow['my_snappi_port']}:{tx_snappi_port_name_for_raw_pkts} -> "
+                         f"{flow['rx_port']}:{rx_snappi_port_name_for_raw_pkts}")
+            test_flow = snappi_config.flows.add(name=flow_name)
+
+            test_flow.tx_rx.port.tx_name = tx_snappi_port_name_for_raw_pkts
+            test_flow.tx_rx.port.rx_name = rx_snappi_port_name_for_raw_pkts
+            test_flow.size.fixed = pket_size
+            test_flow.rate.percentage = 100
+            test_flow.duration.continuous
+
+            ethernet = test_flow.packet.add()
+            ethernet.choice = "ethernet"
+            ethernet.ethernet.src.value = flow['my_src_mac']
+            ethernet.ethernet.dst.value = Common_vars.config_data[dut.hostname]['router_mac_address']
+
+            ipv6_outer = test_flow.packet.add()
+            ipv6_outer.choice = "ipv6"
+            ipv6_outer.ipv6.src.value = flow['my_src_ip']
+            ipv6_outer.ipv6.dst.value = flow['my_ipv6_srv6_dest']
+            ipv6_outer.ipv6.hop_limit.value = 126
+
+            ipv6_inner = test_flow.packet.add()
+            ipv6_inner.choice = "ipv6"
+            ipv6_inner.ipv6.src.value = flow['my_src_ip']
+            ipv6_inner.ipv6.dst.value = flow['rx_port_ip_address']
+            # inner has no next header
+            ipv6_inner.ipv6.next_header.value = 59
+            ipv6_inner.ipv6.hop_limit.value = 126
+
+            index += 1
+
+    snappi_api.set_config(snappi_config)
+    start_stop(snappi_api, operation="start", op_type="protocols")
+
+    logger.info('Wait for Arp to Resolve ...')
+    if wait_for_arp(snappi_api, max_attempts=10, poll_interval_sec=2) != 0:
+        pytest_assert(False, "ARP failed")
+
+    for flow in snappi_api._ixnetwork.Traffic.TrafficItem.find():
+        flow.Tracking.find()[0].TrackBy = ['trackingenabled0']
+
+    if packet_size == 'mix':
+        # Snappi doesn't support custom mix packet sizes yet
+        # Using restpy to make the imix packets
+        for flow in snappi_api._ixnetwork.Traffic.TrafficItem.find():
+            logger.info(f'flow mixed packets: {flow.Name}')
+            flow.ConfigElement.find()[0].FrameSize.PresetDistribution = 'cisco'
+            flow.ConfigElement.find()[0].FrameSize.Type = 'weightedPairs'
+            flow.ConfigElement.find()[0].FrameSize.WeightedPairs = [128, 1, 256, 99, 4096, 98]
+
+    for duthost in duthosts:
+        logger.info(f'sonic-clear counters on DUT: {duthost.hostname} ...')
+        duthost.command("sonic-clear counters")
+
+    logger.info('Starting traffic and polling stats ...')
+    start_stop(snappi_api, operation="start", op_type="traffic")
+
+    # poll_srv6_perf_stats blocks for the full duration, recording
+    # samples every collect_interval seconds. db_reporter accumulates
+    # them in memory.
+    poll_srv6_perf_stats(
+        dut_tg_port_map,
+        duration_sec=test_duration,
+        interval_sec=collect_interval,
+        db_reporter=db_reporter,
+    )
+
+    # name: 'Tx: Port_4 -> Rx: Port_8 src_ipv6_1: 2004::2 dst_ipv6_1: fcbb:bbbb:1:008::
+    #        src_ipv6_2: 2004::2 dst_ipv6_2: 2008::2'
+    # port_rx: Port_8
+    # port_tx: Port_4
+    # rx_l1_rate_bps: 10000000064.0
+    # rx_rate_bps: 8648648704.0
+    # rx_rate_bytes: 1081081088.0
+    # rx_rate_kbps: 8648648.704
+    # rx_rate_mbps: 8648.649
+    # transmit: started
+    # tx_l1_rate_bps: 10000000064.0
+    # tx_rate_bps: 8648648704.0
+    # tx_rate_bytes: 1081081088.0
+    # tx_rate_kbps: 8648648.704
+    # tx_rate_mbps: 8648.649
+
+    start_stop(snappi_api, operation="stop", op_type="traffic")
+
+    stats = get_stats(api=snappi_api,
+                      stat_name="Traffic Item Statistics",
+                      columns=["frames_tx", "frames_rx", "loss"],
+                      return_type='stat_obj')
+    logger.info(f"\nTraffic Item Statistics: {stats}\n")
+
+    # --------------- Trace SRv6 DUT paths for ingress/egress stats -----------------
+    topo = Multi_Tier_Map(conn_graph_facts)
+    # ['switch-t0-1', 'switch-t1-1', 'switch-t2-1', 'switch-t1-2', 'switch-t0-2']
+    full_path_duts = topo.full_path()
+    full_path_duts.pop(0)
+    full_path_duts.pop(-1)
+
+    for dut in Common_vars.dut_hosts:
+        # 'dut_link_port_connections': {'switch-t1-2': ['Ethernet128', 'Ethernet129', 'Ethernet130', 'Ethernet131',
+        #                               'Ethernet132', 'Ethernet133', 'Ethernet134', 'Ethernet135']
+        # }
+        # Get all the link ports on the current dut to get the link port stats
+        grep_for_ports = 'grep '
+        for adjacent_dut, ports in Common_vars.config_data[dut.hostname]['dut_link_port_connections'].items():
+            for port in ports:
+                grep_for_ports += f'-e {port} '
+
+        for tx_port in Common_vars.config_data[dut.hostname]['tx_ports']:
+            grep_for_ports += f'-e {tx_port["my_dut_port"]} '
+
+        cli_command = f'show int counters | {grep_for_ports}'
+        logger.info(f'Getting DUT stats on: {dut.hostname} -> {cli_command}')
+        dut_stats = ('IFACE STATE RX_OK RX_BPS RX_UTIL RX_ERR RX_DRP '
+                     'RX_OVR TX_OK TX_BPS TX_UTIL TX_ERR TX_DRP TX_OVR\n')
+        dut_stats += dut.shell(cli_command)['stdout']
+        Common_vars.dut_stats[dut.hostname] = dut_stats
+
+    half_of_snappi_stats = len(stats) // 2
+    from_t0_1_stats = stats[:half_of_snappi_stats]
+    from_t0_2_stats = stats[half_of_snappi_stats: 2 * half_of_snappi_stats]
+
+    # Now check DUT stats the other direction from t0-2 to t0-1
+    aligned = get_ingress_egress_stats(full_path_duts, Common_vars)
+    t0_1_stat_result = verify_nut_stats(aligned, from_t0_1_stats)
+    full_path_duts.reverse()
+
+    aligned = get_ingress_egress_stats(full_path_duts, Common_vars)
+    t0_2_stat_result = verify_nut_stats(aligned, from_t0_2_stats)
+
+    # ------------------------------------------------------------------------------
+
+    test_failed = False
+    for index, flow_stat in enumerate(stats):
+        flow_name = flow_stat.name
+        frames_tx = flow_stat.frames_tx
+        frames_rx = flow_stat.frames_rx
+        delta = int(frames_tx) - int(frames_rx)
+
+        logger.info(f"{flow_name}: Frames Tx: {frames_tx}  Frames Rx: {frames_rx}  Delta: {delta}")
+
+        if delta != 0 and test_failed is False:
+            # Come in here just one time only
+            test_failed = True
+
+    if test_failed:
+        remove_srv6_config(Common_vars)
+        pytest_assert(False, "SRv6 NUT-test failed")
+
+    if t0_1_stat_result is False:
+        pytest_assert(False, "DUT stat counter failed")
+
+    if t0_2_stat_result is False:
+        pytest_assert(False, "DUT stat counter failed")
+
+    db_reporter.report()

--- a/tests/snappi_tests/dataplane/srv6/test_srv6.py
+++ b/tests/snappi_tests/dataplane/srv6/test_srv6.py
@@ -6,7 +6,7 @@ from itertools import product
 # from rich import print as pr
 import collections
 
-from tests.snappi_tests.srv6.files.srv6_telemetry import poll_srv6_perf_stats
+from tests.snappi_tests.dataplane.srv6.files.srv6_telemetry import poll_srv6_perf_stats
 from snappi_tests.dataplane.files.helper import create_traffic_items, start_stop, get_stats
 
 from tests.common.helpers.assertions import pytest_assert

--- a/tests/snappi_tests/dataplane/srv6/test_srv6.py
+++ b/tests/snappi_tests/dataplane/srv6/test_srv6.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 import re
 from itertools import product
-from rich import print as pr
+# from rich import print as pr
 import collections
 
 from tests.snappi_tests.srv6.files.srv6_telemetry import poll_srv6_perf_stats
@@ -64,7 +64,7 @@ srv6_param_values = {
     "subnet_type":     ["IPv6"],
     # "test_duration":    [1 * 60, 5 * 60, 15 * 60, 60 * 60, 24 * 60 * 60, 2 * 24 * 60 * 60],
     "test_duration":    [10],
-    "packet_size":      [128, 'mix'],
+    "packet_size":      ['mix'],
     "collect_interval": [30],
     "topology":         ["nut-2tiers"],
 }
@@ -74,23 +74,23 @@ srv6_param_product = list(product(*srv6_param_values.values()))
 
 
 @pytest.mark.parametrize(srv6_param_names, srv6_param_product)
-def test_srv6_single_dut(snappi_api,                 # noqa F811
-                         conn_graph_facts,           # noqa F811
-                         fanout_graph_facts_multidut, # noqa F811
-                         duthosts,
-                         set_primary_chassis, # noqa F811
-                         rand_one_dut_hostname,
-                         rand_one_dut_portname_oper_up,
-                         get_snappi_ports, # noqa F811
-                         subnet_type, # noqa F811
-                         packet_size, # noqa F811
-                         test_duration, # noqa F811
-                         collect_interval, # noqa F811
-                         create_snappi_config, # noqa F811
-                         topology,
-                         db_reporter,
-                         local_script_setup_and_teardown
-                         ):
+def test_srv6_nut_test(snappi_api,                 # noqa F811
+                       conn_graph_facts,           # noqa F811
+                       fanout_graph_facts_multidut, # noqa F811
+                       duthosts,
+                       set_primary_chassis, # noqa F811
+                       rand_one_dut_hostname,
+                       rand_one_dut_portname_oper_up,
+                       get_snappi_ports, # noqa F811
+                       subnet_type, # noqa F811
+                       packet_size, # noqa F811
+                       test_duration, # noqa F811
+                       collect_interval, # noqa F811
+                       create_snappi_config, # noqa F811
+                       topology,
+                       db_reporter,
+                       local_script_setup_and_teardown
+                       ):
     Common_vars.dut_hosts = duthosts
     snappi_extra_params = SnappiTestParams()
 
@@ -453,7 +453,7 @@ def test_srv6_single_dut(snappi_api,                 # noqa F811
             logger.info(f'flow mixed packets: {flow.Name}')
             flow.ConfigElement.find()[0].FrameSize.PresetDistribution = 'cisco'
             flow.ConfigElement.find()[0].FrameSize.Type = 'weightedPairs'
-            flow.ConfigElement.find()[0].FrameSize.WeightedPairs = [128, 1, 256, 99, 4096, 98]
+            flow.ConfigElement.find()[0].FrameSize.WeightedPairs = [128, 1, 256, 98, 4096, 98]
 
     for duthost in duthosts:
         logger.info(f'sonic-clear counters on DUT: {duthost.hostname} ...')
@@ -522,6 +522,7 @@ def test_srv6_single_dut(snappi_api,                 # noqa F811
                      'RX_OVR TX_OK TX_BPS TX_UTIL TX_ERR TX_DRP TX_OVR\n')
         dut_stats += dut.shell(cli_command)['stdout']
         Common_vars.dut_stats[dut.hostname] = dut_stats
+        logger.info(dut_stats)
 
     half_of_snappi_stats = len(stats) // 2
     from_t0_1_stats = stats[:half_of_snappi_stats]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Adding new SRv6 test case #1 nut testing

#### How did you do it?
By creating a script that reads the links.csv file to get all the DUT devices to create a NUT and configure SRv6 on the DUTs, ipv6  link interfaces and static routes as shown in the logs below

#### How did you verify/test it?
Creating ipv6 outer dest ip that signifies the srv6 path and verifying all ingress/egress dut stats equal to tgen tx and rx stats on determined paths.

#### Any platform specific information?
The script should handle any amount of t0, t1 and t2

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
### Output
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0438 INFO   | switch-t0-1: SID=200  ->  switch-t0-2: SID=300
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0446 INFO   | fcbb:bbbb:200:300
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0419 INFO   | 
get_complete_srv6_path: index:1 starting_dut:switch-t0-1 -> switch-t0-2

24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0438 INFO   | switch-t0-1: SID=201  ->  switch-t0-2: SID=301
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0446 INFO   | fcbb:bbbb:201:301
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0419 INFO   | 
get_complete_srv6_path: index:2 starting_dut:switch-t0-1 -> switch-t0-2

24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0438 INFO   | switch-t0-1: SID=202  ->  switch-t0-2: SID=302
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0446 INFO   | fcbb:bbbb:202:302
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0419 INFO   | 
get_complete_srv6_path: index:3 starting_dut:switch-t0-1 -> switch-t0-2

24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0438 INFO   | switch-t0-1: SID=203  ->  switch-t0-2: SID=303
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0446 INFO   | fcbb:bbbb:203:303
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0419 INFO   | 
get_complete_srv6_path: index:4 starting_dut:switch-t0-1 -> switch-t0-2

24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0438 INFO   | switch-t0-1: SID=204  ->  switch-t0-2: SID=304
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0446 INFO   | fcbb:bbbb:204:304
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0419 INFO   | 
get_complete_srv6_path: index:5 starting_dut:switch-t0-1 -> switch-t0-2

24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0438 INFO   | switch-t0-1: SID=205  ->  switch-t0-2: SID=305
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0446 INFO   | fcbb:bbbb:205:305
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0419 INFO   | 
get_complete_srv6_path: index:6 starting_dut:switch-t0-1 -> switch-t0-2

24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0438 INFO   | switch-t0-1: SID=206  ->  switch-t0-2: SID=306
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0446 INFO   | fcbb:bbbb:206:306
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0419 INFO   | 
get_complete_srv6_path: index:7 starting_dut:switch-t0-1 -> switch-t0-2

24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0438 INFO   | switch-t0-1: SID=207  ->  switch-t0-2: SID=307
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0446 INFO   | fcbb:bbbb:207:307
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0419 INFO   | 
get_complete_srv6_path: index:0 starting_dut:switch-t0-2 -> switch-t0-1

24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0438 INFO   | switch-t0-2: SID=300  ->  switch-t0-1: SID=200
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0446 INFO   | fcbb:bbbb:300:200
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0419 INFO   | 
get_complete_srv6_path: index:1 starting_dut:switch-t0-2 -> switch-t0-1

24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0438 INFO   | switch-t0-2: SID=301  ->  switch-t0-1: SID=201
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0446 INFO   | fcbb:bbbb:301:201
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0419 INFO   | 
get_complete_srv6_path: index:2 starting_dut:switch-t0-2 -> switch-t0-1

24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0438 INFO   | switch-t0-2: SID=302  ->  switch-t0-1: SID=202
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0446 INFO   | fcbb:bbbb:302:202
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0419 INFO   | 
get_complete_srv6_path: index:3 starting_dut:switch-t0-2 -> switch-t0-1

24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0438 INFO   | switch-t0-2: SID=303  ->  switch-t0-1: SID=203
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0446 INFO   | fcbb:bbbb:303:203
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0419 INFO   | 
get_complete_srv6_path: index:4 starting_dut:switch-t0-2 -> switch-t0-1

24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0438 INFO   | switch-t0-2: SID=304  ->  switch-t0-1: SID=204
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0446 INFO   | fcbb:bbbb:304:204
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0419 INFO   | 
get_complete_srv6_path: index:5 starting_dut:switch-t0-2 -> switch-t0-1

24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0438 INFO   | switch-t0-2: SID=305  ->  switch-t0-1: SID=205
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0446 INFO   | fcbb:bbbb:305:205
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0419 INFO   | 
get_complete_srv6_path: index:6 starting_dut:switch-t0-2 -> switch-t0-1

24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0438 INFO   | switch-t0-2: SID=306  ->  switch-t0-1: SID=206
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0446 INFO   | fcbb:bbbb:306:206
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0419 INFO   | 
get_complete_srv6_path: index:7 starting_dut:switch-t0-2 -> switch-t0-1

24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0438 INFO   | switch-t0-2: SID=307  ->  switch-t0-1: SID=207
24/06/2026 18:24:46 srv6_helper.get_complete_srv6_path       L0446 INFO   | fcbb:bbbb:307:207
24/06/2026 18:24:46 test_srv6.test_srv6_single_dut           L0286 INFO   | --- MY-SIDS and SID-LOCATORS---
24/06/2026 18:24:46 test_srv6.test_srv6_single_dut           L0291 INFO   | Configuring switch-t0-1: sonic-db-cli CONFIG_DB hset "SRV6_MY_LOCATORS|loc1" prefix "fcbb:bbbb:200::" func_len 0
24/06/2026 18:24:47 test_srv6.test_srv6_single_dut           L0297 INFO   |     sonic-db-cli CONFIG_DB hset "SRV6_MY_SIDS|loc1|fcbb:bbbb:200::/48" action uN decap_dscp_mode pipe
24/06/2026 18:24:48 test_srv6.test_srv6_single_dut           L0291 INFO   | Configuring switch-t0-1: sonic-db-cli CONFIG_DB hset "SRV6_MY_LOCATORS|loc2" prefix "fcbb:bbbb:201::" func_len 0
24/06/2026 18:24:48 test_srv6.test_srv6_single_dut           L0297 INFO   |     sonic-db-cli CONFIG_DB hset "SRV6_MY_SIDS|loc2|fcbb:bbbb:201::/48" action uN decap_dscp_mode pipe
24/06/2026 18:24:49 test_srv6.test_srv6_single_dut           L0291 INFO   | Configuring switch-t0-1: sonic-db-cli CONFIG_DB hset "SRV6_MY_LOCATORS|loc3" prefix "fcbb:bbbb:202::" func_len 0
24/06/2026 18:24:50 test_srv6.test_srv6_single_dut           L0297 INFO   |     sonic-db-cli CONFIG_DB hset "SRV6_MY_SIDS|loc3|fcbb:bbbb:202::/48" action uN decap_dscp_mode pipe
24/06/2026 18:24:50 test_srv6.test_srv6_single_dut           L0291 INFO   | Configuring switch-t0-1: sonic-db-cli CONFIG_DB hset "SRV6_MY_LOCATORS|loc4" prefix "fcbb:bbbb:203::" func_len 0
24/06/2026 18:24:51 test_srv6.test_srv6_single_dut           L0297 INFO   |     sonic-db-cli CONFIG_DB hset "SRV6_MY_SIDS|loc4|fcbb:bbbb:203::/48" action uN decap_dscp_mode pipe
24/06/2026 18:24:52 test_srv6.test_srv6_single_dut           L0291 INFO   | Configuring switch-t0-1: sonic-db-cli CONFIG_DB hset "SRV6_MY_LOCATORS|loc5" prefix "fcbb:bbbb:204::" func_len 0
24/06/2026 18:24:52 test_srv6.test_srv6_single_dut           L0297 INFO   |     sonic-db-cli CONFIG_DB hset "SRV6_MY_SIDS|loc5|fcbb:bbbb:204::/48" action uN decap_dscp_mode pipe
24/06/2026 18:24:53 test_srv6.test_srv6_single_dut           L0291 INFO   | Configuring switch-t0-1: sonic-db-cli CONFIG_DB hset "SRV6_MY_LOCATORS|loc6" prefix "fcbb:bbbb:205::" func_len 0
24/06/2026 18:24:54 test_srv6.test_srv6_single_dut           L0297 INFO   |     sonic-db-cli CONFIG_DB hset "SRV6_MY_SIDS|loc6|fcbb:bbbb:205::/48" action uN decap_dscp_mode pipe
24/06/2026 18:24:55 test_srv6.test_srv6_single_dut           L0291 INFO   | Configuring switch-t0-1: sonic-db-cli CONFIG_DB hset "SRV6_MY_LOCATORS|loc7" prefix "fcbb:bbbb:206::" func_len 0
24/06/2026 18:24:55 test_srv6.test_srv6_single_dut           L0297 INFO   |     sonic-db-cli CONFIG_DB hset "SRV6_MY_SIDS|loc7|fcbb:bbbb:206::/48" action uN decap_dscp_mode pipe
24/06/2026 18:24:56 test_srv6.test_srv6_single_dut           L0291 INFO   | Configuring switch-t0-1: sonic-db-cli CONFIG_DB hset "SRV6_MY_LOCATORS|loc8" prefix "fcbb:bbbb:207::" func_len 0
24/06/2026 18:24:57 test_srv6.test_srv6_single_dut           L0297 INFO   |     sonic-db-cli CONFIG_DB hset "SRV6_MY_SIDS|loc8|fcbb:bbbb:207::/48" action uN decap_dscp_mode pipe
24/06/2026 18:24:57 test_srv6.test_srv6_single_dut           L0291 INFO   | Configuring switch-t0-2: sonic-db-cli CONFIG_DB hset "SRV6_MY_LOCATORS|loc1" prefix "fcbb:bbbb:300::" func_len 0
24/06/2026 18:24:58 test_srv6.test_srv6_single_dut           L0297 INFO   |     sonic-db-cli CONFIG_DB hset "SRV6_MY_SIDS|loc1|fcbb:bbbb:300::/48" action uN decap_dscp_mode pipe
24/06/2026 18:24:59 test_srv6.test_srv6_single_dut           L0291 INFO   | Configuring switch-t0-2: sonic-db-cli CONFIG_DB hset "SRV6_MY_LOCATORS|loc2" prefix "fcbb:bbbb:301::" func_len 0
24/06/2026 18:24:59 test_srv6.test_srv6_single_dut           L0297 INFO   |     sonic-db-cli CONFIG_DB hset "SRV6_MY_SIDS|loc2|fcbb:bbbb:301::/48" action uN decap_dscp_mode pipe
24/06/2026 18:25:00 test_srv6.test_srv6_single_dut           L0291 INFO   | Configuring switch-t0-2: sonic-db-cli CONFIG_DB hset "SRV6_MY_LOCATORS|loc3" prefix "fcbb:bbbb:302::" func_len 0
24/06/2026 18:25:00 test_srv6.test_srv6_single_dut           L0297 INFO   |     sonic-db-cli CONFIG_DB hset "SRV6_MY_SIDS|loc3|fcbb:bbbb:302::/48" action uN decap_dscp_mode pipe
24/06/2026 18:25:01 test_srv6.test_srv6_single_dut           L0291 INFO   | Configuring switch-t0-2: sonic-db-cli CONFIG_DB hset "SRV6_MY_LOCATORS|loc4" prefix "fcbb:bbbb:303::" func_len 0
24/06/2026 18:25:02 test_srv6.test_srv6_single_dut           L0297 INFO   |     sonic-db-cli CONFIG_DB hset "SRV6_MY_SIDS|loc4|fcbb:bbbb:303::/48" action uN decap_dscp_mode pipe
24/06/2026 18:25:02 test_srv6.test_srv6_single_dut           L0291 INFO   | Configuring switch-t0-2: sonic-db-cli CONFIG_DB hset "SRV6_MY_LOCATORS|loc5" prefix "fcbb:bbbb:304::" func_len 0
24/06/2026 18:25:03 test_srv6.test_srv6_single_dut           L0297 INFO   |     sonic-db-cli CONFIG_DB hset "SRV6_MY_SIDS|loc5|fcbb:bbbb:304::/48" action uN decap_dscp_mode pipe
24/06/2026 18:25:04 test_srv6.test_srv6_single_dut           L0291 INFO   | Configuring switch-t0-2: sonic-db-cli CONFIG_DB hset "SRV6_MY_LOCATORS|loc6" prefix "fcbb:bbbb:305::" func_len 0
24/06/2026 18:25:05 test_srv6.test_srv6_single_dut           L0297 INFO   |     sonic-db-cli CONFIG_DB hset "SRV6_MY_SIDS|loc6|fcbb:bbbb:305::/48" action uN decap_dscp_mode pipe
24/06/2026 18:25:06 test_srv6.test_srv6_single_dut           L0291 INFO   | Configuring switch-t0-2: sonic-db-cli CONFIG_DB hset "SRV6_MY_LOCATORS|loc7" prefix "fcbb:bbbb:306::" func_len 0
24/06/2026 18:25:07 test_srv6.test_srv6_single_dut           L0297 INFO   |     sonic-db-cli CONFIG_DB hset "SRV6_MY_SIDS|loc7|fcbb:bbbb:306::/48" action uN decap_dscp_mode pipe
24/06/2026 18:25:09 test_srv6.test_srv6_single_dut           L0291 INFO   | Configuring switch-t0-2: sonic-db-cli CONFIG_DB hset "SRV6_MY_LOCATORS|loc8" prefix "fcbb:bbbb:307::" func_len 0
24/06/2026 18:25:10 test_srv6.test_srv6_single_dut           L0297 INFO   |     sonic-db-cli CONFIG_DB hset "SRV6_MY_SIDS|loc8|fcbb:bbbb:307::/48" action uN decap_dscp_mode pipe
24/06/2026 18:25:10 test_srv6.test_srv6_single_dut           L0304 INFO   | --- DUT-to-DUT interface IP addresses ---
24/06/2026 18:25:10 test_srv6.test_srv6_single_dut           L0325 INFO   | DUT:switch-t0-1: sudo config int ip add Ethernet128 5000::1/64
24/06/2026 18:25:11 test_srv6.test_srv6_single_dut           L0325 INFO   | DUT:switch-t0-1: sudo config int ip add Ethernet129 5001::1/64
24/06/2026 18:25:12 test_srv6.test_srv6_single_dut           L0325 INFO   | DUT:switch-t0-1: sudo config int ip add Ethernet130 5002::1/64
24/06/2026 18:25:13 test_srv6.test_srv6_single_dut           L0325 INFO   | DUT:switch-t0-1: sudo config int ip add Ethernet131 5003::1/64
24/06/2026 18:25:14 test_srv6.test_srv6_single_dut           L0325 INFO   | DUT:switch-t0-1: sudo config int ip add Ethernet132 5004::1/64
24/06/2026 18:25:15 test_srv6.test_srv6_single_dut           L0325 INFO   | DUT:switch-t0-1: sudo config int ip add Ethernet133 5005::1/64
24/06/2026 18:25:16 test_srv6.test_srv6_single_dut           L0325 INFO   | DUT:switch-t0-1: sudo config int ip add Ethernet134 5006::1/64
24/06/2026 18:25:17 test_srv6.test_srv6_single_dut           L0325 INFO   | DUT:switch-t0-1: sudo config int ip add Ethernet135 5007::1/64
24/06/2026 18:25:18 test_srv6.test_srv6_single_dut           L0325 INFO   | DUT:switch-t0-2: sudo config int ip add Ethernet128 5000::2/64
24/06/2026 18:25:19 test_srv6.test_srv6_single_dut           L0325 INFO   | DUT:switch-t0-2: sudo config int ip add Ethernet129 5001::2/64
24/06/2026 18:25:19 test_srv6.test_srv6_single_dut           L0325 INFO   | DUT:switch-t0-2: sudo config int ip add Ethernet130 5002::2/64
24/06/2026 18:25:20 test_srv6.test_srv6_single_dut           L0325 INFO   | DUT:switch-t0-2: sudo config int ip add Ethernet131 5003::2/64
24/06/2026 18:25:21 test_srv6.test_srv6_single_dut           L0325 INFO   | DUT:switch-t0-2: sudo config int ip add Ethernet132 5004::2/64
24/06/2026 18:25:22 test_srv6.test_srv6_single_dut           L0325 INFO   | DUT:switch-t0-2: sudo config int ip add Ethernet133 5005::2/64
24/06/2026 18:25:23 test_srv6.test_srv6_single_dut           L0325 INFO   | DUT:switch-t0-2: sudo config int ip add Ethernet134 5006::2/64
24/06/2026 18:25:24 test_srv6.test_srv6_single_dut           L0325 INFO   | DUT:switch-t0-2: sudo config int ip add Ethernet135 5007::2/64
24/06/2026 18:25:25 test_srv6.test_srv6_single_dut           L0337 INFO   | Ping adjacent DUT to learn ARP: switch-t0-1 -> switch-t0-2  pinging 5000::2
24/06/2026 18:25:26 test_srv6.test_srv6_single_dut           L0337 INFO   | Ping adjacent DUT to learn ARP: switch-t0-1 -> switch-t0-2  pinging 5001::2
24/06/2026 18:25:28 test_srv6.test_srv6_single_dut           L0337 INFO   | Ping adjacent DUT to learn ARP: switch-t0-1 -> switch-t0-2  pinging 5002::2
24/06/2026 18:25:30 test_srv6.test_srv6_single_dut           L0337 INFO   | Ping adjacent DUT to learn ARP: switch-t0-1 -> switch-t0-2  pinging 5003::2
24/06/2026 18:25:31 test_srv6.test_srv6_single_dut           L0337 INFO   | Ping adjacent DUT to learn ARP: switch-t0-1 -> switch-t0-2  pinging 5004::2
24/06/2026 18:25:33 test_srv6.test_srv6_single_dut           L0337 INFO   | Ping adjacent DUT to learn ARP: switch-t0-1 -> switch-t0-2  pinging 5005::2
24/06/2026 18:25:35 test_srv6.test_srv6_single_dut           L0337 INFO   | Ping adjacent DUT to learn ARP: switch-t0-1 -> switch-t0-2  pinging 5006::2
24/06/2026 18:25:36 test_srv6.test_srv6_single_dut           L0337 INFO   | Ping adjacent DUT to learn ARP: switch-t0-1 -> switch-t0-2  pinging 5007::2
24/06/2026 18:25:38 test_srv6.test_srv6_single_dut           L0337 INFO   | Ping adjacent DUT to learn ARP: switch-t0-2 -> switch-t0-1  pinging 5000::1
24/06/2026 18:25:40 test_srv6.test_srv6_single_dut           L0337 INFO   | Ping adjacent DUT to learn ARP: switch-t0-2 -> switch-t0-1  pinging 5001::1
24/06/2026 18:25:42 test_srv6.test_srv6_single_dut           L0337 INFO   | Ping adjacent DUT to learn ARP: switch-t0-2 -> switch-t0-1  pinging 5002::1
24/06/2026 18:25:43 test_srv6.test_srv6_single_dut           L0337 INFO   | Ping adjacent DUT to learn ARP: switch-t0-2 -> switch-t0-1  pinging 5003::1
24/06/2026 18:25:45 test_srv6.test_srv6_single_dut           L0337 INFO   | Ping adjacent DUT to learn ARP: switch-t0-2 -> switch-t0-1  pinging 5004::1
24/06/2026 18:25:46 test_srv6.test_srv6_single_dut           L0337 INFO   | Ping adjacent DUT to learn ARP: switch-t0-2 -> switch-t0-1  pinging 5005::1
24/06/2026 18:25:48 test_srv6.test_srv6_single_dut           L0337 INFO   | Ping adjacent DUT to learn ARP: switch-t0-2 -> switch-t0-1  pinging 5006::1
24/06/2026 18:25:50 test_srv6.test_srv6_single_dut           L0337 INFO   | Ping adjacent DUT to learn ARP: switch-t0-2 -> switch-t0-1  pinging 5007::1
24/06/2026 18:25:52 test_srv6.test_srv6_single_dut           L0342 INFO   | --- STATIC ROUTES FOR TGEN PORTS ---
24/06/2026 18:25:52 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-1 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:100::/48" nexthop fc0a::2 ifname Ethernet64
24/06/2026 18:25:52 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-1 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:101::/48" nexthop fc0e::2 ifname Ethernet65
24/06/2026 18:25:54 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-1 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:102::/48" nexthop fc12::2 ifname Ethernet66
24/06/2026 18:25:55 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-1 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:103::/48" nexthop fc16::2 ifname Ethernet67
24/06/2026 18:25:56 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-1 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:104::/48" nexthop fc1a::2 ifname Ethernet68
24/06/2026 18:25:56 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-1 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:105::/48" nexthop fc1e::2 ifname Ethernet69
24/06/2026 18:25:57 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-1 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:106::/48" nexthop fc22::2 ifname Ethernet70
24/06/2026 18:25:58 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-1 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:107::/48" nexthop fc26::2 ifname Ethernet71
24/06/2026 18:25:58 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-1 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:300::/48" nexthop 5000::2 ifname Ethernet128
24/06/2026 18:25:59 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-1 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:301::/48" nexthop 5001::2 ifname Ethernet129
24/06/2026 18:26:00 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-1 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:302::/48" nexthop 5002::2 ifname Ethernet130
24/06/2026 18:26:01 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-1 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:303::/48" nexthop 5003::2 ifname Ethernet131
24/06/2026 18:26:01 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-1 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:304::/48" nexthop 5004::2 ifname Ethernet132
24/06/2026 18:26:02 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-1 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:305::/48" nexthop 5005::2 ifname Ethernet133
24/06/2026 18:26:03 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-1 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:306::/48" nexthop 5006::2 ifname Ethernet134
24/06/2026 18:26:03 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-1 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:307::/48" nexthop 5007::2 ifname Ethernet135
24/06/2026 18:26:04 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-2 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:108::/48" nexthop fc2a::2 ifname Ethernet80
24/06/2026 18:26:05 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-2 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:109::/48" nexthop fc2e::2 ifname Ethernet81
24/06/2026 18:26:05 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-2 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:110::/48" nexthop fc32::2 ifname Ethernet82
24/06/2026 18:26:06 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-2 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:111::/48" nexthop fc36::2 ifname Ethernet83
24/06/2026 18:26:07 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-2 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:112::/48" nexthop fc3a::2 ifname Ethernet84
24/06/2026 18:26:07 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-2 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:113::/48" nexthop fc3e::2 ifname Ethernet85
24/06/2026 18:26:08 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-2 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:114::/48" nexthop fc42::2 ifname Ethernet86
24/06/2026 18:26:08 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-2 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:115::/48" nexthop fc46::2 ifname Ethernet87
24/06/2026 18:26:09 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-2 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:200::/48" nexthop 5000::1 ifname Ethernet128
24/06/2026 18:26:10 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-2 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:201::/48" nexthop 5001::1 ifname Ethernet129
24/06/2026 18:26:10 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-2 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:202::/48" nexthop 5002::1 ifname Ethernet130
24/06/2026 18:26:11 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-2 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:203::/48" nexthop 5003::1 ifname Ethernet131
24/06/2026 18:26:11 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-2 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:204::/48" nexthop 5004::1 ifname Ethernet132
24/06/2026 18:26:12 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-2 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:205::/48" nexthop 5005::1 ifname Ethernet133
24/06/2026 18:26:13 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-2 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:206::/48" nexthop 5006::1 ifname Ethernet134
24/06/2026 18:26:13 test_srv6.test_srv6_single_dut           L0348 INFO   | DUT:switch-t0-2 -> sonic-db-cli CONFIG_DB hset "STATIC_ROUTE|fcbb:bbbb:207::/48" nexthop 5007::1 ifname Ethernet135
24/06/2026 18:26:14 connection._warn                         L0363 WARNING| Verification of certificates is disabled
24/06/2026 18:26:14 connection._info                         L0360 INFO   | Determining the platform and rest_port using the 10.36.77.53 address...
24/06/2026 18:26:14 connection._warn                         L0363 WARNING| Unable to connect to http://10.36.77.53:443.
24/06/2026 18:26:14 connection._warn                         L0363 WARNING| Unable to connect to https://10.36.77.53:443.
24/06/2026 18:26:14 connection._warn                         L0363 WARNING| Unable to connect to http://10.36.77.53:443.
24/06/2026 18:26:14 connection._warn                         L0363 WARNING| Unable to connect to https://10.36.77.53:443.
24/06/2026 18:26:14 connection._warn                         L0363 WARNING| Unable to connect to http://10.36.77.53:11009.
24/06/2026 18:26:14 connection._info                         L0360 INFO   | Connection established to `https://10.36.77.53:11009 on windows`
24/06/2026 18:26:14 connection._info                         L0360 INFO   | Using IxNetwork api server version 26.0.2620.7
24/06/2026 18:26:14 connection._info                         L0360 INFO   | User info IxNetwork/WIN-11RK5TNKNAN/8012
24/06/2026 18:26:14 snappi_api.info                          L1522 INFO   | snappi-1.57.0
24/06/2026 18:26:14 snappi_api.info                          L1522 INFO   | snappi_ixnetwork-1.57.0
24/06/2026 18:26:14 snappi_api.info                          L1522 INFO   | ixnetwork_restpy-1.10.0
24/06/2026 18:26:15 snappi_api.info                          L1522 INFO   | Config validation 0.081s
24/06/2026 18:26:16 snappi_api.info                          L1522 INFO   | Ports configuration 0.172s
24/06/2026 18:26:16 snappi_api.info                          L1522 INFO   | Captures configuration 0.090s
24/06/2026 18:26:16 connection._info                         L0360 INFO   | [0.052s] Timer @ batchadd.py:387 -> Batch Add Completed
24/06/2026 18:26:16 snappi_api.info                          L1522 INFO   | Add location hosts [10.36.84.32, 10.36.84.36, 10.36.84.37] 0.107s
24/06/2026 18:26:16 snappi_api.info                          L1522 INFO   | Location hosts ready [10.36.84.32, 10.36.84.36, 10.36.84.37] 0.018s
24/06/2026 18:26:22 snappi_api.info                          L1522 INFO   | Speed conversion is not require for (port.name, speed) : [('Port_1', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_2', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_3', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_4', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_5', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_6', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_7', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_8', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_9', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_10', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_11', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_12', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_13', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_14', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_15', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_16', 'aresOne-M-EightByOneHundredGigPAM4-106G')]
24/06/2026 18:26:22 snappi_api.info                          L1522 INFO   | Aggregation mode speed change 1.073s
24/06/2026 18:26:22 snappi_api.info                          L1522 INFO   | Location configuration 5.758s
24/06/2026 18:26:22 snappi_api.info                          L1522 INFO   | Layer1 configuration 0.133s
24/06/2026 18:26:22 snappi_api.info                          L1522 INFO   | Lag Configuration 0.007s
24/06/2026 18:26:22 snappi_api.info                          L1522 INFO   | Convert device config : 0.432s
24/06/2026 18:26:23 snappi_api.info                          L1522 INFO   | Create IxNetwork device config : 0.002s
24/06/2026 18:26:24 snappi_api.info                          L1522 INFO   | Push IxNetwork device config : 1.646s
24/06/2026 18:26:24 snappi_api.info                          L1522 INFO   | Devices configuration 2.090s
24/06/2026 18:26:31 snappi_api.info                          L1522 INFO   | Flows configuration 6.685s
24/06/2026 18:26:35 snappi_api.info                          L1522 INFO   | Start interfaces 4.028s
24/06/2026 18:26:35 snappi_api.info                          L1522 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
24/06/2026 18:26:35 helper.start_stop                        L0736 INFO   | Start protocols
24/06/2026 18:26:38 utilities.wait                           L0121 INFO   | Pause 20 seconds, reason: For protocols To start
24/06/2026 18:26:58 test_srv6.test_srv6_single_dut           L0442 INFO   | Wait for Arp to Resolve ...
24/06/2026 18:27:00 test_srv6.test_srv6_single_dut           L0453 INFO   | flow mixed packets: 10.36.84.36/1.1:Port_1 -> 10.36.84.37/3.1:Port_9
24/06/2026 18:27:00 test_srv6.test_srv6_single_dut           L0453 INFO   | flow mixed packets: 10.36.84.36/1.2:Port_2 -> 10.36.84.37/3.2:Port_10
24/06/2026 18:27:00 test_srv6.test_srv6_single_dut           L0453 INFO   | flow mixed packets: 10.36.84.36/1.3:Port_3 -> 10.36.84.37/3.3:Port_11
24/06/2026 18:27:00 test_srv6.test_srv6_single_dut           L0453 INFO   | flow mixed packets: 10.36.84.36/1.4:Port_4 -> 10.36.84.37/3.4:Port_12
24/06/2026 18:27:00 test_srv6.test_srv6_single_dut           L0453 INFO   | flow mixed packets: 10.36.84.36/1.5:Port_5 -> 10.36.84.37/3.5:Port_13
24/06/2026 18:27:01 test_srv6.test_srv6_single_dut           L0453 INFO   | flow mixed packets: 10.36.84.36/1.6:Port_6 -> 10.36.84.37/3.6:Port_14
24/06/2026 18:27:01 test_srv6.test_srv6_single_dut           L0453 INFO   | flow mixed packets: 10.36.84.36/1.7:Port_7 -> 10.36.84.37/3.7:Port_15
24/06/2026 18:27:01 test_srv6.test_srv6_single_dut           L0453 INFO   | flow mixed packets: 10.36.84.36/1.8:Port_8 -> 10.36.84.37/3.8:Port_16
24/06/2026 18:27:01 test_srv6.test_srv6_single_dut           L0453 INFO   | flow mixed packets: 10.36.84.37/3.1:Port_9 -> 10.36.84.36/1.1:Port_1
24/06/2026 18:27:01 test_srv6.test_srv6_single_dut           L0453 INFO   | flow mixed packets: 10.36.84.37/3.2:Port_10 -> 10.36.84.36/1.2:Port_2
24/06/2026 18:27:01 test_srv6.test_srv6_single_dut           L0453 INFO   | flow mixed packets: 10.36.84.37/3.3:Port_11 -> 10.36.84.36/1.3:Port_3
24/06/2026 18:27:01 test_srv6.test_srv6_single_dut           L0453 INFO   | flow mixed packets: 10.36.84.37/3.4:Port_12 -> 10.36.84.36/1.4:Port_4
24/06/2026 18:27:02 test_srv6.test_srv6_single_dut           L0453 INFO   | flow mixed packets: 10.36.84.37/3.5:Port_13 -> 10.36.84.36/1.5:Port_5
24/06/2026 18:27:02 test_srv6.test_srv6_single_dut           L0453 INFO   | flow mixed packets: 10.36.84.37/3.6:Port_14 -> 10.36.84.36/1.6:Port_6
24/06/2026 18:27:02 test_srv6.test_srv6_single_dut           L0453 INFO   | flow mixed packets: 10.36.84.37/3.7:Port_15 -> 10.36.84.36/1.7:Port_7
24/06/2026 18:27:02 test_srv6.test_srv6_single_dut           L0453 INFO   | flow mixed packets: 10.36.84.37/3.8:Port_16 -> 10.36.84.36/1.8:Port_8
24/06/2026 18:27:02 test_srv6.test_srv6_single_dut           L0459 INFO   | sonic-clear counters on DUT: switch-t0-1 ...
24/06/2026 18:27:03 test_srv6.test_srv6_single_dut           L0459 INFO   | sonic-clear counters on DUT: switch-t0-2 ...
24/06/2026 18:27:04 test_srv6.test_srv6_single_dut           L0462 INFO   | Starting traffic and polling stats ...
24/06/2026 18:27:04 helper.start_stop                        L0736 INFO   | Start traffic
24/06/2026 18:27:30 snappi_api.info                          L1522 INFO   | Flows generate/apply 25.274s
24/06/2026 18:27:42 snappi_api.info                          L1522 INFO   | Flows clear statistics 12.196s
24/06/2026 18:27:42 snappi_api.info                          L1522 INFO   | Captures start 0.000s
24/06/2026 18:28:12 snappi_api.info                          L1522 INFO   | Flows start 30.114s
24/06/2026 18:28:12 helper.wait_for                          L0648 INFO   | Waiting for Traffic to Start ...
24/06/2026 18:28:18 helper.wait_for                          L0652 INFO   | Done waiting for Traffic to Start
24/06/2026 18:28:18 srv6_telemetry.poll_srv6_perf_stats      L0466 INFO   | Started polling every 30.00s for 10s
24/06/2026 18:28:18 srv6_telemetry.get_dut_stats             L0233 INFO   | Collecting stats from switch-t0-1
24/06/2026 18:28:48 srv6_telemetry.poll_srv6_perf_stats      L0489 INFO   | Finished polling after 10s.
24/06/2026 18:28:48 helper.start_stop                        L0736 INFO   | Stop traffic
24/06/2026 18:29:00 snappi_api.info                          L1522 INFO   | Flows stop 12.025s
24/06/2026 18:29:00 helper.wait_for                          L0648 INFO   | Waiting for Traffic to Stop ...
24/06/2026 18:29:02 helper.wait_for                          L0652 INFO   | Done waiting for Traffic to Stop
24/06/2026 18:29:02 test_srv6.test_srv6_single_dut           L0497 INFO   | 
24/06/2026 18:29:02 test_srv6.test_srv6_single_dut           L0520 INFO   | Getting DUT stats on: switch-t0-1 -> show int counters | grep -e Ethernet128 -e Ethernet129 -e Ethernet130 -e Ethernet131 -e Ethernet132 -e Ethernet133 -e Ethernet134 -e Ethernet135 -e Ethernet64 -e Ethernet65 -e Ethernet66 -e Ethernet67 -e Ethernet68 -e Ethernet69 -e Ethernet70 -e Ethernet71 
24/06/2026 18:29:06 test_srv6.test_srv6_single_dut           L0525 INFO   | IFACE STATE RX_OK RX_BPS RX_UTIL RX_ERR RX_DRP RX_OVR TX_OK TX_BPS TX_UTIL TX_ERR TX_DRP TX_OVR
 Ethernet64        U  258,222,974  2266.09 MB/s     18.13%         0         0         0  258,201,746  2626.98 MB/s     21.02%         0         0         0
 Ethernet65        U  258,214,312  2265.59 MB/s     18.12%         0         0         0  258,196,202  2627.00 MB/s     21.02%         0         0         0
 Ethernet66        U  258,224,403  2265.11 MB/s     18.12%         0         0         0  258,247,403  2627.00 MB/s     21.02%         0         0         0
 Ethernet67        U  258,207,052  2264.62 MB/s     18.12%         0         0         0  258,233,556  2627.00 MB/s     21.02%         0         0         0
 Ethernet68        U  258,229,472  2264.13 MB/s     18.11%         0         0         0  258,225,118  2627.01 MB/s     21.02%         0         0         0
 Ethernet69        U  258,213,825  2263.65 MB/s     18.11%         0         0         0  258,205,988  2627.02 MB/s     21.02%         0         0         0
 Ethernet70        U  258,243,374  2263.17 MB/s     18.11%         0         0         0  258,215,949  2627.03 MB/s     21.02%         0         0         0
 Ethernet71        U  258,223,556  2262.68 MB/s     18.10%         0         0         0  258,203,811  2627.03 MB/s     21.02%         0         0         0
Ethernet128        U  258,201,864  2232.10 MB/s     17.86%         0         0         0  258,223,096  2627.45 MB/s     21.02%         0         0         0
Ethernet129        U  258,196,202  2231.63 MB/s     17.85%         0         0         0  258,214,316  2627.45 MB/s     21.02%         0         0         0
Ethernet130        U  258,247,403  2231.14 MB/s     17.85%         0         0         0  258,224,407  2627.46 MB/s     21.02%         0         0         0
Ethernet131        U  258,233,556  2230.65 MB/s     17.85%         0         0         0  258,207,056  2627.47 MB/s     21.02%         0         0         0
Ethernet132        U  258,225,118  2230.17 MB/s     17.84%         0         0         0  258,229,476  2627.47 MB/s     21.02%         0         0         0
Ethernet133        U  258,205,988  2229.68 MB/s     17.84%         0         0         0  258,213,829  2627.48 MB/s     21.02%         0         0         0
Ethernet134        U  258,215,949  2229.18 MB/s     17.83%         0         0         0  258,243,378  2627.49 MB/s     21.02%         0         0         0
Ethernet135        U  258,203,811  2228.70 MB/s     17.83%         0         0         0  258,223,560  2627.49 MB/s     21.02%         0         0         0
24/06/2026 18:29:06 test_srv6.test_srv6_single_dut           L0520 INFO   | Getting DUT stats on: switch-t0-2 -> show int counters | grep -e Ethernet128 -e Ethernet129 -e Ethernet130 -e Ethernet131 -e Ethernet132 -e Ethernet133 -e Ethernet134 -e Ethernet135 -e Ethernet80 -e Ethernet81 -e Ethernet82 -e Ethernet83 -e Ethernet84 -e Ethernet85 -e Ethernet86 -e Ethernet87 
24/06/2026 18:29:10 test_srv6.test_srv6_single_dut           L0525 INFO   | IFACE STATE RX_OK RX_BPS RX_UTIL RX_ERR RX_DRP RX_OVR TX_OK TX_BPS TX_UTIL TX_ERR TX_DRP TX_OVR
 Ethernet80        U  258,201,758  969.23 MB/s      7.75%         0         0         0  258,222,978  1097.14 MB/s      8.78%         0         0         0
 Ethernet81        U  258,196,214  969.04 MB/s      7.75%         0         0         0  258,214,316  1097.14 MB/s      8.78%         0         0         0
 Ethernet82        U  258,247,415  968.83 MB/s      7.75%         0         0         0  258,224,407  1097.14 MB/s      8.78%         0         0         0
 Ethernet83        U  258,233,568  968.63 MB/s      7.75%         0         0         0  258,207,056  1097.15 MB/s      8.78%         0         0         0
 Ethernet84        U  258,225,130  968.43 MB/s      7.75%         0         0         0  258,229,476  1097.15 MB/s      8.78%         0         0         0
 Ethernet85        U  258,206,000  968.23 MB/s      7.75%         0         0         0  258,213,829  1097.15 MB/s      8.78%         0         0         0
 Ethernet86        U  258,215,961  968.04 MB/s      7.74%         0         0         0  258,243,378  1097.15 MB/s      8.78%         0         0         0
 Ethernet87        U  258,203,823  967.83 MB/s      7.74%         0         0         0  258,223,560  1097.15 MB/s      8.78%         0         0         0
Ethernet128        U  258,223,098  950.25 MB/s      7.60%         0         0         0  258,201,866  1097.36 MB/s      8.78%         0         0         0
Ethernet129        U  258,214,316  950.04 MB/s      7.60%         0         0         0  258,196,202  1097.36 MB/s      8.78%         0         0         0
Ethernet130        U  258,224,407  949.84 MB/s      7.60%         0         0         0  258,247,403  1097.37 MB/s      8.78%         0         0         0
Ethernet131        U  258,207,056  949.64 MB/s      7.60%         0         0         0  258,233,556  1097.37 MB/s      8.78%         0         0         0
Ethernet132        U  258,229,476  949.43 MB/s      7.60%         0         0         0  258,225,118  1097.37 MB/s      8.78%         0         0         0
Ethernet133        U  258,213,829  949.23 MB/s      7.59%         0         0         0  258,205,988  1097.37 MB/s      8.78%         0         0         0
Ethernet134        U  258,243,378  949.03 MB/s      7.59%         0         0         0  258,215,949  1097.38 MB/s      8.78%         0         0         0
Ethernet135        U  258,223,560  948.83 MB/s      7.59%         0         0         0  258,203,811  1097.38 MB/s      8.78%         0         0         0
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0712 INFO   | 
=== link index 0 ===
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-1    in Ethernet64  (RX_OK=258222974)  ->  out Ethernet128 (TX_OK=258223096)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-2    in Ethernet128 (RX_OK=258223098)  ->  out Ethernet80  (TX_OK=258222978)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0712 INFO   | 
=== link index 1 ===
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-1    in Ethernet65  (RX_OK=258214312)  ->  out Ethernet129 (TX_OK=258214316)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-2    in Ethernet129 (RX_OK=258214316)  ->  out Ethernet81  (TX_OK=258214316)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0712 INFO   | 
=== link index 2 ===
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-1    in Ethernet66  (RX_OK=258224403)  ->  out Ethernet130 (TX_OK=258224407)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-2    in Ethernet130 (RX_OK=258224407)  ->  out Ethernet82  (TX_OK=258224407)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0712 INFO   | 
=== link index 3 ===
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-1    in Ethernet67  (RX_OK=258207052)  ->  out Ethernet131 (TX_OK=258207056)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-2    in Ethernet131 (RX_OK=258207056)  ->  out Ethernet83  (TX_OK=258207056)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0712 INFO   | 
=== link index 4 ===
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-1    in Ethernet68  (RX_OK=258229472)  ->  out Ethernet132 (TX_OK=258229476)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-2    in Ethernet132 (RX_OK=258229476)  ->  out Ethernet84  (TX_OK=258229476)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0712 INFO   | 
=== link index 5 ===
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-1    in Ethernet69  (RX_OK=258213825)  ->  out Ethernet133 (TX_OK=258213829)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-2    in Ethernet133 (RX_OK=258213829)  ->  out Ethernet85  (TX_OK=258213829)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0712 INFO   | 
=== link index 6 ===
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-1    in Ethernet70  (RX_OK=258243374)  ->  out Ethernet134 (TX_OK=258243378)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-2    in Ethernet134 (RX_OK=258243378)  ->  out Ethernet86  (TX_OK=258243378)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0712 INFO   | 
=== link index 7 ===
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-1    in Ethernet71  (RX_OK=258223556)  ->  out Ethernet135 (TX_OK=258223560)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-2    in Ethernet135 (RX_OK=258223560)  ->  out Ethernet87  (TX_OK=258223560)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0712 INFO   | 
=== link index 0 ===
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-2    in Ethernet80  (RX_OK=258201758)  ->  out Ethernet128 (TX_OK=258201866)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-1    in Ethernet128 (RX_OK=258201864)  ->  out Ethernet64  (TX_OK=258201746)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0712 INFO   | 
=== link index 1 ===
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-2    in Ethernet81  (RX_OK=258196214)  ->  out Ethernet129 (TX_OK=258196202)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-1    in Ethernet129 (RX_OK=258196202)  ->  out Ethernet65  (TX_OK=258196202)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0712 INFO   | 
=== link index 2 ===
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-2    in Ethernet82  (RX_OK=258247415)  ->  out Ethernet130 (TX_OK=258247403)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-1    in Ethernet130 (RX_OK=258247403)  ->  out Ethernet66  (TX_OK=258247403)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0712 INFO   | 
=== link index 3 ===
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-2    in Ethernet83  (RX_OK=258233568)  ->  out Ethernet131 (TX_OK=258233556)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-1    in Ethernet131 (RX_OK=258233556)  ->  out Ethernet67  (TX_OK=258233556)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0712 INFO   | 
=== link index 4 ===
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-2    in Ethernet84  (RX_OK=258225130)  ->  out Ethernet132 (TX_OK=258225118)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-1    in Ethernet132 (RX_OK=258225118)  ->  out Ethernet68  (TX_OK=258225118)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0712 INFO   | 
=== link index 5 ===
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-2    in Ethernet85  (RX_OK=258206000)  ->  out Ethernet133 (TX_OK=258205988)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-1    in Ethernet133 (RX_OK=258205988)  ->  out Ethernet69  (TX_OK=258205988)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0712 INFO   | 
=== link index 6 ===
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-2    in Ethernet86  (RX_OK=258215961)  ->  out Ethernet134 (TX_OK=258215949)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-1    in Ethernet134 (RX_OK=258215949)  ->  out Ethernet70  (TX_OK=258215949)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0712 INFO   | 
=== link index 7 ===
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-2    in Ethernet87  (RX_OK=258203823)  ->  out Ethernet135 (TX_OK=258203811)
24/06/2026 18:29:10 srv6_helper.verify_nut_stats             L0719 INFO   |   t0  switch-t0-1    in Ethernet135 (RX_OK=258203811)  ->  out Ethernet71  (TX_OK=258203811)
24/06/2026 18:29:10 test_srv6.test_srv6_single_dut           L0548 INFO   | 10.36.84.36/1.1:Port_1 -> 10.36.84.37/3.1:Port_9: Frames Tx: 258222974  Frames Rx: 258222974  Delta: 0
24/06/2026 18:29:10 test_srv6.test_srv6_single_dut           L0548 INFO   | 10.36.84.36/1.2:Port_2 -> 10.36.84.37/3.2:Port_10: Frames Tx: 258214312  Frames Rx: 258214312  Delta: 0
24/06/2026 18:29:10 test_srv6.test_srv6_single_dut           L0548 INFO   | 10.36.84.36/1.3:Port_3 -> 10.36.84.37/3.3:Port_11: Frames Tx: 258224403  Frames Rx: 258224403  Delta: 0
24/06/2026 18:29:10 test_srv6.test_srv6_single_dut           L0548 INFO   | 10.36.84.36/1.4:Port_4 -> 10.36.84.37/3.4:Port_12: Frames Tx: 258207052  Frames Rx: 258207052  Delta: 0
24/06/2026 18:29:10 test_srv6.test_srv6_single_dut           L0548 INFO   | 10.36.84.36/1.5:Port_5 -> 10.36.84.37/3.5:Port_13: Frames Tx: 258229472  Frames Rx: 258229472  Delta: 0
24/06/2026 18:29:10 test_srv6.test_srv6_single_dut           L0548 INFO   | 10.36.84.36/1.6:Port_6 -> 10.36.84.37/3.6:Port_14: Frames Tx: 258213825  Frames Rx: 258213825  Delta: 0
24/06/2026 18:29:10 test_srv6.test_srv6_single_dut           L0548 INFO   | 10.36.84.36/1.7:Port_7 -> 10.36.84.37/3.7:Port_15: Frames Tx: 258243374  Frames Rx: 258243374  Delta: 0
24/06/2026 18:29:10 test_srv6.test_srv6_single_dut           L0548 INFO   | 10.36.84.36/1.8:Port_8 -> 10.36.84.37/3.8:Port_16: Frames Tx: 258223556  Frames Rx: 258223556  Delta: 0
24/06/2026 18:29:10 test_srv6.test_srv6_single_dut           L0548 INFO   | 10.36.84.37/3.1:Port_9 -> 10.36.84.36/1.1:Port_1: Frames Tx: 258201742  Frames Rx: 258201742  Delta: 0
24/06/2026 18:29:10 test_srv6.test_srv6_single_dut           L0548 INFO   | 10.36.84.37/3.2:Port_10 -> 10.36.84.36/1.2:Port_2: Frames Tx: 258196198  Frames Rx: 258196198  Delta: 0
24/06/2026 18:29:10 test_srv6.test_srv6_single_dut           L0548 INFO   | 10.36.84.37/3.3:Port_11 -> 10.36.84.36/1.3:Port_3: Frames Tx: 258247399  Frames Rx: 258247399  Delta: 0
24/06/2026 18:29:10 test_srv6.test_srv6_single_dut           L0548 INFO   | 10.36.84.37/3.4:Port_12 -> 10.36.84.36/1.4:Port_4: Frames Tx: 258233552  Frames Rx: 258233552  Delta: 0
24/06/2026 18:29:10 test_srv6.test_srv6_single_dut           L0548 INFO   | 10.36.84.37/3.5:Port_13 -> 10.36.84.36/1.5:Port_5: Frames Tx: 258225114  Frames Rx: 258225114  Delta: 0
24/06/2026 18:29:10 test_srv6.test_srv6_single_dut           L0548 INFO   | 10.36.84.37/3.6:Port_14 -> 10.36.84.36/1.6:Port_6: Frames Tx: 258205984  Frames Rx: 258205984  Delta: 0
24/06/2026 18:29:10 test_srv6.test_srv6_single_dut           L0548 INFO   | 10.36.84.37/3.7:Port_15 -> 10.36.84.36/1.7:Port_7: Frames Tx: 258215945  Frames Rx: 258215945  Delta: 0
24/06/2026 18:29:10 test_srv6.test_srv6_single_dut           L0548 INFO   | 10.36.84.37/3.8:Port_16 -> 10.36.84.36/1.8:Port_8: Frames Tx: 258203807  Frames Rx: 258203807  Delta: 0
24/06/2026 18:29:10 db_reporter._report                      L0049 INFO   | DBReporter: Writing 342 metric records to file
24/06/2026 18:29:10 db_reporter._report                      L0097 INFO   | DBReporter: Successfully wrote 342 metric records to /tmp/telemetry_test_qj02jdxp/test_srv6.metrics.json
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------