### PR TITLE
[dhcp_relay] Skip standby ACL teardown check after test failure

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -202,7 +202,7 @@ def get_acl_count_by_mark(rand_unselected_dut, mark):
 
 
 @pytest.fixture(scope="function")
-def verify_acl_drop_on_standby_tor(rand_unselected_dut, dut_dhcp_relay_data, testing_config, tbinfo):
+def verify_acl_drop_on_standby_tor(rand_unselected_dut, dut_dhcp_relay_data, testing_config, tbinfo, request):
     testing_mode, _ = testing_config
     if testing_mode == DUAL_TOR_MODE and "dualtor-aa" not in tbinfo["topo"]["name"]:
         pre_client_dhcp_acl_counts = {}
@@ -221,6 +221,10 @@ def verify_acl_drop_on_standby_tor(rand_unselected_dut, dut_dhcp_relay_data, tes
                                                                                                mark)
 
     yield
+
+    if hasattr(request.node, "rep_call") and request.node.rep_call.failed:
+        logger.info("Skip standby ToR ACL drop validation because the test call failed")
+        return
 
     if testing_mode == DUAL_TOR_MODE and "dualtor-aa" not in tbinfo["topo"]["name"]:
         for client_interface_name, item in pre_client_dhcp_acl_counts.items():


### PR DESCRIPTION
### Description of PR

Summary:
Avoid masking the original DHCP relay PTF failure with a secondary standby ToR ACL drop-count teardown assertion.

Fixes # (issue)
Related ADO PBI: 38614057

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

### Approach
#### What is the motivation for this PR?

In dual-ToR DHCP relay tests, verify_acl_drop_on_standby_tor validates an exact ACL drop delta during fixture teardown. When the test body fails before all DHCP client packets are sent, the teardown still expects the full CLIENT_SENT_PACKET_COUNT delta and raises Drop count ... unexpected, which hides the primary PTF failure.

#### How did you do it?

Inject the pytest 
request fixture and skip the standby ACL drop validation when 
request.node.rep_call.failed is true. Successful test calls still run the same ACL drop-count validation as before.

#### How did you verify/test it?

Ran local validation on the changed file:
- python -m pre_commit run --files tests/dhcp_relay/test_dhcp_relay.py
- python -m py_compile tests\dhcp_relay\test_dhcp_relay.py
- git diff --check

#### Any platform specific information?

Observed in PBI 38614057 on dualtor Arista-7260CX3 and Cisco-8101 platforms; the fix is test-framework logic for all dual-ToR DHCP relay runs.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A