### PR TITLE
[mellanox][loganalyzer] Cleanup Day-old /var/log Dump Files

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
@@ -221,6 +221,12 @@ class AnsibleLogAnalyzer:
         last_check_pos = 0
         syslog_file = "/var/log/syslog"
         prev_syslog_file = "/var/log/syslog.1"
+        rate_limit_indications = [  # marker may be dropped due to rate-limiting
+            "due to rate-limiting",  # rsyslog
+            "Suppressed",  # syslog-ng
+        ]
+        rate_limit_warned = [False, False]  # warn only once for each file
+
         while wait_time <= timeout:
             # look for marker in syslog file
             if os.path.exists(syslog_file):
@@ -232,6 +238,10 @@ class AnsibleLogAnalyzer:
                     for logs in fp:
                         if marker in logs:
                             return True
+                        elif (not rate_limit_warned[0] and
+                              any(indication in logs for indication in rate_limit_indications)):
+                            print("WARNING: log rate-limiting detected, marker may be dropped")
+                            rate_limit_warned[0] = True
                     # record last search position
                     last_check_pos = fp.tell()
 
@@ -243,16 +253,21 @@ class AnsibleLogAnalyzer:
                     for logs in pfp:
                         if marker in logs:
                             return True
+                        elif (not rate_limit_warned[1] and
+                              any(indication in logs for indication in rate_limit_indications)):
+                            print("WARNING: log rate-limiting detected, marker may be dropped")
+                            rate_limit_warned[1] = True
             time.sleep(polling_interval)
             wait_time += polling_interval
 
         return False
 
-    def place_marker(self, log_file_list, marker, wait_for_marker=False):
+    def place_marker(self, log_file_list, marker, wait_for_marker=False, wait_for_timeout=None):
         '''
         @summary: Place marker into '/dev/log' and each log file specified.
         @param log_file_list : List of file paths, to be applied with marker.
         @param marker:         Marker to be placed into log files.
+        @param wait_for_timeout: Maximum seconds to wait for marker in /var/log/syslog.
         '''
 
         for log_file in log_file_list:
@@ -260,7 +275,11 @@ class AnsibleLogAnalyzer:
 
         self.place_marker_to_syslog(marker)
         if wait_for_marker:
-            if self.wait_for_marker(marker) is False:
+            if wait_for_timeout is None:
+                marker_found = self.wait_for_marker(marker)
+            else:
+                marker_found = self.wait_for_marker(marker, timeout=wait_for_timeout)
+            if marker_found is False:
                 raise RuntimeError(
                     "cannot find marker {} in /var/log/syslog".format(marker))
 
@@ -829,7 +848,8 @@ def main(argv):
 
     result = {}
     if action == "init":
-        analyzer.place_marker(log_file_list, analyzer.create_start_marker())
+        analyzer.place_marker(
+            log_file_list, analyzer.create_start_marker(), wait_for_marker=True, wait_for_timeout=30)
         return 0
     elif action == "analyze":
         match_file_list = match_files_in.split(tokenizer)

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
@@ -262,7 +262,7 @@ class AnsibleLogAnalyzer:
 
         return False
 
-    def place_marker(self, log_file_list, marker, wait_for_marker=False, wait_for_timeout=None):
+    def place_marker(self, log_file_list, marker, wait_for_marker=False, wait_for_timeout=120):
         '''
         @summary: Place marker into '/dev/log' and each log file specified.
         @param log_file_list : List of file paths, to be applied with marker.
@@ -275,11 +275,7 @@ class AnsibleLogAnalyzer:
 
         self.place_marker_to_syslog(marker)
         if wait_for_marker:
-            if wait_for_timeout is None:
-                marker_found = self.wait_for_marker(marker)
-            else:
-                marker_found = self.wait_for_marker(marker, timeout=wait_for_timeout)
-            if marker_found is False:
+            if self.wait_for_marker(marker, timeout=wait_for_timeout) is False:
                 raise RuntimeError(
                     "cannot find marker {} in /var/log/syslog".format(marker))
 

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
@@ -32,7 +32,7 @@ import csv
 import time
 import logging
 import logging.handlers
-from datetime import datetime
+from datetime import datetime, timedelta
 
 # ---------------------------------------------------------------------
 # Global variables
@@ -209,6 +209,16 @@ class AnsibleLogAnalyzer:
         # can cause the marker message to be dropped (see #23562).
         time.sleep(2)
 
+    def is_recent_log_line(self, log_line, cutoff):
+        try:
+            # syslog datetime example: "2026 Jul  1 12:11:05.671339"
+            log_time = datetime.strptime(log_line[:20], "%Y %b %d %H:%M:%S")
+        except ValueError:
+            print(f"WARNING: failed to parse log line timestamp, ignoring line: {log_line}")
+            return False
+
+        return log_time >= cutoff
+
     def wait_for_marker(self, marker, timeout=120, polling_interval=10):
         '''
         @summary: Wait the marker to appear in the /var/log/syslog file
