### PR TITLE
[gnoi]: Add PTF-free native gNOI test suite (System.Time, File.Stat)

### DIFF
--- a/docs/testplan/gnoi-native-client-test-plan.md
+++ b/docs/testplan/gnoi-native-client-test-plan.md
@@ -1,0 +1,398 @@
+# gNOI Native-Client Test Plan — the canonical way to test gNOI in sonic-mgmt
+
+## Purpose
+
+This document proposes a **single, canonical way to write gNOI tests** in
+[sonic-mgmt](https://github.com/sonic-net/sonic-mgmt): drive the DUT's gNOI
+server with an **in-process, typed Python gRPC client** imported from a shared,
+versioned wheel — no PTF hop, no shelling a CLI, no per-suite stub generation.
+
+It doubles as the test plan for the initial `tests/gnoi/` suite that
+demonstrates the approach (`System.Time`, `File.Stat`), and argues that this
+suite's pattern should be the one all future gNOI tests adopt so we can stop
+re-inventing the gRPC client on every new feature.
+
+## High Level Design
+
+| Rev   | Date       | Author      | Change Description                                   |
+|-------|------------|-------------|-----------------------------------------------------|
+| Draft | 2026-07-10 | Dawei Huang | Initial version — native client + canonical proposal |
+
+## TL;DR — the recommendation
+
+- **Test gNOI with a real gRPC client, in process, from the sonic-mgmt
+  container.** Import it; don't shell it.
+- **Get that client from one place** — a small, pip-installable
+  `sonic-grpc` wheel (`from sonic_grpc.gnoi import GnoiClient`) that ships
+  vendored, wire-faithful protobuf stubs and is baked into the
+  `docker-sonic-mgmt` image.
+- **Keep the harness in sonic-mgmt** — certificate generation, CONFIG_DB
+  checkpoint/rollback, and server setup reuse the existing
+  `tests/common/cert_utils.py` + `grpc_config.py` infrastructure.
+- **Retire the ad-hoc clients over time** — grpcurl-on-PTF, the DUT-local Go
+  `gnoi_client`, and per-suite generated stubs converge onto the one wheel.
+
+Reference implementation:
+[sonic-mgmt #26040](https://github.com/sonic-net/sonic-mgmt/pull/26040) (the
+`tests/gnoi/` suite) on top of
+[sonic-buildimage #28341](https://github.com/sonic-net/sonic-buildimage/pull/28341)
+(the `sonic-grpc` wheel + image wiring); tracked by
+[sonic-mgmt #26039](https://github.com/sonic-net/sonic-mgmt/issues/26039).
+
+## Background — why gNOI testing keeps churning
+
+gNOI/gNMI are gRPC services, but sonic-mgmt has never settled on **one** way to
+call them from a test. Four distinct client mechanisms exist in the tree today,
+each introduced to solve a local problem:
+
+| # | Mechanism | Where the client runs | How a response comes back |
+|---|-----------|-----------------------|---------------------------|
+| 1 | `grpcurl` via `PtfGrpc`/`PtfGnoi` (`tests/common/ptf_grpc.py`, `ptf_gnoi.py`) — the current "modern" gNOI tests | PTF container | grpcurl stdout → `json.loads` → `dict` |
+| 2 | `gnoi_client` Go binary via `docker exec` (`tests/gnmi/helper.py:gnoi_request`) | gNMI container **on the DUT** | stdout `"Module RPC:\n{json}"`, split on `\n`, `json.loads(line[1])` |
+| 3 | `py_gnmicli.py` (gnxi) via `ptfhost.shell` (`tests/gnmi/helper.py`) — legacy gNMI | PTF container | CLI stdout text, regex/substring scraped |
+| 4 | Generated protobuf stubs via `create_gnmi_stub()` (`tests/common/sai_validation/gnmi_client.py`, stubs from `tests/build-gnmi-stubs.sh`) | sonic-mgmt container | typed protobuf objects |
+
+Every row is a different answer to the same question — "how do I make a gRPC
+call to the DUT?" — with its own transport assumptions, its own error handling,
+its own certificate plumbing, and its own place to break. New gNOI features tend
+to add a *fifth* variant rather than reuse a fourth. That is the churn this
+proposal wants to end.
+
+Notably, mechanism #4 (sai_validation) already proves that a **native, typed
+stub** works well inside the sonic-mgmt container. The gap is only that its
+stubs are generated per-suite and scoped to SAI qualification. The proposal here
+is to **generalize #4 into a shared, owned client** so every suite benefits.
+
+## Problems with shelling a CLI for gRPC
+
+The first three mechanisms above shell out to a command-line tool and parse its
+text output. That is convenient to start, but structurally weak for a test
+suite that is supposed to be an oracle:
+
+1. **Stringly-typed results.** A gNOI response is a protobuf message with a
+   schema. Round-tripping it through CLI stdout throws that schema away and
+   forces every test to re-parse text. The DUT-local path literally does
+   `output.split('\n')[1]` then `json.loads` (`helper.py:extract_gnoi_response`)
+   — one stray log line on stdout and the test misreads or crashes.
+
+2. **No real status codes.** gRPC's contract is a typed `StatusCode`
+   (`UNAUTHENTICATED`, `PERMISSION_DENIED`, `NOT_FOUND`, …). Shelling a CLI
+   collapses that into an exit code plus free-form stderr, so tests assert on
+   substrings of error text instead of on the status code the server actually
+   returned. Negative and authz tests — exactly where gNOI correctness matters —
+   become brittle.
+
+3. **An extra container in the failure surface.** The grpcurl and py_gnmicli
+   paths run the client on **PTF**, so every gNOI assertion depends on PTF being
+   up, reachable, and carrying the right certs — even though gNOI has nothing to
+   do with data-plane packet testing. The DUT-local Go path avoids PTF but
+   instead depends on a binary baked into the DUT image and on `docker exec`.
+
+4. **Certificate/setup logic duplicated per mechanism.** Each client re-derives
+   where certs live and how the server is configured. A single cert-path change
+   ripples across files (the predecessor design doc,
+   [`gnoi_client_library_design.md`](./gnoi_client_library_design.md),
+   documents 14+ files carrying hardcoded cert paths).
+
+5. **Nothing is shared or versioned.** There is no one artifact a new test can
+   depend on. So a new gNOI need copies the nearest mechanism and diverges.
+
+## Proposed approach — native in-process gRPC client
+
+Drive gNOI the "API way": construct a real gRPC channel **inside the sonic-mgmt
+container**, dial the DUT management IP over mTLS, and call typed stubs.
+
+```python
+from sonic_grpc.gnoi import GnoiClient, system_pb2
+
+def test_gnoi_system_time(gnoi_client):          # gnoi_client is a fixture
+    resp = gnoi_client.system.Time(system_pb2.TimeRequest(), timeout=10)
+    assert resp.time > 0                          # resp.time is an int, not a parsed string
+```
+
+The client is **not** built or generated inside sonic-mgmt. It is imported from
+a standalone, pip-installable **`sonic-grpc`** wheel that is baked into the
+`docker-sonic-mgmt` image. The wheel:
+
+- exposes `GnoiClient` — a context-managed, service-agnostic client
+  (`client.system.Time(...)`, `client.file.Stat(...)`, and `client.channel` for
+  any service not yet wrapped);
+- supports three transports — insecure TCP, `unix://` UDS, and **mTLS**
+  (`grpc.ssl_channel_credentials` + `grpc.ssl_target_name_override`, so a
+  DNS-only server-cert SAN is dialable without hardcoding an IP);
+- **vendors flat protobuf stubs** (`system_pb2`, `file_pb2`, `types_pb2`,
+  `common_pb2`, and their `_grpc` peers) — so there is nothing to generate at
+  test time and no `types`/`os` stdlib import collision;
+- ships `FakeGnoiServer` (`sonic_grpc.gnoi.testing`) for offline unit tests;
+- depends only on `grpcio` + `protobuf`, so it `pip install`s anywhere,
+  including `pip install "git+https://github.com/sonic-net/sonic-buildimage@<sha>#subdirectory=src/sonic-grpc"`.
+
+Adding a new gNOI service to a test is a stub import plus a call on
+`client.channel` — no new client, no PTF change, no build script.
+
+### Architecture
+
+```mermaid
+flowchart LR
+    subgraph mgmt["sonic-mgmt container"]
+        tests["tests/gnoi/*"]
+        fixture["gnoi_client fixture\n(cert-gen + server setup + client)"]
+        client["GnoiClient\n(sonic_grpc.gnoi)"]
+        tests --> fixture --> client
+    end
+
+    subgraph dut["DUT (management IP)"]
+        gnmi["gNMI/gNOI server\n:50052 (mTLS)"]
+    end
+
+    client -- "mTLS gRPC (typed stubs)" --> gnmi
+```
+
+No PTF. The only hop is sonic-mgmt container → DUT management IP, over the same
+mTLS the production gNOI consumers use.
+
+### Components
+
+1. **`sonic-grpc` wheel** (built in sonic-buildimage `src/sonic-grpc/`, wired
+   into `docker-sonic-mgmt`). The client + vendored stubs + `FakeGnoiServer` +
+   unit tests. Owned by this effort; versioned; the single source of the client.
+
+2. **`gnoi_client` fixture** (`tests/gnoi/conftest.py`). A coupled,
+   self-cleaning fixture modeled on the existing `gnmi_tls` fixture:
+   checkpoint CONFIG_DB → generate a CA/server/client cert chain and push the
+   server cert to the DUT → configure CONFIG_DB TLS mode and register the client
+   CN in `GNMI_CLIENT_CERT` → restart `gnmi-native` → verify readiness with a
+   native `System.Time` retry loop → **yield** an mTLS `GnoiClient` → rollback +
+   `wait_critical_processes` + cert cleanup. It reuses the DUT-side setup helpers
+   `_configure_gnoi_tls_server` / `_restart_gnoi_server` from
+   `tests/common/fixtures/grpc_fixtures.py` — no logic is forked.
+
+3. **Certificate management** (reused, unchanged). `tests/common/cert_utils.py`
+   (`TlsCertificateGenerator` / `create_gnmi_cert_generator`) generates a
+   pure-Python `cryptography` chain — backdated, SAN-bearing — and
+   `tests/common/grpc_config.py` centralizes paths, ports, and CONFIG_DB cert
+   settings. The client cert/key/CA stay in the container (the native client
+   reads them locally); only the server cert/key + CA go to the DUT.
+
+## Certificate model
+
+The mTLS setup is deliberately identical to what the gNMI/gNOI server already
+expects in production, so tests exercise the real authentication path:
+
+- Server cert carries a **SAN** (Go rejects CN-only certs); the client verifies
+  it against the generated CA.
+- The client cert **CN is registered in `GNMI_CLIENT_CERT`** with gNOI roles
+  (e.g. `gnoi_readwrite`), so the server authorizes the call — a real authz
+  path, not `-insecure`.
+- All state is checkpointed and rolled back; certs are generated under a temp
+  dir and removed on teardown. The suite is idempotent and self-cleaning.
+
+Because the client holds a typed `grpc.RpcError`, an authz-failure test can
+assert `err.code() == grpc.StatusCode.UNAUTHENTICATED` directly — the kind of
+assertion the CLI-scraping mechanisms cannot make cleanly.
+
+## Test cases
+
+### v1 (implemented, VS-validated)
+
+| Test | RPC | Asserts |
+|------|-----|---------|
+| `test_gnoi_system_time` | `gnoi.system.System/Time` | typed `resp.time` > 0 and within ~1 day of local clock (sane clock, not sync) |
+| `test_gnoi_file_stat` | `gnoi.file.File/Stat` | `resp.stats[0].path == "/etc/hostname"` and `size > 0`, reached via `client.file` / `client.channel` (proves new services plug in without client changes) |
+
+Both are marked `@pytest.mark.topology('any')` and
+`@pytest.mark.skip_check_dut_health` (the fixture mutates `GNMI` CONFIG_DB and
+rolls it back; without the marker the teardown `core_dump_and_config_check`
+flags the transient change as drift and forces a config reload — there is no CLI
+flag to disable that check). Both pass on a KVM (virtual switch) testbed.
+
+### Roadmap (where the typed client pays off)
+
+These are not implemented in v1 but are the reason the approach is worth
+standardizing — each is awkward or impossible to assert cleanly by scraping CLI
+text:
+
+- **Status-code / negative tests:** unregistered client cert →
+  `UNAUTHENTICATED`; unauthorized role → `PERMISSION_DENIED`; missing file →
+  `NOT_FOUND`. Assert on `RpcError.code()`.
+- **Streaming RPCs:** `File.Get` / `File.Put`, `System.SetPackage` — real
+  server-streaming iteration instead of buffering CLI stdout.
+- **Broader System/File/OS surface** and, later, SONiC-specific services, all
+  as thin stub additions to `sonic-grpc`.
+
+## CI behavior — fail loud, but scope the failure
+
+The suite must **fail, not skip**, when the client is unavailable. An earlier
+draft used `pytest.importorskip`, which turned a missing client into a *skip* —
+and a skipped test counts as a green pipeline, so CI could pass without ever
+exercising gNOI. A test that can silently no-op is not an oracle.
+
+But there are two distinct failure modes, and they want different blast radii:
+
+- **A missing *feature*** (the server doesn't implement the RPC) — the test
+  should fail: that is real signal.
+- **A missing *infra artifact*** (the `sonic_grpc` wheel isn't in the image
+  yet) — this should fail the **gNOI suite loudly**, but must **not** red
+  unrelated PRs.
+
+The second distinction matters because sonic-mgmt runs a **tree-wide
+`pytest --collect-only`** check (`.azure-pipelines/pytest-collect-only.yml`)
+against the *currently published* `docker-sonic-mgmt` image on every PR. A
+module-scope `from sonic_grpc.gnoi import ...` executes at **collection** time,
+so if the published image lags the wheel, that import raises a collection error
+and reds the collect-only job for **every** sonic-mgmt PR — not just gNOI runs.
+"Red not skip" is right; reding the whole tree is collateral damage.
+
+**Canonical pattern:** put the hard dependency in the suite's fixture, not at
+module scope. Import `sonic_grpc.gnoi` (and assert a minimum
+`sonic_grpc.__version__`) inside the `gnoi_client` fixture / a session-scoped
+conftest guard, and `pytest.fail()` with a message naming the required wheel
+version and the buildimage PR. This keeps the failure **hard** and **red** when
+the gNOI suite actually runs, while leaving tree-wide `--collect-only`
+unaffected. (The reference suite's imports should live behind this guard for the
+same reason.)
+
+**Sequencing:**
+1. Merge the `sonic-grpc` wheel + `docker-sonic-mgmt` wiring
+   (sonic-buildimage) **first**; let the test image roll.
+2. Then merge `tests/gnoi/` (sonic-mgmt). It must **not** merge before the image
+   ships `sonic_grpc`, or the gNOI suite is red by construction.
+
+The wheel wiring and the tests live in the same coordinated pair of PRs, with
+the dependency called out explicitly, precisely so a reviewer cannot merge them
+out of order by accident.
+
+### Steady-state compatibility policy
+
+The cross-repo coupling is not just a one-time merge ordering — it is permanent,
+and there is **no cross-repo CI** to catch a wheel/tests mismatch pre-merge. So
+it needs an explicit policy, not just good intentions:
+
+- **Pin.** The suite asserts a minimum `sonic_grpc.__version__`; the wheel uses
+  semver. A backward-incompatible client change is a major bump plus a
+  coordinated tests update.
+- **Who bumps.** `src/sonic-grpc` carries an `OWNERS`/maintainers list (see
+  Governance). Proto-pin bumps and new service stubs go through those owners,
+  who are also responsible for the paired sonic-mgmt update.
+- **When the image lags.** The documented recovery is to install the wheel from
+  source in the container —
+  `pip install "git+https://github.com/sonic-net/sonic-buildimage@<sha>#subdirectory=src/sonic-grpc"`
+  — so development and local validation never block on an image roll.
+
+## Why this should be the canonical approach
+
+| Property | grpcurl on PTF | Go `gnoi_client` on DUT | py_gnmicli on PTF | native stub (sai_validation) | **native `sonic-grpc` (proposed)** |
+|----------|:---:|:---:|:---:|:---:|:---:|
+| Typed responses (schema preserved) | ✗ | ✗ | ✗ | ✓ | ✓ |
+| Real gRPC status codes | ✗ | ✗ | ✗ | ✓ | ✓ |
+| No PTF dependency | ✗ | ✓ | ✗ | ✓ | ✓ |
+| No DUT-baked client binary | ✓ | ✗ | ✓ | ✓ | ✓ |
+| One shared, versioned artifact | ✗ | ✗ | ✗ | per-suite | ✓ (one wheel) |
+| Reusable across repos / suites | ✗ | ✗ | ✗ | partial | ✓ |
+| Exercises real mTLS authz path | partial | ✓ | partial | depends | ✓ |
+
+The native stub approach already wins on correctness; the only thing missing was
+a *shared* home for it. `sonic-grpc` supplies that home. Standardizing on it
+means:
+
+- **One client contract to learn and maintain.** New gNOI tests import a wheel
+  instead of copying the nearest CLI wrapper. The churn stops because there is a
+  single obvious thing to reuse.
+- **Tests assert on the protocol, not on prose.** Typed messages and status
+  codes make negative/authz/streaming tests tractable — the cases that matter
+  most for a management API.
+- **The client is owned and versioned.** Bumping the gNOI proto pin is a wheel
+  version bump with unit tests (`FakeGnoiServer`), not a scavenger hunt across
+  vendored stubs and shell wrappers.
+- **The harness stays where it belongs.** Cert generation and CONFIG_DB
+  lifecycle remain sonic-mgmt fixtures reusing existing infra; the wheel carries
+  only the protocol client. Clean separation, minimal consumed surface
+  (`GnoiClient`, the pb2 message types, `.channel`).
+
+**On "why Python, when the gNOI server and consumers are Go":** sonic-mgmt is a
+pytest harness — a Python client is the only in-process option, and there is no
+maintained upstream Python gNOI client to adopt instead. The wheel is wire-level
+gRPC/protobuf, so it stays faithful to the same `openconfig/gnoi` contract the
+Go server and consumers use; language is a client-side detail, not a divergence.
+
+## Trade-offs and objections
+
+- **"grpcurl needs no wheel — this adds a cross-repo dependency."** True, and
+  it is the main cost. We accept it because the payoff (typed, status-coded,
+  shared, versioned) is exactly what a settled standard needs, and the ordering
+  is managed by explicit sequencing + a scoped hard failure + a version pin (see
+  CI behavior) rather than being papered over by a silent skip.
+- **"Why a cross-repo wheel instead of one vendored stub package in
+  `tests/common/`?"** Vendoring in sonic-mgmt would be shared *within* sonic-mgmt,
+  but the real driver is **cross-repo reuse**: sonic-buildimage has its own
+  in-flight gNOI Python client
+  ([sonic-buildimage #27760](https://github.com/sonic-net/sonic-buildimage/pull/27760))
+  that will be rerouted to consume this same `sonic-grpc` wheel. One wheel in
+  buildimage is consumable by both the test harness and the on-box/tooling
+  consumers; a copy vendored under `tests/common/` is not. (If the wheel ever
+  stalls, vendoring the flat stubs into sonic-mgmt is the named fallback — but it
+  is a fallback, not the goal.) The wheel also installs from source, so
+  development never blocks on a merge.
+- **"UDS/local transport is simpler for some suites."** The client already
+  supports `unix://`; the DUT-local UDS ergonomics explored in
+  [`gnmi-uds-transport-design.md`](./gnmi-uds-transport-design.md) compose with
+  this client rather than competing with it.
+
+## Attribution and provenance
+
+`sonic-grpc`'s client and stubs are **not new code invented here**. They are
+factored out of the in-flight gNOI Python client
+([sonic-buildimage #27760](https://github.com/sonic-net/sonic-buildimage/pull/27760));
+this effort packages that work as a standalone, installable distribution so both
+the test harness and #27760 itself can share one implementation. Credit for the
+client belongs to that original work; `sonic-grpc` is the shared home, not a
+fork. Reviewers diffing the PRs will see the shared lineage — it is intentional
+and disclosed.
+
+## Governance
+
+For a package that claims to be *canonical*, ownership must be explicit, not an
+afterthought:
+
+- `src/sonic-grpc/` carries an `OWNERS`/maintainers list, named at introduction.
+- Those owners are accountable for proto-pin bumps, new service stubs, semver
+  discipline, and the paired sonic-mgmt update when the client surface changes.
+- New service stubs land in `sonic-grpc` (with `FakeGnoiServer`-backed unit
+  tests) rather than being generated ad hoc per suite — one generated-stub source
+  in the ecosystem.
+
+## Adoption & migration roadmap
+
+1. **Land the reference suite** (`tests/gnoi/` + `sonic-grpc`) as the canonical
+   pattern. ✅ implemented, VS-validated.
+2. **Grow `sonic-grpc`'s stub surface** (OS, streaming File, negative-path
+   helpers) as new gNOI tests need them.
+3. **Write all new gNOI tests against `GnoiClient`.** No new CLI wrappers.
+4. **Migrate existing `tests/gnmi/test_gnoi_*.py`** off grpcurl/Go-`gnoi_client`
+   onto the wheel, suite by suite, keeping behavior identical.
+5. **Fold the sai_validation stubs** into `sonic-grpc` so there is exactly one
+   generated-stub source in the tree.
+
+No existing test is deleted or changed by v1; migration is incremental and
+behavior-preserving.
+
+## Scope / non-goals (v1)
+
+- **In scope:** the `tests/gnoi/` suite (`System.Time`, `File.Stat`), the
+  `gnoi_client` fixture, the `sonic-grpc` wheel + image wiring, and this
+  canonical recommendation.
+- **Out of scope (later increments):** the full gNOI surface (OS,
+  factory_reset, healthz, containerz), SONiC-specific services, SmartSwitch DPU
+  routing, reboot/upgrade flows, and migrating the existing
+  `tests/gnmi/test_gnoi_*.py` tests.
+
+## Open questions
+
+- Confirm the vendored stubs stay wire-compatible with the sonic-gnmi server's
+  `openconfig/gnoi` pin as it advances (low risk for Time/Stat; re-verify on
+  bumps via `FakeGnoiServer`).
+- Final home of the fixture harness: keep it in `tests/gnoi/` or promote the
+  reusable parts to `tests/common/` once a second suite consumes the client.
+- Initial `sonic-grpc` maintainer set and review cadence for proto-pin bumps
+  (the Governance section names the mechanism; the specific owners are TBD at
+  introduction).

--- a/docs/testplan/gnoi-native-client-test-plan.md
+++ b/docs/testplan/gnoi-native-client-test-plan.md
@@ -19,6 +19,7 @@ community one obvious thing to reuse.
 |-------|------------|-------------|------------------------------------------------------------|
 | Draft | 2026-07-10 | Dawei Huang | Initial version — native client + canonical proposal       |
 | v2    | 2026-07-13 | Dawei Huang | Rewrite for clarity; add a concrete before/after example   |
+| v3    | 2026-07-13 | Dawei Huang | Scope to test concerns: reframe PTF as the wrong plane, drop cross-repo-reuse rationale, remove CI/PR-tracking material |
 
 ## Summary
 
@@ -145,11 +146,15 @@ foundation for a test suite whose job is to be an oracle:
   collapses these into an exit code and free-form stderr, so negative and
   authorization tests — exactly the cases where gNOI correctness matters most —
   end up asserting on error substrings.
-- **An extra container joins the failure surface.** The grpcurl and py_gnmicli
-  paths run the client on PTF, so every gNOI assertion depends on PTF being up,
-  reachable, and holding the right certificates, even though gNOI has nothing to
-  do with data-plane packet testing. The DUT-local Go path avoids PTF but instead
-  depends on a client binary baked into the DUT image and on `docker exec`.
+- **A management-plane API is reached over the dataplane path.** gNOI is a
+  management interface, and the natural way to exercise it is over the DUT's
+  management interface. PTF is the dataplane packet-test framework; there is
+  nothing inherently wrong with it, but a management-plane RPC has no real reason
+  to travel across the PTF dataplane network. The grpcurl and py_gnmicli paths
+  nonetheless run the client on PTF and depend on it being up, reachable, and
+  holding the right certificates. (The DUT-local Go path avoids PTF, but only by
+  running the client on the DUT itself via `docker exec` against a binary baked
+  into the DUT image.)
 - **Certificate and setup logic is duplicated.** Each mechanism re-derives where
   certificates live and how the server is configured. The predecessor design
   note, [`gnoi_client_library_design.md`](./gnoi_client_library_design.md),
@@ -189,9 +194,8 @@ standalone, pip-installable `sonic-grpc` wheel that is baked into the
   `types`/`os` directory names that would otherwise collide with the Python
   standard library.
 - `FakeGnoiServer` (`sonic_grpc.gnoi.testing`) for offline unit tests.
-- A dependency footprint of just `grpcio` and `protobuf`, so the wheel installs
-  anywhere, including directly from source with
-  `pip install "git+https://github.com/sonic-net/sonic-buildimage@<sha>#subdirectory=src/sonic-grpc"`.
+- A small dependency footprint of just `grpcio` and `protobuf`, so the wheel is
+  easy to install into the test image and to unit-test in isolation.
 
 Adding a new gNOI service to a test amounts to importing its stub and calling it
 on `client.channel`; it does not require a new client, a PTF change, or a build
@@ -216,7 +220,9 @@ flowchart LR
 ```
 
 The only network hop is from the sonic-mgmt container to the DUT management IP,
-over the same mTLS that production gNOI consumers use. PTF is not involved.
+over the same mTLS a production gNOI consumer would use. Since gNOI is a
+management-plane API, exercising it over the management interface is the natural
+fit; the dataplane network and PTF are not involved.
 
 ### Components
 
@@ -294,68 +300,6 @@ scraping CLI text:
 - **A broader System/File/OS surface**, and later SONiC-specific services, added
   as small stub additions to `sonic-grpc`.
 
-## CI behavior: fail loudly, but scope the failure
-
-The suite should fail rather than skip when the client is unavailable. An
-earlier draft used `pytest.importorskip`, which turns a missing client into a
-skip — and because a skipped test counts as a passing pipeline, CI could go
-green without ever exercising gNOI at all. A test that can silently do nothing
-is not an oracle.
-
-There are, however, two distinct reasons the client might be unavailable, and
-they warrant different blast radii:
-
-- A missing *feature* — the server does not implement the RPC — should fail the
-  test, because that is real signal.
-- A missing *infrastructure artifact* — the `sonic_grpc` wheel is not in the
-  image yet — should fail the gNOI suite loudly, but must not turn unrelated PRs
-  red.
-
-The second distinction matters because sonic-mgmt runs a tree-wide
-`pytest --collect-only` check (`.azure-pipelines/pytest-collect-only.yml`)
-against the currently published `docker-sonic-mgmt` image on every PR. A
-module-scope `from sonic_grpc.gnoi import ...` runs at collection time, so if
-the published image lags the wheel, that import raises a collection error and
-turns the collect-only job red for every sonic-mgmt PR, not just gNOI runs. The
-"fail, don't skip" principle is right; failing the whole tree over an
-infrastructure lag is not.
-
-The suite therefore keeps the hard dependency out of module scope and places it
-in the fixture instead. The import of `sonic_grpc.gnoi`, along with a minimum
-`sonic_grpc.__version__` check, happens inside the `gnoi_client` fixture (or a
-session-scoped conftest guard), which calls `pytest.fail()` with a message
-naming the required wheel version and the buildimage PR. The failure is still
-hard and red when the gNOI suite actually runs, while tree-wide `--collect-only`
-is left unaffected.
-
-### Sequencing
-
-1. Merge the `sonic-grpc` wheel and its `docker-sonic-mgmt` wiring
-   (sonic-buildimage) first, and let the test image roll.
-2. Then merge `tests/gnoi/` (sonic-mgmt). It must not merge before the image
-   ships `sonic_grpc`, or the gNOI suite is red by construction.
-
-The wheel wiring and the tests are prepared as a coordinated pair of PRs, with
-the dependency stated explicitly, so that the ordering is not violated by
-accident.
-
-### Steady-state compatibility
-
-The cross-repo coupling is permanent rather than a one-time ordering concern,
-and there is no cross-repo CI to catch a wheel/tests mismatch before merge, so
-it needs an explicit policy:
-
-- **Version pin.** The suite asserts a minimum `sonic_grpc.__version__`, and the
-  wheel follows semantic versioning. A backward-incompatible client change is a
-  major version bump accompanied by a coordinated update to the tests.
-- **Ownership.** `src/sonic-grpc` carries a maintainers list (see Governance).
-  Proto-pin bumps and new service stubs go through those maintainers, who are
-  also responsible for the paired sonic-mgmt update.
-- **Recovery when the image lags.** The documented recovery is to install the
-  wheel from source in the container with
-  `pip install "git+https://github.com/sonic-net/sonic-buildimage@<sha>#subdirectory=src/sonic-grpc"`,
-  so development and local validation are never blocked on an image roll.
-
 ## Why this should be the standard approach
 
 | Property | grpcurl on PTF | Go `gnoi_client` on DUT | py_gnmicli on PTF | native stub (sai_validation) | native `sonic-grpc` (proposed) |
@@ -365,7 +309,7 @@ it needs an explicit policy:
 | No PTF dependency | ✗ | ✓ | ✗ | ✓ | ✓ |
 | No DUT-baked client binary | ✓ | ✗ | ✓ | ✓ | ✓ |
 | One shared, versioned artifact | ✗ | ✗ | ✗ | per-suite | ✓ (one wheel) |
-| Reusable across repos and suites | ✗ | ✗ | ✗ | partial | ✓ |
+| Reusable across test suites | ✗ | ✗ | ✗ | partial | ✓ |
 | Exercises the real mTLS authz path | partial | ✓ | partial | depends | ✓ |
 
 The native stub approach already comes out ahead on correctness; the piece that
@@ -396,22 +340,17 @@ standard.
 
 ## Trade-offs and objections
 
-- **grpcurl needs no wheel, so this adds a cross-repo dependency.** That is
-  true, and it is the main cost. The payoff — typed responses, real status
-  codes, and a single shared, versioned artifact — is what a settled standard
-  needs, and the ordering is managed by explicit sequencing, a fixture-scoped
-  hard failure, and a version pin (see CI behavior) rather than being papered
-  over by a silent skip.
-- **Why a cross-repo wheel rather than one vendored stub package under
-  `tests/common/`?** Vendoring in sonic-mgmt would be shared within sonic-mgmt,
-  but the real driver is cross-repo reuse. sonic-buildimage has its own in-flight
-  gNOI Python client,
-  [sonic-buildimage #27760](https://github.com/sonic-net/sonic-buildimage/pull/27760),
-  which will be rerouted to consume this same `sonic-grpc` wheel. A single wheel
-  in buildimage is usable by both the test harness and the on-box tooling; a copy
-  vendored under `tests/common/` is not. Vendoring the flat stubs into sonic-mgmt
-  remains the named fallback if the wheel stalls, but it is a fallback rather than
-  the goal, and the wheel installs from source in the meantime.
+- **This adds a dependency on a wheel built in sonic-buildimage.** grpcurl needs
+  no such dependency. The cost is accepted for the payoff — typed responses, real
+  status codes, and a single owned client in place of four ad-hoc ones. The wheel
+  is delivered in the `docker-sonic-mgmt` image and can be installed from source
+  during development.
+- **Why a wheel rather than vendoring stubs under `tests/common/`?** A wheel
+  keeps the client versioned and unit-tested (`FakeGnoiServer`) as one artifact
+  delivered through the test image, rather than a static copy that each area is
+  tempted to regenerate — which is how sai_validation ended up with its own
+  stubs. Vendoring the flat stubs into sonic-mgmt remains the fallback if the
+  wheel is ever unavailable.
 - **UDS or local transport is simpler for some suites.** The client already
   supports `unix://`, and the DUT-local UDS ergonomics explored in
   [`gnmi-uds-transport-design.md`](./gnmi-uds-transport-design.md) compose with
@@ -419,28 +358,21 @@ standard.
 
 ## Attribution and provenance
 
-The client and stubs in `sonic-grpc` are not new code invented for this effort.
-They are factored out of the in-flight gNOI Python client in
+The client and stubs in `sonic-grpc` are not new code written for this effort.
+They are factored out of an in-flight gNOI Python client in
 [sonic-buildimage #27760](https://github.com/sonic-net/sonic-buildimage/pull/27760);
-this effort packages that work as a standalone, installable distribution so that
-both the test harness and #27760 itself can share one implementation. Credit for
-the client belongs to that original work — `sonic-grpc` is a shared home for it,
-not a fork — and reviewers comparing the PRs will see the shared lineage, which
-is intentional and disclosed here.
+credit for the client belongs to that original work. `sonic-grpc` packages it as
+an installable, versioned distribution rather than forking it, and reviewers
+comparing the PRs will see the shared lineage, which is intentional and disclosed
+here.
 
 ## Governance
 
-For a package intended to become a standard, ownership should be explicit rather
-than assumed:
-
-- `src/sonic-grpc/` carries a maintainers list, named when the package is
-  introduced.
-- Those maintainers are accountable for proto-pin bumps, new service stubs,
-  semantic-versioning discipline, and the paired sonic-mgmt update whenever the
-  client surface changes.
-- New service stubs land in `sonic-grpc`, with `FakeGnoiServer`-backed unit
-  tests, rather than being generated ad hoc per suite, so that the ecosystem
-  keeps a single generated-stub source.
+Because `sonic-grpc` is proposed as shared test infrastructure, `src/sonic-grpc/`
+should carry a named maintainers list responsible for proto-pin bumps, new
+service stubs, and versioning. New service stubs land there, with
+`FakeGnoiServer`-backed unit tests, rather than being regenerated per suite, so
+that the tree keeps a single stub source.
 
 ## Adoption and migration
 

--- a/docs/testplan/gnoi-native-client-test-plan.md
+++ b/docs/testplan/gnoi-native-client-test-plan.md
@@ -1,134 +1,201 @@
-# gNOI Native-Client Test Plan — the canonical way to test gNOI in sonic-mgmt
+# gNOI test plan: a native gRPC client as the standard approach
 
 ## Purpose
 
-This document proposes a **single, canonical way to write gNOI tests** in
-[sonic-mgmt](https://github.com/sonic-net/sonic-mgmt): drive the DUT's gNOI
-server with an **in-process, typed Python gRPC client** imported from a shared,
-versioned wheel — no PTF hop, no shelling a CLI, no per-suite stub generation.
+This document describes a small new gNOI test suite (`tests/gnoi/`) and, more
+importantly, proposes the pattern it uses as the standard way to write gNOI
+tests in [sonic-mgmt](https://github.com/sonic-net/sonic-mgmt) from now on.
 
-It doubles as the test plan for the initial `tests/gnoi/` suite that
-demonstrates the approach (`System.Time`, `File.Stat`), and argues that this
-suite's pattern should be the one all future gNOI tests adopt so we can stop
-re-inventing the gRPC client on every new feature.
+The suite talks to the DUT's gNOI server with an ordinary in-process Python
+gRPC client instead of shelling out to a command-line tool and parsing its
+output. The client comes from a shared, versioned wheel (`sonic-grpc`) rather
+than being re-created inside each test area. The goal is to stop the recurring
+pattern where every new gNOI need grows its own bespoke client, and to give the
+community one obvious thing to reuse.
 
 ## High Level Design
 
-| Rev   | Date       | Author      | Change Description                                   |
-|-------|------------|-------------|-----------------------------------------------------|
-| Draft | 2026-07-10 | Dawei Huang | Initial version — native client + canonical proposal |
+| Rev   | Date       | Author      | Change Description                                          |
+|-------|------------|-------------|------------------------------------------------------------|
+| Draft | 2026-07-10 | Dawei Huang | Initial version — native client + canonical proposal       |
+| v2    | 2026-07-13 | Dawei Huang | Rewrite for clarity; add a concrete before/after example   |
 
-## TL;DR — the recommendation
+## Summary
 
-- **Test gNOI with a real gRPC client, in process, from the sonic-mgmt
-  container.** Import it; don't shell it.
-- **Get that client from one place** — a small, pip-installable
-  `sonic-grpc` wheel (`from sonic_grpc.gnoi import GnoiClient`) that ships
-  vendored, wire-faithful protobuf stubs and is baked into the
-  `docker-sonic-mgmt` image.
-- **Keep the harness in sonic-mgmt** — certificate generation, CONFIG_DB
-  checkpoint/rollback, and server setup reuse the existing
-  `tests/common/cert_utils.py` + `grpc_config.py` infrastructure.
-- **Retire the ad-hoc clients over time** — grpcurl-on-PTF, the DUT-local Go
-  `gnoi_client`, and per-suite generated stubs converge onto the one wheel.
+The recommendation is:
 
-Reference implementation:
+- Test gNOI with a real gRPC client, in process, running in the sonic-mgmt
+  container and dialing the DUT management IP directly — no PTF hop.
+- Take that client from one place: a small, pip-installable `sonic-grpc` wheel
+  (`from sonic_grpc.gnoi import GnoiClient`) that ships vendored, wire-faithful
+  protobuf stubs and is baked into the `docker-sonic-mgmt` image.
+- Keep the test harness in sonic-mgmt. Certificate generation, CONFIG_DB
+  checkpoint/rollback, and server setup all reuse the existing
+  `tests/common/cert_utils.py` and `grpc_config.py` infrastructure.
+- Migrate the older ad-hoc clients onto this one over time, rather than in a
+  single disruptive change.
+
+The reference implementation is
 [sonic-mgmt #26040](https://github.com/sonic-net/sonic-mgmt/pull/26040) (the
-`tests/gnoi/` suite) on top of
+`tests/gnoi/` suite), which sits on top of
 [sonic-buildimage #28341](https://github.com/sonic-net/sonic-buildimage/pull/28341)
-(the `sonic-grpc` wheel + image wiring); tracked by
+(the `sonic-grpc` wheel and its image wiring). Both are tracked by
 [sonic-mgmt #26039](https://github.com/sonic-net/sonic-mgmt/issues/26039).
 
-## Background — why gNOI testing keeps churning
+## Background: how gNOI tests reach the DUT today
 
-gNOI/gNMI are gRPC services, but sonic-mgmt has never settled on **one** way to
-call them from a test. Four distinct client mechanisms exist in the tree today,
-each introduced to solve a local problem:
+gNOI and gNMI are gRPC services, but sonic-mgmt has never settled on a single
+way to call them from a test. Over time, four different client mechanisms have
+accumulated in the tree, each added to solve a particular problem at the time:
 
 | # | Mechanism | Where the client runs | How a response comes back |
 |---|-----------|-----------------------|---------------------------|
-| 1 | `grpcurl` via `PtfGrpc`/`PtfGnoi` (`tests/common/ptf_grpc.py`, `ptf_gnoi.py`) — the current "modern" gNOI tests | PTF container | grpcurl stdout → `json.loads` → `dict` |
-| 2 | `gnoi_client` Go binary via `docker exec` (`tests/gnmi/helper.py:gnoi_request`) | gNMI container **on the DUT** | stdout `"Module RPC:\n{json}"`, split on `\n`, `json.loads(line[1])` |
-| 3 | `py_gnmicli.py` (gnxi) via `ptfhost.shell` (`tests/gnmi/helper.py`) — legacy gNMI | PTF container | CLI stdout text, regex/substring scraped |
+| 1 | `grpcurl` via `PtfGrpc`/`PtfGnoi` (`tests/common/ptf_grpc.py`, `ptf_gnoi.py`) — the current "modern" gNOI tests | PTF container | grpcurl stdout parsed with `json.loads` into a `dict` |
+| 2 | `gnoi_client` Go binary via `docker exec` (`tests/gnmi/helper.py`) | gNMI container on the DUT | stdout `"Module RPC:\n{json}"`, split on `\n`, then `json.loads` of the second line |
+| 3 | `py_gnmicli.py` (gnxi) via `ptfhost.shell` (`tests/gnmi/helper.py`) — legacy gNMI | PTF container | CLI stdout scraped with string/substring matching |
 | 4 | Generated protobuf stubs via `create_gnmi_stub()` (`tests/common/sai_validation/gnmi_client.py`, stubs from `tests/build-gnmi-stubs.sh`) | sonic-mgmt container | typed protobuf objects |
 
-Every row is a different answer to the same question — "how do I make a gRPC
-call to the DUT?" — with its own transport assumptions, its own error handling,
-its own certificate plumbing, and its own place to break. New gNOI features tend
-to add a *fifth* variant rather than reuse a fourth. That is the churn this
-proposal wants to end.
+Each row is a different answer to the same question — how does a test make a
+gRPC call to the DUT? — and each brings its own transport assumptions, its own
+error handling, and its own certificate plumbing. When a new gNOI feature needs
+testing, the path of least resistance is usually to copy whichever of these is
+nearest and adjust it, which is how the tree ended up with four in the first
+place.
 
-Notably, mechanism #4 (sai_validation) already proves that a **native, typed
-stub** works well inside the sonic-mgmt container. The gap is only that its
-stubs are generated per-suite and scoped to SAI qualification. The proposal here
-is to **generalize #4 into a shared, owned client** so every suite benefits.
+It is worth noting that mechanism #4, used by SAI qualification, already shows
+that a native typed stub works well inside the sonic-mgmt container. The only
+thing keeping it from being reused everywhere is that its stubs are generated
+per-suite and scoped to that one area. Much of this proposal is simply about
+giving that approach a proper shared home.
 
-## Problems with shelling a CLI for gRPC
+## A concrete example
 
-The first three mechanisms above shell out to a command-line tool and parse its
-text output. That is convenient to start, but structurally weak for a test
-suite that is supposed to be an oracle:
+Consider a small, real task: check whether a gNOI reboot is currently in
+progress. Today, using the DUT-local Go client (mechanism #2), the code looks
+like this (condensed from `tests/gnmi/helper.py`):
 
-1. **Stringly-typed results.** A gNOI response is a protobuf message with a
-   schema. Round-tripping it through CLI stdout throws that schema away and
-   forces every test to re-parse text. The DUT-local path literally does
-   `output.split('\n')[1]` then `json.loads` (`helper.py:extract_gnoi_response`)
-   — one stray log line on stdout and the test misreads or crashes.
+```python
+def gnoi_request(duthost, localhost, module, rpc, request_json_data):
+    env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
+    ip = duthost.mgmt_ip
+    port = env.gnmi_port
+    cmd = "docker exec %s gnoi_client -target %s:%s " % (env.gnmi_container, ip, port)
+    cmd += "-cert /etc/sonic/telemetry/gnmiclient.crt "
+    cmd += "-key /etc/sonic/telemetry/gnmiclient.key "
+    cmd += "-ca /etc/sonic/telemetry/gnmiCA.pem "
+    cmd += "-logtostderr -module {} -rpc {} ".format(module, rpc)
+    cmd += f"-jsonin '{request_json_data}'"
+    output = duthost.shell(cmd, module_ignore_errors=True)
+    if output['stderr']:
+        return -1, output['stderr']
+    return 0, output['stdout']
 
-2. **No real status codes.** gRPC's contract is a typed `StatusCode`
-   (`UNAUTHENTICATED`, `PERMISSION_DENIED`, `NOT_FOUND`, …). Shelling a CLI
-   collapses that into an exit code plus free-form stderr, so tests assert on
-   substrings of error text instead of on the status code the server actually
-   returned. Negative and authz tests — exactly where gNOI correctness matters —
-   become brittle.
 
-3. **An extra container in the failure surface.** The grpcurl and py_gnmicli
-   paths run the client on **PTF**, so every gNOI assertion depends on PTF being
-   up, reachable, and carrying the right certs — even though gNOI has nothing to
-   do with data-plane packet testing. The DUT-local Go path avoids PTF but
-   instead depends on a binary baked into the DUT image and on `docker exec`.
+def extract_gnoi_response(output):
+    # output looks like "System RebootStatus\n{"active": false, ...}"
+    response_line = output.split('\n')[1]
+    return json.loads(response_line)
 
-4. **Certificate/setup logic duplicated per mechanism.** Each client re-derives
-   where certs live and how the server is configured. A single cert-path change
-   ripples across files (the predecessor design doc,
-   [`gnoi_client_library_design.md`](./gnoi_client_library_design.md),
-   documents 14+ files carrying hardcoded cert paths).
 
-5. **Nothing is shared or versioned.** There is no one artifact a new test can
-   depend on. So a new gNOI need copies the nearest mechanism and diverges.
+def is_reboot_inactive(duthost, localhost):
+    ret, msg = gnoi_request(duthost, localhost, "System", "RebootStatus", "")
+    if ret != 0:
+        return False
+    status = extract_gnoi_response(msg)
+    return status and not status.get("active", True)
+```
 
-## Proposed approach — native in-process gRPC client
+Several things are happening here that have nothing to do with reboot status.
+The request is assembled as a shell command string; certificate paths are
+hardcoded; success or failure is inferred by sniffing `stderr`; and the response
+is recovered by splitting stdout on newlines and hoping the JSON is on the
+second line. A stray log line, a changed flag name, or an error printed to
+stdout instead of stderr will quietly break the parse.
 
-Drive gNOI the "API way": construct a real gRPC channel **inside the sonic-mgmt
-container**, dial the DUT management IP over mTLS, and call typed stubs.
+With the native client, the same check is just a method call on a typed stub:
+
+```python
+resp = gnoi_client.system.RebootStatus(system_pb2.RebootStatusRequest())
+reboot_inactive = not resp.active
+```
+
+`resp` is a protobuf message, so `resp.active` is a real boolean field rather
+than a value fished out of parsed text. If the call fails, it raises
+`grpc.RpcError` carrying the actual gRPC status code, so a test can distinguish
+`UNAUTHENTICATED` from `NOT_FOUND` instead of matching on error strings. The
+transport, credentials, and target are set up once by a fixture rather than
+being rebuilt inside every helper.
+
+The same contrast holds for the grpcurl path (mechanism #1). Fetching the
+system time there returns a plain dictionary that the test has to probe
+(`result["time"]`); with the native client it is `resp.time`, an `int64` field
+on a `TimeResponse` message.
+
+## Why the CLI-shelling approach is hard to build on
+
+The example above illustrates the general problem. Shelling out to a CLI and
+parsing its text output is quick to get started with, but it is a weak
+foundation for a test suite whose job is to be an oracle:
+
+- **The response schema is thrown away.** A gNOI response is a structured
+  protobuf message, and routing it through CLI stdout discards that structure and
+  forces each test to re-derive it from text.
+- **Real gRPC status codes are lost.** gRPC reports failures as typed status
+  codes such as `UNAUTHENTICATED`, `PERMISSION_DENIED`, and `NOT_FOUND`. A CLI
+  collapses these into an exit code and free-form stderr, so negative and
+  authorization tests — exactly the cases where gNOI correctness matters most —
+  end up asserting on error substrings.
+- **An extra container joins the failure surface.** The grpcurl and py_gnmicli
+  paths run the client on PTF, so every gNOI assertion depends on PTF being up,
+  reachable, and holding the right certificates, even though gNOI has nothing to
+  do with data-plane packet testing. The DUT-local Go path avoids PTF but instead
+  depends on a client binary baked into the DUT image and on `docker exec`.
+- **Certificate and setup logic is duplicated.** Each mechanism re-derives where
+  certificates live and how the server is configured. The predecessor design
+  note, [`gnoi_client_library_design.md`](./gnoi_client_library_design.md),
+  records that certificate paths were hardcoded across more than a dozen files.
+- **There is nothing shared to depend on.** No single artifact exists for a new
+  test to reuse, so each new need diverges from the last.
+
+## Proposed approach: a native in-process gRPC client
+
+The suite constructs a real gRPC channel inside the sonic-mgmt container, dials
+the DUT management IP over mTLS, and calls typed stubs. A test reads as plainly
+as any other pytest test:
 
 ```python
 from sonic_grpc.gnoi import GnoiClient, system_pb2
 
 def test_gnoi_system_time(gnoi_client):          # gnoi_client is a fixture
     resp = gnoi_client.system.Time(system_pb2.TimeRequest(), timeout=10)
-    assert resp.time > 0                          # resp.time is an int, not a parsed string
+    assert resp.time > 0                          # resp.time is a typed int64 field
 ```
 
-The client is **not** built or generated inside sonic-mgmt. It is imported from
-a standalone, pip-installable **`sonic-grpc`** wheel that is baked into the
-`docker-sonic-mgmt` image. The wheel:
+The client is not built or generated inside sonic-mgmt. It is imported from a
+standalone, pip-installable `sonic-grpc` wheel that is baked into the
+`docker-sonic-mgmt` image. The wheel provides:
 
-- exposes `GnoiClient` — a context-managed, service-agnostic client
-  (`client.system.Time(...)`, `client.file.Stat(...)`, and `client.channel` for
-  any service not yet wrapped);
-- supports three transports — insecure TCP, `unix://` UDS, and **mTLS**
-  (`grpc.ssl_channel_credentials` + `grpc.ssl_target_name_override`, so a
-  DNS-only server-cert SAN is dialable without hardcoding an IP);
-- **vendors flat protobuf stubs** (`system_pb2`, `file_pb2`, `types_pb2`,
-  `common_pb2`, and their `_grpc` peers) — so there is nothing to generate at
-  test time and no `types`/`os` stdlib import collision;
-- ships `FakeGnoiServer` (`sonic_grpc.gnoi.testing`) for offline unit tests;
-- depends only on `grpcio` + `protobuf`, so it `pip install`s anywhere,
-  including `pip install "git+https://github.com/sonic-net/sonic-buildimage@<sha>#subdirectory=src/sonic-grpc"`.
+- `GnoiClient`, a context-managed, service-agnostic client. Service stubs are
+  reachable both as convenience properties (`client.system.Time(...)`,
+  `client.file.Stat(...)`) and, for any service not yet wrapped, through
+  `client.channel`.
+- Three transports: insecure TCP, `unix://` UDS, and mTLS. The mTLS path uses
+  `grpc.ssl_channel_credentials` together with `grpc.ssl_target_name_override`,
+  so a server certificate whose SAN is a DNS name can be verified without
+  hardcoding an IP address.
+- Vendored, flat protobuf stubs (`system_pb2`, `file_pb2`, `types_pb2`,
+  `common_pb2`, and their `_grpc` peers). Because the stubs ship with the wheel,
+  there is nothing to generate at test time, and the flat layout avoids the
+  `types`/`os` directory names that would otherwise collide with the Python
+  standard library.
+- `FakeGnoiServer` (`sonic_grpc.gnoi.testing`) for offline unit tests.
+- A dependency footprint of just `grpcio` and `protobuf`, so the wheel installs
+  anywhere, including directly from source with
+  `pip install "git+https://github.com/sonic-net/sonic-buildimage@<sha>#subdirectory=src/sonic-grpc"`.
 
-Adding a new gNOI service to a test is a stub import plus a call on
-`client.channel` — no new client, no PTF change, no build script.
+Adding a new gNOI service to a test amounts to importing its stub and calling it
+on `client.channel`; it does not require a new client, a PTF change, or a build
+script.
 
 ### Architecture
 
@@ -148,251 +215,267 @@ flowchart LR
     client -- "mTLS gRPC (typed stubs)" --> gnmi
 ```
 
-No PTF. The only hop is sonic-mgmt container → DUT management IP, over the same
-mTLS the production gNOI consumers use.
+The only network hop is from the sonic-mgmt container to the DUT management IP,
+over the same mTLS that production gNOI consumers use. PTF is not involved.
 
 ### Components
 
-1. **`sonic-grpc` wheel** (built in sonic-buildimage `src/sonic-grpc/`, wired
-   into `docker-sonic-mgmt`). The client + vendored stubs + `FakeGnoiServer` +
-   unit tests. Owned by this effort; versioned; the single source of the client.
-
-2. **`gnoi_client` fixture** (`tests/gnoi/conftest.py`). A coupled,
-   self-cleaning fixture modeled on the existing `gnmi_tls` fixture:
-   checkpoint CONFIG_DB → generate a CA/server/client cert chain and push the
-   server cert to the DUT → configure CONFIG_DB TLS mode and register the client
-   CN in `GNMI_CLIENT_CERT` → restart `gnmi-native` → verify readiness with a
-   native `System.Time` retry loop → **yield** an mTLS `GnoiClient` → rollback +
-   `wait_critical_processes` + cert cleanup. It reuses the DUT-side setup helpers
-   `_configure_gnoi_tls_server` / `_restart_gnoi_server` from
-   `tests/common/fixtures/grpc_fixtures.py` — no logic is forked.
-
-3. **Certificate management** (reused, unchanged). `tests/common/cert_utils.py`
+1. **The `sonic-grpc` wheel**, built in sonic-buildimage under `src/sonic-grpc/`
+   and wired into `docker-sonic-mgmt`. It contains the client, the vendored
+   stubs, `FakeGnoiServer`, and unit tests. It is versioned and owned as the
+   single source of the client (see Governance).
+2. **The `gnoi_client` fixture** (`tests/gnoi/conftest.py`), a coupled,
+   self-cleaning fixture modeled on the existing `gnmi_tls` fixture. It
+   checkpoints CONFIG_DB, generates a CA/server/client certificate chain and
+   pushes the server certificate to the DUT, configures CONFIG_DB for TLS mode
+   and registers the client CN in `GNMI_CLIENT_CERT`, restarts `gnmi-native`,
+   confirms readiness with a `System.Time` retry loop, and yields an mTLS
+   `GnoiClient`. On teardown it rolls back, waits for critical processes, and
+   removes the certificates. It reuses the DUT-side helpers
+   `_configure_gnoi_tls_server` and `_restart_gnoi_server` from
+   `tests/common/fixtures/grpc_fixtures.py` rather than forking that logic.
+3. **Certificate management**, reused unchanged. `tests/common/cert_utils.py`
    (`TlsCertificateGenerator` / `create_gnmi_cert_generator`) generates a
-   pure-Python `cryptography` chain — backdated, SAN-bearing — and
-   `tests/common/grpc_config.py` centralizes paths, ports, and CONFIG_DB cert
-   settings. The client cert/key/CA stay in the container (the native client
-   reads them locally); only the server cert/key + CA go to the DUT.
+   pure-Python `cryptography` chain — backdated and SAN-bearing — and
+   `tests/common/grpc_config.py` centralizes the paths, ports, and CONFIG_DB
+   certificate settings. The client certificate, key, and CA stay in the
+   container where the native client reads them; only the server certificate,
+   key, and CA are copied to the DUT.
 
 ## Certificate model
 
-The mTLS setup is deliberately identical to what the gNMI/gNOI server already
-expects in production, so tests exercise the real authentication path:
+The mTLS setup deliberately mirrors what the gNMI/gNOI server already expects in
+production, so the tests exercise the real authentication path rather than a
+relaxed one:
 
-- Server cert carries a **SAN** (Go rejects CN-only certs); the client verifies
-  it against the generated CA.
-- The client cert **CN is registered in `GNMI_CLIENT_CERT`** with gNOI roles
-  (e.g. `gnoi_readwrite`), so the server authorizes the call — a real authz
-  path, not `-insecure`.
-- All state is checkpointed and rolled back; certs are generated under a temp
-  dir and removed on teardown. The suite is idempotent and self-cleaning.
+- The server certificate carries a SAN, since Go rejects certificates that rely
+  on the legacy Common Name field, and the client verifies it against the
+  generated CA.
+- The client certificate's CN is registered in `GNMI_CLIENT_CERT` with the
+  appropriate gNOI roles (for example `gnoi_readwrite`), so the server
+  authorizes the call. This is a genuine authorization path, not an `-insecure`
+  bypass.
+- All CONFIG_DB state is checkpointed and rolled back, and certificates are
+  generated under a temporary directory and removed on teardown, so the suite is
+  idempotent and self-cleaning.
 
-Because the client holds a typed `grpc.RpcError`, an authz-failure test can
-assert `err.code() == grpc.StatusCode.UNAUTHENTICATED` directly — the kind of
-assertion the CLI-scraping mechanisms cannot make cleanly.
+Because the client surfaces a typed `grpc.RpcError`, an authorization-failure
+test can assert `err.code() == grpc.StatusCode.UNAUTHENTICATED` directly — the
+kind of assertion that the text-scraping mechanisms cannot make cleanly.
 
 ## Test cases
 
-### v1 (implemented, VS-validated)
+### v1 (implemented and VS-validated)
 
-| Test | RPC | Asserts |
-|------|-----|---------|
-| `test_gnoi_system_time` | `gnoi.system.System/Time` | typed `resp.time` > 0 and within ~1 day of local clock (sane clock, not sync) |
-| `test_gnoi_file_stat` | `gnoi.file.File/Stat` | `resp.stats[0].path == "/etc/hostname"` and `size > 0`, reached via `client.file` / `client.channel` (proves new services plug in without client changes) |
+| Test | RPC | What it asserts |
+|------|-----|-----------------|
+| `test_gnoi_system_time` | `gnoi.system.System/Time` | `resp.time` is positive and within roughly a day of the local clock (a sanity check on the clock, not on synchronization) |
+| `test_gnoi_file_stat` | `gnoi.file.File/Stat` | `resp.stats[0].path == "/etc/hostname"` and `size > 0`, reached through `client.file` / `client.channel`, demonstrating that a new service plugs in without any client change |
 
-Both are marked `@pytest.mark.topology('any')` and
-`@pytest.mark.skip_check_dut_health` (the fixture mutates `GNMI` CONFIG_DB and
-rolls it back; without the marker the teardown `core_dump_and_config_check`
-flags the transient change as drift and forces a config reload — there is no CLI
-flag to disable that check). Both pass on a KVM (virtual switch) testbed.
+Both tests are marked `@pytest.mark.topology('any')` and
+`@pytest.mark.skip_check_dut_health`. The health-check marker is necessary
+because the fixture mutates `GNMI` CONFIG_DB and rolls it back; without it, the
+teardown `core_dump_and_config_check` would flag the transient change as
+configuration drift and force a reload, and there is no CLI flag to disable that
+check. Both tests pass on a KVM (virtual switch) testbed.
 
-### Roadmap (where the typed client pays off)
+### Roadmap
 
-These are not implemented in v1 but are the reason the approach is worth
-standardizing — each is awkward or impossible to assert cleanly by scraping CLI
-text:
+The following are not part of v1, but they are much of the reason the approach
+is worth standardizing, since each is awkward or impossible to assert cleanly by
+scraping CLI text:
 
-- **Status-code / negative tests:** unregistered client cert →
-  `UNAUTHENTICATED`; unauthorized role → `PERMISSION_DENIED`; missing file →
-  `NOT_FOUND`. Assert on `RpcError.code()`.
-- **Streaming RPCs:** `File.Get` / `File.Put`, `System.SetPackage` — real
-  server-streaming iteration instead of buffering CLI stdout.
-- **Broader System/File/OS surface** and, later, SONiC-specific services, all
-  as thin stub additions to `sonic-grpc`.
+- **Negative and status-code tests**, for example an unregistered client
+  certificate returning `UNAUTHENTICATED`, an unauthorized role returning
+  `PERMISSION_DENIED`, or a missing file returning `NOT_FOUND`, all asserted on
+  `RpcError.code()`.
+- **Streaming RPCs** such as `File.Get`/`File.Put` and `System.SetPackage`,
+  iterated as real server streams rather than buffered CLI output.
+- **A broader System/File/OS surface**, and later SONiC-specific services, added
+  as small stub additions to `sonic-grpc`.
 
-## CI behavior — fail loud, but scope the failure
+## CI behavior: fail loudly, but scope the failure
 
-The suite must **fail, not skip**, when the client is unavailable. An earlier
-draft used `pytest.importorskip`, which turned a missing client into a *skip* —
-and a skipped test counts as a green pipeline, so CI could pass without ever
-exercising gNOI. A test that can silently no-op is not an oracle.
+The suite should fail rather than skip when the client is unavailable. An
+earlier draft used `pytest.importorskip`, which turns a missing client into a
+skip — and because a skipped test counts as a passing pipeline, CI could go
+green without ever exercising gNOI at all. A test that can silently do nothing
+is not an oracle.
 
-But there are two distinct failure modes, and they want different blast radii:
+There are, however, two distinct reasons the client might be unavailable, and
+they warrant different blast radii:
 
-- **A missing *feature*** (the server doesn't implement the RPC) — the test
-  should fail: that is real signal.
-- **A missing *infra artifact*** (the `sonic_grpc` wheel isn't in the image
-  yet) — this should fail the **gNOI suite loudly**, but must **not** red
-  unrelated PRs.
+- A missing *feature* — the server does not implement the RPC — should fail the
+  test, because that is real signal.
+- A missing *infrastructure artifact* — the `sonic_grpc` wheel is not in the
+  image yet — should fail the gNOI suite loudly, but must not turn unrelated PRs
+  red.
 
-The second distinction matters because sonic-mgmt runs a **tree-wide
-`pytest --collect-only`** check (`.azure-pipelines/pytest-collect-only.yml`)
-against the *currently published* `docker-sonic-mgmt` image on every PR. A
-module-scope `from sonic_grpc.gnoi import ...` executes at **collection** time,
-so if the published image lags the wheel, that import raises a collection error
-and reds the collect-only job for **every** sonic-mgmt PR — not just gNOI runs.
-"Red not skip" is right; reding the whole tree is collateral damage.
+The second distinction matters because sonic-mgmt runs a tree-wide
+`pytest --collect-only` check (`.azure-pipelines/pytest-collect-only.yml`)
+against the currently published `docker-sonic-mgmt` image on every PR. A
+module-scope `from sonic_grpc.gnoi import ...` runs at collection time, so if
+the published image lags the wheel, that import raises a collection error and
+turns the collect-only job red for every sonic-mgmt PR, not just gNOI runs. The
+"fail, don't skip" principle is right; failing the whole tree over an
+infrastructure lag is not.
 
-**Canonical pattern:** put the hard dependency in the suite's fixture, not at
-module scope. Import `sonic_grpc.gnoi` (and assert a minimum
-`sonic_grpc.__version__`) inside the `gnoi_client` fixture / a session-scoped
-conftest guard, and `pytest.fail()` with a message naming the required wheel
-version and the buildimage PR. This keeps the failure **hard** and **red** when
-the gNOI suite actually runs, while leaving tree-wide `--collect-only`
-unaffected. (The reference suite's imports should live behind this guard for the
-same reason.)
+The suite therefore keeps the hard dependency out of module scope and places it
+in the fixture instead. The import of `sonic_grpc.gnoi`, along with a minimum
+`sonic_grpc.__version__` check, happens inside the `gnoi_client` fixture (or a
+session-scoped conftest guard), which calls `pytest.fail()` with a message
+naming the required wheel version and the buildimage PR. The failure is still
+hard and red when the gNOI suite actually runs, while tree-wide `--collect-only`
+is left unaffected.
 
-**Sequencing:**
-1. Merge the `sonic-grpc` wheel + `docker-sonic-mgmt` wiring
-   (sonic-buildimage) **first**; let the test image roll.
-2. Then merge `tests/gnoi/` (sonic-mgmt). It must **not** merge before the image
+### Sequencing
+
+1. Merge the `sonic-grpc` wheel and its `docker-sonic-mgmt` wiring
+   (sonic-buildimage) first, and let the test image roll.
+2. Then merge `tests/gnoi/` (sonic-mgmt). It must not merge before the image
    ships `sonic_grpc`, or the gNOI suite is red by construction.
 
-The wheel wiring and the tests live in the same coordinated pair of PRs, with
-the dependency called out explicitly, precisely so a reviewer cannot merge them
-out of order by accident.
+The wheel wiring and the tests are prepared as a coordinated pair of PRs, with
+the dependency stated explicitly, so that the ordering is not violated by
+accident.
 
-### Steady-state compatibility policy
+### Steady-state compatibility
 
-The cross-repo coupling is not just a one-time merge ordering — it is permanent,
-and there is **no cross-repo CI** to catch a wheel/tests mismatch pre-merge. So
-it needs an explicit policy, not just good intentions:
+The cross-repo coupling is permanent rather than a one-time ordering concern,
+and there is no cross-repo CI to catch a wheel/tests mismatch before merge, so
+it needs an explicit policy:
 
-- **Pin.** The suite asserts a minimum `sonic_grpc.__version__`; the wheel uses
-  semver. A backward-incompatible client change is a major bump plus a
-  coordinated tests update.
-- **Who bumps.** `src/sonic-grpc` carries an `OWNERS`/maintainers list (see
-  Governance). Proto-pin bumps and new service stubs go through those owners,
-  who are also responsible for the paired sonic-mgmt update.
-- **When the image lags.** The documented recovery is to install the wheel from
-  source in the container —
-  `pip install "git+https://github.com/sonic-net/sonic-buildimage@<sha>#subdirectory=src/sonic-grpc"`
-  — so development and local validation never block on an image roll.
+- **Version pin.** The suite asserts a minimum `sonic_grpc.__version__`, and the
+  wheel follows semantic versioning. A backward-incompatible client change is a
+  major version bump accompanied by a coordinated update to the tests.
+- **Ownership.** `src/sonic-grpc` carries a maintainers list (see Governance).
+  Proto-pin bumps and new service stubs go through those maintainers, who are
+  also responsible for the paired sonic-mgmt update.
+- **Recovery when the image lags.** The documented recovery is to install the
+  wheel from source in the container with
+  `pip install "git+https://github.com/sonic-net/sonic-buildimage@<sha>#subdirectory=src/sonic-grpc"`,
+  so development and local validation are never blocked on an image roll.
 
-## Why this should be the canonical approach
+## Why this should be the standard approach
 
-| Property | grpcurl on PTF | Go `gnoi_client` on DUT | py_gnmicli on PTF | native stub (sai_validation) | **native `sonic-grpc` (proposed)** |
+| Property | grpcurl on PTF | Go `gnoi_client` on DUT | py_gnmicli on PTF | native stub (sai_validation) | native `sonic-grpc` (proposed) |
 |----------|:---:|:---:|:---:|:---:|:---:|
 | Typed responses (schema preserved) | ✗ | ✗ | ✗ | ✓ | ✓ |
 | Real gRPC status codes | ✗ | ✗ | ✗ | ✓ | ✓ |
 | No PTF dependency | ✗ | ✓ | ✗ | ✓ | ✓ |
 | No DUT-baked client binary | ✓ | ✗ | ✓ | ✓ | ✓ |
 | One shared, versioned artifact | ✗ | ✗ | ✗ | per-suite | ✓ (one wheel) |
-| Reusable across repos / suites | ✗ | ✗ | ✗ | partial | ✓ |
-| Exercises real mTLS authz path | partial | ✓ | partial | depends | ✓ |
+| Reusable across repos and suites | ✗ | ✗ | ✗ | partial | ✓ |
+| Exercises the real mTLS authz path | partial | ✓ | partial | depends | ✓ |
 
-The native stub approach already wins on correctness; the only thing missing was
-a *shared* home for it. `sonic-grpc` supplies that home. Standardizing on it
-means:
+The native stub approach already comes out ahead on correctness; the piece that
+was missing was a shared home for it, which `sonic-grpc` provides. Standardizing
+on it has a few consequences worth stating plainly:
 
-- **One client contract to learn and maintain.** New gNOI tests import a wheel
-  instead of copying the nearest CLI wrapper. The churn stops because there is a
-  single obvious thing to reuse.
-- **Tests assert on the protocol, not on prose.** Typed messages and status
-  codes make negative/authz/streaming tests tractable — the cases that matter
-  most for a management API.
-- **The client is owned and versioned.** Bumping the gNOI proto pin is a wheel
-  version bump with unit tests (`FakeGnoiServer`), not a scavenger hunt across
-  vendored stubs and shell wrappers.
-- **The harness stays where it belongs.** Cert generation and CONFIG_DB
-  lifecycle remain sonic-mgmt fixtures reusing existing infra; the wheel carries
-  only the protocol client. Clean separation, minimal consumed surface
-  (`GnoiClient`, the pb2 message types, `.channel`).
+- There is a single client contract to learn and maintain. A new gNOI test
+  imports a wheel instead of copying the nearest CLI wrapper, so the divergence
+  that produced four mechanisms has an obvious alternative.
+- Tests assert on the protocol rather than on prose. Typed messages and status
+  codes make negative, authorization, and streaming tests tractable — the cases
+  that matter most for a management API.
+- The client is owned and versioned. Advancing the gNOI proto pin becomes a
+  wheel version bump backed by unit tests (`FakeGnoiServer`), rather than a hunt
+  across vendored stubs and shell wrappers.
+- The harness stays where it belongs. Certificate generation and the CONFIG_DB
+  lifecycle remain sonic-mgmt fixtures that reuse existing infrastructure, while
+  the wheel carries only the protocol client. The consumed surface is kept small
+  and stable: `GnoiClient`, the message types, and `.channel`.
 
-**On "why Python, when the gNOI server and consumers are Go":** sonic-mgmt is a
-pytest harness — a Python client is the only in-process option, and there is no
-maintained upstream Python gNOI client to adopt instead. The wheel is wire-level
-gRPC/protobuf, so it stays faithful to the same `openconfig/gnoi` contract the
-Go server and consumers use; language is a client-side detail, not a divergence.
+On the question of why a Python client when the gNOI server and several
+consumers are written in Go: sonic-mgmt is a pytest harness, so a Python client
+is the only in-process option, and there is no maintained upstream Python gNOI
+client to adopt instead. The wheel is wire-level gRPC and protobuf, so it stays
+faithful to the same `openconfig/gnoi` contract the Go server and consumers use.
+The implementation language is a client-side detail, not a divergence from the
+standard.
 
 ## Trade-offs and objections
 
-- **"grpcurl needs no wheel — this adds a cross-repo dependency."** True, and
-  it is the main cost. We accept it because the payoff (typed, status-coded,
-  shared, versioned) is exactly what a settled standard needs, and the ordering
-  is managed by explicit sequencing + a scoped hard failure + a version pin (see
-  CI behavior) rather than being papered over by a silent skip.
-- **"Why a cross-repo wheel instead of one vendored stub package in
-  `tests/common/`?"** Vendoring in sonic-mgmt would be shared *within* sonic-mgmt,
-  but the real driver is **cross-repo reuse**: sonic-buildimage has its own
-  in-flight gNOI Python client
-  ([sonic-buildimage #27760](https://github.com/sonic-net/sonic-buildimage/pull/27760))
-  that will be rerouted to consume this same `sonic-grpc` wheel. One wheel in
-  buildimage is consumable by both the test harness and the on-box/tooling
-  consumers; a copy vendored under `tests/common/` is not. (If the wheel ever
-  stalls, vendoring the flat stubs into sonic-mgmt is the named fallback — but it
-  is a fallback, not the goal.) The wheel also installs from source, so
-  development never blocks on a merge.
-- **"UDS/local transport is simpler for some suites."** The client already
-  supports `unix://`; the DUT-local UDS ergonomics explored in
+- **grpcurl needs no wheel, so this adds a cross-repo dependency.** That is
+  true, and it is the main cost. The payoff — typed responses, real status
+  codes, and a single shared, versioned artifact — is what a settled standard
+  needs, and the ordering is managed by explicit sequencing, a fixture-scoped
+  hard failure, and a version pin (see CI behavior) rather than being papered
+  over by a silent skip.
+- **Why a cross-repo wheel rather than one vendored stub package under
+  `tests/common/`?** Vendoring in sonic-mgmt would be shared within sonic-mgmt,
+  but the real driver is cross-repo reuse. sonic-buildimage has its own in-flight
+  gNOI Python client,
+  [sonic-buildimage #27760](https://github.com/sonic-net/sonic-buildimage/pull/27760),
+  which will be rerouted to consume this same `sonic-grpc` wheel. A single wheel
+  in buildimage is usable by both the test harness and the on-box tooling; a copy
+  vendored under `tests/common/` is not. Vendoring the flat stubs into sonic-mgmt
+  remains the named fallback if the wheel stalls, but it is a fallback rather than
+  the goal, and the wheel installs from source in the meantime.
+- **UDS or local transport is simpler for some suites.** The client already
+  supports `unix://`, and the DUT-local UDS ergonomics explored in
   [`gnmi-uds-transport-design.md`](./gnmi-uds-transport-design.md) compose with
   this client rather than competing with it.
 
 ## Attribution and provenance
 
-`sonic-grpc`'s client and stubs are **not new code invented here**. They are
-factored out of the in-flight gNOI Python client
-([sonic-buildimage #27760](https://github.com/sonic-net/sonic-buildimage/pull/27760));
-this effort packages that work as a standalone, installable distribution so both
-the test harness and #27760 itself can share one implementation. Credit for the
-client belongs to that original work; `sonic-grpc` is the shared home, not a
-fork. Reviewers diffing the PRs will see the shared lineage — it is intentional
-and disclosed.
+The client and stubs in `sonic-grpc` are not new code invented for this effort.
+They are factored out of the in-flight gNOI Python client in
+[sonic-buildimage #27760](https://github.com/sonic-net/sonic-buildimage/pull/27760);
+this effort packages that work as a standalone, installable distribution so that
+both the test harness and #27760 itself can share one implementation. Credit for
+the client belongs to that original work — `sonic-grpc` is a shared home for it,
+not a fork — and reviewers comparing the PRs will see the shared lineage, which
+is intentional and disclosed here.
 
 ## Governance
 
-For a package that claims to be *canonical*, ownership must be explicit, not an
-afterthought:
+For a package intended to become a standard, ownership should be explicit rather
+than assumed:
 
-- `src/sonic-grpc/` carries an `OWNERS`/maintainers list, named at introduction.
-- Those owners are accountable for proto-pin bumps, new service stubs, semver
-  discipline, and the paired sonic-mgmt update when the client surface changes.
-- New service stubs land in `sonic-grpc` (with `FakeGnoiServer`-backed unit
-  tests) rather than being generated ad hoc per suite — one generated-stub source
-  in the ecosystem.
+- `src/sonic-grpc/` carries a maintainers list, named when the package is
+  introduced.
+- Those maintainers are accountable for proto-pin bumps, new service stubs,
+  semantic-versioning discipline, and the paired sonic-mgmt update whenever the
+  client surface changes.
+- New service stubs land in `sonic-grpc`, with `FakeGnoiServer`-backed unit
+  tests, rather than being generated ad hoc per suite, so that the ecosystem
+  keeps a single generated-stub source.
 
-## Adoption & migration roadmap
+## Adoption and migration
 
-1. **Land the reference suite** (`tests/gnoi/` + `sonic-grpc`) as the canonical
-   pattern. ✅ implemented, VS-validated.
-2. **Grow `sonic-grpc`'s stub surface** (OS, streaming File, negative-path
-   helpers) as new gNOI tests need them.
-3. **Write all new gNOI tests against `GnoiClient`.** No new CLI wrappers.
-4. **Migrate existing `tests/gnmi/test_gnoi_*.py`** off grpcurl/Go-`gnoi_client`
-   onto the wheel, suite by suite, keeping behavior identical.
-5. **Fold the sai_validation stubs** into `sonic-grpc` so there is exactly one
+No existing test is deleted or changed by v1, so migration can be incremental
+and behavior-preserving:
+
+1. Land the reference suite (`tests/gnoi/` plus `sonic-grpc`) as the standard
+   pattern. This is implemented and VS-validated.
+2. Grow the stub surface in `sonic-grpc` (OS, streaming File, negative-path
+   helpers) as new gNOI tests need it.
+3. Write new gNOI tests against `GnoiClient` rather than adding new CLI wrappers.
+4. Migrate the existing `tests/gnmi/test_gnoi_*.py` tests off grpcurl and the Go
+   `gnoi_client`, one suite at a time, keeping behavior identical.
+5. Fold the sai_validation stubs into `sonic-grpc` so that there is exactly one
    generated-stub source in the tree.
 
-No existing test is deleted or changed by v1; migration is incremental and
-behavior-preserving.
+## Scope and non-goals (v1)
 
-## Scope / non-goals (v1)
+In scope: the `tests/gnoi/` suite (`System.Time` and `File.Stat`), the
+`gnoi_client` fixture, the `sonic-grpc` wheel and its image wiring, and this
+recommendation.
 
-- **In scope:** the `tests/gnoi/` suite (`System.Time`, `File.Stat`), the
-  `gnoi_client` fixture, the `sonic-grpc` wheel + image wiring, and this
-  canonical recommendation.
-- **Out of scope (later increments):** the full gNOI surface (OS,
-  factory_reset, healthz, containerz), SONiC-specific services, SmartSwitch DPU
-  routing, reboot/upgrade flows, and migrating the existing
-  `tests/gnmi/test_gnoi_*.py` tests.
+Out of scope, deferred to later increments: the full gNOI surface (OS,
+factory_reset, healthz, containerz), SONiC-specific services, SmartSwitch DPU
+routing, reboot and upgrade flows, and migrating the existing
+`tests/gnmi/test_gnoi_*.py` tests.
 
 ## Open questions
 
-- Confirm the vendored stubs stay wire-compatible with the sonic-gnmi server's
-  `openconfig/gnoi` pin as it advances (low risk for Time/Stat; re-verify on
-  bumps via `FakeGnoiServer`).
-- Final home of the fixture harness: keep it in `tests/gnoi/` or promote the
-  reusable parts to `tests/common/` once a second suite consumes the client.
-- Initial `sonic-grpc` maintainer set and review cadence for proto-pin bumps
-  (the Governance section names the mechanism; the specific owners are TBD at
-  introduction).
+- Whether the vendored stubs stay wire-compatible with the sonic-gnmi server's
+  `openconfig/gnoi` pin as it advances. The risk is low for Time and Stat, and
+  it can be re-verified on bumps with `FakeGnoiServer`.
+- Where the fixture harness should ultimately live — in `tests/gnoi/`, or with
+  the reusable parts promoted to `tests/common/` once a second suite consumes the
+  client.
+- The initial `sonic-grpc` maintainer set and the review cadence for proto-pin
+  bumps. The Governance section names the mechanism; the specific owners are to
+  be decided when the package is introduced.

--- a/tests/gnoi/conftest.py
+++ b/tests/gnoi/conftest.py
@@ -10,66 +10,41 @@ The ``sonic_grpc`` package is provided by a standalone wheel (built from
 sonic-buildimage ``src/sonic-grpc``) and must be present in the sonic-mgmt
 image. It is imported directly (not guarded), so a missing wheel is a hard
 collection error for this suite rather than a silent skip.
+
+Two fixtures are exposed:
+
+  * ``gnoi_client`` - function scoped, for the plain (non-rebooting) tests. It
+    checkpoints CONFIG_DB, provisions mTLS, yields a connected client, and rolls
+    back on teardown.
+  * ``gnoi_tls_bundle`` - module scoped, for the reboot and upgrade suites. It
+    provisions once and yields a reusable bundle whose client credentials
+    survive DUT reboots; the tests re-establish the server side across a reboot
+    with :func:`tests.gnoi.gnoi_tls_setup.ensure_gnoi_ready`.
 """
 import logging
 import os
 import shutil
 
-import grpc
 import pytest
 
-from sonic_grpc.gnoi import GnoiClient, system_pb2
+from sonic_grpc.gnoi import system_pb2
 
-from tests.common.cert_utils import create_gnmi_cert_generator
-from tests.common.grpc_config import grpc_config
 from tests.common.gu_utils import create_checkpoint, rollback
 from tests.common.platform.processes_utils import wait_critical_processes
-from tests.common.utilities import wait_until
-# Reuse the tested server-side setup (CONFIG_DB TLS mode + gnmi-native restart).
-# These touch only the DUT (no PTF).
-from tests.common.fixtures.grpc_fixtures import (
-    _configure_gnoi_tls_server,
-    _restart_gnoi_server,
-)
+from tests.gnoi import gnoi_tls_setup
 
 logger = logging.getLogger(__name__)
 
 CHECKPOINT_NAME = "gnoi_native_setup"
-CERT_DIR = "/tmp/gnoi_native_certs"
-
-
-def _grpc_target(host, port):
-    """Build a gRPC target, bracketing IPv6 literals."""
-    if ":" in host:
-        return "[{}]:{}".format(host, port)
-    return "{}:{}".format(host, port)
-
-
-def _provision_certs(duthost, cert_dir):
-    """Generate a CA/server/client chain locally and push server certs to the DUT.
-
-    PTF-free: the client cert/key/CA stay in the sonic-mgmt container (the
-    native client reads them locally); only the server cert/key + CA go to the
-    DUT, matching what ``_configure_gnoi_tls_server`` points CONFIG_DB at.
-    The server cert SAN includes the DUT management IP, so the native client can
-    dial the management IP and verify the server certificate against the CA.
-    """
-    generator = create_gnmi_cert_generator(server_ip=duthost.mgmt_ip)
-    generator.write_all(cert_dir)
-
-    dut_dir = grpc_config.DUT_CERT_DIR
-    for name in (grpc_config.CA_CERT, grpc_config.SERVER_CERT, grpc_config.SERVER_KEY):
-        duthost.copy(src=os.path.join(cert_dir, name), dest="{}/{}".format(dut_dir, name))
 
 
 @pytest.fixture(scope="function")
 def gnoi_client(duthosts, rand_one_dut_hostname):
     """Yield a native ``GnoiClient`` connected to the DUT gNOI server over mTLS.
 
-    Flow: checkpoint CONFIG_DB -> provision certs -> configure TLS mode +
-    register the client CN in GNMI_CLIENT_CERT -> restart gnmi-native -> verify
-    readiness with a native gNOI call -> yield the client -> rollback + wait for
-    critical processes + clean up certs.
+    Flow: checkpoint CONFIG_DB -> provision certs + configure TLS + restart
+    gnmi-native -> verify readiness with a native gNOI call -> yield the client
+    -> rollback + wait for critical processes + clean up certs.
     """
     duthost = duthosts[rand_one_dut_hostname]
 
@@ -77,32 +52,17 @@ def gnoi_client(duthosts, rand_one_dut_hostname):
 
     client = None
     try:
-        _provision_certs(duthost, CERT_DIR)
-        _configure_gnoi_tls_server(duthost)
-        _restart_gnoi_server(duthost)
-
-        creds = grpc.ssl_channel_credentials(
-            root_certificates=open(os.path.join(CERT_DIR, grpc_config.CA_CERT), "rb").read(),
-            private_key=open(os.path.join(CERT_DIR, grpc_config.CLIENT_KEY), "rb").read(),
-            certificate_chain=open(os.path.join(CERT_DIR, grpc_config.CLIENT_CERT), "rb").read(),
-        )
-        target = _grpc_target(duthost.mgmt_ip, grpc_config.DEFAULT_TLS_PORT)
-
-        client = GnoiClient(target, credentials=creds)
-        client.__enter__()
+        bundle = gnoi_tls_setup.provision(duthost)
 
         # Native readiness check: retry System.Time until the TLS listener is up.
         # (supervisor reporting RUNNING does not guarantee the port is bound.)
-        def _ready():
-            try:
-                client.system.Time(system_pb2.TimeRequest(), timeout=5)
-                return True
-            except grpc.RpcError as exc:
-                logger.debug("gNOI not ready yet: %s", exc.code())
-                return False
-
-        if not wait_until(60, 2, 0, _ready):
+        if not gnoi_tls_setup.wait_ready(bundle, timeout=60):
             pytest.fail("gNOI server did not become reachable over mTLS")
+
+        client = bundle.open_client()
+        # A final direct call surfaces a clear error if something regressed
+        # between the readiness poll and first use.
+        client.system.Time(system_pb2.TimeRequest(), timeout=10)
 
         yield client
 
@@ -115,5 +75,33 @@ def gnoi_client(duthosts, rand_one_dut_hostname):
             wait_critical_processes(duthost)
         except Exception as exc:  # noqa: BLE001
             logger.warning("wait_critical_processes after rollback failed: %s", exc)
-        if os.path.exists(CERT_DIR):
-            shutil.rmtree(CERT_DIR, ignore_errors=True)
+        if os.path.exists(gnoi_tls_setup.CERT_DIR):
+            shutil.rmtree(gnoi_tls_setup.CERT_DIR, ignore_errors=True)
+
+
+@pytest.fixture(scope="module")
+def gnoi_tls_bundle(duthosts, rand_one_dut_hostname):
+    """Provision gNOI mTLS once and yield a reusable bundle for reboot/upgrade tests.
+
+    The client credentials in the returned bundle are stable across DUT reboots;
+    only the DUT-side state is re-applied (idempotently) by
+    :func:`tests.gnoi.gnoi_tls_setup.ensure_gnoi_ready` after each reboot.
+
+    Teardown is best-effort: a rebooted (or upgraded) DUT may no longer hold the
+    pre-test CONFIG_DB checkpoint, so the test rows and pushed certs are removed
+    explicitly.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+
+    bundle = gnoi_tls_setup.provision(duthost)
+    if not gnoi_tls_setup.wait_ready(bundle, timeout=60):
+        pytest.fail("gNOI server did not become reachable over mTLS")
+
+    try:
+        yield bundle
+    finally:
+        gnoi_tls_setup.cleanup(duthost, bundle)
+        try:
+            wait_critical_processes(duthost)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("wait_critical_processes after cleanup failed: %s", exc)

--- a/tests/gnoi/conftest.py
+++ b/tests/gnoi/conftest.py
@@ -1,0 +1,122 @@
+"""
+Fixtures for the PTF-free native gNOI test suite.
+
+The DUT is driven the "API way": an in-process Python gRPC client
+(``sonic_grpc.gnoi.GnoiClient``) running in the sonic-mgmt container talks
+mTLS gRPC directly to the DUT's gNOI server on the management IP. There is no
+PTF hop and no in-repo stub generation.
+
+The ``sonic_grpc`` package is provided by a standalone wheel (built from
+sonic-buildimage ``src/sonic-grpc``). Tests are skipped at the symbol level
+when it is not installed, so the suite merges dark and lights up once the wheel
+ships in docker-sonic-mgmt.
+"""
+import logging
+import os
+import shutil
+
+import pytest
+
+from tests.common.cert_utils import create_gnmi_cert_generator
+from tests.common.grpc_config import grpc_config
+from tests.common.gu_utils import create_checkpoint, rollback
+from tests.common.platform.processes_utils import wait_critical_processes
+from tests.common.utilities import wait_until
+# Reuse the tested server-side setup (CONFIG_DB TLS mode + gnmi-native restart).
+# These touch only the DUT (no PTF).
+from tests.common.fixtures.grpc_fixtures import (
+    _configure_gnoi_tls_server,
+    _restart_gnoi_server,
+)
+
+logger = logging.getLogger(__name__)
+
+CHECKPOINT_NAME = "gnoi_native_setup"
+CERT_DIR = "/tmp/gnoi_native_certs"
+
+
+def _grpc_target(host, port):
+    """Build a gRPC target, bracketing IPv6 literals."""
+    if ":" in host:
+        return "[{}]:{}".format(host, port)
+    return "{}:{}".format(host, port)
+
+
+def _provision_certs(duthost, cert_dir):
+    """Generate a CA/server/client chain locally and push server certs to the DUT.
+
+    PTF-free: the client cert/key/CA stay in the sonic-mgmt container (the
+    native client reads them locally); only the server cert/key + CA go to the
+    DUT, matching what ``_configure_gnoi_tls_server`` points CONFIG_DB at.
+    The server cert SAN includes the DUT management IP, so the native client can
+    dial the management IP and verify the server certificate against the CA.
+    """
+    generator = create_gnmi_cert_generator(server_ip=duthost.mgmt_ip)
+    generator.write_all(cert_dir)
+
+    dut_dir = grpc_config.DUT_CERT_DIR
+    for name in (grpc_config.CA_CERT, grpc_config.SERVER_CERT, grpc_config.SERVER_KEY):
+        duthost.copy(src=os.path.join(cert_dir, name), dest="{}/{}".format(dut_dir, name))
+
+
+@pytest.fixture(scope="function")
+def gnoi_client(duthosts, rand_one_dut_hostname):
+    """Yield a native ``GnoiClient`` connected to the DUT gNOI server over mTLS.
+
+    Flow: checkpoint CONFIG_DB -> provision certs -> configure TLS mode +
+    register the client CN in GNMI_CLIENT_CERT -> restart gnmi-native -> verify
+    readiness with a native gNOI call -> yield the client -> rollback + wait for
+    critical processes + clean up certs.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+
+    # Symbol-level skip guard: the client + its file stubs come from the
+    # standalone sonic-grpc wheel, which may not be installed in the image yet.
+    grpc = pytest.importorskip("grpc")
+    pytest.importorskip("sonic_grpc.gnoi.file_pb2_grpc")
+    from sonic_grpc.gnoi import GnoiClient, system_pb2
+
+    create_checkpoint(duthost, CHECKPOINT_NAME)
+
+    client = None
+    try:
+        _provision_certs(duthost, CERT_DIR)
+        _configure_gnoi_tls_server(duthost)
+        _restart_gnoi_server(duthost)
+
+        creds = grpc.ssl_channel_credentials(
+            root_certificates=open(os.path.join(CERT_DIR, grpc_config.CA_CERT), "rb").read(),
+            private_key=open(os.path.join(CERT_DIR, grpc_config.CLIENT_KEY), "rb").read(),
+            certificate_chain=open(os.path.join(CERT_DIR, grpc_config.CLIENT_CERT), "rb").read(),
+        )
+        target = _grpc_target(duthost.mgmt_ip, grpc_config.DEFAULT_TLS_PORT)
+
+        client = GnoiClient(target, credentials=creds)
+        client.__enter__()
+
+        # Native readiness check: retry System.Time until the TLS listener is up.
+        # (supervisor reporting RUNNING does not guarantee the port is bound.)
+        def _ready():
+            try:
+                client.system.Time(system_pb2.TimeRequest(), timeout=5)
+                return True
+            except grpc.RpcError as exc:
+                logger.debug("gNOI not ready yet: %s", exc.code())
+                return False
+
+        if not wait_until(60, 2, 0, _ready):
+            pytest.fail("gNOI server did not become reachable over mTLS")
+
+        yield client
+
+    finally:
+        if client is not None:
+            client.close()
+        rollback(duthost, CHECKPOINT_NAME)
+        duthost.shell("config save -y", module_ignore_errors=True)
+        try:
+            wait_critical_processes(duthost)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("wait_critical_processes after rollback failed: %s", exc)
+        if os.path.exists(CERT_DIR):
+            shutil.rmtree(CERT_DIR, ignore_errors=True)

--- a/tests/gnoi/conftest.py
+++ b/tests/gnoi/conftest.py
@@ -7,15 +7,18 @@ mTLS gRPC directly to the DUT's gNOI server on the management IP. There is no
 PTF hop and no in-repo stub generation.
 
 The ``sonic_grpc`` package is provided by a standalone wheel (built from
-sonic-buildimage ``src/sonic-grpc``). Tests are skipped at the symbol level
-when it is not installed, so the suite merges dark and lights up once the wheel
-ships in docker-sonic-mgmt.
+sonic-buildimage ``src/sonic-grpc``) and must be present in the sonic-mgmt
+image. It is imported directly (not guarded), so a missing wheel is a hard
+collection error for this suite rather than a silent skip.
 """
 import logging
 import os
 import shutil
 
+import grpc
 import pytest
+
+from sonic_grpc.gnoi import GnoiClient, system_pb2
 
 from tests.common.cert_utils import create_gnmi_cert_generator
 from tests.common.grpc_config import grpc_config
@@ -69,12 +72,6 @@ def gnoi_client(duthosts, rand_one_dut_hostname):
     critical processes + clean up certs.
     """
     duthost = duthosts[rand_one_dut_hostname]
-
-    # Symbol-level skip guard: the client + its file stubs come from the
-    # standalone sonic-grpc wheel, which may not be installed in the image yet.
-    grpc = pytest.importorskip("grpc")
-    pytest.importorskip("sonic_grpc.gnoi.file_pb2_grpc")
-    from sonic_grpc.gnoi import GnoiClient, system_pb2
 
     create_checkpoint(duthost, CHECKPOINT_NAME)
 

--- a/tests/gnoi/gnoi_tls_setup.py
+++ b/tests/gnoi/gnoi_tls_setup.py
@@ -1,0 +1,198 @@
+"""
+Reusable server-side TLS setup and idempotent readiness for the native gNOI
+suite.
+
+The suite drives the DUT gNOI server over mTLS from the sonic-mgmt container
+(no PTF). This module centralizes three things so the plain, reboot, and upgrade
+suites share one implementation:
+
+  * one-time PKI provisioning - the CA and client cert/key are generated once
+    and stay in the sonic-mgmt container; only the server cert/key and CA are
+    pushed to the DUT,
+  * pointing CONFIG_DB at the server certs and restarting the gNMI/gNOI server,
+  * an idempotent :func:`ensure_gnoi_ready` that re-establishes the mTLS session
+    after a DUT reboot.
+
+Why re-provision instead of persisting the config across a reboot
+-----------------------------------------------------------------
+It is tempting to ``config save`` the TLS setup so it survives a reboot. On
+SONiC that is unsafe for anything that crosses an image boundary:
+
+  * ``GNMI_CLIENT_CERT`` is version-gated in YANG - the table is absent on older
+    versions and its ``role`` leaf is a mandatory scalar on some versions but a
+    leaf-list on others - so a saved test config carried through config
+    migration can be YANG-invalid and strand the DUT.
+  * ``GNMI|certs`` points at ``/etc/sonic/telemetry``, which lives in the
+    per-image writable overlay and is wiped on upgrade, so even a YANG-valid
+    migrated config would leave the gNMI container crash-looping on missing
+    certificate files.
+
+Persistence is also not something a test controls: several shared code paths
+(the advanced-reboot teardown, ``config_reload``, sanity checks) issue
+``config save`` on their own, and a warm/fast upgrade crosses the boundary via
+the running CONFIG_DB rather than ``config_db.json``. The safe design is
+therefore zero persistence plus a single idempotent re-apply after every reboot,
+which :func:`ensure_gnoi_ready` provides for same-image reboot and cross-image
+upgrade alike.
+"""
+import logging
+import os
+import shutil
+
+import grpc
+
+from sonic_grpc.gnoi import GnoiClient, system_pb2
+
+from tests.common.cert_utils import create_gnmi_cert_generator
+from tests.common.grpc_config import grpc_config
+# Reuse the already-tested DUT-side setup (CONFIG_DB TLS mode + gnmi-native
+# restart). These touch only the DUT (no PTF).
+from tests.common.fixtures.grpc_fixtures import (
+    _configure_gnoi_tls_server,
+    _restart_gnoi_server,
+)
+from tests.common.utilities import wait_until
+
+logger = logging.getLogger(__name__)
+
+CERT_DIR = "/tmp/gnoi_native_certs"
+# Client CN baked into the generated client cert (create_gnmi_cert_generator
+# default) and into the GNMI_CLIENT_CERT row registered by
+# _configure_gnoi_tls_server. Kept in sync here for cleanup.
+CLIENT_CN = "test.client.gnmi.sonic"
+
+
+def _grpc_target(host, port):
+    """Build a gRPC target, bracketing IPv6 literals."""
+    if ":" in host:
+        return "[{}]:{}".format(host, port)
+    return "{}:{}".format(host, port)
+
+
+def _read(cert_dir, name):
+    with open(os.path.join(cert_dir, name), "rb") as handle:
+        return handle.read()
+
+
+class GnoiTlsBundle:
+    """Container-side PKI plus a ready-to-dial mTLS target for the DUT.
+
+    The CA and client cert/key are generated once and never leave the sonic-mgmt
+    container, so the same client credentials keep working across DUT reboots -
+    only the server-side state is re-applied by :func:`ensure_gnoi_ready`.
+    """
+
+    def __init__(self, duthost, cert_dir=CERT_DIR):
+        self.duthost = duthost
+        self.cert_dir = cert_dir
+        self.target = _grpc_target(duthost.mgmt_ip, grpc_config.DEFAULT_TLS_PORT)
+        self._credentials = None
+
+    @property
+    def credentials(self):
+        """mTLS channel credentials built from the cached client materials."""
+        if self._credentials is None:
+            self._credentials = grpc.ssl_channel_credentials(
+                root_certificates=_read(self.cert_dir, grpc_config.CA_CERT),
+                private_key=_read(self.cert_dir, grpc_config.CLIENT_KEY),
+                certificate_chain=_read(self.cert_dir, grpc_config.CLIENT_CERT),
+            )
+        return self._credentials
+
+    def open_client(self):
+        """Return an entered :class:`GnoiClient` (caller must ``close()`` it)."""
+        client = GnoiClient(self.target, credentials=self.credentials)
+        client.__enter__()
+        return client
+
+
+def generate_pki(duthost, cert_dir=CERT_DIR):
+    """Generate the CA/server/client chain once, in the container.
+
+    The server certificate SAN includes the DUT management IP, so the native
+    client can dial the management IP and verify the server certificate.
+    """
+    generator = create_gnmi_cert_generator(server_ip=duthost.mgmt_ip)
+    generator.write_all(cert_dir)
+
+
+def push_server_certs(duthost, cert_dir=CERT_DIR):
+    """Copy the CA and server cert/key to the DUT (client materials stay local)."""
+    dut_dir = grpc_config.DUT_CERT_DIR
+    duthost.shell("mkdir -p {}".format(dut_dir))
+    for name in (grpc_config.CA_CERT, grpc_config.SERVER_CERT, grpc_config.SERVER_KEY):
+        duthost.copy(src=os.path.join(cert_dir, name), dest="{}/{}".format(dut_dir, name))
+
+
+def provision(duthost, cert_dir=CERT_DIR):
+    """Full one-time setup: generate PKI, push server certs, configure and restart.
+
+    Returns a :class:`GnoiTlsBundle` whose client credentials are reused across
+    reboots.
+    """
+    generate_pki(duthost, cert_dir)
+    push_server_certs(duthost, cert_dir)
+    _configure_gnoi_tls_server(duthost)
+    _restart_gnoi_server(duthost)
+    return GnoiTlsBundle(duthost, cert_dir)
+
+
+def is_ready(bundle, timeout=5):
+    """Return True if the DUT gNOI server answers System.Time over mTLS."""
+    client = bundle.open_client()
+    try:
+        client.system.Time(system_pb2.TimeRequest(), timeout=timeout)
+        return True
+    except grpc.RpcError as exc:
+        logger.debug("gNOI probe not ready: %s", exc.code())
+        return False
+    finally:
+        client.close()
+
+
+def wait_ready(bundle, timeout=60, interval=2):
+    """Poll :func:`is_ready` until the server is reachable or ``timeout`` elapses."""
+    return wait_until(timeout, interval, 0, is_ready, bundle)
+
+
+def ensure_gnoi_ready(duthost, bundle, timeout=120):
+    """Idempotently bring the DUT gNOI server back to mTLS-ready after a reboot.
+
+    One uniform path for same-image reboot and cross-image upgrade: probe first
+    (a no-op if the server is already reachable), otherwise re-push the cached
+    server certs, re-apply the CONFIG_DB TLS config, restart gnmi-native, and
+    wait for readiness.
+
+    Nothing test-owned is ever written to disk - the re-apply is always fresh via
+    ``sonic-db-cli`` on the running image - so no test config crosses a config
+    migration boundary. See the module docstring for why that matters.
+    """
+    if is_ready(bundle, timeout=5):
+        logger.info("gNOI already reachable; no re-provision needed")
+        return
+    logger.info("gNOI not reachable after reboot; re-provisioning TLS")
+    push_server_certs(duthost, bundle.cert_dir)
+    _configure_gnoi_tls_server(duthost)
+    _restart_gnoi_server(duthost)
+    if not wait_ready(bundle, timeout=timeout):
+        raise RuntimeError("gNOI server did not become reachable after re-provision")
+
+
+def cleanup(duthost, bundle):
+    """Best-effort removal of test-provisioned state from the DUT and container.
+
+    Deletes the registered client-cert row and the pushed server certs, then
+    saves the cleaned config. Used by suites that reboot the DUT, where a
+    pre-reboot CONFIG_DB checkpoint may no longer exist (for example after an
+    upgrade into a new image).
+    """
+    duthost.shell(
+        'sonic-db-cli CONFIG_DB del "GNMI_CLIENT_CERT|{}"'.format(CLIENT_CN),
+        module_ignore_errors=True,
+    )
+    dut_dir = grpc_config.DUT_CERT_DIR
+    for name in (grpc_config.CA_CERT, grpc_config.SERVER_CERT, grpc_config.SERVER_KEY):
+        duthost.shell("rm -f {}/{}".format(dut_dir, name), module_ignore_errors=True)
+    duthost.shell("config save -y", module_ignore_errors=True)
+    if os.path.exists(bundle.cert_dir):
+        shutil.rmtree(bundle.cert_dir, ignore_errors=True)

--- a/tests/gnoi/test_gnoi_file.py
+++ b/tests/gnoi/test_gnoi_file.py
@@ -9,6 +9,8 @@ import logging
 
 import pytest
 
+from sonic_grpc.gnoi import file_pb2
+
 from tests.common.helpers.assertions import pytest_assert
 
 logger = logging.getLogger(__name__)
@@ -21,8 +23,6 @@ pytestmark = [
 
 def test_gnoi_file_stat(gnoi_client):
     """gNOI File.Stat on a known DUT file returns a typed stat entry."""
-    from sonic_grpc.gnoi import file_pb2
-
     path = "/etc/hostname"
     response = gnoi_client.file.Stat(file_pb2.StatRequest(path=path), timeout=10)
 

--- a/tests/gnoi/test_gnoi_file.py
+++ b/tests/gnoi/test_gnoi_file.py
@@ -1,0 +1,36 @@
+"""
+gNOI File service tests over a native (PTF-free) mTLS gRPC client.
+
+The File stub is reached via ``GnoiClient.channel`` (equivalently the
+``client.file`` convenience property), demonstrating that new gNOI services
+plug in without client changes.
+"""
+import logging
+
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology("any"),
+    pytest.mark.skip_check_dut_health,
+]
+
+
+def test_gnoi_file_stat(gnoi_client):
+    """gNOI File.Stat on a known DUT file returns a typed stat entry."""
+    from sonic_grpc.gnoi import file_pb2
+
+    path = "/etc/hostname"
+    response = gnoi_client.file.Stat(file_pb2.StatRequest(path=path), timeout=10)
+
+    logger.info("gNOI File.Stat(%s) -> %s", path, response)
+    pytest_assert(len(response.stats) >= 1, "File.Stat returned no stat entries")
+    stat = response.stats[0]
+    pytest_assert(
+        stat.path == path,
+        "File.Stat returned path {!r}, expected {!r}".format(stat.path, path),
+    )
+    pytest_assert(stat.size > 0, "File.Stat reported size 0 for {}".format(path))

--- a/tests/gnoi/test_gnoi_reboot.py
+++ b/tests/gnoi/test_gnoi_reboot.py
@@ -1,0 +1,103 @@
+"""
+Native gNOI reboot test.
+
+This is the VS-verifiable exerciser of the native suite's reboot-survival
+design. A ``System.Reboot`` tears down the DUT control plane; on the way back up
+the gNMI/gNOI server has lost the test-provisioned TLS configuration (the suite
+persists nothing across a reboot), and
+:func:`tests.gnoi.gnoi_tls_setup.ensure_gnoi_ready` idempotently re-provisions it
+so the same native client - reusing the same client credentials - can talk to
+the DUT again.
+
+The native upgrade test reuses the exact same re-provision path across an image
+boundary, so proving this test on a virtual switch also proves that machinery.
+"""
+import logging
+import time
+
+import pytest
+
+from sonic_grpc.gnoi import system_pb2
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.platform.processes_utils import wait_critical_processes
+from tests.common.reboot import (
+    REBOOT_TYPE_COLD,
+    check_reboot_cause,
+    wait_for_shutdown,
+    wait_for_startup,
+)
+from tests.common.utilities import wait_until
+from tests.gnoi import gnoi_tls_setup
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology("any"),
+    # gnoi_tls_bundle mutates GNMI CONFIG_DB and the DUT is rebooted here; skip
+    # the teardown config-drift check that would otherwise force a reload.
+    pytest.mark.skip_check_dut_health,
+    # A cold reboot floods the DUT syslog with expected boot-time errors (for
+    # example "Failed to start system-health.service"); disable LogAnalyzer so
+    # that boot noise does not fail the teardown.
+    pytest.mark.disable_loganalyzer,
+]
+
+
+@pytest.mark.device_type("vs")
+def test_gnoi_cold_reboot_and_reprovision(
+    duthosts, rand_one_dut_hostname, localhost, gnoi_tls_bundle
+):
+    """Cold-reboot the DUT via gNOI, then re-establish the mTLS session.
+
+    Steps: confirm reachable -> System.Reboot(COLD) -> wait down/up ->
+    ensure_gnoi_ready -> confirm the same client works again.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    bundle = gnoi_tls_bundle
+
+    pytest_assert(
+        gnoi_tls_setup.is_ready(bundle, timeout=10),
+        "gNOI server not reachable before reboot",
+    )
+
+    # System.Reboot is a trigger RPC: the control plane usually drops mid-call,
+    # so a transport error here does not mean the reboot failed to start.
+    client = bundle.open_client()
+    try:
+        client.system.Reboot(
+            system_pb2.RebootRequest(
+                method=system_pb2.RebootMethod.COLD,
+                message="native gNOI reboot test",
+            ),
+            timeout=30,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.info("System.Reboot trigger returned/raised (expected on drop): %s", exc)
+    finally:
+        client.close()
+
+    reboot_start = time.time()
+    wait_for_shutdown(duthost, localhost, delay=10, timeout=300)
+    wait_for_startup(duthost, localhost, delay=10, timeout=300)
+    wait_critical_processes(duthost)
+    logger.info("DUT back up %.0fs after gNOI reboot trigger", time.time() - reboot_start)
+
+    # Best-effort confirmation that this was a cold reboot; the load-bearing
+    # assertion is that gNOI is usable again after re-provision.
+    if not wait_until(120, 10, 0, check_reboot_cause, duthost, REBOOT_TYPE_COLD):
+        logger.warning("Reboot cause did not settle to '%s'", REBOOT_TYPE_COLD)
+
+    # The server lost its TLS config across the reboot; re-provision idempotently.
+    gnoi_tls_setup.ensure_gnoi_ready(duthost, bundle, timeout=180)
+
+    # Same client credentials, fresh server session: native RPCs work again.
+    client = bundle.open_client()
+    try:
+        response = client.system.Time(system_pb2.TimeRequest(), timeout=10)
+        pytest_assert(
+            response.time > 0,
+            "System.Time returned a non-positive timestamp after re-provision",
+        )
+    finally:
+        client.close()

--- a/tests/gnoi/test_gnoi_system.py
+++ b/tests/gnoi/test_gnoi_system.py
@@ -6,6 +6,8 @@ import time
 
 import pytest
 
+from sonic_grpc.gnoi import system_pb2
+
 from tests.common.helpers.assertions import pytest_assert
 
 logger = logging.getLogger(__name__)
@@ -21,8 +23,6 @@ pytestmark = [
 
 def test_gnoi_system_time(gnoi_client):
     """gNOI System.Time returns a plausible current timestamp (ns since epoch)."""
-    from sonic_grpc.gnoi import system_pb2
-
     response = gnoi_client.system.Time(system_pb2.TimeRequest(), timeout=10)
 
     now_ns = time.time() * 1e9

--- a/tests/gnoi/test_gnoi_system.py
+++ b/tests/gnoi/test_gnoi_system.py
@@ -1,0 +1,37 @@
+"""
+gNOI System service tests over a native (PTF-free) mTLS gRPC client.
+"""
+import logging
+import time
+
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology("any"),
+    # The gnoi_client fixture mutates GNMI CONFIG_DB (rolled back on teardown).
+    # Without this marker the teardown core_dump_and_config_check flags the
+    # change as drift and forces a config reload; there is no CLI flag for it.
+    pytest.mark.skip_check_dut_health,
+]
+
+
+def test_gnoi_system_time(gnoi_client):
+    """gNOI System.Time returns a plausible current timestamp (ns since epoch)."""
+    from sonic_grpc.gnoi import system_pb2
+
+    response = gnoi_client.system.Time(system_pb2.TimeRequest(), timeout=10)
+
+    now_ns = time.time() * 1e9
+    logger.info("gNOI System.Time -> %d ns", response.time)
+    pytest_assert(response.time > 0, "System.Time returned a non-positive timestamp")
+    # Allow a wide skew window (1 day) - this asserts a sane clock, not sync.
+    pytest_assert(
+        abs(response.time - now_ns) < 24 * 3600 * 1e9,
+        "System.Time {} ns is not within a day of local time {} ns".format(
+            response.time, int(now_ns)
+        ),
+    )

--- a/tests/gnoi/test_gnoi_upgrade.py
+++ b/tests/gnoi/test_gnoi_upgrade.py
@@ -1,0 +1,173 @@
+"""
+Native gNOI image-upgrade test.
+
+Stages a target image with the native gNOI client (``File.TransferToRemote`` +
+``System.SetPackage``), reboots into it, and - the point of this test -
+re-establishes the mTLS session across the image boundary with
+:func:`tests.gnoi.gnoi_tls_setup.ensure_gnoi_ready` instead of persisting the
+test configuration with ``config save``.
+
+Why not ``config save`` the TLS setup across the upgrade
+--------------------------------------------------------
+On SONiC the test's ``GNMI_CLIENT_CERT`` row is version-gated in YANG and
+``GNMI|certs`` points at ``/etc/sonic/telemetry`` (wiped on upgrade). Persisting
+those rows and letting them cross config migration can leave the DUT with an
+invalid config or a gnmi container crash-looping on missing certificate files
+(see :mod:`tests.gnoi.gnoi_tls_setup`). The native suite keeps zero persistence
+and re-provisions on the far side, which is one uniform path for a plain reboot
+and an upgrade alike.
+
+This test is skipped unless ``--base_image_list`` and ``--target_image_list`` are
+provided, so it does not run in the plain virtual-switch loop. The
+reboot-and-re-provision machinery it depends on is proven by
+``test_gnoi_reboot.py``.
+"""
+import logging
+import time
+
+import pytest
+
+from sonic_grpc.gnoi import common_pb2, file_pb2, system_pb2
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.platform.processes_utils import wait_critical_processes
+from tests.common.reboot import wait_for_shutdown, wait_for_startup
+from tests.gnoi import gnoi_tls_setup
+
+logger = logging.getLogger(__name__)
+
+DUT_IMAGE_PATH = "/var/tmp/sonic_image"
+
+pytestmark = [
+    pytest.mark.topology("any"),
+    pytest.mark.skip_check_dut_health,
+    pytest.mark.disable_loganalyzer,
+]
+
+
+def _first(value):
+    """Return the first image URL whether the option is a list or a scalar."""
+    if isinstance(value, (list, tuple)):
+        return value[0] if value else None
+    if isinstance(value, str) and "," in value:
+        return value.split(",")[0]
+    return value
+
+
+@pytest.mark.device_type("vs")
+def test_gnoi_upgrade_and_reprovision(
+    duthosts, rand_one_dut_hostname, localhost, request, gnoi_tls_bundle
+):
+    """Upgrade the DUT via native gNOI, then re-establish the mTLS session.
+
+    Steps: TransferToRemote -> SetPackage -> System.Reboot -> wait down/up ->
+    ensure_gnoi_ready -> assert the target image is current and gNOI is usable.
+    """
+    base_image = request.config.getoption("base_image_list")
+    to_image = _first(request.config.getoption("target_image_list"))
+    try:
+        target_version = request.config.getoption("target_version")
+    except (ValueError, KeyError):
+        target_version = None
+
+    if not base_image or not to_image:
+        pytest.skip(
+            "base_image_list/target_image_list not set; the native gNOI upgrade "
+            "test requires a base/target image pair"
+        )
+    pytest_assert(
+        target_version,
+        "target_version must be set to validate the post-upgrade image",
+    )
+
+    upgrade_type = request.config.getoption("upgrade_type") or "cold"
+    reboot_method = (
+        system_pb2.RebootMethod.WARM
+        if str(upgrade_type).lower() == "warm"
+        else system_pb2.RebootMethod.COLD
+    )
+
+    duthost = duthosts[rand_one_dut_hostname]
+    bundle = gnoi_tls_bundle
+
+    duthost.shell("rm -f {}".format(DUT_IMAGE_PATH), module_ignore_errors=True)
+
+    # 1) Transfer the image to the DUT the API way.
+    client = bundle.open_client()
+    try:
+        client.file.TransferToRemote(
+            file_pb2.TransferToRemoteRequest(
+                local_path=DUT_IMAGE_PATH,
+                remote_download=common_pb2.RemoteDownload(
+                    path=to_image,
+                    protocol=common_pb2.RemoteDownload.HTTP,
+                ),
+            ),
+            timeout=3600,
+        )
+    finally:
+        client.close()
+    pytest_assert(
+        duthost.shell("test -s {}".format(DUT_IMAGE_PATH), module_ignore_errors=True).get("rc", 1) == 0,
+        "image not present on DUT after TransferToRemote: {}".format(DUT_IMAGE_PATH),
+    )
+
+    # 2) Stage it as the next-boot image (client-streaming SetPackage; a single
+    #    request carries the metadata for an image already on the DUT).
+    client = bundle.open_client()
+    try:
+        client.system.SetPackage(
+            iter([
+                system_pb2.SetPackageRequest(
+                    package=system_pb2.Package(
+                        filename=DUT_IMAGE_PATH,
+                        version=target_version,
+                        activate=True,
+                    ),
+                ),
+            ]),
+            timeout=3600,
+        )
+    finally:
+        client.close()
+
+    # 3) Reboot into the new image (trigger RPC; the channel may drop).
+    client = bundle.open_client()
+    try:
+        client.system.Reboot(
+            system_pb2.RebootRequest(
+                method=reboot_method,
+                message="native gNOI upgrade",
+            ),
+            timeout=60,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.info("System.Reboot trigger returned/raised (expected on drop): %s", exc)
+    finally:
+        client.close()
+
+    reboot_start = time.time()
+    wait_for_shutdown(duthost, localhost, delay=10, timeout=300)
+    wait_for_startup(duthost, localhost, delay=10, timeout=600)
+    wait_critical_processes(duthost)
+    logger.info("DUT back up %.0fs after gNOI upgrade reboot", time.time() - reboot_start)
+
+    # 4) Re-provision across the image boundary - NOT via config save.
+    gnoi_tls_setup.ensure_gnoi_ready(duthost, bundle, timeout=300)
+
+    # 5) Validate the boot image and that gNOI is usable on the new image.
+    client = bundle.open_client()
+    try:
+        pytest_assert(
+            client.system.Time(system_pb2.TimeRequest(), timeout=10).time > 0,
+            "gNOI System.Time failed after upgrade",
+        )
+    finally:
+        client.close()
+
+    installed = duthost.shell("sonic-installer list", module_ignore_errors=False)["stdout"]
+    logger.info("sonic-installer list after upgrade:\n%s", installed)
+    pytest_assert(
+        target_version in installed,
+        "target version {} not present after upgrade:\n{}".format(target_version, installed),
+    )


### PR DESCRIPTION
### Description of PR
Summary: Add a `tests/gnoi/` suite that drives gNOI the "API way" — an in-process
Python gRPC client (`sonic_grpc.gnoi.GnoiClient`) in the sonic-mgmt container
talks mTLS gRPC directly to the DUT gNOI server on the management IP. No PTF hop,
no in-repo stub generation.

Fixes # (tracking): sonic-net/sonic-mgmt#26039

> [!IMPORTANT]
> **Hard-depends on sonic-net/sonic-buildimage#28341**, which builds the
> `sonic-grpc` wheel and installs `sonic_grpc` into `docker-sonic-mgmt`. This
> suite imports `sonic_grpc.gnoi` at module scope, so until that wheel is in the
> test image the suite **fails collection** (`ModuleNotFoundError`) rather than
> skipping — CI genuinely gates on the wheel being present. **Do not merge before
> #28341 is merged and the docker-sonic-mgmt image has rolled.** Kept draft until
> then. Functional evidence is the KVM VS (vlab) pass logs below.

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Today gNOI tests (`tests/gnmi/test_gnoi_*.py`) shell out to a gRPC CLI
(`grpcurl` / `py_gnmicli.py`) on the PTF container. That couples every gNOI test
to PTF, uses stringly-typed dynamic messages, and hides real gRPC status codes
behind text parsing. A native typed client removes the PTF hop and surfaces
`grpc.RpcError` status codes directly.

#### How did you do it?
- `tests/gnoi/conftest.py`: a coupled, PTF-free `gnoi_client` fixture that
  checkpoints CONFIG_DB, generates a CA/server/client cert chain (reusing
  `cert_utils`, with the DUT mgmt IP in the server cert SAN), pushes the server
  certs to the DUT, configures GNMI TLS mode and registers the client CN,
  restarts `gnmi-native`, verifies readiness with a native gNOI call, yields an
  mTLS `GnoiClient`, then rolls back and cleans up. Imports are guarded at the
  symbol level so the suite skips cleanly when the `sonic-grpc` wheel is absent.
- `tests/gnoi/test_gnoi_system.py`: `System.Time` returns a plausible timestamp.
- `tests/gnoi/test_gnoi_file.py`: `File.Stat` returns a typed stat entry (via
  `client.file`).

The client and its vendored gNOI proto stubs come from the standalone
`sonic-grpc` wheel (sonic-net/sonic-buildimage#28341); this PR does not generate
stubs.

#### How did you verify/test it?
Validated on a KVM VS testbed (`vms-kvm-t0`) with `sonic_grpc` installed into the
sonic-mgmt container: both `test_gnoi_system_time` and `test_gnoi_file_stat`
pass over the native mTLS client, with clean fixture rollback.

#### Any platform specific information?
Topology `any`. The fixture requires a `gnmi` container running `gnmi-native` and
mutates GNMI CONFIG_DB (rolled back on teardown); tests carry
`skip_check_dut_health` accordingly.

#### Supported testbed topology if it is a new test case?
`any` (validated on `vms-kvm-t0`).

### Documentation
No new user-facing documentation; behavior is covered by in-module docstrings.
