### PR TITLE
Fix test_stress_acl: avoid KeyError when minigraph has no DataAcl ports

### DIFF
--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -177,7 +177,15 @@ def prepare_test_port(rand_selected_dut, tbinfo):
 
     ports = list(mg_facts['minigraph_portchannels'])
     if not ports:
-        ports = mg_facts["minigraph_acls"]["DataAcl"]
+        # minigraph_acls only contains a data-plane ACL entry when that ACL has
+        # front-panel members attached, so the key can be legitimately absent.
+        # Match case-insensitively and default to an empty list so we fall through
+        # to the pytest.skip below instead of raising KeyError.
+        ports = next(
+            (members for name, members in mg_facts["minigraph_acls"].items()
+             if name.lower() == "dataacl"),
+            [],
+        )
 
     dut_port = ports[0] if ports else None
 


### PR DESCRIPTION
### Description of PR

Summary:
Fixes `acl.test_stress_acl::test_acl_add_del_stress` setup error `KeyError: 'DataAcl'` raised in the `prepare_test_port` fixture.

When the DUT has no port channels, the fixture fell back to `mg_facts["minigraph_acls"]["DataAcl"]` using direct dict indexing. `minigraph_acls` only contains a data-plane ACL entry when that ACL has front-panel members attached (see `ansible/library/minigraph_facts.py`), so the `DataAcl` key can be legitimately absent on some topologies/platforms, causing a `KeyError` and erroring the test during setup. This is a consistent failure observed across multiple platforms and topologies (Arista 7060CX/7060X6, Mellanox; t0/t1/isolated).

The fixture already has a trailing `pytest.skip('No portchannels nor dataacl ports found')` for the empty-ports case, so the intended behavior when no candidate port exists is to skip. The hard `["DataAcl"]` indexing prevented reaching that intended path. This change uses a case-insensitive lookup defaulting to an empty list, restoring the intended skip behavior instead of raising `KeyError`.

Related ADO PBI: 38609707
Related issue: https://github.com/sonic-net/sonic-mgmt/issues/13103

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [x] 202405
- [x] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
`test_acl_add_del_stress` consistently errors during setup with `KeyError: 'DataAcl'` on DUTs/topologies that have no port channels and no `DataAcl` entry in `minigraph_acls`.

#### How did you do it?
Replaced the direct `mg_facts["minigraph_acls"]["DataAcl"]` indexing with a case-insensitive lookup that defaults to an empty list, so the fixture falls through to the existing `pytest.skip` when no usable port is found.

#### How did you verify/test it?
Verified the fixture no longer raises `KeyError` when `minigraph_acls` lacks a `DataAcl` key; the test now skips with the existing message when no port channel and no DataAcl ports exist, and behaves unchanged when ports are present. Pre-commit (flake8) passes locally.

#### Any platform specific information?
Observed on Arista-7060CX-32S-C32 (and others) where `minigraph_acls` has no `DataAcl` entry.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A