### PR TITLE
Skip drop counter tests on VoQ topology

### DIFF
--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -350,6 +350,21 @@ def setup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
     if tbinfo["topo"]["type"] == "ptf":
         pytest.skip("Unsupported topology {}".format(tbinfo["topo"]))
 
+    # Skip drop counter tests on VoQ topology - drop counters not tracked at ingress port level
+    try:
+        result = duthost.shell("sonic-cfggen -d -v 'DEVICE_METADATA.localhost.switch_type' 2>/dev/null || echo ''")
+        switch_type = result.get('stdout', '').strip()
+        logger.info(f"Device switch_type from sonic-cfggen: {switch_type}")
+        if switch_type and "voq" in switch_type.lower():
+            pytest.skip("Drop counter tests not supported on VoQ (Voice of Quantum) topology - drops not tracked at ingress port level")
+    except Exception as e:
+        logger.warning(f"Unable to check switch_type: {e}")
+    
+    # Fallback: check mg_facts
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    if mg_facts.get("switch_type") == "voq":
+        pytest.skip("Drop counter tests not supported on VoQ (Voice of Quantum) topology - drops not tracked at ingress port level")
+
     # Gather interface facts per asic
     for ns in duthost.get_asic_namespace_list():
         intf_per_namespace[ns if ns is not DEFAULT_NAMESPACE else ''] = \


### PR DESCRIPTION
Skip drop counter tests for VoQ topology due to unsupported tracking at ingress port level. Added checks for switch type and logging for better debugging.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
