### PR TITLE
Fix FDB verification MAC format

### DIFF
--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -129,7 +129,7 @@ def apply_fdb_config(duthost, vlan_id, iface, mac_address, op, type):
 
     def _check_fdb_applied():
         fdb_count = int(duthost.shell(
-            "show mac | grep -i {} | wc -l".format(mac_address))["stdout"])
+            "show mac | grep -i {} | wc -l".format(mac_address.replace("-", ":")))["stdout"])
         if op == "SET":
             return fdb_count >= 1
         else:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #25831 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
The configurable drop counters test programs static FDB entries with hyphenated MAC addresses, but show mac displays MAC addresses in colon-separated format.
The verification path greps show mac using the original hyphenated MAC address, so it can miss an FDB entry that was applied successfully and fail with:

FDB SET operation for <mac> was not applied

Normalize the MAC address to the show mac format before checking the FDB entry.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
Avoid a false failure in  drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down
caused by a MAC address format mismatch.

The test programs the FDB entry with a hyphenated MAC address, for example:

`  72-06-00-01-00-40`
But show mac reports the entry using colon-separated format:

  `72:06:00:01:00:40`

#### How did you do it?
Converted the MAC address from hyphen-separated format to colon-separated
  format before grepping show mac.

#### How did you verify/test it?

##### Failure before the fix:

  drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down[PORT_INGRESS_DROPS-L3_EGRESS_LINK_DOWN]
  `Failed: FDB SET operation for 72-06-00-01-00-40 was not applied`

 Validation after the fix passed in repeated runs of:

 drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down[PORT_INGRESS_DROPS-L3_EGRESS_LINK_DOWN]


#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
No

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A