### PR TITLE
[snappi/bgp]: migrate route-perf ZMQ knob to SYSTEM_DEFAULTS.swss_zmq

### DIFF
--- a/tests/snappi_tests/bgp/files/fine-tunings.yml
+++ b/tests/snappi_tests/bgp/files/fine-tunings.yml
@@ -1,21 +1,40 @@
 baseline_config_db:
   config_db_wo_tuning: true
 
-north_zmq_ring_buffer:
+# swss_zmq replaced the removed DEVICE_METADATA.orch_northbond_route_zmq_enabled
+# leaf; enabled, it drives both northbound route ZMQ and southbound orch<->syncd ZMQ.
+swss_zmq_ring_buffer:
+  SYSTEM_DEFAULTS:
+    swss_zmq:
+      status: "enabled"
   DEVICE_METADATA:
     localhost:
-      orch_northbond_route_zmq_enabled: "true"
       ring_thread_enabled: "true"
 
-north_zmq:
-  DEVICE_METADATA:
-    localhost:
-      orch_northbond_route_zmq_enabled: "true"
+swss_zmq:
+  SYSTEM_DEFAULTS:
+    swss_zmq:
+      status: "enabled"
 
-non_north_zmq_optimized:
+# async_rec enables orchagent's -A async swss recorder (independent of swss_zmq).
+async_rec:
+  SYSTEM_DEFAULTS:
+    async_rec:
+      status: "enabled"
+
+swss_zmq_async_rec:
+  SYSTEM_DEFAULTS:
+    swss_zmq:
+      status: "enabled"
+    async_rec:
+      status: "enabled"
+
+non_swss_zmq_optimized:
+  SYSTEM_DEFAULTS:
+    swss_zmq:
+      status: "disabled"
   DEVICE_METADATA:
     localhost:
-      orch_northbond_route_zmq_enabled: "false"
       synchronous_mode: "enable"
       suppress-fib-pending: "disabled"
       nexthop_group: "enabled"

--- a/tests/snappi_tests/bgp/test_bgp_rib_route_optimztn_perf.py
+++ b/tests/snappi_tests/bgp/test_bgp_rib_route_optimztn_perf.py
@@ -71,6 +71,7 @@ PROFILE_NAMES = [
     if isinstance(cfg, dict) and (
         cfg.get('config_db_wo_tuning')
         or 'DEVICE_METADATA' in cfg
+        or 'SYSTEM_DEFAULTS' in cfg
     )
 ]
 
@@ -112,6 +113,14 @@ def _apply_config_db_profile(duthost, profile_config, original_config):
         config['DEVICE_METADATA']['localhost'] = {}
     meta = profile_config.get('DEVICE_METADATA', {}).get('localhost', {})
     config['DEVICE_METADATA']['localhost'].update(meta)
