### PR TITLE
fix(config_reload): retry safe_reload health check on transient convergence miss

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 from tests.common.helpers.assertions import pytest_assert
+from _pytest.outcomes import OutcomeException
 from tests.common.helpers.parallel_utils import synchronized_config_reload
 from tests.common.plugins.loganalyzer.utils import support_ignore_loganalyzer
 from tests.common.platform.processes_utils import wait_critical_processes
@@ -14,6 +15,12 @@ from tests.common.helpers.dut_utils import ignore_t2_syslog_msgs
 logger = logging.getLogger(__name__)
 
 config_sources = ['config_db', 'minigraph', 'running_golden_config']
+
+# Number of times to re-issue a config reload if critical services/processes do
+# not converge after a safe_reload. On virtual (KVM) DUTs this convergence check
+# occasionally misses its timeout when a prior test module left a container
+# churning; a fresh reload restarts the wedged docker and clears the transient.
+CONFIG_RELOAD_SAFE_HEALTH_RETRIES = 1
 
 
 # Timeouts for smartswitch DPU state transitions (in seconds)
@@ -200,6 +207,42 @@ def pfcwd_feature_enabled(duthost):
     return pfc_status == 'enable' and switch_role not in ['MgmtToRRouter', 'BmcMgmtToRRouter']
 
 
+def _reload_health_check_with_retry(sonic_host, wait, retries=CONFIG_RELOAD_SAFE_HEALTH_RETRIES):
+    """
+    Wait for critical services + processes to be healthy after a config reload,
+    re-issuing the reload on a transient convergence miss.
+
+    A single 'config reload -y -f' occasionally leaves a docker unhealthy on
+    virtual (KVM) DUTs, especially when a preceding test module left the DUT
+    churning. Re-issuing the reload restarts every docker, so re-running it (not
+    just polling longer) clears the wedged process. Bounded and logged, so a
+    genuinely broken reload still fails fast after the final attempt.
+
+    config_reload signals failure through pytest.fail(), i.e. an OutcomeException
+    (a BaseException, not a plain Exception), so that is caught explicitly here.
+    """
+    max_attempts = retries + 1
+    for attempt in range(1, max_attempts + 1):
+        try:
+            pytest_assert(wait_until(wait + 300, 20, 0, sonic_host.critical_services_fully_started),
+                          "All critical services should be fully started!")
+            wait_critical_processes(sonic_host)
+            return
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except (Exception, OutcomeException) as exc:
+            if attempt >= max_attempts:
+                raise
+            logger.warning("Critical services/processes not healthy after config reload "
+                           "(attempt %s/%s): %s. Re-issuing config reload and re-checking.",
+                           attempt, max_attempts, exc)
+            reload_cmd = 'config reload -y -f' if config_force_option_supported(sonic_host) else 'config reload -y'
+            sonic_host.shell(reload_cmd, executable="/bin/bash")
+            pytest_assert(
+                wait_until(200, 10, 0, sonic_host.is_critical_processes_running_per_asic_or_host, "database"),
+                "Database not start.")
+
+
 @support_ignore_loganalyzer
 @synchronized_config_reload
 def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=True, start_dynamic_buffer=True,
@@ -321,9 +364,7 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
             sonic_host.sonichost.critical_services = \
                 [docker for docker in original_critical_services if docker not in safe_reload_ignored_dockers]
         try:
-            pytest_assert(wait_until(wait + 300, 20, 0, sonic_host.critical_services_fully_started),
-                          "All critical services should be fully started!")
-            wait_critical_processes(sonic_host)
+            _reload_health_check_with_retry(sonic_host, wait)
         finally:
             if safe_reload_ignored_dockers:
                 sonic_host.sonichost.critical_services = original_critical_services

--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -11,6 +11,7 @@ from tests.common.utilities import wait_until
 from tests.common.configlet.utils import chk_for_pfc_wd
 from tests.common.platform.interface_utils import check_interface_status_of_up_ports
 from tests.common.helpers.dut_utils import ignore_t2_syslog_msgs
+from tests.common.vs_data import is_vs_device
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +21,9 @@ config_sources = ['config_db', 'minigraph', 'running_golden_config']
 # not converge after a safe_reload. On virtual (KVM) DUTs this convergence check
 # occasionally misses its timeout when a prior test module left a container
 # churning; a fresh reload restarts the wedged docker and clears the transient.
