### PR TITLE
Rotate syslog on `monit var-log` sanity check failure, instead of reboot

### DIFF
--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -85,6 +85,16 @@ def _recover_interfaces(dut, fanouthosts, result, wait_time):
     return action
 
 
+def _recover_monit(dut, result):
+    services_status = result.get('services_status', {})
+    action = 'reboot'
+    if services_status.get('var-log') == 'Resource limit matched':
+        logging.warning("var-log filesystem full on %s, forcing logrotate", dut.hostname)
+        dut.shell("logrotate -f /etc/logrotate.conf", module_ignore_errors=True)
+        action = None
+    return action
+
+
 def _recover_services(dut, result):
     status = result['services_status']
     services = [x for x in status if not status[x]]
@@ -230,6 +240,8 @@ def adaptive_recover(ptfhost, dut, localhost, fanouthosts, nbrhosts, tbinfo, che
                     action = neighbor_vm_restore(dut, nbrhosts, tbinfo, result)
             elif result['check_item'] == "neighbor_macsec_empty":
                 action = neighbor_vm_restore(dut, nbrhosts, tbinfo, result)
+            elif result['check_item'] == 'monit':
+                action = _recover_monit(dut, result)
             elif result['check_item'] in ['processes', 'mux_simulator']:
                 action = 'config_reload'
             else:


### PR DESCRIPTION
https://github.com/sonic-net/sonic-mgmt/issues/25888

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #25888
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->


Adaptive recovery triggered during sanity_check_full when "var-log": "Resource limit matched"
but monit does not have any specific path for recovery and defaults to reboot

This masks the true problem because
/etc/monit/conf.d/sonic-host contains the following

```
check filesystem var-log with path /var/log
    if space usage > 90% for 10 times within 20 cycles then alert repeat every 1 cycles
```
on reboot the 10 times for 20 cycles must be repeated for monit to register the issue again.

my fix is to rotate var log instead of reboot.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
Speed up tests by not fruitlessly rebooting, and replace the recovery that only masks the problem with one that works.

#### How did you do it?
add a monit path for recovery, specifically var-log. call logrotate on the dut.

#### How did you verify/test it?
verified that with the recovery, the dut no longer reboots and that /var/log empties

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202605

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result
Recovery of var log over usage no longer results in an unecessary reboot. Var log resources are freed.

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->