### PR TITLE
Skip SFP thermal test for passive copper N/A DOM

### DIFF
--- a/tests/platform_tests/test_sfp_thermal_state_db.py
+++ b/tests/platform_tests/test_sfp_thermal_state_db.py
@@ -10,6 +10,7 @@ import re
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.platform.transceiver_utils import get_passive_cable_port_list
 
 pytestmark = [
     pytest.mark.topology('any'),
@@ -361,6 +362,37 @@ class TestSfpThermalStateDb:
                 rows_with_thresholds += 1
                 if row_matched:
                     rows_verified += 1
+
+        no_numeric_dom_thresholds = not any([
+            dom_crit_high_values,
+            dom_crit_low_values,
+            dom_high_th_values,
+            dom_low_th_values
+        ])
+
+        # Only apply the passive-copper skip when no port reports a
+        # numeric DOM threshold. Mixed platforms with at least one numeric row
+        # continue through the normal majority-match validation below.
+        if rows_with_thresholds == 0 and no_numeric_dom_thresholds:
+            ports_with_dom_threshold_rows = set(dom_thresholds)
+            passive_cable_ports = set(get_passive_cable_port_list(duthost))
+            non_passive_cable_ports = sorted(
+                ports_with_dom_threshold_rows - passive_cable_ports
+            )
+
+            if non_passive_cable_ports:
+                pytest_assert(
+                    False,
+                    "No numeric TRANSCEIVER_DOM_THRESHOLD temperature values available, "
+                    "but non-passive-copper/unknown transceivers are present: {}".format(
+                        non_passive_cable_ports
+                    )
+                )
+
+            pytest.skip(
+                "No numeric TRANSCEIVER_DOM_THRESHOLD temperature values available "
+                "for passive copper transceivers"
+            )
 
         logger.info("Verified %d/%d SFP rows with thresholds matched TRANSCEIVER_DOM_THRESHOLD",
                     rows_verified, rows_with_thresholds)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #25857 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

**Tracking issue/work item for backport/cherry-pick request:**
Failure type: Day 1 issue

### Approach

#### What is the motivation for this PR?
`test_sfp_thresholds_match_xcvrd_tables` fails on platforms populated
  with passive copper/DAC transceivers when all DOM temperature threshold
  fields are reported as N/A.

  Example failure:

`Failed: Only 0/0 SFP rows had thresholds matching TRANSCEIVER_DOM_THRESHOLD. 
 At least 1 required. CLI SFP rows: 64, DOM threshold ports: 64`

#### How did you do it?
Used the existing `get_passive_cable_port_list()` helper to identify passive copper transceiver ports.

 The test skips only when:
  1. No CLI SFP rows contain numeric threshold values.
  2. No numeric TRANSCEIVER_DOM_THRESHOLD temperature values are present.
  3. All ports with DOM threshold rows are passive copper transceivers.

If any non-passive-copper or unknown transceiver is present, the test
fails instead of skipping.


#### How did you verify/test it?
Verified on affected DUTs that the test skips with:
`No numeric TRANSCEIVER_DOM_THRESHOLD temperature values available for passive copper transceivers`
  
Also verified on optical-transceiver DUTs from the test results that the test continues to pass normally 
when numeric DOM temperature thresholds are present.

#### Any platform specific information?
Observed on Arista 7050CX3/7260CX3 platforms with passive copper/DAC transceivers.

#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A