### PR TITLE
Adding support to Delta PSU 322285 in test_sensors

### DIFF
--- a/tests/platform_tests/sensors_utils/psu_data.yaml
+++ b/tests/platform_tests/sensors_utils/psu_data.yaml
@@ -311,3 +311,36 @@ sensors_checks:
         temp: [ ]
       psu_skips: { }
       sensor_skip_per_version: { }
+    "322285":
+      alarms:
+        fan:
+          - dps460-i2c-*-*/fan1/fan1_alarm
+          - dps460-i2c-*-*/fan1/fan1_fault
+        power:
+          - dps460-i2c-*-*/vin/in1_alarm
+          - dps460-i2c-*-*/vout1/in2_lcrit_alarm
+          - dps460-i2c-*-*/pin/power1_alarm
+          - dps460-i2c-*-*/pout1/power2_max_alarm
+          - dps460-i2c-*-*/iin/curr1_max_alarm
+          - dps460-i2c-*-*/iin/curr1_crit_alarm
+          - dps460-i2c-*-*/iout1/curr2_max_alarm
+          - dps460-i2c-*-*/iout1/curr2_crit_alarm
+        temp:
+          - dps460-i2c-*-*/temp1/temp1_max_alarm
+          - dps460-i2c-*-*/temp2/temp2_max_alarm
+          - dps460-i2c-*-*/temp3/temp3_max_alarm
+      compares:
+        power: [ ]
+        temp:
+          - - dps460-i2c-*-*/temp1/temp1_input
+            - dps460-i2c-*-*/temp1/temp1_max
+          - - dps460-i2c-*-*/temp2/temp2_input
+            - dps460-i2c-*-*/temp2/temp2_max
+          - - dps460-i2c-*-*/temp3/temp3_input
+            - dps460-i2c-*-*/temp3/temp3_max
+      non_zero:
+        fan: [ ]
+        power: [ ]
+        temp: [ ]
+      psu_skips: { }
+      sensor_skip_per_version: { }


### PR DESCRIPTION
### Description of PR
This PR adds support for the Delta PSU **322285** to the platform `test_sensors` test.

The 322285 PSU exposes its hwmon sensor labels in the raw PMBus format (`fan1`, `vin`, `vout1`, `pin`, `pout1`, `iin`, `iout1`, `temp1/2/3`) rather than the descriptive Mellanox labels (`PSU-* Fan 1`, `220V Rail (in)`, ...) used by the previously supported PSUs. Because the existing `psu_data.yaml` entries only covered the descriptive-label PSUs, `test_sensors` failed on devices populated with a 322285 PSU. 
This PR adds a new "322285" model entry to tests/platform_tests/sensors_utils/psu_data.yaml describing the correct alarm/compare/non_zero sensor paths for this PSU.

No change is required in psu_sensors.json: that file is keyed by platform (e.g. x86_64-mlnx_msn2700-r0, which already exists), not by PSU model, so the 322285 PSU reuses the existing platform bus/chip mapping.

Summary:
This PR adds support for the Delta PSU 322285 in test_sensors.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: day-one issue (test lacked coverage for the 322285 PSU sensor labels)

### Approach
#### What is the motivation for this PR?
The `test_sensors` test failed on some `x86_64-mlnx_msn2700-r0` devices populated with a Delta 322285 PSU, because this PSU's sensor labels were not covered in `psu_data.yaml`. This PR adds the missing coverage so the test correctly validates the 322285 PSU sensors.

#### How did you do it?
Added a new `"322285"` PSU-model entry to `tests/platform_tests/sensors_utils/psu_data.yaml`, defining the `alarms` (fan/power/temp), `compares` (temp), and `non_zero` sensor paths that match the 322285 PSU's PMBus hwmon labels. PSUs are distinguished by bus address (58/59/...), so no per-slot label substitution is needed.

#### How did you verify/test it?
Ran test_sensors on a testbed with a 322285 PSU installed.

#### Any platform specific information?
Relevant to Mellanox/NVIDIA platforms that support dynamic PSU sensor testing (`psu_sensors.json`), specifically `x86_64-mlnx_msn2700-r0` devices that ship with the Delta 322285 PSU. The change is additive and does not affect other PSU models or platforms.

#### Supported testbed topology if it's a new test case?
N/A - not a new test case; this is an improvement to the existing `test_sensors` test (topology: `any`).

### Documentation
N/A - no documentation/Wiki changes required for this PSU sensor-data addition.