### PR TITLE
[Dualtor] add support for neighbor mode in golden_config

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -158,6 +158,10 @@
       set_fact:
         prober_type: "{{ testbed_facts['prober_type'] | default(None) }}"
 
+    - name: set neighbor_mode
+      set_fact:
+        neighbor_mode: "{{ testbed_facts['neighbor_mode'] | default(None) }}"
+
     - name: set lit mode
       set_fact:
         is_lit_mode: "{{ testbed_facts.get('is_lit_mode', topo in ['t1-smartswitch-ha', 't1-28-lag', 'smartswitch-t1', 't1-48-lag']) }}"
@@ -921,6 +925,7 @@
           hwsku: "{{ (lab_csv_result.stdout | from_json).hwsku if (port_override_from_links | default(false) | bool) and lab_csv_result is defined and lab_csv_result.rc == 0 and (lab_csv_result.stdout | from_json).hwsku else hwsku }}"
           vm_configuration: "{{ configuration if topo == 't1-filterleaf-lag' else omit }}"
           prober_type: "{{ prober_type | default(omit) }}"
+          neighbor_mode: "{{ neighbor_mode | default(omit) }}"
           is_lit_mode: "{{ is_lit_mode | default(true) }}"
           npu_index: "{{ dut_index | default(0) | int }}"
           bgp_confd_asn: "{{ bgp_confd_asn }}"

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -183,6 +183,7 @@ class GenerateGoldenConfigDBModule(object):
                                     hwsku=dict(required=False, type='str', default=None),
                                     vm_configuration=dict(required=False, type='dict', default={}),
                                     prober_type=dict(required=False, type='str', default=None),
+                                    neighbor_mode=dict(required=False, type='str', default=None),
                                     is_lit_mode=dict(required=False, type='bool', default=True),
                                     npu_index=dict(required=False, type='int', default=0),
                                     duts_list=dict(required=False, type='list', default=[]),
@@ -207,6 +208,7 @@ class GenerateGoldenConfigDBModule(object):
 
         self.vm_configuration = self.module.params['vm_configuration']
         self.prober_type = self.module.params['prober_type']
+        self.neighbor_mode = self.module.params['neighbor_mode']
         self.is_lit_mode = self.module.params['is_lit_mode']
         self.bgp_confd_asn = self.module.params['bgp_confd_asn']
         self.bgp_confd_peers = self.module.params['bgp_confd_peers']
@@ -1126,7 +1128,9 @@ class GenerateGoldenConfigDBModule(object):
 
     def generate_dualtor_golden_config_db(self):
         """
-        Generate golden config for dualtor topology with prober_type support.
+        Generate golden config for dualtor topology with prober_type and
+        neighbor_mode support.
+
         This adds prober_type to existing MUX_CABLE entries from minigraph.
         """
         rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
@@ -1141,14 +1145,18 @@ class GenerateGoldenConfigDBModule(object):
             golden_config_db["DEVICE_METADATA"] = ori_config_db["DEVICE_METADATA"]
         golden_config_db["DEVICE_METADATA"]["localhost"]["buffer_model"] = "traditional"
 
-        # Add prober_type to MUX_CABLE if it exists and prober_type is specified
-        if ("MUX_CABLE" in ori_config_db and "PORT" in ori_config_db
-           and self.prober_type != "" and self.prober_type is not None):
+        if "MUX_CABLE" in ori_config_db and "PORT" in ori_config_db:
             mux_cable_config = copy.deepcopy(ori_config_db["MUX_CABLE"])
             port_config = copy.deepcopy(ori_config_db["PORT"])
-            # Add prober_type to each interface
+
             for intf_name, intf_config in mux_cable_config.items():
-                intf_config["prober_type"] = self.prober_type
+                # Set prober_type only when explicitly provided
+                if self.prober_type and self.prober_type != "":
+                    intf_config["prober_type"] = self.prober_type
+                # Set neighbor_mode only when explicitly provided
+                if self.neighbor_mode and self.neighbor_mode != "":
+                    intf_config["neighbor_mode"] = self.neighbor_mode
+
             golden_config_db["MUX_CABLE"] = mux_cable_config
             golden_config_db["PORT"] = port_config
 

--- a/ansible/testbed.yaml
+++ b/ansible/testbed.yaml
@@ -292,6 +292,7 @@
   ptf_ip: 10.255.0.210/24
   ptf_ipv6: 2001:db8:1::20/64
   prober_type: hardware
+  neighbor_mode: prefix-route
   server: server_1
   vm_base: VM0100
   dut:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Summary:
neighbor_mode knob was added in MUX_CABLE,now we needed an option to run mgmt runs with neighbor mode set as  host-route or prefix-route for any run on dualtor.

How to enable it :

conf-name: docker-ptf
group-name: sonic_cisco
topo: t0
ptf_image_name: docker-ptf-titan
prober_type: hardware
neighbor_mode: prefix-route
ptf: docker-ptf
ptf_ip: 192.168.122.78/24
ptf_ipv6: fc0b::1/64
server: server_1
vm_base: VM0100
dut:
titan-01
inv_name: lab
auto_recover: 'True'
comment: Test ptf titan

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
Support for neighbor_mode was added as part of following PR
https://github.com/sonic-net/sonic-swss/pull/4152

Needed a knob for dualtor setups to use one setting always to test it 

#### How did you do it?
Added a new knob in testbed.yaml which will only be active for dualtor testbeds 
and add neighbor_mode to golden_config_db.json

#### How did you verify/test it?
Ran on local setup

#### Any platform specific information?
By default its set to host-route which is supported by all platforms 

#### Supported testbed topology if it's a new test case?
dualtor

### Documentation
https://github.com/sonic-net/SONiC/pull/2176
