### PR TITLE
Add live-addon docker image upgrade test

### DIFF
--- a/docs/testplan/live_addon_docker_hld.md
+++ b/docs/testplan/live_addon_docker_hld.md
@@ -25,6 +25,7 @@ live in per-ASIC JSON files under `tests/live_addon_docker/files/`.
 | HTTP health endpoint probe from the DUT | Building or publishing docker images |
 | Post-start checks via `verify_live_addon_post_start` (logs and/or supervisord) | Shared tarball distribution between vendors |
 | Optional `version_matrix` skip for image vs SONiC compatibility | |
+| Registry image upgrade test (`test_live_addon_docker_image_upgrade`) | |
 | Registry override per test run (`--live_addon_docker_registry`) | |
 
 **Platform filter:** `asic_type=cisco-8000` only (see
@@ -40,14 +41,19 @@ Post-start validation is **not** duplicated in pytest cases; it runs in the modu
 |------|-----------|
 | `test_live_addon_docker_health_http` | HTTP `/health` returns expected status within probe timeout |
 | `test_live_addon_docker_health_after_config_reload_cycle` | Stop container → `config reload` → `docker run` + full post-start → `config reload` → teardown + `docker run` + restart post-start (120s supervisord) → HTTP health |
+| `test_live_addon_docker_image_upgrade` | Registry pull baseline (`--live_addon_docker_image_tag`) → post-start + health → pull upgrade (`--live_addon_docker_image_upgrade_tag`) → post-start + health (standalone; does not use module fixture) |
 
 **Module fixture** `live_addon_docker_setup_teardown`: install once per module, `docker run`,
 `verify_live_addon_post_start` (full readiness), yield `(duthost, cfg)`, then teardown and
 post-teardown checks.
 
+**Image upgrade test** (`test_live_addon_docker_image_upgrade`) is standalone: it uses
+`live_addon_docker_vendor_cfg_raw`, requires both CLI image tags and registry access, and calls
+`upgrade_live_addon_docker_image` twice (baseline then upgrade).
+
 **Typical runtime (Cisco):** first start may wait up to **900s** for startup logs; config-reload
-cycle adds another full post-start plus a **120s** supervisord poll on restart; HTTP health polls
-up to **900s** when needed.
+cycle adds another full post-start plus a **120s** supervisord poll on restart; upgrade test runs
+two full install cycles; HTTP health polls up to **900s** when needed.
 
 **Topology:** tests are marked `pytest.mark.topology("any")`. Use `-t any` or `-t t1,any` with
 `run_tests.sh` (a bare `-t t1` skips these tests).
@@ -133,14 +139,40 @@ flowchart TD
     P --> Q[Teardown and post checks]
 ```
 
+**Image upgrade test** (`test_live_addon_docker_image_upgrade`) does not use tarball or
+pre-loaded-image fallbacks. It always registry-pulls using explicit CLI tags:
+
+```mermaid
+flowchart TD
+    U0[apply_image_tag_to_config baseline and upgrade tags] --> U0c{same image_ref?}
+    U0c -->|yes| Uskip[pytest.skip]
+    U0c -->|no| U1[registry pull baseline image]
+    U1 --> U2[version_matrix check]
+    U2 --> U3[teardown + rmi stale refs]
+    U3 --> U4[docker run + post-start + HTTP health]
+    U4 -->|run or validation error| Ucleanup[teardown started container and re-raise]
+    U4 --> U5[apply_image_tag_to_config upgrade tag]
+    U5 --> U6[registry pull upgrade image]
+    U6 --> U7[version_matrix check]
+    U7 --> U8[teardown + rmi stale refs keep pulled ref]
+    U8 --> U9[docker run + post-start + HTTP health]
+    U9 -->|run or validation error| Ucleanup
+```
+
+`version_matrix` runs after pull and **before** container teardown during upgrade, so a skip leaves
+the previously running live-addon container in place.
+
 Registry host comes from Ansible `docker_registry_host` or pytest `live_addon_docker_registry`
 (see §7). Tarball path on the DUT is `dut_tarball_home` plus `tarball_filename` from JSON.
 
-**Pull tag selection:**
+**Pull tag selection (module / baseline tests):**
 
-1. `--live_addon_docker_image_tag` if set (CI build id)
+1. `--live_addon_docker_image_tag` if set (baseline / CI build id)
 2. Else tag from `docker_run.image_ref` when not `latest`
 3. Else `duthost.os_version` (same convention as syncd-rpc / `swap_syncd`)
+
+**Image upgrade test** uses `--live_addon_docker_image_tag` for baseline and
+`--live_addon_docker_image_upgrade_tag` for the upgrade pull (both required).
 
 ## 7. Pytest CLI parameters
 
@@ -149,10 +181,11 @@ Registry host comes from Ansible `docker_registry_host` or pytest `live_addon_do
 | `--live-addon-docker-config` | Override path to vendor JSON |
 | `--live-addon-docker-tarball` | Path to `.gz` on the test runner |
 | `--live_addon_docker_registry` | Registry host for pull (overrides Ansible `docker_registry_host` for this module) |
-| `--live_addon_docker_image_tag` | Image tag for pull and `docker_run.image_ref` |
+| `--live_addon_docker_image_tag` | Baseline / module tests: image tag for registry pull and `docker_run.image_ref` |
+| `--live_addon_docker_image_upgrade_tag` | Upgrade test only: target image tag after baseline |
 | `--public_docker_registry` | Use `public_docker_registry_host` without login (same as `swap_syncd`) |
 
-**Example via `run_tests.sh`:**
+**Example via `run_tests.sh` (module tests):**
 
 ```bash
 cd tests
@@ -162,7 +195,15 @@ cd tests
   -t any \
   -c live_addon_docker/test_live_addon_docker.py \
   -i ../ansible/veos \
-  -e "--live_addon_docker_registry=myacr.azurecr.io --live_addon_docker_image_tag=kube-20260527-202505-amd64"
+  -e "--live_addon_docker_registry=myacr.azurecr.io --live_addon_docker_image_tag=baseline-build-001"
+```
+
+**Example (upgrade test):**
+
+```bash
+-e "--live_addon_docker_registry=<ucs-ip>:5000 --public_docker_registry \
+    --live_addon_docker_image_tag=baseline-build-001 \
+    --live_addon_docker_image_upgrade_tag=new-build-002"
 ```
 
 Each vendor or MSFT can point at their own container registry without sharing tarballs.
@@ -265,6 +306,21 @@ Each row may include:
 - Matching row has no `compatible_sonic_globs`
 - DUT SONiC does not match any allowed glob
 
+**Upgrade test skip conditions** (in `test_live_addon_docker_image_upgrade`):
+
+- `pytest.skip` when `--live_addon_docker_image_tag` is omitted (before any DUT steps)
+- `pytest.skip` when `--live_addon_docker_image_upgrade_tag` is omitted (before any DUT steps)
+- `pytest.skip` when baseline and upgrade tags resolve to the same `docker_run.image_ref` (before
+  any DUT steps; compared from config only)
+
+**Upgrade test and `version_matrix`:** `upgrade_live_addon_docker_image` pulls from the registry,
+runs `require_version_matrix_or_skip` on the pulled ref, then tears down the container. If the
+matrix check skips, the prior container (if any) is left running and the test ends without applying
+the incompatible upgrade image.
+
+If `docker run`, post-start validation, or HTTP health raises after a container has been started,
+`upgrade_live_addon_docker_image` tears down that started container before re-raising.
+
 Images built without `com.azure.sonic.manifest` skip until the build pipeline adds standard SONiC
 docker labels.
 
@@ -279,7 +335,32 @@ Example:
 ]
 ```
 
-## 10. Adding a new vendor / ASIC
+## 10. Test cases
+
+Post-start validation is **not** duplicated in pytest cases; it runs in the fixture and inside
+`run_config_reload_live_addon_start_reload_health` on each `docker run`.
+
+| Test | Validates |
+|------|-----------|
+| `test_live_addon_docker_health_http` | HTTP `/health` returns expected status within probe timeout |
+| `test_live_addon_docker_health_after_config_reload_cycle` | Stop container → `config reload` → `docker run` + full post-start → `config reload` → teardown + `docker run` + restart post-start (120s supervisord) → HTTP health |
+| `test_live_addon_docker_image_upgrade` | Registry pull baseline (`--live_addon_docker_image_tag`) → post-start + health → pull upgrade (`--live_addon_docker_image_upgrade_tag`) → post-start + health (standalone; skips without both CLI tags) |
+
+**Module fixture** `live_addon_docker_setup_teardown`: install once per module, `docker run`,
+`verify_live_addon_post_start` (full readiness), yield `(duthost, cfg)`, then teardown and
+post-teardown checks.
+
+**Image upgrade test** uses `live_addon_docker_vendor_cfg_raw` and requires
+`--live_addon_docker_image_tag`, `--live_addon_docker_image_upgrade_tag`, and registry access.
+Each step calls `upgrade_live_addon_docker_image` (registry pull, `version_matrix` check,
+teardown, `docker rmi` of stale refs, `docker run`, post-start, HTTP health). See §9 for skip
+conditions. No `config reload` in this test; default loganalyzer is sufficient.
+
+**Typical runtime (Cisco):** first start may wait up to **900s** for startup logs; config-reload
+cycle adds another full post-start plus a **120s** supervisord poll on restart; upgrade test runs
+two full install cycles; HTTP health polls up to **900s** when needed.
+
+## 11. Adding a new vendor / ASIC
 
 1. Add `tests/live_addon_docker/files/<asic_type>_live_addon_docker.json`.
 2. Set `vendor`, `docker_run.container_name`, `health` port/path, and vendor-specific `cli_args` mounts.
@@ -287,7 +368,7 @@ Example:
 4. Extend `tests_mark_conditions_live_addon_docker.yaml` if the ASIC should not be skipped.
 5. Run with `--live_addon_docker_registry` pointing at the vendor CR.
 
-## 11. Assumptions and constraints
+## 12. Assumptions and constraints
 
 - DUT has Docker and network access to the chosen registry (or a pre-staged image/tarball).
 - Registry credentials come from Ansible `docker_registry_*` in testbed creds unless overridden by CLI.

--- a/tests/live_addon_docker/conftest.py
+++ b/tests/live_addon_docker/conftest.py
@@ -5,7 +5,8 @@ Default path: ``files/<asic_type>_live_addon_docker.json`` (``asic_type`` from t
 Override with ``--live-addon-docker-config``.
 Commands on the DUT are assembled in live_addon_docker_helpers from that JSON only.
 
-Registry and tag at test time: ``--live_addon_docker_registry``, ``--live_addon_docker_image_tag``.
+Registry and tag at test time: ``--live_addon_docker_registry``, ``--live_addon_docker_image_tag`` (baseline /
+module tests), ``--live_addon_docker_image_upgrade_tag`` (upgrade test only).
 """
 
 import logging
@@ -56,8 +57,17 @@ def pytest_addoption(parser):
         action="store",
         default=None,
         help=(
-            "Docker image tag for registry pull and docker_run.image_ref (overrides JSON tag and "
-            "dut os_version for pull). For CI builds, e.g. kube-20260527-202505-amd64."
+            "Docker image tag for baseline / module tests (registry pull and docker_run.image_ref). "
+            "When omitted, registry pull uses dut os_version if image_ref is :latest."
+        ),
+    )
+    parser.addoption(
+        "--live_addon_docker_image_upgrade_tag",
+        action="store",
+        default=None,
+        help=(
+            "Docker image tag for test_live_addon_docker_image_upgrade only (upgrade target after "
+            "baseline --live_addon_docker_image_tag)."
         ),
     )
 
@@ -89,6 +99,23 @@ def live_addon_docker_vendor_cfg(request, duthosts, enum_rand_one_per_hwsku_fron
             cfg["docker_run"]["image_ref"],
         )
     return cfg
+
+
+@pytest.fixture(scope="module")
+def live_addon_docker_vendor_cfg_raw(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    """Vendor JSON from disk without CLI tag overrides (upgrade test applies baseline/upgrade tags)."""
+    opt = request.config.getoption("--live-addon-docker-config")
+    if opt:
+        path = os.path.abspath(opt)
+    else:
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        asic_type = (duthost.facts.get("asic_type") or "").strip()
+        if not asic_type:
+            pytest.fail("DUT asic_type is empty; cannot resolve live-addon docker JSON path")
+        path = lad.default_live_addon_config_path(asic_type)
+    if not os.path.isfile(path):
+        pytest.skip("Live-addon docker config not found: {}".format(path))
+    return lad.load_live_addon_config(path)
 
 
 @pytest.fixture(scope="module")

--- a/tests/live_addon_docker/live_addon_docker_helpers.py
+++ b/tests/live_addon_docker/live_addon_docker_helpers.py
@@ -9,7 +9,8 @@ The JSON must define ``vendor``, ``docker_run`` (``docker load`` if needed, then
 ``docker-live-addon-<vendor>[:tag]`` unless set explicitly (must match ACR repo for registry pull).
 Optional fields: ``tarball_filename``, ``version_matrix``, ``candidate_image_refs``.
 Registry pull uses Ansible ``docker_registry_*`` or pytest ``--live_addon_docker_registry``;
-``--live_addon_docker_image_tag`` overrides pull/run tag. ``--public_docker_registry`` for public host.
+``--live_addon_docker_image_tag`` overrides pull/run tag for baseline and module tests.
+``--live_addon_docker_image_upgrade_tag`` is upgrade-test only. ``--public_docker_registry`` for public host.
 Optional ``version_matrix`` skips when live-addon vs DUT SONiC is not declared compatible
 (see ``require_version_matrix_or_skip``).
 """
@@ -1268,6 +1269,91 @@ def wait_for_health_ready(duthost, health_cfg):
     return last
 
 
+def _require_upgrade_image_tag_applied(cfg):
+    """
+    Ensure ``upgrade_live_addon_docker_image`` was called with config from
+    ``apply_image_tag_to_config`` (explicit CLI tag), not raw JSON defaults.
+    """
+    dr = cfg.get("docker_run") or {}
+    image_tag = (dr.get("image_tag") or "").strip()
+    if not image_tag:
+        pytest.fail(
+            "upgrade_live_addon_docker_image: docker_run.image_tag is required; "
+            "call apply_image_tag_to_config() with --live_addon_docker_image_tag or "
+            "--live_addon_docker_image_upgrade_tag first"
+        )
+    image_ref = (dr.get("image_ref") or "").strip()
+    if not image_ref:
+        pytest.fail("upgrade_live_addon_docker_image: docker_run.image_ref is required")
+    if image_ref_to_tag(image_ref) != image_tag:
+        pytest.fail(
+            "upgrade_live_addon_docker_image: docker_run.image_ref {!r} does not match "
+            "docker_run.image_tag {!r}; call apply_image_tag_to_config() first".format(
+                image_ref, image_tag
+            )
+        )
+
+
+def upgrade_live_addon_docker_image(
+    duthost,
+    cfg,
+    public_docker_registry=False,
+    docker_registry_host_override=None,
+):
+    """
+    Upgrade path: registry-pull ``cfg['docker_run']['image_ref']``, optional ``version_matrix``
+    check, teardown container, remove stale images, ``docker run``, post-start checks, HTTP health.
+
+    Call ``apply_image_tag_to_config`` first (baseline ``--live_addon_docker_image_tag`` or upgrade
+    ``--live_addon_docker_image_upgrade_tag``).
+    Returns ``(cfg_used, (ok, http_code, body))``.
+    """
+    dr = cfg.get("docker_run") or {}
+    _require_upgrade_image_tag_applied(cfg)
+
+    tag = image_ref_to_tag(dr["image_ref"])
+    reg_settings = _live_addon_registry_pull_settings(cfg, registry_image_tag=tag)
+    if reg_settings is None:
+        pytest.fail("upgrade_live_addon_docker_image: cannot build registry pull settings")
+
+    ref = try_registry_pull_live_addon_image(
+        duthost,
+        reg_settings,
+        public_docker_registry=public_docker_registry,
+        docker_registry_host_override=docker_registry_host_override,
+    )
+    if not ref:
+        pytest.fail(
+            "upgrade_live_addon_docker_image: registry pull failed for {!r} "
+            "(registry_host_override={!r})".format(dr["image_ref"], docker_registry_host_override)
+        )
+
+    # Run version_matrix before destructive teardown so pytest.skip leaves the prior
+    # container running when the upgrade image is incompatible.
+    require_version_matrix_or_skip(duthost, cfg, ref)
+
+    docker_manual_teardown(duthost, dr)
+    remove_configured_live_addon_images(duthost, cfg, except_ref=ref)
+
+    cfg_run = copy.deepcopy(cfg)
+    cfg_run["docker_run"]["image_ref"] = ref
+
+    try:
+        docker_run_manual(duthost, cfg_run)
+        verify_live_addon_post_start(duthost, cfg_run)
+        health = wait_for_health_ready(duthost, cfg_run["health"])
+        return cfg_run, health
+    except Exception:
+        try:
+            docker_manual_teardown(duthost, cfg_run["docker_run"])
+        except Exception as exc:
+            logger.warning(
+                "Upgrade helper cleanup failed after start error: %s",
+                exc,
+            )
+        raise
+
+
 def docker_manual_teardown(duthost, docker_run_cfg):
     name = docker_run_cfg["container_name"]
     logger.info("Teardown docker: stop and remove %s", name)
@@ -1275,12 +1361,19 @@ def docker_manual_teardown(duthost, docker_run_cfg):
     duthost.command("sudo docker rm -f {}".format(name), module_ignore_errors=True)
 
 
-def remove_configured_live_addon_images(duthost, cfg):
+def remove_configured_live_addon_images(duthost, cfg, except_ref=None):
     """
     Best-effort ``docker rmi -f`` for ``docker_run.image_ref`` and ``candidate_image_refs``.
     Used immediately before ``docker load`` so the tarball load does not layer on old tags.
+
+    Args:
+        except_ref: Optional image ref to keep (for example the image just pulled during upgrade).
     """
+    keep = (except_ref or "").strip()
     for ref in _image_refs_to_try(cfg):
+        if keep and ref == keep:
+            logger.info("Skipping live-addon image removal (in use): %s", ref)
+            continue
         logger.info("Removing live-addon image before docker load (best-effort): %s", ref)
         duthost.command("sudo docker rmi -f {}".format(ref), module_ignore_errors=True)
 

--- a/tests/live_addon_docker/test_live_addon_docker.py
+++ b/tests/live_addon_docker/test_live_addon_docker.py
@@ -8,10 +8,11 @@ Image resolution (registry first by default, then fallbacks):
 3. **Tarball on test runner** — copy to ``/tmp/`` on DUT
 4. **Image already on DUT** — ``docker image inspect``
 
-Pass ``--live_addon_docker_image_tag`` for CI build tags; ``--live_addon_docker_registry`` per-vendor CR.
+Pass ``--live_addon_docker_image_tag`` for baseline/module tests;
+``--live_addon_docker_image_upgrade_tag`` for the image upgrade test.
 
-Post-start validation (single instance, startup logs or supervisord poll) runs in the module fixture
-and on every ``docker run`` inside helpers — not duplicated in individual tests below.
+Post-start validation runs in the module fixture and on every ``docker run`` inside helpers.
+The image-upgrade test is standalone (does not use the module fixture).
 """
 
 import copy
@@ -26,6 +27,27 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.topology("any"),
 ]
+
+
+def _cli_image_tag(request):
+    val = request.config.getoption("--live_addon_docker_image_tag", default=None)
+    if val and str(val).strip():
+        return str(val).strip()
+    return None
+
+
+def _cli_registry_host(request):
+    val = request.config.getoption("--live_addon_docker_registry", default=None)
+    if val and str(val).strip():
+        return str(val).strip()
+    return None
+
+
+def _cli_image_upgrade_tag(request):
+    val = request.config.getoption("--live_addon_docker_image_upgrade_tag", default=None)
+    if val and str(val).strip():
+        return str(val).strip()
+    return None
 
 
 @pytest.fixture(scope="module")
@@ -85,3 +107,76 @@ def test_live_addon_docker_health_after_config_reload_cycle(
         ok,
         "Health check after config-reload cycle failed: http_code={} body={}".format(code, body),
     )
+
+
+def test_live_addon_docker_image_upgrade(
+    request,
+    duthosts,
+    enum_rand_one_per_hwsku_frontend_hostname,
+    live_addon_docker_vendor_cfg_raw,
+):
+    """
+    Pull baseline image (``--live_addon_docker_image_tag``), start container, then upgrade to
+    ``--live_addon_docker_image_upgrade_tag`` via registry pull and verify post-start + HTTP health.
+
+    Requires registry access (Ansible ``docker_registry_host`` or ``--live_addon_docker_registry``).
+    """
+    baseline_tag = _cli_image_tag(request)
+    upgrade_tag = _cli_image_upgrade_tag(request)
+    if not baseline_tag:
+        pytest.skip("Pass --live_addon_docker_image_tag for baseline live-addon image")
+    if not upgrade_tag:
+        pytest.skip("Pass --live_addon_docker_image_upgrade_tag for upgrade live-addon image")
+
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    cfg_base = live_addon_docker_vendor_cfg_raw
+    pre_cores = lad.get_core_filenames(duthost)
+    public_reg = request.config.getoption("--public_docker_registry")
+    registry_host = _cli_registry_host(request)
+    baseline_cfg = lad.apply_image_tag_to_config(cfg_base, baseline_tag)
+    target_cfg = lad.apply_image_tag_to_config(cfg_base, upgrade_tag)
+    if target_cfg["docker_run"]["image_ref"] == baseline_cfg["docker_run"]["image_ref"]:
+        pytest.skip(
+            "Upgrade tag {!r} matches baseline tag {!r}; use different "
+            "--live_addon_docker_image_upgrade_tag".format(upgrade_tag, baseline_tag)
+        )
+
+    container_started = False
+    try:
+        baseline_cfg, (ok, code, body) = lad.upgrade_live_addon_docker_image(
+            duthost,
+            baseline_cfg,
+            public_docker_registry=public_reg,
+            docker_registry_host_override=registry_host,
+        )
+        container_started = True
+        pytest_assert(
+            ok,
+            "Baseline health check failed before image upgrade: http_code={} body={}".format(
+                code, body
+            ),
+        )
+        logger.info(
+            "Baseline live-addon image installed at %s",
+            baseline_cfg["docker_run"]["image_ref"],
+        )
+
+        target_cfg, (ok, code, body) = lad.upgrade_live_addon_docker_image(
+            duthost,
+            target_cfg,
+            public_docker_registry=public_reg,
+            docker_registry_host_override=registry_host,
+        )
+        pytest_assert(
+            ok,
+            "Health check after image upgrade failed: http_code={} body={}".format(code, body),
+        )
+    finally:
+        if container_started:
+            try:
+                dr = (target_cfg or baseline_cfg or cfg_base).get("docker_run") or {}
+                if dr.get("container_name"):
+                    lad.docker_manual_teardown(duthost, dr)
+            except Exception as exc:
+                logger.warning("Upgrade test teardown command failed: %s", exc)
+            lad.verify_post_teardown(duthost, cfg_base, pre_cores)


### PR DESCRIPTION
### Description of PR

Summary:
Add `test_live_addon_docker_image_upgrade` for live-addon docker image upgrade validation. This PR intentionally has no Jira or `Fixes #` reference.

