### PR TITLE
Improve snmp_helper to support snmpget in vrf scenario

### DIFF
--- a/tests/common/helpers/snmp_helpers.py
+++ b/tests/common/helpers/snmp_helpers.py
@@ -87,10 +87,16 @@ def get_snmp_output(ip, duthost, nbr, creds_all_duts, oid='.1.3.6.1.2.1.1.1.0'):
     ip_tbl_rule_add = "sudo {} -I INPUT 1 -p udp --dport 161 -d {} -j ACCEPT".format(
         iptables_cmd, ip)
     duthost.shell(ip_tbl_rule_add)
-
+    # DUT IP is only accessible through VRF from neighboring devices if the neighbor is a multi-VRF peer
+    # This enhancement only handles the case where the neighbor is EoS
+    vrf_prefix = ""
+    if nbr.get("is_multi_vrf_peer", False):
+        vrf = nbr.get("multi_vrf_data", {}).get("vrf", "")
+        if vrf:
+            vrf_prefix = "sudo ip netns exec ns-{}".format(vrf)
     if isinstance(nbr["host"], EosHost):
-        eos_snmpget = "bash snmpget -v2c -c {} {} {}".format(
-            creds_all_duts[duthost.hostname]['snmp_rocommunity'], ip, oid)
+        eos_snmpget = "bash {} snmpget -v2c -c {} {} {}".format(
+            vrf_prefix, creds_all_duts[duthost.hostname]['snmp_rocommunity'], ip, oid)
         out = nbr['host'].eos_command(commands=[eos_snmpget])
     else:
         command = "docker exec snmp snmpwalk -v 2c -c {} {} {}".format(


### PR DESCRIPTION
### Description of PR
Summary:
Improve `get_snmp_output` in `snmp_helpers.py` to support snmpget in VRF scenarios when the neighbor is an EoS device.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
In multi-VRF testbed topologies, the DUT IP is only accessible through a specific VRF network namespace from EoS neighboring devices. Without this change, snmpget would fail because it is issued outside of the correct VRF context.

#### How did you do it?
Added a `vrf_prefix` computed from `nbr["multi_vrf_data"]["vrf"]` when the neighbor has `is_multi_vrf_peer=True`. The prefix `sudo ip netns exec ns-<vrf>` is prepended to the snmpget command executed on the EoS neighbor via `eos_command`. Safe defaults (`False` and `.get()`) are used to avoid regressions on non-VRF paths.

#### How did you verify/test it?
Tested on a physical testbed with a multi-VRF topology using EoS neighbors.

#### Any platform specific information?
This change only affects EoS neighbors in multi-VRF topologies. Non-VRF and non-EoS code paths are unchanged.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation