### PR TITLE
fix test_po_voq skip condition for empty portchannel

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4013,7 +4013,7 @@ pc/test_po_voq.py:
   skip:
     reason: "Skip for non t2 or Skip since there is no portchannel configured or no portchannel member exists in current topology."
     conditions:
-      - "('t2' not in topo_name and topo_type not in ['lrh', 'urh']) or num_asic == 0 or len(minigraph_portchannels[list(minigraph_portchannels.keys())[0]]['members']) == 0 or asic_type in ['cisco-8000']"
+      - "('t2' not in topo_name and topo_type not in ['lrh', 'urh']) or num_asic == 0 or len(minigraph_portchannels) == 0 or len(minigraph_portchannels[list(minigraph_portchannels.keys())[0]]['members']) == 0 or asic_type in ['cisco-8000']"
 
 pc/test_retry_count.py:
   skip:


### PR DESCRIPTION
### Description of PR

Summary:

The skip condition for `pc/test_po_voq.py` used `list(minigraph_portchannels.keys())[0]`. 
On topologies with no portchannels in ft2 topo, following error will be reported. 

```
INTERNALERROR>   File "/data/cpo-sonic-mgmt-int/tests/common/plugins/conditional_mark/__init__.py", line 608, in evaluate_condition
INTERNALERROR>     raise RuntimeError('Failed to evaluate condition, raw_condition={}, condition_str={}'.format(
INTERNALERROR> RuntimeError: Failed to evaluate condition, raw_condition=('t2' not in topo_name and topo_type not in ['lrh', 'urh']) or num_asic == 0 or len(minigraph_portchannels[list(minigraph_portchannels.keys())[0]]['members']) == 0 or asic_type in ['cisco-8000'], condition_str=('t2' not in topo_name and topo_type not in ['lrh', 'urh']) or num_asic == 0 or len(minigraph_portchannels[list(minigraph_portchannels.keys())[0]]['members']) == 0 or asic_type in ['cisco-8000']
```

This PR adds a `len(minigraph_portchannels) == 0` guard before the indexing.


### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202605

### Approach
#### What is the motivation for this PR?
Evaluating the conditional_mark for `test_po_voq` fails on topologies without any portchannels, because the expression indexes into an empty `minigraph_portchannels` dict.

#### How did you do it?
Added a `len(minigraph_portchannels) == 0` short-circuit before accessing the first key.

#### How did you verify/test it?
Checked the condition on a topology without portchannels — it now evaluates without error and the test is correctly skipped.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
N/A.

### Documentation
No documentation changes needed.
