### PR TITLE
Ignore expected route logs in VXLAN BGP route precedence test

### DIFF
--- a/tests/vxlan/test_vnet_bgp_route_precedence.py
+++ b/tests/vxlan/test_vnet_bgp_route_precedence.py
@@ -131,12 +131,15 @@ def _ignore_route_sync_errlogs(duthosts, rand_one_dut_hostname, loganalyzer):
             # The test intentionally programs an overlapping BGP/VNET route for
             # the same prefix, so orchagent's bulk route create hits
             # SAI_STATUS_ITEM_ALREADY_EXISTS and the rest of the bulk returns
-            # SAI_STATUS_NOT_EXECUTED. Scope each ignore to the specific SAI
-            # status / route context so it cannot mask unrelated route failures.
-            ".*ERR.* flush_creating_entries: EntityBulker.flush create entries failed.*"
-            "status: SAI_STATUS_ITEM_ALREADY_EXISTS.*",
-            ".*ERR.* Encountered failure in create operation, SAI API: SAI_API_ROUTE,"
-            " status: SAI_STATUS_NOT_EXECUTED.*",
+            # SAI_STATUS_NOT_EXECUTED. Each ignore is scoped to the specific SAI
+            # status (where the log line carries one) and route context so it
+            # cannot mask unrelated route failures. The parenthesized two-line
+            # entries below are single regexes (intentional string
+            # concatenation), not separate list items.
+            (".*ERR.* flush_creating_entries: EntityBulker.flush create entries "
+             "failed.*status: SAI_STATUS_ITEM_ALREADY_EXISTS.*"),
+            (".*ERR.* Encountered failure in create operation, SAI API: "
+             "SAI_API_ROUTE, status: SAI_STATUS_NOT_EXECUTED.*"),
             ".*ERR.* addRoutePost: Failed to create route .* with next hop.*",
         ]
         # Ignore in KVM test

--- a/tests/vxlan/test_vnet_bgp_route_precedence.py
+++ b/tests/vxlan/test_vnet_bgp_route_precedence.py
@@ -128,10 +128,16 @@ def _ignore_route_sync_errlogs(duthosts, rand_one_dut_hostname, loganalyzer):
             ".*_M_construct null not valid.*",
             ".*construction from null is not valid.*",
             ".*meta_sai_validate_route_entry.*",
-            ".*ERR.* flush_creating_entries: EntityBulker.flush create entries failed.*",
-            ".*ERR.* start: Encountered failure in create operation.*",
-            ".*ERR.* addRoutePost: Failed to create route.*",
-
+            # The test intentionally programs an overlapping BGP/VNET route for
+            # the same prefix, so orchagent's bulk route create hits
+            # SAI_STATUS_ITEM_ALREADY_EXISTS and the rest of the bulk returns
+            # SAI_STATUS_NOT_EXECUTED. Scope each ignore to the specific SAI
+            # status / route context so it cannot mask unrelated route failures.
+            ".*ERR.* flush_creating_entries: EntityBulker.flush create entries failed.*"
+            "status: SAI_STATUS_ITEM_ALREADY_EXISTS.*",
+            ".*ERR.* Encountered failure in create operation, SAI API: SAI_API_ROUTE,"
+            " status: SAI_STATUS_NOT_EXECUTED.*",
+            ".*ERR.* addRoutePost: Failed to create route .* with next hop.*",
         ]
         # Ignore in KVM test
         KVMIgnoreRegex = [

--- a/tests/vxlan/test_vnet_bgp_route_precedence.py
+++ b/tests/vxlan/test_vnet_bgp_route_precedence.py
@@ -136,10 +136,8 @@ def _ignore_route_sync_errlogs(duthosts, rand_one_dut_hostname, loganalyzer):
             # cannot mask unrelated route failures. The parenthesized two-line
             # entries below are single regexes (intentional string
             # concatenation), not separate list items.
-            (".*ERR.* flush_creating_entries: EntityBulker.flush create entries "
-             "failed.*status: SAI_STATUS_ITEM_ALREADY_EXISTS.*"),
-            (".*ERR.* Encountered failure in create operation, SAI API: "
-             "SAI_API_ROUTE, status: SAI_STATUS_NOT_EXECUTED.*"),
+            ".*ERR.* EntityBulker.flush create entries failed.*SAI_STATUS_ITEM_ALREADY_EXISTS.*",
+            ".*ERR.* Encountered failure in create operation, SAI API: SAI_API_ROUTE.*SAI_STATUS_NOT_EXECUTED.*",
             ".*ERR.* addRoutePost: Failed to create route .* with next hop.*",
         ]
         # Ignore in KVM test

