### PR TITLE
[ha]: Use platform-aware flow comparison in HA tests

### DIFF
--- a/tests/ha/test_ha_bfd_pin.py
+++ b/tests/ha/test_ha_bfd_pin.py
@@ -12,7 +12,7 @@ from constants import (
 from ha_packets import outbound_pl_packets, bootstrap_pl_tcp_flow_outbound
 from tests.ha.conftest import apply_dash_pl_pipeline_config
 from tests.common.helpers.assertions import pytest_assert
-from ha_dash_flow_utils import compare_flow_tables_pdsctl
+from ha_dash_flow_utils import compare_flow_tables
 from ha_utils import (
     bfd_pin_primary,
     bfd_unpin_primary,
@@ -142,7 +142,7 @@ def test_ha_bfd_pin(
                 testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, rcv_outbound_pl_ports)
                 if send_count == 0:
                     logger.info("First packet verified on standby - compare flows")
-                    flow_op = compare_flow_tables_pdsctl(dpuhosts[0], dpuhosts[1])
+                    flow_op = compare_flow_tables(dpuhosts[0], dpuhosts[1])
                     pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
 
             else:
@@ -152,7 +152,7 @@ def test_ha_bfd_pin(
                 testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, rcv_outbound_pl_ports)
                 if send_count == 0:
                     logger.info("First packet verified on primary - compare flows")
-                    flow_op = compare_flow_tables_pdsctl(dpuhosts[0], dpuhosts[1])
+                    flow_op = compare_flow_tables(dpuhosts[0], dpuhosts[1])
                     pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
         except Exception as e:
             if failed_count == 0:

--- a/tests/ha/test_ha_config_reload.py
+++ b/tests/ha/test_ha_config_reload.py
@@ -13,7 +13,7 @@ from ha_packets import outbound_pl_packets, bootstrap_pl_tcp_flow_outbound
 from tests.common.config_reload import config_reload
 from tests.ha.conftest import apply_dash_pl_pipeline_config
 from tests.common.helpers.assertions import pytest_assert
-from ha_dash_flow_utils import compare_flow_tables_pdsctl
+from ha_dash_flow_utils import compare_flow_tables
 from ha_utils import parallel_config_reload_dpuhosts
 
 logger = logging.getLogger(__name__)
@@ -132,7 +132,7 @@ def test_ha_dut_config_reload(
                 testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, rcv_outbound_pl_ports)
                 if send_count == 0:
                     logger.info("First packet verified on standby - compare flows")
-                    flow_op = compare_flow_tables_pdsctl(dpuhosts[0], dpuhosts[1])
+                    flow_op = compare_flow_tables(dpuhosts[0], dpuhosts[1])
                     pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
 
             else:
@@ -142,7 +142,7 @@ def test_ha_dut_config_reload(
                 testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, rcv_outbound_pl_ports)
                 if send_count == 0:
                     logger.info("First packet verified on primary - compare flows")
-                    flow_op = compare_flow_tables_pdsctl(dpuhosts[0], dpuhosts[1])
+                    flow_op = compare_flow_tables(dpuhosts[0], dpuhosts[1])
                     pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
         except Exception as e:
             if failed_count == 0:

--- a/tests/ha/test_ha_config_reload.py
+++ b/tests/ha/test_ha_config_reload.py
@@ -164,8 +164,8 @@ def test_ha_dut_config_reload(
     percentage_loss = (failed_count / send_count) * 100
 
     if (percentage_loss < threshold_loss):
-        logger.info(f"{reload_dut} with {traffic} test OK. Sent: {send_count},"
+        logger.info(f"{reload_dut} with {traffic} test OK. Sent: {send_count}, "
                     f" lost: {failed_count}, loss percentage: {percentage_loss}, threshold: {threshold_loss}")
     else:
-        pytest.fail(f"{reload_dut} with {traffic} test error. Sent: {send_count},"
+        pytest.fail(f"{reload_dut} with {traffic} test error. Sent: {send_count}, "
                     f" lost: {failed_count} loss percentage: {percentage_loss}, threshold: {threshold_loss}")


### PR DESCRIPTION
### Description of PR
Summary:
Use the existing platform-aware HA flow comparison helper in BFD pin and config reload HA tests instead of directly invoking the pdsctl-specific helper.

Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Some SmartSwitch HA tests call the pdsctl-specific flow comparison helper directly. That makes the tests fail on DPU platforms where pdsctl is not available, even though the repository already has a platform-aware flow comparison helper.

#### How did you do it?
Updated the BFD pin and DPU config reload HA tests to call compare_flow_tables(), which selects the appropriate flow dump implementation based on the DPU platform.

#### How did you verify/test it?
- Python syntax checks for the updated HA tests.
- Representative SmartSwitch HA BFD validation: pdsctl-specific failure is resolved; single-side pin variants passed, both-side pin variants exposed packet-loss behavior after BFD pinning.
- Representative SmartSwitch HA DPU config reload validation: 4/4 variants passed.

#### Any platform specific information?
No platform-specific behavior is added; the tests now use the existing platform-aware helper.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A