### PR TITLE
[bgp/test_prefix_list_suppress] Bound vtysh + gate FRR readiness on reload (fix t2 150-min hang)

### DIFF
--- a/tests/bgp/test_prefix_list_suppress.py
+++ b/tests/bgp/test_prefix_list_suppress.py
@@ -70,6 +70,14 @@ DB_ONLY_BAD_PREFIX = "not-a-prefix"
 BGPCFGD_RUNNING_TIMEOUT = 60
 BGPCFGD_RUNNING_INTERVAL = 5
 
+# Hard ceiling for any vtysh invocation. A raw vtysh call blocks forever when
+# FRR has accepted the VTY socket connection but is not servicing it, observed
+# on T2 multi-ASIC KVM after a config reload: the daemons stay RUNNING yet
+# every vtysh sticks in unix_stream_read, which hangs the whole test module
+# until the harness kills it (no result, no XML). Bounding vtysh turns that
+# into a fast, reported failure instead.
+VTYSH_SHELL_TIMEOUT = 60
+
 
 # ---------------------------------------------------------------------------
 # Generic helpers
@@ -169,13 +177,21 @@ def delete_config_db_key_directly(duthost, prefix_type, prefix):
         )
 
 
+def bounded_vtysh_cmd(vtysh_cmd, timeout=VTYSH_SHELL_TIMEOUT):
+    """Prefix a vtysh shell command with ``timeout`` so it can never block the
+    test indefinitely when FRR's VTY socket is unresponsive."""
+    return 'timeout {} {}'.format(timeout, vtysh_cmd)
+
+
 def fetch_vtysh_prefix_list(duthost, asic_index, ipv, name):
     """Return stdout of ``vtysh -n <n> -c 'show <ip|ipv6> prefix-list <name>'``."""
     cmd = get_vtysh_cmd_for_asic(
         duthost, asic_index,
         'vtysh -c "show {} prefix-list {}"'.format(ipv, name),
     )
-    return duthost.shell(cmd, module_ignore_errors=True)["stdout"]
+    return duthost.shell(
+        bounded_vtysh_cmd(cmd), module_ignore_errors=True
+    )["stdout"]
 
 
 def verify_frr_prefix_list_entry(duthost, name, prefix, ipv, present=True):
@@ -289,7 +305,7 @@ def wait_for_frr_ready(duthost, container, asic_index, timeout=480):
     indefinitely when the socket is not yet available.
     """
     vtysh_cmd = get_vtysh_cmd_for_asic(duthost, asic_index, 'vtysh -c "show version"')
-    cmd = 'timeout 10 {}'.format(vtysh_cmd)
+    cmd = bounded_vtysh_cmd(vtysh_cmd, timeout=10)
     pytest_assert(
         wait_until(timeout, 15, 0,
                    lambda c=cmd: duthost.shell(c, module_ignore_errors=True)["rc"] == 0),
@@ -1130,7 +1146,8 @@ class TestPrefixListNegative:
                 )
                 out = duthost.shell(
                     '{} | grep prefix-list '
-                    '| grep -i {} || true'.format(vtysh_cmd, UNKNOWN_TYPE),
+                    '| grep -i {} || true'.format(
+                        bounded_vtysh_cmd(vtysh_cmd), UNKNOWN_TYPE),
                 )["stdout"]
                 pytest_assert(
                     not out.strip(),
@@ -1188,7 +1205,8 @@ class TestPrefixListNegative:
             )
             out = duthost.shell(
                 '{} | grep prefix-list '
-                '| grep -F {!r} || true'.format(vtysh_cmd, MALFORMED_PREFIX),
+                '| grep -F {!r} || true'.format(
+                    bounded_vtysh_cmd(vtysh_cmd), MALFORMED_PREFIX),
             )["stdout"]
             pytest_assert(
                 not out.strip(),
@@ -1217,7 +1235,8 @@ class TestPrefixListNegative:
                 )
                 out = duthost.shell(
                     '{} | grep prefix-list '
-                    '| grep -F {!r} || true'.format(vtysh_cmd, DB_ONLY_BAD_PREFIX),
+                    '| grep -F {!r} || true'.format(
+                        bounded_vtysh_cmd(vtysh_cmd), DB_ONLY_BAD_PREFIX),
                 )["stdout"]
                 pytest_assert(
                     not out.strip(),

--- a/tests/bgp/test_prefix_list_suppress.py
+++ b/tests/bgp/test_prefix_list_suppress.py
@@ -78,6 +78,14 @@ BGPCFGD_RUNNING_INTERVAL = 5
 # into a fast, reported failure instead.
 VTYSH_SHELL_TIMEOUT = 60
 
+# Upper bound for FRR to open and start servicing its VTY socket after a
+# ``config reload`` or a BGP container restart. bgpcfgd RUNNING (and even BGP
+# sessions coming up) does NOT imply vtysh is ready: on T2 multi-ASIC KVM with
+# slow I/O and a large config, FRR can need several minutes before it accepts
+# VTY connections. Anything querying FRR through vtysh must gate on
+# wait_for_frr_ready first so it adapts to system speed instead of racing FRR.
+FRR_READY_TIMEOUT = 480
+
 
 # ---------------------------------------------------------------------------
 # Generic helpers
@@ -296,7 +304,7 @@ def start_bgp_container(duthost, service, container):
     duthost.shell("sudo docker start {}".format(container), module_ignore_errors=True)
 
 
-def wait_for_frr_ready(duthost, container, asic_index, timeout=480):
+def wait_for_frr_ready(duthost, container, asic_index, timeout=FRR_READY_TIMEOUT):
     """Wait until FRR vtysh responds on a specific ASIC.
 
     bgpcfgd RUNNING does NOT imply FRR daemons are ready — on T2 KVM
