### PR TITLE
Disable featured where applicable during syncd swap

### DIFF
--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -107,21 +107,35 @@ def tag_image(duthost, tag, image_name, image_version="latest"):
 
 @contextmanager
 def _feature_monitor_paused(duthost):
-    """Pause the `featured` daemon for the duration of the block, always restoring it.
+    """Pause the `featured` daemon for the duration of the block, restoring prior state.
 
     Swss/syncd graceful shutdown can take ~30s. The `featured` daemon, if used, 
     might restart any feature whose state is 'enabled' as soon as it observes the 
     container is down, racing against the swap shutdown check and causing 
     "Docker and/or BGP failed to shut down in 30s". So we pause it.
     This is a no-op on platforms/images that do not ship `featured`.
+
+    Only units that were active before entering the block are restarted on exit,
+    so a unit that was intentionally stopped/disabled beforehand stays stopped.
     """
+    units = ["featured.timer", "featured"]
+
+    def _is_active(unit):
+        result = duthost.command("systemctl is-active {}".format(unit), module_ignore_errors=True)
+        return result["stdout"].strip() == "active"
+
+    active_units = [unit for unit in units if _is_active(unit)]
+
     logger.info("Pausing featured to prevent container restart during syncd swap")
     duthost.command("systemctl stop featured.timer featured", module_ignore_errors=True)
     try:
         yield
     finally:
-        logger.info("Resuming featured after syncd swap")
-        duthost.command("systemctl start featured.timer featured", module_ignore_errors=True)
+        if active_units:
+            logger.info("Resuming featured after syncd swap: {}".format(" ".join(active_units)))
+            duthost.command("systemctl start {}".format(" ".join(active_units)), module_ignore_errors=True)
+        else:
+            logger.info("featured was not active before syncd swap; leaving it stopped")
 
 
 def swap_syncd(duthost, creds, namespace=DEFAULT_NAMESPACE):

--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -2,6 +2,7 @@
 
 import collections
 import logging
+from contextlib import contextmanager
 
 from tests.common import config_reload
 from tests.common.utilities import wait_until
@@ -104,6 +105,25 @@ def tag_image(duthost, tag, image_name, image_version="latest"):
     duthost.command("docker tag {}:{} {}".format(image_name, image_version, tag))
 
 
+@contextmanager
+def _feature_monitor_paused(duthost):
+    """Pause the `featured` daemon for the duration of the block, always restoring it.
+
+    Swss/syncd graceful shutdown can take ~30s. The `featured` daemon, if used, 
+    might restart any feature whose state is 'enabled' as soon as it observes the 
+    container is down, racing against the swap shutdown check and causing 
+    "Docker and/or BGP failed to shut down in 30s". So we pause it.
+    This is a no-op on platforms/images that do not ship `featured`.
+    """
+    logger.info("Pausing featured to prevent container restart during syncd swap")
+    duthost.command("systemctl stop featured.timer featured", module_ignore_errors=True)
+    try:
+        yield
+    finally:
+        logger.info("Resuming featured after syncd swap")
+        duthost.command("systemctl start featured.timer featured", module_ignore_errors=True)
+
+
 def swap_syncd(duthost, creds, namespace=DEFAULT_NAMESPACE):
     """Replaces the running syncd container with the RPC version of it.
 
@@ -134,58 +154,61 @@ def swap_syncd(duthost, creds, namespace=DEFAULT_NAMESPACE):
     # Force image download to go through mgmt network
     duthost.command("config bgp shutdown all")
 
-    for asic in asics_list:
-        asic.stop_service("swss")
-        asic.delete_container("syncd")
+    # Pause the featured daemon so it cannot restart swss/syncd while they are torn
+    # down for the swap. Always restored when the block exits, even on failure.
+    with _feature_monitor_paused(duthost):
+        for asic in asics_list:
+            asic.stop_service("swss")
+            asic.delete_container("syncd")
 
-    # Set sysctl RCVBUF parameter for tests
-    duthost.command("sysctl -w net.core.rmem_max=609430500")
+        # Set sysctl RCVBUF parameter for tests
+        duthost.command("sysctl -w net.core.rmem_max=609430500")
 
-    # Set sysctl SENDBUF parameter for tests
-    duthost.command("sysctl -w net.core.wmem_max=609430500")
+        # Set sysctl SENDBUF parameter for tests
+        duthost.command("sysctl -w net.core.wmem_max=609430500")
 
-    for asic in asics_list:
-        _perform_swap_syncd_shutdown_check(asic)
+        for asic in asics_list:
+            _perform_swap_syncd_shutdown_check(asic)
 
-    is_syncdrpc_present_locally = duthost.command('docker image inspect ' + docker_rpc_image,
-                                                  module_ignore_errors=True)['rc'] == 0
+        is_syncdrpc_present_locally = duthost.command('docker image inspect ' + docker_rpc_image,
+                                                      module_ignore_errors=True)['rc'] == 0
 
