### PR TITLE
cacl: retry iptables/ip6tables read in verify_cacl to avoid caclmgrd …

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -1081,8 +1081,14 @@ def verify_cacl(duthost, tbinfo, localhost, creds, docker_network,
     expected_iptables_rules, expected_ip6tables_rules = \
         generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expected_dhcp_rules_for_standby)
 
-    stdout = duthost.get_asic_or_sonic_host(asic_index).command("iptables -S")["stdout"]
-    actual_iptables_rules = stdout.strip().split("\n")
+    actual_iptables_rules = []
+
+    def _iptables_rules_present():
+        actual_iptables_rules[:] = \
+            duthost.get_asic_or_sonic_host(asic_index).command("iptables -S")["stdout"].strip().split("\n")
+        return len(set(expected_iptables_rules) - set(actual_iptables_rules)) == 0
+
+    wait_until(60, 5, 0, _iptables_rules_present)
 
     # Ensure all expected iptables rules are present on the DuT
     logger.info("Number of expected iptable rules:{}, number of actual iptables rules:{}"
@@ -1104,8 +1110,14 @@ def verify_cacl(duthost, tbinfo, localhost, creds, docker_network,
     # for i in range(len(expected_iptables_rules)):
     #    pytest_assert(actual_iptables_rules[i] == expected_iptables_rules[i], "iptables rules not in expected order")
 
-    stdout = duthost.get_asic_or_sonic_host(asic_index).command("ip6tables -S")["stdout"]
-    actual_ip6tables_rules = stdout.strip().split("\n")
+    actual_ip6tables_rules = []
+
+    def _ip6tables_rules_present():
+        actual_ip6tables_rules[:] = \
+            duthost.get_asic_or_sonic_host(asic_index).command("ip6tables -S")["stdout"].strip().split("\n")
+        return len(set(expected_ip6tables_rules) - set(actual_ip6tables_rules)) == 0
+
+    wait_until(60, 5, 0, _ip6tables_rules_present)
 
     # Ensure all expected ip6tables rules are present on the DuT
     logger.info("Number of expected ip6table rules:{}, number of actual ip6tables rules:{}"


### PR DESCRIPTION
…rebuild race

verify_cacl read `iptables -S`/`ip6tables -S` once with no retry. caclmgrd rebuilds the chains non-atomically (flush then per-rule re-add) on every reprogram, so a single read could race with an in-progress rebuild and observe transiently-missing FRR loopback rules (dport 2601/2620), causing intermittent "Missing expected iptables rules" failures on multi-ASIC DUTs. Poll with wait_until until all expected rules are present before asserting.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
