### PR TITLE
Fix ACL outer VLAN counter lookup

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -305,8 +305,8 @@ def get_acl_counter(duthost, table_name, rule_name, timeout=ACL_COUNTERS_UPDATE_
                 return True
         return False
 
-    # Wait for orchagent to update the ACL counters
-    if not wait_until(timeout, 2, 0, _check_acl_counter):
+    # Always check once; wait_until with timeout=0 does not call the condition.
+    if not _check_acl_counter() and not wait_until(timeout, 2, 0, _check_acl_counter):
         pytest.fail("Failed to retrieve acl counter for {}|{}".format(table_name, rule_name))
 
     result = duthost.show_and_parse('aclshow -a')


### PR DESCRIPTION
### Description of PR
Fix `tests/acl/test_acl_outer_vlan.py` ACL counter lookup so callers using `timeout=0` still perform one immediate `aclshow -a` check before falling back to `wait_until`.

This addresses SONiC nightly PBI 38606759 where all `TestAclVlanOuter_Ingress` cases failed immediately with `Failed to retrieve acl counter for DATAACL_ingress_ipv4|rule_1` / `DATAACL_ingress_ipv6|rule_1` because `wait_until(0, ...)` never invokes the condition.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://dev.azure.com/msazure/One/_workitems/edit/38606759
Failure type: regression

### Tested branch
<!-- Select each branch where the change was tested. -->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result
N/A - validated by code inspection / log analysis; see Approach > "How did you verify/test it?".

### Approach
#### What is the motivation for this PR?
Nightly ACL outer VLAN ingress tests fail before traffic verification because the pre-traffic counter read calls `get_acl_counter(..., timeout=0)`, but `wait_until` exits without checking the condition when timeout is zero.

#### How did you do it?
Changed `get_acl_counter` to call `_check_acl_counter()` once before using `wait_until`, preserving the zero-timeout caller behavior while allowing already-created ACL counters to be read.

#### How did you verify/test it?
Ran `python -m py_compile tests\acl\test_acl_outer_vlan.py`.

#### Any platform specific information?
Observed in nightly on Broadcom Arista-7060CX-32S-C32 / Arista-7060X6-16PE-384C-B-O128S2 and Mellanox-SN5640-C512S2 T0 topologies.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
