### PR TITLE
Skip test_static_route_removal_after_config_reload on v6 topology

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4951,7 +4951,7 @@ route/test_static_route.py::test_static_route_ipv6_warmboot:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
 
 route/test_static_route.py::test_static_route_removal_after_config_reload:
-  skip:
+  xfail:
     reason: "Testcase ignored on IPv6-only topology due to Github issue https://github.com/sonic-net/sonic-mgmt/issues/25841"
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/25841 and '-v6-' in topo_name"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4950,6 +4950,12 @@ route/test_static_route.py::test_static_route_ipv6_warmboot:
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
 
+route/test_static_route.py::test_static_route_removal_after_config_reload:
+  skip:
+    reason: "Testcase ignored on IPv6-only topology due to Github issue https://github.com/sonic-net/sonic-mgmt/issues/25841"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/25841 and '-v6-' in topo_name"
+
 route/test_static_route.py::test_static_route_warmboot:
   skip:
     reason: "Warm reboot is not supported on dualtor topology"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4951,10 +4951,10 @@ route/test_static_route.py::test_static_route_ipv6_warmboot:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
 
 route/test_static_route.py::test_static_route_removal_after_config_reload:
-  xfail:
-    reason: "Testcase ignored on IPv6-only topology due to Github issue https://github.com/sonic-net/sonic-mgmt/issues/25841"
+  skip:
+    reason: "IPv4 static route test is not applicable to IPv6-only topology; covered by test_static_route_removal_after_config_reload_ipv6"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/25841 and '-v6-' in topo_name"
+      - "'-v6-' in topo_name"
 
 route/test_static_route.py::test_static_route_warmboot:
   skip:


### PR DESCRIPTION
### Description of PR

Summary:
Skip the IPv4 static-route reload test on IPv6-only topologies, where the test is not applicable.

Related to #25841

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: day-one issue

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: case skipped as expected

### Approach
#### What is the motivation for this PR?

The IPv4 case is not applicable to an IPv6-only topology. This PR only scopes the test out for that unsupported topology; it does not change static-route behavior.

#### How did you do it?

Added a conditional-mark skip for the IPv4 test on IPv6-only topologies. The IPv6 companion test continues to cover static-route removal after config reload.

#### How did you verify/test it?

Validated the conditional-mark configuration and its IPv6-only topology scope. Functional test evidence is not included in this PR description.

#### Any platform specific information?

The condition is limited to IPv6-only topologies.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

No documentation change is required.


