### PR TITLE
snappi: reduce pfcwd basic test flake after swss restart

### DIFF
--- a/tests/snappi_tests/pfcwd/files/pfcwd_basic_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_basic_helper.py
@@ -26,6 +26,7 @@ DATA_PKT_SIZE = 1024
 SNAPPI_POLL_DELAY_SEC = 2
 DEVIATION = 0.3
 UDP_PORT_START = 5000
+LOSS_RATE_TOLERANCE = 0.03
 
 
 def run_pfcwd_basic_test(api,
@@ -446,7 +447,10 @@ def __verify_results(rows,
         tgen_loss_packets += data_flow_tx_frames_list[i] - data_flow_rx_frames_list[i]
         loss_rate = 1 - \
             float(data_flow_rx_frames_list[i]) / data_flow_tx_frames_list[i]
-        min_loss_rate = data_flow_min_loss_rate_list[i]
+        # Keep lower bound non-negative while allowing timing jitter tolerance.
+        # Without max(0, ...), zero-loss cases would become negative (e.g., -0.03),
+        # which is not a valid loss-rate bound and could mask counter anomalies.
+        min_loss_rate = max(0, data_flow_min_loss_rate_list[i] - LOSS_RATE_TOLERANCE)
         max_loss_rate = data_flow_max_loss_rate_list[i]
 
         pytest_assert(loss_rate <= max_loss_rate and loss_rate >= min_loss_rate,


### PR DESCRIPTION
### Description of PR

Summary:
Stabilize PFCWD basic test verification after service restart by adding a small tolerance to the expected lower loss-rate bound and clamping the bound to non-negative values in pfcwd_basic_helper.py.  
This addresses flaky failures where observed loss rate is slightly below the strict threshold due to timing jitter during restart/recovery windows.

Fixes # https://github.com/sonic-net/sonic-mgmt/issues/25835

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
N/A

Failure type:
other (test flakiness)

### Approach

#### What is the motivation for this PR?
PFCWD service-restart coverage is flaky because the strict lower loss-rate assertion can fail on small timing variance, even when behavior is otherwise valid. This creates an unnecessary test rerun. 

#### How did you do it?
Updated result verification logic in pfcwd_basic_helper.py:
- Added `LOSS_RATE_TOLERANCE = 0.03`.
- Applied tolerance to the lower bound:
  `min_loss_rate = max(0, data_flow_min_loss_rate_list[i] - LOSS_RATE_TOLERANCE)`.
- Kept upper bound checks unchanged.
- Added inline rationale comments explaining why non-negative clamping is required.

#### How did you verify/test it?
- Local syntax validation:
  `python3 -m py_compile tests/snappi_tests/pfcwd/files/pfcwd_basic_helper.py`
- Change is scoped to assertion threshold handling only in PFCWD basic helper path.

#### Any platform specific information?
No platform-specific behavior change intended. The logic remains generic and only relaxes lower-bound strictness slightly to absorb timing jitter.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation

No documentation update required (test assertion robustness fix only).