### PR TITLE
Fix dynamic ACL binding order validation

### DIFF
--- a/tests/common/gu_utils.py
+++ b/tests/common/gu_utils.py
@@ -537,14 +537,19 @@ def expect_acl_table_match_multiple_bindings(duthost,
                 return False
 
             first_line = output[0]
-            first_line_diff = set(first_line.values()) ^ set(expected_first_line_content)
-            if not set(first_line.values()) == set(expected_first_line_content):
+            table_bindings = [line["binding"] for line in output if line.get("binding")]
+
+            if first_line["binding"] not in expected_bindings:
+                logger.warning(f"Unexpected first ACL table binding: {first_line['binding']}")
+                return False
+
+            actual_first_line = set(first_line.values()) - set(expected_bindings)
+            expected_first_line = set(expected_first_line_content) - set(expected_bindings)
+            first_line_diff = actual_first_line ^ expected_first_line
+            if actual_first_line != expected_first_line:
                 logger.warning(f"First line content does not match. Difference: {first_line_diff}")
                 return False
 
-            table_bindings = [first_line["binding"]]
-            for i in range(len(output)):
-                table_bindings.append(output[i]["binding"])
             table_bindings_diff = set(table_bindings) ^ set(expected_bindings)
             if not set(table_bindings) == set(expected_bindings):
                 logger.warning(f"ACL Table bindings don't fully match. Difference: {table_bindings_diff}")


### PR DESCRIPTION
### Description of PR
Fixes dynamic ACL table validation for multi-binding ACL tables when the SONiC CLI returns bindings in a different order from the test's configured `bind_ports` list.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

### Approach
#### What is the motivation for this PR?
Nightly PBI 38723062 shows `generic_config_updater/test_dynamic_acl.py::test_gcu_acl_dhcp_rule_creation` failing in fixture setup with `First line content does not match. Difference: {'Ethernet46', 'Ethernet0'}`. The ACL table is created and expected bindings include both ports, but `show acl table` can return `Ethernet0` as the first displayed binding while the test expects `bind_ports[0]` (`Ethernet46`) to be first.

#### How did you do it?
Validate the first displayed binding is one of the expected bindings, compare non-binding first-line fields separately, and build the table binding set directly from parsed CLI output. This keeps validating all bindings while removing the invalid assumption about output row order.

#### How did you verify/test it?
- `python -m py_compile tests/common/gu_utils.py`
- Reviewed the failing ElasticTest log from PBI 38723062: actual first binding `Ethernet0`, expected bindings include both `Ethernet0` and `Ethernet46`.

#### Any platform specific information?
Observed on Arista-720DT-G48S4 m0 in 202605 nightly; logic is platform-independent.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A