### PR TITLE
cacl: fix flaky verify_cacl rule check

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -1081,8 +1081,14 @@ def verify_cacl(duthost, tbinfo, localhost, creds, docker_network,
     expected_iptables_rules, expected_ip6tables_rules = \
         generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expected_dhcp_rules_for_standby)
 
-    stdout = duthost.get_asic_or_sonic_host(asic_index).command("iptables -S")["stdout"]
-    actual_iptables_rules = stdout.strip().split("\n")
+    actual_iptables_rules = []
+
+    def _iptables_rules_present():
+        actual_iptables_rules[:] = \
+            duthost.get_asic_or_sonic_host(asic_index).command("iptables -S")["stdout"].strip().split("\n")
+        return len(set(expected_iptables_rules) - set(actual_iptables_rules)) == 0
+
+    wait_until(60, 5, 0, _iptables_rules_present)
 
     # Ensure all expected iptables rules are present on the DuT
     logger.info("Number of expected iptable rules:{}, number of actual iptables rules:{}"
@@ -1104,8 +1110,14 @@ def verify_cacl(duthost, tbinfo, localhost, creds, docker_network,
     # for i in range(len(expected_iptables_rules)):
     #    pytest_assert(actual_iptables_rules[i] == expected_iptables_rules[i], "iptables rules not in expected order")
 
-    stdout = duthost.get_asic_or_sonic_host(asic_index).command("ip6tables -S")["stdout"]
-    actual_ip6tables_rules = stdout.strip().split("\n")
+    actual_ip6tables_rules = []
+
+    def _ip6tables_rules_present():
+        actual_ip6tables_rules[:] = \
+            duthost.get_asic_or_sonic_host(asic_index).command("ip6tables -S")["stdout"].strip().split("\n")
+        return len(set(expected_ip6tables_rules) - set(actual_ip6tables_rules)) == 0
+
+    wait_until(60, 5, 0, _ip6tables_rules_present)
 
     # Ensure all expected ip6tables rules are present on the DuT
     logger.info("Number of expected ip6table rules:{}, number of actual ip6tables rules:{}"

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -175,7 +175,7 @@ def dummy_acl_rules(duthosts, enum_rand_one_per_hwsku_hostname):
         acl_entry = {}
 
         # Alternate between IPv4 and IPv6 addresses (should be 2 IPv4 for every IPv6)
-        src_ip = f"20.0.0.{1 + index}/32" if index % 3 else f"2001::{1 + index}/128"
+        src_ip = f"20.0.0.{1 + index}/32" if index % 3 else f"2001::{1 + index}/128"  # noqa: E231
 
         # Alternate between accept and drop for each rule
         action = "ACCEPT" if index % 2 else "DROP"
@@ -1047,17 +1047,17 @@ def verify_cacl_show_acl_rule(duthost, acl_file):
             if rule_conf_actual[ip_key] != rule_conf_expected["ip"]["config"]["source-ip-address"]:
                 actual = rule_conf_actual[ip_key]
                 expected = rule_conf_expected["ip"]["config"]["source-ip-address"]
-                rule_issues.append(f"  - {rule_name}: Expected IP {expected} does not match {actual}")
+                rule_issues.append(f" - {rule_name}: Expected IP {expected} does not match {actual}")
 
             if rule_conf_actual["action"] != rule_conf_expected["actions"]["config"]["forwarding-action"]:
                 actual = rule_conf_actual["action"]
                 expected = rule_conf_expected["actions"]["config"]["forwarding-action"]
-                rule_issues.append(f"  - {rule_name}: Expected action {expected} does not match {actual}")
+                rule_issues.append(f" - {rule_name}: Expected action {expected} does not match {actual}")
 
             if int(rule_conf_actual["priority"]) != (10000 - int(rule_conf_expected["config"]["sequence-id"])):
                 actual = int(rule_conf_actual["priority"])
                 expected = (10000 - int(rule_conf_expected["config"]["sequence-id"]))
-                rule_issues.append(f"  - {rule_name}: Expected priority {expected} does not match {actual}")
+                rule_issues.append(f" - {rule_name}: Expected priority {expected} does not match {actual}")
 
             if rule_issues:
                 rule_issues_str = '\n'.join(rule_issues)


### PR DESCRIPTION
### Description of PR

Summary:

verify_cacl read `iptables -S`/`ip6tables -S` once with no retry. caclmgrd rebuilds the chains non-atomically (flush then per-rule re-add) on every reprogram, so a single read could race with an in-progress rebuild and observe transiently-missing FRR loopback rules (dport 2601/2620), causing intermittent "Missing expected iptables rules" failures on multi-ASIC DUTs. Poll with wait_until until all expected rules are present before asserting.

Related to: [ADO-38318042](https://msazure.visualstudio.com/One/_workitems/edit/38318042/?view=edit)
### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
[ADO-38318042](https://msazure.visualstudio.com/One/_workitems/edit/38318042/)

Failure type: Regression in test stability after the FRR loopback rules were added to the expected per-ASIC rule set.

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- 202511: `SONiC.20251110.42` -  Both ASIC instances of `test_multiasic_cacl_application` passed on a physical two-ASIC DUT: [test result](https://elastictest.org/scheduler/testplan/6a72f3f0c738d690ad9c2677?testcase=cacl%2Ftest_cacl_application.py&type=console).

### Approach
#### What is the motivation for this PR?
`test_multiasic_cacl_application` (and related cacl tests) intermittently fail with "Missing expected iptables rules" on multi-ASIC DUTs. The rules are correctly programmed; the failure is a test-side race with caclmgrd's non-atomic chain rebuild.

#### How did you do it?
Wrap the `iptables -S` / `ip6tables -S` reads in `verify_cacl` with `wait_until` polling and assert on the converged snapshot instead of a single read.

#### How did you verify/test it?
Both ASIC instances of `test_multiasic_cacl_application` passed on a physical two-ASIC DUT running `SONiC.20251110.42`: [test result](https://elastictest.org/scheduler/testplan/6a72f3f0c738d690ad9c2677?testcase=cacl%2Ftest_cacl_application.py&type=console).