### PR TITLE
[cSONiC] Fix flaky "0 routes to DUT": stop exabgp injector poisoning the eBGP peer-group

### DIFF
--- a/ansible/roles/sonic/templates/configdb-csonic.j2
+++ b/ansible/roles/sonic/templates/configdb-csonic.j2
@@ -1,4 +1,27 @@
 {% set host = configuration[hostname] %}
+{# cSONiC exabgp route-injector -- iBGP via the INTERNAL peer-group.            #}
+{#                                                                              #}
+{# The injector must stay iBGP (remote-as == this neighbor's own bgp_asn) so    #}
+{# the DUT never sees exabgp as a BGP peer -- it only learns the routes the     #}
+{# neighbor re-originates, exactly like a cEOS neighbor.                        #}
+{#                                                                              #}
+{# Problem: SONiC bgpcfgd's general/instance.conf.j2 binds every BGP_NEIGHBOR   #}
+{# entry into the eBGP PEER_V4/V6 peer-group, and FRR rejects a peer-group      #}
+{# with mixed internal/external members. An iBGP injector in BGP_NEIGHBOR       #}
+{# therefore poisons PEER_V4/V6 and (on the nondeterministic apply race) can    #}
+{# get the real eBGP DUT peer refused -> 0 routes advertised to the DUT.        #}
+{#                                                                              #}
+{# Fix: put the injector in BGP_INTERNAL_NEIGHBOR instead. bgpcfgd renders      #}
+{# those via internal/instance.conf.j2 into the separate INTERNAL_PEER_V4/V6    #}
+{# peer-group, so the injector (iBGP) and the DUT peer (eBGP in PEER_V4/V6)     #}
+{# live in different, each-homogeneous peer-groups and never conflict. The      #}
+{# internal manager hard-requires a Loopback4096 (see LOOPBACK_INTERFACE        #}
+{# below); its update-source use is chassis-gated and inert here.               #}
+{% set exabgp_asn = host['bgp']['asn'] %}
+{# Loopback4096 addresses for the internal peer manager dependency. Reuse the   #}
+{# neighbor's Loopback0 addresses (already unique/valid); the loopback is only  #}
+{# needed to satisfy the dependency + as an (inert) update-source.              #}
+{% set _lo0 = host['interfaces'].get('Loopback0', {}) %}
 {% set _role_type_map = {'leaf': 'LeafRouter', 'spine': 'SpineRouter', 'tor': 'ToRRouter', 'core': 'SpineRouter'} %}
 {% set device_type = _role_type_map.get(props.swrole | default('leaf'), 'LeafRouter') %}
 {# Count front-panel Ethernet interfaces so the backplane can be placed past   #}
@@ -67,6 +90,18 @@
 {% endif %}
 {% endif %}
 {% endfor %}
+{# Synthetic Loopback4096 required by bgpcfgd's internal peer manager (used for #}
+{# the exabgp iBGP injector in BGP_INTERNAL_NEIGHBOR). Reuses Loopback0 addrs.  #}
+{{ loopback_comma() }}
+        "Loopback4096": {}
+{% if _lo0['ipv4'] is defined %}
+{{ loopback_comma() }}
+        "Loopback4096|{{ _lo0['ipv4'] }}": {}
+{% endif %}
+{% if _lo0['ipv6'] is defined %}
+{{ loopback_comma() }}
+        "Loopback4096|{{ _lo0['ipv6'] }}": {}
+{% endif %}
     },
 {% set has_portchannel = [] %}
 {% for name, iface in host['interfaces'].items() %}
@@ -167,21 +202,30 @@
         }
 {% endfor %}
 {% endfor %}
+    },
+    "BGP_INTERNAL_NEIGHBOR": {
+{% set bgp_int_comma = joiner(",") %}
+{# exabgp route-injector as iBGP (own ASN) in the INTERNAL peer-group, so the   #}
+{# DUT never sees exabgp and PEER_V4/V6 stays uniformly eBGP. local_addr binds  #}
+{# the session to the neighbor's loopback/backplane address (not Loopback4096,  #}
+{# whose update-source use is chassis-gated off here).                          #}
 {% if props.nhipv4 is defined and props.nhipv4 %}
-{{ bgp_comma() }}
+{{ bgp_int_comma() }}
         "{{ props.nhipv4 }}": {
-            "asn": "{{ host['bgp']['asn'] }}",
+            "asn": "{{ exabgp_asn }}",
             "name": "exabgp_v4",
+            "local_addr": "{{ (_lo0['ipv4'] | default(host['bp_interface']['ipv4'], true)).split('/')[0] }}",
             "admin_status": "up",
             "holdtime": "10",
             "keepalive": "3"
         }
 {% endif %}
 {% if props.nhipv6 is defined and props.nhipv6 %}
-{{ bgp_comma() }}
+{{ bgp_int_comma() }}
         "{{ props.nhipv6 }}": {
-            "asn": "{{ host['bgp']['asn'] }}",
+            "asn": "{{ exabgp_asn }}",
             "name": "exabgp_v6",
+            "local_addr": "{{ (_lo0['ipv6'] | default(host['bp_interface']['ipv6'], true)).split('/')[0] }}",
             "admin_status": "up",
             "holdtime": "10",
             "keepalive": "3"

--- a/ansible/roles/sonic/templates/tests/test_configdb_csonic.py
+++ b/ansible/roles/sonic/templates/tests/test_configdb_csonic.py
@@ -74,21 +74,38 @@ def test_renders_valid_json_with_nexthops():
                                       "nhipv4": "10.10.246.254",
                                       "nhipv6": "fc0a::ff"})
     assert "BGP_NEIGHBOR" in cfg
-    # bgp peers + both exabgp next hops are present.
+    # Real bgp peers stay in BGP_NEIGHBOR (eBGP PEER_V4/V6).
     assert "10.0.0.0" in cfg["BGP_NEIGHBOR"]
-    assert "10.10.246.254" in cfg["BGP_NEIGHBOR"]
-    assert "fc0a::ff" in cfg["BGP_NEIGHBOR"]
+    # The exabgp injector is iBGP -> it goes in BGP_INTERNAL_NEIGHBOR, NOT
+    # BGP_NEIGHBOR (so it never poisons the eBGP PEER_V4/V6 peer-group).
+    assert "10.10.246.254" not in cfg["BGP_NEIGHBOR"]
+    assert "fc0a::ff" not in cfg["BGP_NEIGHBOR"]
+    assert "10.10.246.254" in cfg["BGP_INTERNAL_NEIGHBOR"]
+    assert "fc0a::ff" in cfg["BGP_INTERNAL_NEIGHBOR"]
+    # injector is iBGP: its asn equals this neighbor's own bgp asn.
+    assert cfg["BGP_INTERNAL_NEIGHBOR"]["10.10.246.254"]["asn"] == "64001"
+    # local_addr is the Loopback0 address (no prefix).
+    assert cfg["BGP_INTERNAL_NEIGHBOR"]["10.10.246.254"]["local_addr"] == "100.1.0.29"
+    assert cfg["BGP_INTERNAL_NEIGHBOR"]["fc0a::ff"]["local_addr"] == "2064:100::1d"
+    # Loopback4096 (internal peer manager dependency) is present, reusing
+    # Loopback0's addresses.
+    assert "Loopback4096" in cfg["LOOPBACK_INTERFACE"]
+    assert "Loopback4096|100.1.0.29/32" in cfg["LOOPBACK_INTERFACE"]
+    assert "Loopback4096|2064:100::1d/128" in cfg["LOOPBACK_INTERFACE"]
 
 
 def test_valid_json_without_nexthops():
     """Topologies that do not define nhipv4/nhipv6 must still render valid JSON
-    (no undefined-variable blow-up, no dangling comma)."""
+    (no undefined-variable blow-up, no dangling comma), and emit an empty
+    BGP_INTERNAL_NEIGHBOR."""
     cfg = _render_json(_base_host(), {"swrole": "leaf"})
     nbrs = cfg["BGP_NEIGHBOR"]
     # Only the real bgp peers remain; no empty/None next-hop key sneaks in.
     assert set(nbrs.keys()) == {"10.0.0.0", "fc00::0"}
     assert "" not in nbrs
     assert "None" not in nbrs
+    # No injector -> BGP_INTERNAL_NEIGHBOR renders as an empty (but valid) table.
+    assert cfg["BGP_INTERNAL_NEIGHBOR"] == {}
 
 
 def test_empty_nexthop_is_skipped():
@@ -97,25 +114,28 @@ def test_empty_nexthop_is_skipped():
                                       "nhipv4": "",
                                       "nhipv6": None})
     assert set(cfg["BGP_NEIGHBOR"].keys()) == {"10.0.0.0", "fc00::0"}
+    assert cfg["BGP_INTERNAL_NEIGHBOR"] == {}
 
 
 def test_only_v4_nexthop():
     cfg = _render_json(_base_host(), {"swrole": "leaf",
                                       "nhipv4": "10.10.246.254"})
     nbrs = cfg["BGP_NEIGHBOR"]
-    assert "10.10.246.254" in nbrs
-    assert all(":" not in k or k in ("fc00::0",) for k in nbrs)
-    assert set(nbrs.keys()) == {"10.0.0.0", "fc00::0", "10.10.246.254"}
+    # Real peers only in BGP_NEIGHBOR; the v4 injector is in the internal table.
+    assert set(nbrs.keys()) == {"10.0.0.0", "fc00::0"}
+    assert set(cfg["BGP_INTERNAL_NEIGHBOR"].keys()) == {"10.10.246.254"}
 
 
 def test_no_bgp_peers_only_nexthops():
-    """No real peers, only exabgp next hops: still valid JSON, no leading comma."""
+    """No real peers, only exabgp next hops: still valid JSON, no leading comma.
+    BGP_NEIGHBOR is empty; both injectors land in BGP_INTERNAL_NEIGHBOR."""
     host = _base_host()
     host["bgp"]["peers"] = {}
     cfg = _render_json(host, {"swrole": "leaf",
                               "nhipv4": "10.10.246.254",
                               "nhipv6": "fc0a::ff"})
-    assert set(cfg["BGP_NEIGHBOR"].keys()) == {"10.10.246.254", "fc0a::ff"}
+    assert cfg["BGP_NEIGHBOR"] == {}
+    assert set(cfg["BGP_INTERNAL_NEIGHBOR"].keys()) == {"10.10.246.254", "fc0a::ff"}
 
 
 def test_backplane_placed_after_front_panel_links():


### PR DESCRIPTION
Fixes #25897

### Problem

On a cSONiC (`docker-sonic-vs`) neighbor, the exabgp route-injector and the
real DUT peer both land in bgpcfgd's shared `PEER_V4`/`PEER_V6` peer-group.
That group carries no explicit `remote-as`, so the **first member to bind sets
the group's type** (internal vs external), and FRR then rejects any later
member of the other type **at bind time**:

```
% Peer-group members must be all internal or all external.
```

The injector is iBGP (its remote-as == the neighbor's own `bgp_asn`) and the
DUT peer is eBGP, so one of them is always rejected. Apply order is
nondeterministic, which makes it **flaky**:

- **DUT peer binds first** → group external → the later **iBGP injector** is
  rejected. The test only needs the DUT peer, which is up → pass.
- **Injector binds first** → group internal → the later **eBGP DUT peer** is
  rejected → the DUT peer never activates → 0 prefixes advertised to the DUT
  → fail.

This is the root cause behind intermittent "cSONiC neighbor advertises 0 routes
to the DUT" failures. Full writeup in the linked issue.

### Fix

Move the exabgp injector out of the shared eBGP peer-group and into a separate
`BGP_INTERNAL_NEIGHBOR` entry, which bgpcfgd renders into its own
`INTERNAL_PEER_V4`/`V6` peer-group. The injector (iBGP) and the DUT peer (eBGP)
then live in two homogeneous peer-groups and never trip the FRR homogeneity
check, regardless of apply order.

The injector stays iBGP, which is the intended topology: the DUT never peers
with exabgp — it only learns the routes the neighbor re-originates, exactly
like a cEOS neighbor.

### Changes (cSONiC-scoped)

- `ansible/roles/sonic/templates/configdb-csonic.j2`:
  - Move the exabgp injector from `BGP_NEIGHBOR` into a new
    `BGP_INTERNAL_NEIGHBOR` table (iBGP, `asn` = the neighbor's own `bgp_asn`).
  - Add a synthetic **`Loopback4096`** (reusing the neighbor's `Loopback0`
    addresses): bgpcfgd's internal-peer manager hard-requires it. Its
    `update-source` use is chassis-gated and inert on a non-chassis VS neighbor.
  - Set `local_addr` on the injector to the neighbor's `Loopback0` address.
- `ansible/roles/sonic/templates/tests/test_configdb_csonic.py`: update
  assertions for the new placement.

Non-cSONiC (cEOS/vEOS/…) neighbors are unaffected — this template is
cSONiC-only.

### Verification

- **Unit tests** (updated in this PR): 9/9 pass — the injector renders into
  `BGP_INTERNAL_NEIGHBOR`, `Loopback4096` is present, and `BGP_NEIGHBOR` holds
  only the real eBGP peers.
- **Live cSONiC neighbor:** injector Established as iBGP in `INTERNAL_PEER_V4`
  (6399 prefixes accepted); the eBGP DUT peer Established in `PEER_V4`
  (6401 prefixes sent); and from the DUT's own view it peers **only** with the
  neighbor VMs — exabgp (`10.10.246.x`) is not a DUT peer. Routes flow
  exabgp → injector (iBGP) → neighbor → DUT (eBGP).

### How to test

```
./run_tests.sh -n vms-kvm-t0-csonic -d vlab-01 \
  -c bgp/test_bgp_route_neigh_learning.py \
  -f vtestbed.yaml -i ../ansible/veos_vtb -u \
  -e "--neighbor_type csonic" -e --skip_sanity
```
(after re-deploying the cSONiC neighbors so the new injector config is applied)
