### PR TITLE
Skip thermal platform tests on Cisco-8000

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1375,10 +1375,10 @@ platform_tests/test_memory_exhaustion.py:
 #######################################
 platform_tests/test_platform_info.py::test_show_platform_fanstatus_mocked:
   skip:
-    reason: "Test disabled on Mellanox platforms as it could be un-stable and interfered by the thermal algorithm."
+    reason: "Test disabled on Mellanox and Cisco-8000 platforms as thermal control is unavailable or unstable."
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox']"
+      - "asic_type in ['mellanox', 'cisco-8000']"
       - "'bmc' in topo_type"
 
 platform_tests/test_platform_info.py::test_show_platform_temperature_mocked:
@@ -1391,11 +1391,11 @@ platform_tests/test_platform_info.py::test_show_platform_temperature_mocked:
 
 platform_tests/test_platform_info.py::test_thermal_control_fan_status:
   skip:
-    reason: "Thermal control daemon is not present / Test disabled on Mellanox platforms as it could be un-stable and interfered by the thermal algorithm."
+    reason: "Thermal control daemon is not present / Test disabled on Mellanox and Cisco-8000 platforms as thermal control is unavailable or unstable."
     conditions_logical_operator: or
     conditions:
       - "is_multi_asic==True and release in ['201911']"
-      - "asic_type in ['mellanox']"
+      - "asic_type in ['mellanox', 'cisco-8000']"
       - "'bmc' in topo_type"
 
 platform_tests/test_platform_info.py::test_thermal_control_load_invalid_format_json:


### PR DESCRIPTION
### Description of PR

This change skips platform thermal-control dependent tests on Cisco-8000 platforms. Cisco-8000 uses a BSP-specific thermal policy mechanism and the nightly failure shows `docker exec -i pmon bash -c 'pgrep -f thermalctld'` returns no thermalctld process, causing setup for `test_show_platform_fanstatus_mocked` to fail.

Fixes ADO PBI 38606767.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request

- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202605

### Approach
#### What is the motivation for this PR?
Nightly `platform_tests.test_platform_info::test_show_platform_fanstatus_mocked` on Cisco-8000 fails in `disable_thermal_policy` because no `thermalctld` process exists in pmon.

#### How did you do it?
Extend the existing conditional skip marks for the affected thermal-control tests to include `asic_type == cisco-8000`.

#### How did you verify/test it?
Validated the conditional mark YAML parses successfully with PyYAML.

#### Any platform specific information?
Cisco-8000.

#### Supported testbed topology if it's a new test case?
N/A.

### Documentation
N/A.