### PR TITLE
[qos] Clearer IP-in-IP DSCP test failures + on-failure drop diagnostics

### DIFF
--- a/tests/qos/qos_helpers.py
+++ b/tests/qos/qos_helpers.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from netaddr import IPNetwork
 from .qos_fixtures import lossless_prio_dscp_map, leaf_fanouts      # noqa: F401
 from tests.common.cisco_data import is_cisco_device, copy_set_voq_watchdog_script_cisco_8000, run_dshell_command
+import ipaddress
 import re
 import os
 import json
@@ -426,3 +427,80 @@ def announce_route(ptfip, route, port, action=ANNOUNCE):
     logger.info(" action:{}\n ptfip:{}\n route:{}\n port:{}".format(action, ptfip, route, port))
     install_route_from_exabgp(action, ptfip, route, port)
     logger.info("\n--------------------------------------------------------------------------------")
+
+
+# Limit how many on-failure diagnostic snapshots a single test run will collect, to
+# avoid log explosion when a real outage drops traffic to many destinations.
+_QOS_DROP_DIAG_BUDGET = [5]
+
+
+def reset_qos_drop_diag_budget(budget=5):
+    """Reset the per-run diagnostic snapshot budget. Call at test setup if desired."""
+    _QOS_DROP_DIAG_BUDGET[0] = budget
+
+
+def collect_qos_drop_diagnostics(duthost, dst_ip=None, tag=""):
+    """Best-effort, on-failure DUT snapshot to root-cause a no-egress / forwarding drop.
+
+    Shared across QoS test cases. Composes existing device-object methods and the
+    common drop-counter helpers; it is read-only and NEVER raises, so it is safe to
+    call from inside a packet send/verify loop the moment a packet is found missing.
+
+    Capture it AT the miss (not at teardown): a RIB->FIB / ARP convergence race
+    self-heals within seconds, so a teardown-time snapshot would show a healthy state
+    and miss the evidence.
+
+    Collected (each best-effort):
+      - kernel FIB + nexthops for dst_ip (duthost.get_ip_route_info)
+      - BGP RIB entry for dst_ip            (duthost.get_route)
+      - RIB-vs-FIB route summary            (duthost.get_ip_route_summary)
+      - CRM route/neighbor resource usage   (duthost.get_crm_resources)
+      - ARP/neighbor table                  (duthost.switch_arptable)
+      - ASIC_DB programmed route count      (asic.count_routes)
+      - L2/L3 per-interface drop counters   (drop_counters.get_pkt_drops)
+      - Broadcom only: 'bcmcmd l3 defip show' filtered to dst_ip
+
+    Args:
+        duthost: DUT host object.
+        dst_ip:  Inner/forwarded destination IP that was not received (optional).
+        tag:     Short label included in every log line (e.g. "pipe-dscp6").
+
+    Returns:
+        dict of the collected state (also emitted to the test log at WARNING level).
+        Empty dict if the per-run budget is exhausted.
+    """
+    # Imported here to avoid adding an import-time dependency for callers that never
+    # hit a failure path.
+    from tests.common.helpers.drop_counters.drop_counters import (
+        get_pkt_drops, GET_L2_COUNTERS, GET_L3_COUNTERS)
+
+    if _QOS_DROP_DIAG_BUDGET[0] <= 0:
+        return {}
+    _QOS_DROP_DIAG_BUDGET[0] -= 1
+
+    diag = {}
+
+    def _try(key, fn):
+        try:
+            diag[key] = fn()
+        except Exception as exc:                                    # noqa: BLE001
+            diag[key] = "<collect failed: {}>".format(exc)
+
+    if dst_ip:
+        prefix = "{}/32".format(dst_ip)
+        _try("fib_route", lambda: duthost.get_ip_route_info(ipaddress.ip_network(u"{}".format(prefix))))
+        _try("bgp_rib", lambda: duthost.get_route(prefix))
+    _try("route_summary", lambda: duthost.get_ip_route_summary())
+    _try("crm_resources", lambda: duthost.get_crm_resources())
+    _try("arp_table", lambda: duthost.switch_arptable()["ansible_facts"]["arptable"])
+    _try("asic_db_route_count", lambda: duthost.asic_instance().count_routes("SAI_OBJECT_TYPE_ROUTE_ENTRY"))
+    _try("l2_drops", lambda: get_pkt_drops(duthost, GET_L2_COUNTERS))
+    _try("l3_drops", lambda: get_pkt_drops(duthost, GET_L3_COUNTERS))
+    if duthost.facts.get("asic_type") == "broadcom" and dst_ip:
+        _try("bcm_l3_defip", lambda: duthost.shell(
+            "which bcmcmd > /dev/null && bcmcmd 'l3 defip show' | grep {} || true".format(dst_ip),
+            module_ignore_errors=True)["stdout"])
+
+    logger.warning("[QOS-DROP-DIAG %s] dst=%s diagnostics:\n%s",
+                   tag, dst_ip, json.dumps(diag, indent=2, default=str))
+    return diag