--- a/tests/vxlan/test_vnet_bgp_route_precedence.py
+++ b/tests/vxlan/test_vnet_bgp_route_precedence.py
@@ -133,9 +133,7 @@ def _ignore_route_sync_errlogs(duthosts, rand_one_dut_hostname, loganalyzer):
             # SAI_STATUS_ITEM_ALREADY_EXISTS and the rest of the bulk returns
             # SAI_STATUS_NOT_EXECUTED. Each ignore is scoped to the specific SAI
             # status (where the log line carries one) and route context so it
-            # cannot mask unrelated route failures. The parenthesized two-line
-            # entries below are single regexes (intentional string
-            # concatenation), not separate list items.
+            # cannot mask unrelated route failures.
             ".*ERR.* EntityBulker.flush create entries failed.*SAI_STATUS_ITEM_ALREADY_EXISTS.*",
             ".*ERR.* Encountered failure in create operation, SAI API: SAI_API_ROUTE.*SAI_STATUS_NOT_EXECUTED.*",
             ".*ERR.* addRoutePost: Failed to create route .* with next hop.*",

--- a/tests/vxlan/test_vnet_bgp_route_precedence.py
+++ b/tests/vxlan/test_vnet_bgp_route_precedence.py
@@ -128,6 +128,9 @@ def _ignore_route_sync_errlogs(duthosts, rand_one_dut_hostname, loganalyzer):
             ".*_M_construct null not valid.*",
             ".*construction from null is not valid.*",
             ".*meta_sai_validate_route_entry.*",
+            ".*ERR.* flush_creating_entries: EntityBulker.flush create entries failed.*",
+            ".*ERR.* start: Encountered failure in create operation.*",
+            ".*ERR.* addRoutePost: Failed to create route.*",
 
         ]
         # Ignore in KVM test


### PR DESCRIPTION
### Description of PR

Summary:
Ignore expected transient orchagent route-creation error logs in `vxlan/test_vnet_bgp_route_precedence.py`. The test intentionally programs an overlapping BGP/VNET route for the same prefix to validate route precedence; the datapath assertions pass, but LogAnalyzer fails during teardown on the expected orchagent duplicate/route-creation syslogs emitted by this negative scenario.

ADO: https://dev.azure.com/msazure/One/_workitems/edit/38739638

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://dev.azure.com/msazure/One/_workitems/edit/38739638
Failure type: regression

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- 202605: failure reproduced in nightly (ElasticTest testplan `6a4dc0aecc21929b4e05eabf`, testbed `testbed-bjw2-can-t1-8102-3`, DUT `bjw2-can-8102-*`). The only LogAnalyzer-flagged teardown syslog is the expected `ERR swss#orchagent: :- start: Encountered failure in create operation, SAI API: SAI_API_ROUTE, status: SAI_STATUS_NOT_EXECUTED`, which the updated ignore list now covers. Validated by matching the updated regexes against the exact nightly syslog lines (both the `start:` and `handleSaiFailure:` variants) and confirming they reject the same message with a different SAI status; `python -m py_compile` and pre-commit (`flake8`) pass.

### Approach

#### What is the motivation for this PR?
Nightly `test_vnet_route_after_bgp_with_early_bgp_removal` on 202605 fails only during teardown log analysis. The test adds a monitored VNET route, adds then removes a BGP route for the same prefix, and verifies precedence/datapath. The overlapping route state makes orchagent emit expected transient route-creation errors (`SAI_STATUS_ITEM_ALREADY_EXISTS` on the bulk create and `SAI_STATUS_NOT_EXECUTED` on the remaining per-route creates), which LogAnalyzer treats as unexpected.

#### How did you do it?
Extended the test-specific LogAnalyzer ignore list in `_ignore_route_sync_errlogs` with the expected orchagent route-creation messages, scoped to the specific SAI status codes (`SAI_STATUS_ITEM_ALREADY_EXISTS` / `SAI_STATUS_NOT_EXECUTED`) and route context so the ignore rules cannot mask unrelated route-programming failures.

#### How did you verify/test it?
- `python -m py_compile tests/vxlan/test_vnet_bgp_route_precedence.py`
- pre-commit (`flake8`) passes.
- Verified the updated regexes match the exact 202605 nightly syslog lines while rejecting the same messages carrying a different SAI status.

#### Any platform specific information?
Observed on Cisco-8102-C64, Cisco-8101-O32, Cisco-8101-O8V48, and Cisco-8101-O8C48 T1 topologies in 202605 nightly.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation

N/A
