### PR TITLE
BMC syslog default route helper fixed

### DIFF
--- a/tests/common/helpers/syslog_helpers.py
+++ b/tests/common/helpers/syslog_helpers.py
@@ -18,11 +18,17 @@ def check_default_route(rand_selected_dut):
     duthost = rand_selected_dut
     ret = {'IPv4': False, 'IPv6': False}
 
+    # BMC uses a different routing table
+    if duthost.is_bmc():
+        routing_table = "main"
+    else:
+        routing_table = "default"
+
     logger.info("Checking DUT default route")
-    result = duthost.shell("ip route show default table default | grep via", module_ignore_errors=True)['rc']
+    result = duthost.shell(f"ip route show default table {routing_table} | grep via", module_ignore_errors=True)['rc']
     if result == 0:
         neigh_ip = duthost.shell(
-            "ip route show default table default | cut -d ' ' -f 3", module_ignore_errors=True)['stdout']
+            f"ip route show default table {routing_table} | cut -d ' ' -f 3", module_ignore_errors=True)['stdout']
 
         # We ping here to make sure that the neigh_ip is not stale before checking for reachability
         duthost.shell("ping -c 1 {}".format(neigh_ip), module_ignore_errors=True)
@@ -31,10 +37,11 @@ def check_default_route(rand_selected_dut):
             "ip -4 neigh show {} | grep REACHABLE".format(neigh_ip), module_ignore_errors=True)['rc']
         if result == 0:
             ret['IPv4'] = True
-    result = duthost.shell("ip -6 route show default table default | grep via", module_ignore_errors=True)['rc']
+    result = duthost.shell(f"ip -6 route show default table {routing_table} | grep via",
+                           module_ignore_errors=True)['rc']
     if result == 0:
         neigh_ip = duthost.shell(
-            "ip -6 route show default table default | cut -d ' ' -f 3", module_ignore_errors=True)['stdout']
+            f"ip -6 route show default table {routing_table} | cut -d ' ' -f 3", module_ignore_errors=True)['stdout']
 
         # We ping here to make sure that the neigh_ip is not stale before checking for reachability
         duthost.shell("ping -c 1 {}".format(neigh_ip), module_ignore_errors=True)


### PR DESCRIPTION
### Description of PR
Fixes the default route lookup since the BMC does not have a data plane and uses the "main" routing table, different from the switch.

Summary:
Fixes https://github.com/sonic-net/sonic-mgmt/issues/25801

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605


### Approach
#### What is the motivation for this PR?
Reuse the SONiC switch test for BMC

#### How did you do it?
Added a condition to use the different routing table for the BMC

#### How did you verify/test it?
Ran the test on BMC and regression on non-BMC devices

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
