### PR TITLE
Revert "[acl] Replace time.sleep with wait_until in test_acl_outer_vlan (#22978)"

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -296,20 +296,12 @@ def get_acl_counter(duthost, table_name, rule_name, timeout=ACL_COUNTERS_UPDATE_
     Returns:
         Acl counter value for packets
     """
-    def _check_acl_counter():
-        result = duthost.show_and_parse('aclshow -a')
-        if len(result) == 0:
-            return False
-        for rule in result:
-            if table_name == rule['table name'] and rule_name == rule['rule name']:
-                return True
-        return False
-
     # Wait for orchagent to update the ACL counters
-    if not wait_until(timeout, 2, 0, _check_acl_counter):
-        pytest.fail("Failed to retrieve acl counter for {}|{}".format(table_name, rule_name))
-
+    time.sleep(timeout)
     result = duthost.show_and_parse('aclshow -a')
+
+    if len(result) == 0:
+        pytest.fail("Failed to retrieve acl counter for {}|{}".format(table_name, rule_name))
     for rule in result:
         if table_name == rule['table name'] and rule_name == rule['rule name']:
             return int(rule['packets count'])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This reverts commit d11d9a5d6154b1e7705ebb6b0dbc1be620f578bf
which breaks get_acl_counter: 
1. timeout=0 on the first poll makes wait_until fail immediately instead
of reading the counter without waiting.
2. The second poll returns instantly because wait_until only checks rule
existence, not counter freshness — reading stale values and causing
false failures.

The original time.sleep(timeout) works correctly — it gives orchagent
time to flush updated counters, which is the actual intent.

Fixes #25689
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
Fix a PR that causes regression

#### How did you do it?
Revert the PR

#### How did you verify/test it?
acl/test_acl_outer_vlan.py passed with revert

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
