### PR TITLE
[202511] add parameters MGMT_BRANCH and KVM_IMAGE_BRANCH to pr test template

### DIFF
--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -62,6 +62,14 @@ parameters:
   type: object
   default: {}
 
+- name: MGMT_BRANCH
+  type: string
+  default: $(BUILD_BRANCH)
+
+- name: KVM_IMAGE_BRANCH
+  type: string
+  default: $(BUILD_BRANCH)
+
 jobs:
   - job: get_impacted_area
     displayName: "Get impacted area"
@@ -124,8 +132,8 @@ jobs:
           SCRIPTS: $(SCRIPTS)
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
-          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-          MGMT_BRANCH: $(BUILD_BRANCH)
+          KVM_IMAGE_BRANCH: ${{ parameters.KVM_IMAGE_BRANCH }}
+          MGMT_BRANCH: ${{ parameters.MGMT_BRANCH }}
           COMMON_EXTRA_PARAMS: "--disable_sai_validation "
           ${{ each param in parameters.OVERRIDE_PARAMS }}:
             ${{ param.key }}: ${{ param.value }}
@@ -167,8 +175,8 @@ jobs:
   #         MIN_WORKER: $(INSTANCE_NUMBER)
   #         MAX_WORKER: $(INSTANCE_NUMBER)
   #         DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
-  #         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-  #         MGMT_BRANCH: $(BUILD_BRANCH)
+  #         KVM_IMAGE_BRANCH: ${{ parameters.KVM_IMAGE_BRANCH }}
+  #         MGMT_BRANCH: ${{ parameters.MGMT_BRANCH }}
   #         COMMON_EXTRA_PARAMS: "--disable_sai_validation "
   #         ${{ each param in parameters.OVERRIDE_PARAMS }}:
   #           ${{ param.key }}: ${{ param.value }}
@@ -209,8 +217,8 @@ jobs:
           SCRIPTS: $(SCRIPTS)
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
-          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-          MGMT_BRANCH: $(BUILD_BRANCH)
+          KVM_IMAGE_BRANCH: ${{ parameters.KVM_IMAGE_BRANCH }}
+          MGMT_BRANCH: ${{ parameters.MGMT_BRANCH }}
           COMMON_EXTRA_PARAMS: "--disable_sai_validation "
           ${{ each param in parameters.OVERRIDE_PARAMS }}:
             ${{ param.key }}: ${{ param.value }}
@@ -252,8 +260,8 @@ jobs:
   #         MIN_WORKER: $(INSTANCE_NUMBER)
   #         MAX_WORKER: $(INSTANCE_NUMBER)
   #         COMMON_EXTRA_PARAMS: "--disable_loganalyzer --disable_sai_validation "
-  #         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-  #         MGMT_BRANCH: $(BUILD_BRANCH)
+  #         KVM_IMAGE_BRANCH: ${{ parameters.KVM_IMAGE_BRANCH }}
+  #         MGMT_BRANCH: ${{ parameters.MGMT_BRANCH }}
   #         ${{ each param in parameters.OVERRIDE_PARAMS }}:
   #           ${{ param.key }}: ${{ param.value }}
 
@@ -296,7 +304,8 @@ jobs:
   #         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
   #         COMMON_EXTRA_PARAMS: "--neighbor_type=sonic --disable_sai_validation "
   #         VM_TYPE: vsonic
-  #         MGMT_BRANCH: $(BUILD_BRANCH)
+  #         KVM_IMAGE_BRANCH: ${{ parameters.KVM_IMAGE_BRANCH }}
+  #         MGMT_BRANCH: ${{ parameters.MGMT_BRANCH }}
   #         SPECIFIC_PARAM: '[
   #             {"name": "bgp/test_bgp_fact.py", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"},
   #             {"name": "macsec", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"}
@@ -340,8 +349,8 @@ jobs:
   #         SCRIPTS: $(SCRIPTS)
   #         MIN_WORKER: $(INSTANCE_NUMBER)
   #         MAX_WORKER: $(INSTANCE_NUMBER)
