### PR TITLE
[cherry-pick][202605] Backport ansible-core compatibility fixes

### DIFF
--- a/ansible/module_utils/debug_utils.py
+++ b/ansible/module_utils/debug_utils.py
@@ -1,7 +1,7 @@
 import os
 import re
 import logging
-from ansible.module_utils.basic import datetime
+import datetime
 
 MAX_LOG_FILES_PER_MODULE = 10
 

--- a/tests/common/devices/arista.py
+++ b/tests/common/devices/arista.py
@@ -101,7 +101,7 @@ class AristaHost(AnsibleHostBase):
             else:
                 command = "show lldp neighbors | json"
             output = self.commands(commands=[command])
-            return output["stdout_lines"][0] if output["failed"] is False else False
+            return output["stdout_lines"][0] if output.get("failed", False) is False else False
         except Exception as e:
             logger.error("command {} failed. exception: {}".format(command, repr(e)))
             return False
@@ -228,7 +228,7 @@ class AristaHost(AnsibleHostBase):
             logger.info("Gathering LLDP details")
             command = "show lldp neighbors | json"
             json_output = self.commands(commands=[command])
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 for row in json_output["stdout_lines"][0]["lldpNeighbors"]:
                     lldp_details.update(
                         {
@@ -262,7 +262,7 @@ class AristaHost(AnsibleHostBase):
         command = "show lldp neighbors {} detail | json".format(physical_port)
         try:
             json_output = self.commands(commands=[command])
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 return json_output["stdout_lines"][0]
             return "Failed to get lldp neighbor details due to {}".format(json_output)
         except Exception as e:
@@ -276,7 +276,7 @@ class AristaHost(AnsibleHostBase):
         try:
             command = "show lldp local-info | json"
             json_output = self.commands(commands=[command])
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 return json_output["stdout_lines"][0]["chassisId"]
             return "Failed to get chassis id due to {}".format(json_output)
         except Exception as e:
@@ -289,7 +289,7 @@ class AristaHost(AnsibleHostBase):
         try:
             command = "show lldp local-info | json"
             json_output = self.commands(commands=[command])
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 return json_output["stdout_lines"][0]["managementAddresses"][0]["address"]
             return "Failed to get mgmt IP due to {}".format(json_output)
         except Exception as e:
@@ -302,7 +302,7 @@ class AristaHost(AnsibleHostBase):
         try:
             command = "show version | json"
             json_output = self.commands(commands=[command])
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 return json_output["stdout_lines"][0]["modelName"]
             return "Failed to get platform info due to {}".format(json_output)
         except Exception as e:
@@ -315,7 +315,7 @@ class AristaHost(AnsibleHostBase):
         try:
             command = "show version | json"
             json_output = self.commands(commands=[command])
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 return json_output["stdout_lines"][0]["version"]
             return "Failed to get platform info due to {}".format(json_output)
         except Exception as e:
@@ -440,7 +440,7 @@ class AristaHost(AnsibleHostBase):
             pc_on = pc_name.replace("Port-Channel", "")
             command = "show lacp {} aggregates | json".format(pc_on)
             json_output = self.commands(commands=[command])
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 return json_output["stdout_lines"][0]["portChannels"][pc_name]["bundledPorts"]
             return "Failed to get interfaces in port chancel due to {}".format(json_output)
         except Exception as e:
@@ -460,7 +460,7 @@ class AristaHost(AnsibleHostBase):
         try:
             success_criteria = "line protocol is up"
             intf_status_output = self.commands(commands=[command])
-            if not intf_status_output["failed"]:
+            if not intf_status_output.get("failed", False):
                 logger.info("Interface status check: {} sent to {}".format(command, self.hostname))
                 is_up = success_criteria in intf_status_output["stdout"][0].lower()
                 return is_up, intf_status_output["stdout_lines"][0]
@@ -475,7 +475,7 @@ class AristaHost(AnsibleHostBase):
             logger.info("Gathering ISIS adjacency details")
             command = "show isis neighbors| json"
             output = self.commands(commands=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 isis_instances = output["stdout"][0]["vrfs"]["default"]["isisInstances"].keys()
                 for instance in isis_instances:
                     for key, line in output["stdout"][0]["vrfs"]["default"]["isisInstances"][instance][
@@ -515,7 +515,7 @@ class AristaHost(AnsibleHostBase):
             command = "show isis database"
             output = self.commands(commands=[command])
             lsp_entries = {}
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0]:
                     if "00-0" in line:
                         outline = line.strip().split()
@@ -540,7 +540,7 @@ class AristaHost(AnsibleHostBase):
         try:
             output = self.commands(commands=[command])
             bgp_status = {}
-            if not output["failed"]:
+            if not output.get("failed", False):
                 bgp_peer_info = output["stdout"][0]["vrfs"]["default"]["peers"]
                 for peer_ip, peer_info in bgp_peer_info.items():
                     bgp_status[peer_ip] = peer_info["peerState"]
@@ -569,7 +569,7 @@ class AristaHost(AnsibleHostBase):
         """
         try:
             bgp_peer_details = self.get_bgp_session_details(peer_ip)
-            if not bgp_peer_details["failed"]:
+            if not bgp_peer_details.get("failed", False):
                 bgp_session_status = bgp_peer_details["stdout"][0]["vrfs"]["default"]["peerList"][0]["state"]
 
             else:
@@ -588,7 +588,7 @@ class AristaHost(AnsibleHostBase):
         try:
             json_output = self.commands(commands=[command])
             prefix_adv_status = False
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 bgp_route_entries = json_output["stdout"][0]["vrfs"]["default"]["bgpRouteEntries"]
                 if len(bgp_route_entries) > 0 and prefix in bgp_route_entries:
                     prefix_adv_status = True
@@ -611,7 +611,7 @@ class AristaHost(AnsibleHostBase):
             command = "show mpls ldp neighbor summary | json"
             json_output = self.commands(commands=[command])
             ldp_op_list = []
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 for neighbor in json_output["stdout"][0]["vrfs"]["default"]["neighbors"]:
                     if "state" in neighbor and neighbor["state"] == "stateOperational":
                         ldp_op_list.append(neighbor["tcpPeerIp"]["ip"])
@@ -637,7 +637,7 @@ class AristaHost(AnsibleHostBase):
             for ldpneighbor in ldp_op_list:
                 command = "show ip route {}".format(ldpneighbor)
                 output = self.commands(commands=[command])
-                if not output["failed"]:
+                if not output.get("failed", False):
                     for line in output["stdout_lines"][0]:
                         if "Port-Channel" in line:
                             ldp_int_list.append(line.split(",")[1].strip())
@@ -751,7 +751,7 @@ class AristaHost(AnsibleHostBase):
             commands = ["mka session rekey-period {}".format(rekey_period_value)]
             parents = ["mac security", "profile {}".format(profile_name)]
             output = self.config(lines=commands, parents=parents)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, "Failed to set rekey period due to {}".format(output)
         except Exception as e:
@@ -768,7 +768,7 @@ class AristaHost(AnsibleHostBase):
             """example of output:
             mac security profile macsec-profile-juniper-256-64CKN-64CAK-fallback
             """
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output["stdout_lines"][0][-1].split()[-1]
             return False, "Failed to get macsec profile due to {}".format(output)
         except Exception as e:
@@ -788,7 +788,7 @@ class AristaHost(AnsibleHostBase):
                 return True, "Device {} not support {} log".format(self.hostname, log_type)
             command = "show logging all | grep MKA | grep {} | grep {}".format(interface, log_type)
             output = self.commands(commands=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return len(output["stdout_lines"][0]) > 0, output["stdout"][0]
             return False, "Failed to get macsec status logs due to {}".format(output)
         except Exception as e:
@@ -848,7 +848,7 @@ class AristaHost(AnsibleHostBase):
             """example of output:
             mac security profile macsec-profile-juniper-256-64CKN-64CAK-fallback
             """
-            if not output["failed"]:
+            if not output.get("failed", False):
                 # Returning only MACSEC config.
                 for config in output["stdout_lines"][0]:
                     if "security" in config:
@@ -873,7 +873,7 @@ class AristaHost(AnsibleHostBase):
                     list_command.append(line[1])
             if len(list_command) > 0:
                 output = self.config(lines=commands, parents=parents)
-                if not output["failed"]:
+                if not output.get("failed", False):
                     return True, output
                 return False, "Failed to apply macsec interface config due to {}".format(output)
             return False, "Failed to apply macsec interface config due to no commmand available."
@@ -889,7 +889,7 @@ class AristaHost(AnsibleHostBase):
             parents = ["interface {}".format(interface)]
             commands = ["no mac security profile"]
             output = self.config(lines=commands, parents=parents)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, "Failed to delete macsec interface config due to {}".format(output)
         except Exception as e:
@@ -930,7 +930,7 @@ class AristaHost(AnsibleHostBase):
                 }
             }
             """
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 counter = json_output["stdout"][0]["interfaces"][interface]
                 validated_bytes = counter["countersDetail"]["inPktsOK"]
                 decrypted_bytes = counter["inPktsDecrypted"]
@@ -975,7 +975,7 @@ class AristaHost(AnsibleHostBase):
         try:
             command = "show running-config interfaces loopback 99"
             output = self.commands(commands=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0]:
                     if "ip address" in line:
                         lb_ipv4_addr = line.split()[-1].strip("/32")
@@ -995,7 +995,7 @@ class AristaHost(AnsibleHostBase):
             command = ["no channel-group"]
             parents = ["interface {}".format(interface)]
             output = self.config(lines=command, parents=parents)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, "remove interface {} from ether-bundle {}".format(interface, pcnum)
             else:
                 return False, "Failed to remove interface {} from ether-bundle {}".format(interface, pcnum)
@@ -1015,7 +1015,7 @@ class AristaHost(AnsibleHostBase):
             command = ["channel-group {} mode active".format(pcnum)]
             parents = ["interface {}".format(interface)]
             output = self.config(lines=command, parents=parents)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, "Added interface {} from channel-group  {}".format(interface, pcnum)
             else:
                 return False, "Failed to add interface {} to channel-group {}".format(interface, pcnum)
@@ -1035,7 +1035,7 @@ class AristaHost(AnsibleHostBase):
             parents = []
             command = ["alias testversion show version"]
             output = self.config(lines=command, parents=parents)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 rollback_command = "no alias testversion"
                 self.config(lines=[rollback_command], parents=parents)
                 return True, output
@@ -1099,7 +1099,7 @@ class AristaHost(AnsibleHostBase):
             command = "show ip route aggregate | include {}".format(agg_prefix)
             agg_route_gen_status = False
             output = self.commands(commands=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0]:
                     if agg_prefix in line:
                         agg_route_gen_status = True
@@ -1113,7 +1113,7 @@ class AristaHost(AnsibleHostBase):
             packets_exported = 0
             command = "show flow tracking sampled counters | include messages"
             output = self.commands(commands=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0]:
                     if "messages" in line:
                         counter = line.split()[1].lstrip("(").rstrip(")")
@@ -1137,7 +1137,7 @@ class AristaHost(AnsibleHostBase):
             parents = ["interface {}".format(interface)]
             commands = ["flow tracker sampled {}".format(filter_name)]
             output = self.config(lines=commands, parents=parents)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, output
         except Exception as e:
@@ -1147,7 +1147,7 @@ class AristaHost(AnsibleHostBase):
         try:
             command = "reload all now"
             output = self.commands(commands=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, output
         except Exception as e:

--- a/tests/common/devices/base.py
+++ b/tests/common/devices/base.py
@@ -247,6 +247,14 @@ class AnsibleHostBase(object):
         if (hostname_res.is_failed or 'exception' in hostname_res) and not module_ignore_errors:
             raise RunAnsibleModuleFail("run module {} failed".format(module_name), hostname_res)
 
+        # Ensure 'failed' key is always present for backward compatibility with code that
+        # accesses rc['failed'] directly. The _IGNORE hack above is no longer effective in
+        # ansible-core >= 2.21 where the post-processing behavior changed so that 'failed'
+        # is absent from successful command results. Normalizing here is a single robust fix
+        # that covers all call sites without requiring per-file changes.
+        if 'failed' not in hostname_res:
+            hostname_res['failed'] = hostname_res.is_failed
+
         return hostname_res
 
 

--- a/tests/common/devices/cisco.py
+++ b/tests/common/devices/cisco.py
@@ -187,7 +187,9 @@ class CiscoHost(AnsibleHostBase):
                     commands=[command],
                     module_ignore_errors=True)
             logger.debug('cisco lldp output: %s' % (output))
-            return output['stdout_lines'][0]['Response']['Get']['Operational'] if output['failed'] is False else False
+            if output.get('failed', False):
+                return False
+            return output['stdout_lines'][0]['Response']['Get']['Operational']
         except Exception as e:
             logger.error('command {} failed. exception: {}'.format(command, repr(e)))
         return False
@@ -239,7 +241,9 @@ class CiscoHost(AnsibleHostBase):
             command = 'ping {} count 5'.format(dest)
             output = self.commands(commands=[command])
             logger.debug('ping result: %s' % (output))
-            return re.search('!!!!!', output['stdout'][0]) is not None if output['failed'] is False else False
+            if output.get('failed', False):
+                return False
+            return re.search('!!!!!', output['stdout'][0]) is not None
         except Exception as e:
             logger.error('command {} failed. exception: {}'.format(command, repr(e)))
         return False
@@ -387,7 +391,7 @@ class CiscoHost(AnsibleHostBase):
             header_line = "Device ID       Local Intf                      Hold-time  Capability      Port ID"
             end_line = "Total entries displayed:"
             content_idx = 0
-            if not output['failed']:
+            if not output.get('failed', False):
                 output = [line.strip() for line in output['stdout_lines'][0] if len(line) > 0]
                 for idx, line in enumerate(output):
                     if end_line in line:
@@ -413,7 +417,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             command = "show lldp neigh {} detail".format(physical_port)
             output = self.commands(commands=[command], module_ignore_errors=True)
-            if not output['failed']:
+            if not output.get('failed', False):
                 logger.debug('cisco lldp output: %s' % (output))
                 return output['stdout_lines'][0]
             return "Failed to get lldp detail info for {} due to {}".format(physical_port, output)
@@ -427,7 +431,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             command = "show version | i ^cisco | utility head -n 1"
             output = self.commands(commands=[command], module_ignore_errors=True)
-            if not output['failed']:
+            if not output.get('failed', False):
                 logger.debug('cisco lldp output: %s' % (output))
                 return output['stdout_lines'][0][0].split()[1]
             return "Failed to get platform info due to {}".format(output)
@@ -441,7 +445,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             command = 'show version | in "Version      :"'
             output = self.commands(commands=[command], module_ignore_errors=True)
-            if not output['failed']:
+            if not output.get('failed', False):
                 logger.debug('cisco lldp output: %s' % (output))
                 return output['stdout'][0].split()[-1].strip()
             return "Failed to get version info due to {}".format(output)
@@ -455,7 +459,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             command = "show lldp | i Chassis ID:"
             output = self.commands(commands=[command], module_ignore_errors=True)
-            if not output['failed']:
+            if not output.get('failed', False):
                 logger.debug('cisco lldp output: %s' % (output))
                 return output['stdout_lines'][0][0].split()[-1]
             return "Failed to get chassis id info due to {}".format(output)
@@ -625,7 +629,7 @@ class CiscoHost(AnsibleHostBase):
             pc_name = self.convert_pc_to_be(pc_name)
             command = "show lacp {} | begin eceive".format(pc_name)
             output = self.commands(commands=[command], module_ignore_errors=True)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 logger.debug("cisco lldp output: %s" % (output))
                 interface = [
                     self.elongate_cisco_interface(line.split()[0])
@@ -651,7 +655,7 @@ class CiscoHost(AnsibleHostBase):
             command = "show interfaces {}".format(pc_name)
             success_criteria = "line protocol is up"
             intf_status_output = self.commands(commands=[command], module_ignore_errors=True)
-            if not intf_status_output["failed"]:
+            if not intf_status_output.get("failed", False):
                 logger.info("Interface status check: {} sent to {}".format(command, self.hostname))
                 is_up = success_criteria in intf_status_output["stdout"][0].lower()
                 return is_up, intf_status_output["stdout_lines"][0]
@@ -668,7 +672,7 @@ class CiscoHost(AnsibleHostBase):
             logger.info("Gathering ISIS adjacency details")
             command = "show isis adjacency"
             output = self.commands(commands=[command], module_ignore_errors=True)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for row in output["stdout_lines"][0][3:-2]:
                     row = row.split()
                     isis_details[row[0]] = dict()
@@ -706,7 +710,7 @@ class CiscoHost(AnsibleHostBase):
             command = "show isis database"
             output = self.commands(commands=[command], module_ignore_errors=True)
             lsp_entries = {}
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0]:
                     if "*" in line:
                         outline = line.replace("*", "").split()
@@ -737,7 +741,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             output = self.commands(commands=[command], module_ignore_errors=True)
             bgp_status = {}
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0][1:]:
                     line = line.strip().split()
                     if line[-1].isdigit():
@@ -770,7 +774,7 @@ class CiscoHost(AnsibleHostBase):
         """
         bgp_peer_details = self.get_bgp_session_details(peer_ip)
         try:
-            if not bgp_peer_details["failed"]:
+            if not bgp_peer_details.get("failed", False):
                 for line in bgp_peer_details["stdout_lines"][0]:
                     if "BGP state" in line:
                         bgp_session_status = line.strip().split()[3].strip(",")
@@ -792,7 +796,7 @@ class CiscoHost(AnsibleHostBase):
             command = "show bgp advertised neighbor {} summary | in {}".format(peer_ip, prefix)
             output = self.commands(commands=[command], module_ignore_errors=True)
             prefix_adv_status = False
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0]:
                     if prefix in line:
                         prefix_adv_status = True
@@ -810,7 +814,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             command = 'show mpls ldp neighbor | include "Peer LDP Identifier:|State:"'
             output = self.commands(commands=[command], module_ignore_errors=True)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 ldp_op_list = []
                 for idx in range(0, len(output["stdout_lines"][0]), 2):
                     line1 = output["stdout_lines"][0][idx]
@@ -830,7 +834,7 @@ class CiscoHost(AnsibleHostBase):
             command = "show route {} | include via".format(destination_ip)
             output = self.commands(commands=[command], module_ignore_errors=True)
             interface_list = []
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0]:
                     if "via" in line:
                         next_hop = line.split("via")[-1].strip()
@@ -873,7 +877,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             command = "show mpls traffic-eng tunnels name {} | include Hop0".format(lsp_name)
             output = self.commands(commands=[command], module_ignore_errors=True)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 list_of_interface = []
                 for line in output["stdout_lines"][0]:
                     if "Hop0" in line:
@@ -963,7 +967,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             command = "macsec-policy {} sak-rekey-interval seconds {}".format(profile_name, rekey_period_value)
             output = self.config(lines=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, output
         except Exception as e:
@@ -984,7 +988,7 @@ class CiscoHost(AnsibleHostBase):
             macsec psk-keychain ptx10k-64hexCAK fallback-psk-keychain ptx10k-64hexCAK-fallback policy macsec-xpn-256
             !
             """
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output['stdout_lines'][0][1].split()[-1].strip()
             return False, output
         except Exception as e:
@@ -1007,7 +1011,7 @@ class CiscoHost(AnsibleHostBase):
                 return True, "log {} not supported on device {}".format(log_type, self.hostname)
             command = "show logging last {} | include {} | include {}".format(last_count, log_type, interface)
             output = self.commands(commands=[command])["stdout"][0]
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return len(output["stdout_lines"][0]) > 0, output["stdout"][0]
             return False, str(output)
         except Exception as e:
@@ -1099,7 +1103,7 @@ class CiscoHost(AnsibleHostBase):
             command = "show running-config formal interface {} macsec psk-keychain".format(interface)
             output = self.commands(commands=[command])
             # Returning only MACSEC config.
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for config in output["stdout_lines"][0]:
                     if "psk" in config:
                         return True, config
@@ -1115,7 +1119,7 @@ class CiscoHost(AnsibleHostBase):
         """
         try:
             output = self.config(lines=commands)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, output
         except Exception as e:
@@ -1129,7 +1133,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             command = "no interface {} macsec ".format(interface)
             output = self.config(lines=command)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, output
         except Exception as e:
@@ -1186,7 +1190,7 @@ class CiscoHost(AnsibleHostBase):
             command = ["no bundle id"]
             parents = ["interface {}".format(interface)]
             output = self.config(lines=command, parents=parents)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, "remove interface {} from ether-bundle {}".format(interface, pcnum)
             else:
                 return False, "Failed to remove interface {} from ether-bundle {}".format(interface, pcnum)
@@ -1205,7 +1209,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             command = ["interface {} bundle id {} mode active".format(interface, pcnum)]
             output = self.config(lines=command)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, "Added interface {} from ether-bundle {}".format(interface, pcnum)
             else:
                 return False, "Failed to add interface {} from ether-bundle {}".format(interface, pcnum)
@@ -1224,7 +1228,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             command = ["alias testversion show version"]
             output = self.config(lines=command)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 rollback_command = ["no alias testversion"]
                 self.config(lines=rollback_command)
                 return True, output
@@ -1292,7 +1296,7 @@ class CiscoHost(AnsibleHostBase):
             command = "show route | include {}".format(agg_prefix)
             agg_route_gen_status = False
             output = self.commands(commands=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0]:
                     if agg_prefix in line:
                         agg_route_gen_status = True
@@ -1305,7 +1309,7 @@ class CiscoHost(AnsibleHostBase):
         command = "show platform | include NSHUT | include CPU | exclude RP"
         output = self.commands(commands=[command])
         location_list = []
-        if not output["failed"]:
+        if not output.get("failed", False):
             for line in output["stdout_lines"][0]:
                 if "CPU" in line:
                     location_list.append(line.split()[0])
@@ -1316,7 +1320,7 @@ class CiscoHost(AnsibleHostBase):
             packets_exported = 0
             command = 'show flow exporter IPFIX_MSAZ location {} | include "Packets exported:"'.format(location)
             output = self.commands(commands=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0]:
                     if "Packets exported:" in line:
                         packets_exported += int(line.split()[2])
@@ -1350,7 +1354,7 @@ class CiscoHost(AnsibleHostBase):
                 interface, filter_name, filter_name
             )
             output = self.config(lines=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, output
         except Exception as e:
@@ -1360,7 +1364,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             command = "admin hw-module location all reload noprompt"
             output = self.commands(commands=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, output
         except Exception as e:

--- a/tests/common/devices/cisco.py
+++ b/tests/common/devices/cisco.py
@@ -1010,7 +1010,7 @@ class CiscoHost(AnsibleHostBase):
             elif log_type == "ROLLOVER":
                 return True, "log {} not supported on device {}".format(log_type, self.hostname)
             command = "show logging last {} | include {} | include {}".format(last_count, log_type, interface)
-            output = self.commands(commands=[command])
+            output = self.commands(commands=[command])["stdout"][0]
             if not output.get("failed", False):
                 return len(output["stdout_lines"][0]) > 0, output["stdout"][0]
             return False, str(output)

--- a/tests/common/devices/cisco.py
+++ b/tests/common/devices/cisco.py
@@ -1010,7 +1010,7 @@ class CiscoHost(AnsibleHostBase):
             elif log_type == "ROLLOVER":
                 return True, "log {} not supported on device {}".format(log_type, self.hostname)
             command = "show logging last {} | include {} | include {}".format(last_count, log_type, interface)
-            output = self.commands(commands=[command])["stdout"][0]
+            output = self.commands(commands=[command])
             if not output.get("failed", False):
                 return len(output["stdout_lines"][0]) > 0, output["stdout"][0]
             return False, str(output)

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -202,7 +202,7 @@ class EosHost(AnsibleHostBase):
         # FIXME: out['failed'] will be False even when a command is deprecated, so we have to check out['changed']
         # However, if the lacp rate is already in expected state, out['changed'] will be False and treated as
         # error.
-        if out['failed'] is True or out['changed'] is False:
+        if out.get('failed', False) is True or out['changed'] is False:
             # new eos deprecate lacp rate and use lacp timer command
             out = self.eos_config(
                 lines=['lacp timer %s' % mode],
@@ -596,7 +596,7 @@ class EosHost(AnsibleHostBase):
             lines=['lacp timer multiplier %d' % multiplier],
             parents='interface %s' % interface_name)
 
-        if out['failed'] is True or out['changed'] is False:
+        if out.get('failed', False) is True or out['changed'] is False:
             logging.warning("Unable to set interface [%s] lacp timer multiplier to [%d]" % (interface_name, multiplier))
         else:
             logging.info("Set interface [%s] lacp timer to [%d]" % (interface_name, multiplier))

--- a/tests/common/devices/juniper.py
+++ b/tests/common/devices/juniper.py
@@ -239,7 +239,7 @@ class JuniperHost(AnsibleHostBase):
             nh_result = []
             command = "show route {} table {} active-path exact".format(prefix, table)
             json_output = self.commands(commands=[command], display="json")
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 prefix_info = json_output["stdout"][0]["route-information"][0]["route-table"][0]["rt"][0]
                 if prefix in prefix_info["rt-destination"][0]["data"]:
                     nh_info = {"nh_ip": None, "nh_interface": None, "nh_label_info": None, "nh_lsp_name": None}
@@ -298,7 +298,7 @@ class JuniperHost(AnsibleHostBase):
         command = "show chassis hardware | match fpc | except CPU"
         output = self.commands(session_type="network_cli", commands=[command], display="text")
         fpc_list = []
-        if not output["failed"]:
+        if not output.get("failed", False):
             for line in output["stdout_lines"][0]:
                 if "FPC" in line:
                     fpc_list.append(line.split()[1])
@@ -309,7 +309,7 @@ class JuniperHost(AnsibleHostBase):
             ipfix_export_data = {"count": 0}
             command = "show services accounting flow inline-jflow fpc-slot {}".format(fpc_no)
             output = self.commands(commands=[command], display="json")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 ipfix_export_data["count"] = output["stdout"][0]["services-accounting-information"][0][
                     "inline-jflow-flow-information"
                 ][0]["inline-flows-exported"][0]["data"]
@@ -347,7 +347,7 @@ class JuniperHost(AnsibleHostBase):
             configs = []
             configs.append("set interfaces {} unit 0 family inet filter input {}".format(interface, filter_name))
             output = self.config(lines=configs, comment="push ipfix configs")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, output
         except Exception as e:
@@ -585,7 +585,7 @@ class JuniperHost(AnsibleHostBase):
             command = "show isis adjacency"
             json_output = self.commands(commands=[command], display="json")
             isis_adj_info = {}
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 for line in json_output["stdout"][0]["isis-adjacency-information"][0]["isis-adjacency"]:
                     isis_adj_info.update(
                         {
@@ -621,7 +621,7 @@ class JuniperHost(AnsibleHostBase):
             command = "show isis database"
             json_output = self.commands(commands=[command], display="json")
             lsp_entries = {}
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 for entry in json_output["stdout"][0]["isis-database-information"][0]["isis-database"][1][
                     "isis-database-entry"
                 ]:
@@ -740,7 +740,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             command = "show lldp neighbors"
             output = self.commands(commands=[command], display="json")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for lines in output["stdout"][0]["lldp-neighbors-information"][0]["lldp-neighbor-information"]:
                     lldp_details.update(
                         {
@@ -794,7 +794,7 @@ class JuniperHost(AnsibleHostBase):
             command = "show interfaces {}".format(pc_name)
             success_criteria = "physical link is up"
             intf_status_output = self.commands(session_type="network_cli", commands=[command], display="text")
-            if not intf_status_output["failed"]:
+            if not intf_status_output.get("failed", False):
                 logger.info("Interface status check: {} sent to {}".format(command, self.hostname))
                 is_up = success_criteria in intf_status_output["stdout"][0].lower()
                 return is_up, intf_status_output["stdout"][0]
@@ -814,7 +814,7 @@ class JuniperHost(AnsibleHostBase):
         command = "show lacp interfaces {}".format(pc_name)
         try:
             json_output = self.commands(commands=[command], display="json")
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 interfaces_data = self.extract_val_from_json(json_output["stdout"][0], "lag-lacp-protocol")[0]
                 interfaces = [line["name"][0]["data"] for line in interfaces_data]
                 return interfaces
@@ -830,7 +830,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             command = "show lldp neighbor interface {}".format(physical_port)
             json_output = self.commands(commands=[command], display="json")
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 return json_output["stdout"][0]
             return json_output
         except Exception as e:
@@ -844,7 +844,7 @@ class JuniperHost(AnsibleHostBase):
         command = "show lldp local-information"
         try:
             json_output = self.commands(commands=[command], display="json")
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 chassis_id = json_output["stdout"][0]["lldp-local-info"][0]["lldp-local-chassis-id"][0]["data"]
                 return chassis_id
             return "Failed to get chassis info due to {}".format(json_output)
@@ -860,7 +860,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             command = "show lldp local-information"
             json_output = self.commands(commands=[command], display="json")
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 mgmt_ip = json_output["stdout"][0]["lldp-local-info"][0]["lldp-local-management-address-address"][0][
                     "data"
                 ]
@@ -876,7 +876,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             command = "show lldp local-information"
             json_output = self.commands(commands=[command], display="json")
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 system_description = json_output["stdout"][0]["lldp-local-info"][0]["lldp-local-system-description"][
                     0
                 ]["data"]
@@ -894,7 +894,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             command = "show version"
             json_output = self.commands(commands=[command], display="json")
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 version = json_output["stdout"][0]["software-information"][0]["junos-version"][0]["data"]
                 return version
             return "Failed to get version due to {}".format(json_output)
@@ -1034,7 +1034,7 @@ class JuniperHost(AnsibleHostBase):
                 last_count, log_type
             )
             output = self.commands(session_type="network_cli", commands=[command], display="text")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return len(output["stdout_lines"][0]) > 0, output["stdout"][0]
             return False, "Failed to get macsec status logs due to {}".format(output)
         except Exception as e:
@@ -1054,7 +1054,7 @@ class JuniperHost(AnsibleHostBase):
             example of output:
             set security macsec interfaces et-2/0/14 connectivity-association macsec-xpn-256-ae16
             """
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output["stdout"][0].split()[-1]
             return False, "Failed to get macsec profile due to {}".format(output)
         except Exception as e:
@@ -1090,7 +1090,7 @@ class JuniperHost(AnsibleHostBase):
                 test_msg = "Key type {} not supported".format(key_type)
                 output = {"failed": True, "msg": test_msg}
 
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, str(output)
             return False, "Failed to set macsec key due to {}".format(output)
         except Exception as e:
@@ -1133,7 +1133,7 @@ class JuniperHost(AnsibleHostBase):
             ...
             Output trimmed
             """
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 sc_dict_out = json_output["stdout"][0]["macsec-statistics"][0]["secure-channel-received"][0]
                 validated_bytes = sc_dict_out["validated-bytes"][0]["data"]
                 decrypted_bytes = sc_dict_out["decrypted-bytes"][0]["data"]
@@ -1166,7 +1166,7 @@ class JuniperHost(AnsibleHostBase):
             commands.append("deactivate security macsec interfaces {}".format(interface))
         try:
             output = self.config(lines=commands, comment="deactivate macsec interface")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, "Failed to deactivate macsec interface due to {}".format(output)
         except Exception as e:
@@ -1182,7 +1182,7 @@ class JuniperHost(AnsibleHostBase):
             commands.append("activate security macsec interfaces {}".format(interface))
         try:
             output = self.config(lines=commands, comment="activate macsec interface")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, "Failed to activate macsec interface due to {}".format(output)
         except Exception as e:
@@ -1202,7 +1202,7 @@ class JuniperHost(AnsibleHostBase):
             example of output:
             set security macsec interfaces et-2/0/14 connectivity-association macsec-xpn-256-ae16
             """
-            if not output["failed"]:
+            if not output.get("failed", False):
                 # strip to remove extra /n with string
                 return True, output["stdout"][0].strip()
             return False, "Failed to get macsec config due to {}".format(output)
@@ -1216,7 +1216,7 @@ class JuniperHost(AnsibleHostBase):
         """
         output = self.config(lines=commands, comment="apply_macsec_interface_config")
         try:
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, "Failed to apply macsec interface config due to {}".format(output)
         except Exception as e:
@@ -1230,7 +1230,7 @@ class JuniperHost(AnsibleHostBase):
         command = "delete security macsec interfaces {}".format(interface)
         try:
             output = self.config(lines=[command], comment="remove MACSEC from physical interface")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, "Failed to delete macsec interface config due to {}".format(output)
         except Exception as e:
@@ -1247,7 +1247,7 @@ class JuniperHost(AnsibleHostBase):
                 profile_name, rekey_period_value
             )
             output = self.config(lines=[command], comment="rekey macsec interval")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, "Failed to set rekey period due to {}".format(output)
         except Exception as e:
@@ -1265,7 +1265,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             command = "set system location building microsoft"
             output = self.config(lines=[command], comment="test configure command")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 rollback_command = "del system location building microsoft"
                 self.config(lines=[rollback_command], comment="rollback test configure command")
                 return True, output
@@ -1280,7 +1280,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             command = "show configuration system tacplus-server | display set | match source-address"
             output = self.commands(session_type="network_cli", commands=[command], display="text")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0]:
                     if "source-address" in line:
                         return line.split()[-1]
@@ -1369,7 +1369,7 @@ class JuniperHost(AnsibleHostBase):
         )
         try:
             output = self.config(lines=prod_configs, confirm=2)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, "prod configs pushed to lab router, will rollback by itself in 2 minutes"
             return False, "Failed to apply prod tacacs config due to {}".format(output)
         except Exception as e:
@@ -1410,7 +1410,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             command = "show bgp summary"
             json_output = self.commands(commands=[command], display="json")
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 json_output_dict = json_output["stdout"][0]["bgp-information"][0]["bgp-peer"]
                 bgp_status = {}
                 for bgp_speak in json_output_dict:
@@ -1440,7 +1440,7 @@ class JuniperHost(AnsibleHostBase):
         """
         try:
             bgp_peer_details = self.get_bgp_session_details(peer_ip)
-            if not bgp_peer_details["failed"]:
+            if not bgp_peer_details.get("failed", False):
                 session_status = bgp_peer_details["stdout"][0]["bgp-information"][0]["bgp-peer"][0]["peer-state"][0][
                     "data"
                 ]
@@ -1458,7 +1458,7 @@ class JuniperHost(AnsibleHostBase):
             command = "show route protocol aggregate {} exact".format(agg_prefix)
             agg_route_gen_status = False
             output = self.commands(session_type="network_cli", commands=[command], display="text")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0]:
                     if agg_prefix in line:
                         agg_route_gen_status = True
@@ -1477,7 +1477,7 @@ class JuniperHost(AnsibleHostBase):
             command = "show route advertising-protocol bgp {} {} exact".format(peer_ip, prefix)
             json_output = self.commands(commands=[command], display="json")
             prefix_adv_status = False
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 route_table = json_output["stdout"][0]["route-information"][0]["route-table"][0]["rt"]
                 for element in route_table:
                     if "rt-destination" in element:
@@ -1502,7 +1502,7 @@ class JuniperHost(AnsibleHostBase):
                 "deactivate protocols bgp group IPV6-ICR-SWAN",
             ]
             output = self.config(lines=commands, comment="deactivate bgp with ser")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True
             return False
         except Exception as e:
