### PR TITLE
Test PFC RX frames do not increment port RX counters

### DIFF
--- a/tests/common/helpers/pfc_counters.py
+++ b/tests/common/helpers/pfc_counters.py
@@ -7,6 +7,7 @@ counter verification without cross-feature imports.
 """
 
 from tests.common.platform.device_utils import eos_to_linux_intf, nxos_to_linux_intf, sonic_to_linux_intf
+from tests.common.helpers.drop_counters.drop_counters import GET_L2_COUNTERS, get_pkt_drops
 import os
 import time
 import pytest
@@ -25,6 +26,12 @@ PFC_GEN_FILE_ABSOLUTE_PATH = r'/root/pfc_gen_cpu.py'
 PKT_COUNT = 10
 """ Number of switch priorities """
 PRIO_COUNT = 8
+""" Name of the PFC storm container on MLNX-OS (Onyx) fanout switches """
+ONYX_PFC_CONTAINER_NAME = 'storm'
+""" Number of PFC frames sent per priority per port in the RX_OK isolation test """
+PFC_RX_OK_ISOLATION_PKT_COUNT = 5000
+""" Allowed RX_OK/RX_DRP increase per interface to tolerate background traffic """
+RX_COUNTER_BACKGROUND_MARGIN = 500
 
 
 @pytest.fixture(scope="module")
@@ -66,6 +73,49 @@ def setup_testbed(fanouthosts, duthost, leaf_fanouts):                   # noqa:
         peerdev_ans.host.copy(src=PFC_GEN_FILE_PATH, dest=PFC_GEN_FILE_DEST, force=True)
 
 
+def _resolve_peer_port_name(peerdev_ans, enum_fanout_graph_facts, peer_port):       # noqa: F811
+    """
+    @summary: Map a fanout peer port to its Linux interface name based on the
+              fanout switch OS, and return it together with the fanout HwSku.
+    @param peerdev_ans: Fanout host ansible handle
+    @param enum_fanout_graph_facts: Fanout connection graph facts
+    @param peer_port: Peer port name on the fanout switch
+    @return: Tuple of (peer_port_name, fanout_hwsku)
+    """
+    fanout_os = peerdev_ans.get_fanout_os()
+    fanout_hwsku = enum_fanout_graph_facts[peerdev_ans.hostname]["device_info"]["HwSku"]
+    if fanout_os == "nxos":
+        peer_port_name = nxos_to_linux_intf(peer_port)
+    elif fanout_os == "sonic":
+        peer_port_name = sonic_to_linux_intf(peer_port)
+    else:
+        peer_port_name = eos_to_linux_intf(peer_port, hwsku=fanout_hwsku)
+    return peer_port_name, fanout_hwsku
+
+
+def send_pfc_frame(peerdev_ans, peer_port_name, fanout_hwsku, priority,
+                   pause_time, pkt_count):
+    """
+    @summary: Send `pkt_count` PFC pause frames targeting a single priority to
+              one fanout port.
+    @param peerdev_ans: Fanout host ansible handle
+    @param peer_port_name: Linux interface name on the fanout switch
+    @param fanout_hwsku: Fanout switch HwSku (used to detect MLNX-OS/Onyx)
+    @param priority: PFC priority (0-7); encoded as a class-enable bitmap
+    @param pause_time: Pause time quanta (0-65535); 0 means unpause
+    @param pkt_count: Number of frames to generate
+    """
+    if fanout_hwsku == "MLNX-OS":
+        cmd = 'docker exec %s "python %s -i %s -p %d -t %d -n %d"' % (
+            ONYX_PFC_CONTAINER_NAME, PFC_GEN_FILE_ABSOLUTE_PATH,
+            peer_port_name, 2 ** priority, pause_time, pkt_count)
+        peerdev_ans.host.config(cmd)
+    else:
+        cmd = "sudo python %s -i %s -p %d -t %d -n %d" % (
+            PFC_GEN_FILE_DEST, peer_port_name, 2 ** priority, pause_time, pkt_count)
+        peerdev_ans.host.command(cmd)
+
+
 def run_test(fanouthosts, duthost, conn_graph_facts, enum_fanout_graph_facts, leaf_fanouts,       # noqa: F811
              is_pfc=True, pause_time=65535, check_continuous_pfc=False):
     """
