### PR TITLE
Fix TestRouteConsistency to re-announce on pytest assert failure

### DIFF
--- a/tests/route/test_route_consistency.py
+++ b/tests/route/test_route_consistency.py
@@ -212,13 +212,13 @@ class TestRouteConsistency():
             )
 
             logger.info("Route table is consistent across all the DUTs")
-        except Exception as e:
-            logger.error("Exception occurred: {}".format(e))
+        except (Exception, pytest.fail.Exception) as e:
+            logger.error("Exception occurred: {}. Re-announcing routes to recover!".format(e))
             # announce the routes back in case of any exception
             localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce", path="../ansible/")
             wait_until(self.sleep_interval, 10, 0, self.route_snapshots_match,
                        duthosts, self.pre_test_route_snapshot)
-            raise e
+            raise
 
     def test_bgp_shut_noshut(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, localhost):
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
@@ -267,10 +267,12 @@ class TestRouteConsistency():
                 )
 
             logger.info("Route table is consistent across all the DUTs")
-        except Exception:
+        except (Exception, pytest.fail.Exception) as e:
             # startup bgp back in case of any exception
+            logger.error("Exception occurred: {}. Starting up BGP to recover!".format(e))
             duthost.shell("sudo config bgp startup all")
             wait_until(self.sleep_interval, 10, 0, is_all_neighbor_session_established, duthost)
+            raise
 
     @pytest.mark.disable_loganalyzer
     @pytest.mark.parametrize("container_name, program_name", [
@@ -336,8 +338,9 @@ class TestRouteConsistency():
                 )
 
             logger.info("Route table is consistent across all the DUTs")
-        except Exception:
+        except (Exception, pytest.fail.Exception) as e:
             # startup bgpd back in case of any exception
-            logger.info("Encountered error. Perform a config reload to recover!")
+            logger.error("Encountered error: {}. Perform a config reload to recover!".format(e))
             config_reload(duthost)
             wait_until(self.sleep_interval, 10, 0, is_all_neighbor_session_established, duthost)
+            raise


### PR DESCRIPTION
When `pytest assert routes_have_changed` fails, the test then fails within the `try` but the pytest failure is not caught by the Exception class.

We need to also catch the pytest failure exception for routes to be re-announced.

Same applies for cleanup in the other tests in TestRouteConsistency

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #25891 (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
When running TestRouteConsistency::test_route_withdraw_advertise individually, if it fails from a pytest_assert on the first attempt then subsequent attempts will also fail as it leaves the dut in a poor state.

Reloading/rebooting the dut can recover.

#### How did you do it?
Catch pytest failure as well as generic Exception since pytest failure does not inherit from Exception class.

#### How did you verify/test it?
Reran TestRouteConsistency with the change to see the dut cleans up now.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
