### PR TITLE
[vm_set]: rebuild stale Python 2 PTF container as Python 3

### DIFF
--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -15,6 +15,18 @@
       ptf_imagetag: "latest"
     when: ptf_imagetag is not defined
 
+  - name: Detect Python major version of the existing ptf container
+    shell: docker exec ptf_{{ vm_set_name }} python -c 'import sys; print(sys.version_info[0])'
+    register: ptf_existing_python_major
+    changed_when: false
+    failed_when: false
+    become: yes
+
+  - name: Use the latest (Python 3) ptf image because the existing container runs Python 2
+    set_fact:
+      ptf_imagetag: "latest"
+    when: ptf_existing_python_major.stdout == "2"
+
   - name: Stop mux simulator
     include_tasks: control_mux_simulator.yml
     vars:
@@ -31,7 +43,9 @@
     include_tasks: ptf_portchannel.yml
     vars:
       ptf_portchannel_action: stop
-    when: "'bmc' not in topo"
+    when:
+      - "'bmc' not in topo"
+      - ptf_existing_python_major.stdout != "2"
     ignore_errors: yes
 
   - name: Kill exabgp and ptf_nn_agent processes in PTF container


### PR DESCRIPTION
### Description of PR

Summary:
`restart-ptf` (`ansible/roles/vm_set/tasks/renumber_topo.yml`) tears down and recreates the PTF container, but its first sub-step `Stop PTF portchannel service` runs an Ansible module **on the existing** PTF container *before* it is removed. When that leftover container was created from an old `docker-ptf` image that only ships Python 2 (e.g. the `internal-202412` tag, Debian 10 / Python 2.7), current ansible-core cannot execute on it and the module dies with `MODULE FAILURE: No start of json char found` / `SyntaxError`, aborting restart-ptf **before** it ever reaches the remove/recreate steps. Because the run never gets to replace the container, the Python-2 container survives and every subsequent restart-ptf hits the same wall. 

The pre-existing `ignore_errors: yes` on the `Stop PTF portchannel service` include does not help: on a dynamic `include_tasks` it does not propagate to the tasks inside the include, so the inner module failure still aborts the play.

ADO work item: https://msazure.visualstudio.com/One/_workitems/edit/38650845

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: https://msazure.visualstudio.com/One/_workitems/edit/38650845
Failure type: stale Python-2 `docker-ptf` image left by the ongoing PTF py2->py3 migration

### Approach
#### What is the motivation for this PR?
Nightly restart-ptf on physical testbeds that carry a stale Python-2 `docker-ptf` container (e.g. `internal-202412`) fails at `Stop PTF portchannel service` and can never self-recover, because the run aborts before it removes/recreates the container. This blocks the affected testbeds indefinitely (observed on the same testbeds for weeks).

#### How did you do it?
In `renumber_topo.yml`, before touching the existing PTF container:
1. Detect the Python major version of the existing container with a read-only probe (`changed_when: false`, `failed_when: false`, so it can never fail the play; returns empty when no container exists).
2. When the existing container is Python 2, force `ptf_imagetag: "latest"` so the recreate pulls a Python-3 image, and skip the `Stop PTF portchannel service` step (the module cannot run on Python 2, and the container is removed and recreated right below anyway).

For every non-Python-2 case (Python 3, no container, probe error) behavior is unchanged — the probe is the only added step and it is a no-op read; `ptf_imagetag` and the stop step run exactly as before.

#### How did you verify/test it?
Failing testplans reproducing the issue (nightly, `RESTART_PTF_FAILED`, `MODULE FAILURE: No start of json char found` at `Stop PTF portchannel`):
- vms71-t0-7060x6-f2-1 (2026-07-03): https://elastictest.org/scheduler/testplan/6a4733c0ff94a6a749d84d6f
- vms71-t1-7060x6-f2-2 (2026-07-03): https://elastictest.org/scheduler/testplan/6a4733c09175b28647bd6b27
- vms71-t1-7060x6-f2-2 (2026-05-29): https://elastictest.org/scheduler/testplan/6a1974bf07bc9a4fe28f145a

Validated the fix on the same testbed: testplan https://elastictest.org/scheduler/testplan/6a4d915508377a690d688529 ran on **vms71-t1-7060x6-f2-2** with branch `sakkhurana/fix-restart-ptf` (containing this change) and **succeeded**. In the reproduction logs restart-ptf detected the Python-2 container, skipped the portchannel stop, and recreated the PTF from `docker-ptf:latest`. Confirmed on the server that `ptf_vms71-2` is now `docker-ptf:latest` with the Python-3 entrypoint (`/root/env-python3`).

#### Any platform specific information?
None. The change is testbed-framework (Ansible) only and applies to physical PTF testbeds.

#### Supported testbed topology if it's a new test case?
N/A (not a test case).

### Documentation
N/A.
