### PR TITLE
Fix pmon uptime parsing for long-running containers

### DIFF
--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -12,23 +12,56 @@ from tests.common.utilities import wait_until, get_plt_reboot_ctrl
 
 logger = logging.getLogger(__name__)
 
+# Conversion factors (minutes) for every unit that `docker ps` may emit.
+_DOCKER_UPTIME_UNIT_TO_MINUTES = {
+    "second":  1 / 60,
+    "seconds": 1 / 60,
+    "minute":  1,
+    "minutes": 1,
+    "hour":    60,
+    "hours":   60,
+    "day":     60 * 24,
+    "days":    60 * 24,
+    "week":    60 * 24 * 7,
+    "weeks":   60 * 24 * 7,
+    "month":   60 * 24 * 30,
+    "months":  60 * 24 * 30,
+    "year":    60 * 24 * 365,
+    "years":   60 * 24 * 365,
+}
 
-def check_pmon_uptime_minutes(duthost, minimal_runtime=6):
+
+def check_pmon_uptime_minutes(duthost, minimal_runtime=6, pmon_status=None):
     """
-    @summary: This function checks if pmon uptime is at least the minimal_runtime
-    @return: True pmon has been running at least the minimal_runtime, False for otherwise
+    @summary: Check whether the pmon container has been running for at least minimal_runtime minutes.
+    @param duthost: AnsibleHost object for the DUT. May be None when pmon_status is supplied directly.
+    @param minimal_runtime: Required minimum uptime in minutes (default 6).
+    @param pmon_status: Optional pre-fetched STATUS string from `docker ps` (e.g. "Up 2 months").
+                        When supplied, duthost is not queried. Intended for unit-testing only.
+    @return: True if pmon uptime >= minimal_runtime minutes, False otherwise.
     """
-    result = duthost.command("docker ps | grep pmon", _uses_shell=True)
-    if result["stdout"]:
-        match = re.search(r'Up (\d+) (minutes|hours)', result["stdout"])
-        if match:
-            if match.group(2) == "hours":
-                return int(match.group(1))*60 >= minimal_runtime
-            else:
-                return int(match.group(1)) >= minimal_runtime
-        match = re.search(r'Up About an hour', result["stdout"])
-        if match:
-            return 60 >= minimal_runtime
+    if pmon_status is None:
+        result = duthost.command("docker ps | grep pmon", _uses_shell=True)
+        status_str = result["stdout"] if result["stdout"] else ""
+    else:
+        status_str = pmon_status
+
+    if not status_str:
+        return False
+
+    # Standard form: "Up N <unit>" (e.g. "Up 3 days", "Up 2 months", "Up 6 minutes")
+    match = re.search(r'Up (\d+) (\w+)', status_str)
+    if match:
+        count = int(match.group(1))
+        unit = match.group(2).lower()
+        factor = _DOCKER_UPTIME_UNIT_TO_MINUTES.get(unit)
+        if factor is not None:
+            return count * factor >= minimal_runtime
+
+    # Older docker versions emit "Up About an hour" (no digit) for ~60 minutes.
+    if re.search(r'Up About an hour', status_str):
+        return minimal_runtime <= 60
+
     return False
 
 

--- a/tests/common/unit_tests/unit_test_processes_utils.py
+++ b/tests/common/unit_tests/unit_test_processes_utils.py
@@ -1,0 +1,42 @@
+import pytest
+from tests.common.platform.processes_utils import check_pmon_uptime_minutes
+
+
+@pytest.mark.parametrize("status, minimal_runtime, expected", [
+    # 1. Up 30 seconds
+    ("Up 30 seconds", 6, False),
+    ("Up 30 seconds", 1, False),  # 0.5 min < 1 min
+    # 2. Up 6 minutes
+    ("Up 6 minutes", 6, True),
+    ("Up 6 minutes", 10, False),
+    # 3. Up 3 hours
+    ("Up 3 hours", 6, True),
+    ("Up 3 hours", 180, True),
+    ("Up 3 hours", 181, False),
+    # 4. Up 4 days
+    ("Up 4 days", 6, True),
+    ("Up 4 days", 5760, True),
+    ("Up 4 days", 5761, False),
+    # 5. Up 3 weeks
+    ("Up 3 weeks", 6, True),
+    # 6. Up 2 months
+    ("Up 2 months", 6, True),
+    # 7. Up 1 year
+    ("Up 1 year", 6, True),
+    # Edge case and fallback matching:
+    ("Up About an hour", 6, True),
+    ("Up About an hour", 60, True),
+    ("Up About an hour", 61, False),
+    ("", 6, False),
+])
+def test_check_pmon_uptime_minutes(status, minimal_runtime, expected):
+    # Pass None as duthost since status is pre-fetched and supplied via
+    # pmon_status
+    assert (
+        check_pmon_uptime_minutes(
+            None,
+            minimal_runtime=minimal_runtime,
+            pmon_status=status
+        )
+        == expected
+    )

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -3,7 +3,6 @@ import json
 import pytest
 import os
 import logging
-import re
 import tempfile
 from tests.common.mellanox_data import is_mellanox_device
 from .args.counterpoll_cpu_usage_args import add_counterpoll_cpu_usage_args
@@ -161,25 +160,6 @@ def thermal_manager_enabled(duthosts, enum_rand_one_per_hwsku_hostname):
             "chassis").get("thermal_manager", True)
     if not thermal_manager_available:
         pytest.skip("skipped as thermal manager is not available")
-
-
-def check_pmon_uptime_minutes(duthost, minimal_runtime=6):
-    """
-    @summary: This function checks if pmon uptime is at least the minimal_runtime
-    @return: True pmon has been running at least the minimal_runtime, False for otherwise
-    """
-    result = duthost.command("docker ps | grep pmon", _uses_shell=True)
-    if result["stdout"]:
-        match = re.search(r'Up (\d+) (minutes|hours)', result["stdout"])
-        if match:
-            if match.group(2) == "hours":
-                return int(match.group(1))*60 >= minimal_runtime
-            else:
-                return int(match.group(1)) >= minimal_runtime
-        match = re.search(r'Up About an hour', result["stdout"])
-        if match:
-            return 60 >= minimal_runtime
-    return False
 
 
 def pytest_generate_tests(metafunc):


### PR DESCRIPTION
Fixes #25606

## Summary
The existing implementation of check_pmon_uptime_minutes only handled uptime strings expressed in minutes and hours.

This change adds support for:
- seconds
- minutes
- hours
- days
- weeks
- months
- years

and adds unit tests covering the reported cases.

## Testing
pytest tests/common/unit_tests/unit_test_processes_utils.py -v