### PR TITLE
[lldp][DRAFT] reverse-SNMP mgmt_addr robustness tweak (NOT the fix for the 202605 LLDP regression)

### DIFF
--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -1,4 +1,5 @@
 import contextlib
+import json
 import logging
 import re
 import pytest
@@ -90,44 +91,72 @@ def test_lldp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost,
     config_facts = duthost.asic_instance(
         enum_frontend_asic_index).config_facts(host=duthost.hostname, source="running")['ansible_facts']
     internal_port_list = get_dpu_npu_ports_from_hwsku(duthost)
-    lldpctl_facts = duthost.lldpctl_facts(
-        asic_instance_id=enum_frontend_asic_index,
-        skip_interface_pattern_list=["eth0", "Ethernet-BP", "Ethernet-IB"] + internal_port_list)['ansible_facts']
-    if not list(lldpctl_facts['lldpctl'].items()):
-        pytest.fail("No LLDP neighbors received (lldpctl_facts are empty)")
-    for k, v in list(lldpctl_facts['lldpctl'].items()):
+    # Physical testbeds insert a fanout switch between the DUT and the VM
+    # neighbors, and the fanout also advertises LLDP. A DUT port therefore
+    # reports multiple LLDP neighbors (the real VM neighbor + the fanout).
+    # The keyvalue-based lldpctl_facts collapses them into a single entry
+    # (last one wins), which intermittently keeps the fanout and flakes.
+    # Use "lldpctl -f json" (like test_lldp_syncd) so every neighbor on a port
+    # is visible, then verify the expected minigraph neighbor is among them.
+    asic_str = "" if enum_frontend_asic_index is None else str(enum_frontend_asic_index)
+    lldp_json = json.loads(duthost.shell(
+        "docker exec lldp{} /usr/sbin/lldpctl -f json".format(asic_str))['stdout'])
+    interfaces = lldp_json.get('lldp', {}).get('interface', [])
+    if isinstance(interfaces, dict):
+        interfaces = [interfaces]
+    skip_patterns = ["eth0", "Ethernet-BP", "Ethernet-IB"] + internal_port_list
+    skip_re = re.compile("(?:%s)" % "|".join(skip_patterns)) if skip_patterns else None
+    # local_port -> list of neighbors {name, ifname, descr}
+    learned = {}
+    for iface in interfaces:
+        if not iface:
+            continue
+        local_port = list(iface.keys())[0]
+        if skip_re and skip_re.match(local_port):
+            continue
+        info = iface[local_port] or {}
+        chassis = info.get('chassis', {}) or {}
+        port = info.get('port', {}) or {}
+        learned.setdefault(local_port, []).append({
+            'name': list(chassis.keys())[0] if chassis else '',
+            'ifname': (port.get('id', {}) or {}).get('value', ''),
+            'descr': port.get('descr', '')
+        })
+    if not learned:
+        pytest.fail("No LLDP neighbors received (lldpctl reported no interfaces)")
+    for k, neighbors in learned.items():
+        if k not in config_facts['DEVICE_NEIGHBOR']:
+            continue
+        names = [n['name'] for n in neighbors]
         if converged:
             exp_intf = config_facts['DEVICE_NEIGHBOR'][k]['port']
             vrf = config_facts['DEVICE_NEIGHBOR'][k]['name']
             primary = rev_vrf_map[vrf]
             new_intf = convergence_info['converged_peers'][primary]['intf_mapping'][vrf]['orig_intf_map'][exp_intf]
-            assert v['chassis']['name'] == primary
-            assert v['port']['ifname'] == new_intf
+            match = next((n for n in neighbors if n['name'] == primary), None)
+            assert match is not None, (
+                "LLDP neighbor name mismatch on {}. Expected '{}' among learned {}."
+            ).format(k, primary, names)
+            assert match['ifname'] == new_intf, (
+                "LLDP neighbor interface mismatch on {}. Expected '{}', but got '{}'."
+            ).format(k, new_intf, match['ifname'])
         else:
-            # Compare the LLDP neighbor name with minigraph neigbhor name (exclude the management port)
-            assert v['chassis']['name'] == config_facts['DEVICE_NEIGHBOR'][k]['name']
-            assert v['chassis']['name'] == config_facts['DEVICE_NEIGHBOR'][k]['name'], (
-                "LLDP neighbor name mismatch. Expected '{}', but got '{}'."
-            ).format(
-                config_facts['DEVICE_NEIGHBOR'][k]['name'],
-                v['chassis']['name']
-            )
-            # Compare the LLDP neighbor interface with minigraph neigbhor interface (exclude the management port)
+            exp_name = config_facts['DEVICE_NEIGHBOR'][k]['name']
+            # Tolerate extra neighbors (e.g. fanout): require the expected VM to be present
+            match = next((n for n in neighbors if n['name'] == exp_name), None)
+            assert match is not None, (
+                "LLDP neighbor name mismatch on {}. Expected '{}' among learned {}."
+            ).format(k, exp_name, names)
+            exp_port = config_facts['DEVICE_NEIGHBOR'][k]['port']
             if request.config.getoption("--neighbor_type") == 'eos':
