### PR TITLE
[202511][vm_set] add ptf_registry_host variable to allow PTF image registry override in add_topo

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -160,8 +160,15 @@
   - name: Create ptf container ptf_{{ vm_set_name }}
     docker_container:
       name: ptf_{{ vm_set_name }}
-      image: "{{ docker_registry_host }}/{{ ptf_imagename }}:{{ ptf_imagetag }}"
-      pull: yes
+      image: "{{ ptf_registry_host | default(docker_registry_host) }}/{{ ptf_imagename }}:{{ ptf_imagetag }}"
+      # Set pull to 'missing' when ptf_modified is True (PR test with preloaded image)
+      # to avoid pulling and overwriting the local image. For nightly tests where
+      # ptf_modified is False/undefined, use 'always' to always pull the latest image.
+      # The ptf_modified flag is passed from Azure Pipelines through Elastictest's
+      # add_topo_params as "-e ptf_modified=True" when testing PR built docker-ptf images.
+      # ptf_registry_host can be set independently (e.g. to 'localhost') to override just
+      # the PTF image registry without affecting other images that use docker_registry_host.
+      pull: "{{ 'missing' if (ptf_modified | default(false) | bool) else 'always' }}"
       state: started
       restart: no
       network_mode: none


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Cherry-pick: https://github.com/sonic-net/sonic-mgmt/pull/25773
Summary:
Introduces an optional `ptf_registry_host` Ansible variable scoped exclusively to the PTF container in `add_topo.yml`, allowing the PTF image registry to be overridden independently of `docker_registry_host` which is shared by all other images.
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
When Elastictest pre-loads a custom PTF image from a PR build with `ptf_modified=True`, the image is tagged as localhost/docker-ptf:latest to avoid S360 security alerts and support PR testing
`add_topo.yml` previously composed the PTF container image as `{{ docker_registry_host }}/{{ ptf_imagename }}:{{ ptf_imagetag }}`, making it impossible to reference the locally-tagged `localhost/docker-ptf:latest` image without overriding `docker_registry_host` globally — which would break all other images
#### How did you do it?
Changed the PTF container image reference to `image: "{{ ptf_registry_host | default(docker_registry_host) }}/{{ ptf_imagename }}:{{ ptf_imagetag }}"`
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
