### PR TITLE
[TH6-128] Increase announce routes networks for lt2-o256-u32d224 topo

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -1490,13 +1490,20 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes={}):
     group_nums = int(math.ceil(float(len(t1_vms)) / T1_GROUP_SIZE))
     t1_route_per_group = int(math.ceil(ROUTE_NUMBER_T1 / T1_GROUP_SIZE / group_nums))
 
-    # 32 route each x 4 to match 110 T1
-    extra_ipv4_t1 = itertools.chain(
-        ipaddress.ip_network("192.168.0.0/27"),
-        ipaddress.ip_network("192.169.0.0/27"),
-        ipaddress.ip_network("192.170.0.0/27"),
-        ipaddress.ip_network("192.171.0.0/27"),
+    # 32 addresses per /27; need ceil(len(t1_vms)/32) blocks (min 4).
+    # 224 T1 (needs 7); build enough 192.(168+i).0.0/27 nets.
+    num_extra = max(4, int(math.ceil(float(len(t1_vms)) / 32)))
+    # Second octet 168+i must stay <= 255, so i <= 87 and num_extra <= 88 (~2816 T1 VMs).
+    assert num_extra <= 88, (
+        "fib_lt2_routes: num_extra={} ({} T1 VMs) exceeds scheme limit 88 for 192.(168+i).0.0/27"
+        .format(num_extra, len(t1_vms))
     )
+    extra_networks = []
+    for i in range(num_extra):
+        extra_networks.append(
+            ipaddress.ip_network(UNICODE_TYPE("192.{}.0.0/27".format(168 + i)))
+        )
+    extra_ipv4_t1 = itertools.chain(*extra_networks)
 
     for group in range(group_nums):
         selected_v4_subnets = all_subnetv4[group * t1_route_per_group: group * t1_route_per_group + t1_route_per_group]


### PR DESCRIPTION
### Description of PR

Cherry-pick of #24665 to 202512, requested by @bingwang-ms (the automatic 202512 backport conflicted). Original author: @sanjair-git.

- Fixes the _Announce routes_ task failure during add-topo for LT2 DUTs with more T1 VMs.
- _lt2-o256-u32d224_ has 224 T1 VMs; 202512 currently supports only 110.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

- Bring the _lt2-o256-u32d224_ announce-routes fix (#24665) to 202512. @bingwang-ms flagged that the automatic cherry-pick conflicted.

#### How did you do it?

- Cherry-picked #24665. It conflicted in `fib_lt2_routes` because 202512 still carries the older 4-block hardcode (192.168-192.171.0.0/27, "to match 110 T1"), while #24665 was written against master's 8-block version. Resolved toward the PR's dynamic scheme -- `num_extra = max(4, ceil(len(t1_vms) / 32))` building `192.(168+i).0.0/27` -- so the result matches current master. The scheme is backward-compatible: for any topo with <=128 T1 VMs it produces the same 4 blocks 202512 has today, and only expands (7 blocks for the 224-T1 topo) where more networks are actually needed.

#### How did you verify/test it?

- Confirmed the resolved `fib_lt2_routes` matches master's post-#24665 shape and that the module compiles; relying on 202512 PR CI for the functional run.

#### Any platform specific information?

LT2

### Documentation

N/A
