### PR TITLE
[bgp][test_traffic_shift_lc] Fix Ansible Jinja2 template rendering error in update_golden_config_tsa_enabled

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import random
 import re
 import sys
 import shutil
+import tempfile
 
 import pytest
 import yaml
@@ -453,7 +454,7 @@ def _load_testbed_config(tbfile, tbname):
         if tb.get('conf-name') == tbname:
             return tb
 
-    logger.warning(f"Testbed '{tbname}' not found in '{tbfile}'")
+    logger.warning(f"Testbed '{tbname}' is not in '{tbfile}'")
     return
 
 
@@ -482,7 +483,7 @@ def converge_topo_if_needed(config):
         if neighbor_type not in ("eos", "ceos"):
             logger.info(
                 f"use_converged_peers=True for testbed '{tbname}' but neighbor_type="
-                f"'{neighbor_type}' is not cEOS; skipping converge (converged peer "
+                f"'{neighbor_type}' is not cEOS. skipping converge (converged peer "
                 f"model is cEOS-only)")
             return
 
@@ -525,7 +526,7 @@ def converge_topo_if_needed(config):
 
         os.chmod(topo_file, original_mode)
         os.chown(topo_file, original_uid, original_gid)
-        logger.info(f"File permissions restored to {original_uid}:{original_gid}")
+        logger.info(f"File permissions restored to {original_uid}: {original_gid}")
 
         config.cache.set("converged_topo_file", topo_file)
         config.cache.set("converged_topo_backup", backup_file)
@@ -1407,7 +1408,7 @@ def fanouthosts(enhance_inventory, ansible_adhoc, tbinfo, conn_graph_facts, cred
 
             logging.debug(
                 f"Added serial port mapping: {dut_name} Console{host_port} -> "
-                f"{fanout_host}:{fanout_port} (baud={link_info.get('baud_rate', '9600')})"
+                f"{fanout_host}: {fanout_port} (baud={link_info.get('baud_rate', '9600')})"
             )
 
     logging.info(f"fanouthosts fixture initialized with {len(fanout_hosts)} fanout devices")
@@ -3843,7 +3844,7 @@ def build_gnmi_stubs(request):
             text=True,
             check=False  # Do not raise an exception automatically on non-zero exit
         )
-        logger.info(f"Output of {script_path}:\n{result.stdout}")
+        logger.info(f"Output of {script_path}: \n{result.stdout}")
 
         if result.returncode != 0:
             logger.error(f"{script_path} failed with exit code {result.returncode}")
@@ -3948,7 +3949,14 @@ def update_golden_config_tsa_enabled(duthost, tsa_enabled=True):
         golden_config_db.setdefault("BGP_DEVICE_GLOBAL", {}) \
                         .setdefault("STATE", {})["tsa_enabled"] = tsa_enabled_str
 
-    duthost.copy(content=json.dumps(golden_config_db, indent=4), dest=GOLDEN_CONFIG_DB_PATH)
+    tmp_file = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+    try:
+        json.dump(golden_config_db, tmp_file, indent=4)
+        tmp_file.flush()
+        tmp_file.close()
+        duthost.copy(src=tmp_file.name, dest=GOLDEN_CONFIG_DB_PATH)
+    finally:
+        os.unlink(tmp_file.name)
 
 
 @pytest.fixture(scope="module", autouse=True)


### PR DESCRIPTION

### Description of PR
Introduced in PR https://github.com/sonic-net/sonic-mgmt/pull/23725
When passing the golden_config_db JSON content directly via the Ansible `copy` module's `content=` parameter, Ansible attempts to render the string as a Jinja2 template. If the JSON happens to contain sequences that look like Jinja2 expressions (e.g. when DEVICE_RUNTIME_METADATA or other sections include characters resembling template syntax), Ansible fails with:

  The task includes an option with an undefined variable..
  'DEVICE_RUNTIME_METADATA' is undefined

This causes test_load_minigraph_with_traffic_shift_away (and other tests relying on update_golden_config_tsa_enabled) to break during setup before any actual test logic runs.

Fix:
Write the JSON content to a local temporary file first, then use `copy` with `src=` instead of `content=`. This bypasses Jinja2 templating entirely and safely transfers the file as raw bytes.


Summary:
Fixes # (issue)


### Type of change


- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
Ansible fails with:

  The task includes an option with an undefined variable..
  'DEVICE_RUNTIME_METADATA' is undefined
#### How did you do it?
Write the JSON content to a local temporary file first, then use `copy` with `src=` instead of `content=`. This bypasses Jinja2 templating entirely and safely transfers the file as raw bytes.
#### How did you verify/test it?
Run pass locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
