### PR TITLE
Refactor test_ha_npu_reboot.

### DIFF
--- a/tests/ha/ha_bgp_utils.py
+++ b/tests/ha/ha_bgp_utils.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+from tests.common.devices.eos import EosHost
 from tests.common.helpers.assertions import pytest_assert
 
 
@@ -54,6 +55,104 @@ def check_vip_advertised_to_t2(duthosts, vip):
                   "VIP {} not advertised to T2 peers: {}".format(vip_prefix, missing))
     logger.info("VIP %s advertised to all T2 peers on %s",
                 vip_prefix, [d.hostname for d in duts])
+
+
+def get_dut_t2_local_addrs(duthost):
+    """Return the DUT's local IPv4 BGP addresses used to peer with its T2 neighbors.
+
+    These are the IPs the T2 VMs see as the remote peer for their BGP session
+    with this DUT, i.e. what `peerId` / `peerAddr` would show on the T2 side.
+    """
+    cfg = duthost.get_running_config_facts()
+    addrs = []
+    for peer_cfg in cfg.get("BGP_NEIGHBOR", {}).values():
+        if not peer_cfg.get("name", "").endswith("T2"):
+            continue
+        local = peer_cfg.get("local_addr") or ""
+        if local and ":" not in local:
+            addrs.append(local)
+    return addrs
+
+
+def _vip_path_peer_ids_on_vm(host, vip_prefix):
+    """Return the set of BGP peer IPs from which a neighbor VM has received `vip_prefix`.
+
+    Dispatches on host type (Arista cEOS vs vsonic/FRR). Empty set means the
+    prefix isn't in the VM's BGP RIB at all, or the query failed.
+    """
+    peer_ids = set()
+    try:
+        if isinstance(host, EosHost):
+            cmd = "show ip bgp {} | json".format(vip_prefix)
+            out = host.eos_command(commands=[cmd], module_ignore_errors=True)
+            stdouts = out.get("stdout", [])
+            if not stdouts:
+                return peer_ids
+            data = stdouts[0]
+            if isinstance(data, str):
+                data = json.loads(data)
+            for vrf in data.get("vrfs", {}).values():
+                for entry in vrf.get("bgpRouteEntries", {}).values():
+                    for path in entry.get("bgpRoutePaths", []):
+                        peer = path.get("peerEntry", {}).get("peerAddr")
+                        if peer:
+                            peer_ids.add(peer)
+        else:
+            cmd = 'vtysh -c "show ip bgp {} json"'.format(vip_prefix)
+            res = host.shell(cmd, module_ignore_errors=True)
+            if res.get("failed"):
+                return peer_ids
+            try:
+                data = json.loads(res.get("stdout", ""))
+            except ValueError:
+                return peer_ids
+            for path in data.get("paths", []):
+                peer = path.get("peerId")
+                if peer:
+                    peer_ids.add(peer)
+    except Exception as e:
+        logger.info("BGP query on %s failed: %s",
+                    getattr(host, "hostname", host), e)
+    return peer_ids
+
+
+def is_vip_withdrawn_from_t2_vm(nbrhosts, rebooted_dut_t2_local_ips, vip):
+    """Return True iff no T2 neighbor VM still has `vip`/32 received from any
+    of the rebooted DUT's local BGP IPs.
+
+    Args:
+        nbrhosts: pytest nbrhosts dict (vm_name -> {"host": ..., ...}).
+        rebooted_dut_t2_local_ips: list of IPs that T2 VMs use as the peer
+            address for their BGP session with the rebooted DUT (collected
+            BEFORE reboot via get_dut_t2_local_addrs()).
+        vip: VIP address (no prefix length).
+    """
+    vip_prefix = "{}/32".format(vip)
+    rebooted_ips = set(rebooted_dut_t2_local_ips)
+    if not rebooted_ips:
+        logger.warning("No rebooted-DUT T2 local IPs provided; nothing to check")
+        return True
+
+    saw_via_rebooted = False
+    for vm_name, info in nbrhosts.items():
+        if "T2" not in vm_name:
+            continue
+        host = info.get("host") if isinstance(info, dict) else None
+        if host is None:
+            continue
+
+        peer_ids = _vip_path_peer_ids_on_vm(host, vip_prefix)
+        overlap = peer_ids & rebooted_ips
+        if overlap:
+            logger.info("VM %s still has VIP %s received from rebooted-DUT IP(s) %s",
+                        vm_name, vip_prefix, sorted(overlap))
+            saw_via_rebooted = True
+        else:
+            other = peer_ids - rebooted_ips
+            logger.info("VM %s: VIP %s no longer received from rebooted-DUT IPs "
+                        "(other sources=%s)", vm_name, vip_prefix, sorted(other))
+
+    return not saw_via_rebooted
 
 
 def _ha_bgp_oper(duthost, start=True):

