### PR TITLE
[doc] Add testbed server OS upgrade guide

### DIFF
--- a/docs/testbed/README.md
+++ b/docs/testbed/README.md
@@ -6,6 +6,7 @@
   - [Virtual Switch Testbed Setup](README.testbed.VsSetup.md)
   - [Virtual Switch Multiple Devices Testbed Setup](README.testbed.WANSetup.md)
   - [Setup sonic-mgmt Docker](README.testbed.Docker.md)
+  - [Server OS Upgrade](README.testbed.ServerOSUpgrade.md)
   - [cEOS](README.testbed.cEOS.md)
   - [Routing](README.testbed.Routing.md)
   - [Keysight](README.testbed.Keysight.md)

--- a/docs/testbed/README.testbed.ServerOSUpgrade.md
+++ b/docs/testbed/README.testbed.ServerOSUpgrade.md
@@ -135,8 +135,6 @@ Either replace it, or comment it out and add the NOPASSWD line:
 %sudo ALL=(ALL:ALL) NOPASSWD:ALL
 ```
 
-Save and exit (in `nano`: `Ctrl+O`, `Enter`, then `Ctrl+X`).
-
 Verify (this should **not** prompt for a password):
 
 ```bash
@@ -190,7 +188,7 @@ If the rule is missing, re-add it. For a Mellanox 100G NIC:
    ens4f1 -> ../../devices/pci0000:16/0000:16:02.0/0000:17:00.1/net/ens4f1
    ```
 
-### c) Confirm netplan configuration for `ens4f0` and `ens4f1`
+### c) Confirm netplan configuration for external_port (defined in ansible/host_vars/SERVER.yml, take `ens4f0` / `ens4f1` as example)
 
 **1) Check whether `ens4f0` / `ens4f1` exist:**
 
@@ -222,10 +220,6 @@ cat /etc/netplan/<active-file>.yaml
 > `50-cloud-init.yaml`, etc. Use whichever exists on the host.
 
 **4) Edit the active netplan YAML:**
-
-```bash
-sudo nano /etc/netplan/<active-file>.yaml
-```
 
 Add the interfaces under `ethernets:` (2-space indentation), for example:
 

--- a/docs/testbed/README.testbed.ServerOSUpgrade.md
+++ b/docs/testbed/README.testbed.ServerOSUpgrade.md
@@ -1,0 +1,289 @@
+# SONiC Testbed Server OS Upgrade
+
+## Introduction
+
+This guide covers the safe, standard procedure to upgrade the Ubuntu LTS
+version of a **testbed server** (the host machine that runs the SONiC testbed
+VMs and topology). It includes prerequisites, step-by-step upgrade
+instructions, and the post-upgrade configuration checks that are required to
+keep the testbed fully functional (NIC port naming, netplan, and MTU).
+
+> **Note:** This procedure applies to the testbed *server/host*, not to the
+> SONiC DUT. Drain or pause any running tests and back up critical
+> configuration before you start.
+
+## Supported Upgrade Paths
+
+Ubuntu supports direct upgrades between adjacent LTS (Long-Term Support)
+versions:
+
+| From      | To        | Supported? |
+| --------- | --------- | ---------- |
+| 18.04 LTS | 20.04 LTS | Yes        |
+| 20.04 LTS | 22.04 LTS | Yes        |
+
+## Pre-Upgrade Checklist
+
+System requirements:
+
+1. The server is connected to the internet.
+2. Enough free disk space (at least 2-4 GB free).
+3. `sudo`/root privileges.
+
+## Upgrade Steps
+
+### 1. Fully update the current system
+
+```bash
+sudo apt update
+sudo apt upgrade -y
+sudo apt dist-upgrade -y
+sudo apt autoremove -y
+```
+
+If you are upgrading from 18.04 to 20.04, make sure `lxd` is uninstalled first:
+
+```bash
+sudo apt remove --purge lxd lxd-client
+```
+
+### 2. Check the upgrade tool
+
+Ensure the upgrade manager is installed:
+
+```bash
+sudo apt install update-manager-core
+```
+
+Check the LTS prompt setting:
+
+```bash
+sudo cat /etc/update-manager/release-upgrades
+```
+
+Ensure it contains:
+
+```
+Prompt=lts
+```
+
+### 3. Pre-upgrade checks
+
+**Record the 100G port renaming rules.** Capture the existing udev rules before
+the upgrade so you can restore them afterwards if they are lost:
+
+```bash
+sudo ls /etc/udev/rules.d
+```
+
+### 4. Start the upgrade
+
+```bash
+sudo do-release-upgrade
+```
+
+- For any prompt to update a package or restart a service, choose **yes**.
+- For any prompt asking whether to keep the current config file or use the
+  maintainer's version, choose the **maintainer's version**.
+
+### 5. Reboot and verify the version
+
+The upgrade usually requests a reboot at the end. If it does not, reboot
+manually:
+
+```bash
+sudo reboot
+```
+
+After reboot, verify the version:
+
+```bash
+lsb_release -a
+```
+
+## Post-Upgrade Configuration Checks
+
+A release upgrade can reset NIC naming, netplan, and MTU settings. The
+following checks restore testbed connectivity.
+
+### a) Ensure passwordless sudo (NOPASSWD)
+
+The testbed automation requires members of the `sudo` group to run commands
+without a password prompt. Make sure the following line is present in the
+sudoers configuration:
+
+```
+%sudo ALL=(ALL:ALL) NOPASSWD:ALL
+```
+
+**Recommended method** - edit safely with syntax checking using `visudo`:
+
+```bash
+sudo visudo
+```
+
+Look for:
+
+```
+%sudo ALL=(ALL:ALL) ALL
+```
+
+Either replace it, or comment it out and add the NOPASSWD line:
+
+```
+#%sudo ALL=(ALL:ALL) ALL
+%sudo ALL=(ALL:ALL) NOPASSWD:ALL
+```
+
+Save and exit (in `nano`: `Ctrl+O`, `Enter`, then `Ctrl+X`).
+
+Verify (this should **not** prompt for a password):
+
+```bash
+sudo -k sudo ls
+```
+
+### b) Confirm 100G port renaming
+
+Check whether the 100G port renaming rule is still present after the upgrade:
+
+```bash
+sudo ls /etc/udev/rules.d
+```
+
+If the rule is missing, re-add it. For a Mellanox 100G NIC:
+
+1. Get the PCI IDs:
+
+   ```bash
+   lspci -D | grep -i ethernet | grep -i Mellanox
+   ```
+
+   Example output:
+
+   ```
+   0000:17:00.0 Ethernet controller: Mellanox Technologies MT2892 Family [ConnectX-6 Dx]
+   0000:17:00.1 Ethernet controller: Mellanox Technologies MT2892 Family [ConnectX-6 Dx]
+   ```
+
+2. Add the following lines to `/etc/udev/rules.d/70-persistent-net.rules`
+   (adjust the PCI IDs to match your server):
+
+   ```
+   ACTION=="add", SUBSYSTEM=="net", KERNELS=="0000:17:00.0", NAME:="ens4f0"
+   ACTION=="add", SUBSYSTEM=="net", KERNELS=="0000:17:00.1", NAME:="ens4f1"
+   ```
+
+3. Reboot the server.
+
+4. Verify the rename succeeded:
+
+   ```bash
+   lspci -D | grep -i ethernet | grep -i Mellanox
+   ls -la /sys/class/net/ | grep -i 0000:17:00.
+   ```
+
+   Example output:
+
+   ```
+   ens4f0 -> ../../devices/pci0000:16/0000:16:02.0/0000:17:00.0/net/ens4f0
+   ens4f1 -> ../../devices/pci0000:16/0000:16:02.0/0000:17:00.1/net/ens4f1
+   ```
+
+### c) Confirm netplan configuration for `ens4f0` and `ens4f1`
+
+**1) Check whether `ens4f0` / `ens4f1` exist:**
+
+```bash
+ip a | egrep "ens4f0|ens4f1"
+# or
+ip link show ens4f0
+ip link show ens4f1
+```
+
+If both interfaces are listed, you can stop here. If not, continue.
+
+**2) Find the physical NIC names and MAC addresses:**
+
+```bash
+ip link show
+# or, for a concise list:
+for i in /sys/class/net/*; do printf "%-20s %s\n" "$(basename $i)" "$(cat $i/address)"; done
+```
+
+**3) Identify which netplan YAML file to edit:**
+
+```bash
+ls -l /etc/netplan/
+cat /etc/netplan/<active-file>.yaml
+```
+
+> The active file may be `00-installer-config.yaml`, `01-netcfg.yaml`,
+> `50-cloud-init.yaml`, etc. Use whichever exists on the host.
+
+**4) Edit the active netplan YAML:**
+
+```bash
+sudo nano /etc/netplan/<active-file>.yaml
+```
+
+Add the interfaces under `ethernets:` (2-space indentation), for example:
+
+```yaml
+network:
+  version: 2
+  ethernets:
+    ens4f0:
+      dhcp4: no
+    ens4f1:
+      dhcp4: no
+```
+
+Save (`Ctrl+O`) and exit (`Ctrl+X`).
+
+**5) Apply safely:**
+
+```bash
+sudo netplan try   # if the network stays stable, press ENTER to confirm before timeout
+sudo netplan apply
+```
+
+**6) Verify interfaces and link state:**
+
+```bash
+ip a | egrep "ens4f0|ens4f1"
+ip link show ens4f0
+ip link show ens4f1
+```
+
+### d) Verify interface MTU
+
+On some servers, after the upgrade the DUT stops receiving BGP updates from the
+EOS container because the OVS rules on the server no longer forward BGP updates
+correctly. The root cause is the upgraded server port MTU - it should be
+**9216**.
+
+Check and fix the MTU:
+
+```bash
+# Check the current MTU (shows "mtu 1500" if it is wrong)
+ifconfig ens4f1
+
+# Set the correct MTU
+ip link set dev ens4f1 mtu 9216
+
+# Verify (should now show "mtu 9216")
+ifconfig ens4f1
+```
+
+Example before/after (truncated):
+
+```
+ens4f1: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+...
+ens4f1: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9216
+```
+
+> To make the MTU persistent across reboots, set it in the netplan
+> configuration for the interface (for example, add `mtu: 9216` under
+> `ens4f1:`).

--- a/docs/testbed/README.testbed.ServerOSUpgrade.md
+++ b/docs/testbed/README.testbed.ServerOSUpgrade.md
@@ -30,6 +30,17 @@ System requirements:
 2. Enough free disk space (at least 2-4 GB free).
 3. `sudo`/root privileges.
 
+> **Account & permission model (read first).** Run every step in this guide as
+> the *same* regular Linux account that is a member of the `sudo` group, using
+> `sudo` for privileged commands — not as `root` directly. During the upgrade
+> you may still be prompted for the sudo password; passwordless sudo
+> (`NOPASSWD`, restored in
+> [post-upgrade check (a)](#a-ensure-passwordless-sudo-nopasswd)) is what the
+> testbed *automation* needs afterwards, and is **not** required to perform the
+> upgrade itself. Keeping one consistent account throughout is why the config
+> prompts above recommend preserving host-specific `sudoers`/SSH files: it
+> ensures the restored permission model matches what the automation expects.
+
 ## Upgrade Steps
 
 ### 1. Fully update the current system
@@ -69,12 +80,24 @@ Prompt=lts
 
 ### 3. Pre-upgrade checks
 
-**Record the 100G port renaming rules.** Capture the existing udev rules before
-the upgrade so you can restore them afterwards if they are lost:
+**Back up the 100G port renaming rules (and other host-specific config).**
+A release upgrade can remove or overwrite these files, so capture their *actual
+contents* — not just a directory listing — before you start, so the recovery
+steps have something to restore from:
 
 ```bash
-sudo ls /etc/udev/rules.d
+# Copy the real udev rule files (preserving names/permissions) into a backup dir
+sudo mkdir -p ~/testbed-preupgrade-backup/udev-rules.d
+sudo cp -a /etc/udev/rules.d/. ~/testbed-preupgrade-backup/udev-rules.d/
+
+# Optional: also print them so the exact rules are recorded in your session log
+for f in /etc/udev/rules.d/*.rules; do echo "== $f =="; sudo cat "$f"; done
 ```
+
+It is good practice to back up the other host-specific files the same way
+(so they can be diffed/restored after the upgrade), for example
+`/etc/netplan/`, `/etc/sudoers` and `/etc/sudoers.d/`, and
+`/etc/ssh/sshd_config`.
 
 ### 4. Start the upgrade
 
@@ -83,8 +106,24 @@ sudo do-release-upgrade
 ```
 
 - For any prompt to update a package or restart a service, choose **yes**.
-- For any prompt asking whether to keep the current config file or use the
-  maintainer's version, choose the **maintainer's version**.
+- For any prompt asking whether to keep the currently-installed config file or
+  install the package maintainer's version, **decide per file** instead of
+  applying one answer to everything. At the prompt: `N`/`O` keeps your current
+  file (this is the default), `Y`/`I` installs the maintainer's version, and `D`
+  shows the diff between the two.
+  - **Host-specific / testbed config** — e.g. `sudoers` and `/etc/sudoers.d/*`,
+    SSH (`/etc/ssh/sshd_config`), `netplan`, and the udev net-naming rules
+    (`/etc/udev/rules.d/*`): **keep your currently-installed version** (`N`), or
+    press `D` and merge the changes intentionally. Blindly taking the
+    maintainer's version here can overwrite host-specific settings and break
+    testbed automation or remote recovery after the reboot. Restore anything you
+    lose from the [pre-upgrade backup](#3-pre-upgrade-checks).
+  - **Generic config you have *not* customized**: prefer the **maintainer's
+    version** (`Y`) so you pick up upstream fixes — keeping a stale local copy of
+    a security-relevant file (SSH/PAM defaults, etc.) can leave a known
+    vulnerability unpatched.
+  - **When unsure**, press `D` to review the diff first, then choose based on
+    whether the file carries host-specific customizations.
 
 ### 5. Reboot and verify the version
 
@@ -149,7 +188,16 @@ Check whether the 100G port renaming rule is still present after the upgrade:
 sudo ls /etc/udev/rules.d
 ```
 
-If the rule is missing, re-add it. For a Mellanox 100G NIC:
+If the rule is missing, the quickest fix is to restore it from the
+[pre-upgrade backup](#3-pre-upgrade-checks):
+
+```bash
+sudo cp -a ~/testbed-preupgrade-backup/udev-rules.d/. /etc/udev/rules.d/
+sudo reboot
+```
+
+If you do not have a backup, re-create the rule manually. For a Mellanox 100G
+NIC:
 
 1. Get the PCI IDs:
 


### PR DESCRIPTION
### Description of PR

Summary: Add a new testbed documentation page, `docs/testbed/README.testbed.ServerOSUpgrade.md`, that documents how to safely upgrade the Ubuntu LTS version of a testbed **server/host** (not the SONiC DUT) and the post-upgrade checks required to keep the testbed working. The new page is linked from the testbed docs index (`docs/testbed/README.md`).

This is a documentation-only change (2 files, no code/test changes).

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: N/A
Failure type: other

### Approach
#### What is the motivation for this PR?

Upgrading a testbed server's Ubuntu LTS version can reset host configuration (NIC port naming, netplan, MTU, passwordless sudo), which silently breaks testbed connectivity — e.g. the DUT stops receiving BGP updates from EOS when the server port MTU drops to 1500. There was no documented, repeatable procedure for this, so each upgrade required tribal knowledge to recover. This guide captures the standard process and the checks needed afterward.

#### How did you do it?

Added `docs/testbed/README.testbed.ServerOSUpgrade.md` covering:
- Supported LTS upgrade paths (18.04→20.04, 20.04→22.04) and a pre-upgrade checklist.
- Upgrade steps: full apt update/upgrade, `update-manager-core`, recording udev rules, `do-release-upgrade`, reboot and version verification.
- Post-upgrade configuration checks: passwordless sudo (`%sudo NOPASSWD:ALL`), 100G NIC port renaming via udev (Mellanox example), netplan config for `external_port`, and restoring interface MTU 9216.

Linked the page from the testbed docs index in `docs/testbed/README.md`.

#### How did you verify/test it?

Documentation only — steps were derived from real testbed server upgrades. Verified Markdown renders correctly and the new index link resolves. No automated tests apply.

#### Any platform specific information?

Examples use Ubuntu LTS hosts with Mellanox ConnectX-6 Dx 100G NICs; PCI IDs and interface names (`ens4f0`/`ens4f1`) are illustrative and must be adjusted per server.

#### Supported testbed topology if it's a new test case?

N/A — documentation only.

### Documentation
New testbed doc added and linked from `docs/testbed/README.md`.
