### PR TITLE
[csonic] Provision LACP slow-protocol flows for cSONiC (docker-sonic-vs) T0 neighbors

### DIFF
--- a/ansible/roles/vm_set/tasks/add_csonic_lacp_flows.yml
+++ b/ansible/roles/vm_set/tasks/add_csonic_lacp_flows.yml
@@ -1,0 +1,72 @@
+# cSONiC-specific: ensure LACP slow-protocol PDUs (dst 01:80:c2:00:00:02,
+# ethertype 0x8809) are delivered deterministically between the DUT port and
+# the cSONiC neighbor port on each fan-out OVS bridge (br-<vm>-<fp_num>).
+#
+# Why this is needed for cSONiC but NOT for cEOS:
+#   - A real SONiC neighbor runs Linux teamd for LACP. Its teamd only moves
+#     PortChannel members to selected/collecting-distributing once it receives
+#     LACPDUs back from the DUT. cEOS implements LACP in EOS userspace and is far
+#     more tolerant of the default OVS forwarding set, so cEOS never needed this.
+#   - The default per-bridge flow set installed during bind forwards
+#     neighbor->DUT as a catch-all but only delivers specific protocols
+#     DUT->neighbor; LACP slow-proto multicast is not reliably flooded both ways.
+#   - The base `action=normal` rule added in add_csonic_list.yml is NOT sufficient:
+#     OVS NORMAL did not reliably deliver DUT->neighbor LACPDUs in practice, so
+#     teamd on the neighbor stayed "defaulted" and PortChannels never came up.
+#
+# This installs two explicit, directional output rules per fan-out bridge, matched
+# on the LACP multicast destination MAC, using OVS port *names* (stable across
+# runs) rather than OpenFlow port numbers (which are dynamic). It is strictly
+# additive and gated to vm_type == "csonic", so cEOS flow generation stays
+# byte-identical.
+#
+# Bridge/port discovery is empirical (read from live OVS state) rather than
+# derived from vm_offset: each cSONiC neighbor's uplink may land on any
+# br-<vm>-<fp_num> with tap <vm>-t<fp_num>; we locate the fan-out bridge(s) for
+# the VM that carry BOTH a neighbor tap (<vm>-t*) AND a DUT port (not an
+# injector inje-* and not the neighbor tap), and wire LACP between exactly those
+# two ports. This handles single- and multi-uplink neighbors.
+#
+# Host prerequisite for cSONiC neighbors: the Linux `team` driver AND its mode
+# submodule `team_mode_loadbalance` (plus roundrobin/activebackup) must be
+# loadable on the host kernel, otherwise the neighbor's teamd cannot create the
+# team device at all. See group_vars/vm_host notes / docs.
+
+- name: "csonic-lacp: discover DUT<->neighbor port pairs on each fan-out bridge"
+  become: yes
+  shell: |
+    set -e
+    for vm in {{ VM_targets | join(' ') }}; do
+      for br in $(ovs-vsctl list-br | grep -E "^br-${vm}-[0-9]+$"); do
+        ports=$(ovs-ofctl show "$br" | sed -n 's/^[[:space:]]*[0-9]\+(\([^)]*\)).*/\1/p')
+        nbr=$(echo "$ports" | grep -E "^${vm}-t[0-9]+$" | head -n 1)
+        dut=$(echo "$ports" | grep -v -E "^${vm}-t[0-9]+$" | grep -v '^inje-' | head -n 1)
+        if [ -n "$nbr" ] && [ -n "$dut" ]; then
+          echo "${br} ${dut} ${nbr}"
+        fi
+      done
+    done
+  register: csonic_lacp_pairs
+  changed_when: false
+
+- name: "csonic-lacp: show discovered DUT<->neighbor LACP port pairs"
+  debug:
+    msg: "{{ csonic_lacp_pairs.stdout_lines }}"
+
+- name: "csonic-lacp: install DUT->neighbor 0x8809 (LACP) flows"
+  become: yes
+  command: >-
+    ovs-ofctl add-flow {{ item.split()[0] }}
+    "table=0,priority=20,dl_dst=01:80:c2:00:00:02,in_port={{ item.split()[1] }},actions=output:{{ item.split()[2] }}"
+  loop: "{{ csonic_lacp_pairs.stdout_lines }}"
+  loop_control:
+    label: "{{ item.split()[0] }} ({{ item.split()[1] }} -> {{ item.split()[2] }})"
+
+- name: "csonic-lacp: install neighbor->DUT 0x8809 (LACP) flows"
+  become: yes
+  command: >-
+    ovs-ofctl add-flow {{ item.split()[0] }}
+    "table=0,priority=20,dl_dst=01:80:c2:00:00:02,in_port={{ item.split()[2] }},actions=output:{{ item.split()[1] }}"
+  loop: "{{ csonic_lacp_pairs.stdout_lines }}"
+  loop_control:
+    label: "{{ item.split()[0] }} ({{ item.split()[2] }} -> {{ item.split()[1] }})"

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -326,6 +326,12 @@
     delay: 60
     when: enable_async
 