--- a/tests/ha/ha_bgp_utils.py
+++ b/tests/ha/ha_bgp_utils.py
@@ -78,19 +78,23 @@ def _vip_path_peer_ids_on_vm(host, vip_prefix):
     """Return the set of BGP peer IPs from which a neighbor VM has received `vip_prefix`.
 
     Dispatches on host type (Arista cEOS vs vsonic/FRR). Empty set means the
-    prefix isn't in the VM's BGP RIB at all, or the query failed.
+    prefix isn't in the VM's BGP RIB; ``None`` means the query failed.
     """
     peer_ids = set()
     try:
         if isinstance(host, EosHost):
             cmd = "show ip bgp {} | json".format(vip_prefix)
             out = host.eos_command(commands=[cmd], module_ignore_errors=True)
+            if out.get("failed"):
+                return None
             stdouts = out.get("stdout", [])
             if not stdouts:
-                return peer_ids
+                return None
             data = stdouts[0]
             if isinstance(data, str):
                 data = json.loads(data)
+            if not isinstance(data, dict):
+                return None
             for vrf in data.get("vrfs", {}).values():
                 for entry in vrf.get("bgpRouteEntries", {}).values():
                     for path in entry.get("bgpRoutePaths", []):
@@ -101,24 +105,29 @@ def _vip_path_peer_ids_on_vm(host, vip_prefix):
             cmd = 'vtysh -c "show ip bgp {} json"'.format(vip_prefix)
             res = host.shell(cmd, module_ignore_errors=True)
             if res.get("failed"):
-                return peer_ids
+                return None
             try:
                 data = json.loads(res.get("stdout", ""))
             except ValueError:
-                return peer_ids
+                return None
+            if not isinstance(data, dict):
+                return None
             for path in data.get("paths", []):
                 peer = path.get("peerId")
                 if peer:
                     peer_ids.add(peer)
     except Exception as e:
-        logger.info("BGP query on %s failed: %s",
-                    getattr(host, "hostname", host), e)
+        logger.warning("BGP query on %s failed: %s",
+                       getattr(host, "hostname", host), e)
+        return None
     return peer_ids
 
 
 def is_vip_withdrawn_from_t2_vm(nbrhosts, rebooted_dut_t2_local_ips, vip):
-    """Return True iff no T2 neighbor VM still has `vip`/32 received from any
-    of the rebooted DUT's local BGP IPs.
+    """Return True iff every T2 neighbor VM we could query no longer has
+    `vip`/32 received from any of the rebooted DUT's local BGP IPs. Fails
+    closed (returns False) if `rebooted_dut_t2_local_ips` is empty or no T2
+    VM could be queried successfully.
 
     Args:
         nbrhosts: pytest nbrhosts dict (vm_name -> {"host": ..., ...}).
