### PR TITLE
[ 202511 ] Skip test chassis reboot test on disaggregated chassis

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1222,6 +1222,15 @@ platform_tests/test_advanced_reboot.py::test_warm_reboot_sad:
       - "is_smartswitch==True"
 
 #######################################
+#####   test_chassis_reboot.py  #####
+#######################################
+platform_tests/test_chassis_reboot.py:
+  skip:
+    reason: "Chassis reboot test is not supported on T2 single node topology"
+    conditions:
+      - "'t2_single_node' in topo_name"
+
+#######################################
 #####   test_cont_warm_reboot.py  #####
 #######################################
 platform_tests/test_cont_warm_reboot.py:


### PR DESCRIPTION
### Description of PR

Skip platform_tests/test_chassis_reboot.py test on for disaggregated chassis as it is not applicable.
 
This is manual backport ( resolved cherry pick conflict for 202511 )  of PR https://github.com/sonic-net/sonic-mgmt/pull/23005 already merged into master


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?

`platform_tests/test_chassis_reboot.py` test is specific for modular chassis are not applicable for disaggregated chassis.

#### How did you do it?

Add a conditional mark to skip it on disaggregated topologies.

#### How did you verify/test it?

Applies specifically to t2_single_node (disaggregated/fixed) topologies.
Modular chassis t2 topologies are unaffected and continue to run the test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