--- a/tests/qos/qos_helpers.py
+++ b/tests/qos/qos_helpers.py
@@ -433,13 +433,52 @@ def announce_route(ptfip, route, port, action=ANNOUNCE):
 # avoid log explosion when a real outage drops traffic to many destinations.
 _QOS_DROP_DIAG_BUDGET = [5]
 
+# Per-interface counter columns returned by drop_counters.get_pkt_drops().
+_L2_DROP_COL = "RX_DRP"
+_L3_DROP_COL = "RX_ERR"
+
 
 def reset_qos_drop_diag_budget(budget=5):
     """Reset the per-run diagnostic snapshot budget. Call at test setup if desired."""
     _QOS_DROP_DIAG_BUDGET[0] = budget
 
 
-def collect_qos_drop_diagnostics(duthost, dst_ip=None, tag=""):
+def snapshot_qos_drop_counters(duthost):
+    """Capture a lightweight, read-only counter baseline for later delta computation.
+
+    Cumulative DUT counters (interface RX_DRP / RX_ERR) are only meaningful as a
+    *delta*. Call this once BEFORE sending a batch; pass the result as ``baseline`` to
+    ``collect_qos_drop_diagnostics`` on a miss so the drop can be attributed even after a
+    transient route race has self-healed (the counter increment latches and survives).
+
+    Best-effort; never raises. Two cheap reads (portstat -j, intfstat -j) per call.
+    """
+    from tests.common.helpers.drop_counters.drop_counters import (
+        get_pkt_drops, GET_L2_COUNTERS, GET_L3_COUNTERS)
+    snap = {}
+    for key, cmd in (("l2", GET_L2_COUNTERS), ("l3", GET_L3_COUNTERS)):
+        try:
+            snap[key] = get_pkt_drops(duthost, cmd)
+        except Exception:                                           # noqa: BLE001
+            snap[key] = {}
+    return snap
+
+
+def _counter_delta(current, baseline, column):
+    """Return {interface: delta} for non-zero deltas of ``column`` between two snapshots."""
+    out = {}
+    for iface, cols in (current or {}).items():
+        try:
+            cur = int(cols.get(column, 0))
+            base = int((baseline or {}).get(iface, {}).get(column, 0))
+            if cur - base != 0:
+                out[iface] = cur - base
+        except (ValueError, TypeError):
+            continue
+    return out
+
+
+def collect_qos_drop_diagnostics(duthost, dst_ip=None, tag="", baseline=None):
     """Best-effort, on-failure DUT snapshot to root-cause a no-egress / forwarding drop.
 
     Shared across QoS test cases. Composes existing device-object methods and the
@@ -448,22 +487,26 @@ def collect_qos_drop_diagnostics(duthost, dst_ip=None, tag=""):
 
     Capture it AT the miss (not at teardown): a RIB->FIB / ARP convergence race
     self-heals within seconds, so a teardown-time snapshot would show a healthy state
-    and miss the evidence.
+    and miss the evidence. For a *transient* drop the durable evidence is the counter
+    delta and the swss/syncd route-programming timestamp (both survive the heal), not
+    the absolute route state (which may already look healthy).
 
     Collected (each best-effort):
-      - kernel FIB + nexthops for dst_ip (duthost.get_ip_route_info)
-      - BGP RIB entry for dst_ip            (duthost.get_route)
-      - RIB-vs-FIB route summary            (duthost.get_ip_route_summary)
-      - CRM route/neighbor resource usage   (duthost.get_crm_resources)
-      - ARP/neighbor table                  (duthost.switch_arptable)
-      - ASIC_DB programmed route count      (asic.count_routes)
-      - L2/L3 per-interface drop counters   (drop_counters.get_pkt_drops)
-      - Broadcom only: 'bcmcmd l3 defip show' filtered to dst_ip
+      - Absolute state (labels transient vs persistent):
+          kernel FIB + nexthops (get_ip_route_info), BGP RIB (get_route),
+          RIB-vs-FIB summary (get_ip_route_summary), CRM usage (get_crm_resources),
+          ARP/neighbor table (switch_arptable), ASIC_DB route count (asic.count_routes)
+      - Durable drop evidence (survives a self-healed transient):
+          L2 RX_DRP / L3 RX_ERR counter DELTAS vs ``baseline`` (if provided),
+          swss + syncd route-programming log lines for dst_ip (timestamp vs send time),
+          Broadcom: 'bcmcmd l3 defip show' (route in HW?) and 'bcmcmd show c' (drop bucket)
 
     Args:
-        duthost: DUT host object.
-        dst_ip:  Inner/forwarded destination IP that was not received (optional).
-        tag:     Short label included in every log line (e.g. "pipe-dscp6").
+        duthost:  DUT host object.
+        dst_ip:   Inner/forwarded destination IP that was not received (optional).
+        tag:      Short label included in every log line (e.g. "pipe-dscp6").
+        baseline: Optional counter snapshot from ``snapshot_qos_drop_counters`` taken
+                  before the batch was sent; enables drop-counter DELTA computation.
 
     Returns:
         dict of the collected state (also emitted to the test log at WARNING level).
@@ -486,6 +529,7 @@ def collect_qos_drop_diagnostics(duthost, dst_ip=None, tag=""):
         except Exception as exc:                                    # noqa: BLE001
             diag[key] = "<collect failed: {}>".format(exc)
 
+    # --- Absolute state: route / FIB / neighbor (labels transient vs persistent) ---
     if dst_ip:
         prefix = "{}/32".format(dst_ip)
         _try("fib_route", lambda: duthost.get_ip_route_info(ipaddress.ip_network(u"{}".format(prefix))))
@@ -494,11 +538,40 @@ def collect_qos_drop_diagnostics(duthost, dst_ip=None, tag=""):
     _try("crm_resources", lambda: duthost.get_crm_resources())
     _try("arp_table", lambda: duthost.switch_arptable()["ansible_facts"]["arptable"])
     _try("asic_db_route_count", lambda: duthost.asic_instance().count_routes("SAI_OBJECT_TYPE_ROUTE_ENTRY"))
-    _try("l2_drops", lambda: get_pkt_drops(duthost, GET_L2_COUNTERS))
-    _try("l3_drops", lambda: get_pkt_drops(duthost, GET_L3_COUNTERS))
-    if duthost.facts.get("asic_type") == "broadcom" and dst_ip:
-        _try("bcm_l3_defip", lambda: duthost.shell(
-            "which bcmcmd > /dev/null && bcmcmd 'l3 defip show' | grep {} || true".format(dst_ip),
+
+    # --- Durable drop evidence: counter deltas (survive a self-healed transient) ---
+    current_l2 = None
+    current_l3 = None
+    try:
+        current_l2 = get_pkt_drops(duthost, GET_L2_COUNTERS)
+        current_l3 = get_pkt_drops(duthost, GET_L3_COUNTERS)
+    except Exception as exc:                                        # noqa: BLE001
+        diag["counter_read"] = "<failed: {}>".format(exc)
+    if baseline is not None:
+        diag["l2_rx_drp_delta"] = _counter_delta(current_l2, baseline.get("l2"), _L2_DROP_COL)
+        diag["l3_rx_err_delta"] = _counter_delta(current_l3, baseline.get("l3"), _L3_DROP_COL)
+    else:
+        # No baseline: cumulative values only (less conclusive, but still recorded).
+        diag["l2_drops_cumulative"] = current_l2
+        diag["l3_drops_cumulative"] = current_l3
+
+    # --- Durable race proof: when was the route/neighbor programmed vs sent? ---
+    if dst_ip:
+        _try("swss_route_log", lambda: duthost.shell(
+            "docker logs --since 5m swss 2>&1 | grep -F '{}' | tail -20 || true".format(dst_ip),
+            module_ignore_errors=True)["stdout"])
+        _try("syncd_route_log", lambda: duthost.shell(
+            "docker logs --since 5m syncd 2>&1 | grep -F '{}' | tail -20 || true".format(dst_ip),
+            module_ignore_errors=True)["stdout"])
+
+    # --- Broadcom ASIC: route in hardware + drop bucket ---
+    if duthost.facts.get("asic_type") == "broadcom":
+        if dst_ip:
+            _try("bcm_l3_defip", lambda: duthost.shell(
+                "which bcmcmd > /dev/null && bcmcmd 'l3 defip show' | grep {} || true".format(dst_ip),
+                module_ignore_errors=True)["stdout"])
+        _try("bcm_show_c", lambda: duthost.shell(
+            "which bcmcmd > /dev/null && bcmcmd 'show c' | grep -iE 'disc|drop|rdisc|ripd' || true",
             module_ignore_errors=True)["stdout"])
 
     logger.warning("[QOS-DROP-DIAG %s] dst=%s diagnostics:\n%s",

--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -20,7 +20,7 @@ from tests.common.utilities import get_ipv4_loopback_ip, get_dscp_to_queue_value
     get_egress_queue_pkt_count_all_port_prio, wait_until, get_vlan_from_port
 from tests.common.helpers.assertions import pytest_assert
 from tests.qos.qos_helpers import get_upstream_exabgp_port, announce_route, collect_qos_drop_diagnostics, \
-    snapshot_qos_drop_counters
+    snapshot_qos_drop_counters, reset_qos_drop_diag_budget
 from tests.common.fixtures.duthost_utils import dut_qos_maps_module  # noqa F401
 
 logger = logging.getLogger(__name__)
@@ -429,6 +429,8 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
                 RunAnsibleModuleFail if ptf test fails
         """
         ptf_port_to_dut_port_map = {}
