### PR TITLE
Fix test_thermalctld_leak_status

### DIFF
--- a/tests/platform_tests/daemon/test_thermalctld.py
+++ b/tests/platform_tests/daemon/test_thermalctld.py
@@ -101,8 +101,8 @@ class TestThermalctldDaemon:
                               f"leak_sensor_status '{sensor_status}' "
                               f"not in ['Good', 'Fault']")
 
-            leak_severity = fields.get('leak_severity', '').strip()
-            if leak_severity:
+            leak_severity = fields.get('leak_severity', 'None').strip()
+            if leak_severity != "None":
                 pytest_assert(leak_severity in ['MINOR', 'CRITICAL'],
                               f"leak_severity '{leak_severity}' not in ['MINOR', 'CRITICAL']")
 
@@ -194,11 +194,11 @@ class TestThermalctldDaemon:
             tail=10,
         )
         if existing:
-            logger.info(f"Existing thermalctld leaking-sensor events:\n{existing}")
+            logger.info("Existing thermalctld leaking-sensor events:\n%s", existing)
 
         logged = [t for t, v in trigger_results.items() if v]
         not_logged = [t for t, v in trigger_results.items() if not v]
-        logger.info(f"Confirmed: {logged}; not confirmed: {not_logged}")
+        logger.info("Confirmed: %s; not confirmed: %s", logged, not_logged)
         pytest_assert(
             any(trigger_results.values()),
             f"thermalctld event trigger test found no evidence for: {list(trigger_results.keys())}"
@@ -254,7 +254,7 @@ class TestThermalctldDaemon:
             tail=10,
         )
         if existing:
-            logger.info(f"Real faulty sensor events in syslog:\n{existing}")
+            logger.info("Real faulty sensor events in syslog:\n%s", existing)
         else:
             logger.info("No faulty sensor syslog events found - liquid cooling hardware not present or all sensors ok")
 
@@ -305,7 +305,7 @@ class TestThermalctldDaemon:
             pytest.skip(f"Switch-Host {switch_host.hostname} syslog has no "
                         "'Mirroring TEMPERATURE_INFO to BMC STATE_DB' entry — "
                         "BMC mirror not active on this platform or log has rotated")
-        logger.info(f"Switch-Host mirror push confirmed:\n{mirror_init_log}")
+        logger.info("Switch-Host mirror push confirmed:\n%s", mirror_init_log)
 
         # Step 2: Push was initiated — data MUST have landed in the BMC STATE_DB.
         # If absent here it is a real failure (push initiated but data missing).
@@ -327,14 +327,14 @@ class TestThermalctldDaemon:
                       "BMC syslog missing 'Monitoring chassis thermals' — "
                       "thermalctld may not have initialized chassis-thermal monitoring "
                       "(check switch_bmc=1 in platform_env.conf)")
-        logger.info(f"Chassis-thermal monitoring init confirmed:\n{init_log}")
+        logger.info("Chassis-thermal monitoring init confirmed:\n%s", init_log)
 
         # Informational: any pre-existing CRITICAL events in event.log.
         existing = bmc_log_zgrep(
             self.duthost, r"CRITICAL chassis thermal", tail=5, files=BMC_EVENT_LOG,
         )
         if existing:
-            logger.info(f"Pre-existing CRITICAL chassis thermal events:\n{existing}")
+            logger.info("Pre-existing CRITICAL chassis thermal events:\n%s", existing)
 
         # Steps 4-6: inject a breach and verify the CRITICAL log.
         # Key uses | separator: TEMPERATURE_INFO|<sensor_name> (sonic TABLE_NAME_SEPARATOR).
@@ -361,7 +361,8 @@ class TestThermalctldDaemon:
         match_count = breach_result.get("total", {}).get("match", 0)
         pytest_assert(match_count > 0,
                       "Expected 'CRITICAL chassis thermal' log for injected sensor "
-                      f"{TEST_SENSOR} (120C > 80C threshold) not found in syslog within 90s")
+                      f"{TEST_SENSOR} "
+                      "(120C > 80C threshold) not found in syslog within 90s")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Description of PR
Adds correct handling for "None" leak status returned by redis.
Also fixes the flake8 error than prevent the verifications to pass

Summary:
Fixes https://github.com/sonic-net/sonic-mgmt/issues/25760

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Fix test_thermalctld_leak_status

#### How did you do it?
Treated the redis returned value "None" as string and checked for it, added the enum prefix "LeakSeverity." to the leak_severity expected values

#### How did you verify/test it?
Ran on the BMC testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
