### PR TITLE
Skip unpopulated transceiver ports for Nokia-IXR7220-H6-O256 lt2-o256-u32d224 topo

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -72,6 +72,10 @@ def xcvr_skip_list(duthosts, dpu_npu_port_list, tbinfo):
                 'Ethernet88', 'Ethernet96', 'Ethernet104', 'Ethernet112',
                 'Ethernet216', 'Ethernet224', 'Ethernet232', 'Ethernet240'
                 ])
+        # For lt2-o256-u32d224 topo, skip Ethernet1008/Ethernet1012 as these ports are not
+        # populated with transceivers by design on this testbed
+        elif tbinfo['topo']['name'] == "lt2-o256-u32d224":
+            intf_skip_list[dut.hostname].extend(['Ethernet1008', 'Ethernet1012'])
 
     return intf_skip_list
 


### PR DESCRIPTION
### Description of PR
Summary:
On Nokia-IXR7220-H6-O256 platforms running the `lt2-o256-u32d224` topology, two ports (`Ethernet1008`/`Ethernet1012`) are not populated with transceivers by design on this testbed. This causes SFP presence-related tests (`test_get_presence`, `test_sfpshow.py`, etc.) to fail because the `xcvr_skip_list` fixture does not account for them.

This PR adds these two ports to the skip list for the `lt2-o256-u32d224` topology, following the existing pattern used for the `lt2-p32o64` topology.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Nightly test runs on a Nokia-IXR7220-H6-O256 testbed with the `lt2-o256-u32d224` topology reported SFP presence-related test failures for ports `Ethernet1008`/`Ethernet1012`. These ports are confirmed (physically, on both ends of the link) to be intentionally unpopulated on this testbed topology, not a hardware fault.

#### How did you do it?
Added an `elif` branch in the `xcvr_skip_list` fixture (`tests/platform_tests/conftest.py`) to skip `Ethernet1008`/`Ethernet1012` when the topology is `lt2-o256-u32d224`, matching the existing precedent for the `lt2-p32o64` topology.

#### How did you verify/test it?
Ran `platform_tests/api/test_sfp.py::TestSfpApi::test_get_presence`, `platform_tests/sfp/test_sfpshow.py::test_check_sfp_presence`, and `platform_tests/sfp/test_sfpshow.py::test_check_sfpshow_eeprom` on a physical testbed with a Nokia-IXR7220-H6-O256 DUT running the `lt2-o256-u32d224` topology. All three tests passed with the fix in place.

#### Any platform specific information?
Applies to Nokia-IXR7220-H6-O256 platform with `lt2-o256-u32d224` topology.

#### Supported testbed topology if it's a new test case?
N/A - not a new test case.

### Documentation
N/A