### PR TITLE
[test_system_health] test_service_checker fails due to new pdb module and correct the polling interval

### DIFF
--- a/tests/system_health/files/ignore_device_check.json
+++ b/tests/system_health/files/ignore_device_check.json
@@ -1,6 +1,6 @@
 {
     "services_to_ignore": [],
-    "devices_to_ignore": ["asic","fan","psu"],
+    "devices_to_ignore": ["asic","fan","psu","pdb"],
     "user_defined_checkers": [],
     "polling_interval": 10,
     "led_color": {

--- a/tests/system_health/files/ignore_psu_check.json
+++ b/tests/system_health/files/ignore_psu_check.json
@@ -1,6 +1,6 @@
 {
     "services_to_ignore": [],
-    "devices_to_ignore": ["psu"],
+    "devices_to_ignore": ["psu","pdb"],
     "user_defined_checkers": [],
     "polling_interval": 10,
     "led_color": {

--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -125,8 +125,11 @@ def test_service_checker(duthosts, enum_rand_one_per_hwsku_hostname):
                     error, value)
 
         expect_summary = SUMMARY_OK if not expect_error_dict else SUMMARY_NOT_OK
+        polling_interval = get_system_health_config(
+            duthost, 'polling_interval', FAST_INTERVAL)
         result = wait_until(
-            WAIT_TIMEOUT, 10, 2, check_system_health_info, duthost, 'summary', expect_summary)
+            WAIT_TIMEOUT, min(polling_interval, 10), polling_interval,
+            check_system_health_info, duthost, 'summary', expect_summary)
         # Output the content of whole SYSTEM_HEALTH_INFO table for easy debug when test case failed.
         table_output = redis_get_system_health_info(
             duthost, STATE_DB, HEALTH_TABLE_NAME)


### PR DESCRIPTION
**Description**
system health fails on test_service_checker

Fixes: https://github.com/sonic-net/sonic-mgmt/issues/26654
**Details**
baseline code change on adding Power Distribution Board (pdb)
https://github.com/sonic-net/sonic-buildimage/blob/master/src/system-health/health_checker/hardware_checker.py#L174

https://github.com/sonic-net/SONiC/pull/2219
https://github.com/sonic-net/sonic-buildimage/pull/26829/changes


**example:**
from simulator.
File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 194, in pytest_pyfunc_call
result = testfunction(**testargs)
File "/data/tests/system_health/test_system_health.py", line 133, in test_service_checker
assert result is True, 'Expect summary {}, got {}'.format(
AssertionError: Expect summary OK, got PSU0
PSU0 is missing or not available
PSU1
PSU1 is missing or not available
summary
Not OK

**Summary**
Fixes # (issue)

File | Change
ignore_device_check.json | adds "pdb" to devices_to_ignore
ignore_psu_check.json | adds "pdb" to devices_to_ignore
test_system_health.py | waits using DUT polling_interval instead of hardcoded 10, 2
should follow the file/**.json on     "polling_interval": 

first polling time should not be 2. should be the one more than json config.
otherwise, first polling will fetch the stale info, not from testcase's json.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement

### Back port request
- [] 202405
- [] 202411
- [] 202505
- [] 202511
- [ ] 202605

### Approach
#### What is the motivation for this PR?
testcase failing
#### How did you do it?
we should base on the stderr to find out the root-cause and take action

#### How did you verify/test it?
Yes
**Fix**
3 passed, 3 skipped, 1 warning in 682.66s (0:11:22)
based on
./run_tests.sh -n docker-ptf -d xxxxxx-01 -O -u -l debug -e -s -e --disable_loganalyzer -m individual -p /data/tests/logs -c system_health/test_system_health.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
Generic issue
### Documentation
