### PR TITLE
Add Arista-7060X6-64PE-O128 in TH5 hwsku data lists

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4563,7 +4563,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark:
   xfail:
     reason: "Headroom pool size not supported."
     conditions:
-      - "hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32C-C32', 'Arista-7050CX3-32S-C28S4', 'Arista-7050CX3-32C-C28S4', 'Arista-7050CX3-32S-D48C8', 'Arista-7060X6-16PE-384C-B-O128S2', 'Arista-7060X6-64PE-B-O128'] and asic_type not in ['marvell-teralynx']"
+      - "hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32C-C32', 'Arista-7050CX3-32S-C28S4', 'Arista-7050CX3-32C-C28S4', 'Arista-7050CX3-32S-D48C8', 'Arista-7060X6-16PE-384C-B-O128S2', 'Arista-7060X6-64PE-B-O128', 'Arista-7060X6-64PE-O128'] and asic_type not in ['marvell-teralynx']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq:
   skip:

--- a/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
@@ -2,7 +2,7 @@
   "HWSKU": {
     "Arista-7050QX": ["Arista-7050-QX-32S", "Arista-7050-QX32", "Arista-7050QX-32S-S4Q31", "Arista-7050QX32S-Q32"],
     "Mellanox-SN4600C": ["Mellanox-SN4600C-C64"],
-    "Arista-7060X6": ["Arista-7060X6-64PE-B-C512S2", "Arista-7060X6-64PE-B-C448O16", "Arista-7060X6-16PE-384C-B-O128S2", "Arista-7060X6-64PE-B-O128"],
+    "Arista-7060X6": ["Arista-7060X6-64PE-B-C512S2", "Arista-7060X6-64PE-B-C448O16", "Arista-7060X6-16PE-384C-B-O128S2", "Arista-7060X6-64PE-B-O128", "Arista-7060X6-64PE-O128"],
     "Mellanox-SN5640": ["Mellanox-SN5640-C448O16", "Mellanox-SN5640-C512S2"],
     "Arista-7060CX": ["Arista-7060CX-32S-C32", "Arista-7060CX-32S-D48C8"],
     "Arista-7260CX3": ["Arista-7260CX3-C64", "Arista-7260CX3-D108C8", "Arista-7260CX3-D108C10"],


### PR DESCRIPTION
### Description of PR

Summary:
Fixes #25974

Add `Arista-7060X6-64PE-O128` to have same set of testing as `Arista-7060X6-64PE-B-O128`, as they are the same hwsku. 

- `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` —
    remove  `Arista-7060X6-64PE-O128` from xfail list as it supports headroom test cases.
- `tests/common/plugins/memory_utilization/memory_utilization_dependence.json` —
   use the same memory threshold as other `Arista-7060X6` HWSKU for `Arista-7060X6-64PE-B-O128`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: #25974
Failure type: day-one issue

### Approach
#### What is the motivation for this PR?
Ensure `Arista-7060X6-64PE-O128` is treated the same as its sibling
`Arista-7060X6-64PE-B-O128`, so QoS SAI headroom-pool-watermark testing and
memory-utilization thresholds work correctly on this TH5 platform.

#### How did you do it?
Added `Arista-7060X6-64PE-O128` alongside the existing `Arista-7060X6-64PE-B-O128`
entry in both the `testQosSaiHeadroomPoolWatermark` xfail whitelist and the
`Arista-7060X6` HWSKU map.

#### How did you verify/test it?
Validated the edited YAML and JSON parse correctly. The change is a data-list
addition mirroring the already-supported `-B-O128` sibling on identical TH5/O128
hardware.

#### Any platform specific information?
Broadcom Tomahawk5 (TH5), Arista 7060X6-64PE, hwsku `Arista-7060X6-64PE-O128`
(e.g. `lt2-o128` topology).

#### Supported testbed topology if it's a new test case?
N/A — not a new test case.

### Documentation
N/A
