### PR TITLE
[ci][202511] sonic-ubuntu-1c agent pool: migrate from python3-pip to uv to address S360 vulnerability (#25721)

### DIFF
--- a/.azure-pipelines/cancel-previous-elastictest-testplan.yml
+++ b/.azure-pipelines/cancel-previous-elastictest-testplan.yml
@@ -75,7 +75,7 @@ steps:
       set -e
       echo "Step: cancel previous testplans for PR"
 
-      pip install PyYAML
+      sudo uv pip install --system PyYAML
 
       rm -f new_test_plan_id.txt
 

--- a/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
+++ b/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
@@ -66,8 +66,7 @@ steps:
 - script: |
     set -x
 
-    pip install azure-kusto-data
-    pip install azure-kusto-data azure-identity
+    sudo uv pip install --system azure-kusto-data azure-identity
 
     INSTANCE_NUMBER=$(python ./.azure-pipelines/impacted_area_testing/calculate_instance_number.py --scripts $(SCRIPTS) --topology ${{ parameters.TOPOLOGY }} --branch ${{ parameters.BUILD_BRANCH }} --prepare_time ${{ parameters.PREPARE_TIME }} --target_pr_test_time $(TARGET_PR_TEST_TIME))
 

--- a/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
+++ b/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
@@ -61,8 +61,7 @@ steps:
       echo "##vso[task.setvariable variable=TEST_SCRIPTS;isOutput=true]$TEST_SCRIPTS"
       exit 0
     fi
-    pip install PyYAML
-    pip install natsort
+    sudo uv pip install --system PyYAML natsort
 
     FINAL_FEATURES=""
     IFS=' ' read -ra FEATURES_LIST <<< "$(DIFF_FOLDERS)"

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -270,8 +270,7 @@ steps:
       set -e
       echo "Step: Trigger Test"
 
-
-      pip install PyYAML
+      sudo uv pip install --system PyYAML
 
       rm -f new_test_plan_id.txt
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,8 @@ stages:
     displayName: "Static Analysis"
     timeoutInMinutes: 10
     continueOnError: false
-    pool: sonic-ubuntu-1c
+    pool:
+      vmImage: ubuntu-latest
     steps:
     - template: .azure-pipelines/pre-commit-check.yml
 
@@ -55,7 +56,8 @@ stages:
     displayName: "Validate Test Cases"
     timeoutInMinutes: 30
     continueOnError: false
-    pool: sonic-ubuntu-1c
+    pool:
+      vmImage: ubuntu-latest
     steps:
     - template: .azure-pipelines/pytest-collect-only.yml
       parameters:
@@ -64,21 +66,24 @@ stages:
   - job: dependency_check
     displayName: "Dependency Check"
     timeoutInMinutes: 10
-    pool: sonic-ubuntu-1c
+    pool:
+      vmImage: ubuntu-latest
     steps:
       - template: .azure-pipelines/dependency-check.yml
 
   - job: markers_check
     displayName: "Markers Check"
     timeoutInMinutes: 10
-    pool: sonic-ubuntu-1c
+    pool:
+      vmImage: ubuntu-latest
     steps:
       - template: .azure-pipelines/markers-check.yml
 
   - job: meta_check
     displayName: "Meta check"
     timeoutInMinutes: 10
-    pool: sonic-ubuntu-1c
+    pool:
+      vmImage: ubuntu-latest
     steps:
       - template: .azure-pipelines/meta-check.yml
 


### PR DESCRIPTION
Cherry-pick of #25721 to `202511`.

Original PR: [ci] sonic-ubuntu-1c agent pool: migrate from python3-pip to uv to address S360 vulnerability (#25721)

### Summary
S360 flags `python3-pip` on the self-hosted `sonic-ubuntu-1c` / `sonic-ubuntu-1c-2` agent pools as a security vulnerability. This removes vulnerable pip usage on those pools:
- Replaced `pip install` with `sudo uv pip install --system` for steps running on those pools.
- Moved lightweight pre-merge check jobs to the Microsoft-hosted `ubuntu-latest` pool.

### Cherry-pick conflict resolution
- `azure-pipelines.yml`: kept the 5 pre-test job pool changes (`sonic-ubuntu-1c` -> `vmImage: ubuntu-latest`). Dropped the `Skip_Expiry_Unit_Tests` stage hunk because that stage and `tools/skip_expiry` do not exist on `202511`.
- `.azure-pipelines/probe-tests/steps/run-probe-tests.yml`: modify/delete conflict — the file does not exist on `202511`, so it remains deleted.

Signed-off-by: Yijing Yan <yijingyan@microsoft.com>