### PR TITLE
[bgp] Fix test_bgp_router_id faky module-timeout hang

### DIFF
--- a/tests/bgp/test_bgp_router_id.py
+++ b/tests/bgp/test_bgp_router_id.py
@@ -1,8 +1,8 @@
 import pytest
 import logging
 import re
-import time
 
+from tests.common.fixtures.duthost_utils import wait_bgp_sessions
 from tests.common.helpers.assertions import pytest_require, pytest_assert
 from tests.common.helpers.bgp import (
     get_asic_config_facts,
@@ -22,6 +22,8 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 CUSTOMIZED_BGP_ROUTER_ID = "8.8.8.8"
+VTYSH_SHOW_CMD_TIMEOUT_SEC = 60
+VTYSH_SHOW_CMD_KILL_GRACE_SEC = 5
 
 
 def run_config_db_cmd(duthost, enum_asic_index, cmd, module_ignore_errors=True):
@@ -51,9 +53,16 @@ def verify_bgp_peer(neighbor_type, nbrhost, localip, expected_bgp_router_id, is_
 
 def verify_bgp(enum_asic_index, duthost, expected_bgp_router_id, neighbor_type, nbrhosts, tbinfo):
     is_v6_topo = is_ipv6_only_topology(tbinfo)
-    cmd = "vtysh -c \"show ipv6 bgp summary\"" if is_v6_topo else "vtysh -c \"show ip bgp summary\""
-    cmd = get_vtysh_cmd_for_asic(duthost, enum_asic_index, cmd)
-    output = duthost.shell(cmd, module_ignore_errors=True)["stdout"]
+    vtysh_cmd = "vtysh -c \"show ipv6 bgp summary\"" if is_v6_topo else "vtysh -c \"show ip bgp summary\""
+    vtysh_cmd = get_vtysh_cmd_for_asic(duthost, enum_asic_index, vtysh_cmd)
+    bounded_cmd = "timeout -k {} {} {}".format(
+        VTYSH_SHOW_CMD_KILL_GRACE_SEC, VTYSH_SHOW_CMD_TIMEOUT_SEC, vtysh_cmd)
+    res = duthost.shell(bounded_cmd, module_ignore_errors=True)
+    rc = res.get("rc")
+    output = res.get("stdout", "") or ""
+    pytest_assert(rc == 0, (
+        "Failed to run '{}' (rc={}). stderr: {}; stdout: {}"
+    ).format(vtysh_cmd, rc, res.get("stderr", ""), output[:200]))
 
     # Verify router id from DUT itself
     pattern = r"BGP router identifier (\d+\.\d+\.\d+\.\d+)"
@@ -165,8 +174,10 @@ def restart_bgp(duthost, tbinfo):
     pytest_assert(wait_until(100, 10, 10, duthost.is_service_fully_started_per_asic_or_host, "bgp"), "BGP not started.")
     pytest_assert(wait_until(100, 10, 10, duthost.check_default_route,
                              ipv4=not is_ipv6_only_topology(tbinfo)), "Default route not ready")
-    # After restarting bgp, add time wait for bgp_facts to fetch latest status
-    time.sleep(20)
+    # wait_bgp_sessions polls per-ASIC BGP state
+    # (multi-ASIC aware, default 120s, auto-extended to 900s on modular chassis) so verification
+    # only runs once sessions have actually re-established.
+    wait_bgp_sessions(duthost)
 
 
 @pytest.fixture()


### PR DESCRIPTION
### Description of PR

Summary:
`bgp/test_bgp_router_id.py` has been flagged as flaky as it failed on **29 distinct PRs within a 14-day window** (still active), predominantly on the **t2** KVM topology. The result reported by elastictest is the wrapper message `Test failed and no xml file created`, which hides the real failure: the **module hangs and is SIGKILLed by the 150-minute module timeout**, so no JUnit XML is ever written.

Root cause: `restart_bgp()` returns after a fixed `time.sleep(20)` while `bgpd`/`zebra` may still be initializing. The first post-restart verification call in `verify_bgp()`, `show ip bgp summary`, is issued through an ansible SSH call with **no command timeout**. When `vtysh`/`bgpd` is not yet servicing requests, that call blocks indefinitely and the whole module hangs to the timeout. The same non-convergence, when it does not wedge, produces the quick-fail variants seen in the same window (`Cannot get actual BGP router id from []`, `BGP session not established ... got 'active'`, `Router advertised unexpected ... Actual output: <empty>`).

Fixes # (flaky test surfaced by the PR-test flakiness panel; no separate GitHub issue filed)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: 38708466 
Failure type: regression

### Approach
#### What is the motivation for this PR?
Remove a chronic PR-blocking flake. Over the last 14 days this single test hung and burned the full 150-minute module budget on 29 distinct PRs, each time reported only as "Test failed and no xml file created".

#### How did you do it?
Two changes in `tests/bgp/test_bgp_router_id.py`:
1. In `restart_bgp()`, replace the blind `time.sleep(20)` with `wait_bgp_sessions(duthost)`, so verification only runs once every BGP session has re-established (also drops the now-unused `import time`).
2. In `verify_bgp()`, bound the DUT summary command with `timeout 60`, so a wedged `vtysh` fails fast (rc=124, XML written, retryable) instead of hanging the whole module.

#### How did you verify/test it?
Reproduced the hang deterministically on a VS (KVM) testbed, confirmed the fix bounds it, then ran the patched test to a pass on a live DUT.

Exact production failure (elastictest plan `6a4bcf11260e9f5d99855ca6`, t2, PR 1153940):
```
16:40:07  test_bgp_router_id_set[vlab-t2-1-1-0] call        # after restart_bgp + sleep(20)
16:40:07  AnsibleModule::shell  vtysh -n 0 -c "show ip bgp summary"   <-- issued, never returns
16:52:04  transport._log | EOF in transport thread          # SSH channel reset 12 min later
19:06:39  Test Module Timeout: bgp/test_bgp_router_id.py running 150.01 min (timeout 9000s) -> SIGKILL, no XML
```

Deterministic reproduction (t1-lag KVM, `bgpd` force-stopped to lose the race), before vs after the fix:
```
Scenario               | Before fix                | After fix (timeout 60)
bgpd stopped (broken)  | rc=124, wall=200s (hung*) | rc=2,  wall=61s (bounded, clean)
bgpd healthy           | rc=0,   wall=3s           | rc=0,  wall=3s  (unchanged)
```

Full patched test on a live t1-lag DUT:
```
bgp/test_bgp_router_id.py::test_bgp_router_id_set[vlab-03-None] PASSED
1 passed in 365.70s (0:06:05)
```

Elastictest testplans where the hang was observed (all t2, 14-day window):
- PR 1153940: https://elastictest.org/scheduler/test-plan/6a4bcf11260e9f5d99855ca6
- PR 1153267: https://elastictest.org/scheduler/test-plan/6a4a0a2aa577b9de602ff4c4
- PR 1156367: https://elastictest.org/scheduler/test-plan/6a48af52a577b9de602ff3f6
- PR 1156045: https://elastictest.org/scheduler/test-plan/6a484801260e9f5d99855a08
- PR 1155524: https://elastictest.org/scheduler/test-plan/6a476ebd260e9f5d99855906
- PR 1155525: https://elastictest.org/scheduler/test-plan/6a475ec89175b28647bd6b72
- PR 1154920: https://elastictest.org/scheduler/test-plan/6a4715e1ff94a6a749d84d49
- PR 1155049: https://elastictest.org/scheduler/test-plan/6a46f9b39175b28647bd6ae9

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A (existing test; `pytest.mark.topology('any')`).

### Documentation
N/A.