-                assert v['port']['ifname'] == config_facts['DEVICE_NEIGHBOR'][k]['port'], (
-                    "LLDP neighbor port interface name mismatch. Expected '{}', but got '{}'."
-                ).format(
-                    config_facts['DEVICE_NEIGHBOR'][k]['port'],
-                    v['port']['ifname']
-                )
+                assert match['ifname'] == exp_port, (
+                    "LLDP neighbor port ifname mismatch on {}. Expected '{}', but got '{}'."
+                ).format(k, exp_port, match['ifname'])
             else:
                 # Dealing with KVM that advertises port description
-                assert v['port']['descr'] == config_facts['DEVICE_NEIGHBOR'][k]['port'], (
-                    "LLDP neighbor port description mismatch. Expected '{}', but got '{}'."
-                ).format(
-                    config_facts['DEVICE_NEIGHBOR'][k]['port'],
-                    v['port']['descr']
-                )
+                assert match['descr'] == exp_port, (
+                    "LLDP neighbor port description mismatch on {}. Expected '{}', but got '{}'."
+                ).format(k, exp_port, match['descr'])
 
 
 def _neighbor_has_lldp_entry(localhost, hostip, snmp_community, neighbor_interface):

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -195,18 +195,55 @@ def check_lldp_neighbor(duthost, localhost, eos, sonic, collect_techsupport_all_
 
     nei_meta = config_facts.get('DEVICE_NEIGHBOR_METADATA', {})
 
-    for k, v in list(lldpctl_facts['lldpctl'].items()):
-        try:
-            hostip = v['chassis']['mgmt-ip']
-        except Exception:
-            logger.info("Neighbor device {} does not sent management IP via lldp".format(v['chassis']['name']))
-            hostip = nei_meta[v['chassis']['name']]['mgmt_addr']
+    # Read LLDP via json so a port's multiple neighbors (the real VM neighbor +
+    # the fanout switch on physical testbeds) are all visible. The keyvalue
+    # lldpctl_facts collapses a port's neighbors field-by-field (last write
+    # wins), which can mix the VM's identity with the physical fanout's
+    # mgmt-ip; the SNMP reverse-check then queries the fanout (which does not
+    # answer SNMP) instead of the cEOS VM and times out intermittently.
+    # Verify only the minigraph neighbors, and use the minigraph-provisioned
+    # mgmt addr (the address the framework uses to reach the VM) as the SNMP
+    # target rather than any LLDP-advertised mgmt-ip.
+    lldp_json = json.loads(duthost.shell(
+        "docker exec lldp{} /usr/sbin/lldpctl -f json".format('' if asic is None else asic))['stdout'])
+    lldp_interfaces = lldp_json.get('lldp', {}).get('interface', [])
+    if isinstance(lldp_interfaces, dict):
+        lldp_interfaces = [lldp_interfaces]
+    skip_re = re.compile("(?:%s)" % "|".join(["eth0", "Ethernet-BP", "Ethernet-IB"] + internal_port_list))
+    learned = {}
+    for iface in lldp_interfaces:
+        if not iface:
+            continue
+        local_port = list(iface.keys())[0]
+        if skip_re.match(local_port):
+            continue
+        info = iface[local_port] or {}
+        chassis = info.get('chassis', {}) or {}
+        port = info.get('port', {}) or {}
+        cname = list(chassis.keys())[0] if chassis else ''
+        learned.setdefault(local_port, []).append({
+            'name': cname,
+            'port_id': (port.get('id', {}) or {}).get('value', ''),
+        })
 
+    for k in config_facts['DEVICE_NEIGHBOR']:
+        if k not in learned:
+            continue
+        exp_name = config_facts['DEVICE_NEIGHBOR'][k]['name']
+        # Tolerate extra neighbors (e.g. fanout): require the expected VM neighbor.
+        match = next((n for n in learned[k] if n['name'] == exp_name), None)
+        assert match is not None, (
+            "LLDP neighbor name mismatch on {}. Expected '{}' among learned {}."
+        ).format(k, exp_name, [n['name'] for n in learned[k]])
+        # Use the minigraph-provisioned mgmt addr (the VM the framework reaches),
+        # not any LLDP-advertised mgmt-ip (which can be the fanout on physical tb).
+        hostip = nei_meta.get(exp_name, {}).get('mgmt_addr')
+        if not hostip:
+            pytest.fail("No mgmt_addr for neighbor {} in DEVICE_NEIGHBOR_METADATA".format(exp_name))
+        neighbor_interface = match['port_id']
         if request.config.getoption("--neighbor_type") == 'eos':
-            neighbor_interface = v['port']['ifname']
             snmp_community = eos['snmp_rocommunity']
         else:
-            neighbor_interface = v['port']['local']
             snmp_community = sonic['snmp_rocommunity']
 
         # After swss restart, the DUT's LLDP entry on the neighbor may have aged out

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -167,18 +167,21 @@ def check_lldp_neighbor(duthost, localhost, eos, sonic, collect_techsupport_all_
     nei_meta = config_facts.get('DEVICE_NEIGHBOR_METADATA', {})
 
     for k, v in list(lldpctl_facts['lldpctl'].items()):
-        # Use the minigraph-provisioned mgmt addr (the address the framework uses
-        # to reach the VM) as the SNMP target rather than the LLDP-advertised
-        # mgmt-ip. On physical testbeds a port can learn both the real VM neighbor
-        # and the fanout switch; the keyvalue lldpctl_facts merges a port's
-        # neighbors field-by-field (last write wins), so mgmt-ip can end up being
-        # the fanout's (which does not answer SNMP) even when the name is the VM,
-        # making the reverse SNMP check time out intermittently.
-        neighbor_name = v['chassis'].get('name')
-        if neighbor_name in nei_meta and nei_meta[neighbor_name].get('mgmt_addr'):
+        # Prefer the minigraph-provisioned mgmt addr as the reverse-SNMP target.
+        # On physical testbeds a port can learn both the real VM neighbor and the
+        # fanout switch; the keyvalue lldpctl_facts merges a port's neighbors
+        # field-by-field (last write wins), so the LLDP-advertised chassis.mgmt-ip
+        # can end up being the fanout's (which does not answer SNMP) even when the
+        # name is the VM, making the reverse SNMP check time out intermittently.
+        # The minigraph mgmt_addr always points at the neighbor VM (on KVM both
+        # resolve to the same VM, so behavior there is unchanged).
+        neighbor_name = v['chassis']['name']
+        try:
             hostip = nei_meta[neighbor_name]['mgmt_addr']
-        else:
-            hostip = v['chassis'].get('mgmt-ip')
+        except KeyError:
+            logger.info("Neighbor device {} not found in minigraph metadata; "
+                        "falling back to LLDP-advertised mgmt-ip".format(neighbor_name))
+            hostip = v['chassis']['mgmt-ip']
 
         if request.config.getoption("--neighbor_type") == 'eos':
             neighbor_interface = v['port']['ifname']

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -136,36 +136,74 @@ def test_lldp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost,
                 ).format(k, exp_port, match['descr'])
 
 
+def _iter_lldp_neighbors(chassis, sibling_port):
+    """Yield (neighbor_name, port_dict) for every neighbor learned on a port.
+
+    "lldpctl -f json" is not consistent: a single neighbor's chassis is an
+    object keyed by system name ({"ARISTA01T1": {...}}), while a port that
+    learns multiple neighbors (a fanout on physical testbeds, or extra
+    neighbors flooded onto the port on KVM) becomes either an object with
+    several such keys or a list. The remote port may be nested under each
+    chassis (multi-neighbor) or a sibling of chassis (single neighbor). Handle
+    all of these so no neighbor is dropped -- taking only the first key hides
+    the real minigraph neighbor behind an unrelated one.
+    """
+    def _one(name, cdata):
+        cdata = cdata if isinstance(cdata, dict) else {}
+        port = cdata.get('port') or sibling_port or {}
+        return (name if isinstance(name, str) else ''), port
+
+    items = chassis if isinstance(chassis, list) else [chassis]
+    for entry in items:
+        if not isinstance(entry, dict):
+            continue
+        # Fielded form: {"id": ..., "name": "ARISTA01T1", "port": {...}}
+        if isinstance(entry.get('name'), str):
+            yield _one(entry['name'], entry)
+        else:
+            # Keyed-by-name form: {"ARISTA01T1": {...}, "ARISTA02T1": {...}}
+            for name, cdata in entry.items():
+                yield _one(name, cdata)
+
+
 def _get_lldp_neighbors_by_port(duthost, asic_index, skip_patterns):
     """Return {local_port: [{'name', 'ifname', 'descr'}, ...]} from `lldpctl -f json`.
 
-    JSON output preserves every neighbor on a port, unlike the keyvalue
+    "lldpctl -f json" preserves every neighbor on a port, unlike the keyvalue
     lldpctl_facts which collapses a port's neighbors (last write wins). On
-    physical testbeds a port can learn both the real VM neighbor and the fanout
-    switch, so callers must tolerate more than one neighbor per port.
+    physical (fanout) and KVM testbeds a single DUT port can report multiple
+    LLDP neighbors, so every neighbor must be captured -- keeping only the first
+    drops the real minigraph neighbor and makes callers fail with
+    "neighbor name mismatch ... among learned ['<unrelated neighbor>']".
     """
     asic_str = "" if asic_index is None else str(asic_index)
-    lldp_json = json.loads(duthost.shell(
-        "docker exec lldp{} /usr/sbin/lldpctl -f json".format(asic_str))['stdout'])
-    interfaces = lldp_json.get('lldp', {}).get('interface', [])
-    if isinstance(interfaces, dict):
-        interfaces = [interfaces]
     skip_re = re.compile("(?:%s)" % "|".join(skip_patterns)) if skip_patterns else None
+
+    raw = duthost.shell(
+        "docker exec lldp{} /usr/sbin/lldpctl -f json".format(asic_str))['stdout']
+    logger.debug("lldpctl -f json output: %s", raw)
+    interfaces = json.loads(raw).get('lldp', {}).get('interface', [])
+    # A single interface is rendered as a dict keyed by port name; multiple
+    # interfaces as a list of single-key dicts. Normalize both to (port, info)
+    # so every port is captured (a plain `[interfaces]` wrap would keep only
+    # the first port of the dict form).
+    if isinstance(interfaces, dict):
+        entries = list(interfaces.items())
+    else:
+        entries = [(list(i.keys())[0], list(i.values())[0]) for i in interfaces if i]
+
     learned = {}
-    for iface in interfaces:
-        if not iface:
-            continue
-        local_port = list(iface.keys())[0]
+    for local_port, info in entries:
         if skip_re and skip_re.match(local_port):
             continue
-        info = iface[local_port] or {}
-        chassis = info.get('chassis', {}) or {}
-        port = info.get('port', {}) or {}
-        learned.setdefault(local_port, []).append({
-            'name': list(chassis.keys())[0] if chassis else '',
-            'ifname': (port.get('id', {}) or {}).get('value', ''),
-            'descr': port.get('descr', ''),
-        })
+        info = info or {}
+        sibling_port = info.get('port', {}) or {}
+        for name, port in _iter_lldp_neighbors(info.get('chassis', {}), sibling_port):
+            learned.setdefault(local_port, []).append({
+                'name': name,
+                'ifname': (port.get('id', {}) or {}).get('value', ''),
+                'descr': port.get('descr', ''),
+            })
     return learned
 
 

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -1,5 +1,4 @@
 import contextlib
-import json
 import logging
 import re
 import pytest
@@ -91,120 +90,44 @@ def test_lldp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost,
     config_facts = duthost.asic_instance(
         enum_frontend_asic_index).config_facts(host=duthost.hostname, source="running")['ansible_facts']
     internal_port_list = get_dpu_npu_ports_from_hwsku(duthost)
-    # Physical testbeds put a fanout switch between the DUT and the VM
-    # neighbors, and the fanout also advertises LLDP, so a DUT port can report
-    # multiple neighbors (the real VM + the fanout). Read via "lldpctl -f json"
-    # so all of them are visible; the keyvalue lldpctl_facts collapses a port's
-    # neighbors (last write wins), which intermittently keeps the fanout.
-    learned = _get_lldp_neighbors_by_port(
-        duthost, enum_frontend_asic_index,
-        ["eth0", "Ethernet-BP", "Ethernet-IB"] + internal_port_list)
-    if not learned:
-        pytest.fail("No LLDP neighbors received (lldpctl reported no interfaces)")
-    for k, neighbors in learned.items():
-        if k not in config_facts['DEVICE_NEIGHBOR']:
-            continue
-        names = [n['name'] for n in neighbors]
+    lldpctl_facts = duthost.lldpctl_facts(
+        asic_instance_id=enum_frontend_asic_index,
+        skip_interface_pattern_list=["eth0", "Ethernet-BP", "Ethernet-IB"] + internal_port_list)['ansible_facts']
+    if not list(lldpctl_facts['lldpctl'].items()):
+        pytest.fail("No LLDP neighbors received (lldpctl_facts are empty)")
+    for k, v in list(lldpctl_facts['lldpctl'].items()):
         if converged:
             exp_intf = config_facts['DEVICE_NEIGHBOR'][k]['port']
             vrf = config_facts['DEVICE_NEIGHBOR'][k]['name']
             primary = rev_vrf_map[vrf]
             new_intf = convergence_info['converged_peers'][primary]['intf_mapping'][vrf]['orig_intf_map'][exp_intf]
-            match = next((n for n in neighbors if n['name'] == primary), None)
-            assert match is not None, (
-                "LLDP neighbor name mismatch on {}. Expected '{}' among learned {}."
-            ).format(k, primary, names)
-            assert match['ifname'] == new_intf, (
-                "LLDP neighbor interface mismatch on {}. Expected '{}', but got '{}'."
-            ).format(k, new_intf, match['ifname'])
+            assert v['chassis']['name'] == primary
+            assert v['port']['ifname'] == new_intf
         else:
-            exp_name = config_facts['DEVICE_NEIGHBOR'][k]['name']
-            # Tolerate extra neighbors (e.g. fanout): require the expected VM to be present
-            match = next((n for n in neighbors if n['name'] == exp_name), None)
-            assert match is not None, (
-                "LLDP neighbor name mismatch on {}. Expected '{}' among learned {}."
-            ).format(k, exp_name, names)
-            exp_port = config_facts['DEVICE_NEIGHBOR'][k]['port']
+            # Compare the LLDP neighbor name with minigraph neigbhor name (exclude the management port)
+            assert v['chassis']['name'] == config_facts['DEVICE_NEIGHBOR'][k]['name']
+            assert v['chassis']['name'] == config_facts['DEVICE_NEIGHBOR'][k]['name'], (
+                "LLDP neighbor name mismatch. Expected '{}', but got '{}'."
+            ).format(
+                config_facts['DEVICE_NEIGHBOR'][k]['name'],
+                v['chassis']['name']
+            )
+            # Compare the LLDP neighbor interface with minigraph neigbhor interface (exclude the management port)
             if request.config.getoption("--neighbor_type") == 'eos':
-                assert match['ifname'] == exp_port, (
-                    "LLDP neighbor port ifname mismatch on {}. Expected '{}', but got '{}'."
-                ).format(k, exp_port, match['ifname'])
+                assert v['port']['ifname'] == config_facts['DEVICE_NEIGHBOR'][k]['port'], (
+                    "LLDP neighbor port interface name mismatch. Expected '{}', but got '{}'."
+                ).format(
+                    config_facts['DEVICE_NEIGHBOR'][k]['port'],
+                    v['port']['ifname']
+                )
             else:
                 # Dealing with KVM that advertises port description
-                assert match['descr'] == exp_port, (
-                    "LLDP neighbor port description mismatch on {}. Expected '{}', but got '{}'."
-                ).format(k, exp_port, match['descr'])
-
-
-def _iter_lldp_neighbors(chassis, sibling_port):
-    """Yield (neighbor_name, port_dict) for every neighbor learned on a port.
-
-    "lldpctl -f json" is not consistent: a single neighbor's chassis is an
-    object keyed by system name ({"ARISTA01T1": {...}}), while a port that
-    learns multiple neighbors (a fanout on physical testbeds, or extra
-    neighbors flooded onto the port on KVM) becomes either an object with
-    several such keys or a list. The remote port may be nested under each
-    chassis (multi-neighbor) or a sibling of chassis (single neighbor). Handle
-    all of these so no neighbor is dropped -- taking only the first key hides
-    the real minigraph neighbor behind an unrelated one.
-    """
-    def _one(name, cdata):
-        cdata = cdata if isinstance(cdata, dict) else {}
-        port = cdata.get('port') or sibling_port or {}
-        return (name if isinstance(name, str) else ''), port
-
-    items = chassis if isinstance(chassis, list) else [chassis]
-    for entry in items:
-        if not isinstance(entry, dict):
-            continue
-        # Fielded form: {"id": ..., "name": "ARISTA01T1", "port": {...}}
-        if isinstance(entry.get('name'), str):
-            yield _one(entry['name'], entry)
-        else:
-            # Keyed-by-name form: {"ARISTA01T1": {...}, "ARISTA02T1": {...}}
-            for name, cdata in entry.items():
-                yield _one(name, cdata)
-
-
-def _get_lldp_neighbors_by_port(duthost, asic_index, skip_patterns):
-    """Return {local_port: [{'name', 'ifname', 'descr'}, ...]} from `lldpctl -f json`.
-
-    "lldpctl -f json" preserves every neighbor on a port, unlike the keyvalue
-    lldpctl_facts which collapses a port's neighbors (last write wins). On
-    physical (fanout) and KVM testbeds a single DUT port can report multiple
-    LLDP neighbors, so every neighbor must be captured -- keeping only the first
-    drops the real minigraph neighbor and makes callers fail with
-    "neighbor name mismatch ... among learned ['<unrelated neighbor>']".
-    """
-    asic_str = "" if asic_index is None else str(asic_index)
-    skip_re = re.compile("(?:%s)" % "|".join(skip_patterns)) if skip_patterns else None
-
-    raw = duthost.shell(
-        "docker exec lldp{} /usr/sbin/lldpctl -f json".format(asic_str))['stdout']
-    logger.debug("lldpctl -f json output: %s", raw)
-    interfaces = json.loads(raw).get('lldp', {}).get('interface', [])
-    # A single interface is rendered as a dict keyed by port name; multiple
-    # interfaces as a list of single-key dicts. Normalize both to (port, info)
-    # so every port is captured (a plain `[interfaces]` wrap would keep only
-    # the first port of the dict form).
-    if isinstance(interfaces, dict):
-        entries = list(interfaces.items())
-    else:
-        entries = [(list(i.keys())[0], list(i.values())[0]) for i in interfaces if i]
-
-    learned = {}
-    for local_port, info in entries:
-        if skip_re and skip_re.match(local_port):
-            continue
-        info = info or {}
-        sibling_port = info.get('port', {}) or {}
-        for name, port in _iter_lldp_neighbors(info.get('chassis', {}), sibling_port):
-            learned.setdefault(local_port, []).append({
-                'name': name,
-                'ifname': (port.get('id', {}) or {}).get('value', ''),
-                'descr': port.get('descr', ''),
-            })
-    return learned
+                assert v['port']['descr'] == config_facts['DEVICE_NEIGHBOR'][k]['port'], (
+                    "LLDP neighbor port description mismatch. Expected '{}', but got '{}'."
+                ).format(
+                    config_facts['DEVICE_NEIGHBOR'][k]['port'],
+                    v['port']['descr']
+                )
 
 
 def _neighbor_has_lldp_entry(localhost, hostip, snmp_community, neighbor_interface):
@@ -224,7 +147,12 @@ def check_lldp_neighbor(duthost, localhost, eos, sonic, collect_techsupport_all_
             '' if asic is None else asic))
     dut_system_description = res['stdout']
     internal_port_list = get_dpu_npu_ports_from_hwsku(duthost)
