### PR TITLE
Ignore benign syncd FlexCounter port-removed noise in test_snmp_queue_counters

### DIFF
--- a/tests/snmp/test_snmp_queue_counters.py
+++ b/tests/snmp/test_snmp_queue_counters.py
@@ -203,8 +203,19 @@ def test_snmp_queue_counters(duthosts,
             r".* ERR memory_checker: \[memory_checker\] "
             r"Failed to get container ID of.*",
             r".* ERR memory_checker: \[memory_checker\] "
-            r"cgroup memory usage file.*"
+            r"cgroup memory usage file.*",
         ]
+        # This test triggers multiple config_reload calls (including one
+        # in the module teardown that is not wrapped by
+        # ignore_loganalyzer). On platforms with a large port count,
+        # syncd may log this benign FlexCounter cleanup message when a
+        # port's counters are still being polled right after the port
+        # object was removed/recreated. The port is simply dropped from
+        # the active counter poll list; no functional impact.
+        ignore_regex_list.append(
+            r".* ERR syncd\d*#syncd: :- processFlexCounterEvent: port VID oid:0x[0-9a-fA-F]+, "
+            r"was not found \(probably port was removed/splitted\) and will remove from counters now.*"
+        )
         if duthost.sonichost.facts['platform_asic'] == 'broadcom':
             ignore_regex_list.append(
                 r".* ERR swss#orchagent:\s*.*\s*"


### PR DESCRIPTION
### Description of PR
Summary:
`tests/snmp/test_snmp_queue_counters.py` triggers multiple `config_reload` calls, including one in the module-scoped `teardown` fixture that is **not** wrapped by `ignore_loganalyzer`. On platforms with a large port count (e.g. Nokia-IXR7220-H6-O256, 226 front-panel ports), syncd may log an ERR-level FlexCounter message such as:
```
processFlexCounterEvent: port VID oid:0x..., was not found (probably port was removed/splitted) and will remove from counters now
```
whenever a port's counter polling races with the port object being removed/recreated during `config_reload`. This is expected, self-healing behavior (the port is simply dropped from the active counter poll list) and not indicative of a functional problem, but since it's logged at ERR level, it was causing spurious `loganalyzer` ERROR-at-teardown failures in this specific test.

This PR adds an `ignore_regex` entry scoped to `test_snmp_queue_counters` only, following the existing pattern already used in the same test function for other expected `config_reload` noise (memory_checker, orchagent hash algorithm messages).

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Nightly test runs on a Nokia-IXR7220-H6-O256 testbed reported an `ERROR at teardown` failure in `snmp/test_snmp_queue_counters.py` due to the `loganalyzer` autouse fixture matching benign syncd FlexCounter cleanup noise (triggered by this test's `config_reload` calls) as an unexpected error.

#### How did you do it?
Added a new `ignore_regex` entry to the existing `ignore_regex_list` inside `test_snmp_queue_counters` in `tests/snmp/test_snmp_queue_counters.py`, matching the `processFlexCounterEvent: port VID oid:... was not found (probably port was removed/splitted)` message. The ignore is scoped to this test only (not a global loganalyzer ignore-list change).

#### How did you verify/test it?
Reproduced the failure on a physical testbed with a Nokia-IXR7220-H6-O256 DUT: `snmp/test_snmp_queue_counters.py` reliably hit `ERROR at teardown` due to 112 matched instances of this message during the test's `config_reload` calls. After adding the test-scoped ignore pattern, re-ran the same test and confirmed it now passes (`1 passed`) with no teardown error.

#### Any platform specific information?
Not platform-specific (generic syncd/FlexCounter message), but more likely to manifest on platforms with a large port count such as Nokia-IXR7220-H6-O256.

#### Supported testbed topology if it's a new test case?
N/A - not a new test case.

### Documentation
N/A