### PR TITLE
[tests/console]: fix test_console_reversessh race between pexpect sendline and DUT-side console session

### DIFF
--- a/tests/console/test_console_reversessh.py
+++ b/tests/console/test_console_reversessh.py
@@ -10,6 +10,7 @@ from tests.common.helpers.console_helper import (
     get_host_ip_and_creds,
     wait_for_line_idle,
 )
+from tests.common.utilities import wait_until
 
 pytestmark = [
     pytest.mark.topology('c0', 'c0-lo', 'bmc')
@@ -87,9 +88,10 @@ def test_console_reversessh_connectivity(duthost, creds, conn_graph_facts):  # n
         client.expect('[Pp]assword:')
         client.sendline(dutpass)
 
-        # Check the console line state again
+        # Wait for the DUT to register the console session as BUSY (avoid
+        # client/DUT race: sendline returns before picocom is spawned).
         pytest_assert(
-            check_target_line_status(duthost, target_line, "BUSY"),
+            wait_until(10, 1, 0, check_target_line_status, duthost, target_line, "BUSY"),
             "Target line {} is idle while reverse SSH session is up".format(target_line))
     except Exception as e:
         pytest.fail("Not able to do reverse SSH to remote host via DUT: {}".format(e))
@@ -124,9 +126,10 @@ def test_console_reversessh_force_interrupt(duthost, creds, conn_graph_facts):  
         client.expect('[Pp]assword:')
         client.sendline(dutpass)
 
-        # Check the console line state again
+        # Wait for the DUT to register the console session as BUSY (avoid
+        # client/DUT race: sendline returns before picocom is spawned).
         pytest_assert(
-            check_target_line_status(duthost, target_line, "BUSY"),
+            wait_until(10, 1, 0, check_target_line_status, duthost, target_line, "BUSY"),
             "Target line {} is idle while reverse SSH session is up".format(target_line))
     except Exception as e:
         pytest.fail("Not able to do reverse SSH to remote host via DUT: {}".format(e))
@@ -187,9 +190,10 @@ def test_console_reversessh_custom_default_escape_character(duthost, creds, conn
         client.expect('[Pp]assword:')
         client.sendline(dutpass)
 
-        # Check the console line state again
+        # Wait for the DUT to register the console session as BUSY (avoid
+        # client/DUT race: sendline returns before picocom is spawned).
         pytest_assert(
-            check_target_line_status(duthost, target_line, "BUSY"),
+            wait_until(10, 1, 0, check_target_line_status, duthost, target_line, "BUSY"),
             "Target line {} is idle while reverse SSH session is up".format(target_line))
 
         # Try to send default escape sequence (ctrl-A + ctrl-X) - should NOT exit

--- a/tests/console/test_console_reversessh.py
+++ b/tests/console/test_console_reversessh.py
@@ -91,7 +91,7 @@ def test_console_reversessh_connectivity(duthost, creds, conn_graph_facts):  # n
         # Wait for the DUT to register the console session as BUSY (avoid
         # client/DUT race: sendline returns before picocom is spawned).
         pytest_assert(
-            wait_until(10, 1, 0, check_target_line_status, duthost, target_line, "BUSY"),
+            wait_until(3, 1, 0, check_target_line_status, duthost, target_line, "BUSY"),
             "Target line {} is idle while reverse SSH session is up".format(target_line))
     except Exception as e:
         pytest.fail("Not able to do reverse SSH to remote host via DUT: {}".format(e))
@@ -129,7 +129,7 @@ def test_console_reversessh_force_interrupt(duthost, creds, conn_graph_facts):  
         # Wait for the DUT to register the console session as BUSY (avoid
         # client/DUT race: sendline returns before picocom is spawned).
         pytest_assert(
-            wait_until(10, 1, 0, check_target_line_status, duthost, target_line, "BUSY"),
+            wait_until(3, 1, 0, check_target_line_status, duthost, target_line, "BUSY"),
             "Target line {} is idle while reverse SSH session is up".format(target_line))
     except Exception as e:
         pytest.fail("Not able to do reverse SSH to remote host via DUT: {}".format(e))
@@ -193,7 +193,7 @@ def test_console_reversessh_custom_default_escape_character(duthost, creds, conn
         # Wait for the DUT to register the console session as BUSY (avoid
         # client/DUT race: sendline returns before picocom is spawned).
         pytest_assert(
-            wait_until(10, 1, 0, check_target_line_status, duthost, target_line, "BUSY"),
+            wait_until(3, 1, 0, check_target_line_status, duthost, target_line, "BUSY"),
             "Target line {} is idle while reverse SSH session is up".format(target_line))
 
         # Try to send default escape sequence (ctrl-A + ctrl-X) - should NOT exit


### PR DESCRIPTION
pexpect.spawn(ssh).sendline(pwd) returns as soon as the password bytes are written to the local ssh client; the DUT still needs to authenticate, run its ForcedCommand (connect line N -> consutil connect N -> picocom /dev/C0-N), and only after picocom is spawned does 'show line N' report BUSY. The tests fire check_target_line_status() immediately after sendline() over a warm ansible ControlMaster SSH, whose round-trip is fast enough to observe IDLE and fail the assertion.

Poll for BUSY (up to 3s) before the one-shot check in all three tests so passing runs pay only the actual DUT-side setup cost.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix a race in `tests/console/test_console_reversessh.py` where `check_target_line_status(duthost, target_line, "BUSY")` is asserted immediately after `pexpect.spawn(ssh).sendline(pwd)`. `sendline()` returns as soon as the password bytes are handed to the local ssh client, but on the DUT side the reverse-SSH ForcedCommand (`connect line N` -> `consutil connect N` -> `picocom /dev/C0-N`) still has to authenticate and spawn picocom before `show line N` reports `BUSY`. Over a warm ansible ControlMaster the follow-up `show line N` can win the race and observe `IDLE`, failing the assertion.

Wrap the assertion in `wait_until(3, 1, 0, check_target_line_status, duthost, target_line, "BUSY")` in all three testcases so a fast DUT is not penalized, while a slow-to-spawn picocom gets up to 3 seconds to register the session as `BUSY`.

Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
`test_console_reversessh_connectivity`, `test_console_reversessh_force_interrupt`, and `test_console_reversessh_custom_default_escape_character` intermittently fail on the `check_target_line_status(..., "BUSY")` assertion because it fires before the DUT-side picocom is actually spawned. The failure is a client/DUT race, not a real product issue, and is more likely on fast switches with a warm ansible ControlMaster SSH.

#### How did you do it?
Replace the immediate `check_target_line_status(...)` assertion after `client.sendline(dutpass)` with `wait_until(3, 1, 0, check_target_line_status, duthost, target_line, "BUSY")` in all three testcases. The wrapper polls once per second for up to 3 seconds, so the passing path is bounded by the actual DUT-side setup cost while the flaky window is closed.

#### How did you verify/test it?
Ran the modified `tests/console/test_console_reversessh.py` on `testbed-bjw3-can-7215c1-5` (Nokia-7215-C1, topology `c0-lo`):

```
============ 10 passed, 372 warnings, 3 errors in 764.30s (0:12:44) ============
```

All 10 collected test items PASSED:
- `test_console_reversessh_connectivity`
- `test_console_reversessh_force_interrupt`
- `test_console_reversessh_custom_default_escape_character[b|e|f|g|k|n|p|y]` (8 parametrized cases)

The 3 `ERROR` entries are teardown-only, caused by the post-run sanity check's `monit`/`check_orchagent_usage` step (missing `100.1.0.x` default routes on this c0-lo testbed) and are unrelated to the modified code path.

#### Any platform specific information?
No platform-specific logic; the change only touches Python test code. The 3s upper bound was chosen from the observed DUT-side setup time on Nokia-7215-C1 and should be sufficient for other c0/c0-lo/bmc consoles running the same ForcedCommand path.

#### Supported testbed topology if it's a new test case?
Not a new test case. Existing topology markers are unchanged: `c0`, `c0-lo`, `bmc`.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A (test-only fix).
