### PR TITLE
[dut_console] Fix console stress echo timeout and PS2 recovery

### DIFF
--- a/tests/common/connections/ssh_console_conn.py
+++ b/tests/common/connections/ssh_console_conn.py
@@ -121,6 +121,9 @@ class SSHConsoleConn(BaseConsoleConn):
         delay_factor = max(self.select_delay_factor(delay_factor), 1)
         for _ in range(max_attempts):
             try:
+                # Send Ctrl-C first to abort any pending command or PS2 continuation left by a prior session.
+                self.write_channel("\x03")
+                time.sleep(0.5 * delay_factor)
                 self.write_channel(self.RETURN)
                 # Accumulate output so a lagging prompt is reliably observed.
                 output = ""

--- a/tests/dut_console/test_console_stress.py
+++ b/tests/dut_console/test_console_stress.py
@@ -33,10 +33,12 @@ def test_console_stress_output(duthost_console):
     # Each line: "LINE_XXXX: " + 10 blocks of '0123456789' (110 chars per line)
     # Generate 1000 lines = 110,000 chars total
     num_lines = 1000
+    # Disable echo verification: the wrapped 9600-baud echo never matches and a half-typed command leaves a PS2 prompt.
     output = duthost_console.send_command(
         f"python3 -c \"for i in range({num_lines}): print(f'LINE_{{i:04d}}: ' + '0123456789' * 10)\"",  # noqa: E231
         read_timeout=300,
-        expect_string=PROMPT_PATTERN
+        expect_string=PROMPT_PATTERN,
+        cmd_verify=False
     )
 
     # Parse output into lines


### PR DESCRIPTION
### Description of PR

Summary:
Fixes two `dut_console` test failures seen on nightly runs (7060 t1-lag): `test_console_stress` failing with a netmiko `ReadTimeout`, and `test_escape_character` erroring with a closed console socket. Both trace to one root cause in the console stress command handling.

- **`test_console_stress`**: the large-output probe sends a long `python3 -c "..."` one-liner over the serial console at 9600 baud. netmiko's default command-echo verification (`command_echo_read`) tries to match the echoed command as one contiguous string, but at 9600 baud the echo wraps across serial lines, so the pattern never matches and `send_command` raises `ReadTimeout`. This also left the command half-typed at the shell, sitting at a bash **PS2 continuation prompt** (`> `).
- **`test_escape_character`**: collateral damage from the above — a fresh console session lands on the leftover PS2 prompt, where `\n`/`exit` cannot recover, and the connection setup fails (socket closed).

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
ADO: 38502256 (https://dev.azure.com/msazure/One/_workitems/edit/38502256)
Failure type: regression (surfaced on internal-202605 nightly; console echo behavior at 9600 baud)

### Approach
#### What is the motivation for this PR?
Make the `dut_console` stress and escape-character tests robust to serial echo wrapping and to a leftover PS2 continuation prompt, so a stuck console session recovers cleanly.

#### How did you do it?
- `tests/dut_console/test_console_stress.py`: pass `cmd_verify=False` to `send_command` so netmiko does not attempt to verify the wrapped command echo. The output is still validated afterwards via `expect_string=PROMPT_PATTERN` and line parsing.
- `tests/common/connections/ssh_console_conn.py`: in `_recover_to_login_prompt`, send `Ctrl-C` (`\x03`) before `RETURN` on each attempt to abort any pending command or PS2 continuation prompt left by a prior session.

#### How did you verify/test it?
Ran the `dut_console` feature on an Elastictest testbed (7060 t1-lag, image `SONiC.20260510.02` / internal-202605) against the fix branch. Result: 28 tests, 23 passed, 0 failed, 0 errors, 5 skipped. Specifically `test_console_stress` and `test_escape_character` both PASSED (previously FAILED/ERR).

#### Any platform specific information?
Reproduced on Arista 7060 consoles at 9600 baud; the fix is generic to the netmiko serial console path and not platform specific.

#### Supported testbed topology if it's a new test case?
N/A — existing tests.

### Documentation
N/A — no documentation changes required.
