### PR TITLE
[vxlan/test_scale_ecmp]: verify VNET route (re)programming in ASIC_DB

### DIFF
--- a/tests/vxlan/test_scale_ecmp.py
+++ b/tests/vxlan/test_scale_ecmp.py
@@ -11,6 +11,7 @@ from tests.ptf_runner import ptf_runner
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa:F401
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
 from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 ecmp_utils = Ecmp_Utils()
@@ -46,21 +47,95 @@ def apply_chunk(duthost, payload, name):
     duthost.shell(f"sonic-cfggen -j {dest} --write-to-db")
 
 
+def _get_asic_route_nexthop(duthost, prefix):
+    """
+    Return the SAI next-hop(-group) OID that the given overlay prefix resolves to
+    in ASIC_DB, or an empty string if the route is not present in the ASIC.
+    """
+    route_entries = duthost.shell(
+        "sonic-db-cli ASIC_DB keys "
+        "'ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:*" + prefix + "*'"
+    )["stdout_lines"]
+    if not route_entries:
+        return ""
+    return duthost.shell(
+        f"sonic-db-cli ASIC_DB hget '{route_entries[0]}' SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID"
+    )["stdout"].strip()
+
+
+def _is_asic_nexthop_group(duthost, oid):
+    """Return True if the given SAI OID is a next-hop group (i.e. an ECMP route)."""
+    if not oid:
+        return False
+    nh_group_entry = "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP_GROUP:" + oid
+    return duthost.shell(f"sonic-db-cli ASIC_DB exists '{nh_group_entry}'")["stdout"].strip() == "1"
+
+
+def _count_asic_nexthop_group_members(duthost, group_oid):
+    """
+    Return the number of members programmed into the given next-hop group in
+    ASIC_DB. Uses a server-side redis EVAL so the whole scan runs in one call
+    instead of an HGET per member.
+    """
+    lua = (
+        "local ks=redis.call('KEYS',KEYS[1]); local c=0; "
+        "for _,k in ipairs(ks) do "
+        "if redis.call('HGET',k,ARGV[1])==ARGV[2] then c=c+1 end end; return c"
+    )
+    cmd = (
+        f'sonic-db-cli ASIC_DB EVAL "{lua}" 1 '
+        '"ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER:*" '
+        '"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID" '
+        f'"{group_oid}"'
+    )
+    out = duthost.shell(cmd)["stdout"].strip()
+    return int(out) if out.isdigit() else 0
+
+
 def _update_vxlan_endpoints(duthost, vnet, prefix, endpoints, vni, mac_address=None):
     ep_str = ",".join(endpoints)
     logger.info(
         f"Updating VNET_ROUTE_TUNNEL {vnet}|{prefix} "
         f"with {len(endpoints)} endpoints, vni={vni}, mac={mac_address}"
     )
+    route_key = f"VNET_ROUTE_TUNNEL|{vnet}|{prefix}"
+
+    # Delete any existing route first.
+    duthost.shell(f"sonic-db-cli CONFIG_DB del '{route_key}'")
+    pytest_assert(
+        wait_until(30, 2, 0, lambda: _get_asic_route_nexthop(duthost, prefix) == ""),
+        f"VNET route {prefix} was not withdrawn from ASIC_DB after deletion"
+    )
+
     cmd = (
-        f"sonic-db-cli CONFIG_DB hmset 'VNET_ROUTE_TUNNEL|{vnet}|{prefix}' "
+        f"sonic-db-cli CONFIG_DB hmset '{route_key}' "
         f"endpoint '{ep_str}' vni '{vni}'"
     )
     if mac_address:
         cmd += f" mac_address '{mac_address}'"
 
     duthost.shell(cmd)
-    time.sleep(3)
+
+    # Verify the route is (re)programmed into the ASIC with a next-hop that
+    # matches the requested fan-out: a next-hop group whose member count equals
+    # the number of endpoints for ECMP (>1 endpoint), or a single next-hop
+    # otherwise. Checking the member count (not just "is it a group") catches a
+    # partially-programmed group, e.g. when the ASIC returns
+    # SAI_STATUS_INSUFFICIENT_RESOURCES and leaves an under-populated/stale group.
+    def _route_programmed():
+        nhid = _get_asic_route_nexthop(duthost, prefix)
+        if not nhid:
+            return False
+        if len(endpoints) > 1:
+            if not _is_asic_nexthop_group(duthost, nhid):
+                return False
+            return _count_asic_nexthop_group_members(duthost, nhid) == len(endpoints)
+        return True
+
+    pytest_assert(
+        wait_until(60, 3, 0, _route_programmed),
+        f"VNET route {prefix} was not programmed into ASIC_DB with {len(endpoints)} endpoint(s)"
+    )
 
 
 def get_available_vlan_id_and_ports(cfg_facts, num_ports_needed):
