### PR TITLE
Skip the test on Mellanox platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1624,7 +1624,7 @@ dut_console/test_console_chassis_conn.py::test_console_availability_serial_ports
     reason: "Skipping test because test is not supported on this hwsku"
     conditions_logical_operator: or
     conditions:
-      - "platform in ['x86_64-nokia_ixr7250e_36x400g-r0', 'x86_64-nokia_ixr7250_x3b-r0']"
+      - "platform in ['x86_64-nokia_ixr7250e_36x400g-r0', 'x86_64-nokia_ixr7250_x3b-r0', 'x86_64-nvidia_sn5640-r0']"
       - "'t2_single_node' in topo_name or topo_type in ['lrh', 'urh']"
 
 dut_console/test_console_stress.py:

--- a/tests/dut_console/test_console_chassis_conn.py
+++ b/tests/dut_console/test_console_chassis_conn.py
@@ -4,10 +4,18 @@ import time
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.console_helper import get_target_lines, handle_pexpect_exceptions
+from tests.common.mellanox_data import is_mellanox_device
 
 pytestmark = [
     pytest.mark.topology("t2", "lrh", "urh")  # Test is only for T2 Chassis
 ]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def skip_mellanox_device(duthosts, enum_supervisor_dut_hostname):
+    duthost = duthosts[enum_supervisor_dut_hostname]
+    if is_mellanox_device(duthost):
+        pytest.skip("Skipping test because test is not supported on Mellanox device.")
 
 
 def test_console_availability_serial_ports(duthost, duthosts, creds, enum_supervisor_dut_hostname):


### PR DESCRIPTION

### Description of PR
get_target_lines() is called by console tests (e.g. test_console_ availability_serial_ports) that iterate over remote line cards connected to a modular-chassis supervisor. When the DUT has no online LINE-CARDx entries in STATE_DB CHASSIS_MODULE_TABLE (e.g. running on a t2-isolated single-DUT setup, chassisd not running, or no remote line cards attached), the helper currently calls pytest.fail("No line cards are online."), which surfaces as a spurious test failure on setups that simply do not apply to the test.

Skip the test script on Mellanox platform.


Summary:
Fixes # (issue)
pytest.fail("No line cards are online.")

### Type of change


- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
Script dut_console/test_console_chassis_conn.py failed on Mellanox SN5640 in line:
`pytest.fail("No line cards are online.")`
#### How did you do it?
Skip the test script on Mellanox platform.
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

