### PR TITLE
[acl] Wait for ACL counter to increment in test_acl_outer_vlan

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -283,7 +283,7 @@ def send_and_verify_traffic(ptfadapter, pkt, exp_pkt, src_port_list, dst_port_li
         testutils.verify_no_packet_any(ptfadapter, exp_pkt, ports=dst_port_list)
 
 
-def get_acl_counter(duthost, table_name, rule_name, timeout=ACL_COUNTERS_UPDATE_INTERVAL):
+def get_acl_counter(duthost, table_name, rule_name, timeout=ACL_COUNTERS_UPDATE_INTERVAL, baseline=None):
     """
     Get Acl counter packets value
 
@@ -292,28 +292,35 @@ def get_acl_counter(duthost, table_name, rule_name, timeout=ACL_COUNTERS_UPDATE_
         table_name: Acl Table name
         rule_name: Acl rule name
         timeout: Timeout for Acl counters to update
+        baseline: If set, wait until the counter increments beyond this value.
+                  Used for the post-traffic read so we wait for the counter to
+                  actually reflect the sent packets, not just for the row to exist.
 
     Returns:
         Acl counter value for packets
     """
-    def _check_acl_counter():
+    def _read_acl_counter():
         result = duthost.show_and_parse('aclshow -a')
-        if len(result) == 0:
-            return False
         for rule in result:
             if table_name == rule['table name'] and rule_name == rule['rule name']:
-                return True
-        return False
+                return int(rule['packets count'])
+        return None
 
-    # Wait for orchagent to update the ACL counters
-    if not wait_until(timeout, 2, 0, _check_acl_counter):
+    def _check_acl_counter():
+        value = _read_acl_counter()
+        if value is None:
+            return False
+        # When a baseline is given, wait for the counter to actually increment.
+        return value > baseline if baseline is not None else True
+
+    # Wait for orchagent to update the ACL counters when requested.
+    if timeout > 0 and not wait_until(timeout, 2, 0, _check_acl_counter):
         pytest.fail("Failed to retrieve acl counter for {}|{}".format(table_name, rule_name))
 
-    result = duthost.show_and_parse('aclshow -a')
-    for rule in result:
-        if table_name == rule['table name'] and rule_name == rule['rule name']:
-            return int(rule['packets count'])
-    pytest.fail("Failed to retrieve acl counter for {}|{}".format(table_name, rule_name))
+    value = _read_acl_counter()
+    if value is None:
+        pytest.fail("Failed to retrieve acl counter for {}|{}".format(table_name, rule_name))
+    return value
 
 
 def craft_packet(src_mac, dst_mac, dst_ip, ip_version, stage, tagged_mode, vlan_id=10, outer_vlan_id=0, pkt_type=None):
@@ -573,7 +580,7 @@ class AclVlanOuterTest_Base(object):
 
             count_before = get_acl_counter(duthost, table_name, RULE_1, timeout=0)
             send_and_verify_traffic(ptfadapter, pkt, exp_pkt, src_port, dst_port, pkt_action=action)
-            count_after = get_acl_counter(duthost, table_name, RULE_1)
+            count_after = get_acl_counter(duthost, table_name, RULE_1, baseline=count_before)
 
             logger.info("Verify Acl counter incremented {} > {}".format(count_after, count_before))
             pytest_assert(count_after >= count_before + 1,


### PR DESCRIPTION
### Description of PR

Summary:
`test_acl_outer_vlan` reads the ACL rule counter before and after sending traffic and asserts `count_after >= count_before + 1`. `get_acl_counter()` relied on `wait_until(timeout, 2, 0, _check_acl_counter)`, but `_check_acl_counter` only checked that the ACL rule **row exists** (always true after setup), so it returned on the very first poll. As a result:

- The post-traffic `count_after` read returned immediately, before the counter refreshed (`ACL_COUNTERS_UPDATE_INTERVAL = 15s`), making `count_after >= count_before + 1` flaky.
- The baseline `count_before` read (called with `timeout=0`) failed outright, because `wait_until(0, ...)` returns without ever checking the condition -> `Failed to retrieve acl counter for DATAACL_ingress_*|rule_1`.

This is an alternative to #25483 that also addresses the review feedback there (the post-traffic read must wait for the counter to actually **increment**, not just for the row to exist), **without** reverting #22978.

Fixes the failures tracked in ADO PBI 38502280.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
`get_acl_counter` waited only for the ACL row to exist, not for the counter to increment after traffic, and failed for the `timeout=0` immediate read. Both stem from #22978 replacing `time.sleep(timeout)` with a `wait_until` whose condition is satisfied on the first poll.

#### How did you do it?
- Add a `baseline` parameter to `get_acl_counter`. When set, the poll condition waits until the rule's packet count **exceeds** the baseline (up to `timeout`), so the post-traffic read waits for the real increment while still returning as soon as the counter updates -- preserving the sleep-free polling goal of #22978 / #20256.
- Skip the wait loop entirely when `timeout=0`, so the immediate baseline read no longer trips the `wait_until(0, ...)` guaranteed-failure path.
- Pass `baseline=count_before` for the post-traffic `count_after` read.

#### How did you verify/test it?
- flake8 clean; Python syntax validated.
- Pending: run `tests/acl/test_acl_outer_vlan.py` ingress cases on a physical testbed to confirm the counter increment is observed within the interval.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A

Related ADO PBI: 38502280
