### PR TITLE
Clarify backport request requirements in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,6 +40,10 @@ work item above. The linked tracker should explain the failure in detail,
 including whether it is a day-one issue or a regression, the affected
 branch/image/platform/test, and why this branch needs the fix. Backport or
 cherry-pick requests without a linked issue/work item may not be favored.
+
+If you request a backport/cherry-pick, provide both:
+1. A GitHub issue or Microsoft ADO work item tracking the change.
+2. Test evidence from the target branch(es) requested below.
 -->
 - [ ] 202311
 - [ ] 202405
@@ -49,7 +53,7 @@ cherry-pick requests without a linked issue/work item may not be favored.
 - [ ] 202512
 - [ ] 202605
 
-Tracking issue/work item for backport/cherry-pick request:
+Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
 Failure type: <!-- day-one issue / regression / other -->
 
 ### Approach
@@ -58,6 +62,10 @@ Failure type: <!-- day-one issue / regression / other -->
 #### How did you do it?
 
 #### How did you verify/test it?
+<!--
+If you request a backport/cherry-pick, include test evidence from the target
+branch(es), not only from master.
+-->
 
 #### Any platform specific information?
 


### PR DESCRIPTION
### Description of PR
Summary:
Clarify the PR template requirements for backport/cherry-pick requests. Requesters must provide both a GitHub issue or Microsoft ADO work item and target-branch test evidence.

Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
N/A
Failure type: N/A

### Approach
#### What is the motivation for this PR?
Backport/cherry-pick requests are easier to triage when they include traceability and branch-specific validation. The template already asks for tracking information, but it did not explicitly require target-branch test evidence in the same backport request flow.

#### How did you do it?
Updated `.github/PULL_REQUEST_TEMPLATE.md` to require a GitHub issue or Microsoft ADO work item and test evidence from requested target branch(es) when a backport/cherry-pick is requested.

#### How did you verify/test it?
Documentation/template-only change. Verified the markdown diff locally.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
