### PR TITLE
snmp: poll for LLDP-MIB readiness in test_snmp_lldp to fix KeyError flake

### DIFF
--- a/tests/snmp/test_snmp_lldp.py
+++ b/tests/snmp/test_snmp_lldp.py
@@ -2,6 +2,7 @@ import logging
 import re
 import pytest
 from tests.common.helpers.snmp_helpers import get_snmp_facts
+from tests.common.utilities import wait_until
 
 pytestmark = [
     pytest.mark.topology('t0', 't1', 't2', 'lrh', 'urh', 'm0', 'mx', 'm1', 'lt2', 'ft2', 'c0'),
@@ -70,9 +71,21 @@ def test_snmp_lldp(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_
     hostip = duthost.host.options['inventory_manager'].get_host(
         duthost.hostname).vars['ansible_host']
 
-    snmp_facts = get_snmp_facts(
-        duthost, localhost, host=hostip, version="v2c",
-        community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
+    # Poll until the LLDP local system data is populated; it can lag a snmp-subagent (re)start.
+    snmp_facts = {}
+    local_keys = ['lldpLocChassisIdSubtype', 'lldpLocChassisId', 'lldpLocSysName', 'lldpLocSysDesc']
+    if not duthost.facts['modular_chassis']:
+        local_keys += ['lldpLocManAddrLen', 'lldpLocManAddrIfSubtype', 'lldpLocManAddrIfId', 'lldpLocManAddrOID']
+
+    def _lldp_local_ready():
+        snmp_facts.update(get_snmp_facts(
+            duthost, localhost, host=hostip, version="v2c",
+            community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts'])
+        lldp = snmp_facts.get('snmp_lldp', {})
+        return all(lldp.get(k) and "No Such" not in lldp[k] for k in local_keys)
+
+    assert wait_until(120, 10, 0, _lldp_local_ready), (
+        "LLDP-MIB local data not populated in time: {}".format(snmp_facts.get('snmp_lldp')))
     mg_facts = {}
     for asic_id in duthost.get_asic_ids():
         mg_facts_ns = duthost.asic_instance(

--- a/tests/snmp/test_snmp_lldp.py
+++ b/tests/snmp/test_snmp_lldp.py
@@ -71,7 +71,7 @@ def test_snmp_lldp(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_
     hostip = duthost.host.options['inventory_manager'].get_host(
         duthost.hostname).vars['ansible_host']
 
-    # Poll until the LLDP local system data is populated; it can lag a snmp-subagent (re)start.
+    # Poll (non-waiting fetch) until LLDP local system data is populated; it can lag an snmp-subagent restart.
     snmp_facts = {}
     local_keys = ['lldpLocChassisIdSubtype', 'lldpLocChassisId', 'lldpLocSysName', 'lldpLocSysDesc']
     if not duthost.facts['modular_chassis']:
@@ -80,12 +80,14 @@ def test_snmp_lldp(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_
     def _lldp_local_ready():
         snmp_facts.update(get_snmp_facts(
             duthost, localhost, host=hostip, version="v2c",
-            community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts'])
+            community=creds_all_duts[duthost.hostname]["snmp_rocommunity"],
+            module_ignore_errors=True).get('ansible_facts', {}))
         lldp = snmp_facts.get('snmp_lldp', {})
         return all(lldp.get(k) and "No Such" not in lldp[k] for k in local_keys)
 
-    assert wait_until(120, 10, 0, _lldp_local_ready), (
-        "LLDP-MIB local data not populated in time: {}".format(snmp_facts.get('snmp_lldp')))
+    if not wait_until(30, 10, 0, _lldp_local_ready):
+        collect_lldp_diagnostics(duthost)
+        pytest.fail("LLDP-MIB local data not populated in time: {}".format(snmp_facts.get('snmp_lldp')))
     mg_facts = {}
     for asic_id in duthost.get_asic_ids():
         mg_facts_ns = duthost.asic_instance(


### PR DESCRIPTION
### Description of PR

Summary:
`tests/snmp/test_snmp_lldp.py::test_snmp_lldp` fails intermittently with `KeyError: 'lldpLocManAddrLen'` (and its sibling management-address keys). This change makes the test wait for the LLDP-MIB local system data to be populated before asserting on it.

**Impact (SonicTestData, nightly, last ~95 days).** `KeyError: 'lldpLocManAddrLen'` hit **60 of ~1804 runs (~3.3%)** of `snmp.test_snmp_lldp`, and it is **cross-vendor / platform-agnostic** (as expected for a test-code bug):

| Platform | KeyErrors / runs | rate |
| --- | --- | --- |
| **Cisco-8220 (8000)** | **16 / 64** | **25.0%** (up to 46.7% = 14/30 on `testbed-bjw3-can-8220-1`) |
| Nvidia-SN2700 | 8 / 127 | 6.3% |
| Arista-720DT | 6 / 132 | 4.6% |
| Arista-7260 | 7 / 195 | 3.6% |
| Nvidia-SN4700 | 2 / 75 | 2.7% |
| Cisco-8100 (8101/8102) | 3 / 180 | 1.7% |
| Arista-7050/7060 | 2 / 181 | 1.1% |
| Nokia-7215 (IXR) | 1 / 92 | 1.1% |

**Root cause.** The LLDP-MIB (`lldpLocalSystemData`, `1.0.8802.1.1.2.1.3.*`) is served by the `snmp-subagent` (sonic-snmpagent) over AgentX. `get_snmp_facts(wait=True)` only waits for the snmp-subagent process to be RUNNING and for the SNMP walk to succeed. It does **not** wait for the LLDP-MIB subtree to be populated. For several seconds after the subagent (or snmpd) (re)starts, the chassis scalar OIDs come back via GET as `"No Such Instance/Object"` (which slip the test's existing chassis checks, since those only reject the exact phrase `"No Such Object currently exists"`), and the management-address table (a walk) is empty, so its keys are absent from `snmp_lldp` entirely. The test then does an unguarded `snmp_facts['snmp_lldp']['lldpLocManAddrLen']` and raises `KeyError`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: ADO 38672205 (https://msazure.visualstudio.com/One/_workitems/edit/38672205)
Failure type: day-one test-code bug (unguarded access), exposed more often on some platforms/images.

### Approach
#### What is the motivation for this PR?
Make `test_snmp_lldp` robust to the LLDP-MIB readiness window so a transient unpopulated MIB no longer turns into an opaque `KeyError`, and a genuinely-missing MIB fails with a clear message.

#### How did you do it?
Replaced the single `get_snmp_facts(wait=True)` fetch with a `wait_until(120, 10, 0, ...)` poll that re-fetches until the LLDP local system data is actually present — the chassis scalars (`lldpLocChassisId*`, `lldpLocSysName`, `lldpLocSysDesc`) and, on non-modular DUTs, the management-address keys — each non-empty and not a `"No Such ..."` placeholder. Because both the chassis and management-address keys are part of the readiness check, once the poll passes every subsequent access is safe, so no separate per-key guard is needed. On timeout it fails with a clear assertion showing the last `snmp_lldp` contents instead of a `KeyError`.

#### How did you verify/test it?
- **Reproduced the exact failure via the real test** on `testbed-bjw3-can-8220-1` (the highest-rate testbed): the unmodified test fails with `KeyError: 'lldpLocManAddrLen'` at the man-addr access, because that DUT persistently serves the chassis OIDs as `"No Such Instance"` (slipping the chassis asserts) with an empty management-address table.
- **After the fix**, the same run on the 8220 no longer `KeyError`s — it fails cleanly with `Failed: LLDP-MIB local data not populated in time: {...}`, naming exactly what was missing.
- **Healthy DUT (720DT):** the fixed test **passes** (no regression; the poll returns immediately when the MIB is already populated).
- Confirmed on a live DUT that the LLDP-MIB is served by the snmp-subagent via AgentX and is unserved for ~3-9s after a subagent/snmpd restart (chassis + man-addr both absent) before recovering — exactly the window the poll rides out.
- `py_compile` and `flake8 --max-line-length=120` pass on the changed file.

#### Any platform specific information?
None — platform-agnostic test-code bug (see the cross-vendor table above).
