### PR TITLE
Fix iface namingmode CMIS loganalyzer ignore

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -41,7 +41,8 @@ def ignore_host_lane_count_loganalyzer(enum_rand_one_per_hwsku_frontend_hostname
         # when loganalyzer is disabled, the object could be None
         if loganalyzer:
             ignoreRegex = [
-                (".*ERR pmon#xcvrd.*: no suitable app for the port appl .* host_lane_count [0-9] host_speed.*"),
+                (".*ERR pmon#(xcvrd|CmisManagerTask).*:.*no suitable app for the port appl .* "
+                 "host_lane_count [0-9]+ host_speed.*"),
             ]
             loganalyzer[enum_rand_one_per_hwsku_frontend_hostname].ignore_regex.extend(ignoreRegex)
 
@@ -1282,7 +1283,8 @@ class TestConfigInterface():
         configure_speed = supported_speeds[0] if supported_speeds else native_speed
 
         ignore_host_lane_count_loganalyzer(ignore_condition=duthost.facts['hwsku'] in ["Arista-7060X6-64PE-P32O64",
-                                                                                       "Arista-7060X6-64PE-P64"])
+                                                                                       "Arista-7060X6-64PE-P64",
+                                                                                       "Cisco-8102-28FH-DPU-O"])
 
         if not self.check_speed_change(duthost, asic_index, interface, configure_speed):
             pytest.skip(


### PR DESCRIPTION
### Description of PR

Summary:
Fixes loganalyzer teardown failures in `iface_namingmode/test_iface_namingmode.py::TestConfigInterface::test_config_interface_speed` when Cisco-8102-28FH-DPU-O emits CMIS `no suitable app for the port` syslog messages during runtime interface speed changes.

Related ADO PBI: 38614066

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

The nightly PBI 38614066 tracks `test_config_interface_speed` failures on Cisco-8102-28FH-DPU-O. The test passes its speed-change assertions, but loganalyzer fails during teardown because `pmon#CmisManagerTask` emits `no suitable app for the port appl ... host_lane_count ... host_speed ...` while the port speed is changed.

The existing ignore helper only matched `pmon#xcvrd` format and was enabled only for selected Arista platforms, so it did not cover the Cisco-8102 CMIS log format.

#### How did you do it?

Expanded the expected loganalyzer ignore regex to match both `xcvrd` and `CmisManagerTask` CMIS formats, and enabled the ignore for `Cisco-8102-28FH-DPU-O` in `test_config_interface_speed`.

#### How did you verify/test it?

Ran pre-commit on the changed file:

`python -m pre_commit run --files tests/iface_namingmode/test_iface_namingmode.py`

All hooks passed, including flake8.

#### Any platform specific information?

Cisco-8102-28FH-DPU-O.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.