### PR TITLE
Poll for gnmi server listening port instead of a fixed-delay single check

### DIFF
--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 GNMI_CONTAINER_NAME = ''
 GNMI_PROGRAM_NAME = ''
 GNMI_PORT = 0
-# Wait 15 seconds after starting GNMI server
+# Time budget (seconds) for the GNMI server to start listening
 GNMI_SERVER_START_WAIT_TIME = 15
 
 
@@ -64,14 +64,19 @@ def apply_cert_config(duthost, vrf_name=None):
     add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
     add_gnmi_client_common_name(duthost, "test.client.revoked.gnmi.sonic", role)
 
-    time.sleep(GNMI_SERVER_START_WAIT_TIME)
-    dut_command = "sudo netstat -nap | grep %d" % env.gnmi_port
-    output = duthost.shell(dut_command, module_ignore_errors=True)
+    # Poll for the listening port instead of a single fixed-delay check: the gnmi server can
+    # briefly drop and rebind its listener while it hot-reloads the freshly copied cert/key pair.
+    def _gnmi_server_listening():
+        cmd = f"sudo ss -ltnp | grep {env.gnmi_port} | grep {env.gnmi_process}"
+        return duthost.shell(cmd, module_ignore_errors=True)['stdout'].strip() != ""
+
+    server_started = wait_until(GNMI_SERVER_START_WAIT_TIME * 2, 3, 5, _gnmi_server_listening)
     if duthost.facts['platform'] != 'x86_64-kvm_x86_64-r0':
         is_time_synced = wait_until(80, 3, 0, check_system_time_sync, duthost)
         assert is_time_synced, "Failed to synchronize DUT system time with NTP Server"
-    if env.gnmi_process not in output['stdout']:
-        # Dump tcp port status and gnmi log
+    if not server_started:
+        # Dump listening port status and gnmi log
+        output = duthost.shell(f"sudo ss -ltnp | grep {env.gnmi_port}", module_ignore_errors=True)
         logger.info("TCP port status: " + output['stdout'])
         dump_gnmi_log(duthost)
         dump_system_status(duthost)
