### PR TITLE
Accept nightly args in SAI mock UT

### DIFF
--- a/tests/saitests/mock/ut/conftest.py
+++ b/tests/saitests/mock/ut/conftest.py
@@ -15,6 +15,31 @@ from probing_observer import ProbingObserver  # noqa: E402
 from executor_registry import ExecutorRegistry  # noqa: E402
 
 
+def pytest_addoption(parser):
+    """Accept SONiC nightly runner options that are unused by these unit tests."""
+    ignored_options = [
+        ("--testbed", {"action": "store", "default": None}),
+        ("--testbed_file", {"action": "store", "default": None}),
+        ("--kube_master", {"action": "store", "default": None}),
+        ("--topology", {"action": "store", "default": None}),
+        ("--skip_pre_sanity", {"action": "store_true", "default": False}),
+        ("--post_check", {"action": "store_true", "default": False}),
+        ("--py_saithrift_url", {"action": "store", "default": None}),
+        ("--sad_case_list", {"action": "store", "default": None}),
+        ("--allow_recover", {"action": "store_true", "default": False}),
+        ("--inventory", {"action": "store", "default": None}),
+        ("--host-pattern", {"action": "store", "default": None}),
+        ("--cov", {"action": "append", "default": []}),
+        ("--cov-branch", {"action": "store_true", "default": False}),
+        ("--cov-report", {"action": "append", "default": []}),
+    ]
+    for option, kwargs in ignored_options:
+        try:
+            parser.addoption(option, help="Ignored by saitests mock unit tests", **kwargs)
+        except ValueError:
+            pass
+
+
 @pytest.fixture(autouse=True)
 def reset_executor_registry():
     """


### PR DESCRIPTION
### Description of PR
Summary:
Accept SONiC nightly runner options in `tests/saitests/mock/ut/conftest.py` so standalone SAI mock unit-test pytest roots can parse the nightly invocation before collecting `test_stream_manager.py`.

ADO: https://dev.azure.com/msazure/One/_workitems/edit/38693480

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://dev.azure.com/msazure/One/_workitems/edit/38693480
Failure type: regression

### Tested branch
<!-- Select each branch where the change was tested. -->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result
N/A - validated by code inspection / log analysis; see Approach > "How did you verify/test it?".

### Approach
#### What is the motivation for this PR?

The master nightly run fails before test collection for `saitests/mock/ut/test_stream_manager.py`. The local `pytest.ini` makes `tests/saitests/mock/ut` the pytest root, so the normal SONiC pytest options from repository-level plugins are not registered. Pytest exits with `unrecognized arguments` and no junit XML is created.

#### How did you do it?

Added local no-op registrations for SONiC nightly runner options that are unused by these unit tests. Existing plugin-provided options are skipped if already registered.

#### How did you verify/test it?

Ran `python -m pytest saitests/mock/ut/test_stream_manager.py` from `tests` with the same nightly argument set from the ElasticTest console, including `--testbed`, `--testbed_file`, `--topology`, `--skip_pre_sanity`, `--post_check`, `--py_saithrift_url`, `--sad_case_list`, and `--allow_recover`; the command completed successfully.

#### Any platform specific information?

N/A. This is a unit-test argument parsing fix.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation
N/A.
