### PR TITLE
[ansible/upgrade]: bind image download to eth0 mgmt path

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -161,7 +161,7 @@ def download_new_sonic_image(module, new_image_url, save_as):
         log("Downloading new image using curl")
         exec_command(
             module,
-            cmd="curl -Lo {} {}".format(save_as, new_image_url),
+            cmd="curl --interface eth0 -Lo {} {}".format(save_as, new_image_url),
             msg="downloading new image"
         )
         log("Completed downloading image")


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (issue)

The DUT downloads the upgrade image itself via `curl`. On a topology where the DUT installs a BGP-learned default route over its data-plane PortChannels, that default route takes precedence over the mgmt path, so traffic to the mgmt image server is sent into the fabric and blackholed. The download fails with `rc=28` (0 bytes) and the upgrade aborts. The mgmt interface can reach the server fine. This binds the download to `eth0` so it always uses the mgmt path, regardless of the BGP default route. `eth0` is the canonical SONiC mgmt port and is already hardcoded elsewhere in this repo (e.g. `dut_basic_facts.py`, `interfaces.j2`).

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Image download runs on the DUT and uses the default route. When the DUT has a BGP-learned default route over data-plane links, the mgmt image server is unreachable and the upgrade fails (`rc=28`).

#### How did you do it?
Add `--interface eth0` to the `curl` command in `download_new_sonic_image` so the download always egresses the mgmt interface.

#### How did you verify/test it?
On an affected DUT, the default `curl` to the image server timed out (`rc=28`) while `curl --interface eth0` returned `HTTP 200`.

#### Any platform specific information?
None.

#### Supported testbed topology if it's a new test case?
N/A.

### Documentation
No.
