### PR TITLE
Adapt advance warm reboot test on the isolated topology

### DIFF
--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -40,6 +40,7 @@ class Arista(host_device.HostDevice):
         self.reboot_type = test_params['reboot_type']
         self.bgp_v4_v6_time_diff = test_params['bgp_v4_v6_time_diff']
         self.lacp_pdu_timings = list()
+        self.has_dut_portchannels = test_params.get('has_dut_portchannels', True)
 
     def __del__(self):
         self.disconnect()
@@ -77,7 +78,8 @@ class Arista(host_device.HostDevice):
         version_output = self.do_cmd('show version')
         self.veos_version = self.parse_version(version_output)
 
-        self.show_lacp_command = self.parse_supported_show_lacp_command()
+        if self.has_dut_portchannels:
+            self.show_lacp_command = self.parse_supported_show_lacp_command()
         self.show_ip_bgp_command = self.parse_supported_bgp_neighbor_command()
         self.show_ipv6_bgp_command = self.parse_supported_bgp_neighbor_command(
             v4=False)
@@ -142,6 +144,19 @@ class Arista(host_device.HostDevice):
 
         return
 
+    def get_portchannel_changetime(self):
+        portchannel_output = self.do_cmd("show interfaces po1 | json")
+        portchannel_output = "\n".join(portchannel_output.split("\r\n")[1:-1])
+        if not portchannel_output.strip():
+            raise RuntimeError("Empty output from 'show interfaces po1 | json'")
+        try:
+            po_info = json.loads(portchannel_output, strict=False)
+            return po_info['interfaces']['Port-Channel1']['lastStatusChangeTimestamp']
+        except (json.JSONDecodeError, KeyError, TypeError) as err:
+            raise RuntimeError(
+                "Failed to parse Port-Channel1 status: {}".format(err)
+            )
+
     def run(self):
         data = {}
         debug_data = {}
@@ -155,11 +170,9 @@ class Arista(host_device.HostDevice):
         cur_time = time.time()
         sample = {}
         samples = {}
-        portchannel_output = self.do_cmd("show interfaces po1 | json")
-        portchannel_output = "\n".join(portchannel_output.split("\r\n")[1:-1])
-        sample["po_changetime"] = json.loads(portchannel_output, strict=False)[
-            'interfaces']['Port-Channel1']['lastStatusChangeTimestamp']
-        samples[cur_time] = sample
+        if self.has_dut_portchannels:
+            sample["po_changetime"] = self.get_portchannel_changetime()
+            samples[cur_time] = sample
 
         while not (quit_enabled and v4_routing_ok and v6_routing_ok):
             cmd = None
@@ -171,15 +184,20 @@ class Arista(host_device.HostDevice):
                     quit_enabled = True
                     continue
 
-                if (cmd == 'cpu_down' or cmd == 'cpu_going_up' or cmd == 'cpu_up'):
+                if self.has_dut_portchannels and (
+                        cmd == 'cpu_down' or cmd == 'cpu_going_up' or cmd == 'cpu_up'):
                     last_lacppdu_time_before_reboot = self.check_last_lacppdu_time()
                     if last_lacppdu_time_before_reboot is not None:
                         self.lacp_pdu_timings.append(last_lacppdu_time_before_reboot)
 
             cur_time = time.time()
             info = {}
-            lacp_output = self.do_cmd(self.show_lacp_command)
-            info['lacp'] = self.parse_lacp(lacp_output)
+            lacp_output = None
+            if self.has_dut_portchannels:
+                lacp_output = self.do_cmd(self.show_lacp_command)
+                info['lacp'] = self.parse_lacp(lacp_output)
+            else:
+                info['lacp'] = True
             bgp_neig_output = self.do_cmd(self.show_ip_bgp_command)
             info['bgp_neig'] = self.parse_bgp_neighbor(bgp_neig_output)
 