@@ -127,13 +136,14 @@ def is_vip_withdrawn_from_t2_vm(nbrhosts, rebooted_dut_t2_local_ips, vip):
             BEFORE reboot via get_dut_t2_local_addrs()).
         vip: VIP address (no prefix length).
     """
-    vip_prefix = "{}/32".format(vip)
     rebooted_ips = set(rebooted_dut_t2_local_ips)
     if not rebooted_ips:
-        logger.warning("No rebooted-DUT T2 local IPs provided; nothing to check")
-        return True
+        logger.warning("No rebooted-DUT T2 local IPs provided.")
+        return False
 
+    vip_prefix = "{}/32".format(vip)
     saw_via_rebooted = False
+    queried_any = False
     for vm_name, info in nbrhosts.items():
         if "T2" not in vm_name:
             continue
@@ -142,6 +152,11 @@ def is_vip_withdrawn_from_t2_vm(nbrhosts, rebooted_dut_t2_local_ips, vip):
             continue
 
         peer_ids = _vip_path_peer_ids_on_vm(host, vip_prefix)
+        if peer_ids is None:
+            logger.warning("BGP query on T2 VM %s failed; skipping", vm_name)
+            continue
+
+        queried_any = True
         overlap = peer_ids & rebooted_ips
         if overlap:
             logger.info("VM %s still has VIP %s received from rebooted-DUT IP(s) %s",
@@ -151,6 +166,10 @@ def is_vip_withdrawn_from_t2_vm(nbrhosts, rebooted_dut_t2_local_ips, vip):
             other = peer_ids - rebooted_ips
             logger.info("VM %s: VIP %s no longer received from rebooted-DUT IPs "
                         "(other sources=%s)", vm_name, vip_prefix, sorted(other))
+
+    if not queried_any:
+        logger.warning("No T2 neighbor VM could be queried successfully.")
+        return False
 
     return not saw_via_rebooted
 

--- a/tests/ha/ha_dpu_utils.py
+++ b/tests/ha/ha_dpu_utils.py
@@ -88,11 +88,17 @@ def check_dpu_module_status(duthost, power_status, dpu_name):
     """
     output_dpu_status = duthost.shell(
         'show chassis module status | grep %s' % (dpu_name), module_ignore_errors=True)
-    stdout = output_dpu_status.get("stdout", "")
+    stdout = output_dpu_status.get("stdout", "").lower()
 
-    if "offline" in stdout.lower():
+    if "offline" in stdout:
         logger.info(f"'{dpu_name}' is offline on {duthost.hostname}")
         return power_status == "off"
-    else:
+    elif "online" in stdout:
         logger.info(f"'{dpu_name}' is online on {duthost.hostname}")
         return power_status == "on"
+    else:
+        logger.warning(
+            f"'{dpu_name}' status on {duthost.hostname} is neither 'online' nor "
+            f"'offline'; stdout={stdout!r}"
+        )
+        return False

--- a/tests/ha/ha_dpu_utils.py
+++ b/tests/ha/ha_dpu_utils.py
@@ -98,7 +98,7 @@ def check_dpu_module_status(duthost, power_status, dpu_name):
         return power_status == "on"
     else:
         logger.warning(
-            f"'{dpu_name}' status on {duthost.hostname} is neither 'online' nor "
-            f"'offline'; stdout={stdout!r}"
+            f"{dpu_name} status on {duthost.hostname} is neither online nor "
+            f"offline. stdout={stdout!r}"
         )
         return False

