### PR TITLE
[csonic] Support BGP graceful-restart neighbor operations on CsonicHost

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -28,6 +28,7 @@ from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common import constants
 from tests.common.devices.eos import EosHost
 from tests.common.devices.sonic import SonicHost
+from tests.common.devices.csonic import CsonicHost
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +108,7 @@ def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo
                         parents=['router bgp {}'.format(asn), 'address-family ipv6'],
                         module_ignore_errors=True)
                     )
-        elif isinstance(node['host'], SonicHost):
+        elif isinstance(node['host'], (SonicHost, CsonicHost)):
             node_results.append(node['host'].config(
                 lines=['bgp graceful-restart', 'bgp graceful-restart restart-time 300'],
                 parents=['router bgp {}'.format(asn)],
@@ -180,7 +181,7 @@ def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo
                         parents=['router bgp {}'.format(asn), 'address-family ipv6'],
                         module_ignore_errors=True)
                     )
-        elif isinstance(node['host'], SonicHost):
+        elif isinstance(node['host'], (SonicHost, CsonicHost)):
             node_results.append(node['host'].config(
                 lines=['no bgp graceful-restart', 'no bgp graceful-restart restart-time 300'],
                 parents=['router bgp {}'.format(asn)],

--- a/tests/common/devices/csonic.py
+++ b/tests/common/devices/csonic.py
@@ -118,6 +118,55 @@ class CsonicHost(NeighborDevice):
         logger.info("CsonicHost [%s] shutting down %s", self.container_name, ifname)
         return self._docker_exec("ip link set {} down".format(ifname))
 
+    def start_bgpd(self):
+        """Start the BGP daemon on the cSONiC (docker-sonic-vs) neighbor.
+
+        cSONiC neighbors run FRR natively under supervisor (no inner bgp docker),
+        and the BGP configuration is pushed into FRR by ``bgpcfgd`` from CONFIG_DB.
+        Starting ``bgpd`` alone brings it back with an empty running-config, so
+        ``bgpcfgd`` is restarted afterwards to re-apply the BGP config (mirroring
+        SonicHost.start_bgpd's bgpcfgd restart). Without this the neighbor comes
+        back up with no BGP sessions.
+        """
+        result = self._docker_exec("supervisorctl start bgpd", module_ignore_errors=True)
+        # 'already started' is fine; re-apply config so sessions actually come up.
+        self._docker_exec("supervisorctl restart bgpcfgd", module_ignore_errors=True)
+        return result
+
+    def kill_bgpd(self):
+        """Stop the BGP daemon on the cSONiC neighbor (used to drive graceful restart)."""
+        return self._docker_exec("supervisorctl stop bgpd", module_ignore_errors=True)
+
+    def check_bgp_session_state(self, neigh_ips, neigh_desc=None, state="established", vrf="default"):
+        """Return True iff every IP in ``neigh_ips`` is in the target BGP ``state``.
+
+        Queries FRR directly via ``vtysh -c 'show ip bgp neighbors <ip> json'``
+        (the result is keyed by neighbor IP, with ``bgpState`` carrying the
+        session state), matching the contract EosHost/SonicHost expose for the
+        graceful-restart helper. ``neigh_desc`` is accepted for signature
+        compatibility but not required for the cSONiC check.
+        """
+        neigh_ips = [ip.lower() for ip in neigh_ips]
+        ok = []
+        for neighbor_ip in neigh_ips:
+            if vrf and vrf != "default":
+                cmd = "vtysh -c 'show ip bgp vrf {} neighbors {} json'".format(vrf, neighbor_ip)
+            else:
+                cmd = "vtysh -c 'show ip bgp neighbors {} json'".format(neighbor_ip)
+            result = self._docker_exec(cmd, module_ignore_errors=True)
+            if result['rc'] != 0 or not result['stdout']:
+                continue
+            try:
+                info = json.loads(result['stdout'])
+            except (json.JSONDecodeError, ValueError):
+                continue
+            nbinfo = info.get(neighbor_ip) or info.get(neighbor_ip.lower()) or {}
+            if str(nbinfo.get('bgpState', '')).lower() == state.lower():
+                ok.append(neighbor_ip)
+        logger.info("CsonicHost [%s] check_bgp_session_state: %s/%s in state '%s'",
+                    self.container_name, len(ok), len(neigh_ips), state)
+        return len(ok) == len(neigh_ips)
+
     def no_shutdown(self, ifname):
         """Bring up an interface."""
         logger.info("CsonicHost [%s] bringing up %s", self.container_name, ifname)
@@ -146,25 +195,43 @@ class CsonicHost(NeighborDevice):
                 return result['stdout']
         return {}
 
-    def config(self, lines=None, parents=None):
+    def config(self, lines=None, parents=None, **kwargs):
         """
-        Configure via vtysh (loose compatibility with EOS config style).
-        Translates config lines to vtysh commands.
+        Apply FRR configuration via vtysh, mirroring the EOS/SONiC ``config``
+        (Ansible ``*_config``) style used by the test framework.
+
+        ``lines``/``parents`` follow the ios/eos_config convention: ``parents``
+        are the config-mode context (e.g. ``router bgp 65100``) and ``lines`` are
+        applied within it. Both may be a single string or a list of strings.
+
+        The commands must run inside vtysh configuration mode, so they are wrapped
+        with ``configure terminal``; without it vtysh executes each ``-c`` at the
+        top-level enable prompt and config-mode commands fail with
+        ``% Unknown command`` (so the configuration silently never applies).
+
+        Extra kwargs (e.g. ``module_ignore_errors``, ``timeout``) are accepted for
+        compatibility with the EosHost/SonicHost ``config`` interface and passed
+        through to the underlying executor.
         """
         if not lines:
             return {}
-        cmds = []
-        if parents:
-            for p in parents:
-                cmds.append(p)
-        for line in lines:
-            cmds.append(line)
+
+        def _as_list(val):
+            if val is None:
+                return []
+            if isinstance(val, str):
+                return [val]
+            return list(val)
+
+        cmds = ["configure terminal"]
+        cmds.extend(_as_list(parents))
+        cmds.extend(_as_list(lines))
 
         vtysh_cmd = "vtysh"
         for c in cmds:
             vtysh_cmd += " -c '{}'".format(c)
 
-        return self._docker_exec(vtysh_cmd)
+        return self._docker_exec(vtysh_cmd, **kwargs)
 
     def fetch(self, src=None, dest=None, **kwargs):
         """


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (no separate issue filed; part of the cSONiC docker-sonic-vs T0-neighbor enablement)

`tests/bgp/test_bgp_gr_helper.py` (BGP graceful-restart) did not work against cSONiC (docker-sonic-vs) virtual neighbors:

1. `tests/bgp/conftest.py::setup_bgp_graceful_restart` dispatched neighbor config on `isinstance(node['host'], SonicHost)`, which excludes `CsonicHost`, so GR was never configured on cSONiC neighbors.
2. `CsonicHost.config()` emitted each vtysh `-c` command at the top-level enable prompt without entering configuration mode, so config-mode commands (e.g. `router bgp <asn>`) failed with `% Unknown command` and silently did not apply.
3. `CsonicHost` lacked the `start_bgpd` / `kill_bgpd` / `check_bgp_session_state` helpers the GR test drives on the neighbor.

This only affects runs with `--neighbor_type csonic`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Make BGP graceful-restart (`test_bgp_gr_helper`) pass against cSONiC (docker-sonic-vs) T0 neighbors.

#### How did you do it?

- `tests/bgp/conftest.py`: import `CsonicHost` and widen the two neighbor-config dispatches in `setup_bgp_graceful_restart` from `isinstance(host, SonicHost)` to `isinstance(host, (SonicHost, CsonicHost))`.
- `tests/common/devices/csonic.py`:
  - `config()` now wraps the applied lines with `configure terminal` (so config-mode commands actually take effect), accepts single-string or list `lines`/`parents`, and passes through extra kwargs (`module_ignore_errors`, etc.) for interface compatibility with EosHost/SonicHost.
  - Added `start_bgpd()` (restarts `bgpd` then `bgpcfgd` so FRR re-applies BGP config from CONFIG_DB), `kill_bgpd()`, and `check_bgp_session_state()` (queries FRR via `vtysh -c 'show ip bgp neighbors <ip> json'` and checks `bgpState`), mirroring the contract EosHost/SonicHost expose to the GR helper.

#### How did you verify/test it?

Ran `test_bgp_gr_helper` on a T0 testbed with docker-sonic-vs cSONiC neighbors (`--neighbor_type csonic`); it passes. flake8 clean; both files byte-compile.

#### Any platform specific information?

cSONiC-neighbor (docker-sonic-vs) specific; no DUT/platform changes.

#### Supported testbed topology if it's a new test case?

N/A (existing test).

### Documentation

N/A.
