### PR TITLE
[tests/vxlan]: Configure sport as part of vxlan switch configuration

### DIFF
--- a/tests/common/vxlan_ecmp_utils.py
+++ b/tests/common/vxlan_ecmp_utils.py
@@ -6,6 +6,7 @@
 '''
 
 from sys import getsizeof
+import json
 import re
 import time
 import logging
@@ -373,29 +374,31 @@ class Ecmp_Utils(object):
 
         return ret_list
 
-    def configure_vxlan_switch(self, duthost, vxlan_port=4789, dutmac=None):
+    def configure_vxlan_switch(self, duthost, vxlan_port=4789, dutmac=None,
+                               vxlan_sport=None, vxlan_mask=None):
         '''
            Configure the VxLAN parameters for the DUT.
            This step is completely optional.
 
-           duthost: AnsibleHost structure of the DUT.
+           duthost    : AnsibleHost structure of the DUT.
            vxlan_port : The UDP port to be used for VxLAN traffic.
            dutmac     : The mac address to be configured in the DUT.
+           vxlan_sport: The base UDP source port for VxLAN sport entropy.
+           vxlan_mask : The number of bits to vary in the source port range.
         '''
         if dutmac is None:
             dutmac = "aa:bb:cc:dd:ee:ff"
 
-        switch_config = '''
-    [
-            {{
-                    "SWITCH_TABLE:switch": {{
-                            "vxlan_port": "{}",
-                            "vxlan_router_mac": "{}"
-                    }},
-                    "OP": "SET"
-            }}
-    ]
-    '''.format(vxlan_port, dutmac)
+        switch_fields = {
+            "vxlan_port": str(vxlan_port),
+            "vxlan_router_mac": str(dutmac)
+        }
+        if vxlan_sport is not None:
+            switch_fields["vxlan_sport"] = str(vxlan_sport)
+        if vxlan_mask is not None:
+            switch_fields["vxlan_mask"] = str(vxlan_mask)
+
+        switch_config = json.dumps([{"SWITCH_TABLE:switch": switch_fields, "OP": "SET"}], indent=4)
         self.apply_config_in_swss(duthost, switch_config, "vnet_switch")
 
     def apply_config_in_swss(self, duthost, config, name="swss_"):

--- a/tests/vxlan/conftest.py
+++ b/tests/vxlan/conftest.py
@@ -54,6 +54,22 @@ def pytest_addoption(parser):
     )
 
     vxlan_group.addoption(
+        "--vxlan_sport",
+        action="store",
+        default=5120,
+        type=int,
+        help="Base UDP source port for VxLAN sport entropy"
+    )
+
+    vxlan_group.addoption(
+        "--vxlan_mask",
+        action="store",
+        default=7,
+        type=int,
+        help="Number of bits to vary in the VxLAN UDP source port range"
+    )
+
+    vxlan_group.addoption(
         "--num_vnet",
         action="store",
         default=5,

--- a/tests/vxlan/test_scale_ecmp.py
+++ b/tests/vxlan/test_scale_ecmp.py
@@ -329,7 +329,7 @@ def test_vxlan_mac_vni(ptfhost, one_vnet_setup_teardown):
 
     # --- Build deterministic MAC list ---
     # 52:54:00:00:xx:yy (unique per endpoint)
-    mac_list = [f"52:54:00:{i//256:02x}:{i%256:02x}:aa" for i in range(num_endpoints)]
+    mac_list = [f"52:54:00:{i//256:02x}:{i % 256:02x}:aa" for i in range(num_endpoints)]
     mac_list_str = ",".join(mac_list)
     updated_vni = 5001
 
@@ -483,7 +483,7 @@ def test_ecmp_scale_modify_mac(ptfhost, one_vnet_setup_teardown):
     time.sleep(5)
 
     # Step 2 — Initial MAC list
-    mac_list = [f"52:54:00:{i//256:02x}:{i%256:02x}:aa" for i in range(num)]
+    mac_list = [f"52:54:00:{i//256:02x}:{i % 256:02x}:aa" for i in range(num)]
     mac_string = ",".join(mac_list)
 
     # Push initial MAC list
@@ -492,7 +492,7 @@ def test_ecmp_scale_modify_mac(ptfhost, one_vnet_setup_teardown):
 
     # Step 3 — Random index to modify
     mod_idx = random.randint(0, num - 1)
-    new_mac = f"52:54:99:{mod_idx//256:02x}:{mod_idx%256:02x}:cc"
+    new_mac = f"52:54:99:{mod_idx//256:02x}:{mod_idx % 256:02x}:cc"
     logger.info(f"Modifying MAC for endpoint index {mod_idx}: new MAC = {new_mac}")
 
     # Update the list

--- a/tests/vxlan/test_scale_ecmp.py
+++ b/tests/vxlan/test_scale_ecmp.py
@@ -107,7 +107,8 @@ def get_available_vlan_id_and_ports(cfg_facts, num_ports_needed):
 
 # ---------- Single-VNET setup ----------
 def vxlan_setup_one_vnet(duthost, ptfhost, tbinfo, cfg_facts,
-                         config_facts, dut_indx, vxlan_port):
+                         config_facts, dut_indx, vxlan_port,
+                         vxlan_sport=None, vxlan_mask=None):
     ports = get_available_vlan_id_and_ports(config_facts, 1)
     pytest_assert(ports and len(ports) >= 1, "Not enough ports for VNET setup")
 
@@ -154,7 +155,8 @@ def vxlan_setup_one_vnet(duthost, ptfhost, tbinfo, cfg_facts,
     )
     time.sleep(5)
 
-    ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=vxlan_port)
+    ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=vxlan_port,
+                                      vxlan_sport=vxlan_sport, vxlan_mask=vxlan_mask)
 
     return {
         "dut_vtep": dut_vtep,
@@ -188,6 +190,8 @@ def one_vnet_setup_teardown(
         duts_map = tbinfo["duts_map"]
         dut_indx = duts_map[duthost.hostname]
         vxlan_port = request.config.option.vxlan_port
+        vxlan_sport = request.config.option.vxlan_sport
+        vxlan_mask = request.config.option.vxlan_mask
 
         # Determine platform-specific ECMP limit
         platform = duthost.facts.get("platform", "").lower()
@@ -202,7 +206,8 @@ def one_vnet_setup_teardown(
             num_endpoints = min(num_endpoints, max_ecmp_limit)
 
         setup_params = vxlan_setup_one_vnet(duthost, ptfhost, tbinfo, cfg_facts,
-                                            config_facts, dut_indx, vxlan_port)
+                                            config_facts, dut_indx, vxlan_port,
+                                            vxlan_sport=vxlan_sport, vxlan_mask=vxlan_mask)
         setup_params["num_endpoints"] = num_endpoints
     except Exception as e:
         logger.error("Exception raised in setup: {}".format(repr(e)))

--- a/tests/vxlan/test_vxlan_tunnel_route_scale.py
+++ b/tests/vxlan/test_vxlan_tunnel_route_scale.py
@@ -314,7 +314,7 @@ def vxlan_setup_config(config_facts, cfg_facts, duthost, dut_indx, ptfhost,
     logger.info(f"Egress PTF interfaces: {egress_ptf_if}")
 
     vxlan_router_mac = configure_vxlan_switch_with_mac(duthost, vxlan_port,
-                                                        vxlan_sport=vxlan_sport, vxlan_mask=vxlan_mask)
+                                                       vxlan_sport=vxlan_sport, vxlan_mask=vxlan_mask)
 
     logger.info("Waiting for all VNET routes to appear in STATE_DB (max 120s)")
     ready_state = wait_until(
@@ -456,8 +456,8 @@ def test_vxlan_scale_config_reload(vxlan_scale_setup_teardown, ptfhost, duthosts
     logger.info("Reconfiguring VXLAN switch after config reload")
     vxlan_port = setup_params["vxlan_port"]
     vxlan_router_mac = configure_vxlan_switch_with_mac(duthost, vxlan_port,
-                                                        vxlan_sport=setup_params.get("vxlan_sport"),
-                                                        vxlan_mask=setup_params.get("vxlan_mask"))
+                                                       vxlan_sport=setup_params.get("vxlan_sport"),
+                                                       vxlan_mask=setup_params.get("vxlan_mask"))
     setup_params["mac_switch"] = vxlan_router_mac
 
     logger.info("Running PTF traffic after config reload")

--- a/tests/vxlan/test_vxlan_tunnel_route_scale.py
+++ b/tests/vxlan/test_vxlan_tunnel_route_scale.py
@@ -190,16 +190,18 @@ def get_vxlan_router_mac(duthost):
     return vxlan_router_mac
 
 
-def configure_vxlan_switch_with_mac(duthost, vxlan_port):
+def configure_vxlan_switch_with_mac(duthost, vxlan_port, vxlan_sport=None, vxlan_mask=None):
     """Configure VXLAN switch and return the MAC address used"""
     vxlan_router_mac = get_vxlan_router_mac(duthost)
     logger.info(f"Using VXLAN router MAC: {vxlan_router_mac}")
-    ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=vxlan_port, dutmac=vxlan_router_mac)
+    ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=vxlan_port, dutmac=vxlan_router_mac,
+                                      vxlan_sport=vxlan_sport, vxlan_mask=vxlan_mask)
     return vxlan_router_mac
 
 
 def vxlan_setup_config(config_facts, cfg_facts, duthost, dut_indx, ptfhost,
-                       tbinfo, num_vnets, routes_per_vnet, vnet_base, vxlan_port, samples_per_vnet):
+                       tbinfo, num_vnets, routes_per_vnet, vnet_base, vxlan_port, samples_per_vnet,
+                       vxlan_sport=None, vxlan_mask=None):
     ports = get_available_vlan_id_and_ports(config_facts, num_vnets)
     pytest_assert(ports and len(ports) >= num_vnets, "Not enough ports for VNET setup")
 
@@ -311,7 +313,8 @@ def vxlan_setup_config(config_facts, cfg_facts, duthost, dut_indx, ptfhost,
     pytest_assert(egress_ptf_if, "No egress PTF interfaces discovered from PortChannels")
     logger.info(f"Egress PTF interfaces: {egress_ptf_if}")
 
-    vxlan_router_mac = configure_vxlan_switch_with_mac(duthost, vxlan_port)
+    vxlan_router_mac = configure_vxlan_switch_with_mac(duthost, vxlan_port,
+                                                        vxlan_sport=vxlan_sport, vxlan_mask=vxlan_mask)
 
     logger.info("Waiting for all VNET routes to appear in STATE_DB (max 120s)")
     ready_state = wait_until(
@@ -336,6 +339,8 @@ def vxlan_setup_config(config_facts, cfg_facts, duthost, dut_indx, ptfhost,
         "vnet_ptf_map": vnet_ptf_map,
         "egress_ptf_if": egress_ptf_if,
         "vxlan_port": vxlan_port,
+        "vxlan_sport": vxlan_sport,
+        "vxlan_mask": vxlan_mask,
         "router_mac": duthost.facts["router_mac"],
         "mac_switch": vxlan_router_mac,
         "samples_per_vnet": samples_per_vnet,
@@ -362,6 +367,8 @@ def vxlan_scale_setup_teardown(duthosts, rand_one_dut_hostname, ptfhost, tbinfo,
         duts_map = tbinfo["duts_map"]
         dut_indx = duts_map[duthost.hostname]
         vxlan_port = request.config.option.vxlan_port
+        vxlan_sport = request.config.option.vxlan_sport
+        vxlan_mask = request.config.option.vxlan_mask
 
         logger.info(f"Using num_vnets={num_vnets}, routes_per_vnet={routes_per_vnet}")
 
@@ -376,7 +383,9 @@ def vxlan_scale_setup_teardown(duthosts, rand_one_dut_hostname, ptfhost, tbinfo,
             routes_per_vnet,
             vnet_base,
             vxlan_port,
-            samples_per_vnet
+            samples_per_vnet,
+            vxlan_sport=vxlan_sport,
+            vxlan_mask=vxlan_mask
         )
     except Exception as e:
         logger.error("Exception raised in setup: {}".format(repr(e)))
@@ -446,7 +455,9 @@ def test_vxlan_scale_config_reload(vxlan_scale_setup_teardown, ptfhost, duthosts
     # Reconfigure VXLAN switch with correct MAC after reload
     logger.info("Reconfiguring VXLAN switch after config reload")
     vxlan_port = setup_params["vxlan_port"]
-    vxlan_router_mac = configure_vxlan_switch_with_mac(duthost, vxlan_port)
+    vxlan_router_mac = configure_vxlan_switch_with_mac(duthost, vxlan_port,
+                                                        vxlan_sport=setup_params.get("vxlan_sport"),
+                                                        vxlan_mask=setup_params.get("vxlan_mask"))
     setup_params["mac_switch"] = vxlan_router_mac
 
     logger.info("Running PTF traffic after config reload")


### PR DESCRIPTION
…for scale tests

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
The outer UDP source port in a Vxlan encapsulated packet is a hash derived value. In some platforms, based on the inner fields, the hash derived source port is getting programmed in the IANA assigned port range due to which the packet is not reaching PTF due to the OVS rules on the test server. This is specially evident in scale tests where the combination of inner fields are more.

As a fix for this, added logic to pass the source port and source port mask during vxlan switch configuration and set it under SWITCH_TABLE. Also, added logic to pass the source port and source port mask as runtime arguments. 

Currently, for scale tests, test_scale_ecmp and test_vxlan_tunnel_route_scale, default source port and source port mask values are passed during vxlan switch configuration by default. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Tested on Cisco 8223 platform. 
[test_scale_ecmp_2026-07-28-06-46-45.log](https://github.com/user-attachments/files/30481251/test_scale_ecmp_2026-07-28-06-46-45.log)


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
