### PR TITLE
Fix CACL setup minigraph reload golden config

### DIFF
--- a/tests/generic_config_updater/test_cacl.py
+++ b/tests/generic_config_updater/test_cacl.py
@@ -9,7 +9,7 @@ from tests.common.gu_utils import generate_tmpfile, delete_tmpfile
 from tests.common.gu_utils import format_json_patch_for_multiasic
 from tests.common.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
 from tests.common.utilities import wait_until
-from tests.common.config_reload import config_reload
+from tests.common.config_reload import config_reload_minigraph_with_rendered_golden_config_override
 
 # Test on t0 topo to verify functionality and to choose predefined variable
 # admin@vlab-01:~$ show acl table
@@ -49,8 +49,8 @@ def get_iptable_rules(duthost, ip_netns_namespace_prefix):
 @pytest.fixture(scope="module", autouse=True)
 def restore_test_env(duthosts, rand_one_dut_front_end_hostname):
     duthost = duthosts[rand_one_dut_front_end_hostname]
-    config_reload(duthost, config_source="minigraph", safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True,
-                  override_config=True)
+    config_reload_minigraph_with_rendered_golden_config_override(
+        duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
     yield
 
 


### PR DESCRIPTION
### Description of PR
Fix `generic_config_updater/test_cacl.py` setup to render `/etc/sonic/golden_config_db.json` before using minigraph reload with golden-config override.

The test previously called `config_reload(..., override_config=True)` directly. That produces `config load_minigraph -y -o -p /etc/sonic/golden_config_db.json`, but does not create the golden config file first, so setup can fail with `Cannot find '/etc/sonic/golden_config_db.json'!`.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202605

### Approach
#### What is the motivation for this PR?
[Nightly PBI 38591370](https://msazure.visualstudio.com/One/_workitems/edit/38591370) shows all CACL cases erroring in module setup because minigraph reload requests a golden config override file that is absent on the DUT.

#### How did you do it?
Use `config_reload_minigraph_with_rendered_golden_config_override`, which renders the default golden config file from the current config before calling minigraph reload with `override_config=True`.

#### How did you verify/test it?
Ran `python -m py_compile tests\\generic_config_updater\\test_cacl.py`.

#### Any platform specific information?
Observed on T0; fix is platform independent.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A