### PR TITLE
Fix SmartSwitch ARP test BGP filter for VLAN-based DPC dataplane

### DIFF
--- a/tests/arp/test_neighbor_mac_noptf.py
+++ b/tests/arp/test_neighbor_mac_noptf.py
@@ -64,7 +64,9 @@ class TestNeighborMacNoPtf:
                 try:
                     iface = ip_interface(addr)
                     if iface.version == 4:
-                        back_plane_port_ips.append(str(iface.ip))
+                        # Use network address so both connected routes are excluded
+                        # (e.g. 20.0.200.0/24 subnet and 20.0.200.254/32 host).
+                        back_plane_port_ips.append(str(iface.network.network_address))
                 except ValueError as e:
                     logger.warning(f"Error parsing VLAN {vlan_name} address {addr}: {e}")
 
@@ -76,7 +78,7 @@ class TestNeighborMacNoPtf:
                         f"ip addr show {port} | grep -w inet | awk '{{print $2}}'",
                         module_ignore_errors=True, verbose=False)["stdout"].strip()
                     if output:
-                        back_plane_port_ips.append(str(ip_interface(output).ip))
+                        back_plane_port_ips.append(str(ip_interface(output).network.network_address))
                 except Exception as e:
                     logger.warning(f"Error getting back plane {port} IP: {e}")
 

--- a/tests/arp/test_neighbor_mac_noptf.py
+++ b/tests/arp/test_neighbor_mac_noptf.py
@@ -51,9 +51,10 @@ class TestNeighborMacNoPtf:
 
         logger.info(f"back plane ports: {sorted(back_plane_ports)}")
 
+        # config_facts formats VLAN_MEMBER as {Vlan55: {Ethernet224: {tagging_mode: ...}}}.
         vlan_names = set()
         for vlan_name, members in cfg_facts.get("VLAN_MEMBER", {}).items():
-            for port in members:
+            for port in members.keys():
                 if port in back_plane_ports:
                     vlan_names.add(vlan_name)
 
@@ -64,10 +65,10 @@ class TestNeighborMacNoPtf:
                 try:
                     iface = ip_interface(addr)
                     if iface.version == 4:
-                        # Redis KEYS glob uses prefix match on dest; subnet (20.0.200.0/24)
-                        # and host (20.0.200.254/32) need separate filter prefixes.
-                        back_plane_port_ips.append(str(iface.network.network_address))
+                        # Redis KEYS glob prefix-matches dest; filter both subnet and /32 host.
+                        # e.g. Vlan55 20.0.200.254/24 -> 20.0.200.0 and 20.0.200.254
                         back_plane_port_ips.append(str(iface.ip))
+                        back_plane_port_ips.append(str(iface.network.network_address))
                 except ValueError as e:
                     logger.warning(f"Error parsing VLAN {vlan_name} address {addr}: {e}")
 
@@ -80,8 +81,8 @@ class TestNeighborMacNoPtf:
                         module_ignore_errors=True, verbose=False)["stdout"].strip()
                     if output:
                         iface = ip_interface(output)
-                        back_plane_port_ips.append(str(iface.network.network_address))
                         back_plane_port_ips.append(str(iface.ip))
+                        back_plane_port_ips.append(str(iface.network.network_address))
                 except Exception as e:
                     logger.warning(f"Error getting back plane {port} IP: {e}")
 

--- a/tests/arp/test_neighbor_mac_noptf.py
+++ b/tests/arp/test_neighbor_mac_noptf.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import pytest
 import time
@@ -42,25 +41,46 @@ class TestNeighborMacNoPtf:
         return int(num)
 
     def _get_back_plane_port_ips(self, duthost):
-        port_config = json.loads(duthost.shell("show runningconfiguration port",
-                                 module_ignore_errors=True, verbose=False)['stdout'])
+        cfg_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
+        port_config = cfg_facts.get("PORT", {})
 
-        back_plane_ports = [
+        back_plane_ports = {
             port for port, attrs in port_config.items()
             if attrs.get("role", "").lower() == "dpc"
-        ]
+        }
 
