### PR TITLE
[QoS] Fix PFCXonTest TypeError: restore 'in hwsku' on Arista-7060X6 check

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -3227,7 +3227,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             if check_leackout_compensation_support(asic_type, hwsku):
                 pkts_num_leak_out = 0
 
-            if hwsku in ('DellEMC-Z9332f-M-O16C64', 'DellEMC-Z9332f-O32') or 'Arista-7060X6' \
+            if hwsku in ('DellEMC-Z9332f-M-O16C64', 'DellEMC-Z9332f-O32') or 'Arista-7060X6' in hwsku \
                     or 'Nokia-IXR7220-H6' in hwsku:
                 send_packet(
                     self, src_port_id, pkt,
@@ -3270,7 +3270,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             xmit_2_counters_base, _ = sai_thrift_read_port_counters(
                 self.dst_client, asic_type, port_list['dst'][dst_port_2_id]
             )
-            if hwsku in ('DellEMC-Z9332f-M-O16C64', 'DellEMC-Z9332f-O32') or 'Arista-7060X6' \
+            if hwsku in ('DellEMC-Z9332f-M-O16C64', 'DellEMC-Z9332f-O32') or 'Arista-7060X6' in hwsku \
                     or 'Nokia-IXR7220-H6' in hwsku:
                 send_packet(
                     self, src_port_id, pkt2,
@@ -3322,7 +3322,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             log_message('step {}: {}\n'.format(step_id, step_desc), to_stderr=True)
             xmit_3_counters_base, _ = sai_thrift_read_port_counters(
                 self.dst_client, asic_type, port_list['dst'][dst_port_3_id])
-            if hwsku in ('DellEMC-Z9332f-M-O16C64', 'DellEMC-Z9332f-O32') or 'Arista-7060X6' \
+            if hwsku in ('DellEMC-Z9332f-M-O16C64', 'DellEMC-Z9332f-O32') or 'Arista-7060X6' in hwsku \
                     or 'Nokia-IXR7220-H6' in hwsku:
                 send_packet(self, src_port_id, pkt3,
                             pkts_num_egr_mem + pkts_num_leak_out + 1)


### PR DESCRIPTION
### Description of PR

Summary:
Fix a `TypeError` in `PFCXonTest` caused by an operator-precedence bug in the `hwsku` check, which makes `qos/test_qos_sai.py::testQosSaiPfcXonLimit` fail on Broadcom TH1 boxes (e.g. `Arista-7060CX-32S-C32`):

```
File "/root/saitests/py3/sai_qos_tests.py", line 3234, in runTest
    (pkts_num_egr_mem + pkts_num_leak_out + pkts_num_trig_pfc - ...
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
```

Fixes # (issue)
38502281

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: regression

### Approach
#### What is the motivation for this PR?
https://github.com/sonic-net/sonic-mgmt/pull/24668
`testQosSaiPfcXonLimit` fails on Broadcom TH1 platforms with `TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'`. The `hwsku` condition in `PFCXonTest` was split across lines and dropped `in hwsku` from the `'Arista-7060X6'` term at three sites (lines 3230/3273/3325):

```python
if hwsku in ('DellEMC-Z9332f-M-O16C64', 'DellEMC-Z9332f-O32') or 'Arista-7060X6' \
        or 'Nokia-IXR7220-H6' in hwsku:
```

Python evaluates this as `(hwsku in (...)) or ('Arista-7060X6') or ('Nokia-IXR7220-H6' in hwsku)`. The bare non-empty string literal `'Arista-7060X6'` is always truthy, so the condition is `True` for **every** hwsku, forcing all DUTs into the `pkts_num_egr_mem` branch. On TH1 boxes `pkts_num_egr_mem` is `None` (only computed at runtime for `cisco-8000` + `src_dst_asic_diff`), producing the `None + int` TypeError.

#### How did you do it?

Restore the missing `in hwsku` at the three sites, matching the sibling `PFCtest` condition (line 2361) and the other conditions in the file that correctly kept `'Arista-7060X6' in hwsku`.

#### How did you verify/test it?

Verified on Broadcom TH1 t0 testbeds with an `internal-202605` image, on Elastictest.

- **PFCXon fix in isolation** — `Arista-7060CX-32S-D48C8` t0: the two cases that previously reproduced the crash, `testQosSaiPfcXonLimit[single_asic-xon_1]` and `[single_asic-xon_2]`, now **PASS** (before this fix they failed with `TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'`).
- **Combined run** (this PR + the port-selection fix #25856) — `Arista-7060CX-32S-C32` t0: full `qos/test_qos_sai.py` = **16 passed / 0 failed / 0 errors** (294 skipped), pretest + posttest passed, no testbed error codes. Log inspection confirmed both `PFCXonTest` cases ran with real traffic and passed.

> Note: this PR and #25856 fix two independent regressions from #24668 — this one the `PFCXonTest` `TypeError`, #25856 the TH1 `PortChannel` port-selection `KeyError`. The two changes touch different files/code paths and can merge independently, but both are needed for a fully green `qos/test_qos_sai.py` run on Broadcom TH1 t0.

#### Any platform specific information?

Affects Broadcom platforms where `pkts_num_egr_mem` is not supplied (e.g. TH1/TH2/TH3 such as `Arista-7060CX-32S-C32`). Platforms that legitimately populate `pkts_num_egr_mem` (`DellEMC-Z9332f-*`, `Arista-7060X6`, `Nokia-IXR7220-H6`) still take the intended branch.

#### Supported testbed topology if it's a new test case?

N/A — bug fix to an existing test.

### Documentation

N/A