### PR TITLE
[wol] Move PTF IP responder setup/teardown into shared ptfhost_utils helpers

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 import json
+import time
 import os
 import pytest
 import logging
@@ -162,6 +163,54 @@ def remove_ip_addresses(ptfhost):
     if icmp_responder_status["rc"] == 0 and "RUNNING" in icmp_responder_status["stdout"]:
         logger.debug("restart icmp_responder after restart ptf ports")
         ptfhost.shell("supervisorctl restart icmp_responder", module_ignore_errors=True)
+
+
+def setup_ptf_ip_responder(duthost, ptfhost, responder_conf_path, ip_intf_pairs, route=False):
+    # Use route=True when the responder IP is not in the DUT interface subnet/VLAN
+    # and needs an explicit host route through that interface.
+    arp_responder_conf = {}
+    ping_commands = []
+    for ip, dut_intf, ptf_index in ip_intf_pairs:
+        ip_addr = ip_interface(str(ip)).ip
+        arp_responder_conf.setdefault("eth{}".format(ptf_index), []).append(str(ip_addr))
+        ping = "ping6" if ip_addr.version == 6 else "ping"
+        ping_commands.append("{} -c 1 -w 1 -I {} {}".format(ping, dut_intf, ip_addr))
+
+    ptfhost.copy(content=json.dumps(arp_responder_conf), dest=responder_conf_path)
+    ptfhost.host.options["variable_manager"].extra_vars.update(
+        {"arp_responder_args": "--conf {}".format(responder_conf_path)})
+    ptfhost.template(src="templates/arp_responder.conf.j2", dest="/etc/supervisor/conf.d/arp_responder.conf")
+    ptfhost.shell("supervisorctl reread && supervisorctl update && supervisorctl restart arp_responder")
+
+    if route:
+        for ip, dut_intf, _ in ip_intf_pairs:
+            duthost.shell(_ptf_ip_route_cmd("replace", ip, dut_intf))
+    duthost.command("sonic-clear fdb all")
+    duthost.command("sonic-clear arp")
+    duthost.command("sonic-clear ndp")
+    time.sleep(20)
+    for cmd in ping_commands:
+        duthost.shell(cmd, module_ignore_errors=True)
+
+
+def teardown_ptf_ip_responder(duthost, ptfhost, responder_conf_path, ip_intf_pairs=None, route=False):
+    ptfhost.shell("supervisorctl stop arp_responder", module_ignore_errors=True)
+    ptfhost.file(path=responder_conf_path, state="absent")
+    ptfhost.file(path="/etc/supervisor/conf.d/arp_responder.conf", state="absent")
+    ptfhost.shell("supervisorctl reread && supervisorctl update", module_ignore_errors=True)
+    if route and ip_intf_pairs:
+        for ip, dut_intf, _ in ip_intf_pairs:
+            duthost.shell(_ptf_ip_route_cmd("del", ip, dut_intf), module_ignore_errors=True)
+    duthost.command("sonic-clear fdb all")
+    duthost.command("sonic-clear arp")
+    duthost.command("sonic-clear ndp")
+
+
+def _ptf_ip_route_cmd(action, ip, dut_intf):
+    ip_addr = ip_interface(str(ip)).ip
+    route_prefix_len = 128 if ip_addr.version == 6 else 32
+    return "ip -{} route {} {}/{} dev {}".format(
+        ip_addr.version, action, ip_addr, route_prefix_len, dut_intf)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -198,7 +198,8 @@ def teardown_ptf_ip_responder(duthost, ptfhost, responder_conf_path, ip_intf_pai
     ptfhost.file(path=responder_conf_path, state="absent")
     ptfhost.file(path="/etc/supervisor/conf.d/arp_responder.conf", state="absent")
     ptfhost.shell("supervisorctl reread && supervisorctl update", module_ignore_errors=True)
-    if route and ip_intf_pairs:
+    if route:
+        assert ip_intf_pairs, "ip_intf_pairs is required when route=True to clean up host routes"
         for ip, dut_intf, _ in ip_intf_pairs:
             duthost.shell(_ptf_ip_route_cmd("del", ip, dut_intf), module_ignore_errors=True)
     duthost.command("sonic-clear fdb all")

--- a/tests/wol/conftest.py
+++ b/tests/wol/conftest.py
@@ -2,9 +2,8 @@ import pytest
 import random
 import ipaddress
 import logging
-import json
-import time
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py  # noqa: F401
+from tests.common.fixtures.ptfhost_utils import setup_ptf_ip_responder, teardown_ptf_ip_responder
 
 
 ARP_RESPONDER_PATH = "/tmp/new_arp_responder_conf.json"
@@ -73,41 +72,13 @@ def random_intf_pair_to_remove_under_vlan(duthost, random_vlan, random_intf_pair
 
 def setup_ip_on_ptf(duthost, ptfhost, ip, intf_pairs):
     ptfhost.remove_ip_addresses()
-    ip = ipaddress.ip_address(ip)
-    if isinstance(ip, ipaddress.IPv4Address):
-        ping = "ping"
-    if isinstance(ip, ipaddress.IPv6Address):
-        ping = "ping6"
-    arp_responder_conf = {}
-    ping_commands = []
-    for dut_intf, ptf_index in intf_pairs:
-        arp_responder_conf["eth{}".format(ptf_index)] = [ip.__str__()]
-        ping_commands.append("{} -c 1 -w 1 -I {} {}".format(ping, dut_intf, ip))
-    with open(ARP_RESPONDER_PATH, "w") as f:
-        json.dump(arp_responder_conf, f)
-    ptfhost.copy(src=ARP_RESPONDER_PATH, dest=ARP_RESPONDER_PATH)
-    ptfhost.host.options["variable_manager"].extra_vars.update(
-            {"arp_responder_args": "--conf " + ARP_RESPONDER_PATH})
-    ptfhost.template(src="templates/arp_responder.conf.j2", dest="/etc/supervisor/conf.d/arp_responder.conf")
-    ptfhost.shell("supervisorctl reread && supervisorctl update")
-    ptfhost.shell("supervisorctl restart arp_responder")
-
-    duthost.command("sonic-clear fdb all")
-    duthost.command("sonic-clear arp")
-    duthost.command("sonic-clear ndp")
-    time.sleep(20)
-    for cmd in ping_commands:
-        duthost.shell(cmd, module_ignore_errors=True)
+    setup_ptf_ip_responder(
+        duthost, ptfhost, ARP_RESPONDER_PATH,
+        [(ip, dut_intf, ptf_index) for dut_intf, ptf_index in intf_pairs])
 
 
 def remove_ip_on_ptf(duthost, ptfhost):
-    ptfhost.shell("supervisorctl stop arp_responder")
-    ptfhost.shell("rm -f {}".format(ARP_RESPONDER_PATH))
-    ptfhost.shell("rm -f /etc/supervisor/conf.d/arp_responder.conf")
-    ptfhost.shell("supervisorctl reread && supervisorctl update")
-    duthost.command("sonic-clear fdb all")
-    duthost.command("sonic-clear arp")
-    duthost.command("sonic-clear ndp")
+    teardown_ptf_ip_responder(duthost, ptfhost, ARP_RESPONDER_PATH)
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
### Description of PR

Summary:
Prerequisite refactor **split out of #23432**. It lifts the inline PTF arp/IP-responder setup
and teardown out of `tests/wol/conftest.py` into two reusable helpers in
`tests/common/fixtures/ptfhost_utils.py` (`setup_ptf_ip_responder` / `teardown_ptf_ip_responder`),
so the follow-up DHCPv6-relay `dhcpmon` tests can share the exact same responder plumbing instead
of duplicating it.

- ADO: 38739769
- Dependencies: none — this is the base PR of the stack.
- Unblocks: #23432 (`add dhcpmon check for dhcpv6`), which is itself the sonic-mgmt test
  counterpart of sonic-buildimage #27277.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

Not requested — this is a master-only, behavior-preserving test-framework refactor with no
change shipped to any release branch.

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Tested branch
- [x] 202605

### Test result
- 202605: `SONiC.20260510.06` — full `tests/wol` module on `testbed-bjw2-can-720dt-5` (720dt, `m0`): **52 passed / 2 failed**. The refactored shared helpers `setup_ptf_ip_responder` / `teardown_ptf_ip_responder` set up and tear down the PTF arp/IP responder correctly (0 setup errors; 0 Import/Attribute/Name/NoneType errors). The 2 failures — `test_wol_send_from_vlan[11:22:33:44:55:66-3-1000]` and `test_wol_send_from_vlan_udp[ipv4-5678-192.168.0.1-3-1000]` — are testbed host-scheduling jitter on the multi-packet inter-send interval check (`count=3, interval=1000ms`, ±100ms margin: observed ~2.3s / ~0.82s), not the refactored code. Co-validated on `internal-202605` on top of the WoL async-send deflake #26258 (202605 backport of #25982), which was cherry-picked together.

### Approach
#### What is the motivation for this PR?
The DHCPv6-relay `dhcpmon` tests in #23432 need to bring an IP up on the PTF host and answer
ARP/ND for it — which is exactly what `tests/wol/conftest.py` already does with inline
`arp_responder` + `supervisor` + `sonic-clear` logic. Rather than copy that logic into a second
suite, this PR extracts it into a shared helper so both suites use a single implementation. It is
deliberately split out as a **small, behavior-preserving base PR** so that (a) #23432's diff stays
focused on the actual DHCPv6 test logic, and (b) this refactor can be reviewed and merged on its
own.

#### How did you do it?
- Added `setup_ptf_ip_responder(duthost, ptfhost, responder_conf_path, ip_intf_pairs, route=False)`
  and `teardown_ptf_ip_responder(...)` to `tests/common/fixtures/ptfhost_utils.py`. They
  encapsulate the existing flow: write the `arp_responder` conf JSON, copy it to the PTF, render
  `/etc/supervisor/conf.d/arp_responder.conf`, `supervisorctl reread/update/restart arp_responder`,
  clear the DUT `fdb`/`arp`/`ndp`, and (on teardown) stop the responder and remove its files.
  `ip_intf_pairs` carries `(ip, dut_intf, ptf_index)` tuples so both IPv4 and IPv6 are handled, and
  an optional `route=` flag (default `False`, i.e. the current WoL behavior) additionally installs
  a route to the responder IP — the DHCPv6 follow-up (#23432) is the consumer of that flag.
- Rewired `tests/wol/conftest.py`'s `setup_ip_on_ptf` / `remove_ip_on_ptf` to call the new helpers,
  deleting the now-duplicated inline logic (net −29 lines in the WoL conftest).

#### How did you verify/test it?
No behavioral change to the WoL suite — the conftest now calls a helper that performs the identical
`arp_responder` config / supervisor lifecycle / `sonic-clear` steps, with `route=False` preserving
the original behavior. The existing `ArpResponderInfo` namedtuple in `ptfhost_utils.py` is
untouched. `py_compile` clean; PR CI green (26/26).

#### Any platform specific information?
None — this is PTF-side test framework only, with no platform or topology dependency.

##### Work item tracking
- Microsoft ADO **(number only)**: 38739769

