### PR TITLE
Fix(loganalyzer): use fetch_no_slurp to avoid memory spike on DUT

### DIFF
--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -551,7 +551,7 @@ class LogAnalyzer:
 
         @param dest: File path to store downloaded log file.
         """
-        self.ansible_host.fetch(dest=dest, src=self.extracted_syslog, flat="yes")
+        self.ansible_host.fetch_no_slurp(src=self.extracted_syslog, dest=dest, flat=True)
 
     def save_extracted_file(self, dest, src):
         """
@@ -561,4 +561,4 @@ class LogAnalyzer:
 
         @param src: Source path to store downloaded file.
         """
-        self.ansible_host.fetch(dest=dest, src=src, flat="yes")
+        self.ansible_host.fetch_no_slurp(src=src, dest=dest, flat=True)


### PR DESCRIPTION
### Description of PR
Summary:
Replace ansible fetch (which uses slurp) with fetch_no_slurp in
loganalyzer save_extracted_log and save_extracted_file methods.

The slurp module loads the entire file into memory with ~5-10x
amplification (base64 + JSON), causing DUT free memory to drop
below threshold when syslog files are large (300-400 MB).

fetch_no_slurp uses SCP/SFTP streaming instead, avoiding the
memory issue entirely.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
Offending process seems to be the python process (pid: 211939) initiated by sonic-mgmt test suite. This is consuming 3.1g 
```
211936 root      20   0   20552   5928   4748 S   0.0   0.1   0:00.01 sudo
 211938 root      20   0    2672   1692   1576 S   0.0   0.0   0:00.00 sh
 211939 root      20   0 3295384   3.1g   6648 S   0.0  40.5   0:15.38 python3+
 215081 root      20   0       0      0      0 I   0.0   0.0   0:07.66 kworker+
```
slurp is the classic Ansible memory hog because it has no streaming — it reads the whole file, base64‑encodes it, and ships it as JSON over stdout/SSH. For a file of size N, peak RAM is roughly 5–10× N because these copies coexist:

Raw file bytes | DUT slurp process | N
-- | -- | --
base64 encoding | DUT slurp process | 1.33 N
JSON document on stdout | DUT slurp process | ~1.33 N
stdout read into one string | controller (pytest/ansible) | ~1.33 N
json.loads dict holding the b64 string | controller | ~1.33 N (transient ×2)
base64decode back to bytes | controller | N

So a /tmp/syslog of only ~300–400 MB easily produces 3+ GB peak RSS once you sum the DUT‑side slurp process and the controller‑side fetch action plugin handling all those simultaneous copies. That's exactly how you land at 3.1 GB.
#### How did you do it?
Replace it with no_slurp method.
#### How did you verify/test it?
Test suite passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
NA