+    lldpctl_facts = duthost.lldpctl_facts(
+        asic_instance_id=asic,
+        skip_interface_pattern_list=["eth0", "Ethernet-BP", "Ethernet-IB"] + internal_port_list)['ansible_facts']
     config_facts = duthost.asic_instance(asic).config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    if not list(lldpctl_facts['lldpctl'].items()):
+        pytest.fail("No LLDP neighbors received (lldpctl_facts are empty)")
     # We use the MAC of mgmt port to generate chassis ID as LLDPD dose.
     # To be compatible with PR #3331, we keep using router MAC on T2 devices
     switch_mac = ""
@@ -238,34 +166,25 @@ def check_lldp_neighbor(duthost, localhost, eos, sonic, collect_techsupport_all_
 
     nei_meta = config_facts.get('DEVICE_NEIGHBOR_METADATA', {})
 
-    # Read LLDP via json so a port's multiple neighbors (the real VM neighbor +
-    # the fanout on physical testbeds) are all visible, then verify only the
-    # minigraph neighbors and use the minigraph-provisioned mgmt addr as the
-    # SNMP target (not any LLDP-advertised mgmt-ip, which can be the fanout's
-    # and does not answer SNMP, causing intermittent timeouts).
-    learned = _get_lldp_neighbors_by_port(
-        duthost, asic, ["eth0", "Ethernet-BP", "Ethernet-IB"] + internal_port_list)
-    if not learned:
-        pytest.fail("No LLDP neighbors received (lldpctl reported no interfaces)")
+    for k, v in list(lldpctl_facts['lldpctl'].items()):
+        # Use the minigraph-provisioned mgmt addr (the address the framework uses
+        # to reach the VM) as the SNMP target rather than the LLDP-advertised
+        # mgmt-ip. On physical testbeds a port can learn both the real VM neighbor
+        # and the fanout switch; the keyvalue lldpctl_facts merges a port's
+        # neighbors field-by-field (last write wins), so mgmt-ip can end up being
+        # the fanout's (which does not answer SNMP) even when the name is the VM,
+        # making the reverse SNMP check time out intermittently.
+        neighbor_name = v['chassis'].get('name')
+        if neighbor_name in nei_meta and nei_meta[neighbor_name].get('mgmt_addr'):
+            hostip = nei_meta[neighbor_name]['mgmt_addr']
+        else:
+            hostip = v['chassis'].get('mgmt-ip')
 
-    for k in config_facts['DEVICE_NEIGHBOR']:
-        if k not in learned:
-            continue
-        exp_name = config_facts['DEVICE_NEIGHBOR'][k]['name']
-        # Tolerate extra neighbors (e.g. fanout): require the expected VM neighbor.
-        match = next((n for n in learned[k] if n['name'] == exp_name), None)
-        assert match is not None, (
-            "LLDP neighbor name mismatch on {}. Expected '{}' among learned {}."
-        ).format(k, exp_name, [n['name'] for n in learned[k]])
-        # Use the minigraph-provisioned mgmt addr (the VM the framework reaches),
-        # not any LLDP-advertised mgmt-ip (which can be the fanout on physical tb).
-        hostip = nei_meta.get(exp_name, {}).get('mgmt_addr')
-        if not hostip:
-            pytest.fail("No mgmt_addr for neighbor {} in DEVICE_NEIGHBOR_METADATA".format(exp_name))
-        neighbor_interface = match['ifname']
         if request.config.getoption("--neighbor_type") == 'eos':
+            neighbor_interface = v['port']['ifname']
             snmp_community = eos['snmp_rocommunity']
         else:
+            neighbor_interface = v['port']['local']
             snmp_community = sonic['snmp_rocommunity']
 
         # After swss restart, the DUT's LLDP entry on the neighbor may have aged out

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -91,37 +91,14 @@ def test_lldp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost,
     config_facts = duthost.asic_instance(
         enum_frontend_asic_index).config_facts(host=duthost.hostname, source="running")['ansible_facts']
     internal_port_list = get_dpu_npu_ports_from_hwsku(duthost)
-    # Physical testbeds insert a fanout switch between the DUT and the VM
-    # neighbors, and the fanout also advertises LLDP. A DUT port therefore
-    # reports multiple LLDP neighbors (the real VM neighbor + the fanout).
-    # The keyvalue-based lldpctl_facts collapses them into a single entry
-    # (last one wins), which intermittently keeps the fanout and flakes.
-    # Use "lldpctl -f json" (like test_lldp_syncd) so every neighbor on a port
-    # is visible, then verify the expected minigraph neighbor is among them.
-    asic_str = "" if enum_frontend_asic_index is None else str(enum_frontend_asic_index)
-    lldp_json = json.loads(duthost.shell(
-        "docker exec lldp{} /usr/sbin/lldpctl -f json".format(asic_str))['stdout'])
-    interfaces = lldp_json.get('lldp', {}).get('interface', [])
-    if isinstance(interfaces, dict):
-        interfaces = [interfaces]
-    skip_patterns = ["eth0", "Ethernet-BP", "Ethernet-IB"] + internal_port_list
-    skip_re = re.compile("(?:%s)" % "|".join(skip_patterns)) if skip_patterns else None
-    # local_port -> list of neighbors {name, ifname, descr}
-    learned = {}
-    for iface in interfaces:
-        if not iface:
-            continue
-        local_port = list(iface.keys())[0]
-        if skip_re and skip_re.match(local_port):
-            continue
-        info = iface[local_port] or {}
-        chassis = info.get('chassis', {}) or {}
-        port = info.get('port', {}) or {}
-        learned.setdefault(local_port, []).append({
-            'name': list(chassis.keys())[0] if chassis else '',
-            'ifname': (port.get('id', {}) or {}).get('value', ''),
-            'descr': port.get('descr', '')
-        })
+    # Physical testbeds put a fanout switch between the DUT and the VM
+    # neighbors, and the fanout also advertises LLDP, so a DUT port can report
+    # multiple neighbors (the real VM + the fanout). Read via "lldpctl -f json"
+    # so all of them are visible; the keyvalue lldpctl_facts collapses a port's
+    # neighbors (last write wins), which intermittently keeps the fanout.
+    learned = _get_lldp_neighbors_by_port(
+        duthost, enum_frontend_asic_index,
+        ["eth0", "Ethernet-BP", "Ethernet-IB"] + internal_port_list)
     if not learned:
         pytest.fail("No LLDP neighbors received (lldpctl reported no interfaces)")
     for k, neighbors in learned.items():
@@ -159,6 +136,39 @@ def test_lldp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost,
                 ).format(k, exp_port, match['descr'])
 
 
