### PR TITLE
process_monitoring: replace monit start delay comment-out with zero value to avoid None return from get_bootup_timeout

### DIFF
--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -144,7 +144,11 @@ def modify_monit_config_and_restart(duthosts, rand_one_dut_hostname):
 
     logger.info("Modifying Monit config to eliminate start delay and decrease interval ...")
     duthost.shell("sudo sed -i 's/set daemon 60/set daemon 10/' /etc/monit/monitrc")
-    duthost.shell("sudo sed -i '/with start delay 300/s/^./#/' /etc/monit/monitrc")
+    # Replace the delay value with 0 rather than commenting out the line.
+    # Commenting the line causes health_checker.Config.get_bootup_timeout() to
+    # return None (implicit), which later triggers a TypeError when comparing
+    # uptime against the timeout and prevents the system-health LED from updating.
+    duthost.shell("sudo sed -i 's/with start delay 300/with start delay 0/' /etc/monit/monitrc")
 
     logger.info("Restart Monit service ...")
     duthost.shell("sudo systemctl restart monit")


### PR DESCRIPTION
### Description of PR
Summary:
Fix `test_critical_process_monitoring` commenting out `with start delay` in `/etc/monit/monitrc`, which causes `health_checker.Config.get_bootup_timeout()` to return `None` and breaks subsequent system health LED tests.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

`tests/process_monitoring/test_critical_process_monitoring.py` fixture `modify_monit_config_and_restart` uses:
```
sudo sed -i '/with start delay 300/s/^./#/' /etc/monit/monitrc
```
This **comments out** the `with start delay 300` line in `/etc/monit/monitrc` (by replacing the first character with `#`).

If the fixture teardown is skipped or interrupted (e.g. session crash), the file is left with the line commented out. This causes `health_checker.Config.get_bootup_timeout()` to return `None` implicitly — the function reads the file, skips the commented line, finds no match, and falls off the end of the `try` block. Subsequently, `manager.py` evaluates `uptime < get_bootup_timeout()` which becomes `float < None`, raising a `TypeError` that silently prevents the system-health LED from ever being updated.

This was observed on testbed `vms13-lt2-nokia-th6-1` where `test_service_checker_with_process_exit` (in `tests/system_health/test_system_health.py`) kept failing with:
```
AssertionError: System status LED 'green' does not match any colors defined in config: {'blinking green', 'amber'}
```
and the DUT logs showed:
```
Failed to set system led due to - TypeError("'<' not supported between instances of 'float' and 'NoneType'")
```

#### How did you do it?

Replace the `s/^./#/` sed (which comments out the line) with a substitution that sets the delay to `0`:
```
sudo sed -i 's/with start delay 300/with start delay 0/' /etc/monit/monitrc
```
This achieves the same goal (no effective start delay for monit) while keeping the line **active** so `get_bootup_timeout()` always returns a valid integer.

#### How did you verify/test it?

- Confirmed the broken `monitrc` state on Nokia TH6 DUT matched the output of the sed command
- Confirmed `get_bootup_timeout()` returns `None` when `with start delay` is commented out by tracing `health_checker/config.py` logic

#### Any platform specific information?

Observed on Nokia IXR7220 H6 (`vms13-lt2-nokia-th6-1`), but the bug is generic — any platform where teardown is skipped would be affected.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation
