### PR TITLE
Gate route check during override config reloads

### DIFF
--- a/tests/override_config_table/test_override_config_table.py
+++ b/tests/override_config_table/test_override_config_table.py
@@ -21,6 +21,10 @@ CONFIG_DB_BACKUP = "/etc/sonic/config_db.json_before_override"
 
 pytestmark = [
     pytest.mark.topology('t0', 't1', 'any'),
+    # This module performs repeated minigraph/config reloads with golden config
+    # overrides. Gate routeCheck at module boundaries so transient churn does
+    # not poison the following test module.
+    pytest.mark.disable_route_check,
 ]
 
 LOSSY_HWSKU = mellanox_data.LOSSY_ONLY_HWSKUS + broadcom_data.LOSSY_ONLY_HWSKUS

--- a/tests/override_config_table/test_override_config_table_masic.py
+++ b/tests/override_config_table/test_override_config_table_masic.py
@@ -22,6 +22,10 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('t2', 'lrh', 'urh', 't1'),
+    # This module performs repeated minigraph/config reloads with golden config
+    # overrides. Gate routeCheck at module boundaries so transient churn does
+    # not poison the following test module.
+    pytest.mark.disable_route_check,
     pytest.mark.disable_loganalyzer,
 ]
 


### PR DESCRIPTION
### Description of PR

Summary:
Gate routeCheck for `tests/override_config_table` modules while they perform repeated golden-config override reloads.

Why needed:
The override-config-table tests intentionally reload minigraph/config with golden config overrides and then restore CONFIG_DB/golden config. That reload and config-apply churn can transiently affect routeCheck and the next module even when the override-config behavior under test is correct. Marking these modules with `disable_route_check` gates routeCheck at the test-module boundary.

Related log evidence:

```text
23/06/2026 07:38:39 conftest.restore_golden_config_db        L3736 INFO   | [restore_golden_config_db] Restored /etc/sonic/golden_config_db.json
23/06/2026 07:38:39 conftest.temporarily_disable_route_check L3289 INFO   | Skipping temporarily_disable_route_check fixture
```

```text
cmd": "echo \"[]\" | sudo config apply-patch /dev/stdin",
"start": "2026-06-23 07:38:26.319077",
"end": "2026-06-23 07:39:35.016417",
"delta": "0:01:08.697340",
"stdout": "Patch Applier: localhost: Patch application starting.
Patch Applier: localhost: Patch: []
...
Patch Applier: asic15 patch application completed.
Patch applied successfully."
```

```text
Program 'routeCheck'
  status                       Status ok
  monitoring status            Waiting
  monitoring mode              active
  on reboot                    start
  last exit value              0
  last output                  -
  data collected               Fri, 03 Jul 2026 01:13:17
```

Fix evidence:

```python
pytest.mark.disable_route_check,
```

How `pytest.mark.disable_route_check` handles the issue:

The autouse module fixture `temporarily_disable_route_check` checks whether the test module has the `disable_route_check` marker. For allowed chassis topologies (`t2`, `ut2`, `lt2`), it does the following sequence on all frontend DUT nodes:

1. Before the test body runs, poll `sudo route_check.py` until it passes.
2. Stop the monit-managed `routeCheck` program and wait until monit reports it is not monitored.
3. Run the marked test module while it performs expected minigraph/config reload churn.
4. After the test body finishes, poll `sudo route_check.py` again until the route state has converged.
5. In a `finally` block, restart the monit-managed `routeCheck` program and wait until monit reports `Status ok`.

That sequence prevents routeCheck from firing during the intentional reload/config churn, while still requiring the route table to be healthy before routeCheck is re-enabled.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: N/A
Failure type: other

### Approach
#### What is the motivation for this PR?

Avoid routeCheck false positives caused by expected minigraph/config reload churn in override-config-table tests.

#### How did you do it?

Added `pytest.mark.disable_route_check` to both single-ASIC and multi-ASIC override-config-table test modules.

#### How did you verify/test it?

Local syntax check:

```bash
PYTHONPYCACHEPREFIX=/private/tmp/pycache-override-routecheck python3 -m py_compile tests/override_config_table/test_override_config_table.py tests/override_config_table/test_override_config_table_masic.py
```

Runtime validation requires a SONiC testbed running the override-config-table tests.

#### Any platform specific information?

No platform-specific code added.

#### Supported testbed topology if it's a new test case?

Existing topology marks are unchanged.

### Documentation

No external documentation update; this is a targeted test stability fix.
