### PR TITLE
[ssh] Fix flaky CPU/memory recovery check in test_ssh_stress

### DIFF
--- a/tests/ssh/test_ssh_stress.py
+++ b/tests/ssh/test_ssh_stress.py
@@ -35,6 +35,13 @@ done = False
 max_cpu = 0
 max_mem = 0
 
+# After the stress test, CPU and memory should drop back close to where they started.
+# We take a few readings while things settle and keep the lowest one, then allow it to
+# sit at most RECOVER_THRESHOLD above the pre-test baseline before calling it a failure.
+RECOVER_THRESHOLD = 0.2    # how far a metric may stay above its pre-test baseline (fraction)
+SETTLE_POLLS = 6           # how many readings to take while waiting for usage to settle
+SETTLE_INTERVAL = 5        # seconds to wait between those readings
+
 
 @pytest.fixture
 def setup_teardown(duthosts, rand_one_dut_hostname):
@@ -77,9 +84,17 @@ def setup_teardown(duthosts, rand_one_dut_hostname):
 
 
 def get_system_stats(duthost):
-    """Gets Memory and CPU usage from DUT"""
-    stdout_lines = duthost.command("vmstat")["stdout_lines"]
-    data = list(map(float, stdout_lines[2].split()))
+    """Return the DUT's current memory and CPU usage, each as a fraction (0-1).
+
+    Plain ``vmstat`` reports CPU usage averaged since boot. Over a short test that
+    average barely moves, so the peak seen during the test and the reading taken
+    afterwards look almost the same. ``vmstat 1 2`` adds a second row measured over
+    one second, so we read that last row to get the load right now.
+    """
+    # The last line of `vmstat 1 2` is the 1-second (current) sample; line [2] would
+    # be the since-boot average.
+    stdout_lines = duthost.command("vmstat 1 2")["stdout_lines"]
+    data = list(map(float, stdout_lines[-1].split()))
 
     total_memory = sum(data[2:6])
     used_memory = sum(data[4:6])
@@ -144,26 +159,46 @@ def work(dut_mgmt_ip, commands, baselines, username, password):
     ssh.close()
 
 
+def _assert_usage_recovered(resource, baseline, peak, lowest):
+    """Fail if a resource did not settle back near its pre-test baseline after the test.
+
+    ``resource`` is a label used only in the message ("CPU" / "Memory"); ``baseline``,
+    ``peak`` and ``lowest`` are usage fractions (0-1).
+    """
+    pytest_assert(
+        lowest - baseline < RECOVER_THRESHOLD,
+        "{} usage did not recover after the test: it stayed more than {:.0f} points above the "
+        "pre-test baseline.\nBaseline: {}, In-test peak: {}, Lowest after test: {}".format(
+            resource, RECOVER_THRESHOLD * 100, baseline, peak, lowest))
+
+
 def run_post_test_system_check(init_mem, init_cpu, duthost):
-    time.sleep(10)
+    """Check that CPU and memory settle back near their pre-test baseline.
 
-    post_mem, post_cpu = get_system_stats(duthost)
+    The SSH worker threads stop asynchronously, so the first reading taken after the
+    test can still be high. We take several readings, keep the lowest (most recovered)
+    one, and compare it to the pre-test baseline.
 
-    if post_mem-init_mem >= 0.2:
-        pytest_assert(max_mem-post_mem > 0.1,
-                      "Memory increased by more than 20 points during test and did not reduce from raised value\n\
-                      Initial Value: {}, Max value: {}, Post-Test Value: {}".format(init_mem, max_mem, post_mem))
-        logging.warning(
-            "Memory usage did not reduce to original value after test. "
-            "Initial Value: {}, Max value: {}, Post-Test Value: {}".format(init_mem, max_mem, post_mem))
+    We compare against the baseline on purpose, not against the in-test peak. The old
+    check ("peak minus a single later reading") failed whenever that later reading
+    happened to be at or above the peak -- reporting a problem even when usage had
+    actually recovered.
+    """
+    lowest_mem, lowest_cpu = 1.0, 1.0
+    for _ in range(SETTLE_POLLS):
+        time.sleep(SETTLE_INTERVAL)
+        mem, cpu = get_system_stats(duthost)
+        lowest_mem = min(lowest_mem, mem)
+        lowest_cpu = min(lowest_cpu, cpu)
+        logging.info(
+            "Waiting for usage to settle: CPU={:.3f} MEM={:.3f} (lowest so far CPU={:.3f} MEM={:.3f})".format(
+                cpu, mem, lowest_cpu, lowest_mem))
+        # Stop early once both have come back down near the baseline.
+        if lowest_cpu - init_cpu < RECOVER_THRESHOLD and lowest_mem - init_mem < RECOVER_THRESHOLD:
+            break
 
