### PR TITLE
tests: fix bad truthy conditions

### DIFF
--- a/spytest/apis/routing/bgp.py
+++ b/spytest/apis/routing/bgp.py
@@ -4505,7 +4505,7 @@ def config_bgp(dut, **kwargs):
         if 'bgp_bestpath_selection' in bgp_router_kwargs:
             # This option hasn't been used in scripts.
             bgp_router_kwargs['best_path_cmd'] = bgp_router_kwargs.pop('bgp_bestpath_selection')
-            if ('med missing-as-worst confed' or 'med missing-as-worst') in bgp_bestpath_selection:
+            if any(cmd in bgp_bestpath_selection for cmd in ('med missing-as-worst confed', 'med missing-as-worst')):
                 bgp_router_kwargs['best_path_cmd'] = 'med confed missing-as-worst'
 
         if 'import-check' in config_type_list:
@@ -5888,7 +5888,7 @@ def config_bgp(dut, **kwargs):
                             if not delete_rest(dut, rest_url=url):
                                 st.error("failed to unconfig med confed")
 
-                    if ('med missing-as-worst confed' or 'med missing-as-worst') in bgp_bestpath_selection:
+                    if any(cmd in bgp_bestpath_selection for cmd in ('med missing-as-worst confed', 'med missing-as-worst')):
                         if config_cmd != 'no':
                             global_data["openconfig-network-instance:bgp"]["global"]["route-selection-options"]["config"].update({"openconfig-bgp-ext:med-missing-as-worst": True})
                         else:

--- a/tests/dualtor/test_orchagent_active_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_active_tor_downstream.py
@@ -80,7 +80,7 @@ def test_active_tor_remove_neighbor_downstream_active(
     @contextlib.contextmanager
     def remove_neighbor(ptfhost, duthost, server_ip, ip_version, neighbor_details):
         # restore ipv4 neighbor since it is statically configured
-        flush_neighbor_ct = flush_neighbor(duthost, server_ip, restore=ip_version == "ipv4" or "ipv6")
+        flush_neighbor_ct = flush_neighbor(duthost, server_ip, restore=ip_version in ("ipv4", "ipv6"))
         try:
             ptfhost.shell("supervisorctl stop arp_responder", module_ignore_errors=True)
             # stop garp_service since there is no equivalent in production

--- a/tests/generic_config_updater/test_incremental_qos.py
+++ b/tests/generic_config_updater/test_incremental_qos.py
@@ -169,10 +169,10 @@ def calculate_field_value(duthost, tbinfo, field):
     config_headroom_int_sum = 0
     neighbor_type_to_pg_headroom_map = get_neighbor_type_to_pg_headroom_map(duthost)
     for neighbor_type in neighbor_type_to_pg_headroom_map:
-        if neighbor_type == "SpineRouter" or "LeafRouter":
+        if neighbor_type in ("SpineRouter", "LeafRouter"):
             config_headroom_uplink_multiplier = neighbor_type_to_pg_headroom_map[neighbor_type]
             config_headroom_int_sum = uplink * config_headroom_uplink_multiplier + config_headroom_int_sum
-        elif neighbor_type == "LeafRouter" or "Server":
+        elif neighbor_type in ("LeafRouter", "Server"):
             config_headroom_downlink_multiplier = neighbor_type_to_pg_headroom_map[neighbor_type]
             config_headroom_int_sum = downlink * config_headroom_downlink_multiplier + config_headroom_int_sum
     config_headroom = LOSSLESS_PGS * config_headroom_int_sum


### PR DESCRIPTION
Summary:
Fixes several bad Python truthy conditions where expressions with "or" and string literals always evaluated truthy or failed to check the intended alternatives.

This PR:
- Fixes the dualtor restore condition to explicitly check ipv4/ipv6.
- Fixes GCU QoS neighbor type checks to use explicit membership tests.
- Fixes BGP bestpath selection checks so both "med missing-as-worst confed" and "med missing-as-worst" are evaluated.

Issue:
Fixes #25952

Testing:
- Ran: git grep checks for the old bad patterns
- Ran: python3 -m py_compile tests/dualtor/test_orchagent_active_tor_downstream.py
- Ran: python3 -m py_compile tests/generic_config_updater/test_incremental_qos.py
- Ran: python3 -m py_compile spytest/apis/routing/bgp.py
- Ran: git diff --check