+def _get_lldp_neighbors_by_port(duthost, asic_index, skip_patterns):
+    """Return {local_port: [{'name', 'ifname', 'descr'}, ...]} from `lldpctl -f json`.
+
+    JSON output preserves every neighbor on a port, unlike the keyvalue
+    lldpctl_facts which collapses a port's neighbors (last write wins). On
+    physical testbeds a port can learn both the real VM neighbor and the fanout
+    switch, so callers must tolerate more than one neighbor per port.
+    """
+    asic_str = "" if asic_index is None else str(asic_index)
+    lldp_json = json.loads(duthost.shell(
+        "docker exec lldp{} /usr/sbin/lldpctl -f json".format(asic_str))['stdout'])
+    interfaces = lldp_json.get('lldp', {}).get('interface', [])
+    if isinstance(interfaces, dict):
+        interfaces = [interfaces]
+    skip_re = re.compile("(?:%s)" % "|".join(skip_patterns)) if skip_patterns else None
+    learned = {}
+    for iface in interfaces:
+        if not iface:
+            continue
+        local_port = list(iface.keys())[0]
+        if skip_re and skip_re.match(local_port):
+            continue
+        info = iface[local_port] or {}
+        chassis = info.get('chassis', {}) or {}
+        port = info.get('port', {}) or {}
+        learned.setdefault(local_port, []).append({
+            'name': list(chassis.keys())[0] if chassis else '',
+            'ifname': (port.get('id', {}) or {}).get('value', ''),
+            'descr': port.get('descr', ''),
+        })
+    return learned
+
+
 def _neighbor_has_lldp_entry(localhost, hostip, snmp_community, neighbor_interface):
     """Return True if the neighbor's LLDP table contains the expected interface."""
     nei_lldp_facts = localhost.lldp_facts(
@@ -176,12 +186,7 @@ def check_lldp_neighbor(duthost, localhost, eos, sonic, collect_techsupport_all_
             '' if asic is None else asic))
     dut_system_description = res['stdout']
     internal_port_list = get_dpu_npu_ports_from_hwsku(duthost)
