### PR TITLE
[platform_tests] test_cont_warm_reboot: fix image install path and warm-up CoPP throttling

### DIFF
--- a/tests/common/platform/args/cont_warm_reboot_args.py
+++ b/tests/common/platform/args/cont_warm_reboot_args.py
@@ -38,3 +38,12 @@ def add_cont_warm_reboot_args(parser):
         default="current",
         help="Comma separated list of images to be installed during continuous reboot test",
     )
+
+    parser.addoption(
+        "--neighbor_miss_copp_pps",
+        action="store",
+        type=int,
+        default=2000,
+        help="neighbor_miss CoPP rate (pps) applied before each reboot so the warm-up's bulk "
+             "ARP resolution isn't throttled below the data-plane readiness threshold",
+    )

--- a/tests/platform_tests/test_cont_warm_reboot.py
+++ b/tests/platform_tests/test_cont_warm_reboot.py
@@ -7,15 +7,17 @@ import traceback
 import pytest
 import logging
 from datetime import datetime
+from urllib.parse import urlparse
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.upgrade_helpers import install_sonic
 from tests.common.reboot import get_reboot_cause
 from tests.common.fixtures.advanced_reboot import AdvancedReboot
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa: F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # noqa: F401
 
-from tests.common.platform.device_utils import RebootHealthError,\
-    check_services, check_interfaces_and_transceivers, check_neighbors,\
+from tests.common.platform.device_utils import RebootHealthError, \
+    check_services, check_interfaces_and_transceivers, check_neighbors, \
     verify_no_coredumps, handle_test_error
 from tests.platform_tests.verify_dut_health import wait_until_uptime, get_test_report
 
@@ -29,12 +31,13 @@ MAX_WAIT_TIME_FOR_REBOOT_CAUSE = 120
 
 
 class ContinuousReboot:
-    def __init__(self, request, duthost, ptfhost, localhost, conn_graph_facts):
+    def __init__(self, request, duthost, ptfhost, localhost, conn_graph_facts, tbinfo):
         self.request = request
         self.duthost = duthost
         self.ptfhost = ptfhost
         self.localhost = localhost
         self.conn_graph_facts = conn_graph_facts