+  # cSONiC-only: after DUT+neighbor ports are bound to the fan-out bridges,
+  # install explicit directional LACP (0x8809) flows so the neighbor's Linux
+  # teamd can negotiate PortChannels with the DUT. No-op / not included for cEOS.
+  - include_tasks: add_csonic_lacp_flows.yml
+    when: vm_type is defined and vm_type == "csonic" and "bmc" not in topo
+
   - name: Bind topology {{ topo }} to DPUs.
     vm_topology:
       cmd: "bind"


### PR DESCRIPTION
### What this PR does

cSONiC (`docker-sonic-vs`) T0 neighbors run **Linux `teamd`** for LACP. `teamd` only moves PortChannel members to collecting/distributing once it receives LACPDUs back from the DUT. In practice the default per-fan-out-bridge OVS flow set (and a bare `action=normal` rule) did **not** reliably deliver **DUT→neighbor** LACP slow-protocol multicast (dst `01:80:c2:00:00:02`, ethertype `0x8809`), so the neighbor's `teamd` stayed `defaulted` and PortChannels never came up. cEOS implements LACP in userspace and tolerates the default forwarding set, so it never needed this.

This PR adds cSONiC-only LACP flow provisioning:

- **`ansible/roles/vm_set/tasks/add_csonic_lacp_flows.yml`** (new) — installs explicit **directional** output rules per fan-out bridge (`br-<vm>-<fp_num>`), matched on the LACP multicast MAC, using stable OVS port **names** rather than dynamic OpenFlow port numbers. Bridge/port discovery is empirical (read from live OVS state) so single- and multi-uplink neighbors are both handled.
- **`ansible/roles/vm_set/tasks/add_topo.yml`** — include the task after port binding, gated to `vm_type == "csonic"` (and skipped for `bmc` topos).

The change is **strictly additive and `csonic`-gated**, so cEOS flow generation is byte-identical.

### Why this is scoped to LACP only

This PR previously also carried LLDP / neighbor-health changes. Those are dropped because they are handled separately and in a way that keeps cSONiC consistent with cEOS:

- **LLDP** is verified via **SNMP** (same path as cEOS / real-SONiC neighbors), now that the SNMP agent is being added to the `docker-sonic-vs` image — see sonic-net/sonic-buildimage#28091 (*Include snmp container (snmpd + snmp-subagent)*) — and `SNMP_COMMUNITY` is seeded into the cSONiC CONFIG_DB templates by #25701. A separate `lldpctl`-based path is therefore unnecessary and would diverge cSONiC from cEOS.
- **Neighbor health** for `CsonicHost` is addressed by #25540.
- **BGP `router-id`** read for cSONiC is addressed by #25534.

So this PR is intentionally narrowed to the one piece not covered elsewhere: the host-side OVS LACP flow provisioning required for cSONiC PortChannels to come up.

### Host prerequisite

cSONiC neighbors require the Linux `team` driver and its mode submodules (`team_mode_loadbalance`, plus `roundrobin`/`activebackup`) to be loadable on the **vm_host** kernel; otherwise the neighbor's `teamd` cannot create the team device at all.

### Testing

Verified on a `vms-kvm-t0-csonic` testbed: with the flows installed, the cSONiC neighbor's `teamd` receives DUT LACPDUs and PortChannel members move to `collecting/distributing`; without them, members stay `defaulted`. cEOS topologies are unaffected (task is `csonic`-gated and not included for cEOS).

Tracking issue: #25756

Signed-off-by: Nikhil Hegde <nikhilhegde@microsoft.com>