### PR TITLE
[bgp] Fix AttributeError on single-ASIC DUT in test_bgp_authentication

### DIFF
--- a/tests/bgp/test_bgp_authentication.py
+++ b/tests/bgp/test_bgp_authentication.py
@@ -51,7 +51,7 @@ def get_peer_addrs(tbinfo, tor1, dut_asn, confed_asn):
 
 
 def get_bgp_neighbor_info(duthost, asic_index, tor1, bgp_facts=None):
-    skip_hosts = set([host.lower() for host in duthost.get_asic_namespace_list()])
+    skip_hosts = set([host.lower() for host in duthost.get_asic_namespace_list() if host])
     if bgp_facts is None:
         bgp_facts = duthost.bgp_facts(instance_id=asic_index)['ansible_facts']
     neighbor_info = {


### PR DESCRIPTION

### Description of PR
get_bgp_neighbor_info() crashes with:

`  AttributeError: 'NoneType' object has no attribute 'lower'`

when iterating duthost.get_asic_namespace_list(), because single-ASIC DUTs return [None] from that helper. 
Skip None entries before calling .lower() to make the function work on both single-ASIC and multi-ASIC platforms.

Summary:
Fixes # (issue)


### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
get_bgp_neighbor_info() crashes with:

`  AttributeError: 'NoneType' object has no attribute 'lower'`
#### How did you do it?
Skip None entries before calling .lower() to make the function work on both single-ASIC and multi-ASIC platforms.
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