-    lldpctl_facts = duthost.lldpctl_facts(
-        asic_instance_id=asic,
-        skip_interface_pattern_list=["eth0", "Ethernet-BP", "Ethernet-IB"] + internal_port_list)['ansible_facts']
     config_facts = duthost.asic_instance(asic).config_facts(host=duthost.hostname, source="running")['ansible_facts']
-    if not list(lldpctl_facts['lldpctl'].items()):
-        pytest.fail("No LLDP neighbors received (lldpctl_facts are empty)")
     # We use the MAC of mgmt port to generate chassis ID as LLDPD dose.
     # To be compatible with PR #3331, we keep using router MAC on T2 devices
     switch_mac = ""
@@ -196,35 +201,14 @@ def check_lldp_neighbor(duthost, localhost, eos, sonic, collect_techsupport_all_
     nei_meta = config_facts.get('DEVICE_NEIGHBOR_METADATA', {})
 
     # Read LLDP via json so a port's multiple neighbors (the real VM neighbor +
-    # the fanout switch on physical testbeds) are all visible. The keyvalue
-    # lldpctl_facts collapses a port's neighbors field-by-field (last write
-    # wins), which can mix the VM's identity with the physical fanout's
-    # mgmt-ip; the SNMP reverse-check then queries the fanout (which does not
-    # answer SNMP) instead of the cEOS VM and times out intermittently.
-    # Verify only the minigraph neighbors, and use the minigraph-provisioned
-    # mgmt addr (the address the framework uses to reach the VM) as the SNMP
-    # target rather than any LLDP-advertised mgmt-ip.
-    lldp_json = json.loads(duthost.shell(
-        "docker exec lldp{} /usr/sbin/lldpctl -f json".format('' if asic is None else asic))['stdout'])
-    lldp_interfaces = lldp_json.get('lldp', {}).get('interface', [])
-    if isinstance(lldp_interfaces, dict):
-        lldp_interfaces = [lldp_interfaces]
-    skip_re = re.compile("(?:%s)" % "|".join(["eth0", "Ethernet-BP", "Ethernet-IB"] + internal_port_list))
-    learned = {}
-    for iface in lldp_interfaces:
-        if not iface:
-            continue
-        local_port = list(iface.keys())[0]
-        if skip_re.match(local_port):
-            continue
-        info = iface[local_port] or {}
-        chassis = info.get('chassis', {}) or {}
-        port = info.get('port', {}) or {}
-        cname = list(chassis.keys())[0] if chassis else ''
-        learned.setdefault(local_port, []).append({
-            'name': cname,
-            'port_id': (port.get('id', {}) or {}).get('value', ''),
-        })
+    # the fanout on physical testbeds) are all visible, then verify only the
+    # minigraph neighbors and use the minigraph-provisioned mgmt addr as the
+    # SNMP target (not any LLDP-advertised mgmt-ip, which can be the fanout's
+    # and does not answer SNMP, causing intermittent timeouts).
+    learned = _get_lldp_neighbors_by_port(
+        duthost, asic, ["eth0", "Ethernet-BP", "Ethernet-IB"] + internal_port_list)
+    if not learned:
+        pytest.fail("No LLDP neighbors received (lldpctl reported no interfaces)")
 
     for k in config_facts['DEVICE_NEIGHBOR']:
         if k not in learned:
@@ -240,7 +224,7 @@ def check_lldp_neighbor(duthost, localhost, eos, sonic, collect_techsupport_all_
         hostip = nei_meta.get(exp_name, {}).get('mgmt_addr')
         if not hostip:
             pytest.fail("No mgmt_addr for neighbor {} in DEVICE_NEIGHBOR_METADATA".format(exp_name))
-        neighbor_interface = match['port_id']
+        neighbor_interface = match['ifname']
         if request.config.getoption("--neighbor_type") == 'eos':
             snmp_community = eos['snmp_rocommunity']
         else:


### PR DESCRIPTION
> ⚠️ **Reassessment (converted to draft):** Nightly data shows the tracked 8101 failures are a **202605 image regression** (whole lldp module ~0% pass on internal-202605 vs ~100% on internal-202511, same testbeds; dominant signature `LLDP_ENTRY_TABLE keys do not match lldpctl interface indexes` in `test_lldp_syncd`). **This PR's `mgmt_addr` change does not address that** and is not the fix. See the reassessment comment for evidence.

---
### Description of PR  Summary: Fixes flaky `lldp/test_lldp.py::test_lldp_neighbor` and `::test_lldp_neighbor_post_swss_reboot` on physical (fanout-fronted) testbeds, where the LLDP reverse-SNMP check intermittently times out because it targets the **fanout switch's** mgmt IP instead of the neighbor VM's.  Fixes # (no standalone GitHub issue — surfaced by SONiC nightly triage on 8101 physical testbeds; ~20% failure rate over the last 90 days, every failure querying a fanout `10.3.146.x` address)  ### Type of change  - [x] Bug fix - [ ] Testbed and Framework(new/improvement) - [ ] New Test case     - [ ] Skipped for non-supported platforms - [ ] Test case improvement   ### Back port request - [ ] 202311 - [ ] 202405 - [ ] 202411 - [ ] 202505 - [ ] 202511 - [ ] 202512 - [ ] 202605  Tracking issue/work item for backport/cherry-pick request: Failure type: **202605 image regression** — on identical 8101 testbeds the whole lldp module (test_lldp, test_lldp_neighbor, and all six test_lldp_syncd entry-table cases) passes ~100% on internal-202511 but ~0% on internal-202605; dominant signature `LLDP_ENTRY_TABLE keys do not match lldpctl interface indexes`. This PR does **not** address that root cause — see the reassessment note above.  ### Approach #### What is the motivation for this PR? On physical testbeds a fanout switch sits between the DUT and the cEOS VM neighbors, and the fanout **also** advertises LLDP, so a DUT port can learn **two** LLDP neighbors (the real minigraph VM + the fanout). The keyvalue `lldpctl_facts` collapses a port's neighbors field-by-field (last write wins), so the reverse-SNMP check in `check_lldp_neighbor` sometimes targets the collapsed `chassis.mgmt-ip` that belongs to the **fanout** (e.g. `10.3.146.x`). The fanout does not answer SNMP, so the check times out:  > `Neighbor 10.3.146.x did not learn LLDP on interface 'Ethernet1' within 30s`  #### How did you do it? Minimal, targeted change in `check_lldp_neighbor`: for the SNMP reverse-check, target the minigraph-provisioned `DEVICE_NEIGHBOR_METADATA[name]['mgmt_addr']` of the neighbor VM instead of the LLDP-advertised `chassis.mgmt-ip`, so it never queries the fanout. When the neighbor name has no minigraph `mgmt_addr`, it falls back to the advertised `mgmt-ip` (previous behavior).  Everything else stays on the original keyvalue `lldpctl_facts` path, so KVM/vlab behavior is identical to `master` — on KVM `mgmt_addr` resolves to the same VM the advertised `mgmt-ip` did. Net change: `+12/-5` in `tests/lldp/test_lldp.py`.  > Note: an earlier revision of this PR rewrote neighbor discovery to parse `lldpctl -f json`; that broke KVM (json reported the wrong single neighbor per port, e.g. `Ethernet116 -> ARISTA01T1` instead of `ARISTA02T1`), so it was reverted in favor of this minimal reverse-SNMP-target fix.  #### How did you verify/test it? - `flake8 --max-line-length=120` and `py_compile` clean; Azure PR pre-test gates (Static Analysis, Validate Test Cases, Meta/Dependency/Markers checks) all green. - KVM/vlab: the change is a no-op for neighbor identity (`mgmt_addr` resolves to the same VM), so `kvmtest` lldp continues to pass. - Physical validation: run `test_lldp_neighbor` / `test_lldp_neighbor_post_swss_reboot` repeatedly on an 8101 (or any fanout-fronted) testbed and confirm no reverse-SNMP timeouts.  #### Any platform specific information? The symptom is specific to physical testbeds fronted by a fanout switch that also advertises LLDP (e.g. 8101). KVM/vlab is unaffected.  #### Supported testbed topology if it's a new test case? N/A — not a new test case.  ### Documentation N/A — no documentation/wiki change required.