@@ -221,42 +231,47 @@ class AnsibleLogAnalyzer:
         last_check_pos = 0
         syslog_file = "/var/log/syslog"
         prev_syslog_file = "/var/log/syslog.1"
+
+        # when checking for rate limit messages we only care
+        # about those which occur after the marker was added, so
+        # messages older than one minute from the wait start are ignored
+        cutoff = datetime.now() - timedelta(minutes=1)
+
         rate_limit_indications = [  # marker may be dropped due to rate-limiting
             "due to rate-limiting",  # rsyslog
             "Suppressed",  # syslog-ng
         ]
         rate_limit_warned = [False, False]  # warn only once for each file
 
+        def scan_log_file(log_file, last_pos, warned):
+            if not os.path.exists(log_file):
+                return False, 0, False
+
+            with open(log_file, 'r') as fp:
+                fp.seek(last_pos)
+                for logs in fp:
+                    if marker in logs:
+                        return True, last_pos, warned
+                    elif (not warned and
+                          any(indication in logs for indication in rate_limit_indications) and
+                          self.is_recent_log_line(logs, cutoff)):
+                        print("WARNING: log rate-limiting detected, marker may be dropped")
+                        warned = True
+                return False, fp.tell(), warned
+
         while wait_time <= timeout:
-            # look for marker in syslog file
-            if os.path.exists(syslog_file):
-                with open(syslog_file, 'r') as fp:
-                    # resume from last search position
-                    if last_check_pos:
-                        fp.seek(last_check_pos)
-                    # check if marker in the file
-                    for logs in fp:
-                        if marker in logs:
-                            return True
-                        elif (not rate_limit_warned[0] and
-                              any(indication in logs for indication in rate_limit_indications)):
-                            print("WARNING: log rate-limiting detected, marker may be dropped")
-                            rate_limit_warned[0] = True
-                    # record last search position
-                    last_check_pos = fp.tell()
+            found_marker, last_check_pos, rate_limit_warned[0] = scan_log_file(
+                syslog_file, last_check_pos, rate_limit_warned[0])
+            if found_marker:
+                return True
 
             # logs might get rotated while waiting for marker
             # look for marker in syslog.1 file
-            if os.path.exists(prev_syslog_file):
-                with open(prev_syslog_file, 'r') as pfp:
-                    # check if marker in the file
-                    for logs in pfp:
-                        if marker in logs:
-                            return True
-                        elif (not rate_limit_warned[1] and
-                              any(indication in logs for indication in rate_limit_indications)):
-                            print("WARNING: log rate-limiting detected, marker may be dropped")
-                            rate_limit_warned[1] = True
+            found_marker, _, rate_limit_warned[1] = scan_log_file(
+                prev_syslog_file, 0, rate_limit_warned[1])
+            if found_marker:
+                return True
+
             time.sleep(polling_interval)
             wait_time += polling_interval
 

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
@@ -10,12 +10,12 @@ Description:    This file contains the log analyzer functionality in order
                 Design is available in https://github.com/sonic-net/SONiC/wiki/LogAnalyzer
 
 Usage:          Examples of how to use log analyzer
