### PR TITLE
[conditional_mark][pc/test_po_voq] Guard against empty minigraph_portchannels

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4031,7 +4031,7 @@ pc/test_po_voq.py:
   skip:
     reason: "Skip for non t2 or Skip since there is no portchannel configured or no portchannel member exists in current topology."
     conditions:
-      - "('t2' not in topo_name and topo_type not in ['lrh', 'urh']) or num_asic == 0 or len(minigraph_portchannels[list(minigraph_portchannels.keys())[0]]['members']) == 0 or asic_type in ['cisco-8000']"
+      - "('t2' not in topo_name and topo_type not in ['lrh', 'urh']) or num_asic == 0 or len(minigraph_portchannels) == 0 or len(minigraph_portchannels[list(minigraph_portchannels.keys())[0]]['members']) == 0 or asic_type in ['cisco-8000']"
 
 pc/test_retry_count.py:
   skip:


### PR DESCRIPTION

### Description of PR
The skip condition for **pc/test_po_voq.py** indexes the first PortChannel via `list(minigraph_portchannels.keys())[0]`, which raises IndexError when minigraph_portchannels is empty:

  IndexError: list index out of range
  RuntimeError: Failed to evaluate condition, raw_condition=
    ('t2' not in topo_name and topo_type not in ['lrh', 'urh'])
    or num_asic == 0
    or len(minigraph_portchannels[list(minigraph_portchannels.keys())[0]]['members']) == 0
    or asic_type in ['cisco-8000']

This breaks test collection on t2-isolated topologies where no PortChannels are configured.

Add `len(minigraph_portchannels) == 0` as a short-circuit guard before the indexing expression, so the condition evaluates cleanly to "skip" on topologies without any PortChannel.


Summary:
Fixes # (issue)
Skip condition evaluate failure on t2 isolated topology of pc/test_po_voq.py

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
The skip condition for pc/test_po_voq.py is failing on t2 isolated topology
#### How did you do it?
Update the skip conditions
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

