### PR TITLE
Skip test on t2-isolated topology

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -45,7 +45,8 @@ pytestmark = [
     pytest.mark.multi_binding_acl,
     pytest.mark.disable_loganalyzer,  # Disable automatic loganalyzer, since we use it for the test
     pytest.mark.topology("t0", "t1", "t2", "lrh", "urh", "lt2", "m0", "mx", "m1"),
-    pytest.mark.disable_memory_utilization
+    pytest.mark.disable_memory_utilization,
+    pytest.mark.usefixtures('skip_t2_isolated_topo')
 ]
 
 MAX_WAIT_TIME_FOR_INTERFACES = 360

--- a/tests/bgp/test_bgp_azng_migration.py
+++ b/tests/bgp/test_bgp_azng_migration.py
@@ -12,7 +12,7 @@ pytestmark = [
 ]
 
 
-def test_bgp_azng_migration(duthosts, enum_upstream_dut_hostname):
+def test_bgp_azng_migration(skip_t2_isolated_topo, duthosts, enum_upstream_dut_hostname):
 
     duthost = duthosts[enum_upstream_dut_hostname]
 

--- a/tests/bgp/test_prefix_list.py
+++ b/tests/bgp/test_prefix_list.py
@@ -73,7 +73,7 @@ def verify_prefix_in_fib_table(duthost, prefix):
     # Check whether prefix in FIB table
     for asic_index in duthost.get_frontend_asic_ids():
         asic_ns = f"-n asic{asic_index}" if duthost.is_multi_asic else ""
-        cmd = f"sonic-db-cli {asic_ns} APPL_DB hgetall \"ROUTE_TABLE:{prefix}\""
+        cmd = f"sonic-db-cli {asic_ns} APPL_DB hgetall \"ROUTE_TABLE:{prefix}\""  # noqa: E231
         output = duthost.shell(cmd)["stdout"].strip().replace("'", "\"")
         route_info = json.loads(output) if output else {}
         if route_info == {} or ("blackhole" in route_info and route_info["blackhole"] == "true"):
