### PR TITLE
tests/fib: fix ipinip_hash_negative topology guard and skip nvgre_hash for Nokia

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -655,6 +655,8 @@ def test_ipinip_hash_negative(add_default_route_to_dut, duthosts,           # no
                               ptfhost, ipver, tbinfo, mux_server_url, ignore_ttl, single_fib_for_duts,  # noqa: F811
                               duts_running_config_facts, duts_minigraph_facts, mux_status_from_nic_simulator,
                               request):                  # noqa: F811
+    # Only run this test on T1 or T0 (including dualtor) topologies
+    pytest_require(tbinfo['topo']['type'] in ['t1', 't0'], "The test case runs on T1 or T0 topology")
     hash_keys = ['inner_length']
     fib_files = fib_info_files_per_function(duthosts, ptfhost, duts_running_config_facts, duts_minigraph_facts,
                                             tbinfo, request)
@@ -773,6 +775,8 @@ def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                
     # For NVGRE, default hash key is inner 5-tuple.
     # Due to current limitation, NVGRE hash keys are updated for different vendors.
     # Hash-key will be updated once we get the full support.
+    pytest_require('nokia' not in duthost.facts.get('platform', ''),
+                   "Nokia platform NVGRE inner frame hashing is not fully supported")
     hash_keys = ['src-ip', 'dst-ip', 'src-port', 'dst-port', 'src-mac', 'dst-mac']
     if duthost.facts['asic_type'] in ["cisco-8000"]:
         logging.info("Cisco: hash-key is src-mac, dst-mac")


### PR DESCRIPTION
### Description of PR

Summary:

Fix two test failures in `tests/fib/test_fib.py` observed on Nokia TH6 testbed (lt2 topology).

### Type of change

- [x] Bug fix

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Two test failures were observed when running `test_fib.py` on a Nokia TH6 testbed (`lt2` topology):

1. `test_ipinip_hash_negative[ipv4]` - FAILED with PTF error `Did not receive expected packet on any of ports` because the `lt2` topology does not have IPinIP tunnels configured. The sibling test `test_ipinip_hash` already has a `pytest_require(tbinfo[topo][type] in [t1, t0])` guard, but `test_ipinip_hash_negative` was missing it.

2. `test_nvgre_hash[*]` (all 4 variants) - FAILED with `AssertionError` in `check_balancing` because Nokia TH6 hardware does not perform ECMP load-balancing based on NVGRE inner-frame fields. Nokia platforms report `asic_type=broadcom` so the existing per-vendor overrides (cisco-8000, mellanox, marvell-teralynx, vpp) do not catch them.

#### How did you do it?

1. **`test_ipinip_hash_negative`**: Added the same topology guard that exists in `test_ipinip_hash`:
   ```python
   pytest_require(tbinfo[topo][type] in [t1, t0], "The test case runs on T1 or T0 topology")
   ```

2. **`test_nvgre_hash`**: Added a skip for Nokia platforms (detected via `duthost.facts[platform]` containing `nokia`) since Nokia NVGRE inner-frame hashing is not fully supported:
   ```python
   pytest_require(nokia not in duthost.facts.get(platform, ),
                  "Nokia platform NVGRE inner frame hashing is not fully supported")
   ```

#### How did you verify/test it?

Ran the full `fib/test_fib.py` suite on Nokia TH6 testbed (`vms13-lt2-nokia-th6-1`). Without the fix, 5 tests fail (`test_ipinip_hash_negative[ipv4]` and all 4 `test_nvgre_hash` variants). With these fixes applied, those tests will be properly skipped on unsupported topologies/platforms.

#### Any platform specific information?

- Nokia TH6 (Nokia-IXR7220-H6-O256, platform `x86_64-nokia_ixr7220_h6_128-r0`) uses `lt2` topology
- Nokia platforms report `asic_type=broadcom` so platform-based detection uses `duthost.facts[platform]`

### Documentation
N/A