+    # SYSTEM_DEFAULTS holds the consolidated swss_zmq route-performance knob
+    # (replaces the removed DEVICE_METADATA.orch_northbond_route_zmq_enabled leaf).
+    sys_defaults = profile_config.get('SYSTEM_DEFAULTS', {})
+    if sys_defaults:
+        if 'SYSTEM_DEFAULTS' not in config:
+            config['SYSTEM_DEFAULTS'] = {}
+        for entry, fields in sys_defaults.items():
+            config['SYSTEM_DEFAULTS'].setdefault(entry, {}).update(fields)
     with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
         json.dump(config, f, indent=4)
         config_tmp_path = f.name


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (no separate issue — follow-up to the ZMQ knob consolidation, sonic-buildimage #27674 and siblings, all merged)

The route-performance ZMQ toggle used by the snappi RIB route-optimization perf test was consolidated on the SONiC image side: the per-field `DEVICE_METADATA.localhost.orch_northbond_route_zmq_enabled` leaf was **removed** from `sonic-device_metadata.yang` and replaced by the `SYSTEM_DEFAULTS` list entry `swss_zmq` (`status: enabled|disabled`). `orch_zmq_tables.conf.j2` now gates `ROUTE_TABLE`/`LABEL_ROUTE_TABLE` on `SYSTEM_DEFAULTS.swss_zmq.status == "enabled"`.

Because `tests/snappi_tests/bgp/files/fine-tunings.yml` still wrote the old leaf into `config_db.json` and `config reload`ed, the ZMQ profiles **silently stopped enabling ZMQ** (the perf runs measured non-ZMQ behavior, mislabeled) and risked a YANG validation failure on reload. This PR migrates those profiles to the new knob and teaches the test's profile plumbing to apply `SYSTEM_DEFAULTS` entries.

**Coupling note:** `swss_zmq=enabled` now drives **both** northbound route ZMQ **and** southbound orchagent↔syncd SAI ZMQ (`orchagent.sh` and syncd's `syncd_init_common.sh` share `swss_vars.j2`, both adding `-z zmq_sync`). This is a behavior change vs the original northbound-only leaf; for a T2/DNX route-perf test it exercises the full route path, which is the intended target.

**Profile renaming:** since the `swss_zmq` knob is no longer northbound-only, the misleading `north_*` profile-name prefixes are dropped (these keys are labels only — no dashboard/CI/doc references them):

| Old name | New name | Meaning |
| --- | --- | --- |
| `north_zmq_ring_buffer` | `swss_zmq_ring_buffer` | ZMQ enabled + ring thread |
| `north_zmq` | `swss_zmq` | ZMQ enabled, no ring thread |
| `non_north_zmq_optimized` | `non_swss_zmq_optimized` | ZMQ disabled + non-ZMQ optimizations |

`nexthop_group` is retained in the ZMQ-disabled profile — it is an unrelated, still-valid FRR knob (`sonic-device_metadata.yang` leaf `nexthop_group`, consumed by `zebra.conf.j2`), not a ZMQ field.

**Additional profiles:** two profiles are added for the independent `async_rec` optimization knob (a `SYSTEM_DEFAULTS` list entry driving orchagent's `-A` async swss recorder, orthogonal to `swss_zmq`):

| Profile | Config | Purpose |
| --- | --- | --- |
| `async_rec` | `SYSTEM_DEFAULTS.async_rec.status=enabled` | async recorder standalone |
| `swss_zmq_async_rec` | `swss_zmq=enabled` + `async_rec=enabled` | combined, to isolate async_rec's marginal contribution vs the `swss_zmq` profile |

These are run on a need basis; no test-code change was required since the profile plumbing applies `SYSTEM_DEFAULTS` entries generically.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: regression (test infra broken by the merged ZMQ knob consolidation)

### Approach
#### What is the motivation for this PR?
Keep the snappi BGP RIB route-optimization perf test functional after the ZMQ knob consolidation. Without this change the ZMQ-enabled profiles no longer turn on route ZMQ, so the test measures the wrong configuration (and the removed leaf risks a `config reload` YANG failure).

#### How did you do it?
- `tests/snappi_tests/bgp/files/fine-tunings.yml`: replaced `DEVICE_METADATA.localhost.orch_northbond_route_zmq_enabled` with `SYSTEM_DEFAULTS.swss_zmq.status` in all three profiles (`enabled` for `swss_zmq` and `swss_zmq_ring_buffer`, `disabled` for `non_swss_zmq_optimized`), and renamed the profiles to drop the inaccurate `north_` prefix. Kept the still-valid DEVICE_METADATA leaves (`ring_thread_enabled`, `synchronous_mode`, `suppress-fib-pending`, `nexthop_group`). Added two `async_rec` profiles (`async_rec`, `swss_zmq_async_rec`).
- `tests/snappi_tests/bgp/test_bgp_rib_route_optimztn_perf.py`: added `SYSTEM_DEFAULTS` to the `PROFILE_NAMES` validity filter (so the now-`SYSTEM_DEFAULTS`-only `swss_zmq` profile is still selected) and deep-merged `SYSTEM_DEFAULTS` entries into config_db in `_apply_config_db_profile`, mirroring the existing DEVICE_METADATA merge.

#### How did you verify/test it?
- `python -m py_compile` on the test — passes.
- `flake8 --max-line-length=120` (repo pre-commit setting) — clean.
- Loader/apply dry-run: `PROFILE_NAMES` retains all three profiles including the `SYSTEM_DEFAULTS`-only `swss_zmq`; `_apply_config_db_profile` merges `SYSTEM_DEFAULTS.swss_zmq.status` correctly (enabled/enabled/disabled), preserves the kept DEVICE_METADATA leaves, and does not clobber pre-existing config. No stale `orch_northbond_route_zmq_enabled` or `north_` profile name remains.
- A full route-performance run requires the physical snappi/IXIA T2 testbed and is not reproducible in a KVM/VS environment; there is no image or daemon change in this PR.

#### Any platform specific information?
`swss_zmq` southbound ZMQ end-to-end applies to platforms whose syncd honors it (DPU, and DNX/voq T2 after the context_config ZMQ veto was removed). The test targets T2 route-performance testbeds.

#### Supported testbed topology if it's a new test case?
Not a new test case — existing `tgen` (snappi) topology, T2 route-performance.

### Documentation
N/A

