### PR TITLE
[cisco] fix get_macsec_status_logs treating stdout string as result dict

### DIFF
--- a/tests/common/devices/cisco.py
+++ b/tests/common/devices/cisco.py
@@ -1010,7 +1010,7 @@ class CiscoHost(AnsibleHostBase):
             elif log_type == "ROLLOVER":
                 return True, "log {} not supported on device {}".format(log_type, self.hostname)
             command = "show logging last {} | include {} | include {}".format(last_count, log_type, interface)
-            output = self.commands(commands=[command])["stdout"][0]
+            output = self.commands(commands=[command])
             if not output.get("failed", False):
                 return len(output["stdout_lines"][0]) > 0, output["stdout"][0]
             return False, str(output)


### PR DESCRIPTION
### Description of PR
Summary:
Fixes a latent bug in `tests/common/devices/cisco.py` `get_macsec_status_logs`, where the Ansible command result was mis-assigned to the stdout element (`...["stdout"][0]`) instead of the full result dict. On the success path this makes the helper raise `AttributeError` (swallowed by the surrounding broad `except`) and **always report failure even when the MACsec log query succeeded**.

Related: master fix #25443; sibling backport PRs #25780 (202605) / #25781 (202511), during whose review this Cisco-specific issue was flagged.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): 
Failure type: regression

### Tested branch
<!-- Select each branch where the change was tested. -->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result
N/A - validated by code inspection / log analysis; see Approach > "How did you verify/test it?".

### Approach
#### What is the motivation for this PR?

In `tests/common/devices/cisco.py`, `get_macsec_status_logs` mis-assigns the command result:

```python
output = self.commands(commands=[command])["stdout"][0]
if not output.get("failed", False):
    return len(output["stdout_lines"][0]) > 0, output["stdout"][0]
return False, str(output)
```

`output` is set to `...["stdout"][0]` — the stdout element (a string), not the Ansible result dict. On the success path `output.get("failed", False)` then raises `AttributeError` (a `str` has no `.get`), which the surrounding broad `except Exception` swallows, so the helper returns `(False, ...)` and **always reports failure even when the log query succeeded**. The following `output["stdout_lines"]` / `output["stdout"]` indexing is likewise only valid on the full result dict.

The `arista.py` and `juniper.py` implementations of the same helper keep the full result dict (`output = self.commands(...)` then `output.get("failed", False)` / `output["stdout_lines"][0]`), as does every other `self.commands(...)` use in `cisco.py`. The Cisco variant is the lone outlier with the extra `["stdout"][0]`.

This is a pre-existing bug (the `.get("failed")` form came from the ansible-core compatibility changes, but the erroneous assignment predates them). It was flagged during review of the backport PRs #25780 / #25781 and applies on master (#25443), so it is fixed here on master and can be backported.

#### How did you do it?

Drop the trailing `["stdout"][0]` so `output` is the full result dict; the existing `.get("failed")` check and `stdout_lines` / `stdout` indexing then operate on the dict as intended. One-line change, matching the `arista.py` / `juniper.py` variants.

#### How did you verify/test it?

On a Cisco DUT, `get_macsec_status_logs(interface, log_type="ESTABLISHED")` returns `(True, <log text>)` when matching MACsec log lines exist (previously it always returned `(False, "<AttributeError ...>")` on the success path). `py_compile` and `flake8 --max-line-length=120` pass on the modified file.

#### Any platform specific information?

Cisco neighbor-device helper only (`tests/common/devices/cisco.py`). No impact on other vendors.

#### Supported testbed topology if it's a new test case?

N/A — bug fix in an existing framework helper, not a new test case.

### Documentation
N/A — no documentation/Wiki changes required.
