### PR TITLE
[pre-commit] Fix flake8 reporting issues on unmodified lines

### DIFF
--- a/.azure-pipelines/common2/scripts/flake8-diff-filter.py
+++ b/.azure-pipelines/common2/scripts/flake8-diff-filter.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+Run flake8 on the given files, but only report violations that fall on
+lines added or modified relative to a base commit.
+
+flake8 (like most linters) always checks a file's entire contents, so
+touching a single line of a file causes it to re-report every pre-existing
+style issue in that file, even on lines the change never touched. This
+wrapper filters flake8's output down to only the lines actually changed
+between --base and --head, so CI only flags issues introduced by the change.
+
+The rulesets below mirror the flake8 hook definitions in
+.pre-commit-config.yaml (the tests/common2-specific hook is intentionally
+not mirrored here, since those files are filtered out before this runs).
+
+See: https://github.com/sonic-net/sonic-mgmt/issues/25351
+"""
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+HUNK_RE = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@')
+VIOLATION_RE = re.compile(r'^(?P<path>[^:]+):(?P<line>\d+):\d+: ')
+
+# These mirror the per-hook args in .pre-commit-config.yaml. flake8 also
+# auto-discovers the repo's .flake8 file (per-file-ignores, exclude), so those
+# are honored here exactly as they are under pre-commit. The '.py' filter is a
+# slightly narrower approximation of pre-commit's content-based `types: [python]`
+# (it skips extensionless Python scripts), which errs on the safe side of not
+# reporting rather than over-reporting.
+RULESETS = [
+    {
+        'match': lambda f: f.endswith('.py') and not f.startswith('spytest/'),
+        'args': ['--max-line-length=120'],
+    },
+    {
+        'match': lambda f: f.endswith('.py') and f.startswith('spytest/'),
+        'args': ['--max-line-length=120', '--ignore=E1,E2,E3,E5,E7,W5'],
+    },
+]
+
+
+def changed_lines(base, head, path):
+    """Return the set of line numbers in `path`@head added/modified since base."""
+    out = subprocess.run(
+        ['git', 'diff', '-U0', base, head, '--', path],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    lines = set()
+    for line in out.splitlines():
+        m = HUNK_RE.match(line)
+        if not m:
+            continue
+        start = int(m.group(1))
+        count = int(m.group(2)) if m.group(2) is not None else 1
+        if count == 0:
+            # Pure deletion hunk; nothing added on the new-file side.
+            continue
+        lines.update(range(start, start + count))
+    return lines
+
+
+def run_flake8(files, flake8_args):
+    if not files:
+        return ''
+    proc = subprocess.run(
+        ['flake8'] + flake8_args + files,
+        capture_output=True, text=True,
+    )
+    return proc.stdout
+
+
+def filter_violations(output, base, head, cache):
+    kept = []
+    for line in output.splitlines():
+        m = VIOLATION_RE.match(line)
+        if not m:
+            # Not a per-line violation (e.g. a fatal flake8 error); keep it
+            # so problems are never silently swallowed.
+            kept.append(line)
+            continue
+        path, lineno = m.group('path'), int(m.group('line'))
+        if path not in cache:
+            cache[path] = changed_lines(base, head, path)
+        if lineno in cache[path]:
+            kept.append(line)
+    return kept
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--base', required=True, help='Base commit/ref to diff against')
+    parser.add_argument('--head', default='HEAD', help='Head commit/ref (default: HEAD)')
+    parser.add_argument('files', nargs='*', help='Files to lint')
+    args = parser.parse_args()
+
+    # Skip files that no longer exist (e.g. deleted by this change); flake8
+    # can't lint them, and they have no "current" lines to report on anyway.
+    existing_files = [f for f in args.files if os.path.isfile(f)]
+
+    line_cache = {}
+    all_kept = []
+    for ruleset in RULESETS:
+        files = [f for f in existing_files if ruleset['match'](f)]
+        if not files:
+            continue
+        output = run_flake8(files, ruleset['args'])
+        if output.strip():
+            all_kept.extend(filter_violations(output, args.base, args.head, line_cache))
+
+    if all_kept:
+        print('\n'.join(all_kept))
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.azure-pipelines/common2/scripts/flake8-diff-filter.py
+++ b/.azure-pipelines/common2/scripts/flake8-diff-filter.py
@@ -63,13 +63,20 @@ def changed_lines(base, head, path):
 
 
 def run_flake8(files, flake8_args):
+    """Run flake8 and return (stdout, stderr, returncode).
+
+    flake8 exits 0 when clean and 1 when it finds lint violations; any higher
+    exit code means flake8 itself failed to run (bad config, plugin load
+    failure, internal error) and typically reports the reason only on stderr.
+    Callers must inspect the return code so such failures are not swallowed.
+    """
     if not files:
-        return ''
+        return '', '', 0
     proc = subprocess.run(
         ['flake8'] + flake8_args + files,
         capture_output=True, text=True,
     )
-    return proc.stdout
+    return proc.stdout, proc.stderr, proc.returncode
 
 
 def filter_violations(output, base, head, cache):
@@ -106,9 +113,19 @@ def main():
         files = [f for f in existing_files if ruleset['match'](f)]
         if not files:
             continue
-        output = run_flake8(files, ruleset['args'])
-        if output.strip():
-            all_kept.extend(filter_violations(output, args.base, args.head, line_cache))
+        stdout, stderr, rc = run_flake8(files, ruleset['args'])
+        if rc > 1:
+            # flake8 failed to run (not a lint finding). Surface its output
+            # verbatim and fail the wrapper so the error is never silently
+            # swallowed -- otherwise, since flake8 is SKIPped in the
+            # pre-commit run, this would let style regressions ship green.
+            all_kept.append('flake8 failed to run (exit status %d):' % rc)
+            detail = (stderr or stdout).strip()
+            if detail:
+                all_kept.extend(detail.splitlines())
+            continue
+        if stdout.strip():
+            all_kept.extend(filter_violations(stdout, args.base, args.head, line_cache))
 
     if all_kept:
         print('\n'.join(all_kept))

--- a/.azure-pipelines/pre-commit-check.yml
+++ b/.azure-pipelines/pre-commit-check.yml
@@ -16,16 +16,48 @@ steps:
 - script: |
     set -x
     sudo pip install pre-commit
+    # Pin to the same flake8 version used by the flake8 hook in
+    # .pre-commit-config.yaml, since flake8 is also run directly below
+    # (outside of pre-commit) for diff-based line filtering.
+    sudo pip install flake8==6.0.0
     pre-commit install-hooks
   displayName: 'Prepare pre-commit check'
 
 - script: |
+    # Determine the base commit to diff against: the merge-base with the
+    # PR's target branch (falling back to the previous commit for non-PR
+    # builds). Using HEAD^ here previously only looked at the most recent
+    # commit, which is incorrect for multi-commit PRs.
+    TARGET_BRANCH_RAW="${SYSTEM_PULLREQUEST_TARGETBRANCH:-master}"
+    TARGET_BRANCH="${TARGET_BRANCH_RAW#refs/heads/}"
+    git fetch origin "${TARGET_BRANCH}" 2>/dev/null || true
+    BASE_COMMIT=$(git merge-base HEAD "origin/${TARGET_BRANCH}" 2>/dev/null || echo HEAD^)
+    echo "Using base commit ${BASE_COMMIT} (target branch: ${TARGET_BRANCH})"
+
     # Run pre-commit check and capture the output
-    CHANGED_FILES=$(git diff --name-only HEAD^ HEAD)
+    CHANGED_FILES=$(git diff --name-only "${BASE_COMMIT}" HEAD)
     FILTERED_FILES=$(echo "$CHANGED_FILES" | grep -v '^tests/common2')
+    RC=0
+    out=""
     if [ -n "$FILTERED_FILES" ]; then
-      out=`pre-commit run --color never --files $FILTERED_FILES`
+      # Run every pre-commit hook except flake8. flake8 checks a file's
+      # entire contents, so it is run separately below with diff-based line
+      # filtering to avoid reporting pre-existing issues on lines this PR
+      # did not modify (see sonic-net/sonic-mgmt#25351).
+      out=`SKIP=flake8 pre-commit run --color never --files $FILTERED_FILES`
       RC=$?
+
+      # Capture stderr as well as stdout so an unexpected failure in the
+      # filter script (or flake8 itself) surfaces in the report instead of
+      # producing a red build with no explanation.
+      flake8_out=`python3 .azure-pipelines/common2/scripts/flake8-diff-filter.py --base "$BASE_COMMIT" --head HEAD $FILTERED_FILES 2>&1`
+      flake8_rc=$?
+      if [ -n "$flake8_out" ]; then
+        out="$out"$'\n\nflake8 (only issues on lines modified by this PR)........................Failed\n'"$flake8_out"
+      fi
+      if [ $flake8_rc -ne 0 ]; then
+        RC=1
+      fi
     else
       out="No files outside tests/common2 to check."
       RC=0

--- a/.azure-pipelines/pre-commit-check.yml
+++ b/.azure-pipelines/pre-commit-check.yml
@@ -11,6 +11,11 @@ steps:
 
 - checkout: self
   clean: true
+  # Full history is required so `git merge-base HEAD origin/<target>` below can
+  # resolve the PR's fork point. A shallow checkout would make merge-base fail
+  # and silently fall back to HEAD^, reintroducing the multi-commit bug this
+  # job is meant to fix.
+  fetchDepth: 0
   displayName: 'checkout sonic-mgmt repo'
 
 - script: |
@@ -30,13 +35,25 @@ steps:
     # commit, which is incorrect for multi-commit PRs.
     TARGET_BRANCH_RAW="${SYSTEM_PULLREQUEST_TARGETBRANCH:-master}"
     TARGET_BRANCH="${TARGET_BRANCH_RAW#refs/heads/}"
-    git fetch origin "${TARGET_BRANCH}" 2>/dev/null || true
-    BASE_COMMIT=$(git merge-base HEAD "origin/${TARGET_BRANCH}" 2>/dev/null || echo HEAD^)
+    # Fetch directly into the remote-tracking ref so `git merge-base` can
+    # resolve it. A plain `git fetch origin <branch>` only updates FETCH_HEAD
+    # in some checkout configurations, leaving origin/<branch> missing/stale.
+    git fetch origin "${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}" 2>/dev/null \
+      || git fetch origin "${TARGET_BRANCH}" 2>/dev/null \
+      || true
+    BASE_COMMIT=$(git merge-base HEAD "origin/${TARGET_BRANCH}" 2>/dev/null || true)
+    if [ -z "$BASE_COMMIT" ]; then
+      # Loud fallback: merge-base failed (e.g. tracking ref unavailable), so
+      # diff-based filtering degrades to the single most recent commit and may
+      # report pre-existing issues or miss earlier commits in a multi-commit PR.
+      echo "WARNING: could not determine merge-base with origin/${TARGET_BRANCH}; falling back to HEAD^" >&2
+      BASE_COMMIT=HEAD^
+    fi
     echo "Using base commit ${BASE_COMMIT} (target branch: ${TARGET_BRANCH})"
 
     # Run pre-commit check and capture the output
     CHANGED_FILES=$(git diff --name-only "${BASE_COMMIT}" HEAD)
-    FILTERED_FILES=$(echo "$CHANGED_FILES" | grep -v '^tests/common2')
+    FILTERED_FILES=$(echo "$CHANGED_FILES" | grep -v '^tests/common2/')
     RC=0
     out=""
     if [ -n "$FILTERED_FILES" ]; then

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,10 @@ repos:
     -   id: check-added-large-files
     -   id: check-ast
 
+# NOTE: The flake8 rev and the per-hook args below are mirrored by the
+# diff-aware CI wrapper in .azure-pipelines/common2/scripts/flake8-diff-filter.py
+# (RULESETS) and the flake8 pin in .azure-pipelines/pre-commit-check.yml. Keep
+# them in sync when changing the version or the general/spytest args.
 -   repo: https://github.com/PyCQA/flake8
     rev: 6.0.0
     hooks:


### PR DESCRIPTION
### Description of PR

Summary:
The pre-commit check job runs `pre-commit run --files <changed files>`, which lints each touched file's **entire contents** with flake8. Any pre-existing style issue anywhere in a touched file is therefore reported, even on lines the PR never modified. The base commit was also hardcoded to `HEAD^`, which is wrong for multi-commit PRs. This PR makes flake8 report only issues on lines the PR actually changed.

Ref #25351

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Ref #25351: touching one line of a file causes CI to re-report every pre-existing flake8 issue in that file, producing failures on issues the PR did not introduce.

#### How did you do it?

- `.azure-pipelines/pre-commit-check.yml`: compute the base commit as `git merge-base HEAD origin/<target branch>` instead of `HEAD^`, so the diff covers the whole PR and stays pinned to its fork point even if the target branch advances.
- Skip flake8 inside `pre-commit run` (`SKIP=flake8`) and run it via a new diff-aware wrapper, `.azure-pipelines/common2/scripts/flake8-diff-filter.py`, which filters flake8's output down to violations on lines added/modified since the base commit (parsed from `git diff -U0` hunks). Its output/exit code are merged into the existing report. The repo's `.flake8` (per-file-ignores/exclude) is auto-discovered, so behavior matches pre-commit.

#### How did you verify/test it?

- Local git sandbox: pre-existing issues on untouched lines are dropped; a new issue on a modified line is still reported.
- Validated YAML, `bash -n`/`shellcheck`, and ran `flake8` + `py_compile` on the new script.

#### Any platform specific information?

N/A

