### PR TITLE
Skip platform warm / fast reboot test on unsupported Nexthop platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1322,6 +1322,7 @@ platform_tests/test_cont_warm_reboot.py:
       - "'dualtor' in topo_name"
       - "'isolated' in topo_name"
       - "topo_type not in ['t0']"
+      - "'x86_64-nexthop_' in platform and not platform.startswith('x86_64-nexthop_4010')"
       - "is_smartswitch==True"
 
 #######################################
@@ -1475,6 +1476,7 @@ platform_tests/test_reboot.py::test_fast_reboot:
       - "is_smartswitch==True"
       - "hwsku in ['Mellanox-SN4700-O32', 'Mellanox-SN4600C-C64', 'Nokia-M0-7215', 'Nokia-7215']"
       - "'f2' in topo_name"
+      - "'x86_64-nexthop_' in platform and not platform.startswith('x86_64-nexthop_4010')"
   xfail:
     reason: "case failed and waiting for fix"
     conditions:
@@ -1502,6 +1504,7 @@ platform_tests/test_reboot.py::test_warm_reboot:
       - "hwsku in ['Arista-7050CX3-32S-C28S4']"
       - "'isolated' in topo_name"
       - "'f2' in topo_name"
+      - "'x86_64-nexthop_' in platform and not platform.startswith('x86_64-nexthop_4010')"
   xfail:
     reason: "case failed and waiting for fix"
     conditions:


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Test warm/fast reboot on NH-4010 platform. Skip on other Nexthop platforms.

Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?

Test warm/fast reboot on NH-4010 platform

#### How did you do it?

Skip platform_tests/test_reboot.py::test_fast_reboot and platform_tests/test_reboot.py::test_warm_reboot unless on NH-4010

#### How did you verify/test it?

Run the platform_tests/test_reboot.py test suite

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
