### PR TITLE
Fix SFP thermal TEMPERATURE_INFO key filtering

### DIFF
--- a/tests/platform_tests/test_sfp_thermal_state_db.py
+++ b/tests/platform_tests/test_sfp_thermal_state_db.py
@@ -27,6 +27,11 @@ class TestSfpThermalStateDb:
     TRANSCEIVER_DOM_FLAG tables in STATE_DB.
     """
 
+    SFP_SENSOR_PATTERN = re.compile(
+        r"\bxsfp\s+module\s+\d+\b|transceiver|optic",
+        re.IGNORECASE
+    )
+
     def _get_sfp_ports_with_dom_temperature(self, duthost):
         """Return list of port names that have TRANSCEIVER_DOM_TEMPERATURE entries."""
         result = duthost.shell(
@@ -88,11 +93,9 @@ class TestSfpThermalStateDb:
     def _is_sfp_sensor(self, sensor_name):
         """
         Determine if a sensor name refers to an SFP/transceiver temperature.
-        Matches patterns like 'xSFP module N Temp'.
+        Matches canonical 'xSFP module N Temp' names and transceiver/optic aliases.
         """
-        sensor_lower = sensor_name.lower()
-        return ("sfp" in sensor_lower or "transceiver" in sensor_lower or
-                "optic" in sensor_lower)
+        return bool(self.SFP_SENSOR_PATTERN.search(sensor_name))
 
     def test_sfp_temperature_present_in_show_platform_temperature(
             self, duthosts, enum_rand_one_per_hwsku_hostname):
@@ -500,10 +503,7 @@ class TestSfpThermalStateDb:
         )
 
         keys = result["stdout"].strip().split("\n")
-        sfp_keys = [
-            k for k in keys
-            if any(pattern in k.lower() for pattern in ["sfp", "transceiver", "xsfp", "optic"])
-        ]
+        sfp_keys = [k for k in keys if self._is_sfp_sensor(k)]
 
         logger.info("TEMPERATURE_INFO keys: %d total, %d SFP-related",
                     len(keys), len(sfp_keys))
@@ -542,7 +542,7 @@ class TestSfpThermalStateDb:
 
         non_sfp_sensors = [
             name for name in sensor_names
-            if not any(p in name.lower() for p in ["sfp", "transceiver", "xsfp", "optic"])
+            if not self._is_sfp_sensor(name)
         ]
 
         pytest_assert(


### PR DESCRIPTION
### Description of PR
Fixes `test_no_sfp_entries_in_temperature_info` so it only flags transceiver/DOM-style temperature keys in `TEMPERATURE_INFO` instead of any platform sensor whose name contains `sfp`.

The nightly failure in PBI 38723065 found `TEMPERATURE_INFO|SFP+ connector temp sensor` on Arista-720DT. This is a connector/platform thermal sensor name, not an xcvrd DOM transceiver entry, so the previous broad substring check produced a false failure.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://dev.azure.com/msazure/One/_workitems/edit/38723065
Failure type: regression

### Tested branch
<!-- Select each branch where the change was tested. -->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- master: `python -m py_compile tests/platform_tests/test_sfp_thermal_state_db.py` and `python -m flake8 tests/platform_tests/test_sfp_thermal_state_db.py --max-line-length=120` pass. The matcher cases below also pass; PR CI is rerunning after rebasing onto current master.
- 202605: PBI 38723065 records consistent failures on 20260510.02/.04 for `TEMPERATURE_INFO|SFP+ connector temp sensor`. The revised classifier rejects that exact platform-sensor key while still matching `xSFP module 1 Temp`, `Transceiver_1 Temp`, and `Optical Module 1` as transceiver/DOM-style names.

### Approach

#### What is the motivation for this PR?

The test should verify that duplicate transceiver/DOM temperature entries are not published in `TEMPERATURE_INFO`. It should not fail for platform connector/cage sensors that legitimately include `SFP` in the sensor name.

#### How did you do it?

Tightened the shared `_is_sfp_sensor` classifier to match canonical `xSFP module <n>` names while preserving `transceiver` and `optic` aliases, then reused it for both the duplicate-entry and platform-sensor checks. This avoids treating connector/cage sensor names such as `SFP+ connector temp sensor` as DOM entries.

#### How did you verify/test it?

- Ran `python -m py_compile tests/platform_tests/test_sfp_thermal_state_db.py`.
- Ran `python -m flake8 tests/platform_tests/test_sfp_thermal_state_db.py --max-line-length=120`.
- Confirmed `TEMPERATURE_INFO|SFP+ connector temp sensor` and `SFP cage temp sensor` do not match.
- Confirmed canonical/alias names `xSFP module 1 Temp`, `Transceiver_1 Temp`, and `Optical Module 1` still match.

#### Any platform specific information?

Observed on Arista-720DT-G48S4 M0/MX nightly runs.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation
N/A
