### PR TITLE
[test_nbr_health] Handle CsonicHost neighbors

### DIFF
--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -5,6 +5,7 @@ import logging
 from .common.helpers.assertions import pytest_assert
 from .common.devices.eos import EosHost
 from .common.devices.sonic import SonicHost
+from .common.devices.csonic import CsonicHost
 
 logger = logging.getLogger(__name__)
 
@@ -141,6 +142,17 @@ def test_neighbors_health(duthosts, localhost, nbrhosts, eos, sonic, enum_fronte
             if failmsg:
                 fails.append(failmsg)
 
+            failmsg = check_sonic_bgp_facts(k, nbrhost)
+            if failmsg:
+                fails.append(failmsg)
+
+        elif isinstance(nbrhost, CsonicHost):
+            # cSONiC neighbors are docker-sonic-vs containers reached via
+            # ``docker exec`` rather than SSH. They intentionally do not run
+            # snmpd and do not expose a routable management address, so the
+            # SNMP and mgmt-addr fact checks used for SonicHost are not
+            # applicable. FRR/vtysh is available inside the container, so the
+            # SONiC BGP check works verbatim via CsonicHost.command().
             failmsg = check_sonic_bgp_facts(k, nbrhost)
             if failmsg:
                 fails.append(failmsg)


### PR DESCRIPTION
### Description of PR

Summary:
`tests/test_nbr_health.py::test_neighbors_health` dispatches on the neighbor host object type with only two branches, `EosHost` and `SonicHost`, and falls through to an `else` branch that reports:

```
Failed: neighbor type <name> is unknown
```

Since the introduction of `tests/common/devices/csonic.py` (`CsonicHost`), topologies that use cSONiC neighbors — e.g. the `vms-kvm-t1-csonic` / `vms-kvm-t2-csonic` testbeds where every neighbor is a `docker-sonic-vs` container instead of a real Arista or SONiC device — fail this sanity check with one `"unknown"` line per neighbor, even when every BGP session is Established and every PortChannel is up.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach

#### What is the motivation for this PR?

Without this change, `test_neighbors_health` cannot pass on any cSONiC-neighbor topology. The failure is purely a gap in the test dispatch — every neighbor's BGP session and health may be fine, but the test cannot express it because `CsonicHost` is neither `EosHost` nor `SonicHost`.

#### How did you do it?

Added a third `elif isinstance(nbrhost, CsonicHost)` branch after the existing `SonicHost` branch. The new branch reuses `check_sonic_bgp_facts`, which just runs `host.command('vtysh -c "show ip bgp sum"')` and works verbatim through `CsonicHost.command()` (both return the same `stdout_lines` dict shape).

The SNMP (`check_snmp`) and mgmt-address (`check_sonic_facts`) checks used for `SonicHost` are deliberately **not** invoked for `CsonicHost`:
- A cSONiC container is reached via `docker exec`, not SSH.
- It does not run `snmpd`.
- It does not expose a routable management address (`.facts['mgmt_interface']` does not apply).

These checks would fail spuriously on a healthy cSONiC neighbor.

#### How did you verify/test it?

Ran on the `vms-kvm-t1-csonic` testbed (`vlab-03`, 24 cSONiC neighbors: 8 SpineRouter T2 + 16 ToRRouter T0), using:

```
./run_tests.sh -n vms-kvm-t1-csonic -d vlab-03 -t t1,any \
  -f vtestbed.yaml -i veos_vtb -u -e --disable_loganalyzer \
  -c test_nbr_health.py
```

- **Before this change:** `test_neighbors_health` failed with 24 `"neighbor type ARISTAxxTx is unknown"` lines (one per cSONiC neighbor).
- **After this change:**
  ```
  test_nbr_health.py::test_neighbors_health[vlab-03] PASSED  [100%]
  1 passed, 40 warnings in 34.90s
  ```

#### Any platform specific information?

None — the change is scoped to the `CsonicHost` branch and does not touch the existing `EosHost` or `SonicHost` code paths, so real EOS and real SONiC neighbor topologies are unaffected.

#### Supported testbed topology if it's a new test case?

N/A — existing test case, no topology-marker changes.

### Documentation

No documentation changes required.
