### PR TITLE
Fix the deprecated lacp rate command in cEOS 4.35

### DIFF
--- a/ansible/roles/eos/templates/dpu-tor.j2
+++ b/ansible/roles/eos/templates/dpu-tor.j2
@@ -77,7 +77,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
 {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/lt2-o128-tor.j2
+++ b/ansible/roles/eos/templates/lt2-o128-tor.j2
@@ -156,7 +156,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
  no shutdown
 !

--- a/ansible/roles/eos/templates/m0-mx.j2
+++ b/ansible/roles/eos/templates/m0-mx.j2
@@ -107,7 +107,7 @@ interface {{ if_name }}
  vrf {{ vrf }}
             {% if if_data['lacp'] is defined %}
  channel-group {{ if_data['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
             {% endif %}
             {% if if_data['ipv4'] is defined %}
  ip address {{ if_data['ipv4'] }}

--- a/ansible/roles/eos/templates/t0-8-lag-leaf.j2
+++ b/ansible/roles/eos/templates/t0-8-lag-leaf.j2
@@ -72,7 +72,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
 {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/t0-isolated-d2u254s1-tor.j2
+++ b/ansible/roles/eos/templates/t0-isolated-d2u254s1-tor.j2
@@ -112,7 +112,7 @@ interface {{ if_name }}
  vrf {{ vrf }}
             {% if if_data['lacp'] is defined %}
  channel-group {{ if_data['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
             {% endif %}
             {% if if_data['ipv4'] is defined %}
  ip address {{ if_data['ipv4'] }}

--- a/ansible/roles/eos/templates/t0-leaf-lag-2.j2
+++ b/ansible/roles/eos/templates/t0-leaf-lag-2.j2
@@ -77,7 +77,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
 {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/t0-leaf.j2
+++ b/ansible/roles/eos/templates/t0-leaf.j2
@@ -112,7 +112,7 @@ interface {{ if_name }}
  vrf {{ vrf }}
             {% if if_data['lacp'] is defined %}
  channel-group {{ if_data['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
             {% endif %}
             {% if if_data['ipv4'] is defined %}
  ip address {{ if_data['ipv4'] }}
@@ -143,7 +143,7 @@ interface {{ name }}
         {% endif %}
         {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
         {% endif %}
         {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/t0-mclag-leaf.j2
+++ b/ansible/roles/eos/templates/t0-mclag-leaf.j2
@@ -72,7 +72,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
 {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/t0-v6-leaf.j2
+++ b/ansible/roles/eos/templates/t0-v6-leaf.j2
@@ -112,7 +112,7 @@ interface {{ if_name }}
  vrf {{ vrf }}
             {% if if_data['lacp'] is defined %}
  channel-group {{ if_data['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
             {% endif %}
             {% if if_data['ipv4'] is defined %}
  ip address {{ if_data['ipv4'] }}
@@ -143,7 +143,7 @@ interface {{ name }}
         {% endif %}
         {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
         {% endif %}
         {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/t1-28-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-28-lag-spine.j2
@@ -72,7 +72,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
 {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/t1-28-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-28-lag-tor.j2
@@ -81,7 +81,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
  no shutdown
 !

--- a/ansible/roles/eos/templates/t1-48-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-48-lag-spine.j2
@@ -72,7 +72,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
 {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/t1-48-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-48-lag-tor.j2
@@ -81,7 +81,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
  no shutdown
 !

--- a/ansible/roles/eos/templates/t1-56-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-56-lag-tor.j2
@@ -81,7 +81,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
  no shutdown
 !

--- a/ansible/roles/eos/templates/t1-64-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-64-lag-tor.j2
@@ -155,7 +155,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
  no shutdown
 !

--- a/ansible/roles/eos/templates/t1-8-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-8-lag-spine.j2
@@ -76,7 +76,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
 {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/t1-8-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-8-lag-tor.j2
@@ -85,7 +85,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
  no shutdown
 !

--- a/ansible/roles/eos/templates/t1-f2-d10u8-spine.j2
+++ b/ansible/roles/eos/templates/t1-f2-d10u8-spine.j2
@@ -72,7 +72,7 @@ interface {{ name }}
     {% endif %}
     {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
     {% endif %}
     {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/t1-f2-d10u8-tor.j2
+++ b/ansible/roles/eos/templates/t1-f2-d10u8-tor.j2
@@ -81,7 +81,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
  no shutdown
 !

--- a/ansible/roles/eos/templates/t1-filterleaf-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-filterleaf-lag-spine.j2
@@ -72,7 +72,7 @@ port-channel min-links 2
 {% endif %}
 {% if iface['lacp'] is defined %}
 channel-group {{ iface['lacp'] }} mode active
-lacp rate normal
+lacp timer normal
 {% endif %}
 {% if iface['ipv4'] is defined %}
 ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/t1-filterleaf-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-filterleaf-lag-tor.j2
@@ -85,7 +85,7 @@ ipv6 nd ra suppress
 {% endif %}
 {% if iface['lacp'] is defined %}
 channel-group {{ iface['lacp'] }} mode active
-lacp rate normal
+lacp timer normal
 {% endif %}
 no shutdown
 !

--- a/ansible/roles/eos/templates/t1-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-lag-spine.j2
@@ -112,7 +112,7 @@ interface {{ if_name }}
  vrf {{ vrf }}
             {% if if_data['lacp'] is defined %}
  channel-group {{ if_data['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
             {% endif %}
             {% if if_data['ipv4'] is defined %}
  ip address {{ if_data['ipv4'] }}
@@ -143,7 +143,7 @@ interface {{ name }}
         {% endif %}
         {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
         {% endif %}
         {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/t1-smartswitch-ha-spine.j2
+++ b/ansible/roles/eos/templates/t1-smartswitch-ha-spine.j2
@@ -72,7 +72,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
 {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/t1-smartswitch-ha-tor.j2
+++ b/ansible/roles/eos/templates/t1-smartswitch-ha-tor.j2
@@ -72,7 +72,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
 {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/t2-core.j2
+++ b/ansible/roles/eos/templates/t2-core.j2
@@ -97,7 +97,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
 {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/t2-leaf.j2
+++ b/ansible/roles/eos/templates/t2-leaf.j2
@@ -84,7 +84,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
 {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/t2-vs-core.j2
+++ b/ansible/roles/eos/templates/t2-vs-core.j2
@@ -79,7 +79,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
 {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/t2-vs-leaf.j2
+++ b/ansible/roles/eos/templates/t2-vs-leaf.j2
@@ -79,7 +79,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
 {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/wan-2dut-core.j2
+++ b/ansible/roles/eos/templates/wan-2dut-core.j2
@@ -72,7 +72,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
 {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/wan-3link-tg-core.j2
+++ b/ansible/roles/eos/templates/wan-3link-tg-core.j2
@@ -72,7 +72,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
 {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/wan-4link-core.j2
+++ b/ansible/roles/eos/templates/wan-4link-core.j2
@@ -72,7 +72,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
 {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/wan-ecmp-core.j2
+++ b/ansible/roles/eos/templates/wan-ecmp-core.j2
@@ -76,7 +76,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
 {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/wan-pub-core.j2
+++ b/ansible/roles/eos/templates/wan-pub-core.j2
@@ -72,7 +72,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
 {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/ansible/roles/eos/templates/wan-pub-isis-core.j2
+++ b/ansible/roles/eos/templates/wan-pub-isis-core.j2
@@ -90,7 +90,7 @@ interface {{ name }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
- lacp rate normal
+ lacp timer normal
 {% endif %}
 {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -479,14 +479,12 @@ class EosHost(AnsibleHostBase):
 
     def set_interface_lacp_rate_mode(self, interface_name, mode):
         out = self.eos_config(
-            lines=['lacp rate %s' % mode],
+            lines=['lacp timer %s' % mode],
             parents='interface %s' % interface_name)
 
-        # FIXME: out['failed'] will be False even when a command is deprecated, so we have to check out['changed']
-        # However, if the lacp rate is already in expected state, out['changed'] will be False and treated as
+        # If the lacp timer is already in expected state, out['changed'] will be False and treated as
         # error.
         if out.get('failed', False) is True or out['changed'] is False:
-            # new eos deprecate lacp rate and use lacp timer command
             out = self.eos_config(
                 lines=['lacp timer %s' % mode],
                 parents='interface %s' % interface_name)
@@ -496,7 +494,7 @@ class EosHost(AnsibleHostBase):
             else:
                 logging.info("Set interface [%s] lacp timer to [%s]" % (interface_name, mode))
         else:
-            logging.info("Set interface [%s] lacp rate to [%s]" % (interface_name, mode))
+            logging.info("Set interface [%s] lacp timer to [%s]" % (interface_name, mode))
         return out
 
     def is_multiagent(self):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
In cEOS 4.35, the command of 'lacp rate' is deprecated and replaced by 'lacp time'.
The fix updated the commands in both templates and test code.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #26000 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
In cEOS 4.35, the deprecated command, 'lacp rate', is no longer accepted, which will cause test fail.

#### How did you do it?
Replace 'lacp rate' with 'lacp timer'.

#### How did you verify/test it?
Run pc/test_lag_2.py test on t1-64-lag topo. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
