### PR TITLE
Use asic commands for ipv6 erspan as the cli does not support it

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -1013,6 +1013,37 @@ class BaseEverflowTest(object):
             self.remove_policer_config(duthost, policer, config_method)
 
     @staticmethod
+    def _build_v6_erspan_asic_command(session_info, asic_index=None, queue_num=None, policer=None):
+        """Build the ASIC command string for adding an ERSPAN mirror session
+
+        This is required as the CLI does not yet support adding IPv6 ERSPAN sessions.
+
+        Args:
+            session_info: Mirror session parameters dict.
+            asic_index: Optional ASIC index number.
+            queue_num: Optional queue number.
+            policer: Optional policer name.
+
+        Returns:
+            str: The ASIC command string.
+        """
+        per_asic_index = f"-n asic{asic_index} " if asic_index is not None else ""
+        command = (f"sonic-db-cli {per_asic_index}CONFIG_DB HSET "
+                   f"'MIRROR_SESSION|{session_info['session_name']}' "
+                   f"'dscp' '{session_info['session_dscp']}' "
+                   f"'dst_ip' '{session_info['session_dst_ipv6']}' "
+                   f"'gre_type' '{session_info['session_gre']}' "
+                   f"'type' '{session_info['session_type']}' "
+                   f"'src_ip' '{session_info['session_src_ipv6']}' "
+                   f"'ttl' '{session_info['session_ttl']}'")
+        if queue_num is not None:
+            command += f" 'queue' '{queue_num}'"
+        if policer is not None:
+            command += f" 'policer' '{policer}'"
+
+        return command
+
+    @staticmethod
     def _build_erspan_cli_command(session_info, queue_num=None,
                                   direction=None, policer=None,
                                   use_erspan_subcmd=False,
@@ -1120,12 +1151,23 @@ class BaseEverflowTest(object):
                             )
                         )
             else:
-                command = BaseEverflowTest._build_erspan_cli_command(
-                    session_info, queue_num=queue_num,
-                    policer=policer, use_erspan_subcmd=False,
-                    erspan_ip_ver=erspan_ip_ver
-                )
-                duthost.command(command)
+                if erspan_ip_ver == 4:
+                    command = BaseEverflowTest._build_erspan_cli_command(
+                        session_info, queue_num=queue_num,
+                        policer=policer, use_erspan_subcmd=False,
+                        erspan_ip_ver=erspan_ip_ver
+                    )
+                    duthost.command(command)
+                else:
+                    # Adding IPv6 ERSPAN sessions for each asic, from the CLI is currently not supported.
+                    commands_list = [
+                            BaseEverflowTest._build_v6_erspan_asic_command(session_info, asic_index=asic_index,
+                                                                           queue_num=queue_num, policer=policer)
+                            for asic_index in duthost.get_frontend_asic_ids()
+                    ]
+
+                    for cmd in commands_list:
+                        duthost.command(cmd)
 
         elif config_method == CONFIG_MODE_CONFIGLET:
             pass


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
When running eveflow tests which require erspan IPv6 mirroring, use ASIC commands as the CLI does not support that AF.

Introduced by: https://github.com/sonic-net/sonic-mgmt/pull/22663

Summary:
Fixes #25990
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
Restore fallback commands to prevent test failures due to CLI command syntax violations.

#### How did you do it?
Restored original fallback code to allow for ASIC commands to be run if the erspan AF is IPv6.

#### How did you verify/test it?
Verified that all testlets of everflow/test_everflow_per_interface.py are passing with this change.

#### Any platform specific information?
None.

#### Supported testbed topology if it's a new test case?
None.

### Documentation
None.
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
