### PR TITLE
[log_analyzer] Ignore loganalyzer add marker logs

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -519,3 +519,6 @@ r, ".* ERR auditd.*: auditd queue full reporting limit reached - ending dropped 
 # ctrmgrd k8s join warnings (old k8s version incompatibility with Docker 28.x)
 r, ".* ERR ctrmgrd\.py: Refer file .* for troubleshooting tips.*"
 r, ".* ERR ctrmgrd\.py:.*\[WARNING SystemVerification\]:.*Docker version is not on the list of validated versions.*"
+
+# Ignore loganalyzer add marker logs in case the test name matches an error pattern
+r, ".*INFO.*ansible.*loganalyzer.py.*--action add.*marker.*"


### PR DESCRIPTION
### Description of PR

Summary:
If the test case name matches any pattern in loganalyzer_common_match.txt, the loganalyzer add marker log will be mis-captured as an error by loganalyzer.

Example: " INFO python3.13[845329]: ansible-ansible.legacy.command Invoked with _raw_params=python /tmp/loganalyzer.py --action add_end_marker --run_id test_crash_active_dpu_traffic_on_active[syncd].2026-06-29-15:47:08..."

The test name test_crash_active_dpu_traffic_on_active matches the pattern "crash": https://github.com/sonic-net/sonic-mgmt/blob/3e1c7214400018b0bcc594d91f308baac811da6e/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_match.txt#L1

So, we need ignore the add marker log to avoid the false alarm.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: day-one issue

### Approach
#### What is the motivation for this PR?
Fix a false alarm issue in loganalyzer
#### How did you do it?
Ignore loganalyzer add marker logs by adding a pattern ".*INFO.*ansible.*loganalyzer.py.*--action add.*marker.*" to loganalyzer_common_ignore.txt.
#### How did you verify/test it?
Run the test test_ha_dpu_process_crash.py on smartswitch HA testbed, the error is not seen again.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A