### PR TITLE
Keep fw_pkg fixture BMC agnostic

### DIFF
--- a/tests/platform_tests/api/test_bmc.py
+++ b/tests/platform_tests/api/test_bmc.py
@@ -14,6 +14,7 @@ from tests.common.helpers.platform_api import bmc
 from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service    # noqa: F401
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
 from .platform_api_test_base import PlatformApiTestBase
+from tests.platform_tests.conftest import extract_fw_data
 from tests.common.helpers.firmware_helper import show_firmware, FW_TYPE_UPDATE, PLATFORM_COMP_PATH_TEMPLATE
 
 
@@ -88,6 +89,14 @@ class TestBMCApi(PlatformApiTestBase):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         if not bmc.is_bmc_exists(duthost):
             pytest.skip("BMC is not present, skipping BMC platform API tests")
+
+    @pytest.fixture(scope="class")
+    def bmc_fw_pkg(self, fw_pkg_name, skip_if_no_bmc):
+        """Load BMC firmware package only after BMC presence is confirmed."""
+        if fw_pkg_name is None:
+            pytest.skip("No fw package specified.")
+
+        yield extract_fw_data(fw_pkg_name)
 
     @pytest.fixture(scope="class")
     def bmc_ip(self, duthosts, enum_rand_one_per_hwsku_hostname, skip_if_no_bmc):
@@ -337,7 +346,7 @@ class TestBMCApi(PlatformApiTestBase):
             logger.info(f"Writing updated 'platform_components.json' to localhost: {local_comp_file_path}")
             with open(local_comp_file_path, 'w') as comp_file:
                 json.dump(json_data, comp_file, indent=4)
-                logger.info(f"Updated 'platform_components.json':\n{json.dumps(json_data, indent=4)}")
+                logger.info("Updated 'platform_components.json':\n%s", json.dumps(json_data, indent=4))
 
             logger.info(f"Copying 'platform_components.json' to {duthost.hostname}: {remote_comp_file_path}")
             duthost.copy(src=local_comp_file_path, dest=remote_comp_file_path)
@@ -540,8 +549,8 @@ class TestBMCApi(PlatformApiTestBase):
         pytest_assert(duthost.command(
             f"ls -l {bmc_dump_path}")["rc"] == 0, f"BMC dump file not found: {bmc_dump_path}")
 
-    def test_bmc_firmware_update(self, duthosts, enum_rand_one_per_hwsku_hostname, fw_pkg, bmc_firmware_command_type,
-                                 backup_platform_file, bmc_ip, request):
+    def test_bmc_firmware_update(self, duthosts, enum_rand_one_per_hwsku_hostname, bmc_fw_pkg,
+                                 bmc_firmware_command_type, backup_platform_file, bmc_ip, request):
         """
         Test BMC firmware update with platform API and CLI
 
@@ -563,6 +572,7 @@ class TestBMCApi(PlatformApiTestBase):
             'show platform firmware status'
         """
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        fw_pkg = bmc_fw_pkg
         bmc_version_origin = self._get_bmc_version(duthost)
         logger.info(f"BMC version origin: {bmc_version_origin}")
         logger.info(f"Testing with command type: {bmc_firmware_command_type}")
@@ -668,7 +678,7 @@ class TestBMCApi(PlatformApiTestBase):
                         f"response: {sessions_result['stdout']}")
                 member_session_ids = self._extract_ids_from_members(sessions_data)
                 pytest_assert(session_id in member_session_ids,
-                              f"Session {session_id} not found in Members: {member_session_ids}")
+                              "Session {} not present in Members: {}".format(session_id, member_session_ids))
 
             with allure.step("Create event subscription"):
                 subscription_data = json.dumps({"Destination": "https://example.com/events", "Protocol": "Redfish"})

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -12,7 +12,6 @@ from tests.common.platform.device_utils import MGFX_HWSKU, MGFX_XCVR_INTF
 from tests.common.platform.transceiver_utils import get_passive_cable_port_list, get_cmis_cable_ports_and_ver
 from tests.common.helpers.firmware_helper import PLATFORM_COMP_PATH_TEMPLATE
 from tests.common.platform.interface_utils import get_ports_with_flat_memory
-from tests.common.helpers.platform_api import bmc
 
 logger = logging.getLogger(__name__)
 
@@ -277,11 +276,7 @@ def cmis_cable_ports_and_ver(duthosts):
 
 
 @pytest.fixture(scope='module')
-def fw_pkg(duthosts, enum_rand_one_per_hwsku_hostname, fw_pkg_name):
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    if not bmc.is_bmc_exists(duthost):
-        pytest.skip("BMC is not present, skipping BMC platform API tests")
-
+def fw_pkg(fw_pkg_name):
     if fw_pkg_name is None:
         pytest.skip("No fw package specified.")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #25925 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
