### PR TITLE
ci: disable KVM PR tests on 202505, keep pre-test checks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,8 @@ stages:
 
 - stage: Test
   dependsOn: Pre_test
-  condition: and(succeeded(), not(canceled()), in(dependencies.Pre_test.result, 'Succeeded'))
+  # KVM/Elastictest PR tests disabled on 202505 (ADO 38681685); Pre_test checks still run.
+  condition: false
   variables:
   - group: SONiC-Elastictest
   - name: inventory


### PR DESCRIPTION
Disables the Elastictest KVM `Test` stage (sets `condition: false`) so PRs targeting 202505 no longer run the impacted-area KVM tests, while the lightweight `Pre_test` checks (static analysis, markers, dependency and test-case validation) keep running.

This replaces the earlier `pr: none` approach so PR validation is not removed wholesale.

Internal tracking: ADO 38681685.
