### PR TITLE
Fix IPv6 everflow mirror session setup

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -1120,12 +1120,31 @@ class BaseEverflowTest(object):
                             )
                         )
             else:
-                command = BaseEverflowTest._build_erspan_cli_command(
-                    session_info, queue_num=queue_num,
-                    policer=policer, use_erspan_subcmd=False,
-                    erspan_ip_ver=erspan_ip_ver
-                )
-                duthost.command(command)
+                if erspan_ip_ver == 4:
+                    command = BaseEverflowTest._build_erspan_cli_command(
+                        session_info, queue_num=queue_num,
+                        policer=policer, use_erspan_subcmd=False,
+                        erspan_ip_ver=erspan_ip_ver
+                    )
+                    duthost.command(command)
+                else:
+                    for asic_index in duthost.get_frontend_asic_ids():
+                        # Adding IPv6 ERSPAN sessions from the CLI is not supported.
+                        command = f"sonic-db-cli -n asic{asic_index} " if asic_index is not None else "sonic-db-cli "
+                        command += (
+                            f"CONFIG_DB HSET 'MIRROR_SESSION|{session_info['session_name']}' "
+                            f"'dscp' '{session_info['session_dscp']}' "
+                            f"'dst_ip' '{session_info['session_dst_ipv6']}' "
+                            f"'gre_type' '{session_info['session_gre']}' "
+                            f"'type' '{session_info['session_type']}' "
+                            f"'src_ip' '{session_info['session_src_ipv6']}' "
+                            f"'ttl' '{session_info['session_ttl']}'"
+                        )
+                        if queue_num:
+                            command += f" 'queue' {queue_num}"
+                        if policer:
+                            command += f" 'policer' {policer}"
+                        duthost.command(command)
 
         elif config_method == CONFIG_MODE_CONFIGLET:
             pass


### PR DESCRIPTION
### Description of PR
Fix IPv6 Everflow mirror session setup for tests that call `BaseEverflowTest.apply_mirror_config()` without a mirror direction. The legacy CLI path (`config mirror_session add`) only accepts IPv4 addresses, so IPv6 ERSPAN setup currently fails before the test runs.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [x] 202605
- [x] 202511

### Approach
#### What is the motivation for this PR?
Nightly PBI 38739634 fails in `everflow/test_everflow_per_interface.py::test_everflow_packet_format` during setup with `Error: 1111::1:1:1:1 is not a valid IPv4 address` because the test utility passes IPv6 addresses to `config mirror_session add`.

#### How did you do it?
Restore the direct CONFIG_DB setup path for IPv6 ERSPAN mirror sessions when no direction is requested, while keeping the existing CLI path for IPv4 sessions.

#### How did you verify/test it?
Ran Python syntax validation:
`python -m py_compile tests/everflow/everflow_test_utilities.py`

#### Any platform specific information?
Observed on Nokia-7215-A1-G48S4 M0 in 202605 nightly; Kusto also shows the same signature across multiple platforms.

### Documentation
N/A