### PR TITLE
[ci][202511] wire PTF image tag through impacted-area PR tests

### DIFF
--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -28,6 +28,10 @@ parameters:
   type: string
   default: ""
 
+- name: PTF_IMAGE_TAG
+  type: string
+  default: ""
+
 - name: PTF_MODIFIED
   type: string
   default: "False"
@@ -113,6 +117,7 @@ jobs:
           TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
           MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
           MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+          PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
           PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
           EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
           TOPOLOGY: t0
@@ -154,6 +159,7 @@ jobs:
   #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
   #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
   #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+  #         PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
   #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
   #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
   #         TOPOLOGY: t0
@@ -196,6 +202,7 @@ jobs:
           TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
           MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
           MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+          PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
           PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
           EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
           TOPOLOGY: t1-lag
@@ -237,6 +244,7 @@ jobs:
   #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
   #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
   #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+  #         PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
   #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
   #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
   #         TOPOLOGY: dualtor
@@ -278,6 +286,7 @@ jobs:
   #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
   #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
   #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+  #         PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
   #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
   #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
   #         TOPOLOGY: t0-64-32
@@ -324,6 +333,7 @@ jobs:
   #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
   #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
   #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+  #         PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
   #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
   #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
   #         TOPOLOGY: dpu
@@ -369,6 +379,7 @@ jobs:
   #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
   #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
   #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+  #         PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
   #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
   #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
   #         TOPOLOGY: t1-8-lag
@@ -412,6 +423,7 @@ jobs:
           TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
           MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
           MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+          PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
           PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
           EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
           TOPOLOGY: t2


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
cherry-pick: https://github.com/sonic-net/sonic-mgmt/pull/25487
Summary:
Update the PR test template to enable PR checker to pass PTF_IMAGE_TAG through all impacted-area test jobs

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Today, PR test jobs can control whether the PTF image was modified (PTF_MODIFIED), but they do not have a first-class way to pin the exact PTF image tag for impacted-area execution. By adding PTF_IMAGE_TAG as a template parameter and wiring it through all Elastictest PR jobs, the pipeline gains deterministic image selection, easier triage, and cleaner operational control for PTF-related validation in PR workflows.
#### How did you do it?
Updated the PR test template to:
- add PTF_IMAGE_TAG as a top-level parameter
- pass PTF_IMAGE_TAG into each Elastictest job invocation

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