@@ -1522,7 +1522,7 @@ class JuniperHost(AnsibleHostBase):
                 "activate protocols bgp group IPV6-ICR-SWAN",
             ]
             output = self.config(lines=commands, comment="activate bgp with ser")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True
             return False
         except Exception as e:
@@ -1536,7 +1536,7 @@ class JuniperHost(AnsibleHostBase):
         """
         try:
             output = self.config(lines=["deactivate protocols rsvp"], comment="deactivate protocol rsvp")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, "Failed to deactivate rsvp protocol due to {}".format(output)
         except Exception as e:
@@ -1550,7 +1550,7 @@ class JuniperHost(AnsibleHostBase):
         """
         try:
             output = self.config(lines=["activate protocols rsvp"], comment="activate protocol rsvp")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             else:
                 return False, "Failed to activate rsvp protocol due to {}".format(output)
@@ -1562,7 +1562,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             command = "show route {} table {} active-path exact".format(prefix_with_mask, table)
             json_output = self.commands(commands=[command], display="json")
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 if "route-table" in json_output["stdout"][0]["route-information"][0]:
                     route_table = json_output["stdout"][0]["route-information"][0]["route-table"][0]
                     destination = route_table["rt"][0]["rt-destination"][0]["data"]
@@ -1585,7 +1585,7 @@ class JuniperHost(AnsibleHostBase):
                 "deactivate system extensions extension-service application file apcacertagent-junos",
             ]
             output = self.config(lines=commands, comment="deactivate swan agent")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, output
         except Exception as e:
