### PR TITLE
Test BGP Session - T1 Update

### DIFF
--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -37,12 +37,26 @@ def enable_container_autorestart(duthosts, enum_frontend_dut_hostname):
             duthost.shell("sudo config feature autorestart {} disabled".format(feature))
 
 
+def _map_bgp_neighbor_to_interfaces(neighbor_name, dev_nbrs, portchannels):
+    """Map a BGP neighbor device name to local DUT member interfaces."""
+    interfaces = {}
+    for ifname, nbr_info in dev_nbrs.items():
+        if nbr_info.get('name') != neighbor_name:
+            continue
+        if ifname in portchannels:
+            for member in portchannels[ifname]:
+                if member in dev_nbrs:
+                    interfaces[member] = dev_nbrs[member]
+        else:
+            interfaces[ifname] = nbr_info
+    return interfaces
+
+
 @pytest.fixture(scope='module')
 def setup(duthosts, enum_frontend_dut_hostname, enum_rand_one_frontend_asic_index,
           nbrhosts, fanouthosts):
     duthost = duthosts[enum_frontend_dut_hostname]
     asic_index = enum_rand_one_frontend_asic_index
-    asichost = duthost.asic_instance(asic_index)
 
     config_facts = get_asic_config_facts(duthost, asic_index)
     # If frr_mgmt_framework_config is set to true, expect vrf name in the config facts