-    if is_syncdrpc_present_locally:
-        tag_image(
-            duthost,
-            "{}:latest".format(docker_syncd_name),
-            docker_rpc_image,
-            'latest'
-        )
-    else:
-        # After swss stops, the management plane (PortChannel default route) may be
-        # unavailable for ~60s. Poll until the registry responds before docker login.
-        registry_host = creds.get("docker_registry_host", "")
+        if is_syncdrpc_present_locally:
+            tag_image(
+                duthost,
+                "{}:latest".format(docker_syncd_name),
+                docker_rpc_image,
+                'latest'
+            )
+        else:
+            # After swss stops, the management plane (PortChannel default route) may be
+            # unavailable for ~60s. Poll until the registry responds before docker login.
+            registry_host = creds.get("docker_registry_host", "")
 
-        def mgmt_plane_ready():
-            cmd = ("curl -s -o /dev/null -w '%{http_code}' --max-time 5 "
-                   "https://" + registry_host + "/v2/")
-            result = duthost.command(cmd, module_ignore_errors=True)
-            return result["rc"] == 0
+            def mgmt_plane_ready():
+                cmd = ("curl -s -o /dev/null -w '%{http_code}' --max-time 5 "
+                       "https://" + registry_host + "/v2/")
+                result = duthost.command(cmd, module_ignore_errors=True)
+                return result["rc"] == 0
 
-        if registry_host:
-            logger.info("Waiting for management plane to recover before docker login...")
-            if not wait_until(120, 5, 0, mgmt_plane_ready):
-                logger.warning("Management plane did not recover within 120s — proceeding to docker login anyway")
-        registry = load_docker_registry_info(duthost, creds)
-        download_image(duthost, registry, docker_rpc_image, duthost.os_version)
+            if registry_host:
+                logger.info("Waiting for management plane to recover before docker login...")
+                if not wait_until(120, 5, 0, mgmt_plane_ready):
+                    logger.warning("Management plane did not recover within 120s — proceeding to docker login anyway")
+            registry = load_docker_registry_info(duthost, creds)
+            download_image(duthost, registry, docker_rpc_image, duthost.os_version)
 
-        tag_image(
-            duthost,
-            "{}:latest".format(docker_syncd_name),
-            "{}/{}".format(registry.host, docker_rpc_image),
-            duthost.os_version
-        )
+            tag_image(
+                duthost,
+                "{}:latest".format(docker_syncd_name),
+                "{}/{}".format(registry.host, docker_rpc_image),
+                duthost.os_version
+            )
 
-    logger.info("Reloading config and restarting swss...")
-    config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
-    for asic in asics_list:
-        _perform_syncd_liveness_check(asic)
+        logger.info("Reloading config and restarting swss...")
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
+        for asic in asics_list:
+            _perform_syncd_liveness_check(asic)
 
 
 def restore_default_syncd(duthost, creds, namespace=DEFAULT_NAMESPACE):
@@ -210,19 +233,20 @@ def restore_default_syncd(duthost, creds, namespace=DEFAULT_NAMESPACE):
     elif duthost.facts.get("platform_asic") == "broadcom-legacy-th":
         docker_syncd_name = docker_syncd_name + "-legacy-th"
 
-    for asic in asics_list:
-        asic.stop_service("swss")
-        asic.delete_container("syncd")
+    with _feature_monitor_paused(duthost):
+        for asic in asics_list:
+            asic.stop_service("swss")
+            asic.delete_container("syncd")
 
-    tag_image(
-        duthost,
-        "{}:latest".format(docker_syncd_name),
-        docker_syncd_name,
-        duthost.os_version
-    )
+        tag_image(
+            duthost,
+            "{}:latest".format(docker_syncd_name),
+            docker_syncd_name,
+            duthost.os_version
+        )
 
-    logger.info("Reloading config and restarting swss...")
-    config_reload(duthost)
+        logger.info("Reloading config and restarting swss...")
+        config_reload(duthost)
 
     # Remove the RPC image from the duthost
     docker_rpc_image = docker_syncd_name + "-rpc"

--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -115,8 +115,11 @@ def _feature_monitor_paused(duthost):
     "Docker and/or BGP failed to shut down in 30s". So we pause it.
     This is a no-op on platforms/images that do not ship `featured`.
 
