### PR TITLE
Fix validate_asic_route to query per-ASIC ASIC_DB on multi-ASIC DUTs

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -542,10 +542,15 @@ def validate_asic_route(duthost, prefix):
     """
     Check if a route exists in the routing table of the asic.
     """
-    asicdb = AsicDbCli(duthost)
-    route_table = asicdb.dump("ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY")
-    if prefix in str(route_table):
-        return True
+    if duthost.is_multi_asic:
+        asic_instances = [duthost.asic_instance(asic_id) for asic_id in duthost.get_frontend_asic_ids()]
+    else:
+        asic_instances = [duthost]
+    for asic in asic_instances:
+        asicdb = AsicDbCli(asic)
+        route_table = asicdb.dump("ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY")
+        if prefix in str(route_table):
+            return True
     return False
 
 


### PR DESCRIPTION
### **Description of PR**

Summary: Fix `validate_asic_route` in the Everflow test utilities so it looks up the mirror-session destination route in the correct per-ASIC `ASIC_DB` on multi-ASIC DUTs.

Related to:  [ADO-38573016](https://msazure.visualstudio.com/One/_workitems/edit/38573016/?view=edit)

### **Type of change**

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### **Back port request**

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### **Approach**

#### **What is the motivation for this PR?**

On multi-ASIC DUTs, Everflow test cases (`test_everflow_basic_forwarding`, `test_everflow_neighbor_mac_change`, `test_everflow_frwd_with_bkg_trf`, `test_everflow_fwd_recircle_port_queue_check`, for both `erspan_ipv4` and `erspan_ipv6`) fail because the gate `wait_until(120, 10, 0, validate_asic_route, remote_dut, prefix)` always times out.

The test installs the mirror-session destination route into a specific frontend ASIC namespace via `add_route(remote_dut, prefix, peer_ip, remote_namespace)`, but `validate_asic_route` passes the whole `duthost` (a `MultiAsicSonicHost`) to `AsicDbCli`. `AsicDbCli.dump()` only executes `ip netns exec <namespace> sonic-db-dump` when it is given a `SonicAsic`; when handed the full host it queries the host default namespace `ASIC_DB`. As a result the per-ASIC route entry is never found and the check times out, even though the route is programmed correctly and mirroring itself works.

#### **How did you do it?**

Make `validate_asic_route` ASIC-aware: on multi-ASIC DUTs iterate the frontend ASICs (`duthost.get_frontend_asic_ids()` → `duthost.asic_instance(asic_id)`) and query each ASIC's `ASIC_DB` through `AsicDbCli(asic)`, returning `True` as soon as the prefix is found in any of them. Single-ASIC behavior is unchanged. This mirrors the multi-ASIC pattern already used by `validate_acl_rule_rids` / `validate_acl_rules_in_asic_db` in the same file.

#### **How did you verify/test it?**

Reproduced on a multi-ASIC T2 DUT: all Everflow forwarding cases were failing at the `validate_asic_route` timeout. Confirmed the route is actually programmed (the previous flow, which used a fixed sleep before sending traffic, passed on the same hardware), so only the new validation helper was broken on multi-ASIC. With this change `validate_asic_route` inspects the correct per-ASIC `ASIC_DB` and finds the route. Re-running the Everflow suite on the multi-ASIC testbed to confirm all cases pass; single-ASIC platforms are unaffected.

#### **Any platform specific information?**

Only affects multi-ASIC DUTs. The single-ASIC code path is functionally unchanged.

### **Supported testbed topology if it's a new test case?**

N/A — this is a fix to existing Everflow tests, not a new test case (applies to `t2`/`any` multi-ASIC topologies).
