### PR TITLE
[HA] Add FNIC case for Planned SWO and update Planned Shutdown test

### DIFF
--- a/tests/ha/test_ha_planned_shutdown_fnic.py
+++ b/tests/ha/test_ha_planned_shutdown_fnic.py
@@ -34,6 +34,16 @@ pytestmark = [
 ]
 
 
+def _send_and_verify_outbound(ptfadapter, send_port, pkt, exp_pkt, recv_ports, label):
+    testutils.send(ptfadapter, send_port, pkt, 1)
+    try:
+        testutils.verify_packet_any_port(ptfadapter, exp_pkt, recv_ports)
+        return 0
+    except (Exception, pytest.fail.Exception) as e:
+        logger.info("%s outbound packet dropped: %s", label, e)
+        return 1
+
+
 @pytest.fixture(autouse=True, scope="function")
 def common_setup_teardown(
     localhost,
@@ -96,6 +106,8 @@ def test_ha_planned_shutdown(
         ptfadapter.dataplane.flush()
         time.sleep(1)
         send_count = 0
+        loss_count = 0
+        first_packet_received = False
         while not reached_max_time:
             sport = random.randint(49152, 65535)
             dport = random.randint(49152, 65535)
@@ -104,12 +116,20 @@ def test_ha_planned_shutdown(
                 inner_sport=sport, inner_dport=dport, vni=pl.ENI_TRUSTED_VNI,
                 tcp_flag_syn=True,  # each iteration is a unique 5-tuple; SYN creates a new flow.
             )
-            testutils.send(ptfadapter, dash_pl_config[0][LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
-            testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, rcv_outbound_pl_ports)
-            if send_count == 0:
+            packet_loss = _send_and_verify_outbound(
+                ptfadapter,
+                dash_pl_config[0][LOCAL_PTF_INTF],
+                vm_to_dpu_pkt,
+                exp_dpu_to_pe_pkt,
+                rcv_outbound_pl_ports,
+                "primary shutdown",
+            )
+            loss_count += packet_loss
+            if not first_packet_received and packet_loss == 0:
                 logger.info("HA: First packet received - compare flows")
                 flow_op = compare_flow_tables_pdsctl(dpuhosts[0], dpuhosts[1])
                 pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
+                first_packet_received = True
             send_count += 1
             # After we send initial_send_count packets, awake perform_ha_action thread
             if send_count == initial_send_count:
@@ -127,7 +147,8 @@ def test_ha_planned_shutdown(
         pytest_assert(verify_ha_state(duthosts[1], standby_vdpu_key, "standalone"),
                       "Standby HA state is not standalone")
 
-        logging.info(f"HA: Primary shutdown all {send_count} packets received")
+        logging.info("HA: Primary shutdown traffic complete: sent=%d, lost=%d", send_count, loss_count)
+        pytest_assert(loss_count == 0, f"Primary shutdown lost {loss_count} packets")
 
         # Re-activate primary
         set_dash_ha_scope(localhost, duthosts[0], ptfhost, primary_vdpu_key, "dead", ha_owner, disabled=True)
@@ -150,6 +171,8 @@ def test_ha_planned_shutdown(
     ptfadapter.dataplane.flush()
     time.sleep(1)
     send_count = 0
+    loss_count = 0
+    first_packet_received = False
 
     while not reached_max_time:
         sport = random.randint(49152, 65535)
@@ -159,12 +182,20 @@ def test_ha_planned_shutdown(
             inner_sport=sport, inner_dport=dport, vni=pl.ENI_TRUSTED_VNI,
             tcp_flag_syn=True,  # each iteration is a unique 5-tuple; SYN creates a new flow.
         )
-        testutils.send(ptfadapter, dash_pl_config[0][LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
-        testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, rcv_outbound_pl_ports)
-        if send_count == 0:
+        packet_loss = _send_and_verify_outbound(
+            ptfadapter,
+            dash_pl_config[0][LOCAL_PTF_INTF],
+            vm_to_dpu_pkt,
+            exp_dpu_to_pe_pkt,
+            rcv_outbound_pl_ports,
+            "standby shutdown",
+        )
+        loss_count += packet_loss
+        if not first_packet_received and packet_loss == 0:
             logger.info("HA: First packet received - compare flows")
             flow_op = compare_flow_tables(dpuhosts[0], dpuhosts[1])
             pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
+            first_packet_received = True
         send_count += 1
         # After we send initial_send_count packets, awake perform_ha_action thread
         if send_count == initial_send_count:
@@ -181,7 +212,8 @@ def test_ha_planned_shutdown(
     pytest_assert(verify_ha_state(duthosts[0], primary_vdpu_key, "standalone"),
                   "Primary HA state is not standalone")
 
-    logging.info(f"HA: standby shutdown all {send_count} packets received")
+    logging.info("HA: Standby shutdown traffic complete: sent=%d, lost=%d", send_count, loss_count)
+    pytest_assert(loss_count == 0, f"Standby shutdown lost {loss_count} packets")
 
     logger.info(
         "HA: Post-shutdown - send outbound packet with inner_sport=%s then compare flow tables",
@@ -195,8 +227,15 @@ def test_ha_planned_shutdown(
         vni=pl.ENI_TRUSTED_VNI,
         tcp_flag_syn=True,  # post-shutdown packet uses a new 5-tuple; SYN creates the flow.
     )
-    testutils.send(ptfadapter, dash_pl_config[0][LOCAL_PTF_INTF], vm_post_sd, 1)
-    testutils.verify_packet_any_port(ptfadapter, exp_post_sd, rcv_outbound_pl_ports)
+    post_shutdown_loss = _send_and_verify_outbound(
+        ptfadapter,
+        dash_pl_config[0][LOCAL_PTF_INTF],
+        vm_post_sd,
+        exp_post_sd,
+        rcv_outbound_pl_ports,
+        "post-shutdown",
+    )
+    pytest_assert(post_shutdown_loss == 0, "Post-shutdown outbound packet was dropped")
 
     # Re-activate standby
     set_dash_ha_scope(localhost, duthosts[1], ptfhost, standby_vdpu_key, "dead", ha_owner, disabled=True)
@@ -204,6 +243,6 @@ def test_ha_planned_shutdown(
                                              owner=ha_owner), "Failed to re-activate HA on standby")
 
     flow_post = compare_flow_tables(
-        dpuhosts[0], dpuhosts[1], verbose=True, flow_state=True
+        dpuhosts[0], dpuhosts[1], verbose=False, flow_state=True
     )
     pytest_assert(flow_post, "Expected identical flow tables after launch from standalone (bulk sync)")

--- a/tests/ha/test_ha_planned_swo_fnic.py
+++ b/tests/ha/test_ha_planned_swo_fnic.py
@@ -1,0 +1,298 @@
+import logging
+import queue
+import threading
+import time
+
+import configs.privatelink_config as pl
+import ptf.packet as scapy
+import ptf.testutils as testutils
+import pytest
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.dash_utils import verify_tunnel_packets
+from tests.ha.conftest import apply_dash_pl_pipeline_config
+from constants import (
+    LOCAL_PTF_INTF,
+    REMOTE_PTF_RECV_INTF,
+    REMOTE_PTF_SEND_INTF,
+)
+from ha_dash_flow_utils import compare_flow_tables
+from ha_packets import inbound_pl_packets, outbound_pl_packets, bootstrap_pl_tcp_flow_outbound
+from ha_utils import verify_ha_state, set_dash_ha_scope, parallel_config_reload_dpuhosts
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('t1-smartswitch-ha'),
+    pytest.mark.skip_check_dut_health
+]
+
+PLANNED_SWO_OUTER_ENCAP = "vxlan"
+
+# Fixed inner L4 ports for the single repeated floating-NIC flow.
+FNIC_INNER_SPORT = 6789
+FNIC_INNER_DPORT = 4567
+
+
+@pytest.fixture(autouse=True, scope="module")
+def common_setup_teardown(
+    localhost,
+    duthosts,
+    ptfhost,
+    skip_config,
+    dpuhosts,
+    setup_ha_config,
+    setup_dash_ha_from_json,
+    ha_owner,
+    setup_gnmi_server,
+    set_vxlan_udp_sport_range,
+    setup_npu_dpu  # noqa: F811
+):
+    if skip_config:
+        return
+
+    apply_dash_pl_pipeline_config(localhost, duthosts, dpuhosts, ptfhost, floating_nic=True)
+
+    yield
+    parallel_config_reload_dpuhosts(dpuhosts)
+
+
+def _planned_swo_phase(
+    ptfadapter,
+    localhost,
+    ptfhost,
+    swo_duthost,
+    swo_scope_key,
+    peer_duthost,
+    peer_scope_key,
+    expected_swo_state,
+    expected_peer_state,
+    ha_owner,
+    send_ptf_intf,
+    label,
+    *,
+    vm_to_dpu_pkt=None,
+    exp_dpu_to_pe_pkt=None,
+    rcv_outbound_pl_ports=None,
+    pe_to_dpu_pkt=None,
+    exp_dpu_to_vm_pkt=None,
+    send_pe_ptf_intf=None,
+    t2_ports=None,
+    tunnel_endpoint_ips=None,
+    dpuhosts=None,
+):
+    """Run one planned-switchover phase using floating-NIC traffic: send traffic, trigger SWO, verify HA state.
+
+    Send the same floating-NIC packet each iteration, verify outbound egress on the PTF and the inbound
+    (reverse) return path tunneled to the T2 (upstream) ports via verify_tunnel_packets. Because the active side
+    flips during switchover, t2_ports should cover both DUTs' upstream ports.
+
+    Args:
+        swo_duthost: DUT on which we request standby (the one being switched over).
+        swo_scope_key: HA scope key for the SWO DUT.
+        peer_duthost: The other DUT in the HA pair.
+        peer_scope_key: HA scope key for the peer DUT.
+        expected_swo_state: Expected HA state on swo_duthost after SWO (e.g. "standby").
+        expected_peer_state: Expected HA state on peer_duthost after SWO (e.g. "active").
+        ha_owner: Owner string from ha_owner fixture ("dpu" or "switch").
+        label: Human-readable label for logging (e.g. "primary" / "secondary").
+    """
+    rate_pps = 10
+    initial_send_count = 10
+    delay = 1.0 / rate_pps
+    t_max = time.time() + 60
+
+    pytest_assert(
+        vm_to_dpu_pkt is not None and exp_dpu_to_pe_pkt is not None and rcv_outbound_pl_ports is not None,
+        "one-flow mode requires vm_to_dpu_pkt, exp_dpu_to_pe_pkt, rcv_outbound_pl_ports",
+    )
+    pytest_assert(
+        pe_to_dpu_pkt is not None and exp_dpu_to_vm_pkt is not None and send_pe_ptf_intf is not None
+        and t2_ports is not None and tunnel_endpoint_ips is not None,
+        "one-flow mode requires reverse-path pe_to_dpu_pkt, exp_dpu_to_vm_pkt, send_pe_ptf_intf, "
+        "t2_ports, tunnel_endpoint_ips",
+    )
+    tunnel_endpoint_counts = {ip: 0 for ip in tunnel_endpoint_ips}
+
+    packet_sending_flag = queue.Queue(1)
+
+    def swo_action():
+        while packet_sending_flag.empty() or (not packet_sending_flag.get()):
+            time.sleep(0.2)
+        logging.info("Set %s to standby (planned switchover)", label)
+        set_dash_ha_scope(localhost, swo_duthost, ptfhost, swo_scope_key, "unspecified", ha_owner)
+        set_dash_ha_scope(localhost, peer_duthost, ptfhost, peer_scope_key, "active", ha_owner)
+
+    swo_thread = threading.Thread(target=swo_action, name=f"{label}_swo_action_thread")
+    swo_thread.start()
+    reached_max_time = False
+    ptfadapter.dataplane.flush()
+    time.sleep(1)
+    send_count = 0
+    outbound_loss_count = 0
+    return_path_loss_count = 0
+    first_outbound_received = False
+    first_return_path_received = False
+
+    while not reached_max_time:
+        testutils.send(ptfadapter, send_ptf_intf, vm_to_dpu_pkt, 1)
+        try:
+            testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, rcv_outbound_pl_ports)
+            if not first_outbound_received:
+                logger.info("First outbound packet received")
+                first_outbound_received = True
+        except (Exception, pytest.fail.Exception) as e:
+            outbound_loss_count += 1
+            logger.info("%s outbound packet dropped: %s", label, e)
+
+        testutils.send(ptfadapter, send_pe_ptf_intf, pe_to_dpu_pkt, 1)
+        try:
+            verify_tunnel_packets(ptfadapter, t2_ports, exp_dpu_to_vm_pkt, tunnel_endpoint_counts)
+            if not first_return_path_received:
+                logger.info("First return-path packet received")
+                first_return_path_received = True
+        except (Exception, pytest.fail.Exception) as e:
+            return_path_loss_count += 1
+            logger.info("%s return-path packet dropped: %s", label, e)
+
+        send_count += 1
+        if send_count == initial_send_count:
+            logging.info("Awake SWO action thread")
+            packet_sending_flag.put(True)
+
+        time.sleep(delay)
+
+        reached_max_time = time.time() > t_max
+
+    swo_thread.join()
+    time.sleep(1)
+
+    total_loss_count = outbound_loss_count + return_path_loss_count
+    logging.info(
+        "%s planned switchover traffic complete: sent=%d, lost=%d "
+        "(outbound=%d, return-path=%d, return-path endpoints=%s)",
+        label, send_count, total_loss_count, outbound_loss_count, return_path_loss_count, tunnel_endpoint_counts,
+    )
+
+    pytest_assert(verify_ha_state(swo_duthost, swo_scope_key, expected_swo_state),
+                  f"{label} HA state is not {expected_swo_state} after planned switchover")
+    pytest_assert(verify_ha_state(peer_duthost, peer_scope_key, expected_peer_state),
+                  f"Peer HA state is not {expected_peer_state} after {label} planned switchover")
+
+    if dpuhosts is not None:
+        try:
+            flow_ok = compare_flow_tables(dpuhosts[0], dpuhosts[1], verbose=True, flow_state=True)
+            if not flow_ok:
+                logger.warning("%s flow tables differ after planned switchover", label)
+        except Exception as e:
+            logger.warning("%s failed to dump/compare flow tables after planned switchover: %s", label, e)
+
+    pytest_assert(
+        total_loss_count == 0,
+        f"{label} planned switchover lost {total_loss_count} packets "
+        f"(outbound={outbound_loss_count}, return-path={return_path_loss_count})",
+    )
+
+    logging.info(
+        "%s planned switchover complete, all %d packet pairs received (return-path: %s)",
+        label, send_count, tunnel_endpoint_counts,
+    )
+
+
+def test_ha_planned_swo_fnic(
+    ptfadapter,
+    localhost,
+    duthosts,
+    ptfhost,
+    dpuhosts,
+    activate_dash_ha_from_json,
+    ha_owner,
+    dash_pl_config,
+    get_t2_info,
+    primary_vdpu_key,
+    standby_vdpu_key,
+):
+    """Planned SWO with one repeated floating-NIC flow; verify each packet on the PTF.
+
+    Only supported when ha_owner is "switch" (Mellanox SN4280 platform).
+
+    Phase 1: Switch primary (active) to standby.
+    Phase 2: Switch secondary (now active) again to standby.
+    """
+
+    if ha_owner != "switch":
+        pytest.skip("Planned switchover is only supported when owner is 'switch'")
+
+    vm_to_dpu_pkt, exp_dpu_to_pe_pkt = outbound_pl_packets(
+        dash_pl_config[0], PLANNED_SWO_OUTER_ENCAP, floating_nic=True,
+        inner_sport=FNIC_INNER_SPORT, inner_dport=FNIC_INNER_DPORT, vni=pl.ENI_TRUSTED_VNI
+    )
+    pe_to_dpu_pkt, exp_dpu_to_vm_pkt = inbound_pl_packets(
+        dash_pl_config[0], floating_nic=True, inner_sport=FNIC_INNER_DPORT, inner_dport=FNIC_INNER_SPORT
+    )
+    exp_dpu_to_vm_pkt.set_do_not_care_packet(scapy.IP, "dst")
+    exp_dpu_to_vm_pkt = ptfadapter.update_payload(exp_dpu_to_vm_pkt)
+    rcv_outbound_pl_ports = dash_pl_config[0][REMOTE_PTF_RECV_INTF] + dash_pl_config[1][REMOTE_PTF_RECV_INTF]
+    send_ptf_intf = dash_pl_config[0][LOCAL_PTF_INTF]
+    send_pe_ptf_intf = dash_pl_config[0][REMOTE_PTF_SEND_INTF]
+    t2_ports = get_t2_info[duthosts[0].hostname] + get_t2_info[duthosts[1].hostname]
+
+    # Default HA traffic is TCP. Bootstrap the stateful flow with SYN so repeated
+    # outbound/inbound ACK packets match the established connection across SWO.
+    bootstrap_pl_tcp_flow_outbound(
+        ptfadapter,
+        dash_pl_config[0],
+        PLANNED_SWO_OUTER_ENCAP,
+        recv_ports=rcv_outbound_pl_ports,
+        floating_nic=True,
+        inner_sport=FNIC_INNER_SPORT,
+        inner_dport=FNIC_INNER_DPORT,
+        vni=pl.ENI_TRUSTED_VNI,
+    )
+
+    _planned_swo_phase(
+        ptfadapter=ptfadapter,
+        localhost=localhost,
+        ptfhost=ptfhost,
+        swo_duthost=duthosts[0],
+        swo_scope_key=primary_vdpu_key,
+        peer_duthost=duthosts[1],
+        peer_scope_key=standby_vdpu_key,
+        expected_swo_state="standby",
+        expected_peer_state="active",
+        ha_owner=ha_owner,
+        send_ptf_intf=send_ptf_intf,
+        label="primary",
+        vm_to_dpu_pkt=vm_to_dpu_pkt,
+        exp_dpu_to_pe_pkt=exp_dpu_to_pe_pkt,
+        rcv_outbound_pl_ports=rcv_outbound_pl_ports,
+        pe_to_dpu_pkt=pe_to_dpu_pkt,
+        exp_dpu_to_vm_pkt=exp_dpu_to_vm_pkt,
+        send_pe_ptf_intf=send_pe_ptf_intf,
+        t2_ports=t2_ports,
+        tunnel_endpoint_ips=pl.TUNNEL1_ENDPOINT_IPS,
+        dpuhosts=dpuhosts,
+    )
+
+    _planned_swo_phase(
+        ptfadapter=ptfadapter,
+        localhost=localhost,
+        ptfhost=ptfhost,
+        swo_duthost=duthosts[1],
+        swo_scope_key=standby_vdpu_key,
+        peer_duthost=duthosts[0],
+        peer_scope_key=primary_vdpu_key,
+        expected_swo_state="standby",
+        expected_peer_state="active",
+        ha_owner=ha_owner,
+        send_ptf_intf=send_ptf_intf,
+        label="secondary",
+        vm_to_dpu_pkt=vm_to_dpu_pkt,
+        exp_dpu_to_pe_pkt=exp_dpu_to_pe_pkt,
+        rcv_outbound_pl_ports=rcv_outbound_pl_ports,
+        pe_to_dpu_pkt=pe_to_dpu_pkt,
+        exp_dpu_to_vm_pkt=exp_dpu_to_vm_pkt,
+        send_pe_ptf_intf=send_pe_ptf_intf,
+        t2_ports=t2_ports,
+        tunnel_endpoint_ips=pl.TUNNEL1_ENDPOINT_IPS,
+        dpuhosts=dpuhosts,
+    )


### PR DESCRIPTION
### Description of PR

This PR adds DASH HA coverage for floating-NIC (FNIC) traffic during planned SWO HA operations. Also update the Planned SD test

Summary:

- Adds test_ha_planned_swo_fnic.py for planned SWO validation with FNIC traffic.
- Validates outbound VM-to-DPU FNIC traffic on PTF receive ports.
- Validates inbound PE-to-DPU return traffic as tunneled traffic on T2/upstream ports.
- Verifies HA state after each planned switchover phase.
- Updates planned shutdown FNIC handling to collect all drops and inspect flow dump before failing.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: other

#### How did you verify/test it?

Ran the new test on mellanox smartswitch

#### Any platform specific information?

The test is only supported when `ha_owner == "switch"` and is skipped otherwise.

#### Supported testbed topology if it's a new test case?

`t1-smartswitch-ha`

### Documentation

N/A. This is a new HA test case; no separate documentation update was added.