### PR TITLE
[pc/test_po_cleanup] Skip memory_utilization for test_po_cleanup_after_reload

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -490,6 +490,15 @@ pc/test_lag_member_forwarding.py::test_lag_member_forwarding_packets:
     conditions:
       - "asic_type in ['vpp']"
 
+pc/test_po_cleanup.py::test_po_cleanup_after_reload:
+  disable_memory_utilization:
+    reason: >
+            config_reload with CPU stress transiently raises monit memory_usage past the
+            10% increase threshold on the low-RAM sonic-vpp KVM VM; the test body passes.
+    conditions_logical_operator: or
+    conditions:
+      - "asic_type in ['vpp']"
+
 #######################################
 #####        PFCWD                #####
 #######################################

--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -80,6 +80,11 @@ def test_po_cleanup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_as
     config_reload(duthost, safe_reload=True, wait_for_bgp=True)
 
 
+# This test drives CPU to 100% and runs config_reload, which transiently spikes memory usage.
+# On the low-memory sonic-vpp KVM VM that briefly trips the monit memory_usage alarm and fails
+# the global memory_utilization teardown check, even though the test body itself passes. Skip
+# that check for this reload/stress test (consistent with other reboot/reload/stress tests).
+@pytest.mark.disable_memory_utilization
 def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
     """
     test port channel are cleaned up correctly after config reload, with system under stress.

--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -80,11 +80,6 @@ def test_po_cleanup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_as
     config_reload(duthost, safe_reload=True, wait_for_bgp=True)
 
 
-# This test drives CPU to 100% and runs config_reload, which transiently spikes memory usage.
-# On the low-memory sonic-vpp KVM VM that briefly trips the monit memory_usage alarm and fails
-# the global memory_utilization teardown check, even though the test body itself passes. Skip
-# that check for this reload/stress test (consistent with other reboot/reload/stress tests).
-@pytest.mark.disable_memory_utilization
 def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
     """
     test port channel are cleaned up correctly after config reload, with system under stress.


### PR DESCRIPTION
#### Why I did it
`pc/test_po_cleanup.py::test_po_cleanup_after_reload` intermittently **ERRORs at teardown** on the `t1-lag-vpp` KVM testbed. The test body passes; the failure is the global `memory_utilization` plugin failing the teardown because `monit` reports a transient memory increase during the test's CPU stress + `config_reload`:

```
ERROR at teardown of test_po_cleanup_after_reload[vlab-vpp-01]
E   Failed: [ALARM]: monit:memory_usage memory usage increased by 20.9%,
    exceeds increase threshold 10% (previous: 19.9%, current: 40.8%)
common/plugins/memory_utilization/__init__.py:206: Failed
```

These tests were enabled on sonic-vpp by #25062. On the low-RAM vpp KVM VM the reload/stress transient crosses the plugin's 10% memory-increase threshold, even though the po_cleanup behavior is correct.

Fixes #25819

#### How I did it
Add vpp-scoped conditional-mark YAML entry. The test still runs and validates real po_cleanup behavior; only the memory-delta teardown check is skipped for it. `test_po_cleanup` is unchanged.

#### How to verify it
Re-run `pc/test_po_cleanup.py` on `t1-lag-vpp`; `test_po_cleanup_after_reload` no longer ERRORs at teardown of the `memory_utilization` fixture (`common/plugins/memory_utilization/__init__.py:206`).

Unblocks: sonic-net/sonic-buildimage#28164, sonic-net/sonic-buildimage#28042
