### PR TITLE
Fix the issue introduced in github #25087

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -378,13 +378,15 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_selected_front_end_dut, ran
     elif tbinfo['topo']['type'] in ['t0']:
         try:
             vlan_config = tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']['default_vlan_config']
-            if vlan_config == 'two_vlan_a':
-                logging.info("topo {} has 2 vlans".format(tbinfo['topo']['name']))
-                DOWNSTREAM_DST_IP = DOWNSTREAM_DST_IP_VLAN2000 if vlan_name == "Vlan2000" else DOWNSTREAM_DST_IP_VLAN
-                DOWNSTREAM_IP_TO_ALLOW = DOWNSTREAM_IP_TO_ALLOW_VLAN2000 if vlan_name == "Vlan2000" \
-                    else DOWNSTREAM_IP_TO_ALLOW_VLAN
-                DOWNSTREAM_IP_TO_BLOCK = DOWNSTREAM_IP_TO_BLOCK_VLAN2000 if vlan_name == "Vlan2000" \
-                    else DOWNSTREAM_IP_TO_BLOCK_VLAN
+            if vlan_config in ('one_vlan_a', 'two_vlan_a'):
+                if vlan_config == 'two_vlan_a' and vlan_name == "Vlan2000":
+                    DOWNSTREAM_DST_IP = DOWNSTREAM_DST_IP_VLAN2000
+                    DOWNSTREAM_IP_TO_ALLOW = DOWNSTREAM_IP_TO_ALLOW_VLAN2000
+                    DOWNSTREAM_IP_TO_BLOCK = DOWNSTREAM_IP_TO_BLOCK_VLAN2000
+                else:
+                    DOWNSTREAM_DST_IP = DOWNSTREAM_DST_IP_VLAN     # 192.168.0.123
+                    DOWNSTREAM_IP_TO_ALLOW = DOWNSTREAM_IP_TO_ALLOW_VLAN  # 192.168.0.122
+                    DOWNSTREAM_IP_TO_BLOCK = DOWNSTREAM_IP_TO_BLOCK_VLAN   # 192.168.0.121
         except KeyError:
             logger.error("topo {} keys are missing in the tbinfo:{}".format(tbinfo['topo']['name'], tbinfo))
     if topo in ["t0", "mx", "m0_vlan"]:


### PR DESCRIPTION

### Description of PR
The PR https://github.com/sonic-net/sonic-mgmt/pull/25087 lead to IP and rule not fully matched 

The four cases are affected:
test_icmp_match_forwarded[ipv4-egress-uplink->downlink-default-Vlan1000] 
test_icmp_match_forwarded[ipv4-ingress-uplink->downlink-default-Vlan1000] 
test_icmp_match_forwarded[ipv4-egress-uplink->downlink-default-Vlan1000] 
test_icmp_match_forwarded[ipv4-ingress-uplink->downlink-default-Vlan1000]


Summary:
Fixes # (issue)


### Type of change


- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: regression

### Approach
#### What is the motivation for this PR?
The PR https://github.com/sonic-net/sonic-mgmt/pull/25087 lead to IP and rule not fully matched 
#### How did you do it?
Add vlan configuration for one_vlan_a
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
