### PR TITLE
Fix apswitch template rendering

### DIFF
--- a/ansible/plugins/action/apswitch.py
+++ b/ansible/plugins/action/apswitch.py
@@ -8,6 +8,13 @@ from ansible.module_utils._text import to_text
 import ast
 import sys
 
+try:
+    from ansible.template import trust_as_template
+except ImportError:
+    def trust_as_template(data):
+        return data
+
+
 # If the version of the Python interpreter is greater or equal to 3, set the unicode variable to the str class.
 if sys.version_info[0] >= 3:
     unicode = str
@@ -52,9 +59,8 @@ class ActionModule(ActionBase):
                 _template = self._loader.path_dwim_relative(
                     self._loader.get_basedir(), 'templates', _template)
 
-            f = open(_template, 'r')
-            template_data = to_text(f.read())
-            f.close()
+            with open(_template, 'r') as f:
+                template_data = trust_as_template(to_text(f.read()))
 
             _template = self._templar.template(template_data)
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #25829 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
With latest Ansible ( 2.19+) behavior , arbitrary strings passed to `Templar` are
not rendered as templates unless they are marked trusted.

Refer: 
https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_core_2.19.html#template-trust-model-inversion

Under `Template trust model inversion`, Ansible documents the new behavior:
Only strings marked as loaded from a trusted source are eligible to be 
rendered as templates.

The same section also states that custom plugins sourcing template strings
 must use public APIs to apply trust where appropriate. That is the case here:
 `ansible/plugins/action/apswitch.py` is a custom action plugin that reads the
 EOS PFC storm template from disk and passes the raw string to `Templar`.
With latest Ansible, that string is left unrendered unless it is wrapped with
`trust_as_template()`.

`apswitch.py` reads the EOS PFC storm template from disk and passes the raw
file content to `Templar`. Since the content was not trusted, Jinja variables
were not rendered before sending the command to the fanout. As a result, raw
Jinja content was sent to EOS and `pfc_gen_brcm_xgs.py` was not launched.

This caused PFCWD tests to fail with no PFC storm detected on the selected
DUT port.

#### How did you do it?
Imported `trust_as_template` from `ansible.template` and wrapped the file
content read from the EOS fanout template before passing it to
`self._templar.template()`.

#### How did you verify/test it?
##### Before the fix:

  - pfc_gen_brcm_xgs.py was not started on the fanout.
  - PFCWD tests failed with No port matching EthernetXX detected storm.

##### After the fix:

  - pfc_gen_brcm_xgs.py started correctly on the fanout.
  - Example passing test:

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
No 

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A