### PR TITLE
[Dualtor] Run test with all neighbor_mode and prober_type values

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -32,6 +32,7 @@ function show_help_and_exit()
     echo "    -w             : warm run, don't clear cache before running tests"
     echo "    -x             : print commands and their arguments as they are executed"
     echo "    -6             : IPv6-only management mode (use IPv6 for DUT mgmt connectivity)"
+    echo "    -M             : run all 4 prober_type x neighbor_mode MUX_CABLE combos (dualtor/dualtor_io only)"
 
     exit $1
 }
@@ -126,6 +127,7 @@ function setup_environment()
     DPU_NAME="None"
     NO_CLEAR_CACHE="False"
     IPV6_ONLY_MGMT="False"
+    MUX_COMBO_MODE="False"
 
     export ANSIBLE_CONFIG=${BASE_PATH}/ansible
     export ANSIBLE_LIBRARY=${BASE_PATH}/ansible/library/
@@ -288,6 +290,7 @@ function run_debug_tests()
     echo "POST_LOGGING_OPTIONS:  ${POST_LOGGING_OPTIONS}"
     echo "UTIL_TOPOLOGY_OPTIONS: ${UTIL_TOPOLOGY_OPTIONS}"
     echo "NO_CLEAR_CACHE:        ${NO_CLEAR_CACHE}"
+    echo "MUX_COMBO_MODE:        ${MUX_COMBO_MODE}"
 
     echo "PYTEST_COMMON_OPTS:    ${PYTEST_COMMON_OPTS}"
 }
@@ -406,6 +409,53 @@ function run_bsl_tests()
     python3 -m pytest ${SCRIPT_PATH} ${PYTEST_COMMON_OPTS} --skip_sanity --disable_loganalyzer --junit-xml=logs/bsl.xml --log-file logs/bsl.log -m bsl
 }
 
+function run_mux_combo_tests()
+{
+    # Run dualtor/dualtor_io suites for all 4 prober_type x neighbor_mode combos.
+    # Each combination gets its own full pytest invocation so the session-scoped
+    # fixture apply_mux_cable_combo in tests/common/dualtor/mux_cable_config.py
+    # picks up --prober_type and --neighbor_mode and applies them before tests.
+
+    MUX_COMBOS=(
+        "hardware,host-route"
+        "hardware,prefix-route"
+        "software,host-route"
+        "software,prefix-route"
+    )
+
+    COMBO_RC=0
+
+    for combo in "${MUX_COMBOS[@]}"; do
+        IFS=',' read -r PROBER_TYPE NEIGHBOR_MODE <<< "$combo"
+        echo "============================================================"
+        echo "=== MUX COMBO: prober_type=${PROBER_TYPE}, neighbor_mode=${NEIGHBOR_MODE} ==="
+        echo "============================================================"
+
+        COMBO_EXTRA="${EXTRA_PARAMETERS} --prober_type ${PROBER_TYPE} --neighbor_mode ${NEIGHBOR_MODE}"
+
+        if [[ x"${OMIT_FILE_LOG}" != x"True" ]]; then
+            COMBO_LOG_DIR="${LOG_PATH}/mux_combo_${PROBER_TYPE}_${NEIGHBOR_MODE}"
+            mkdir -p ${COMBO_LOG_DIR}
+            COMBO_LOGGING="--junit-xml=${COMBO_LOG_DIR}/tr.xml --log-file=${COMBO_LOG_DIR}/test.log"
+        else
+            COMBO_LOGGING=""
+        fi
+
+        echo Running: ${PYTEST_EXEC} ${TEST_CASES} ${PYTEST_COMMON_OPTS} ${COMBO_LOGGING} ${TEST_TOPOLOGY_OPTIONS} ${COMBO_EXTRA} --cache-clear
+        ${PYTEST_EXEC} ${TEST_CASES} ${PYTEST_COMMON_OPTS} ${COMBO_LOGGING} ${TEST_TOPOLOGY_OPTIONS} ${COMBO_EXTRA} --cache-clear
+        ret_code=$?
+
+        if [ ${ret_code} -ne 0 ]; then
+            echo "=== MUX COMBO ${PROBER_TYPE}/${NEIGHBOR_MODE} failed with rc=${ret_code} ==="
+            COMBO_RC=1
+        else
+            echo "=== MUX COMBO ${PROBER_TYPE}/${NEIGHBOR_MODE} passed ==="
+        fi
+    done
+
+    return ${COMBO_RC}
+}
+
 setup_environment
 
 for arg in "$@"; do
@@ -429,7 +479,7 @@ for arg in "$@"; do
     fi
 done
 
-while getopts "h?a:b:Bc:C:d:e:Ef:F:H:i:I:k:l:m:n:oOp:q:rs:S:t:uxw6" opt; do
+while getopts "h?a:b:Bc:C:d:e:Ef:F:H:i:I:k:l:m:Mn:oOp:q:rs:S:t:uxw6" opt; do
     case ${opt} in
         h|\? )
             show_help_and_exit 0
@@ -482,6 +532,9 @@ while getopts "h?a:b:Bc:C:d:e:Ef:F:H:i:I:k:l:m:n:oOp:q:rs:S:t:uxw6" opt; do
             ;;
         m )
             TEST_METHOD=${OPTARG}
+            ;;
+        M )
+            MUX_COMBO_MODE="True"
             ;;
         n )
             TESTBED_NAME=${OPTARG}
@@ -551,6 +604,8 @@ RC=0
 
 if [[ x"${BSL}" == x"True" ]]; then
     run_bsl_tests || RC=$?
+elif [[ x"${MUX_COMBO_MODE}" == x"True" ]]; then
+    run_mux_combo_tests || RC=$?
 else
     run_${TEST_METHOD}_tests || RC=$?
 fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Needed to test multiple modes which we can set for prober_type and neighbor_mode 
for dualtor topologies . Needed a option to run all the combos together but cant use pytest fixture to generate test 
because this requires config reload for each combo apply . if we run the config before each test then 
test run time will increase by 20 mins per test case.

I made changes such that it will do new run per-combo so overall time increase at max will be 30 min per run not per test.

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
There are multiple modes which we can set for prober_type and neighbor_mode 
for dualtor topologies . Needed a option to run all the combos together .

#### How did you do it?

Added a option -M which will call ptest with all possible combinations again and again

#### How did you verify/test it?

Ran on local setup

#### Any platform specific information?
Not all platforms might support all the combos

#### Supported testbed topology if it's a new test case?
dualtor

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
