### PR TITLE
Disable memory checks for show techsupport secret tests

### DIFF
--- a/tests/show_techsupport/test_techsupport_no_secret.py
+++ b/tests/show_techsupport/test_techsupport_no_secret.py
@@ -7,7 +7,8 @@ logger = logging.getLogger(__name__)
 
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.disable_memory_utilization
 ]
 
 


### PR DESCRIPTION
### Description of PR
Disable memory utilization monitoring for show techsupport secret validation tests.

The test intentionally runs `show techsupport` and extracts the generated dump. That workload can temporarily raise DUT used memory/page cache and trigger the global memory_utilization fixture even when the functional test passes. Nightly PBI 38614051 failed in teardown with `free:used memory usage increased by 23.0%`, while the test body passed.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [x] 202511

### Approach
#### What is the motivation for this PR?
Avoid false nightly failures from the memory_utilization fixture for a memory-intensive diagnostic dump test.

#### How did you do it?
Added `pytest.mark.disable_memory_utilization` to `tests/show_techsupport/test_techsupport_no_secret.py`.

#### How did you verify/test it?
Static verification of the test marker and the memory_utilization plugin behavior. The plugin explicitly skips monitoring when the marker is present.

#### Any platform specific information?
Observed on 202511 T1 cisco-8000 nightly, but the false memory alarm can occur on multiple platforms.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A