### PR TITLE
[202605] [bgp/test_bgp_vnet]: Corrected the PTF index get call (#25618)

### DIFF
--- a/tests/bgp/test_bgp_vnet.py
+++ b/tests/bgp/test_bgp_vnet.py
@@ -449,14 +449,14 @@ def _check_vnet2_all_dynamic_peers_established(duthost):
         return False
 
 
-def get_ptf_port_index(interface_name):
+def get_ptf_port_index(interface_name, mg_facts):
     """
-    Convert Ethernet interface name to PTF port index (Ethernet112 → 28).
+    Convert Ethernet interface name to PTF port index using the minigraph port map.
     """
-    return int(interface_name.replace("Ethernet", "")) // 4
+    return mg_facts['minigraph_ptf_indices'][interface_name]
 
 
-def get_expected_unexpected_ptf_ports(cfg_facts, vnet_expected, vnet_unexpected):
+def get_expected_unexpected_ptf_ports(cfg_facts, vnet_expected, vnet_unexpected, mg_facts):
     """
     Return two lists of unique PTF port indices:
     - expected_ptf_ports: ports belonging to vnet_expected
@@ -487,7 +487,7 @@ def get_expected_unexpected_ptf_ports(cfg_facts, vnet_expected, vnet_unexpected)
                 # Malformed key (should be pc|member)
                 continue
             if pc in portchannels:
-                ptf_ports.add(get_ptf_port_index(iface))
+                ptf_ports.add(get_ptf_port_index(iface, mg_facts))
         return sorted(ptf_ports)
 
     expected_ptf_ports = collect_ptf_ports(expected_portchannels)
@@ -558,7 +558,7 @@ def test_dynamic_peer_vnet(duthosts, rand_one_dut_hostname, cfg_facts):
         pytest.fail("Vnet testing setup failed: {}".format(repr(e)))
 
 
-def test_bgp_vnet_route_forwarding(ptfadapter, duthosts, rand_one_dut_hostname, cfg_facts):
+def test_bgp_vnet_route_forwarding(ptfadapter, duthosts, rand_one_dut_hostname, cfg_facts, mg_facts):
     '''
     Verify that the traffic to the peer in Vnet1 is forwarded correctly.
     Send a UDP packet to with the destination as one of the routes learned via bgp in Vnet1
@@ -584,7 +584,7 @@ def test_bgp_vnet_route_forwarding(ptfadapter, duthosts, rand_one_dut_hostname, 
         # Discover the destination IP from the live FIB so the test is not
         # tied to a topology-specific hardcoded address.
         dst_ip = _get_vnet1_bgp_dst_ip(duthost)
-        expected_ports, unexpected_ports = get_expected_unexpected_ptf_ports(cfg_facts, "Vnet1", "Vnet2")
+        expected_ports, unexpected_ports = get_expected_unexpected_ptf_ports(cfg_facts, "Vnet1", "Vnet2", mg_facts)
         assert expected_ports, \
             "No PTF ports found for Vnet1; check PORTCHANNEL_INTERFACE vnet_name in cfg_facts"
         assert unexpected_ports, \

--- a/tests/bgp/test_bgp_vnet.py
+++ b/tests/bgp/test_bgp_vnet.py
@@ -294,7 +294,7 @@ def validate_dynamic_peer_established(bgp_summary, template):
         ), f"BGP peer {dyn_peer1} not in Established state or missing from summary"
         assert (
             dyn_peer2 not in bgp_summary['ipv4Unicast']['peers']
-        ), f"BGP peer {dyn_peer2} should not be in show bgp summary output"
+        ), f"BGP peer {dyn_peer2} should be absent from show bgp summary output"
 
 
 def modify_dynamic_peer_cfg(duthost, template):


### PR DESCRIPTION
Cherry-pick / backport of #25618 to the `202605` branch.

### Description of PR

Summary:
Fixes # (issue)

`get_ptf_port_index` was using a hardcoded `// 4` to derive the PTF port index from the interface name. This breaks on DUTs whose interfaces use a stride of 8. The call is corrected to use `mg_facts['minigraph_ptf_indices']`, making the API platform agnostic.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
`get_ptf_port_index` computed the PTF port index as `int(interface_name.replace("Ethernet", "")) // 4`. This hardcoded 4-lane-stride assumption is not platform agnostic and produces incorrect PTF indices on platforms that use a stride of 8 (e.g. Cisco 8223), causing `test_bgp_vnet_route_forwarding` to inspect the wrong data-plane ports.

#### How did you do it?
- Changed `get_ptf_port_index` to look the interface up in the minigraph port map (`mg_facts['minigraph_ptf_indices'][interface_name]`) instead of doing arithmetic on the interface number.
- Threaded the `mg_facts` fixture through `get_expected_unexpected_ptf_ports` and `test_bgp_vnet_route_forwarding`.
- Minor assertion message cleanup (E713).

#### How did you verify/test it?
Verified on the Cisco 8223 platform in the original PR (#25618). This backport is a clean cherry-pick of that change onto `202605`.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A (not a new test case)

### Documentation
N/A