@@ -288,7 +363,7 @@ def test_vxlan_mac_vni(ptfhost, one_vnet_setup_teardown):
 
     # --- Build deterministic MAC list ---
     # 52:54:00:00:xx:yy (unique per endpoint)
-    mac_list = [f"52:54:00:{i//256:02x}:{i%256:02x}:aa" for i in range(num_endpoints)]
+    mac_list = ["52:54:00:%02x:%02x:aa" % (i // 256, i % 256) for i in range(num_endpoints)]
     mac_list_str = ",".join(mac_list)
     updated_vni = 5001
 
@@ -442,7 +517,7 @@ def test_ecmp_scale_modify_mac(ptfhost, one_vnet_setup_teardown):
     time.sleep(5)
 
     # Step 2 — Initial MAC list
-    mac_list = [f"52:54:00:{i//256:02x}:{i%256:02x}:aa" for i in range(num)]
+    mac_list = ["52:54:00:%02x:%02x:aa" % (i // 256, i % 256) for i in range(num)]
     mac_string = ",".join(mac_list)
 
     # Push initial MAC list
@@ -451,7 +526,7 @@ def test_ecmp_scale_modify_mac(ptfhost, one_vnet_setup_teardown):
 
     # Step 3 — Random index to modify
     mod_idx = random.randint(0, num - 1)
-    new_mac = f"52:54:99:{mod_idx//256:02x}:{mod_idx%256:02x}:cc"
+    new_mac = "52:54:99:%02x:%02x:cc" % (mod_idx // 256, mod_idx % 256)
     logger.info(f"Modifying MAC for endpoint index {mod_idx}: new MAC = {new_mac}")
 
     # Update the list


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?

`tests/vxlan/test_scale_ecmp.py` reprograms a single VNET tunnel route
(`VNET_ROUTE_TUNNEL|Vnet1|150.0.3.1/32`) many times with different endpoint
sets. It previously did an in-place `hmset` and only slept before sending
traffic. When a reprogram failed to apply in hardware — e.g. the ASIC returns
`SAI_STATUS_INSUFFICIENT_RESOURCES` while building a large ECMP next-hop group —
`vnetorch` left the *previous* (or partially-built) next-hop group installed.
Later cases then silently encapsulated to **stale endpoints**, which showed up
as the PTF test receiving `Received VXLAN pkt to unexpected endpoint ...` and
running for hours instead of failing. The test had no way to detect that the
route it configured was not the route actually in the ASIC.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?

Reworked `_update_vxlan_endpoints()` to make each update synchronous with the
ASIC and to fail fast when hardware programming doesn't match intent:
- **Delete first**: remove the `VNET_ROUTE_TUNNEL` entry and `wait_until` the
  overlay route is withdrawn from `ASIC_DB`, so a failed update can't fall back
  to a stale next-hop group.
- **Verify (re)programming**: after re-adding, `wait_until` the ASIC route
  resolves to a next-hop, and — for ECMP (>1 endpoint) — that it is a
  `SAI_OBJECT_TYPE_NEXT_HOP_GROUP` whose **member count equals the number of
  endpoints**. The member count is obtained with a single server-side redis
  `EVAL` (one call instead of an HGET per member).
- Added helpers `_get_asic_route_nexthop`, `_is_asic_nexthop_group`,
  `_count_asic_nexthop_group_members`.

Net effect: a route that can't be fully programmed (e.g. an ECMP width that
exceeds the platform's per-group member limit) now fails with a clear assertion
(`VNET route ... was not programmed into ASIC_DB with N endpoint(s)`) instead of
leaving the suite to run traffic against stale state.

#### How did you verify/test it?
```
vxlan/test_scale_ecmp.py::test_ecmp_two_endpoints PASSED                                                                                                                                                                                             [ 12%]
vxlan/test_scale_ecmp.py::test_ecmp_change_endpoints PASSED                                                                                                                                                                                          [ 25%]
vxlan/test_scale_ecmp.py::test_ecmp_scale FAILED                                                                                                                                                                                                     [ 37%]
vxlan/test_scale_ecmp.py::test_vxlan_mac_vni FAILED                                                                                                                                                                                                  [ 50%]
vxlan/test_scale_ecmp.py::test_ecmp_scale_add_endpoint FAILED                                                                                                                                                                                        [ 62%]
vxlan/test_scale_ecmp.py::test_ecmp_scale_delete_endpoint FAILED                                                                                                                                                                                     [ 75%]
vxlan/test_scale_ecmp.py::test_ecmp_scale_modify_endpoint FAILED                                                                                                                                                                                     [ 87%]
vxlan/test_scale_ecmp.py::test_ecmp_scale_modify_mac FAILED                                                                                                                                                                                          [100%]


========================================================================================================================= FAILURES =========================================================================================================================
_____________________________________________________________________________________________________________________ test_ecmp_scale ______________________________________________________________________________________________________________________

ptfhost = <tests.common.devices.ptf.PTFHost object at 0x7fb70e18db50>
one_vnet_setup_teardown = ({'dst_ip': '150.0.3.1', 'dut_vtep': '10.1.0.32', 'num_endpoints': 4000, 'ptf_ingress_port': 13, ...}, <MultiAsicSonicHost str2-8101c1-01>, <tests.common.devices.ptf.PTFHost object at 0x7fb70e18db50>)

    def test_ecmp_scale(ptfhost, one_vnet_setup_teardown):
        logger.info("Running test_ecmp_scale")
        setup, duthost, _ = one_vnet_setup_teardown
        num_endpoints = setup["num_endpoints"]

        base_ip = int(IPv4Address("100.0.10.1"))
        endpoints = [str(IPv4Address(base_ip + i)) for i in range(num_endpoints)]
>       _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, endpoints, VNI)

vxlan/test_scale_ecmp.py:340:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

duthost = <MultiAsicSonicHost str2-8101c1-01>, vnet = 'Vnet1', prefix = '150.0.3.1/32', endpoints = ['100.0.10.1', '100.0.10.2', '100.0.10.3', '100.0.10.4', '100.0.10.5', '100.0.10.6', ...], vni = 10000, mac_address = None

    def _update_vxlan_endpoints(duthost, vnet, prefix, endpoints, vni, mac_address=None):
        ep_str = ",".join(endpoints)
        logger.info(
            f"Updating VNET_ROUTE_TUNNEL {vnet}|{prefix} "
            f"with {len(endpoints)} endpoints, vni={vni}, mac={mac_address}"
        )
        route_key = f"VNET_ROUTE_TUNNEL|{vnet}|{prefix}"

        # Delete any existing route first. An in-place hmset can leave the previous
        # ECMP group installed in the ASIC if the new set fails to program, which
        # makes later tests encapsulate to stale endpoints. Deleting forces vnetorch
        # to withdraw the old next-hops before the new ones are programmed.
        duthost.shell(f"sonic-db-cli CONFIG_DB del '{route_key}'")
        pytest_assert(
            wait_until(30, 2, 0, lambda: _get_asic_route_nexthop(duthost, prefix) == ""),
            f"VNET route {prefix} was not withdrawn from ASIC_DB after deletion"
        )

        cmd = (
            f"sonic-db-cli CONFIG_DB hmset '{route_key}' "
            f"endpoint '{ep_str}' vni '{vni}'"
        )
        if mac_address:
            cmd += f" mac_address '{mac_address}'"

        duthost.shell(cmd)

        # Verify the route is (re)programmed into the ASIC with a next-hop that
        # matches the requested fan-out: a next-hop group whose member count equals
        # the number of endpoints for ECMP (>1 endpoint), or a single next-hop
        # otherwise. Checking the member count (not just "is it a group") catches a
        # partially-programmed group, e.g. when the ASIC returns
        # SAI_STATUS_INSUFFICIENT_RESOURCES and leaves an under-populated/stale group.
        def _route_programmed():
            nhid = _get_asic_route_nexthop(duthost, prefix)
            if not nhid:
                return False
            if len(endpoints) > 1:
                if not _is_asic_nexthop_group(duthost, nhid):
                    return False
                return _count_asic_nexthop_group_members(duthost, nhid) == len(endpoints)
            return True

>       pytest_assert(
            wait_until(60, 3, 0, _route_programmed),
            f"VNET route {prefix} was not programmed into ASIC_DB with {len(endpoints)} endpoint(s)"
        )
E       Failed: VNET route 150.0.3.1/32 was not programmed into ASIC_DB with 4000 endpoint(s)
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
