### PR TITLE
[topo] Add tgen-ft2-3 topology definition

### DIFF
--- a/ansible/vars/topo_tgen-ft2-3.yml
+++ b/ansible/vars/topo_tgen-ft2-3.yml
@@ -1,0 +1,158 @@
+topology:
+  VMs:
+    ARISTA02LT2:
+      vlans:
+        - 1
+      vm_offset: 0
+    ARISTA03LT2:
+      vlans:
+        - 2
+      vm_offset: 1
+    ARISTA04LT2:
+      vlans:
+        - 3
+      vm_offset: 2
+  disabled_host_interfaces:
+    - 0
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
+    - 9
+    - 10
+    - 11
+    - 12
+    - 13
+    - 14
+    - 15
+    - 16
+    - 17
+    - 18
+    - 19
+    - 20
+    - 21
+    - 22
+    - 23
+    - 24
+    - 25
+    - 26
+    - 27
+    - 28
+    - 29
+    - 30
+    - 31
+    - 32
+    - 33
+    - 34
+    - 35
+    - 36
+    - 37
+    - 38
+    - 39
+    - 40
+    - 41
+    - 42
+    - 43
+    - 44
+    - 45
+    - 46
+    - 47
+    - 48
+    - 49
+    - 50
+    - 51
+    - 52
+    - 53
+    - 54
+    - 55
+    - 56
+    - 57
+    - 58
+    - 59
+    - 60
+    - 61
+    - 62
+    - 63
+
+configuration_properties:
+  common:
+    dut_asn: 4200300000
+    dut_confed_asn: 4200100000
+    dut_confed_peers: "4200200000 4200400000"
+    dut_type: FabricSpineRouter
+    nhipv4: 10.10.246.254
+    nhipv6: FC0A::FF
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 128
+    leaf_asn_start: 4000000000
+    tor_asn_start: 410000000
+    swrole: lowerspine
+
+configuration:
+  ARISTA02LT2:
+    properties:
+    - common
+    bgp:
+      asn: 4200200000
+      confed_asn: 4200100000
+      confed_peers: "4200300000,4200400000"
+      peers:
+        4200300000:
+          - 10.2.2.2
+          - fc00::5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.2/32
+        ipv6: 2064:100:0:2::/128
+      Ethernet1:
+        ipv4: 10.2.2.3/31
+        ipv6: fc00::6/126
+    bp_interface:
+      ipv4: 10.10.246.3/24
+      ipv6: fc0a::3/64
+  ARISTA03LT2:
+    properties:
+    - common
+    bgp:
+      asn: 4200200000
+      confed_asn: 4200100000
+      confed_peers: "4200300000,4200400000"
+      peers:
+        4200300000:
+          - 10.2.2.4
+          - fc00::9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.3/32
+        ipv6: 2064:100:0:3::/128
+      Ethernet1:
+        ipv4: 10.2.2.5/31
+        ipv6: fc00::a/126
+    bp_interface:
+      ipv4: 10.10.246.4/24
+      ipv6: fc0a::4/64
+  ARISTA04LT2:
+    properties:
+    - common
+    bgp:
+      asn: 4200200000
+      confed_asn: 4200100000
+      confed_peers: "4200300000,4200400000"
+      peers:
+        4200300000:
+          - 10.2.2.6
+          - fc00::d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.4/32
+        ipv6: 2064:100:0:4::/128
+      Ethernet1:
+        ipv4: 10.2.2.7/31
+        ipv6: fc00::e/126
+    bp_interface:
+      ipv4: 10.10.246.5/24
+      ipv6: fc0a::5/64


### PR DESCRIPTION
### Description of PR

Adds a new tgen topology, `tgen-ft2-3`, for snappi/tgen testing on ft2 topo.
Two things:
1. use the port2-4. 
    - In this way, this can co-exist with ft2-16 topo where port 1,5,... are used.
2. 10.2.2.x subnet for FT2.
   - This is to avoid issue where 10.0.x.x subnet may have some issue with ARP resolution on IXIA device.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Adds a `tgen-ft2-3` topo for snappi/tgen testing on ft2 topo.

#### How did you do it?
define the topo.

#### How did you verify/test it?

Deployed the topology on a tgen testbed and confirmed the DUT and neighbors come up as expected.

#### Any platform specific information?

No. Topology definition only, no code changes.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
