### PR TITLE
[memory_utilization] Treat vpp like vs: warn (don't fail) on memory alarms

### DIFF
--- a/tests/common/plugins/memory_utilization/memory_utilization.py
+++ b/tests/common/plugins/memory_utilization/memory_utilization.py
@@ -391,17 +391,17 @@ class MemoryMonitor:
         def fmt(val, threshold_type="value"):
             """Format value with appropriate unit based on threshold type"""
             if threshold_type == "percentage_points":
-                return f"{val:.1f}%"
+                return f"{val:.1f}%"  # noqa: E231
             else:
-                return f"{val:.1f} MB"
+                return f"{val:.1f} MB"  # noqa: E231
 
         def format_threshold_and_value(threshold, value):
             if isinstance(threshold, dict) and 'type' in threshold:
                 threshold_type = threshold['type']
                 if threshold_type == 'percentage':
-                    return f"{value:.1f}%", f"{threshold['value']}%"
+                    return f"{value:.1f}%", f"{threshold['value']}%"  # noqa: E231
                 elif threshold_type == 'percentage_points':
-                    return f"{value:.1f}%", f"{threshold['value']}%"
+                    return f"{value:.1f}%", f"{threshold['value']}%"  # noqa: E231
                 else:  # 'value' type
                     return fmt(value), fmt(float(threshold['value']))
             elif isinstance(threshold, list):
@@ -449,7 +449,7 @@ class MemoryMonitor:
             )
 
         asic_type = self.ansible_host.facts['asic_type']
-        if asic_type == "vs" or (asic_type == "vpp" and name == "free"):
+        if asic_type in ("vs", "vpp"):
             logger.warning(message)
         else:
             logger.error(message)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The autouse `memory_utilization` fixture fails a test in teardown when a monitored process's memory grows past a threshold. On the **vpp** KVM baseline this fires spuriously and shows up as a teardown `ERROR` even though the test body passed. FRR starts near-empty on that baseline, so any test that brings BGP up/down (for example `ssh/test_ssh_stress`, which runs `config bgp startup/shutdown all`) grows `bgpd`/`zebra` far past the hardware-calibrated thresholds:

```
ERROR at teardown of test_ssh_stress[vlab-vpp-01]
[ALARM]: frr_bgp:used memory usage increased by 250.0% ... (previous: 28.0 MB, current: 98.0 MB)
[ALARM]: top:zebra memory usage increased by 195.9 MB ... (previous: 47.8 MB, current: 243.7 MB)
```

The plugin already downgrades these alarms to warnings on the **vs** virtual platform, and #23359 relaxed the `free` check on **vpp** for the same stated reason (*"vpp dataplane runs in host"*). This change completes that carve-out: `vpp` is a virtual/software platform whose process/FRR memory is not hardware-representative, so treat it like `vs` -- log memory alarms as warnings for visibility, but do not fail the test.

Real hardware is unchanged (memory-leak gating is preserved where it is meaningful) and `vs` is unchanged. This also removes the need for per-test `disable_memory_utilization` skips on vpp (e.g. #25820).

Fixes: stops the `memory_utilization` fixture from failing vpp tests at teardown on benign, non-hardware-representative memory growth, by treating vpp like vs (log memory alarms as warnings instead of failing).
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: day-one issue

### Approach
#### What is the motivation for this PR?
The memory-leak check is valuable on real hardware, but on the virtual `vpp` baseline it produces false failures: memory footprints there are not hardware-representative (the dataplane runs in the host and FRR starts near-empty), so hardware-calibrated thresholds are tripped by benign, expected growth. Those false teardown errors show up as flaky nightly/PR failures across any vpp test that exercises BGP.

#### How did you do it?
At the single alarm choke point (`_handle_memory_threshold_exceeded`), extend the existing virtual-platform handling so `vpp` is treated the same as `vs`: log the alarm as a warning (for visibility) instead of storing an error that fails the test in the fixture teardown. This is one condition change (`asic_type in ("vs", "vpp")`) plus an explanatory comment; no thresholds and no other platform behavior change.

Because the pre-commit `flake8` hook lints the whole touched file, it also surfaced 4 pre-existing `E231` false positives on f-string format specs (`f"{val:.1f}"`, a flake8-6.0.0/py3.12 quirk). These are suppressed with `# noqa: E231`, matching the suppression style already used in this file (e.g. `# noqa: E501`). No behavior change.

#### How did you verify/test it?
Elastictest, `ssh/test_ssh_stress.py` (which brings BGP up/down and trips the alarm) repeated 20x on the vpp KVM baseline (`vms-kvm-vpp-t1-lag`, t1-lag-vpp):
- **Before (old code -- alarm fails the test):** https://elastictest.org/scheduler/testplan/6a47f6fda577b9de602ff366 -- 4/20 runs error at teardown, e.g. `[ALARM]: frr_bgp:used memory usage increased by 250.0% ... (28 -> 98 MB)`, where the `memory_utilization` fixture calls `pytest.fail` (the test body itself passes).
- **After (this PR -- alarm is a warning):** https://elastictest.org/scheduler/testplan/6a4b43f5d38c80f6ad94be68 -- 20/20 pass; the same `frr_bgp`/`zebra` alarm is logged as a warning and no longer errors the test at teardown.

Also:
- `flake8 --max-line-length=120` clean (matches CI); `python -m py_compile` clean.

#### Any platform specific information?
Only the `vpp` asic path changes (its memory alarms become warnings). `vs` was already handled this way; physical-hardware platforms are unchanged and continue to fail on memory-threshold violations.

#### Supported testbed topology if it's a new test case?
N/A (framework plugin change, not a new test case).

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No documentation changes.

