### PR TITLE
[console] Default fast_cli=False in BaseConsoleConn

### DIFF
--- a/tests/common/connections/base_console_conn.py
+++ b/tests/common/connections/base_console_conn.py
@@ -52,6 +52,12 @@ class BaseConsoleConn(CiscoBaseConnection):
             if key in kwargs:
                 del kwargs[key]
 
+        # netmiko's fast_cli=True default silently sets global_delay_factor
+        # to 0.1, which shrinks login polling budgets too tightly for
+        # serial-console getty timing. Default it off; callers can still
+        # opt in via kwargs.
+        kwargs.setdefault('fast_cli', False)
+
         # Allow legacy KEX and host key algorithms for older console servers
         # (e.g. Cisco SSH-2.0-Cisco-1.25) that only support legacy crypto.
         # paramiko 5.x removed these from _preferred_kex, _kex_info,


### PR DESCRIPTION
### Description of PR

netmiko's `fast_cli=True` default rewrites `global_delay_factor` 1 → 0.1, shrinking `login_stage_2`'s Password-prompt window to ~1.1s. Slower serial-console gettys miss that window and intermittently fail console login. Default `fast_cli=False` in `BaseConsoleConn`; callers can still opt in.

Summary: Default fast_cli off for `BaseConsoleConn` subclasses.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type:

### Approach
#### What is the motivation for this PR?

Intermittent console-login failures on slower DUTs, caused by netmiko `fast_cli` scaling the login polling budget by 10x.

#### How did you do it?

`kwargs.setdefault('fast_cli', False)` in `BaseConsoleConn.__init__`.

#### How did you verify/test it?

Ran `dut_console/test_escape_character.py` on physical testbeds, 3 runs each. All pass with the fix.

#### Any platform specific information?

None.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.
