### PR TITLE
Update test_system_is_running

### DIFF
--- a/tests/system_health/test_system_status.py
+++ b/tests/system_health/test_system_status.py
@@ -10,7 +10,7 @@ pytestmark = [
 def test_system_is_running(duthost):
     def is_system_ready(duthost):
         status = duthost.shell('sudo systemctl is-system-running', module_ignore_errors=True)['stdout']
-        return status != "starting"
+        return status == "running"
 
     if not wait_until(180, 10, 0, is_system_ready, duthost):
         pytest.fail('Failed to find routed interface in 180 s')


### PR DESCRIPTION
Summary: Update case test_system_is_running
Fixes # 

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [X] 202605

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- master: case pass
- 202605: case pass

### Approach
#### What is the motivation for this PR?
`test_system_is_running` only treated the `starting` state as "not ready", so any other `systemctl is-system-running` result — including `degraded` — was considered a pass. A `degraded` system means one or more systemd units have failed, so the previous check silently masked real problems.


#### How did you do it?
This changes the readiness check to require the `running` state instead.

#### How did you verify/test it?
Regression test pass

#### Any platform specific information?
All

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A