### PR TITLE
Set the subport of un even split 400G port to 2

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -983,6 +983,20 @@
             seconds: 5
           when: use_ipv6_mgmt|default(false)|bool
 
+        - name: Configure Mellanox-SN5640-C508O1X2 Ethernet508 subport after minigraph load
+          block:
+          - name: Set Ethernet508 subport for Mellanox-SN5640-C508O1X2 uneven port 64 breakout
+            become: true
+            shell: sonic-db-cli CONFIG_DB hset "PORT|Ethernet508" subport 2
+
+          - name: Save subport configuration
+            become: true
+            shell: config save -y
+          when:
+          - init_cfg_profile is not defined
+          - hwsku is defined
+          - hwsku == 'Mellanox-SN5640-C508O1X2'
+
         - name: execute cli "config load_minigraph -y" to apply new minigraph
           become: true
           shell: config load_minigraph -y

--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -24,6 +24,22 @@ BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 TEMPLATE_DIR = os.path.join(BASE_DIR, 'templates')
 GOLDEN_CONFIG_TEMPLATE = os.path.join(TEMPLATE_DIR, 'golden_config_db.j2')
 DEFAULT_GOLDEN_CONFIG_PATH = '/etc/sonic/golden_config_db.json'
+C508O1X2_HWSKU = 'Mellanox-SN5640-C508O1X2'
+
+
+def _configure_c508o1x2_subport_after_minigraph(sonic_host):
+    """
+    Mellanox-SN5640-C508O1X2 uses uneven port 64 breakout; Ethernet508 needs subport 2
+    in CONFIG_DB after minigraph load (same as config_sonic_basedon_testbed.yml).
+    """
+    if sonic_host.facts.get('hwsku') != C508O1X2_HWSKU:
+        return
+
+    logger.info('Setting Ethernet508 subport=2 for %s', C508O1X2_HWSKU)
+    sonic_host.shell('sonic-db-cli CONFIG_DB hset "PORT|Ethernet508" subport 2')
+
+    logger.info('Saving subport configuration for %s', C508O1X2_HWSKU)
+    sonic_host.shell('sudo config save -y')
 
 
 def config_system_checks_passed(duthost, delayed_services=[]):
@@ -271,6 +287,8 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
                 'sonic-db-cli CONFIG_DB hset "DEVICE_METADATA|localhost" zebra_nexthop {}'.format(zebra_nexthop)
             )
         time.sleep(60)
+        if is_dut:
+            _configure_c508o1x2_subport_after_minigraph(sonic_host)
         if start_bgp:
             sonic_host.shell('config bgp startup all')
         if is_buffer_model_dynamic:


### PR DESCRIPTION

### Description of PR
For the hwsku Mellanox-SN5640-C508O1X2
When deploy un even split at the last port, the subport of 400G port should be set as '2' for software control mode

Apply Mellanox-SN5640-C508O1X2 subport to 2 after minigraph reload in tests
Set CONFIG_DB Ethernet508 subport=2 for Mellanox-SN5640-C508O1X2 in config_reload() when loading minigraph, matching deploy-mg behavior in config_sonic_basedon_testbed.yml.

According to the discussion result with MSFT, it's a temp work around. When the formal implementation is ready, this WA should be reverted.

Summary:
Fixes # (issue)


### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
The uneven split port should be UP after deploy hwsku Mellanox-SN5640-C508O1X2
#### How did you do it?
Add a temp workaround, set the Ethernet508 subport of hwsku Mellanox-SN5640-C508O1X2 as "2"
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
