### PR TITLE
extend db_config_timeout due to bad ssh connection

### DIFF
--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -672,6 +672,11 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
         # files AND redis connectivity before running config_reload, which also waits
         # for BGP sessions to re-establish.
         db_config_timeout = 120
+
+        WEAK_CPU_PALTFORM_LIST = ['x86_64-mlnx_msn2700-r0']
+        # extra timeout needed for platforms with weak cpu
+        if duthost.facts["platform"] in WEAK_CPU_PALTFORM_LIST:
+            db_config_timeout = 240
         if duthost.facts.get("modular_chassis"):
             db_config_timeout = max(db_config_timeout, 600)
 

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -672,6 +672,11 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
         # files AND redis connectivity before running config_reload, which also waits
         # for BGP sessions to re-establish.
         db_config_timeout = 120
+
+        WEAK_CPU_PLATFORM_LIST = ['x86_64-mlnx_msn2700-r0']
+        # extra timeout needed for platforms with weak cpu
+        if duthost.facts["platform"] in WEAK_CPU_PLATFORM_LIST:
+            db_config_timeout = 240
         if duthost.facts.get("modular_chassis"):
             db_config_timeout = max(db_config_timeout, 600)
 


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (issue)

On Mellanox SN2700, this test can fail because the correct ssh connection can not be established in 120s. In two tries, the test cannot detect the existence of database_config.json. 

`Failed: database_config.json not ready after 120s -- DUT recovery incomplete`

log below can be observed, indicating that the ansible job hang till timeout. 

```
DEBUG    tests.common.utilities:utilities.py:137 Wait until _all_db_configs_ready is True, timeout is 120 seconds, checking interval is 5, delay is 0 seconds
DEBUG    tests.common.utilities:utilities.py:147 Time elapsed: 0.000000 seconds
DEBUG    tests.common.devices.base:base.py:177 /root/mars/workspace/sonic-mgmt/tests/common/devices/base.py::_run_wrapper#163: AnsibleModule::shell, args=["test -f /var/run/redis/sonic-db/database_config.json"], kwargs={"module_ignore_errors": true}
INFO     root:__init__.py:199 [Parallel Fixture] Current worker threads status:
No alive worker thread found.
INFO     root:__init__.py:199 [Parallel Fixture] Current worker threads status:
No alive worker thread found.
INFO     root:__init__.py:199 [Parallel Fixture] Current worker threads status:
No alive worker thread found.
INFO     root:__init__.py:199 [Parallel Fixture] Current worker threads status:
No alive worker thread found.
INFO     root:__init__.py:199 [Parallel Fixture] Current worker threads status:
No alive worker thread found.
INFO     root:__init__.py:199 [Parallel Fixture] Current worker threads status:
No alive worker thread found.
INFO     root:__init__.py:199 [Parallel Fixture] Current worker threads status:
No alive worker thread found.
DEBUG    tests.common.devices.base:base.py:225 /root/mars/workspace/sonic-mgmt/tests/common/devices/base.py::_run_wrapper#163: AnsibleModule::shell Result => {"failed": true, "msg": "Timeout (62s) waiting for privilege escalation prompt: ", "_ansible_no_log": false}
ERROR    tests.common.utilities:utilities.py:154 Exception caught while checking _all_db_configs_ready:Traceback (most recent call last):
  File "/root/mars/workspace/sonic-mgmt/tests/common/utilities.py", line 150, in wait_until
    check_result = condition(*args, **kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/mars/workspace/sonic-mgmt/tests/process_monitoring/test_critical_process_monitoring.py", line 691, in _all_db_configs_ready
    if duthost.shell(
       ^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/collections/__init__.py", line 1135, in __getitem__
    raise KeyError(key)
KeyError: 'rc'
, error:'rc'
DEBUG    tests.common.utilities:utilities.py:165 _all_db_configs_ready is False, wait 5 seconds and check again
DEBUG    tests.common.utilities:utilities.py:147 Time elapsed: 67.123199 seconds
DEBUG    tests.common.devices.base:base.py:177 /root/mars/workspace/sonic-mgmt/tests/common/devices/base.py::_run_wrapper#163: AnsibleModule::shell, args=["test -f /var/run/redis/sonic-db/database_config.json"], kwargs={"module_ignore_errors": true}
INFO     root:__init__.py:199 [Parallel Fixture] Current worker threads status:
No alive worker thread found.
INFO     root:__init__.py:199 [Parallel Fixture] Current worker threads status:
No alive worker thread found.
INFO     root:__init__.py:199 [Parallel Fixture] Current worker threads status:
No alive worker thread found.
INFO     root:__init__.py:199 [Parallel Fixture] Current worker threads status:
No alive worker thread found.
INFO     root:__init__.py:199 [Parallel Fixture] Current worker threads status:
No alive worker thread found.
INFO     root:__init__.py:199 [Parallel Fixture] Current worker threads status:
No alive worker thread found.
DEBUG    tests.common.devices.base:base.py:225 /root/mars/workspace/sonic-mgmt/tests/common/devices/base.py::_run_wrapper#163: AnsibleModule::shell Result => {"failed": true, "msg": "Timeout (62s) waiting for privilege escalation prompt: ", "_ansible_no_log": false}
ERROR    tests.common.utilities:utilities.py:154 Exception caught while checking _all_db_configs_ready:Traceback (most recent call last):
  File "/root/mars/workspace/sonic-mgmt/tests/common/utilities.py", line 150, in wait_until
    check_result = condition(*args, **kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/mars/workspace/sonic-mgmt/tests/process_monitoring/test_critical_process_monitoring.py", line 691, in _all_db_configs_ready
    if duthost.shell(
       ^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/collections/__init__.py", line 1135, in __getitem__
    raise KeyError(key)
KeyError: 'rc'
, error:'rc'
DEBUG    tests.common.utilities:utilities.py:165 _all_db_configs_ready is False, wait 5 seconds and check again
INFO     root:__init__.py:199 [Parallel Fixture] Current worker threads status:
No alive worker thread found.
DEBUG    tests.common.utilities:utilities.py:170 _all_db_configs_ready is still False after 120 seconds, exit with False
```
### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: 

### Approach
#### What is the motivation for this PR?
Fix a faliure
#### How did you do it?
Extend the timeout so that correct connect can setup
#### How did you verify/test it?
The test can pass on SN2700 with new timeout. We think that this issue is related to the way how ansible control master handle the ssh connection. The first round of 'test -f' always hang until timeout(62s) even though on some setup the test cas pass. When testing in local, I tried to kill the control master process to establish a new ssh connection after the power cycle, the command directly returned in seconds. Please check if this is a bug.
#### Any platform specific information?
Currently only observed on Mellanox 2700, can be fixed by extend the timeout
#### Supported testbed topology if it's a new test case?

### Documentation