### PR TITLE
[ci]sonic-ubuntu-1c agent pool: migrate from python3-pip to uv to address S360 vulnerability

### DIFF
--- a/.azure-pipelines/cancel-previous-elastictest-testplan.yml
+++ b/.azure-pipelines/cancel-previous-elastictest-testplan.yml
@@ -75,7 +75,7 @@ steps:
       set -e
       echo "Step: cancel previous testplans for PR"
 
-      pip install PyYAML
+      sudo uv pip install --system PyYAML
 
       rm -f new_test_plan_id.txt
 

--- a/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
+++ b/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
@@ -67,8 +67,7 @@ steps:
 - script: |
     set -x
 
-    pip install azure-kusto-data
-    pip install azure-kusto-data azure-identity
+    sudo uv pip install --system azure-kusto-data azure-identity
 
     INSTANCE_NUMBER=$(python ./.azure-pipelines/impacted_area_testing/calculate_instance_number.py --scripts $(SCRIPTS) --topology ${{ parameters.TOPOLOGY }} --branch ${{ parameters.BUILD_BRANCH }} --prepare_time ${{ parameters.PREPARE_TIME }} --target_pr_test_time $(TARGET_PR_TEST_TIME))
 

--- a/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
+++ b/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
@@ -61,8 +61,7 @@ steps:
       echo "##vso[task.setvariable variable=TEST_SCRIPTS;isOutput=true]$TEST_SCRIPTS"
       exit 0
     fi
-    pip install PyYAML
-    pip install natsort
+    sudo uv pip install --system PyYAML natsort
 
     FINAL_FEATURES=""
     IFS=' ' read -ra FEATURES_LIST <<< "$(DIFF_FOLDERS)"

--- a/.azure-pipelines/probe-tests/steps/run-probe-tests.yml
+++ b/.azure-pipelines/probe-tests/steps/run-probe-tests.yml
@@ -9,7 +9,7 @@ steps:
   - script: |
       set -e
 
-      pip install pytest pytest-cov pytest-mock pytest-order coverage
+      sudo uv pip install --system pytest pytest-cov pytest-mock pytest-order coverage
 
       source .azure-pipelines/probe-tests/scripts/get-changed-probe-files.sh
 

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -278,8 +278,7 @@ steps:
       set -e
       echo "Step: Trigger Test"
 
-
-      pip install PyYAML
+      sudo uv pip install --system PyYAML
 
       rm -f new_test_plan_id.txt
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,7 +82,8 @@ stages:
     displayName: "Static Analysis"
     timeoutInMinutes: 10
     continueOnError: false
-    pool: sonic-ubuntu-1c
+    pool:
+      vmImage: ubuntu-latest
     steps:
     - template: .azure-pipelines/pre-commit-check.yml
 
@@ -90,7 +91,8 @@ stages:
     displayName: "Validate Test Cases"
     timeoutInMinutes: 30
     continueOnError: false
-    pool: sonic-ubuntu-1c
+    pool:
+      vmImage: ubuntu-latest
     steps:
     - template: .azure-pipelines/pytest-collect-only.yml
       parameters:
@@ -99,21 +101,24 @@ stages:
   - job: dependency_check
     displayName: "Dependency Check"
     timeoutInMinutes: 10
-    pool: sonic-ubuntu-1c
+    pool:
+      vmImage: ubuntu-latest
     steps:
       - template: .azure-pipelines/dependency-check.yml
 
   - job: markers_check
     displayName: "Markers Check"
     timeoutInMinutes: 10
-    pool: sonic-ubuntu-1c
+    pool:
+      vmImage: ubuntu-latest
     steps:
       - template: .azure-pipelines/markers-check.yml
 
   - job: meta_check
     displayName: "Meta check"
     timeoutInMinutes: 10
-    pool: sonic-ubuntu-1c
+    pool:
+      vmImage: ubuntu-latest
     steps:
       - template: .azure-pipelines/meta-check.yml
 
@@ -139,8 +144,7 @@ stages:
 
     - script: |
         set -euo pipefail
-        python -m pip install --upgrade pip
-        python -m pip install pytest requests PyYAML
+        sudo uv pip install --system pytest requests PyYAML
       displayName: "Install unit test dependencies"
 
     - script: |


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
S360 scans the self-hosted `sonic-ubuntu-1c` and `sonic-ubuntu-1c-2` agent pools and flags `python3-pip` on them as a security vulnerability. The required version for `python3-pip` is only available in ubuntu pro.
```
"VulnId": 6035751,
"VulnerabilityName": Ubuntu Security Notification for pip Vulnerabilities (USN-8344-1),
"ScanResult": #table cols="3"
Package Installed_Version Required_Version
python3-pip 22.0.2+dfsg-1ubuntu0.7 22.0.2+dfsg-1ubuntu0.7+esm1
```
This PR removes vulnerable pip usage from those pools.
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
`sonic-ubuntu-1c` and `sonic-ubuntu-1c-2` self-hosted agent pools are scanned by S360, and `python3-pip` on them is reported as a security vulnerability. The CI needs to stop using the vulnerable `pip` on those pools.
#### How did you do it?
- For pipeline steps that run on `sonic-ubuntu-1c`/ `sonic-ubuntu-1c-2`, replaced `pip install` with `sudo uv pip install --system` 
- Moved the lightweight pre-merge check jobs from `sonic-ubuntu-1c` to the Microsoft-hosted pool `ubuntu-latest`

#### How did you verify/test it?
Validated through the PR checker
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
