### PR TITLE
HA Wait for ansible reachability before DPU reload.

### DIFF
--- a/tests/ha/ha_utils.py
+++ b/tests/ha/ha_utils.py
@@ -12,8 +12,36 @@ from gnmi_utils import apply_messages
 logger = logging.getLogger(__name__)
 
 
+def _wait_for_dpuhost_reachable(dpuhost, timeout=300, interval=10):
+    """
+    Wait until ``dpuhost`` is reachable via the Ansible transport.
+    """
+    def _check():
+        try:
+            res = dpuhost.ping(module_ignore_errors=True)
+        except Exception as e:  # noqa: BLE001 - AnsibleConnectionFailure et al
+            logger.info(
+                f"{dpuhost.hostname} not yet reachable: "
+                f"{type(e).__name__}: {e}"
+            )
+            return False
+        if res.get("failed"):
+            logger.info(
+                f"{dpuhost.hostname} ping module reported failed: {res}"
+            )
+            return False
+        return True
+
+    return wait_until(timeout, interval, 0, _check)
+
+
 def _config_reload_dpuhost(dpuhost):
     logger.info(f"config reload on {dpuhost.hostname}")
+    if not _wait_for_dpuhost_reachable(dpuhost):
+        logger.warning(
+            f"{dpuhost.hostname} did not become reachable before "
+            f"config reload; proceeding anyway"
+        )
     config_reload(dpuhost, safe_reload=True, yang_validate=False)
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
After NPU reboot cases, ansible reachability to DPUs must be restored before attempting to reload DPU config during teardown fixtures. Adding a poll to check for this before attempting the reload.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
NPU reboot cases were occasionally failing due to DPU ansible reachability after the NPU reboot, exposed by recent parallelization of the reload fixture. Before attempting to execute commands for the DPU after a reboot, need to ensure the DPU is reachable by ansible first.

#### How did you do it?
Added a poll to check ansible reachability before issuing DPU reload commands.

#### How did you verify/test it?
Ran tests/ha/test_ha_npu_reboot.py with the change in a smartswitch HA testbed:
```
------------------------------------------------------- generated xml file: /data/sonic-mgmt/tests/logs/ha/test_ha_npu_reboot.xml --------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
--------------------------------------------------------------------------------- live log sessionfinish ---------------------------------------------------------------------------------
INFO     root:__init__.py:67 Can not get Allure report URL. Please check logs
===================================================================== 4 passed, 1505 warnings in 4762.41s (1:19:22) ======================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
