### PR TITLE
[pfcwd] Avoid EOS fanout shell for PFC storm hwsku lookup

### DIFF
--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -16,8 +16,7 @@ logger = logging.getLogger(__name__)
 
 def get_chip_name_if_asic_pfc_storm_supported(fanout):
     hwSkuInfo = {
-        "Arista DCS-7060DX5": "Tomahawk4",
-        "Arista DCS-7060PX5": "Tomahawk4",
+        "Arista DCS-7060DX5": "Tomahawk4",`r`n        "Arista-7060DX5": "Tomahawk4",`r`n        "Arista DCS-7060PX5": "Tomahawk4",`r`n        "Arista-7060PX5": "Tomahawk4",
         "Arista DCS-7060X6": "Tomahawk5",
         "Arista-7060X6": "Tomahawk5",
         "Arista-7060X6-64PE-P32O64": "Tomahawk5",
@@ -157,12 +156,7 @@ class PFCStorm(object):
         if not out['stat']['exists'] or not out['stat']['isdir']:
             self.peer_device.file(path=pfc_gen_fpath, state="touch")
 
-    def _get_eos_fanout_version(self):
-        """
-        Get version info for eos fanout device
-        """
-        cmd = 'Cli -c "show version"'
-        return self.peer_device.shell(cmd)['stdout_lines']
+    def _get_eos_fanout_version(self):`r`n        """`r`n        Get hwsku info for eos fanout device from inventory.`r`n        """`r`n        return [self.peer_info['hwsku']]
 
     def _get_sonic_fanout_hwsku(self):
         """
@@ -463,3 +457,4 @@ class PFCMultiStorm(object):
         """
         for hndle in self.storm_handle:
             self.storm_handle[hndle].stop_storm()
+

--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -16,7 +16,10 @@ logger = logging.getLogger(__name__)
 
 def get_chip_name_if_asic_pfc_storm_supported(fanout):
     hwSkuInfo = {
-        "Arista DCS-7060DX5": "Tomahawk4",`r`n        "Arista-7060DX5": "Tomahawk4",`r`n        "Arista DCS-7060PX5": "Tomahawk4",`r`n        "Arista-7060PX5": "Tomahawk4",
+        "Arista DCS-7060DX5": "Tomahawk4",
+        "Arista-7060DX5": "Tomahawk4",
+        "Arista DCS-7060PX5": "Tomahawk4",
+        "Arista-7060PX5": "Tomahawk4",
         "Arista DCS-7060X6": "Tomahawk5",
         "Arista-7060X6": "Tomahawk5",
         "Arista-7060X6-64PE-P32O64": "Tomahawk5",
@@ -156,7 +159,11 @@ class PFCStorm(object):
         if not out['stat']['exists'] or not out['stat']['isdir']:
             self.peer_device.file(path=pfc_gen_fpath, state="touch")
 
-    def _get_eos_fanout_version(self):`r`n        """`r`n        Get hwsku info for eos fanout device from inventory.`r`n        """`r`n        return [self.peer_info['hwsku']]
+    def _get_eos_fanout_version(self):
+        """
+        Get hwsku info for eos fanout device from inventory.
+        """
+        return [self.peer_info['hwsku']]
 
     def _get_sonic_fanout_hwsku(self):
         """

--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -200,7 +200,8 @@ class PFCStorm(object):
                 dest=self._PFC_GEN_DIR[self.peer_device.os]
                 )
             if self.fanout_asic_type == 'mellanox':
-                cmd = f"docker cp {self._PFC_GEN_DIR[self.peer_device.os]}/{self.pfc_gen_file} syncd:/root/"
+                cmd = "docker cp {}/{} syncd:/root/".format(
+                    self._PFC_GEN_DIR[self.peer_device.os], self.pfc_gen_file)
                 self.peer_device.shell(cmd)
 
     def update_queue_index(self, q_idx):
@@ -464,4 +465,3 @@ class PFCMultiStorm(object):
         """
         for hndle in self.storm_handle:
             self.storm_handle[hndle].stop_storm()
-


### PR DESCRIPTION
### Description of PR
PFCWD tests can fail during PFC storm setup when an EOS fanout still has Python 3.7, because ansible-core now requires Python >= 3.8 for the generic shell module. The test only needs the fanout HwSKU to select the PFC generator template, and that HwSKU is already available from fanout graph/inventory.

This change uses the existing inventory HwSKU for EOS fanouts instead of running `Cli -c "show version"` through Ansible shell.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://dev.azure.com/msazure/One/_workitems/edit/38609714
Failure type: regression

### Tested branch
<!-- Select each branch where the change was tested. -->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result
N/A - validated by code inspection / log analysis; see Approach > "How did you verify/test it?".

### Approach
#### What is the motivation for this PR?
SONiC nightly PBI 38609714 tracks `pfcwd.test_pfcwd_function.TestPfcwdFunc::test_pfcwd_actions` failures on 20260510 T1/mellanox. The traceback fails in `PFCStorm.deploy_pfc_gen()` while calling `_get_eos_fanout_version()`: `ansible-core requires a minimum of Python version 3.8. Current version: 3.7.3` on the EOS fanout.

#### How did you do it?
Return the EOS fanout HwSKU from `peer_info['hwsku']`, which is populated from fanout graph/inventory during initialization, avoiding the unnecessary remote shell command. Added dash-form mappings for DX5/PX5 inventory names to preserve chip-name matching coverage.

#### How did you verify/test it?
Ran `python -m py_compile tests/common/helpers/pfc_storm.py`.

#### Any platform specific information?
Observed on mellanox T1 DUT with Arista EOS fanout `Arista-7260CX3`.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
