### PR TITLE
Add NASA debug plugin support.

### DIFF
--- a/tests/common/plugins/nasa_debug/__init__.py
+++ b/tests/common/plugins/nasa_debug/__init__.py
@@ -1,0 +1,45 @@
+import logging
+import pytest
+
+from .nasa_debug_utils import (  # noqa: F401 - re-exported public API
+    NASA_DEBUG_ENTITY,
+    NASA_DEBUG_DUMP_DIR,
+    nasa_entity_debug_set,
+    get_nasa_entity_debug_enabled,
+    get_nasa_entity_debug_file,
+    nasa_debuggability_enable,
+    nasa_debuggability_disable,
+    nasa_debuggability_enable_all,
+    nasa_debuggability_disable_all,
+    get_file_size,
+    nasa_ct_dump_set,
+    get_nasa_ct_dump_enabled,
+    NASA_CT_DUMP_SENTINEL,
+    NASA_CT_DUMP_FILES,
+    NASA_FLOW_DUMP_PATTERN,
+    NASA_MST_DUMP_PATTERNS,
+    get_techsupport_file_list,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def pytest_addoption(parser):
+    """Add --nasa_debug command line option to pytest."""
+    parser.addoption(
+        "--nasa_debug",
+        action="store_true",
+        help="Turn on NASA debuggability for the tests to enable the debug info in the tech support."
+    )
+
+
+def pytest_configure(config):
+    if config.getoption("--nasa_debug"):
+        config.pluginmanager.import_plugin("tests.common.plugins.nasa_debug.nasa_debug_fixtures")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def nasa_debug(request):
+    """Session-scoped fixture that returns the --nasa_debug option value."""
+    logger.info("Fixture NASA debug: {}".format(request.config.getoption("--nasa_debug")))
+    return request.config.getoption("--nasa_debug")

--- a/tests/common/plugins/nasa_debug/nasa_debug_fixtures.py
+++ b/tests/common/plugins/nasa_debug/nasa_debug_fixtures.py
@@ -1,0 +1,27 @@
+import pytest
+import logging
+from .nasa_debug_utils import nasa_debuggability_enable_all, nasa_debuggability_disable_all
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def enable_nasa_debuggability(request, dpuhosts):
+    """Automatically enable NASA debuggability before each test module.
+
+    This fixture enables NASA debug on all DPUs before the test module runs
+    and disables it after the module completes.
+
+    Args:
+        request: pytest request object
+        dpuhosts: List of DPU host objects (from SmartSwitch fixture)
+    """
+    # for DASH tests, enable the debuggability on all DPUs
+    logger.info("Enabling NASA debuggability to capture tech support info")
+    nasa_debuggability_enable_all(dpuhosts)
+
+    yield
+
+    # for DASH tests, disable the debuggability on all DPUs
+    logger.info("Disabling NASA debuggability to capture tech support info")
+    nasa_debuggability_disable_all(dpuhosts)

--- a/tests/common/plugins/nasa_debug/nasa_debug_utils.py
+++ b/tests/common/plugins/nasa_debug/nasa_debug_utils.py
@@ -1,0 +1,193 @@
+import logging
+import os
+from shlex import quote
+from enum import Enum
+from collections import namedtuple
+
+from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
+
+logger = logging.getLogger(__name__)
+
+
+# Parametrization for the NASA CLI helper commands
+NASA_DEBUG_ENTITY_CONTENT = namedtuple("NASA_DEBUG_ENTITY_CONTENT", ["title", "nasa_helper_key", "config_key"])
+NASA_DEBUG_DUMP_DIR = "/var/log/bluefield/sdk-dumps"
+NASA_CT_DUMP_SENTINEL = "/var/run/sonic-platform-nvidia-bluefield/techsupport-sdk-ct-dump.enabled"
+NASA_CT_DUMP_FILES = [
+    "stats.log.gz",
+    "stats_query.log.gz",
+    "general.log.gz",
+    "routing.log.gz",
+    "vnets.dump.gz",
+    "counters.dump.gz",
+    "enis.log.gz",
+    "acls.log.gz",
+    "meter_policies.log.gz",
+    "crm.log.gz",
+    "ct_table_log.bin.gz",
+    "ct_table_log_ipvx.bin.gz",
+]
+NASA_FLOW_DUMP_PATTERN = "flow_dump_*.jsonl.gz"
+NASA_MST_DUMP_PATTERNS = [
+    "mstdump_full_*_iter1of3.log.gz",
+    "mstdump_full_*_iter2of3.log.gz",
+    "mstdump_full_*_iter3of3.log.gz",
+]
+
+
+class NASA_DEBUG_ENTITY(Enum):
+    CONFIG_RECORD = NASA_DEBUG_ENTITY_CONTENT(title="Configuration Record",
+                                              nasa_helper_key="get_sai_debug_mode",
+                                              config_key="config-record")
+    PACKET_DROP = NASA_DEBUG_ENTITY_CONTENT(title="Packet Drop",
+                                            nasa_helper_key="get_packet_debug_mode",
+                                            config_key="packet-drop")
+
+
+def get_nasa_entity_debug_enabled(dpuhost, entity):
+    """Check if a NASA debug entity is enabled on a DPU.
+
+    Args:
+        dpuhost: DPU host object
+        entity: NASA_DEBUG_ENTITY enum member
+
+    Returns:
+        bool: True if enabled, False if disabled
+
+    Raises:
+        ValueError: If the status is neither 'enabled' nor 'disabled'
+    """
+    result = dpuhost.shell(f"nasa-cli-helper.py {entity.value.nasa_helper_key}")['stdout'].strip()
+    if result == "disabled":
+        return False
+    if result == "enabled":
+        return True
+
+    raise ValueError(f"Unexpected {entity.value.title} status: {result}")
+
+
+def get_nasa_entity_debug_file(dpuhost, entity):
+    """Get the current debug file path for a NASA debug entity.
+
+    Args:
+        dpuhost: DPU host object
+        entity: NASA_DEBUG_ENTITY enum member
+
+    Returns:
+        str or None: File path if debug is active and file exists, None otherwise
+    """
+    result = dpuhost.shell(f"nasa-cli-helper.py {entity.value.nasa_helper_key} -f")
+    debug_file = result['stdout'].rstrip('\x00').strip()
+    # check if the file exists
+    if debug_file != "None" and dpuhost.shell(f"stat {quote(debug_file)}")['rc'] == 0:
+        return debug_file
+    return None
+
+
+def nasa_entity_debug_set(dpuhost, entity, enable):
+    """Enable or disable a NASA debug entity on a DPU.
+
+    Args:
+        dpuhost: DPU host object
+        entity: NASA_DEBUG_ENTITY enum member
+        enable: bool - True to enable, False to disable
+    """
+    logger.info(f"{'Enabling' if enable else 'Disabling'} NASA {entity.value.title} on {dpuhost.hostname}")
+    dpuhost.shell(f"sudo config platform nvidia-bluefield sdk "
+                  f"{entity.value.config_key} {'enabled' if enable else 'disabled'}")
+
+
+def nasa_debuggability_enable(dpuhost):
+    """Enable all NASA debug entities on a single DPU."""
+    for entity in NASA_DEBUG_ENTITY:
+        nasa_entity_debug_set(dpuhost, entity, True)
+
+
+def nasa_debuggability_enable_all(dpuhosts):
+    """Enable all NASA debug entities on all DPUs in parallel."""
+    with SafeThreadPoolExecutor(max_workers=len(dpuhosts)) as executor:
+        for temp_dpuhost in dpuhosts:
+            executor.submit(nasa_debuggability_enable, temp_dpuhost)
+
+
+def nasa_debuggability_disable(dpuhost):
+    """Disable all NASA debug entities on a single DPU."""
+    for entity in NASA_DEBUG_ENTITY:
+        nasa_entity_debug_set(dpuhost, entity, False)
+
+
+def nasa_debuggability_disable_all(dpuhosts):
+    """Disable all NASA debug entities on all DPUs in parallel."""
+    with SafeThreadPoolExecutor(max_workers=len(dpuhosts)) as executor:
+        for temp_dpuhost in dpuhosts:
+            executor.submit(nasa_debuggability_disable, temp_dpuhost)
+
+
+def get_file_size(dpuhost, file_path):
+    """Get file size in bytes using stat command.
+
+    Args:
+        dpuhost: DPU host object
+        file_path: Path to the file on the DPU
+
+    Returns:
+        int: File size in bytes
+    """
+    result = dpuhost.shell(f"stat -c %s {file_path}")
+    return int(result['stdout'].strip())
+
+
+def nasa_ct_dump_set(dpuhost, enable):
+    """Enable or disable NASA CT dump inclusion in techsupport.
+
+    Uses the platform CLI command to create or remove the sentinel file
+    inside the syncd container.
+
+    Args:
+        dpuhost: DPU host object
+        enable: bool - True to enable, False to disable
+    """
+    state = "enabled" if enable else "disabled"
+    logger.info(f"{'Enabling' if enable else 'Disabling'} NASA CT dump in techsupport on {dpuhost.hostname}")
+    dpuhost.shell(f"sudo config platform nvidia-bluefield sdk techsupport-ct-dump {state}")
+
+
+def get_nasa_ct_dump_enabled(dpuhost):
+    """Check if NASA CT dump is enabled (sentinel file exists in syncd container).
+
+    Args:
+        dpuhost: DPU host object
+
+    Returns:
+        bool: True if enabled, False if disabled
+    """
+    rc = dpuhost.shell(
+        f"docker exec syncd test -f {NASA_CT_DUMP_SENTINEL}",
+        module_ignore_errors=True
+    )['rc']
+    return rc == 0
+
+
+def get_techsupport_file_list(dpuhost, tech_support_file):
+    """List all files inside a techsupport tarball with the top-level prefix stripped.
+
+    Args:
+        dpuhost: DPU host object
+        tech_support_file: Full path to the techsupport .tar.gz file on the DPU
+
+    Returns:
+        list[str]: List of file paths inside the tarball (prefix stripped)
+    """
+    result = dpuhost.shell(f"tar tzf {quote(tech_support_file)}")
+    basename = os.path.basename(tech_support_file)
+    prefix = basename.replace(".tar.gz", "") + "/"
+    files = []
+    for line in result['stdout_lines']:
+        line = line.strip()
+        if line.startswith(prefix):
+            stripped = line[len(prefix):]
+            if stripped:
+                files.append(stripped)
+        elif line:
+            files.append(line)
+    return files

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,7 +106,8 @@ CUSTOM_MSG_PREFIX = "sonic_custom_msg"
 GOLDEN_CONFIG_DB_PATH = "/etc/sonic/golden_config_db.json"
 GOLDEN_CONFIG_DB_PATH_ORI = "/etc/sonic/golden_config_db.json.origin.backup"
 
-pytest_plugins = ('tests.common.plugins.ptfadapter',
+pytest_plugins = ('tests.common.plugins.nasa_debug',
+                  'tests.common.plugins.ptfadapter',
                   'tests.common.plugins.ansible_fixtures',
                   'tests.common.plugins.dut_monitor',
                   'tests.common.plugins.loganalyzer',


### PR DESCRIPTION
### Description of PR
Summary:
Add a new pytest plugin (tests/common/plugins/nasa_debug/) to enable and manage NASA debuggability on DPU hosts during test runs. When --nasa_debug is passed, the plugin automatically enables NASA debug entities on all DPUs before each test module and disables them after the module completes, so debug information is captured in techsupport dumps.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
- master: pass

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Added a new pytest plugin under tests/common/plugins/nasa_debug/ and registered it in tests/conftest.py:

1. **__init__.py** — Plugin entry point:
- Adds --nasa_debug CLI option
- Conditionally loads nasa_debug_fixtures when the flag is set
- Exposes a session-scoped nasa_debug fixture and re-exports public utility APIs
2.  **nasa_debug_fixtures.py** — Module-scoped autouse fixture enable_nasa_debuggability:
- Enables NASA debug on all DPUs (dpuhosts) before each test module
- Disables it after the module completes
3. **nasa_debug_utils.py** — Helper functions:
- Enable/disable NASA debug entities (CONFIG_RECORD, PACKET_DROP) via config platform nvidia-bluefield sdk
- Enable/disable CT dump inclusion in techsupport via sentinel file
- Query debug status and active debug file paths via nasa-cli-helper.py
- Parallel enable/disable across DPUs using SafeThreadPoolExecutor
- Parse techsupport tarball file lists for validation

#### How did you verify/test it?
Verified plugin loads correctly and --nasa_debug option is recognized. 

#### Any platform specific information?
DPU only
#### Supported testbed topology if it's a new test case?
Any
### Documentation
NA