This adds a standalone upgrade test that pulls a baseline live-addon image with `--live_addon_docker_image_tag`, pulls an upgrade image with `--live_addon_docker_image_upgrade_tag`, starts each image through the existing `docker run` path, and validates post-start checks plus HTTP health.

Why needed:
The existing live-addon tests validate install/start and config-reload behavior, but they do not validate the registry-driven image upgrade path. The new test covers the baseline-to-upgrade flow and hardens skip paths so incompatible or equal tags do not teardown a working container before the test can skip.

Related evidence:
No live-addon runtime log file was present in the local workspace for this PR body. The related source-PR validation snippet from the existing upstream PR shows the intended test was run successfully:

```text
live_addon_docker/test_live_addon_docker.py::test_live_addon_docker_health_http[mth64-m5-2]
live_addon_docker/test_live_addon_docker.py::test_live_addon_docker_health_after_config_reload_cycle[mth64-m5-2]
live_addon_docker/test_live_addon_docker.py::test_live_addon_docker_image_upgrade[mth64-m5-2]
================= 3 passed, 323 warnings in 2349.06s (0:39:09) =================
```

The relevant code-path evidence is in `tests/live_addon_docker/test_live_addon_docker.py`: equal baseline/upgrade tags skip before DUT mutation, and `tests/live_addon_docker/live_addon_docker_helpers.py`: `require_version_matrix_or_skip()` runs before `docker_manual_teardown()` in the upgrade helper.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: N/A
Failure type: other

### Approach
#### What is the motivation for this PR?

Add coverage for live-addon docker image upgrade from a baseline registry tag to a target registry tag.

#### How did you do it?

Added an upgrade-specific CLI option, helper flow, standalone pytest case, and HLD updates. The helper validates explicit image tags, pulls from the configured registry, checks the optional version matrix before teardown, keeps the just-pulled image during cleanup, starts the container, validates post-start state, and checks HTTP health.

#### How did you verify/test it?

Local syntax check:

```bash
PYTHONPYCACHEPREFIX=/private/tmp/pycache-live-addon python3 -m py_compile tests/live_addon_docker/conftest.py tests/live_addon_docker/live_addon_docker_helpers.py tests/live_addon_docker/test_live_addon_docker.py
```

Runtime validation requires a SONiC testbed with a live-addon registry and should be run with baseline and upgrade tags.

#### Any platform specific information?

Uses the existing `files/<asic_type>_live_addon_docker.json` selection. The included vendor JSON is for `cisco-8000`.

#### Supported testbed topology if it's a new test case?

`pytest.mark.topology("any")`, subject to vendor JSON availability and registry access.

### Documentation

Updated `docs/testplan/live_addon_docker_hld.md` with the upgrade flow, CLI options, skip behavior, and coverage.