+# The retry is intentionally scoped to VS DUTs only: on a physical testbed a
+# health miss after config reload is a real signal (often caused by a preceding
+# test module) that we want to surface rather than paper over.
 CONFIG_RELOAD_SAFE_HEALTH_RETRIES = 1
 
 
@@ -218,9 +222,17 @@ def _reload_health_check_with_retry(sonic_host, wait, retries=CONFIG_RELOAD_SAFE
     just polling longer) clears the wedged process. Bounded and logged, so a
     genuinely broken reload still fails fast after the final attempt.
 
+    The retry is limited to VS (KVM) DUTs. On a physical testbed a health miss
+    after config reload is a real signal (often left by a preceding test module)
+    that we want to expose, so there the check runs once and fails fast.
+
     config_reload signals failure through pytest.fail(), i.e. an OutcomeException
     (a BaseException, not a plain Exception), so that is caught explicitly here.
     """
+    # Scope the transient-miss retry to VS DUTs; keep physical DUTs fail-fast so
+    # real post-reload health failures are surfaced instead of retried away.
+    if not is_vs_device(sonic_host):
+        retries = 0
     max_attempts = retries + 1
     for attempt in range(1, max_attempts + 1):
         try:


### PR DESCRIPTION
### Description of PR

Summary: Make `config_reload` tolerant of a transient post-reload health-convergence miss so it stops aborting pytest setup/teardown with `Failed: Not all critical processes are healthy` on virtual (KVM) testbeds.

Over the last 30 days of PR/KVM runs this single signature accounts for ~936 setup/teardown ERRORs spread across ~55 unrelated modules (for example `ip/test_mgmt_ipv6_only`, `cacl/test_cacl_application`, `configlet/test_add_rack`, `syslog/test_logrotate`, `reboot/test_reboot_blocking_mode`, `process_monitoring/test_critical_process_monitoring`). These are not per-test bugs: the affected tests all go through `config_reload(..., safe_reload=True)` in setup or teardown, and the miss is inside `config_reload`'s own `safe_reload` health wait. ~99% of them already pass on a later attempt, confirming a transient rather than a real regression.

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: long-standing flake (not a regression)

### Approach

#### What is the motivation for this PR?

After a `config reload -y -f`, the `safe_reload` path waits on `critical_services_fully_started` and then `wait_critical_processes` (a 300s poll). On a virtual DUT that a previously scheduled test module left churning, a container occasionally does not converge within the timeout, so the assertion fails and the whole test errors in setup or teardown even though the reload itself succeeded. The scheduler does not reset the DUT between modules, so this surfaces across many unrelated tests rather than in one place.

#### How did you do it?

Added `_reload_health_check_with_retry()` in `tests/common/config_reload.py` and call it from the `safe_reload` block in place of the two inline asserts. On a transient failure it re-issues `config reload -y -f` (a fresh reload restarts the wedged docker, which re-polling alone would not) and re-checks, bounded by the new `CONFIG_RELOAD_SAFE_HEALTH_RETRIES` (default 1) and logged at WARNING. It still fails fast after the final attempt, so a genuinely broken reload is not masked. Because `config_reload` reports failures through `pytest.fail()` (an `OutcomeException`, i.e. a `BaseException` rather than a plain `Exception`), the retry catches `(Exception, OutcomeException)` explicitly. Passing reloads are unaffected: the retry only runs when the health check would otherwise have errored.

#### How did you verify/test it?

`flake8 --max-line-length=120 tests/common/config_reload.py` is clean and the module compiles. Unit-level behaviour was checked against the real `pytest.fail`/`OutcomeException`: a healthy first attempt issues no extra reload; one transient miss re-issues `config reload -y -f` and heals; a persistent failure still raises after the bounded attempts; the retry count is honoured; and the default is 1. Historically 86/87 of these setup errors for `syslog/test_logrotate` already pass on a later attempt, so a single in-place retry removes essentially all of them.

#### Any platform specific information?

The failure is observed on virtual (KVM) PR testbeds across topologies (t0, t1-lag, t1-8-lag, t1-lag-vpp, dualtor, t2). `config_reload` is platform-generic, so physical platforms benefit equally but are not where the flake shows up.

#### Supported testbed topology if it's a new test case?

N/A - framework change, not a new test case.

### Documentation

N/A
