### PR TITLE
tests/zmq: configure insecure mode and use TLS in gnmi_set

### DIFF
--- a/tests/zmq/test_gnmi_zmq.py
+++ b/tests/zmq/test_gnmi_zmq.py
@@ -80,7 +80,7 @@ def gnmi_set(duthost, ptfhost, delete_list, update_list, replace_list):
     ip = duthost.mgmt_ip
     port = 8080
     cmd = '/root/env-python3/bin/python /root/gnxi/gnmi_cli_py/py_gnmicli.py '
-    cmd += '--timeout 30 -g '
+    cmd += '--timeout 30 -g -o example.com '
     cmd += '-t %s -p %u ' % (ip, port)
     cmd += '-xo sonic-db '
     cmd += '-m set-update '

--- a/tests/zmq/test_gnmi_zmq.py
+++ b/tests/zmq/test_gnmi_zmq.py
@@ -80,7 +80,7 @@ def gnmi_set(duthost, ptfhost, delete_list, update_list, replace_list):
     ip = duthost.mgmt_ip
     port = 8080
     cmd = '/root/env-python3/bin/python /root/gnxi/gnmi_cli_py/py_gnmicli.py '
-    cmd += '--timeout 30 --notls '
+    cmd += '--timeout 30 -g '
     cmd += '-t %s -p %u ' % (ip, port)
     cmd += '-xo sonic-db '
     cmd += '-m set-update '
@@ -117,6 +117,7 @@ def gnmi_set(duthost, ptfhost, delete_list, update_list, replace_list):
 def test_gnmi_zmq(duthosts,
                   rand_one_dut_hostname,
                   ptfhost,
+                  setup_gnmi_insecure,
                   enable_zmq):
     duthost = duthosts[rand_one_dut_hostname]
 


### PR DESCRIPTION
### Description of PR

Summary:
Complete the switch from `--notls` (cleartext gRPC) to TLS in the ZMQ gNMI test. PR #24045 updated the server side and most test commands but left `gnmi_set` in `test_gnmi_zmq.py` still using `--notls`.

Fixes the remaining cleartext client connection in the ZMQ test.

### Type of change

- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

After #24045, the gNMI server in test environments starts with `--insecure` (TLS with self-signed cert). The `gnmi_set` helper in `test_gnmi_zmq.py` was still connecting with `--notls` (cleartext gRPC), causing a TLS/plaintext mismatch that breaks the test.

#### How did you do it?

Two changes to `tests/zmq/test_gnmi_zmq.py`:

1. Add `setup_gnmi_insecure` as a fixture parameter to `test_gnmi_zmq`. This fixture (already in `conftest.py`) sets `GNMI|certs` with empty fields so telemetry restarts with `--insecure` before the test runs.

2. Change `gnmi_set` to use `-g -o example.com` instead of `--notls`. `-g` tells py_gnmicli to auto-fetch the server's self-signed cert; `-o example.com` overrides hostname verification to match the cert's SAN.

#### How did you verify/test it?

Tested on VS (KVM, x86_64-kvm_x86_64-r0):
- Restarted telemetry with `--insecure`
- Ran py_gnmicli with `-g -o example.com` against port 8080
- Connection succeeded; gRPC reached application layer (Unimplemented on invalid xpath, not a connectivity error)
- Confirmed `-g` without `-o example.com` fails hostname verification as expected

#### Any platform specific information?

None. The self-signed cert (`testcert.NewCert()`) used by `--insecure` mode has `example.com` as its SAN across all platforms.

#### Supported testbed topology if it's a new test case?

N/A (test case improvement)

### Documentation

N/A