@@ -1602,7 +1602,7 @@ class JuniperHost(AnsibleHostBase):
                 "activate system extensions extension-service application file apcacertagent-junos",
             ]
             output = self.config(lines=commands, comment="activate swan agent")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, output
         except Exception as e:
@@ -1662,7 +1662,7 @@ class JuniperHost(AnsibleHostBase):
                 ...
              Output trimmed
             """
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 rsvp_nbrs = json_output["stdout"][0]["rsvp-neighbor-information"][0]["rsvp-neighbor"]
                 for rsvp_nbr in rsvp_nbrs:
                     if str(rsvp_nbr["rsvp-neighbor-address"][0]["data"]) == str(neighbor):
@@ -1686,7 +1686,7 @@ class JuniperHost(AnsibleHostBase):
         command = "show configuration interfaces lo0"
         try:
             json_output = self.commands(commands=[command], display="json")["stdout"][0]
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 ipv4_addresses = json_output["configuration"]["interfaces"]["interface"][0]["unit"][0]["family"][
                     "inet"
                 ]["address"]
@@ -1710,7 +1710,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             commands = ["deactivate interfaces {} gigether-options 802.3ad".format(interface)]
             output = self.config(lines=commands, comment="deactivate interface {} from ae {}".format(interface, pcnum))
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, "Deactivated interface {} from ae{}".format(interface, pcnum)
             return False, "Failed to deactivate interface {} from ae{}".format(interface, pcnum)
         except Exception as e:
@@ -1726,7 +1726,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             commands = ["activate interfaces {} gigether-options 802.3ad".format(interface)]
             output = self.config(lines=commands, comment="activate interface {} from ae {}".format(interface, pcnum))
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, "Activated interface {} from ae{}".format(interface, pcnum)
             return False, "Failed to activate interface {} from ae{}".format(interface, pcnum)
         except Exception as e:
@@ -1736,7 +1736,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             command = "request system reboot both-routing-engines"
             output = self.commands(commands=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, output
         except Exception as e:

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -2382,7 +2382,7 @@ Totals               6450                 6449
             ))
         except RunAnsibleModuleFail:
             return False
-        return not rc['failed']
+        return not rc.get('failed', False)
 
     def ping_v6(self, ipv6, count=1, ns_arg=""):
         """
