### PR TITLE
Removed admin_up checks from test_switch_host_status_control

### DIFF
--- a/tests/platform_tests/api/test_switch_host_module.py
+++ b/tests/platform_tests/api/test_switch_host_module.py
@@ -149,16 +149,16 @@ class TestSwitchHostModuleApi(PlatformApiTestBase):
             self.expect(ret is True, f"set_admin_state(False) should return True, got {ret!r}")
             wait_until(180, 10, 0, lambda: _oper() == 'offline')
             self.expect(
-                wait_until(180, 10, 0, lambda: _cli_status()[0] == 'offline' and _admin_off(_cli_status()[1])),
-                f"CLI status did not reach offline/off after admin-down, got {_cli_status()!r}"
+                wait_until(180, 10, 0, lambda: _cli_status()[0] == 'offline'),
+                f"CLI status did not reach offline after admin-down, got {_cli_status()!r}"
             )
 
             ret = module_api.set_admin_state(platform_api_conn, self.sw_idx, True)
             self.expect(ret is True, f"set_admin_state(True) should return True, got {ret!r}")
             wait_until(420, 10, 30, lambda: host.critical_services_fully_started())
             self.expect(
-                wait_until(420, 10, 30, lambda: _cli_status()[0] == 'online' and _admin_on(_cli_status()[1])),
-                f"CLI status did not return to online/on after admin-up, got {_cli_status()!r}"
+                wait_until(420, 10, 30, lambda: _cli_status()[0] == 'online'),
+                f"CLI status did not return to online after admin-up, got {_cli_status()!r}"
             )
 
             post_boot = host.shell("uptime -s").get('stdout', '').strip()


### PR DESCRIPTION
### Description of PR

Summary:
Remove the admin_up checks from test_switch_host_status_control since admin_up is the config option and the test is calling the API directly.
Test test is calling the platform API to toggle the SWITCH-HOST power.
The config and admin status does not change.

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605



### Approach
#### What is the motivation for this PR?
Fix the expected CLI state in the test

#### How did you do it?
Removed the admin state checks, as driven by the config

#### How did you verify/test it?
Ran the test on the BMC testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