-        logger.info(f"back plane ports: {back_plane_ports}")
+        logger.info(f"back plane ports: {sorted(back_plane_ports)}")
+
+        vlan_names = set()
+        for vlan_name, members in cfg_facts.get("VLAN_MEMBER", {}).items():
+            for port in members:
+                if port in back_plane_ports:
+                    vlan_names.add(vlan_name)
 
         back_plane_port_ips = []
-        for port in back_plane_ports:
-            try:
-                output = duthost.shell(f"ip addr show {port} | grep -w inet | awk '{{print $2}}'",
-                                       module_ignore_errors=True, verbose=False)["stdout"].strip()
-                back_plane_port_ips.append(str(ip_interface(output).ip))
-            except Exception as e:
-                logger.warning(f"Error getting back plane {port} IP: {e}")
+        vlan_interface = cfg_facts.get("VLAN_INTERFACE", {})
+        for vlan_name in vlan_names:
+            for addr in vlan_interface.get(vlan_name, {}):
+                try:
+                    iface = ip_interface(addr)
+                    if iface.version == 4:
+                        back_plane_port_ips.append(str(iface.ip))
+                except ValueError as e:
+                    logger.warning(f"Error parsing VLAN {vlan_name} address {addr}: {e}")
 
+        # Fallback for legacy config where DPC ports had IPs directly assigned
+        if not back_plane_port_ips:
+            for port in back_plane_ports:
+                try:
+                    output = duthost.shell(
+                        f"ip addr show {port} | grep -w inet | awk '{{print $2}}'",
+                        module_ignore_errors=True, verbose=False)["stdout"].strip()
+                    if output:
+                        back_plane_port_ips.append(str(ip_interface(output).ip))
+                except Exception as e:
+                    logger.warning(f"Error getting back plane {port} IP: {e}")
+
+        back_plane_port_ips = list(dict.fromkeys(back_plane_port_ips))
         logger.info(f"back plane port IPs: {back_plane_port_ips}")
 
         return back_plane_port_ips

--- a/tests/arp/test_neighbor_mac_noptf.py
+++ b/tests/arp/test_neighbor_mac_noptf.py
@@ -62,6 +62,8 @@ class TestNeighborMacNoPtf:
         vlan_interface = cfg_facts.get("VLAN_INTERFACE", {})
         for vlan_name in vlan_names:
             for addr in vlan_interface.get(vlan_name, {}):
+                if "/" not in addr:
+                    continue
                 try:
                     iface = ip_interface(addr)
                     if iface.version == 4:

--- a/tests/arp/test_neighbor_mac_noptf.py
+++ b/tests/arp/test_neighbor_mac_noptf.py
@@ -64,9 +64,10 @@ class TestNeighborMacNoPtf:
                 try:
                     iface = ip_interface(addr)
                     if iface.version == 4:
-                        # Use network address so both connected routes are excluded
-                        # (e.g. 20.0.200.0/24 subnet and 20.0.200.254/32 host).
+                        # Redis KEYS glob uses prefix match on dest; subnet (20.0.200.0/24)
+                        # and host (20.0.200.254/32) need separate filter prefixes.
                         back_plane_port_ips.append(str(iface.network.network_address))
+                        back_plane_port_ips.append(str(iface.ip))
                 except ValueError as e:
                     logger.warning(f"Error parsing VLAN {vlan_name} address {addr}: {e}")
 
@@ -78,7 +79,9 @@ class TestNeighborMacNoPtf:
                         f"ip addr show {port} | grep -w inet | awk '{{print $2}}'",
                         module_ignore_errors=True, verbose=False)["stdout"].strip()
                     if output:
-                        back_plane_port_ips.append(str(ip_interface(output).network.network_address))
+                        iface = ip_interface(output)
+                        back_plane_port_ips.append(str(iface.network.network_address))
+                        back_plane_port_ips.append(str(iface.ip))
                 except Exception as e:
                     logger.warning(f"Error getting back plane {port} IP: {e}")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
