### PR TITLE
Add file stat end to end tests

### DIFF
--- a/tests/gnmi/test_gnoi_file.py
+++ b/tests/gnmi/test_gnoi_file.py
@@ -112,10 +112,12 @@ def test_file_transfer_to_remote(gnmi_tls, ptfhost, duthosts, rand_one_dut_hostn
 @pytest.fixture(scope="module", autouse=False)
 def reapply_cert_config(duthosts, rand_one_dut_hostname, localhost):
     """Restore a consistent TLS cert state for gnoi_request-based tests.
+
     After gnmi_tls tests run, gnmiserver.key (overwritten with CA_C's key by
     grpc_fixtures) no longer matches gnmiserver.crt (CA_B cert left by
     setup_gnmi_rotated_server). Restarting gnmi with mismatched files fails
     with 'private key does not match public key'.
+
     Fix: regenerate a fresh CA + server cert + client cert, copy to DUT, then
     restart gnmi via apply_cert_config so all cert files are consistent.
     """
@@ -124,37 +126,57 @@ def reapply_cert_config(duthosts, rand_one_dut_hostname, localhost):
     prepare_server_cert(duthost, localhost, dut_ip=duthost.mgmt_ip)
     prepare_client_cert(localhost)
     copy_certificate_to_dut(duthost)
-    apply_cert_config(duthost)
+    try:
+        apply_cert_config(duthost)
+    except AssertionError as e:
+        # On multi-ASIC KVM DUTs the platform string doesn't match 'x86_64-kvm_x86_64-r0'
+        # so apply_cert_config's NTP sync check runs and fails — even though gnmi is running.
+        # Swallow NTP failures only; gnmi port reachability was already verified inside
+        # apply_cert_config before the assertion, so tests can proceed safely.
+        if "NTP" not in str(e):
+            raise
+        logger.warning("NTP sync check failed on %s (KVM/virtual env): %s — gnmi is running, proceeding.",
+                       duthost.hostname, e)
 
 
 def test_gnoi_file_stat_regular_file(duthosts, rand_one_dut_hostname, localhost, reapply_cert_config):  # noqa: F811
     """Stat a known regular file; verify path, size, last_modified, permissions and umask.
+
     PR #697: HandleStat returns exactly one StatInfo for a regular file.
     The path field must round-trip the host-visible path (no /mnt/host prefix).
     umask is the constant defaultUmask = 0022 = 18 decimal.
     """
     duthost = duthosts[rand_one_dut_hostname]
+
     ret, msg = gnoi_request(duthost, localhost, "File", "Stat", '{"path": "/etc/hostname"}')
     pytest_assert(ret == 0, "File.Stat failed unexpectedly: {}".format(msg))
+
     resp = extract_gnoi_response(msg)
     pytest_assert(resp is not None, "Failed to parse File.Stat response: {}".format(msg))
+
     # Regular file must yield exactly one StatInfo entry.
     stats = resp.get("stats", [])
     pytest_assert(len(stats) == 1,
                   "Expected exactly 1 StatInfo for regular file, got {}: {}".format(len(stats), resp))
+
     entry = stats[0]
     logger.info("File.Stat regular file entry: {}".format(entry))
+
     # path must round-trip the requested host-visible path (PR strips /mnt/host prefix on output).
     pytest_assert(entry.get("path") == "/etc/hostname",
                   "Expected path '/etc/hostname', got: {}".format(entry.get("path")))
+
     # size must be positive for a non-empty file.
     pytest_assert(int(entry.get("size", 0)) > 0,
                   "Expected non-zero size for /etc/hostname, got: {}".format(entry.get("size")))
+
     # last_modified is UnixNano — must be a positive integer.
     pytest_assert(int(entry.get("last_modified", 0)) > 0,
                   "Expected positive last_modified timestamp, got: {}".format(entry.get("last_modified")))
+
     # permissions field must be present.
     pytest_assert("permissions" in entry, "stat entry missing 'permissions'")
+
     # umask is the constant defaultUmask = 0022 octal = 18 decimal (PR hardcodes this).
     pytest_assert(int(entry.get("umask", -1)) == 18,
                   "Expected umask=18 (0022 octal), got: {}".format(entry.get("umask")))
@@ -162,6 +184,7 @@ def test_gnoi_file_stat_regular_file(duthosts, rand_one_dut_hostname, localhost,
 
 def test_gnoi_file_stat_directory(duthosts, rand_one_dut_hostname, localhost, reapply_cert_config):  # noqa: F811
     """Stat a directory; verify non-recursive listing returns immediate children only.
+
     PR #697 contract:
     - The directory itself is NOT included in results.
     - Each StatInfo.path is the immediate child's host-visible path (starts with '<dir>/').
@@ -169,24 +192,31 @@ def test_gnoi_file_stat_directory(duthosts, rand_one_dut_hostname, localhost, re
     - Directory child entries have size=0 (PR: "Leave size=0 for dirs").
     """
     duthost = duthosts[rand_one_dut_hostname]
+
     ret, msg = gnoi_request(duthost, localhost, "File", "Stat", '{"path": "/etc/sonic"}')
     pytest_assert(ret == 0, "File.Stat on directory failed unexpectedly: {}".format(msg))
+
     resp = extract_gnoi_response(msg)
     pytest_assert(resp is not None, "Failed to parse File.Stat response: {}".format(msg))
+
     stats = resp.get("stats", [])
     pytest_assert(len(stats) >= 1,
                   "Expected at least one child entry for /etc/sonic, got: {}".format(resp))
     logger.info("File.Stat directory returned {} entries".format(len(stats)))
+
     # The directory itself must NOT appear in the listing (non-recursive children only).
     self_paths = [e.get("path") for e in stats if e.get("path") == "/etc/sonic"]
     pytest_assert(len(self_paths) == 0,
                   "Directory /etc/sonic must not appear in its own listing, but found: {}".format(self_paths))
+
     for entry in stats:
         child_path = entry.get("path", "")
         logger.info("Directory child entry: {}".format(entry))
+
         # Each child path must be directly under /etc/sonic/ (non-recursive).
         pytest_assert(child_path.startswith("/etc/sonic/"),
                       "Child path '{}' does not start with '/etc/sonic/'".format(child_path))
+
         # Required fields per gNOI StatInfo proto.
         pytest_assert(int(entry.get("last_modified", 0)) > 0,
                       "Child '{}' missing valid last_modified".format(child_path))
@@ -199,6 +229,7 @@ def test_gnoi_file_stat_directory(duthosts, rand_one_dut_hostname, localhost, re
 def test_gnoi_file_stat_not_found(duthosts, rand_one_dut_hostname, localhost, reapply_cert_config):  # noqa: F811
     """Stat a non-existent path; expect NOT_FOUND error."""
     duthost = duthosts[rand_one_dut_hostname]
+
     ret, msg = gnoi_request(duthost, localhost, "File", "Stat",
                             '{"path": "/etc/this_path_does_not_exist_gnoi_test"}')
     pytest_assert(ret != 0, "File.Stat should have failed for non-existent path but returned success")
@@ -218,6 +249,7 @@ def test_gnoi_file_stat_invalid_argument(
         duthosts, rand_one_dut_hostname, localhost, bad_path, reason, reapply_cert_config):  # noqa: F811
     """Stat with invalid path arguments; expect INVALID_ARGUMENT error."""
     duthost = duthosts[rand_one_dut_hostname]
+
     json_data = '{{"path": "{}"}}'.format(bad_path)
     ret, msg = gnoi_request(duthost, localhost, "File", "Stat", json_data)
     pytest_assert(ret != 0,
@@ -232,26 +264,34 @@ def test_gnoi_file_stat_invalid_argument(
 def test_gnoi_file_stat_permissions_decimal_octal(
         duthosts, rand_one_dut_hostname, localhost, reapply_cert_config):  # noqa: F811
     """Verify permissions field is encoded as decimal-octal per gNOI proto.
+
     PR #697 contract (statInfoFromFileInfo):
       strconv.FormatUint(uint64(mode.Perm()), 8)  -> octal string e.g. "644"
       strconv.ParseUint(octalStr, 10, 32)          -> decimal int 644
+
     So mode 0644 -> permissions=644 (NOT 420, which is the raw decimal of 0644).
     /etc/hostname on SONiC has mode 0644, so the expected value is 644.
     """
     duthost = duthosts[rand_one_dut_hostname]
+
     ret, msg = gnoi_request(duthost, localhost, "File", "Stat", '{"path": "/etc/hostname"}')
     pytest_assert(ret == 0, "File.Stat failed unexpectedly: {}".format(msg))
+
     resp = extract_gnoi_response(msg)
     pytest_assert(resp is not None, "Failed to parse File.Stat response: {}".format(msg))
+
     stats = resp.get("stats", [])
     pytest_assert(len(stats) == 1, "Expected exactly 1 StatInfo for /etc/hostname")
+
     entry = stats[0]
     permissions = int(entry.get("permissions", -1))
     logger.info("File.Stat permissions field value: {}".format(permissions))
+
     # /etc/hostname is mode 0644; decimal-octal encoding yields 644 (not 420).
     pytest_assert(permissions == 644,
                   "Expected permissions=644 (decimal-octal for mode 0644), got: {} "
                   "(hint: 420 means the old DBus decimal encoding is still in use)".format(permissions))
+
     # Structural check: all digits must be valid octal (0-7), never 8 or 9.
     pytest_assert(
         all(d in "01234567" for d in str(permissions)),

--- a/tests/gnmi/test_gnoi_file.py
+++ b/tests/gnmi/test_gnoi_file.py
@@ -226,4 +226,3 @@ def test_gnoi_file_stat_permissions_decimal_octal(gnmi_tls, duthosts, rand_one_d
         all(d in "01234567" for d in str(permissions)),
         "permissions '{}' contains digit 8 or 9 — not a valid decimal-octal value".format(permissions)
     )
-    

--- a/tests/gnmi/test_gnoi_file.py
+++ b/tests/gnmi/test_gnoi_file.py
@@ -98,11 +98,13 @@ def test_file_transfer_to_remote(gnmi_tls, ptfhost, duthosts, rand_one_dut_hostn
 
 
 def test_gnoi_file_stat_regular_file(gnmi_tls):  # noqa: F811
-    """Stat a known regular file; verify path, size, last_modified, permissions and umask.
+    """Verify File.Stat on a regular file returns a single StatInfo per the gNOI proto contract.
 
-    PR #697: HandleStat returns exactly one StatInfo for a regular file.
-    The path field must round-trip the host-visible path (no /mnt/host prefix).
-    umask is the constant defaultUmask = 0022 = 18 decimal.
+    Per the gNOI File proto:
+    - Exactly one StatInfo is returned for a regular file.
+    - path is the host-visible path (no /mnt/host prefix).
+    - size, last_modified, permissions, and umask fields are populated.
+    - umask is 0022 (18 decimal).
     """
     resp = gnmi_tls.gnoi.file_stat("/etc/hostname")
 
@@ -125,12 +127,13 @@ def test_gnoi_file_stat_regular_file(gnmi_tls):  # noqa: F811
 
 
 def test_gnoi_file_stat_directory(gnmi_tls):  # noqa: F811
-    """Stat a directory; verify non-recursive listing returns immediate children only.
+    """Verify File.Stat on a directory returns immediate children per the gNOI proto contract.
 
-    PR #697 contract:
-    - The directory itself is NOT included in results.
-    - Each StatInfo.path is the immediate child's host-visible path (starts with '<dir>/').
-    - Each entry has path, last_modified, permissions, umask fields.
+    Per the gNOI File proto contract for directory paths:
+    - Only immediate children are returned (non-recursive).
+    - The directory itself is NOT included in the results.
+    - Each child StatInfo contains: path, last_modified, permissions, and umask fields.
+    - Each child path is the full host-visible path (e.g. '/etc/sonic/<child>').
     """
     resp = gnmi_tls.gnoi.file_stat("/etc/sonic")
 
@@ -157,7 +160,7 @@ def test_gnoi_file_stat_directory(gnmi_tls):  # noqa: F811
 
 
 def test_gnoi_file_stat_not_found(gnmi_tls):  # noqa: F811
-    """Stat a non-existent path; expect NOT_FOUND error."""
+    """Verify File.Stat returns NOT_FOUND error for a non-existent path"""
     try:
         gnmi_tls.gnoi.file_stat("/etc/this_path_does_not_exist_gnoi_test")
         pytest_assert(False, "File.Stat should have failed for non-existent path but returned success")
@@ -193,12 +196,10 @@ def test_gnoi_file_stat_invalid_argument(gnmi_tls, bad_path, reason):  # noqa: F
 def test_gnoi_file_stat_permissions_decimal_octal(gnmi_tls, duthosts, rand_one_dut_hostname):  # noqa: F811
     """Verify permissions field is encoded as decimal-octal per gNOI proto.
 
-    PR #697 contract (statInfoFromFileInfo):
-      strconv.FormatUint(uint64(mode.Perm()), 8)  -> octal string e.g. "644"
-      strconv.ParseUint(octalStr, 10, 32)          -> decimal int 644
-
-    The expected value is derived dynamically from the DUT so the test
-    verifies the encoding invariant regardless of the file's actual mode.
+    Per the gNOI File proto, the permissions field encodes the file mode
+    as its octal string interpreted as a decimal integer (e.g. mode 0644 -> 644).
+    The test fetches the actual mode from the DUT and verifies the encoding holds,
+    independent of the specific file's permissions value.
     """
     duthost = duthosts[rand_one_dut_hostname]
     # Get the actual octal mode string from the DUT (e.g. "644")

--- a/tests/gnmi/test_gnoi_file.py
+++ b/tests/gnmi/test_gnoi_file.py
@@ -97,12 +97,6 @@ def test_file_transfer_to_remote(gnmi_tls, ptfhost, duthosts, rand_one_dut_hostn
             logger.warning(f"Cleanup failed: {cleanup_e}")
 
 
-# ---------------------------------------------------------------------------
-# Uses gnoi_request / extract_gnoi_response over gnmi TCP transport.
-# No TLS fixture dependency — gnoi_client runs inside the gnmi container on DUT.
-# ---------------------------------------------------------------------------
-
-
 def test_gnoi_file_stat_regular_file(gnmi_tls):  # noqa: F811
     """Stat a known regular file; verify path, size, last_modified, permissions and umask.
 
@@ -123,8 +117,8 @@ def test_gnoi_file_stat_regular_file(gnmi_tls):  # noqa: F811
                   "Expected path '/etc/hostname', got: {}".format(entry.get("path")))
     pytest_assert(int(entry.get("size", 0)) > 0,
                   "Expected non-zero size for /etc/hostname, got: {}".format(entry.get("size")))
-    pytest_assert(int(entry.get("last_modified", 0)) > 0,
-                  "Expected positive last_modified timestamp, got: {}".format(entry.get("last_modified")))
+    pytest_assert(int(entry.get("last_modified") or entry.get("lastModified") or 0) > 0,
+                  "Expected positive last_modified timestamp, got: {}".format(entry.get("lastModified")))
     pytest_assert("permissions" in entry, "stat entry missing 'permissions'")
     pytest_assert(int(entry.get("umask", -1)) == 18,
                   "Expected umask=18 (0022 octal), got: {}".format(entry.get("umask")))
@@ -154,7 +148,7 @@ def test_gnoi_file_stat_directory(gnmi_tls):  # noqa: F811
         logger.info("Directory child entry: {}".format(entry))
         pytest_assert(child_path.startswith("/etc/sonic/"),
                       "Child path '{}' does not start with '/etc/sonic/'".format(child_path))
-        pytest_assert(int(entry.get("last_modified", 0)) > 0,
+        pytest_assert(int(entry.get("last_modified") or entry.get("lastModified") or 0) > 0,
                       "Child '{}' missing valid last_modified".format(child_path))
         pytest_assert("permissions" in entry,
                       "Child '{}' missing 'permissions'".format(child_path))
@@ -218,7 +212,3 @@ def test_gnoi_file_stat_permissions_decimal_octal(gnmi_tls):  # noqa: F811
     pytest_assert(permissions == 644,
                   "Expected permissions=644 (decimal-octal for mode 0644), got: {} "
                   "(hint: 420 means the old DBus decimal encoding is still in use)".format(permissions))
-    pytest_assert(
-        all(d in "01234567" for d in str(permissions)),
-        "permissions '{}' contains digit 8 or 9 — not a valid decimal-octal value".format(permissions)
-    )

--- a/tests/gnmi/test_gnoi_file.py
+++ b/tests/gnmi/test_gnoi_file.py
@@ -222,4 +222,3 @@ def test_gnoi_file_stat_permissions_decimal_octal(gnmi_tls):  # noqa: F811
         all(d in "01234567" for d in str(permissions)),
         "permissions '{}' contains digit 8 or 9 — not a valid decimal-octal value".format(permissions)
     )
-    

--- a/tests/gnmi/test_gnoi_file.py
+++ b/tests/gnmi/test_gnoi_file.py
@@ -52,11 +52,11 @@ def test_file_transfer_to_remote(gnmi_tls, ptfhost, duthosts, rand_one_dut_hostn
         ptfhost.command(f"cd /tmp && python -m http.server {http_port}", module_async=True)
         # 3. Wait for HTTP server to start
         ptf_ip = ptfhost.mgmt_ip
-        logger.info(f"Waiting for HTTP server to start at {ptf_ip}:{http_port}")
+        logger.info("Waiting for HTTP server to start at {}:{}".format(ptf_ip, http_port))
 
         def server_ready():
             try:
-                result = ptfhost.command(f"curl -f --max-time 2 {ptf_ip}:{http_port}",
+                result = ptfhost.command("curl -f --max-time 2 {}:{}".format(ptf_ip, http_port),
                                          module_ignore_errors=True)
                 return result["rc"] == 0
             except Exception:
@@ -64,7 +64,7 @@ def test_file_transfer_to_remote(gnmi_tls, ptfhost, duthosts, rand_one_dut_hostn
         wait_until(30, 2, 2, server_ready)
         logger.info("HTTP server is ready")
         # 4. Test TransferToRemote
-        remote_url = f"http://{ptf_ip}:{http_port}/{test_filename}"
+        remote_url = "http://{}:{}/{}".format(ptf_ip, http_port, test_filename)
         logger.info(f"Testing TransferToRemote: {remote_url} -> {local_path}")
         result = gnmi_tls.gnoi.file_transfer_to_remote(
             local_path=local_path,

--- a/tests/gnmi/test_gnoi_file.py
+++ b/tests/gnmi/test_gnoi_file.py
@@ -104,7 +104,6 @@ def test_file_transfer_to_remote(gnmi_tls, ptfhost, duthosts, rand_one_dut_hostn
 
 
 # ---------------------------------------------------------------------------
-# gNOI File.Stat e2e tests (ADO #38245965)
 # Uses gnoi_request / extract_gnoi_response over gnmi TCP transport.
 # No TLS fixture dependency — gnoi_client runs inside the gnmi container on DUT.
 # ---------------------------------------------------------------------------
@@ -246,4 +245,3 @@ def test_gnoi_file_stat_permissions_decimal_octal(
         all(d in "01234567" for d in str(permissions)),
         "permissions '{}' contains digit 8 or 9 — not a valid decimal-octal value".format(permissions)
     )
-    

--- a/tests/gnmi/test_gnoi_file.py
+++ b/tests/gnmi/test_gnoi_file.py
@@ -222,3 +222,4 @@ def test_gnoi_file_stat_permissions_decimal_octal(gnmi_tls):  # noqa: F811
         all(d in "01234567" for d in str(permissions)),
         "permissions '{}' contains digit 8 or 9 — not a valid decimal-octal value".format(permissions)
     )
+    

--- a/tests/gnmi/test_gnoi_file.py
+++ b/tests/gnmi/test_gnoi_file.py
@@ -10,6 +10,12 @@ import logging
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.fixtures.grpc_fixtures import gnmi_tls  # noqa: F401
+from tests.gnmi.helper import gnoi_request, extract_gnoi_response
+from tests.gnmi.helper import apply_cert_config
+from tests.common.helpers.gnmi_utils import (
+    prepare_root_cert, prepare_server_cert, prepare_client_cert,
+    copy_certificate_to_dut,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -95,3 +101,149 @@ def test_file_transfer_to_remote(gnmi_tls, ptfhost, duthosts, rand_one_dut_hostn
             logger.info("Cleanup completed")
         except Exception as cleanup_e:
             logger.warning(f"Cleanup failed: {cleanup_e}")
+
+
+# ---------------------------------------------------------------------------
+# gNOI File.Stat e2e tests (ADO #38245965)
+# Uses gnoi_request / extract_gnoi_response over gnmi TCP transport.
+# No TLS fixture dependency — gnoi_client runs inside the gnmi container on DUT.
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="module", autouse=False)
+def reapply_cert_config(duthosts, rand_one_dut_hostname, localhost):
+    """Restore a consistent TLS cert state for gnoi_request-based tests.
+    After gnmi_tls tests run, gnmiserver.key (overwritten with CA_C's key by
+    grpc_fixtures) no longer matches gnmiserver.crt (CA_B cert left by
+    setup_gnmi_rotated_server). Restarting gnmi with mismatched files fails
+    with 'private key does not match public key'.
+    Fix: regenerate a fresh CA + server cert + client cert, copy to DUT, then
+    restart gnmi via apply_cert_config so all cert files are consistent.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    prepare_root_cert(localhost)
+    prepare_server_cert(duthost, localhost, dut_ip=duthost.mgmt_ip)
+    prepare_client_cert(localhost)
+    copy_certificate_to_dut(duthost)
+    apply_cert_config(duthost)
+def test_gnoi_file_stat_regular_file(duthosts, rand_one_dut_hostname, localhost, reapply_cert_config):  # noqa: F811
+    """Stat a known regular file; verify path, size, last_modified, permissions and umask.
+    PR #697: HandleStat returns exactly one StatInfo for a regular file.
+    The path field must round-trip the host-visible path (no /mnt/host prefix).
+    umask is the constant defaultUmask = 0022 = 18 decimal.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    ret, msg = gnoi_request(duthost, localhost, "File", "Stat", '{"path": "/etc/hostname"}')
+    pytest_assert(ret == 0, "File.Stat failed unexpectedly: {}".format(msg))
+    resp = extract_gnoi_response(msg)
+    pytest_assert(resp is not None, "Failed to parse File.Stat response: {}".format(msg))
+    # Regular file must yield exactly one StatInfo entry.
+    stats = resp.get("stats", [])
+    pytest_assert(len(stats) == 1,
+                  "Expected exactly 1 StatInfo for regular file, got {}: {}".format(len(stats), resp))
+    entry = stats[0]
+    logger.info("File.Stat regular file entry: {}".format(entry))
+    # path must round-trip the requested host-visible path (PR strips /mnt/host prefix on output).
+    pytest_assert(entry.get("path") == "/etc/hostname",
+                  "Expected path '/etc/hostname', got: {}".format(entry.get("path")))
+    # size must be positive for a non-empty file.
+    pytest_assert(int(entry.get("size", 0)) > 0,
+                  "Expected non-zero size for /etc/hostname, got: {}".format(entry.get("size")))
+    # last_modified is UnixNano — must be a positive integer.
+    pytest_assert(int(entry.get("last_modified", 0)) > 0,
+                  "Expected positive last_modified timestamp, got: {}".format(entry.get("last_modified")))
+    # permissions field must be present.
+    pytest_assert("permissions" in entry, "stat entry missing 'permissions'")
+    # umask is the constant defaultUmask = 0022 octal = 18 decimal (PR hardcodes this).
+    pytest_assert(int(entry.get("umask", -1)) == 18,
+                  "Expected umask=18 (0022 octal), got: {}".format(entry.get("umask")))
+def test_gnoi_file_stat_directory(duthosts, rand_one_dut_hostname, localhost, reapply_cert_config):  # noqa: F811
+    """Stat a directory; verify non-recursive listing returns immediate children only.
+    PR #697 contract:
+    - The directory itself is NOT included in results.
+    - Each StatInfo.path is the immediate child's host-visible path (starts with '<dir>/').
+    - Each entry has path, last_modified, permissions, umask fields.
+    - Directory child entries have size=0 (PR: "Leave size=0 for dirs").
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    ret, msg = gnoi_request(duthost, localhost, "File", "Stat", '{"path": "/etc/sonic"}')
+    pytest_assert(ret == 0, "File.Stat on directory failed unexpectedly: {}".format(msg))
+    resp = extract_gnoi_response(msg)
+    pytest_assert(resp is not None, "Failed to parse File.Stat response: {}".format(msg))
+    stats = resp.get("stats", [])
+    pytest_assert(len(stats) >= 1,
+                  "Expected at least one child entry for /etc/sonic, got: {}".format(resp))
+    logger.info("File.Stat directory returned {} entries".format(len(stats)))
+    # The directory itself must NOT appear in the listing (non-recursive children only).
+    self_paths = [e.get("path") for e in stats if e.get("path") == "/etc/sonic"]
+    pytest_assert(len(self_paths) == 0,
+                  "Directory /etc/sonic must not appear in its own listing, but found: {}".format(self_paths))
+    for entry in stats:
+        child_path = entry.get("path", "")
+        logger.info("Directory child entry: {}".format(entry))
+        # Each child path must be directly under /etc/sonic/ (non-recursive).
+        pytest_assert(child_path.startswith("/etc/sonic/"),
+                      "Child path '{}' does not start with '/etc/sonic/'".format(child_path))
+        # Required fields per gNOI StatInfo proto.
+        pytest_assert(int(entry.get("last_modified", 0)) > 0,
+                      "Child '{}' missing valid last_modified".format(child_path))
+        pytest_assert("permissions" in entry,
+                      "Child '{}' missing 'permissions'".format(child_path))
+        pytest_assert(int(entry.get("umask", -1)) == 18,
+                      "Child '{}' expected umask=18, got: {}".format(child_path, entry.get("umask")))
+def test_gnoi_file_stat_not_found(duthosts, rand_one_dut_hostname, localhost, reapply_cert_config):  # noqa: F811
+    """Stat a non-existent path; expect NOT_FOUND error."""
+    duthost = duthosts[rand_one_dut_hostname]
+    ret, msg = gnoi_request(duthost, localhost, "File", "Stat",
+                            '{"path": "/etc/this_path_does_not_exist_gnoi_test"}')
+    pytest_assert(ret != 0, "File.Stat should have failed for non-existent path but returned success")
+    logger.info("File.Stat NOT_FOUND response: {}".format(msg))
+    pytest_assert(
+        "NotFound" in msg or "not found" in msg.lower() or "no such file" in msg.lower(),
+        "Expected NOT_FOUND error, got: {}".format(msg)
+    )
+@pytest.mark.parametrize("bad_path,reason", [
+    ("", "empty path"),
+    ("etc/hostname", "relative path"),
+    ("/mnt/host/etc/hostname", "/mnt/host-prefixed path"),
+], ids=["empty", "relative", "mnt-host"])
+def test_gnoi_file_stat_invalid_argument(
+        duthosts, rand_one_dut_hostname, localhost, bad_path, reason, reapply_cert_config):  # noqa: F811
+    """Stat with invalid path arguments; expect INVALID_ARGUMENT error."""
+    duthost = duthosts[rand_one_dut_hostname]
+    json_data = '{{"path": "{}"}}'.format(bad_path)
+    ret, msg = gnoi_request(duthost, localhost, "File", "Stat", json_data)
+    pytest_assert(ret != 0,
+                  "File.Stat should have failed for {} ('{}') but returned success".format(reason, bad_path))
+    logger.info("File.Stat INVALID_ARGUMENT ({}) response: {}".format(reason, msg))
+    pytest_assert(
+        "InvalidArgument" in msg or "invalid argument" in msg.lower() or "invalid" in msg.lower(),
+        "Expected INVALID_ARGUMENT error for {} ('{}'): {}".format(reason, bad_path, msg)
+    )
+def test_gnoi_file_stat_permissions_decimal_octal(
+        duthosts, rand_one_dut_hostname, localhost, reapply_cert_config):  # noqa: F811
+    """Verify permissions field is encoded as decimal-octal per gNOI proto.
+    PR #697 contract (statInfoFromFileInfo):
+      strconv.FormatUint(uint64(mode.Perm()), 8)  -> octal string e.g. "644"
+      strconv.ParseUint(octalStr, 10, 32)          -> decimal int 644
+    So mode 0644 -> permissions=644 (NOT 420, which is the raw decimal of 0644).
+    /etc/hostname on SONiC has mode 0644, so the expected value is 644.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    ret, msg = gnoi_request(duthost, localhost, "File", "Stat", '{"path": "/etc/hostname"}')
+    pytest_assert(ret == 0, "File.Stat failed unexpectedly: {}".format(msg))
+    resp = extract_gnoi_response(msg)
+    pytest_assert(resp is not None, "Failed to parse File.Stat response: {}".format(msg))
+    stats = resp.get("stats", [])
+    pytest_assert(len(stats) == 1, "Expected exactly 1 StatInfo for /etc/hostname")
+    entry = stats[0]
+    permissions = int(entry.get("permissions", -1))
+    logger.info("File.Stat permissions field value: {}".format(permissions))
+    # /etc/hostname is mode 0644; decimal-octal encoding yields 644 (not 420).
+    pytest_assert(permissions == 644,
+                  "Expected permissions=644 (decimal-octal for mode 0644), got: {} "
+                  "(hint: 420 means the old DBus decimal encoding is still in use)".format(permissions))
+    # Structural check: all digits must be valid octal (0-7), never 8 or 9.
+    pytest_assert(
+        all(d in "01234567" for d in str(permissions)),
+        "permissions '{}' contains digit 8 or 9 — not a valid decimal-octal value".format(permissions)
+    )
+    

--- a/tests/gnmi/test_gnoi_file.py
+++ b/tests/gnmi/test_gnoi_file.py
@@ -107,6 +107,8 @@ def test_file_transfer_to_remote(gnmi_tls, ptfhost, duthosts, rand_one_dut_hostn
 # Uses gnoi_request / extract_gnoi_response over gnmi TCP transport.
 # No TLS fixture dependency — gnoi_client runs inside the gnmi container on DUT.
 # ---------------------------------------------------------------------------
+
+
 @pytest.fixture(scope="module", autouse=False)
 def reapply_cert_config(duthosts, rand_one_dut_hostname, localhost):
     """Restore a consistent TLS cert state for gnoi_request-based tests.
@@ -123,6 +125,8 @@ def reapply_cert_config(duthosts, rand_one_dut_hostname, localhost):
     prepare_client_cert(localhost)
     copy_certificate_to_dut(duthost)
     apply_cert_config(duthost)
+
+
 def test_gnoi_file_stat_regular_file(duthosts, rand_one_dut_hostname, localhost, reapply_cert_config):  # noqa: F811
     """Stat a known regular file; verify path, size, last_modified, permissions and umask.
     PR #697: HandleStat returns exactly one StatInfo for a regular file.
@@ -154,6 +158,8 @@ def test_gnoi_file_stat_regular_file(duthosts, rand_one_dut_hostname, localhost,
     # umask is the constant defaultUmask = 0022 octal = 18 decimal (PR hardcodes this).
     pytest_assert(int(entry.get("umask", -1)) == 18,
                   "Expected umask=18 (0022 octal), got: {}".format(entry.get("umask")))
+
+
 def test_gnoi_file_stat_directory(duthosts, rand_one_dut_hostname, localhost, reapply_cert_config):  # noqa: F811
     """Stat a directory; verify non-recursive listing returns immediate children only.
     PR #697 contract:
@@ -188,6 +194,8 @@ def test_gnoi_file_stat_directory(duthosts, rand_one_dut_hostname, localhost, re
                       "Child '{}' missing 'permissions'".format(child_path))
         pytest_assert(int(entry.get("umask", -1)) == 18,
                       "Child '{}' expected umask=18, got: {}".format(child_path, entry.get("umask")))
+
+
 def test_gnoi_file_stat_not_found(duthosts, rand_one_dut_hostname, localhost, reapply_cert_config):  # noqa: F811
     """Stat a non-existent path; expect NOT_FOUND error."""
     duthost = duthosts[rand_one_dut_hostname]
@@ -199,6 +207,8 @@ def test_gnoi_file_stat_not_found(duthosts, rand_one_dut_hostname, localhost, re
         "NotFound" in msg or "not found" in msg.lower() or "no such file" in msg.lower(),
         "Expected NOT_FOUND error, got: {}".format(msg)
     )
+
+
 @pytest.mark.parametrize("bad_path,reason", [
     ("", "empty path"),
     ("etc/hostname", "relative path"),
@@ -217,6 +227,8 @@ def test_gnoi_file_stat_invalid_argument(
         "InvalidArgument" in msg or "invalid argument" in msg.lower() or "invalid" in msg.lower(),
         "Expected INVALID_ARGUMENT error for {} ('{}'): {}".format(reason, bad_path, msg)
     )
+
+
 def test_gnoi_file_stat_permissions_decimal_octal(
         duthosts, rand_one_dut_hostname, localhost, reapply_cert_config):  # noqa: F811
     """Verify permissions field is encoded as decimal-octal per gNOI proto.

--- a/tests/gnmi/test_gnoi_file.py
+++ b/tests/gnmi/test_gnoi_file.py
@@ -10,12 +10,6 @@ import logging
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.fixtures.grpc_fixtures import gnmi_tls  # noqa: F401
-from tests.gnmi.helper import gnoi_request, extract_gnoi_response
-from tests.gnmi.helper import apply_cert_config
-from tests.common.helpers.gnmi_utils import (
-    prepare_root_cert, prepare_server_cert, prepare_client_cert,
-    copy_certificate_to_dut,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -109,52 +103,15 @@ def test_file_transfer_to_remote(gnmi_tls, ptfhost, duthosts, rand_one_dut_hostn
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(scope="module", autouse=False)
-def reapply_cert_config(duthosts, rand_one_dut_hostname, localhost):
-    """Restore a consistent TLS cert state for gnoi_request-based tests.
-
-    After gnmi_tls tests run, gnmiserver.key (overwritten with CA_C's key by
-    grpc_fixtures) no longer matches gnmiserver.crt (CA_B cert left by
-    setup_gnmi_rotated_server). Restarting gnmi with mismatched files fails
-    with 'private key does not match public key'.
-
-    Fix: regenerate a fresh CA + server cert + client cert, copy to DUT, then
-    restart gnmi via apply_cert_config so all cert files are consistent.
-    """
-    duthost = duthosts[rand_one_dut_hostname]
-    prepare_root_cert(localhost)
-    prepare_server_cert(duthost, localhost, dut_ip=duthost.mgmt_ip)
-    prepare_client_cert(localhost)
-    copy_certificate_to_dut(duthost)
-    try:
-        apply_cert_config(duthost)
-    except AssertionError as e:
-        # On multi-ASIC KVM DUTs the platform string doesn't match 'x86_64-kvm_x86_64-r0'
-        # so apply_cert_config's NTP sync check runs and fails — even though gnmi is running.
-        # Swallow NTP failures only; gnmi port reachability was already verified inside
-        # apply_cert_config before the assertion, so tests can proceed safely.
-        if "NTP" not in str(e):
-            raise
-        logger.warning("NTP sync check failed on %s (KVM/virtual env): %s — gnmi is running, proceeding.",
-                       duthost.hostname, e)
-
-
-def test_gnoi_file_stat_regular_file(duthosts, rand_one_dut_hostname, localhost, reapply_cert_config):  # noqa: F811
+def test_gnoi_file_stat_regular_file(gnmi_tls):  # noqa: F811
     """Stat a known regular file; verify path, size, last_modified, permissions and umask.
 
     PR #697: HandleStat returns exactly one StatInfo for a regular file.
     The path field must round-trip the host-visible path (no /mnt/host prefix).
     umask is the constant defaultUmask = 0022 = 18 decimal.
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    resp = gnmi_tls.gnoi.file_stat("/etc/hostname")
 
-    ret, msg = gnoi_request(duthost, localhost, "File", "Stat", '{"path": "/etc/hostname"}')
-    pytest_assert(ret == 0, "File.Stat failed unexpectedly: {}".format(msg))
-
-    resp = extract_gnoi_response(msg)
-    pytest_assert(resp is not None, "Failed to parse File.Stat response: {}".format(msg))
-
-    # Regular file must yield exactly one StatInfo entry.
     stats = resp.get("stats", [])
     pytest_assert(len(stats) == 1,
                   "Expected exactly 1 StatInfo for regular file, got {}: {}".format(len(stats), resp))
@@ -162,49 +119,32 @@ def test_gnoi_file_stat_regular_file(duthosts, rand_one_dut_hostname, localhost,
     entry = stats[0]
     logger.info("File.Stat regular file entry: {}".format(entry))
 
-    # path must round-trip the requested host-visible path (PR strips /mnt/host prefix on output).
     pytest_assert(entry.get("path") == "/etc/hostname",
                   "Expected path '/etc/hostname', got: {}".format(entry.get("path")))
-
-    # size must be positive for a non-empty file.
     pytest_assert(int(entry.get("size", 0)) > 0,
                   "Expected non-zero size for /etc/hostname, got: {}".format(entry.get("size")))
-
-    # last_modified is UnixNano — must be a positive integer.
     pytest_assert(int(entry.get("last_modified", 0)) > 0,
                   "Expected positive last_modified timestamp, got: {}".format(entry.get("last_modified")))
-
-    # permissions field must be present.
     pytest_assert("permissions" in entry, "stat entry missing 'permissions'")
-
-    # umask is the constant defaultUmask = 0022 octal = 18 decimal (PR hardcodes this).
     pytest_assert(int(entry.get("umask", -1)) == 18,
                   "Expected umask=18 (0022 octal), got: {}".format(entry.get("umask")))
 
 
-def test_gnoi_file_stat_directory(duthosts, rand_one_dut_hostname, localhost, reapply_cert_config):  # noqa: F811
+def test_gnoi_file_stat_directory(gnmi_tls):  # noqa: F811
     """Stat a directory; verify non-recursive listing returns immediate children only.
 
     PR #697 contract:
     - The directory itself is NOT included in results.
     - Each StatInfo.path is the immediate child's host-visible path (starts with '<dir>/').
     - Each entry has path, last_modified, permissions, umask fields.
-    - Directory child entries have size=0 (PR: "Leave size=0 for dirs").
     """
-    duthost = duthosts[rand_one_dut_hostname]
-
-    ret, msg = gnoi_request(duthost, localhost, "File", "Stat", '{"path": "/etc/sonic"}')
-    pytest_assert(ret == 0, "File.Stat on directory failed unexpectedly: {}".format(msg))
-
-    resp = extract_gnoi_response(msg)
-    pytest_assert(resp is not None, "Failed to parse File.Stat response: {}".format(msg))
+    resp = gnmi_tls.gnoi.file_stat("/etc/sonic")
 
     stats = resp.get("stats", [])
     pytest_assert(len(stats) >= 1,
                   "Expected at least one child entry for /etc/sonic, got: {}".format(resp))
     logger.info("File.Stat directory returned {} entries".format(len(stats)))
 
-    # The directory itself must NOT appear in the listing (non-recursive children only).
     self_paths = [e.get("path") for e in stats if e.get("path") == "/etc/sonic"]
     pytest_assert(len(self_paths) == 0,
                   "Directory /etc/sonic must not appear in its own listing, but found: {}".format(self_paths))
@@ -212,12 +152,8 @@ def test_gnoi_file_stat_directory(duthosts, rand_one_dut_hostname, localhost, re
     for entry in stats:
         child_path = entry.get("path", "")
         logger.info("Directory child entry: {}".format(entry))
-
-        # Each child path must be directly under /etc/sonic/ (non-recursive).
         pytest_assert(child_path.startswith("/etc/sonic/"),
                       "Child path '{}' does not start with '/etc/sonic/'".format(child_path))
-
-        # Required fields per gNOI StatInfo proto.
         pytest_assert(int(entry.get("last_modified", 0)) > 0,
                       "Child '{}' missing valid last_modified".format(child_path))
         pytest_assert("permissions" in entry,
@@ -226,18 +162,18 @@ def test_gnoi_file_stat_directory(duthosts, rand_one_dut_hostname, localhost, re
                       "Child '{}' expected umask=18, got: {}".format(child_path, entry.get("umask")))
 
 
-def test_gnoi_file_stat_not_found(duthosts, rand_one_dut_hostname, localhost, reapply_cert_config):  # noqa: F811
+def test_gnoi_file_stat_not_found(gnmi_tls):  # noqa: F811
     """Stat a non-existent path; expect NOT_FOUND error."""
-    duthost = duthosts[rand_one_dut_hostname]
-
-    ret, msg = gnoi_request(duthost, localhost, "File", "Stat",
-                            '{"path": "/etc/this_path_does_not_exist_gnoi_test"}')
-    pytest_assert(ret != 0, "File.Stat should have failed for non-existent path but returned success")
-    logger.info("File.Stat NOT_FOUND response: {}".format(msg))
-    pytest_assert(
-        "NotFound" in msg or "not found" in msg.lower() or "no such file" in msg.lower(),
-        "Expected NOT_FOUND error, got: {}".format(msg)
-    )
+    try:
+        gnmi_tls.gnoi.file_stat("/etc/this_path_does_not_exist_gnoi_test")
+        pytest_assert(False, "File.Stat should have failed for non-existent path but returned success")
+    except Exception as e:
+        err = str(e)
+        logger.info("File.Stat NOT_FOUND response: {}".format(err))
+        pytest_assert(
+            "NotFound" in err or "not found" in err.lower() or "no such file" in err.lower(),
+            "Expected NOT_FOUND error, got: {}".format(err)
+        )
 
 
 @pytest.mark.parametrize("bad_path,reason", [
@@ -245,24 +181,22 @@ def test_gnoi_file_stat_not_found(duthosts, rand_one_dut_hostname, localhost, re
     ("etc/hostname", "relative path"),
     ("/mnt/host/etc/hostname", "/mnt/host-prefixed path"),
 ], ids=["empty", "relative", "mnt-host"])
-def test_gnoi_file_stat_invalid_argument(
-        duthosts, rand_one_dut_hostname, localhost, bad_path, reason, reapply_cert_config):  # noqa: F811
+def test_gnoi_file_stat_invalid_argument(gnmi_tls, bad_path, reason):  # noqa: F811
     """Stat with invalid path arguments; expect INVALID_ARGUMENT error."""
-    duthost = duthosts[rand_one_dut_hostname]
+    try:
+        gnmi_tls.gnoi.file_stat(bad_path)
+        pytest_assert(False,
+                      "File.Stat should have failed for {} ('{}') but returned success".format(reason, bad_path))
+    except Exception as e:
+        err = str(e)
+        logger.info("File.Stat INVALID_ARGUMENT ({}) response: {}".format(reason, err))
+        pytest_assert(
+            "InvalidArgument" in err or "invalid argument" in err.lower() or "invalid" in err.lower(),
+            "Expected INVALID_ARGUMENT error for {} ('{}'): {}".format(reason, bad_path, err)
+        )
 
-    json_data = '{{"path": "{}"}}'.format(bad_path)
-    ret, msg = gnoi_request(duthost, localhost, "File", "Stat", json_data)
-    pytest_assert(ret != 0,
-                  "File.Stat should have failed for {} ('{}') but returned success".format(reason, bad_path))
-    logger.info("File.Stat INVALID_ARGUMENT ({}) response: {}".format(reason, msg))
-    pytest_assert(
-        "InvalidArgument" in msg or "invalid argument" in msg.lower() or "invalid" in msg.lower(),
-        "Expected INVALID_ARGUMENT error for {} ('{}'): {}".format(reason, bad_path, msg)
-    )
 
-
-def test_gnoi_file_stat_permissions_decimal_octal(
-        duthosts, rand_one_dut_hostname, localhost, reapply_cert_config):  # noqa: F811
+def test_gnoi_file_stat_permissions_decimal_octal(gnmi_tls):  # noqa: F811
     """Verify permissions field is encoded as decimal-octal per gNOI proto.
 
     PR #697 contract (statInfoFromFileInfo):
@@ -272,13 +206,7 @@ def test_gnoi_file_stat_permissions_decimal_octal(
     So mode 0644 -> permissions=644 (NOT 420, which is the raw decimal of 0644).
     /etc/hostname on SONiC has mode 0644, so the expected value is 644.
     """
-    duthost = duthosts[rand_one_dut_hostname]
-
-    ret, msg = gnoi_request(duthost, localhost, "File", "Stat", '{"path": "/etc/hostname"}')
-    pytest_assert(ret == 0, "File.Stat failed unexpectedly: {}".format(msg))
-
-    resp = extract_gnoi_response(msg)
-    pytest_assert(resp is not None, "Failed to parse File.Stat response: {}".format(msg))
+    resp = gnmi_tls.gnoi.file_stat("/etc/hostname")
 
     stats = resp.get("stats", [])
     pytest_assert(len(stats) == 1, "Expected exactly 1 StatInfo for /etc/hostname")
@@ -287,12 +215,9 @@ def test_gnoi_file_stat_permissions_decimal_octal(
     permissions = int(entry.get("permissions", -1))
     logger.info("File.Stat permissions field value: {}".format(permissions))
 
-    # /etc/hostname is mode 0644; decimal-octal encoding yields 644 (not 420).
     pytest_assert(permissions == 644,
                   "Expected permissions=644 (decimal-octal for mode 0644), got: {} "
                   "(hint: 420 means the old DBus decimal encoding is still in use)".format(permissions))
-
-    # Structural check: all digits must be valid octal (0-7), never 8 or 9.
     pytest_assert(
         all(d in "01234567" for d in str(permissions)),
         "permissions '{}' contains digit 8 or 9 — not a valid decimal-octal value".format(permissions)

--- a/tests/gnmi/test_gnoi_file.py
+++ b/tests/gnmi/test_gnoi_file.py
@@ -190,16 +190,24 @@ def test_gnoi_file_stat_invalid_argument(gnmi_tls, bad_path, reason):  # noqa: F
         )
 
 
-def test_gnoi_file_stat_permissions_decimal_octal(gnmi_tls):  # noqa: F811
+def test_gnoi_file_stat_permissions_decimal_octal(gnmi_tls, duthosts, rand_one_dut_hostname):  # noqa: F811
     """Verify permissions field is encoded as decimal-octal per gNOI proto.
 
     PR #697 contract (statInfoFromFileInfo):
       strconv.FormatUint(uint64(mode.Perm()), 8)  -> octal string e.g. "644"
       strconv.ParseUint(octalStr, 10, 32)          -> decimal int 644
 
-    So mode 0644 -> permissions=644 (NOT 420, which is the raw decimal of 0644).
-    /etc/hostname on SONiC has mode 0644, so the expected value is 644.
+    The expected value is derived dynamically from the DUT so the test
+    verifies the encoding invariant regardless of the file's actual mode.
     """
+    duthost = duthosts[rand_one_dut_hostname]
+    # Get the actual octal mode string from the DUT (e.g. "644")
+    actual_octal = duthost.shell("stat -c %a /etc/hostname")["stdout"].strip()
+    # decimal-octal encoding: the octal string is re-read as a decimal integer
+    expected_permissions = int(actual_octal)
+    logger.info("DUT /etc/hostname mode: octal={} expected_permissions={}".format(
+        actual_octal, expected_permissions))
+
     resp = gnmi_tls.gnoi.file_stat("/etc/hostname")
 
     stats = resp.get("stats", [])
@@ -209,6 +217,13 @@ def test_gnoi_file_stat_permissions_decimal_octal(gnmi_tls):  # noqa: F811
     permissions = int(entry.get("permissions", -1))
     logger.info("File.Stat permissions field value: {}".format(permissions))
 
-    pytest_assert(permissions == 644,
-                  "Expected permissions=644 (decimal-octal for mode 0644), got: {} "
-                  "(hint: 420 means the old DBus decimal encoding is still in use)".format(permissions))
+    pytest_assert(permissions == expected_permissions,
+                  "Expected permissions={} (decimal-octal of mode 0{}) got: {} "
+                  "(hint: {} means raw decimal encoding is in use)".format(
+                      expected_permissions, actual_octal, permissions,
+                      int(actual_octal, 8)))
+    pytest_assert(
+        all(d in "01234567" for d in str(permissions)),
+        "permissions '{}' contains digit 8 or 9 — not a valid decimal-octal value".format(permissions)
+    )
+    


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Adds sonic-mgmt end-to-end tests for the in-house gNOI File.Stat implementation introduced in
sonic-net/sonic-gnmi#697. Tests run over the gnmi TCP transport against a real DUT using
`gnoi_request` / `extract_gnoi_response` (same pattern as `test_gnoi_killprocess.py`) and are
appended to `tests/gnmi/test_gnoi_file.py` without modifying any existing tests.

ADO: 38245965
Parent ADO: 38245952
Parent PR for refernce to build tests: sonic-net/sonic-gnmi#697 (merged)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?

sonic-net/sonic-gnmi#697 replaced the legacy DBus host-service path for `File.Stat` with a
pure-Go in-house implementation using the `/mnt/host` bind mount. The new implementation adds
support for directory listings (non-recursive) and enforces stricter input validation
(`InvalidArgument` for empty / relative / `/mnt/host`-prefixed paths). This PR provides the
corresponding sonic-mgmt e2e test coverage required by ADO #38245965.

#### How did you do it?

Appended 5 new test functions and a `reapply_cert_config` module-scoped fixture to the existing
`tests/gnmi/test_gnoi_file.py`, leaving all original tests untouched:

- **`reapply_cert_config` fixture** — regenerates a consistent TLS cert set (CA + server + client)
  before the new tests run, working around a cert-file mismatch left by the `gnmi_tls` fixture
  teardown (`gnmiserver.key` and `gnmiserver.crt` end up from different CA generations).

- **`test_gnoi_file_stat_regular_file`** — Stats `/etc/hostname`; asserts exactly 1 `StatInfo`,
  path round-trips as `/etc/hostname` (verifies `/mnt/host` prefix is stripped on output), `size > 0`,
  `last_modified > 0` (UnixNano), `permissions` present, `umask == 18` (0022 octal, hardcoded
  `defaultUmask` in PR #697).

- **`test_gnoi_file_stat_directory`** — Stats `/etc/sonic`; asserts the directory itself is **not**
  included in results (key contract: "directory itself is intentionally not included"), all child
  paths start with `/etc/sonic/` (non-recursive), each child has `last_modified`, `permissions`,
  and `umask == 18`.

- **`test_gnoi_file_stat_not_found`** — Stats a non-existent path; asserts `ret != 0` and
  `code = NotFound` in the response.

- **`test_gnoi_file_stat_invalid_argument`** (parametrized: `empty`, `relative`, `mnt-host`) —
  Asserts `code = InvalidArgument` for each of the three invalid input categories defined in
  PR #697's `HandleStat`.

- **`test_gnoi_file_stat_permissions_decimal_octal`** — Stats `/etc/hostname` (mode `0644`);
  asserts `permissions == 644` (decimal-octal encoding per gNOI proto), **not** `420` (the raw
  decimal value that the legacy DBus implementation incorrectly returned).

#### How did you verify/test it?

All 9 tests in `tests/gnmi/test_gnoi_file.py` (2 original + 7 new) were run on testbed
`vms24-t0-7260-2` against DUT `str2-7260cx3-acs-9` (Arista 7260CX3) with the updated
`docker-sonic-gnmi` image (build 1158578, includes sonic-net/sonic-gnmi#697):

```
PASSED  test_file_stat[vrf_default_1]
PASSED  test_file_transfer_to_remote[vrf_default_1]
PASSED  test_gnoi_file_stat_regular_file[vrf_default_1]
PASSED  test_gnoi_file_stat_directory[vrf_default_1]
PASSED  test_gnoi_file_stat_not_found[vrf_default_1]
PASSED  test_gnoi_file_stat_invalid_argument[vrf_default_1-empty]
PASSED  test_gnoi_file_stat_invalid_argument[vrf_default_1-relative]
PASSED  test_gnoi_file_stat_invalid_argument[vrf_default_1-mnt-host]
PASSED  test_gnoi_file_stat_permissions_decimal_octal[vrf_default_1]

9 passed in 723.28s (0:12:03)
```

#### Any platform specific information?

Tested on Arista 7260CX3. Tests use `pytest.mark.topology('any')` and have no
platform-specific dependencies — they require only that the DUT runs a gnmi image
that includes sonic-net/sonic-gnmi#697.

#### Supported testbed topology if it's a new test case?

`any`

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

No documentation update required — this PR only adds test cases for an already-merged
feature (sonic-net/sonic-gnmi#697).
