### PR TITLE
[pretest]: Recover offline SmartSwitch DPU modules

### DIFF
--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -37,27 +37,26 @@ DPU_RECOVERY_STARTUP_RETRY_TIMEOUT = 720
 DPU_RECOVERY_STARTUP_RETRY_INTERVAL = 60
 
 
-def _parse_chassis_module_status(output):
-    """Parse 'show chassis modules status' output into module status entries."""
+def _parse_chassis_module_status(rows):
+    """Normalize parsed 'show chassis modules status' rows into DPU module status entries."""
     entries = []
-    for line in output.splitlines():
-        fields = line.split()
-        if not fields or not re.match(r"^DPU\d+$", fields[0]):
+    for row in rows:
+        name = row.get("name", "")
+        if not re.match(r"^DPU\d+$", name):
             continue
-        if len(fields) < 4:
-            logger.warning("Skipping unexpected chassis module line: %s", line)
+        if "oper-status" not in row or "admin-status" not in row:
+            logger.warning("Skipping unexpected chassis module status row: %s", row)
             continue
         entries.append({
-            "name": fields[0],
-            "oper_status": fields[-3],
-            "admin_status": fields[-2],
+            "name": name,
+            "oper_status": row["oper-status"],
+            "admin_status": row["admin-status"],
         })
     return entries
 
 
 def _show_chassis_module_status(duthost):
-    result = duthost.shell("show chassis modules status", module_ignore_errors=True)
-    return result.get("stdout", "")
+    return duthost.show_and_parse("show chassis modules status", module_ignore_errors=True)
 
 
 def _is_dpu_online_up(duthost, dpu_name):

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -31,6 +31,89 @@ pytestmark = [
 
 FEATURE_STATE_VERIFYING_THRESHOLD_SECS = 600
 FEATURE_STATE_VERIFYING_INTERVAL_SECS = 10
+DPU_RECOVERY_STATE_TIMEOUT = 600
+DPU_RECOVERY_STATE_INTERVAL = 30
+DPU_RECOVERY_STARTUP_RETRY_TIMEOUT = 720
+DPU_RECOVERY_STARTUP_RETRY_INTERVAL = 60
+
+
+def _parse_chassis_module_status(output):
+    """Parse 'show chassis modules status' output into module status entries."""
+    entries = []
+    for line in output.splitlines():
+        fields = line.split()
+        if not fields or not re.match(r"^DPU\d+$", fields[0]):
+            continue
+        if len(fields) < 4:
+            logger.warning("Skipping unexpected chassis module line: %s", line)
+            continue
+        entries.append({
+            "name": fields[0],
+            "oper_status": fields[-3],
+            "admin_status": fields[-2],
+        })
+    return entries
+
+
+def _show_chassis_module_status(duthost):
+    result = duthost.shell("show chassis modules status", module_ignore_errors=True)
+    return result.get("stdout", "")
+
+
+def _is_dpu_online_up(duthost, dpu_name):
+    for entry in _parse_chassis_module_status(_show_chassis_module_status(duthost)):
+        if entry["name"] == dpu_name:
+            return (entry["oper_status"].lower() == "online" and
+                    entry["admin_status"].lower() == "up")
+    return False
+
+
+def _startup_dpu_when_transition_settled(duthost, dpu_name):
+    result = duthost.shell(
+        "sudo config chassis modules startup {}".format(dpu_name),
+        module_ignore_errors=True
+    )
+    output = "{}\n{}".format(result.get("stdout", ""), result.get("stderr", ""))
+    if "state transition is already in progress" in output.lower():
+        logger.info("%s: startup of %s is still blocked by state transition",
+                    duthost.hostname, dpu_name)
+        return False
+    return True
+
+
+def _recover_admin_up_offline_dpu(duthost, dpu_name):
+    logger.warning("%s: recovering %s because admin is up but oper is not Online",
+                   duthost.hostname, dpu_name)
+    duthost.shell("sudo config chassis modules shutdown {}".format(dpu_name))
+
+    pytest_assert(
+        wait_until(DPU_RECOVERY_STARTUP_RETRY_TIMEOUT, DPU_RECOVERY_STARTUP_RETRY_INTERVAL, 0,
+                   _startup_dpu_when_transition_settled, duthost, dpu_name),
+        "{}: {} startup was still blocked by a state transition".format(duthost.hostname, dpu_name)
+    )
+    pytest_assert(
+        wait_until(DPU_RECOVERY_STATE_TIMEOUT, DPU_RECOVERY_STATE_INTERVAL, 0,
+                   _is_dpu_online_up, duthost, dpu_name),
+        "{}: {} did not recover to Online/up".format(duthost.hostname, dpu_name)
+    )
+
+
+def test_recover_admin_up_offline_dpu_modules(duthosts, tbinfo):
+    """Recover SmartSwitch DPU modules that are admin-up but not operationally Online."""
+    topo_name = tbinfo.get("topo", {}).get("name", "")
+    if "smartswitch" not in topo_name:
+        pytest.skip("DPU module recovery is only applicable to SmartSwitch testbeds")
+
+    def recover_dpus(duthost):
+        entries = _parse_chassis_module_status(_show_chassis_module_status(duthost))
+        for entry in entries:
+            if (entry["admin_status"].lower() == "up" and
+                    entry["oper_status"].lower() != "online"):
+                _recover_admin_up_offline_dpu(duthost, entry["name"])
+
+    with SafeThreadPoolExecutor(max_workers=len(duthosts)) as executor:
+        for duthost in duthosts:
+            executor.submit(recover_dpus, duthost)
 
 
 def test_features_state(duthosts, localhost):


### PR DESCRIPTION
### Description of PR

Summary:
Add SmartSwitch pretest recovery for DPU modules that are administratively up but not operationally online. The pretest now performs a controlled module shutdown/startup and waits for the DPU to return to Online/up before later tests start.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type:

### Approach
#### What is the motivation for this PR?

SmartSwitch HA tests can fail during setup when a DPU module is still administratively up but remains operationally offline and unreachable. Recovering this condition during pretest prevents unrelated test setup failures.

#### How did you do it?

Added a SmartSwitch-only pretest check that parses chassis module status, detects DPU modules in admin-up/non-online state, runs a controlled shutdown/startup recovery, retries startup while a chassis transition is in progress, and waits for Online/up before continuing.

#### How did you verify/test it?

- `python -m py_compile tests/test_pretest.py`
- Targeted SmartSwitch HA pretest validation on representative hardware: 1 passed.

#### Any platform specific information?

Applies only to SmartSwitch testbeds; non-SmartSwitch topologies skip this pretest.

#### Supported testbed topology if it's a new test case?

N/A. This is a pretest framework recovery step for SmartSwitch topologies.

### Documentation

N/A.