-    Only units that were active before entering the block are restarted on exit,
-    so a unit that was intentionally stopped/disabled beforehand stays stopped.
+    Each unit is restored to its exact pre-swap state on exit: units that were
+    active on entry are restarted, and units that were inactive on entry are
+    (re-)stopped. The latter matters because `config_reload` inside the block
+    can bring `featured` back up, so we must not leave it running when it was
+    intentionally stopped/disabled beforehand.
     """
     units = ["featured.timer", "featured"]
 
@@ -125,17 +128,22 @@ def _feature_monitor_paused(duthost):
         return result["stdout"].strip() == "active"
 
     active_units = [unit for unit in units if _is_active(unit)]
+    inactive_units = [unit for unit in units if unit not in active_units]
 
     logger.info("Pausing featured to prevent container restart during syncd swap")
     duthost.command("systemctl stop featured.timer featured", module_ignore_errors=True)
     try:
         yield
     finally:
+        # Restore each unit to its pre-swap state. config_reload may have
+        # started featured, so re-stop any unit that was inactive on entry.
         if active_units:
             logger.info("Resuming featured after syncd swap: {}".format(" ".join(active_units)))
             duthost.command("systemctl start {}".format(" ".join(active_units)), module_ignore_errors=True)
-        else:
-            logger.info("featured was not active before syncd swap; leaving it stopped")
+        if inactive_units:
+            logger.info("Re-stopping featured units inactive before syncd swap: {}".format(
+                " ".join(inactive_units)))
+            duthost.command("systemctl stop {}".format(" ".join(inactive_units)), module_ignore_errors=True)
 
 
 def swap_syncd(duthost, creds, namespace=DEFAULT_NAMESPACE):

--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -109,9 +109,9 @@ def tag_image(duthost, tag, image_name, image_version="latest"):
 def _feature_monitor_paused(duthost):
     """Pause the `featured` daemon for the duration of the block, restoring prior state.
 
-    Swss/syncd graceful shutdown can take ~30s. The `featured` daemon, if used, 
-    might restart any feature whose state is 'enabled' as soon as it observes the 
-    container is down, racing against the swap shutdown check and causing 
+    Swss/syncd graceful shutdown can take ~30s. The `featured` daemon, if used,
+    might restart any feature whose state is 'enabled' as soon as it observes the
+    container is down, racing against the swap shutdown check and causing
     "Docker and/or BGP failed to shut down in 30s". So we pause it.
     This is a no-op on platforms/images that do not ship `featured`.
 


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (Internal to Cisco)

On platforms that run the `featured` daemon (e.g. Cisco-8000 G200X), swapping in the RPC `syncd` container intermittently fails with:

```
Docker and/or BGP failed to shut down in 30s
```

The swss/syncd graceful shutdown on these platforms can take ~30s. During that window, `featured` (driven by `featured.timer`, which fires every ~1s) observes the swss container in the `enabled` state but down, and restarts it, racing the swap shutdown check in `_perform_swap_syncd_shutdown_check` and causing the timeout even though the swap would otherwise succeed.

This PR wraps the syncd teardown in a `_feature_monitor_paused` context manager that stops `featured` (and `featured.timer`) for the duration of the swap and always restores the pre-swap state, even on failure. It is a no-op on
images that do not ship `featured`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: day-one issue (affects QoS/CoPP/SAI swap on Cisco-8000 G200X)

### Approach
#### What is the motivation for this PR?

The QoS `swapSyncd` fixture (and CoPP `copp_testbed`, `sai_qualify`) fail on Cisco-8000 G200X testbeds because the `featured` daemon restarts swss/syncd mid-swap. The 30s shutdown check in `_perform_swap_syncd_shutdown_check` then times out even though the swap would otherwise succeed, making QoS/CoPP/SAI test runs on affected platforms unreliable. Note that swss.service's own `Restart=always` is not the culprit for a clean `systemctl stop`; `featured` is.

#### How did you do it?

- Added a `_feature_monitor_paused(duthost)` context manager in `tests/common/system_utils/docker.py` that stops `featured.timer featured` on entry and restores their prior state in a `finally` block on exit, with `module_ignore_errors=True` so it is a safe no-op where `featured` is absent.
- The manager captures each unit's pre-swap active/inactive state and, on exit, restarts only the units that were active before, and re-stops units that were inactive before. The re-stop matters because `config_reload` inside the swap can bring `featured` back up; without it the daemon would be left running when it had been intentionally stopped/disabled beforehand.
- Wrapped the syncd teardown/reload sequence in both `swap_syncd` and `restore_default_syncd` with the new context manager so `featured` cannot restart the containers while they are being replaced.
- No behavioral change to the swap logic itself; only the surrounding feature-monitor state is paused and restored.

#### How did you verify/test it?

- Verified the manager stops `featured.timer`/`featured` before the swap and restores the exact pre-swap state afterward, and that failures inside the block still restore the daemon (context manager `finally`).
- Confirmed it is a no-op on images without `featured` (commands ignore errors).
- Exercised via the QoS `swapSyncd` path on a Cisco-8000 G200X testbed, where the "failed to shut down in 30s" error previously reproduced. Observed clean pause -> resume cycles in the run logs with no "failed to shut down in 30s" occurrences, and the swap proceeding through config reload and the syncd liveness check.

#### Any platform specific information?

Targets platforms that ship the `featured` daemon (Cisco-8000 G200X observed).
On all other platforms the added `systemctl stop/start` calls are harmless
no-ops due to `module_ignore_errors=True`.

#### Supported testbed topology if it's a new test case?

N/A - not a new test case (framework bug fix).

### Documentation

No documentation changes required.