Failure type: regression
Relevant PR : https://github.com/sonic-net/sonic-mgmt/pull/24950

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Failure type: regression caused by https://github.com/sonic-net/sonic-mgmt/pull/24950

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test results 
202605-specific image/test result evidence
Testing done on Non BMC Platform 

**1. fwutil tests are skipped with correct reason**
```
AzDevOps@bc5dcbfe4254:/data/tests$ sudo ./run_tests.sh -n dtAA -m individual -r \
   -t any,util,dualtor,t0 \
   -p logs_fwutil_non_bmc \
   -f ../ansible/testbed.yaml -u \
   -e "--ignore-conditional-mark" \
   -c "platform_tests/fwutil/test_fwutil.py::test_fwutil_install_url"
```

```
platform_tests/fwutil/test_fwutil.py::test_fwutil_install_url[CPLD-None] SKIPPED (No fw package specified.)                                                                                                                                                                            [ 25%]
platform_tests/fwutil/test_fwutil.py::test_fwutil_install_url[ONIE-None] SKIPPED (No fw package specified.)                                                                                                   [ 50%]
platform_tests/fwutil/test_fwutil.py::test_fwutil_install_url[BIOS-None] SKIPPED (No fw package specified.)                                                                                                   [ 75%]
platform_tests/fwutil/test_fwutil.py::test_fwutil_install_url[FPGA-None] SKIPPED (No fw package specified.)                                                                                                   [100%]
```
**Logs** 
[test_fwutil.py::test_fwutil_install_url.log](https://github.com/user-attachments/files/30922326/test_fwutil.py.test_fwutil_install_url.log)
[test_fwutil.py::test_fwutil_install_url.xml](https://github.com/user-attachments/files/30922328/test_fwutil.py.test_fwutil_install_url.xml)

**2. bmc tests are skipped with right reason** 
```
sudo ./run_tests.sh -n dtAA -m individual -r \
   -t any,util,dualtor,t0 \
   -p logs_fwutil_non_bmc \
   -f ../ansible/testbed.yaml -u \
   -c "platform_tests/api/test_bmc.py::TestBMCApi::test_bmc_firmware_update"
```

```
platform_tests/api/test_bmc.py::TestBMCApi::test_bmc_firmware_update[install-None-ld209] SKIPPED (BMC is not present, skipping BMC platform API tests)                                                        [ 25%]
platform_tests/api/test_bmc.py::TestBMCApi::test_bmc_firmware_update[update-None-ld209] SKIPPED (BMC is not present, skipping BMC platform API tests)                                                         [ 50%]
platform_tests/api/test_bmc.py::TestBMCApi::test_bmc_firmware_update[install-None-ldp204] SKIPPED (BMC is not present, skipping BMC platform API tests)                                                       [ 75%]
platform_tests/api/test_bmc.py::TestBMCApi::test_bmc_firmware_update[update-None-ldp204] SKIPPED (BMC is not present, skipping BMC platform API tests)                                                        [100%]
```
**Logs :** 
[test_bmc.py::TestBMCApi::test_bmc_firmware_update.log](https://github.com/user-attachments/files/30922312/test_bmc.py.TestBMCApi.test_bmc_firmware_update.log)
[test_bmc.py::TestBMCApi::test_bmc_firmware_update.xml](https://github.com/user-attachments/files/30922314/test_bmc.py.TestBMCApi.test_bmc_firmware_update.xml)


### Approach

#### What is the motivation for this PR?

Generic fwutil tests should not be gated by BMC presence. On platforms
 without BMC support, they should run or skip for their own fwutil/platform
 reasons instead of using a BMC API-specific skip reason.

#### How did you do it?

Removed the BMC presence check from the shared `fw_pkg` fixture and added
 a BMC-specific `bmc_fw_pkg` fixture in `api/test_bmc.py`.

Updated `test_bmc_firmware_update` to use `bmc_fw_pkg`, preserving the BMC
presence check for the BMC firmware update path only.

#### How did you verify/test it?

**Scenario 1:** 

BMC API test on a non-BMC DUT still skips with the BMC-specific message:

  platform_tests/api/test_bmc.py::TestBMCApi::test_bmc_firmware_update[install-ldp205]
  SKIPPED (BMC is not present, skipping BMC platform API tests)

  platform_tests/api/test_bmc.py::TestBMCApi::test_bmc_firmware_update[update-ldp205]
  SKIPPED (BMC is not present, skipping BMC platform API tests)

  **Scenario 2:** 

Generic fwutil test no longer BMC-skips and reaches generic fw_pkg handling:

  platform_tests/fwutil/test_fwutil.py::test_fwutil_install_url[ONIE-None]
  SKIPPED (No fw package specified.)

  platform_tests/fwutil/test_fwutil.py::test_fwutil_install_url[BIOS-None]
  SKIPPED (No fw package specified.)

  platform_tests/fwutil/test_fwutil.py::test_fwutil_install_url[FPGA-None]
  SKIPPED (No fw package specified.)




#### Any platform specific information?


#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
