### PR TITLE
Fix eth0 validation in neighbor-centric LLDP views

### DIFF
--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -327,6 +327,7 @@ def eth0_has_lldp_neighbor(duthost):
         return False
     return int(match.group(1)) > 0
 
+
 def verify_lldp_table(duthost, intf_status_output, test_name=""):
     """
     Verify LLDP table interfaces match interface status (admin up, no PortChannels).

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -311,6 +311,22 @@ def get_expected_chassis_mac(duthost, asic, tbinfo):
         return duthost.get_dut_iface_mac(mgmt_alias).lower()
 
 
+def eth0_has_lldp_neighbor(duthost):
+    """Return True if lldpd has discovered a remote LLDP neighbor on eth0.
+    show lldp table lists remote neighbors per local port. eth0 appears only
+    when the management path delivers LLDP frames from a peer. Standard lab
+    testbeds (t0/t1/t2) typically do not forward mgmt LLDP; see test_lldp_mgmt.py.
+    """
+    result = duthost.shell(
+        "docker exec lldp lldpcli show neighbors ports eth0 summary",
+        module_ignore_errors=True)
+    if result.get("rc", 0) != 0:
+        return False
+    match = re.search(r"Total entries displayed:\s*(\d+)", result["stdout"])
+    if not match:
+        return False
+    return int(match.group(1)) > 0
+
 def verify_lldp_table(duthost, intf_status_output, test_name=""):
     """
     Verify LLDP table interfaces match interface status (admin up, no PortChannels).
@@ -338,11 +354,13 @@ def verify_lldp_table(duthost, intf_status_output, test_name=""):
     logger.info("LLDP table interfaces{}: {}".format(context, sorted(lldp_table_interfaces)))
     logger.info("LLDP table interfaces in total: {}".format(len(lldp_table_interfaces)))
 
-    # On virtual/KVM testbeds, eth0 has no LLDP neighbor so it won't appear in the LLDP table
-    if is_virtual_platform(duthost):
+    # show lldp table is a remote-neighbor table; require eth0 only when lldpd
+    # has discovered a mgmt LLDP peer.
+    if is_virtual_platform(duthost) or not eth0_has_lldp_neighbor(duthost):
         if 'eth0' not in lldp_table_interfaces:
-            logger.info("eth0 not in LLDP table (expected on virtual/KVM testbed){}"
-                        .format(context))
+            logger.info(
+                "eth0 not in LLDP table (no mgmt LLDP neighbor on this testbed){}"
+                .format(context))
     else:
         pytest_assert('eth0' in lldp_table_interfaces,
                       "eth0 is missing from LLDP table{}".format(context))
@@ -489,11 +507,13 @@ def verify_lldpctl_facts(duthost, enum_frontend_asic_index, intf_status_output, 
         skip_interface_pattern_list=["Ethernet-BP", "Ethernet-IB"] + internal_port_list
     )['ansible_facts']
 
-    # Verify eth0 is in lldpctl_facts (only on physical testbeds)
-    if is_virtual_platform(duthost):
+    # lldpctl_facts returns interfaces with LLDP neighbors; require eth0 only when
+    # lldpd has discovered a mgmt LLDP peer.
+    if is_virtual_platform(duthost) or not eth0_has_lldp_neighbor(duthost):
         if 'eth0' not in lldpctl_facts.get('lldpctl', {}):
-            logger.info("eth0 not in lldpctl_facts (expected on virtual/KVM testbed){}"
-                        .format(context))
+            logger.info(
+                "eth0 not in lldpctl_facts (no mgmt LLDP neighbor on this testbed){}"
+                .format(context))
     else:
         pytest_assert('eth0' in lldpctl_facts.get('lldpctl', {}),
                       "eth0 is missing from lldpctl_facts{}".format(context))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix eth0 LLDP validation in test_lldp_interfaces and test_lldp_interfaces_config_reload to handle testbeds where management network does not forward LLDP frames.

Fixes # (issue)
Tests test_lldp_interfaces and test_lldp_interfaces_config_reload were failing with assertion errors on physical lab testbeds:

- eth0 is missing from LLDP table
- eth0 is missing from lldpctl_facts

The root cause is a test-expectation mismatch, not a broken LLDP stack. show lldp table and lldpctl_facts are neighbor tables—they only list interfaces with discovered LLDP neighbors. On standard lab testbeds (t0/t1/t2), the management infrastructure typically does not forward LLDP frames to eth0, a behavior already documented in test_lldp_mgmt.py.

The original code only exempted KVM platforms via is_virtual_platform(), but physical lab testbeds without mgmt LLDP also need exemption.

Bug id : https://github.com/sonic-net/sonic-mgmt/pull/25657
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

LLDP interface validation tests run on various testbed topologies. When the management network does not deliver LLDP frames to eth0, the tests should not fail—eth0 LLDP is enabled and working, but there is simply no LLDP neighbor to discover. The test incorrectly treated the neighbor table as proof that eth0 LLDP is enabled, causing false failures on testbeds where mgmt LLDP is unavailable.

This was observed during internal testing on Cisco super-t0 Superbolt lab testbed where front-panel LLDP was healthy (8 T1 neighbors) but eth0 had no LLDP neighbor due to management network configuration.

#### How did you do it?

1. Added helper function eth0_has_lldp_neighbor(duthost) that queries lldpd directly:
       `docker exec lldp lldpcli show neighbors ports eth0 summary`
        Returns True only if eth0 has at least one discovered LLDP neighbor.
2. Updated verify_lldp_table() eth0 check:
- Before: Assert eth0 presence on all non-KVM platforms
- After: Assert eth0 presence only when eth0_has_lldp_neighbor() returns True

3. Updated verify_lldpctl_facts() with the same logic for consistency.

This ensures:

- Tests pass on testbeds where management LLDP is unavailable
- Tests still validate eth0 on setups that DO have management LLDP neighbors

#### How did you verify/test it?

1. Verified eth0_has_lldp_neighbor() correctly detects presence/absence of mgmt LLDP neighbor by parsing lldpcli show neighbors ports eth0 summary output.
2. Ran test_lldp_interfaces and test_lldp_interfaces_config_reload on testbed without mgmt LLDP—tests now pass with informative log messages instead of assertion failures.

#### Any platform specific information?
N/A - This fix applies to all platforms where management network does not forward LLDP frames.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