@@ -312,6 +320,21 @@ def wait_for_frr_ready(duthost, container, asic_index, timeout=480):
         "FRR vtysh not responsive within {}s on {} of {}".format(
             timeout, container, duthost.hostname),
     )
+
+
+def wait_for_all_frr_ready(duthost, timeout=FRR_READY_TIMEOUT):
+    """Wait until FRR's VTY socket is responsive on every frontend ASIC.
+
+    Must be called after any ``config reload`` / BGP restart before FRR is
+    queried through vtysh. On T2 multi-ASIC KVM the BGP daemons can report
+    RUNNING (and even bring their sessions up) minutes before their VTY socket
+    starts accepting connections, so a prefix-list query issued too early would
+    otherwise block. Gating here keeps every later vtysh call fast and adapts
+    to system speed (returns as soon as FRR answers on each ASIC).
+    """
+    for asic_index in duthost.get_frontend_asic_ids():
+        container = bgp_container_name(duthost, asic_index)
+        wait_for_frr_ready(duthost, container, asic_index, timeout=timeout)
 
 
 def restart_bgp_container(duthost):
@@ -659,6 +682,7 @@ class TestAnchorPrefixRegression:
             duthost.shell("sudo config save -y")
             config_reload(duthost, safe_reload=True, wait_for_bgp=True)
             wait_for_bgpcfgd(duthost)