-                sudo python loganalyzer.py \
-                    --out_dir /home/hrachya/projects/loganalyzer/log.analyzer.results \
-                    --action analyze \
-                    --run_id myTest114 \
-                    --logs file3.log \
-                    -m /home/hrachya/projects/loganalyzer/match.file.1.log,/home/hrachya/projects/loganalyzer/match.file.2.log \    # noqa: E501 W605
+                sudo python loganalyzer.py \\
+                    --out_dir /home/hrachya/projects/loganalyzer/log.analyzer.results \\
+                    --action analyze \\
+                    --run_id myTest114 \\
+                    --logs file3.log \\
+                    -m /home/hrachya/projects/loganalyzer/match.file.1.log,/home/hrachya/projects/loganalyzer/match.file.2.log \\    # noqa: E501
                     -i ignore.file.1.log,ignore.file.2.log -v
 '''
 
@@ -210,12 +210,23 @@ class AnsibleLogAnalyzer:
         time.sleep(2)
 
     def is_recent_log_line(self, log_line, cutoff):
+        # This mirrors timestamp parsing logic from ansible/library/extract_log.py::convert_date.
+        timestamp_match = re.match(r'^\d{4}\s{1}\S{3}\s{1,2}\d{1,2} \d{2}:\d{2}:\d{2}\.?\d*', log_line)
+        if timestamp_match:
+            str_date = timestamp_match.group(0)
+        else:
+            timestamp_match = re.match(r'^\S{3}\s{1,2}\d{1,2} \d{2}:\d{2}:\d{2}\.?\d*', log_line)
+            if not timestamp_match:
+                return False
+            str_date = '{:04d} '.format(cutoff.year) + timestamp_match.group(0)
+
         try:
-            # syslog datetime example: "2026 Jul  1 12:11:05.671339"
-            log_time = datetime.strptime(log_line[:20], "%Y %b %d %H:%M:%S")
+            log_time = datetime.strptime(str_date, "%Y %b %d %H:%M:%S.%f")
         except ValueError:
-            print(f"WARNING: failed to parse log line timestamp, ignoring line: {log_line}")
-            return False
+            log_time = datetime.strptime(str_date, "%Y %b %d %H:%M:%S")
+
+        if log_time < cutoff and cutoff.month == 12 and log_time.month == 1:
+            log_time = log_time.replace(year=cutoff.year + 1)
 
         return log_time >= cutoff
 

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -457,17 +457,19 @@ def get_sai_sdk_dump_file(duthost, dump_file_name):
     allure.attach.file(compressed_dump_file, dump_file_name, extension=".tar.gz")
 
 
-def reap_sai_sdk_dump_files(duthost, age_sec=None):
+def reap_dump_files(duthost, dump_folder, age_sec=None):
     """
         /var/log is a smaller partition, which can get filled by
-        SAI SDK dump files. This function cleans up dump files
+        dump files. This function cleans up stale dump files under dump_folder
         older than age_sec (seconds).
 
         Args:
             duthost: Device Under Test (DUT)
+            dump_folder: Directory containing dump files to remove.
             age_sec: If specified, only remove files older than this many seconds; else remove all.
     """
-    dump_folder = "/var/log/sdk_dbg"
+    if not dump_folder or dump_folder == "/" or not dump_folder.startswith("/"):
+        raise ValueError("dump_folder must be an absolute non-root path")
 
     res = duthost.shell("test -d '{}'".format(dump_folder), module_ignore_errors=True)
     if res.get("rc", 1) != 0:
@@ -482,7 +484,7 @@ def reap_sai_sdk_dump_files(duthost, age_sec=None):
     elif age_sec is not None:
         raise TypeError("age_sec must be an int or None")
 
-    logger.info("Removing SAI SDK dump files from %s on %s", dump_folder, duthost.hostname)
+    logger.info("Removing stale dump files from %s on %s", dump_folder, duthost.hostname)
     duthost.shell(cmd + " -exec rm -f -- {} +")
 
 

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -457,6 +457,35 @@ def get_sai_sdk_dump_file(duthost, dump_file_name):
     allure.attach.file(compressed_dump_file, dump_file_name, extension=".tar.gz")
 
 
+def reap_sai_sdk_dump_files(duthost, age_sec=None):
+    """
+        /var/log is a smaller partition, which can get filled by
+        SAI SDK dump files. This function cleans up dump files
+        older than age_sec (seconds).
+
+        Args:
+            duthost: Device Under Test (DUT)
+            age_sec: If specified, only remove files older than this many seconds; else remove all.
+    """
+    dump_folder = "/var/log/sdk_dbg"
+
+    res = duthost.shell("test -d '{}'".format(dump_folder), module_ignore_errors=True)
+    if res.get("rc", 1) != 0:
+        return
+
+    cmd = "find '{}' -mindepth 1 -type f".format(dump_folder)
+
+    if isinstance(age_sec, int):
+        if age_sec < 0:
+            raise ValueError("age_sec must be non-negative")
+        cmd += " -mmin +{}".format(age_sec // 60)
+    elif age_sec is not None:
+        raise TypeError("age_sec must be an int or None")
+
+    logger.info("Removing SAI SDK dump files from %s on %s", dump_folder, duthost.hostname)
+    duthost.shell(cmd + " -exec rm -f -- {} +")
+
+
 def is_mellanox_devices(hwsku):
     """
     A helper function to check if a given sku is Mellanox device

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -471,11 +471,11 @@ def reap_dump_files(duthost, dump_folder, age_sec=None):
     if not dump_folder or dump_folder == "/" or not dump_folder.startswith("/"):
         raise ValueError("dump_folder must be an absolute non-root path")
 
-    res = duthost.shell("test -d '{}'".format(dump_folder), module_ignore_errors=True)
+    res = duthost.shell("sudo test -d '{}'".format(dump_folder), module_ignore_errors=True)
     if res.get("rc", 1) != 0:
         return
 
-    cmd = "find '{}' -mindepth 1 -type f".format(dump_folder)
+    cmd = "sudo find '{}' -mindepth 1 -type f".format(dump_folder)
 
     if isinstance(age_sec, int):
         if age_sec < 0:

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -503,14 +503,14 @@ def try_reap_dump_folder(duthost, dump_folder, age_sec=None, watermark_mb=None):
         if age_sec < 0:
             logger.warning("age_sec must be non-negative")
             return False
-        cmd += " -mmin +{}".format(age_sec // 60)
+        cmd += " -mmin +{}".format((age_sec + 59) // 60)
     elif age_sec is not None:
         logger.warning("age_sec must be an int or None")
         return False
 
     res = duthost.shell("sudo test -d '{}'".format(dump_folder), module_ignore_errors=True)
     if res.get("rc", 1) != 0:
-        logger.warning("Dump folder %s does not exist on %s", dump_folder, duthost.hostname)
+        logger.info("Dump folder %s does not exist on %s", dump_folder, duthost.hostname)
         return False
 
     if watermark_mb is not None and not is_folder_size_over_watermark(duthost, dump_folder, watermark_mb):
@@ -520,7 +520,11 @@ def try_reap_dump_folder(duthost, dump_folder, age_sec=None, watermark_mb=None):
         return False
 
     logger.info("Removing stale dump files from %s on %s", dump_folder, duthost.hostname)
-    duthost.shell(cmd + " -exec rm -f -- {} +")
+    res = duthost.shell(cmd + " -exec rm -f -- {} +", module_ignore_errors=True)
+    if res.get("rc", 1) != 0:
+        logger.warning("Failed to remove stale dump files from %s on %s", dump_folder, duthost.hostname)
+        return False
+
     return True
 
 

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -457,35 +457,71 @@ def get_sai_sdk_dump_file(duthost, dump_file_name):
     allure.attach.file(compressed_dump_file, dump_file_name, extension=".tar.gz")
 
 
-def reap_dump_files(duthost, dump_folder, age_sec=None):
+def is_folder_size_over_watermark(duthost, folder, watermark_mb):
+    """
+        Return True if a folder on the DUT exceeds watermark_mb.
+
+        Args:
+            duthost: Device Under Test (DUT)
+            folder: Directory to measure.
+            watermark_mb: Watermark in megabytes.
+    """
+    if watermark_mb is None or watermark_mb < 0:
+        logger.warning("Invalid watermark %s for folder %s", watermark_mb, folder)
+        return False
+
+    res = duthost.shell("sudo du -sm '{}'".format(folder), module_ignore_errors=True)
+    if res.get("rc", 1) != 0:
+        logger.warning("Failed to get size for folder %s on %s", folder, duthost.hostname)
+        return False
+
+    try:
+        ret = int(res.get("stdout", "0").split()[0])
+    except (ValueError, IndexError):
+        logger.warning("Failed to parse size for folder %s on %s: %s",
+                       folder, duthost.hostname, res.get("stdout", ""))
+        return False
+
+    return ret > watermark_mb
+
+
+def try_reap_dump_folder(duthost, dump_folder, age_sec=None, watermark_mb=None):
     """
         /var/log is a smaller partition, which can get filled by
         dump files. This function cleans up stale dump files under dump_folder
-        older than age_sec (seconds).
+        older than age_sec (seconds) when dump_folder exceeds watermark_mb.
 
         Args:
             duthost: Device Under Test (DUT)
             dump_folder: Directory containing dump files to remove.
             age_sec: If specified, only remove files older than this many seconds; else remove all.
+            watermark_mb: If specified, only remove files when dump_folder usage exceeds this many megabytes.
     """
-    if not dump_folder or dump_folder == "/" or not dump_folder.startswith("/"):
-        raise ValueError("dump_folder must be an absolute non-root path")
+
+    cmd = "sudo find '{}' -mindepth 1 -type f".format(dump_folder)
+    if isinstance(age_sec, int):
+        if age_sec < 0:
+            logger.warning("age_sec must be non-negative")
+            return False
+        cmd += " -mmin +{}".format(age_sec // 60)
+    elif age_sec is not None:
+        logger.warning("age_sec must be an int or None")
+        return False
 
     res = duthost.shell("sudo test -d '{}'".format(dump_folder), module_ignore_errors=True)
     if res.get("rc", 1) != 0:
-        return
+        logger.warning("Dump folder %s does not exist on %s", dump_folder, duthost.hostname)
+        return False
 
-    cmd = "sudo find '{}' -mindepth 1 -type f".format(dump_folder)
-
-    if isinstance(age_sec, int):
-        if age_sec < 0:
-            raise ValueError("age_sec must be non-negative")
-        cmd += " -mmin +{}".format(age_sec // 60)
-    elif age_sec is not None:
-        raise TypeError("age_sec must be an int or None")
+    if watermark_mb is not None and not is_folder_size_over_watermark(duthost, dump_folder, watermark_mb):
+        logger.info(
+            "Skip removing stale dump files from %s on %s: size <= watermark %s MB",
+            dump_folder, duthost.hostname, watermark_mb)
+        return False
 
     logger.info("Removing stale dump files from %s on %s", dump_folder, duthost.hostname)
     duthost.shell(cmd + " -exec rm -f -- {} +")
+    return True
 
 
 def is_mellanox_devices(hwsku):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ from tests.common.utilities import get_duts_from_host_pattern
 from tests.common.utilities import get_upstream_neigh_type, get_downstream_neigh_type, file_exists_on_dut
 from tests.common.helpers.dut_utils import is_supervisor_node, is_frontend_node, create_duthost_console, creds_on_dut, \
     is_enabled_nat_for_dpu, get_dpu_names_and_ssh_ports, enable_nat_for_dpus, is_macsec_capable_node, \
-    get_supervisor_for_linecard, create_linecard_console, reap_sai_sdk_dump_files
+    get_supervisor_for_linecard, create_linecard_console, reap_dump_files
 from tests.common.cache import FactsCache
 from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert as pt_assert
@@ -105,7 +105,7 @@ HOST_FIXTURE_FAILED_RC = 15
 CUSTOM_MSG_PREFIX = "sonic_custom_msg"
 GOLDEN_CONFIG_DB_PATH = "/etc/sonic/golden_config_db.json"
 GOLDEN_CONFIG_DB_PATH_ORI = "/etc/sonic/golden_config_db.json.origin.backup"
-SAI_SDK_DUMP_FILE_REAP_AGE_SEC = 24 * 60 * 60
+STALE_DUMP_FILE_REAP_AGE_SEC = 24 * 60 * 60
 
 pytest_plugins = ('tests.common.plugins.ptfadapter',
                   'tests.common.plugins.ansible_fixtures',
@@ -788,9 +788,10 @@ def duthost(duthosts, request):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def reap_old_sai_sdk_dump_files(duthosts):
+def reap_stale_dump_files(duthosts):
     for duthost in duthosts:
-        reap_sai_sdk_dump_files(duthost, age_sec=SAI_SDK_DUMP_FILE_REAP_AGE_SEC)
+        reap_dump_files(duthost, "/var/log/sdk_dbg", age_sec=STALE_DUMP_FILE_REAP_AGE_SEC)
+        reap_dump_files(duthost, "/var/log/sai_failure_dump", age_sec=STALE_DUMP_FILE_REAP_AGE_SEC)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ from tests.common.utilities import get_duts_from_host_pattern
 from tests.common.utilities import get_upstream_neigh_type, get_downstream_neigh_type, file_exists_on_dut
 from tests.common.helpers.dut_utils import is_supervisor_node, is_frontend_node, create_duthost_console, creds_on_dut, \
     is_enabled_nat_for_dpu, get_dpu_names_and_ssh_ports, enable_nat_for_dpus, is_macsec_capable_node, \
-    get_supervisor_for_linecard, create_linecard_console
+    get_supervisor_for_linecard, create_linecard_console, reap_sai_sdk_dump_files
 from tests.common.cache import FactsCache
 from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert as pt_assert
@@ -105,6 +105,7 @@ HOST_FIXTURE_FAILED_RC = 15
 CUSTOM_MSG_PREFIX = "sonic_custom_msg"
 GOLDEN_CONFIG_DB_PATH = "/etc/sonic/golden_config_db.json"
 GOLDEN_CONFIG_DB_PATH_ORI = "/etc/sonic/golden_config_db.json.origin.backup"
+SAI_SDK_DUMP_FILE_REAP_AGE_SEC = 24 * 60 * 60
 
 pytest_plugins = ('tests.common.plugins.ptfadapter',
                   'tests.common.plugins.ansible_fixtures',
@@ -784,6 +785,12 @@ def duthost(duthosts, request):
     duthost = duthosts[dut_index]
 
     return duthost
+
+
+@pytest.fixture(scope="session", autouse=True)
+def reap_old_sai_sdk_dump_files(duthosts):
+    for duthost in duthosts:
+        reap_sai_sdk_dump_files(duthost, age_sec=SAI_SDK_DUMP_FILE_REAP_AGE_SEC)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ from tests.common.utilities import get_duts_from_host_pattern
 from tests.common.utilities import get_upstream_neigh_type, get_downstream_neigh_type, file_exists_on_dut
 from tests.common.helpers.dut_utils import is_supervisor_node, is_frontend_node, create_duthost_console, creds_on_dut, \
     is_enabled_nat_for_dpu, get_dpu_names_and_ssh_ports, enable_nat_for_dpus, is_macsec_capable_node, \
-    get_supervisor_for_linecard, create_linecard_console, reap_dump_files
+    get_supervisor_for_linecard, create_linecard_console, try_reap_dump_folder
 from tests.common.cache import FactsCache
 from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert as pt_assert
@@ -106,6 +106,7 @@ CUSTOM_MSG_PREFIX = "sonic_custom_msg"
 GOLDEN_CONFIG_DB_PATH = "/etc/sonic/golden_config_db.json"
 GOLDEN_CONFIG_DB_PATH_ORI = "/etc/sonic/golden_config_db.json.origin.backup"
 STALE_DUMP_FILE_REAP_AGE_SEC = 24 * 60 * 60
+DUMP_FILE_CLEANUP_WATERMARK_MB = 768
 
 pytest_plugins = ('tests.common.plugins.ptfadapter',
                   'tests.common.plugins.ansible_fixtures',
@@ -788,10 +789,16 @@ def duthost(duthosts, request):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def reap_stale_dump_files(duthosts):
+def try_reap_stale_dump_files(duthosts):
     for duthost in duthosts:
-        reap_dump_files(duthost, "/var/log/sdk_dbg", age_sec=STALE_DUMP_FILE_REAP_AGE_SEC)
-        reap_dump_files(duthost, "/var/log/sai_failure_dump", age_sec=STALE_DUMP_FILE_REAP_AGE_SEC)
+        try_reap_dump_folder(
+            duthost, "/var/log/sdk_dbg",
+            age_sec=STALE_DUMP_FILE_REAP_AGE_SEC,
+            watermark_mb=DUMP_FILE_CLEANUP_WATERMARK_MB)
+        try_reap_dump_folder(
+            duthost, "/var/log/sai_failure_dump",
+            age_sec=STALE_DUMP_FILE_REAP_AGE_SEC,
+            watermark_mb=DUMP_FILE_CLEANUP_WATERMARK_MB)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -454,7 +454,7 @@ def _load_testbed_config(tbfile, tbname):
         if tb.get('conf-name') == tbname:
             return tb
 
-    logger.warning(f"Testbed '{tbname}' not found in '{tbfile}'")
+    logger.warning("Testbed '{}' not found in '{}'".format(tbname, tbfile))
     return
 
 
@@ -482,9 +482,9 @@ def converge_topo_if_needed(config):
         neighbor_type = config.getoption("--neighbor_type")
         if neighbor_type not in ("eos", "ceos"):
             logger.info(
-                f"use_converged_peers=True for testbed '{tbname}' but neighbor_type="
-                f"'{neighbor_type}' is not cEOS; skipping converge (converged peer "
-                f"model is cEOS-only)")
+                "use_converged_peers=True for testbed '{}' but neighbor_type="
+                "'{}' is not cEOS; skipping converge (converged peer "
+                "model is cEOS-only)".format(tbname, neighbor_type))
             return
 
         logger.info(f"use_converged_peers=True for testbed '{tbname}', starting converge...")
@@ -526,7 +526,7 @@ def converge_topo_if_needed(config):
 
         os.chmod(topo_file, original_mode)
         os.chown(topo_file, original_uid, original_gid)
-        logger.info(f"File permissions restored to {original_uid}:{original_gid}")
+        logger.info("File permissions restored to {}:{}".format(original_uid, original_gid))
 
         config.cache.set("converged_topo_file", topo_file)
         config.cache.set("converged_topo_backup", backup_file)
@@ -1420,8 +1420,9 @@ def fanouthosts(enhance_inventory, ansible_adhoc, tbinfo, conn_graph_facts, cred
             fanout.add_serial_port_map(dut_name, host_port, fanout_port, baud_rate, flow_control)
 
             logging.debug(
-                f"Added serial port mapping: {dut_name} Console{host_port} -> "
-                f"{fanout_host}:{fanout_port} (baud={link_info.get('baud_rate', '9600')})"
+                "Added serial port mapping: {} Console{} -> "
+                "{}:{} (baud={})".format(dut_name, host_port, fanout_host, fanout_port,
+                                         link_info.get('baud_rate', '9600'))
             )
 
     logging.info(f"fanouthosts fixture initialized with {len(fanout_hosts)} fanout devices")
@@ -3857,7 +3858,7 @@ def build_gnmi_stubs(request):
             text=True,
             check=False  # Do not raise an exception automatically on non-zero exit
         )
-        logger.info(f"Output of {script_path}:\n{result.stdout}")
+        logger.info("Output of {}:\n{}".format(script_path, result.stdout))
 
         if result.returncode != 0:
             logger.error(f"{script_path} failed with exit code {result.returncode}")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Introduces a function that deletes stale (> 1 day old) sdk_dbg and sai_failure_dump entries to prevent /var/log from filling on Mellanox devices, which cause ENOSPC on some test cases.

Additionally will print a warning to the console if rate limiting is detected while attempting to place a marker, aimed at diagnosing additional log-related test failures; inspecting syslog shows rate-limiting sometimes occurs during tests which may cause the marker to drop.

Summary:
ADO: 38614040,38099232

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
We have seen a number of test failures relating to logs that involve LogAnalyzer failing to find start/end markers. The markers could be dropped for a number of reasons:

1. ENOSPC caused by /var/log being full.
2. Dropped due to rate-limiting in syslog.
3. Race-condition on syslog reload (see https://github.com/sonic-net/sonic-mgmt/pull/22447 and https://github.com/sonic-net/sonic-mgmt/pull/23591).

The race-condition has been fixed in those PRs and this PR seeks to fix 1 and 2.

#### How did you do it?
Added a helper function that is capable of deleting files from a directory that are greater than 1 day old, and if the disk usage of that folder is greater than 768M (~18% of the 4G disk). This is called on /var/log/sdk_dbg and /var/log/sai_failure_dump.

#### How did you verify/test it?

#### Any platform specific information?
AFAIK this is mainly a Mellanox issue due to sdk_dbg.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
