### PR TITLE
[snappi][bgp] Fix RIB-IN capacity: correct max_routes tracking and protocol stop state

### DIFF
--- a/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
@@ -1128,7 +1128,7 @@ def get_RIB_IN_capacity(snappi_api,
             """ Stopping Protocols """
             logger.info("Stopping all protocols ...")
             cs = snappi_api.control_state()
-            cs.protocol.all.state = cs.protocol.all.START
+            cs.protocol.all.state = cs.protocol.all.STOP
             snappi_api.set_control_state(cs)
             wait(TIMEOUT, "For Protocols To STOP")
     except Exception as e:

--- a/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
@@ -1073,8 +1073,8 @@ def get_RIB_IN_capacity(snappi_api,
         wait(TIMEOUT, "For Traffic To start")
 
     try:
+        max_routes = 0
         for j in range(start_value, 100000000000, step_value):
-            max_routes = start_value
             tx_frate, rx_frate = [], []
             run_traffic(j)
             flow_stats = get_flow_stats(snappi_api)
@@ -1099,6 +1099,7 @@ def get_RIB_IN_capacity(snappi_api,
                 snappi_api.set_control_state(cs)
                 wait(TIMEOUT-20, "For Traffic To stop")
                 break
+            max_routes = j
             logger.info('Stopping Traffic')
             cs = snappi_api.control_state()
             cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.STOP
@@ -1115,7 +1116,7 @@ def get_RIB_IN_capacity(snappi_api,
             flow_stats = get_flow_stats(snappi_api)
             logger.info('Loss% : {}'.format(flow_stats[0].loss))
             if float(flow_stats[0].loss) <= 0.001:
-                max_routes = start_value
+                max_routes = routes[i]
                 pass
             else:
                 max_routes = routes[i]-int(step_value/8)


### PR DESCRIPTION
### Description of PR

Summary:
Fixes two bugs in `get_RIB_IN_capacity()` (`bgp_convergence_helper.py`):

1. `max_routes` was initialized to `start_value` inside the loop body, so it
   was reset on every iteration and never reflected the actual last-passed
   route count. Moved initialization to `0` before the loop; updated to `j`
   only after a successful (no-loss) iteration.

2. Protocol teardown used `cs.protocol.all.START` instead of
   `cs.protocol.all.STOP`, so protocols were never stopped at the end of the
   test, leaving the testbed in a dirty state for subsequent runs.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
The capacity test reported an incorrect (too low) `max_routes` value and left
BGP protocols running after the test, polluting subsequent test runs.

#### How did you do it?
- Moved `max_routes = 0` before the loop; moved `max_routes = j` to the end
  of each successful loop body.
- Changed `max_routes = start_value` → `max_routes = routes[i]` in the binary
  search refinement block.
- Fixed `cs.protocol.all.START` → `cs.protocol.all.STOP` in teardown.

#### How did you verify/test it?
Ran `test_bgp_RIB_IN_capacity` on a 4-port tgen testbed. Confirmed reported
`max_routes` matches the last successfully passed route count and protocols
stop cleanly after the test.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