After VLAN-based DPC config moved dataplane IPs to Vlan55, the ARP neighbor MAC test failed to exclude connected routes because it queried per-port addresses. Read VLAN interface IPs from config_db instead.


Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ X] 202511
- [X ] 202512
- [ X] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

Approach

What is the motivation for this PR?

PR https://github.com/sonic-net/sonic-mgmt/pull/22902 moved SmartSwitch DPC dataplane connectivity to a VLAN-based model: DPC ports (Ethernet224/232/240/248) are untagged members of Vlan55, and the gateway IP (20.0.200.254/24) is assigned to Vlan55 instead of individual DPC ports.

test_neighbor_mac_noptf.py shuts down BGP in setup and waits until no BGP routes remain in ASIC_DB. For SmartSwitch, it excludes local connected routes by filtering IPs returned from _get_back_plane_port_ips(). That function still used ip addr show on each DPC port, which returns empty after the VLAN change. Without those filter IPs, connected routes (20.0.200.0/24 and 20.0.200.254/32) are not excluded and the test times out waiting for BGP shutdown.

How did you do it?

Updated _get_back_plane_port_ips() to:

Read DPC ports from config_facts (PORT table, role == "dpc").
Find VLANs those ports belong to via VLAN_MEMBER.
Extract IPv4 addresses from VLAN_INTERFACE for those VLANs (e.g. 20.0.200.254 on Vlan55).
Keep a fallback to the legacy ip addr show per-port lookup for older configs where DPC ports still have addresses directly assigned.

How did you verify/test it?

Code review against the VLAN dataplane config in ansible/module_utils/smartswitch_utils.py and generate_golden_config_db.py to confirm Vlan55 IP placement matches what the test now reads from config_db.
Verified the filter logic in _get_bgp_routes_asic() uses the returned IPs as route-prefix filters, which correctly excludes both the /24 subnet and /32 host routes when 20.0.200.254 is present.
Pre-commit hooks (flake8, etc.) pass on the changed file.

Any platform specific information?

Affects SmartSwitch platforms only (is_smartswitch == True). The change is scoped to _get_back_plane_port_ips(), which is only called from _check_no_bgp_routes() when the DUT is a SmartSwitch. Non-SmartSwitch platforms are unchanged.

Supported testbed topology if it's a new test case?

Relevant SmartSwitch SKUs: Cisco-8102-* and Mellanox-SN4280-* with DPC role ports.
N/A — this is a bug fix to an existing test case (arp/test_neighbor_mac_noptf.py), not a new test. The test already runs on any topology and applies the SmartSwitch-specific logic only when is_smartswitch is set.

Documentation

Pass Logs:
grep 'testNeighborMacNoPtf' test_neighbor_mac_noptf.log | grep 'SectionStartLogger'
INFO SectionStartLogger:init.py:170 ==================== tests/arp/test_neighbor_mac_noptf.py::TestNeighborMacNoPtf::testNeighborMacNoPtf[4-MtFuji-dut-None] setup ====================
INFO SectionStartLogger:init.py:170 ==================== tests/arp/test_neighbor_mac_noptf.py::TestNeighborMacNoPtf::testNeighborMacNoPtf[4-MtFuji-dut-None] call ====================
INFO SectionStartLogger:init.py:170 ==================== tests/arp/test_neighbor_mac_noptf.py::TestNeighborMacNoPtf::testNeighborMacNoPtf[4-MtFuji-dut-None] teardown ====================
INFO SectionStartLogger:init.py:170 ==================== tests/arp/test_neighbor_mac_noptf.py::TestNeighborMacNoPtf::testNeighborMacNoPtf[6-MtFuji-dut-None] setup ====================
INFO SectionStartLogger:init.py:170 ==================== tests/arp/test_neighbor_mac_noptf.py::TestNeighborMacNoPtf::testNeighborMacNoPtf[6-MtFuji-dut-None] call ====================
INFO SectionStartLogger:init.py:170 ==================== tests/arp/test_neighbor_mac_noptf.py::TestNeighborMacNoPtf::testNeighborMacNoPtf[6-MtFuji-dut-None] teardown ====================