-  #         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-  #         MGMT_BRANCH: $(BUILD_BRANCH)
+  #         KVM_IMAGE_BRANCH: ${{ parameters.KVM_IMAGE_BRANCH }}
+  #         MGMT_BRANCH: ${{ parameters.MGMT_BRANCH }}
   #         COMMON_EXTRA_PARAMS: "--disable_sai_validation "
   #         SPECIFIC_PARAM: '[
   #             {"name": "dash/test_dash_vnet.py", "param": "--skip_dataplane_checking"}
@@ -387,8 +396,8 @@ jobs:
   #         MIN_WORKER: $(INSTANCE_NUMBER)
   #         MAX_WORKER: $(INSTANCE_NUMBER)
   #         NUM_ASIC: 4
-  #         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-  #         MGMT_BRANCH: $(BUILD_BRANCH)
+  #         KVM_IMAGE_BRANCH: ${{ parameters.KVM_IMAGE_BRANCH }}
+  #         MGMT_BRANCH: ${{ parameters.MGMT_BRANCH }}
   #         COMMON_EXTRA_PARAMS: "--disable_sai_validation "
   #         ${{ each param in parameters.OVERRIDE_PARAMS }}:
   #           ${{ param.key }}: ${{ param.value }}
@@ -430,8 +439,8 @@ jobs:
           SCRIPTS: $(SCRIPTS)
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
-          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-          MGMT_BRANCH: $(BUILD_BRANCH)
+          KVM_IMAGE_BRANCH: ${{ parameters.KVM_IMAGE_BRANCH }}
+          MGMT_BRANCH: ${{ parameters.MGMT_BRANCH }}
           COMMON_EXTRA_PARAMS: "--disable_sai_validation "
           ${{ each param in parameters.OVERRIDE_PARAMS }}:
             ${{ param.key }}: ${{ param.value }}


### PR DESCRIPTION
### Description of PR

Summary:
Cherry-pick: https://github.com/sonic-net/sonic-mgmt/pull/25536

Add two new pipeline parameters, `MGMT_BRANCH` and `KVM_IMAGE_BRANCH`, to `.azure-pipelines/pr_test_template.yml` and use them in place of the hardcoded `$(BUILD_BRANCH)` value across all test jobs.

Both parameters default to `$(BUILD_BRANCH)`, so the existing behavior is unchanged when callers do not pass them. Templates that consume `pr_test_template.yml` can now override the sonic-mgmt branch and the KVM image branch independently (for example, to run a PR's tests against a different mgmt branch or KVM image branch).

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

The `KVM_IMAGE_BRANCH` and `MGMT_BRANCH` values were hardcoded to `$(BUILD_BRANCH)` in every job of `pr_test_template.yml`, so there was no way for a caller to point the test run at a different sonic-mgmt branch or KVM image branch. Parameterizing these allows callers to override the branches when needed.

#### How did you do it?

- Added two new template parameters with defaults preserving current behavior:
  - `MGMT_BRANCH` (default `$(BUILD_BRANCH)`)
  - `KVM_IMAGE_BRANCH` (default `$(BUILD_BRANCH)`)
- Replaced every hardcoded `KVM_IMAGE_BRANCH: $(BUILD_BRANCH)` and `MGMT_BRANCH: $(BUILD_BRANCH)` with `${{ parameters.KVM_IMAGE_BRANCH }}` and `${{ parameters.MGMT_BRANCH }}` across all jobs in the template.

#### How did you verify/test it?

Validated the YAML template parameter expansion through the Azure Pipelines PR test runs. With no parameters passed, the jobs resolve to `$(BUILD_BRANCH)` (identical to previous behavior); when overridden, the jobs pick up the provided branch values.

#### Any platform specific information?

No. This is a CI/pipeline template change only; no platform-specific code is affected.

#### Supported testbed topology if it's a new test case?

N/A — not a new test case.

### Documentation

No documentation changes required.
