### PR TITLE
[vxlan]: Skip test_vxlan_multiple_tunnels.py on Cisco 8102

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -6135,7 +6135,7 @@ vxlan/test_vxlan_multiple_tunnels.py:
   skip:
     reason: "VxLAN multi-tunnel test is not yet supported on multi-ASIC platform. Also this test cannot currently run on most platforms."
     conditions:
-      - "(is_multi_asic == True) or (platform not in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-nvidia_sn4280-r0', 'x86_64-8102_28fh_dpu_o-r0'])"
+      - "(is_multi_asic == True) or (platform not in ['x86_64-8101_32fh_o-r0', 'x86_64-nvidia_sn4280-r0', 'x86_64-8102_28fh_dpu_o-r0'])"
 
 vxlan/test_vxlan_route_advertisement.py:
   skip:


### PR DESCRIPTION
### Description of PR

Summary:
Skip `vxlan/test_vxlan_multiple_tunnels.py` on the Cisco 8102 platform (`x86_64-8102_64h_o-r0`), where this test is not supported.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: other

### Approach
#### What is the motivation for this PR?

`vxlan/test_vxlan_multiple_tunnels.py` is not supported on the Cisco 8102 platform (`x86_64-8102_64h_o-r0`) and should be skipped there.

#### How did you do it?

Removed `x86_64-8102_64h_o-r0` from the supported-platform allowlist of the existing skip
condition in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`. With Cisco 8102
no longer in the allowlist, the `platform not in [...]` clause evaluates to true on that platform,
so the test is skipped there.

#### How did you verify/test it?

- Confirmed the YAML file still parses successfully with `yaml.safe_load`.
- Simulated the condition evaluation across platforms and verified only Cisco 8102
  (`x86_64-8102_64h_o-r0`) single-ASIC changes from RUN to SKIP, while Cisco 8101,
  Nvidia SN4280, the Cisco 8102 28FH DPU variant, and other platforms remain unchanged.

#### Any platform specific information?

Cisco 8102 (`x86_64-8102_64h_o-r0`) only. The Cisco 8102 28FH DPU/SmartSwitch variant
(`x86_64-8102_28fh_dpu_o-r0`) is intentionally not affected.

#### Supported testbed topology if it's a new test case?

N/A — conditional skip only.

### Documentation

N/A
