### PR TITLE
[gnmi] Fix IPv6 target formatting in gnmi_subscribe_polling (#25980)

### DIFF
--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -285,7 +285,7 @@ def gnmi_set(duthost, ptfhost, delete_list, update_list, replace_list, cert=None
     if rc != 0 or "GRPC error" in combined or "rpc error" in combined:
         dump_gnmi_log(duthost)
         dump_system_status(duthost)
-        raise Exception("py_gnmicli failed rc={}\nSTDOUT:\n{}\nSTDERR:\n{}".format(rc, stdout, stderr))
+        raise Exception(f"py_gnmicli failed rc={rc}\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}")  # noqa: E231
 
 
 def gnmi_get(duthost, ptfhost, path_list, ip=None):

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -2,6 +2,7 @@ import time
 import logging
 import pytest
 import json
+import ipaddress
 from tests.common.utilities import wait_until
 from tests.common.platform.device_utils import get_dpu_ip, get_dpu_port
 from tests.common.helpers.gnmi_utils import GNMIEnvironment, add_gnmi_client_common_name, del_gnmi_client_common_name, \
@@ -334,6 +335,32 @@ def gnmi_get(duthost, ptfhost, path_list, ip=None):
         raise Exception("error:" + msg)
 
 
+def _bracket_ipv6(ip):
+    """Wrap an IPv6 literal in brackets for use in a host:port target.
+
+    gnmi_cli/gnoi_client take the server address as ``-a <host>:<port>``.
+    A bare IPv6 address contains colons that collide with the ``:<port>``
+    separator, so IPv6 literals must be written as ``[<ipv6>]:<port>``.
+    IPv4 addresses, hostnames and already-bracketed IPv6 values are returned
+    unchanged.
+
+    Args:
+        ip: server address (IPv4/IPv6 literal, hostname, or ``[ipv6]``).
+
+    Returns:
+        The address with IPv6 literals wrapped in brackets.
+    """
+    if not ip or ip.startswith('['):
+        return ip
+    try:
+        if ipaddress.ip_address(ip).version == 6:
+            return f"[{ip}]"
+    except ValueError:
+        # Not an IP literal (e.g. a hostname); leave it untouched.
+        pass
+    return ip
+
+
 # py_gnmicli does not fully support POLLING mode
 # Use gnmi_cli instead
 def gnmi_subscribe_polling(duthost, ptfhost, path_list, interval_ms, count, ip=None, vrf_name=None):
@@ -358,8 +385,13 @@ def gnmi_subscribe_polling(duthost, ptfhost, path_list, interval_ms, count, ip=N
         return "", ""
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     if ip is None:
-        dut_facts = duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts']
-        ip = f"[{duthost.mgmt_ip}]" if dut_facts.get('is_mgmt_ipv6_only', False) else duthost.mgmt_ip
+        ip = duthost.mgmt_ip
+    # gnmi_cli expects the target as -a <host>:<port>. IPv6 literals must be
+    # wrapped in brackets ([<ipv6>]:<port>) so the address colons are not
+    # confused with the host:port separator. Normalize here so bracketing is
+    # applied whether `ip` was defaulted from duthost.mgmt_ip or passed in
+    # explicitly (e.g. a bare IPv6 dut_ip from a VRF config).
+    ip = _bracket_ipv6(ip)
     port = env.gnmi_port
     interval = interval_ms / 1000.0
     # For a non-default VRF the gnmi container does not have `ip vrf exec`


### PR DESCRIPTION
### Description of PR

Summary:
Fixes #25980

After #20456 parameterized the gNMI polling tests over VRF configurations,
`test_gnmi_configdb_polling_01` fails deterministically on DUTs with
IPv6-only management addresses. The VRF parameterization now passes the DUT
IP explicitly (`ip=vrf_config["dut_ip"]`), which is a bare IPv6 literal.

`gnmi_subscribe_polling()` only wrapped the address in brackets on the
default path (`ip is None`); when `ip` is supplied explicitly the IPv6
brackets were skipped, so the command built an invalid target
`-a 2001:db8:...:PORT`. `gnmi_cli` cannot parse the colon-laden bare IPv6
against the `:port` separator, times out, and returns empty output. The
test then fails because `msg.count("bgp_asn")` is `0` instead of the
expected `3`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: regression (introduced by #20456)

### Approach
#### What is the motivation for this PR?
Make `gnmi_subscribe_polling()` connect successfully on IPv6-only management
DUTs so `test_gnmi_configdb_polling_01` passes, regardless of whether the
server IP is defaulted from `duthost.mgmt_ip` or passed in explicitly by the
VRF-parameterized test.

#### How did you do it?
Added a small `_bracket_ipv6()` helper that wraps IPv6 literals as
`[<ipv6>]:<port>` (using `ipaddress.ip_address(...).version == 6`) and left
IPv4 addresses, hostnames, and already-bracketed values untouched. The
helper is applied in `gnmi_subscribe_polling()` after `ip` is resolved, so
bracketing is correct on both the defaulted and explicit paths. The default
path no longer needs the `is_mgmt_ipv6_only` fact lookup, since bracketing is
now driven by the actual address family.

#### How did you verify/test it?
- Unit-verified `_bracket_ipv6()` against IPv4, bare IPv6, already-bracketed
  IPv6, link-local IPv6, hostname, empty, and `None` inputs — the bug-repro
  IPv6 now yields the correct target `-a [2001:db8:...]:8080`.
- `python3 -m py_compile tests/gnmi/helper.py` — clean.
- `flake8 --max-line-length=120 tests/gnmi/helper.py` — clean.
- Elastictest CI (gnmi tests run on t0/t1-lag).

#### Any platform specific information?
No. The fix is generic; it only affects how the gNMI polling client target
string is formatted for IPv6 addresses.

#### Supported testbed topology if it's a new test case?
N/A — fix to an existing helper used by `gnmi/test_gnmi_configdb.py`.

### Documentation
No documentation changes required.

🤖 *This response was generated by an AI agent on behalf of @yxieca.*
