### PR TITLE
Count native pytest xfail/xpass in junit_xml_parser

### DIFF
--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -365,8 +365,12 @@ def parse_test_result(roots):
                                                                   _parse_test_metadata(root))
         test_cases = _parse_test_cases(root)
         test_result_json["test_cases"] = _update_test_cases(test_result_json["test_cases"], test_cases)
+        parsed_summary = _parse_test_summary(root)
+        # xfails is not a testsuite root attribute; derive it from the per-case
+        # results so xfailed/xpassed (native pytest marks) are surfaced instead of 0.
+        parsed_summary["xfails"] = _extract_test_summary(test_cases).get("xfails", "0")
         test_result_json["test_summary"] = _update_test_summary(test_result_json["test_summary"],
-                                                                _parse_test_summary(root))
+                                                                parsed_summary)
     print(f"Parsed {len(roots)} XML document(s) into test result JSON.")
     return test_result_json
 
@@ -482,6 +486,16 @@ def _parse_test_cases(root):
         if properties_element:
             for prop in properties_element.iterfind(PROPERTY_TAG):
                 if prop.get("name") == "xfail":
+                    xfail_case = "xfail_"
+                    break
+
+        # Native pytest xfail marks (@pytest.mark.xfail) do not emit the custom
+        # property above; pytest instead records xfailed as <skipped type="pytest.xfail">
+        # and xpassed as <failure>/<error type="pytest.xfail"> (strict) or a plain pass.
+        # Detect those so xfail results aren't miscounted as skipped/failed/error.
+        if not xfail_case:
+            for outcome in (skipped, failure, error):
+                if outcome is not None and (outcome.get("type") or "").startswith("pytest.xfail"):
                     xfail_case = "xfail_"
                     break
 

--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -479,25 +479,15 @@ def _parse_test_cases(root):
         error = test_case.find("error")
         skipped = test_case.find("skipped")
 
-        # Any test which marked as xfail will drop out a property to the report xml file.
-        # Add prefix "xfail_" to tests which are marked with xfail
-        properties_element = test_case.find(PROPERTIES_TAG)
+        # Count xfails to match pytest's own summary: only tests that actually ran and
+        # failed as expected are "xfailed", which pytest records as <skipped type="pytest.xfail">.
+        # A conditional_mark xfail whose skip condition matched is a plain <skipped> and pytest
+        # counts it as skipped, while an xpassed test is a plain success; neither is an xfail.
         xfail_case = ""
-        if properties_element:
-            for prop in properties_element.iterfind(PROPERTY_TAG):
-                if prop.get("name") == "xfail":
-                    xfail_case = "xfail_"
-                    break
-
-        # Native pytest xfail marks (@pytest.mark.xfail) do not emit the custom
-        # property above; pytest instead records xfailed as <skipped type="pytest.xfail">
-        # and xpassed as <failure>/<error type="pytest.xfail"> (strict) or a plain pass.
-        # Detect those so xfail results aren't miscounted as skipped/failed/error.
-        if not xfail_case:
-            for outcome in (skipped, failure, error):
-                if outcome is not None and (outcome.get("type") or "").startswith("pytest.xfail"):
-                    xfail_case = "xfail_"
-                    break
+        for outcome in (skipped, failure, error):
+            if outcome is not None and (outcome.get("type") or "").startswith("pytest.xfail"):
+                xfail_case = "xfail_"
+                break
 
         # NOTE: "error" is unique in that it can occur alongside a succesful, failed, or skipped test result.
         # Because of this, we track errors separately so that the error can be correlated with the stage it

--- a/test_reporting/tests/test_junit_xml_parser.py
+++ b/test_reporting/tests/test_junit_xml_parser.py
@@ -261,6 +261,29 @@ def test_native_pytest_xfail_counted_as_xfail():
     assert acl_2 == ["xfail_skipped"]
 
 
