### PR TITLE
[CsonicHost] Add neighbor API parity methods for BGP/OSPF/loopback tests

### DIFF
--- a/tests/common/devices/csonic.py
+++ b/tests/common/devices/csonic.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 import subprocess
+import time
 
 from tests.common.devices.base import NeighborDevice
 
@@ -144,6 +145,8 @@ class CsonicHost(NeighborDevice):
         failed = False
         for cmd in cmds:
             res = self._docker_exec(cmd, module_ignore_errors=True)
+            if not isinstance(res, dict):
+                res = {'rc': 1, 'stderr': str(res)}
             rc = res.get('rc', 0)
             results.append({
                 'cmd': cmd,
@@ -245,13 +248,28 @@ class CsonicHost(NeighborDevice):
 
         Mirrors SonicHost.start_bgpd: after starting bgpd, restart bgpcfgd so
         the CONFIG_DB-derived BGP configuration is re-applied to FRR (starting
-        bgpd alone leaves FRR without the config bgpcfgd renders).
+        bgpd alone leaves FRR without the config bgpcfgd renders). Waits for
+        bgpd to report RUNNING (bounded) before restarting bgpcfgd, and surfaces
+        a non-zero bgpcfgd-restart rc so a failed config re-apply is not silent.
         """
         result = self._docker_exec("supervisorctl start bgpd", module_ignore_errors=True)
         if result.get('rc', 1) != 0:
             return result
-        # Give bgpd a moment to come up, then restart bgpcfgd to re-apply config.
-        self._docker_exec("supervisorctl restart bgpcfgd", module_ignore_errors=True)
+        # Wait for bgpd to actually be RUNNING before restarting bgpcfgd, rather
+        # than relying on timing luck.
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            status = self._docker_exec("supervisorctl status bgpd", module_ignore_errors=True)
+            if 'RUNNING' in str(status.get('stdout', '')):
+                break
+            time.sleep(2)
+        else:
+            logger.warning("CsonicHost [%s] start_bgpd: bgpd did not reach RUNNING "
+                           "within timeout; restarting bgpcfgd anyway", self.container_name)
+        cfg = self._docker_exec("supervisorctl restart bgpcfgd", module_ignore_errors=True)
+        if cfg.get('rc', 1) != 0:
+            logger.warning("CsonicHost [%s] start_bgpd: bgpcfgd restart failed rc=%s stderr=%s",
+                           self.container_name, cfg.get('rc'), cfg.get('stderr', ''))
         return result
 
     def _bgp_summary_peers(self, afi, vrf):
@@ -297,12 +315,21 @@ class CsonicHost(NeighborDevice):
         neigh_desc_available = False
 
         peers = {}
-        peers.update(self._bgp_summary_peers('ipv4', vrf))
-        # v6 peers live in the ipv6 summary; merge both address families.
-        for k, v in self._bgp_summary_peers('ipv6', vrf).items():
-            peers.setdefault(k, v)
+        # Merge both address families. Distinct v4/v6 neighbor IPs make key
+        # collisions unexpected, but use update() for both so we never silently
+        # drop a v6 peer just because a same-string key appeared under v4.
+        for afi in ('ipv4', 'ipv6'):
+            for k, v in self._bgp_summary_peers(afi, vrf).items():
+                peers[k.lower()] = v
 
         if not peers:
+            # Empty here means either FRR/vtysh did not answer / JSON failed to
+            # parse, or no peers are established yet. Under wait_until both look
+            # the same, so log so a genuine FRR error is distinguishable from
+            # slow convergence.
+            logger.warning("CsonicHost [%s] check_bgp_session_state: no peers from "
+                           "BGP summary (FRR not answering, parse failure, or none "
+                           "established yet)", self.container_name)
             return False
 
         for k, v in list(peers.items()):
@@ -361,14 +388,18 @@ class CsonicHost(NeighborDevice):
         seen = set()
         for afi in ('ipv4', 'ipv6'):
             for ip, info in self._bgp_neighbors_json(afi).items():
-                if not isinstance(info, dict) or ip in seen:
+                key = ip.lower() if isinstance(ip, str) else ip
+                if not isinstance(info, dict) or key in seen:
                     continue
-                seen.add(ip)
+                seen.add(key)
                 remote_as = info.get('remoteAs')
                 try:
                     asn = int(remote_as) if remote_as is not None else None
                 except (TypeError, ValueError):
-                    asn = remote_as
+                    logger.warning("CsonicHost [%s] minigraph_facts: could not parse "
+                                   "remoteAs=%r for peer %s; setting asn=None",
+                                   self.container_name, remote_as, ip)
+                    asn = None
                 bgp_sessions.append({
                     'name': info.get('hostname'),
                     'addr': ip,

--- a/tests/common/devices/csonic.py
+++ b/tests/common/devices/csonic.py
@@ -43,6 +43,22 @@ class CsonicHost(NeighborDevice):
     def __repr__(self):
         return self.__str__()
 
+    def __hash__(self):
+        # CsonicHost is stored as the ['host'] value of a NeighborDevice and is
+        # used interchangeably with EosHost/SonicHost, which are hashable plain
+        # objects. CsonicHost inherits NeighborDevice(dict), which is unhashable,
+        # so some tests (e.g. iface_loopback_action) that place neighbor hosts in
+        # a set or use them as dict keys raise "unhashable type: 'CsonicHost'".
+        # Identity is the container name, so hash/eq on that keep host objects
+        # hashable and distinct without relying on dict contents.
+        return hash(self.container_name)
+
+    def __eq__(self, other):
+        return isinstance(other, CsonicHost) and self.container_name == other.container_name
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def _docker_exec(self, cmd, **kwargs):
         """Run a command inside the Docker container via docker exec."""
         docker_cmd = ['docker', 'exec', self.container_name, 'bash', '-c', cmd]
@@ -113,15 +129,59 @@ class CsonicHost(NeighborDevice):
         """Run a list of commands inside the container, returning a result per command."""
         return [self._docker_exec(cmd, **kwargs) for cmd in cmds]
 
+    def shell_cmds(self, cmds=None, continue_on_fail=False, **kwargs):
+        """Run a sequence of shell commands, one result per command.
+
+        Mirrors the ``shell_cmds`` Ansible module (used against EosHost/SonicHost
+        neighbors, e.g. ospf/conftest.py) so cSONiC neighbors accept the same
+        call. Returns the module-compatible shape ``{'cmds': [...], 'results':
+        [{'cmd','stdout','stderr','rc',...}], 'failed': bool}``. By default it
+        stops at the first failing command (matching the module's
+        ``continue_on_fail=False`` default) unless ``continue_on_fail`` is set.
+        """
+        cmds = cmds or []
+        results = []
+        failed = False
+        for cmd in cmds:
+            res = self._docker_exec(cmd, module_ignore_errors=True)
+            rc = res.get('rc', 0)
+            results.append({
+                'cmd': cmd,
+                'stdout': res.get('stdout', ''),
+                'stdout_lines': res.get('stdout_lines', []),
+                'stderr': res.get('stderr', ''),
+                'stderr_lines': res.get('stderr_lines', []),
+                'rc': rc,
+                'err_msg': res.get('stderr', '') if rc != 0 else '',
+            })
+            if rc != 0:
+                failed = True
+                if not continue_on_fail:
+                    break
+        return {'cmds': cmds, 'results': results, 'failed': failed}
+
     def shutdown(self, ifname):
-        """Shut down an interface."""
+        """Shut down an interface.
+
+        Mirrors ``SonicHost.shutdown`` (``config interface shutdown``) rather
+        than a raw ``ip link`` change, since a cSONiC neighbor IS SONiC:
+        driving the port through the SONiC CLI updates CONFIG_DB and lets the
+        orchestration (portchannel/BGP) react correctly, which
+        ``ip link set ... down`` would bypass.
+        """
         logger.info("CsonicHost [%s] shutting down %s", self.container_name, ifname)
-        return self._docker_exec("ip link set {} down".format(ifname))
+        return self._docker_exec("config interface shutdown {}".format(ifname),
+                                 module_ignore_errors=True)
 
     def no_shutdown(self, ifname):
-        """Bring up an interface."""
+        """Bring up an interface.
+
+        Mirrors ``SonicHost.no_shutdown`` (``config interface startup``); see
+        :meth:`shutdown` for why the SONiC CLI is used instead of ``ip link``.
+        """
         logger.info("CsonicHost [%s] bringing up %s", self.container_name, ifname)
-        return self._docker_exec("ip link set {} up".format(ifname))
+        return self._docker_exec("config interface startup {}".format(ifname),
+                                 module_ignore_errors=True)
 
     def get_route(self, prefix):
         """Get route info from FRR."""
@@ -150,10 +210,16 @@ class CsonicHost(NeighborDevice):
         """
         Configure via vtysh (loose compatibility with EOS config style).
         Translates config lines to vtysh commands.
+
+        Config-mode commands (e.g. ``router bgp``, ``bgp graceful-restart``)
+        must run inside FRR's configuration mode; vtysh rejects them with
+        ``% Unknown command`` when issued at the enable prompt. We therefore
+        prepend ``configure terminal`` so ``parents`` and ``lines`` are applied
+        in config context, matching how EosHost.config()/SonicHost config work.
         """
         if not lines:
             return {}
-        cmds = []
+        cmds = ['configure terminal']
         if parents:
             for p in parents:
                 cmds.append(p)
@@ -166,9 +232,149 @@ class CsonicHost(NeighborDevice):
 
         return self._docker_exec(vtysh_cmd, **kwargs)
 
+    def kill_bgpd(self):
+        """Stop the BGP daemon inside the cSONiC container.
+
+        Mirrors SonicHost.kill_bgpd (supervisorctl stop bgpd) so GR tests can
+        take the neighbor's bgpd down and bring it back.
+        """
+        return self._docker_exec("supervisorctl stop bgpd", module_ignore_errors=True)
+
     def start_bgpd(self):
-        """Start the BGP daemon inside the cSONiC container."""
-        return self._docker_exec("supervisorctl start bgpd", module_ignore_errors=True)
+        """Start the BGP daemon inside the cSONiC container.
+
+        Mirrors SonicHost.start_bgpd: after starting bgpd, restart bgpcfgd so
+        the CONFIG_DB-derived BGP configuration is re-applied to FRR (starting
+        bgpd alone leaves FRR without the config bgpcfgd renders).
+        """
+        result = self._docker_exec("supervisorctl start bgpd", module_ignore_errors=True)
+        if result.get('rc', 1) != 0:
+            return result
+        # Give bgpd a moment to come up, then restart bgpcfgd to re-apply config.
+        self._docker_exec("supervisorctl restart bgpcfgd", module_ignore_errors=True)
+        return result
+
+    def _bgp_summary_peers(self, afi, vrf):
+        """Return the FRR BGP summary peers dict for an address family.
+
+        Runs ``show bgp vrf <vrf> <afi> summary json`` via vtysh and returns the
+        per-neighbor ``peers`` mapping (keyed by neighbor IP). Returns an empty
+        dict if BGP/FRR is not answering or the address family is absent.
+        """
+        cmd = "vtysh -c 'show bgp vrf {} {} summary json'".format(vrf, afi)
+        result = self._docker_exec(cmd, module_ignore_errors=True)
+        if result.get('rc') != 0 or not result.get('stdout'):
+            return {}
+        try:
+            data = json.loads(result['stdout'])
+        except (json.JSONDecodeError, ValueError):
+            return {}
+        # FRR nests the summary under an address-family key
+        # ("ipv4Unicast"/"ipv6Unicast") rather than EOS's vrfs.<vrf>.peers.
+        af_key = 'ipv4Unicast' if afi == 'ipv4' else 'ipv6Unicast'
+        return data.get(af_key, {}).get('peers', {}) or {}
+
+    def check_bgp_session_state(self, neigh_ips, neigh_desc=None,
+                                state="established", vrf="default"):
+        """Check whether the given BGP neighbors are in the target state.
+
+        Mirrors ``EosHost.check_bgp_session_state`` so cSONiC neighbors can be
+        used interchangeably by tests (e.g. bgp/test_bgp_gr_helper.py). State is
+        read from FRR via vtysh JSON. FRR's summary does not populate a peer
+        ``description`` field, so neighbor descriptions are matched only when
+        FRR reports one; otherwise the check passes on IP/state alone.
+
+        @param neigh_ips: list of BGP neighbor IPs to verify
+        @param neigh_desc: optional list of expected neighbor descriptions
+        @param state: target peer state (default "established")
+        @param vrf: VRF name (default "default")
+        @return: True if all neigh_ips are in the target state
+        """
+        neigh_ips = [ip.lower() for ip in neigh_ips]
+        neigh_desc = neigh_desc or []
+        neigh_ips_ok = []
+        neigh_desc_ok = []
+        neigh_desc_available = False
+
+        peers = {}
+        peers.update(self._bgp_summary_peers('ipv4', vrf))
+        # v6 peers live in the ipv6 summary; merge both address families.
+        for k, v in self._bgp_summary_peers('ipv6', vrf).items():
+            peers.setdefault(k, v)
+
+        if not peers:
+            return False
+
+        for k, v in list(peers.items()):
+            peer_state = str(v.get('state', '')).lower()
+            if peer_state == state.lower():
+                if k.lower() in neigh_ips:
+                    neigh_ips_ok.append(k.lower())
+                desc = v.get('description')
+                if desc:
+                    neigh_desc_available = True
+                    if desc in neigh_desc:
+                        neigh_desc_ok.append(desc)
+
+        logger.info("CsonicHost [%s] check_bgp_session_state: neigh_ips_ok=%s "
+                    "neigh_desc_available=%s neigh_desc_ok=%s",
+                    self.container_name, str(neigh_ips_ok),
+                    str(neigh_desc_available), str(neigh_desc_ok))
+
+        if neigh_desc_available and neigh_desc:
+            return (len(set(neigh_ips)) == len(set(neigh_ips_ok))
+                    and len(neigh_desc) == len(neigh_desc_ok))
+        return len(set(neigh_ips)) == len(set(neigh_ips_ok))
+
+    def _bgp_neighbors_json(self, afi):
+        """Return FRR's ``show <afi> bgp neighbors json`` mapping (ip -> info)."""
+        show = 'show ip bgp neighbors json' if afi == 'ipv4' \
+            else 'show bgp ipv6 neighbors json'
+        result = self._docker_exec("vtysh -c '{}'".format(show),
+                                   module_ignore_errors=True)
+        if result.get('rc') != 0 or not result.get('stdout'):
+            return {}
+        try:
+            data = json.loads(result['stdout'])
+        except (json.JSONDecodeError, ValueError):
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def minigraph_facts(self, host=None, **kwargs):
+        """Synthesize minigraph-style BGP facts for this cSONiC neighbor.
+
+        Mirrors the ``minigraph_facts`` Ansible module for the fields tests
+        consume from a *neighbor* (e.g. ospf/conftest.py reads
+        ``minigraph_bgp`` and matches ``name == duthost.hostname`` to recover the
+        DUT's peer address/ASN as seen by this neighbor). A cSONiC neighbor has
+        no minigraph XML, so we derive the peer list from FRR: each BGP peer
+        yields ``name`` (FRR's advertised peer ``hostname``), ``addr`` (peer IP)
+        and ``asn`` (peer ``remoteAs``). Peers whose hostname FRR reports as
+        ``Unknown`` (e.g. exabgp route injectors) are still included with that
+        name, so only real DUT-facing sessions match ``duthost.hostname``.
+
+        @param host: accepted for signature parity with the Ansible module
+                     (callers pass ``host=<hostname>``); unused here.
+        @return: dict with a ``minigraph_bgp`` list of {name, addr, asn} entries.
+        """
+        bgp_sessions = []
+        seen = set()
+        for afi in ('ipv4', 'ipv6'):
+            for ip, info in self._bgp_neighbors_json(afi).items():
+                if not isinstance(info, dict) or ip in seen:
+                    continue
+                seen.add(ip)
+                remote_as = info.get('remoteAs')
+                try:
+                    asn = int(remote_as) if remote_as is not None else None
+                except (TypeError, ValueError):
+                    asn = remote_as
+                bgp_sessions.append({
+                    'name': info.get('hostname'),
+                    'addr': ip,
+                    'asn': asn,
+                })
+        return {'minigraph_bgp': sorted(bgp_sessions, key=lambda x: str(x['addr']))}
 
     def fetch(self, src=None, dest=None, **kwargs):
         """

--- a/tests/common/unit_tests/devices/unit_test_csonic_host.py
+++ b/tests/common/unit_tests/devices/unit_test_csonic_host.py
@@ -1,0 +1,217 @@
+"""
+Unit tests for tests/common/devices/csonic.py (CsonicHost).
+
+CsonicHost mirrors the EosHost/SonicHost neighbor API for cSONiC
+(docker-sonic-vs) neighbors by parsing FRR/vtysh JSON obtained via
+``_docker_exec``. These tests mock ``_docker_exec`` with representative FRR
+JSON so the pure parsing/merging logic can be verified without a live
+container. They cover:
+
+  * minigraph_facts        - synthesizing {'minigraph_bgp': [...]} from FRR
+                             ``show ip/ipv6 bgp neighbors json``
+  * check_bgp_session_state - reading ``show bgp <afi> summary json`` and
+                             deciding established-ness
+  * _bgp_summary_peers      - summary parsing + FRR address-family nesting
+  * _bgp_neighbors_json     - neighbors parsing + malformed-output handling
+
+Follows the repo unit-test convention (unit_test_*.py, unittest.mock).
+"""
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+# Make the repo root importable so ``tests.common.devices.csonic`` resolves
+# regardless of the pytest invocation directory.
+_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(_TEST_DIR)))
+)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from tests.common.devices.csonic import CsonicHost  # noqa: E402
+
+
+def make_host():
+    """Instantiate a CsonicHost without touching Docker (init does no I/O)."""
+    return CsonicHost("csonic_test_VM0100")
+
+
+def docker_ok(stdout):
+    """Shape a successful _docker_exec return with the given stdout."""
+    return {"rc": 0, "stdout": stdout, "stderr": ""}
+
+
+# --- FRR JSON fixtures -----------------------------------------------------
+
+# ``show ip bgp neighbors json`` (v4) / ``show bgp ipv6 neighbors json`` (v6)
+NEIGHBORS_V4 = {
+    "10.0.0.56": {"hostname": "dut-1", "remoteAs": 65100},
+    "10.0.0.58": {"hostname": "Unknown", "remoteAs": "64600"},
+}
+NEIGHBORS_V6 = {
+    "FC00::71": {"hostname": "dut-1", "remoteAs": "not-a-number"},
+}
+
+# ``show bgp vrf default ipv4 summary json`` etc.
+SUMMARY_V4 = {
+    "ipv4Unicast": {
+        "peers": {
+            "10.0.0.56": {"state": "Established", "description": "DUT"},
+            "10.0.0.58": {"state": "Active"},
+        }
+    }
+}
+SUMMARY_V6 = {
+    "ipv6Unicast": {
+        "peers": {
+            "fc00::71": {"state": "Established"},
+        }
+    }
+}
+
+
+def route_docker_exec(cmd, **kwargs):
+    """Dispatch mock: return the right FRR JSON based on the vtysh command."""
+    import json as _json
+    if "show ip bgp neighbors json" in cmd:
+        return docker_ok(_json.dumps(NEIGHBORS_V4))
+    if "show bgp ipv6 neighbors json" in cmd:
+        return docker_ok(_json.dumps(NEIGHBORS_V6))
+    if "ipv4 summary json" in cmd:
+        return docker_ok(_json.dumps(SUMMARY_V4))
+    if "ipv6 summary json" in cmd:
+        return docker_ok(_json.dumps(SUMMARY_V6))
+    return {"rc": 1, "stdout": "", "stderr": "unexpected cmd"}
+
+
+# --- minigraph_facts -------------------------------------------------------
+
+class TestMinigraphFacts:
+    def test_flat_shape_and_contents(self):
+        """Returns the flat {'minigraph_bgp': [...]} shape the ospf/conftest
+        caller consumes (it reads mg['minigraph_bgp'] directly, NOT
+        mg['ansible_facts']['minigraph_bgp'])."""
+        host = make_host()
+        with patch.object(host, "_docker_exec", side_effect=route_docker_exec):
+            facts = host.minigraph_facts(host="dut-1")
+        assert set(facts.keys()) == {"minigraph_bgp"}
+        entries = facts["minigraph_bgp"]
+        # 2 v4 peers + 1 v6 peer, all distinct IPs
+        assert len(entries) == 3
+        by_addr = {e["addr"]: e for e in entries}
+        assert by_addr["10.0.0.56"]["name"] == "dut-1"
+        assert by_addr["10.0.0.56"]["asn"] == 65100          # int passthrough
+        assert by_addr["10.0.0.58"]["asn"] == 64600          # numeric string -> int
+        # exabgp-style injectors are still included with FRR's 'Unknown' name
+        assert by_addr["10.0.0.58"]["name"] == "Unknown"
+
+    def test_asn_parse_failure_is_none(self):
+        """A non-numeric remoteAs yields asn=None (loud), not the raw string,
+        so a downstream ``== <int asn>`` comparison fails predictably."""
+        host = make_host()
+        with patch.object(host, "_docker_exec", side_effect=route_docker_exec):
+            facts = host.minigraph_facts()
+        v6 = next(e for e in facts["minigraph_bgp"] if e["addr"] == "FC00::71")
+        assert v6["asn"] is None
+
+    def test_dedup_is_case_insensitive(self):
+        """If FRR ever reports the same peer under both AFIs with differing
+        case, it is counted once (dedup key is normalized)."""
+        host = make_host()
+        dup_v6 = {"10.0.0.56": {"hostname": "dut-1", "remoteAs": 65100}}
+
+        def side(cmd, **kwargs):
+            import json as _json
+            if "show ip bgp neighbors json" in cmd:
+                return docker_ok(_json.dumps({"10.0.0.56": {"hostname": "dut-1", "remoteAs": 65100}}))
+            if "show bgp ipv6 neighbors json" in cmd:
+                return docker_ok(_json.dumps(dup_v6))
+            return {"rc": 1, "stdout": "", "stderr": ""}
+
+        with patch.object(host, "_docker_exec", side_effect=side):
+            facts = host.minigraph_facts()
+        assert len(facts["minigraph_bgp"]) == 1
+
+    def test_empty_when_frr_unavailable(self):
+        host = make_host()
+        with patch.object(host, "_docker_exec",
+                          return_value={"rc": 1, "stdout": "", "stderr": "down"}):
+            assert host.minigraph_facts() == {"minigraph_bgp": []}
+
+
+# --- check_bgp_session_state ----------------------------------------------
+
+class TestCheckBgpSessionState:
+    def test_all_established_true(self):
+        host = make_host()
+        with patch.object(host, "_docker_exec", side_effect=route_docker_exec):
+            assert host.check_bgp_session_state(["10.0.0.56"]) is True
+
+    def test_case_insensitive_v6_match(self):
+        """Caller may pass an uppercase v6 IP; summary keys are lowercased."""
+        host = make_host()
+        with patch.object(host, "_docker_exec", side_effect=route_docker_exec):
+            assert host.check_bgp_session_state(["FC00::71"]) is True
+
+    def test_not_established_false(self):
+        host = make_host()
+        with patch.object(host, "_docker_exec", side_effect=route_docker_exec):
+            # 10.0.0.58 is Active, not Established
+            assert host.check_bgp_session_state(["10.0.0.58"]) is False
+
+    def test_v4_and_v6_both_required(self):
+        host = make_host()
+        with patch.object(host, "_docker_exec", side_effect=route_docker_exec):
+            assert host.check_bgp_session_state(["10.0.0.56", "fc00::71"]) is True
+
+    def test_empty_summary_returns_false(self):
+        host = make_host()
+        with patch.object(host, "_docker_exec",
+                          return_value={"rc": 1, "stdout": "", "stderr": "no frr"}):
+            assert host.check_bgp_session_state(["10.0.0.56"]) is False
+
+    def test_description_matching(self):
+        host = make_host()
+        with patch.object(host, "_docker_exec", side_effect=route_docker_exec):
+            # description present for 10.0.0.56 ("DUT"); matching desc passes
+            assert host.check_bgp_session_state(["10.0.0.56"], neigh_desc=["DUT"]) is True
+            # wrong description fails when FRR does report one
+            assert host.check_bgp_session_state(["10.0.0.56"], neigh_desc=["OTHER"]) is False
+
+
+# --- lower-level parsers ---------------------------------------------------
+
+class TestSummaryAndNeighborParsers:
+    def test_summary_peers_afi_nesting(self):
+        host = make_host()
+        with patch.object(host, "_docker_exec", side_effect=route_docker_exec):
+            v4 = host._bgp_summary_peers("ipv4", "default")
+            v6 = host._bgp_summary_peers("ipv6", "default")
+        assert set(v4.keys()) == {"10.0.0.56", "10.0.0.58"}
+        assert set(v6.keys()) == {"fc00::71"}
+
+    def test_summary_peers_malformed_json_is_empty(self):
+        host = make_host()
+        with patch.object(host, "_docker_exec",
+                          return_value=docker_ok("this is not json")):
+            assert host._bgp_summary_peers("ipv4", "default") == {}
+
+    def test_neighbors_json_malformed_is_empty(self):
+        host = make_host()
+        with patch.object(host, "_docker_exec",
+                          return_value=docker_ok("<<garbage>>")):
+            assert host._bgp_neighbors_json("ipv4") == {}
+
+    def test_neighbors_json_nonobject_is_empty(self):
+        """A JSON array (not an object) must not blow up .items()."""
+        host = make_host()
+        with patch.object(host, "_docker_exec", return_value=docker_ok("[1,2,3]")):
+            assert host._bgp_neighbors_json("ipv4") == {}
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([os.path.abspath(__file__), "-v"]))


### PR DESCRIPTION
## Description

Follow-up to #25474. `CsonicHost` is stored as the `['host']` object of a `NeighborDevice` and is meant to be used interchangeably with `EosHost`/`SonicHost`, but several tests call methods/behaviors it did not implement, producing `AttributeError` or `unhashable type: 'CsonicHost'` when run with `--neighbor_type csonic`:

- `ospf/conftest.py` calls `neighbor.minigraph_facts(host=...)` and `neighbor.shell_cmds(cmds=...)`
- `iface_loopback_action` places neighbor hosts in a set / uses them as dict keys, which fails because `CsonicHost` inherits `NeighborDevice(dict)` and is therefore unhashable (unlike `EosHost`/`SonicHost`, which are plain objects)
- `bgp/test_bgp_session.py` toggles neighbor ports via `shutdown()`/`no_shutdown()`

## Changes

Adds/mirrors the corresponding `EosHost`/`SonicHost` behavior on `CsonicHost` (all additive, only affects the cSONiC neighbor path):

- **`minigraph_facts(host=None)`** — synthesize `minigraph_bgp` `{name, addr, asn}` entries from FRR (`show ip/ipv6 bgp neighbors json`); the peer's advertised `hostname` is used as `name` so tests can match `name == duthost.hostname`.
- **`shell_cmds(cmds, continue_on_fail=False)`** — run a sequence of commands and return the `shell_cmds` module-compatible result shape (`{cmds, results:[{cmd,stdout,stderr,rc,...}], failed}`).
- **`__hash__`/`__eq__`/`__ne__`** — make `CsonicHost` hashable by container name so it can be used in sets / as dict keys like the other host classes.
- **`shutdown()`/`no_shutdown()`** — use the SONiC CLI (`config interface shutdown/startup`) instead of a raw `ip link` change, since a cSONiC neighbor is SONiC and the port must be driven through CONFIG_DB for the orchestration (portchannel/BGP) to react.
- **`check_bgp_session_state()`, `kill_bgpd()`, `start_bgpd()`** (with `bgpcfgd` re-apply), and **`config()`** (run in `configure terminal` context) to mirror the Eos/Sonic host BGP / graceful-restart helpers.

### Review hardening (commit 2)

Follow-ups from the review (yxieca AI review + @lguohan), all on the cSONiC neighbor path:

- **`start_bgpd`** — replace the timing-luck comment with a bounded wait for `bgpd` to report `RUNNING` before restarting `bgpcfgd`, and log a non-zero `bgpcfgd`-restart rc so a failed config re-apply is no longer silent.
- **`check_bgp_session_state`** — merge both address families with `update()` on a case-normalized key (instead of v4 `update()` / v6 `setdefault()`), so a v6 peer is never silently dropped on a same-string key; log at `WARNING` when the summary is empty so a genuine FRR/vtysh error is distinguishable from slow convergence under `wait_until`.
- **`minigraph_facts`** — on `remoteAs` parse failure set `asn=None` and log (rather than falling back to the raw string, which would break a downstream `== <int asn>` comparison); normalize the dedup key so a peer reported under both AFIs with differing case is counted once.
- **`shell_cmds`** — defensively coerce a non-dict `_docker_exec` result so the advertised graceful-failure contract holds.

> Note on `minigraph_facts` return shape: it is intentionally the flat `{'minigraph_bgp': [...]}` that the sole caller consumes — `ospf/conftest.py` reads `neigh_mg_facts['minigraph_bgp']` directly, not `['ansible_facts']['minigraph_bgp']` — so wrapping it in `ansible_facts` would break that caller.

## How I did it

Added the methods to `tests/common/devices/csonic.py`, mirroring the signatures/semantics of `EosHost`/`SonicHost`.

Added `tests/common/unit_tests/devices/unit_test_csonic_host.py`, which mocks `_docker_exec` with sample FRR JSON and exercises `minigraph_facts`, `check_bgp_session_state`, and the summary/neighbor parsers — including the `asn`-coercion, v4/v6 merge, case-normalization, and malformed-JSON edge cases raised in review. (No existing `devices/*.py` host class had unit tests, so none were present before.)

## How to verify it

On a `vms-kvm-t0-csonic` testbed (`--neighbor_type csonic`), the affected tests no longer raise `AttributeError`/`unhashable` and resolve to the same `asic_type`-based skips the cEOS baseline gets:

- `ospf/test_ospf.py` → 2 skipped (`asic_type in ['vs']`)
- `ospf/test_ospf_bfd.py` → 1 skipped (same rule)
- `iface_loopback_action/test_iface_loopback_action.py` → 3 skipped (`asic_type not in ['mellanox']`)

The new methods were additionally smoke-tested live against `docker-sonic-vs` neighbor containers (`minigraph_facts` returns the correct DUT-facing peer, `shell_cmds` honors fail-stop / `continue_on_fail`, hashability holds, and `shutdown`/`no_shutdown` toggle admin state via the SONiC CLI). The unit tests (`unit_test_csonic_host.py`) run standalone (`--noconftest`): **14 passed.**

flake8-clean (`--max-line-length=120`), `py_compile` OK, DCO signed.
