### PR TITLE
[bgp] Route cSONiC neighbor BGP-neighbor query through vtysh in test_bgp_router_id

### DIFF
--- a/tests/bgp/test_bgp_router_id.py
+++ b/tests/bgp/test_bgp_router_id.py
@@ -20,11 +20,23 @@ CUSTOMIZED_BGP_ROUTER_ID = "8.8.8.8"
 
 
 def verify_bgp_peer(neighbor_type, nbrhost, localip, expected_bgp_router_id, is_v6_topo, vrf="default"):
-    if neighbor_type in ("sonic", "csonic"):
+    if neighbor_type == "sonic":
         if is_v6_topo:
             cmd = "show ipv6 bgp neighbors {}".format(localip)
         else:
             cmd = "show ip bgp neighbors {}".format(localip)
+    elif neighbor_type == "csonic":
+        # cSONiC neighbors execute commands via `docker exec ... bash -c`, where the
+        # SONiC Click `show` CLI does not expose `show ip bgp neighbors` (it returns
+        # `Error: No such command 'bgp'`). Query FRR directly through vtysh, matching
+        # the idiom CsonicHost already uses for config/get_route.
+        #
+        # The router ID is address-family-independent and FRR's `show ip bgp
+        # neighbors <ip>` view emits the `BGP version 4, remote router ID ...` line
+        # the test greps for BOTH v4 and v6 neighbors. The `show bgp ipv6 unicast
+        # neighbors <ip>` view does NOT print that line, so use `show ip bgp
+        # neighbors` for the v6 topo as well.
+        cmd = "vtysh -c 'show ip bgp neighbors {}'".format(localip)
     elif neighbor_type == "eos":
         if is_v6_topo:
             cmd = "/usr/bin/Cli -c \"show ipv6 bgp peers {} vrf {}\"".format(localip, vrf)


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (no separate issue filed; part of the cSONiC docker-sonic-vs T0-neighbor enablement)

`tests/bgp/test_bgp_router_id.py::verify_bgp_peer()` grouped `sonic` and `csonic` neighbors together and issued `show ip bgp neighbors <ip>` as a plain command. cSONiC (docker-sonic-vs) neighbors execute commands via `docker exec ... bash -c`, where SONiC's Click `show` CLI has no `bgp neighbors` subcommand (it returns `Error: No such command "bgp"`). The command therefore produced empty output and `test_bgp_router_id` failed for cSONiC neighbors with `Cannot get remote BGP router id from []`.

This only affects runs with `--neighbor_type csonic`. The `sonic` and `eos` paths are unchanged.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Make `test_bgp_router_id` pass against cSONiC (docker-sonic-vs) virtual neighbors, part of enabling cSONiC as a T0 neighbor type.

#### How did you do it?

Split the `csonic` branch out of the shared `sonic` path in `verify_bgp_peer()` and route the query through `vtysh -c 'show ip bgp neighbors <ip>'`, matching the idiom `CsonicHost` already uses for `config`/`get_route`. The router ID is address-family-independent, and FRR's `show ip bgp neighbors <ip>` view emits the `BGP version 4, remote router ID ...` line the test greps for on both v4 and v6 neighbors, so the same command is used for the v6 topo as well (`show bgp ipv6 unicast neighbors ...` does not print that line).

#### How did you verify/test it?

Ran `test_bgp_router_id` on a T0 testbed with docker-sonic-vs cSONiC neighbors (`--neighbor_type csonic`); all 4 cases pass. Confirmed the `sonic`/`eos` code paths are untouched. flake8 clean.

#### Any platform specific information?

cSONiC-neighbor (docker-sonic-vs) specific; no DUT/platform changes.

#### Supported testbed topology if it's a new test case?

N/A (existing test).

### Documentation

N/A.
