### PR TITLE
[202605] Update test_crm_neighbor TC to handle NH scale (#23391)

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -985,7 +985,7 @@ def test_crm_neighbor(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                                         ip_ver=ip_ver)
     nexthop_used, nexthop_available = get_crm_stats(get_nexthop_stats, duthost)
     if is_cisco_device(duthost):
-        CISCO_8000_ADD_NEIGHBORS = nexthop_available
+        CISCO_8000_ADD_NEIGHBORS = min(2000, nexthop_available)
     asic_type = duthost.facts['asic_type']
     skip_stats_check = True if asic_type == "vs" else False
     RESTORE_CMDS["crm_threshold_name"] = "ipv{ip_ver}_neighbor".format(ip_ver=ip_ver)


### PR DESCRIPTION
Cherry-pick / backport of #23391 to the `202605` branch.

### Description of PR

Summary:
Fixes # (issue)
CRM NH scale issue

Problem:
On cisco asics, scale for NHs can be up to ~32k. Currently we try to add 32k neighbors as that is the number set to `CISCO_8000_ADD_NEIGHBORS`, which causes a timeout failure because adding tens of thousands of neighbors takes longer than the 60-second polling window used to verify CRM counter convergence, causing the test to fail. The test only needs enough neighbors to push above 1% for threshold verification.

Fix:
Cap neighbors at 2000 or the number of nexthops available (whichever is lower, since we cannot add more neighbors than NHs supported). This is well above 1% of any current Cisco 8000 resource pool for NHs per CRM, which satisfies the threshold verification requirement and is future proof until scale reaches ~200k for NHs.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Handle NH scale for newer platforms.

#### How did you do it?
Cap `CISCO_8000_ADD_NEIGHBORS` at `min(2000, nexthop_available)` so the neighbor count stays high enough to satisfy the >1% CRM threshold verification while avoiding the 60-second convergence timeout.

#### How did you verify/test it?
Ran the CRM neighbor testcase on a setup with scale at 32k NH; the test passes (2 passed).

#### Any platform specific information?
Cisco 8000 ASICs.

#### Supported testbed topology if it's a new test case?
N/A (test case improvement).

### Documentation
N/A