@@ -279,7 +284,7 @@ def gnmi_set(duthost, ptfhost, delete_list, update_list, replace_list, cert=None
     if rc != 0 or "GRPC error" in combined or "rpc error" in combined:
         dump_gnmi_log(duthost)
         dump_system_status(duthost)
-        raise Exception(f"py_gnmicli failed rc={rc}\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}")
+        raise Exception("py_gnmicli failed rc={}\nSTDOUT:\n{}\nSTDERR:\n{}".format(rc, stdout, stderr))
 
 
 def gnmi_get(duthost, ptfhost, path_list, ip=None):

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -71,9 +71,6 @@ def apply_cert_config(duthost, vrf_name=None):
         return duthost.shell(cmd, module_ignore_errors=True)['stdout'].strip() != ""
 
     server_started = wait_until(GNMI_SERVER_START_WAIT_TIME * 2, 3, 5, _gnmi_server_listening)
-    if duthost.facts['platform'] != 'x86_64-kvm_x86_64-r0':
-        is_time_synced = wait_until(80, 3, 0, check_system_time_sync, duthost)
-        assert is_time_synced, "Failed to synchronize DUT system time with NTP Server"
     if not server_started:
         # Dump listening port status and gnmi log
         output = duthost.shell(f"sudo ss -ltnp | grep {env.gnmi_port}", module_ignore_errors=True)
@@ -81,6 +78,9 @@ def apply_cert_config(duthost, vrf_name=None):
         dump_gnmi_log(duthost)
         dump_system_status(duthost)
         pytest.fail("Failed to start gnmi server")
+    if duthost.facts['platform'] != 'x86_64-kvm_x86_64-r0':
+        is_time_synced = wait_until(80, 3, 0, check_system_time_sync, duthost)
+        assert is_time_synced, "Failed to synchronize DUT system time with NTP Server"
     return stopped_programs
 
 

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 GNMI_CONTAINER_NAME = ''
 GNMI_PROGRAM_NAME = ''
 GNMI_PORT = 0
-# Time budget (seconds) for the GNMI server to start listening
+# Base wait unit (seconds) for GNMI server startup; the listening-port poll allows up to 2x this
 GNMI_SERVER_START_WAIT_TIME = 15
 
 
@@ -67,13 +67,13 @@ def apply_cert_config(duthost, vrf_name=None):
     # Poll for the listening port instead of a single fixed-delay check: the gnmi server can
     # briefly drop and rebind its listener while it hot-reloads the freshly copied cert/key pair.
     def _gnmi_server_listening():
-        cmd = f"sudo ss -ltnp | grep {env.gnmi_port} | grep {env.gnmi_process}"
+        cmd = 'sudo ss -ltnp | grep ":{} " | grep {}'.format(env.gnmi_port, env.gnmi_process)
         return duthost.shell(cmd, module_ignore_errors=True)['stdout'].strip() != ""
 
     server_started = wait_until(GNMI_SERVER_START_WAIT_TIME * 2, 3, 5, _gnmi_server_listening)
     if not server_started:
         # Dump listening port status and gnmi log
-        output = duthost.shell(f"sudo ss -ltnp | grep {env.gnmi_port}", module_ignore_errors=True)
+        output = duthost.shell('sudo ss -ltnp | grep ":{} "'.format(env.gnmi_port), module_ignore_errors=True)
         logger.info("TCP port status: " + output['stdout'])
         dump_gnmi_log(duthost)
         dump_system_status(duthost)


### PR DESCRIPTION
### Description of PR

Summary:
`tests/gnmi/helper.py::apply_cert_config` can fail intermittently during setup with `pytest.fail("Failed to start gnmi server")`, even though the gnmi server is listening a moment later. This change makes the readiness check poll for the listening port instead of doing a single fixed-delay check.

Microsoft ADO: 38656822

**Root cause of the "Failed to start gnmi server" flake.** After starting the gnmi server, `apply_cert_config` slept a fixed 15s and then ran a single `netstat` check. The gnmi server hot-reloads its certificate on inotify file events under `/etc/sonic/telemetry`. `create_gnmi_certs` copies the cert files one at a time, so the new `gnmiserver.crt` can land a few hundred milliseconds before the matching `gnmiserver.key`. During that window `tls.LoadX509KeyPair` fails ("private key does not match public key") and the server closes its listener, then rebinds as soon as the matching key arrives.

Evidence from the failing 720DT nightly run (202511, Cisco-8102): the debug test log's `GNMI log:` dump shows the server bind `[::]:50052`, then bounce on the cert inotify events during `create_gnmi_certs` (about 800ms with the port closed), then rebind. In the same run the server process stayed alive throughout (`ps` shows `/usr/sbin/telemetry --port 50052`) and was serving gNMI RPCs within seconds on either side of the failed check, which confirms it recovered on its own rather than failing to start. The single fixed-delay `netstat` check simply landed in one of these transient closed windows.

**Why this is a test fix and not an image fix.** I reviewed the sonic-gnmi `iNotifyCertMonitoring` cert monitor in `telemetry.go` on both the exact commit shipped in the deployed image and current master. They are byte-identical. On each cert file event it validates the cert/key pair and rebinds the listener accordingly. Recovery is event-driven and prompt once a valid pair is on disk, and no self-timer is needed because the completing cert write is itself the trigger. Closing the listener on a transient mismatch is correct fail-closed behavior, so no image change is warranted and the fix belongs on the test side.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Make `apply_cert_config` robust to the transient listener bounce that happens while the gnmi server hot-reloads the freshly copied cert/key pair. Today a single fixed-delay check can catch the server mid-bounce and fail setup, even though the server recovers on its own within about a second.

#### How did you do it?
Replaced the fixed `time.sleep(15)` plus single `netstat` check with `wait_until(GNMI_SERVER_START_WAIT_TIME * 2, 3, 5, ...)` polling for the listening port. The poll uses `ss -ltnp | grep <port> | grep <process>`, the same listening-only check already used by the gnmi health check elsewhere in this file, which is more precise than the previous broad `netstat | grep <port>`. It rides out the transient cert-reload bounce and any slow YANG-model init, and returns as soon as the server is listening. On timeout it dumps the same diagnostics (port status, gnmi log, system status) and raises `pytest.fail`. There is no behavior change on the happy path.

This PR also fixes a pre-existing flake8 `E231` on an f-string in `gnmi_set()` by switching it to `str.format()`. The literal colons inside that f-string are flagged by the CI runner's Python 3.12 flake8 (PEP 701 f-string tokenization) the first time the file is linted, which this PR triggers by touching the file. Converting to a plain string literal keeps the exact same message and removes the finding at the source.

#### How did you verify/test it?
* Root-caused from the nightly debug test log (`GNMI log:` dump): confirmed the server binds `:50052`, bounces on the cert inotify events during `create_gnmi_certs` (port closed for about 800ms until the matching key lands), then rebinds. The same log shows the server process alive throughout and serving RPCs seconds around the failed check, so it recovered on its own.
* Confirmed the recovery mechanism by reading sonic-gnmi `iNotifyCertMonitoring` on both the deployed image commit and master (identical), establishing that polling for the port is the correct and sufficient test-side fix.
