### PR TITLE
Set the timeout to wait for the SSH to 250s

### DIFF
--- a/tests/cacl/test_cacl_function.py
+++ b/tests/cacl/test_cacl_function.py
@@ -117,7 +117,7 @@ def test_cacl_function(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cr
                                  state='started',
                                  search_regex=SONIC_SSH_REGEX,
                                  delay=0,
-                                 timeout=210,
+                                 timeout=250,
                                  module_ignore_errors=True)
 
         pytest_assert(not res.is_failed, "SSH did not start working when expected. {}".format(res.get('msg', '')))


### PR DESCRIPTION
### Description of PR
Matching the sleep time of 250 in config_service_acls.sh On BMC where is there is NTP or SNMP, SSH is the only thing to check and the delay before the 210 timeout is not sufficient.

Setting the 250s will ensure the config_service_acls.sh finishes

Summary:
Fixed the test failure on the BMC that has no delays due to the no SNMP or NTP checks

Fixes: https://github.com/sonic-net/sonic-mgmt/issues/25759

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605


### Approach
#### What is the motivation for this PR?
Fix the reused SONiC tests on BMC

#### How did you do it?
Updated the timeout to match the sleep step in the test script

#### How did you verify/test it?
Ran the regression on the BMC setup

#### Any platform specific information?
SONiC-BMC

#### Supported testbed topology if it's a new test case?

### Documentation