@@ -2408,7 +2408,7 @@ Totals               6450                 6449
             ))
         except RunAnsibleModuleFail:
             return False
-        return not rc['failed']
+        return not rc.get('failed', False)
 
     def is_backend_portchannel(self, port_channel, mg_facts):
         ports = mg_facts["minigraph_portchannels"].get(port_channel)
@@ -3053,7 +3053,7 @@ print(device_prefix)
         )
 
         res: ShellResult = self.shell(command, module_ignore_errors=True)
-        if res['failed']:
+        if res.get('failed', False):
             error_msg = f"Failed to start socat on port {port}: {res.get('stderr', '')}"
             logging.error(error_msg)
             raise RuntimeError(error_msg)
@@ -3134,7 +3134,7 @@ print(device_prefix)
         )
 
         res: ShellResult = self.shell(command, module_ignore_errors=True)
-        if res['failed']:
+        if res.get('failed', False):
             error_msg = f"Failed to bridge ports {port1} and {port2}: {res.get('stderr', '')}"
             logging.error(error_msg)
             raise RuntimeError(error_msg)
@@ -3228,7 +3228,7 @@ print(device_prefix)
         )
 
         res: ShellResult = self.shell(command, module_ignore_errors=True)
-        if res['failed']:
+        if res.get('failed', False):
             error_msg = f"Failed to bridge port {port} to {remote_host}:{remote_port}: {res.get('stderr', '')}"
             logging.error(error_msg)
             raise RuntimeError(error_msg)

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -294,7 +294,7 @@ class SonicAsic(object):
             ))
         except RunAnsibleModuleFail:
             return False
