### PR TITLE
Fix liquid cooling leak test for CLI/schema redesign

### DIFF
--- a/tests/common/helpers/liquid_leakage_control_test_helper.py
+++ b/tests/common/helpers/liquid_leakage_control_test_helper.py
@@ -96,7 +96,7 @@ def verify_leakage_status(dut, leakage_index_list, expected_status):
     for index in leakage_index_list:
         for leak_status in leakage_status_list:
             if leak_status['name'] == f"leakage{index}":
-                if leak_status['leaking'].lower() != expected_status.lower():
+                if leak_status['leak'].lower() != expected_status.lower():
                     failed_leakage_list.append(index)
                     logging.info(f"Leakage status is not as expected: {leak_status}")
                 else:
@@ -148,7 +148,7 @@ def verify_leakage_status_in_state_db(dut, leakage_index_list, expected_status):
     failed_leakage_list = []
     success_leakage_list = []
     for index in leakage_index_list:
-        leak_status = state_db.get(f"LIQUID_COOLING_INFO|leakage{index}", {}).get("value", {}).get("leak_status")
+        leak_status = state_db.get(f"LIQUID_COOLING_INFO|leakage{index}", {}).get("value", {}).get("leaking")
         if leak_status != expected_status:
             failed_leakage_list.append(index)
             logging.info(f"Leakage status in state db is not as expected: {leak_status}")
@@ -191,9 +191,10 @@ def startmonitor_gnmi_event(duthost, ptfhost):
     """
     dut_mgmt_ip = duthost.mgmt_ip
     timeout = WAIT_GNMI_LD_EVENT_TIMEOUT
-    gnmi_subscribe_cmd = f"python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t {dut_mgmt_ip} -p 50052 -m subscribe \
-    -x all[heartbeat=2] -xt EVENTS -o ndastreamingservertest --subscribe_mode 0 --submode 1 --interval 0 \
-    --update_count 0 --create_connections 1 --filter_event_regex sonic-events-host --timeout {timeout} -n"
+    gnmi_subscribe_cmd = (
+        f"python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t {dut_mgmt_ip} -p 50052 -m subscribe "
+        "-x all[heartbeat=2] -xt EVENTS -o ndastreamingservertest --subscribe_mode 0 --submode 1 --interval 0 "
+        f"--update_count 0 --create_connections 1 --filter_event_regex sonic-events-host --timeout {timeout} -n")
     result = ptfhost.shell(gnmi_subscribe_cmd, module_ignore_errors=True)['stdout']
     logging.info(f"gnmi subscribe cmd: {gnmi_subscribe_cmd} \n gnmi event result: {result}")
     return result
@@ -263,6 +264,12 @@ def setup_gnmi_server(duthosts, rand_one_dut_hostname, localhost, ptfhost):
 @pytest.fixture(scope="module", autouse=True)
 def skip_when_no_liquid_cooling_system(duthosts, enum_rand_one_per_hwsku_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    # This test relies on hw-management sysfs and the switch-specific 'leakage<index>' sensor naming.
+    # Integrated BMC devices expose leak sensors through the platform API with different names and
+    # counts, and are covered by platform_tests/api/test_liquid_cooling_leakage.py instead.
+    if duthost.is_bmc():
+        pytest.skip("Liquid cooling leakage detection is switch-only; "
+                    "BMC is covered by platform_tests/api/test_liquid_cooling_leakage.py")
     if not is_liquid_cooling_system_supported(duthost):
         pytest.skip("No liquid cooling leakage sensors found on device")
 


### PR DESCRIPTION
### Description of PR

The liquid cooling leak detection feature was redesigned in [sonic-utilities #4417](https://github.com/sonic-net/sonic-utilities/pull/4417): the CLI was renamed and the STATE_DB schema updated. This aligns the switch-side test helper with the new CLI/schema and keeps the integrated BMC out of this switch-only test.

#### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement
- [ ] New feature
- [ ] Skipped for non-supported platforms

### Back port request

- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202605
- [x] 202608

### Approach
#### What is the motivation for this PR?

The liquid cooling leak detection feature was redesigned in https://github.com/sonic-net/sonic-utilities/pull/4417 the CLI was renamed and the STATE_DB schema updated. Need align the change on the testcase.

#### How did you do it?

- `verify_leakage_status`: read the `leak` column (renamed from `Leaking`) in `show platform leak status` output
- `verify_leakage_status_in_state_db`: read the `leaking` field (renamed from `leak_status`) in the `LIQUID_COOLING_INFO` STATE_DB table
- `skip_when_no_liquid_cooling_system`: skip on integrated BMC devices, since BMC leak sensors use different names/counts and are covered by `platform_tests/api/test_liquid_cooling_leakage.py`

#### How did you verify/test it?

Ran the liquid cooling leak test on a liquid-cooled switch against a build with the redesigned CLI/schema; verified the test passes and that it is correctly skipped on integrated BMC devices.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
