### PR TITLE
test_cont_link_flap wait until memory stable instead of sleep, with extended time for T2

### DIFF
--- a/tests/platform_tests/link_flap/test_cont_link_flap.py
+++ b/tests/platform_tests/link_flap/test_cont_link_flap.py
@@ -8,7 +8,6 @@ Parameters:
 
 import logging
 import pytest
-import time
 import math
 import re
 
@@ -70,6 +69,24 @@ class TestContLinkFlap(object):
             frr_daemon_memory_per_asics[asic.asic_index] = total_memory
 
         return frr_daemon_memory_per_asics
+
+    def check_frr_daemon_memory_stable(self, duthost, prev_usages_per_asic, threshold_percent=1):
+        unstable = False
+        for daemon, prev_usage in prev_usages_per_asic.items():
+            current_usage = self.get_frr_daemon_memory_usage(duthost, daemon)
+            pytest_assert(current_usage.keys() == prev_usage.keys(),
+                          "{} ASIC keys changed between frr memory stability checks: "
+                          "expected {}, got {}".format(daemon, set(prev_usage.keys()), set(current_usage.keys())))
+
+            for asic_index, prev_mem in prev_usage.items():
+                curr_mem = current_usage[asic_index]
+                change_percent = float('inf') if prev_mem == 0 else abs(curr_mem - prev_mem) / prev_mem * 100
+                if change_percent > threshold_percent:
+                    unstable = True
+                    logging.debug("asic%s FRR %s memory not stable: %.2f MiB -> %.2f MiB (%.1f%%)",
+                                  asic_index, daemon, prev_mem, curr_mem, change_percent)
+            prev_usages_per_asic[daemon] = current_usage
+        return not unstable
 
     @staticmethod
     def _parse_memory_value(line):
@@ -197,8 +214,13 @@ class TestContLinkFlap(object):
 
             pytest.fail(str(failmsg))
 
-        # Wait 30s for the memory usage to be stable
-        time.sleep(30)
+        # Wait for FRR daemon memory to stabilize
+        wait_timeout = 60 if 't2' in tbinfo['topo']['name'] else 30
+        memory_usages = {}
+        for daemon in frr_demons_to_check:
+            memory_usages[daemon] = self.get_frr_daemon_memory_usage(duthost, daemon)
+        if not wait_until(wait_timeout, 5, 5, self.check_frr_daemon_memory_stable, duthost, memory_usages):
+            logging.warning("FRR daemon memory did not stabilize within {}s, proceeding to check".format(wait_timeout))
 
         # Record memory status at end
         memory_output = duthost.shell("show system-memory")["stdout"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #27007
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

Make `platform_tests/link_flap/test_cont_link_flap.py` more consistent on T2 testbeds.

The test previously waited 30s arbitrarily. Use wait_until instead with an upper max wait time of 60s for T2, this pattern is used earlier in the test as well.

Note that if "stability" is not reached within the wait until, the test still proceeds to the final check.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