+        # Fresh on-failure-diagnostics budget per test run (module-global counter).
+        reset_qos_drop_diag_budget()
         if "backend" in tbinfo["topo"]["type"]:
             pytest.skip("Dscp-queue mapping is not supported on {}".format(tbinfo["topo"]["type"]))
 
@@ -688,6 +690,8 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
         global output_table, packet_egressed_success
         output_table = []
         packet_egressed_success = []
+        # Fresh on-failure-diagnostics budget per test run (module-global counter).
+        reset_qos_drop_diag_budget()
 
         def check_tunnel_dscp_mode(duthost, dscp_mode):
             real_dscp_mode = duthost.shell('redis-cli hget "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" "dscp_mode"')["stdout"]

--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -2,6 +2,7 @@
 Test cases for testing DSCP to Queue mapping for IP-IP packets in SONiC.
 """
 import time
+import copy
 import logging
 import pytest
 import allure
@@ -18,7 +19,7 @@ from tests.common.helpers.ptf_tests_helper import downstream_links, upstream_lin
 from tests.common.utilities import get_ipv4_loopback_ip, get_dscp_to_queue_value, find_egress_queue, \
     get_egress_queue_pkt_count_all_port_prio, wait_until, get_vlan_from_port
 from tests.common.helpers.assertions import pytest_assert
-from tests.qos.qos_helpers import get_upstream_exabgp_port, announce_route
+from tests.qos.qos_helpers import get_upstream_exabgp_port, announce_route, collect_qos_drop_diagnostics
 from tests.common.fixtures.duthost_utils import dut_qos_maps_module  # noqa F401
 
 logger = logging.getLogger(__name__)
@@ -215,45 +216,87 @@ def create_ipip_packet(outer_src_mac,
     return outer_pkt, exp_pkt
 
 
+def _classify_packet_miss(ptfadapter, exp_pkt, ptf_dst_port_ids):
+    """Distinguish a forwarding drop from a DSCP mismatch when a verify fails.
+
+    Re-checks for the same packet while ignoring the IP DSCP/TOS byte. If a packet now
+    matches, it egressed but with the wrong DSCP (real DSCP-handling behavior); if still
+    nothing matches, the packet was not forwarded at all (routing/FIB/infra).
+    """
+    try:
+        dscp_agnostic = copy.deepcopy(exp_pkt)
+        dscp_agnostic.set_do_not_care_scapy(IP, 'tos')
+        testutils.verify_packet_any_port(ptfadapter, dscp_agnostic, ports=ptf_dst_port_ids, timeout=2)
+        return "DSCP_MISMATCH"
+    except AssertionError:
+        return "FORWARDING_DROP"
+    except Exception:                                              # noqa: BLE001
+        return "UNKNOWN_MISS"
+
+
 def send_and_verify_traffic(ptfadapter,
                             pkt_list,
                             exp_pkt_list,
                             ptf_src_port_id,
-                            ptf_dst_port_ids):
+                            ptf_dst_port_ids,
+                            duthost=None,
+                            inner_dst_ip_list=None,
+                            diag_tag=""):
     """