+        self.tbinfo = tbinfo
         self.continuous_reboot_count = request.config.getoption(
             "--continuous_reboot_count")
         self.continuous_reboot_delay = request.config.getoption(
@@ -42,6 +45,7 @@ class ContinuousReboot:
         self.reboot_type = request.config.getoption("--reboot_type")
         self.image_location = request.config.getoption("--image_location")
         self.image_list = request.config.getoption("--image_list")
+        self.neighbor_miss_copp_pps = request.config.getoption("--neighbor_miss_copp_pps")
         self.current_image = self.duthost.shell(
             'sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
         self.test_report = dict()
@@ -51,10 +55,56 @@ class ContinuousReboot:
 
         self.init_reporting()
 
+    def image_exists(self, image_path):
+        # Checked from the sonic-mgmt host: this only asks "is the image there",
+        # independent of the DUT's mgmt routing state.
+        http_code = self.localhost.shell(
+            "curl -o /dev/null --silent -Iw '%{{http_code}}' {}".format(image_path),
+            module_ignore_errors=True)["stdout"]
+        if http_code != '200':
+            logging.info("Image existence check returned HTTP {} for {}".format(http_code, image_path))
+        return http_code == '200'
+
+    def _dut_stdout(self, cmd):
+        return self.duthost.shell(cmd, module_ignore_errors=True).get("stdout", "").strip()
+
+    def ensure_dut_can_resolve(self, host):
+        """
+        install_sonic() downloads on the DUT by URL, but a freshly booted image
+        has no nameserver configured. If the DUT can't resolve the image host,
+        point it at the testbed DNS (.254 of the mgmt subnet). Best-effort.
+        """
+        if not host or self._dut_stdout("getent hosts {} | head -1".format(host)):
+            return
+        mgmt_ip = self._dut_stdout(
+            "ip -4 addr show eth0 | grep -oP '(?<=inet\\s)\\d+\\.\\d+\\.\\d+\\.\\d+'")
+        if not mgmt_ip:
+            logging.warning("Could not determine eth0 IP on DUT; skipping DNS setup")
+            return
+        dns = ".".join(mgmt_ip.split(".")[:3]) + ".254"
+        self.duthost.command(
+            "config dns nameserver add {}".format(dns), module_ignore_errors=True)
+
+    def ensure_neighbor_miss_copp(self):
+        """
+        Raise the neighbor_miss CoPP rate so the warm-up's bulk ARP resolution
+        isn't throttled below the data-plane readiness threshold. Re-run before
+        every reboot; the default (200 pps) is restored on each image boot. Full
+        COPP_GROUP entry so it passes YANG validation.
+        """
+        result = self.duthost.shell(
+            "sonic-db-cli CONFIG_DB HSET 'COPP_GROUP|queue1_group3' "
+            "trap_action trap trap_priority 1 queue 1 meter_type packets "
+            "mode sr_tcm cir {pps} cbs {pps} red_action drop".format(pps=self.neighbor_miss_copp_pps),
+            module_ignore_errors=True)
+        if result.get("rc") != 0:
+            logging.warning("Failed to raise neighbor_miss CoPP rate: {}".format(result.get("stderr", "")))
+
     def init_reporting(self):
         self.reboot_count = None
         self.current_image = None
         self.is_new_image = None
+        self.target_version = None
         self.test_duration = None
         self.critical_services = None
         self.interfaces = None
@@ -79,6 +129,7 @@ class ContinuousReboot:
         @param reboot_kwargs: The argument used by reboot_helper
         """
         logging.info("Run %s reboot on DUT" % self.reboot_type)
+        self.ensure_neighbor_miss_copp()
         self.run_reboot_testcase()
         # Wait until uptime reaches allowed value
         wait_until_uptime(self.duthost, self.continuous_reboot_delay)
@@ -117,9 +168,9 @@ class ContinuousReboot:
             'sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
         if self.is_new_image is True:
             # After boot-up, verify that the required image is running on the DUT
-            if self.advancedReboot.binaryVersion != self.current_image:
+            if self.target_version != self.current_image:
                 raise RebootHealthError("Image installation failed.\
-                    Expected: {}. Found: {}".format(self.advancedReboot.binaryVersion, self.current_image))
+                    Expected: {}. Found: {}".format(self.target_version, self.current_image))
 
     def check_test_params(self):
         while True:
@@ -160,13 +211,9 @@ class ContinuousReboot:
                     image_install_list)].strip()
                 image_path = install_info.get(
                     'location').strip() + "/" + self.new_image
-                file_exists = self.duthost.command(
-                    "curl -o /dev/null --silent -Iw '%{{http_code}}' {}".format(image_path),
-                    module_ignore_errors=True)["stdout"]
-                if file_exists != '200':
-                    logging.info("Remote image file {} does not exist. Curl returned: {}".format(
-                        image_path, file_exists))
-                    logging.warning("Continuing the test with current image")
+                if not self.image_exists(image_path):
+                    logging.warning(
+                        "Image {} does not exist; continuing with current image".format(image_path))
                     self.new_image = "current"
             except ValueError:
                 logging.warning(
@@ -175,16 +222,14 @@ class ContinuousReboot:
         if self.new_image == "current":
             logging.info(
                 "Next image is set to current - skip image installation")
-            self.advancedReboot.newSonicImage = None
             self.is_new_image = False
         else:
-            self.advancedReboot.newSonicImage = image_path
-            self.advancedReboot.cleanupOldSonicImages = True
+            # Install via the shared upgrade helper, which handles the mgmt
+            # routing for the download; AdvancedReboot only does the reboot.
+            self.ensure_dut_can_resolve(urlparse(image_path).hostname)
+            logging.info("Installing image {} on DUT".format(image_path))
+            self.target_version = install_sonic(self.duthost, image_path, self.tbinfo)
             self.is_new_image = True
-            logging.info(
-                "Image to be installed on DUT - {}".format(image_path))
-        self.advancedReboot.imageInstall()
-        if self.advancedReboot.newImage:
             # The image upgrade will delete all the preexisting cores
             self.pre_existing_cores = 0
 
@@ -324,7 +369,6 @@ class ContinuousReboot:
             self.test_report = get_test_report()
             self.sub_test_result = all(
                 [check is True for check in list(self.test_report.values())])
-            self.advancedReboot.newSonicImage = None
             self.test_end_time = datetime.now()
             self.create_test_report()
             logging.info(
@@ -378,7 +422,7 @@ def test_continuous_reboot(request, duthosts, enum_rand_one_per_hwsku_frontend_h
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     continuous_reboot = ContinuousReboot(
-        request, duthost, ptfhost, localhost, conn_graph_facts)
+        request, duthost, ptfhost, localhost, conn_graph_facts, tbinfo)
     continuous_reboot.start_continuous_reboot(
         request, duthosts, duthost, ptfhost, localhost, vmhost, tbinfo, creds)
     continuous_reboot.test_teardown()


### PR DESCRIPTION
### Description of PR

Summary:
Resolves #26539

`platform_tests/test_cont_warm_reboot.py` has two reliability problems:

1. It downloads images through its own legacy path with no mgmt-routing handling, so when the DUT cannot reach the image server it silently falls back to rebooting the current image — no upgrade is actually tested.
2. Its warm-up phase can time out before any reboot is issued: clearing ARP/FDB makes all VLAN hosts re-resolve at once, and the default neighbor_miss CoPP rate throttles resolution below the readiness threshold.

This PR installs through the shared `install_sonic()` helper (which handles mgmt routing) and raises the neighbor_miss CoPP rate before each reboot.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: N/A
Failure type: N/A

### Approach
#### What is the motivation for this PR?

The test predates `install_sonic()` (#1841 landed three weeks before #1939 introduced it), so it kept its own download path (`AdvancedReboot.newSonicImage` -> curl on the DUT) that never picked up the mgmt-routing handling the upgrade-path tests got. On testbeds where the DUT has no default route — or a BGP-learned default route pointing at the fabric — the download fails and the test silently degrades. Separately, with ~500 VLAN hosts, the post-clear ARP burst exceeds the default neighbor_miss CoPP rate (200 pps), so `wait_dut_to_warm_up()` times out at 300s and the reboot is never issued.

#### How did you do it?

- Install through the shared `install_sonic()` helper, same as the upgrade-path tests. AdvancedReboot now only performs the reboot; its `newSonicImage` download path is no longer used here. Also removes a redundant direct `imageInstall()` call (`runRebootTestcase()` already does the testbed setup internally).
- The image existence pre-check runs from the sonic-mgmt host, so it purely answers "is the image there", independent of DUT routing; the HTTP code is logged on failure.
- Best-effort DNS step: only if the DUT cannot resolve the image host, point it at the testbed nameserver.
- Raise the neighbor_miss CoPP rate before every reboot (it resets on each image boot); the rate is a test option (`--neighbor_miss_copp_pps`, default 2000), and the full COPP_GROUP entry is written so it passes YANG validation.

#### How did you verify/test it?

Ran on a physical T0 testbed (800G Broadcom platform) with a two-image `--image_list`: image download + install go through `install_sonic()`, the warm-up passes (data plane comes up), and the DUT warm-reboots into the new image (verified on-box: new image Current after reboot, swss/syncd active, reboot-cause `warm-reboot`).

#### Any platform specific information?

The neighbor_miss CoPP group name (`queue1_group3`) matches the default copp_cfg.json mapping.

#### Supported testbed topology if it's a new test case?

Existing test, t0.

### Documentation

N/A.

