### PR TITLE
[snappi][bgp] Fix RIB-IN convergence: correct protocol/route operation order and increase iterations

### DIFF
--- a/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
@@ -847,16 +847,6 @@ def get_rib_in_convergence(snappi_api,
         for i in range(0, iteration):
             logger.info(
                 '|---- RIB-IN Convergence test, Iteration : {} ----|'.format(i+1))
-            """ withdraw all routes before starting traffic """
-            logger.info('Withdraw All Routes before starting traffic')
-            cs = snappi_api.control_state()
-            cs.protocol.route.names = route_names
-            cs.protocol.route.state = cs.protocol.route.WITHDRAW
-            snappi_api.set_control_state(cs)
-            if mem_cpu_monitor is not None:
-                mem_cpu_monitor.snapshot(
-                    event="Route_Withdrawal_started_iter_{}".format(i + 1))
-            wait(TIMEOUT, "For Routes to be withdrawn")
             """ Starting Protocols """
             logger.info("Starting all protocols ...")
             cs = snappi_api.control_state()
@@ -865,7 +855,17 @@ def get_rib_in_convergence(snappi_api,
             if mem_cpu_monitor is not None:
                 mem_cpu_monitor.snapshot(
                     event="Protocols_started_iter_{}".format(i + 1))
-            wait(WAIT_INTERVAL, "For Protocols To start")
+            wait(TIMEOUT, "For Protocols To start")
+            """ Withdraw all routes so DUT RIB is empty before starting traffic """
+            logger.info('Withdraw All Routes before starting traffic')
+            cs = snappi_api.control_state()
+            cs.protocol.route.names = route_names
+            cs.protocol.route.state = cs.protocol.route.WITHDRAW
+            snappi_api.set_control_state(cs)
+            if mem_cpu_monitor is not None:
+                mem_cpu_monitor.snapshot(
+                    event="Route_Withdrawal_started_iter_{}".format(i + 1))
+            wait(TIMEOUT-10, "For Routes to be withdrawn")
             """ Start Traffic """
             logger.info('Starting Traffic')
             cs = snappi_api.control_state()

--- a/tests/snappi_tests/bgp/test_bgp_local_link_failover.py
+++ b/tests/snappi_tests/bgp/test_bgp_local_link_failover.py
@@ -10,7 +10,7 @@ pytestmark = [pytest.mark.topology('tgen')]
 
 
 @pytest.mark.parametrize('multipath', [2])
-@pytest.mark.parametrize('convergence_test_iterations', [1])
+@pytest.mark.parametrize('convergence_test_iterations', [5])
 @pytest.mark.parametrize('number_of_routes', [1000])
 @pytest.mark.parametrize('route_type', ['IPv4'])
 def test_bgp_convergence_for_local_link_failover(snappi_api,                   # noqa: F811


### PR DESCRIPTION
### Description of PR

Summary:
Fixes the operation order in `get_rib_in_convergence()` and increases the
default iteration count in `test_bgp_local_link_failover`.

Routes were withdrawn *before* protocols were started, so the DUT RIB was
never populated: the withdrawal had no effect and traffic always saw a full
RIB, making the convergence measurement invalid. The correct sequence is:
start protocols → wait for routes to converge → withdraw routes → start
traffic → measure recovery time.

The wait after protocol start was also too short (`WAIT_INTERVAL`); changed
to `TIMEOUT` so the DUT has time to install all routes before withdrawal.

`convergence_test_iterations` increased from 1 to 5 for statistically
meaningful results.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
With the original operation order the RIB-IN convergence measurement was
invalid: rx rate never dropped to zero before traffic started, so convergence
time was always near zero and the test passed vacuously.

#### How did you do it?
- Swapped the protocol-start and route-withdraw blocks so protocols come up
  before routes are withdrawn.
- Changed post-protocol-start wait from `WAIT_INTERVAL` to `TIMEOUT`.
- Adjusted post-withdrawal wait to `TIMEOUT-10`.
- Bumped `convergence_test_iterations` from 1 to 5.

#### How did you verify/test it?
Ran `test_bgp_convergence_for_local_link_failover` on a tgen testbed.
Confirmed rx rate drops to zero after route withdrawal and recovers
measurably when routes are re-advertised.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
