### PR TITLE
[csonic] Restore CHASSIS_APP_DB for SpineRouter neighbors so bgpcfgd starts

### DIFF
--- a/ansible/roles/sonic/tasks/csonic.yml
+++ b/ansible/roles/sonic/tasks/csonic.yml
@@ -50,6 +50,34 @@
     msg: "Config load failed: {{ config_load_result.stderr }}"
   when: config_load_result.rc != 0 and config_load_result.rc is defined
 
+# cSONiC neighbors that emulate a SpineRouter (e.g. T2 nodes in T1/T2 topologies)
+# render DEVICE_METADATA type=SpineRouter, so sonic-py-common is_chassis() returns
+# True and bgpcfgd instantiates ChassisAppDbMgr, which calls getDbId('CHASSIS_APP_DB').
+# A cSONiC neighbor is a single container, not a real chassis, so the image's
+# start.sh strips CHASSIS_APP_DB (and the redis_chassis instance) from
+# database_config.json -> bgpcfgd crash-loops and never emits 'router bgp'.
+# Re-add CHASSIS_APP_DB pointing at the local redis instance so ChassisAppDbMgr
+# connects locally. Idempotent and harmless for non-SpineRouter neighbors.
+- name: Ensure CHASSIS_APP_DB exists so bgpcfgd works on SpineRouter cSONiC neighbors
+  become: yes
+  shell: |
+    docker exec -i csonic_{{ vm_set_name }}_{{ inventory_hostname }} python3 - <<'PYEOF'
+    import json
+    f = '/var/run/redis/sonic-db/database_config.json'
+    d = json.load(open(f))
+    d.setdefault('DATABASES', {}).setdefault(
+        'CHASSIS_APP_DB', {'id': 12, 'separator': '|', 'instance': 'redis'})
+    json.dump(d, open(f, 'w'), indent=4)
+    PYEOF
+  delegate_to: "{{ VM_host[0] }}"
+  changed_when: false
+
+- name: Restart bgpcfgd after ensuring CHASSIS_APP_DB (cSONiC)
+  become: yes
+  command: docker exec csonic_{{ vm_set_name }}_{{ inventory_hostname }} supervisorctl restart bgpcfgd
+  delegate_to: "{{ VM_host[0] }}"
+  changed_when: false
+
 - name: Collect front panel interfaces expected from CONFIG_DB
   set_fact:
     csonic_fp_interfaces: "{{ configuration[hostname]['interfaces'].keys() | select('match', '^Ethernet[0-9]+$') | list }}"

--- a/ansible/vtestbed.yaml
+++ b/ansible/vtestbed.yaml
@@ -83,6 +83,26 @@
   use_converged_peers: True
   comment: Tests virtual switch vm
 
+- conf-name: vms-kvm-t1-csonic
+  group-name: vms6-2
+  topo: t1-lag
+  ptf_image_name: docker-ptf
+  ptf: ptf-02
+  ptf_ip: 10.250.0.106/24
+  ptf_ipv6: fec0::ffff:afa:6/64
+  server: server_1
+  vm_base: VM0104
+  vm_type: csonic
+  dut:
+    - vlab-03
+  inv_name: veos_vtb
+  # TODO(converged-peers): csonic neighbors are non-cEOS, so the converged
+  # (multi-VRF) peer model is gated off in conftest.py / testbed-cli.sh and
+  # never runs here. Re-enable once converged peers support csonic.
+  # use_converged_peers: True
+  auto_recover: 'False'
+  comment: Tests cSONiC virtual switch VMs on T1 LAG topology
+
 - conf-name: vms-kvm-t0-2
   group-name: vms6-3
   topo: t0


### PR DESCRIPTION
### Description

cSONiC neighbors that emulate a SpineRouter (e.g. the T2 nodes in T1/T2 topologies) render `DEVICE_METADATA` `type=SpineRouter` in their CONFIG_DB. `sonic-py-common` `device_info.is_chassis()` returns `True` for that type, so `bgpcfgd` instantiates `ChassisAppDbMgr`, which calls `swsscommon.SonicDBConfig.getDbId('CHASSIS_APP_DB')`.

A cSONiC neighbor is a single container, not a real chassis, so the `docker-sonic-vs` `start.sh` runs `update_chassisdb_config -d` and strips `CHASSIS_APP_DB` (and the `redis_chassis` instance) from `database_config.json`. `bgpcfgd` then crash-loops with:

```
CRIT #bgpcfgd: Got an exception Failed to find CHASSIS_APP_DB database
IndexError: Failed to find CHASSIS_APP_DB database in : key
```

and never emits a `router bgp` stanza, so those neighbors never establish BGP with the DUT. This does not surface on T0 cSONiC (the documented example) because T0 has no SpineRouter neighbors — it only appears once a topology (T1/T2) includes SpineRouter neighbors.

### Root cause

`is_chassis()` is `True` whenever `DEVICE_METADATA.localhost.type == 'SpineRouter'`, which makes `bgpcfgd` add `ChassisAppDbMgr` (needs `CHASSIS_APP_DB`). But on a non-chassis cSONiC container `start.sh` removes `CHASSIS_APP_DB` from `database_config.json`, so the manager's `getDbId('CHASSIS_APP_DB')` raises and `bgpcfgd` never generates FRR BGP config.

### Fix

After loading the neighbor CONFIG_DB in `ansible/roles/sonic/tasks/csonic.yml`, re-add a `CHASSIS_APP_DB` entry pointing at the local `redis` instance and restart `bgpcfgd`, so `ChassisAppDbMgr` connects locally instead of crashing. The step is idempotent (`setdefault`) and harmless for non-SpineRouter neighbors, where `bgpcfgd` never adds the manager.

Also adds a `vms-kvm-t1-csonic` testbed definition (`t1-lag` topology, cSONiC neighbors) that exercises SpineRouter neighbors and reproduces the issue.

### Testing

- Brought the testbed up end-to-end: `testbed-cli.sh ... -k csonic add-topo vms-kvm-t1-csonic` + `deploy-mg vms-kvm-t1-csonic`.
  - Before the fix: the 8 SpineRouter (T2) neighbors' `bgpcfgd` crash-looped (`IndexError: Failed to find CHASSIS_APP_DB database`) and produced no `router bgp`; their BGP sessions stayed down.
  - After the fix: all **24/24 BGP sessions Established** (8 SpineRouter T2 + 16 ToRRouter T0), IPv4 and IPv6, and **8/8 PortChannels `LACP(A)(Up)`**. All 24 neighbors' `bgpcfgd` stable/`RUNNING`.
- Ran the documented smoke test via `run_tests.sh` inside the sonic-mgmt container:
  ```
  ./run_tests.sh -n vms-kvm-t1-csonic -d vlab-03 -c bgp/test_bgp_fact.py -f vtestbed.yaml -i ../ansible/veos_vtb -e --neighbor_type=csonic
  ```
  Result: `bgp/test_bgp_fact.py::test_bgp_facts[vlab-03-None]` **PASSED** (pretest 9 passed/4 skipped, target 1 passed, posttest 4 passed/2 skipped; 0 failed).

Verified on the SONiC VS (`docker-sonic-vs`) topology.