@@ -73,57 +87,12 @@ def setup(duthosts, enum_frontend_dut_hostname, enum_rand_one_frontend_asic_inde
     pytest_assert(wait_until(120, 5, 0, duthost.check_bgp_session_state, list(bgp_neighbors.keys())),
                   "Not all BGP sessions are established on DUT")
 
-    ip_intfs = asichost.show_and_parse('show ip interface')
-    ipv6_intfs = asichost.show_and_parse('show ipv6 interfaces')
-    logger.debug("setup ip_intfs {}".format(ip_intfs))
-
-    # Create a mapping of neighbor IP to interfaces and their details
-    neighbor_ip_to_interfaces = {}
-
-    # Loop through the ip_intfs list to populate the mapping
-    for ip_intf in ip_intfs:
-        neighbor_ip = ip_intf['neighbor ip']
-        interface_name = ip_intf['interface']
-        if neighbor_ip not in neighbor_ip_to_interfaces:
-            neighbor_ip_to_interfaces[neighbor_ip] = {}
-
-        # Check if the interface is in portchannels and get the relevant devices
-        if interface_name in portchannels:
-            for dev_name in portchannels[interface_name]:
-                if dev_name in dev_nbrs and dev_nbrs[dev_name]['name'] == ip_intf['bgp neighbor']:
-                    neighbor_ip_to_interfaces[neighbor_ip][dev_name] = dev_nbrs[dev_name]
-        # If not in portchannels, check directly in dev_nbrs
-        elif interface_name in dev_nbrs and dev_nbrs[interface_name]['name'] == ip_intf['bgp neighbor']:
-            neighbor_ip_to_interfaces[neighbor_ip][interface_name] = dev_nbrs[interface_name]
-
-    # Loop through the ip_intfs list to populate the mapping
-    for ipv6_intf in ipv6_intfs:
-        neighbor_ip = ipv6_intf['neighbor ip']
-        interface_name = ipv6_intf['interface']
-        if neighbor_ip not in neighbor_ip_to_interfaces:
-            neighbor_ip_to_interfaces[neighbor_ip] = {}
-
-        # Check if the interface is in portchannels and get the relevant devices
-        if interface_name in portchannels:
-            for dev_name in portchannels[interface_name]:
-                if dev_name in dev_nbrs and dev_nbrs[dev_name]['name'] == ipv6_intf['bgp neighbor']:
-                    neighbor_ip_to_interfaces[neighbor_ip][dev_name] = dev_nbrs[dev_name]
-        # If not in portchannels, check directly in dev_nbrs
-        elif interface_name in dev_nbrs and dev_nbrs[interface_name]['name'] == ipv6_intf['bgp neighbor']:
-            neighbor_ip_to_interfaces[neighbor_ip][interface_name] = dev_nbrs[interface_name]
-
-    # Update bgp_neighbors with the new 'interface' key
-    # If frr_mgmt_framework_config is set to true, expect vrf name in the config facts
     for ip, details in bgp_neighbors.items():
-        logger.debug(ip)
-        if check_frr_mgmt_framework_config(duthost, asic_index):
-            get_ip = f"({vrfname}, '{ip}')"
-        else:
-            get_ip = ip
-        logger.debug(neighbor_ip_to_interfaces)
-        logger.debug(neighbor_ip_to_interfaces[get_ip])
-        if get_ip in neighbor_ip_to_interfaces:
-            details['interface'] = neighbor_ip_to_interfaces[get_ip]
+        interfaces = _map_bgp_neighbor_to_interfaces(
+            details['name'], dev_nbrs, portchannels
+        )
+        if interfaces:
+            details['interface'] = interfaces
 
     bgp_neighbor = None
     for ip, details in bgp_neighbors.items():

--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -19,7 +19,7 @@ pytestmark = [
 
 @pytest.fixture
 def enable_container_autorestart(duthosts, enum_frontend_dut_hostname):
-    # Enable autorestart for all features
+    # Enable autorestart for all features.
     duthost = duthosts[enum_frontend_dut_hostname]
     feature_list, _ = duthost.get_feature_status()
     feature_list.pop('frr_bmp', None)

--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -6,7 +6,7 @@ from tests.common.platform.device_utils import fanout_switch_port_lookup
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
-from tests.common.helpers.bgp import get_asic_config_facts, get_db_cli_prefix
+from tests.common.helpers.bgp import get_asic_config_facts
 from tests.common.reboot import reboot
 
 logger = logging.getLogger(__name__)
@@ -36,17 +36,24 @@ def enable_container_autorestart(duthosts, enum_frontend_dut_hostname):
             duthost.shell("sudo config feature autorestart {} disabled".format(feature))
 
 
-def _map_bgp_neighbor_to_interfaces(neighbor_name, dev_nbrs):
+def _map_bgp_neighbor_to_interfaces(neighbor_name, dev_nbrs, portchannels=None):
     """Map a BGP neighbor device name to local DUT member interfaces.
 
-    DEVICE_NEIGHBOR keys are physical ports (Ethernet*). LAG members appear as
-    their own entries, so no PortChannel-name lookup is needed here.
+    DEVICE_NEIGHBOR keys are physical ports (Ethernet*) or LAG interfaces
+    (PortChannel*). LAG-backed neighbors are expanded to member ports via
+    PORTCHANNEL_MEMBER; members that also appear directly are included once.
     """
     interfaces = {}
+    portchannels = portchannels or {}
     for ifname, nbr_info in dev_nbrs.items():
         if nbr_info.get('name') != neighbor_name:
             continue
-        interfaces[ifname] = nbr_info
+        if ifname in portchannels:
+            for member in portchannels[ifname]:
+                if member in dev_nbrs:
+                    interfaces[member] = dev_nbrs[member]
+        else:
+            interfaces[ifname] = nbr_info
     return interfaces
 
 
@@ -64,9 +71,10 @@ def setup(duthosts, enum_frontend_dut_hostname, enum_rand_one_frontend_asic_inde
     duthost = duthosts[enum_frontend_dut_hostname]
     asic_index = enum_rand_one_frontend_asic_index
 
+    asichost = duthost.asic_instance(asic_index)
     config_facts = get_asic_config_facts(duthost, asic_index)
-    # If frr_mgmt_framework_config is set to true, expect vrf name in the config facts
-    if check_frr_mgmt_framework_config(duthost, asic_index):
+    # DEVICE_METADATA lives in host CONFIG_DB; use duthost helper, not per-ASIC namespace.
+    if duthost.get_frr_mgmt_framework_config():
         all_bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {})
         all_bgp_neighbors = all_bgp_neighbors[vrfname]
     else:
@@ -89,12 +97,13 @@ def setup(duthosts, enum_frontend_dut_hostname, enum_rand_one_frontend_asic_inde
     logger.debug("setup dev_nbrs {}".format(dev_nbrs))
     logger.debug("setup portchannels {}".format(portchannels))
 
-    # verify sessions are established
-    pytest_assert(wait_until(120, 5, 0, duthost.check_bgp_session_state, list(bgp_neighbors.keys())),
-                  "Not all BGP sessions are established on DUT")
+    # verify sessions are established on the selected ASIC
+    neigh_ips = list(bgp_neighbors.keys())
+    pytest_assert(wait_until(120, 5, 0, asichost.check_bgp_session_state, neigh_ips),
+                  "Not all BGP sessions are established on DUT ASIC {}".format(asic_index))
 
     for ip, details in bgp_neighbors.items():
-        interfaces = _map_bgp_neighbor_to_interfaces(details['name'], dev_nbrs)
+        interfaces = _map_bgp_neighbor_to_interfaces(details['name'], dev_nbrs, portchannels)
         if interfaces:
             details['interface'] = interfaces
 
@@ -122,8 +131,8 @@ def setup(duthosts, enum_frontend_dut_hostname, enum_rand_one_frontend_asic_inde
 
     yield setup_info
 
-    # verify sessions are established after test
-    if not duthost.check_bgp_session_state(bgp_neighbors):
+    # verify sessions are established after test on the selected ASIC
+    if not asichost.check_bgp_session_state(neigh_ips):
         local_interfaces = list(bgp_neighbors[bgp_neighbor]['interface'].keys())
         for port in local_interfaces:
             fanout, fanout_port = fanout_switch_port_lookup(fanouthosts, duthost.hostname, port)
@@ -136,26 +145,8 @@ def setup(duthosts, enum_frontend_dut_hostname, enum_rand_one_frontend_asic_inde
             nbrhosts[neighbor_name]['host'].no_shutdown(neighbor_port)
             time.sleep(1)
 
-        pytest_assert(wait_until(120, 10, 0, duthost.check_bgp_session_state, list(bgp_neighbors.keys())),
-                      "Not all BGP sessions are established on DUT")
-
-
-def check_frr_mgmt_framework_config(duthost, asic_index):
-    """
-    Check if frr_mgmt_framework_config is set to "true" in DEVICE_METADATA
-
-    Args:
-        duthost: DUT host object
-        asic_index: ASIC index for namespace-scoped CONFIG_DB access
-
-    Returns:
-        bool: True if frr_mgmt_framework_config is "true", False otherwise
-    """
-    cmd = '{} CONFIG_DB HGET "DEVICE_METADATA|localhost" "frr_mgmt_framework_config"'.format(
-        get_db_cli_prefix(duthost, asic_index)
-    )
-    frr_config = duthost.shell(cmd)
-    return frr_config.get("stdout", "").strip() == "true"
+        pytest_assert(wait_until(120, 10, 0, asichost.check_bgp_session_state, neigh_ips),
+                      "Not all BGP sessions are established on DUT ASIC {}".format(asic_index))
 
 
 def verify_bgp_session_down(duthost, bgp_neighbor, asic_index):
@@ -365,5 +356,5 @@ def test_bgp_session_interface_down(duthosts, enum_frontend_dut_hostname, fanout
     if test_type == "swss_docker":
         # It may take up to 6 minutes after restarting swss for BGP sessions to be up
         timeout = 360
-    pytest_assert(wait_until(timeout, 10, 0, duthost.check_bgp_session_state, list(setup['neighhosts'].keys())),
-                  "Not all BGP sessions are established on DUT")
+    pytest_assert(wait_until(timeout, 10, 0, asichost.check_bgp_session_state, list(setup['neighhosts'].keys())),
+                  "Not all BGP sessions are established on DUT ASIC {}".format(asic_index))

--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -6,6 +6,7 @@ from tests.common.platform.device_utils import fanout_switch_port_lookup
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
+from tests.common.helpers.bgp import get_asic_config_facts, get_db_cli_prefix
 from tests.common.helpers.dut_utils import is_virtual_platform
 from tests.common.reboot import reboot
 
@@ -18,9 +19,9 @@ pytestmark = [
 
 
 @pytest.fixture
-def enable_container_autorestart(duthosts, rand_one_dut_hostname):
+def enable_container_autorestart(duthosts, enum_frontend_dut_hostname):
     # Enable autorestart for all features
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_frontend_dut_hostname]
     feature_list, _ = duthost.get_feature_status()
     feature_list.pop('frr_bmp', None)
     container_autorestart_states = duthost.get_container_autorestart_states()
@@ -37,33 +38,43 @@ def enable_container_autorestart(duthosts, rand_one_dut_hostname):
 
 
 @pytest.fixture(scope='module')
-def setup(duthosts, rand_one_dut_hostname, nbrhosts, fanouthosts):
-    duthost = duthosts[rand_one_dut_hostname]
+def setup(duthosts, enum_frontend_dut_hostname, enum_rand_one_frontend_asic_index,
+          nbrhosts, fanouthosts):
+    duthost = duthosts[enum_frontend_dut_hostname]
+    asic_index = enum_rand_one_frontend_asic_index
+    asichost = duthost.asic_instance(asic_index)
 
-    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    config_facts = get_asic_config_facts(duthost, asic_index)
     # If frr_mgmt_framework_config is set to true, expect vrf name in the config facts
-    if check_frr_mgmt_framework_config(duthost):
-        bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {})
-        bgp_neighbors = bgp_neighbors[vrfname]
+    if check_frr_mgmt_framework_config(duthost, asic_index):
+        all_bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {})
+        all_bgp_neighbors = all_bgp_neighbors[vrfname]
     else:
-        bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {})
+        all_bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {})
+    bgp_neighbors = {
+        ip: details for ip, details in all_bgp_neighbors.items()
+        if details.get('name') in nbrhosts
+    }
+    if not bgp_neighbors:
+        pytest.skip(
+            "No external BGP neighbors on ASIC {} of DUT {}".format(asic_index, duthost.hostname)
+        )
+
     portchannels = config_facts.get('PORTCHANNEL_MEMBER', {})
     dev_nbrs = config_facts.get('DEVICE_NEIGHBOR', {})
-    bgp_neighbor = list(bgp_neighbors.keys())[0]
 
     logger.debug("setup config_facts {}".format(config_facts))
     logger.debug("setup nbrhosts {}".format(nbrhosts))
     logger.debug("setup bgp_neighbors {}".format(bgp_neighbors))
     logger.debug("setup dev_nbrs {}".format(dev_nbrs))
     logger.debug("setup portchannels {}".format(portchannels))
-    logger.debug("setup test_neighbor {}".format(bgp_neighbor))
 
     # verify sessions are established
     pytest_assert(wait_until(120, 5, 0, duthost.check_bgp_session_state, list(bgp_neighbors.keys())),
                   "Not all BGP sessions are established on DUT")
 
-    ip_intfs = duthost.show_and_parse('show ip interface')
-    ipv6_intfs = duthost.show_and_parse('show ipv6 interfaces')
+    ip_intfs = asichost.show_and_parse('show ip interface')
+    ipv6_intfs = asichost.show_and_parse('show ipv6 interfaces')
     logger.debug("setup ip_intfs {}".format(ip_intfs))
 
     # Create a mapping of neighbor IP to interfaces and their details
@@ -105,7 +116,7 @@ def setup(duthosts, rand_one_dut_hostname, nbrhosts, fanouthosts):
     # If frr_mgmt_framework_config is set to true, expect vrf name in the config facts
     for ip, details in bgp_neighbors.items():
         logger.debug(ip)
-        if check_frr_mgmt_framework_config(duthost):
+        if check_frr_mgmt_framework_config(duthost, asic_index):
             get_ip = f"({vrfname}, '{ip}')"
         else:
             get_ip = ip
@@ -114,9 +125,24 @@ def setup(duthosts, rand_one_dut_hostname, nbrhosts, fanouthosts):
         if get_ip in neighbor_ip_to_interfaces:
             details['interface'] = neighbor_ip_to_interfaces[get_ip]
 
+    bgp_neighbor = None
+    for ip, details in bgp_neighbors.items():
+        if details.get('interface'):
+            bgp_neighbor = ip
+            break
+    if bgp_neighbor is None:
+        pytest.skip(
+            "No external BGP neighbor with mapped interface on ASIC {} of DUT {}".format(
+                asic_index, duthost.hostname
+            )
+        )
+
+    logger.debug("setup test_neighbor {}".format(bgp_neighbor))
+
     setup_info = {
         'neighhosts': bgp_neighbors,
-        "test_neighbor": bgp_neighbor
+        "test_neighbor": bgp_neighbor,
+        "asic_index": asic_index,
     }
 
     logger.debug('Setup_info: {}'.format(setup_info))
@@ -141,23 +167,27 @@ def setup(duthosts, rand_one_dut_hostname, nbrhosts, fanouthosts):
                       "Not all BGP sessions are established on DUT")
 
 
-def check_frr_mgmt_framework_config(duthost):
+def check_frr_mgmt_framework_config(duthost, asic_index):
     """
     Check if frr_mgmt_framework_config is set to "true" in DEVICE_METADATA
 
     Args:
         duthost: DUT host object
+        asic_index: ASIC index for namespace-scoped CONFIG_DB access
 
     Returns:
         bool: True if frr_mgmt_framework_config is "true", False otherwise
     """
-    frr_config = duthost.shell('sonic-db-cli CONFIG_DB HGET "DEVICE_METADATA|localhost" "frr_mgmt_framework_config"')
-    return frr_config == "true"
+    cmd = '{} CONFIG_DB HGET "DEVICE_METADATA|localhost" "frr_mgmt_framework_config"'.format(
+        get_db_cli_prefix(duthost, asic_index)
+    )
+    frr_config = duthost.shell(cmd)
+    return frr_config.get("stdout", "").strip() == "true"
 
 
-def verify_bgp_session_down(duthost, bgp_neighbor):
-    """Verify the bgp session to the DUT is established."""
-    bgp_facts = duthost.bgp_facts()["ansible_facts"]
+def verify_bgp_session_down(duthost, bgp_neighbor, asic_index):
+    """Verify the bgp session to the DUT is down."""
+    bgp_facts = duthost.bgp_facts(instance_id=asic_index)["ansible_facts"]
     return (
         bgp_neighbor in bgp_facts["bgp_neighbors"]
         and bgp_facts["bgp_neighbors"][bgp_neighbor]["state"] != "established"
@@ -215,7 +245,7 @@ def _restore_neighbors(nbrhosts, setup, neighbor_name, local_interfaces):
 
 
 @pytest.fixture
-def failure_injection(duthosts, rand_one_dut_hostname, fanouthosts, nbrhosts, setup):
+def failure_injection(duthosts, enum_frontend_dut_hostname, fanouthosts, nbrhosts, setup):
     """Fixture to guarantee cleanup of injected failures.
 
     The test body calls inject() to apply the failure after skip checks pass.
@@ -223,7 +253,8 @@ def failure_injection(duthosts, rand_one_dut_hostname, fanouthosts, nbrhosts, se
 
     See: https://github.com/sonic-net/sonic-mgmt/issues/22246
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_frontend_dut_hostname]
+    asichost = duthost.asic_instance(setup['asic_index'])
     state = {'injected': False, 'failure_type': None}
 
     class FailureContext:
@@ -244,8 +275,8 @@ def failure_injection(duthosts, rand_one_dut_hostname, fanouthosts, nbrhosts, se
             else:
                 raise ValueError("Unsupported failure_type: {}".format(failure_type))
 
-            duthost.shell('show ip bgp summary', module_ignore_errors=True)
-            duthost.shell('show ipv6 bgp summary', module_ignore_errors=True)
+            asichost.shell('show ip bgp summary', module_ignore_errors=True)
+            asichost.shell('show ipv6 bgp summary', module_ignore_errors=True)
 
         def restore(self):
             """Explicitly restore injected failures so the test can verify recovery.
@@ -273,7 +304,7 @@ def failure_injection(duthosts, rand_one_dut_hostname, fanouthosts, nbrhosts, se
 @pytest.mark.parametrize("test_type", ["bgp_docker", "swss_docker", "reboot"])
 @pytest.mark.parametrize("failure_type", ["interface", "neighbor"])
 @pytest.mark.disable_loganalyzer
-def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts, localhost,
+def test_bgp_session_interface_down(duthosts, enum_frontend_dut_hostname, fanouthosts, localhost,
                                     enable_container_autorestart,
                                     nbrhosts, setup, test_type, failure_type, tbinfo,
                                     failure_injection):
@@ -283,7 +314,9 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
     4: do the test, reset bgp or swss or do the reboot
     5: Verify all bgp sessions are up
     '''
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_frontend_dut_hostname]
+    asic_index = setup['asic_index']
+    asichost = duthost.asic_instance(asic_index)
 
     # Skip the test on dualtor with reboot test type
     pytest_require(
@@ -315,7 +348,7 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
     # default keepalive is 60 seconds, hold time 180 seconds. Use 240 seconds to provide a safety margin
     # and avoid a race condition where BGP takes the full hold time (~180s) to go down.
     pytest_assert(
-        wait_until(240, 10, 0, verify_bgp_session_down, duthost, neighbor),
+        wait_until(240, 10, 0, verify_bgp_session_down, duthost, neighbor, asic_index),
         "neighbor {} state is still established".format(neighbor)
     )
 
@@ -326,12 +359,12 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
     # - In Debian 13, this is correctly counted, causing the start limit to be reached and bgp service cannot start.
     # To avoid this issue, reset the systemd failed state counter before service restart.
     if test_type in ("bgp_docker", "swss_docker"):
-        duthost.shell("sudo systemctl reset-failed bgp.service")
+        duthost.shell("sudo systemctl reset-failed {}".format(asichost.get_service_name("bgp")))
 
     if test_type == "bgp_docker":
-        duthost.shell("systemctl restart bgp")
+        duthost.restart_service_on_asic("bgp", asic_index)
     elif test_type == "swss_docker":
-        duthost.shell("systemctl restart swss")
+        duthost.shell("sudo systemctl restart {}".format(asichost.get_service_name("swss")))
     elif test_type == "reboot":
         # Use warm reboot for t0, cold reboot for others
         topo_name = tbinfo["topo"]["name"]

--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -346,7 +346,7 @@ def test_bgp_session_interface_down(duthosts, enum_frontend_dut_hostname, fanout
     pytest_assert(wait_until(360, 10, 120, duthost.critical_services_fully_started),
                   "Not all critical services are fully started")
 
-    # Restore interfaces/neighbors before verifying BGP recovery
+    # Restore interfaces/neighbors before verifying BGP recovery.
     failure_injection.restore()
 
     pytest_assert(wait_until(120, 10, 30, duthost.critical_services_fully_started),

--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -36,18 +36,17 @@ def enable_container_autorestart(duthosts, enum_frontend_dut_hostname):
             duthost.shell("sudo config feature autorestart {} disabled".format(feature))
 
 
-def _map_bgp_neighbor_to_interfaces(neighbor_name, dev_nbrs, portchannels):
-    """Map a BGP neighbor device name to local DUT member interfaces."""
+def _map_bgp_neighbor_to_interfaces(neighbor_name, dev_nbrs):
+    """Map a BGP neighbor device name to local DUT member interfaces.
+
+    DEVICE_NEIGHBOR keys are physical ports (Ethernet*). LAG members appear as
+    their own entries, so no PortChannel-name lookup is needed here.
+    """
     interfaces = {}
     for ifname, nbr_info in dev_nbrs.items():
         if nbr_info.get('name') != neighbor_name:
             continue
-        if ifname in portchannels:
-            for member in portchannels[ifname]:
-                if member in dev_nbrs:
-                    interfaces[member] = dev_nbrs[member]
-        else:
-            interfaces[ifname] = nbr_info
+        interfaces[ifname] = nbr_info
     return interfaces
 
 
@@ -87,9 +86,7 @@ def setup(duthosts, enum_frontend_dut_hostname, enum_rand_one_frontend_asic_inde
                   "Not all BGP sessions are established on DUT")
 
     for ip, details in bgp_neighbors.items():
-        interfaces = _map_bgp_neighbor_to_interfaces(
-            details['name'], dev_nbrs, portchannels
-        )
+        interfaces = _map_bgp_neighbor_to_interfaces(details['name'], dev_nbrs)
         if interfaces:
             details['interface'] = interfaces
 
@@ -243,8 +240,8 @@ def failure_injection(duthosts, enum_frontend_dut_hostname, fanouthosts, nbrhost
             else:
                 raise ValueError("Unsupported failure_type: {}".format(failure_type))
 
-            asichost.shell('show ip bgp summary', module_ignore_errors=True)
-            asichost.shell('show ipv6 bgp summary', module_ignore_errors=True)
+            asichost.run_vtysh('-c "show ip bgp summary"')
+            asichost.run_vtysh('-c "show ipv6 bgp summary"')
 
         def restore(self):
             """Explicitly restore injected failures so the test can verify recovery.

--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -50,6 +50,14 @@ def _map_bgp_neighbor_to_interfaces(neighbor_name, dev_nbrs):
     return interfaces
 
 
+def _log_bgp_summary(duthost, asic_index):
+    """Log per-ASIC BGP summary after failure injection; never fail the test."""
+    asichost = duthost.asic_instance(asic_index)
+    ns_opt = asichost.cli_ns_option
+    for cmd in ('show ip bgp summary', 'show ipv6 bgp summary'):
+        duthost.shell('{} {}'.format(cmd, ns_opt).strip(), module_ignore_errors=True)
+
+
 @pytest.fixture(scope='module')
 def setup(duthosts, enum_frontend_dut_hostname, enum_rand_one_frontend_asic_index,
           nbrhosts, fanouthosts):
@@ -219,7 +227,6 @@ def failure_injection(duthosts, enum_frontend_dut_hostname, fanouthosts, nbrhost
     See: https://github.com/sonic-net/sonic-mgmt/issues/22246
     """
     duthost = duthosts[enum_frontend_dut_hostname]
-    asichost = duthost.asic_instance(setup['asic_index'])
     state = {'injected': False, 'failure_type': None}
 
     class FailureContext:
@@ -240,8 +247,7 @@ def failure_injection(duthosts, enum_frontend_dut_hostname, fanouthosts, nbrhost
             else:
                 raise ValueError("Unsupported failure_type: {}".format(failure_type))
 
-            asichost.run_vtysh('-c "show ip bgp summary"')
-            asichost.run_vtysh('-c "show ipv6 bgp summary"')
+            _log_bgp_summary(duthost, setup['asic_index'])
 
         def restore(self):
             """Explicitly restore injected failures so the test can verify recovery.

--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -36,33 +36,17 @@ def enable_container_autorestart(duthosts, enum_frontend_dut_hostname):
             duthost.shell("sudo config feature autorestart {} disabled".format(feature))
 
 
-def _map_bgp_neighbor_to_interfaces(neighbor_name, dev_nbrs, portchannels=None):
+def _map_bgp_neighbor_to_interfaces(neighbor_name, dev_nbrs):
     """Map a BGP neighbor device name to local DUT member interfaces.
 
-    DEVICE_NEIGHBOR keys are physical ports (Ethernet*) or LAG interfaces
-    (PortChannel*). LAG-backed neighbors are expanded to member ports via
-    PORTCHANNEL_MEMBER; members that also appear directly are included once.
+    DEVICE_NEIGHBOR keys are physical ports (Ethernet*). LAG members appear
+    as their own entries, so no PortChannel-name lookup is needed here.
     """
     interfaces = {}
-    portchannels = portchannels or {}
     for ifname, nbr_info in dev_nbrs.items():
-        if nbr_info.get('name') != neighbor_name:
-            continue
-        if ifname in portchannels:
-            for member in portchannels[ifname]:
-                if member in dev_nbrs:
-                    interfaces[member] = dev_nbrs[member]
-        else:
+        if nbr_info.get('name') == neighbor_name:
             interfaces[ifname] = nbr_info
     return interfaces
-
-
-def _log_bgp_summary(duthost, asic_index):
-    """Log per-ASIC BGP summary after failure injection; never fail the test."""
-    asichost = duthost.asic_instance(asic_index)
-    ns_opt = asichost.cli_ns_option
-    for cmd in ('show ip bgp summary', 'show ipv6 bgp summary'):
-        duthost.shell('{} {}'.format(cmd, ns_opt).strip(), module_ignore_errors=True)
 
 
 @pytest.fixture(scope='module')
@@ -73,12 +57,9 @@ def setup(duthosts, enum_frontend_dut_hostname, enum_rand_one_frontend_asic_inde
 
     asichost = duthost.asic_instance(asic_index)
     config_facts = get_asic_config_facts(duthost, asic_index)
-    # DEVICE_METADATA lives in host CONFIG_DB; use duthost helper, not per-ASIC namespace.
+    all_bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {})
     if duthost.get_frr_mgmt_framework_config():
-        all_bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {})
-        all_bgp_neighbors = all_bgp_neighbors[vrfname]
-    else:
-        all_bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {})
+        all_bgp_neighbors = all_bgp_neighbors.get(vrfname, {})
     bgp_neighbors = {
         ip: details for ip, details in all_bgp_neighbors.items()
         if details.get('name') in nbrhosts
@@ -88,14 +69,12 @@ def setup(duthosts, enum_frontend_dut_hostname, enum_rand_one_frontend_asic_inde
             "No external BGP neighbors on ASIC {} of DUT {}".format(asic_index, duthost.hostname)
         )
 
-    portchannels = config_facts.get('PORTCHANNEL_MEMBER', {})
     dev_nbrs = config_facts.get('DEVICE_NEIGHBOR', {})
 
     logger.debug("setup config_facts {}".format(config_facts))
     logger.debug("setup nbrhosts {}".format(nbrhosts))
     logger.debug("setup bgp_neighbors {}".format(bgp_neighbors))
     logger.debug("setup dev_nbrs {}".format(dev_nbrs))
-    logger.debug("setup portchannels {}".format(portchannels))
 
     # verify sessions are established on the selected ASIC
     neigh_ips = list(bgp_neighbors.keys())
@@ -103,7 +82,7 @@ def setup(duthosts, enum_frontend_dut_hostname, enum_rand_one_frontend_asic_inde
                   "Not all BGP sessions are established on DUT ASIC {}".format(asic_index))
 
     for ip, details in bgp_neighbors.items():
-        interfaces = _map_bgp_neighbor_to_interfaces(details['name'], dev_nbrs, portchannels)
+        interfaces = _map_bgp_neighbor_to_interfaces(details['name'], dev_nbrs)
         if interfaces:
             details['interface'] = interfaces
 
@@ -238,7 +217,9 @@ def failure_injection(duthosts, enum_frontend_dut_hostname, fanouthosts, nbrhost
             else:
                 raise ValueError("Unsupported failure_type: {}".format(failure_type))
 
-            _log_bgp_summary(duthost, setup['asic_index'])
+            ns_opt = duthost.asic_instance(setup['asic_index']).cli_ns_option
+            for cmd in ('show ip bgp summary', 'show ipv6 bgp summary'):
+                duthost.shell('{} {}'.format(cmd, ns_opt).strip(), module_ignore_errors=True)
 
         def restore(self):
             """Explicitly restore injected failures so the test can verify recovery.
@@ -294,10 +275,11 @@ def test_bgp_session_interface_down(duthosts, enum_frontend_dut_hostname, fanout
     if failure_type == "interface" and not fanouthosts:
         pytest.skip("Fanout hosts not available; interface failure test requires fanout switches")
 
-    # Skip VS cases that need fanout or reboot support
-    if duthost.facts.get("asic_type") in ("vs", "vpp"):
-        if failure_type == "interface" or test_type == "reboot":
-            pytest.skip("BGP session test is not supported on Virtual Switch for interface failure or reboot")
+    # Skip VS/VPP cases that need fanout or reboot support
+    if duthost.facts.get("asic_type") in ("vs", "vpp") and (
+        failure_type == "interface" or test_type == "reboot"
+    ):
+        pytest.skip("BGP session test is not supported on Virtual Switch for interface failure or reboot")
 
     # Skip the test if BGP or SWSS autorestart is disabled
     autorestart_states = duthost.get_container_autorestart_states()

--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -6,7 +6,7 @@ from tests.common.platform.device_utils import fanout_switch_port_lookup
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
-from tests.common.helpers.bgp import get_asic_config_facts
+from tests.common.helpers.bgp import get_asic_config_facts, map_bgp_neighbor_to_interfaces
 from tests.common.reboot import reboot
 
 logger = logging.getLogger(__name__)
@@ -34,19 +34,6 @@ def enable_container_autorestart(duthosts, enum_frontend_dut_hostname):
         # Disable container autorestart back if it was initially disabled.
         if status == 'enabled' and container_autorestart_states[feature] == 'disabled':
             duthost.shell("sudo config feature autorestart {} disabled".format(feature))
-
-
-def _map_bgp_neighbor_to_interfaces(neighbor_name, dev_nbrs):
-    """Map a BGP neighbor device name to local DUT member interfaces.
-
-    DEVICE_NEIGHBOR keys are physical ports (Ethernet*). LAG members appear
-    as their own entries, so no PortChannel-name lookup is needed here.
-    """
-    interfaces = {}
-    for ifname, nbr_info in dev_nbrs.items():
-        if nbr_info.get('name') == neighbor_name:
-            interfaces[ifname] = nbr_info
-    return interfaces
 
 
 @pytest.fixture(scope='module')
@@ -82,7 +69,7 @@ def setup(duthosts, enum_frontend_dut_hostname, enum_rand_one_frontend_asic_inde
                   "Not all BGP sessions are established on DUT ASIC {}".format(asic_index))
 
     for ip, details in bgp_neighbors.items():
-        interfaces = _map_bgp_neighbor_to_interfaces(details['name'], dev_nbrs)
+        interfaces = map_bgp_neighbor_to_interfaces(details['name'], dev_nbrs)
         if interfaces:
             details['interface'] = interfaces
 

--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -7,7 +7,6 @@ from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.bgp import get_asic_config_facts, get_db_cli_prefix
-from tests.common.helpers.dut_utils import is_virtual_platform
 from tests.common.reboot import reboot
 
 logger = logging.getLogger(__name__)
@@ -297,9 +296,14 @@ def test_bgp_session_interface_down(duthosts, enum_frontend_dut_hostname, fanout
             duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_smartswitch")):
         pytest.skip("Warm Reboot is not supported on isolated topology or smartswitch")
 
-    # Skip the test on Virtual Switch due to fanout switch dependency and warm reboot
-    if is_virtual_platform(duthost) and (failure_type == "interface" or test_type == "reboot"):
-        pytest.skip("BGP session test is not supported on Virtual Switch")
+    # Interface failure requires fanout switches to shut the physical link
+    if failure_type == "interface" and not fanouthosts:
+        pytest.skip("Fanout hosts not available; interface failure test requires fanout switches")
+
+    # Skip VS cases that need fanout or reboot support
+    if duthost.facts.get("asic_type") in ("vs", "vpp"):
+        if failure_type == "interface" or test_type == "reboot":
+            pytest.skip("BGP session test is not supported on Virtual Switch for interface failure or reboot")
 
     # Skip the test if BGP or SWSS autorestart is disabled
     autorestart_states = duthost.get_container_autorestart_states()

--- a/tests/common/helpers/bgp.py
+++ b/tests/common/helpers/bgp.py
@@ -68,6 +68,20 @@ def get_asic_config_facts(duthost, asic_index):
     )["ansible_facts"]
 
 
+def map_bgp_neighbor_to_interfaces(neighbor_name, dev_nbrs):
+    """Map a BGP neighbor device name to local DUT member interfaces.
+
+    ``dev_nbrs`` is the ASIC-scoped ``DEVICE_NEIGHBOR`` table from
+    :func:`get_asic_config_facts`. Keys are physical ports (Ethernet*).
+    LAG members appear as their own entries, so no PortChannel lookup is needed.
+    """
+    interfaces = {}
+    for ifname, nbr_info in dev_nbrs.items():
+        if nbr_info.get('name') == neighbor_name:
+            interfaces[ifname] = nbr_info
+    return interfaces
+
+
 def get_vtysh_cmd_for_asic(duthost, asic_index, cmd):
     """Rewrite a ``vtysh ...`` command to target the given ASIC's namespace.
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t1_multiasic.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t1_multiasic.yaml
@@ -43,11 +43,6 @@ bgp/test_bgp_sentinel.py:
     conditions:
     - asic_type in ['vs'] and 't1-8-lag' in topo_name
     reason: This test case either cannot pass or should be skipped on virtual chassis
-bgp/test_bgp_session.py:
-  skip:
-    conditions:
-    - asic_type in ['vs'] and 't1-8-lag' in topo_name
-    reason: This test case either cannot pass or should be skipped on virtual chassis
 bgp/test_bgp_stress_link_flap.py:
   skip:
     conditions:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enable test_bgp_session on multi-ASIC T1 topology by making the test ASIC and namespace-aware. This test verifies BGP session recovery after a link/neighbor failure combined with a BGP restart, SWSS restart, or reboot. 
Previously, the test assumed a single global BGP, which caused incorrect neighbor/interface selection on multi-ASIC DUTs.  
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
test_bgp_session is marked for T1 topology as well as T0, but the test logic was originally written for single-ASIC T0 behavior. On multi-ASIC, it picked neighbors and interfaces from the wrong namespace and restarted the wrong BGP/SWSS instances, so it was marked to skip on T1. This PR addresses this issue to allow the test to run as expected on T1 as well as T0. 

#### How did you do it?
- Use ASIC config facts per frontend ASIC, filter BGP neighbors to external peers, and pick the first neighbor with a mapped interface for shutdown testing. 
- Use `duthost.get_frr_mgmt_framework_config()` (host CONFIG_DB) instead of the broken local helper that compared the shell dict to `"true"`, so the FRR-management/VRF `BGP_NEIGHBOR` path is actually used when enabled.
- Ensure output matches selected namespace
- Final recovery check uses filtered neighbor list for that DUT
- Specific service restarts, instead of global. 

#### How did you verify/test it?
- Code quality checks locally
- GitHub Azure and other checks pipeline for verification of functionality. 

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
