### PR TITLE
[ACL] Fix outer VLAN counter reads

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -296,12 +296,20 @@ def get_acl_counter(duthost, table_name, rule_name, timeout=ACL_COUNTERS_UPDATE_
     Returns:
         Acl counter value for packets
     """
-    # Wait for orchagent to update the ACL counters
-    time.sleep(timeout)
-    result = duthost.show_and_parse('aclshow -a')
+    def _check_acl_counter():
+        result = duthost.show_and_parse('aclshow -a')
+        if len(result) == 0:
+            return False
+        for rule in result:
+            if table_name == rule['table name'] and rule_name == rule['rule name']:
+                return True
+        return False
 
-    if len(result) == 0:
+    # Wait for orchagent to update the ACL counters
+    if not wait_until(timeout, 2, 0, _check_acl_counter):
         pytest.fail("Failed to retrieve acl counter for {}|{}".format(table_name, rule_name))
+
+    result = duthost.show_and_parse('aclshow -a')
     for rule in result:
         if table_name == rule['table name'] and rule_name == rule['rule name']:
             return int(rule['packets count'])

--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -283,7 +283,7 @@ def send_and_verify_traffic(ptfadapter, pkt, exp_pkt, src_port_list, dst_port_li
         testutils.verify_no_packet_any(ptfadapter, exp_pkt, ports=dst_port_list)
 
 
-def get_acl_counter(duthost, table_name, rule_name, timeout=ACL_COUNTERS_UPDATE_INTERVAL):
+def get_acl_counter(duthost, table_name, rule_name, timeout=ACL_COUNTERS_UPDATE_INTERVAL, min_count=None):
     """
     Get Acl counter packets value
 
@@ -302,11 +302,11 @@ def get_acl_counter(duthost, table_name, rule_name, timeout=ACL_COUNTERS_UPDATE_
             return False
         for rule in result:
             if table_name == rule['table name'] and rule_name == rule['rule name']:
-                return True
+                return min_count is None or int(rule['packets count']) >= min_count
         return False
 
     # Wait for orchagent to update the ACL counters
-    if not wait_until(timeout, 2, 0, _check_acl_counter):
+    if not (_check_acl_counter() or wait_until(timeout, 2, 0, _check_acl_counter)):
         pytest.fail("Failed to retrieve acl counter for {}|{}".format(table_name, rule_name))
 
     result = duthost.show_and_parse('aclshow -a')
@@ -573,7 +573,7 @@ class AclVlanOuterTest_Base(object):
 
             count_before = get_acl_counter(duthost, table_name, RULE_1, timeout=0)
             send_and_verify_traffic(ptfadapter, pkt, exp_pkt, src_port, dst_port, pkt_action=action)
-            count_after = get_acl_counter(duthost, table_name, RULE_1)
+            count_after = get_acl_counter(duthost, table_name, RULE_1, min_count=count_before + 1)
 
             logger.info("Verify Acl counter incremented {} > {}".format(count_after, count_before))
             pytest_assert(count_after >= count_before + 1,

--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -283,7 +283,7 @@ def send_and_verify_traffic(ptfadapter, pkt, exp_pkt, src_port_list, dst_port_li
         testutils.verify_no_packet_any(ptfadapter, exp_pkt, ports=dst_port_list)
 
 
-def get_acl_counter(duthost, table_name, rule_name, timeout=ACL_COUNTERS_UPDATE_INTERVAL, min_count=None):
+def get_acl_counter(duthost, table_name, rule_name, timeout=ACL_COUNTERS_UPDATE_INTERVAL, min_count=0):
     """
     Get Acl counter packets value
 
@@ -292,28 +292,28 @@ def get_acl_counter(duthost, table_name, rule_name, timeout=ACL_COUNTERS_UPDATE_
         table_name: Acl Table name
         rule_name: Acl rule name
         timeout: Timeout for Acl counters to update
+        min_count: Wait until the counter reaches at least this value (default 0 = read current value)
 
     Returns:
         Acl counter value for packets
     """
+    counter = {}
+
     def _check_acl_counter():
-        result = duthost.show_and_parse('aclshow -a')
-        if len(result) == 0:
-            return False
-        for rule in result:
+        for rule in duthost.show_and_parse('aclshow -a'):
             if table_name == rule['table name'] and rule_name == rule['rule name']:
-                return min_count is None or int(rule['packets count']) >= min_count
+                count = int(rule['packets count'])
+                if count >= min_count:
+                    counter['value'] = count
+                    return True
+                return False
         return False
 
     # Wait for orchagent to update the ACL counters
     if not (_check_acl_counter() or wait_until(timeout, 2, 0, _check_acl_counter)):
         pytest.fail("Failed to retrieve acl counter for {}|{}".format(table_name, rule_name))
 
-    result = duthost.show_and_parse('aclshow -a')
-    for rule in result:
-        if table_name == rule['table name'] and rule_name == rule['rule name']:
-            return int(rule['packets count'])
-    pytest.fail("Failed to retrieve acl counter for {}|{}".format(table_name, rule_name))
+    return counter['value']
 
 
 def craft_packet(src_mac, dst_mac, dst_ip, ip_version, stage, tagged_mode, vlan_id=10, outer_vlan_id=0, pkt_type=None):


### PR DESCRIPTION
### Description of PR

Summary:
The original change #22978 ("[acl] Replace `time.sleep` with `wait_until` in
`test_acl_outer_vlan`") was reverted by #25690 because switching the baseline
counter read to `wait_until` with `timeout=0` meant the counter check was never
executed once, and post-traffic reads could race asynchronous ACL counter
updates — making the outer-VLAN ingress tests flaky.

This PR re-lands the reverted `time.sleep` → `wait_until` change **together with
the fix** for those two problems, so it can go back in safely:
- a `timeout=0` baseline lookup still performs exactly one immediate counter read;
- post-traffic reads `wait_until` the ACL counter reaches its expected minimum
  value, tolerating the asynchronous counter update.

Fixes # (issue)

ADO: No matching ADO work item found.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

<!-- The failure was observed on the internal 202605 nightly (image SONiC.20260510.04,
Arista-7060CX-32S-C32, t0); the fix was verified on the internal-202605 branch + image
(see verification below). -->
Tracking issue/work item for backport/cherry-pick request:
Observed on the internal `202605` nightly (image `SONiC.20260510.04`,
`Arista-7060CX-32S-C32`, `t0`). No triage-bot ADO work item was filed for this
subtest; the failure was self-diagnosed and verified on the same platform/topology.
Failure type: regression (asynchronous ACL counter update + timeout=0 baseline read).

### Approach
#### What is the motivation for this PR?
The `time.sleep` → `wait_until` change from #22978 was reverted (#25690) because it
introduced two counter-read defects: a `timeout=0` baseline read never executed the
counter check, and post-traffic reads did not tolerate the asynchronous ACL counter
update. Those defects made `acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress`
flaky. This PR reintroduces the reverted change with both defects fixed.

#### How did you do it?
Re-applied #22978's `time.sleep` → `wait_until` change, then fixed the test helper to
evaluate the ACL counter check once before entering `wait_until`, and to optionally
wait for the counter to reach an expected minimum value after traffic.

#### How did you verify/test it?

Local checks:
- `python3 -m py_compile tests/acl/test_acl_outer_vlan.py`
- `flake8 --max-line-length=120 tests/acl/test_acl_outer_vlan.py`

Elastictest runs — both against the **internal-202605** sonic-mgmt branch
(`dev/xuliping/20260709_internal-202605_acl-outer-vlan-counter-timeout-fix`) and
the **202605** image (`SONiC.20260510.04`), on `testbed-bjw3-can-t0-7060-5`
(Arista-7060CX-32S-C32, t0), test `acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress`:

| Run | Elastictest plan | Passed | Failed | Skipped | Result |
|-----|------------------|:------:|:------:|:-------:|--------|
| Single | `6a4f0e874a4c0e59051ee0f3` | 16 | 0 | — | FINISHED / SUCCESS |
| ×10 stability | `6a4f1f6d4a4c0e59051ee10e` | 160 | 0 | 19 | FINISHED / SUCCESS |

This master PR carries the same diff re-landed on `master`.

#### Any platform specific information?
Verified on Arista-7060CX-32S-C32, t0 topology.

#### Supported testbed topology if it's a new test case?
N/A.

### Documentation
N/A.



