### PR TITLE
Suppress false-positive flake8 E231/E713 on f-strings in packet_trimming_helper

### DIFF
--- a/tests/packet_trimming/packet_trimming_helper.py
+++ b/tests/packet_trimming/packet_trimming_helper.py
@@ -713,7 +713,7 @@ def fill_egress_buffer(duthost, ptfadapter, port_id, buffer_size, target_queue, 
 
     # Check queue counters before filling
     for interface in interfaces:
-        logger.info(f"Queue counters before filling for {interface}:")
+        logger.info(f"Queue counters before filling for {interface}:")  # noqa: E231
         duthost.shell(f"show queue counters {interface}")
         duthost.shell(f"show queue counters {interface} --json")
 
@@ -853,7 +853,7 @@ def fill_egress_buffer(duthost, ptfadapter, port_id, buffer_size, target_queue, 
 
     # Check queue counters after filling
     for interface in interfaces:
-        logger.info(f"Queue counters after filling for {interface}:")
+        logger.info(f"Queue counters after filling for {interface}:")  # noqa: E231
         duthost.shell(f"show queue counters {interface}")
         duthost.shell(f"show queue counters {interface} --json")
 
@@ -1249,7 +1249,7 @@ def compute_buffer_threshold_for_common_device(duthost, interface, queue_id):
         static_threshold = int(buffer_profile["size"]) + int(buffer_scale * pool_size * STATIC_THRESHOLD_MULTIPLIER)
 
         logger.info(f"Computed buffer threshold for queue {queue_id} on {interface}: {static_threshold}")
-        logger.info(f"Pool size: {pool_size}, Buffer scale: {buffer_scale:.4f}, "
+        logger.info(f"Pool size: {pool_size}, Buffer scale: {buffer_scale:.4f}, "  # noqa: E231
                     f"Buffer size: {static_threshold}")
 
         return static_threshold
@@ -1528,10 +1528,10 @@ def configure_trimming_acl(duthost, test_ports):
     # Verify ACL configuration
     logger.info("Verifying ACL configuration")
     result = duthost.shell("show acl table")
-    logger.info(f"ACL tables:\n{result['stdout']}")
+    logger.info(f"ACL tables:\n{result['stdout']}")  # noqa: E231
 
     result = duthost.shell("show acl rule")
-    logger.info(f"ACL rules:\n{result['stdout']}")
+    logger.info(f"ACL rules:\n{result['stdout']}")  # noqa: E231
 
     # Verify table was created successfully
     if ACL_TABLE_NAME not in result["stdout"]:
@@ -1772,10 +1772,10 @@ def update_service_port_buffer_profile(duthost, service_port):
     # Verify buffer configuration
     logger.info("Verifying buffer configuration")
     result = duthost.shell(f"redis-cli -n 4 HGETALL 'BUFFER_PG|{service_port}|0'")
-    logger.info(f"BUFFER_PG|{service_port}|0 configuration:\n{result['stdout']}")
+    logger.info(f"BUFFER_PG|{service_port}|0 configuration:\n{result['stdout']}")  # noqa: E231
 
     result = duthost.shell(f"redis-cli -n 4 HGETALL 'BUFFER_PORT_INGRESS_PROFILE_LIST|{service_port}'")
-    logger.info(f"BUFFER_PORT_INGRESS_PROFILE_LIST|{service_port} configuration:\n{result['stdout']}")
+    logger.info(f"BUFFER_PORT_INGRESS_PROFILE_LIST|{service_port} configuration:\n{result['stdout']}")  # noqa: E231
 
     if "ingress_lossy_profile" not in result["stdout"]:
         raise RuntimeError(f"Buffer configuration for {service_port} was not applied successfully")
@@ -1830,7 +1830,7 @@ def update_service_port_qos_map(duthost, service_port):
     # Verify QoS map configuration
     logger.info("Verifying QoS map configuration")
     result = duthost.shell(f"redis-cli -n 4 HGETALL 'PORT_QOS_MAP|{service_port}'")
-    logger.info(f"PORT_QOS_MAP|{service_port} configuration:\n{result['stdout']}")
+    logger.info(f"PORT_QOS_MAP|{service_port} configuration:\n{result['stdout']}")  # noqa: E231
 
     if "AZURE" not in result["stdout"]:
         raise RuntimeError(f"QoS map configuration for {service_port} was not applied successfully")
@@ -1930,7 +1930,7 @@ def update_port_info_for_portchannel(port_dict, portchannel_name, portchannel_me
     new_port_info['ptf_port_id'] = member_ptf_ids
     new_port_info['dut_members'] = portchannel_members
 
-    logger.info(f"Updated port info for PortChannel {portchannel_name}: ptf_port_ids={member_ptf_ids},"
+    logger.info(f"Updated port info for PortChannel {portchannel_name}: ptf_port_ids={member_ptf_ids},"  # noqa: E231
                 f"dut_members={portchannel_members}")
 
     return {portchannel_name: new_port_info}
@@ -2076,7 +2076,7 @@ def get_interface_peer_addresses(mg_facts, interface_name):
 
     # Check if the required interface list exists in mg_facts
     if interface_list_key not in mg_facts:
-        logger.warning(f"Interface list '{interface_list_key}' not found in minigraph facts")
+        logger.warning(f"Interface list '{interface_list_key}' not found in minigraph facts")  # noqa: E713
         return ipv4_peer_addr, ipv6_peer_addr
 
     for interface in mg_facts[interface_list_key]:
@@ -2949,9 +2949,9 @@ def compare_counters(counter1, counter2, keys_to_compare):
 
     for key in keys_to_compare:
         if key not in counter1:
-            raise KeyError(f"Key '{key}' not found in counter1")
+            raise KeyError(f"Key '{key}' not found in counter1")  # noqa: E713
         if key not in counter2:
-            raise KeyError(f"Key '{key}' not found in counter2")
+            raise KeyError(f"Key '{key}' not found in counter2")  # noqa: E713
 
         value1 = counter1[key]
         value2 = counter2[key]


### PR DESCRIPTION
### Description of PR

Summary:
The pre-commit flake8 hook in CI runs on whole changed files, so contributors
touching `tests/packet_trimming/packet_trimming_helper.py` (e.g. PR #25608) hit
12 pre-existing flake8 failures that are all false positives. CI pins flake8
6.0.0 / pycodestyle 2.10 on Python 3.8, whose older tokenizer mis-parses the
contents of f-strings:

- E231 "missing whitespace after ':'/','": flagged on literal colons/commas
  inside f-string text (e.g. `{interface}:`, `:\n`) and on a format spec
  (`{buffer_scale:.4f}`).
- E713 "test for membership should be 'not in'": flagged on the literal words
  "not found in" inside f-strings, which are plain message text, not membership
  tests.

Newer pycodestyle (2.11+) no longer mis-fires on these, but the repo's pinned
version does. This PR adds targeted `# noqa: E231` / `# noqa: E713` suppressions
on exactly those f-string lines so the file lints clean under the pinned CI
toolchain. No code logic is changed; all lines remain under 120 chars.

Fixes the spurious lint failures seen on PR #25608 and unblocks any future PR
that edits this file.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
The pinned CI flake8/pycodestyle emits false-positive E231/E713 on f-string
contents in `packet_trimming_helper.py`. Because pre-commit lints whole changed
files, these legacy false positives block unrelated PRs that touch the file.

#### How did you do it?
Added `# noqa: E231` / `# noqa: E713` comments to the 12 specific f-string lines
that the pinned pycodestyle mis-flags. No functional change.

#### How did you verify/test it?
- Confirmed the 12 flagged lines are all literal f-string content / format specs,
  not real violations (no actual `not x in y` membership tests exist in the file).
- Ran `flake8 --max-line-length=120` on the file: clean.
- Verified every touched line stays under the 120-char limit.

#### Any platform specific information?
None. Lint-only change.

#### Supported testbed topology if it's a new test case?
N/A.
