### PR TITLE
Update ferret for wr_arp test to adapt on the isolated topology

### DIFF
--- a/tests/arp/files/ferret.py
+++ b/tests/arp/files/ferret.py
@@ -324,11 +324,15 @@ def extract_iface_names(config_file):
     with open(config_file) as fp:
         graph = json.load(fp)
 
+    port_indices = graph['minigraph_port_indices']
     net_ports = []
-    for name, val in list(graph['minigraph_portchannels'].items()):
-        members = ['eth%d' % graph['minigraph_port_indices'][member]
+    for name, val in list(graph.get('minigraph_portchannels', {}).items()):
+        members = ['eth%d' % port_indices[member]
                    for member in val['members']]
         net_ports.extend(members)
+
+    if not net_ports:
+        net_ports = graph.get('net_ports', [])
 
     return net_ports
 

--- a/tests/common/arp_utils.py
+++ b/tests/common/arp_utils.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import get_ptf_eth_ports_from_minigraph_interfaces
 from tests.ptf_runner import ptf_runner
 
 # Globals
@@ -28,10 +29,15 @@ def __prepareVxlanConfigData(duthost, ptfhost, tbinfo):
         'minigraph_port_indices': mgFacts['minigraph_ptf_indices'],
         'minigraph_portchannel_interfaces': mgFacts['minigraph_portchannel_interfaces'],
         'minigraph_portchannels': mgFacts['minigraph_portchannels'],
+        'minigraph_interfaces': mgFacts['minigraph_interfaces'],
         'minigraph_lo_interfaces': mgFacts['minigraph_lo_interfaces'],
         'vlan_facts': vlan_facts,
         'dut_mac': duthost.facts['router_mac']
     }
+    if not vxlanConfigData.get('minigraph_portchannels'):
+        vxlanConfigData['net_ports'] = get_ptf_eth_ports_from_minigraph_interfaces(
+            vxlanConfigData['minigraph_interfaces'],
+            vxlanConfigData['minigraph_port_indices'])
     with open(VXLAN_CONFIG_FILE, 'w') as file:
         file.write(json.dumps(vxlanConfigData, indent=4))
 

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -722,6 +722,16 @@ def str2bool(str):
     return str.lower() not in ["0", "false", "no"]
 
 
+def get_ptf_eth_ports_from_minigraph_interfaces(minigraph_interfaces, port_indices):
+    """Map minigraph L3 interfaces to PTF eth names when no portchannels exist."""
+    net_ports = []
+    for intf in minigraph_interfaces or []:
+        attachto = intf['attachto']
+        if attachto in port_indices:
+            net_ports.append('eth%d' % port_indices[attachto])
+    return net_ports
+
+
 def setup_ferret(duthost, ptfhost, tbinfo):
     '''
         Sets Ferret service on PTF host.
@@ -744,11 +754,16 @@ def setup_ferret(duthost, ptfhost, tbinfo):
             'minigraph_port_indices': mgFacts['minigraph_ptf_indices'],
             'minigraph_portchannel_interfaces': mgFacts['minigraph_portchannel_interfaces'],
             'minigraph_portchannels': mgFacts['minigraph_portchannels'],
+            'minigraph_interfaces': mgFacts['minigraph_interfaces'],
             'minigraph_lo_interfaces': mgFacts['minigraph_lo_interfaces'],
             'minigraph_vlans': mgFacts['minigraph_vlans'],
             'minigraph_vlan_interfaces': mgFacts['minigraph_vlan_interfaces'],
             'dut_mac': duthost.facts['router_mac']
         }
+        if not vxlanConfigData.get('minigraph_portchannels'):
+            vxlanConfigData['net_ports'] = get_ptf_eth_ports_from_minigraph_interfaces(
+                vxlanConfigData['minigraph_interfaces'],
+                vxlanConfigData['minigraph_port_indices'])
         with open(VXLAN_CONFIG_FILE, 'w') as file:
             file.write(json.dumps(vxlanConfigData, indent=4))
 


### PR DESCRIPTION


### Description of PR
Adjust ferret to make it run on the isolated topology
Handle the situation that no portchannel exists
Based on the design code change:
https://github.com/sonic-net/sonic-buildimage/pull/27860

Summary:
Fixes # (issue)

### Type of change


- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
The wr_arp test could not run pass on the isolated topology
#### How did you do it?
Adjust ferret to make it run on the isolated topology
Handle the situation that no portchannel exists
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
