### PR TITLE
Parametrize and fix test_show_platform_leak_commands

### DIFF
--- a/tests/platform_tests/cli/test_show_bmc.py
+++ b/tests/platform_tests/cli/test_show_bmc.py
@@ -30,6 +30,18 @@ pytestmark = [
     pytest.mark.topology('bmc')
 ]
 
+SHOW_PLATFORM_LEAK_COMMANDS = [
+    ("show platform leak rack-manager alerts",
+     ['Severity', 'Timestamp'],
+     "No rack-manager alerts found"),
+    ("show platform leak profiles",
+     ['Sensor-Type', 'Max-Minor-Duration-Sec'],
+     "No leak profiles found"),
+    ("show platform leak status",
+     ['Name', 'Leak', 'leak-severity'],
+     "No leak sensor data found"),
+]
+
 
 class TestBmcCliCommands:
     """
@@ -77,7 +89,7 @@ class TestBmcCliCommands:
         has_shutdown_timeout = 'shutdown-timeout (sec)' in output_lower
         pytest_assert(has_shutdown_timeout,
                       "show chassis module status: missing 'Shutdown-Timeout (sec)' column on BMC")
-        logger.info(f"show chassis module status output:\n{output}")
+        logger.info(f"show chassis module status output: \n{output}")
 
     def test_show_platform_temperature(self):
         """
@@ -107,7 +119,7 @@ class TestBmcCliCommands:
 
         has_threshold = any(term in output_lower for term in ['high th', 'crit', 'threshold'])
         logger.info(f"show platform temperature: threshold columns present={has_threshold}")
-        logger.info(f"show platform temperature output:\n{output}")
+        logger.info(f"show platform temperature output: \n{output}")
 
         # Cross-check: BMC must surface paired Switch-Host sensors. Skip if Switch-Host unreachable.
         host = get_switch_host_or_skip_test(self.duthost)
@@ -127,7 +139,7 @@ class TestBmcCliCommands:
                       "Switch-Host 'show platform temperature' returned no sensor rows")
         overlap = host_sensors & bmc_sensors
         pytest_assert(overlap,
-                      f"BMC 'show platform temperature' must include ≥1 Switch-Host sensor; "
+                      f"BMC 'show platform temperature' must include ≥1 Switch-Host sensor. "
                       f"switch_host={sorted(host_sensors)} bmc={sorted(bmc_sensors)}")
         logger.info(f"BMC surfaces {len(overlap)} Switch-Host sensor(s): {sorted(overlap)}")
 
@@ -376,7 +388,12 @@ class TestBmcCliCommands:
                     module_ignore_errors=True
                 )
 
-    def test_show_platform_leak_commands(self):
+    @pytest.mark.parametrize(
+        'cmd,expected_fields,expected_output_when_empty',
+        SHOW_PLATFORM_LEAK_COMMANDS,
+        ids=['rack-manager-alerts', 'leak-profiles', 'leak-status'],
+    )
+    def test_show_platform_leak_commands(self, cmd, expected_fields, expected_output_when_empty):
         """
         Verify show platform leak commands produce valid output (LC platforms).
 
@@ -389,24 +406,18 @@ class TestBmcCliCommands:
         test_liquid_cool_config_commands (config-write + verify loop), so it's
         not re-checked here.
         """
-        leak_commands = [
-            ("show platform leak rack-manager alerts",
-             ['Severity', 'Timestamp']),
-            ("show platform leak profiles",
-             ['Sensor-Type', 'Max-Minor-Duration-Sec']),
-            ("show platform leak status",
-             ['Name', 'Leak', 'leak-severity']),
-        ]
-
-        for cmd, expected_fields in leak_commands:
-            result = self.duthost.shell(f"{cmd} 2>&1", module_ignore_errors=True)
-            if result['rc'] != 0:
-                logger.info(f"{cmd!r} not available (expected on non-LC systems)")
-                continue
-            output = result['stdout']
-            for field in expected_fields:
-                pytest_assert(field.lower() in output.lower(),
-                              f"{cmd!r} output missing expected column '{field}'")
+        result = self.duthost.shell(f"{cmd} 2>&1", module_ignore_errors=True)
+        if result['rc'] != 0:
+            pytest.skip(f"{cmd!r} not available (expected on non-LC systems)")
+        output = result['stdout'].strip().lower()
+        if expected_output_when_empty.lower() == output:
+            pytest.skip(f"{cmd!r} returned empty table output")
+        parsed_output = self.duthost._parse_show(result['stdout_lines'])
+        pytest_assert(len(parsed_output) > 0, f"{cmd!r} returned the table with 0 data rows")
+        parsed_fields = set(map(str.lower, parsed_output[0].keys()))
+        for field in expected_fields:
+            pytest_assert(field.lower() in parsed_fields,
+                          f"{cmd!r} output missing expected column '{field}' (available: {parsed_fields})")
 
 
 def test_show_version_serial_numbers_bmc(duthosts, enum_rand_one_per_hwsku_hostname, request):


### PR DESCRIPTION
### Description of PR
This test parametrizes the test_show_platform_leak_commands and adds handling for the empty table cases

Summary:
Fixes https://github.com/sonic-net/sonic-mgmt/issues/25761

### Type of change
- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605


### Approach
#### What is the motivation for this PR?
Prevent test failure, correctly handle the empty table output

#### How did you do it?
Added the parameter for the empty table, used output parsing

#### How did you verify/test it?
Ran on SONiC BMC

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
