### PR TITLE
Fix get_bmc_host to load and initialize by the hostname

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -381,7 +381,8 @@ class MultiAsicSonicHost(object):
         pytest_assert(self.sonichost.is_bmc(), "get_bmc_host() can only be called on a BMC device")
         bmc_host_hostname = self.duthosts.tbinfo.get('bmc_host')
         pytest_assert(bmc_host_hostname, "bmc_host field not defined in testbed YAML")
-        return self.duthosts[bmc_host_hostname]
+        return MultiAsicSonicHost(self.duthosts.ansible_adhoc, bmc_host_hostname,
+                                  self.duthosts, self.duthosts.tbinfo['topo']['type'])
 
     def get_bmc_from_host(self):
         """Return the MultiAsicSonicHost of the paired BMC for this switch host."""


### PR DESCRIPTION
### Description of PR
This PR fixes get_bmc_host that fails to lookup the bmc_host in the duthosts.
Instead it needs it initialize it specifically

Summary:
Instead of looking up the duthosts it initializes the MultiAsicSonicHost instance

Fixes: https://github.com/sonic-net/sonic-mgmt/issues/25790

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605


### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

