### PR TITLE
Fix cEOS converged neighbor EOS templates and vm_topology error message

### DIFF
--- a/ansible/roles/eos/templates/lt2-o128-tor.j2
+++ b/ansible/roles/eos/templates/lt2-o128-tor.j2
@@ -30,17 +30,13 @@ hostname {{ hostname }}
 vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
 !
 {% endif %}
-{% if converged %}
 vrf instance MGMT
+{% if converged %}
 {% for vrf_name in conv_config['vrf'] %}
 vrf instance {{ vrf_name }}
 {% endfor %}
-!
-{% else %}
-vrf definition MGMT
- rd 1:1
-!
 {% endif %}
+!
 spanning-tree mode mstp
 !
 aaa root secret 0 123456

--- a/ansible/roles/eos/templates/t1-64-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-64-lag-tor.j2
@@ -29,17 +29,13 @@ hostname {{ hostname }}
 vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
 !
 {% endif %}
-{% if converged %}
 vrf instance MGMT
+{% if converged %}
 {% for vrf_name in conv_config['vrf'] %}
 vrf instance {{ vrf_name }}
 {% endfor %}
-!
-{% else %}
-vrf definition MGMT
- rd 1:1
-!
 {% endif %}
+!
 spanning-tree mode mstp
 !
 aaa root secret 0 123456

--- a/ansible/roles/eos/templates/t1-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-lag-spine.j2
@@ -1,15 +1,15 @@
 {% set host = configuration[hostname] %}
 {% set converged = topo_is_multi_vrf|default(false)|bool %}
 {% if converged %}
-    {% set conv_config = convergence_data["converged_peers"][hostname] %}
-    {% set conv_mapping = convergence_data["convergence_mapping"][hostname] %}
-    {% set ptf_bp_addrs = convergence_data["ptf_backplane_addrs"] %}
+{% set conv_config = convergence_data["converged_peers"][hostname] %}
+{% set conv_mapping = convergence_data["convergence_mapping"][hostname] %}
+{% set ptf_bp_addrs = convergence_data["ptf_backplane_addrs"] %}
 {% endif %}
 {% set mgmt_ip = ansible_host %}
 {% if vm_type is defined and vm_type == "ceos" %}
-    {% set mgmt_if_index = 0 %}
+{% set mgmt_if_index = 0 %}
 {% else %}
-    {% set mgmt_if_index = 1 %}
+{% set mgmt_if_index = 1 %}
 {% endif %}
 no schedule tech-support
 !
@@ -31,9 +31,9 @@ vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
 {% endif %}
 vrf instance MGMT
 {% if converged %}
-    {% for vrf_name in conv_config['vrf'] %}
+{% for vrf_name in conv_config['vrf'] %}
 vrf instance {{vrf_name}}
-    {% endfor %}
+{% endfor %}
 !
 {% endif %}
 spanning-tree mode mstp
@@ -54,15 +54,15 @@ snmp-server vrf MGMT
 ip routing
 ip routing vrf MGMT
 {% if converged %}
-    {% for vrf_name in conv_config['vrf'] %}
+{% for vrf_name in conv_config['vrf'] %}
 ip routing vrf {{vrf_name}}
-    {% endfor %}
+{% endfor %}
 {% endif %}
 ipv6 unicast-routing
 {% if converged %}
-    {% for vrf_name in conv_config['vrf'] %}
+{% for vrf_name in conv_config['vrf'] %}
 ipv6 unicast-routing vrf {{vrf_name}}
-    {% endfor %}
+{% endfor %}
 {% endif %}
 !
 {% if disable_ceos_mgmt_gateway is defined and disable_ceos_mgmt_gateway == 'yes'%}
@@ -91,84 +91,84 @@ interface {{ bp_ifname }}
  switchport mode trunk
  no shutdown
 !
-    {% for vrf in conv_mapping %}
-        {% for if_name, if_data in conv_config['vrf'][vrf].items() %}
+{% for vrf in conv_mapping %}
+{% for if_name, if_data in conv_config['vrf'][vrf].items() %}
 interface {{ if_name }}
-            {% if if_name.startswith('Vlan') %}
+{% if if_name.startswith('Vlan') %}
  description {{ vrf }} backplane
-            {% endif %}
-            {% if if_name.startswith('Loopback') %}
+{% endif %}
+{% if if_name.startswith('Loopback') %}
  description {{ vrf }} LOOPBACK
-            {% endif %}
-            {% if if_name.startswith('Port-Channel') %}
+{% endif %}
+{% if if_name.startswith('Port-Channel') %}
  port-channel min-links 1
  mtu 9214
  no switchport
-            {% endif %}
-            {% if if_name.startswith('Ethernet') %}
+{% endif %}
+{% if if_name.startswith('Ethernet') %}
  mtu 9214
  no switchport