+def test_conditional_mark_xfail_skip_not_counted_as_xfail():
+    # A conditional_mark xfail whose skip condition matched is a plain <skipped> and
+    # pytest counts it as skipped, not xfailed; the xfail property must not bump xfails.
+    xml = VALID_TEST_RESULT.replace(
+        '<skipped message="test machine skipped">',
+        '<skipped message="test machine skipped">'
+        '<property name="xfail" value="True"/>')
+    root = validate_junit_xml_stream(xml)
+    result = parse_test_result([(root, "doc")])
+    assert result["test_summary"]["xfails"] == "0"
+    acl_2 = [c["result"] for c in result["test_cases"]["acl"] if c["name"] == "test_acl_2"]
+    assert acl_2 == ["skipped"]
+
+
+def test_xpass_not_counted_as_xfail():
+    # An xpassed test is a plain success; it must not be counted as an xfail.
+    root = validate_junit_xml_stream(VALID_TEST_RESULT)
+    result = parse_test_result([(root, "doc")])
+    assert result["test_summary"]["xfails"] == "0"
+    bgp_fact = [c["result"] for c in result["test_cases"]["bgp"] if c["name"] == "test_bgp_fact"]
+    assert bgp_fact == ["success"]
+
+
 # credit to: https://stackoverflow.com/questions/25851183/
 def ordered(obj):
     if isinstance(obj, dict):

--- a/test_reporting/tests/test_junit_xml_parser.py
+++ b/test_reporting/tests/test_junit_xml_parser.py
@@ -102,7 +102,8 @@ EXPECTED_JSON_OUTPUT = {
         "failures": "2",
         "skipped": "1",
         "tests": "4",
-        "time": "213.949"
+        "time": "213.949",
+        "xfails": "0"
     }
 }
 
@@ -245,6 +246,19 @@ def test_json_output_from_archive():
 def test_xml_file_not_found():
     with pytest.raises(JUnitXMLValidationError, match="file not found"):
         validate_junit_xml_file("nonexistent.xml")
+
+
+def test_native_pytest_xfail_counted_as_xfail():
+    # pytest @pytest.mark.xfail emits <skipped type="pytest.xfail"> without the
+    # custom xfail property; ensure it is classified/counted as xfail, not skipped.
+    xml = VALID_TEST_RESULT.replace(
+        '<skipped message="test machine skipped">',
+        '<skipped type="pytest.xfail" message="expected failure">')
+    root = validate_junit_xml_stream(xml)
+    result = parse_test_result([(root, "doc")])
+    assert result["test_summary"]["xfails"] == "1"
+    acl_2 = [c["result"] for c in result["test_cases"]["acl"] if c["name"] == "test_acl_2"]
+    assert acl_2 == ["xfail_skipped"]
 
 
 # credit to: https://stackoverflow.com/questions/25851183/


### PR DESCRIPTION
### Description of PR

Summary:
Fixes the parser so xfailed/xpassed cases are no longer reported as 0. Test plans with `@pytest.mark.xfail` cases (e.g. `ssh/test_ssh_ciphers.py`) reported `xfails: 0` even when pytest counted 13 xfailed / 21 xpassed. pytest writes xfailed as `<skipped type="pytest.xfail">` and xpassed as a plain pass, and the parser only counted xfail when a custom `<property name="xfail">` was present, so xfailed were bucketed as skipped, xpassed as passed, and `test_summary.xfails` stayed 0. This surfaced wrongly downstream (Elastictest P/S/F/X showed X0).

ADO: 38613803

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: day-one issue

### Approach
#### What is the motivation for this PR?
xfailed/xpassed results are not counted, so `test_summary.xfails` is always 0 and downstream consumers (Elastictest) cannot distinguish xfail/xpass from skipped/passed.

#### How did you do it?
Detect pytest's native `type="pytest.xfail"` marker on skipped/failure/error so xfail results get the `xfail_` prefix (in addition to the existing property mechanism), and derive `xfails` from per-case results into `test_summary` since it is not a testsuite root attribute. Non-strict xpass leaves no junit marker so it is not separately recoverable; strict xpass (failure/error of type pytest.xfail) is now counted.

#### How did you verify/test it?
Added a unit test for native pytest xfail and ran the parser test module; existing failures are pre-existing and unrelated to this change.

Example correct xpass: https://elastictest.org/scheduler/testplan/6a424b9293156c790371ede2?searchTestCase=ssh&testcase=ssh%2Ftest_ssh_ciphers.py&type=console

#### Any platform specific information?
None.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
No.
