### PR TITLE
Fix YANG validation empty patch flake

### DIFF
--- a/tests/common/helpers/yang_utils.py
+++ b/tests/common/helpers/yang_utils.py
@@ -17,7 +17,9 @@ def run_yang_validation(duthost, stage="validation"):
     logger.info(f"Running YANG validation on {duthost.hostname} ({stage})")
     try:
         result = duthost.shell(
-            'echo "[]" | sudo config apply-patch /dev/stdin',
+            "sudo sh -c 'patch_file=$(mktemp /etc/sonic/yang_empty_patch.XXXXXX) && "
+            "printf \"[]\" > \"$patch_file\" && config apply-patch \"$patch_file\"; "
+            "rc=$?; rm -f \"$patch_file\"; exit $rc'",
             module_ignore_errors=True
         )
 


### PR DESCRIPTION
### Description of PR
Summary:
Fix intermittent YANG validation failures where an empty JSON patch is piped through sudo to `config apply-patch /dev/stdin` and `config` sometimes receives empty stdin, causing `Expecting value: line 1 column 1 (char 0)` during pre/post-test validation.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Nightly PBI 38690039 hit a teardown failure after `bgp/test_bgp_peer_shutdown.py::test_bgp_peer_shutdown` passed. The post-test `yang_validation_check` fixture failed while applying an empty patch:

`echo "[]" | sudo config apply-patch /dev/stdin`

The error was `Failed to apply patch due to: Expecting value: line 1 column 1 (char 0)`, which indicates `config apply-patch` received empty input instead of the expected `[]` JSON patch. This is a test helper flake, not a BGP product failure.

#### How did you do it?
Write the empty patch to a short-lived file under `/etc/sonic` and pass the file path to `config apply-patch`, preserving the original exit code and removing the file afterwards. This avoids the fragile pipe + sudo + `/dev/stdin` path.

#### How did you verify/test it?
- `python -m py_compile tests/common/helpers/yang_utils.py`
- Reviewed the failing nightly log from PBI 38690039 and confirmed the failure signature matches the changed command path.

#### Any platform specific information?
None. The helper is shared across platforms.

#### Supported testbed topology if it's a new test case?
N/A.

### Documentation
N/A.