### PR TITLE
[qos] Only stop/restart SONiC fanout LLDP when it was running

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -3529,7 +3529,10 @@ class QosSaiBase(QosBase):
         out of scope for this PR.
 
         What this DOES cover:
-        - Fanout-self originated LLDP (stopped via container)
+        - Fanout-self originated LLDP, but only when the LLDP container is
+          running before the test. Fanouts where LLDP is already stopped
+          (e.g. Cisco 8101) are left untouched and are NOT restarted on
+          teardown, so the fixture never changes their LLDP state.
 
         What this does NOT cover (limitation, tracked in #24236):
         - VM-originated LLDP/LACP that transits through the SONiC fanout
@@ -3540,29 +3543,42 @@ class QosSaiBase(QosBase):
         - EOS neighbor LACP multiplier 600 (no EOS-side LAG flap)
         - DUT LLDP/BGP/radvd stopped by stopServices fixture
         """
-        # Stop LLDP container once per fanout (covers fanout-self LLDP).
-        # The 202511 fanout role only stops LLDP for marvell-teralynx;
-        # broadcom SONiC fanouts still run LLDP by default.
-        # Assumption: LLDP is running before the test; "docker stop" rc=0 does
-        # not distinguish "stopped now" from "was already stopped", so the
-        # teardown's symmetric "docker start" will start LLDP even on fanouts
-        # where it was previously off. This is acceptable for the testbeds
-        # in scope (#24236) where LLDP runs by default on Broadcom SONiC.
+        # Stop the LLDP container only when it is *currently running*, and
+        # only restart in teardown the fanouts we actually stopped (tracked
+        # via sonic_lldp_stopped). Rationale: on some SONiC fanouts (e.g.
+        # Cisco 8101) LLDP is intentionally kept stopped/disabled; a symmetric
+        # "docker start" in teardown would wrongly turn it back on. Gating on
+        # the live running state means we (a) never start a container that was
+        # already down, and (b) leave such fanouts untouched. On fanouts where
+        # LLDP runs by default (e.g. Broadcom SONiC) behaviour is unchanged:
+        # it is stopped for the test and restored afterwards.
         if fanout_name not in sonic_lldp_stopped:
             try:
-                result = fanout.host.command(
-                    "docker stop lldp", module_ignore_errors=True)
-                if result.get('failed', False) or result.get('rc', 0) != 0:
-                    logger.warning(
-                        "permit_only_test_traffic_on_fanout: "
-                        "docker stop lldp on SONiC %s returned rc=%s, "
-                        "output=%s", fanout_name, result.get('rc', '?'),
-                        result.get('stdout', result.get('stderr', '')))
-                else:
-                    sonic_lldp_stopped.add(fanout_name)
+                running = fanout.host.command(
+                    "docker ps -q --filter name=lldp --filter status=running",
+                    module_ignore_errors=True)
+                lldp_running = (not running.get('failed', False)
+                                and running.get('rc', 0) == 0
+                                and bool((running.get('stdout') or '').strip()))
+                if not lldp_running:
                     logger.info(
-                        "permit_only_test_traffic_on_fanout: stopped lldp "
-                        "container on SONiC %s", fanout_name)
+                        "permit_only_test_traffic_on_fanout: lldp already "
+                        "stopped on SONiC %s; leaving fanout untouched",
+                        fanout_name)
+                else:
+                    result = fanout.host.command(
+                        "docker stop lldp", module_ignore_errors=True)
+                    if result.get('failed', False) or result.get('rc', 0) != 0:
+                        logger.warning(
+                            "permit_only_test_traffic_on_fanout: "
+                            "docker stop lldp on SONiC %s returned rc=%s, "
+                            "output=%s", fanout_name, result.get('rc', '?'),
+                            result.get('stdout', result.get('stderr', '')))
+                    else:
+                        sonic_lldp_stopped.add(fanout_name)
+                        logger.info(
+                            "permit_only_test_traffic_on_fanout: stopped lldp "
+                            "container on SONiC %s", fanout_name)
             except Exception as e:
                 logger.warning(
                     "permit_only_test_traffic_on_fanout: "


### PR DESCRIPTION
### Description of PR

Summary:
Make the `permit_only_test_traffic_on_fanout` QoS fixture idempotent on SONiC fanouts so it no longer turns LLDP back on where LLDP was intentionally kept stopped.

Partially addresses #24236.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

The `permit_only_test_traffic_on_fanout` fixture (PRs #24212 / #24317) stops the LLDP container on SONiC fanouts during `testQosSaiHeadroomPoolSize` / `testQosSaiHeadroomPoolWatermark` and restarts it in teardown. The restart is **unconditional**: any fanout where the fixture ran `docker stop lldp` is later `docker start lldp`-ed, regardless of the LLDP state before the test.

On SONiC fanouts where LLDP is intentionally kept stopped/disabled (e.g. Cisco 8101 fanouts, where the fanout role runs `config feature autorestart lldp disabled`), this symmetric restart wrongly turns LLDP back on after the test. Operators who deliberately keep fanout LLDP off see it silently come back whenever a `qos_sai` run lands on that testbed. The existing code comment already flagged this as a known limitation (`docker stop` rc=0 does not distinguish "stopped now" from "was already stopped").

#### How did you do it?

Make the SONiC-fanout LLDP handling state-aware in `_apply_sonic_filter`:

- Before stopping, check whether the LLDP container is actually running (`docker ps -q --filter name=lldp --filter status=running`).
- Only run `docker stop lldp` and record the fanout in `sonic_lldp_stopped` when LLDP is running.
- Teardown is unchanged: it only restarts fanouts in `sonic_lldp_stopped`. Since we now only add fanouts we actually stopped, teardown restores LLDP only where it was running before, and never starts it on fanouts where it was already down.

Net effect:
- SONiC fanouts with LLDP already stopped (e.g. Cisco 8101): left untouched (only a read-only `docker ps`), never restarted.
- SONiC fanouts with LLDP running by default (e.g. Broadcom SONiC): unchanged behaviour, stopped for the test and restored afterwards. No regression to the coverage added in #24317.

#### How did you verify/test it?

- `python -m py_compile tests/qos/qos_sai_base.py` passes.
- `flake8 --max-line-length=120 tests/qos/qos_sai_base.py` clean.
- Reviewed the teardown path (`_teardown_test_traffic_filter` restarts only `sonic_lldp_stopped`): a fanout with LLDP already stopped is never added to the set and thus never restarted.

#### Any platform specific information?

- Affects testbeds running `testQosSaiHeadroomPoolSize` / `testQosSaiHeadroomPoolWatermark` with SONiC fanouts.
- The EOS fanout path is unchanged.

#### Supported testbed topology if it's a new test case?

N/A (fixture bug fix for existing tests).

### Documentation

N/A
