### PR TITLE
Fix LLDP restart regression on SONiC fanouts in QoS tests

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -3633,17 +3633,22 @@ class QosSaiBase(QosBase):
             if was_running:
                 try:
                     fanout = fanouthosts[fanout_name]
-                    fanout.host.command(
+                    result = fanout.host.command(
                         "docker start lldp", module_ignore_errors=True)
-                    logger.info(
-                        "permit_only_test_traffic_on_fanout: restarted lldp "
-                        "container on SONiC %s (was originally running)",
-                        fanout_name)
+                    # Check return code to avoid false positive in logs
+                    if result.get('rc', 0) == 0:
+                        logger.info(
+                            "permit_only_test_traffic_on_fanout: restarted lldp "
+                            "container on SONiC %s (was originally running)", fanout_name)
+                    else:
+                        logger.warning(
+                            "permit_only_test_traffic_on_fanout: " 
+                            "docker start lldp on SONiC %s returned rc=%s, "
+                            "LLDP may not be running", fanout_name, result.get('rc', '?'))
                 except Exception as e:
                     logger.warning(
                         "permit_only_test_traffic_on_fanout: "
-                        "failed to restart lldp on SONiC %s: %s",
-                        fanout_name, str(e))
+                        "failed to restart lldp on SONiC %s: %s", fanout_name, str(e))
             else:
                 logger.info(
                     "permit_only_test_traffic_on_fanout: NOT restarting lldp "

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -3336,7 +3336,7 @@ class QosSaiBase(QosBase):
         eos_restore_list = []
         fanout_restore_list = []
         acl_created_fanouts = {}  # fanout_name -> fanout_os (for cleanup dispatch)
-        sonic_lldp_stopped = set()  # fanout names where we stopped lldp container
+        sonic_lldp_stopped = {}  # fanout_name -> was_running (True if LLDP was originally running)
         lacpd_stopped = False
         acl_name = "QOS_TEST_WHITELIST"
         teamd_docker = src_asic.get_docker_name("teamd")
@@ -3525,13 +3525,16 @@ class QosSaiBase(QosBase):
         # Stop LLDP container once per fanout (covers fanout-self LLDP).
         # The 202511 fanout role only stops LLDP for marvell-teralynx;
         # broadcom SONiC fanouts still run LLDP by default.
-        # Assumption: LLDP is running before the test; "docker stop" rc=0 does
-        # not distinguish "stopped now" from "was already stopped", so the
-        # teardown's symmetric "docker start" will start LLDP even on fanouts
-        # where it was previously off. This is acceptable for the testbeds
-        # in scope (#24236) where LLDP runs by default on Broadcom SONiC.
+        # Fix for regression from PR #24317: Check if LLDP was originally running
+        # before stopping. Only restart in teardown if it was originally running.
+        # This preserves the fanout's original LLDP state.
         if fanout_name not in sonic_lldp_stopped:
             try:
+                # Check if LLDP container was running BEFORE stopping it
+                check_result = fanout.host.shell(
+                    "docker ps -q -f name=lldp", module_ignore_errors=True)
+                was_running = bool(check_result.get('stdout', '').strip())
+
                 result = fanout.host.command(
                     "docker stop lldp", module_ignore_errors=True)
                 if result.get('failed', False) or result.get('rc', 0) != 0:
@@ -3541,10 +3544,12 @@ class QosSaiBase(QosBase):
                         "output=%s", fanout_name, result.get('rc', '?'),
                         result.get('stdout', result.get('stderr', '')))
                 else:
-                    sonic_lldp_stopped.add(fanout_name)
+                    # Store original state so we only restart if it was running
+                    sonic_lldp_stopped[fanout_name] = was_running
                     logger.info(
                         "permit_only_test_traffic_on_fanout: stopped lldp "
-                        "container on SONiC %s", fanout_name)
+                        "container on SONiC %s (was_running=%s)",
+                        fanout_name, was_running)
             except Exception as e:
                 logger.warning(
                     "permit_only_test_traffic_on_fanout: "
@@ -3621,17 +3626,28 @@ class QosSaiBase(QosBase):
                     "permit_only_test_traffic_on_fanout: "
                     "failed to delete ACL on %s: %s", fanout_name, str(e))
 
