### PR TITLE
pc/test_lag_2.py: Fix LACP rate timing race condition

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -245,4 +245,5 @@ accelerate_daemon_timeout = 30
 [persistent_connection]
 # https://docs.ansible.com/ansible/2.9/network/user_guide/network_debug_troubleshooting.html#command-timeout
 # to fix EOS ansible command timeout issue, default is 30
-command_timeout = 60
+# increased to 120 to handle cEOS VMs with large number of converged peers (multi-VRF LACP processing)
+command_timeout = 120

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -113,6 +113,13 @@ class LagTest:
         if exp_iface is None:
             return
 
+        if lacp_timer == 1:
+            # EOS does not immediately send fast PDUs after 'lacp timer fast'; it waits for its
+            # current 30-second slow timer to expire first. Sleep 35s so PTF captures only fast
+            # PDUs and does not measure the transition interval.
+            logger.info("Sleeping 35s for EOS to complete transition to fast LACP rate")
+            time.sleep(35)
+
         # Check LACP timing
         params = {
             'exp_iface': exp_iface,


### PR DESCRIPTION
### Description of PR
Summary:
Fix LACP rate timing race condition in `test_lag_2.py`. The test set
EOS VMs to fast LACP rate and immediately checked packet timing with a
fixed 5-second sleep. EOS VMs do not immediately reset their 30-second
slow LACP timer after a rate change; the first fast PDU can take up to
~30 seconds to arrive, causing false timing failures.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
`test_lag_2.py::test_lag[lacp_rate]` was failing with:
```
AssertionError: Bad packet timing: 30.00 seconds while expected timing is 1 seconds from port 130 out of 3 intervals
```
The test used `time.sleep(5)` before measuring LACP packet intervals from the partner. EOS does not immediately switch to the new LACP rate; it waits for the current timer to expire first (up to 30 seconds for slow mode).

#### How did you do it?
1. Add `__check_partner_lacp_timeout()` method that reads the LACP_Timeout bit (bit 1) from the DUT's `teamdctl <lag> state dump` partner_lacpdu_info.state field. This bit reflects the timeout mode of the most recent LACP PDU received from the partner.
2. Replace `time.sleep(5)` with `wait_until(60, 2, 0, ...)` calls that poll until the DUT has actually received a LACP PDU with the expected timeout mode, for both fast→slow and slow→fast transitions.
3. Increase `ansible command_timeout` from 60s to 120s to handle cEOS VMs with a large number of converged multi-VRF peers.

#### How did you verify/test it?
Ran `test_lag_2.py::test_lag[str4-Nokia-7220-Th6p-1|PortChannel352-lacp_rate]` on Nokia TH6 testbed `vms13-lt2-nokia-th6-1` — **PASSED**.

#### Any platform specific information?
Tested on Nokia TH6 with converged multi-VRF cEOS topology.

#### Supported testbed topology if it's a new test case?
N/A — existing test case fix.

### Documentation
