### PR TITLE
Skip test_system_is_running on KVM via conditional_mark

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5528,6 +5528,12 @@ system_health/test_system_health.py::test_service_checker_with_process_exit:
       - "branch in ['internal-202012']"
       - "build_version.split('.')[1].isdigit() and int(build_version.split('.')[1]) <= 44"
 
+system_health/test_system_status.py::test_system_is_running:
+  skip:
+    reason: "watchdog-control can not load on kvm testbed, leaving the system in 'degraded' state so 'systemctl is-system-running' never returns 'running'."
+    conditions:
+      - "https://github.com/sonic-net/sonic-buildimage/issues/19879 and asic_type in ['vs']"
+
 system_health/test_watchdog.py::test_orchagent_watchdog:
   skip:
     reason: "orchagent watchdog test requires SWSS/orchagent; BMC SONiC image has no orchagent"


### PR DESCRIPTION
Summary: Skip test_system_is_running on KVM
Fixes # (issue)


### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [x] 202608

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [x] 202608

### Test result
- master: case skip as expected
- 202605: case skip as expected
- 202608: case skip as expected

Tracking issue/work item for backport/cherry-pick request:
Failure type:

### Approach
#### What is the motivation for this PR?
`test_system_is_running` only treated the `starting` state as "not ready", so any other `systemctl is-system-running` result — including `degraded` — was considered a pass.

PR https://github.com/sonic-net/sonic-mgmt/pull/25656 changes the readiness check to require the **running** state instead. The change will affect the case run on KVM platform.

On KVM the watchdog-control service cannot load, leaving the system in degraded state, so 'systemctl is-system-running' never returns 'running'. 

#### How did you do it?
Skip the case on vs platform

#### How did you verify/test it?
Regression pass

#### Any platform specific information?
vs platform

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