+            wait_for_all_frr_ready(duthost)
 
             pytest_assert(
                 verify_config_db_entry(duthost, ANCHOR_TYPE, v4, present=True),
@@ -1044,6 +1068,7 @@ class TestSuppressPrefix:
             duthost.shell("sudo config save -y")
             config_reload(duthost, safe_reload=True, wait_for_bgp=True)
             wait_for_bgpcfgd(duthost)
+            wait_for_all_frr_ready(duthost)
 
             pytest_assert(
                 wait_until(

--- a/tests/common/helpers/yang_utils.py
+++ b/tests/common/helpers/yang_utils.py
@@ -2,6 +2,15 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Hard ceiling for the apply-patch probe. ``config apply-patch`` runs vtysh and
+# other FRR/DB queries under the hood, which block forever when the DUT's FRR
+# VTY socket is wedged (observed on T2 multi-ASIC KVM after a config reload).
+# Without a bound this teardown hangs the whole test module until the harness
+# kills it, producing no junit XML. A generous timeout keeps a healthy DUT
+# (an empty patch applies in a few seconds) while turning a wedged DUT into a
+# fast, reported failure.
+APPLY_PATCH_TIMEOUT = 300
+
 
 def run_yang_validation(duthost, stage="validation"):
     """
@@ -17,11 +26,19 @@ def run_yang_validation(duthost, stage="validation"):
     logger.info(f"Running YANG validation on {duthost.hostname} ({stage})")
     try:
         result = duthost.shell(
-            'echo "[]" | sudo config apply-patch /dev/stdin',
+            "timeout {} bash -c 'echo \"[]\" | sudo config apply-patch /dev/stdin'".format(
+                APPLY_PATCH_TIMEOUT),
             module_ignore_errors=True
         )
 
-        if result['rc'] != 0:
+        if result['rc'] == 124:
+            error = (
+                f"config apply-patch did not complete within {APPLY_PATCH_TIMEOUT}s "
+                f"(DUT likely unresponsive)"
+            )
+            logger.error(f"YANG validation timed out on {duthost.hostname} ({stage}): {error}")
+            return {'failed': True, 'error': error}
+        elif result['rc'] != 0:
             error = result.get('stderr', result.get('stdout', 'Unknown error'))
             logger.error(f"YANG validation failed on {duthost.hostname} ({stage}): {error}")
             return {'failed': True, 'error': error}


### PR DESCRIPTION
### Description of PR
`bgp/test_prefix_list_suppress.py` fails 100% on the **t2** KVM lane (0 passes since 2026-06-01, incl. master baseline) with the Elastictest verdict "Test failed and no xml file created": the module runs ~150 min, is hard-killed with no junit XML, and the plan is retried/cancelled ("stuck half way").

Root cause (reproduced live on vms-kvm-t2): on `config reload`, **zebra crashes** (SIGABRT, assertion in `route_next()` during a northbound YANG RIB-route walk); the ~876 MB core is gzip-compressed by `coredump-compress`, freezing zebra for minutes, so its VTY socket stops accepting and every `vtysh` blocks forever. The test's post-reload vtysh / `config apply-patch` calls are unbounded, so the whole module hangs. Details + fix for the crash: sonic-net/sonic-buildimage#28239.

This PR makes the **test framework** robust to that wedge so it fails fast with a result and junit XML instead of hanging for 150 min. It does not by itself make t2 green - that needs the zebra fix (#28239).

### Type of change
- [x] Bug fix
- [x] Testbed and Framework (new/improvement)

### Approach
#### What is the motivation for this PR?
PR #24840 added this module on 2026-06-01 (the exact start of the 100% t2 failures). #25498 recognised the post-restart vtysh block and added `wait_for_frr_ready()` (adaptive 480 s VTY-readiness gate) - but wired it only into `restart_bgp_container()`, leaving the `config reload` verification path and several `vtysh` / teardown calls unbounded, so any one of them still hangs the module forever on a wedged DUT.

#### How did you do it?
1. `tests/bgp/test_prefix_list_suppress.py`
   - `VTYSH_SHELL_TIMEOUT` + `bounded_vtysh_cmd()`; wrapped every previously-unbounded `vtysh` call (`fetch_vtysh_prefix_list`, the 3 `TestPrefixListNegative` reads, and `wait_for_frr_ready`).
   - `FRR_READY_TIMEOUT` + `wait_for_all_frr_ready()` (per frontend ASIC); call it after `wait_for_bgpcfgd()` in both `*_persists_through_reload` tests so the reload path gates on FRR VTY-readiness (completes #25498).
2. `tests/common/helpers/yang_utils.py`
   - Bound the YANG-validation teardown `config apply-patch` with `timeout` and treat rc 124 as an explicit failure (this is where the fleet hang actually lands).

On a healthy DUT there is no behaviour change (vtysh returns well under the ceiling; an empty apply-patch is a few seconds). On a wedged DUT the module now fails fast with junit XML.

#### How did you verify/test it?
- Reproduced the hang end-to-end on vms-kvm-t2 and confirmed the fix converts the 150-min no-XML hang into a bounded FAIL that writes junit XML.
- Verified the FRR-readiness gate mechanism directly (froze bgpd: `vtysh` returns rc 124 while `bgpcfgd` still RUNNING; recovers on unfreeze).
- Root-caused the underlying zebra crash (filed as sonic-net/sonic-buildimage#28239).
- `flake8 --max-line-length=120` clean; `py_compile` clean.

### Documentation
No documentation changes.
