### PR TITLE
Ignore benign ACL/mirror session rollback-order noise in test_monitor_config

### DIFF
--- a/tests/generic_config_updater/conftest.py
+++ b/tests/generic_config_updater/conftest.py
@@ -113,6 +113,15 @@ def ignore_expected_loganalyzer_exceptions(request, duthosts, loganalyzer):
             # sonic-swss/orchagent/crmorch.cpp
             ".*ERR swss[0-9]*#orchagent.*getResAvailableCounters.*",  # test_monitor_config
             ".*ERR swss[0-9]*#orchagent.*objectTypeGetAvailability.*",  # test_monitor_config
+            # GCU tries several JsonPatch sortings when rolling back the ACL rule/mirror
+            # session/policer config added by test_monitor_config; some transient
+            # orderings apply the ACL rule removal before the mirror session removal
+            # (or vice versa), which orchagent logs as an ERR before the final,
+            # correctly-ordered patch converges to the expected state.
+            r".*ERR swss[0-9]*#orchagent.*activate: Mirror rule references mirror session "
+            r"\"mirror_session_dscp\" that does not exist yet.*",  # test_monitor_config
+            r".*ERR swss[0-9]*#orchagent.*add: Failed to create ACL rule RULE_1 "
+            r"in table EVERFLOW_DSCP.*",  # test_monitor_config
             ".*ERR dhcp_relay[0-9]*#dhcrelay.*",  # test_dhcp_relay
 
             # sonic-sairedis/vslib/HostInterfaceInfo.cpp: Need investigation


### PR DESCRIPTION
### Description of PR
Summary:
`generic_config_updater/test_monitor_config.py` uses GCU (Generic Config Updater) checkpoints and rollback to add/remove an ACL rule and mirror session, including a final rollback (in the module-scoped `setup_env` teardown) back to the pre-test state. During this final rollback, `orchagent` logs ERR-level messages such as:
```
activate: Mirror rule references mirror session "mirror_session_dscp" that does not exist yet
add: Failed to create ACL rule RULE_1 in table EVERFLOW_DSCP
```

Root cause: `AclOrch` and `MirrorOrch` are independently-scheduled orchestration modules that consume CONFIG_DB changes asynchronously, so there is no guarantee the ACL rule (which references the mirror session via `MIRROR_INGRESS_ACTION`) and the mirror session itself are removed in dependency order during rollback. AclOrch's rule (re-)creation path (`AclRuleMirror::activate()` in `orchagent/aclorch.cpp`) can transiently observe the mirror session as already gone and log this benign error before the ACL rule is itself deleted moments later by its own consumer loop. No SAI/hardware programming occurs during this failed attempt (the function returns before any SAI call), and the rule is always fully and correctly removed afterward - confirmed by `verify_no_monitor_config` passing cleanly every time.

This class of GCU rollback-ordering noise for this test is already acknowledged as **non-platform-specific**: the same `ignore_expected_loganalyzer_exceptions` fixture already documents "GCU will try several sortings of JsonPatch until the sorting passes yang validation" and already contains two unscoped ignore entries for this same test (`getResAvailableCounters` / `objectTypeGetAvailability`, added in 2022), which land on a different internal call than the one hit here. This PR adds the ACL-rule/mirror-session variant, which was not previously covered.

This PR adds two `ignore_regex` entries, scoped to the exact ACL table/rule/mirror-session names used by `test_monitor_config`, to the shared `generic_config_updater` `ignore_expected_loganalyzer_exceptions` fixture, following the existing precedent.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Nightly test runs on a Nokia-IXR7220-H6-O256 testbed reported an `ERROR at teardown` failure in `generic_config_updater/test_monitor_config.py::test_monitor_config_tc1_suite` due to the `loganalyzer` autouse fixture matching transient, benign orchagent errors emitted while AclOrch and MirrorOrch race during the test's final config rollback.

#### How did you do it?
Added two `ignore_regex` entries to the existing `ignoreRegex` list inside the `ignore_expected_loganalyzer_exceptions` fixture in `tests/generic_config_updater/conftest.py`, matching the exact "Mirror rule references mirror session ... that does not exist yet" and "Failed to create ACL rule RULE_1 in table EVERFLOW_DSCP" messages used by `test_monitor_config`.

#### How did you verify/test it?
Reproduced the failure reliably on a physical testbed with a Nokia-IXR7220-H6-O256 DUT using the unmodified test (confirmed baseline reproduction). Traced the exact source of the log line in `orchagent/aclorch.cpp` (`AclRuleMirror::activate()`, called from the rule-creation path `AclOrch::doAclRuleTask` / `addAclRule`) to confirm it is a non-fatal, self-recovering condition: on failure the rule is marked `PENDING_CREATION` and retried, with no SAI/hardware programming performed, until the corresponding `DEL_COMMAND` for the same rule is processed and cleanly removes it. Also confirmed (by removing the POLICER config entirely in an experiment) that this race is unrelated to policer/`is_policer_supported()`. After adding the ignore patterns, re-ran the same test and confirmed it now passes (`1 passed`) with no teardown error.

#### Any platform specific information?
Reproduced and verified on Nokia-IXR7220-H6-O256. The underlying race (AclOrch/MirrorOrch consuming CONFIG_DB changes asynchronously) is a generic SONiC/SWSS architecture trait present on all platforms; this specific log-line variant has not been confirmed on other platforms, but the same fixture already contains two other unscoped, non-platform-specific ignore entries for this same test covering a different manifestation of the same underlying GCU-patch-sorting/rollback-ordering behavior.

#### Supported testbed topology if it's a new test case?
N/A - not a new test case.

### Documentation
N/A