### PR TITLE
[csonic] Provision an IPv4 management IP on cSONiC neighbor eth0

### DIFF
--- a/ansible/roles/sonic/tasks/csonic.yml
+++ b/ansible/roles/sonic/tasks/csonic.yml
@@ -85,6 +85,38 @@
   register: bp_ifup_result
   failed_when: false
 
+# The docker-sonic-vs neighbor image does not run hostcfgd, so a MGMT_INTERFACE
+# entry in CONFIG_DB would not be applied to the kernel eth0 on its own (unlike
+# a full SONiC image). Program the IPv4 management address on eth0 directly here
+# so the neighbor is reachable on the mgmt network -- e.g. for the SNMP/LLDP-MIB
+# verification in tests/lldp/test_lldp.py, which queries the neighbor at its
+# advertised mgmt-ip. Mirrors the explicit front-panel/backplane link-up steps
+# above. Gated + idempotent: only runs when the neighbor has a mgmt IP, and
+# 'replace' tolerates the address already being present on re-runs.
+# NOTE: rendering the mgmt address into the neighbor CONFIG_DB (MGMT_INTERFACE/
+# MGMT_PORT) is deferred to the follow-up hostcfgd PR.
+- name: Apply management IPv4 address on eth0 (docker-sonic-vs has no hostcfgd)
+  become: yes
+  command: >
+    docker exec csonic_{{ vm_set_name }}_{{ inventory_hostname }}
+    ip address replace {{ ansible_host }}/{{ mgmt_prefixlen }} dev eth0
+  delegate_to: "{{ VM_host[0] }}"
+  when:
+    - ansible_host is defined and ansible_host | length > 0
+    - mgmt_prefixlen is defined and (mgmt_prefixlen | string) | length > 0
+  register: csonic_mgmt_ip_result
+  failed_when: false
+
+- name: Ensure eth0 is up
+  become: yes
+  command: docker exec csonic_{{ vm_set_name }}_{{ inventory_hostname }} ip link set eth0 up
+  delegate_to: "{{ VM_host[0] }}"
+  when:
+    - ansible_host is defined and ansible_host | length > 0
+    - mgmt_prefixlen is defined and (mgmt_prefixlen | string) | length > 0
+  failed_when: false
+  changed_when: false
+
 - name: Wait for bgpcfgd to configure FRR from ConfigDB
   become: yes
   command: >


### PR DESCRIPTION
## What / why

cSONiC (`docker-sonic-vs`) neighbors come up with only an IPv6 link-local on `eth0` (the interface bridged onto the testbed mgmt bridge), so:

- the neighbor is not reachable on the mgmt network at its inventory `ansible_host` (e.g. `10.250.0.51`), and
- it advertises an IPv6-only mgmt-ip in LLDP.

`tests/lldp/test_lldp.py` reads the neighbor's advertised mgmt-ip and queries it over SNMP. With only an IPv6 mgmt-ip, `pysnmp` (IPv4/UDP transport) fails with `Bad IPv4/UDP transport address ...@161` before it can verify anything. Giving the neighbor its IPv4 mgmt address makes it advertise an IPv4 mgmt-ip and answer SNMP on it, so the existing IPv4 SNMP path works for cSONiC exactly like it does for cEOS — **no test-side change, no skip**.

Complements #25701 (SNMP_COMMUNITY in the neighbor CONFIG_DB) and the snmpd-in-`docker-sonic-vs` work; together, SNMP-based LLDP verification passes against cSONiC neighbors.

## Change

- `docker-sonic-vs` does **not** run `hostcfgd`, so a `MGMT_INTERFACE` entry in CONFIG_DB would not be applied to the kernel `eth0` on its own (unlike a full SONiC image). `roles/sonic/tasks/csonic.yml` now programs the IPv4 address on `eth0` (and ensures it is up) directly after config load, mirroring the existing front-panel/backplane link-up steps. Gated on the neighbor having a mgmt IP (`ansible_host` + `mgmt_prefixlen`) and uses `ip address replace`, so it is idempotent across re-runs.

## Deferred

Rendering the mgmt address into the neighbor CONFIG_DB (`MGMT_INTERFACE`/`MGMT_PORT`, in `configdb-csonic.j2` / `configdb-t0-leaf.j2`) is intentionally **deferred to the follow-up PR that adds `hostcfgd` to `docker-sonic-vs`**, where that CONFIG_DB entry would actually be consumed. Until then the direct `eth0` programming above is sufficient, and this PR keeps the CONFIG_DB templates and their unit tests byte-identical.

Tracking issue: #25706
