### PR TITLE
[vpp][testbed] Disable virtio ctrl_vlan on VPP KVM DUTs

### DIFF
--- a/ansible/roles/vm_set/templates/sonic.xml.j2
+++ b/ansible/roles/vm_set/templates/sonic.xml.j2
@@ -133,4 +133,18 @@
 {% endif %}
   </devices>
   <seclabel type='dynamic' model='apparmor' relabel='yes'/>
+{% if asic_type == 'vpp' %}
+  {#
+    Disable the virtio-net control-VQ VLAN filter for VPP DUTs. VPP/DPDK drives the
+    NIC directly and never registers VLANs with the virtio control plane, so with the
+    qemu default (ctrl_vlan=on) qemu silently drops every VLAN-tagged frame before it
+    reaches VPP. That breaks any VLAN sub-interface / L3 sub-port dataplane test (e.g.
+    iface_loopback_action) while leaving untagged traffic working. libvirt has no
+    attribute for this control, so it is set via a qemu -global override.
+  #}
+  <qemu:commandline>
+    <qemu:arg value='-global'/>
+    <qemu:arg value='virtio-net-pci.ctrl_vlan=off'/>
+  </qemu:commandline>
+{% endif %}
 </domain>


### PR DESCRIPTION
#### Why I did it

On VPP DUTs, the qemu virtio-net-pci NICs default to ctrl_vlan on and drop every VLAN-tagged frame before it reaches VPP or DPDK (which registers no VLANs). As a result, L3 sub-interface RIFs never work on the KVM testbed, so the iface_loopback_action test cannot pass for sub-port RIFs.

Feature tracking issue: sonic-net/sonic-buildimage#25788

#### How I did it

For asic_type equal to vpp DUTs only, add "-global virtio-net-pci.ctrl_vlan=off" via the qemu commandline in sonic.xml.j2, with an explanatory comment. There are no resource changes, and non-VPP DUTs are unaffected.

#### How to verify it

On a VPP KVM DUT, run a tagged versus untagged counter test: before the change, tagged frames do not arrive at VPP; after the change, they do. Confirm non-VPP DUTs are unchanged.

#### Which release branch to backport (provide reason below if selected)

None.

#### Description for the changelog

Disable virtio ctrl_vlan on VPP KVM DUTs so VLAN-tagged frames reach VPP.

Part of sonic-net/sonic-buildimage#25788.


---

### PR series (landing order)

Tracking issue: sonic-net/sonic-buildimage#25788

1. HLD: sonic-net/SONiC#2462
2. sonic_ext plugin, nodes and binary API: sonic-net/sonic-platform-vpp#259
3. vslib/vpp SAI adapter and defect fixes: sonic-net/sonic-sairedis#1983 (depends on 2)
4. Testbed virtio ctrl_vlan off: sonic-net/sonic-mgmt#26035
5. Enablement, lands last: sonic-net/sonic-mgmt#26036 (depends on 2, 3, 4)

