### PR TITLE
Fix system health PSU ignore check timing race in test_system_health_…

### DIFF
--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -384,7 +384,8 @@ def test_system_health_config(duthosts, enum_rand_one_per_hwsku_hostname,
                         duthost, STATE_DB, HEALTH_TABLE_NAME, psu_name)
                     return not value or expect_value != value
 
-                assert wait_until(DEFAULT_INTERVAL, FAST_INTERVAL, 0, _check_psu_is_ignored, duthost, psu_name), \
+                assert wait_until(DEFAULT_INTERVAL, FAST_INTERVAL, FAST_INTERVAL,
+                                  _check_psu_is_ignored, duthost, psu_name), \
                     'PSU check is still performed after it is configured to be ignored'
 
 


### PR DESCRIPTION
### Description of PR

`test_system_health_config` mocks a PSU as missing while the PSU check is on the
ignore list, then asserts (via `wait_until`) that the fault never shows up in the
`SYSTEM_HEALTH_INFO` STATE_DB table. The `_check_psu_is_ignored` condition treats
the check as "ignored" when the PSU field is **empty or does not contain the
expected fault**.

The `wait_until` call used an initial delay of `0`, so its first evaluation could
run before `healthd` had completed a poll cycle after the PSU was mocked missing.
At that moment the STATE_DB field is still empty, the condition returns `True`, and
the assertion passes immediately — a **false positive** that would pass even if the
PSU ignore feature was broken.

Give `healthd` one poll cycle before the first check by setting the `wait_until`
initial delay to `FAST_INTERVAL`. This way, if the PSU check were *not* actually
being ignored, the fault would have been populated into STATE_DB and the assertion
would correctly fail.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

Close a false-positive window in the PSU ignore check: with no initial delay, the
first `wait_until` poll could read an empty STATE_DB field before `healthd` polled
and pass regardless of whether the ignore actually worked.

#### How did you do it?

Changed the `wait_until` initial delay for `_check_psu_is_ignored` from `0` to
`FAST_INTERVAL`, so the first check only runs after `healthd` has had a poll cycle
to detect the mocked PSU fault.

#### How did you verify/test it?

Ran `test_system_health_config` on the testbed and confirmed the PSU ignore check
still passes when the feature works, and no longer passes prematurely on an empty
pre-poll read.

#### Any platform specific information?

None — the change is confined to test timing in
`tests/system_health/test_system_health.py` and does not alter SONiC runtime
behavior.

#### Supported testbed topology if it's a new test case?

Not a new test case; same topologies where `test_system_health` already runs.

### Documentation

- [ ] Not required. Adjusts test timing only; no user-facing or runtime changes.