### PR TITLE
[C0] Update timeout fomula for test_console_loopback

### DIFF
--- a/tests/console/test_console_loopback.py
+++ b/tests/console/test_console_loopback.py
@@ -72,17 +72,14 @@ def test_console_loopback_echo(setup_c0, creds, conn_graph_facts, baud_rate, flo
         console_fanout.command("config console flow_control {} {}".format(flow_control, target_line))
         console_fanout.set_loopback(target_line, baud_rate, flow_control_bool)
         delay_factor = 3.2
-        if duthost.facts['platform'] in ['arm64-nokia_ixs7215_c1xa-r0']:
-            delay_factor *= 10.0
-    if duthost.facts['platform'].startswith('arm64-c8220tg_48a'):
-        delay_factor *= 4.0
 
     dutip, dutuser, dutpass = get_host_ip_and_creds(duthost, creds)
 
     packet_size = 64
 
     # Estimate a reasonable data transfer time based on configured baud rate
-    timeout_sec = (packet_size * 10) * delay_factor / int(baud_rate)
+    overhead_seconds = 0.1
+    timeout_sec = overhead_seconds + (packet_size * 10) * delay_factor / int(baud_rate)
     ressh_user = "{}:{}".format(dutuser, target_line)
 
     client = None


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md
-->
### Description of PR

Summary: Re-evaluate the timeout formula in `test_console_loopback` so it reflects the actual round-trip cost.

The old formula `(packet_size * 10) * delay_factor / baud_rate` models only the on-wire transmission time and scales inversely with baud rate. The real round-trip also includes baud-independent overhead: SSH round-trip through the mgmt LAN, sshd + pty + picocom bridge on the DUT, and pexpect's poll granularity. Splitting the timeout into a fixed term plus a wire-time term is a more accurate model, and lets us drop the platform-specific fudge factors that were compensating for the missing term.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type:

### Approach
#### What is the motivation for this PR?

The existing formula only accounts for on-wire time, so the timeout shrinks with baud rate even though the fixed SSH/pty/pexpect overhead does not. This forced per-platform multipliers to keep the timeout usable, and still left tight cases at high baud rates.

#### How did you do it?

`timeout = overhead_seconds + wire_time`, with `overhead_seconds = 0.1`. Platform-specific multipliers removed since the fixed term makes them unnecessary.

0.1 s covers the observed fixed overhead on an idle test env: SSH RTT through the mgmt LAN (a few switches), sshd + pty + picocom on the DUT, and pexpect's 10 ms poll — typically 15-30 ms, leaving headroom for jitter.

#### How did you verify/test it?

Ran `test_console_loopback.py` on 4 physical testbeds covering:

- Nokia-7215-C1: same-host and diff-host (`c0-lo` and `c0`)
- Cisco-C8220TG: same-host and diff-host (`c0-lo` and `c0`)

Result: 24 passed, 8 skipped (pingpong skips on same-host by design), 0 failed.

#### Any platform specific information?

None — the fixed overhead term makes the platform-specific multipliers unnecessary.

#### Supported testbed topology if it's a new test case?

N/A (existing test).

### Documentation

N/A.
