### PR TITLE
Fix missing Option 82 in stress test ACK packets for dualtor mode

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -810,7 +810,7 @@ class DHCPTest(DataplaneBaseTest):
                           dhcp_lease=self.LEASE_TIME,
                           padding_bytes=0,
                           set_broadcast_bit=True)
-        if (self.link_selection and self.source_interface):
+        if (self.link_selection and self.source_interface) or self.dual_tor:
             dhcp_ack_packet[scapy.DHCP].options.insert(
                 dhcp_ack_packet[scapy.DHCP].options.index("end"),
                 (82, self.option82)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In dualtor mode, dhcp4relay resolves the target VLAN from Option 82's circuit-id in server replies. The 202605 refactor of create_dhcp_ack_packet() added conditional Option 82 insertion but only for link_selection mode, missing the dual_tor case. This caused dhcp4relay to fall back to giaddr resolution, which resolved to Loopback0 and logged ERR — failing loganalyzer even though counter validation passed.


Summary:
Fixes # [25880](https://github.com/sonic-net/sonic-mgmt/issues/25880)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
In dualtor mode, dhcp4relay resolves the target VLAN from Option 82's circuit-id in server replies. The 202605 refactor of create_dhcp_ack_packet() added conditional Option 82 insertion but only for link_selection mode, missing the dual_tor case. This caused dhcp4relay to fall back to giaddr resolution, which resolved to Loopback0 and logged ERR — failing loganalyzer even though counter validation passed.
#### How did you do it?
Add  to the Option 82 insertion condition at line 813, matching the existing behavior in create_dhcp_offer_packet().

#### How did you verify/test it?
Verified by running test_dhcpmon_relay_counters_stress[ack-sonic-relay-agent]

#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
