### PR TITLE
Fix QoS probe Broadcom portchannel PTF index lookup

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1353,11 +1353,10 @@ class QosSaiBase(QosBase):
             use_separated_upkink_dscp_tc_map = separated_dscp_to_tc_map_on_uplink(dut_qos_maps)
             for portConfig in intf_map:
                 intf = portConfig["attachto"].split(".")[0]
+                if isBroadcomDevice(src_dut) and intf in src_mgFacts["minigraph_portchannels"]:
+                    intf = src_mgFacts["minigraph_portchannels"][intf]['members'][0]
                 portIndex = src_mgFacts["minigraph_ptf_indices"][intf]
                 if ipaddress.ip_interface(portConfig['peer_addr']).ip.version == ip_version:
-                    if isBroadcomDevice(src_dut):
-                        if intf in src_mgFacts["minigraph_portchannels"]:
-                            intf = src_mgFacts["minigraph_portchannels"][portConfig["attachto"]]['members'][0]
                     if portIndex in testPortIds[src_dut_index][src_asic_index]:
                         portIpMap = {'peer_addr': portConfig["peer_addr"]}
                         if 'vlan' in portConfig:


### PR DESCRIPTION
### Description of PR

Summary:
Fixes Broadcom QoS probe setup failure tracked by ADO PBI 38682187.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Nightly qos.test_qos_probe.TestQosProbe::testQosHeadroomPoolProbe on master failed during dutConfig setup on Broadcom T0 with KeyError: 'PortChannel101'. The fixture uses minigraph_portchannel_interfaces for Broadcom and attempted to look up the PortChannel name directly in minigraph_ptf_indices, which only contains physical port names.

#### How did you do it?

For Broadcom PortChannel interfaces, map the PortChannel to its first member before reading minigraph_ptf_indices. This matches the existing intent to use the member port for Broadcom and moves the mapping before the PTF index lookup.

#### How did you verify/test it?

Ran:
- python -m py_compile tests/qos/qos_sai_base.py
- python -m pre_commit run --files tests/qos/qos_sai_base.py

#### Any platform specific information?

Broadcom T0, observed on Arista-7260CX3-D108C10 / t0-118.

#### Supported testbed topology if it's a new test case?

N/A. Existing QoS probe fixture fix.

### Documentation

N/A.

Related ADO PBI: 38682187