### PR TITLE
[202605] Add a topo check for ipv4 pass all OVS rule. (#25341)

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -317,6 +317,7 @@ class VMTopology(object):
         # For now distinguish a cable topology since it does not contain any vms and there are two ToR's
         self._is_cable = True if len(
             self.duts_name) > 1 and 'VMs' not in self.topo else False
+        self._is_smartswitch_ha = self.topo.get('topo_type') == 't1-smartswitch-ha'
 
         self.host_interfaces = self.topo.get('host_interfaces', [])
         if self.dut_interfaces:
@@ -1297,8 +1298,12 @@ class VMTopology(object):
                         (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
             bind_helper("ovs-ofctl add-flow %s table=0,priority=6,udp6,in_port=%s,udp_dst=4784,action=output:%s" %
                         (br_name, dut_iface_id, injected_iface_id))
-            bind_helper("ovs-ofctl add-flow %s table=0,priority=5,ip,in_port=%s,action=output:%s,%s" %
-                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            if self._is_smartswitch_ha:
+                bind_helper("ovs-ofctl add-flow %s table=0,priority=5,ip,in_port=%s,action=output:%s,%s" %
+                            (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            else:
+                bind_helper("ovs-ofctl add-flow %s table=0,priority=5,ip,in_port=%s,action=output:%s" %
+                            (br_name, dut_iface_id, injected_iface_id))
             bind_helper("ovs-ofctl add-flow %s table=0,priority=5,ipv6,in_port=%s,action=output:%s,%s" %
                         (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
             bind_helper("ovs-ofctl add-flow %s table=0,priority=3,in_port=%s,action=output:%s,%s" %

--- a/ansible/vars/topo_t1-smartswitch-ha.yml
+++ b/ansible/vars/topo_t1-smartswitch-ha.yml
@@ -1,4 +1,5 @@
 topology:
+  topo_type: t1-smartswitch-ha
   dut_num: 2
   VMs:
     ARISTA01T2:


### PR DESCRIPTION
### Description of PR

Backport of #25341 to the `202605` branch.

Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/24466

IPv4 pass-all rule added for smartswitch HA topology is causing BFD packets to loop in regular multihop BFD test.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
IPv4 pass-all OVS rule was added for smartswitch HA topology, but it is causing BFD multihop cases to fail on other topologies.

#### How did you do it?
Adding a topology check to apply the pass all only for HA topos and keep the original rule otherwise.

Cherry-picked from commit 5d6618a3672486ac9c644c1e83ca2641770d10fd (#25341).

#### How did you verify/test it?
Tested on smartswitch HA testbed, and running PR sonic-mgmt for other topos.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