-    if post_cpu-init_cpu >= 0.2:
-        pytest_assert(max_cpu-post_cpu > 0.1,
-                      "CPU usage increased by more than 20 points during test and did not reduce from raised value\n\
-                      Initial Value: {}, Max value: {}, Post-Test Value: {}".format(init_cpu, max_cpu, post_cpu))
-        logging.warning(
-            "CPU usage did not reduce to original value after test. "
-            "Initial Value: {}, Max value: {}, Post-Test Value: {}".format(init_cpu, max_cpu, post_cpu))
+    _assert_usage_recovered("CPU", init_cpu, max_cpu, lowest_cpu)
+    _assert_usage_recovered("Memory", init_mem, max_mem, lowest_mem)
 
 
 def get_baseline_time(ssh, command):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
`test_ssh_stress` opens many SSH sessions to stress the DUT, then checks that CPU and memory settle back down once the load stops. That final recovery check (`run_post_test_system_check`) is flaky on the VPP KVM baseline -- it reports a failure even when the DUT is healthy:

```
Failed: CPU usage increased by more than 20 points during test and did not reduce from raised value
Initial Value: 0.25252525252525254, Max value: 0.47, Post-Test Value: 0.47
```

Why it happens -- two small issues that combine:

1. **The measurement is misleading.** `get_system_stats()` calls plain `vmstat`, which reports CPU usage *averaged since boot*. During a short test that average hardly moves, so the peak recorded during the test (`max_cpu`) and the reading taken afterwards (`post_cpu`) come out almost equal.
2. **The comparison is unreliable.** The check asserted `max_cpu - post_cpu > 0.1` (i.e. "did CPU drop a bit from its peak?"). Because those two numbers are nearly equal, `post_cpu` often lands *at or above* `max_cpu` -- note `Max == Post == 0.47` above -- so the difference is `<= 0` and the test fails, even though CPU never actually stayed high.

Fixes the failures tracked in ADO PBI 38650838.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: ADO 38650838
Failure type: day-one issue

### Approach
#### What is the motivation for this PR?
The check is meant to catch a real problem -- CPU or memory staying high after the test -- but as written it also fires on healthy runs, so the test is unreliable on the VPP baseline.

#### How did you do it?
Two changes, both about how usage is measured and interpreted (the stress test itself is unchanged):

1. **Measure the current load, not the since-boot average.** `get_system_stats()` now runs `vmstat 1 2` and reads the 1-second sample, so `max_cpu` and the post-test readings reflect the load right now.
2. **Compare against the starting baseline, not the peak.** After the test, take a few readings while usage settles, keep the lowest one, and require it to be within 20 points of the pre-test baseline. A process that stays busy still fails the check; a normal spike that settles (even with a noisy first reading) passes. The 20-point sensitivity is unchanged.

#### How did you verify/test it?
Elastictest, `ssh/test_ssh_stress.py` repeated 20x on `vms-kvm-vpp-t1-lag` (t1-lag-vpp, VPP):
- **Before (master -- reproduces the bug):** https://elastictest.org/scheduler/testplan/6a47b0475f6e97252deeb62a -- run #15 fails in the test body with `CPU usage increased by more than 20 points ... did not reduce` (`Initial 0.2525, Max 0.47, Post 0.47`).
- **After (this PR -- fixed):** https://elastictest.org/scheduler/testplan/6a47f6fda577b9de602ff366 -- 20/20 with no CPU-recovery failure. (The 4 non-blocking errors there are an unrelated `memory_utilization` teardown alarm on frr_bgp/zebra memory that also occurs on master; it is not this test's check and is out of scope for this PR.)

Also:
- Unit-checked the two functions with a mock DUT: `vmstat 1 2` parsing reads the current sample; a normal spike -> recover passes; a process that stays busy still fails.
- `flake8 --max-line-length=120` clean; `py_compile` clean.

#### Any platform specific information?
On `master`, `test_ssh_stress` runs only on `asic_type == 'vpp'`, so this primarily affects the VPP KVM baseline.

#### Supported testbed topology if it's a new test case?
N/A (existing test, not a new test case).

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No documentation changes.
