### PR TITLE
Fix dualtor link down duplication tolerance

### DIFF
--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -84,10 +84,14 @@ def test_active_link_down_downstream_active(
     Send traffic from T1 to active ToR and shutdown the active ToR link.
     Verify switchover and disruption lasts < 1 second
     """
+    allowed_duplication, merge_duplications = link_down_downstream_active_duplication_setting
+
     if cable_type == CableType.active_standby:
         send_t1_to_server_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs
+            allowed_disruption=3, allowed_duplication=allowed_duplication,
+            action=shutdown_fanout_upper_tor_intfs,
+            merge_duplications_into_disruptions=merge_duplications
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -96,7 +100,6 @@ def test_active_link_down_downstream_active(
         )
 
     if cable_type == CableType.active_active:
-        allowed_duplication, merge_duplications = link_down_downstream_active_duplication_setting
         send_t1_to_server_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
             allowed_disruption=1, allowed_duplication=allowed_duplication,


### PR DESCRIPTION
### Description of PR

Summary:
Apply the existing Cisco/Mellanox dualtor downstream duplication tolerance to the active-standby `test_active_link_down_downstream_active` path.

Fixes # (issue)
Related ADO PBI: 38614035

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

Note: observed on 202605; please consider backporting to 202605 if applicable.

### Approach
#### What is the motivation for this PR?

SONiC nightly on Cisco dualtor active-standby failed because `test_active_link_down_downstream_active` saw burst duplicate packets during active link down (`packet id 7 has 15 duplications`) while the test used the default max duplicate count of 2. The same file already defines platform-specific duplication tolerance for Cisco/Mellanox and applies it to the active-active branch and active ToR downlink tests, but not this active-standby path.

#### How did you do it?

Moved `link_down_downstream_active_duplication_setting` unpacking before the cable-type branch and passed `allowed_duplication` and `merge_duplications_into_disruptions` into the active-standby `send_t1_to_server_with_action` call.

#### How did you verify/test it?

Ran pre-commit on the changed file:
`python -m pre_commit run --files tests/dualtor_io/test_link_failure.py`

#### Any platform specific information?

Cisco/Mellanox dualtor platforms use the existing tolerance; non-Cisco/Mellanox platforms keep the previous default behavior because the fixture returns `None` and `False`.

#### Supported testbed topology if it's a new test case?

N/A. Existing dualtor test.

### Documentation

N/A.