@@ -80,7 +130,7 @@ def run_test(fanouthosts, duthost, conn_graph_facts, enum_fanout_graph_facts, le
     asic = duthost.asic_instance()
     asic_type = duthost.facts["asic_type"]
     conn_facts = conn_graph_facts['device_conn'].get(duthost.hostname, {})
-    onyx_pfc_container_name = 'storm'
+    onyx_pfc_container_name = ONYX_PFC_CONTAINER_NAME
     int_status = asic.show_interface(command="status")[
         'ansible_facts']['int_status']
     """ We only test active physical interfaces that have connection graph entries """
@@ -106,27 +156,13 @@ def run_test(fanouthosts, duthost, conn_graph_facts, enum_fanout_graph_facts, le
                     continue
 
                 peerdev_ans = fanouthosts[peer_device]
-                fanout_os = peerdev_ans.get_fanout_os()
-                fanout_hwsku = enum_fanout_graph_facts[peerdev_ans.hostname]["device_info"]["HwSku"]
-                if fanout_os == "nxos":
-                    peer_port_name = nxos_to_linux_intf(peer_port)
-                elif fanout_os == "sonic":
-                    peer_port_name = sonic_to_linux_intf(peer_port)
-                else:
-                    peer_port_name = eos_to_linux_intf(
-                        peer_port, hwsku=fanout_hwsku)
+                peer_port_name, fanout_hwsku = _resolve_peer_port_name(
+                    peerdev_ans, enum_fanout_graph_facts, peer_port)
 
                 if is_pfc:
                     for priority in range(PRIO_COUNT):
-                        if fanout_hwsku == "MLNX-OS":
-                            cmd = 'docker exec %s "python %s -i %s -p %d -t %d -n %d"' % (
-                                onyx_pfc_container_name, PFC_GEN_FILE_ABSOLUTE_PATH,
-                                peer_port_name, 2 ** priority, pause_time, PKT_COUNT)
-                            peerdev_ans.host.config(cmd)
-                        else:
-                            cmd = "sudo python %s -i %s -p %d -t %d -n %d" % (
-                                PFC_GEN_FILE_DEST, peer_port_name, 2 ** priority, pause_time, PKT_COUNT)
-                            peerdev_ans.host.command(cmd)
+                        send_pfc_frame(peerdev_ans, peer_port_name, fanout_hwsku,
+                                       priority, pause_time, PKT_COUNT)
                 else:
                     if fanout_hwsku == "MLNX-OS":
                         cmd = 'docker exec %s "python %s -i %s -g -t %d -n %d"' % (
@@ -254,3 +290,103 @@ def run_test(fanouthosts, duthost, conn_graph_facts, enum_fanout_graph_facts, le
                             "PFC RX counter value is not zero for interface {} and priority {}. "
                             "Expected value: 0, but got {}."
                         ).format(intf, i, pfc_rx[intf]['Rx'][i])
+
+
+def get_rx_port_counters(duthost):
+    """
+    @summary: Retrieve RX_OK and RX_DRP counters for all ports in a single
+              `portstat -j` pass (multi-ASIC aware via get_pkt_drops).
+    @param duthost: dut host information
+    @return: Dict mapping interface name to {'RX_OK': int, 'RX_DRP': int}
+    """
+    raw_counters = get_pkt_drops(duthost, GET_L2_COUNTERS)
+
+    counters = {}
+    for port, stats in list(raw_counters.items()):
+        rx_ok = stats.get('RX_OK')
+        rx_drp = stats.get('RX_DRP')
+        counters[port] = {
+            'RX_OK': int(str(rx_ok).replace(',', '')) if rx_ok not in (None, 'N/A') else 0,
+            'RX_DRP': int(str(rx_drp).replace(',', '')) if rx_drp not in (None, 'N/A') else 0,
+        }
+    return counters
+
+
+def run_rx_ok_isolation_test(fanouthosts, duthost, conn_graph_facts,       # noqa: F811
+                             enum_fanout_graph_facts, leaf_fanouts,
+                             pkt_count=PFC_RX_OK_ISOLATION_PKT_COUNT,
+                             margin=RX_COUNTER_BACKGROUND_MARGIN,
+                             pause_time=65535):
+    """
+    @summary: Verify that PFC pause frames are consumed by the MAC and are NOT
+              counted as normal RX packets (RX_OK) or RX drops (RX_DRP) on the
+              DUT interfaces.
+
+              A large burst of PFC frames is sent across all priorities to every
+              active physical interface first; only then is a single counter
+              snapshot compared against the baseline (one stats retrieval pass).
+              The RX_OK and RX_DRP deltas must each stay within `margin` to
+              tolerate background control-plane traffic.
+    @param duthost: The object for interacting with DUT through ansible
+    @param conn_graph_facts: Testbed topology connectivity information
+    @param leaf_fanouts: Leaf fanout switches
+    @param pkt_count: Number of PFC frames to send per priority per port
+    @param margin: Allowed RX_OK/RX_DRP increase per interface
+    @param pause_time: Pause time quanta (0-65535) in the frame
+    """
+    setup_testbed(fanouthosts, duthost, leaf_fanouts)
+    asic = duthost.asic_instance()
+    asic_type = duthost.facts["asic_type"]
+    if asic_type == 'vs':
+        pytest.skip("PFC RX_OK isolation test is not applicable to the VS platform")
+
+    conn_facts = conn_graph_facts['device_conn'].get(duthost.hostname, {})
+    int_status = asic.show_interface(command="status")['ansible_facts']['int_status']
+    """ We only test active physical interfaces that have connection graph entries """
+    active_phy_intfs = [intf for intf in int_status if
+                        intf.startswith('Ethernet') and
+                        int_status[intf]['admin_state'] == 'up' and
+                        int_status[intf]['oper_state'] == 'up' and
+                        intf in conn_facts]
+
+    """ Baseline RX counters for all ports in a single retrieval """
+    baseline = get_rx_port_counters(duthost)
+
+    """ Send all PFC frames first, across all priorities and all ports """
+    for intf in active_phy_intfs:
+        peer_device = conn_facts[intf]['peerdevice']
+        peer_port = conn_facts[intf]['peerport']
+
+        if peer_device not in fanouthosts:
+            continue
+
+        peerdev_ans = fanouthosts[peer_device]
+        peer_port_name, fanout_hwsku = _resolve_peer_port_name(
+            peerdev_ans, enum_fanout_graph_facts, peer_port)
+        for priority in range(PRIO_COUNT):
+            send_pfc_frame(peerdev_ans, peer_port_name, fanout_hwsku,
+                           priority, pause_time, pkt_count)
+
+    """ SONiC takes some time to update counters in database """
+    time.sleep(5)
+
+    """ Validate RX counters in one single retrieval swoop """
+    after = get_rx_port_counters(duthost)
+
+    failures = []
+    for intf in active_phy_intfs:
+        if intf not in baseline or intf not in after:
+            continue
+        rx_ok_delta = after[intf]['RX_OK'] - baseline[intf]['RX_OK']
+        rx_drp_delta = after[intf]['RX_DRP'] - baseline[intf]['RX_DRP']
+        if rx_ok_delta > margin or rx_drp_delta > margin:
+            failures.append((intf, rx_ok_delta, rx_drp_delta))
+            logger.error(
+                "Interface %s: RX_OK increased by %d, RX_DRP increased by %d "
+                "(allowed margin %d) after receiving %d PFC frames per priority",
+                intf, rx_ok_delta, rx_drp_delta, margin, pkt_count)
+
+    assert len(failures) == 0, (
+        "PFC frames were counted as RX_OK or RX_DRP beyond the allowed margin of {} "
+        "on the following interfaces [(intf, rx_ok_delta, rx_drp_delta)]: {}"
+    ).format(margin, failures)

--- a/tests/common/helpers/pfc_counters.py
+++ b/tests/common/helpers/pfc_counters.py
@@ -29,9 +29,9 @@ PRIO_COUNT = 8
 """ Name of the PFC storm container on MLNX-OS (Onyx) fanout switches """
 ONYX_PFC_CONTAINER_NAME = 'storm'
 """ Number of PFC frames sent per priority per port in the RX_OK isolation test """
-PFC_RX_OK_ISOLATION_PKT_COUNT = 5000
+PFC_RX_OK_ISOLATION_PKT_COUNT = 1000
 """ Allowed RX_OK/RX_DRP increase per interface to tolerate background traffic """
-RX_COUNTER_BACKGROUND_MARGIN = 500
+RX_COUNTER_BACKGROUND_MARGIN = 100
 
 
 @pytest.fixture(scope="module")

--- a/tests/common/helpers/pfc_counters.py
+++ b/tests/common/helpers/pfc_counters.py
@@ -224,27 +224,11 @@ def run_test(fanouthosts, duthost, conn_graph_facts, enum_fanout_graph_facts, le
                         continue
 
                     peerdev_ans = fanouthosts[peer_device]
-                    fanout_os = peerdev_ans.get_fanout_os()
-                    fanout_hwsku = enum_fanout_graph_facts[peerdev_ans.hostname]["device_info"]["HwSku"]
-                    if fanout_os == "nxos":
-                        peer_port_name = nxos_to_linux_intf(peer_port)
-                    elif fanout_os == "sonic":
-                        peer_port_name = sonic_to_linux_intf(peer_port)
-                    else:
-                        peer_port_name = eos_to_linux_intf(
-                            peer_port, hwsku=fanout_hwsku)
+                    peer_port_name, fanout_hwsku = _resolve_peer_port_name(
+                        peerdev_ans, enum_fanout_graph_facts, peer_port)
 
-                    if fanout_hwsku == "MLNX-OS":
-                        cmd = 'docker exec %s "python %s -i %s -p %d -t %d -n %d"' % (
-                            onyx_pfc_container_name, PFC_GEN_FILE_ABSOLUTE_PATH,
-                            peer_port_name, 2 ** priority, pause_time, PKT_COUNT)
-                        send_frames = lambda: peerdev_ans.host.config(cmd)  # noqa: E731
-                    else:
-                        cmd = "sudo python %s -i %s -p %d -t %d -n %d" % (
-                            PFC_GEN_FILE_DEST, peer_port_name, 2 ** priority, pause_time, PKT_COUNT)
-                        send_frames = lambda: peerdev_ans.host.command(cmd)  # noqa: E731
-
-                    send_frames()
+                    send_pfc_frame(peerdev_ans, peer_port_name, fanout_hwsku,
+                                   priority, pause_time, PKT_COUNT)
 
                     pfc_rx = {}
                     for attempt in range(1, MAX_RETRIES + 1):
@@ -264,7 +248,8 @@ def run_test(fanouthosts, duthost, conn_graph_facts, enum_fanout_graph_facts, le
                                 "(got %s), retrying send", attempt, intf, priority,
                                 pfc_rx[intf]['Rx'][priority])
                             duthost.sonic_pfc_counters(method="clear")
-                            send_frames()
+                            send_pfc_frame(peerdev_ans, peer_port_name, fanout_hwsku,
+                                           priority, pause_time, PKT_COUNT)
 
                 else:
                     time.sleep(5)

--- a/tests/common/helpers/pfc_counters.py
+++ b/tests/common/helpers/pfc_counters.py
@@ -101,7 +101,8 @@ def send_pfc_frame(peerdev_ans, peer_port_name, fanout_hwsku, priority,
     @param peerdev_ans: Fanout host ansible handle
     @param peer_port_name: Linux interface name on the fanout switch
     @param fanout_hwsku: Fanout switch HwSku (used to detect MLNX-OS/Onyx)
-    @param priority: PFC priority (0-7); encoded as a class-enable bitmap
+    @param priority: PFC priority index (0-7). Pass the index, not a bitmap; it
+                     is converted to a class-enable bitmap internally via 2 ** priority.
     @param pause_time: Pause time quanta (0-65535); 0 means unpause
     @param pkt_count: Number of frames to generate
     """
@@ -319,11 +320,12 @@ def run_rx_ok_isolation_test(fanouthosts, duthost, conn_graph_facts,       # noq
     @param margin: Allowed RX_OK/RX_DRP increase per interface
     @param pause_time: Pause time quanta (0-65535) in the frame
     """
-    setup_testbed(fanouthosts, duthost, leaf_fanouts)
-    asic = duthost.asic_instance()
     asic_type = duthost.facts["asic_type"]
     if asic_type == 'vs':
         pytest.skip("PFC RX_OK isolation test is not applicable to the VS platform")
+
+    setup_testbed(fanouthosts, duthost, leaf_fanouts)
+    asic = duthost.asic_instance()
 
     conn_facts = conn_graph_facts['device_conn'].get(duthost.hostname, {})
     int_status = asic.show_interface(command="status")['ansible_facts']['int_status']
@@ -338,6 +340,7 @@ def run_rx_ok_isolation_test(fanouthosts, duthost, conn_graph_facts,       # noq
     baseline = get_rx_port_counters(duthost)
 
     """ Send all PFC frames first, across all priorities and all ports """
+    tested_intfs = []
     for intf in active_phy_intfs:
         peer_device = conn_facts[intf]['peerdevice']
         peer_port = conn_facts[intf]['peerport']
@@ -351,6 +354,14 @@ def run_rx_ok_isolation_test(fanouthosts, duthost, conn_graph_facts,       # noq
         for priority in range(PRIO_COUNT):
             send_pfc_frame(peerdev_ans, peer_port_name, fanout_hwsku,
                            priority, pause_time, pkt_count)
+        tested_intfs.append(intf)
+
+    """ Guard against an empty run masquerading as a pass """
+    assert len(tested_intfs) > 0, (
+        "No active physical interfaces with a reachable fanout were exercised, so "
+        "PFC RX counter isolation could not be validated. Check the testbed "
+        "topology and fanout connectivity."
+    )
 
     """ SONiC takes some time to update counters in database """
     time.sleep(5)
@@ -358,9 +369,14 @@ def run_rx_ok_isolation_test(fanouthosts, duthost, conn_graph_facts,       # noq
     """ Validate RX counters in one single retrieval swoop """
     after = get_rx_port_counters(duthost)
 
+    """ Validate every active interface, not only the ones we sent frames to """
     failures = []
     for intf in active_phy_intfs:
         if intf not in baseline or intf not in after:
+            logger.warning(
+                "Interface %s missing from the %s counter snapshot; skipping its "
+                "RX_OK/RX_DRP validation", intf,
+                "baseline" if intf not in baseline else "post-send")
             continue
         rx_ok_delta = after[intf]['RX_OK'] - baseline[intf]['RX_OK']
         rx_drp_delta = after[intf]['RX_DRP'] - baseline[intf]['RX_DRP']

--- a/tests/common/helpers/pfc_counters.py
+++ b/tests/common/helpers/pfc_counters.py
@@ -29,9 +29,9 @@ PRIO_COUNT = 8
 """ Name of the PFC storm container on MLNX-OS (Onyx) fanout switches """
 ONYX_PFC_CONTAINER_NAME = 'storm'
 """ Number of PFC frames sent per priority per port in the RX_OK isolation test """
-PFC_RX_OK_ISOLATION_PKT_COUNT = 1000
+PFC_RX_OK_ISOLATION_PKT_COUNT = 5000
 """ Allowed RX_OK/RX_DRP increase per interface to tolerate background traffic """
-RX_COUNTER_BACKGROUND_MARGIN = 100
+RX_COUNTER_BACKGROUND_MARGIN = 2000
 
 
 @pytest.fixture(scope="module")

--- a/tests/qos/test_pfc_counters.py
+++ b/tests/qos/test_pfc_counters.py
@@ -1,6 +1,7 @@
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, enum_fanout_graph_facts     # noqa: F401
 from tests.common.helpers.pfc_counters import leaf_fanouts      # noqa: F401
 from tests.common.helpers.pfc_counters import run_test
+from tests.common.helpers.pfc_counters import run_rx_ok_isolation_test
 import pytest
 import logging
 
@@ -72,3 +73,17 @@ def test_continous_pfc(fanouthosts, duthosts, enum_rand_one_per_hwsku_frontend_h
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     run_test(fanouthosts, duthost, conn_graph_facts,
              enum_fanout_graph_facts, leaf_fanouts, check_continuous_pfc=True)
+
+
+def test_pfc_frames_not_counted_as_rx_ok(fanouthosts, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                                         conn_graph_facts, enum_fanout_graph_facts, leaf_fanouts):   # noqa: F811
+    """
+    @Summary: Verify PFC pause frames are consumed by the MAC and are NOT counted
+              as normal RX packets (RX_OK) or RX drops (RX_DRP) on DUT interfaces.
+              A large burst of frames is sent across all priorities and ports,
+              then RX_OK/RX_DRP deltas are checked against a margin that tolerates
+              background control-plane traffic.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    run_rx_ok_isolation_test(fanouthosts, duthost, conn_graph_facts,
+                             enum_fanout_graph_facts, leaf_fanouts)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
New PFC counter test to verify that interface RX_OK and RX_DROP do not increment in response to PFC frames. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Fill a test gap. 

#### How did you do it?
Make parts of the run_test function for test_pfc_counters.py more abstract, then use them in an isolated and independent test case. 

#### How did you verify/test it?
Verified on 2 Cisco-8000 series asics. 
Also verified with Cisco-8000/202605 branch
<img width="1128" height="119" alt="image" src="https://github.com/user-attachments/assets/704d3b19-9082-482b-ae27-4061f5821ebc" />


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
