### PR TITLE
Update the test case name in test_ha_planned_shutdown_fnic.py

### DIFF
--- a/tests/ha/test_ha_planned_shutdown_fnic.py
+++ b/tests/ha/test_ha_planned_shutdown_fnic.py
@@ -58,7 +58,7 @@ def common_setup_teardown(
     parallel_config_reload_dpuhosts(dpuhosts)
 
 
-def test_ha_planned_shutdown(
+def test_ha_planned_shutdown_fnic(
     ptfadapter,
     localhost,
     duthosts,


### PR DESCRIPTION
### Description of PR

Summary:
The test case name in test_ha_planned_shutdown_fnic.py is the same as the one in test_ha_planned_shutdown.py.
It's a little bit confusing when we are reviewing the test results or trying to locate the loganalyzer marker in the syslog.
Add a _fnic suffix in the test case name, same as the other fnic tests.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Update the test case name in test_ha_planned_shutdown_fnic.py
#### How did you do it?
Adding a _fnic suffix in the test case name, same as the other fnic tests.
#### How did you verify/test it?
Run the test test_ha_planned_shutdown_fnic.py on SN4280 HA testbed.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A