### PR TITLE
[bgp][test_bgp_vnet] Use safe_reboot=True to fix flaky post-reboot BGP convergence

### DIFF
--- a/tests/bgp/test_bgp_vnet.py
+++ b/tests/bgp/test_bgp_vnet.py
@@ -102,7 +102,7 @@ def setup_vnet_cfg(duthost, localhost, cfg_facts):
                      dest="/tmp/config_db_vnet.json")
     duthost.shell("cp /tmp/config_db_vnet.json /etc/sonic/config_db.json")
 
-    reboot(duthost, localhost)
+    reboot(duthost, localhost, safe_reboot=True)
 
     bgp_asn = cfg_facts.get('DEVICE_METADATA', {}).get('localhost', {}).get('bgp_asn', '')
     duthost.shell(
@@ -136,7 +136,7 @@ def restore_config_db(localhost, duthost):
                        search_regex='OpenSSH_[\\w\\.]+ Debian',
                        timeout=180)   # Similiar approach to increase the chance that the next line get executed.
     duthost.shell("mv /etc/sonic/config_db.json.bak /etc/sonic/config_db.json")
-    reboot(duthost, localhost)
+    reboot(duthost, localhost, safe_reboot=True)
 
 
 @pytest.fixture(scope="module", autouse=True)


### PR DESCRIPTION
## Description of PR

`tests/bgp/test_bgp_vnet.py` reboots the DUT in `setup_vnet_cfg()` (after applying the VNET config) and in `restore_config_db()` (teardown). Both used the default `reboot(duthost, localhost)`, i.e. `safe_reboot=False`, which only sleeps for a fixed `wait` period after SSH becomes reachable and then lets the test proceed.

On slower platforms the switch has not finished bringing up all critical services by the time that fixed sleep expires (and on `cisco-8000` it may still be initializing). As a result the test starts asserting on VRF/BGP convergence before the control plane is actually ready.

This was observed on **two different Cisco platforms**, where the test failed with:

```
AssertionError: Timed out waiting for VRF BGP peers to reach 6400 prefixes
```

Passing `safe_reboot=True` replaces the blind fixed sleep with active readiness gating inside `reboot()`:
- `docker` service running
- `database` critical processes + `redis` up
- **all critical services fully started**

This removes the "proceeded too early" race so the VRF BGP peers have had a chance to establish and learn routes before the prefix-count assertions run. The reboot mechanism itself is unchanged.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case enhancement
- [ ] Skipped for non-supported platforms
- [ ] Documentation

### Back port request

- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

## Approach
### What is the motivation for this PR?

Fix intermittent failures of `test_bgp_vnet` on Cisco platforms caused by the test resuming before the DUT control plane is fully up after the setup reboot.

### How did you do it?

Added `safe_reboot=True` to the two `reboot()` calls in `test_bgp_vnet.py` (`setup_vnet_cfg()` and `restore_config_db()`).

### How did you verify/test it?

Ran `test_bgp_vnet` on the affected Cisco platforms; with `safe_reboot=True` the test no longer proceeds before critical services are ready, and the `6400 prefixes` timeout assertion no longer triggers.

## Documentation

No documentation changes.