### PR TITLE
Fix rif_port_down fixture with link restoration

### DIFF
--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -412,7 +412,7 @@ def setup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
 
 
 @pytest.fixture
-def rif_port_down(duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup, fanouthosts):
+def rif_port_down(duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup, fanouthosts, request):
     """Shut RIF interface and return neighbor IP address attached to this interface."""
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="drop_packet_rif_port_down")
@@ -432,10 +432,57 @@ def rif_port_down(duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup, fa
     pytest_assert(ip_dst, 'Unable to find IP address for neighbor "{}"'.format(vm_name))
 
     fanout_neighbor, fanout_intf = fanout_switch_port_lookup(fanouthosts, duthost.hostname, rif_member_iface)
+    is_link_shutdown = False
+
+    logger.info(
+        "rif_port_down selected: dut=%s rif_member_iface=%s fanout=%s fanout_intf=%s vm=%s ip_dst=%s",
+        duthost.hostname,
+        rif_member_iface,
+        getattr(fanout_neighbor, "hostname", str(fanout_neighbor)),
+        fanout_intf,
+        vm_name,
+        ip_dst,
+    )
+
+    def _restore_link():
+        if not is_link_shutdown:
+            logger.info("rif_port_down finalizer: link was not shutdown, skip restore")
+            return
+
+        logger.info(
+            "rif_port_down finalizer: restoring fanout link fanout=%s intf=%s",
+            getattr(fanout_neighbor, "hostname", str(fanout_neighbor)),
+            fanout_intf,
+        )
+        try:
+            loganalyzer.expect_regex = [LOG_EXPECT_PORT_OPER_UP_RE.format(rif_member_iface)]
+            with loganalyzer as _:
+                if hasattr(fanout_neighbor, "startup"):
+                    fanout_neighbor.startup(fanout_intf)
+                else:
+                    fanout_neighbor.no_shutdown(fanout_intf)
+                time.sleep(PORT_STATE_UPDATE_INTERNAL)
+        except Exception:
+            logger.exception("rif_port_down finalizer: restore with loganalyzer failed, retrying best-effort")
+            try:
+                if hasattr(fanout_neighbor, "startup"):
+                    fanout_neighbor.startup(fanout_intf)
+                else:
+                    fanout_neighbor.no_shutdown(fanout_intf)
+            except Exception:
+                logger.exception(
+                    "rif_port_down finalizer: best-effort restore failed fanout=%s intf=%s",
+                    getattr(fanout_neighbor, "hostname", str(fanout_neighbor)),
+                    fanout_intf,
+                )
+
+    request.addfinalizer(_restore_link)
 
     loganalyzer.expect_regex = [LOG_EXPECT_PORT_OPER_DOWN_RE.format(rif_member_iface)]
     with loganalyzer as _:
+        logger.info("rif_port_down setup: shutting down fanout intf %s", fanout_intf)
         fanout_neighbor.shutdown(fanout_intf)
+        is_link_shutdown = True
         # Add a delay to ensure loganalyzer can find a match in the log. Without this delay, there's a
         # chance it might miss the matching log.
         time.sleep(PORT_STATE_UPDATE_INTERNAL)
@@ -444,12 +491,6 @@ def rif_port_down(duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup, fa
 
     yield ip_dst
 
-    loganalyzer.expect_regex = [LOG_EXPECT_PORT_OPER_UP_RE.format(rif_member_iface)]
-    with loganalyzer as _:
-        fanout_neighbor.no_shutdown(fanout_intf)
-        # Add a delay to ensure loganalyzer can find a match in the log. Without this delay, there's a
-        # chance it might miss the matching log.
-        time.sleep(PORT_STATE_UPDATE_INTERNAL)
 
 
 @pytest.fixture(params=["port_channel_members", "vlan_members", "rif_members"])

--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -457,18 +457,12 @@ def rif_port_down(duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup, fa
         try:
             loganalyzer.expect_regex = [LOG_EXPECT_PORT_OPER_UP_RE.format(rif_member_iface)]
             with loganalyzer as _:
-                if hasattr(fanout_neighbor, "startup"):
-                    fanout_neighbor.startup(fanout_intf)
-                else:
-                    fanout_neighbor.no_shutdown(fanout_intf)
+                fanout_neighbor.no_shutdown(fanout_intf)
                 time.sleep(PORT_STATE_UPDATE_INTERNAL)
         except Exception:
             logger.exception("rif_port_down finalizer: restore with loganalyzer failed, retrying best-effort")
             try:
-                if hasattr(fanout_neighbor, "startup"):
-                    fanout_neighbor.startup(fanout_intf)
-                else:
-                    fanout_neighbor.no_shutdown(fanout_intf)
+                fanout_neighbor.no_shutdown(fanout_intf)
             except Exception:
                 logger.exception(
                     "rif_port_down finalizer: best-effort restore failed fanout=%s intf=%s",

--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -492,7 +492,6 @@ def rif_port_down(duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup, fa
     yield ip_dst
 
 
-
 @pytest.fixture(params=["port_channel_members", "vlan_members", "rif_members"])
 def tx_dut_ports(request, setup, tbinfo):
     """ Fixture for getting port members of specific port group """

--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -458,17 +458,12 @@ def rif_port_down(duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup, fa
             loganalyzer.expect_regex = [LOG_EXPECT_PORT_OPER_UP_RE.format(rif_member_iface)]
             with loganalyzer as _:
                 fanout_neighbor.no_shutdown(fanout_intf)
+                # Add a delay to ensure loganalyzer can find a match in the log. Without this delay, there's a
+                # chance it might miss the matching log.
                 time.sleep(PORT_STATE_UPDATE_INTERNAL)
         except Exception:
-            logger.exception("rif_port_down finalizer: restore with loganalyzer failed, retrying best-effort")
-            try:
-                fanout_neighbor.no_shutdown(fanout_intf)
-            except Exception:
-                logger.exception(
-                    "rif_port_down finalizer: best-effort restore failed fanout=%s intf=%s",
-                    getattr(fanout_neighbor, "hostname", str(fanout_neighbor)),
-                    fanout_intf,
-                )
+            logger.exception("rif_port_down finalizer: restore with loganalyzer failed")
+            raise
 
     request.addfinalizer(_restore_link)
 


### PR DESCRIPTION
This change makes [rif_port_down] recovery reliable when the test fails before or during log analysis.

In the original fixture, link restoration lived only in the post-yield teardown path. That meant the recovery call was conditional on the fixture successfully reaching yield first. In failing runs, the setup block raised inside the first [LogAnalyzer] context before yield because the expected Port <rif> oper state set from up to down message was missing. Once that happened, pytest treated the fixture as a setup error and never resumed execution into the post-yield section, so the original [no_shutdown] path was never entered. That is why the original code “had a [no_shutdown]” but still left the link down: the code existed, but control flow never reached it.

The new implementation in tests/drop_packets/drop_packets.py fixes that by registering a finalizer before the risky shutdown/loganalyzer sequence starts. The finalizer is tied to the fixture lifecycle itself, not to whether execution reaches the teardown block after yield. Once [is_link_shutdown] is set, [_restore_link()] will run even if setup fails, the test body fails, or log analysis throws. It first tries the normal restore path with the expected up-log check, and if that log check fails it falls back to a best-effort restore without letting the exception prevent the interface from being brought back.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Before:
there was a testbed that has swapped link mapping with fanout. Eth16 and Eth20, the drop_packet test chose Eth20 as testing port and try to admin shut from fanout side, and because of the wrong mapping, the Eth16 was showing oper down on dut side, thus loganalyzer failed, and didn't recover the link by calling no_shutdown because it is placed after yield. 
This is causing all following tests to fail because of unable to recover the dut, the restore method from nightly are just config reload from dut, nothing to be done on fanout side. 
e.g. 
https://elastictest.org/scheduler/testplan/6a3ec32d42b6aa8b676ff904?testcase=drop_packets%2Ftest_drop_counters.py%7C%7C%7C1&type=console&searchTestCase=

After the PR fix:
even if mapping is still wrong, running test_drop_counters.py will also fail to find the regex in syslog, but all links are up after test run:
```
     Interface            Lanes    Speed    MTU    FEC    Alias            Vlan    Oper    Admin                                             Type    Asym PFC
--------------  ---------------  -------  -----  -----  -------  --------------  ------  -------  -----------------------------------------------  ----------
     Ethernet0      35,34,33,32     400G   9100    N/A     etp1  PortChannel101      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
     Ethernet4      37,36,39,38     400G   9100    N/A     etp2          routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
     Ethernet8      40,41,42,43     400G   9100    N/A     etp3  PortChannel103      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet12      46,47,44,45     400G   9100    N/A     etp4  PortChannel104      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet16      50,51,48,49     400G   9100    N/A     etp5  PortChannel104      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet20      52,53,54,55     400G   9100    N/A     etp6          routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet24      56,57,58,59     400G   9100    N/A     etp7          routed    down     down                                              N/A         off
    Ethernet28      62,63,60,61     400G   9100    N/A     etp8          routed    down     down                                              N/A         off
    Ethernet32  123,122,121,120     400G   9100    N/A     etp9          routed    down     down                                              N/A         off
    Ethernet36  125,124,127,126     400G   9100    N/A    etp10          routed    down     down                                              N/A         off
    Ethernet40      96,97,98,99     400G   9100    N/A    etp11          routed    down     down                                              N/A         off
    Ethernet44  102,103,100,101     400G   9100    N/A    etp12          routed    down     down                                              N/A         off
    Ethernet48  114,115,112,113     400G   9100    N/A    etp13          routed    down     down                                              N/A         off
    Ethernet52  116,117,118,119     400G   9100    N/A    etp14          routed    down     down                                              N/A         off
    Ethernet56  104,105,106,107     400G   9100    N/A    etp15          routed    down     down                                              N/A         off
    Ethernet60  110,111,108,109     400G   9100    N/A    etp16          routed    down     down                                              N/A         off
    Ethernet64      72,73,74,75     400G   9100    N/A    etp17          routed    down     down                                              N/A         off
    Ethernet68      76,77,78,79     400G   9100    N/A    etp18          routed    down     down                                              N/A         off
    Ethernet72      64,65,66,67     400G   9100    N/A    etp19          routed    down     down                                              N/A         off
    Ethernet76      68,69,70,71     400G   9100    N/A    etp20          routed    down     down                                              N/A         off
    Ethernet80      88,89,90,91     400G   9100    N/A    etp21          routed    down     down                                              N/A         off
    Ethernet84      92,93,94,95     400G   9100    N/A    etp22          routed    down     down                                              N/A         off
    Ethernet88      80,81,82,83     400G   9100    N/A    etp23          routed    down     down                                              N/A         off
    Ethernet92      84,85,86,87     400G   9100    N/A    etp24          routed    down     down                                              N/A         off
    Ethernet96      16,17,18,19     400G   9100    N/A    etp25          routed    down     down                                              N/A         off
   Ethernet100      20,21,22,23     400G   9100    N/A    etp26          routed    down     down                                              N/A         off
   Ethernet104      24,25,26,27     400G   9100    N/A    etp27          routed    down     down                                              N/A         off
   Ethernet108      28,29,30,31     400G   9100    N/A    etp28          routed    down     down                                              N/A         off
   Ethernet112          0,1,2,3     400G   9100    N/A    etp29          routed    down     down                                              N/A         off
   Ethernet116          4,5,6,7     400G   9100    N/A    etp30          routed    down     down                                              N/A         off
   Ethernet120        8,9,10,11     400G   9100    N/A    etp31          routed    down     down                                              N/A         off
   Ethernet124      12,13,14,15     400G   9100    N/A    etp32          routed    down     down                                              N/A         off
   Ethernet128  168,169,170,171     400G   9100    N/A    etp33          routed    down     down                                              N/A         off
   Ethernet132  172,173,174,175     400G   9100    N/A    etp34          routed    down     down                                              N/A         off
   Ethernet136  160,161,162,163     400G   9100    N/A    etp35          routed    down     down                                              N/A         off
   Ethernet140  164,165,166,167     400G   9100    N/A    etp36          routed    down     down                                              N/A         off
   Ethernet144  184,185,186,187     400G   9100    N/A    etp37          routed    down     down                                              N/A         off
   Ethernet148  188,189,190,191     400G   9100    N/A    etp38          routed    down     down                                              N/A         off
   Ethernet152  176,177,178,179     400G   9100    N/A    etp39          routed    down     down                                              N/A         off
   Ethernet156  180,181,182,183     400G   9100    N/A    etp40          routed    down     down                                              N/A         off
   Ethernet160  248,249,250,251     400G   9100    N/A    etp41          routed    down     down                                              N/A         off
   Ethernet164  252,253,254,255     400G   9100    N/A    etp42          routed    down     down                                              N/A         off
   Ethernet168  240,241,242,243     400G   9100    N/A    etp43          routed    down     down                                              N/A         off
   Ethernet172  244,245,246,247     400G   9100    N/A    etp44          routed    down     down                                              N/A         off
   Ethernet176  232,233,234,235     400G   9100    N/A    etp45          routed    down     down                                              N/A         off
   Ethernet180  236,237,238,239     400G   9100    N/A    etp46          routed    down     down                                              N/A         off
   Ethernet184  224,225,226,227     400G   9100    N/A    etp47          routed    down     down                                              N/A         off
   Ethernet188  228,229,230,231     400G   9100    N/A    etp48          routed    down     down                                              N/A         off
   Ethernet192  210,211,208,209     400G   9100    N/A    etp49          routed    down     down                                              N/A         off
   Ethernet196  212,213,214,215     400G   9100    N/A    etp50          routed    down     down                                              N/A         off
   Ethernet200  200,201,202,203     400G   9100    N/A    etp51          routed    down     down                                              N/A         off
   Ethernet204  206,207,204,205     400G   9100    N/A    etp52          routed    down     down                                              N/A         off
   Ethernet208  219,218,217,216     400G   9100    N/A    etp53          routed    down     down                                              N/A         off
   Ethernet212  221,220,223,222     400G   9100    N/A    etp54          routed    down     down                                              N/A         off
   Ethernet216  192,193,194,195     400G   9100    N/A    etp55          routed    down     down                                              N/A         off
   Ethernet220  198,199,196,197     400G   9100    N/A    etp56          routed    down     down                                              N/A         off
   Ethernet224  154,155,152,153     400G   9100    N/A    etp57          routed    down     down                                              N/A         off
   Ethernet228  156,157,158,159     400G   9100    N/A    etp58          routed    down     down                                              N/A         off
   Ethernet232  144,145,146,147     400G   9100    N/A    etp59          routed    down     down                                              N/A         off
   Ethernet236  150,151,148,149     400G   9100    N/A    etp60          routed    down     down                                              N/A         off
   Ethernet240  139,138,137,136     400G   9100    N/A    etp61          routed    down     down                                              N/A         off
   Ethernet244  141,140,143,142     400G   9100    N/A    etp62          routed    down     down                                              N/A         off
   Ethernet248  128,129,130,131     400G   9100    N/A    etp63          routed    down     down                                              N/A         off
   Ethernet252  134,135,132,133     400G   9100    N/A    etp64          routed    down     down                                              N/A         off
 Ethernet-Rec0              280      10G   9100    N/A  Recirc0          routed      up       up                                              N/A         off
PortChannel101              N/A     400G   9100    N/A      N/A          routed      up       up                                              N/A         N/A
PortChannel103              N/A     400G   9100    N/A      N/A          routed      up       up                                              N/A         N/A
PortChannel104              N/A     800G   9100    N/A      N/A          routed      up       up                                              N/A         N/A
```



#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
