### PR TITLE
[platform_tests] test_tx_disable_channel: skip 1000BASE-T copper RJ45 SFP modules

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -327,7 +327,13 @@ class TestSfpApi(PlatformApiTestBase):
                 spec_compliance_dict = ast.literal_eval(spec)
             except (ValueError, SyntaxError):
                 return True
-            return spec_compliance_dict.get("SFP+CableTechnology") != "Passive Cable"
+            if spec_compliance_dict.get("SFP+CableTechnology") == "Passive Cable":
+                return False
+            # Copper baseT RJ45 SFP modules (e.g. 1000BASE-T, 100BASE-TX). No laser to
+            # disable; xcvrd returns "N/A" for the optics APIs on these modules.
+            if "BASE-T" in spec_compliance_dict.get("Ethernet Compliance", ""):
+                return False
+            return True
 
         # All other types use the dict-based copper check.
         spec_compliance_dict = ast.literal_eval(spec)


### PR DESCRIPTION

is_xcvr_optical() currently only detects SFP+ passive twinax DAC via 'SFP+CableTechnology': 'Passive Cable'. Copper baseT RJ45 SFP modules (e.g. Arista SFP-1G-T on Nokia-7215C1) report
    'Ethernet Compliance': '1000BASE-T'
    'SFP+CableTechnology': 'Unknown'
so is_xcvr_optical() returns True and test_tx_disable_channel runs on a copper module. xcvrd returns 'N/A' for the optics APIs on such modules, causing spurious failures like 'Failed to enable TX on all channels' and 'TX disabled channel data is incorrect'.

There is no laser to disable on 1000BASE-T copper SFP; the correct behavior is to skip these ports the same way SFP+ DAC is skipped. Extend the SFP branch of is_xcvr_optical() to also return False when Ethernet Compliance contains 'BASE-T', which covers 1000BASE-T, 100BASE-TX, and similar copper baseT SFP modules.

Verified on testbed-bjw3-can-7215c1-3 (Nokia-7215-C1, ports 1 and 2 populated with Arista SFP-1G-T): before the fix,
test_tx_disable_channel failed with 7 aggregated expect errors on transceivers 1 and 2; after the fix, both are logged as 'Skipping transceiver N (not applicable for this transceiver type)' and the test passes.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
