### PR TITLE
Handle unsupported PFCWD stop GCU operations

### DIFF
--- a/tests/generic_config_updater/test_pfcwd_status.py
+++ b/tests/generic_config_updater/test_pfcwd_status.py
@@ -258,15 +258,19 @@ def test_stop_pfcwd(duthost, enum_rand_one_frontend_asic_index,
     # Removing the JSON patch formatting because the above patch includes interfaces
     # that may belong to multiple ASICs, and the formatting has already been handled per interface.
     # json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    op = 'remove'
     try:
         tmpfile = generate_tmpfile(duthost)
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
-        expect_op_success(duthost, output)
-        pfcwd_updated_config = duthost.shell("show pfcwd config")
-        pytest_assert(not pfcwd_updated_config['rc'], "Unable to read updated pfcwd config")
-        pytest_assert(exp_str not in pfcwd_updated_config['stdout'].split(),
-                      "pfcwd unexpectedly still running")
-        check_config_update(duthost, expected_count)
+        if is_valid_platform_and_version(duthost, "PFC_WD", "PFCWD enable/disable", op):
+            expect_op_success(duthost, output)
+            pfcwd_updated_config = duthost.shell("show pfcwd config")
+            pytest_assert(not pfcwd_updated_config['rc'], "Unable to read updated pfcwd config")
+            pytest_assert(exp_str not in pfcwd_updated_config['stdout'].split(),
+                          "pfcwd unexpectedly still running")
+            check_config_update(duthost, expected_count)
+        else:
+            expect_op_failure(output)
     finally:
         delete_tmpfile(duthost, tmpfile)
 

--- a/tests/generic_config_updater/test_pfcwd_status.py
+++ b/tests/generic_config_updater/test_pfcwd_status.py
@@ -259,6 +259,7 @@ def test_stop_pfcwd(duthost, enum_rand_one_frontend_asic_index,
     # that may belong to multiple ASICs, and the formatting has already been handled per interface.
     # json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
     op = 'remove'
+    tmpfile = None
     try:
         tmpfile = generate_tmpfile(duthost)
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
@@ -272,7 +273,8 @@ def test_stop_pfcwd(duthost, enum_rand_one_frontend_asic_index,
         else:
             expect_op_failure(output)
     finally:
-        delete_tmpfile(duthost, tmpfile)
+        if tmpfile:
+            delete_tmpfile(duthost, tmpfile)
 
 
 @pytest.mark.parametrize('port', ['single', 'all'])
@@ -314,6 +316,7 @@ def test_start_pfcwd(duthost, enum_rand_one_frontend_asic_index,
     # Removing the JSON patch formatting because the above patch includes interfaces
     # that may belong to multiple ASICs, and the formatting has already been handled per interface.
     # json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    tmpfile = None
     try:
         tmpfile = generate_tmpfile(duthost)
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
@@ -327,4 +330,5 @@ def test_start_pfcwd(duthost, enum_rand_one_frontend_asic_index,
         else:
             expect_op_failure(output)
     finally:
-        delete_tmpfile(duthost, tmpfile)
+        if tmpfile:
+            delete_tmpfile(duthost, tmpfile)


### PR DESCRIPTION
### Description of PR
Summary: Fix `generic_config_updater/test_pfcwd_status.py::test_stop_pfcwd` on platforms/versions where GCU `PFC_WD` remove is not supported by `rdma_config_update_validator`. `test_start_pfcwd` already tolerates this via `is_valid_platform_and_version(...)`; this applies the same handling to `test_stop_pfcwd` for the `remove` operation, and hardens `tmpfile` cleanup in both tests.

Fixes # (issue)
ADO: https://dev.azure.com/msazure/One/_workitems/edit/38609713

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://dev.azure.com/msazure/One/_workitems/edit/38609713
Failure type: regression

### Tested branch
<!-- Select each branch where the change was tested. -->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result
N/A - validated by code inspection / log analysis; see Approach > "How did you verify/test it?".

### Approach
#### What is the motivation for this PR?
Nightly PBI 38609713 reports `test_stop_pfcwd` failures on 202511/T2 with `Failed: Command is not running successfully`; the apply-patch output shows `rdma_config_update_validator returned False`. On platforms/versions where GCU does not support the `PFC_WD` `remove` operation, the test unconditionally expects success and fails. The same unguarded pattern also exists on 202605.

#### How did you do it?
`test_start_pfcwd` already checks `is_valid_platform_and_version(duthost, "PFC_WD", "PFCWD enable/disable", op)` and expects an operation failure when the platform/version does not support the GCU operation. Applied the same logic to `test_stop_pfcwd` for the `remove` operation (`expect_op_success` when supported, `expect_op_failure` otherwise). Also initialized `tmpfile = None` before the `try` and guarded `delete_tmpfile` with `if tmpfile:` in both tests (review feedback) so a failure in `generate_tmpfile()` no longer masks the original exception with `UnboundLocalError`.

#### How did you verify/test it?
`python -m py_compile tests/generic_config_updater/test_pfcwd_status.py` and `flake8 --max-line-length=120` are clean.

#### Any platform specific information?
Observed on T2 202511 nightly (release images `SONiC.20251110.x`). `is_valid_platform_and_version` is operation-specific, so `remove` support is independent of `add`. The 202605 branch carries the same test-code gap, hence the 202605 backport request.

#### Supported testbed topology if it's a new test case?
N/A (existing test; topologies t0/t1).

### Documentation
N/A
