### PR TITLE
[ssh] Fix flaky test_ssh_stress CPU/memory recovery check

### DIFF
--- a/tests/ssh/test_ssh_stress.py
+++ b/tests/ssh/test_ssh_stress.py
@@ -35,6 +35,15 @@ done = False
 max_cpu = 0
 max_mem = 0
 
+# Post-test CPU/memory recovery check tunables. After the stress load stops we poll
+# several instantaneous samples and require the best (lowest) reading to be within
+# RECOVER_THRESHOLD of the pre-test baseline. Comparing the settled reading against the
+# baseline (init) -- not the in-test peak (max) -- avoids false failures when a single
+# late sample happens to be >= the recorded peak.
+RECOVER_THRESHOLD = 0.2    # allowed elevation above the pre-test baseline (fraction)
+SETTLE_POLLS = 6           # number of post-test settle samples
+SETTLE_INTERVAL = 5        # seconds between settle samples
+
 
 @pytest.fixture
 def setup_teardown(duthosts, rand_one_dut_hostname):
@@ -77,9 +86,15 @@ def setup_teardown(duthosts, rand_one_dut_hostname):
 
 
 def get_system_stats(duthost):
-    """Gets Memory and CPU usage from DUT"""
-    stdout_lines = duthost.command("vmstat")["stdout_lines"]
-    data = list(map(float, stdout_lines[2].split()))
+    """Gets instantaneous Memory and CPU usage from DUT.
+
+    ``vmstat`` with no interval reports CPU averaged since boot, which barely moves
+    during a short test (so the in-test peak and the post-test sample look almost
+    identical). ``vmstat 1 2`` prints a second row sampled over 1 second; use that
+    last row so CPU reflects the current instantaneous load.
+    """
+    stdout_lines = duthost.command("vmstat 1 2")["stdout_lines"]
+    data = list(map(float, stdout_lines[-1].split()))
 
     total_memory = sum(data[2:6])
     used_memory = sum(data[4:6])
@@ -145,25 +160,37 @@ def work(dut_mgmt_ip, commands, baselines, username, password):
 
 
 def run_post_test_system_check(init_mem, init_cpu, duthost):
-    time.sleep(10)
+    """Verify CPU/memory return near their pre-test baseline after the stress ends.
 
-    post_mem, post_cpu = get_system_stats(duthost)
+    The SSH load is asynchronous, so the first post-test samples may still be
+    elevated. Poll several instantaneous samples, keep the best (lowest) reading,
+    and compare it against the pre-test baseline (init) rather than the in-test
+    peak (max): peak-minus-a-single-late-sample is not a reliable recovery signal
+    and produces false failures when that late sample is >= the peak.
+    """
+    best_mem, best_cpu = 1.0, 1.0
+    for _ in range(SETTLE_POLLS):
+        time.sleep(SETTLE_INTERVAL)
+        post_mem, post_cpu = get_system_stats(duthost)
+        best_mem = min(best_mem, post_mem)
+        best_cpu = min(best_cpu, post_cpu)
+        logging.info(
+            "Post-test settle sample: CPU={:.3f} MEM={:.3f} (best so far CPU={:.3f} MEM={:.3f})".format(
+                post_cpu, post_mem, best_cpu, best_mem))
+        if (best_cpu - init_cpu) < RECOVER_THRESHOLD and (best_mem - init_mem) < RECOVER_THRESHOLD:
+            break
 
-    if post_mem-init_mem >= 0.2:
-        pytest_assert(max_mem-post_mem > 0.1,
-                      "Memory increased by more than 20 points during test and did not reduce from raised value\n\
-                      Initial Value: {}, Max value: {}, Post-Test Value: {}".format(init_mem, max_mem, post_mem))
-        logging.warning(
-            "Memory usage did not reduce to original value after test. "
-            "Initial Value: {}, Max value: {}, Post-Test Value: {}".format(init_mem, max_mem, post_mem))
+    pytest_assert(
+        best_cpu - init_cpu < RECOVER_THRESHOLD,
+        "CPU usage stayed more than {:.0f} points above the pre-test baseline after the stress ended.\n"
+        "Initial Value: {}, Max value: {}, Best post-test Value: {}".format(
+            RECOVER_THRESHOLD * 100, init_cpu, max_cpu, best_cpu))
 