-            {% endif %}
+{% endif %}
  vrf {{ vrf }}
-            {% if if_data['lacp'] is defined %}
+{% if if_data['lacp'] is defined %}
  channel-group {{ if_data['lacp'] }} mode active
  lacp rate normal
-            {% endif %}
-            {% if if_data['ipv4'] is defined %}
+{% endif %}
+{% if if_data['ipv4'] is defined %}
  ip address {{ if_data['ipv4'] }}
-            {% endif %}
-            {% if if_data['ipv6'] is defined %}
+{% endif %}
+{% if if_data['ipv6'] is defined %}
  ipv6 enable
  ipv6 address {{ if_data['ipv6'] }}
  ipv6 nd ra suppress
  ipv6 nd dad disabled
-            {% endif %}
+{% endif %}
  no shutdown
 !
-        {% endfor %}
-    {% endfor %}
+{% endfor %}
+{% endfor %}
 !
 {% else %}
-    {% for name, iface in host['interfaces'].items() %}
+{% for name, iface in host['interfaces'].items() %}
 interface {{ name }}
-        {% if name.startswith('Loopback') %}
+{% if name.startswith('Loopback') %}
  description LOOPBACK
-        {% else %}
+{% else %}
  mtu 9214
  no switchport
  no shutdown
-        {% endif %}
-        {% if name.startswith('Port-Channel') %}
+{% endif %}
+{% if name.startswith('Port-Channel') %}
  port-channel min-links 2
-        {% endif %}
-        {% if iface['lacp'] is defined %}
+{% endif %}
+{% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
  lacp rate normal
-        {% endif %}
-        {% if iface['ipv4'] is defined %}
+{% endif %}
+{% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}
-        {% endif %}
-        {% if iface['ipv6'] is defined %}
+{% endif %}
+{% if iface['ipv6'] is defined %}
  ipv6 enable
  ipv6 address {{ iface['ipv6'] }}
  ipv6 nd ra suppress
-        {% endif %}
+{% endif %}
  no shutdown
 !
-    {% endfor %}
+{% endfor %}
 !
 interface {{ bp_ifname }}
  description backplane
  no switchport
  no shutdown
-    {% if host['bp_interface']['ipv4'] is defined %}
+{% if host['bp_interface']['ipv4'] is defined %}
  ip address {{ host['bp_interface']['ipv4'] }}
-    {% endif %}
-    {% if host['bp_interface']['ipv6'] is defined %}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
  ipv6 enable
  ipv6 address {{ host['bp_interface']['ipv6'] }}
  ipv6 nd ra suppress
-    {% endif %}
+{% endif %}
  no shutdown
 !
 {% endif %}
@@ -177,58 +177,58 @@ router bgp {{ conv_config['bgp']['asn'] }}
  vrf MGMT
   rd 1:1
  exit
-    {% for vrf in conv_config['vrf'] %}
+{% for vrf in conv_config['vrf'] %}
  vrf {{ vrf }}
-        {% set vrf_bgp = configuration[vrf]['bgp'] %}
-        {% set vrf_intfs = conv_config['vrf'][vrf] %}
-        {% set lo_config = vrf_intfs|get_first_loopback %}
-        {% if vrf_bgp['router-id'] is defined %}
+{% set vrf_bgp = configuration[vrf]['bgp'] %}
+{% set vrf_intfs = conv_config['vrf'][vrf] %}
+{% set lo_config = vrf_intfs|get_first_loopback %}
+{% if vrf_bgp['router-id'] is defined %}
   router-id {{ vrf_bgp['router-id'] }}
-        {% else %}
-            {% if lo_config['ipv4'] is defined %}
+{% else %}
+{% if lo_config['ipv4'] is defined %}
   router-id {{ lo_config['ipv4']|ansible.utils.ipaddr('address') }}
-            {% endif %}
-        {% endif %}
+{% endif %}
+{% endif %}
   local-as {{ vrf_bgp['asn'] }}
 {% if vrf_bgp['confed_asn'] is defined and vrf_bgp['confed_asn'] %}
   bgp confederation identifier {{ vrf_bgp['confed_asn'] }}
   bgp confederation peers {{ vrf_bgp['confed_peers'] | replace(',', ' ') }}
 {% endif %}
-        {% for asn, remote_ips in vrf_bgp['peers'].items() %}
-            {% for remote_ip in remote_ips %}
+{% for asn, remote_ips in vrf_bgp['peers'].items() %}
+{% for remote_ip in remote_ips %}
   neighbor {{ remote_ip }} remote-as {{ asn }}
   neighbor {{ remote_ip }} description {{ asn }}
   neighbor {{ remote_ip }} next-hop-self
-                {% if remote_ip|ipv6 %}
+{% if remote_ip|ipv6 %}
   address-family ipv6
    neighbor {{ remote_ip }} activate
   exit
-                {% endif %}
-            {% endfor %}
-        {% endfor %}
-        {% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
   neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} remote-as {{ vrf_bgp['asn'] }}
   neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} next-hop-peer
   neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} description exabgp_v4
