### PR TITLE
Added "--" to sonic-db-cli HSET command.

### DIFF
--- a/tests/common/helpers/sonic_db.py
+++ b/tests/common/helpers/sonic_db.py
@@ -260,7 +260,7 @@ def redis_hset(duthost, db, key, **fields):
         return
     parts = ' '.join("{k} {v}".format(k=k, v=v) for k, v in fields.items())
     duthost.shell(
-        "sonic-db-cli {db} HSET '{key}' {parts}".format(db=db, key=key, parts=parts),
+        "sonic-db-cli {db} -- HSET '{key}' {parts}".format(db=db, key=key, parts=parts),
         module_ignore_errors=True
     )
 


### PR DESCRIPTION
### Description of PR
Adding the double dash to escape the command arguments starting with "-"

Summary:
Fixes https://github.com/sonic-net/sonic-mgmt/issues/25931

### Type of change


- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [X] 202608

### Approach
#### What is the motivation for this PR?
The command errors in the test and does not set the sensor in the STATE_DB

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
