### PR TITLE
[bgp][test_bgp_vnet] Make post-reboot VNET BGP readiness robust

### DIFF
--- a/tests/bgp/test_bgp_vnet.py
+++ b/tests/bgp/test_bgp_vnet.py
@@ -11,6 +11,7 @@ from natsort import natsorted
 import pytest
 
 from tests.common.reboot import reboot
+from tests.common.platform.interface_utils import check_interface_status_of_up_ports
 from tests.common.storage_backend.backend_utils import skip_test_module_over_backend_topologies     # noqa F401
 from tests.common.utilities import wait_until
 import ptf.testutils as testutils
@@ -26,6 +27,10 @@ logger = logging.getLogger(__name__)
 
 # global variables
 g_vars = {}
+
+# Wait budget for all admin-up ports to become operationally up after a reboot.
+INTF_UP_WAIT_TIMEOUT = 300
+INTF_UP_WAIT_INTERVAL = 10
 
 TEMPLATE_CONFIGS = {
     "vnet_dynamic_peer_add": {
@@ -103,6 +108,17 @@ def setup_vnet_cfg(duthost, localhost, cfg_facts):
     duthost.shell("cp /tmp/config_db_vnet.json /etc/sonic/config_db.json")
 
     reboot(duthost, localhost)
+
+    # After reboot, wait until all admin-up ports are operationally up before
+    # configuring/validating BGP, so that VRF (VNET) peers have working
+    # underlay links to establish over.
+    assert wait_until(
+        INTF_UP_WAIT_TIMEOUT,
+        INTF_UP_WAIT_INTERVAL,
+        0,
+        check_interface_status_of_up_ports,
+        duthost,
+    ), "Not all admin-up ports are operationally up after reboot"
 
     bgp_asn = cfg_facts.get('DEVICE_METADATA', {}).get('localhost', {}).get('bgp_asn', '')
     duthost.shell(
@@ -348,7 +364,7 @@ def dynamic_range_add_delete(duthost, template):
     validate_dynamic_peer_established(bgp_summary, template)
 
 
-BGP_VNET_PEER_WAIT_TIMEOUT = 60
+BGP_VNET_PEER_WAIT_TIMEOUT = 300
 BGP_VNET_PEER_WAIT_INTERVAL = 10
 
 
@@ -505,6 +521,20 @@ def test_dynamic_peer_vnet(duthosts, rand_one_dut_hostname, cfg_facts):
         props = g_vars['props']
         route_count = props['podset_number'] * \
             props['tor_number'] * props['tor_subnet_number']
+
+        # Dynamic (listen-range) peers are passive on the DUT and only come up
+        # after ARISTA initiates the session (following its ConnectRetry), which
+        # is later than the DUT-initiated static peers.  Wait for them to appear
+        # and reach Established first, so the prefix-count wait and validation
+        # below also cover the dynamic peers instead of skipping them while they
+        # are still absent from the summary.
+        assert wait_until(
+            BGP_VNET_PEER_WAIT_TIMEOUT,
+            BGP_VNET_PEER_WAIT_INTERVAL,
+            0,
+            _check_vnet2_all_dynamic_peers_established,
+            duthost,
+        ), "Timed out waiting for Vnet2 dynamic peers to reach Established"
 
         # After the post-reboot setup the VRF-scoped BGP sessions need extra
         # time to reach Established and learn routes.  Poll until all peers


### PR DESCRIPTION
## Description of PR

`tests/bgp/test_bgp_vnet.py` reboots the DUT in `setup_vnet_cfg()` (after applying the VNET config) and then validates VNET/VRF BGP convergence. On two different Cisco platforms the test intermittently failed, first with:

```
AssertionError: Timed out waiting for VRF BGP peers to reach 6400 prefixes
```

and, after that was addressed, with a follow-on flake:

```
AssertionError: BGP peer 10.0.0.9 not in Established state or missing from summary
```

### Root causes (confirmed from DUT `bgpd.log`)

- The post-reboot wait budget (`60s`) was far too small; VNET VRF BGP only finishes converging (6400 prefixes) several minutes after a cold reboot.
- The existing readiness poll only checks peers **already present** in the VRF summary, so it is blind to the dynamic (`BGPSLBPassive` listen-range) peers. Those peers are passive on the DUT and only come up after the ARISTA neighbor initiates the session (following its ConnectRetry) — later than the DUT-initiated static peers. The static peers converge first, the wait returns, and the subsequent one-shot dynamic-peer assertion runs before the dynamic peers have connected.

### Fixes

- Increase `BGP_VNET_PEER_WAIT_TIMEOUT` `60 -> 300` (matches the `wait + 300/10s` pattern used by `reboot()`'s `wait_for_bgp` path).
- After reboot, wait for all admin-up ports to be operationally up (`check_interface_status_of_up_ports`) before configuring/validating BGP, using dedicated `INTF_UP_WAIT_TIMEOUT`/`INTF_UP_WAIT_INTERVAL` constants.
- Before validating, explicitly wait for the `Vnet2` dynamic peers to appear and reach `Established` (via `_check_vnet2_all_dynamic_peers_established`), so the prefix-count wait and validation also cover the dynamic peers instead of skipping them while they are still absent from the summary.

> Note: an earlier iteration of this PR used `safe_reboot=True`. That was dropped because `snmpd` fails to bind on this VNET configuration (Loopback0 moved into a VRF), which makes `safe_reboot` gate on a service that can never come up here.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case enhancement
- [ ] Skipped for non-supported platforms
- [ ] Documentation

### Back port request

- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

## Approach

### What is the motivation for this PR?

Fix intermittent failures of `test_bgp_vnet` on Cisco platforms caused by the test validating VNET/VRF BGP convergence before the control plane — including the passive dynamic peers — has fully converged after the setup reboot.

### How did you do it?

See "Fixes" above: larger convergence budget, an interface-up gate after reboot, and an explicit wait for the passive dynamic VNET peers to reach Established before validation.

### How did you verify/test it?

Ran `test_bgp_vnet` on the affected Cisco platform (simulated testbed). With these changes the `6400 prefixes` timeout and the `10.0.0.9 not Established` assertion no longer trigger, and the test passes.

## Documentation

No documentation changes.