@@ -335,7 +335,7 @@ def verify(duthost, announced_neighbors, not_announced_neighbors, ip_version, ne
     return result
 
 
-def test_prefix_list_tsa(common_setup_and_teardown, localhost, tbinfo, ptfhost, request):
+def test_prefix_list_tsa(skip_t2_isolated_topo, common_setup_and_teardown, localhost, tbinfo, ptfhost, request):
     (anchor_prefixes, anchor_contributing_routes, announced_neighbors, not_announced_neighbors,
      downstream_nbr_names, ip_version, duthost) = common_setup_and_teardown
     neighbor_type = request.config.getoption("neighbor_type")
@@ -382,7 +382,7 @@ def test_prefix_list_tsa(common_setup_and_teardown, localhost, tbinfo, ptfhost, 
                   "Prefix announcing is unexpected after TSB: {}".format(result["prefix_announcing"]))
 
 
-def test_prefix_list_specific_routes(common_setup_and_teardown, localhost, tbinfo, ptfhost,
+def test_prefix_list_specific_routes(skip_t2_isolated_topo, common_setup_and_teardown, localhost, tbinfo, ptfhost,
                                      request):
     (anchor_prefixes, anchor_contributing_routes, announced_neighbors, not_announced_neighbors,
      downstream_nbr_names, ip_version, duthost) = common_setup_and_teardown

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -453,7 +453,7 @@ def _load_testbed_config(tbfile, tbname):
         if tb.get('conf-name') == tbname:
             return tb
 
-    logger.warning(f"Testbed '{tbname}' not found in '{tbfile}'")
+    logger.warning(f"Testbed '{tbname}' not in '{tbfile}'")
     return
 
 
@@ -482,7 +482,8 @@ def converge_topo_if_needed(config):
         if neighbor_type not in ("eos", "ceos"):
             logger.info(
                 f"use_converged_peers=True for testbed '{tbname}' but neighbor_type="
-                f"'{neighbor_type}' is not cEOS; skipping converge (converged peer "
+                f"'{neighbor_type}' is not cEOS "
+                f"skipping converge (converged peer "
                 f"model is cEOS-only)")
             return
 
@@ -525,7 +526,7 @@ def converge_topo_if_needed(config):
 
         os.chmod(topo_file, original_mode)
         os.chown(topo_file, original_uid, original_gid)
-        logger.info(f"File permissions restored to {original_uid}:{original_gid}")
+        logger.info(f"File permissions restored to {original_uid}: {original_gid}")
 
         config.cache.set("converged_topo_file", topo_file)
         config.cache.set("converged_topo_backup", backup_file)
@@ -1407,7 +1408,7 @@ def fanouthosts(enhance_inventory, ansible_adhoc, tbinfo, conn_graph_facts, cred
 
             logging.debug(
                 f"Added serial port mapping: {dut_name} Console{host_port} -> "
-                f"{fanout_host}:{fanout_port} (baud={link_info.get('baud_rate', '9600')})"
+                f"{fanout_host}: {fanout_port} (baud={link_info.get('baud_rate', '9600')})"
             )
 
     logging.info(f"fanouthosts fixture initialized with {len(fanout_hosts)} fanout devices")
@@ -3843,7 +3844,7 @@ def build_gnmi_stubs(request):
             text=True,
             check=False  # Do not raise an exception automatically on non-zero exit
         )
-        logger.info(f"Output of {script_path}:\n{result.stdout}")
+        logger.info(f"Output of {script_path}: \n{result.stdout}")
 
         if result.returncode != 0:
             logger.error(f"{script_path} failed with exit code {result.returncode}")
@@ -4266,3 +4267,9 @@ def restore_counter_poll(rand_selected_dut):
         parsed_counterpoll_before,
         parsed_counterpoll_after
     )
+
+
+@pytest.fixture(scope='module')
+def skip_t2_isolated_topo(tbinfo):
+    if 't2-isolated' in tbinfo['topo']['name']:
+        pytest.skip("test is not applicable to t2-isolated topology due to T3 neighbors needed")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -453,7 +453,7 @@ def _load_testbed_config(tbfile, tbname):
         if tb.get('conf-name') == tbname:
             return tb
 
-    logger.warning(f"Testbed '{tbname}' not found in '{tbfile}'")
+    logger.warning(f"Testbed '{tbname}' not in '{tbfile}'")
     return
 
 
@@ -482,7 +482,8 @@ def converge_topo_if_needed(config):
         if neighbor_type not in ("eos", "ceos"):
             logger.info(
                 f"use_converged_peers=True for testbed '{tbname}' but neighbor_type="
-                f"'{neighbor_type}' is not cEOS; skipping converge (converged peer "
+                f"'{neighbor_type}' is not cEOS "
+                f"skipping converge (converged peer "
                 f"model is cEOS-only)")
             return
 
@@ -525,7 +526,7 @@ def converge_topo_if_needed(config):
 
         os.chmod(topo_file, original_mode)
         os.chown(topo_file, original_uid, original_gid)
-        logger.info(f"File permissions restored to {original_uid}:{original_gid}")
+        logger.info(f"File permissions restored to {original_uid}: {original_gid}")
 
         config.cache.set("converged_topo_file", topo_file)
         config.cache.set("converged_topo_backup", backup_file)
@@ -1407,7 +1408,7 @@ def fanouthosts(enhance_inventory, ansible_adhoc, tbinfo, conn_graph_facts, cred
 
             logging.debug(
                 f"Added serial port mapping: {dut_name} Console{host_port} -> "
-                f"{fanout_host}:{fanout_port} (baud={link_info.get('baud_rate', '9600')})"
+                f"{fanout_host}: {fanout_port} (baud={link_info.get('baud_rate', '9600')})"
             )
 
     logging.info(f"fanouthosts fixture initialized with {len(fanout_hosts)} fanout devices")
@@ -3862,7 +3863,7 @@ def build_gnmi_stubs(request):
             text=True,
             check=False  # Do not raise an exception automatically on non-zero exit
         )
-        logger.info(f"Output of {script_path}:\n{result.stdout}")
+        logger.info(f"Output of {script_path}: \n{result.stdout}")
 
         if result.returncode != 0:
             logger.error(f"{script_path} failed with exit code {result.returncode}")
@@ -4298,3 +4299,9 @@ def ansible_root(request):
     else:
         tbfile = request.config.getoption("testbed_file")
         return pathlib.Path(tbfile).parent
+
+
+@pytest.fixture(scope='module')
+def skip_t2_isolated_topo(tbinfo):
+    if 't2-isolated' in tbinfo['topo']['name']:
+        pytest.skip("test is not applicable to t2-isolated topology due to T3 neighbors needed")

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -33,7 +33,8 @@ from tests.common.helpers.assertions import pytest_require
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.usefixtures('skip_t2_isolated_topo')
 ]
 
 # Usually src-mac, dst-mac, vlan-id are optional hash keys. Not all the platform supports these optional hash keys.

