### PR TITLE
BMC switch-host default admin-up

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -998,6 +998,12 @@ class GenerateGoldenConfigDBModule(object):
         else:
             return config
 
+    def set_switch_host_admin_up_config(self, config):
+        """Set switch-host admin_up by default"""
+        ori_config_db = json.loads(config)
+        ori_config_db.setdefault("CHASSIS_MODULE", {}).setdefault("SWITCH-HOST", {})["admin_status"] = "up"
+        return json.dumps(ori_config_db, indent=4)
+
     def generate_default_init_config_db(self):
         rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
         if rc != 0:
@@ -1271,6 +1277,10 @@ class GenerateGoldenConfigDBModule(object):
             module_msg = module_msg + " for c0"
         else:
             config = self.generate_default_init_config_db()
+
+        # set switch-host admin_up by default for BMC
+        if "bmc" in self.topo_name:
+            config = self.set_switch_host_admin_up_config(config)
 
         # update dns config
         config = self.update_dns_config(config)


### PR DESCRIPTION
### Description of PR
Set the default admin_up for the BMC SWITCH-HOST

Summary:
BMC tests expects that the SWITCH-HOST is admin_up and Online at the start, setting the admin_up explicitly in he golden config

### Type of change

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:

### Approach
#### What is the motivation for this PR?
Configure the testbed for running the tests.
switch-host shutdown command reports it already down, while it is admin_up and online

#### How did you do it?
Set  BMC SWITCH-HOST admin_up by default

#### How did you verify/test it?
Deployed the test bed, confirmed successful shutdown command for the switch-host

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

