### PR TITLE
tests/crm: Fix ACL table key lookup and CRM counter polling

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -133,17 +133,21 @@ def apply_acl_config(duthost, asichost, test_name, collector, entry_num=1):
     # Wait for ACL configuration to propagate by polling for ACL table key
     logger.info("Waiting for ACL configuration to propagate...")
 
+    acl_tbl_key = None
+
     def _acl_config_applied():
+        nonlocal acl_tbl_key
         try:
-            get_acl_tbl_key(asichost)
+            acl_tbl_key = get_acl_tbl_key(asichost)
             return True
-        except Exception:
+        except BaseException:
+            acl_tbl_key = None
             return False
 
     pytest_assert(wait_until(CONFIG_UPDATE_TIME * 3, CRM_POLLING_INTERVAL, 0, _acl_config_applied),
                   "ACL configuration did not propagate within timeout")
 
-    collector["acl_tbl_key"] = get_acl_tbl_key(asichost)
+    collector["acl_tbl_key"] = acl_tbl_key
 
 
 def generate_mac(num):
@@ -226,28 +230,29 @@ def apply_fdb_config(duthost, test_name, vlan_id, iface, entry_num):
 
 
 def get_acl_tbl_key(asichost):
-    """ Get ACL entry keys """
-    cmd = "{} ASIC_DB KEYS \"*SAI_OBJECT_TYPE_ACL_ENTRY*\"".format(asichost.sonic_db_cli)
-    acl_tbl_keys = asichost.shell(cmd)["stdout"].split()
+    """ Get ACL entry keys.
+    """
+    db_cli = asichost.sonic_db_cli
+    cmd = (
+        'keys=$({db} ASIC_DB KEYS "*SAI_OBJECT_TYPE_ACL_ENTRY*"); '
+        'for k in $keys; do '
+        '  et=$({db} ASIC_DB HGET "$k" SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE); '
+        '  case "$et" in '
+        '    *2048*) '
+        '      tid=$({db} ASIC_DB HGET "$k" SAI_ACL_ENTRY_ATTR_TABLE_ID); '
+        '      if [ -n "$tid" ]; then echo "$tid"; exit 0; fi ;; '
+        '  esac; '
+        'done; '
+        'exit 1'
+    ).format(db=db_cli)
 
-    # Get ethertype for ACL entry and match ACL which was configured to ethertype value
-    cmd = "{db_cli} ASIC_DB HGET {item} \"SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE\""
-    for item in acl_tbl_keys:
-        out = asichost.shell(cmd.format(db_cli=asichost.sonic_db_cli, item=item))["stdout"]
-        logging.info(out)
-        if "2048" in out:
-            key = item
-            break
-    else:
-        pytest.fail("Ether type was not found in SAI ACL Entry table")
+    result = asichost.shell(cmd, module_ignore_errors=True)
+    oid = (result.get("stdout") or "").strip()
+    if result.get("rc", 1) != 0 or not oid:
+        pytest.fail("Valid ACL entry (EtherType=2048 with TABLE_ID) not found")
 
-    # Get ACL table key
-    cmd = "{db_cli} ASIC_DB HGET {key} \"SAI_ACL_ENTRY_ATTR_TABLE_ID\""
-    oid = asichost.shell(cmd.format(db_cli=asichost.sonic_db_cli, key=key))["stdout"]
     logging.info(oid)
-    acl_tbl_key = "CRM:ACL_TABLE_STATS:{0}".format(oid.replace("oid:", ""))
-
-    return acl_tbl_key
+    return "CRM:ACL_TABLE_STATS:{0}".format(oid.replace("oid:", ""))
 
 
 def verify_thresholds(duthost, asichost, **kwargs):
@@ -1235,6 +1240,12 @@ def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hos
     RESTORE_CMDS["crm_threshold_name"] = "acl_entry"
     crm_stats_acl_entry_used = 0
     crm_stats_acl_entry_available = 0
+
+    wait_for_crm_counter_update(
+        get_acl_entry_stats, duthost,
+        expected_used=crm_stats_acl_entry_used + 4,
+        oper_used=">=", timeout=60, interval=2,
+    )
 
     # Get new "crm_stats_acl_entry" used and available counter value
     new_crm_stats_acl_entry_used, new_crm_stats_acl_entry_available = get_crm_stats(get_acl_entry_stats, duthost)


### PR DESCRIPTION
### Summary:
test_acl_entry fails intermittently in the full CRM suite on Cisco 8000 during the ACL shrink phase (apply_acl_config(..., entry_num=1)), with:

Ether type was not found in SAI ACL Entry table

This change fixes broken retry behavior in apply_acl_config() so the test waits for ASIC_DB to settle instead of failing on a transient read.

### Fixes 

After acl-loader update full, CONFIG_DB is updated immediately, but orchagent/syncd update ASIC_DB asynchronously. During ACL shrink (many rules → 1), get_acl_tbl_key() can run while old ACL entry OIDs are still being removed. In that window:

