### PR TITLE
[C1] Skipping packet counter assertion in some ip_packet tests for nokia-vs platforms

### DIFF
--- a/tests/ip/test_ip_packet.py
+++ b/tests/ip/test_ip_packet.py
@@ -675,8 +675,8 @@ class TestIPPacket(object):
         tx_drp = sum_ifaces_counts(portstat_out, out_ifaces, "tx_drp")
         tx_err = sum_ifaces_counts(rif_counter_out, out_rif_ifaces, "tx_err") if rif_support else 0
 
-        if asic_type == "vs":
-            logger.info("Skipping packet count check on VS platform")
+        if asic_type in ["vs", "nokia-vs"]:
+            logger.info("Skipping packet count check on {} platform".format(asic_type))
             return
         pytest_assert(rx_ok >= self.PKT_NUM_MIN,
                       "Received {} packets in rx, not in expected range".format(rx_ok))
@@ -735,8 +735,8 @@ class TestIPPacket(object):
         tx_drp = sum_ifaces_counts(portstat_out, out_ifaces, "tx_drp")
         tx_rif_err = sum_ifaces_counts(rif_counter_out, out_rif_ifaces, "tx_err") if rif_support else 0
 
-        if asic_type == "vs":
-            logger.info("Skipping packet count check on VS platform")
+        if asic_type in ["vs", "nokia-vs"]:
+            logger.info("Skipping packet count check on {} platform".format(asic_type))
             return
         pytest_assert(rx_ok >= self.PKT_NUM_MIN,
                       "Received {} packets in rx, not in expected range".format(rx_ok))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
nokia-vs is a non-asic platform. so the behavior for updating drop/receive counters is different from hardware ASIC based platforms. So, this PR adds nokia-vs to skip condition before packet assertion
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [x] 202603 

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
Skip packet counter assertions on nokia-vs platforms as drop/receive counters are not updated as expected
#### How did you do it?
Added nokia-vs to condition that checks for asic_type before packet counter assertion starts
#### How did you verify/test it?
Run test_drop_l3_ip_packet_non_dut_mac and test_drop_ip_packet_with_wrong_0xffff_chksum tests from ip suite
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
