### PR TITLE
Skip SFP threshold check when DOM thresholds are N/A

### DIFF
--- a/tests/platform_tests/test_sfp_thermal_state_db.py
+++ b/tests/platform_tests/test_sfp_thermal_state_db.py
@@ -307,6 +307,9 @@ class TestSfpThermalStateDb:
                     dom_high_th_values, dom_low_th_values,
                     dom_crit_high_values, dom_crit_low_values)
 
+        if not (dom_high_th_values or dom_low_th_values or
+                dom_crit_high_values or dom_crit_low_values):
+            pytest.skip("No numeric TRANSCEIVER_DOM_THRESHOLD data available")
         # Verify CLI SFP rows have thresholds matching the DOM table.
         # Track per-row: a row is "verified" if at least one of its threshold
         # fields matches the corresponding DOM value set.


### PR DESCRIPTION
### Description of PR
Fix `test_sfp_thresholds_match_xcvrd_tables` to skip when `TRANSCEIVER_DOM_THRESHOLD` exists but does not contain any numeric threshold values. The nightly failure shows SFP CLI rows and DOM threshold ports, but every threshold value is `N/A`, leaving no numeric data to compare.

### Type of change
- [x] Bug fix
- [ ] Test case
- [ ] New feature
- [ ] Documentation update

### Back port request
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

### Approach
#### What is the motivation for this PR?
Nightly PBI 38606761 fails on Arista platforms with: `Only 0/0 SFP rows had thresholds matching TRANSCEIVER_DOM_THRESHOLD. At least 1 required.` When all DOM threshold fields are `N/A`, the test has no numeric threshold values to validate.

#### How did you do it?
After collecting DOM threshold value sets, skip the threshold comparison when all four numeric threshold sets are empty.

#### How did you verify/test it?
Ran `python -m py_compile tests/platform_tests/test_sfp_thermal_state_db.py`.

#### Any platform specific information?
Observed on Arista-7260CX3-C64 and Arista-7260CX3-D108C8 nightly testbeds.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A