### PR TITLE
show_techsupport: allow credentials directory to be absent from dump

### DIFF
--- a/tests/show_techsupport/test_techsupport_no_secret.py
+++ b/tests/show_techsupport/test_techsupport_no_secret.py
@@ -165,5 +165,6 @@ def test_credentials_dir_removed_from_show_techsupport(
     dump_extract_path = "./{0}".format(dump_file_name.replace(".tar.gz", ""))
 
     # check no files exist under etc/sonic/credentials/ in the dump
-    find_command = "find {0}/etc/sonic/credentials/ -type f 2>/dev/null".format(dump_extract_path)
+    find_command = "test ! -d {0}/etc/sonic/credentials/ || find {0}/etc/sonic/credentials/ -type f"\
+        .format(dump_extract_path)
     check_no_result(duthost, find_command)


### PR DESCRIPTION
### Description of PR

Summary:
Allow `test_credentials_dir_removed_from_show_techsupport` to pass when the techsupport dump omits the entire `etc/sonic/credentials/` directory. A missing credentials directory means no credential files leaked, but the previous `find <missing-dir>` command returned rc=1 and caused a false `Failed: None` result.

Fixes #25943

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
Kusto data for 202605 showed flaky body failures in `show_techsupport/test_techsupport_no_secret.py::test_credentials_dir_removed_from_show_techsupport`, primarily on Arista 7260CX3 t0-116, with summary `Failed: None`. Other query failures were unrelated setup/teardown issues.

The test verifies that no files under `/etc/sonic/credentials/` are included in the techsupport dump. If the whole directory is absent from the extracted dump, that is a valid secure outcome, but `find <missing-dir> -type f 2>/dev/null` returns rc=1. `check_no_result()` requires rc=0, so the test failed despite no credential file leakage.

#### How did you do it?
Changed the assertion command to first accept the directory being absent, and only run `find` when it exists:

```bash
test ! -d <dump>/etc/sonic/credentials/ || find <dump>/etc/sonic/credentials/ -type f
```

This preserves the existing behavior when the directory exists: any files under it are printed and `check_no_result()` fails.

#### How did you verify/test it?
- `python -m py_compile tests/show_techsupport/test_techsupport_no_secret.py` passes.
- Manual style sanity checks passed: no changed line over 120 characters and no trailing whitespace.
- Verified the PR branch is a one-commit / one-file diff against upstream `master`.

#### Any platform specific information?
Observed as a flaky false failure on 202605, mainly Arista 7260CX3 t0-116, but the test logic is platform-independent.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A