KEYS may return stale OIDs ("zombie" keys) where HGET ETHER_TYPE is empty
New valid OIDs may not yet appear in the KEYS snapshot
A later retry with a fresh KEYS scan usually succeeds once syncd finishes.

### Two issues in apply_acl_config() prevented that:

Broken retry handling — _acl_config_applied() used except Exception, but get_acl_tbl_key() calls pytest.fail(), which raises _pytest.outcomes.Failed (a BaseException, not caught by except Exception). The failure could abort instead of being retried.

Duplicate unguarded call — After wait_until() succeeded, the code called get_acl_tbl_key() again with no retry. That second call could fail immediately on another bad ASIC_DB snapshot, producing the exact error above.



### What Changed
In apply_acl_config():

Store the ACL table key from the successful poll attempt
Change except Exception to except BaseException so pytest.fail is treated as "not ready yet"
Reuse the stored key instead of calling get_acl_tbl_key() a second time
get_acl_tbl_key() itself is unchanged.


## Why `get_acl_tbl_key()` Was Also Changed

Although the retry bug is fixed by the changes in `apply_acl_config()`, retries
are only useful if each attempt completes quickly enough to catch ASIC_DB in a
consistent state. The original `get_acl_tbl_key()` was too slow per attempt,
which made the retry path itself part of the problem.

### Problem with the original implementation

The original code issued one shell/`sonic-db-cli` call per ASIC_DB lookup:

1. One `KEYS *SAI_OBJECT_TYPE_ACL_ENTRY*` call to list all ACL entry OIDs.
2. One `HGET ... SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE` call **per key** in that
   list, executed sequentially from the test runner.
3. One more `HGET ... SAI_ACL_ENTRY_ATTR_TABLE_ID` call once a match was found.

Every one of those calls is a separate `asichost.shell(...)` round trip
(SSH → docker exec → redis-cli). On a fully-loaded Cisco 8000 with many
in-flight ACL entries during shrink, a single invocation could take several
seconds. Each `wait_until` retry then paid that full cost again, so the
poll interval drifted far away from the configured value and the function
spent most of its time iterating over stale "zombie" OIDs that were already
on their way out of ASIC_DB.

### Effect on the retry path

Because each attempt was slow:

- The KEYS snapshot used by an attempt was already stale by the time the
  per-key HGETs finished.
- Retries were spaced much wider than intended, so we frequently missed the
  short window where ASIC_DB held a clean, post-shrink view.
- In the worst case the test exhausted its retry budget before syncd ever
  converged, producing the `Ether type was not found in SAI ACL Entry table`
  failure even though the rule did eventually appear.

### Fix

`get_acl_tbl_key()` now performs the entire lookup in a **single** shell
invocation. The loop over keys, the EtherType match, and the TABLE_ID fetch
all run on the DUT inside one `sonic-db-cli`-driven shell pipeline, and the
function returns as soon as the first valid entry is found. The Python side
sees one round trip instead of `1 + N + 1`.

This keeps each retry attempt short and consistent, so:

- The KEYS list and the HGETs that act on it come from (effectively) the
  same ASIC_DB snapshot.
- `wait_until` actually polls at its configured cadence instead of drifting.
- We reliably hit the window after syncd finishes the shrink, which is what
  makes the retry fix in `apply_acl_config()` effective in practice.

Net result: same external behavior and same return value, but dramatically
fewer ASIC_DB round trips per attempt and a much tighter, more responsive
retry loop.


#### Why wait_for_crm_counter_update was added in verify_acl_crm_stats
apply_acl_config() returns as soon as the SAI ACL_ENTRY is visible in ASIC_DB, but CRM counters in COUNTERS_DB aren't updated until crmagent's next poll — which only happens after syncd and the SDK have actually programmed the rule into hardware. On a busy DUT this lag is multi-second. The expand path in verify_acl_crm_stats was doing a one-shot get_crm_stats() read ~1 s after apply_acl_config() returned and asserting on the result, so it raced crmagent and read the stale pre-apply value, failing with "counter was not incremented". The preconfig and shrink paths in the same function already wait on the counter via wait_for_crm_counter_update / wait_until(check_crm_stats); the expand path was the only one missing it. This change mirrors that existing pattern with the same helper and the same 60 s timeout, removing the race without altering the assertion itself.


## Motivation
The previous implementation made multiple separate shell calls to ASIC DB and could race when ACL configuration had not fully propagated. This caused intermittent CRM ACL test failures when the ACL table key lookup or counter reads happened too early.

## Test plan
- [ ] Run CRM ACL tests on affected platforms: `pytest tests/crm/test_crm.py -k acl`
- [ ] Verify ACL table key is resolved correctly after `apply_acl_config`
- [ ] Confirm `crm_stats_acl_entry_used` counter increments as expected after ACL config

Signed-off-by: rishi rewadkar <rrewadka@cisco.com>
