### PR TITLE
[GCU]Adding GCU add-cluster test case load qos 

### DIFF
--- a/tests/generic_config_updater/add_cluster/test_load_qos.py
+++ b/tests/generic_config_updater/add_cluster/test_load_qos.py
@@ -44,7 +44,7 @@ def apply_patch_remove_qos_for_namespace(duthost,
             "path": "/{}/{}".format(namespace, path)
         })
 
-        tmpfile = generate_tmpfile(duthost)
+    tmpfile = generate_tmpfile(duthost)
 
     if apply:
 
@@ -83,7 +83,7 @@ def apply_patch_add_qos_for_namespace(duthost,
     from function 'apply_patch_remove_qos_for_namespace'.
 
     This function adds QoS configuration for the specified namespace by applying a patch on the DUT host.
-    It utilizesn the qos_config dictionary that includes all the requried information to add.
+    It utilizes the qos_config dictionary that includes all the required information to add.
     Optionally, it can verify the applied changes to ensure they meet the expected parameters.
 
     Args:

--- a/tests/generic_config_updater/add_cluster/test_load_qos.py
+++ b/tests/generic_config_updater/add_cluster/test_load_qos.py
@@ -1,0 +1,205 @@
+import json
+import logging
+import pytest
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.gu_utils import apply_patch, delete_tmpfile, expect_op_success, generate_tmpfile
+from tests.generic_config_updater.add_cluster.helpers import add_content_to_patch_file, \
+    change_interface_admin_state_for_namespace, get_cfg_info_from_dut
+
+pytestmark = [
+        pytest.mark.topology("t2")
+        ]
+
+logger = logging.getLogger(__name__)
+
+
+# -----------------------------
+# Helper functions that modify configuration via apply-patch
+# -----------------------------
+
+def apply_patch_remove_qos_for_namespace(duthost,
+                                         namespace,
+                                         apply=True,
+                                         verify=True,
+                                         patch_file=""):
+    """
+    Applies a patch to remove QoS configurations for a specific namespace on the DUT host.
+
+    This function removes QoS configurations from the specified namespace by applying a patch on the DUT host.
+    It can optionally verify that the QoS settings have been removed after the operation.
+
+    Applies changes at configuration paths:
+     - /<namespace>/BUFFER_PG
+     - /<namespace>/PORT_QOS_MAP
+    """
+
+    logger.info("{}: Removing QoS for ASIC namespace {}".format(
+        duthost.hostname, namespace)
+        )
+    json_patch = []
+    paths_to_remove = ['BUFFER_PG', 'PORT_QOS_MAP']
+    for path in paths_to_remove:
+        json_patch.append({
+            "op": "remove",
+            "path": "/{}/{}".format(namespace, path)
+        })
+
+        tmpfile = generate_tmpfile(duthost)
+
+    if apply:
+
+        try:
+            output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
+            expect_op_success(duthost, output)
+            if verify is True:
+                # verify CONFIG_DB
+                for path in paths_to_remove:
+                    logger.info("Verifying CONFIG_DB is cleared for path {}.".format(path))
+                    pytest_assert(not get_cfg_info_from_dut(duthost, path, namespace),
+                                  "Found unexpected QoS config for {} in CONFIG_DB.".format(path))
+                logger.info("CONFIG_DB successfully verified that doesn't contain QoS config.")
+                # verify APPL_DB
+                appl_db_tables = ['BUFFER_PG_TABLE']
+                for table in appl_db_tables:
+                    cmd = "sonic-db-cli -n {} APPL_DB keys {}:*".format(namespace, table)
+                    logger.info("Verifying APPL_DB table {} is cleared.".format(table))
+                    pytest_assert(not duthost.shell(cmd)["stdout"],
+                                  "Found unexpected QoS config for {} in APPL_DB.".format(table))
+                logger.info("APPL_DB successfully verified that doesn't contain QoS config.")
+        finally:
+            delete_tmpfile(duthost, tmpfile)
+    else:
+        add_content_to_patch_file(json.dumps(json_patch, indent=4), patch_file)
+
+
+def apply_patch_add_qos_for_namespace(duthost,
+                                      namespace,
+                                      qos_config,
+                                      apply=True,
+                                      verify=True,
+                                      patch_file=""):
+    """
+    Applies a patch to add QoS configuration for a specific namespace on the DUT host that had been previously removed
+    from function 'apply_patch_remove_qos_for_namespace'.
+
+    This function adds QoS configuration for the specified namespace by applying a patch on the DUT host.
+    It utilizesn the qos_config dictionary that includes all the requried information to add.
+    Optionally, it can verify the applied changes to ensure they meet the expected parameters.
+
+    Args:
+        duthost (object): DUT host object where the patch to add interfaces will be applied.
+        namespace (str): The namespace where the network interfaces should be added.
+        qos_config (dict): A dictionary containing the QoS configuration parameters to be applied.
+        verify (bool, optional): If True, verifies the configuration after applying the patch. Defaults to True.
+
+    Returns:
+        None
+
+    Raises:
+        Exception: If the patch or verification fails.
+    """
+    logger.info("{}: Adding QoS for ASIC namespace {}".format(
+        duthost.hostname, namespace)
+        )
+    json_patch = []
+    for path, value in list(qos_config.items()):
+        json_patch.append({
+            "op": "add",
+            "path": "/{}/{}".format(namespace, path),
+            "value": value
+        })
+
+    if apply:
+
+        tmpfile = generate_tmpfile(duthost)
+        logger.info("Temporary file: {}".format(tmpfile))
+        try:
+            output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
+            expect_op_success(duthost, output)
+            if verify is True:
+                # verify CONFIG_DB
+                for path, value in list(qos_config.items()):
+                    logger.info("Verifying CONFIG_DB is added back for path {}.".format(path))
+                    pytest_assert(get_cfg_info_from_dut(duthost, path, namespace) == value,
+                                  "Didn't find expected QoS config for {} in CONFIG_DB.".format(path))
+                logger.info("CONFIG_DB successfully verified to contain expected QoS config.")
+                # verify APPL_DB
+                appl_db_tables = ['BUFFER_PG']
+                for table in appl_db_tables:
+                    cmd = "sonic-db-cli -n {} APPL_DB keys {}_TABLE:*".format(namespace, table)
+                    logger.info("Verifying APPL_DB table {} includes valid config.".format(table))
+                    pytest_assert(len(duthost.shell(cmd)["stdout"].split('\n')) == len(qos_config.get(table)),
+                                  "Didn't find expected config for {} in APPL_DB.".format(table))
+                logger.info("APPL_DB successfully verified to include QoS config.")
+        finally:
+            delete_tmpfile(duthost, tmpfile)
+    else:
+        add_content_to_patch_file(json.dumps(json_patch, indent=4), patch_file)
+
+
+# -----------------------------
+# Test Definitions
+# -----------------------------
+
+@pytest.mark.disable_loganalyzer
+def test_load_qos(duthosts,
+                  rand_one_dut_front_end_hostname,
+                  enum_rand_one_asic_namespace):
+    """
+    Verifies QoS changes in the configuration path via the `apply-patch` mechanism,
+    specifically for the following configuration tables:
+    BUFFER_PG, PORT_QOS_MAP.
+
+    Steps involved:
+    1. **Backup of existing configuration**: The current configuration in the aforementioned tables is saved.
+    2. **Removal operation**: The `apply-patch remove` command is used to delete any info related to these config paths.
+    3. **Addition operation**: The initial saved configuration is restored using the `apply-patch add` command.
+
+    During both the removal and addition phases, the following verifications are performed:
+    - Ensure the changes have been correctly applied.
+    - Confirm that the changes are properly reflected in `CONFIG_DB`.
+    - Validate the propagation of changes to relevant tables in `APPL_DB`.
+
+    Parameters:
+    - `duthosts`: The DUT (Device Under Test) hosts participating in the test.
+    - `rand_one_dut_front_end_hostname`: The randomly selected hostname of one front-end DUT.
+    - `enum_rand_one_asic_namespace`: The randomly selected asic namespace.
+
+    """
+
+    duthost = duthosts[rand_one_dut_front_end_hostname]
+
+    config_facts = duthost.config_facts(
+        host=duthost.hostname, source="running", namespace=enum_rand_one_asic_namespace
+        )['ansible_facts']
+
+    buffer_pg_info = get_cfg_info_from_dut(duthost, 'BUFFER_PG', enum_rand_one_asic_namespace)
+    port_qos_map_info = get_cfg_info_from_dut(duthost, 'PORT_QOS_MAP', enum_rand_one_asic_namespace)
+    qos_config = {'BUFFER_PG': buffer_pg_info,
+                  'PORT_QOS_MAP': port_qos_map_info}
+
+    # shutdown interfaces for namespace
+    change_interface_admin_state_for_namespace(config_facts,
+                                               duthost,
+                                               enum_rand_one_asic_namespace,
+                                               status='down',
+                                               apply=True,
+                                               verify=True)
+    # remove qos for namespace
+    apply_patch_remove_qos_for_namespace(duthost,
+                                         enum_rand_one_asic_namespace,
+                                         apply=True,
+                                         verify=True)
+    # add qos for namespace
+    apply_patch_add_qos_for_namespace(duthost,
+                                      enum_rand_one_asic_namespace,
+                                      qos_config,
+                                      apply=True,
+                                      verify=True)
+    # startup interfaces for namespace
+    change_interface_admin_state_for_namespace(config_facts,
+                                               duthost,
+                                               enum_rand_one_asic_namespace,
+                                               status='up',
+                                               apply=True,
+                                               verify=True)

--- a/tests/generic_config_updater/add_cluster/test_load_qos.py
+++ b/tests/generic_config_updater/add_cluster/test_load_qos.py
@@ -1,10 +1,11 @@
 import json
 import logging
 import pytest
-from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.gu_utils import apply_patch, delete_tmpfile, expect_op_success, generate_tmpfile
 from tests.generic_config_updater.add_cluster.helpers import add_content_to_patch_file, \
     change_interface_admin_state_for_namespace, get_cfg_info_from_dut
+from tests.common.utilities import wait_until
 
 pytestmark = [
         pytest.mark.topology("t2")
@@ -19,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 def apply_patch_remove_qos_for_namespace(duthost,
                                          namespace,
+                                         qos_config,
                                          apply=True,
                                          verify=True,
                                          patch_file=""):
@@ -36,36 +38,126 @@ def apply_patch_remove_qos_for_namespace(duthost,
     logger.info("{}: Removing QoS for ASIC namespace {}".format(
         duthost.hostname, namespace)
         )
-    json_patch = []
-    paths_to_remove = ['BUFFER_PG', 'PORT_QOS_MAP']
-    for path in paths_to_remove:
-        json_patch.append({
-            "op": "remove",
-            "path": "/{}/{}".format(namespace, path)
-        })
+
+    #  Read the current CONFIG_DB so that we know exactly which keys exist for
+    buffer_pg_cfg = qos_config.get('BUFFER_PG') or {}
+    port_qos_map_cfg = qos_config.get('PORT_QOS_MAP') or {}
+
+    ns_path = '' if namespace is None else '/' + namespace
+
+    def _build_remove_ops(table_name, table_cfg):
+        """
+        Build per-key 'remove' ops for one table, filtering out any keys that
+        aren't per-port (e.g. 'global' in PORT_QOS_MAP, which we intentionally
+        leave in place to avoid unbinding the switch-level DSCP_TO_TC map).
+        If the set of keys we'd remove equals the full contents of the table
+        in ConfigDb, the table would end up empty and SONiC's GCU validator
+        rejects that ("empty tables ... not allowed in ConfigDb"). In that
+        case, emit a single table-level remove instead.
+        """
+        per_key_ops = []
+        keys_removed = []
+        for k in table_cfg:
+            if not k.startswith('Ethernet'):
+                # Skip non-port keys such as 'global'.
+                continue
+            per_key_ops.append({
+                "op": "remove",
+                "path": "{}/{}/{}".format(ns_path, table_name, k),
+            })
+            keys_removed.append(k)
+        if per_key_ops and len(keys_removed) == len(table_cfg):
+            logger.info(
+                "Every key in %s would be removed; using table-level remove "
+                "to avoid the ConfigDb empty-table rejection.", table_name,
+            )
+            per_key_ops = [{
+                "op": "remove",
+                "path": "{}/{}".format(ns_path, table_name),
+            }]
+            # keys_removed already lists all per-port keys we're clearing,
+            # keep it so the verify block below can still assert on them.
+        return per_key_ops, keys_removed
+
+    buffer_pg_ops, buffer_pg_removed = _build_remove_ops('BUFFER_PG', buffer_pg_cfg)
+    port_qos_map_ops, port_qos_map_removed = _build_remove_ops('PORT_QOS_MAP', port_qos_map_cfg)
+    json_patch = buffer_pg_ops + port_qos_map_ops
+
+    pytest_assert(json_patch,
+                  "No BUFFER_PG or PORT_QOS_MAP entries to remove "
+                  "in namespace {}.".format(namespace))
 
     tmpfile = generate_tmpfile(duthost)
 
     if apply:
-
         try:
             output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
             expect_op_success(duthost, output)
             if verify is True:
-                # verify CONFIG_DB
-                for path in paths_to_remove:
-                    logger.info("Verifying CONFIG_DB is cleared for path {}.".format(path))
-                    pytest_assert(not get_cfg_info_from_dut(duthost, path, namespace),
-                                  "Found unexpected QoS config for {} in CONFIG_DB.".format(path))
-                logger.info("CONFIG_DB successfully verified that doesn't contain QoS config.")
-                # verify APPL_DB
-                appl_db_tables = ['BUFFER_PG_TABLE']
-                for table in appl_db_tables:
-                    cmd = "sonic-db-cli -n {} APPL_DB keys {}:*".format(namespace, table)
-                    logger.info("Verifying APPL_DB table {} is cleared.".format(table))
-                    pytest_assert(not duthost.shell(cmd)["stdout"],
-                                  "Found unexpected QoS config for {} in APPL_DB.".format(table))
-                logger.info("APPL_DB successfully verified that doesn't contain QoS config.")
+                # Verify CONFIG_DB - only the removed per-port keys should be gone.
+                logger.info("Verifying CONFIG_DB no longer contains removed per-port entries.")
+                buffer_pg_after = get_cfg_info_from_dut(duthost, 'BUFFER_PG', namespace) or {}
+                port_qos_map_after = get_cfg_info_from_dut(duthost, 'PORT_QOS_MAP', namespace) or {}
+                for buffer_key in buffer_pg_removed:
+                    pytest_assert(
+                        buffer_key not in buffer_pg_after,
+                        "BUFFER_PG entry {} unexpectedly remained in CONFIG_DB.".format(buffer_key),
+                    )
+                for port_key in port_qos_map_removed:
+                    pytest_assert(
+                        port_key not in port_qos_map_after,
+                        "PORT_QOS_MAP entry {} unexpectedly remained in CONFIG_DB.".format(port_key),
+                    )
+                logger.info("CONFIG_DB successfully verified: active-port QoS entries removed.")
+                # Verify APPL_DB - the per-port BUFFER_PG_TABLE and
+                # PORT_QOS_TABLE keys we removed from CONFIG_DB should be gone.
+                # Also log everything that IS still present in these tables so
+                # any leftover / unexpected entries are visible at a glance.
+
+                ns_prefix = '' if namespace is None else '-n ' + namespace
+                appl_targets = [
+                    ('BUFFER_PG_TABLE', buffer_pg_removed),
+                    ('PORT_QOS_TABLE', port_qos_map_removed),
+                ]
+
+                def _appl_keys(appl_table):
+                    """Current list of APPL_DB keys under `appl_table`."""
+                    cmd = "sonic-db-cli {} APPL_DB keys {}:*".format(
+                        ns_prefix, appl_table)
+                    return [
+                        k for k in duthost.shell(cmd)["stdout"].splitlines()
+                        if k
+                    ]
+
+                for appl_table, removed_keys in appl_targets:
+                    expected_gone = {
+                        "{}:{}".format(appl_table, cfg_key.replace('|', ':'))
+                        for cfg_key in removed_keys
+                    }
+                    if expected_gone:
+                        logger.info(
+                            "Verifying APPL_DB %s no longer contains %d "
+                            "removed key(s): %s",
+                            appl_table, len(expected_gone),
+                            sorted(expected_gone),
+                        )
+                        pytest_assert(
+                            wait_until(
+                                30, 2, 0,
+                                lambda a=appl_table, e=expected_gone:
+                                not (e & set(_appl_keys(a))),
+                            ),
+                            "APPL_DB {} still contains removed keys: {}".format(
+                                appl_table,
+                                sorted(expected_gone & set(_appl_keys(appl_table))),
+                            ),
+                        )
+                    remaining = sorted(_appl_keys(appl_table))
+                    logger.info(
+                        "APPL_DB %s post-remove contents : %s",
+                        appl_table,
+                        remaining if remaining else "<empty>",
+                    )
         finally:
             delete_tmpfile(duthost, tmpfile)
     else:
@@ -101,47 +193,148 @@ def apply_patch_add_qos_for_namespace(duthost,
     logger.info("{}: Adding QoS for ASIC namespace {}".format(
         duthost.hostname, namespace)
         )
+
+    ns_path = '' if namespace is None else '/' + namespace
+    buffer_pg_saved = qos_config.get('BUFFER_PG') or {}
+    port_qos_map_saved = qos_config.get('PORT_QOS_MAP') or {}
+
+    # 2) Build the payload:
+    #    a) If a table is currently absent in CONFIG_DB (because remove
+    #       cleaned out its last key), first re-create it
+    #    b) Then one "add" op per active-port key from qos_config.
+
+    buffer_pg_current = get_cfg_info_from_dut(duthost, 'BUFFER_PG', namespace)
+    port_qos_map_current = get_cfg_info_from_dut(duthost, 'PORT_QOS_MAP', namespace)
+
     json_patch = []
-    for path, value in list(qos_config.items()):
+    if buffer_pg_saved and buffer_pg_current is None:
         json_patch.append({
             "op": "add",
-            "path": "/{}/{}".format(namespace, path),
-            "value": value
+            "path": "{}/BUFFER_PG".format(ns_path),
+            "value": {},
         })
+    if port_qos_map_saved and port_qos_map_current is None:
+        json_patch.append({
+            "op": "add",
+            "path": "{}/PORT_QOS_MAP".format(ns_path),
+            "value": {},
+        })
+    # BUFFER_PG per-key adds (key = "<port>|<pg_profile>").
+    buffer_pg_added = []
+    for buffer_key, value in buffer_pg_saved.items():
+            json_patch.append({
+                "op": "add",
+                "path": "{}/BUFFER_PG/{}".format(ns_path, buffer_key),
+                "value": value,
+            })
+            buffer_pg_added.append(buffer_key)
+    # PORT_QOS_MAP per-key adds (key = "<port>").
+    port_qos_map_added = []
+    for port_key, value in port_qos_map_saved.items():
+        if not port_key.startswith('Ethernet'):
+            continue
+        json_patch.append({
+                "op": "add",
+                "path": "{}/PORT_QOS_MAP/{}".format(ns_path, port_key),
+                "value": value,
+            })
+        port_qos_map_added.append(port_key)
+    pytest_assert(json_patch,
+                  "No BUFFER_PG or PORT_QOS_MAP entries to re-add for active "
+                  "interfaces in namespace {}.".format(namespace))
 
     if apply:
-
         tmpfile = generate_tmpfile(duthost)
         logger.info("Temporary file: {}".format(tmpfile))
         try:
             output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
             expect_op_success(duthost, output)
             if verify is True:
-                # verify CONFIG_DB
-                for path, value in list(qos_config.items()):
-                    logger.info("Verifying CONFIG_DB is added back for path {}.".format(path))
-                    pytest_assert(get_cfg_info_from_dut(duthost, path, namespace) == value,
-                                  "Didn't find expected QoS config for {} in CONFIG_DB.".format(path))
-                logger.info("CONFIG_DB successfully verified to contain expected QoS config.")
-                # verify APPL_DB
-                appl_db_tables = ['BUFFER_PG']
-                for table in appl_db_tables:
-                    cmd = "sonic-db-cli -n {} APPL_DB keys {}_TABLE:*".format(namespace, table)
-                    logger.info("Verifying APPL_DB table {} includes valid config.".format(table))
-                    pytest_assert(len(duthost.shell(cmd)["stdout"].split('\n')) == len(qos_config.get(table)),
-                                  "Didn't find expected config for {} in APPL_DB.".format(table))
-                logger.info("APPL_DB successfully verified to include QoS config.")
+                # Verify CONFIG_DB - the re-added per-port entries must match
+                # the values we captured before removal.
+                logger.info("Verifying CONFIG_DB contains the re-added per-port entries.")
+                buffer_pg_after = get_cfg_info_from_dut(duthost, 'BUFFER_PG', namespace) or {}
+                port_qos_map_after = get_cfg_info_from_dut(duthost, 'PORT_QOS_MAP', namespace) or {}
+                for buffer_key in buffer_pg_added:
+                    pytest_assert(
+                        buffer_pg_after.get(buffer_key) == buffer_pg_saved[buffer_key],
+                        "BUFFER_PG entry {} in CONFIG_DB does not match expected value.".format(
+                            buffer_key),
+                    )
+                for port_key in port_qos_map_added:
+                    pytest_assert(
+                        port_qos_map_after.get(port_key) == port_qos_map_saved[port_key],
+                        "PORT_QOS_MAP entry {} in CONFIG_DB does not match expected value.".format(
+                            port_key),
+                    )
+                logger.info("CONFIG_DB successfully verified: per-port QoS entries restored.")
         finally:
             delete_tmpfile(duthost, tmpfile)
     else:
         add_content_to_patch_file(json.dumps(json_patch, indent=4), patch_file)
 
 
+def verify_qos_in_appl_db(duthost, namespace, qos_config, timeout=60, interval=5):
+    """
+    Verify APPL_DB reflects qos_config after interfaces are up.
+    Uses wait_until to tolerate asynchronous propagation.
+    """
+    ns_prefix = "" if namespace is None else "-n " + namespace
+    # PORT_QOS_MAP intentionally skipped as APPL_DB
+    # do not maintain PORT_QOS_TABLE entries
+    table_map = {'BUFFER_PG': 'BUFFER_PG_TABLE'}
+    def _keys(appl_table):
+        cmd = "sonic-db-cli {} APPL_DB keys {}:*".format(ns_prefix, appl_table)
+        return [k for k in duthost.shell(cmd)["stdout"].splitlines() if k]
+    for cfg_table, appl_table in table_map.items():
+        expected = qos_config.get(cfg_table) or {}
+        if not expected:
+            continue
+        logger.info("Verifying APPL_DB table {} matches CONFIG_DB {}.".format(appl_table, cfg_table))
+        pytest_assert(
+            wait_until(timeout, interval, 0,
+                       lambda: len(_keys(appl_table)) == len(expected)),
+            "APPL_DB table {} has {} keys, expected {}.".format(
+                appl_table, len(_keys(appl_table)), len(expected)),
+        )
+
+
+
 # -----------------------------
 # Test Definitions
 # -----------------------------
 
-@pytest.mark.disable_loganalyzer
+@pytest.fixture(autouse=True)
+def ignore_expected_qos_errors(loganalyzer, rand_one_dut_front_end_hostname):
+    """Ignore errors that are expected while QoS is torn down and re-applied."""
+    if loganalyzer:
+        ignore_regexes = [
+            # -----------------------------------------------------------
+            # Broadcom T2: port-level DSCP_TC (SAI_PORT_ATTR_QOS_DSCP_TO_TC_MAP)
+            # cannot be re-bound at runtime. QosOrch drops the batch and
+            # syncd emits SAI_STATUS_NOT_IMPLEMENTED. NOTE: the switch-level
+            # variant is no longer triggered because this test does not
+            # remove/re-add PORT_QOS_MAP/'global'.
+            # -----------------------------------------------------------
+            r".*ERR syncd[0-9]*#syncd:.*sendApiResponse:.*SAI_COMMON_API_SET.*"
+            r"SAI_STATUS_NOT_IMPLEMENTED.*",
+            r".*ERR syncd[0-9]*#syncd:.*processQuadEvent:.*VID:.*RID:.*",
+            r".*ERR swss[0-9]*#orchagent:.*doTask:.*Failed to process QOS task, drop it.*",
+            # -----------------------------------------------------------
+            # BUFFER_PG churn: whole-table remove then per-key add produces
+            # transient errors from buffermgrd / BufferOrch.
+            # -----------------------------------------------------------
+            r".*ERR swss[0-9]*#buffermgrd.*",
+            r".*ERR swss[0-9]*#orchagent.*BufferOrch.*",
+            # -----------------------------------------------------------
+            # QoS / port admin state cycling.
+            # -----------------------------------------------------------
+            r".*ERR swss[0-9]*#orchagent.*QosOrch.*",
+            r".*ERR swss[0-9]*#orchagent.*setPortPfcAsym.*",
+            r".*ERR syncd[0-9]*#syncd.*SAI_API_(BUFFER|QOS_MAP|QUEUE).*",
+        ]
+        loganalyzer[rand_one_dut_front_end_hostname].ignore_regex.extend(ignore_regexes)
+
 def test_load_qos(duthosts,
                   rand_one_dut_front_end_hostname,
                   enum_rand_one_asic_namespace):
@@ -175,9 +368,20 @@ def test_load_qos(duthosts,
 
     buffer_pg_info = get_cfg_info_from_dut(duthost, 'BUFFER_PG', enum_rand_one_asic_namespace)
     port_qos_map_info = get_cfg_info_from_dut(duthost, 'PORT_QOS_MAP', enum_rand_one_asic_namespace)
+    pytest_require(
+        buffer_pg_info and port_qos_map_info,
+        "Skipping: DUT {} namespace {} has no BUFFER_PG or PORT_QOS_MAP config to exercise.".format(
+            duthost.hostname, enum_rand_one_asic_namespace),
+    )
     qos_config = {'BUFFER_PG': buffer_pg_info,
                   'PORT_QOS_MAP': port_qos_map_info}
 
+    # remove qos for namespace
+    apply_patch_remove_qos_for_namespace(duthost,
+                                         enum_rand_one_asic_namespace,
+                                         qos_config,
+                                         apply=True,
+                                         verify=True)
     # shutdown interfaces for namespace
     change_interface_admin_state_for_namespace(config_facts,
                                                duthost,
@@ -185,11 +389,6 @@ def test_load_qos(duthosts,
                                                status='down',
                                                apply=True,
                                                verify=True)
-    # remove qos for namespace
-    apply_patch_remove_qos_for_namespace(duthost,
-                                         enum_rand_one_asic_namespace,
-                                         apply=True,
-                                         verify=True)
     # add qos for namespace
     apply_patch_add_qos_for_namespace(duthost,
                                       enum_rand_one_asic_namespace,
@@ -203,3 +402,5 @@ def test_load_qos(duthosts,
                                                status='up',
                                                apply=True,
                                                verify=True)
+    # verify APPL_DB
+    verify_qos_in_appl_db(duthost, enum_rand_one_asic_namespace, qos_config)

--- a/tests/generic_config_updater/add_cluster/test_load_qos.py
+++ b/tests/generic_config_updater/add_cluster/test_load_qos.py
@@ -222,12 +222,12 @@ def apply_patch_add_qos_for_namespace(duthost,
     # BUFFER_PG per-key adds (key = "<port>|<pg_profile>").
     buffer_pg_added = []
     for buffer_key, value in buffer_pg_saved.items():
-            json_patch.append({
-                "op": "add",
-                "path": "{}/BUFFER_PG/{}".format(ns_path, buffer_key),
-                "value": value,
-            })
-            buffer_pg_added.append(buffer_key)
+        json_patch.append({
+            "op": "add",
+            "path": "{}/BUFFER_PG/{}".format(ns_path, buffer_key),
+            "value": value,
+        })
+        buffer_pg_added.append(buffer_key)
     # PORT_QOS_MAP per-key adds (key = "<port>").
     port_qos_map_added = []
     for port_key, value in port_qos_map_saved.items():
@@ -283,6 +283,7 @@ def verify_qos_in_appl_db(duthost, namespace, qos_config, timeout=60, interval=5
     # PORT_QOS_MAP intentionally skipped as APPL_DB
     # do not maintain PORT_QOS_TABLE entries
     table_map = {'BUFFER_PG': 'BUFFER_PG_TABLE'}
+
     def _keys(appl_table):
         cmd = "sonic-db-cli {} APPL_DB keys {}:*".format(ns_prefix, appl_table)
         return [k for k in duthost.shell(cmd)["stdout"].splitlines() if k]
@@ -298,11 +299,10 @@ def verify_qos_in_appl_db(duthost, namespace, qos_config, timeout=60, interval=5
                 appl_table, len(_keys(appl_table)), len(expected)),
         )
 
-
-
 # -----------------------------
 # Test Definitions
 # -----------------------------
+
 
 @pytest.fixture(autouse=True)
 def ignore_expected_qos_errors(loganalyzer, rand_one_dut_front_end_hostname):
@@ -334,6 +334,7 @@ def ignore_expected_qos_errors(loganalyzer, rand_one_dut_front_end_hostname):
             r".*ERR syncd[0-9]*#syncd.*SAI_API_(BUFFER|QOS_MAP|QUEUE).*",
         ]
         loganalyzer[rand_one_dut_front_end_hostname].ignore_regex.extend(ignore_regexes)
+
 
 def test_load_qos(duthosts,
                   rand_one_dut_front_end_hostname,

--- a/tests/generic_config_updater/add_cluster/test_load_qos.py
+++ b/tests/generic_config_updater/add_cluster/test_load_qos.py
@@ -87,9 +87,8 @@ def apply_patch_remove_qos_for_namespace(duthost,
                   "No BUFFER_PG or PORT_QOS_MAP entries to remove "
                   "in namespace {}.".format(namespace))
 
-    tmpfile = generate_tmpfile(duthost)
-
     if apply:
+        tmpfile = generate_tmpfile(duthost)
         try:
             output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
             expect_op_success(duthost, output)
@@ -115,9 +114,10 @@ def apply_patch_remove_qos_for_namespace(duthost,
                 # any leftover / unexpected entries are visible at a glance.
 
                 ns_prefix = '' if namespace is None else '-n ' + namespace
+                # PORT_QOS_MAP intentionally skipped as APPL_DB
+                # do not maintain PORT_QOS_TABLE entries
                 appl_targets = [
                     ('BUFFER_PG_TABLE', buffer_pg_removed),
-                    ('PORT_QOS_TABLE', port_qos_map_removed),
                 ]
 
                 def _appl_keys(appl_table):
@@ -287,17 +287,29 @@ def verify_qos_in_appl_db(duthost, namespace, qos_config, timeout=60, interval=5
     def _keys(appl_table):
         cmd = "sonic-db-cli {} APPL_DB keys {}:*".format(ns_prefix, appl_table)
         return [k for k in duthost.shell(cmd)["stdout"].splitlines() if k]
+
     for cfg_table, appl_table in table_map.items():
-        expected = qos_config.get(cfg_table) or {}
-        if not expected:
+        expected_cfg = qos_config.get(cfg_table) or {}
+        if not expected_cfg:
             continue
-        logger.info("Verifying APPL_DB table {} matches CONFIG_DB {}.".format(appl_table, cfg_table))
-        pytest_assert(
-            wait_until(timeout, interval, 0,
-                       lambda: len(_keys(appl_table)) == len(expected)),
-            "APPL_DB table {} has {} keys, expected {}.".format(
-                appl_table, len(_keys(appl_table)), len(expected)),
+        expected = {
+            "{}:{}".format(appl_table, cfg_key.replace('|', ':'))
+            for cfg_key in expected_cfg
+        }
+        logger.info(
+            "Verifying APPL_DB table {} matches CONFIG_DB {} ({} keys).".format(
+                appl_table, cfg_table, len(expected)),
         )
+
+        def _matches(_expected=expected, _table=appl_table):
+            return set(_keys(_table)) == _expected
+
+        pytest_assert(
+            wait_until(timeout, interval, 0, _matches),
+            "APPL_DB table {} keys mismatch. expected={}, actual={}".format(
+                appl_table, sorted(expected), sorted(_keys(appl_table))),
+        )
+
 
 # -----------------------------
 # Test Definitions
@@ -316,20 +328,22 @@ def ignore_expected_qos_errors(loganalyzer, rand_one_dut_front_end_hostname):
             # variant is no longer triggered because this test does not
             # remove/re-add PORT_QOS_MAP/'global'.
             # -----------------------------------------------------------
-            r".*ERR syncd[0-9]*#syncd:.*sendApiResponse:.*SAI_COMMON_API_SET.*"
-            r"SAI_STATUS_NOT_IMPLEMENTED.*",
+            (
+                r".*ERR syncd[0-9]*#syncd:.*sendApiResponse:.*SAI_COMMON_API_SET.*"
+                r"SAI_STATUS_NOT_IMPLEMENTED.*"
+            ),
             r".*ERR syncd[0-9]*#syncd:.*processQuadEvent:.*VID:.*RID:.*",
             r".*ERR swss[0-9]*#orchagent:.*doTask:.*Failed to process QOS task, drop it.*",
             # -----------------------------------------------------------
             # BUFFER_PG churn: whole-table remove then per-key add produces
             # transient errors from buffermgrd / BufferOrch.
             # -----------------------------------------------------------
-            r".*ERR swss[0-9]*#buffermgrd.*",
-            r".*ERR swss[0-9]*#orchagent.*BufferOrch.*",
+            r".*ERR swss[0-9]*#buffermgrd:.*Failed to apply.*BUFFER_PG.*",
+            r".*ERR swss[0-9]*#orchagent:.*BufferOrch.*Failed to process.*",
             # -----------------------------------------------------------
             # QoS / port admin state cycling.
             # -----------------------------------------------------------
-            r".*ERR swss[0-9]*#orchagent.*QosOrch.*",
+            r".*ERR swss[0-9]*#orchagent:.*QosOrch.*Failed to set.*DSCP_TO_TC.*",
             r".*ERR swss[0-9]*#orchagent.*setPortPfcAsym.*",
             r".*ERR syncd[0-9]*#syncd.*SAI_API_(BUFFER|QOS_MAP|QUEUE).*",
         ]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
(recreated_PR20653 -https://github.com/sonic-net/sonic-mgmt/pull/20653)
This PR adds test case load_qos.py as part of add-cluster GCU new scenarios.
This was originally included under https://github.com/sonic-net/sonic-mgmt/pull/14887
It also has dependency on common functions added via above PR.
Summary:
This PR is recreated from PR20653 + enhancement from pr comments 
the test refactor from bulk remove/add of whole QoS tables to per‑key operations that spare PORT_QOS_MAP/global, add empty‑table fallback for GCU, thread qos_config through the remove step, split CONFIG_DB and APPL_DB verification into targeted per‑key checks (with a wait_until‑based post‑add APPL_DB verifier, and reorder the test sequence to remove → shutdown → add → startup → verify.

Fixes # (issue)

<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
This PR incorporates the comments from the old PR#20653
- Corrected the namespace usage for single-ASIC t2 linecard
-  verifying APPL_DB with ports up and wrapping the read in wait_until
- Added targeted loganalyzer.ignore_regex
- Reorder the test sequence

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
