### PR TITLE
docs: update testbed setup Ubuntu version

### DIFF
--- a/docs/testbed/README.testbed.Setup.md
+++ b/docs/testbed/README.testbed.Setup.md
@@ -4,7 +4,7 @@ This document describes the steps to setup the testbed and deploy a topology.
 
 ## Prepare Testbed Server
 
-- Install Ubuntu 20.04 amd64 on the server. (ubuntu-20.04.1-live-server-amd64.iso)
+- Install Ubuntu 22.04 or Ubuntu 24.04 amd64 on the server.
 - Install Ubuntu prerequisites
     ```
     sudo apt -y update


### PR DESCRIPTION
Summary:
Updates docs/testbed/README.testbed.Setup.md to remove the outdated Ubuntu 20.04 reference and align the testbed setup instructions with the currently documented Ubuntu 22.04 / Ubuntu 24.04 guidance.

Issue:
Fixes #25292

Testing:

* Documentation-only change.
* Verified the outdated "Ubuntu 20.04" reference was removed.
* Verified the setup doc now references Ubuntu 22.04 or Ubuntu 24.04.
