### PR TITLE
Fix race condition in test_dynamic_acl rule check

### DIFF
--- a/tests/common/gu_utils.py
+++ b/tests/common/gu_utils.py
@@ -554,8 +554,20 @@ def expect_acl_table_match_multiple_bindings(duthost,
         pytest_assert(wait_until(30, 5, 0, check_table), "ACL table does not contain expected bindings")
 
 
-def expect_acl_rule_match(duthost, rulename, expected_content_list, setup):
-    """Check if acl rule shows as expected"""
+def expect_acl_rule_match(duthost, rulename, expected_content_list, setup, timeout=15, interval=2):
+    """Check if acl rule shows as expected.
+
+    GCU writes the rule to CONFIG_DB synchronously, but orchagent programs it to the
+    ASIC asynchronously (draining its queue in lexicographic key order) and only then
+    writes the STATE_DB status to "Active". At scale a freshly-added rule can read back
+    as "N/A" / "Pending creation" for several seconds, so poll until it matches instead
+    of checking exactly once.
+
+    Args:
+        timeout: Maximum seconds to wait for the rule to reach the expected state.
+                 Increase for large/scale patches where programming takes longer.
+        interval: Seconds between polls.
+    """
 
     cmds = "show acl rule DYNAMIC_ACL_TABLE {}".format(rulename)
 
@@ -565,20 +577,35 @@ def expect_acl_rule_match(duthost, rulename, expected_content_list, setup):
 
     for dut in duts_to_check:
 
-        output = dut.show_and_parse(cmds)
+        def rule_matches():
+            # Return True/False (never assert) so wait_until can keep polling.
+            # wait_until swallows pytest.fail.Exception, so an assert here would be
+            # silently treated as a retry rather than a hard failure.
+            output = dut.show_and_parse(cmds)
 
-        rule_lines = len(output)
+            rule_lines = len(output)
+            if rule_lines < 1:
+                logger.warning("'{}' is not a rule on this device yet".format(rulename))
+                return False
 
-        pytest_assert(rule_lines >= 1, "'{}' is not a rule on this device".format(rulename))
+            first_line = output[0].values()
+            if not set(first_line) <= set(expected_content_list):
+                logger.warning("Rule '{}' not matching yet. Got {}, want subset of {}".format(
+                    rulename, list(first_line), expected_content_list))
+                return False
 
-        first_line = output[0].values()
+            if rule_lines > 1:
+                for i in range(1, rule_lines):
+                    if output[i]["match"] not in expected_content_list:
+                        logger.warning("Unexpected match condition for '{}': {}".format(
+                            rulename, output[i]["match"]))
+                        return False
+            return True
 
-        pytest_assert(set(first_line) <= set(expected_content_list), "ACL Rule details do not match!")
-
-        if rule_lines > 1:
-            for i in range(1, rule_lines):
-                pytest_assert(output[i]["match"] in expected_content_list,
-                              "Unexpected match condition found: " + str(output[i]["match"]))
+        pytest_assert(
+            wait_until(timeout, interval, 0, rule_matches),
+            "ACL rule '{}' did not reach expected state within {}s "
+            "(status likely N/A/Pending creation)".format(rulename, timeout))
 
 
 def expect_acl_rule_removed(duthost, rulename, setup):

--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -1089,7 +1089,9 @@ def dynamic_acl_apply_forward_scale_rules(duthost, setup):
         expect_op_success(duthost, output)
 
     for rule_name, expected_content in expected_rule_contents.items():
-        expect_acl_rule_match(duthost, rule_name, expected_content, setup)
+        # Scale patch adds ~150 rules at once; orchagent programs them to the ASIC
+        # asynchronously in lexicographic order, so allow a longer settle window.
+        expect_acl_rule_match(duthost, rule_name, expected_content, setup, timeout=60)
 
 
 def dynamic_acl_apply_drop_scale_rules(duthost, setup):
@@ -1120,7 +1122,7 @@ def dynamic_acl_apply_drop_scale_rules(duthost, setup):
 
         expect_op_success(duthost, output)
 
-    expect_acl_rule_match(duthost, rule_name, expected_content, setup)
+    expect_acl_rule_match(duthost, rule_name, expected_content, setup, timeout=60)
 
 
 def dynamic_acl_remove_ip_forward_rule(duthost, ip_type, setup):


### PR DESCRIPTION


Summary:
Fixes recent failures of test_dynamic_acl on internal builds that were caused by the scale test checking for ACL rule existence too quickly.

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [x] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Fix recent test case failures of the scale test that were caused by a race condition between SAI/orchagent applying the ACL and us calling "show acl rule" to check the rules existence.  Logs from when the problem happened:

<img width="1396" height="463" alt="image" src="https://github.com/user-attachments/assets/50b9a924-fac7-42a8-a0f0-bd60c5020ce0" />


#### How did you do it?

Changed the expect_acl_rule_match method to continually poll for the rule for a default of 15 seconds, scaled up to 60 seconds for the scale rule test, and only fail if it is still missing after that.
