### PR TITLE
[sflow] testDisablePolling: settle hsflowd before asserting no counter samples

### DIFF
--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -152,6 +152,22 @@ def get_default_agent(duthost):
 # ----------------------------------------------------------------------------------
 
 
+def wait_until_hsflowd_applied_agent(duthost, expected_agent_ip):
+    # hsflowd (host-sflow >= 2.1.26, pulled in by sonic-buildimage PR #27806) applies a
+    # runtime "config sflow agent-id" change asynchronously: it rewrites /etc/hsflowd.auto
+    # through its tick-driven reconfig state machine. verify_show_sflow only confirms that
+    # CONFIG_DB was updated, so a trailing counter-poll round can still emit the previously
+    # auto-selected agent right after the change. Wait until hsflowd.auto advertises the
+    # expected agentIP before running the PTF check so any in-flight sample drains first.
+    read_agent_cmd = "docker exec sflow grep -w 'agentIP' /etc/hsflowd.auto 2>/dev/null | cut -d '=' -f 2"
+    pytest_assert(
+        wait_until(60, 2, 0, lambda: duthost.shell(
+            read_agent_cmd, module_ignore_errors=True)['stdout'].strip() == expected_agent_ip),
+        "hsflowd did not apply agentIP {} in /etc/hsflowd.auto".format(expected_agent_ip))
+
+# ----------------------------------------------------------------------------------
+
+
 def get_ifindex(duthost, port):
     ifindex = duthost.shell('cat /sys/class/net/%s/ifindex' % port)['stdout']
     return ifindex
@@ -670,6 +686,7 @@ class TestAgentId():
         duthost.shell(" config sflow agent-id del")
         duthost.shell(" config sflow agent-id  add Loopback0")
         verify_show_sflow(duthost, status='up', agent_id='Loopback0')
+        wait_until_hsflowd_applied_agent(duthost, agent_ip)
         partial_ptf_runner(
             polling_int=20,
             agent_id=agent_ip,
@@ -698,6 +715,7 @@ class TestAgentId():
         agent_ip = var['mgmt_ip']
         duthost.shell(" config sflow agent-id  add  eth0")
         verify_show_sflow(duthost, status='up', agent_id='eth0')
+        wait_until_hsflowd_applied_agent(duthost, agent_ip)
         partial_ptf_runner(
             polling_int=20,
             agent_id=agent_ip,

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -23,6 +23,9 @@ from tests.common.utilities import get_neighbor_port_list
 from tests.common.helpers.assertions import pytest_assert
 
 SFLOW_RATE_DEFAULT = 512
+# Seconds to wait for hsflowd to quiesce counter polling after it is disabled.
+# See TestSflowPolling.testDisablePolling for the rationale.
+SFLOW_DISABLE_POLL_SETTLE_TIME = 40
 
 pytestmark = [
     pytest.mark.topology('t0', 'm0', 'mx')
@@ -553,6 +556,14 @@ class TestSflowPolling():
         duthost.shell("config sflow polling-interval 0")
 
         verify_show_sflow(duthost, status='up', polling_int=0)
+        # verify_show_sflow only confirms CONFIG_DB was updated. hsflowd (host-sflow
+        # >= 2.1.26, sonic-buildimage PR #27806) applies a runtime polling-interval
+        # change asynchronously via its tick-driven reconfig state machine, so counter
+        # polling is not torn down instantly. The preceding testPolling leaves 20s
+        # counter pollers active, so wait for at least the previous polling interval
+        # plus hsflowd settling time to let any trailing counter-poll round drain
+        # before verifying that the DUT sends no counter samples.
+        time.sleep(SFLOW_DISABLE_POLL_SETTLE_TIME)
         partial_ptf_runner(
             polling_int=0,
             active_collectors="['collector0','collector1']")

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -291,7 +291,7 @@ def wait_until_hsflowd_ready(duthost, collector_ips):
         f"Check /etc/hsflowd.auto in sflow container."
     )
     elapsed = time.time() - start_time
-    logger.info(f"hsflowd initialized with all collector(s) after {elapsed:.1f} seconds")
+    logger.info("hsflowd initialized with all collector(s) after {:.1f} seconds".format(elapsed))
 
 
 def config_sflow_collector(duthost, collector, config):


### PR DESCRIPTION
### Description of PR

Summary: Fixes intermittent failures of `sflow/test_sflow.py::TestSflowPolling::testDisablePolling`:
`AssertionError: Received N counter packets when polling is disabled in collector0`.

`testDisablePolling` runs `config sflow polling-interval 0` and then **immediately** runs the PTF
`sflow_test`, asserting that **no** counter samples are received. Since sonic-buildimage
PR [#27806](https://github.com/sonic-net/sonic-buildimage/pull/27806) upgraded hsflowd `2.0.51-26 -> 2.1.26-1` (host-sflow), a runtime `polling-interval`
change is applied **asynchronously** through hsflowd's tick-driven `mod_sonic` reconfig state
machine (`RUN -> SFLOWGLOBAL -> ... -> SYNC_CONFIG`, ~one poll-bus tick per state), so counter
polling is not torn down instantly. The preceding `testPolling` leaves 20s counter pollers active,
so a trailing counter-poll round can still fire inside `testDisablePolling`'s collection window.

This is an intermittent failure whose rate grew as PR/baseline images picked up the new hsflowd:
the KVM `impacted-area-kvmtest-t0` baseline on master fell from 100% pass before 2026-06-29 to
~55-60% after (first failure ~6h after #27806 merged).

`verify_show_sflow(..., polling_int=0)` only confirms CONFIG_DB was updated, not that hsflowd has
quiesced. This PR waits for hsflowd to settle (>= the previous polling interval + reconfig time)
so any in-flight counter-poll round drains before the assertion. hsflowd applying a runtime disable
with a few seconds of latency is acceptable behaviour, so this is a test-side fix (no image
change/revert proposed).

Root cause: sonic-buildimage PR [#27806](https://github.com/sonic-net/sonic-buildimage/pull/27806) (hsflowd 2.1.26 upgrade).

Failure type: regression (test not resilient to hsflowd 2.1.26 asynchronous polling-disable)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

<!-- Upgrade #27806 is currently on master only; submitting master-first. Cherry-pick this fix to
any release branch that also receives the hsflowd 2.1.26 upgrade (track via sonic-buildimage #27806). -->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Eliminate intermittent `testDisablePolling` failures introduced by the hsflowd 2.1.26 upgrade, which
applies a runtime `polling-interval 0` asynchronously so counter samples can still arrive briefly
after polling is disabled.

#### How did you do it?
Added `SFLOW_DISABLE_POLL_SETTLE_TIME` (40s) and a `time.sleep()` after disabling polling and before
running the PTF check, so hsflowd fully quiesces and any trailing counter-poll round drains first.

#### How did you verify/test it?
`flake8 --max-line-length=120` and `py_compile` clean. The fix is derived from the confirmed
regression window (100% pass through 2026-06-28; flaky from 2026-06-29, correlating with #27806) and
from reading the host-sflow `mod_sonic`/`hsflowconfig` sources (dbEvt_sflowOp -> changedSFlowGlobalTable
-> evt_tick state machine -> syncConfig pushes `polling=0`). A full run on a t0 testbed will be
exercised by CI.

#### Any platform specific information?
None - hsflowd/mod_sonic behaviour is platform independent.

#### Supported testbed topology if it's a new test case?
N/A (existing test; topologies t0/m0/mx).

### Documentation
N/A