-    Send traffic and verify that traffic was received
+    Send traffic and verify that traffic was received.
+
+    A per-packet result is appended to the module-global ``packet_egressed_success``
+    (True on egress, False on miss) for every packet in ``pkt_list``, so the list length
+    always equals ``len(pkt_list)`` and callers can index it safely (no IndexError).
+
+    On a miss the failure is classified (FORWARDING_DROP vs DSCP_MISMATCH) and, when a
+    ``duthost`` is provided, an on-the-spot diagnostic snapshot is collected via
+    ``collect_qos_drop_diagnostics`` while the (often transient) DUT state is still fresh.
 
     Args:
         ptfadapter: PTF adapter
-        pkt: Packet that should be sent
-        exp_pkt: Expected packet
+        pkt_list: Packets to send
+        exp_pkt_list: Expected (masked) packets
         ptf_src_port_id: Source port of ptf
         ptf_dst_port_ids: Possible destination ports of ptf
+        duthost: Optional DUT host; when set, collect drop diagnostics on a miss
+        inner_dst_ip_list: Optional inner destination IPs aligned with pkt_list, used for
+            clearer logging and targeted diagnostics
+        diag_tag: Optional label prefix for diagnostic log lines
+
+    Returns:
+        list aligned with pkt_list: the receiving ptf port per packet, or None on a miss
     """
-    pkt_egress_index = 0
+    global packet_egressed_success
     ptf_dst_port_list = []
     logger.info("Send packet(s) from port {} from downstream to upstream".format(ptf_src_port_id))
 
-    try:
-        for pkt, exp_pkt in zip(pkt_list, exp_pkt_list):
-            ptfadapter.dataplane.flush()
-            testutils.send(ptfadapter, ptf_src_port_id, pkt, count=DEFAULT_PKT_COUNT)
-            logger.info(f"Send packet: {pkt}, expected packet: {exp_pkt}")
+    for idx, (pkt, exp_pkt) in enumerate(zip(pkt_list, exp_pkt_list)):
+        dst_ip = inner_dst_ip_list[idx] if inner_dst_ip_list and idx < len(inner_dst_ip_list) else None
+        ptfadapter.dataplane.flush()
+        testutils.send(ptfadapter, ptf_src_port_id, pkt, count=DEFAULT_PKT_COUNT)
+        logger.info(f"Send packet (inner dst {dst_ip}): {pkt}, expected packet: {exp_pkt}")
+        try:
             result = testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=ptf_dst_port_ids, timeout=5)
             if isinstance(result, bool):
                 logger.info("Return a dummy value for VS platform")
                 port_index = 0
             else:
                 port_index, _ = result
-            logger.info("Received packet(s) on port {}".format(ptf_dst_port_ids[port_index]))
-            global packet_egressed_success
+            logger.info("Received expected packet(s) for inner dst {} on port {}".format(
+                dst_ip, ptf_dst_port_ids[port_index]))
             packet_egressed_success.append(True)
             ptf_dst_port_list.append(ptf_dst_port_ids[port_index])
-            pkt_egress_index += 1
-        return ptf_dst_port_list
-    except AssertionError as detail:
-        if "Did not receive expected packet on any of ports" in str(detail):
-            logger.error("Expected packet(s) was not received on any of the ports -> {}".format(ptf_dst_port_ids))
+        except AssertionError as detail:
+            reason = _classify_packet_miss(ptfadapter, exp_pkt, ptf_dst_port_ids)
+            logger.error("MISS (%s): inner dst %s, expected packet not matched on ports %s -> %s",
+                         reason, dst_ip, ptf_dst_port_ids, detail)
+            packet_egressed_success.append(False)
+            ptf_dst_port_list.append(None)
+            if duthost is not None:
+                collect_qos_drop_diagnostics(duthost, dst_ip=dst_ip,
+                                             tag="{}-idx{}-{}".format(diag_tag, idx, reason))
+    return ptf_dst_port_list
 
 
 def find_queue_count_and_value(duthost, queue_val_list, dut_egress_port_list):
@@ -262,6 +305,12 @@ def find_queue_count_and_value(duthost, queue_val_list, dut_egress_port_list):
     egress_queue_count_list = []
     egress_queue_val_list = []
     for dut_egress_port, queue_val in zip(dut_egress_port_list, queue_val_list):
+        if dut_egress_port is None:
+            # Packet for this destination did not egress; keep lists aligned so the
+            # caller's verdict loop can classify it as "no packets egressed".
+            egress_queue_count_list.append(0)
+            egress_queue_val_list.append(-1)
+            continue
         egress_queue_count = egress_queue_counts_all_queues[dut_egress_port][queue_val]
         egress_queue_val = find_egress_queue(egress_queue_counts_all_queues[dut_egress_port], DEFAULT_PKT_COUNT)
         egress_queue_count_list.append(egress_queue_count)
@@ -451,7 +500,10 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
                                                                pkt_list=pkt_list,
                                                                exp_pkt_list=exp_pkt_list,
                                                                ptf_src_port_id=ptf_src_port_id,
-                                                               ptf_dst_port_ids=ptf_dst_port_ids)
+                                                               ptf_dst_port_ids=ptf_dst_port_ids,
+                                                               duthost=duthost,
+                                                               inner_dst_ip_list=inner_dst_pkt_ip_list,
+                                                               diag_tag="{}-batch{}".format(decap_mode, rotating_dscp))
 
             except ConnectionError as e:
                 # Sending large number of packets can cause socket buffer to be full and leads connection timeout.
@@ -466,6 +518,12 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
             dut_egress_port_list = []
             for i in range(step):
                 dst_ptf_port_id = dst_ptf_port_id_list[i]
+                if dst_ptf_port_id is None:
+                    # Packet for this DSCP/destination did not egress; placeholder keeps
+                    # dut_egress_port_list aligned with step so the verdict loop below can
+                    # classify it as "no packets egressed".
+                    dut_egress_port_list.append(None)
+                    continue
                 if dst_ptf_port_id in ptf_port_to_dut_port_map:
                     dut_egress_port = ptf_port_to_dut_port_map[dst_ptf_port_id]
                 else:
@@ -650,7 +708,10 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
                                             pkt_list=pkt_list,
                                             exp_pkt_list=exp_pkt_list,
                                             ptf_src_port_id=ptf_src_port_id,
-                                            ptf_dst_port_ids=ptf_dst_port_ids)
+                                            ptf_dst_port_ids=ptf_dst_port_ids,
+                                            duthost=duthost,
+                                            inner_dst_ip_list=inner_dst_pkt_ip_list,
+                                            diag_tag="pipe-batch{}".format(rotating_dscp))
                 except ConnectionError as e:
                     logger.error("{}: Try reducing DEFAULT_PKT_COUNT value".format(str(e)))
                     failed_once = True
@@ -659,17 +720,20 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
                     cur_dscp = rotating_dscp + i
                     if packet_egressed_success[i]:
                         logger.info(f"SUCCESS: Inner DSCP {cur_dscp} preserved in decapsulated packet")
-                        output_table.append([cur_dscp, "SUCCESS - DSCP PRESERVED"])
+                        output_table.append([cur_dscp, inner_dst_pkt_ip_list[i], "SUCCESS - DSCP PRESERVED"])
                     else:
-                        logger.info(f"FAILURE: Inner DSCP {cur_dscp} not found in decapsulated packet")
-                        output_table.append([cur_dscp, "FAILURE - DSCP NOT PRESERVED"])
+                        logger.info(f"FAILURE: Inner DSCP {cur_dscp} (inner dst {inner_dst_pkt_ip_list[i]}) not "
+                                    f"received after decap; see MISS/QOS-DROP-DIAG logs for "
+                                    f"FORWARDING_DROP vs DSCP_MISMATCH classification")
+                        output_table.append([cur_dscp, inner_dst_pkt_ip_list[i],
+                                             "FAILURE - NOT PRESERVED/FORWARDED"])
                         failed_once = True
 
                 packet_egressed_success = []
 
         logger.info("Pipe mode DSCP preservation test results:\n{}"
                     .format(tabulate(output_table,
-                                     headers=["Inner Packet DSCP Value", "Result"])))
+                                     headers=["Inner Packet DSCP Value", "Inner Dst IP", "Result"])))
         output_table = []
 
         pytest_assert(not failed_once, "FAIL: One or more inner DSCP values were not preserved after decap."

--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -217,13 +217,28 @@ def create_ipip_packet(outer_src_mac,
     return outer_pkt, exp_pkt
 
 
-def _classify_packet_miss(ptfadapter, exp_pkt, ptf_dst_port_ids):
-    """Distinguish a forwarding drop from a DSCP mismatch when a verify fails.
+def _classify_packet_miss(ptfadapter, exp_pkt, ptf_dst_port_ids, extra_ports=None):
+    """Classify why a verify failed: wrong egress port, DSCP mismatch, or a real drop.
 
-    Re-checks for the same packet while ignoring the IP DSCP/TOS byte. If a packet now
-    matches, it egressed but with the wrong DSCP (real DSCP-handling behavior); if still
-    nothing matches, the packet was not forwarded at all (routing/FIB/infra).
+    1. WRONG_EXPECTED_PORT: the (correctly DSCP-preserved) packet egressed on a port that
+       was excluded from ``ptf_dst_port_ids`` (e.g. the route egresses over a PortChannel
+       whose member is the PTF source port). Re-checks on ``ptf_dst_port_ids + extra_ports``.
+    2. DSCP_MISMATCH: a packet egressed on an expected port but with the wrong DSCP
+       (re-check ignoring the IP DSCP/TOS byte) -> real DSCP-handling behavior.
+    3. FORWARDING_DROP: nothing matched anywhere -> not forwarded (routing/FIB/infra).
     """
