### PR TITLE
[202605] tests/crm: Fix ACL table key lookup and CRM counter polling (#25824)

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -133,17 +133,21 @@ def apply_acl_config(duthost, asichost, test_name, collector, entry_num=1):
     # Wait for ACL configuration to propagate by polling for ACL table key
     logger.info("Waiting for ACL configuration to propagate...")
 
+    acl_tbl_key = None
+
     def _acl_config_applied():
+        nonlocal acl_tbl_key
         try:
-            get_acl_tbl_key(asichost)
+            acl_tbl_key = get_acl_tbl_key(asichost)
             return True
-        except Exception:
+        except BaseException:
+            acl_tbl_key = None
             return False
 
     pytest_assert(wait_until(CONFIG_UPDATE_TIME * 3, CRM_POLLING_INTERVAL, 0, _acl_config_applied),
                   "ACL configuration did not propagate within timeout")
 
-    collector["acl_tbl_key"] = get_acl_tbl_key(asichost)
+    collector["acl_tbl_key"] = acl_tbl_key
 
 
 def generate_mac(num):
@@ -226,28 +230,29 @@ def apply_fdb_config(duthost, test_name, vlan_id, iface, entry_num):
 
 
 def get_acl_tbl_key(asichost):
-    """ Get ACL entry keys """
-    cmd = "{} ASIC_DB KEYS \"*SAI_OBJECT_TYPE_ACL_ENTRY*\"".format(asichost.sonic_db_cli)
-    acl_tbl_keys = asichost.shell(cmd)["stdout"].split()
+    """ Get ACL entry keys.
+    """
+    db_cli = asichost.sonic_db_cli
+    cmd = (
+        'keys=$({db} ASIC_DB KEYS "*SAI_OBJECT_TYPE_ACL_ENTRY*"); '
+        'for k in $keys; do '
+        '  et=$({db} ASIC_DB HGET "$k" SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE); '
+        '  case "$et" in '
+        '    *2048*) '
+        '      tid=$({db} ASIC_DB HGET "$k" SAI_ACL_ENTRY_ATTR_TABLE_ID); '
+        '      if [ -n "$tid" ]; then echo "$tid"; exit 0; fi ;; '
+        '  esac; '
+        'done; '
+        'exit 1'
+    ).format(db=db_cli)
 
-    # Get ethertype for ACL entry and match ACL which was configured to ethertype value
-    cmd = "{db_cli} ASIC_DB HGET {item} \"SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE\""
-    for item in acl_tbl_keys:
-        out = asichost.shell(cmd.format(db_cli=asichost.sonic_db_cli, item=item))["stdout"]
-        logging.info(out)
-        if "2048" in out:
-            key = item
-            break
-    else:
-        pytest.fail("Ether type was not found in SAI ACL Entry table")
+    result = asichost.shell(cmd, module_ignore_errors=True)
+    oid = (result.get("stdout") or "").strip()
+    if result.get("rc", 1) != 0 or not oid:
+        pytest.fail("Valid ACL entry (EtherType=2048 with TABLE_ID) not found")
 
-    # Get ACL table key
-    cmd = "{db_cli} ASIC_DB HGET {key} \"SAI_ACL_ENTRY_ATTR_TABLE_ID\""
-    oid = asichost.shell(cmd.format(db_cli=asichost.sonic_db_cli, key=key))["stdout"]
     logging.info(oid)
-    acl_tbl_key = "CRM:ACL_TABLE_STATS:{0}".format(oid.replace("oid:", ""))
-
-    return acl_tbl_key
+    return "CRM:ACL_TABLE_STATS:{0}".format(oid.replace("oid:", ""))
 
 
 def verify_thresholds(duthost, asichost, **kwargs):
@@ -1231,6 +1236,12 @@ def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hos
     RESTORE_CMDS["crm_threshold_name"] = "acl_entry"
     crm_stats_acl_entry_used = 0
     crm_stats_acl_entry_available = 0
+
+    wait_for_crm_counter_update(
+        get_acl_entry_stats, duthost,
+        expected_used=crm_stats_acl_entry_used + 4,
+        oper_used=">=", timeout=60, interval=2,
+    )
 
     # Get new "crm_stats_acl_entry" used and available counter value
     new_crm_stats_acl_entry_used, new_crm_stats_acl_entry_available = get_crm_stats(get_acl_entry_stats, duthost)


### PR DESCRIPTION
### Description of PR

Cherry-pick / backport of #25824 to the `202605` branch.

Summary:
Fixes intermittent `test_acl_entry` failures in the full CRM suite on Cisco 8000 during the ACL shrink phase, where `get_acl_tbl_key()` fails with `Ether type was not found in SAI ACL Entry table`. The failure is a test-side race with asynchronous ASIC_DB / CRM counter updates, not a product bug.

Fixes # (issue)
Source PR: sonic-net/sonic-mgmt#25824 (merged to `master`).

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: sonic-net/sonic-mgmt#25824 (original PR; no separate tracking issue)
Failure type: other (intermittent / flaky test race with asynchronous ASIC_DB and CRM counter updates)

### Approach
#### What is the motivation for this PR?
After `acl-loader update full`, CONFIG_DB is updated immediately, but orchagent/syncd update ASIC_DB asynchronously. During ACL shrink (many rules to 1), `get_acl_tbl_key()` can run while old ACL entry OIDs are still being removed, so `KEYS` returns stale "zombie" OIDs whose `HGET ETHER_TYPE` is empty while new valid OIDs are not yet in the snapshot. This produced intermittent `Ether type was not found in SAI ACL Entry table` failures on busy Cisco 8000 DUTs, even though the rule did eventually appear.

#### How did you do it?
- `apply_acl_config()`: catch `BaseException` (not just `Exception`) in the retry helper so the `pytest.fail()` raised by `get_acl_tbl_key()` is treated as "not ready yet" and retried; cache the ACL table key from the successful poll instead of calling `get_acl_tbl_key()` a second time (removes a duplicate unguarded call that could fail on another bad snapshot).
- `get_acl_tbl_key()`: perform the whole `KEYS` -> EtherType match -> `TABLE_ID` lookup in a single `sonic-db-cli` shell pipeline on the DUT, returning as soon as the first valid entry is found. Each retry is now one round trip instead of `1 + N + 1`, so attempts stay fast and read a consistent ASIC_DB snapshot and `wait_until` polls at its configured cadence.
- `verify_acl_crm_stats()`: add `wait_for_crm_counter_update()` on the expand path before reading the counter, mirroring the existing preconfig/shrink paths, to remove the race with crmagent's COUNTERS_DB poll (which lags ASIC_DB by multiple seconds on a busy DUT).

#### How did you verify/test it?
Cherry-picked cleanly from commit `112072ab7030eac3d68f1a4a5a8596244975e37d` (#25824). Confirmed `flake8` and `python -m py_compile` pass on `tests/crm/test_crm.py`. The original change was validated by running the CRM ACL tests (`pytest tests/crm/test_crm.py -k acl`) on Cisco 8000.

#### Any platform specific information?
Observed on Cisco 8000; the change is a platform-agnostic, test-side reliability improvement (no product/config changes).

#### Supported testbed topology if it's a new test case?
N/A - improvement to an existing test case.

### Documentation
N/A
