### PR TITLE
Fix nbrhosts fixture slowness on large topologies

### DIFF
--- a/tests/common/devices/base.py
+++ b/tests/common/devices/base.py
@@ -128,11 +128,32 @@ class AnsibleHostBase(object):
                 return obj.data
             return super().default(obj)
 
+    # Cache HostManager instances so the inventory is only parsed once per unique
+    # ansible_adhoc + kwargs combo. Without this, large topologies (e.g. 252 VMs)
+    # re-parse the full inventory on every __init__ call, making the nbrhosts
+    # fixture extremely slow.
+    _host_manager_cache = {}
+    _host_manager_cache_lock = threading.Lock()
+
+    @classmethod
+    def _get_host_manager(cls, ansible_adhoc, hostname, **kwargs):
+        # Exclude host_pattern from the cache key: different hostnames share the
+        # same underlying inventory, so we should reuse the same HostManager.
+        cache_key_kwargs = {k: v for k, v in kwargs.items() if k != 'host_pattern'}
+        cache_key = (id(ansible_adhoc), tuple(sorted(cache_key_kwargs.items())))
+        with cls._host_manager_cache_lock:
+            if cache_key not in cls._host_manager_cache:
+                cls._host_manager_cache[cache_key] = ansible_adhoc(
+                    host_pattern=hostname, **kwargs)
+            return cls._host_manager_cache[cache_key]
+
     def __init__(self, ansible_adhoc, hostname, *args, **kwargs):
         if hostname == 'localhost':
             self.host = ansible_adhoc(connection='local', host_pattern=hostname)[hostname]
         else:
-            self.host = ansible_adhoc(become=True, host_pattern=hostname, *args, **kwargs)[hostname]
+            host_manager = self._get_host_manager(
+                ansible_adhoc, hostname, become=True, host_pattern=hostname, *args, **kwargs)
+            self.host = host_manager[hostname]
             host_vars = self.host.options["inventory_manager"].get_host(hostname).vars
             ansible_host = host_vars.get("ansible_host")
             ansible_hostv6 = host_vars.get("ansible_hostv6")

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -278,9 +278,20 @@ class EosHost(AnsibleHostBase):
         # ``{logical: converged}`` map so tests can keep using the per-logical
         # name reported by minigraph. Left as None on stock topologies.
         self.intf_map = None
+        self._ansible_adhoc = ansible_adhoc
+        self._localhost = None
         AnsibleHostBase.__init__(self, ansible_adhoc, hostname)
-        self.localhost = ansible_adhoc(inventory='localhost', connection='local',
-                                       host_pattern="localhost")["localhost"]
+
+    @property
+    def localhost(self):
+        """Lazy-initialize the localhost ansible host to avoid the overhead of
+        creating an ansible host manager for every EosHost instance at init time.
+        Only ``exec_template`` uses this, so most tests never pay the cost."""
+        if self._localhost is None:
+            self._localhost = self._ansible_adhoc(
+                inventory='localhost', connection='local',
+                host_pattern="localhost")["localhost"]
+        return self._localhost
 
     def __getattr__(self, module_name):
         if module_name.startswith('eos_'):


### PR DESCRIPTION
### Description of PR
Summary:
On topologies with many EOS VMs (e.g. 252 VMs in LT2), the `nbrhosts` session fixture was extremely slow — taking several minutes to initialize. This PR fixes the root cause with two changes.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Every call to `AnsibleHostBase.__init__` invokes `ansible_adhoc(become=True, ...)`, which calls `plugin.initialize()` and creates a brand-new `HostManagerV213`. Each creation parses the full Ansible inventory from disk (`DataLoader` + `InventoryManager` + `VariableManager`). On a topology with 252 VMs and 8 parallel workers, this means ~32 rounds × multiple inventory parses per round — each taking several seconds.

Additionally, `EosHost.__init__` eagerly creates a second `HostManager` for `localhost` (used only by `exec_template`), adding another 252 unnecessary inventory loads.

#### How did you do it?
**Fix 1 (`base.py`):** Add a class-level `HostManager` cache in `AnsibleHostBase`. Hosts sharing the same `ansible_adhoc` function and kwargs reuse a single cached `HostManager` (one inventory parse). Protected by a `threading.Lock` for thread-safety. `host_pattern` is excluded from the cache key since it only filters hosts, not loads inventory.

**Fix 2 (`eos.py`):** Convert `EosHost.localhost` from an eagerly-initialized attribute to a lazy `@property`. It is only materialized when first accessed (only `exec_template` uses it), so the 252 extra inventory loads during `nbrhosts` setup are eliminated entirely.

#### How did you verify/test it?
Tested on a physical testbed with a 252-VM LT2 topology using EOS neighbors. `nbrhosts` initialization time dropped from several minutes (fixture never completing within reasonable time) to ~67 seconds.

#### Any platform specific information?
Applies to any topology using EOS neighbors. The caching is generic and safe for all `AnsibleHostBase` subclasses.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation