### PR TITLE
[lldp] Dedup lldpctl interfaces to tolerate fanout duplicates (test_lldp_syncd)

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -274,9 +274,22 @@ def assert_lldp_interfaces(
             "Unexpected type for lldpctl interfaces: {}".format(type(lldpctl_interface))
         )
 
+    # De-duplicate: on fanout-fronted testbeds a port can learn multiple LLDP
+    # neighbors (e.g. the peer device + the fanout switch), so lldpctl lists the
+    # same interface more than once. LLDP_ENTRY_TABLE keys and `show lldp table`
+    # output are already unique/de-duplicated (see get_show_lldp_table_output),
+    # so collapse duplicates here to compare like-for-like. A genuinely extra or
+    # missing interface still fails the assert below.
+    lldpctl_interfaces = list(dict.fromkeys(lldpctl_interfaces))
+
+    db_set = set(lldp_entry_keys)
+    lldpctl_set = set(lldpctl_interfaces)
     pytest_assert(
         sorted(lldp_entry_keys) == sorted(lldpctl_interfaces),
-        "LLDP_ENTRY_TABLE keys do not match lldpctl interface indexes",
+        "LLDP_ENTRY_TABLE keys do not match lldpctl interface indexes. "
+        "In DB but not in lldpctl: {}. In lldpctl but not in DB: {}".format(
+            db_set - lldpctl_set, lldpctl_set - db_set
+        ),
     )
 
 


### PR DESCRIPTION
### Description of PR

Summary:
Fixes the flaky `lldp/test_lldp_syncd.py::test_lldp_entry_table_*` failures — `Failed: LLDP_ENTRY_TABLE keys do not match lldpctl interface indexes` — on fanout-fronted testbeds, by de-duplicating the `lldpctl` interface list before comparing it against the (already-unique) `LLDP_ENTRY_TABLE` keys.

Fixes # (no standalone GitHub issue — surfaced by SONiC nightly triage; cross-vendor: Cisco/Arista/Mellanox/Nexthop, first seen 2026-05-14)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: test flakiness — a **lab-topology artifact**, not a product bug. Present across image lines (202511/202605/master). Production devices have no fanout, so they are unaffected.

### Approach
#### What is the motivation for this PR?
On fanout-fronted testbeds a DUT port can learn **multiple** LLDP neighbors (the peer device **and** the fanout switch), so `lldpctl` lists the same interface more than once. The test's three sources handle those duplicates inconsistently:
- `get_lldp_entry_keys` reads **redis** `LLDP_ENTRY_TABLE` keys → inherently unique per interface;
- `get_show_lldp_table_output` **de-duplicates** (`list(dict.fromkeys(...))`, added in #23193 with an explicit fanout comment);
- but `assert_lldp_interfaces` builds `lldpctl_interfaces` **without** de-duplication.

So `sorted(unique_redis_keys) != sorted(lldpctl_with_fanout_duplicate)` and the assert fails. #23193 fixed the `show lldp table` path but **missed** the `lldpctl` path — this PR closes that gap.

Nightly data (90d): the signature is intermittent per build/testbed but **persistent within a run** (0/12 retried cases recovered), consistent with the fanout being physically present — i.e. a deterministic lab artifact, not a race.

#### How did you do it?
De-duplicate `lldpctl_interfaces` the same way `get_show_lldp_table_output` already does. Also added a `In DB but not in lldpctl / In lldpctl but not in DB` diff to the assert message (mirroring the sibling `show lldp table` assert) for easier triage.

This is **safe**: a *genuinely* extra/missing interface still survives de-duplication and still fails the assert — so it fixes the fanout-duplicate artifact **without masking** any real `LLDP_ENTRY_TABLE`/`lldpctl` divergence.

#### How did you verify/test it?
`python -m py_compile` and `flake8 --max-line-length=120` clean (the only flake8 hits are pre-existing `F824` on unrelated `nonlocal` lines, from a pyflakes newer than the pinned 6.0.0). The change is a no-op on non-fanout setups (no duplicates to collapse), so KVM/vlab and production behavior is unchanged; it removes the false failure on fanout-fronted physical testbeds.

> Note: I could not fetch the raw `lldpctl` JSON from a failing run to 100% confirm every failure is a same-name duplicate vs a distinct interface (log access unavailable), but #23193's own comment documents exactly this fanout-duplicate behavior, and the de-dup is safe either way (distinct interfaces still fail).

#### Any platform specific information?
Affects fanout-fronted physical testbeds only (cross-vendor). KVM/vlab and production (no fanout) are unaffected.

#### Supported testbed topology if it's a new test case?
N/A — not a new test case.

### Documentation
N/A — no documentation/wiki change required.