--- a/tests/generic_config_updater/add_cluster/test_add_cluster.py
+++ b/tests/generic_config_updater/add_cluster/test_add_cluster.py
@@ -178,8 +178,10 @@ def remove_cluster_via_sonic_db_cli_chassis_packet(config_facts,
 
         # BGP_NEIGHBOR, DEVICE_NEIGHBOR, DEVICE_NEIGHBOR_METADATA
         for table in ["BGP_NEIGHBOR", "DEVICE_NEIGHBOR", "DEVICE_NEIGHBOR_METADATA"]:
-            cmd = f"sudo sonic-db-cli {cli_namespace_prefix} CONFIG_DB keys '{table}*' \
-                | xargs -r -n1 sudo sonic-db-cli {cli_namespace_prefix} CONFIG_DB del"
+            cmd = (
+                f"sudo sonic-db-cli {cli_namespace_prefix} CONFIG_DB keys '{table}*' "
+                f"| xargs -r -n1 sudo sonic-db-cli {cli_namespace_prefix} CONFIG_DB del"
+            )
             run_and_check(json_namespace, cmd, f"Clearing table {table}")
 
         # INTERFACE
@@ -571,8 +573,10 @@ def remove_cluster_via_sonic_db_cli(config_facts,
 
         # BGP_NEIGHBOR, DEVICE_NEIGHBOR, DEVICE_NEIGHBOR_METADATA
         for table in ["BGP_NEIGHBOR", "DEVICE_NEIGHBOR", "DEVICE_NEIGHBOR_METADATA"]:
-            cmd = f"sudo sonic-db-cli {cli_namespace_prefix} CONFIG_DB keys '{table}*' \
-                | xargs -r -n1 sudo sonic-db-cli {cli_namespace_prefix} CONFIG_DB del"
+            cmd = (
+                f"sudo sonic-db-cli {cli_namespace_prefix} CONFIG_DB keys '{table}*' "
+                f"| xargs -r -n1 sudo sonic-db-cli {cli_namespace_prefix} CONFIG_DB del"
+            )
             run_and_check(json_namespace, cmd, f"Clearing table {table}")
 
         # INTERFACE
@@ -590,8 +594,10 @@ def remove_cluster_via_sonic_db_cli(config_facts,
 
         # PORTCHANNEL_INTERFACE, PORTCHANNEL_MEMBER
         for table in ["PORTCHANNEL_INTERFACE", "PORTCHANNEL_MEMBER"]:
-            cmd = f"sudo sonic-db-cli {cli_namespace_prefix} CONFIG_DB keys '{table}*' \
-                | xargs -r -n1 sudo sonic-db-cli {cli_namespace_prefix} CONFIG_DB del"
+            cmd = (
+                f"sudo sonic-db-cli {cli_namespace_prefix} CONFIG_DB keys '{table}*' "
+                f"| xargs -r -n1 sudo sonic-db-cli {cli_namespace_prefix} CONFIG_DB del"
+            )
             run_and_check(json_namespace, cmd, f"Clearing table {table}")
 
         # ACL
@@ -600,8 +606,10 @@ def remove_cluster_via_sonic_db_cli(config_facts,
             run_and_check(json_namespace, cmd, f"Removing ACL_TABLE {acl_table} ports")
 
         # PORTCHANNEL
-        cmd = f"sudo sonic-db-cli {cli_namespace_prefix} CONFIG_DB keys 'PORTCHANNEL*' \
-            | xargs -r -n1 sudo sonic-db-cli {cli_namespace_prefix} CONFIG_DB del"
+        cmd = (
+            f"sudo sonic-db-cli {cli_namespace_prefix} CONFIG_DB keys 'PORTCHANNEL*' "
+            f"| xargs -r -n1 sudo sonic-db-cli {cli_namespace_prefix} CONFIG_DB del"
+        )
         run_and_check(json_namespace, cmd, "Clearing table PORTCHANNEL")
 
         # CABLE_LENGTH
@@ -619,8 +627,10 @@ def remove_cluster_via_sonic_db_cli(config_facts,
                           f"sudo sonic-db-cli {cli_namespace_prefix} CONFIG_DB hset 'PORT|{iface}' admin_status down",
                           f"Set {iface} admin down")
         # BUFFER_PG
-        cmd = f"sudo sonic-db-cli {cli_namespace_prefix} CONFIG_DB keys 'BUFFER_PG*' \
-            | xargs -r -n1 sudo sonic-db-cli {cli_namespace_prefix} CONFIG_DB del"
+        cmd = (
+            f"sudo sonic-db-cli {cli_namespace_prefix} CONFIG_DB keys 'BUFFER_PG*' "
+            f"| xargs -r -n1 sudo sonic-db-cli {cli_namespace_prefix} CONFIG_DB del"
+        )
         run_and_check(json_namespace, cmd, "Clearing table BUFFER_PG")
 
         # PORT_QOS_MAP
@@ -1799,7 +1809,8 @@ def setup_add_cluster(tbinfo,
 # Test Definitions
 # -----------------------------
 
-def test_add_cluster(tbinfo,
+def test_add_cluster(skip_t2_isolated_topo,
+                     tbinfo,
                      duthosts,
                      initialize_random_variables,
                      ptfadapter,

--- a/tests/generic_config_updater/add_cluster/test_add_cluster.py
+++ b/tests/generic_config_updater/add_cluster/test_add_cluster.py
@@ -1774,7 +1774,8 @@ def setup_add_cluster(tbinfo,
 # Test Definitions
 # -----------------------------
 
-def test_add_cluster(tbinfo,
+def test_add_cluster(skip_t2_isolated_topo,
+                     tbinfo,
                      duthosts,
                      initialize_random_variables,
                      ptfadapter,

--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -386,7 +386,7 @@ def get_dev_port_and_route(duthost, asichost, dst_prefix_set):
     return dev_port, route_to_ping
 
 
-def test_route_flap(duthosts, tbinfo, ptfhost, ptfadapter,
+def test_route_flap(skip_t2_isolated_topo, duthosts, tbinfo, ptfhost, ptfadapter,
                     get_function_completeness_level, announce_default_routes,
                     enum_rand_one_per_hwsku_frontend_hostname,
                     enum_upstream_dut_hostname, enum_rand_one_frontend_asic_index,


### PR DESCRIPTION

### Description of PR
The test relies on `enum_upstream_dut_hostname` fixture which requires the DUT to have at least one upstream neighbor of type T3 when the topology type is t2. On topology t2-isolated-d128s2, the DUT only has T1 neighbors by design, so the fixture fails with:

**tests/bgp/test_bgp_azng_migration.py**
**tests/generic_config_updater/add_cluster/test_add_cluster.py**

```
  Failed: Did not find a dut in duthosts that for topo type t2 that
  has upstream nbr type T3
```

**tests/bgp/test_prefix_list.py**

```
  Failed: Prefix announcing is unexpected before adding specific
  routes: {'50c0::/48', '60c0::/48', ...}
```

tests/acl/test_acl.py
tests/fib/test_fib.py
Skip acl and fib test on topology t2-isolated-d128s2
All the neighbors are T1 neighbor, there is no upstream neighbors
The acl and fib test rely on the upstream role, as a result, they could not be run

tests/route/test_route_flap.py
Route flap test request uplink neighbor T3

This is a topology applicability issue.
Skip the test on isolated t2 topologies.

Summary:
Fixes # (issue)


### Type of change


- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
Cases failing on t2-isolated topology:
**tests/bgp/test_bgp_azng_migration.py**
**tests/generic_config_updater/add_cluster/test_add_cluster.py**

  Failed: Did not find a dut in duthosts that for topo type t2 that
  has upstream nbr type T3

**tests/bgp/test_prefix_list.py**

  Failed: Prefix announcing is unexpected before adding specific
  routes: {'50c0::/48', '60c0::/48', ...}
#### How did you do it?
Skip the test on isolated t2 topologies due to no T3 neighbor in the topology.
#### How did you verify/test it?
Run pass locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

