### PR TITLE
Fix: KeyError in test_arp_garp_enabled

### DIFF
--- a/tests/arp/test_arp_extended.py
+++ b/tests/arp/test_arp_extended.py
@@ -25,6 +25,7 @@ def _check_neighbor_entry(duthost, ip, version):
     switch_arptable = duthost.switch_arptable()['ansible_facts']
     return ip in switch_arptable['arptable'][version]
 
+
 def _has_garp_entry(duthost, arp_request_ip, arp_src_mac, vlan_intfs):
     switch_arptable = duthost.switch_arptable()['ansible_facts']
     return ('arptable' in switch_arptable and
@@ -32,6 +33,7 @@ def _has_garp_entry(duthost, arp_request_ip, arp_src_mac, vlan_intfs):
             arp_request_ip in switch_arptable['arptable']['v4'] and
             switch_arptable['arptable']['v4'][arp_request_ip]['macaddress'].lower() == arp_src_mac.lower() and
             switch_arptable['arptable']['v4'][arp_request_ip]['interface'] in vlan_intfs)
+
 
 def test_arp_accept_value(rand_selected_dut, garp_enabled, config_facts):
     """

--- a/tests/arp/test_arp_extended.py
+++ b/tests/arp/test_arp_extended.py
@@ -25,6 +25,13 @@ def _check_neighbor_entry(duthost, ip, version):
     switch_arptable = duthost.switch_arptable()['ansible_facts']
     return ip in switch_arptable['arptable'][version]
 
+def _has_garp_entry(duthost, arp_request_ip, arp_src_mac, vlan_intfs):
+    switch_arptable = duthost.switch_arptable()['ansible_facts']
+    return ('arptable' in switch_arptable and
+            'v4' in switch_arptable['arptable'] and
+            arp_request_ip in switch_arptable['arptable']['v4'] and
+            switch_arptable['arptable']['v4'][arp_request_ip]['macaddress'].lower() == arp_src_mac.lower() and
+            switch_arptable['arptable']['v4'][arp_request_ip]['interface'] in vlan_intfs)
 
 def test_arp_accept_value(rand_selected_dut, garp_enabled, config_facts):
     """
@@ -94,9 +101,8 @@ def test_arp_garp_enabled(rand_selected_dut, garp_enabled, ip_and_intf_info, int
 
     vlan_intfs = list(config_facts['VLAN_INTERFACE'].keys())
 
-    switch_arptable = duthost.switch_arptable()['ansible_facts']
-    pytest_assert(switch_arptable['arptable']['v4'][arp_request_ip]['macaddress'].lower() == arp_src_mac.lower())
-    pytest_assert(switch_arptable['arptable']['v4'][arp_request_ip]['interface'] in vlan_intfs)
+    pytest_assert(wait_until(10, 1, 0, _has_garp_entry, duthost, arp_request_ip, arp_src_mac, vlan_intfs),
+                  "GARP not learned: IP {} not found with MAC {}".format(arp_request_ip, arp_src_mac))
 
 
 def test_arp_garp_out_of_subnet_not_learned(rand_selected_dut, garp_enabled, ip_and_intf_info,


### PR DESCRIPTION
Signed-off-by: Deepanshi Chourasia <deepanshi.chourasia@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

This PR fixes an intermittent KeyError failure in test_arp_garp_enabled caused by a race condition between GARP packet transmission and ARP table validation. 
```
switch_arptable = duthost.switch_arptable()['ansible_facts']
pytest_assert(switch_arptable['arptable']['v4'][arp_request_ip]['macaddress'].lower() == arp_src_mac.lower())
E       KeyError: '192.169.0.4'
```

Fixes # (issue)

*Root Cause*
The test sends a GARP (Gratuitous ARP) packet and immediately validates the ARP table entry. However, there is a race condition where the validation executes before the control plane has fully processed the GARP and populated the ARP table entry. This results in intermittent KeyError failures when the ARP entry does not exist at the time of lookup.

*Fix*
Replace the one-shot assertion with a polling mechanism using wait_until(10, 1, ...) that retries the ARP table lookup until the entry is present or timeout occurs. This approach:

- Polls every 1 second for up to 10 seconds
- Uses a predicate-based check instead of direct assertion
- Provides a clearer failure message if the entry never appears

<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
The test_arp_garp_enabled test experiences intermittent KeyError failures due to a race condition. The test sends a GARP (Gratuitous ARP) packet and immediately validates the ARP table entry, but the control plane may not have finished processing the GARP and populating the ARP table by the time the assertion executes. This causes sporadic test failures with KeyError: '192.169.0.4' when the ARP entry does not yet exist.

#### How did you do it?
Replaced the one-shot assertion with a polling mechanism using wait_until(10, 1, ...) that:

- Polls the ARP table every 1 second for up to 10 seconds
- Uses a predicate-based check to verify the ARP entry exists and MAC address matches
- Returns a clear failure message if the entry never appears within the timeout

This allows the test to tolerate the inherent timing variability in control plane GARP processing without masking actual failures.

#### How did you verify/test it?

Verified locally that the test passes consistently after the change

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
