### PR TITLE
[dhcp_relay]: Drop duplicate dual-tor link-selection SubOption 5 in VRF DHCPv4 relay ptf test

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -210,6 +210,8 @@ class DHCPTest(DataplaneBaseTest):
         self.option82 += struct.pack('BB', self.REMOTE_ID_SUBOPTION, len(remote_id_string))
         self.option82 += remote_id_string.encode('utf-8')
 
+        link_selection_added = False  # set below; dual-tor block skips SubOption 5 if set
+
         if self.relay_agent == "sonic-relay-agent":
             # Structure:
             #  Byte 0: Suboption number, always set to 5
@@ -219,6 +221,7 @@ class DHCPTest(DataplaneBaseTest):
                 link_selection_ip = bytes(list(map(int, self.link_selection_ip.split('.'))))
                 self.option82 += struct.pack('BB', self.LINK_SELECTION_SUBOPTION, 4)
                 self.option82 += link_selection_ip
+                link_selection_added = True
 
             # The structure is as follows:
             #  Byte 0: Suboption number, always set to 11
@@ -246,11 +249,14 @@ class DHCPTest(DataplaneBaseTest):
         #  Byte 0: Suboption number, always set to 5
         #  Byte 1: Length of suboption data in bytes, always set to 4 (ipv4 addr has 4 bytes)
         #  Bytes 2+: vlan ip addr
-        if self.dual_tor:
+        # Relay emits link-selection (SubOption 5) once; skip this legacy dual-tor
+        # copy if the block above already added it (see commit msg).
+        if self.dual_tor and not link_selection_added:
             link_selection = bytes(
                 list(map(int, self.relay_iface_ip.split('.'))))
             self.option82 += struct.pack('BB', self.LINK_SELECTION_SUBOPTION, 4)
             self.option82 += link_selection
+            link_selection_added = True
 
         # We'll assign our client the IP address 1 greater than our relay interface (i.e., gateway) IP
         self.client_ip = incrementIpAddress(self.relay_iface_ip, 1)


### PR DESCRIPTION
### Description of PR
Summary:
`test_dhcp_relay_with_different_non_default_vrf` (and `..._non_default_vrf`) fail **only on
dual-tor** with `discover packet counts are not equal 0 != 48`. The relay forwards every DISCOVER
correctly; the ptf **expected** Option-82 does not byte-match the relay's actual packet.

This PR fixes one of two independent dual-tor expectation bugs: a **duplicate LINK_SELECTION
Option-82 SubOption 5**. Companion Remote-ID fix is in #26055 — both are required for the dual-tor
VRF discover check to pass.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): ADO 38757666
Failure type: day-one issue (test-side dual-tor duplicate SubOption 5 expectation defect)

### Approach
#### What is the motivation for this PR?
`DHCPTest.setUp()` builds the expected Option-82 with **two separate** LINK_SELECTION (SubOption 5)
appends, at **different positions**:
- the sonic-relay-agent block — when `(link_selection and source_interface) or server_vrf` — value
  `link_selection_ip`, placed **before** SubOption 11/151;
- the legacy `if self.dual_tor:` block **at the end** — value = VLAN IP, placed **after** everything.

On dual-tor + VRF both fire, so the expected Option-82 carries SubOption 5 **twice** (83B) while the
relay emits it **once** (77B) → the mask never matches → count 0. Single-tor never hits the second
append, which is why the signature is dual-tor-only.

The relay agent is authoritative. In `sonic-net/sonic-dhcp-relay`,
[`dhcp4relay/src/dhcp4relay.cpp`](https://github.com/sonic-net/sonic-dhcp-relay/blob/master/dhcp4relay/src/dhcp4relay.cpp)
Option-82 is encoded in a single linear pass, and link-selection is emitted by **one** guard,
between Remote-ID and Server-Override (master line numbers at this writing):

```cpp
L496  encode_tlv(... OPTION82_SUBOPT_CIRCUIT_ID ...)              // 1
L512  encode_tlv(... OPTION82_SUBOPT_REMOTE_ID ...)              // 2
L519  if (m_config.is_dualTor || config->link_selection_opt == "enable")  // 5  <- single append
L522      encode_tlv(... OPTION82_SUBOPT_LINK_SELECTION ...)
L528  if (config->server_id_override_opt == "enable")            // 11
L538  if (config->vrf_selection_opt == "enable" ...)             // 151
```

So exactly one SubOption 5 belongs **between** Remote-ID and Server-Override — where the
sonic-relay-agent block already places it; the trailing dual-tor copy is the extra.

#### How did you do it?
Track whether SubOption 5 was added with a `link_selection_added` flag, set `True` at **each** site
that appends it (so the flag always reflects reality — it stays accurate even after the dual-tor
append), and guard the legacy dual-tor append with `if self.dual_tor and not link_selection_added:` —
no re-evaluating the condition. Dual-tor non-VRF (the relay's `is_dualTor` path) still gets it;
single-tor is unchanged.

**Not merged into a single append on purpose:** the two ptf sites live at different Option-82
positions, and collapsing them would reorder SubOption 5 vs 11 in combos where only
`server_id_override` is set — and sub-option order is part of the byte-match (see `dhcp4relay.cpp`).

#### How did you verify/test it?
On a dual-tor 7260 testbed, ptf's own `Mask` matched the DUT's captured relayed discover only after
removing the duplicate SubOption 5 (expected 77B == actual 77B). With this plus #26055 the discover
verification passes (count 48 == 48).

**Target-branch (202605) validation** — on `internal-202605`, image `20260510.05` (BJW dual-ToR
hardware), as part of the combined dhcpv4-relay PTF-expectation fix stack:
- `test_dhcp_relay_default` — **2/2 passed** (`isc-relay-agent` + `sonic-relay-agent`).
- `test_dhcp_relay_unicast_mac` — **2/2 passed** (both relay implementations).

#### Any platform specific information?
Dual-tor topology specific.

#### Supported testbed topology if it's a new test case?
N/A (existing test fix).

### Documentation
N/A

Microsoft ADO: 38757666
