### PR TITLE
[202511] ci: run all impacted-area topology jobs in PR checker (#25255)

### DIFF
--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -130,48 +130,48 @@ jobs:
           ${{ each param in parameters.OVERRIDE_PARAMS }}:
             ${{ param.key }}: ${{ param.value }}
 
-  # - job: impacted_area_t0_2vlans_elastictest
-  #   displayName: "impacted-area-kvmtest-t0-2vlans by Elastictest"
-  #   dependsOn:
-  #   - get_impacted_area
-  #   - cancel_previous_test_plan_for_same_pr
-  #   condition: and(not(canceled()), succeeded(), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-2vlans_checker'))
-  #   variables:
-  #     TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-  #   timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
-  #   continueOnError: false
-  #   pool: ${{ parameters.AGENT_POOL }}
-  #   steps:
-  #     - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
-  #       - checkout: ${{ parameters.SONIC_MGMT_NAME }}
-  #         displayName: "Checkout sonic-mgmt repository"
+  - job: impacted_area_t0_2vlans_elastictest
+    displayName: "impacted-area-kvmtest-t0-2vlans by Elastictest"
+    dependsOn:
+    - get_impacted_area
+    - cancel_previous_test_plan_for_same_pr
+    condition: and(not(canceled()), succeeded(), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-2vlans_checker'))
+    variables:
+      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+    timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
+    continueOnError: false
+    pool: ${{ parameters.AGENT_POOL }}
+    steps:
+      - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
+        - checkout: ${{ parameters.SONIC_MGMT_NAME }}
+          displayName: "Checkout sonic-mgmt repository"
 
-  #     - template: impacted_area_testing/calculate-instance-numbers.yml
-  #       parameters:
-  #         TOPOLOGY: t0-2vlans
-  #         BUILD_BRANCH: $(BUILD_BRANCH)
+      - template: impacted_area_testing/calculate-instance-numbers.yml
+        parameters:
+          TOPOLOGY: t0-2vlans
+          BUILD_BRANCH: $(BUILD_BRANCH)
 
-  #     - template: run-test-elastictest-template.yml
-  #       parameters:
-  #         BUILD_REASON: ${{ parameters.BUILD_REASON }}
-  #         RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
-  #         STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
-  #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
-  #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
-  #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
-  #         PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
-  #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
-  #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
-  #         TOPOLOGY: t0
-  #         SCRIPTS: $(SCRIPTS)
-  #         MIN_WORKER: $(INSTANCE_NUMBER)
-  #         MAX_WORKER: $(INSTANCE_NUMBER)
-  #         DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
-  #         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-  #         MGMT_BRANCH: $(BUILD_BRANCH)
-  #         COMMON_EXTRA_PARAMS: "--disable_sai_validation "
-  #         ${{ each param in parameters.OVERRIDE_PARAMS }}:
-  #           ${{ param.key }}: ${{ param.value }}
+      - template: run-test-elastictest-template.yml
+        parameters:
+          BUILD_REASON: ${{ parameters.BUILD_REASON }}
+          RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
+          STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
+          TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
+          MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
+          MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+          PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
+          PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
+          EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
+          TOPOLOGY: t0
+          SCRIPTS: $(SCRIPTS)
+          MIN_WORKER: $(INSTANCE_NUMBER)
+          MAX_WORKER: $(INSTANCE_NUMBER)
+          DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
+          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+          MGMT_BRANCH: $(BUILD_BRANCH)
+          COMMON_EXTRA_PARAMS: "--disable_sai_validation "
+          ${{ each param in parameters.OVERRIDE_PARAMS }}:
+            ${{ param.key }}: ${{ param.value }}
 
   - job: impacted_area_t1_lag_elastictest
     displayName: "impacted-area-kvmtest-t1-lag by Elastictest"
@@ -215,183 +215,183 @@ jobs:
           ${{ each param in parameters.OVERRIDE_PARAMS }}:
             ${{ param.key }}: ${{ param.value }}
 
-  # - job: impacted_area_dualtor_elastictest
-  #   displayName: "impacted-area-kvmtest-dualtor by Elastictest"
-  #   dependsOn:
-  #   - get_impacted_area
-  #   - cancel_previous_test_plan_for_same_pr
-  #   condition: and(not(canceled()), succeeded(), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dualtor_checker'))
-  #   variables:
-  #     TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-  #   timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
-  #   continueOnError: false
-  #   pool: ${{ parameters.AGENT_POOL }}
-  #   steps:
-  #     - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
-  #       - checkout: ${{ parameters.SONIC_MGMT_NAME }}
-  #         displayName: "Checkout sonic-mgmt repository"
+  - job: impacted_area_dualtor_elastictest
+    displayName: "impacted-area-kvmtest-dualtor by Elastictest"
+    dependsOn:
+    - get_impacted_area
+    - cancel_previous_test_plan_for_same_pr
+    condition: and(not(canceled()), succeeded(), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dualtor_checker'))
+    variables:
+      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+    timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
+    continueOnError: false
+    pool: ${{ parameters.AGENT_POOL }}
+    steps:
+      - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
+        - checkout: ${{ parameters.SONIC_MGMT_NAME }}
+          displayName: "Checkout sonic-mgmt repository"
 
-  #     - template: impacted_area_testing/calculate-instance-numbers.yml
-  #       parameters:
-  #         TOPOLOGY: dualtor
-  #         BUILD_BRANCH: $(BUILD_BRANCH)
+      - template: impacted_area_testing/calculate-instance-numbers.yml
+        parameters:
+          TOPOLOGY: dualtor
+          BUILD_BRANCH: $(BUILD_BRANCH)
 
-  #     - template: run-test-elastictest-template.yml
-  #       parameters:
-  #         BUILD_REASON: ${{ parameters.BUILD_REASON }}
-  #         RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
-  #         STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
-  #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
-  #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
-  #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
-  #         PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
-  #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
-  #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
-  #         TOPOLOGY: dualtor
-  #         SCRIPTS: $(SCRIPTS)
-  #         MIN_WORKER: $(INSTANCE_NUMBER)
-  #         MAX_WORKER: $(INSTANCE_NUMBER)
-  #         COMMON_EXTRA_PARAMS: "--disable_loganalyzer --disable_sai_validation "
-  #         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-  #         MGMT_BRANCH: $(BUILD_BRANCH)
-  #         ${{ each param in parameters.OVERRIDE_PARAMS }}:
-  #           ${{ param.key }}: ${{ param.value }}
+      - template: run-test-elastictest-template.yml
+        parameters:
+          BUILD_REASON: ${{ parameters.BUILD_REASON }}
+          RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
+          STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
+          TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
+          MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
+          MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+          PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
+          PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
+          EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
+          TOPOLOGY: dualtor
+          SCRIPTS: $(SCRIPTS)
+          MIN_WORKER: $(INSTANCE_NUMBER)
+          MAX_WORKER: $(INSTANCE_NUMBER)
+          COMMON_EXTRA_PARAMS: "--disable_loganalyzer --disable_sai_validation "
+          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+          MGMT_BRANCH: $(BUILD_BRANCH)
+          ${{ each param in parameters.OVERRIDE_PARAMS }}:
+            ${{ param.key }}: ${{ param.value }}
 
-  # - job: impacted_area_t0_sonic_elastictest
-  #   displayName: "impacted-area-kvmtest-t0-sonic by Elastictest"
-  #   dependsOn:
-  #   - get_impacted_area
-  #   - cancel_previous_test_plan_for_same_pr
-  #   condition: and(not(canceled()), succeeded(), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-sonic_checker'))
-  #   variables:
-  #     TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-  #   timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
-  #   continueOnError: false
-  #   pool: ${{ parameters.AGENT_POOL }}
-  #   steps:
-  #     - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
-  #       - checkout: ${{ parameters.SONIC_MGMT_NAME }}
-  #         displayName: "Checkout sonic-mgmt repository"
+  - job: impacted_area_t0_sonic_elastictest
+    displayName: "impacted-area-kvmtest-t0-sonic by Elastictest"
+    dependsOn:
+    - get_impacted_area
+    - cancel_previous_test_plan_for_same_pr
+    condition: and(not(canceled()), succeeded(), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-sonic_checker'))
+    variables:
+      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+    timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
+    continueOnError: false
+    pool: ${{ parameters.AGENT_POOL }}
+    steps:
+      - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
+        - checkout: ${{ parameters.SONIC_MGMT_NAME }}
+          displayName: "Checkout sonic-mgmt repository"
 
-  #     - template: impacted_area_testing/calculate-instance-numbers.yml
-  #       parameters:
-  #         TOPOLOGY: t0-sonic
-  #         BUILD_BRANCH: $(BUILD_BRANCH)
+      - template: impacted_area_testing/calculate-instance-numbers.yml
+        parameters:
+          TOPOLOGY: t0-sonic
+          BUILD_BRANCH: $(BUILD_BRANCH)
 
-  #     - template: run-test-elastictest-template.yml
-  #       parameters:
-  #         BUILD_REASON: ${{ parameters.BUILD_REASON }}
-  #         RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
-  #         STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
-  #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
-  #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
-  #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
-  #         PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
-  #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
-  #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
-  #         TOPOLOGY: t0-64-32
-  #         SCRIPTS: $(SCRIPTS)
-  #         MIN_WORKER: $(INSTANCE_NUMBER)
-  #         MAX_WORKER: $(INSTANCE_NUMBER)
-  #         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-  #         COMMON_EXTRA_PARAMS: "--neighbor_type=sonic --disable_sai_validation "
-  #         VM_TYPE: vsonic
-  #         MGMT_BRANCH: $(BUILD_BRANCH)
-  #         SPECIFIC_PARAM: '[
-  #             {"name": "bgp/test_bgp_fact.py", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"},
-  #             {"name": "macsec", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"}
-  #           ]'
-  #         ${{ each param in parameters.OVERRIDE_PARAMS }}:
-  #           ${{ param.key }}: ${{ param.value }}
+      - template: run-test-elastictest-template.yml
+        parameters:
+          BUILD_REASON: ${{ parameters.BUILD_REASON }}
+          RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
+          STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
+          TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
+          MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
+          MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+          PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
+          PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
+          EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
+          TOPOLOGY: t0-64-32
+          SCRIPTS: $(SCRIPTS)
+          MIN_WORKER: $(INSTANCE_NUMBER)
+          MAX_WORKER: $(INSTANCE_NUMBER)
+          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+          COMMON_EXTRA_PARAMS: "--neighbor_type=sonic --disable_sai_validation "
+          VM_TYPE: vsonic
+          MGMT_BRANCH: $(BUILD_BRANCH)
+          SPECIFIC_PARAM: '[
+              {"name": "bgp/test_bgp_fact.py", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"},
+              {"name": "macsec", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"}
+            ]'
+          ${{ each param in parameters.OVERRIDE_PARAMS }}:
+            ${{ param.key }}: ${{ param.value }}
 
-  # - job: impacted_area_dpu_elastictest
-  #   displayName: "impacted-area-kvmtest-dpu by Elastictest"
-  #   dependsOn:
-  #   - get_impacted_area
-  #   - cancel_previous_test_plan_for_same_pr
-  #   condition: and(not(canceled()), succeeded(), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dpu_checker'))
-  #   variables:
-  #     TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-  #   timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
-  #   continueOnError: false
-  #   pool: ${{ parameters.AGENT_POOL }}
-  #   steps:
-  #     - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
-  #       - checkout: ${{ parameters.SONIC_MGMT_NAME }}
-  #         displayName: "Checkout sonic-mgmt repository"
+  - job: impacted_area_dpu_elastictest
+    displayName: "impacted-area-kvmtest-dpu by Elastictest"
+    dependsOn:
+    - get_impacted_area
+    - cancel_previous_test_plan_for_same_pr
+    condition: and(not(canceled()), succeeded(), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dpu_checker'))
+    variables:
+      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+    timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
+    continueOnError: false
+    pool: ${{ parameters.AGENT_POOL }}
+    steps:
+      - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
+        - checkout: ${{ parameters.SONIC_MGMT_NAME }}
+          displayName: "Checkout sonic-mgmt repository"
 
-  #     - template: impacted_area_testing/calculate-instance-numbers.yml
-  #       parameters:
-  #         TOPOLOGY: dpu
-  #         BUILD_BRANCH: $(BUILD_BRANCH)
+      - template: impacted_area_testing/calculate-instance-numbers.yml
+        parameters:
+          TOPOLOGY: dpu
+          BUILD_BRANCH: $(BUILD_BRANCH)
 
-  #     - template: run-test-elastictest-template.yml
-  #       parameters:
-  #         BUILD_REASON: ${{ parameters.BUILD_REASON }}
-  #         RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
-  #         STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
-  #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
-  #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
-  #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
-  #         PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
-  #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
-  #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
-  #         TOPOLOGY: dpu
-  #         SCRIPTS: $(SCRIPTS)
-  #         MIN_WORKER: $(INSTANCE_NUMBER)
-  #         MAX_WORKER: $(INSTANCE_NUMBER)
-  #         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-  #         MGMT_BRANCH: $(BUILD_BRANCH)
-  #         COMMON_EXTRA_PARAMS: "--disable_sai_validation "
-  #         SPECIFIC_PARAM: '[
-  #             {"name": "dash/test_dash_vnet.py", "param": "--skip_dataplane_checking"}
-  #           ]'
-  #         ${{ each param in parameters.OVERRIDE_PARAMS }}:
-  #           ${{ param.key }}: ${{ param.value }}
+      - template: run-test-elastictest-template.yml
+        parameters:
+          BUILD_REASON: ${{ parameters.BUILD_REASON }}
+          RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
+          STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
+          TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
+          MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
+          MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+          PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
+          PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
+          EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
+          TOPOLOGY: dpu
+          SCRIPTS: $(SCRIPTS)
+          MIN_WORKER: $(INSTANCE_NUMBER)
+          MAX_WORKER: $(INSTANCE_NUMBER)
+          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+          MGMT_BRANCH: $(BUILD_BRANCH)
+          COMMON_EXTRA_PARAMS: "--disable_sai_validation "
+          SPECIFIC_PARAM: '[
+              {"name": "dash/test_dash_vnet.py", "param": "--skip_dataplane_checking"}
+            ]'
+          ${{ each param in parameters.OVERRIDE_PARAMS }}:
+            ${{ param.key }}: ${{ param.value }}
 
-  # # This PR checker aims to run all t1 test scripts on multi-asic topology.
-  # - job: impacted_area_multi_asic_t1_elastictest
-  #   displayName: "impacted-area-kvmtest-multi-asic-t1 by Elastictest"
-  #   dependsOn:
-  #   - get_impacted_area
-  #   - cancel_previous_test_plan_for_same_pr
-  #   condition: and(not(canceled()), succeeded(), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't1_checker'))
-  #   variables:
-  #     TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-  #   timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
-  #   continueOnError: false
-  #   pool: ${{ parameters.AGENT_POOL }}
-  #   steps:
-  #     - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
-  #       - checkout: ${{ parameters.SONIC_MGMT_NAME }}
-  #         displayName: "Checkout sonic-mgmt repository"
+  # This PR checker aims to run all t1 test scripts on multi-asic topology.
+  - job: impacted_area_multi_asic_t1_elastictest
+    displayName: "impacted-area-kvmtest-multi-asic-t1 by Elastictest"
+    dependsOn:
+    - get_impacted_area
+    - cancel_previous_test_plan_for_same_pr
+    condition: and(not(canceled()), succeeded(), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't1_checker'))
+    variables:
+      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+    timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
+    continueOnError: false
+    pool: ${{ parameters.AGENT_POOL }}
+    steps:
+      - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
+        - checkout: ${{ parameters.SONIC_MGMT_NAME }}
+          displayName: "Checkout sonic-mgmt repository"
 
-  #     - template: impacted_area_testing/calculate-instance-numbers.yml
-  #       parameters:
-  #         TOPOLOGY: t1
-  #         BUILD_BRANCH: $(BUILD_BRANCH)
+      - template: impacted_area_testing/calculate-instance-numbers.yml
+        parameters:
+          TOPOLOGY: t1
+          BUILD_BRANCH: $(BUILD_BRANCH)
 
-  #     - template: run-test-elastictest-template.yml
-  #       parameters:
-  #         BUILD_REASON: ${{ parameters.BUILD_REASON }}
-  #         RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
-  #         STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
-  #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
-  #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
-  #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
-  #         PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
-  #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
-  #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
-  #         TOPOLOGY: t1-8-lag
-  #         SCRIPTS: $(SCRIPTS)
-  #         MIN_WORKER: $(INSTANCE_NUMBER)
-  #         MAX_WORKER: $(INSTANCE_NUMBER)
-  #         NUM_ASIC: 4
-  #         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-  #         MGMT_BRANCH: $(BUILD_BRANCH)
-  #         COMMON_EXTRA_PARAMS: "--disable_sai_validation "
-  #         ${{ each param in parameters.OVERRIDE_PARAMS }}:
-  #           ${{ param.key }}: ${{ param.value }}
+      - template: run-test-elastictest-template.yml
+        parameters:
+          BUILD_REASON: ${{ parameters.BUILD_REASON }}
+          RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
+          STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
+          TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
+          MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
+          MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+          PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
+          PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
+          EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
+          TOPOLOGY: t1-8-lag
+          SCRIPTS: $(SCRIPTS)
+          MIN_WORKER: $(INSTANCE_NUMBER)
+          MAX_WORKER: $(INSTANCE_NUMBER)
+          NUM_ASIC: 4
+          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+          MGMT_BRANCH: $(BUILD_BRANCH)
+          COMMON_EXTRA_PARAMS: "--disable_sai_validation "
+          ${{ each param in parameters.OVERRIDE_PARAMS }}:
+            ${{ param.key }}: ${{ param.value }}
 
   - job: impacted_area_t2_elastictest
     displayName: "impacted-area-kvmtest-t2 by Elastictest"


### PR DESCRIPTION
#### Why I did it

Backport of #25255 to **202511**.

The impacted-area PR test on 202511 only runs the `t0`, `t1-lag` and `t2` topologies. Every other topology job (`t0-2vlans`, `dualtor`, `t0-sonic`, `dpu`, `multi-asic-t1`) is commented out in `.azure-pipelines/pr_test_template.yml`, left over from #22836 ("Temporary skip test jobs in PR checker except t0/t1-lag/t2"). As a result the dualtor topology (and the others) never runs in PR validation on this branch, even when the impacted-area scan collects its checker scripts.

On master this was fixed by setting the `INCLUDE_JOBS` default to `all` (#25255), which unblocks the already-active dualtor job. 202511 has no `INCLUDE_JOBS` gating, so the equivalent fix is to re-enable the commented-out topology jobs.

##### Work item tracking
- Microsoft ADO **(number only)**: 38213269

#### How I did it

Uncommented the `impacted_area_t0_2vlans_elastictest`, `impacted_area_dualtor_elastictest`, `impacted_area_t0_sonic_elastictest`, `impacted_area_dpu_elastictest` and `impacted_area_multi_asic_t1_elastictest` jobs in `.azure-pipelines/pr_test_template.yml`, so every impacted-area topology job runs when its checker is in scope, matching master's `INCLUDE_JOBS: "all"` behaviour. The change is purely removing the `# ` comment prefix from the existing job definitions; it is CI/pipeline configuration only, with no product code, image content, or YANG/config_db schema affected.

#### How to verify it

Trigger PR validation on 202511. Confirm the **impacted-area-kvmtest-dualtor by Elastictest** job (and t0-2vlans / t0-sonic / dpu / multi-asic-t1) now runs when its checker is impacted, while t0 / t1-lag / t2 continue to run unchanged.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

This PR is itself the 202511 backport of #25255.

#### Tested branch (Please provide the tested image version)

- [ ] N/A — CI/pipeline configuration change; validated by this PR's own PR-test run.

#### Description for the changelog

ci: run all impacted-area topology jobs in the 202511 PR checker

#### Link to config_db schema for YANG module changes

N/A — no YANG/config_db changes.