+    # 1. Did it egress on an excluded port (correct DSCP)?
+    extra = [p for p in (extra_ports or []) if p not in ptf_dst_port_ids]
+    if extra:
+        try:
+            testutils.verify_packet_any_port(ptfadapter, exp_pkt,
+                                             ports=list(ptf_dst_port_ids) + extra, timeout=2)
+            return "WRONG_EXPECTED_PORT"
+        except AssertionError:
+            pass
+        except Exception:                                          # noqa: BLE001
+            pass
+    # 2. Did it egress with the wrong DSCP?
     try:
         dscp_agnostic = copy.deepcopy(exp_pkt)
         dscp_agnostic.set_do_not_care_scapy(IP, 'tos')
@@ -294,7 +309,8 @@ def send_and_verify_traffic(ptfadapter,
             packet_egressed_success.append(True)
             ptf_dst_port_list.append(ptf_dst_port_ids[port_index])
         except AssertionError as detail:
-            reason = _classify_packet_miss(ptfadapter, exp_pkt, ptf_dst_port_ids)
+            reason = _classify_packet_miss(ptfadapter, exp_pkt, ptf_dst_port_ids,
+                                           extra_ports=[ptf_src_port_id])
             logger.error("MISS (%s): inner dst %s, expected packet not matched on ports %s -> %s",
                          reason, dst_ip, ptf_dst_port_ids, detail)
             packet_egressed_success.append(False)
@@ -375,8 +391,12 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
         ptf_dst_port_ids = get_stream_ptf_ports(links)
         pytest_assert(ptf_dst_port_ids, f"ptf_dst_port_ids is {ptf_dst_port_ids}")
 
-        if ptf_src_port_id in ptf_dst_port_ids:
-            ptf_dst_port_ids.remove(ptf_src_port_id)
+        # NOTE: Do NOT remove ptf_src_port_id from the expected egress set. The expected
+        # packet is the DECAPPED inner packet, which has different headers from the
+        # injected outer IP-in-IP packet, so it can never false-match the injected
+        # traffic. A route can legitimately egress over a PortChannel whose member is the
+        # source port; with the source removed, a decapped packet that LAG-hashes back
+        # onto that source member is wrongly reported as "not received" (flaky failure).
 
         return {
             'ptf_src_port_id': ptf_src_port_id,

--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -19,7 +19,8 @@ from tests.common.helpers.ptf_tests_helper import downstream_links, upstream_lin
 from tests.common.utilities import get_ipv4_loopback_ip, get_dscp_to_queue_value, find_egress_queue, \
     get_egress_queue_pkt_count_all_port_prio, wait_until, get_vlan_from_port
 from tests.common.helpers.assertions import pytest_assert
-from tests.qos.qos_helpers import get_upstream_exabgp_port, announce_route, collect_qos_drop_diagnostics
+from tests.qos.qos_helpers import get_upstream_exabgp_port, announce_route, collect_qos_drop_diagnostics, \
+    snapshot_qos_drop_counters
 from tests.common.fixtures.duthost_utils import dut_qos_maps_module  # noqa F401
 
 logger = logging.getLogger(__name__)
@@ -271,6 +272,11 @@ def send_and_verify_traffic(ptfadapter,
     ptf_dst_port_list = []
     logger.info("Send packet(s) from port {} from downstream to upstream".format(ptf_src_port_id))
 
+    # Cumulative drop counters are only meaningful as a delta. Capture a baseline once,
+    # before sending, so a miss can be attributed even after a transient route race has
+    # self-healed (the counter increment latches). Only when diagnostics are enabled.
+    diag_baseline = snapshot_qos_drop_counters(duthost) if duthost is not None else None
+
     for idx, (pkt, exp_pkt) in enumerate(zip(pkt_list, exp_pkt_list)):
         dst_ip = inner_dst_ip_list[idx] if inner_dst_ip_list and idx < len(inner_dst_ip_list) else None
         ptfadapter.dataplane.flush()
@@ -294,7 +300,7 @@ def send_and_verify_traffic(ptfadapter,
             packet_egressed_success.append(False)
             ptf_dst_port_list.append(None)
             if duthost is not None:
-                collect_qos_drop_diagnostics(duthost, dst_ip=dst_ip,
+                collect_qos_drop_diagnostics(duthost, dst_ip=dst_ip, baseline=diag_baseline,
                                              tag="{}-idx{}-{}".format(diag_tag, idx, reason))
     return ptf_dst_port_list
 


### PR DESCRIPTION
### Description of PR

Summary:
`qos/test_qos_dscp_mapping.py::test_pipe_mode_dscp_preservation` (new in 202605) is flaky (~14–29% on 7060CX) and fails with a confusing `IndexError`, capturing no DUT state to explain it.

**Root cause (reproduced and confirmed via the diagnostics added here):** the test injects from a randomly-selected PTF port that can be a **member of a PortChannel** which is also the route nexthop for an inner destination. `_setup_test_params` **removed the source port** from `ptf_dst_port_ids`, so when the decapped (DSCP-correct) packet **LAG-hashed back onto that source member**, the test reported a **false miss**. It is **not** a packet drop, **not** a DSCP/decap defect, and **not** a route-convergence race. The expected packet is the **decapped inner** packet, which has different headers from the injected **outer IP-in-IP** packet, so removing the source port was unnecessary and harmful.

ADO: 38023429

### Type of change

- [x] Bug fix
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511  &nbsp; <!-- N/A: test_pipe_mode_dscp_preservation does not exist on 202511 -->

> Note: `test_pipe_mode_dscp_preservation` / `dscp_config_pipe` are **new in 202605** and do not exist on 202511 (202511 used upstream-only `ptf_uplink_ports`). No back-port applies.

### Approach
#### What is the motivation for this PR?
Eliminate the flaky false failure, make any future failure self-explanatory, and capture on-failure DUT evidence so a recurrence can be root-caused from the logs.

#### How did you do it?
**The fix:**
- `_setup_test_params`: **stop removing `ptf_src_port_id` from `ptf_dst_port_ids`**. The route can legitimately egress over a PortChannel whose member is the source port; the decapped inner packet never false-matches the injected outer packet.

**Clarity + diagnosability (also catch any future mis-port/drop):**
- `send_and_verify_traffic`: record a **per-packet** `True`/`False` so the verdict loops can't `IndexError`; classify each miss as **`WRONG_EXPECTED_PORT`** (egressed correctly on an excluded port) / `DSCP_MISMATCH` / `FORWARDING_DROP`.
- New shared, read-only, never-raising QoS helper `qos_helpers.collect_qos_drop_diagnostics` (+ `snapshot_qos_drop_counters`) collects, **at the moment of a miss**, the FIB/BGP route + ARP + ASIC_DB route count + L2/L3 drop-counter deltas + swss/syncd route-programming timestamps + Broadcom `bcmcmd l3 defip`/`show c`. Budget-capped; only the cheap per-batch counter baseline runs on healthy runs.
- Result table now includes the inner destination IP.

#### How did you verify/test it?
- **Reproduced the failure** on Elastictest (7060CX `t1-lag`, internal-202605) on the **first** repeat iteration with the diagnostics-only build; the captured `QOS-DROP-DIAG` FIB showed the nexthop `PortChannel123` and the verify message showed the packet **received with the correct DSCP on the excluded source-member port** — confirming the root cause.
- **Verified the fix** by re-running `qos/test_qos_dscp_mapping.py` with `repeat_times=10` on `vms6-t1-7060` (Arista-7060CX-32S-C32, t1-lag) — Elastictest plan **`6a3e481bf9d3963c406e25cf`** (https://elastictest.org/scheduler/testplan/6a3e481bf9d3963c406e25cf). All repeated iterations pass with **0 failures** (no more false miss; `test_pipe_mode_dscp_preservation` passes every iteration).
- `py_compile` + `flake8 --max-line-length=120` pass (only pre-existing `F824` globals, identical on `master`).
- Healthy runs are behavior-unchanged; the heavier diagnostics run only on a miss.

#### Any platform specific information?
`bcmcmd` diagnostics are gated on `asic_type == 'broadcom'` and guarded by `which bcmcmd`. All other diagnostics are platform-agnostic, best-effort, and never fail the test.

#### Supported testbed topology if it's a new test case?
N/A — existing `t0`/`t1` coverage unchanged.

### Documentation
N/A