### PR TITLE
[snappi][lacp] Fix traffic/protocol cleanup and timing in add/remove link tests

### DIFF
--- a/tests/snappi_tests/lacp/files/lacp_dut_helper.py
+++ b/tests/snappi_tests/lacp/files/lacp_dut_helper.py
@@ -348,7 +348,19 @@ def get_lacp_add_remove_link_from_dut(snappi_api,
                 dut_port_name, i+1))
             duthost.shell(
                 "sudo config portchannel member add PortChannel2 %s\n" % (dut_port_name))
+            """ Stopping Traffic """
+            logger.info('Stopping Traffic')
+            cs = snappi_api.control_state()
+            cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.STOP
+            snappi_api.set_control_state(cs)
+            wait(TIMEOUT-10, "For Traffic To stop")
 
+        """ Stopping all protocols """
+        logger.info('Stopping all protocols')
+        cs = snappi_api.control_state()
+        cs.protocol.all.state = cs.protocol.all.STOP
+        snappi_api.set_control_state(cs)
+        wait(TIMEOUT-10, "For Protocols To stop")
         table.append('%s Link Failure' % dut_port_name)
         table.append(number_of_routes)
         table.append(iteration)

--- a/tests/snappi_tests/lacp/files/lacp_dut_helper.py
+++ b/tests/snappi_tests/lacp/files/lacp_dut_helper.py
@@ -332,7 +332,7 @@ def get_lacp_add_remove_link_from_dut(snappi_api,
                 'Simulating Link Failure on {} from dut side '.format(port_name))
             duthost.shell(
                 "sudo config portchannel member del PortChannel2 %s\n" % (dut_port_name))
-            wait(TIMEOUT-20, "For Link to go down and traffic to stabilize")
+            wait(TIMEOUT, "For Link to go down and traffic to stabilize")
             flows = get_flow_stats(snappi_api)
             for flow in flows:
                 tx_frate.append(flow.frames_tx_rate)

--- a/tests/snappi_tests/lacp/files/lacp_dut_helper.py
+++ b/tests/snappi_tests/lacp/files/lacp_dut_helper.py
@@ -348,19 +348,20 @@ def get_lacp_add_remove_link_from_dut(snappi_api,
                 dut_port_name, i+1))
             duthost.shell(
                 "sudo config portchannel member add PortChannel2 %s\n" % (dut_port_name))
-            """ Stopping Traffic """
+            wait(TIMEOUT, "For Link to go up")
+            # Stopping Traffic
             logger.info('Stopping Traffic')
             cs = snappi_api.control_state()
             cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.STOP
             snappi_api.set_control_state(cs)
-            wait(TIMEOUT-10, "For Traffic To stop")
+            wait(TIMEOUT-10, "For Traffic To STOP")
 
-        """ Stopping all protocols """
+        # Stopping all protocols
         logger.info('Stopping all protocols')
         cs = snappi_api.control_state()
         cs.protocol.all.state = cs.protocol.all.STOP
         snappi_api.set_control_state(cs)
-        wait(TIMEOUT-10, "For Protocols To stop")
+        wait(TIMEOUT-10, "For Protocols To STOP")
         table.append('%s Link Failure' % dut_port_name)
         table.append(number_of_routes)
         table.append(iteration)

--- a/tests/snappi_tests/lacp/files/lacp_physical_helper.py
+++ b/tests/snappi_tests/lacp/files/lacp_physical_helper.py
@@ -396,11 +396,23 @@ def get_lacp_add_remove_link_physically(snappi_api,
             cs.port.link.port_names = [port_name]
             cs.port.link.state = cs.port.link.UP
             snappi_api.set_control_state(cs)
+            """ Stopping Traffic at the end of iteration """
+            logger.info('Stopping Traffic')
+            cs = snappi_api.control_state()
+            cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.STOP
+            snappi_api.set_control_state(cs)
+            wait(TIMEOUT-10, "For Traffic To STOP")
         table.append('%s Link Failure' % port_name)
         table.append(number_of_routes)
         table.append(iteration)
         table.append(mean(avg_delta))
         table.append(mean(avg))
+        """ Stopping Protocols """
+        logger.info("Stopping all protocols ...")
+        cs = snappi_api.control_state()
+        cs.protocol.all.state = cs.protocol.all.STOP
+        snappi_api.set_control_state(cs)
+        wait(TIMEOUT-10, "For Protocols To STOP")
         return table
     table = []
     """ Iterating link flap test on all the rx ports """

--- a/tests/snappi_tests/lacp/files/lacp_physical_helper.py
+++ b/tests/snappi_tests/lacp/files/lacp_physical_helper.py
@@ -396,6 +396,7 @@ def get_lacp_add_remove_link_physically(snappi_api,
             cs.port.link.port_names = [port_name]
             cs.port.link.state = cs.port.link.UP
             snappi_api.set_control_state(cs)
+            wait(TIMEOUT, "For Link to go up")
             """ Stopping Traffic at the end of iteration """
             logger.info('Stopping Traffic')
             cs = snappi_api.control_state()


### PR DESCRIPTION
### Description of PR

Summary:
Fixes state leakage and timing issues in the LACP add/remove link helpers
(`lacp_dut_helper.py`, `lacp_physical_helper.py`):

1. **Missing per-iteration cleanup**: Traffic and protocols were never stopped
   between iterations. Active flows and BGP sessions from one iteration bled
   into the next, producing incorrect packet-loss readings and occasional hangs.
   Added traffic-stop at the end of each iteration in both helpers; protocols are stopped once per port (after the full iteration loop), since they are only started once per port.

2. **Insufficient wait after link removal** (`lacp_dut_helper`): Wait was
   `TIMEOUT-20` (10 s), too short for traffic to stabilize on 1000-route scale.
   Restored to `TIMEOUT` (30 s).

3. **Missing wait for link up** (`lacp_physical_helper`): After bringing the
   physical link back up the helper immediately stopped traffic, racing with
   LACP negotiation. Added `wait(TIMEOUT, "For Link to go up")` before the
   traffic-stop.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
Without per-iteration cleanup, traffic counters and BGP sessions accumulate
across iterations, making convergence measurements unreliable and causing
sporadic test failures.

#### How did you do it?
- Added traffic-stop (flow_transmit.STOP) at the end of each iteration in both helpers. Protocol-stop (protocol.all.STOP) runs once per port after the iteration loop completes — protocols are started once per port and do not need to be restarted between iterations.
- Restored `wait(TIMEOUT, ...)` (was `TIMEOUT-20`) after link removal in
  `lacp_dut_helper`.
- Added `wait(TIMEOUT, "For Link to go up")` after `link.UP` in
  `lacp_physical_helper` before stopping traffic.

#### How did you verify/test it?
Ran 5-iteration add/remove link tests on a tgen testbed. Confirmed packet-loss
readings are consistent across all 5 iterations and the test completes cleanly
without hangs.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
