### PR TITLE
202605: Make sure lldp is populated after dut/service restart

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -357,6 +357,21 @@ def verify_all_interfaces_lldp_content(db_instance, lldp_entry_keys, lldpctl_out
         verify_each_interface_lldp_content(db_instance, interface, lldpctl_interfaces)
 
 
+def wait_until_lldp_populated(duthost, db_instance, after_event_str):
+    keys_match = wait_until(90, 2, 0, check_lldp_table_keys, duthost, db_instance)
+    pytest_assert(keys_match, "LLDP_ENTRY_TABLE keys do not match 'show lldp table' output")
+    lldp_entry_keys = get_lldp_entry_keys(db_instance)
+    # Wait until all interfaces are up and lldp entries are populated
+    result = wait_until(300, 2, 0, verify_lldp_entry, db_instance, lldp_entry_keys)
+    if not result:
+        failed_entries = {}
+        for interface in lldp_entry_keys:
+            if not verify_lldp_entry(db_instance, [interface]):
+                failed_entries[interface] = get_lldp_entry_content(db_instance, interface)
+        msg = (f"After {after_event_str}, not all LLDP_ENTRY_TABLE entries are not correct: {failed_entries}")
+        pytest_assert(False, msg)
+
+
 # Test case 1: Verify LLDP_ENTRY_TABLE content against lldpctl output
 def test_lldp_entry_table_content(
     duthosts, enum_rand_one_per_hwsku_frontend_hostname, db_instance
@@ -395,16 +410,8 @@ def test_lldp_entry_table_after_syncd_orchagent(
     assert wait_until(600, 5, 120, duthost.critical_services_fully_started), \
         "Not all critical services are fully started"
     time.sleep(60)
-    # Wait until all interfaces are up and lldp entries are populated
-    for interface in lldp_entry_keys:
-        result = wait_until(300, 2, 0, verify_lldp_entry, db_instance, [interface])
-        entry_content = get_lldp_entry_content(db_instance, interface)
-        pytest_assert(
-            result,
-            "After restart swss and syncd, interface {} LLDP_ENTRY_TABLE entry is not correct:{}".format(
-                interface, entry_content
-            ),
-        )
+    wait_until_lldp_populated(duthost, db_instance, "restart swss and syncd")
+
     # To get lldp entry keys again after all interfaces are up
     lldp_entry_keys, show_lldp_table_int_list, lldpctl_output = get_lldp_data(duthost, db_instance)
 
@@ -488,6 +495,7 @@ def test_lldp_entry_table_after_lldp_restart(
             "active (running)" in result,
             "LLDP service is not running",
         )
+    wait_until_lldp_populated(duthost, db_instance, "lldp restart")
     verify_all_interfaces_lldp_content(db_instance, lldp_entry_keys, lldpctl_output, show_lldp_table_int_list)
 
 
@@ -512,8 +520,6 @@ def test_lldp_entry_table_after_reboot(
 
     # Wait till we have all lldp entries in the DB after reboot. It's found in scaling
     # setup this may take some time to happen.
-    keys_match = wait_until(90, 5, 30, check_lldp_table_keys, duthost, db_instance)
-    if not keys_match:
-        assert keys_match, "LLDP_ENTRY_TABLE keys do not match 'show lldp table' output"
+    wait_until_lldp_populated(duthost, db_instance, "cold reboot")
     lldp_entry_keys, show_lldp_table_int_list, lldpctl_output = get_lldp_data(duthost, db_instance)
     verify_all_interfaces_lldp_content(db_instance, lldp_entry_keys, lldpctl_output, show_lldp_table_int_list)


### PR DESCRIPTION
Timing on full-topos is such that straight assertions in cpu_shaper
tests can be flaky. Use wait_until when fetching and verifying cpu
queue shapers before and after DUT reboot to get test passrate to
reflect eventual state.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #25176

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Improve passrate on topologies in 202511 and 202605 by improving test to be less reliant on straight assertions which have timing isses.

#### How did you do it?
Use wait_until to assert on eventual state.
 
#### How did you verify/test it?
Verifed test is no longer flaky on multiple topologies.

#### Any platform specific information?
None.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->