### PR TITLE
[lldp] Skip eth0 in test_lldp_entry_table_after_syncd_orchagent recovery check

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -443,6 +443,13 @@ def test_lldp_entry_table_after_syncd_orchagent(
         assert keys_match, "LLDP_ENTRY_TABLE keys do not match 'show lldp table' output"
     # Get the ldap keys before restart syncd and swss
     lldp_entry_keys = get_lldp_entry_keys(db_instance)
+    # The management interface eth0 may appear in LLDP_ENTRY_TABLE (its LLDP neighbor is the
+    # management switch), but eth0 LLDP is not controlled by syncd/orchagent and is therefore not
+    # a reliable readiness condition for front-panel LLDP entry recovery after a swss/syncd
+    # restart. Exclude it, consistent with the other LLDP_ENTRY_TABLE test cases in this file.
+    testable_interfaces = [iface for iface in lldp_entry_keys if iface != "eth0"]
+    if not testable_interfaces:
+        pytest.skip("No front-panel LLDP neighbors to verify after swss/syncd restart")
 
     logging.info("Stop and start swss and syncd on DUT")
     # It's found that restart swss container could cause swss service to go down. In most of OC tests
@@ -465,7 +472,7 @@ def test_lldp_entry_table_after_syncd_orchagent(
         "BGP sessions did not reach Established state after swss restart",
     )
     # Wait until all interfaces are up and lldp entries are populated
-    for interface in lldp_entry_keys:
+    for interface in testable_interfaces:
         result = wait_until(300, 2, 0, verify_lldp_entry, db_instance, [interface])
         entry_content = get_lldp_entry_content(db_instance, interface)
         pytest_assert(


### PR DESCRIPTION
### Description of PR

Summary:
Fixes `lldp.test_lldp_syncd.test_lldp_entry_table_after_syncd_orchagent` failure on testbeds whose only LLDP neighbor is on the management interface `eth0` (e.g. M0_MX / Nokia-7215, marvell-prestera).

The post-restart recovery loop iterated over **all** `LLDP_ENTRY_TABLE` keys, including the management interface `eth0`. On such testbeds `lldp_entry_keys = ['eth0']`, and after a swss/syncd restart `eth0`'s entry transiently holds only `lldp_rem_time_mark`, so `verify_lldp_entry` (which requires `len(entry_content) > 1`) never succeeds within the 300s wait and the test fails:

`E  Failed: After restart swss and syncd, interface eth0 LLDP_ENTRY_TABLE entry is not correct:{'lldp_rem_time_mark': '2946'}`

`eth0` LLDP runs over the management network and is **not** controlled by syncd/orchagent, so it is not a valid readiness condition for front-panel LLDP entry recovery. This mirrors the existing handling in `test_lldp_entry_table_after_all_batched_flap`, which already excludes `eth0` via `[iface for iface in lldp_entry_keys if iface != "eth0"]`.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The test fails consistently on testbeds that only have a management-interface LLDP neighbor. The failure is in the test logic, not the product: `eth0` is the management interface and its LLDP recovery is unrelated to the swss/syncd (ASIC dataplane) restart this test exercises.

#### How did you do it?
In `test_lldp_entry_table_after_syncd_orchagent`, after fetching `lldp_entry_keys` build `testable_interfaces = [iface for iface in lldp_entry_keys if iface != "eth0"]` and iterate the recovery loop over that list. When no front-panel neighbors remain, `pytest.skip` instead of silently verifying nothing. This is consistent with the eth0 handling already present in the sibling flap test cases in the same file.

#### How did you verify/test it?
- Confirmed against the captured ElasticTest failure data (testbed bjw2-can-7215-1, Nokia-7215, M0_MX): `lldp_entry_keys = ['eth0']` only, and the recovery loop failed on `eth0` with the partial `{'lldp_rem_time_mark': ...}` entry. With the fix, `eth0` is excluded and the test skips on this management-only testbed; on testbeds with front-panel neighbors the recovery loop still runs unchanged for those ports.
- `pre-commit` (trailing-whitespace / end-of-file-fixer / python-ast / flake8) passes on the changed file.

#### Any platform specific information?
Observed on marvell-prestera / Nokia-7215 (M0_MX). The change is platform-agnostic and only relaxes an assumption that every `LLDP_ENTRY_TABLE` key (including `eth0`) is a syncd/orchagent-managed front-panel port.

#### Supported testbed topology if it's a new test case?
N/A (existing test).

### Documentation
N/A

Related ADO PBI: 38458798