### PR TITLE
[platform_tests] Fix test_restart_swss flaky "Not all critical processes are healthy" from swss start-limit

### DIFF
--- a/tests/platform_tests/test_sequential_restart.py
+++ b/tests/platform_tests/test_sequential_restart.py
@@ -5,6 +5,7 @@ This script is to cover the test case 'Sequential syncd/swss restart' in the SON
 https://github.com/sonic-net/SONiC/blob/master/doc/pmon/sonic_platform_test_plan.md
 """
 import logging
+import re
 
 import pytest
 
@@ -25,9 +26,12 @@ pytestmark = [
 
 
 @pytest.fixture(autouse=True, scope="function")
-def heal_testbed(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
-    # Nothing to do before test
+def heal_testbed(duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    # Clear systemd's start-limit counter on all critical units so this test's deliberate
+    # service restart isn't rejected with "start request repeated too quickly".
+    for critical_service in [re.sub(r'(\d+)$', r'@\1', s) for s in duthost.critical_services]:
+        duthost.shell("sudo systemctl reset-failed {}.service".format(critical_service))
     yield
     status, details = get_critical_processes_status(duthost)
     if not status:
@@ -35,19 +39,6 @@ def heal_testbed(duthosts, rand_one_dut_hostname):
     # After this test run, rsyslogd is going down if all BGP session established and routes populated
     # restarting syslog to over come this issue, so that subsequent test run will not have errors/failures
     duthost.shell("sudo systemctl restart syslog")
-
-
-def is_service_hiting_start_limit(duthost, container_name):
-    """
-    @summary: Determine whether the container can not be restarted is due to
-              start-limit-hit or not
-    """
-    service_status = duthost.shell("sudo systemctl status {}.service | grep 'Active'".format(container_name))
-    for line in service_status["stdout_lines"]:
-        if "start-limit-hit" in line:
-            return True
-
-    return False
 
 
 def restart_service_and_check(localhost, dut, enum_frontend_asic_index, service, interfaces, xcvr_skip_list,
@@ -59,16 +50,11 @@ def restart_service_and_check(localhost, dut, enum_frontend_asic_index, service,
 
     asichost = dut.asic_instance(enum_frontend_asic_index)
     service_name = asichost.get_service_name(service)
+
     if dut.facts["platform"] == "x86_64-cel_e1031-r0":
         dut.shell("sudo systemctl stop {} && sleep 30 && sudo systemctl start {}".format(service_name, service_name))
     else:
         dut.command("sudo systemctl restart {}".format(service_name))
-
-    for container in dut.get_default_critical_services_list():
-        if is_service_hiting_start_limit(dut, container) is True:
-            logging.info("{} hits start limit and clear reset-failed flag".format(container))
-            dut.shell("sudo systemctl reset-failed {}.service".format(container))
-            dut.shell("sudo systemctl start {}.service".format(container))
 
     logging.info("Wait until all critical services are fully started")
     wait_critical_processes(dut)


### PR DESCRIPTION
### Description of PR

Summary: Fixes the flaky `platform_tests/test_sequential_restart.py::test_restart_swss`
failure `Not all critical processes are healthy`.

`test_sequential_restart` restarts `swss` (and `syncd`), which cascades restarts to the
dependent critical services (`syncd`/`bgp`/`teamd`). systemd rate-limits each unit to
`StartLimitBurst=3` per `StartLimitIntervalSec` and counts every start, including
successful restarts. When earlier tests or config reloads in the same session have
already consumed that budget within the window, the restart here (or the restart it
cascades to) trips the limit, leaving the service `start-limit-hit` and dead, so
`wait_critical_processes` times out with `Not all critical processes are healthy`.

The existing recovery ran after the restart and iterated
`dut.get_default_critical_services_list()`, which returns only the host services
`pmon`, `snmp` and `database`. It never included `swss` or the services its restart
cascades to, so it never cleared the limit on the unit that actually tripped.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: https://msazure.visualstudio.com/One/_workitems/edit/38693909
Failure type: regression (observed on internal-202511)

### Approach
#### What is the motivation for this PR?

`test_restart_swss` intermittently fails with `Not all critical processes are healthy` on
the nightly fleet. Root cause is systemd's start rate-limit on `swss` (and the services
its restart cascades to), not an actual inability of the services to start.

#### How did you do it?

The `heal_testbed` fixture (autouse, per test) now clears the systemd start-limit budget
for the DUT's full set of critical services (`dut.critical_services`, which covers `swss`,
`syncd`, `bgp`, `teamd`, `lldp`, `database`, `pmon`, `snmp`) with `reset-failed` before
each test runs. This gives every service a clean, uniform slate so the deliberate restart
is not blocked by starts that earlier modules accumulated within the same window.
`dut.critical_services` is populated when the DUT object is built, so it is available even
when sanity checks are skipped. Per-ASIC service names (for example `swss0` on a multi-ASIC
DUT) are mapped to their systemd instance unit (`swss@0`) before the `reset-failed`,
matching the convention in `tests/common/platform/device_utils.py`. The fixture is bound to
`enum_rand_one_per_hwsku_hostname` so the reset (and its existing post-test syslog restart)
target the same DUT the test restarts. A test also expects a fresh, healthy DUT to begin
with: an earlier test that left a critical service down would have failed in its own health
checks.

The restart and the normal `wait_critical_processes` wait are left unchanged. There is no
tolerant restart, no start/heal of any service, and no in-loop reset or retry during the
wait. `reset-failed` only clears systemd's start-attempt counter and failed flag; it does
not start or heal a service. Critical-process health is asserted separately by the
process-based `wait_critical_processes` / `check_critical_processes`, which inspect the
actual container processes rather than the systemd unit state, so a service that truly
cannot start still fails the wait. This keeps the fix from masking a real failure.

This also restores the test's original intent (PRs #1991 and #1992): the test must fail
on a genuine `swss`/`orchagent` crash, and the `heal_testbed` fixture restores DUT health
in teardown. The previous post-restart start-limit loop was added incidentally in the
multi-asic enablement PR #2728 and did not address the cascade services.

#### How did you verify/test it?

Reproduced on a physical Mellanox-SN4600C-C64 running internal-202511. Restarting `swss`
repeatedly within a 20-minute window, as the sequential-restart tests plus neighboring
platform_tests modules and config reloads do, trips `swss.service` `StartLimitBurst=3`
and leaves `swss`, `syncd`, `bgp` and `teamd` down, matching the nightly signature. A
single fresh restart never trips it. Clearing the budget with `reset-failed` before the
restart lets the same sequence pass, and `reset-failed` on an active unit was confirmed
to clear the start-limit counter. Repeat-run validation on hardware is in progress.

#### Any platform specific information?

The mechanism is platform-independent (systemd start rate-limit). Reproduced on
Mellanox-SN4600C. The `x86_64-cel_e1031-r0` stop/sleep/start path is preserved.

#### Supported testbed topology if it's a new test case?

N/A (existing test case).

### Documentation

N/A

##### Work item tracking
- Microsoft ADO (number only): 38699918
