### PR TITLE
[202511] Skip updating WRED profiles with `wred_green_enabled=false`

### DIFF
--- a/tests/generic_config_updater/test_ecn_config_update.py
+++ b/tests/generic_config_updater/test_ecn_config_update.py
@@ -143,7 +143,7 @@ def get_wred_profiles(duthost, cli_namespace_prefix):
 
 
 # Determines how the value of each field should change to satisfy different constraints (explained below).
-def determine_delta_values(ecn_data, fields):
+def determine_delta_values(ecn_data, fields, wred_green_enabled):
     # Extra care should be taken when changing "green_min_threshold" and "green_max_threshold". "green_min_threshold"
     # must always be less than or equal to "green_max_threshold". Also, "green_max_threshold" must be less than
     # the available buffer pool size. Note that some platforms (e.g., Mellanox) round-up the value of
@@ -151,6 +151,9 @@ def determine_delta_values(ecn_data, fields):
     # value must still be less than the buffer pool size. So to avoid potential issues, we never attempt to increase
     # "green_max_threshold".
     delta = {"green_min_threshold": 0, "green_max_threshold": 0, "green_drop_probability": 0}
+
+    if not wred_green_enabled:  # If 'wred_green_enable' is false, don't change the WRED profile.
+        return delta
 
     min_threshold = int(ecn_data["green_min_threshold"])
     max_threshold = int(ecn_data["green_max_threshold"])
@@ -197,12 +200,19 @@ def determine_delta_values(ecn_data, fields):
     return delta
 
 
+@pytest.fixture
+def create_tmpfile(duthost):
+    tmpfile = generate_tmpfile(duthost)
+    yield tmpfile
+    delete_tmpfile(duthost, tmpfile)
+
+
 @pytest.mark.parametrize("configdb_field", ["green_min_threshold", "green_max_threshold", "green_drop_probability",
                          "green_min_threshold,green_max_threshold,green_drop_probability"])
 @pytest.mark.parametrize("operation", ["replace"])
 def test_ecn_config_updates(duthost, ensure_dut_readiness, configdb_field, operation,
-                            enum_rand_one_frontend_asic_index, cli_namespace_prefix):
-    tmpfile = generate_tmpfile(duthost)
+                            enum_rand_one_frontend_asic_index, cli_namespace_prefix, create_tmpfile):  # noqa F811
+    tmpfile = create_tmpfile
     logger.info("tmpfile {} created for json patch of field: {} and operation: {}"
                 .format(tmpfile, configdb_field, operation))
     namespace = duthost.get_namespace_from_asic_id(enum_rand_one_frontend_asic_index)
@@ -215,37 +225,33 @@ def test_ecn_config_updates(duthost, ensure_dut_readiness, configdb_field, opera
     # new_values is a dictionary from WRED profile name to its field-value mapping (with new values)
     # for the fields in configdb_field.
     new_values = {}
-    # Creating a JSON patch for all WRED profiles in CONFIG_DB.
+    # Creating a JSON patch for all WRED profiles in CONFIG_DB for which 'wred_green_enable' is true.
     for wred_profile in wred_profiles:
         ecn_data = duthost.shell("sonic-db-cli {} CONFIG_DB hgetall 'WRED_PROFILE|{}'"
                                  .format(cli_namespace_prefix, wred_profile))['stdout']
         ecn_data = ast.literal_eval(ecn_data)
-        delta = determine_delta_values(ecn_data, fields)
-        if all(delta[f] == 0 for f in fields):
-            logger.info(f"Skipping WRED profile {wred_profile}: all deltas are 0, no real value change possible.")
-            continue
+        wred_green_enabled = ecn_data.get("wred_green_enable", "false").lower() == "true"
+        if not wred_green_enabled:
+            logger.info(f"Not modifying the WRED profile {wred_profile} since 'wred_green_enable' is false.")
+        delta = determine_delta_values(ecn_data, fields, wred_green_enabled)
         new_values[wred_profile] = {}
         for field in fields:
             value = int(ecn_data[field])
             value += delta[field]
             new_values[wred_profile][field] = value
-
-            logger.info("value to be added to json patch: {}, operation: {}, field: {}"
-                        .format(value, operation, field))
-
-            json_patch.append(
-                              {"op": "{}".format(operation),
-                               "path": f"/WRED_PROFILE/{wred_profile}/{field}",
-                               "value": "{}".format(value)})
+            if wred_green_enabled:
+                logger.info("value to be added to json patch: {}, operation: {}, field: {}"
+                            .format(value, operation, field))
+                json_patch.append(
+                                  {"op": "{}".format(operation),
+                                   "path": f"/WRED_PROFILE/{wred_profile}/{field}",
+                                   "value": "{}".format(value)})
 
     if not json_patch:
         pytest.skip("All WRED profiles have zero deltas for the requested fields, skipping test.")
 
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
                                                  is_asic_specific=True, asic_namespaces=[namespace])
-    try:
-        output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
-        expect_op_success(duthost, output)
-        ensure_application_of_updated_config(duthost, fields, new_values, cli_namespace_prefix)
-    finally:
-        delete_tmpfile(duthost, tmpfile)
+    output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
+    expect_op_success(duthost, output)
+    ensure_application_of_updated_config(duthost, fields, new_values, cli_namespace_prefix)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR is a manual cherry-pick of PR #24532 since it was not automatically ported to 202511 for some reason.

Summary:
Skip updating WRED profiles for which `wred_green_enabled` is false.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [] 202511

### Approach
#### What is the motivation for this PR?
Ensuring that tests don't fail when for some WRED profiles, `wred_green_enabled=false`.

#### How did you do it?
We set all delta values to 0 if `wred_green_enabled=false` for a WRED profile and do not create a JSON patch for that profile.

#### How did you verify/test it?
Ran the tests:
```
generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[None-replace-green_min_threshold] PASSED                                    [ 25%]
generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[None-replace-green_max_threshold] PASSED                                    [ 50%]
generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[None-replace-green_drop_probability] PASSED                                 [ 75%]
generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[None-replace-green_min_threshold,green_max_threshold,green_drop_probability] PASSED [100%]
```

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