-        return not rc['failed']
+        return not rc.get('failed', False)
 
     def ping_v6(self, ipv6, count=1):
         """
@@ -316,7 +316,7 @@ class SonicAsic(object):
             ))
         except RunAnsibleModuleFail:
             return False
-        return not rc['failed']
+        return not rc.get('failed', False)
 
     def is_backend_portchannel(self, port_channel):
         mg_facts = self.sonichost.minigraph_facts(host=self.sonichost.hostname)['ansible_facts']


### PR DESCRIPTION
### Description of PR
Cherry-pick the ansible-core 2.21 compatibility fixes listed in #25685 to **202605**.

Included in this PR:
- #25419
- #25443
- #25482

Already present on **202605**, so it is not duplicated in this diff:
- #25545 via #25774

Sibling backports of the same set: #25781 (202511) and #25782 (202505) — both merged. This is the remaining branch.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

This PR **is** the backport to 202605; no further backport is requested from it.

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #25685
Failure type: regression

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

202605: static validation of this head (`4b81859`) plus cherry-pick equivalence checks. No testbed run.
- `python -m py_compile` on all eight changed files — passes.
- `python -m flake8 --max-line-length=120` on all eight changed files — the only reports are two pre-existing `E721` lines (`tests/common/devices/cisco.py`, `tests/common/devices/eos.py`) that are byte-identical on `202605` and untouched here.
- No unguarded `["failed"]` reads remain on this head: `tests/common/devices/sonic.py` has none, and the two that are left (`tests/common/devices/eos.py`, `tests/common/devices/cisco.py`) are inside an explicit `('failed' in cmd_output_obj and ...)` membership check, so `KeyError` is unreachable.
- Azure.sonic-mgmt on this head: 25/25 checks green.

### Approach
Applied the cherry-picks with `-x` in issue order. For **202605**, #25545 was already merged to the target branch, so that cherry-pick was an empty/no-op and was skipped. The `ansible/module_utils/debug_utils.py` hunk (`from ansible.module_utils.basic import datetime` → `import datetime`) has since landed on 202605 through another change; both sides now make the identical edit, so the three-way merge resolves it without conflict.

#### Known follow-up (deliberately not in this PR)
Per the review discussion on this PR, the `tests/common/devices/cisco.py::get_macsec_status_logs` defect — `output = self.commands(...)["stdout"][0]` assigns the stdout payload rather than the Ansible result dict — was fixed separately on master in #25910 (merged 2026-07-24) instead of being folded in here. That fix is **not yet on 202605**, so after this cherry-pick lands `get_macsec_status_logs` on 202605 will still need #25910 backported on its own.

### Documentation
N/A
