### PR TITLE
Add vendor utility docker validation tests

### DIFF
--- a/tests/vendor_utility_docker/__init__.py
+++ b/tests/vendor_utility_docker/__init__.py
@@ -1,0 +1,1 @@
+# Vendor utility docker (SONiC application extension) install and validation tests

--- a/tests/vendor_utility_docker/conftest.py
+++ b/tests/vendor_utility_docker/conftest.py
@@ -1,0 +1,182 @@
+"""
+Vendor utility docker tests load a single JSON that defines docker_run, health, and validation.
+
+Default path: ``files/<asic_type>_utility_docker.json`` (``asic_type`` from the enum DUT), for
+example ``files/cisco-8000_utility_docker.json``. Override with ``--utility-docker-config``.
+Commands on the DUT are assembled in utility_docker_helpers from that JSON only.
+"""
+
+import logging
+import os
+
+import pytest
+
+from tests.vendor_utility_docker import utility_docker_helpers as udh
+
+logger = logging.getLogger(__name__)
+
+
+def _cli_image_tag(request):
+    """Registry / image ref tag from pytest (CI build id), if set."""
+    for opt in ("--live_addon_docker_image_tag", "--utility-docker-image-tag"):
+        val = request.config.getoption(opt, default=None)
+        if val and str(val).strip():
+            return str(val).strip()
+    return None
+
+
+def _cli_registry_host(request):
+    """Optional registry host override (same role as live-addon registry CLI)."""
+    for opt in ("--live_addon_docker_registry", "--utility-docker-registry"):
+        val = request.config.getoption(opt, default=None)
+        if val and str(val).strip():
+            return str(val).strip()
+    return None
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--utility-docker-config",
+        action="store",
+        default=None,
+        help=(
+            "Path to vendor utility docker JSON (default: files/<asic_type>_utility_docker.json "
+            "from DUT facts, e.g. files/cisco-8000_utility_docker.json; fails if missing)"
+        ),
+    )
+    parser.addoption(
+        "--utility-docker-tarball",
+        action="store",
+        default=None,
+        help="Full path to the .gz image on the test runner (default: <vendor_utility_docker>/tarball_filename from JSON)",
+    )
+    parser.addoption(
+        "--live_addon_docker_image_tag",
+        action="store",
+        default=None,
+        help=(
+            "Docker image tag for registry pull and docker_run.image_ref (overrides JSON tag and "
+            "dut os_version for pull). Use for CI builds, e.g. kube-20260527-202505-amd64."
+        ),
+    )
+    parser.addoption(
+        "--utility-docker-image-tag",
+        action="store",
+        default=None,
+        help="Alias for --live_addon_docker_image_tag.",
+    )
+    parser.addoption(
+        "--live_addon_docker_registry",
+        action="store",
+        default=None,
+        help="Registry host for utility docker pull (overrides Ansible docker_registry_host).",
+    )
+    parser.addoption(
+        "--utility-docker-registry",
+        action="store",
+        default=None,
+        help="Alias for --live_addon_docker_registry.",
+    )
+
+
+@pytest.fixture(scope="module")
+def utility_docker_vendor_cfg(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    opt = request.config.getoption("--utility-docker-config")
+    if opt:
+        path = os.path.abspath(opt)
+    else:
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        asic_type = (duthost.facts.get("asic_type") or "").strip()
+        if not asic_type:
+            pytest.fail("DUT asic_type is empty; cannot resolve vendor utility docker JSON path")
+        path = udh.default_vendor_config_path(asic_type)
+        logger.info(
+            "utility_docker_vendor_cfg: using default from asic_type=%s -> %s",
+            asic_type,
+            path,
+        )
+    if not os.path.isfile(path):
+        pytest.fail("Vendor utility docker config not found: {}".format(path))
+    cfg = udh.load_vendor_config(path)
+    tag = _cli_image_tag(request)
+    if tag:
+        cfg = udh.apply_image_tag_to_config(cfg, tag)
+        logger.info("utility_docker_vendor_cfg: image tag overridden by CLI -> %s", cfg["docker_run"]["image_ref"])
+    return cfg
+
+
+@pytest.fixture(scope="module")
+def utility_docker_vendor_cfg_raw(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    """Vendor JSON from disk without CLI image-tag override (used for upgrade baseline)."""
+    opt = request.config.getoption("--utility-docker-config")
+    if opt:
+        path = os.path.abspath(opt)
+    else:
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        asic_type = (duthost.facts.get("asic_type") or "").strip()
+        if not asic_type:
+            pytest.fail("DUT asic_type is empty; cannot resolve vendor utility docker JSON path")
+        path = udh.default_vendor_config_path(asic_type)
+    if not os.path.isfile(path):
+        pytest.fail("Vendor utility docker config not found: {}".format(path))
+    return udh.load_vendor_config(path)
+
+
+@pytest.fixture(scope="module")
+def utility_docker_local_tarball_optional(request, utility_docker_vendor_cfg):
+    """
+    Path to .gz on the test runner if that file exists; otherwise None.
+    Resolution on the DUT (image already loaded vs ~/ vs copy) is done in
+    utility_docker_install_source — same idea as swap_syncd using local docker images.
+    """
+    override = request.config.getoption("--utility-docker-tarball")
+    local_path = udh.resolve_local_tarball_path(utility_docker_vendor_cfg, udh.MODULE_DIR, override)
+    if os.path.isfile(local_path):
+        logger.info("Utility docker tarball on test runner: %s", local_path)
+        return local_path
+    logger.info(
+        "No utility tarball on test runner at %s — will use image or tarball on DUT if present",
+        local_path,
+    )
+    return None
+
+
+@pytest.fixture(scope="module")
+def utility_docker_install_source(
+    request,
+    duthosts,
+    enum_rand_one_per_hwsku_frontend_hostname,
+    utility_docker_vendor_cfg,
+    utility_docker_local_tarball_optional,
+):
+    """
+    Decide install source (priority; registry first when configured, same Ansible creds as swap_syncd):
+    1) registry pull on DUT (docker pull + tag); use --public_docker_registry like swap_syncd for public host
+    2) tarball under admin home on DUT (~/tarball_filename)
+    3) tarball on test runner (copy to /tmp on DUT)
+    4) image already on DUT (docker image inspect)
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    public_reg = request.config.getoption("--public_docker_registry")
+    registry_host = _cli_registry_host(request)
+    res = udh.resolve_utility_install_source(
+        duthost,
+        utility_docker_vendor_cfg,
+        utility_docker_local_tarball_optional,
+        public_docker_registry=public_reg,
+        registry_image_tag=_cli_image_tag(request),
+        registry_host_override=registry_host,
+    )
+    if res.kind == "none":
+        pytest.skip(
+            "Utility docker not available: no matching image on DUT, no tarball at {}, "
+            "and no tarball on the test runner. Pre-load the image (`docker load`), copy "
+            "{1} to the DUT home dir, place {1} under tests/vendor_utility_docker/ on the test "
+            "runner, pass --utility-docker-tarball, or ensure docker_registry_host in Ansible creds "
+            "for registry pull (or omit docker_registry_host so registry is skipped and use a tarball / local image)."
+            .format(udh.dut_home_tarball_path(utility_docker_vendor_cfg), utility_docker_vendor_cfg["tarball_filename"])
+        )
+    if res.kind == "runner_tarball":
+        duthost.copy(src=utility_docker_local_tarball_optional, dest=res.remote_tarball_path)
+    logger.info("utility_docker_install_source: kind=%s", res.kind)
+    yield duthost, res

--- a/tests/vendor_utility_docker/files/README.txt
+++ b/tests/vendor_utility_docker/files/README.txt
@@ -1,0 +1,78 @@
+Vendor JSON files in this directory
+====================================
+
+- cisco-8000_utility_docker.json — default when DUT ``asic_type`` is ``cisco-8000``
+  (``files/<asic_type>_utility_docker.json``).
+
+Other ASICs: add ``files/<asic_type>_utility_docker.json`` or pass:
+
+  --utility-docker-config tests/vendor_utility_docker/files/myvendor_utility_docker.json
+
+CI image tag and registry (pytest)
+----------------------------------
+
+  --live_addon_docker_image_tag <tag>
+  --live_addon_docker_registry <host>
+
+Aliases: ``--utility-docker-image-tag``, ``--utility-docker-registry``.
+
+The tag overrides ``docker_run.image_ref`` in JSON and is used for ``docker pull`` (instead of
+``duthost.os_version`` when set). Example::
+
+  pytest tests/vendor_utility_docker/ ... \
+    --live_addon_docker_image_tag=kube-20260527-202505-amd64
+
+``test_utility_docker_image_upgrade`` requires ``--live_addon_docker_image_tag``: baseline pull
+uses DUT ``os_version``; upgrade pull uses the CLI tag.
+
+Command lines executed on the DUT are built only from vendor JSON (see utility_docker_helpers.py).
+After tests, cleanup verification (cores, syslog, container gone) is implemented in code, not in JSON.
+
+Registry pull (docker pull on DUT, same config as syncd-rpc)
+-------------------------------------------------------------
+
+**By default** a registry pull runs **first** (no extra keys in vendor JSON). It uses the same
+Ansible ``docker_registry_host`` / ``docker_registry_username`` / ``docker_registry_password`` as
+``swap_syncd`` (see ``tests.common.system_utils.docker.load_docker_registry_info``). Pull ref is
+``{docker_registry_host}/{repository}:{duthost.os_version}`` where ``repository`` is parsed from
+``docker_run.image_ref`` (text before the last ``:``), matching the tag convention used for RPC
+images. Then ``docker tag`` to ``docker_run.image_ref`` when the pulled ref differs.
+
+If pull or tag fails or ``docker_registry_host`` is unset (registry step skipped), the framework
+falls back to a tarball on the DUT, tarball on the test runner, then an image already on the DUT.
+
+Pass pytest ``--public_docker_registry`` to pull from ``public_docker_registry_host`` without
+registry login, same as the QoS ``swap_syncd`` path (``tests/conftest.py``).
+
+Optional version_matrix (log only; tests are not skipped on mismatch)
+---------------------------------------------------------------------
+
+Omit the key, use null, or [] to disable. The check runs after the image is on the DUT
+(``docker load`` or already present) and before ``docker run``, using ``docker image inspect``
+(full JSON, no fragile ``-f`` templates).
+
+Each row may filter the **utility** side by any combination of (both use the same metadata
+string, not the Docker ``:tag``):
+
+- ``utility_image_version_glob`` — fnmatch on ``package.version`` from label ``com.azure.sonic.manifest``.
+- ``utility_package_version_glob`` — fnmatch on the same ``package.version`` value.
+
+Omit a key to skip that dimension. If either glob key is set but the manifest / ``package.version``
+is missing, that row does not match.
+
+**SONiC** side: ``compatible_sonic_globs`` are matched (fnmatch) against ``duthost.os_version``,
+``duthost.sonic_release``, and the first line of ``show version``. Trains like ``202411``,
+``202505`` in builds such as ``SONiC.azure_cisco_202411.39653-dirty-...`` are matched with
+globs like ``202411*``, ``202505*``.
+
+Examples::
+
+  "version_matrix": [
+    {
+      "utility_package_version_glob": "202405*",
+      "compatible_sonic_globs": ["202411*", "202505*"]
+    }
+  ]
+
+Mismatch is logged only; tests continue. For skip-on-mismatch behavior see live-addon
+(``tests/live_addon_docker/`` and ``require_version_matrix_or_skip``).

--- a/tests/vendor_utility_docker/files/cisco-8000_utility_docker.json
+++ b/tests/vendor_utility_docker/files/cisco-8000_utility_docker.json
@@ -1,0 +1,40 @@
+{
+  "vendor": "cisco",
+  "description": "Cisco utility docker (docker-cisco-utility) for Cisco 8000 ASIC. By default docker pull from the same Ansible docker_registry_* registry as syncd-rpc (repository from docker_run.image_ref, tag dut os_version); use pytest --public_docker_registry for public host like swap_syncd. On failure or unset docker_registry_host, DUT tarball, runner tarball, or image on DUT. No sonic-package-manager or config feature. Pass --utility-docker-config for other JSON files.",
+  "tarball_filename": "docker-cisco-utility.gz",
+  "dut_tarball_home": "/home/admin",
+  "candidate_image_refs": [],
+  "version_matrix": [
+    {
+      "utility_package_version_glob": "202405*",
+      "compatible_sonic_globs": ["202411*", "202505*"]
+    }
+  ],
+  "docker_run": {
+    "image_ref": "docker-cisco-utility:latest",
+    "container_name": "cisco-utility",
+    "cli_args": [
+      "-t",
+      "--privileged",
+      "--pid=host",
+      "-v", "/:/hostroot:rw",
+      "-v", "/opt/cisco:/opt/cisco",
+      "--tmpfs", "/tmp/",
+      "--net=host",
+      "--log-opt", "max-size=2M",
+      "--log-opt", "max-file=5"
+    ]
+  },
+  "health": {
+    "port": 50180,
+    "url_path": "/health",
+    "bind_host": "127.0.0.1",
+    "expect_http_code": 200,
+    "wait_seconds_before_check": 0,
+    "probe_interval_seconds": 30,
+    "probe_timeout_seconds": 900
+  },
+  "validation": {
+    "docker_container_name": "cisco-utility"
+  }
+}

--- a/tests/vendor_utility_docker/test_utility_docker.py
+++ b/tests/vendor_utility_docker/test_utility_docker.py
@@ -1,0 +1,187 @@
+"""
+Install and validate a vendor utility docker via ``docker run`` (no sonic-package-manager).
+
+Image resolution (registry first by default, then fallbacks; same ``docker_registry_*`` Ansible
+creds as ``swap_syncd`` / ``tests.common.system_utils.docker``):
+
+1. **Registry** — ``docker pull`` then ``docker tag`` to ``docker_run.image_ref`` (same Ansible
+   ``docker_registry_*`` as syncd-rpc; use ``--public_docker_registry`` for public host, same as swap_syncd).
+2. **Tarball on DUT** — ``/home/admin/<tarball_filename>`` — ``sudo docker load -i`` then ``docker run``.
+3. **Tarball on test runner** — copy to ``/tmp/`` on DUT, then ``docker load -i`` and ``docker run``.
+4. **Image already on DUT** — ``docker image inspect`` on ``docker_run.image_ref`` / ``candidate_image_refs``.
+
+Before install: any existing utility container is stopped and removed; if a tarball will be loaded,
+configured utility images are removed so ``docker load`` starts clean.
+
+If none of the above apply, tests skip.
+"""
+
+import copy
+import logging
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.dut_utils import is_container_running
+from tests.vendor_utility_docker import utility_docker_helpers as udh
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology("any"),
+]
+
+
+@pytest.fixture(scope="module")
+def utility_docker_setup_teardown(utility_docker_install_source, utility_docker_vendor_cfg):
+    duthost, src = utility_docker_install_source
+    cfg0 = utility_docker_vendor_cfg
+    pre_cores = udh.get_core_filenames(duthost)
+    cfg = None
+
+    try:
+        udh.prepare_utility_docker_install(duthost, cfg0, src)
+        if src.kind == "image_present":
+            ref = src.image_ref
+            cfg = copy.deepcopy(cfg0)
+            cfg["docker_run"]["image_ref"] = ref
+        else:
+            remote_tarball = src.remote_tarball_path
+            load_out = udh.docker_load(duthost, remote_tarball)
+            ref = udh.parse_image_from_docker_load(load_out)
+            cfg = copy.deepcopy(cfg0)
+            if ref:
+                cfg["docker_run"]["image_ref"] = ref
+
+        udh.log_version_matrix_compatibility(duthost, cfg0, cfg["docker_run"]["image_ref"])
+        udh.docker_run_manual(duthost, cfg)
+        cname = (cfg.get("docker_run") or {}).get("container_name")
+        if cname:
+            udh.verify_utility_container_startup_logs(duthost, cname)
+            udh.verify_utility_container_processes(duthost, cname)
+
+        yield duthost, cfg
+
+    finally:
+        try:
+            if cfg is not None:
+                udh.docker_manual_teardown(duthost, cfg["docker_run"])
+        except Exception as exc:
+            logger.warning("Teardown command failed (cleanup checks still run): %s", exc)
+        udh.verify_post_teardown(duthost, cfg if cfg is not None else cfg0, pre_cores)
+
+
+def test_utility_docker_image_and_container(utility_docker_setup_teardown):
+    duthost, cfg = utility_docker_setup_teardown
+    val = cfg.get("validation", {})
+    cname = val.get("docker_container_name", cfg.get("docker_run", {}).get("container_name"))
+    if cname:
+        pytest_assert(
+            is_container_running(duthost, cname),
+            "Container {!r} is not running (expected it running). Check docker logs on the DUT.".format(cname),
+        )
+
+
+def test_utility_docker_health_http(utility_docker_setup_teardown):
+    duthost, cfg = utility_docker_setup_teardown
+    health = cfg["health"]
+    ok, code, body = udh.wait_for_health_ready(duthost, health)
+    pytest_assert(ok, "Health check failed: http_code={} body={}".format(code, body))
+
+
+def test_utility_docker_health_after_config_reload_cycle(
+    utility_docker_setup_teardown, loganalyzer
+):
+    """
+    Config reload, wait (see ``CONFIG_RELOAD_UTILITY_CYCLE_WAIT_SECONDS``), start utility via
+    ``docker run``, config reload again, then validate HTTP health.
+    """
+    duthost, cfg = utility_docker_setup_teardown
+    ok, code, body = udh.run_config_reload_utility_start_reload_health(
+        duthost, cfg, loganalyzer=loganalyzer
+    )
+    pytest_assert(
+        ok,
+        "Health check after config-reload cycle failed: http_code={} body={}".format(code, body),
+    )
+
+
+def _cli_image_tag(request):
+    for opt in ("--live_addon_docker_image_tag", "--utility-docker-image-tag"):
+        val = request.config.getoption(opt, default=None)
+        if val and str(val).strip():
+            return str(val).strip()
+    return None
+
+
+def _cli_registry_host(request):
+    for opt in ("--live_addon_docker_registry", "--utility-docker-registry"):
+        val = request.config.getoption(opt, default=None)
+        if val and str(val).strip():
+            return str(val).strip()
+    return None
+
+
+def test_utility_docker_image_upgrade(
+    request,
+    duthosts,
+    enum_rand_one_per_hwsku_frontend_hostname,
+    utility_docker_vendor_cfg_raw,
+):
+    """
+    Pull baseline image (DUT ``os_version`` tag), start container, then upgrade to
+    ``--live_addon_docker_image_tag`` via registry pull and verify health/processes/logs.
+
+    Requires registry access (Ansible ``docker_registry_host`` or ``--live_addon_docker_registry``).
+    """
+    target_tag = _cli_image_tag(request)
+    if not target_tag:
+        pytest.skip(
+            "Pass --live_addon_docker_image_tag (or --utility-docker-image-tag) to run upgrade test"
+        )
+
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    cfg_base = utility_docker_vendor_cfg_raw
+    pre_cores = udh.get_core_filenames(duthost)
+    public_reg = request.config.getoption("--public_docker_registry")
+    registry_host = _cli_registry_host(request)
+    baseline_cfg = None
+    target_cfg = None
+
+    try:
+        baseline_cfg = udh.apply_image_tag_to_config(cfg_base, duthost.os_version)
+        udh.prepare_utility_docker_install(
+            duthost, baseline_cfg, udh.InstallSource("image_present", None, None)
+        )
+        baseline_cfg, _ = udh.upgrade_utility_docker_image(
+            duthost,
+            baseline_cfg,
+            public_docker_registry=public_reg,
+            registry_host_override=registry_host,
+        )
+        logger.info("Baseline utility image installed at %s", baseline_cfg["docker_run"]["image_ref"])
+
+        target_cfg = udh.apply_image_tag_to_config(cfg_base, target_tag)
+        if target_cfg["docker_run"]["image_ref"] == baseline_cfg["docker_run"]["image_ref"]:
+            pytest.skip(
+                "Upgrade target tag {!r} matches baseline os_version tag; pick a different "
+                "--live_addon_docker_image_tag".format(target_tag)
+            )
+
+        target_cfg, (ok, code, body) = udh.upgrade_utility_docker_image(
+            duthost,
+            target_cfg,
+            public_docker_registry=public_reg,
+            registry_host_override=registry_host,
+        )
+        pytest_assert(
+            ok,
+            "Health check after image upgrade failed: http_code={} body={}".format(code, body),
+        )
+    finally:
+        try:
+            dr = (target_cfg or baseline_cfg or cfg_base).get("docker_run") or {}
+            if dr.get("container_name"):
+                udh.docker_manual_teardown(duthost, dr)
+        except Exception as exc:
+            logger.warning("Upgrade test teardown command failed: %s", exc)
+        udh.verify_post_teardown(duthost, cfg_base, pre_cores)

--- a/tests/vendor_utility_docker/utility_docker_helpers.py
+++ b/tests/vendor_utility_docker/utility_docker_helpers.py
@@ -1,0 +1,922 @@
+"""Helpers for loading, installing, and validating vendor utility docker images on the DUT.
+
+Commands run on the DUT are built only from the vendor JSON (see ``files/*.json``).
+Default path: ``files/<asic_type>_utility_docker.json`` (``asic_type`` from DUT facts, e.g.
+``files/cisco-8000_utility_docker.json``). Override with ``--utility-docker-config``.
+
+The JSON must define ``docker_run`` (``docker load`` if needed, then ``docker run``), ``health``,
+and ``validation`` (container name for checks). Optional fields: ``tarball_filename``, ``version_matrix``.
+Registry pull (on by default when ``docker_registry_host`` is set) uses the same Ansible
+``docker_registry_*`` fields as ``swap_syncd``; pass pytest ``--public_docker_registry`` to use
+``public_docker_registry_host`` with no login, same as the QoS swap_syncd path.
+Optional ``version_matrix`` lists compatible pairs of utility ``package.version`` (from image label
+``com.azure.sonic.manifest``) vs SONiC trains (see ``log_version_matrix_compatibility``; log only).
+Container running / name lists use shared helpers
+(``tests.common.helpers.dut_utils.is_container_running``, ``SonicHost.get_all_containers``).
+Post-install teardown checks (no new cores, container removed, syslog grep) are fixed in this module.
+"""
+
+import collections
+import copy
+import fnmatch
+import json
+import logging
+import os
+import re
+import shlex
+import time
+
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.dut_utils import creds_on_dut, is_container_running
+from tests.common.system_utils.docker import download_image, load_docker_registry_info
+from tests.common.utilities import wait_until
+
+logger = logging.getLogger(__name__)
+
+MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# Expected utility container processes (supervisord stack).
+UTILITY_CONTAINER_EXPECTED_PROCESSES = (
+    "supervisord",
+    "start.sh",
+    "health_monitor",
+    "health_server",
+)
+
+# SONiC DUT default login home (same idea as admin $HOME for pre-staged tarballs)
+DUT_ADMIN_HOME = "/home/admin"
+
+# Post-teardown checks (always on; not configurable via vendor JSON)
+_DEFAULT_SYSLOG_TAIL_LINES = 400
+_DOCKER_RUN_UP_TIMEOUT = 120
+_DOCKER_RUN_UP_INTERVAL = 3
+_DEFAULT_SYSLOG_ERROR_PATTERN = (
+    "(segfault|SIGSEGV|SIGABRT|Out of memory|oom-kill|FATAL|panic)"
+)
+
+# Used by ``run_config_reload_utility_start_reload_health``: pause after first reload before ``docker run``.
+CONFIG_RELOAD_UTILITY_CYCLE_WAIT_SECONDS = 60
+
+InstallSource = collections.namedtuple(
+    "InstallSource", ["kind", "remote_tarball_path", "image_ref"]
+)
+# kind: "image_present" | "dut_home_tarball" | "runner_tarball" | "none"
+# Registry installs use kind "image_present" after pull+tag (see try_registry_pull_utility_image).
+
+
+def default_vendor_config_path(asic_type):
+    """
+    Return absolute path to ``files/<asic_type>_utility_docker.json`` under this package.
+
+    ``asic_type`` is typically ``duthost.facts['asic_type']`` (e.g. ``cisco-8000``).
+    """
+    name = (asic_type or "").strip()
+    if not name:
+        raise ValueError("asic_type is empty")
+    return os.path.abspath(os.path.join(MODULE_DIR, "files", "{}_utility_docker.json".format(name)))
+
+
+def load_vendor_config(config_path):
+    """Load vendor JSON parameters."""
+    with open(config_path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def apply_image_tag_to_config(cfg, image_tag):
+    """
+    Return a copy of ``cfg`` with ``docker_run.image_ref`` tag replaced by ``image_tag``.
+
+    Repository (text before the last ``:``) is unchanged.
+    """
+    tag = (image_tag or "").strip()
+    if not tag:
+        return cfg
+    out = copy.deepcopy(cfg)
+    dr = out.get("docker_run") or {}
+    ref = (dr.get("image_ref") or "").strip()
+    repo = _image_repository_from_image_ref(ref) or ref
+    dr["image_ref"] = "{}:{}".format(repo, tag)
+    out["docker_run"] = dr
+    return out
+
+
+def image_ref_to_tag(image_ref):
+    """Return the tag or digest label after ':' in a docker image ref, or 'latest' if missing."""
+    if not image_ref or not isinstance(image_ref, str):
+        return "latest"
+    ref = image_ref.strip()
+    if ":" in ref:
+        return ref.split(":")[-1].strip()
+    return "latest"
+
+
+def utility_image_tag_for_matrix(cfg, install_source):
+    """
+    Docker image ref tag (part after ``:``), for logging / resolution only.
+
+    ``version_matrix`` uses ``package.version`` from image metadata, not this tag.
+
+    If the image is already on the DUT, use that ref's tag. Otherwise use docker_run.image_ref
+    (expected tag after docker load).
+    """
+    if install_source.kind == "image_present" and install_source.image_ref:
+        return image_ref_to_tag(install_source.image_ref)
+    dr = cfg.get("docker_run") or {}
+    return image_ref_to_tag(dr.get("image_ref", ""))
+
+
+def sonic_matches_sonic_glob(duthost, glob_pattern):
+    """
+    True if DUT ``os_version``, ``sonic_release``, or ``show version`` one-liner matches glob.
+
+    Trains like ``202411``, ``202505`` appear in strings such as
+    ``SONiC.azure_cisco_202411.39653-dirty-...`` or ``202411.1.2.3.4``; globs like ``202411*``
+    match the full ``os_version`` line.
+    """
+    if fnmatch.fnmatch(duthost.os_version, glob_pattern):
+        return True
+    sr = getattr(duthost, "sonic_release", None)
+    if sr and fnmatch.fnmatch(str(sr), glob_pattern):
+        return True
+    try:
+        ver_line = duthost.shell("show version | head -1", module_ignore_errors=True).get("stdout", "")
+        if ver_line.strip() and fnmatch.fnmatch(ver_line.strip(), glob_pattern):
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def get_docker_image_config_labels(duthost, image_ref):
+    """
+    Return ``Config.Labels`` from ``docker image inspect`` (full JSON, no Go ``-f`` templates).
+
+    Azure/Cisco utility images often set ``com.azure.sonic.manifest`` (JSON string) and ``Tag``.
+    """
+    if not image_ref or not str(image_ref).strip():
+        return {}
+    qref = shlex.quote(str(image_ref).strip())
+    out = duthost.shell("sudo docker image inspect {}".format(qref), module_ignore_errors=True)
+    if out.get("rc") != 0:
+        logger.warning("docker image inspect failed for %s: %s", image_ref, out.get("stderr", ""))
+        return {}
+    try:
+        data = json.loads(out["stdout"])
+        if not data:
+            return {}
+        return data[0].get("Config", {}).get("Labels") or {}
+    except (ValueError, TypeError, KeyError, IndexError) as exc:
+        logger.warning("Could not parse docker image inspect JSON for %s: %s", image_ref, exc)
+        return {}
+
+
+def package_version_from_azure_sonic_manifest_labels(labels):
+    """
+    Parse ``package.version`` from label ``com.azure.sonic.manifest`` (JSON), e.g. ``202405.1.0-0``.
+    """
+    if not labels:
+        return None
+    raw = labels.get("com.azure.sonic.manifest")
+    if not raw or not isinstance(raw, str):
+        return None
+    try:
+        manifest = json.loads(raw)
+        pkg = manifest.get("package") or {}
+        ver = pkg.get("version")
+        return str(ver).strip() if ver is not None else None
+    except (ValueError, TypeError, AttributeError):
+        return None
+
+
+def tag_label_from_image_labels(labels):
+    """Optional ``Tag`` label on the image (e.g. build id string)."""
+    if not labels:
+        return None
+    t = labels.get("Tag")
+    return str(t).strip() if t else None
+
+
+def _version_matrix_row_matches_utility(row, package_version):
+    """
+    Row may filter by ``utility_image_version_glob`` and/or ``utility_package_version_glob``.
+
+    Both keys apply to ``package.version`` parsed from label ``com.azure.sonic.manifest`` (not the
+    Docker image ``:tag``). If a key is set but ``package_version`` is missing, the row does not
+    match.
+    """
+    if "utility_image_version_glob" in row and row["utility_image_version_glob"] is not None:
+        if not package_version:
+            return False
+        if not fnmatch.fnmatch(package_version, row["utility_image_version_glob"]):
+            return False
+    if "utility_package_version_glob" in row and row["utility_package_version_glob"] is not None:
+        if not package_version:
+            return False
+        if not fnmatch.fnmatch(package_version, row["utility_package_version_glob"]):
+            return False
+    return True
+
+
+def log_version_matrix_compatibility(duthost, cfg, resolved_image_ref):
+    """
+    Optional JSON ``version_matrix``: log utility vs DUT SONiC compatibility; never skip or fail.
+
+    Images without ``com.azure.sonic.manifest`` / ``package.version`` (e.g. SONIC_SIMPLE_DOCKER_IMAGES
+    builds) log a warning and tests continue. Call after the image is on the DUT and before
+    ``docker run``.
+    """
+    matrix = cfg.get("version_matrix")
+    if not matrix:
+        return
+
+    labels = get_docker_image_config_labels(duthost, resolved_image_ref)
+    utility_tag = image_ref_to_tag(resolved_image_ref)
+    package_ver = package_version_from_azure_sonic_manifest_labels(labels)
+    manifest_raw = (labels or {}).get("com.azure.sonic.manifest")
+
+    if package_ver is None:
+        logger.warning(
+            "version_matrix: image %r has no package.version from com.azure.sonic.manifest "
+            "(manifest label present=%s, docker tag=%r). Tests continue; add SONiC manifest labels "
+            "to the image build for matrix matching.",
+            resolved_image_ref,
+            bool(manifest_raw),
+            utility_tag,
+        )
+
+    matching_rows = []
+    for row in matrix:
+        if _version_matrix_row_matches_utility(row, package_ver):
+            matching_rows.append(row)
+
+    if not matching_rows:
+        logger.warning(
+            "version_matrix: no row matches package.version=%r (image ref %r, ref tag=%r, "
+            "labels Tag=%r). Tests continue.",
+            package_ver,
+            resolved_image_ref,
+            utility_tag,
+            tag_label_from_image_labels(labels),
+        )
+        return
+
+    allowed = []
+    for row in matching_rows:
+        allowed.extend(row.get("compatible_sonic_globs") or [])
+
+    if not allowed:
+        logger.warning(
+            "version_matrix: matching row has no compatible_sonic_globs (package.version=%r). "
+            "Tests continue.",
+            package_ver,
+        )
+        return
+
+    if any(sonic_matches_sonic_glob(duthost, g) for g in allowed):
+        logger.info(
+            "version_matrix: compatible (package.version=%r, os_version=%r, allowed=%s)",
+            package_ver,
+            duthost.os_version,
+            allowed,
+        )
+        return
+
+    logger.warning(
+        "version_matrix: DUT SONiC not listed as compatible: os_version=%r sonic_release=%r; "
+        "package.version=%r (ref tag=%r); allowed sonic globs: %s. Tests continue.",
+        duthost.os_version,
+        getattr(duthost, "sonic_release", ""),
+        package_ver,
+        utility_tag,
+        allowed,
+    )
+
+
+def require_version_matrix_or_skip(duthost, cfg, resolved_image_ref):
+    """Backward-compatible alias: only logs (no skip)."""
+    log_version_matrix_compatibility(duthost, cfg, resolved_image_ref)
+
+
+def _image_refs_to_try(cfg):
+    """Names/tags to match swap_syncd-style 'already on DUT' behavior (docker image inspect)."""
+    refs = []
+    dr = cfg.get("docker_run") or {}
+    if dr.get("image_ref"):
+        refs.append(dr["image_ref"].strip())
+    for extra in cfg.get("candidate_image_refs", []):
+        ex = extra.strip()
+        if ex and ex not in refs:
+            refs.append(ex)
+    return refs
+
+
+def find_existing_utility_image(duthost, cfg):
+    """
+    Return first image ref that exists in local docker storage on the DUT, or None.
+    Same idea as swap_syncd checking `docker image inspect docker-syncd-<vendor>-rpc`.
+    """
+    for ref in _image_refs_to_try(cfg):
+        if image_exists(duthost, ref):
+            logger.info("Found existing utility image on DUT: %s", ref)
+            return ref
+    return None
+
+
+def dut_home_tarball_path(cfg):
+    """Path under admin home for a pre-copied .gz (e.g. ~/docker-cisco-utility.gz)."""
+    name = cfg.get("tarball_filename")
+    if not name:
+        raise ValueError("vendor config must set tarball_filename")
+    home = cfg.get("dut_tarball_home", DUT_ADMIN_HOME)
+    return os.path.join(home, name)
+
+
+def dut_file_exists(duthost, path):
+    return duthost.command("sudo test -f {}".format(path), module_ignore_errors=True)["rc"] == 0
+
+
+def _image_repository_from_image_ref(image_ref):
+    """Return repository part before the last ':' in ``name:tag``; ``image_ref`` if no colon."""
+    ref = (image_ref or "").strip()
+    if not ref:
+        return None
+    pos = ref.rfind(":")
+    if pos <= 0:
+        return ref
+    return ref[:pos].strip()
+
+
+def _utility_registry_pull_settings(cfg, registry_image_tag=None):
+    """
+    Return settings for a utility image ``docker pull`` using the same registry as syncd-rpc
+    (``docker_registry_host`` / login from ``creds_on_dut``). No separate vendor JSON for the registry.
+
+    Pull uses repository from ``docker_run.image_ref`` (text before the last ``:``). Tag is
+    ``registry_image_tag`` when set (CLI / JSON ``docker_run.image_ref``), else ``duthost.os_version``
+    at pull time (same convention as ``swap_syncd`` / ``download_image`` for RPC images).
+
+    Returns None when ``docker_run.image_ref`` is missing.
+    """
+    dr = cfg.get("docker_run") or {}
+    target_ref = (dr.get("image_ref") or "").strip()
+    if not target_ref:
+        return None
+
+    image_name = _image_repository_from_image_ref(target_ref)
+    if not image_name:
+        logger.warning("utility registry pull: cannot parse repository from docker_run.image_ref")
+        return None
+
+    tag_override = (registry_image_tag or "").strip() or image_ref_to_tag(target_ref)
+    if tag_override == "latest" and registry_image_tag is None:
+        image_version = None
+    else:
+        image_version = tag_override
+
+    return {"image_name": image_name, "image_version": image_version, "target_ref": target_ref}
+
+
+def resolve_utility_install_source(
+    duthost,
+    cfg,
+    local_runner_tarball_path,
+    public_docker_registry=False,
+    registry_image_tag=None,
+    registry_host_override=None,
+):
+    """
+    Resolve where to get the image from.
+
+    **Registry is tried first** when ``docker_run.image_ref`` is set and Ansible defines
+    ``docker_registry_host`` (after applying ``public_docker_registry`` the same way as
+    ``swap_syncd``: host becomes ``public_docker_registry_host``, username/password cleared).
+    Image name is derived from ``docker_run.image_ref``, tag from ``duthost.os_version``. On failure
+    or missing registry host, resolution continues with DUT tarball, runner tarball, then an image
+    already in docker storage.
+
+    1) ``docker pull`` + ``docker tag`` to ``docker_run.image_ref`` (when registry path active).
+    2) Tarball under admin home on DUT — ``docker load -i``.
+    3) Tarball on the ansible test runner — copy to /tmp on DUT, then ``docker load -i``.
+    4) Image already on DUT (docker image inspect).
+
+    If none apply, returns InstallSource(kind='none', ...).
+    """
+    reg_settings = _utility_registry_pull_settings(cfg, registry_image_tag=registry_image_tag)
+    if reg_settings is not None:
+        ref = try_registry_pull_utility_image(
+            duthost,
+            reg_settings,
+            public_docker_registry=public_docker_registry,
+            registry_host_override=registry_host_override,
+        )
+        if ref:
+            logger.info("Utility docker image from registry: %s", ref)
+            return InstallSource("image_present", None, ref)
+        logger.info("Utility registry pull did not produce an image; trying DUT tarball, runner tarball, local image")
+
+    dut_path = dut_home_tarball_path(cfg)
+    if dut_file_exists(duthost, dut_path):
+        logger.info("Utility docker tarball on DUT (will docker load): %s", dut_path)
+        return InstallSource("dut_home_tarball", dut_path, None)
+
+    if local_runner_tarball_path and os.path.isfile(local_runner_tarball_path):
+        base = os.path.basename(local_runner_tarball_path)
+        remote = "/tmp/{}".format(base)
+        logger.info("Utility docker tarball on test runner (will copy to DUT then docker load): %s", remote)
+        return InstallSource("runner_tarball", remote, None)
+
+    ref = find_existing_utility_image(duthost, cfg)
+    if ref:
+        logger.info("Utility docker image already on DUT (no docker load): %s", ref)
+        return InstallSource("image_present", None, ref)
+
+    return InstallSource("none", None, None)
+
+
+def resolve_local_tarball_path(config, search_dir, tarball_override):
+    """
+    Resolve path to the .gz image on the ansible test server (before copy to DUT).
+
+    Search order:
+    1) tarball_override (pytest --utility-docker-tarball)
+    2) search_dir / config['tarball_filename'] (default search_dir is this test module directory)
+    """
+    if tarball_override:
+        return os.path.abspath(tarball_override)
+    name = config.get("tarball_filename")
+    if not name:
+        raise ValueError("vendor config must set tarball_filename")
+    return os.path.abspath(os.path.join(search_dir, name))
+
+
+def try_registry_pull_utility_image(
+    duthost,
+    settings,
+    public_docker_registry=False,
+    registry_host_override=None,
+):
+    """
+    Pull ``{registry}/{image_name}:{image_version}`` on the DUT (Ansible ``creds`` / registry same
+    as ``swap_syncd`` / ``download_image``), then ``docker tag`` to ``settings['target_ref']``
+    when the pulled ref differs.
+
+    When ``public_docker_registry`` is true, applies the same credential override as the
+    ``swap_syncd`` fixture in ``tests/conftest.py`` (``docker_registry_host`` from
+    ``public_docker_registry_host``, clear username/password).
+
+    ``registry_host_override`` (pytest ``--live_addon_docker_registry``) replaces
+    ``docker_registry_host`` for this pull only.
+
+    ``settings`` comes from ``_utility_registry_pull_settings``. Returns ``target_ref`` on success,
+    or None on failure (caller tries tarballs / local image).
+    """
+    image_name = settings["image_name"]
+    target_ref = settings["target_ref"]
+
+    if public_docker_registry:
+        creds = copy.deepcopy(creds_on_dut(duthost))
+        creds["docker_registry_host"] = creds.get("public_docker_registry_host")
+        creds["docker_registry_username"] = ""
+        creds["docker_registry_password"] = ""
+    else:
+        creds = creds_on_dut(duthost)
+    if registry_host_override:
+        creds = copy.deepcopy(creds)
+        creds["docker_registry_host"] = registry_host_override.strip()
+    try:
+        registry = load_docker_registry_info(duthost, creds)
+    except ValueError as exc:
+        logger.warning("utility registry pull: %s", exc)
+        return None
+
+    ver = settings.get("image_version")
+    if ver is not None and str(ver).strip():
+        image_version = str(ver).strip()
+    else:
+        image_version = duthost.os_version
+
+    logger.info(
+        "utility registry pull: docker pull %s/%s:%s then tag as %s",
+        registry.host,
+        image_name,
+        image_version,
+        target_ref,
+    )
+    try:
+        download_image(duthost, registry, image_name, image_version)
+    except RuntimeError as exc:
+        logger.warning("utility registry pull: download failed: %s", exc)
+        return None
+
+    source_ref = "{}/{}:{}".format(registry.host, image_name, image_version)
+    if source_ref != target_ref:
+        duthost.command(
+            "docker tag {} {}".format(shlex.quote(source_ref), shlex.quote(target_ref))
+        )
+    if not image_exists(duthost, target_ref):
+        logger.warning("utility registry pull: target image %r not present after pull/tag", target_ref)
+        return None
+    return target_ref
+
+
+def build_docker_load_command(remote_tarball):
+    """``docker load`` line; ``remote_tarball`` is path on the DUT."""
+    return "sudo docker load -i {}".format(remote_tarball)
+
+
+def build_docker_run_command(cfg):
+    """
+    Full ``docker run`` command from ``cfg['docker_run']``.
+
+    Uses ``detach`` (default true) -> ``-d``, then ``cli_args``, then
+    ``--name <container_name> <image_ref>``.
+    """
+    dr = cfg["docker_run"]
+    image_ref = dr["image_ref"]
+    name = dr["container_name"]
+    args = dr.get("cli_args", [])
+    if not isinstance(args, list):
+        raise ValueError("docker_run.cli_args must be a list of argv tokens")
+    parts = []
+    if dr.get("sudo", True):
+        parts.append("sudo")
+    parts.extend(["docker", "run"])
+    if dr.get("detach", True):
+        parts.append("-d")
+    parts.extend(args)
+    parts.extend(["--name", name, image_ref])
+    return " ".join(parts)
+
+
+def parse_image_from_docker_load(load_output):
+    """
+    Try to extract name:tag from `docker load` stdout/stderr.
+    Example: 'Loaded image: docker-cisco-utility:20241110.22'
+    """
+    match = re.search(r"Loaded image:\s*(\S+)", load_output)
+    if match:
+        return match.group(1).strip()
+    return None
+
+
+def docker_load(duthost, remote_tarball):
+    """
+    Run ``sudo docker load -i <tarball>`` on the DUT. Fails the ansible command if load fails.
+    Returns combined stdout+stderr for parsing (some docker builds log ``Loaded image`` on stderr).
+    """
+    cmd = build_docker_load_command(remote_tarball)
+    logger.info("Running: %s", cmd)
+    result = duthost.command(cmd)
+    out = (result.get("stdout") or "").strip()
+    err = (result.get("stderr") or "").strip()
+    combined = (out + "\n" + err).strip()
+    logger.info("docker load stdout: %s", out)
+    if err:
+        logger.info("docker load stderr: %s", err)
+    return combined
+
+
+def get_container_process_comm_list(duthost, container_name):
+    """Return process command names from ``docker top`` (comm column)."""
+    cname = shlex.quote(container_name)
+    out = duthost.command(
+        "sudo docker top {} -eo comm".format(cname),
+        module_ignore_errors=True,
+    )
+    if out.get("rc") != 0:
+        return []
+    lines = (out.get("stdout") or "").splitlines()
+    if len(lines) <= 1:
+        return []
+    return [line.strip() for line in lines[1:] if line.strip()]
+
+
+def verify_utility_container_processes(duthost, container_name, expected_processes=None):
+    """
+    Assert the utility container is running expected processes (supervisord stack).
+    """
+    expected = expected_processes or UTILITY_CONTAINER_EXPECTED_PROCESSES
+    comms = get_container_process_comm_list(duthost, container_name)
+    joined = " ".join(comms)
+    logger.info("Utility container %r processes (comm): %s", container_name, comms)
+    missing = []
+    for proc in expected:
+        if not any(proc in comm for comm in comms):
+            missing.append(proc)
+    pytest_assert(
+        not missing,
+        "Container {!r} missing expected process(es) {} (docker top comm: {!r})".format(
+            container_name, missing, comms
+        ),
+    )
+
+
+def verify_utility_container_startup_logs(duthost, container_name, log_tail=200):
+    """
+    Check container logs mention supervisord startup (process supervisor for utility stack).
+    """
+    cname = shlex.quote(container_name)
+    logs = duthost.command(
+        "sudo docker logs --tail {} {} 2>&1".format(int(log_tail), cname),
+        module_ignore_errors=True,
+    ).get("stdout", "")
+    logger.info("Utility container %r startup logs (last %s lines):\n%s", container_name, log_tail, logs[-4000:])
+    logs_lower = logs.lower()
+    pytest_assert(
+        "supervisord" in logs_lower or "supervisor" in logs_lower,
+        "Container {!r} logs do not mention supervisord/supervisor (tail {} lines)".format(
+            container_name, log_tail
+        ),
+    )
+
+
+def upgrade_utility_docker_image(
+    duthost,
+    cfg,
+    public_docker_registry=False,
+    registry_host_override=None,
+):
+    """
+    Automated upgrade: stop/remove container, pull target image (registry), run, verify processes/logs/health.
+
+    Target image ref and pull tag come from ``cfg['docker_run']['image_ref']`` (apply CLI tag to cfg first).
+    Returns ``(cfg_used, health_result)`` with health_result ``(ok, http_code, body)``.
+    """
+    dr = cfg.get("docker_run") or {}
+    if not dr.get("image_ref"):
+        pytest.fail("upgrade_utility_docker_image: docker_run.image_ref is required")
+
+    docker_manual_teardown(duthost, dr)
+    remove_configured_utility_images(duthost, cfg)
+
+    tag = image_ref_to_tag(dr["image_ref"])
+    reg_settings = _utility_registry_pull_settings(cfg, registry_image_tag=tag)
+    if reg_settings is None:
+        pytest.fail("upgrade_utility_docker_image: cannot build registry pull settings")
+
+    ref = try_registry_pull_utility_image(
+        duthost,
+        reg_settings,
+        public_docker_registry=public_docker_registry,
+        registry_host_override=registry_host_override,
+    )
+    if not ref:
+        pytest.fail(
+            "upgrade_utility_docker_image: registry pull failed for {!r} (registry_host_override={!r})".format(
+                dr["image_ref"], registry_host_override
+            )
+        )
+
+    cfg_run = copy.deepcopy(cfg)
+    cfg_run["docker_run"]["image_ref"] = ref
+    log_version_matrix_compatibility(duthost, cfg, ref)
+    docker_run_manual(duthost, cfg_run)
+    cname = dr["container_name"]
+    verify_utility_container_startup_logs(duthost, cname)
+    verify_utility_container_processes(duthost, cname)
+    health = wait_for_health_ready(duthost, cfg_run["health"])
+    return cfg_run, health
+
+
+def docker_run_manual(duthost, cfg):
+    """Run container using ``build_docker_run_command(cfg)`` (all options from vendor JSON)."""
+    cmd = build_docker_run_command(cfg)
+    logger.info("Running: %s", cmd)
+    duthost.command(cmd)
+    cname = (cfg.get("docker_run") or {}).get("container_name")
+    if not cname:
+        return
+
+    def _running():
+        return is_container_running(duthost, cname)
+
+    if wait_until(_DOCKER_RUN_UP_TIMEOUT, _DOCKER_RUN_UP_INTERVAL, 0, _running):
+        return
+
+    ps_out = duthost.command(
+        "sudo docker ps -a --filter name={} --no-trunc".format(cname),
+        module_ignore_errors=True,
+    ).get("stdout", "")
+    log_out = duthost.command(
+        "sudo docker logs --tail 120 {} 2>&1".format(cname),
+        module_ignore_errors=True,
+    ).get("stdout", "")
+    pytest_assert(
+        False,
+        "Container {!r} did not stay running after docker run (waited {}s). "
+        "docker ps -a:\n{}\n\ndocker logs:\n{}".format(
+            cname, _DOCKER_RUN_UP_TIMEOUT, ps_out, log_out
+        ),
+    )
+
+
+def image_exists(duthost, image_ref):
+    # Quote for refs that contain special chars
+    out = duthost.command(
+        "sudo docker image inspect {}".format(image_ref), module_ignore_errors=True
+    )
+    return out["rc"] == 0
+
+
+def build_health_check_curl_command(health_cfg):
+    """curl used for validation; fields from JSON ``health`` section."""
+    port = int(health_cfg["port"])
+    path = health_cfg.get("url_path", "/health")
+    host = health_cfg.get("bind_host", "127.0.0.1")
+    return (
+        "curl -sS -m 15 -o /tmp/utility_docker_health.out -w '%{{http_code}}' "
+        "http://{}:{}{}".format(host, port, path)
+    )
+
+
+def http_health_check(duthost, health_cfg):
+    """
+    Query HTTP health endpoint from the DUT (container typically uses --net=host).
+    Returns (ok: bool, http_code: str, body_snippet: str).
+    """
+    expect = str(health_cfg.get("expect_http_code", 200))
+    curl = build_health_check_curl_command(health_cfg)
+    code = duthost.command(curl)["stdout"].strip()
+    body = duthost.command("sudo cat /tmp/utility_docker_health.out", module_ignore_errors=True).get(
+        "stdout", ""
+    )[:500]
+    ok = code == expect
+    return ok, code, body
+
+
+def run_config_reload_utility_start_reload_health(duthost, resolved_cfg, loganalyzer=None):
+    """
+    Run: stop utility container, ``config reload``, sleep, ``docker run`` (utility), ``config reload``,
+    then HTTP health (same semantics as ``wait_for_health_ready``).
+
+    ``resolved_cfg`` must be the vendor JSON dict with ``docker_run.image_ref`` set after tarball load
+    or image resolution (same object the module fixture uses for ``docker_run_manual``).
+    """
+    from tests.common.config_reload import config_reload
+
+    docker_manual_teardown(duthost, resolved_cfg["docker_run"])
+    logger.info("First config reload (utility container stopped)")
+    config_reload(
+        duthost,
+        config_source="config_db",
+        ignore_loganalyzer=loganalyzer,
+    )
+    logger.info(
+        "Waiting %s s after first config reload before starting utility container",
+        CONFIG_RELOAD_UTILITY_CYCLE_WAIT_SECONDS,
+    )
+    time.sleep(CONFIG_RELOAD_UTILITY_CYCLE_WAIT_SECONDS)
+
+    cfg_run = copy.deepcopy(resolved_cfg)
+    docker_run_manual(duthost, cfg_run)
+    logger.info("Second config reload (utility container running)")
+    config_reload(
+        duthost,
+        config_source="config_db",
+        ignore_loganalyzer=loganalyzer,
+    )
+    return wait_for_health_ready(duthost, resolved_cfg["health"])
+
+
+def wait_for_health_ready(duthost, health_cfg):
+    """
+    Honor ``health.wait_seconds_before_check`` (e.g. 900 for slow readiness), then either a
+    single probe or repeated probes per ``probe_timeout_seconds`` / ``probe_interval_seconds``.
+    Returns (ok, http_code, body) from the last attempt.
+    """
+    initial = int(health_cfg.get("wait_seconds_before_check", 0))
+    if initial > 0:
+        logger.info("Health: sleeping %s s before first probe (JSON wait_seconds_before_check)", initial)
+        time.sleep(initial)
+
+    timeout = int(health_cfg.get("probe_timeout_seconds", 0))
+    interval = int(health_cfg.get("probe_interval_seconds", 30))
+    if timeout <= 0:
+        return http_health_check(duthost, health_cfg)
+
+    last = (False, "", "")
+
+    def _probe():
+        nonlocal last
+        last = http_health_check(duthost, health_cfg)
+        return last[0]
+
+    polled = wait_until(timeout, interval, 0, _probe)
+    pytest_assert(polled, "Health endpoint did not return expect_http_code within {} s".format(timeout))
+    return last
+
+
+def docker_manual_teardown(duthost, docker_run_cfg):
+    name = docker_run_cfg["container_name"]
+    logger.info("Teardown docker: stop and remove %s", name)
+    duthost.command("sudo docker stop {} 2>/dev/null || true".format(name), module_ignore_errors=True)
+    duthost.command("sudo docker rm -f {}".format(name), module_ignore_errors=True)
+
+
+def remove_configured_utility_images(duthost, cfg):
+    """
+    Best-effort ``docker rmi -f`` for ``docker_run.image_ref`` and ``candidate_image_refs``.
+    Used immediately before ``docker load`` so the tarball load does not layer on old tags.
+    """
+    for ref in _image_refs_to_try(cfg):
+        logger.info("Removing utility image before docker load (best-effort): %s", ref)
+        duthost.command("sudo docker rmi -f {}".format(ref), module_ignore_errors=True)
+
+
+def prepare_utility_docker_install(duthost, cfg, install_source):
+    """
+    At test start: stop and remove the utility container if it is still running.
+    When install uses a tarball (``docker load``), remove configured image refs before load.
+    When using an image already on the DUT (no tarball), only the container is removed.
+    """
+    dr = cfg.get("docker_run")
+    if not dr:
+        return
+    docker_manual_teardown(duthost, dr)
+    if install_source.kind == "image_present":
+        return
+    remove_configured_utility_images(duthost, cfg)
+
+
+def get_core_filenames(duthost):
+    """Filenames under /var/core/ (same rules as platform tests)."""
+    if "20191130" in duthost.os_version:
+        out = duthost.shell("ls /var/core/ 2>/dev/null | grep -v python || true")["stdout"]
+    else:
+        out = duthost.shell("ls /var/core/ 2>/dev/null || true")["stdout"]
+    return set(line.strip() for line in out.splitlines() if line.strip())
+
+
+def verify_no_new_core_files(duthost, pre_cores):
+    post = get_core_filenames(duthost)
+    new_files = post - pre_cores
+    pytest_assert(
+        not new_files,
+        "New core file(s) appeared under /var/core/: {}".format(", ".join(sorted(new_files))),
+    )
+
+
+def verify_container_absent(duthost, container_name):
+    """Use ``SonicHost.get_all_containers()`` (escaped docker format, same as rest of sonic-mgmt)."""
+    if not container_name:
+        return
+    all_names = duthost.get_all_containers()
+    pytest_assert(
+        container_name not in all_names,
+        "Container {} still present after teardown".format(container_name),
+    )
+
+
+def verify_syslog_clean_after_teardown(duthost, cfg):
+    """
+    Tail syslog; if any line mentions the utility (hints) and matches the default error pattern, fail.
+    """
+    tail_lines = _DEFAULT_SYSLOG_TAIL_LINES
+    err_pat = _DEFAULT_SYSLOG_ERROR_PATTERN
+    hints = []
+    val = cfg.get("validation") or {}
+    if val.get("docker_container_name"):
+        hints.append(val["docker_container_name"])
+    dr = cfg.get("docker_run") or {}
+    if dr.get("container_name"):
+        cname = dr["container_name"]
+        if cname not in hints:
+            hints.append(cname)
+    image_ref = dr.get("image_ref", "")
+    if image_ref:
+        base = image_ref.split(":")[0].split("/")[-1]
+        if base and base not in hints:
+            hints.append(base)
+    if not hints:
+        return
+    hint_alt = "|".join(re.escape(h) for h in hints)
+    script = (
+        "sudo tail -n {n} /var/log/syslog 2>/dev/null | grep -iE '({hints})' | grep -iE '{err}' || true"
+    ).format(n=tail_lines, hints=hint_alt, err=err_pat)
+    bad = duthost.command(script, module_ignore_errors=True).get("stdout", "").strip()
+    pytest_assert(
+        not bad,
+        "Syslog lines after teardown matched error pattern for utility hints:\n{}".format(bad[:2000]),
+    )
+
+
+def verify_post_teardown(duthost, cfg, pre_core_filenames):
+    """
+    After stop/uninstall: assert no new core files, utility container absent, syslog spot-check.
+    Behavior is fixed in code (not vendor JSON).
+
+    Relation to sonic-mgmt infra (keep these checks):
+    - Loganalyzer runs per test and does not analyze syslog after the last test returns; uninstall
+      in the module fixture runs after that, so a tail+grep for utility hints still adds coverage.
+    - core_dump_and_config_check (module autouse) compares /var/core at module boundaries but does
+      not pytest.fail on new cores; it logs and records cache for telemetry. The assert here fails
+      the run if new cores appeared during this fixture.
+    """
+    val = cfg.get("validation") or {}
+    cname = val.get("docker_container_name", (cfg.get("docker_run") or {}).get("container_name"))
+
+    verify_no_new_core_files(duthost, pre_core_filenames)
+    verify_container_absent(duthost, cname)
+    verify_syslog_clean_after_teardown(duthost, cfg)


### PR DESCRIPTION
### Description of PR

Summary:
Add `tests/vendor_utility_docker` validation coverage for vendor utility docker install, health, config-reload cycle, and image upgrade. This PR intentionally has no Jira or `Fixes #` reference.

Why needed:
The source test-case fix changed vendor utility docker selection from a hard-coded Cisco filename/marker to `files/<asic_type>_utility_docker.json` selected from DUT facts. That avoids carrying a Cisco-only pytest marker and lets unsupported platforms fail or skip based on missing vendor JSON rather than collecting under an incorrect marker.

Related evidence:
No vendor utility docker runtime log file was present in the local workspace for this PR body. The source patch evidence shows the condition/default-config issue being fixed:

```diff
-    pytest.mark.cisco_8000,
```

```diff
-DEFAULT_CONFIG = os.path.join(MODULE_DIR, "files", "cisco_utility_docker.json")
+def default_vendor_config_path(asic_type):
+    return os.path.abspath(os.path.join(MODULE_DIR, "files", "{}_utility_docker.json".format(name)))
```

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: N/A
Failure type: other

### Approach
#### What is the motivation for this PR?

Add vendor utility docker validation while keeping platform selection data-driven by DUT `asic_type` and vendor JSON availability.

#### How did you do it?

Added the vendor utility docker pytest module, helper functions, Cisco 8000 JSON, and file README. The default config path is resolved from `duthost.facts['asic_type']`, with `--utility-docker-config` available for explicit override. Registry pulls use the existing docker registry configuration path and support public-registry mode.

#### How did you verify/test it?

Local syntax check:

```bash
PYTHONPYCACHEPREFIX=/private/tmp/pycache-vendor-utility python3 -m py_compile tests/vendor_utility_docker/conftest.py tests/vendor_utility_docker/utility_docker_helpers.py tests/vendor_utility_docker/test_utility_docker.py
```

Runtime validation requires a SONiC testbed with the vendor utility image/tarball or registry access.

#### Any platform specific information?

The included vendor config is `tests/vendor_utility_docker/files/cisco-8000_utility_docker.json`; other ASICs can add their own `files/<asic_type>_utility_docker.json` or pass `--utility-docker-config`.

#### Supported testbed topology if it's a new test case?

`pytest.mark.topology("any")`, subject to vendor JSON and image availability.

### Documentation

Added `tests/vendor_utility_docker/files/README.txt` with vendor JSON, registry, tag, and compatibility notes.