### PR TITLE
[tests/bgp] Consolidate multi-ASIC namespace / sonic-db-cli / vtysh helpers (#25707)

### DIFF
--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -13,8 +13,12 @@ from natsort import natsorted
 import ipaddr as ipaddress
 from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_ALL_NEIGHBOR_MAP, DEFAULT_NAMESPACE, \
-    DEFAULT_ASIC_ID
+from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_ALL_NEIGHBOR_MAP, DEFAULT_NAMESPACE
+from tests.common.helpers.bgp import (
+    get_db_cli_prefix,
+    get_asic_namespace,
+    namespace_cli_arg,
+)
 from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
 from tests.common.helpers.parallel import reset_ansible_local_tmp
 from tests.common.helpers.parallel import parallel_run
@@ -215,14 +219,13 @@ def remove_bgp_neighbors(duthost, asic_index):
     """
     Remove the bgp neigbors for a particular BGP instance
     """
-    namespace = duthost.get_namespace_from_asic_id(asic_index)
-    namespace_prefix = '-n ' + namespace if namespace else ''
+    namespace_prefix = namespace_cli_arg(get_asic_namespace(duthost, asic_index))
+    db_cli = get_db_cli_prefix(duthost, asic_index)
 
     # Convert the json formatted result of sonic-cfggen into bgp_neighbors dict
     bgp_neighbors = json.loads(duthost.command("sudo sonic-cfggen {} -d --var-json {}"
                                .format(namespace_prefix, "BGP_NEIGHBOR"))["stdout"])
-    cmd = 'sudo sonic-db-cli {} CONFIG_DB keys "BGP_NEI*" | xargs sonic-db-cli {} CONFIG_DB del'\
-          .format(namespace_prefix, namespace_prefix)
+    cmd = 'sudo {db_cli} CONFIG_DB keys "BGP_NEI*" | xargs {db_cli} CONFIG_DB del'.format(db_cli=db_cli)
     duthost.shell(cmd)
 
     # Restart BGP instance on that asic
@@ -236,8 +239,7 @@ def restore_bgp_neighbors(duthost, asic_index, bgp_neighbors):
     """
     Restore the bgp neigbors for a particular BGP instance
     """
-    namespace = duthost.get_namespace_from_asic_id(asic_index)
-    namespace_prefix = '-n ' + namespace if namespace else ''
+    namespace_prefix = namespace_cli_arg(get_asic_namespace(duthost, asic_index))
 
     # Convert the bgp_neighbors dict into json format after adding the table name.
     bgp_neigh_dict = {"BGP_NEIGHBOR": bgp_neighbors}
@@ -409,15 +411,17 @@ def prepare_eos_routes(bgp_allow_list_setup, ptfhost, nbrhosts, tbinfo):
 
 def apply_allow_list(duthost, namespace, allow_list, allow_list_file_path):
     duthost.copy(content=json.dumps(allow_list, indent=3), dest=allow_list_file_path)
-    duthost.shell('sonic-cfggen {} -j {} -w'.format('-n ' + namespace if namespace else '', allow_list_file_path))
+    duthost.shell('sonic-cfggen {} -j {} -w'.format(namespace_cli_arg(namespace), allow_list_file_path))
     time.sleep(3)
 
 
 def remove_allow_list(duthost, namespace, allow_list_file_path):
-    allow_list_keys = duthost.shell('sonic-db-cli {} CONFIG_DB keys "BGP_ALLOWED_PREFIXES*"'
-                                    .format('-n ' + namespace if namespace else ''))['stdout_lines']
+    db_cli = "sonic-db-cli {}".format(namespace_cli_arg(namespace)).rstrip()
+    allow_list_keys = duthost.shell(
+        '{} CONFIG_DB keys "BGP_ALLOWED_PREFIXES*"'.format(db_cli)
+    )['stdout_lines']
     for key in allow_list_keys:
-        duthost.shell('sonic-db-cli {} CONFIG_DB del "{}"'.format('-n ' + namespace if namespace else '', key))
+        duthost.shell('{} CONFIG_DB del "{}"'.format(db_cli, key))
 
     duthost.shell('rm -rf {}'.format(allow_list_file_path))
 
@@ -1023,9 +1027,10 @@ def verify_dut_configdb_tsa_value(duthost):
     tsa_config = list()
     tsa_enabled = False
     for asic_index in duthost.get_frontend_asic_ids():
-        prefix = "-n asic{}".format(asic_index) if asic_index != DEFAULT_ASIC_ID else ''
-        output = duthost.shell('sonic-db-cli {} CONFIG_DB HGET \'BGP_DEVICE_GLOBAL|STATE\' \'tsa_enabled\''.
-                               format(prefix))['stdout']
+        db_cli = get_db_cli_prefix(duthost, asic_index)
+        output = duthost.shell(
+            "{} CONFIG_DB HGET 'BGP_DEVICE_GLOBAL|STATE' 'tsa_enabled'".format(db_cli)
+        )['stdout']
         tsa_config.append(output)
     if 'true' in tsa_config:
         tsa_enabled = True

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -16,6 +16,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_ALL_NEIGHBOR_MAP, DEFAULT_NAMESPACE
 from tests.common.helpers.bgp import (
     get_db_cli_prefix,
+    get_db_cli_prefix_for_namespace,
     get_asic_namespace,
     namespace_cli_arg,
 )
@@ -416,7 +417,7 @@ def apply_allow_list(duthost, namespace, allow_list, allow_list_file_path):
 
 
 def remove_allow_list(duthost, namespace, allow_list_file_path):
-    db_cli = "sonic-db-cli {}".format(namespace_cli_arg(namespace)).rstrip()
+    db_cli = get_db_cli_prefix_for_namespace(namespace)
     allow_list_keys = duthost.shell(
         '{} CONFIG_DB keys "BGP_ALLOWED_PREFIXES*"'.format(db_cli)
     )['stdout_lines']

--- a/tests/bgp/test_bgp_bbr_default_state.py
+++ b/tests/bgp/test_bgp_bbr_default_state.py
@@ -7,6 +7,7 @@ import pytest
 from jinja2 import Template
 from natsort import natsorted
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.bgp import namespace_cli_arg
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.utilities import delete_running_config
 from tests.common.gu_utils import apply_patch, expect_op_success
@@ -99,7 +100,7 @@ def disable_bbr(duthost, namespace):
 
 
 def get_bbr_status_from_config_db(duthost, namespace):
-    namespace_prefix = '-n ' + namespace if namespace else ''
+    namespace_prefix = namespace_cli_arg(namespace)
     return duthost.shell(
         'sonic-db-cli {} CONFIG_DB HGET "BGP_BBR|all" "status"'.format(namespace_prefix)
     )['stdout'].strip().strip('"')

--- a/tests/bgp/test_bgp_dual_asn.py
+++ b/tests/bgp/test_bgp_dual_asn.py
@@ -11,6 +11,7 @@ from tests.common.utilities import skip_release
 from tests.common.utilities import wait_tcp_connection
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.bgp import namespace_cli_arg
 from tests.common2.routing.bgp.bgp_route_control import update_routes
 from tests.common.gu_utils import get_bgp_speaker_runningconfig
 from tests.common.gu_utils import apply_patch, expect_op_success
@@ -290,9 +291,9 @@ class BgpDualAsn:
         del_keys = " ".join('"BGP_PEER_RANGE|{}"'.format(n) for n in test_peer_ranges)
         ns_list = duthost.get_frontend_asic_namespace_list() or [None]
         for ns in ns_list:
-            ns_flag = "-n {} ".format(ns) if ns else ""
+            ns_flag = namespace_cli_arg(ns)
             duthost.shell(
-                "sonic-db-cli {}CONFIG_DB del {}".format(ns_flag, del_keys),
+                "sonic-db-cli {} CONFIG_DB del {}".format(ns_flag, del_keys),
                 module_ignore_errors=True
             )
 

--- a/tests/bgp/test_prefix_list_suppress.py
+++ b/tests/bgp/test_prefix_list_suppress.py
@@ -22,6 +22,11 @@ import yaml
 
 from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.helpers.bgp import (
+    get_asic_namespace,
+    get_vtysh_cmd_for_asic,
+    namespace_cli_arg,
+)
 from tests.common.utilities import wait_until
 
 
@@ -91,20 +96,6 @@ def has_chassisdb_conf(duthost):
     return duthost.stat(path=CHASSISDB_CONF)["stat"]["exists"]
 
 
-def asic_ns_for_db_cli(duthost, asic_index):
-    """Build the sonic-db-cli namespace flag for a given frontend asic index."""
-    if duthost.is_multi_asic and asic_index is not None:
-        return "-n asic{}".format(asic_index)
-    return ""
-
-
-def asic_ns_for_vtysh(duthost, asic_index):
-    """Build the vtysh namespace flag for a given frontend asic index."""
-    if duthost.is_multi_asic and asic_index is not None:
-        return "-n {}".format(asic_index)
-    return ""
-
-
 def op_prefix_with_cmd(duthost, prefix_type, prefix, action, ignore_error=False):
     """Run ``sudo prefix_list <action> <type> <prefix>``."""
     pytest_assert(
@@ -145,7 +136,7 @@ def verify_config_db_entry(duthost, prefix_type, prefix, present):
     """
     key = 'PREFIX_LIST|{}|{}'.format(prefix_type, prefix)
     for asic_index in duthost.get_frontend_asic_ids():
-        ns = asic_ns_for_db_cli(duthost, asic_index)
+        ns = namespace_cli_arg(get_asic_namespace(duthost, asic_index))
         cmd = 'sonic-db-cli {} CONFIG_DB keys "{}"'.format(ns, key).strip()
         out = duthost.shell(cmd)["stdout"].strip()
         has_key = key in out
@@ -162,7 +153,7 @@ def write_config_db_key_directly(duthost, prefix_type, prefix):
     """Bypass the CLI and write straight into CONFIG_DB on every frontend asic."""
     key = 'PREFIX_LIST|{}|{}'.format(prefix_type, prefix)
     for asic_index in duthost.get_frontend_asic_ids():
-        ns = asic_ns_for_db_cli(duthost, asic_index)
+        ns = namespace_cli_arg(get_asic_namespace(duthost, asic_index))
         duthost.shell(
             'sonic-db-cli {} CONFIG_DB hset "{}" NULL NULL'.format(ns, key).strip()
         )
@@ -171,7 +162,7 @@ def write_config_db_key_directly(duthost, prefix_type, prefix):
 def delete_config_db_key_directly(duthost, prefix_type, prefix):
     key = 'PREFIX_LIST|{}|{}'.format(prefix_type, prefix)
     for asic_index in duthost.get_frontend_asic_ids():
-        ns = asic_ns_for_db_cli(duthost, asic_index)
+        ns = namespace_cli_arg(get_asic_namespace(duthost, asic_index))
         duthost.shell(
             'sonic-db-cli {} CONFIG_DB DEL "{}"'.format(ns, key).strip(),
             module_ignore_errors=True,
@@ -180,8 +171,10 @@ def delete_config_db_key_directly(duthost, prefix_type, prefix):
 
 def fetch_vtysh_prefix_list(duthost, asic_index, ipv, name):
     """Return stdout of ``vtysh -n <n> -c 'show <ip|ipv6> prefix-list <name>'``."""
-    ns = asic_ns_for_vtysh(duthost, asic_index)
-    cmd = 'vtysh {} -c "show {} prefix-list {}"'.format(ns, ipv, name).strip()
+    cmd = get_vtysh_cmd_for_asic(
+        duthost, asic_index,
+        'vtysh -c "show {} prefix-list {}"'.format(ipv, name),
+    )
     return duthost.shell(cmd, module_ignore_errors=True)["stdout"]
 
 
@@ -295,8 +288,8 @@ def wait_for_frr_ready(duthost, container, asic_index, timeout=480):
     its VTY socket. Uses 'timeout 10' to prevent vtysh from blocking
     indefinitely when the socket is not yet available.
     """
-    ns = asic_ns_for_vtysh(duthost, asic_index)
-    cmd = 'timeout 10 vtysh {} -c "show version"'.format(ns).strip()
+    vtysh_cmd = get_vtysh_cmd_for_asic(duthost, asic_index, 'vtysh -c "show version"')
+    cmd = 'timeout 10 {}'.format(vtysh_cmd)
     pytest_assert(
         wait_until(timeout, 15, 0,
                    lambda c=cmd: duthost.shell(c, module_ignore_errors=True)["rc"] == 0),
@@ -1132,10 +1125,12 @@ class TestPrefixListNegative:
             )
             # Defensive: the unknown name must not appear in any FRR prefix-list.
             for asic_index in duthost.get_frontend_asic_ids():
-                ns = asic_ns_for_vtysh(duthost, asic_index)
+                vtysh_cmd = get_vtysh_cmd_for_asic(
+                    duthost, asic_index, 'vtysh -c "show running-config"'
+                )
                 out = duthost.shell(
-                    'vtysh {} -c "show running-config" | grep prefix-list '
-                    '| grep -i {} || true'.format(ns, UNKNOWN_TYPE),
+                    '{} | grep prefix-list '
+                    '| grep -i {} || true'.format(vtysh_cmd, UNKNOWN_TYPE),
                 )["stdout"]
                 pytest_assert(
                     not out.strip(),
@@ -1188,10 +1183,12 @@ class TestPrefixListNegative:
             "bgpcfgd did not return to RUNNING after CLI accepted malformed prefix",
         )
         for asic_index in duthost.get_frontend_asic_ids():
-            ns = asic_ns_for_vtysh(duthost, asic_index)
+            vtysh_cmd = get_vtysh_cmd_for_asic(
+                duthost, asic_index, 'vtysh -c "show running-config"'
+            )
             out = duthost.shell(
-                'vtysh {} -c "show running-config" | grep prefix-list '
-                '| grep -F {!r} || true'.format(ns, MALFORMED_PREFIX),
+                '{} | grep prefix-list '
+                '| grep -F {!r} || true'.format(vtysh_cmd, MALFORMED_PREFIX),
             )["stdout"]
             pytest_assert(
                 not out.strip(),
@@ -1215,10 +1212,12 @@ class TestPrefixListNegative:
                 "bgpcfgd did not return to RUNNING after malformed-prefix write",
             )
             for asic_index in duthost.get_frontend_asic_ids():
-                ns = asic_ns_for_vtysh(duthost, asic_index)
+                vtysh_cmd = get_vtysh_cmd_for_asic(
+                    duthost, asic_index, 'vtysh -c "show running-config"'
+                )
                 out = duthost.shell(
-                    'vtysh {} -c "show running-config" | grep prefix-list '
-                    '| grep -F {!r} || true'.format(ns, DB_ONLY_BAD_PREFIX),
+                    '{} | grep prefix-list '
+                    '| grep -F {!r} || true'.format(vtysh_cmd, DB_ONLY_BAD_PREFIX),
                 )["stdout"]
                 pytest_assert(
                     not out.strip(),
@@ -1235,7 +1234,7 @@ class TestPrefixListNegative:
         before = {
             asic_index: duthost.shell(
                 'sonic-db-cli {} CONFIG_DB keys "PREFIX_LIST|*"'.format(
-                    asic_ns_for_db_cli(duthost, asic_index)
+                    namespace_cli_arg(get_asic_namespace(duthost, asic_index))
                 ).strip(),
             )["stdout"]
             for asic_index in duthost.get_frontend_asic_ids()
@@ -1250,7 +1249,7 @@ class TestPrefixListNegative:
         after = {
             asic_index: duthost.shell(
                 'sonic-db-cli {} CONFIG_DB keys "PREFIX_LIST|*"'.format(
-                    asic_ns_for_db_cli(duthost, asic_index)
+                    namespace_cli_arg(get_asic_namespace(duthost, asic_index))
                 ).strip(),
             )["stdout"]
             for asic_index in duthost.get_frontend_asic_ids()

--- a/tests/bgp/test_seq_idf_isolation.py
+++ b/tests/bgp/test_seq_idf_isolation.py
@@ -3,6 +3,7 @@ import pytest
 import random
 from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.bgp import get_db_cli_prefix
 from tests.common.helpers.constants import DEFAULT_ASIC_ID
 from tests.common.utilities import wait_until
 from route_checker import assert_only_loopback_routes_announced_to_neighs, parse_routes_on_neighbors
@@ -52,9 +53,7 @@ def get_idf_isolation_state(host, cmd="sudo idf_isolation status"):
 def check_idf_isolation_support(duthost):
     # For multi-asic, check DB in one of the namespaces
     asic_index = 0 if duthost.is_multi_asic else DEFAULT_ASIC_ID
-    namespace = duthost.get_namespace_from_asic_id(asic_index)
-    sonic_db_cmd = "sonic-db-cli {}".format("-n " +
-                                            namespace if namespace else "")
+    sonic_db_cmd = get_db_cli_prefix(duthost, asic_index)
     idf_isolation_state_in_db = duthost.shell(
         '{} CONFIG_DB HGET "BGP_DEVICE_GLOBAL|STATE" "idf_isolation_state"'.format(sonic_db_cmd),
         module_ignore_errors=False)['stdout_lines']

--- a/tests/bgp/traffic_checker.py
+++ b/tests/bgp/traffic_checker.py
@@ -1,5 +1,6 @@
 import logging
 from tests.common.helpers.constants import DEFAULT_ASIC_ID
+from tests.common.helpers.bgp import get_db_cli_prefix
 from tests.bgp.constants import TS_NORMAL, TS_MAINTENANCE, TS_INCONSISTENT, TS_NO_NEIGHBORS, TS_UNEXPECTED
 
 logger = logging.getLogger(__name__)
@@ -42,9 +43,7 @@ def get_traffic_shift_state(host, cmd="TSC"):
 def check_tsa_persistence_support(duthost):
     # For multi-asic, check DB in one of the namespaces
     asic_index = 0 if duthost.is_multi_asic else DEFAULT_ASIC_ID
-    namespace = duthost.get_namespace_from_asic_id(asic_index)
-    sonic_db_cmd = "sonic-db-cli {}".format("-n " +
-                                            namespace if namespace else "")
+    sonic_db_cmd = get_db_cli_prefix(duthost, asic_index)
     tsa_in_configdb = duthost.shell('{} CONFIG_DB HGET "BGP_DEVICE_GLOBAL|STATE" "tsa_enabled"'.format(sonic_db_cmd),
                                     module_ignore_errors=False)['stdout_lines']
     if not tsa_in_configdb:

--- a/tests/common/helpers/bgp.py
+++ b/tests/common/helpers/bgp.py
@@ -10,6 +10,67 @@ NEIGHBOR_SAVE_DEST_TMPL = "/tmp/neighbor_%s.j2"
 BGP_SAVE_DEST_TMPL = "/tmp/bgp_%s.j2"
 
 
+# ---------------------------------------------------------------------------
+# Shared multi-ASIC helpers
+#
+# These helpers consolidate plumbing that was previously open-coded across
+# tests/bgp/* and tests/common/helpers/bgp.py: resolving an ASIC index to a
+# namespace, building namespace-scoped sonic-db-cli / sonic-cfggen / vtysh
+# command strings, and fetching namespace-scoped config_facts.
+#
+# They accept an ``asic_index`` that may be ``None`` (default / single-ASIC),
+# and degrade to non-namespaced commands in that case.
+# ---------------------------------------------------------------------------
+
+
+def get_asic_namespace(duthost, asic_index):
+    """Return the Linux namespace name for the given ASIC index.
+
+    Returns ``None`` (the default namespace) for single-ASIC DUTs or when
+    ``asic_index`` is ``DEFAULT_ASIC_ID``.
+    """
+    return duthost.get_namespace_from_asic_id(asic_index)
+
+
+def namespace_cli_arg(namespace):
+    """Return the ``-n <namespace>`` argument shared by sonic-db-cli and sonic-cfggen.
+
+    Returns an empty string for the default namespace so the resulting command
+    works unchanged on single-ASIC DUTs.
+    """
+    return "-n {}".format(namespace) if namespace else ""
+
+
+def get_db_cli_prefix(duthost, asic_index):
+    """Return a fully-formed ``sonic-db-cli`` prefix for an ASIC.
+
+    Example::
+
+        sonic-db-cli                  # single-ASIC / default namespace
+        sonic-db-cli -n asic1         # multi-ASIC, namespace asic1
+    """
+    arg = namespace_cli_arg(get_asic_namespace(duthost, asic_index))
+    return "sonic-db-cli {}".format(arg).rstrip()
+
+
+def get_asic_config_facts(duthost, asic_index):
+    """Return ``ansible_facts`` from a namespace-scoped ``config_facts`` call."""
+    namespace = get_asic_namespace(duthost, asic_index)
+    return duthost.config_facts(
+        host=duthost.hostname, source="running", namespace=namespace
+    )["ansible_facts"]
+
+
+def get_vtysh_cmd_for_asic(duthost, asic_index, cmd):
+    """Rewrite a ``vtysh ...`` command to target the given ASIC's namespace.
+
+    On single-ASIC DUTs (``asic_index`` is the default), the command is
+    returned unchanged.
+    """
+    namespace = get_asic_namespace(duthost, asic_index)
+    return duthost.get_vtysh_cmd_for_namespace(cmd, namespace)
+
+
 def _write_variable_from_j2_to_configdb(duthost, template_file, **kwargs):
     save_dest_path = kwargs.pop("save_dest_path", "/tmp/temp.j2")
     keep_dest_file = kwargs.pop("keep_dest_file", True)
@@ -64,9 +125,8 @@ def run_bgp_facts(duthost, enum_asic_index):
     """compare the bgp facts between observed states and target state"""
 
     bgp_facts = duthost.bgp_facts(instance_id=enum_asic_index)['ansible_facts']
-    namespace = duthost.get_namespace_from_asic_id(enum_asic_index)
-    config_facts = duthost.config_facts(host=duthost.hostname, source="running", namespace=namespace)['ansible_facts']
-    sonic_db_cmd = "sonic-db-cli {}".format("-n " + namespace if namespace else "")
+    config_facts = get_asic_config_facts(duthost, enum_asic_index)
+    sonic_db_cmd = get_db_cli_prefix(duthost, enum_asic_index)
     bgp_confed_asn = config_facts.get('BGP_DEVICE_GLOBAL', {}).get('CONFED', {}).get('asn', None)
     bgp_asn = int(config_facts['DEVICE_METADATA']['localhost']['bgp_asn'].encode().decode("utf-8"))
     for k, v in list(bgp_facts['bgp_neighbors'].items()):

--- a/tests/common/helpers/bgp.py
+++ b/tests/common/helpers/bgp.py
@@ -49,8 +49,15 @@ def get_db_cli_prefix(duthost, asic_index):
         sonic-db-cli                  # single-ASIC / default namespace
         sonic-db-cli -n asic1         # multi-ASIC, namespace asic1
     """
-    arg = namespace_cli_arg(get_asic_namespace(duthost, asic_index))
-    return "sonic-db-cli {}".format(arg).rstrip()
+    return get_db_cli_prefix_for_namespace(get_asic_namespace(duthost, asic_index))
+
+
+def get_db_cli_prefix_for_namespace(namespace):
+    """Like :func:`get_db_cli_prefix`, but for callers that already hold a
+    resolved ``namespace`` (e.g. helpers that take a ``namespace`` parameter
+    rather than an ``asic_index``).
+    """
+    return "sonic-db-cli {}".format(namespace_cli_arg(namespace)).rstrip()
 
 
 def get_asic_config_facts(duthost, asic_index):


### PR DESCRIPTION
### Description of PR

Summary:
Consolidate the multi-ASIC namespace / `sonic-db-cli` / `sonic-cfggen` / `vtysh` plumbing that is currently open-coded across the BGP test suite into a single set of shared helpers in `tests/common/helpers/bgp.py`, and migrate the existing callsites in `tests/common/helpers/bgp.py`, `tests/bgp/bgp_helpers.py`, and five additional test scripts under `tests/bgp/`.

Refs: #25707

The BGP suite reinvents the same 3–5 line pattern in many places — resolving an ASIC index to a Linux namespace, building `'-n ' + namespace if namespace else ''`, constructing `sonic-db-cli {ns} CONFIG_DB ...` strings, fetching namespace-scoped `config_facts`, and rewriting `vtysh ...` for a namespace. Each new multi-ASIC test conversion (most recently #25683) adds another copy. This PR centralizes that plumbing.

This PR is delivered as two commits:
1. **`tests/bgp: consolidate multi-ASIC namespace / sonic-db-cli / vtysh helpers`** — introduces the helpers and migrates `tests/common/helpers/bgp.py::run_bgp_facts` plus 5 functions in `tests/bgp/bgp_helpers.py`.
2. **`tests/bgp: migrate test-script callsites to shared multi-ASIC helpers`** — applies the helpers to the remaining open-coded callsites in 5 BGP test scripts, including dropping two duplicate local helpers (`asic_ns_for_db_cli`, `asic_ns_for_vtysh`) in `test_prefix_list_suppress.py`.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: N/A — pure refactor, not requesting backport.

### Approach

#### What is the motivation for this PR?

The same multi-ASIC plumbing is open-coded across the BGP test suite, e.g.:

```python
namespace = duthost.get_namespace_from_asic_id(enum_asic_index)
config_facts = duthost.config_facts(host=duthost.hostname, source="running",
                                    namespace=namespace)['ansible_facts']
sonic_db_cmd = "sonic-db-cli {}".format("-n " + namespace if namespace else "")
```

Concrete examples on `master` before this PR:

- `tests/common/helpers/bgp.py::run_bgp_facts` — canonical 3-liner.
- `tests/bgp/bgp_helpers.py` — same pattern in `remove_bgp_neighbors`,
  `restore_bgp_neighbors`, `apply_allow_list`, `remove_allow_list`, and
  `verify_dut_configdb_tsa_value` (the latter additionally hard-codes
  `"asic{N}"` as the namespace name rather than going through
  `get_namespace_from_asic_id`).
- `tests/bgp/test_prefix_list_suppress.py` — two local helpers
  `asic_ns_for_db_cli` and `asic_ns_for_vtysh` and 12 callsites.
- `tests/bgp/traffic_checker.py::check_tsa_persistence_support` and
  `tests/bgp/test_seq_idf_isolation.py::check_idf_isolation_support` —
  identical 3-line copies of the `run_bgp_facts` pattern.
- `tests/bgp/test_bgp_bbr_default_state.py::get_bbr_status_from_config_db`
  and `tests/bgp/test_bgp_dual_asn.py` — additional inline copies.
- PR #25683 (`test_bgp_router_id.py` multi-ASIC update) adds yet another
  local copy of the same four helpers inside the test module because
  there is currently no shared API.

#### How did you do it?

**Commit 1** — added five helpers to `tests/common/helpers/bgp.py`:

| Helper | Purpose |
|---|---|
| `get_asic_namespace(duthost, asic_index)` | `None`-safe wrapper around `duthost.get_namespace_from_asic_id` |
| `namespace_cli_arg(namespace)` | `-n <ns>` or `""` — shared by `sonic-db-cli` and `sonic-cfggen` |
| `get_db_cli_prefix(duthost, asic_index)` | Full `sonic-db-cli` / `sonic-db-cli -n asic1` prefix (no trailing whitespace) |
| `get_asic_config_facts(duthost, asic_index)` | Namespace-scoped `config_facts(...)['ansible_facts']` |
| `get_vtysh_cmd_for_asic(duthost, asic_index, cmd)` | Thin shim over `duthost.get_vtysh_cmd_for_namespace` |

All five degrade to a no-op on single-ASIC DUTs (where the namespace is `None`), so callers do not need to branch. Migrated `run_bgp_facts` and 5 functions in `tests/bgp/bgp_helpers.py`.

**Commit 2** — migrated the remaining test-script callsites:

- `tests/bgp/test_prefix_list_suppress.py` — deleted the two duplicate local helpers `asic_ns_for_db_cli` and `asic_ns_for_vtysh`; replaced all 12 callsites.
- `tests/bgp/traffic_checker.py::check_tsa_persistence_support` and `tests/bgp/test_seq_idf_isolation.py::check_idf_isolation_support` — collapsed the 3-line pattern into one `get_db_cli_prefix(...)` call.
- `tests/bgp/test_bgp_bbr_default_state.py::get_bbr_status_from_config_db` — uses `namespace_cli_arg(namespace)`.
- `tests/bgp/test_bgp_dual_asn.py` — uses `namespace_cli_arg(ns)`.

In two places this also drops a `"-n asic{N}"` hardcoded namespace-name assumption in favor of `get_namespace_from_asic_id`, which is the API-level source of truth.

`tests/bgp/test_bgp_router_id.py` is intentionally **not** migrated in this PR; that file gains its local helper copies in #25683 and will be cleaned up once that PR merges (called out in the tracking issue).

#### How did you verify/test it?

- AST parse and `flake8 --max-line-length=120` clean on all changed files. The only pre-existing flake8 hits in `tests/bgp/bgp_helpers.py` (lines 916/918) are unrelated to this change.
- This is a pure refactor: the shell-command strings produced by every migrated callsite are equivalent to before. The two `"asic{N}"`-hardcoding fixes (`verify_dut_configdb_tsa_value` and `test_prefix_list_suppress.py`) are functionally equivalent for SONiC's standard namespace naming.
- No tests added; existing BGP regression coverage exercises every migrated callsite.

#### Any platform specific information?

N/A — applies to all multi-ASIC platforms (T1/T2) and is a no-op on single-ASIC DUTs.

#### Supported testbed topology if it's a new test case?

N/A — refactor only, not a new test.

### Documentation

N/A