--- a/tests/ha/test_ha_npu_reboot.py
+++ b/tests/ha/test_ha_npu_reboot.py
@@ -269,8 +269,8 @@ def test_ha_npu_reboot(
     threshold_loss = THRESHOLD_LOSS_PERCENT
     percentage_loss = (failed_count / send_count) * 100
     if (percentage_loss < threshold_loss):
-        logger.info(f"{npu_reboot} with {traffic} test OK. Sent: {send_count},"
-                    f" not received: {failed_count}, loss: {percentage_loss}, threshold: {threshold_loss}")
+        logger.info(f"{npu_reboot} with {traffic} test OK. Sent: {send_count}, "
+                    f"not received: {failed_count}, loss: {percentage_loss}, threshold: {threshold_loss}")
     else:
-        pytest.fail(f"{npu_reboot} with {traffic} test error. Sent: {send_count},"
-                    f" not received: {failed_count} loss: {percentage_loss}, threshold: {threshold_loss}")
+        pytest.fail(f"{npu_reboot} with {traffic} test error. Sent: {send_count}, "
+                    f"not received: {failed_count} loss: {percentage_loss}, threshold: {threshold_loss}")

--- a/tests/ha/test_ha_npu_reboot.py
+++ b/tests/ha/test_ha_npu_reboot.py
@@ -26,6 +26,7 @@ from ha_dash_flow_utils import compare_flow_tables
 from tests.common.reboot import reboot_smartswitch, wait_for_startup
 from tests.ha.conftest import get_interface_ip
 from tests.ha.ha_dpu_utils import CHECK_DPU_STATE_TIMEOUT, CHECK_DPU_STATE_TIME_INT, check_dpu_up_state
+from ha_bgp_utils import get_dut_t2_local_addrs, is_vip_withdrawn_from_t2_vm
 from ha_utils import parallel_config_reload_dpuhosts
 
 
@@ -40,6 +41,7 @@ pytestmark = [
 THRESHOLD_LOSS_PERCENT = 2.0
 RATE_PPS = 20
 INITIAL_SEND_COUNT = 100
+TRAFFIC_WINDOW_SECONDS = 300
 
 
 @pytest.fixture(scope="function")
@@ -125,32 +127,37 @@ def common_setup_teardown(
 
 
 """
-We are testing 4 scenarios:
-    1. Traffic to Primary and Primary NPU reboot
-    2. Traffic to Primary and Standby NPU reboot
-    3. Traffic to Standby and Primary NPU reboot
-    4. Traffic to Standby and Standby NPU reboot
-For each scenario, we will send traffic for 60 seconds and check if the packet loss is within the threshold.
+Two scenarios:
+    1. Traffic to Primary, Standby NPU reboot (no switchover; primary keeps serving).
+    2. Traffic to Standby, Primary NPU reboot (switchover; standby DPU transitions
+       to standalone).
+For each scenario we send traffic for TRAFFIC_WINDOW_SECONDS and check that
+the loss is within the threshold. After the reboot we additionally verify the
+rebooted NPU has withdrawn its VIP /32 BGP advertisement.
 """
 
 
 @pytest.mark.parametrize(
-    "standby_npu_reboot", [True, False],
-    ids=["Standby NPU Reboot", "Primary NPU Reboot"]
-)
-@pytest.mark.parametrize(
-    "traffic_to_standby", [True, False],
-    ids=["Standby Traffic", "Primary Traffic"]
+    "traffic_to_standby,standby_npu_reboot",
+    [
+        (False, True),    # Traffic to Primary, Standby NPU reboot
+        (True, False),    # Traffic to Standby, Primary NPU reboot (switchover)
+    ],
+    ids=[
+        "Traffic to Primary - Standby NPU Reboot",
+        "Traffic to Standby - Primary NPU Reboot (Switchover)",
+    ],
 )
 def test_ha_npu_reboot(
     ptfadapter,
     localhost,
     duthosts,
     dpuhosts,
+    nbrhosts,
     activate_dash_ha_from_json,
     dash_pl_config,
     standby_npu_reboot,
-    traffic_to_standby
+    traffic_to_standby,
 ):
     traffic = "traffic to standby" if traffic_to_standby else "traffic to primary"
     npu_reboot = "standby NPU reboot" if standby_npu_reboot else "primary NPU reboot"
@@ -161,14 +168,14 @@ def test_ha_npu_reboot(
     delay = 1.0 / rate_pps
     rcv_outbound_pl_ports = dash_pl_config[0][REMOTE_PTF_RECV_INTF] + dash_pl_config[1][REMOTE_PTF_RECV_INTF]
 
-    if traffic_to_standby:
-        vm_to_dpu_pkt, exp_dpu_to_pe_pkt = outbound_pl_packets(dash_pl_config[1], encap_proto)
-    else:
-        vm_to_dpu_pkt, exp_dpu_to_pe_pkt = outbound_pl_packets(dash_pl_config[0], encap_proto)
+    traffic_idx = 1 if traffic_to_standby else 0
+    rebooted_idx = 1 if standby_npu_reboot else 0
+
+    vm_to_dpu_pkt, exp_dpu_to_pe_pkt = outbound_pl_packets(dash_pl_config[traffic_idx], encap_proto)
 
     # Bootstrap stateful TCP flow on the DPU so subsequent ACK packets match the established flow.
     bootstrap_pl_tcp_flow_outbound(
-        ptfadapter, dash_pl_config[1] if traffic_to_standby else dash_pl_config[0], encap_proto,
+        ptfadapter, dash_pl_config[traffic_idx], encap_proto,
         recv_ports=rcv_outbound_pl_ports,
     )
 
@@ -178,7 +185,13 @@ def test_ha_npu_reboot(
     send_count = 0
     failed_count = 0
 
-    dut = duthosts[1] if standby_npu_reboot else duthosts[0]
+    dut = duthosts[rebooted_idx]
+
+    # Capture the rebooted DUT's local IPs to its T2 BGP peers BEFORE the reboot,
+    # so the post-reboot check from the neighbor VM side does not depend on the
+    # rebooted DUT being reachable.
+    rebooted_dut_t2_local_ips = get_dut_t2_local_addrs(dut)
+    logger.info(f"Rebooted DUT {dut.hostname} T2 local IPs: {rebooted_dut_t2_local_ips}")
 
     def npu_ha_action():
         # wait for a number of packets to be sent, then simulate failure
@@ -194,37 +207,27 @@ def test_ha_npu_reboot(
 
     t = threading.Thread(target=npu_ha_action, name="npu_ha_action_thread")
     t.start()
-    t_max = time.time() + 60
-    reached_max_time = False
+    t_max = time.time() + TRAFFIC_WINDOW_SECONDS
     ptfadapter.dataplane.flush()
     time.sleep(1)
 
-    while not reached_max_time:
-        # After we send initial_send_count packets, awake link_ha_action thread
+    while time.time() < t_max:
+        # After we send initial_send_count packets, awake npu_ha_action thread
         if send_count == initial_send_count:
             logger.info("Awake HA action thread")
             action_event.set()
 
         try:
-            if traffic_to_standby:
-                if send_count == 0:
-                    logger.info("Send first packet to standby")
-                testutils.send(ptfadapter, dash_pl_config[1][LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
-                testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, rcv_outbound_pl_ports)
-                if send_count == 0:
-                    logger.info("First packet to standby received - compare flows")
-                    flow_op = compare_flow_tables(dpuhosts[0], dpuhosts[1])
-                    pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
-
-            else:
-                if send_count == 0:
-                    logger.info("Send first packet to primary")
-                testutils.send(ptfadapter, dash_pl_config[0][LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
-                testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, rcv_outbound_pl_ports)
-                if send_count == 0:
-                    logger.info("First packet to primary received - compare flows")
-                    flow_op = compare_flow_tables(dpuhosts[0], dpuhosts[1])
-                    pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
+            if send_count == 0:
+                logger.info(f"Send first packet to {'standby' if traffic_to_standby else 'primary'}")
+            testutils.send(
+                ptfadapter, dash_pl_config[traffic_idx][LOCAL_PTF_INTF], vm_to_dpu_pkt, 1,
+            )
+            testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, rcv_outbound_pl_ports)
+            if send_count == 0:
+                logger.info("First packet received - compare flows")
+                flow_op = compare_flow_tables(dpuhosts[0], dpuhosts[1])
+                pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
         except Exception as e:
             if failed_count == 0:
                 if send_count == 0:
@@ -237,18 +240,31 @@ def test_ha_npu_reboot(
 
         send_count += 1
         time.sleep(delay)
-        reached_max_time = time.time() > t_max
 
     t.join()
     time.sleep(2)
 
+    rebooted_dut = duthosts[rebooted_idx]
+
+    # Verify the VIP /32 is no longer received by any T2 neighbor VM from the
+    # rebooted DUT (BGP session torn down or VIP withdrawn). Checked from the
+    # neighbor VMs so it does not depend on the rebooted DUT being reachable.
+    pytest_assert(
+        wait_until(
+            60, 10, 0,
+            is_vip_withdrawn_from_t2_vm,
+            nbrhosts, rebooted_dut_t2_local_ips, pl.APPLIANCE_VIP,
+        ),
+        f"VIP {pl.APPLIANCE_VIP} was not withdrawn from T2 neighbor VMs' BGP RIB "
+        f"for {rebooted_dut.hostname} after {npu_reboot}",
+    )
+
     # wait for NPU and DPU to be up
-    dut = duthosts[1] if standby_npu_reboot else duthosts[0]
-    wait_for_startup(dut, localhost, delay=10, timeout=600)
+    wait_for_startup(rebooted_dut, localhost, delay=10, timeout=600)
     status = wait_until(CHECK_DPU_STATE_TIMEOUT, CHECK_DPU_STATE_TIME_INT, 0,
-                        check_dpu_up_state, dut, dpu_id)
+                        check_dpu_up_state, rebooted_dut, dpu_id)
     if not status:
-        logger.error(f"DPU{dpu_id} not up on {dut.hostname}")
+        logger.error(f"DPU{dpu_id} not up on {rebooted_dut.hostname}")
 
     threshold_loss = THRESHOLD_LOSS_PERCENT
     percentage_loss = (failed_count / send_count) * 100

--- a/tests/ha/test_ha_npu_reboot.py
+++ b/tests/ha/test_ha_npu_reboot.py
@@ -26,7 +26,7 @@ from ha_dash_flow_utils import compare_flow_tables
 from tests.common.reboot import reboot_smartswitch, wait_for_startup
 from tests.ha.conftest import get_interface_ip
 from tests.ha.ha_dpu_utils import CHECK_DPU_STATE_TIMEOUT, CHECK_DPU_STATE_TIME_INT, check_dpu_up_state
-from ha_bgp_utils import get_dut_t2_local_addrs, is_vip_withdrawn_from_t2_vm
+from tests.ha.ha_bgp_utils import get_dut_t2_local_addrs, is_vip_withdrawn_from_t2_vm
 from ha_utils import parallel_config_reload_dpuhosts
 
 
@@ -192,6 +192,11 @@ def test_ha_npu_reboot(
     # rebooted DUT being reachable.
     rebooted_dut_t2_local_ips = get_dut_t2_local_addrs(dut)
     logger.info(f"Rebooted DUT {dut.hostname} T2 local IPs: {rebooted_dut_t2_local_ips}")
+    pt_require(
+        rebooted_dut_t2_local_ips,
+        f"No IPv4 T2 BGP local peer addresses on {dut.hostname}; "
+        "skipping VIP-withdrawal verification (topology has no T2 IPv4 BGP peers).",
+    )
 
     def npu_ha_action():
         # wait for a number of packets to be sent, then simulate failure

--- a/tests/ha/test_ha_npu_reboot.py
+++ b/tests/ha/test_ha_npu_reboot.py
@@ -194,7 +194,7 @@ def test_ha_npu_reboot(
     logger.info(f"Rebooted DUT {dut.hostname} T2 local IPs: {rebooted_dut_t2_local_ips}")
     pt_require(
         rebooted_dut_t2_local_ips,
-        f"No IPv4 T2 BGP local peer addresses on {dut.hostname}; "
+        f"No IPv4 T2 BGP local peer addresses on {dut.hostname}, "
         "skipping VIP-withdrawal verification (topology has no T2 IPv4 BGP peers).",
     )
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

Refactor tests/ha/test_ha_npu_reboot.py to run two paired scenarios (Traffic to Primary with Standby NPU Reboot, and Traffic to Standby with Primary NPU Reboot Switchover) over a 300 second traffic window, add a positive verification that the rebooted NPU's VIP is withdrawn from the T2 neighbor VMs' BGP RIB, and tighten check_dpu_module_status so a failed show chassis module status is no longer reported as online.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
Previous NPU reboot traffic loop could exit before the reboot shutdown completed, resulting in false positives. Updating traffic window so that NPU reboot shutdown happens during the traffic loop. Also adding surface BGP convergence as a first-class signal alongside dataplane loss, so a regression that loses dataplane but keeps the VIP advertised, or vice versa, can be caught instead of trivially passing.

#### How did you do it?
Extended the traffic window so the NPU's full outage now falls within the test. Added a new neighbor-side BGP verification that captures the rebooted DUT's BGP local addresses before the reboot and then, after the traffic loop and before recovery, polls each T2 neighbor VM's BGP RIB to confirm none of them still receive the VIP from the rebooted DUT. Tightened the DPU chassis-status helper so it only reports the DPU as online when the chassis status output actually says so, instead of defaulting to online whenever the output is not offline.

#### How did you verify/test it?
Ran on smartswitch HA testbed:
```
-- generated xml file: /data/sonic-mgmt/tests/logs/ha/test_ha_npu_reboot.xml ---
---------------------------- live log sessionfinish ----------------------------
INFO     root:__init__.py:67 Can not get Allure report URL. Please check logs
INFO:root:[Parallel Fixture] Terminating parallel fixture manager
INFO:root:Can not get Allure report URL. Please check logs
================= 2 passed, 813 warnings in 2585.82s (0:43:05) =================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