-        # Restart LLDP container on SONiC fanouts where we stopped it
-        for fanout_name in sonic_lldp_stopped:
-            try:
-                fanout = fanouthosts[fanout_name]
-                fanout.host.command(
-                    "docker start lldp", module_ignore_errors=True)
-            except Exception as e:
-                logger.warning(
-                    "permit_only_test_traffic_on_fanout: "
-                    "failed to restart lldp on SONiC %s: %s",
-                    fanout_name, str(e))
+        # Restart LLDP container on SONiC fanouts ONLY if it was originally running
+        # This fixes the regression from PR #24317 where LLDP was restarted
+        # unconditionally, even on fanouts where it was disabled by design.
+        for fanout_name, was_running in sonic_lldp_stopped.items():
+            if was_running:
+                try:
+                    fanout = fanouthosts[fanout_name]
+                    fanout.host.command(
+                        "docker start lldp", module_ignore_errors=True)
+                    logger.info(
+                        "permit_only_test_traffic_on_fanout: restarted lldp "
+                        "container on SONiC %s (was originally running)",
+                        fanout_name)
+                except Exception as e:
+                    logger.warning(
+                        "permit_only_test_traffic_on_fanout: "
+                        "failed to restart lldp on SONiC %s: %s",
+                        fanout_name, str(e))
+            else:
+                logger.info(
+                    "permit_only_test_traffic_on_fanout: NOT restarting lldp "
+                    "on SONiC %s (was not originally running)", fanout_name)
 
         logger.info("permit_only_test_traffic_on_fanout: teardown complete")
 

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -3642,7 +3642,7 @@ class QosSaiBase(QosBase):
                             "container on SONiC %s (was originally running)", fanout_name)
                     else:
                         logger.warning(
-                            "permit_only_test_traffic_on_fanout: " 
+                            "permit_only_test_traffic_on_fanout: "
                             "docker start lldp on SONiC %s returned rc=%s, "
                             "LLDP may not be running", fanout_name, result.get('rc', '?'))
                 except Exception as e:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes the regression introduced by PR #24317 where LLDP was unconditionally restarted on SONiC fanouts during QoS test teardown, causing subsequent LLDP tests to fail with dual-neighbor mismatches.

Fixes # (issue)
Check if LLDP container was running before stopping it, and only restart during teardown if it was originally running. This preserves the fanout's original LLDP state.
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
PR #24317 added SONiC fanout support to permit_only_test_traffic_on_fanout() in qos_sai_base.py. The implementation stops the LLDP container on SONiC fanouts during test setup and unconditionally restarts it during teardown via docker start lldp.

This causes a regression on testbeds where LLDP is intentionally disabled on the fanout (e.g., marvell-teralynx fanouts, or any fanout where LLDP was manually disabled). After QoS tests complete, the teardown restarts LLDP even though it was originally off.

Impact: On dualtor topologies, when fanout LLDP is restarted:

1. The DUT sees dual LLDP neighbors on uplink ports (T1 VM + fanout)
2. lldpctl returns more neighbor entries than LLDP_ENTRY_TABLE keys
3. test_lldp_syncd.py fails with: LLDP_ENTRY_TABLE keys do not match lldpctl interface indexes

This was observed on multiple testbeds where ~30% of LLDP test runs failed intermittently depending on whether QoS tests ran before them.

#### How did you do it?
Modified permit_only_test_traffic_on_fanout() to preserve the fanout's original LLDP state:

1. Changed sonic_lldp_stopped from set() to dict() to track both the fanout name and whether LLDP was originally running

2. Added state check before stopping LLDP:
```
check_result = fanout.host.shell("docker ps -q -f name=lldp", module_ignore_errors=True)
was_running = bool(check_result.get('stdout', '').strip())
```

3. Store original state in dict:

```sonic_lldp_stopped[fanout_name] = was_running```

4. Modified teardown to conditionally restart:
```
for fanout_name, was_running in sonic_lldp_stopped.items():
    if was_running:
        fanout.host.command("docker start lldp", module_ignore_errors=True)
    else:
        logger.info("NOT restarting lldp on %s (was not originally running)", fanout_name)
  ```
#### How did you verify/test it?

1. Reproduced the issue: On m6-28 testbed with LLDP disabled on fanout:

- Ran QoS test → LLDP restarted on fanout during teardown
- Ran test_lldp_syncd.py → Failed with dual-neighbor mismatch

2. Verified the fix:

- Applied the fix
- Ran QoS test → LLDP NOT restarted (was_running=False logged)
- Ran test_lldp_syncd.py → Passed (only T1 VM neighbors seen)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
