### PR TITLE
Skip the BMC test for test_show_chassis_module_status

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -963,6 +963,15 @@ platform_tests/broadcom/test_ser.py:
 ##############################################
 #####  cli/test_show_chassis_module.py  #####
 ##############################################
+platform_tests/cli/test_show_bmc.py::TestBmcCliCommands::test_show_chassis_module_status:
+  skip:
+    reason: Discrepancy between the pmon and pmon test design
+    conditions:
+      - https://github.com/sonic-net/SONiC/issues/2410
+
+##############################################
+#####  cli/test_show_chassis_module.py  #####
+##############################################
 platform_tests/cli/test_show_chassis_module.py::test_show_chassis_module_midplane_status:
   skip:
     reason: "Not supported on T2 single node topology"


### PR DESCRIPTION
### Description of PR
Skip the test_show_chassis_module_status test based on the open issue

Summary:
Issue to skip: https://github.com/sonic-net/SONiC/issues/2410

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605


Failure type: day-one issue

### Approach
#### What is the motivation for this PR?
Skip the failing test until fixed

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

