### PR TITLE
[arp] Fix flaky test_dut_arping_learns_mac: arp the port whose MAC is asserted

### DIFF
--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -299,19 +299,35 @@ def test_dut_arping_learns_mac(
     ptf_info = ptf_interface_info
     dut_info = dut_interface_info
 
-    # Setup PTF responder info
-    vlan_name, ipv4_base, _, ip_offset = setup_vlan_arp_responder
-    ptf_responder_ip = str(ipv4_base.ip + ip_offset)
-    logger.info("PTF responder IP (setup_vlan_arp_responder): {}".format(ptf_responder_ip))
+    # Setup PTF responder info.
+    #
+    # setup_vlan_arp_responder configures the ARP responder for *every* VLAN
+    # member, giving each PTF port eth{idx} its own responder IP
+    # (ipv4_base.ip + idx + 1), and yields the offset of the *last* member it
+    # iterated. Using that yielded offset makes the DUT arping an IP answered by
+    # the last VLAN member's port, whose MAC is NOT ptf_info['mac'] (which is the
+    # MAC of this test's ptf_interface_info port). The assertion then only passes
+    # when the target port's MAC happens to already be in the FDB (leftover from a
+    # prior test case or relearned by background traffic within the window),
+    # which makes the test flaky.
+    #
+    # Arp the responder IP that belongs to the SAME port whose MAC we assert, so
+    # the ARP reply carries ptf_info['mac'] and the stimulus deterministically
+    # satisfies the check.
+    vlan_name, ipv4_base, _, _ = setup_vlan_arp_responder
+    ptf_responder_ip = str(ipv4_base.ip + ptf_info['index'] + 1)
+    logger.info("PTF port eth{} responder IP: {} (MAC {})".format(
+        ptf_info['index'], ptf_responder_ip, ptf_info['mac']))
     logger.info("DUT VLAN IPv4: {}".format(dut_info['ipv4']))
 
-    # Simulate arping from DUT to PTF interface
+    # Simulate arping from DUT to the PTF port under test
     dut_info['host'].shell(f"arping -c 1 -I {dut_info['vlan_name']} {ptf_responder_ip}")
 
     # Confirm MAC is learned on DUT FDB
     pt_assert(
         wait_until(10, 1, 0, fdb_has_mac, dut_info['host'], ptf_info['mac']),
-        "FDB did not learn PTF MAC after DUT arping"
+        "FDB did not learn PTF MAC {} after DUT arping {}".format(
+            ptf_info['mac'], ptf_responder_ip)
     )
 
 

--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -132,8 +132,9 @@ def neighbor_learned(dut, target_ip):
 
 
 def appl_db_neighbor_syncd(dut, vlan_name, target_ip, exp_mac):
-    asic_db_mac = dut.shell(f"sonic-db-cli APPL_DB hget 'NEIGH_TABLE:{vlan_name}:{target_ip}' 'neigh'")['stdout']
-    logger.info(f"DUT neighbor mac: {asic_db_mac} of entry {vlan_name}:{target_ip}")
+    cmd = f"sonic-db-cli APPL_DB hget 'NEIGH_TABLE:{vlan_name}:{target_ip}' 'neigh'"  # noqa: E231
+    asic_db_mac = dut.shell(cmd)['stdout']
+    logger.info(f"DUT neighbor mac: {asic_db_mac} of entry {vlan_name}:{target_ip}")  # noqa: E231
     return exp_mac.lower() == asic_db_mac.lower()
 
 
@@ -163,7 +164,7 @@ def test_kernel_asic_mac_mismatch(
         else:
             target_ip = ipv6_base.ip + ip_offset
 
-    rand_selected_dut.shell(f"ping -c1 -W1 {target_ip}; true")
+    rand_selected_dut.shell(f"ping -c1 -W1 {target_ip}; true")  # noqa: E702
 
     pt_assert(wait_until(10, 1, 0, neighbor_learned, rand_selected_dut, target_ip),
               f"Neighbor {target_ip} not learned on {rand_selected_dut}")
@@ -180,13 +181,13 @@ def test_kernel_asic_mac_mismatch(
 
     logger.info("Manually setting APPL_DB MAC address")
     rand_selected_dut.shell(
-        f"sonic-db-cli APPL_DB hset 'NEIGH_TABLE:{vlan_name}:{target_ip}' 'neigh' '00:00:00:00:00:00'"
+        f"sonic-db-cli APPL_DB hset 'NEIGH_TABLE:{vlan_name}:{target_ip}' 'neigh' '00:00:00:00:00:00'"  # noqa: E231
     )
     asic_db_mac = rand_selected_dut.shell(
-        f"sonic-db-cli APPL_DB hget 'NEIGH_TABLE:{vlan_name}:{target_ip}' 'neigh'"
+        f"sonic-db-cli APPL_DB hget 'NEIGH_TABLE:{vlan_name}:{target_ip}' 'neigh'"  # noqa: E231
     )['stdout']
     pt_assert(target_mac.lower() != asic_db_mac.lower(),
-              f"APPL_DB MAC was not corrupted: expected 00:00:00:00:00:00 but got {asic_db_mac}. "
+              f"APPL_DB MAC was not corrupted: expected 00:00:00:00:00:00 but got {asic_db_mac}. "  # noqa: E231
               "Ensure arp_update is stopped before modifying APPL_DB.")
     logger.info("APPL_DB and kernel are out of sync (expected)")
 

--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -150,7 +150,10 @@ def test_kernel_asic_mac_mismatch(
     rand_selected_dut, ip_version, setup_vlan_arp_responder,  # noqa: F811
     tbinfo
 ):
-    vlan_name, ipv4_base, ipv6_base, ip_offset, _ = setup_vlan_arp_responder
+    # This test just needs a valid responder IP to ping; use the last configured
+    # member and pick v4/v6 by ip_version.
+    arp = setup_vlan_arp_responder
+    vlan_name = arp.vlan
     if 'dualtor' in tbinfo['topo']['name']:
         servers = mux_cable_server_ip(rand_selected_dut)
         intf = random.choice(list(servers))
@@ -159,10 +162,9 @@ def test_kernel_asic_mac_mismatch(
         else:
             target_ip = servers[intf]['server_ipv6'].split('/')[0]
     else:
-        if ip_version == 4:
-            target_ip = ipv4_base.ip + ip_offset
-        else:
-            target_ip = ipv6_base.ip + ip_offset
+        responder_ips = arp.responder_cfg[list(arp.responder_cfg)[-1]]
+        # values are [ipv4, ipv6]; [ipv6] on IPv6-only topos.
+        target_ip = responder_ips[0] if ip_version == 4 else responder_ips[-1]
 
     rand_selected_dut.shell(f"ping -c1 -W1 {target_ip}; true")  # noqa: E702
 
@@ -302,21 +304,10 @@ def test_dut_arping_learns_mac(
 
     # Setup PTF responder info.
     #
-    # setup_vlan_arp_responder configures the ARP responder for *every* VLAN
-    # member, giving each PTF port eth{idx} its own responder IP, and exposes
-    # that mapping as arp_responder_cfg (keyed eth{idx} -> [ipv4, ipv6]). The
-    # scalar offset it also yields is only the *last* member it iterated, whose
-    # port MAC is NOT ptf_info['mac'] (the MAC of this test's ptf_interface_info
-    # port). Arping an IP answered by the wrong port makes the assertion pass
-    # only when the target port's MAC happens to already be in the FDB (leftover
-    # from a prior test case or relearned by background traffic within the
-    # window), which makes the test flaky.
-    #
-    # Look up the responder IP of the SAME port whose MAC we assert, keyed by
-    # ptf_info['interface'] (eth{idx}). This reads back the exact IP the
-    # responder was configured with, so the ARP reply carries ptf_info['mac']
-    # and the stimulus deterministically satisfies the check.
-    _, _, _, _, arp_responder_cfg = setup_vlan_arp_responder
+    # responder_cfg maps eth<idx> -> [ipv4, ipv6], each VLAN member's own
+    # responder IP. Look up the SAME port whose MAC we assert (ptf_info
+    # ['interface']) so the ARP reply carries ptf_info['mac'] and is deterministic.
+    arp_responder_cfg = setup_vlan_arp_responder.responder_cfg
     ptf_iface = ptf_info['interface']
     pt_assert(
         ptf_iface in arp_responder_cfg,

--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -150,7 +150,7 @@ def test_kernel_asic_mac_mismatch(
     rand_selected_dut, ip_version, setup_vlan_arp_responder,  # noqa: F811
     tbinfo
 ):
-    vlan_name, ipv4_base, ipv6_base, ip_offset = setup_vlan_arp_responder
+    vlan_name, ipv4_base, ipv6_base, ip_offset, _ = setup_vlan_arp_responder
     if 'dualtor' in tbinfo['topo']['name']:
         servers = mux_cable_server_ip(rand_selected_dut)
         intf = random.choice(list(servers))
@@ -303,20 +303,28 @@ def test_dut_arping_learns_mac(
     # Setup PTF responder info.
     #
     # setup_vlan_arp_responder configures the ARP responder for *every* VLAN
-    # member, giving each PTF port eth{idx} its own responder IP
-    # (ipv4_base.ip + idx + 1), and yields the offset of the *last* member it
-    # iterated. Using that yielded offset makes the DUT arping an IP answered by
-    # the last VLAN member's port, whose MAC is NOT ptf_info['mac'] (which is the
-    # MAC of this test's ptf_interface_info port). The assertion then only passes
-    # when the target port's MAC happens to already be in the FDB (leftover from a
-    # prior test case or relearned by background traffic within the window),
-    # which makes the test flaky.
+    # member, giving each PTF port eth{idx} its own responder IP, and exposes
+    # that mapping as arp_responder_cfg (keyed eth{idx} -> [ipv4, ipv6]). The
+    # scalar offset it also yields is only the *last* member it iterated, whose
+    # port MAC is NOT ptf_info['mac'] (the MAC of this test's ptf_interface_info
+    # port). Arping an IP answered by the wrong port makes the assertion pass
+    # only when the target port's MAC happens to already be in the FDB (leftover
+    # from a prior test case or relearned by background traffic within the
+    # window), which makes the test flaky.
     #
-    # Arp the responder IP that belongs to the SAME port whose MAC we assert, so
-    # the ARP reply carries ptf_info['mac'] and the stimulus deterministically
-    # satisfies the check.
-    vlan_name, ipv4_base, _, _ = setup_vlan_arp_responder
-    ptf_responder_ip = str(ipv4_base.ip + ptf_info['index'] + 1)
+    # Look up the responder IP of the SAME port whose MAC we assert, keyed by
+    # ptf_info['interface'] (eth{idx}). This reads back the exact IP the
+    # responder was configured with, so the ARP reply carries ptf_info['mac']
+    # and the stimulus deterministically satisfies the check.
+    _, _, _, _, arp_responder_cfg = setup_vlan_arp_responder
+    ptf_iface = ptf_info['interface']
+    pt_assert(
+        ptf_iface in arp_responder_cfg,
+        "PTF port {} under test is not a VLAN member configured on the ARP "
+        "responder (configured: {})".format(
+            ptf_iface, sorted(arp_responder_cfg))
+    )
+    ptf_responder_ip = arp_responder_cfg[ptf_iface][0]
     logger.info("PTF port eth{} responder IP: {} (MAC {})".format(
         ptf_info['index'], ptf_responder_ip, ptf_info['mac']))
     logger.info("DUT VLAN IPv4: {}".format(dut_info['ipv4']))

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -254,7 +254,10 @@ def setup_vlan_arp_responder(ptfhost, rand_selected_dut, tbinfo):
     logger.info("Start arp_responder")
     ptfhost.command('supervisorctl start arp_responder')
 
-    yield vlan, ipv4_base, ipv6_base, ip_offset
+    # Yield arp_responder_cfg (keyed eth<ptf_index> -> [ipv4, ipv6]) so a consumer
+    # can look up the responder IP of the specific port under test rather than
+    # relying on ip_offset, which only carries the last iterated member's offset.
+    yield vlan, ipv4_base, ipv6_base, ip_offset, arp_responder_cfg
 
     ptfhost.command('supervisorctl stop arp_responder')
     # Remove the rendered config so it can't mislead diagnostics or be picked up

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import json
 import os
 import pytest
@@ -182,6 +183,11 @@ def copy_arp_responder_py(ptfhost):
     ptfhost.file(path=os.path.join(OPT_DIR, ARP_RESPONDER_PY), state="absent")
 
 
+# responder_cfg: eth<ptf_index> -> [ipv4, ipv6] ([ipv6] on IPv6-only topos),
+# the exact IP(s) the responder answers per port.
+ArpResponderInfo = namedtuple("ArpResponderInfo", ["vlan", "responder_cfg"])
+
+
 @pytest.fixture(scope="module", autouse=True)
 def setup_vlan_arp_responder(ptfhost, rand_selected_dut, tbinfo):
     arp_responder_cfg = {}
@@ -254,10 +260,7 @@ def setup_vlan_arp_responder(ptfhost, rand_selected_dut, tbinfo):
     logger.info("Start arp_responder")
     ptfhost.command('supervisorctl start arp_responder')
 
-    # Yield arp_responder_cfg (keyed eth<ptf_index> -> [ipv4, ipv6]) so a consumer
-    # can look up the responder IP of the specific port under test rather than
-    # relying on ip_offset, which only carries the last iterated member's offset.
-    yield vlan, ipv4_base, ipv6_base, ip_offset, arp_responder_cfg
+    yield ArpResponderInfo(vlan=vlan, responder_cfg=arp_responder_cfg)
 
     ptfhost.command('supervisorctl stop arp_responder')
     # Remove the rendered config so it can't mislead diagnostics or be picked up


### PR DESCRIPTION
### Description of PR

Fixes #25922

De-flake `arp/test_arp_update.py::test_dut_arping_learns_mac`.

**Bug:** the test asserts the MAC of its port under test (`ptf_interface_info`, e.g. `eth1`) lands in the DUT FDB after the DUT arpings a responder IP — but it arped the IP built from `ip_offset`, which `setup_vlan_arp_responder` only sets to the **last** iterated VLAN member (e.g. `eth24`). So the responder answered with the wrong port's MAC; the assertion could only pass on leftover/relearned FDB state (bond-slave background traffic within the 10 s window). Purge + no relearn → FAIL, then PASS on re-run. A neighbor-image rebase shifts FDB timing and **exposes** this; it doesn't cause it.

**Fix:** `setup_vlan_arp_responder` already builds `arp_responder_cfg` (`eth<idx> -> [ipv4, ipv6]`, each member's own responder IP). Yield that map (as `ArpResponderInfo(vlan, responder_cfg)`) instead of the scalar `ipv4_base/ipv6_base/ip_offset` — `ip_offset` only ever carried the last member's offset. The test now looks up its own port (`ptf_info['interface']`) in `responder_cfg` and arps that IP, so the reply carries `ptf_info['mac']`. Deterministic.

Test-only; platform / neighbor-type agnostic (same wrong-target math, cEOS just wins the coin flip more often). Introduced by #22148.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework (new/improvement)
- [ ] Test case (new/improvement)

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] Others

### Approach

**Motivation:** `test_dut_arping_learns_mac` is intermittently flaky (`FDB did not learn PTF MAC after DUT arping`) — it arps the last VLAN member's responder IP while asserting a different port's MAC, so it only passes on lucky FDB state.

**How:**
- `setup_vlan_arp_responder` yields `ArpResponderInfo(vlan, responder_cfg)` (single source of truth) instead of `vlan, ipv4_base, ipv6_base, ip_offset`.
- `test_dut_arping_learns_mac` looks up its port under test in `responder_cfg` and arps that exact IP; `pt_assert` guards a non-member selection.
- `test_kernel_asic_mac_mismatch` updated for the new return type (reads vlan + last member from the same map; behavior unchanged).

**Verify:** `py_compile` + `flake8 --max-line-length=120` clean. `responder_cfg[ptf_info['interface']][0]` is by construction the IP whose responder MAC equals `ptf_info['mac']`, making the assertion deterministic.

### Note: unrelated Python 3.12 lint fix included

Static Analysis (`flake8`) flags **pre-existing** f-string lines this change doesn't functionally touch: under Python 3.12 (PEP 701) `pycodestyle` tokenizes f-string internals, so colons/semicolons inside string literals (Redis keys `NEIGH_TABLE:{vlan}:{ip}`, MAC `00:00:00:00:00:00`, shell separator `;`) trip `E231`/`E702`. They can't take real whitespace without changing the keys/MAC/command, so I added `# noqa` suppressions per existing repo convention and split one line to stay under 120 chars.