-    if post_cpu-init_cpu >= 0.2:
-        pytest_assert(max_cpu-post_cpu > 0.1,
-                      "CPU usage increased by more than 20 points during test and did not reduce from raised value\n\
-                      Initial Value: {}, Max value: {}, Post-Test Value: {}".format(init_cpu, max_cpu, post_cpu))
-        logging.warning(
-            "CPU usage did not reduce to original value after test. "
-            "Initial Value: {}, Max value: {}, Post-Test Value: {}".format(init_cpu, max_cpu, post_cpu))
+    pytest_assert(
+        best_mem - init_mem < RECOVER_THRESHOLD,
+        "Memory usage stayed more than {:.0f} points above the pre-test baseline after the stress ended.\n"
+        "Initial Value: {}, Max value: {}, Best post-test Value: {}".format(
+            RECOVER_THRESHOLD * 100, init_mem, max_mem, best_mem))
 
 
 def get_baseline_time(ssh, command):


### PR DESCRIPTION
### Description of PR

`ssh/test_ssh_stress.py::test_ssh_stress` fails intermittently on the **t1-lag-vpp** KVM baseline (on `master` it runs only on `asic_type == 'vpp'`, skipped on other asics via `conditional_mark`). The post-test system check reports a false failure although the DUT is healthy:

```
Failed: CPU usage increased by more than 20 points during test and did not reduce from raised value
Initial Value: 0.25252525252525254, Max value: 0.47, Post-Test Value: 0.47
```

Root cause (two parts):
1. `get_system_stats` read bare `vmstat`, which reports CPU **averaged since boot**. Over a ~5 min test that average barely moves, so the in-test peak (`max_cpu`) and the single post-test sample (`post_cpu`) end up nearly identical.
2. The check asserted `max_cpu - post_cpu > 0.1`. When the late `post_cpu` sample lands `>= max_cpu` (a measurement artifact -- note `Max == Post == 0.47` above), the difference is `<= 0` and the assertion fails even though CPU never actually stayed elevated.

Fixes the failures tracked in ADO PBI 38650838.

### Type of change

- [x] Bug fix
- [x] Test case improvement

### Approach
#### What is the motivation for this PR?
`run_post_test_system_check` verifies that CPU/memory return toward their pre-test baseline after the SSH stress load, but it fails intermittently on shared VPP KVM hosts even though the DUT is healthy, for the two reasons above.

#### How did you do it?
- Sample **instantaneously** with `vmstat 1 2` (the 1-second delta row) so the peak and post-test readings are meaningful instead of since-boot averages.
- **Poll** several post-test samples, keep the best (lowest), and compare it against the **pre-test baseline (`init`)** rather than the in-test peak. A genuinely stuck-high process still fails; a normal spike-then-recover (even with a noisy first sample) passes. The 20-point sensitivity is unchanged, so this does not introduce new false positives from benign page-cache growth.

#### How did you verify/test it?
- Reproduced the exact failure end-to-end on the VPP KVM baseline (`vms-kvm-vpp-t1-lag`, master KVM build): 1/20 repeats failed with the signature above.
- Unit-validated the patched functions with a mock DUT: `vmstat 1 2` instantaneous-row parsing is correct; a normal spike -> recover passes; a stuck-high-CPU regression still fails.
- `flake8 --max-line-length=120` clean; `py_compile` clean.

#### Any platform specific information?
On `master`, `test_ssh_stress` runs only on `asic_type == 'vpp'`, so this primarily affects the VPP KVM baseline.

### Documentation
No documentation changes.
