### PR TITLE
[vlan/test_vlan_ping]: Fix dualtor lower-ToR VM port resolution

### DIFF
--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -76,8 +76,11 @@ def vlan_ping_setup(duthosts, rand_one_dut_hostname, ptfhost, nbrhosts, tbinfo, 
         else:
             interface_name = 'Ethernet1'
             dev_name = 'eth1'
-        # in case of lower tor host we need to use the next portchannel
-        if "dualtor-aa" in tbinfo["topo"]["name"] and rand_one_dut_hostname == lower_tor_host.hostname:
+        # The dualtor T1 neighbor has the following port-channel configuration:
+        #   Port-Channel1 -> upper ToR
+        #   Port-Channel2 -> lower ToR
+        # If the randomly selected DUT is the lower ToR, we need to use Port-Channel2
+        if "dualtor" in tbinfo["topo"]["name"] and rand_one_dut_hostname == lower_tor_host.hostname:
             interface_name = 'Port-Channel2'
             dev_name = 'po2'
 
@@ -147,7 +150,7 @@ def vlan_ping_setup(duthosts, rand_one_dut_hostname, ptfhost, nbrhosts, tbinfo, 
                 vm_host_info['port_index_list'] = ifaces_list
             break
 
-    py_assert('port_index_list' in vm_host_info,
+    py_assert('port_index_list' in vm_host_info and vm_host_info['port_index_list'],
               "Could not find interface connecting to VM {} with address {}".format(vm_name, vm_addr))
 
     # getting the ipv4, ipv6 and vlan id of a vlan in DUT with 2 or more vlan members
@@ -281,8 +284,10 @@ def verify_icmp_packet(dut_mac, src_port, dst_port, ptfadapter, tbinfo,
                 raise e  # If it fails on the last attempt, raise the exception
 
 
+@pytest.mark.dualtor_active_standby_toggle_to_random_tor_manual_mode
+@pytest.mark.dualtor_active_active_setup_standby_on_random_unselected_tor_manual_mode
 def test_vlan_ping(vlan_ping_setup, duthosts, rand_one_dut_hostname, ptfadapter, tbinfo,
-                   toggle_all_simulator_ports_to_rand_selected_tor_m, populate_mac_table):  # noqa: F811
+                   ptfhost, populate_mac_table):  # noqa: F811
     """
     test for checking connectivity of statically added ipv4 and ipv6 arp entries
     """


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
Fix `test_vlan_ping` failure on dualtor.

```
    def fail(self, msg=None):
        """Fail immediately, with the given message."""
>       raise self.failureException(msg)
E       AssertionError: Received expected packet on port 134 for device 0, but it should have arrived on one of these ports: [].
```
* Microsoft ADO (number only): 38614020

#### How did you do it?
On active-standby dualtor (e.g. dualtor-120), when the lower ToR is the
selected DUT, the fixture read the neighbor VM's Port-Channel1
(upper-ToR-facing) address. That address matches no lower-ToR
port-channel peer_addr, so port_index_list came out empty and
verify_packet_any_port() checked zero ports, failing with 'Did not
receive expected packet on any of ports []'. Select the VM's
Port-Channel2 for the lower ToR on all dualtor topologies, not just
dualtor-aa.

* EOS vm config:
  * `Port-Channel1` -> upper ToR
  * `Port-Channel2` -> lower ToR
```
{'Loopback0': {'ipv4': '100.1.0.32/32', 'ipv6': '2064:100::20/128'}, 'Ethernet1': {'lacp': 1, 'dut_index': 0}, 'Ethernet2': {'lacp': 1, 'dut_index': 0}, 'Ethernet3': {'lacp': 2, 'dut_index': 1}, 'Ethernet4': {'lacp': 2, 'dut_index': 1}, 'Port-Channel1': {'ipv4': '10.0.0.63/31', 'ipv6': 'fc00::7e/126'}, 'Port-Channel2': {'ipv4': '10.0.1.63/31', 'ipv6': 'fc00::1:7e/126'}}
```

Also:
* assert port_index_list is non-empty (not just present) to fail
fast with a clear message;
* toggle mux via the dualtor
active-standby/active-active manual-mode markers 
* stop garp_service/arp_responder on the PTF before flushing VLAN neighbors so
stale entries are not repopulated.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you verify/test it?

```
vlan/test_vlan_ping.py::test_vlan_ping PASSED                                                                                                                                                                                                      [100%]


======================================================================================================== 1 passed, 91 warnings in 334.95s (0:05:34) ========================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