-        {% endif %}
-        {% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
+{% endif %}
+{% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
   neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} remote-as {{ vrf_bgp['asn'] }}
   neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} next-hop-peer
   neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} description exabgp_v6
-        {% endif %}
+{% endif %}
   address-family ipv4
-        {% if lo_config['ipv4'] is defined %}
+{% if lo_config['ipv4'] is defined %}
    network {{ lo_config['ipv4'] }}
-        {% endif %}
+{% endif %}
   exit
   address-family ipv6
    neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} activate
-        {% if lo_config['ipv6'] is defined %}
+{% if lo_config['ipv6'] is defined %}
    network {{ lo_config['ipv6'] }}
-        {% endif %}
+{% endif %}
   exit
  exit
-    {% endfor %}
+{% endfor %}
 {% else %}
 router bgp {{ host['bgp']['asn'] }}
  vrf MGMT
@@ -242,37 +242,37 @@ router bgp {{ host['bgp']['asn'] }}
 !
 {% endif %}
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
-    {% for remote_ip in remote_ips %}
+{% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-            {% if remote_ip | ansible.utils.ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit
-            {% endif %}
-        {% endfor %}
-    {% endfor %}
-    {% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
  neighbor {{ props.nhipv4 }} remote-as {{ host['bgp']['asn'] }}
  neighbor {{ props.nhipv4 }} description exabgp_v4
-    {% endif %}
-    {% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
+{% endif %}
+{% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
  neighbor {{ props.nhipv6 }} remote-as {{ host['bgp']['asn'] }}
  neighbor {{ props.nhipv6 }} description exabgp_v6
  address-family ipv6
   neighbor {{ props.nhipv6 }} activate
  exit
-    {% endif %}
+{% endif %}
  !
-    {% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
-        {% if iface['ipv4'] is defined %}
+{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+{% if iface['ipv4'] is defined %}
  network {{ iface['ipv4'] }}
-        {% endif %}
-        {% if iface['ipv6'] is defined %}
+{% endif %}
+{% if iface['ipv6'] is defined %}
  network {{ iface['ipv6'] }}
-        {% endif %}
-    {% endfor %}
+{% endif %}
+{% endfor %}
 {% endif %}
 !
 management api http-commands

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -300,8 +300,8 @@ class VMTopology(object):
                 vm_bridge_regx = OVS_FP_BRIDGE_REGEX % vmname
                 num_intfs = len([intf for intf in intf_names if re.search(vm_bridge_regx, intf)])
                 if len(attrs['vlans']) > num_intfs:
-                    raise Exception("Wrong vlans parameter for hostname %s, vm %s. Too many vlans. Maximum is %d"
-                                    % (hostname, vmname, num_intfs))
+                    raise Exception("Wrong vlans parameter for hostname %s, vm %s. Too many vlans. Maximum is %d %s"
+                                    % (hostname, vmname, num_intfs, str(attrs['vlans'])))
 
         self.VM_LINKs = {}
         if 'VM_LINKs' in self.topo:


### PR DESCRIPTION
### Description of PR
Summary:
Fix EOS template issues for cEOS converged neighbor (multi-VRF) mode and improve vm_topology error messaging.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

1. EOS templates `lt2-o128-tor.j2` and `t1-64-lag-tor.j2` conditionally create `vrf instance MGMT` only in converged mode, falling back to `vrf definition MGMT` otherwise. `vrf instance MGMT` should always be created.

2. In `t1-lag-spine.j2`, Jinja2 control directives (`{% set %}`, `{% for %}`, `{% endfor %}`, `{% endif %}`) had inconsistent leading whitespace that would render as extra whitespace in the generated config.

3. In `vm_topology.py`, the vlans parameter validation error message did not include the actual vlans value, making debugging difficult.

#### How did you do it?

- `lt2-o128-tor.j2` / `t1-64-lag-tor.j2`: Move `vrf instance MGMT` outside the `{% if converged %}` block so it is always created. Remove the `{% else %}` branch with `vrf definition MGMT`.
- `t1-lag-spine.j2`: Remove leading whitespace from Jinja2 control directives in the converged neighbor blocks.
- `vm_topology.py`: Add `str(attrs['vlans'])` to the exception message for the vlans parameter validation error.

#### How did you verify/test it?

Verified template rendering produces correct EOS configuration for both converged and non-converged topologies.

#### Any platform specific information?

Affects lt2-o128, t1-64-lag, and t1-lag topologies using cEOS VMs.

#### Supported testbed topology if it is a new test case?

N/A

### Documentation
N/A
