### PR TITLE
[snappi] fix in get_addr_in_subnet function in common_helpers to fix case-sensitive IPv6 addresses

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -188,17 +188,41 @@ def get_pg_dropped_packets(duthost, phys_intf, prio, asic_value=None):
 
 def get_addrs_in_subnet(subnet, number_of_ip, exclude_ips=None):
     """
-    Efficiently yield N IPs from a subnet, skipping excluded IPs.
-    Handles large IPv6 subnets quickly.
+    Return up to ``number_of_ip`` host IP strings from ``subnet``, skipping
+    any address in ``exclude_ips``.
+
+    Excluded addresses are parsed with :func:`ipaddress.ip_address`, so IPv6
+    matches are case-insensitive and independent of textual compression
+    (e.g. ``2001:DB8::1`` matches the same host as ``2001:db8::1``).
+
+    Usable hosts follow :meth:`ipaddress.IPv4Network.hosts` /
+    :meth:`ipaddress.IPv6Network.hosts` (including RFC 3021 IPv4 /31).
+
+    Only the first ``number_of_ip`` non-excluded hosts are returned; the list
+    may be shorter if the subnet or exclusions leave fewer candidates.
+
+    Args:
+        subnet: IPv4 or IPv6 network CIDR string.
+        number_of_ip: Maximum number of addresses to return.
+        exclude_ips: Optional iterable of addresses to omit (strings or types
+            accepted by :func:`ipaddress.ip_address`).
+
+    Returns:
+        list of IP strings in the form produced by ``str()`` on the
+        corresponding address object (IPv6 lowercase compressed).
     """
     net = ipaddress.ip_network(subnet, strict=False)
-    exclude_set = set(exclude_ips) if exclude_ips else set()
-    results = []
+    exclude_set = set()
+    if exclude_ips:
+        for raw in exclude_ips:
+            if raw is None:
+                continue
+            token = raw.strip() if isinstance(raw, str) else raw
+            exclude_set.add(ipaddress.ip_address(token))
 
-    # Calculate the first usable host (for IPv4, skip network & broadcast)
-    hosts = net.hosts() if net.version == 4 else net.hosts()
-    for addr in hosts:
-        if str(addr) not in exclude_set:
+    results = []
+    for addr in net.hosts():
+        if addr not in exclude_set:
             results.append(str(addr))
             if len(results) == number_of_ip:
                 break

--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -218,7 +218,10 @@ def get_addrs_in_subnet(subnet, number_of_ip, exclude_ips=None):
             if raw is None:
                 continue
             token = raw.strip() if isinstance(raw, str) else raw
-            exclude_set.add(ipaddress.ip_address(token))
+            try:
+                exclude_set.add(ipaddress.ip_address(token))
+            except ValueError:
+                continue
 
     results = []
     for addr in net.hosts():

--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -189,17 +189,41 @@ def get_pg_dropped_packets(duthost, phys_intf, prio, asic_value=None):
 
 def get_addrs_in_subnet(subnet, number_of_ip, exclude_ips=None):
     """
-    Efficiently yield N IPs from a subnet, skipping excluded IPs.
-    Handles large IPv6 subnets quickly.
+    Return up to ``number_of_ip`` host IP strings from ``subnet``, skipping
+    any address in ``exclude_ips``.
+
+    Excluded addresses are parsed with :func:`ipaddress.ip_address`, so IPv6
+    matches are case-insensitive and independent of textual compression
+    (e.g. ``2001:DB8::1`` matches the same host as ``2001:db8::1``).
+
+    Usable hosts follow :meth:`ipaddress.IPv4Network.hosts` /
+    :meth:`ipaddress.IPv6Network.hosts` (including RFC 3021 IPv4 /31).
+
+    Only the first ``number_of_ip`` non-excluded hosts are returned; the list
+    may be shorter if the subnet or exclusions leave fewer candidates.
+
+    Args:
+        subnet: IPv4 or IPv6 network CIDR string.
+        number_of_ip: Maximum number of addresses to return.
+        exclude_ips: Optional iterable of addresses to omit (strings or types
+            accepted by :func:`ipaddress.ip_address`).
+
+    Returns:
+        list of IP strings in the form produced by ``str()`` on the
+        corresponding address object (IPv6 lowercase compressed).
     """
     net = ipaddress.ip_network(subnet, strict=False)
-    exclude_set = set(exclude_ips) if exclude_ips else set()
-    results = []
+    exclude_set = set()
+    if exclude_ips:
+        for raw in exclude_ips:
+            if raw is None:
+                continue
+            token = raw.strip() if isinstance(raw, str) else raw
+            exclude_set.add(ipaddress.ip_address(token))
 
-    # Calculate the first usable host (for IPv4, skip network & broadcast)
-    hosts = net.hosts() if net.version == 4 else net.hosts()
-    for addr in hosts:
-        if str(addr) not in exclude_set:
+    results = []
+    for addr in net.hosts():
+        if addr not in exclude_set:
             results.append(str(addr))
             if len(results) == number_of_ip:
                 break

--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -219,7 +219,10 @@ def get_addrs_in_subnet(subnet, number_of_ip, exclude_ips=None):
             if raw is None:
                 continue
             token = raw.strip() if isinstance(raw, str) else raw
-            exclude_set.add(ipaddress.ip_address(token))
+            try:
+                exclude_set.add(ipaddress.ip_address(token))
+            except ValueError:
+                continue
 
     results = []
     for addr in net.hosts():


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

The function get_addr_in_subnet receives network-subnet, number of IPs to be returned back and exclude IPs list.

**Why /31 prefix-length could fail:**
Older Python: /31 hosts() could return empty → function returns [] → callers like [0] raise IndexError.
Policy mismatch: some labs treat the “network” side of /31 as non-assignable.
Short/empty results: at most 2 addresses on /31; exclusions or large number_of_ip can yield fewer than requested.

Note - Since the latest Python versions already handle this, this is not an issue anymore.

**IPv6 and exclude_ips (case/spelling):**
Exclusions were stored as raw strings; comparison was str(addr) not in exclude_set.
str(IPv6Address('2001:db8::1')) → "2001:db8::1" does not match "2001:DB8::1" in a string set.
Same issue for compressed vs expanded forms.


Summary:
Fixes #25634 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
With IPv6 addresses if minigraph.xml had upper-case IPv6 addresses, then function would sometimes return the same address as next-hop address (configured on IXIA end-point). 
```
str(IPv6Address('2001:db8::1')) → "2001:db8::1" does not match "2001:DB8::1" in a string set.
```
However, in this case function could return the same address, thus DUT configuration failed (in case where it tried to configure next-hop BGP endpoint and ended up with same address as local-address).

#### How did you do it?

Changes in get_addrs_in_subnet:
 - exclude_ips as real addresses — parse each entry with ipaddress.ip_address() (strip strings); store in a set of address objects.
 - IPv6 case/spelling — addr not in exclude_set instead of string comparison.
 - hosts() — removed redundant if net.version == 4 else; both use net.hosts().
 - Docstring — documents list return, IPv6 normalization, RFC 3021 /31, and possible shorter results.
 
#### How did you verify/test it?
Tested with case different IPv6 addresses on local clone.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
