### PR TITLE
[lldp] Fix test_lldp_syncd LLDP_ENTRY_TABLE vs lldpctl key comparison (eth0 + duplicate neighbors)

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -274,9 +274,19 @@ def assert_lldp_interfaces(
             "Unexpected type for lldpctl interfaces: {}".format(type(lldpctl_interface))
         )
 
+    # lldpctl reports the management interface (eth0) and may list the same
+    # front-panel port more than once when it has multiple LLDP neighbors
+    # (e.g. fanout + T1 switch in dualtor). LLDP_ENTRY_TABLE / "show lldp table"
+    # store a single entry per physical interface and do not track eth0, so
+    # normalize the lldpctl interface set (drop eth0, dedup) before comparing.
+    lldpctl_iface_set = set(lldpctl_interfaces) - {"eth0"}
+    db_iface_set = set(lldp_entry_keys)
     pytest_assert(
-        sorted(lldp_entry_keys) == sorted(lldpctl_interfaces),
-        "LLDP_ENTRY_TABLE keys do not match lldpctl interface indexes",
+        db_iface_set == lldpctl_iface_set,
+        "LLDP_ENTRY_TABLE keys do not match lldpctl interface indexes. "
+        "In DB but not in lldpctl: {}. In lldpctl but not in DB: {}".format(
+            db_iface_set - lldpctl_iface_set, lldpctl_iface_set - db_iface_set
+        ),
     )
 
 


### PR DESCRIPTION
### Description of PR

Summary:
Fixes `lldp.test_lldp_syncd` failures (e.g. `test_lldp_entry_table_after_reboot`) where the
`LLDP_ENTRY_TABLE` keys vs. `lldpctl` interface comparison in `assert_lldp_interfaces` fails even
though `LLDP_ENTRY_TABLE` and `show lldp table` agree.

`assert_lldp_interfaces` compared the per-interface DB keys against the raw `lldpctl` interface
list using a sorted-list equality. That `lldpctl` list:

- includes the **management interface `eth0`** (which has a real LLDP neighbor — the management
  switch — but is not tracked in `LLDP_ENTRY_TABLE` / `show lldp table`), and
- lists the **same front-panel port multiple times** when it has more than one LLDP neighbor
  (e.g. fanout + T1 switch in dualtor / scaling setups).

Example failure on `cisco-8000` T1: the `db_set == cli_set` check passed (DB == `show lldp table`),
but the second assert failed because
`lldpctl_interfaces = ['eth0', 'Ethernet200', 'Ethernet200', 'Ethernet204', 'Ethernet204', ...]`.

This mirrors the existing dedup already applied to `get_show_lldp_table_output` (single entry per
interface) and the set-based `db_set == cli_set` check. The fix normalizes the `lldpctl` interface
set (drop `eth0`, dedup) and compares as sets, and improves the assertion message to show the
symmetric difference. It is a strict relaxation, so previously-passing runs still pass while real
interface-coverage mismatches are still detected.

Fixes ADO PBI 38606777.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
`test_lldp_syncd` consistently fails on platforms/topologies where `lldpctl` reports the management
interface and/or duplicate LLDP neighbors per port, even though the SONiC `LLDP_ENTRY_TABLE` is
correct. The test logic, not the product, is at fault.

#### How did you do it?
In `assert_lldp_interfaces`, instead of `sorted(lldp_entry_keys) == sorted(lldpctl_interfaces)`,
build `lldpctl_iface_set = set(lldpctl_interfaces) - {"eth0"}` and assert it equals
`set(lldp_entry_keys)`, with a clearer diff-based failure message. This is consistent with the
`show lldp table` dedup and the existing `db_set == cli_set` set comparison, and with other tests in
this file that already special-case `eth0`.

#### How did you verify/test it?
- Confirmed against the captured failure data: with the fix, the `cisco-8000` after-reboot case
  (eth0 + duplicate `Ethernet200/204` in `lldpctl`) now passes, a clean matching case still passes,
  and a genuine interface-coverage mismatch is still flagged.
- `pre-commit` (flake8 / python-ast / trailing-whitespace) passes on the changed file.

#### Any platform specific information?
Observed on `cisco-8000`; the normalization is platform-agnostic and only relaxes assumptions that
`lldpctl` never reports `eth0` or duplicate neighbors.

#### Supported testbed topology if it's a new test case?
N/A (existing test).

### Documentation
N/A
