### PR TITLE
[lldp] Remove duplicate bare assert hiding neighbor name mismatch diagnostics

### DIFF
--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -105,7 +105,6 @@ def test_lldp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost,
             assert v['port']['ifname'] == new_intf
         else:
             # Compare the LLDP neighbor name with minigraph neigbhor name (exclude the management port)
-            assert v['chassis']['name'] == config_facts['DEVICE_NEIGHBOR'][k]['name']
             assert v['chassis']['name'] == config_facts['DEVICE_NEIGHBOR'][k]['name'], (
                 "LLDP neighbor name mismatch. Expected '{}', but got '{}'."
             ).format(


### PR DESCRIPTION
### Description of PR

Summary:
`test_lldp` had two consecutive `assert` statements with the **same condition** for the LLDP neighbor name check. The first is a bare `assert` (no message); the second carries the descriptive "Expected '{}', but got '{}'" message. The bare assert shadows the descriptive one, so every LLDP neighbor name mismatch surfaced only as an uninformative bare `AssertionError`. This removes the redundant bare assert so the descriptive message is shown.

Context: nightly data (`internal-202605`, 30 days, grouped by failure reason) shows these name-mismatch failures are **flaky** (the same testbed both passes and fails, e.g. `vms61-t1-8101-04` 2 fail / 3 pass) and concentrated on the neighbor **`Ethernet1`** link across **8101/7060/8102 T1** testbeds. Because the current bare assert hides the actual learned chassis name, the failures are undiagnosable. Restoring the descriptive message lets the next failure show exactly which neighbor sysName was learned (Expected vs got) — the prerequisite for root-causing the flaky behaviour.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
LLDP neighbor name mismatch failures in nightly surface as a bare `AssertionError` with no detail, because a redundant bare assert (introduced in #22171) shadows the descriptive assert that immediately follows it. This blocks diagnosing which neighbor's learned sysName mismatches the minigraph.

#### How did you do it?
Removed the duplicate bare `assert v['chassis']['name'] == config_facts['DEVICE_NEIGHBOR'][k]['name']` in `test_lldp`, keeping the immediately-following assert that has the identical condition plus the "LLDP neighbor name mismatch. Expected '{}', but got '{}'." message.

#### How did you verify/test it?
`python -m py_compile tests/lldp/test_lldp.py` passes. Single-line deletion; the retained assert has an identical condition, so behaviour is unchanged except the failure message is now informative.

#### Any platform specific information?
None — diagnostic-only change.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A