@@ -197,15 +215,13 @@ class Arista(host_device.HostDevice):
                 self.log('BGP routing for ipv6 OK: %s' % (v6_routing_ok))
             info["bgp_route_v6"] = v6_routing_ok
 
-            portchannel_output = self.do_cmd("show interfaces po1 | json")
-            portchannel_output = "\n".join(
-                portchannel_output.split("\r\n")[1:-1])
-            sample["po_changetime"] = json.loads(portchannel_output, strict=False)[
-                'interfaces']['Port-Channel1']['lastStatusChangeTimestamp']
+            if self.has_dut_portchannels:
+                sample["po_changetime"] = self.get_portchannel_changetime()
 
             if not run_once:
-                # clear Portchannel counters
-                self.do_cmd("clear counters Port-Channel 1")
+                if self.has_dut_portchannels:
+                    # clear Portchannel counters
+                    self.do_cmd("clear counters Port-Channel 1")
 
                 self.ipv4_gr_enabled, self.ipv6_gr_enabled, self.gr_timeout = self.parse_bgp_neighbor_once(
                     bgp_neig_output)
@@ -215,14 +231,17 @@ class Arista(host_device.HostDevice):
                     run_once = True
 
             data[cur_time] = info
-            samples[cur_time] = sample
+            if self.has_dut_portchannels:
+                samples[cur_time] = sample
             if self.DEBUG:
-                debug_data[cur_time] = {
-                    'show lacp neighbor': lacp_output,
+                debug_entry = {
                     'show ip bgp neighbors': bgp_neig_output,
                     'show ip route bgp': bgp_route_v4_output,
                     'show ipv6 route bgp': bgp_route_v6_output,
                 }
+                if lacp_output is not None:
+                    debug_entry['show lacp neighbor'] = lacp_output
+                debug_data[cur_time] = debug_entry
             time.sleep(1)
 
         attempts = 60
@@ -268,14 +287,18 @@ class Arista(host_device.HostDevice):
         self.log('Checking BGP GR peer status on VM')
         self.check_gr_peer_status(data)
         cli_data = {}
-        cli_data['lacp'] = self.check_series_status(
-            data, "lacp",         "LACP session")
+        if self.has_dut_portchannels:
+            cli_data['lacp'] = self.check_series_status(
+                data, "lacp",         "LACP session")
+            cli_data['po'] = self.check_change_time(
+                samples, "po_changetime", "PortChannel interface")
+        else:
+            cli_data['lacp'] = (0, 0)
+            cli_data['po'] = (0, 0)
         cli_data['bgp_v4'] = self.check_series_status(
             data, "bgp_route_v4", "BGP v4 routes")
         cli_data['bgp_v6'] = self.check_series_status(
             data, "bgp_route_v6", "BGP v6 routes")
-        cli_data['po'] = self.check_change_time(
-            samples, "po_changetime", "PortChannel interface")
 
         if 'route_timeout' in log_data:
             route_timeout = log_data['route_timeout']
@@ -459,7 +482,9 @@ class Arista(host_device.HostDevice):
         for prefix, attrs in obj["routes"].items():
             if "routeAction" not in attrs or attrs["routeAction"] != "forward":
                 continue
-            if all("Port-Channel" in via["interface"] for via in attrs["vias"]):
+            if not self.has_dut_portchannels:
+                prefixes.add(prefix)
+            elif all("Port-Channel" in via["interface"] for via in attrs["vias"]):
                 prefixes.add(prefix)
 
         return set(expects) == prefixes

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -374,9 +374,11 @@ class ReloadTest(BaseTest):
                     ports_in_vlan.append(self.port_indices[ifname])
             ports_per_vlan[vlan] = ports_in_vlan
 
-        active_portchannels = list()
-        for neighbor_info in list(self.vm_dut_map.values()):
-            active_portchannels.append(neighbor_info["dut_portchannel"])
+        active_portchannels = [
+            neighbor_info["dut_portchannel"]
+            for neighbor_info in self.vm_dut_map.values()
+            if "dut_portchannel" in neighbor_info
+        ]
 
         pc_ifaces = []
         for pc in portchannel_content.values():
@@ -393,6 +395,14 @@ class ReloadTest(BaseTest):
             for pc in portchannel_content.values():
                 if not pc['name'] in pc_in_vlan and pc['name'] in peer_active_portchannels:
                     dualtor_pc_ifaces.extend([self.peer_port_indices[member] for member in pc['members']])
+
+        # Isolated topologies have no portchannels; use routed neighbor ports as uplinks.
+        if not pc_ifaces:
+            pc_ifaces = sorted(set(
+                ptf_port
+                for neighbor_info in self.vm_dut_map.values()
+                for ptf_port in neighbor_info.get('ptf_ports', [])
+            ))
 
         return ports_per_vlan, pc_ifaces, dualtor_pc_ifaces
 
@@ -558,6 +568,12 @@ class ReloadTest(BaseTest):
         self.get_neigh_port_info()
         self.get_portchannel_info()
 
+    def has_portchannels(self):
+        portchannel_content = self.read_json('portchannel_ports_file')
+        if portchannel_content:
+            return True
+        return any('dut_portchannel' in info for info in self.vm_dut_map.values())
+
     def build_vlan_if_port_mapping(self):
         portchannel_content = self.read_json('portchannel_ports_file')
         portchannel_names = [pc['name'] for pc in portchannel_content.values()]
@@ -613,6 +629,10 @@ class ReloadTest(BaseTest):
 
     def init_sad_oper(self):
         if self.sad_oper:
+            if 'lag' in self.sad_oper and not self.has_dut_portchannels:
+                raise Exception(
+                    "Sad operation '%s' requires portchannels, but none exist on this topology"
+                    % self.sad_oper)
             self.log("Preboot/Inboot Operations:")
             self.sad_handle = sp.SadTest(self.sad_oper, self.ssh_targets, self.portchannel_ports,
                                          self.vm_dut_map, self.test_params, self.vlan_ports, self.ports_per_vlan)
@@ -686,6 +706,8 @@ class ReloadTest(BaseTest):
         self.build_peer_mapping()
         self.ports_per_vlan, self.portchannel_ports, self.dualtor_portchannel_ports = \
             self.read_vlan_portchannel_ports()
+        self.has_dut_portchannels = self.has_portchannels()
+        self.test_params['has_dut_portchannels'] = self.has_dut_portchannels
         self.vlan_ports = []
         for ports in self.ports_per_vlan.values():
             self.vlan_ports += ports
@@ -1560,6 +1582,9 @@ class ReloadTest(BaseTest):
         """
         Ensure there are no interface flaps after warm-boot
         """
+        if not self.has_dut_portchannels:
+            self.log("Skip neighbor LAG flap check: topology has no portchannels")
+            return
         for neigh in self.ssh_targets:
             flap_cnt = None
             if self.test_params['neighbor_type'] == "sonic":
@@ -1850,7 +1875,7 @@ class ReloadTest(BaseTest):
                     max_lacp_session_wait = lacp_session_wait
                 prev_time = new_time
 
-        if 'warm-reboot' in self.reboot_type:
+        if 'warm-reboot' in self.reboot_type and self.has_dut_portchannels:
             if max_lacp_session_wait and max_lacp_session_wait >= max_allowed_lacp_session_wait and not self.kvm_test:
                 self.fails['dut'].add("LACP session likely terminated by neighbor ({})".format(ip) +
                                       " post-reboot lacpdu came after {}s of lacpdu pre-boot"

--- a/ansible/roles/test/files/ptftests/sad_path.py
+++ b/ansible/roles/test/files/ptftests/sad_path.py
@@ -29,6 +29,7 @@ class SadTest(object):
         return self.shandle.retreive_test_info(), self.shandle.retreive_logs()
 
     def route_setup(self):
+        self.shandle.vm_reconnect()
         self.shandle.modify_routes()
         return self.shandle.retreive_logs()
 
@@ -44,6 +45,7 @@ class SadTest(object):
         return self.shandle.retreive_logs()
 
     def revert(self):
+        self.shandle.vm_reconnect()
         self.shandle.sad_setup()
         return self.shandle.retreive_logs()
 
@@ -145,6 +147,12 @@ class SadPath(object):
             else:
                 self.vm_handles[neigh_vm] = Arista(neigh_vm, None, self.test_args)
             self.vm_handles[neigh_vm].connect()
+
+    def vm_reconnect(self):
+        for vm in self.neigh_vms:
+            if vm in self.vm_handles:
+                self.vm_handles[vm].disconnect()
+        self.vm_connect()
 
     def __del__(self):
         self.vm_disconnect()

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -205,7 +205,9 @@ class AdvancedReboot:
                 self.duthost.host.options['variable_manager']._hostvars[self.vmhost.hostname]['vm_host_password']
 
         self.hostMaxLen = len(self.rebootData['arista_vms']) - 1
-        self.lagMemberCnt = len(list(self.mgFacts['minigraph_portchannels'].values())[0]['members'])
+        portchannels = self.mgFacts.get('minigraph_portchannels', {})
+        if portchannels:
+            self.lagMemberCnt = len(list(portchannels.values())[0]['members'])
         self.vlanMaxCnt = len(list(self.mgFacts['minigraph_vlans'].values())[0]['members']) - 1
 
         self.rebootData['dut_hostname'] = self.mgFacts['minigraph_mgmt_interface']['addr']

--- a/tests/common/platform/warmboot_sad_cases.py
+++ b/tests/common/platform/warmboot_sad_cases.py
@@ -17,84 +17,67 @@ SAD_CASE_LIST = [
     "sad_inboot"
 ]
 
+LAG_SAD_CASE_TYPES = ("sad_lag", "sad_lag_member")
+
+
+def _is_lag_sad_item(item):
+    return (isinstance(item, str) and 'lag' in item) or \
+           isinstance(item, (DutLagMemberDown, NeighLagMemberDown))
+
+
+def _filter_lag_sad_cases(cases):
+    if not cases:
+        return cases
+    return [item for item in cases if not _is_lag_sad_item(item)]
+
+
+def should_skip_lag_sad_cases(duthost, tbinfo, sad_case_type, sad_preboot_list):
+    """Skip when topology has no portchannels but the case still needs LAG sad paths."""
+    has_portchannels = bool(
+        duthost.get_extended_minigraph_facts(tbinfo).get('minigraph_portchannels', {}))
+    if has_portchannels:
+        return False
+    if sad_case_type in LAG_SAD_CASE_TYPES:
+        return True
+    if not sad_preboot_list:
+        return False
+    return any(_is_lag_sad_item(item) for item in sad_preboot_list)
+
+
+def _lag_string_cases(has_portchannels, *cases):
+    return list(cases) if has_portchannels else []
+
+
+def _lag_member_cases(duthost, nbrhosts, fanouthosts, has_portchannels,
+                      dut_vm_count, neigh_vm_count, port_count):
+    if not has_portchannels:
+        return []
+    return [
+        DutLagMemberDown(duthost, nbrhosts, DatetimeSelector(dut_vm_count),
+                         PhyPropsPortSelector(duthost, port_count)),
+        NeighLagMemberDown(duthost, nbrhosts, fanouthosts, DatetimeSelector(neigh_vm_count),
+                           PhyPropsPortSelector(duthost, port_count)),
+    ]
+
+
+def _full_lag_member_cases(duthost, nbrhosts, fanouthosts, has_portchannels, lag_member_cnt):
+    # Only meaningful when LAG has multiple members; single-member LAGs are
+    # already covered by _lag_member_cases(..., port_count=1).
+    if not has_portchannels or lag_member_cnt <= 1:
+        return []
+    return [
+        DutLagMemberDown(duthost, nbrhosts, DatetimeSelector(2),
+                         PhyPropsPortSelector(duthost, lag_member_cnt)),
+        NeighLagMemberDown(duthost, nbrhosts, fanouthosts, DatetimeSelector(3),
+                           PhyPropsPortSelector(duthost, lag_member_cnt)),
+    ]
+
 
 def get_sad_case_list(duthost, nbrhosts, fanouthosts, vmhost, tbinfo, sad_case_type):
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-    lagMemberCnt = len(list(mg_facts['minigraph_portchannels'].values())[0]['members'])
-
-    sad_preboot_cases = {
-        "sad": [
-            'neigh_bgp_down',               # Shutdown single BGP session on remote device (VM) before reboot DUT
-            'dut_bgp_down',                 # Shutdown single BGP session on DUT brefore rebooting it
-            'dut_lag_down',                 # Shutdown single LAG session on DUT brefore rebooting it
-            'neigh_lag_down',               # Shutdown single LAG session on remote device (VM) before reboot DUT
-            # Shutdown 1 LAG member corresponding to 1 remote device (VM) on DUT
-            DutLagMemberDown(duthost, nbrhosts, DatetimeSelector(1), PhyPropsPortSelector(duthost, 1)),
-            # Shutdown 1 LAG member on 1 remote device (VM)
-            NeighLagMemberDown(duthost, nbrhosts, fanouthosts, DatetimeSelector(1), PhyPropsPortSelector(duthost, 1)),
-            # Shutdown 1 vlan port (interface) on DUT
-            DutVlanMemberDown(duthost, PhyPropsPortSelector(duthost, 1)),
-            # Shutdown 1 vlan port (interface) on fanout
-            NeighVlanMemberDown(duthost, fanouthosts, vmhost, PhyPropsPortSelector(duthost, 1))
-        ],
-
-        "multi_sad": [
-                'neigh_bgp_down:2',     # Shutdown single BGP session on 2 remote devices (VMs) before reboot DUT
-                'dut_bgp_down:3',       # Shutdown 3 BGP sessions on DUT brefore rebooting it
-                'dut_lag_down:2',       # Shutdown 2 LAG sessions on DUT brefore rebooting it
-                'neigh_lag_down:3',     # Shutdown 1 LAG session on 3 remote devices (VMs) before reboot DUT
-                # Shutdown 1 LAG member of 3 LAG sessions corresponding to 3 remote devices (VM)
-                # on DUT
-                DutLagMemberDown(duthost, nbrhosts, DatetimeSelector(3), PhyPropsPortSelector(duthost, 1)),
-                # Shutdown 1 LAG member of 2 LAG sessions on 2 remote devices (VM) (1 each)
-                NeighLagMemberDown(duthost, nbrhosts, fanouthosts, DatetimeSelector(2),
-                                   PhyPropsPortSelector(duthost, 1)),
-                DutVlanMemberDown(duthost, PhyPropsPortSelector(duthost, 4)),
-                NeighVlanMemberDown(duthost, fanouthosts, vmhost, PhyPropsPortSelector(duthost, 4)),
-            ] + ([
-                # Shutdown <lag count> LAG member(s) of 2 LAG sessions corresponding to 2 remote
-                # devices (VM) on DUT
-                DutLagMemberDown(duthost, nbrhosts, DatetimeSelector(2), PhyPropsPortSelector(duthost, lagMemberCnt)),
-                # Shutdown <lag count> LAG member(s) of 3 LAG sessions on 3 remote devices (VM)
-                # (1 each)
-                NeighLagMemberDown(duthost, nbrhosts, fanouthosts, DatetimeSelector(3),
-                                   PhyPropsPortSelector(duthost, lagMemberCnt)),
-            ] if tbinfo['topo']['name'] in ['t0-64', 't0-116', 't0-118', 't0-64-32'] else []),
-
-        "sad_bgp": [
-                'neigh_bgp_down:2',     # Shutdown single BGP session on 2 remote devices (VMs) before reboot DUT
-                'dut_bgp_down:3',       # Shutdown 3 BGP sessions on DUT brefore rebooting it
-            ],
-
-        "sad_lag_member": [
-                # Shutdown 1 LAG member of 3 LAG sessions corresponding to 3 remote devices (VM)
-                # on DUT
-                DutLagMemberDown(duthost, nbrhosts, DatetimeSelector(3), PhyPropsPortSelector(duthost, 1)),
-                # Shutdown 1 LAG member of 2 LAG sessions on 2 remote devices (VM) (1 each)
-                NeighLagMemberDown(duthost, nbrhosts, fanouthosts, DatetimeSelector(2),
-                                   PhyPropsPortSelector(duthost, 1)),
-            ] + ([
-                # Shutdown <lag count> LAG member(s) of 2 LAG sessions corresponding to 2 remote
-                # devices (VM) on DUT
-                DutLagMemberDown(duthost, nbrhosts, DatetimeSelector(2), PhyPropsPortSelector(duthost, lagMemberCnt)),
-                # Shutdown <lag count> LAG member(s) of 3 LAG sessions on 3 remote devices (VM)
-                # (1 each)
-                NeighLagMemberDown(duthost, nbrhosts, fanouthosts, DatetimeSelector(3),
-                                   PhyPropsPortSelector(duthost, lagMemberCnt)),
-            ] if tbinfo['topo']['name'] in ['t0-64', 't0-116', 't0-118', 't0-64-32'] else []),
-
-        "sad_lag": [
-                'dut_lag_down:2',               # Shutdown 2 LAG sessions on DUT brefore rebooting it
-                'neigh_lag_down:3',             # Shutdown 1 LAG session on 3 remote devices (VMs) before reboot DUT
-            ],
-
-        "sad_vlan_port": [
-                # Shutdown 4 vlan ports (interfaces) on DUT
-                DutVlanMemberDown(duthost, PhyPropsPortSelector(duthost, 4)),
-                # Shutdown 4 vlan ports (interfaces) on fanout
-                NeighVlanMemberDown(duthost, fanouthosts, vmhost, PhyPropsPortSelector(duthost, 4)),
-            ]
-    }
+    portchannels = mg_facts.get('minigraph_portchannels', {})
+    has_portchannels = bool(portchannels)
+    lagMemberCnt = len(list(portchannels.values())[0]['members']) if portchannels else 0
 
     sad_inboot_cases = {
         "sad_inboot": [
@@ -103,4 +86,55 @@ def get_sad_case_list(duthost, nbrhosts, fanouthosts, vmhost, tbinfo, sad_case_t
         ]
     }
 
-    return sad_preboot_cases.get(sad_case_type), sad_inboot_cases.get(sad_case_type)
+    if not has_portchannels and sad_case_type in LAG_SAD_CASE_TYPES:
+        return None, sad_inboot_cases.get(sad_case_type)
+
+    sad_preboot_cases = {
+        "sad": [
+            'neigh_bgp_down',               # Shutdown single BGP session on remote device (VM) before reboot DUT
+            'dut_bgp_down',                 # Shutdown single BGP session on DUT brefore rebooting it
+        ] + _lag_string_cases(has_portchannels,
+                              'dut_lag_down', 'neigh_lag_down') + _lag_member_cases(
+            duthost, nbrhosts, fanouthosts, has_portchannels, 1, 1, 1) + [
+            # Shutdown 1 vlan port (interface) on DUT
+            DutVlanMemberDown(duthost, PhyPropsPortSelector(duthost, 1)),
+            # Shutdown 1 vlan port (interface) on fanout
+            NeighVlanMemberDown(duthost, fanouthosts, vmhost, PhyPropsPortSelector(duthost, 1))
+        ],
+
+        "multi_sad": [
+            'neigh_bgp_down:2',     # Shutdown single BGP session on 2 remote devices (VMs) before reboot DUT
+            'dut_bgp_down:3',       # Shutdown 3 BGP sessions on DUT before rebooting it
+        ] + _lag_string_cases(has_portchannels,
+                              'dut_lag_down:2', 'neigh_lag_down:3') + _lag_member_cases(
+            duthost, nbrhosts, fanouthosts, has_portchannels, 3, 2, 1) + [
+            DutVlanMemberDown(duthost, PhyPropsPortSelector(duthost, 4)),
+            NeighVlanMemberDown(duthost, fanouthosts, vmhost, PhyPropsPortSelector(duthost, 4)),
+        ] + _full_lag_member_cases(duthost, nbrhosts, fanouthosts, has_portchannels, lagMemberCnt),
+
+        "sad_bgp": [
+            'neigh_bgp_down:2',     # Shutdown single BGP session on 2 remote devices (VMs) before reboot DUT
+            'dut_bgp_down:3',       # Shutdown 3 BGP sessions on DUT before rebooting it
+        ],
+
+        "sad_lag_member": _lag_member_cases(
+            duthost, nbrhosts, fanouthosts, has_portchannels, 3, 2, 1
+        ) + _full_lag_member_cases(duthost, nbrhosts, fanouthosts, has_portchannels, lagMemberCnt),
+
+        "sad_lag": _lag_string_cases(has_portchannels,
+                                     'dut_lag_down:2', 'neigh_lag_down:3'),
+
+        "sad_vlan_port": [
+            # Shutdown 4 vlan ports (interfaces) on DUT
+            DutVlanMemberDown(duthost, PhyPropsPortSelector(duthost, 4)),
+            # Shutdown 4 vlan ports (interfaces) on fanout
+            NeighVlanMemberDown(duthost, fanouthosts, vmhost, PhyPropsPortSelector(duthost, 4)),
+        ]
+    }
+
+    sad_preboot = sad_preboot_cases.get(sad_case_type)
+    sad_inboot = sad_inboot_cases.get(sad_case_type)
+    if not has_portchannels and sad_preboot:
+        sad_preboot = _filter_lag_sad_cases(sad_preboot)
+
+    return sad_preboot, sad_inboot

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -8,7 +8,7 @@ from tests.common.fixtures.duthost_utils import backup_and_restore_config_db    
 from tests.common.fixtures.advanced_reboot import get_advanced_reboot           # noqa: F401
 from tests.common.fixtures.consistency_checker.consistency_checker import consistency_checker_provider  # noqa: F401
 from tests.platform_tests.verify_dut_health import add_fail_step_to_reboot      # noqa: F401
-from tests.common.platform.warmboot_sad_cases import get_sad_case_list, SAD_CASE_LIST
+from tests.common.platform.warmboot_sad_cases import get_sad_case_list, SAD_CASE_LIST, should_skip_lag_sad_cases
 from tests.common.platform.device_utils import advanceboot_loganalyzer  # noqa: F401
 from tests.common.platform.device_utils import verify_dut_health  # noqa: F401
 from tests.common.platform.device_utils import advanceboot_neighbor_restore  # noqa: F401
@@ -194,6 +194,8 @@ def test_warm_reboot_sad(duthosts, rand_one_dut_hostname, nbrhosts, fanouthosts,
 
     sad_preboot_list, sad_inboot_list = get_sad_case_list(
         duthost, nbrhosts, fanouthosts, vmhost, tbinfo, sad_case_type)
+    if should_skip_lag_sad_cases(duthost, tbinfo, sad_case_type, sad_preboot_list):
+        pytest.skip("LAG sad cases require portchannels, not available on this topology")
     advancedReboot.runRebootTestcase(
         prebootList=sad_preboot_list,
         inbootList=sad_inboot_list


### PR DESCRIPTION


### Description of PR
Adapt advance warm reboot test on the isolated topology 
Remove lacp or portchannel validations on the isolated topology
Related design PR: https://github.com/sonic-net/sonic-buildimage/pull/27860


Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
Run warm-reboot and sad test on the isolated topology
#### How did you do it?
Remove lacp or portchannel validations on the isolated topology
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
