### PR TITLE
Fix the deprecated vrf configuration command for cEOS 4.35

### DIFF
--- a/ansible/roles/eos/templates/dpu-tor.j2
+++ b/ansible/roles/eos/templates/dpu-tor.j2
@@ -24,8 +24,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -106,6 +105,9 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}

--- a/ansible/roles/eos/templates/lt2-o128-tor.j2
+++ b/ansible/roles/eos/templates/lt2-o128-tor.j2
@@ -37,8 +37,7 @@ vrf instance {{ vrf_name }}
 {% endfor %}
 !
 {% else %}
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 {% endif %}
 spanning-tree mode mstp
@@ -257,6 +256,9 @@ router bgp {{ conv_config['bgp']['asn'] }}
 {% endfor %}
 {% else %}
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}

--- a/ansible/roles/eos/templates/t0-8-lag-leaf.j2
+++ b/ansible/roles/eos/templates/t0-8-lag-leaf.j2
@@ -19,8 +19,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -101,6 +100,9 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}

--- a/ansible/roles/eos/templates/t0-backend-leaf.j2
+++ b/ansible/roles/eos/templates/t0-backend-leaf.j2
@@ -25,8 +25,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -128,6 +127,9 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}

--- a/ansible/roles/eos/templates/t0-leaf-lag-2.j2
+++ b/ansible/roles/eos/templates/t0-leaf-lag-2.j2
@@ -24,8 +24,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -106,6 +105,9 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}

--- a/ansible/roles/eos/templates/t0-mclag-leaf.j2
+++ b/ansible/roles/eos/templates/t0-mclag-leaf.j2
@@ -19,8 +19,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -101,6 +100,9 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}

--- a/ansible/roles/eos/templates/t1-28-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-28-lag-spine.j2
@@ -19,8 +19,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -101,6 +100,9 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}

--- a/ansible/roles/eos/templates/t1-28-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-28-lag-tor.j2
@@ -20,8 +20,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -102,6 +101,9 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}

--- a/ansible/roles/eos/templates/t1-48-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-48-lag-spine.j2
@@ -19,8 +19,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -101,6 +100,9 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}

--- a/ansible/roles/eos/templates/t1-48-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-48-lag-tor.j2
@@ -20,8 +20,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -102,6 +101,9 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}

--- a/ansible/roles/eos/templates/t1-56-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-56-lag-tor.j2
@@ -20,8 +20,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -102,6 +101,9 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}

--- a/ansible/roles/eos/templates/t1-64-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-64-lag-tor.j2
@@ -36,8 +36,7 @@ vrf instance {{ vrf_name }}
 {% endfor %}
 !
 {% else %}
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 {% endif %}
 spanning-tree mode mstp
@@ -256,6 +255,9 @@ router bgp {{ conv_config['bgp']['asn'] }}
 {% endfor %}
 {% else %}
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}

--- a/ansible/roles/eos/templates/t1-8-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-8-lag-spine.j2
@@ -24,8 +24,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -104,6 +103,9 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}

--- a/ansible/roles/eos/templates/t1-8-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-8-lag-tor.j2
@@ -25,8 +25,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -105,6 +104,9 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}

--- a/ansible/roles/eos/templates/t1-backend-tor.j2
+++ b/ansible/roles/eos/templates/t1-backend-tor.j2
@@ -25,8 +25,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -128,6 +127,9 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}

--- a/ansible/roles/eos/templates/t1-f2-d10u8-spine.j2
+++ b/ansible/roles/eos/templates/t1-f2-d10u8-spine.j2
@@ -19,8 +19,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -101,6 +100,9 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}

--- a/ansible/roles/eos/templates/t1-f2-d10u8-tor.j2
+++ b/ansible/roles/eos/templates/t1-f2-d10u8-tor.j2
@@ -20,8 +20,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -102,6 +101,9 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}

--- a/ansible/roles/eos/templates/t1-filterleaf-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-filterleaf-lag-spine.j2
@@ -19,8 +19,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
-rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -101,6 +100,9 @@ ipv6 nd ra suppress
 no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
 router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else
 host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
 !

--- a/ansible/roles/eos/templates/t1-filterleaf-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-filterleaf-lag-tor.j2
@@ -20,8 +20,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
-rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -106,6 +105,9 @@ ipv6 nd ra suppress
 no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
 router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
 !
 graceful-restart restart-time {{ bgp_gr_timer }}

--- a/ansible/roles/eos/templates/t1-smartswitch-ha-spine.j2
+++ b/ansible/roles/eos/templates/t1-smartswitch-ha-spine.j2
@@ -19,8 +19,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -101,6 +100,9 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}

--- a/ansible/roles/eos/templates/t1-smartswitch-ha-tor.j2
+++ b/ansible/roles/eos/templates/t1-smartswitch-ha-tor.j2
@@ -19,8 +19,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -101,6 +100,9 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}

--- a/ansible/roles/eos/templates/t2-core.j2
+++ b/ansible/roles/eos/templates/t2-core.j2
@@ -24,8 +24,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -125,6 +124,9 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}

--- a/ansible/roles/eos/templates/t2-leaf.j2
+++ b/ansible/roles/eos/templates/t2-leaf.j2
@@ -24,8 +24,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -112,6 +111,9 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% if host['bgp']['confed_asn'] is defined and host['bgp']['confed_peers'] is defined %}

--- a/ansible/roles/eos/templates/t2-vs-core.j2
+++ b/ansible/roles/eos/templates/t2-vs-core.j2
@@ -19,8 +19,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -107,6 +106,9 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}

--- a/ansible/roles/eos/templates/t2-vs-leaf.j2
+++ b/ansible/roles/eos/templates/t2-vs-leaf.j2
@@ -19,8 +19,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !
@@ -107,6 +106,9 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}

--- a/ansible/roles/eos/templates/wan-2dut-core.j2
+++ b/ansible/roles/eos/templates/wan-2dut-core.j2
@@ -19,8 +19,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !

--- a/ansible/roles/eos/templates/wan-3link-tg-core.j2
+++ b/ansible/roles/eos/templates/wan-3link-tg-core.j2
@@ -19,8 +19,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !

--- a/ansible/roles/eos/templates/wan-4link-core.j2
+++ b/ansible/roles/eos/templates/wan-4link-core.j2
@@ -19,8 +19,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !

--- a/ansible/roles/eos/templates/wan-ecmp-core.j2
+++ b/ansible/roles/eos/templates/wan-ecmp-core.j2
@@ -19,8 +19,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !

--- a/ansible/roles/eos/templates/wan-pub-core.j2
+++ b/ansible/roles/eos/templates/wan-pub-core.j2
@@ -19,8 +19,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !

--- a/ansible/roles/eos/templates/wan-pub-isis-core.j2
+++ b/ansible/roles/eos/templates/wan-pub-isis-core.j2
@@ -25,8 +25,7 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+vrf instance MGMT
 !
 spanning-tree mode mstp
 !


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In cEOS build 4.35, the old syntax of 'vrf definition' is no longer accepted, which caused the missing configuration on the management interface of neighbor VMs. The Ansible shutdown/no_shutdown commands failed to execute on the neighbor VM due to unreachable mgmt interface.

Summary:
Fixes #26025 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
To fix the deprecated VRF configuration command on impacted topos.

#### How did you do it?
Replaced the deprecated comand 'vrf definition' with 'vrf instance' and removed the unnecessary 'rd 1:1' next to it. For the templates having BGP route configuration, added vrf MGMT and rd 1:1.

#### How did you verify/test it?
Run test_bgp_stress_link_flap.py and verify no failure.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
