### PR TITLE
Set VXLAN tunnel ttl_mode to pipe for cisco-8000 in vnet BGP scale test

### DIFF
--- a/tests/bgp/test_bgp_vnet_scale.py
+++ b/tests/bgp/test_bgp_vnet_scale.py
@@ -243,14 +243,18 @@ echo "==== PTF cleanup end ===="
     ptfhost.shell("bash {}".format(script_path), module_ignore_errors=True)
 
 
-def generate_dut_config_ptf(vnet_count, subifs_per_vnet, peer_asn, port_bindings, cfg_facts):
+def generate_dut_config_ptf(vnet_count, subifs_per_vnet, peer_asn, port_bindings, cfg_facts, asic_type=None):
     dut_vtep = get_loopback_ip(cfg_facts)
+
+    vxlan_tunnel_entry = {"src_ip": dut_vtep}
+    # On cisco-8000, base topology IP-in-IP decap tunnels may already use pipe TTL mode.
+    # Set VXLAN decap ttl_mode to pipe so orchagent passes DECAP_TTL_MODE consistently.
+    if asic_type == "cisco-8000":
+        vxlan_tunnel_entry["ttl_mode"] = "pipe"
 
     config_db = {
         "VXLAN_TUNNEL": {
-            VXLAN_TUNNEL_NAME: {
-                "src_ip": dut_vtep,
-            }
+            VXLAN_TUNNEL_NAME: vxlan_tunnel_entry,
         },
         "VNET": {},
         "PORTCHANNEL": {},
@@ -467,6 +471,7 @@ def vnet_bgp_setup(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, vnet_count,
             peer_asn,
             wl_bindings,
             cfg_facts,
+            duthost.facts.get("asic_type"),
         )
 
         apply_config_to_dut(duthost, vnet_config, "vnet")


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #  https://github.com/sonic-net/sonic-mgmt/issues/27102

Set `VXLAN_TUNNEL.ttl_mode` to `"pipe"` for `cisco-8000` platforms in the VNET BGP scale test fixture, so orchagent passes `DECAP_TTL_MODE=PIPE` when creating the shared VXLAN tunnel `vtep_v4`.

**Background:**  
T0 topology already has IP-in-IP decap tunnels configured with `ttl_mode: pipe`. Orchagent creates VNET VXLAN tunnels with hardcoded `ENCAP_TTL_MODE=PIPE` but only sends `DECAP_TTL_MODE` when `VXLAN_TUNNEL.ttl_mode` is set in CONFIG_DB. Without it, VXLAN tunnel create can fail on some Cisco platforms and VNET/BGP setup never completes.




<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Test result

master: Fix is already present.
202605: local - PASSED .

### Approach
#### What is the motivation for this PR?
`bgp/test_bgp_vnet_scale_*` can fail on `cisco-8000` during module setup because the shared VXLAN tunnel is created without an explicit decap TTL mode while encap TTL mode is PIPE.

#### How did you do it?
- Added optional `asic_type` parameter to `generate_dut_config_ptf()`.
- Build `VXLAN_TUNNEL` with `src_ip` by default.
- When `asic_type == "cisco-8000"`, add `"ttl_mode": "pipe"`.
- Pass `duthost.facts.get("asic_type")` from `vnet_bgp_setup()`.

#### How did you verify/test it?
- Code review against failing syslog/sairedis evidence from internal CI runs showing VXLAN tunnel create without `DECAP_TTL_MODE`.
- Test is already limited to `pytest.mark.asic("cisco-8000")`.
- Pending: re-run `bgp/test_bgp_vnet_scale_summary` and `bgp/test_bgp_vnet_scale_dataplane` on `cisco-8000` hardware.

#### Any platform specific information?
- Change applies only when `asic_type == "cisco-8000"`.
- No change for other ASICs.
- Aligns test CONFIG with existing pattern used in other VXLAN tests that set `ttl_mode="pipe"`.


#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
