### PR TITLE
Normalize MAC comparison in FIB PTF tests

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -426,7 +426,7 @@ class FibTest(BaseTest):
                 exp_src_mac = self.ptf_test_port_map[str(
                     rcvd_port)]["target_src_mac"][0]
             actual_src_mac = scapy.Ether(rcvd_pkt).src
-            if exp_src_mac != actual_src_mac:
+            if str(exp_src_mac).lower() != str(actual_src_mac).lower():
                 raise Exception(
                     "Pkt sent from {} to {} on port {} was rcvd pkt on {} which is one of the expected ports, "
                     "but the src mac doesn't match, expected {}, got {}".
@@ -534,7 +534,7 @@ class FibTest(BaseTest):
                 exp_src_mac = self.ptf_test_port_map[str(
                     rcvd_port)]["target_src_mac"][0]
             actual_src_mac = scapy.Ether(rcvd_pkt).src
-            if exp_src_mac != actual_src_mac:
+            if str(exp_src_mac).lower() != str(actual_src_mac).lower():
                 raise Exception(
                     "Pkt sent from {} to {} on port {} was rcvd pkt on {} which is one of the expected ports, "
                     "but the src mac doesn't match, expected {}, got {}".

--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -369,7 +369,7 @@ class HashTest(BaseTest):
             exp_src_mac = self.ptf_test_port_map[str(
                 rcvd_port)]["target_src_mac"][0]
         actual_src_mac = scapy.Ether(rcvd_pkt).src
-        if exp_src_mac != actual_src_mac:
+        if str(exp_src_mac).lower() != str(actual_src_mac).lower():
             raise Exception("Pkt sent from {} to {} on port {} was rcvd pkt on {} which is one of the expected ports, "
                             "but the src mac doesn't match, expected {}, got {}".
                             format(ip_src, ip_dst, src_port, rcvd_port, exp_src_mac, actual_src_mac))


### PR DESCRIPTION
### Description of PR
Summary:
Normalize expected and actual source MAC strings before comparing in FIB/hash PTF checks. Some platforms/log paths provide the expected router MAC in uppercase while Scapy returns the received packet MAC in lowercase; the values are identical MAC addresses and should not fail due to string casing.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/38666751

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request: ADO 38666751
Failure type: other

### Approach
#### What is the motivation for this PR?
Nightly fib/test_fib.py::test_ecmp_group_member_flap failed on 202605 with "src mac doesn't match" where expected 8C:7A:00:F6:E8:73 and actual 8c:7a:00:f6:e8:73 differ only by case.

#### How did you do it?
Compare MAC strings case-insensitively in the FIB and hash PTF validation paths.

#### How did you verify/test it?
Ran python -m py_compile on ansible/roles/test/files/ptftests/py3/fib_test.py and ansible/roles/test/files/ptftests/py3/hash_test.py.

#### Any platform specific information?
Observed on Nokia-7215-A1-MGX-G48S4 / marvell-prestera mx topology, but the comparison is platform independent.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
