### PR TITLE
[csonic] Add SNMP_COMMUNITY to cSONiC neighbor CONFIG_DB templates

### DIFF
--- a/ansible/roles/sonic/templates/configdb-csonic.j2
+++ b/ansible/roles/sonic/templates/configdb-csonic.j2
@@ -148,6 +148,11 @@
 {% endif %}
 {% endif %}
     },
+    "SNMP_COMMUNITY": {
+        "{{ snmp_rocommunity | default('public') }}": {
+            "TYPE": "RO"
+        }
+    },
     "BGP_NEIGHBOR": {
 {% set bgp_comma = joiner(",") %}
 {% for asn, remote_ips in host['bgp']['peers'].items() %}

--- a/ansible/roles/sonic/templates/configdb-t0-leaf.j2
+++ b/ansible/roles/sonic/templates/configdb-t0-leaf.j2
@@ -131,6 +131,11 @@
 {% endif %}
 {% endif %}
     },
+    "SNMP_COMMUNITY": {
+        "{{ snmp_rocommunity | default('public') }}": {
+            "TYPE": "RO"
+        }
+    },
     "BGP_NEIGHBOR": {
 {% set bgp_comma = joiner(",") %}
 {% for asn, remote_ips in host['bgp']['peers'].items() %}


### PR DESCRIPTION
#### Why I did it

cSONiC neighbors (docker-sonic-vs containers used as testbed neighbors) are configured purely from the `configdb-*.j2` templates in `ansible/roles/sonic/templates`. Unlike a normal SONiC DUT/KVM image, they never run the `docker-snmp` `snmp.yml` → `snmp_yml_to_configdb.py` step that populates the `SNMP_COMMUNITY` table in CONFIG_DB.

As a result, the rendered `/etc/snmp/snmpd.conf` contains no `rocommunity` line (only the `systemonly` view), so `snmpd` listens on UDP/161 but every query times out. SNMP-based verification against cSONiC neighbors — e.g. pulling LLDP neighbors via LLDP-MIB (`1.0.8802.1.1.2.1.4`) through the snmp-subagent — is therefore impossible out of the box.

#### How I did it

Add an `SNMP_COMMUNITY` (RO) entry to the cSONiC CONFIG_DB templates:
- `configdb-t0-leaf.j2` — the T0-leaf neighbor template
- `configdb-csonic.j2` — the generic fallback used for non-T0-leaf topologies (the `first_found` chain in `roles/sonic/tasks/csonic_config.yml` resolves `configdb-{{ topo }}-{{ swrole }}.j2` → `configdb-{{ swrole }}.j2` → `configdb-csonic.j2`)

The community string is sourced from the Ansible `snmp_rocommunity` variable — the same variable the cEOS neighbor templates already use (`roles/eos/templates/*.j2`: `snmp-server community {{ snmp_rocommunity }} ro`) — with a `public` default fallback so rendering never breaks if the var is unset.

```jinja2
"SNMP_COMMUNITY": {
    "{{ snmp_rocommunity | default('public') }}": {
        "TYPE": "RO"
    }
},
```

`config load /var/sonic/config_db.json` at container boot then applies the `SNMP_COMMUNITY` table the same way a production DUT does, and the snmp-subagent becomes reachable.

#### How to verify it

1. Deploy a cSONiC testbed (`-k csonic add-topo` + `deploy-mg`).
2. On a neighbor: `docker exec csonic_<vmset>_<vm> cat /etc/snmp/snmpd.conf | grep rocommunity` → shows the community.
3. Query LLDP-MIB remote table and compare to `lldpctl`:
   ```
   snmpwalk -v2c -c <snmp_rocommunity> <neighbor> 1.0.8802.1.1.2.1.4.1.1.9   # lldpRemSysName
   ```
   Returns the DUT's system name, matching `docker exec <neighbor> lldpctl`.

Validated locally: both templates rendered via Ansible `lookup('template', ...)` produce valid JSON; community resolves to the `eos`-group `snmp_rocommunity` value for cSONiC neighbor hosts (VM01xx), and to `public` via the default fallback otherwise.



#### Related issue

Refs #25706 — cSONiC SNMP LLDP verification. This PR is a prerequisite (without `SNMP_COMMUNITY`, SNMP queries against cSONiC neighbors time out entirely); the remaining IPv6-mgmt-ip transport-address handling in `tests/lldp/test_lldp.py` is tracked separately in #25706 and is not closed by this PR.
