### PR TITLE
snmp: poll for LLDP remote-neighbor table convergence in test_snmp_lldp

### DIFF
--- a/tests/snmp/test_snmp_lldp.py
+++ b/tests/snmp/test_snmp_lldp.py
@@ -2,6 +2,7 @@ import logging
 import re
 import pytest
 from tests.common.helpers.snmp_helpers import get_snmp_facts
+from tests.common.utilities import wait_until
 
 pytestmark = [
     pytest.mark.topology('t0', 't1', 't2', 'lrh', 'urh', 'm0', 'mx', 'm1', 'lt2', 'ft2', 'c0'),
@@ -136,22 +137,32 @@ def test_snmp_lldp(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_
             minigraph_lldp_nei.append(k)
     logger.info('minigraph_lldp_nei: {}'.format(minigraph_lldp_nei))
 
-    # Check if lldpRemTable is present
     active_intf = []
-    for k, v in list(snmp_facts['snmp_interfaces'].items()):
-        if "lldpRemChassisIdSubtype" in v and \
-           "lldpRemChassisId" in v and \
-           "lldpRemPortIdSubtype" in v and \
-           "lldpRemPortId" in v and \
-           "lldpRemPortDesc" in v and \
-           "lldpRemSysName" in v and \
-           "lldpRemSysDesc" in v and \
-           "lldpRemSysCapSupported" in v and \
-           "lldpRemSysCapEnabled" in v:
-            active_intf.append(k)
+
+    def _lldp_rem_table_ready():
+        nonlocal snmp_facts, active_intf
+        snmp_facts = get_snmp_facts(
+            duthost, localhost, host=hostip, version="v2c",
+            community=creds_all_duts[duthost.hostname]["snmp_rocommunity"],
+            module_ignore_errors=True).get('ansible_facts', snmp_facts)
+        active_intf = []
+        for k, v in list(snmp_facts['snmp_interfaces'].items()):
+            if "lldpRemChassisIdSubtype" in v and \
+               "lldpRemChassisId" in v and \
+               "lldpRemPortIdSubtype" in v and \
+               "lldpRemPortId" in v and \
+               "lldpRemPortDesc" in v and \
+               "lldpRemSysName" in v and \
+               "lldpRemSysDesc" in v and \
+               "lldpRemSysCapSupported" in v and \
+               "lldpRemSysCapEnabled" in v:
+                active_intf.append(k)
+        return len(active_intf) >= len(minigraph_lldp_nei) * 0.8
+
+    converged = wait_until(120, 10, 0, _lldp_rem_table_ready)
     logger.info('lldpRemTable: {}'.format(active_intf))
 
-    assert len(active_intf) >= len(minigraph_lldp_nei) * 0.8, (
+    assert converged, (
         "Number of active interfaces is less than expected. "
         "Expected at least 80% of minigraph LLDP neighbors to be active. "
         "Active interfaces: {} "


### PR DESCRIPTION
### Description of PR

Summary:
`tests/snmp/test_snmp_lldp.py::test_snmp_lldp` reads the SNMP `lldpRemTable` once and asserts
that at least 80% of the minigraph LLDP neighbors are present. That single read is flaky.

**Root cause:** The `lldpRemTable` is populated by the snmp-subagent from lldpd's neighbor
data, which re-converges over tens of seconds after any data-plane disruption (port flap,
reboot, etc.). `get_snmp_facts(wait=True)` only waits for the snmp-subagent *process* to be
running, not for the remote-neighbor table to (re)populate. A single snapshot can therefore
land in that reconvergence window with fewer than 80% of the neighbors present and fail.

**Fix:** Wrap the existing check in a bounded `wait_until` so it re-reads the SNMP facts until
the 80% threshold is met, then asserts. If the neighbors never appear within the timeout, the
assertion still fails with the observed counts, so a genuine outage is not masked. The check
body, threshold, and failure message are unchanged.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: regression (test flake surfaced by SNMP remote-table reconvergence timing)

### Approach
#### What is the motivation for this PR?
`snmp.test_snmp_lldp` has ~107 nightly failures over 95 days with
`AssertionError: ... Expected at least 80% of minigraph LLDP neighbors to be active`,
concentrated on Nokia-7215 and Arista-720DT (m0 / mx / c0 topologies with only 2-3 neighbors,
where a single missing neighbor drops below 80%). The failures are a timing artifact: the SNMP
remote-neighbor table is transiently incomplete when the test reads it once, not a genuine
neighbor outage.

#### How did you do it?
Kept the existing one-shot `lldpRemTable` check (same OID set, same 80% threshold, same failure
message) and wrapped it in a bounded `wait_until` that re-reads the SNMP facts until the check
passes. Assert on the `wait_until` result so that if the table never converges within the
timeout, the test fails with the observed neighbor counts. A real regression is not masked.

#### How did you verify/test it?
Reproduced on a physical Nokia-7215-C1 (topo c0). With a data-plane disruption timed to land
the SNMP query in the reconvergence window:
- the **unpatched** test fails with the exact nightly signature
  (`Active interfaces: 1, Minigraph LLDP neighbors: 3`);
- the **patched** test re-reads, rides out the window, and passes;
- a no-disruption run passes unchanged (no regression).

#### Any platform specific information?
None. The change is platform-agnostic; it only affects how many times the SNMP facts are
sampled before the existing assertion.

#### Supported testbed topology if it's a new test case?
N/A (existing test).
