### PR TITLE
[packet_trimming] Detect Mellanox trimming support at runtime instead of hwsku allowlist

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3909,7 +3909,7 @@ packet_trimming:
     conditions:
       - "release in ['202505']"
       - "asic_type in ['vs']"
-      - "hwsku not in ['Arista-7060X6-64PE-B-C448O16', 'Arista-7060X6-64PE-B-C512S2', 'Mellanox-SN5640-C448O16', 'Mellanox-SN5640-C512S2']"
+      - "asic_type not in ['mellanox'] and hwsku not in ['Arista-7060X6-64PE-B-C448O16', 'Arista-7060X6-64PE-B-C512S2']"
   xfail:
     reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
     conditions:


### PR DESCRIPTION
Summary: Let Mellanox platforms rely on the runtime `SWITCH_TRIMMING_CAPABLE` capability check (the `skip_if_packet_trimming_not_supported` fixture) to decide whether packet_trimming tests run, instead of maintaining a hardcoded hwsku allowlist in `tests_mark_conditions.yaml`.

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- master: case pass
- 202605: case pass

### Approach
#### What is the motivation for this PR?
PR https://github.com/sonic-net/sonic-mgmt/pull/19714 added a condition to skip packet_trimming tests on unsupported platforms using a hardcoded hwsku allowlist:
```
- "hwsku not in ['Arista-7060X6-64PE-B-C448O16', 'Arista-7060X6-64PE-B-C512S2', 'Mellanox-SN5640-C448O16', 'Mellanox-SN5640-C512S2']"
```
The trimming feature is supported not only on those four hwskus but also on new platforms/SKUs (e.g. `Mellanox-SN6600_LD-P64O128C2`, `Mellanox-SN6600_LD-P128C2`). Maintaining a static allowlist means every new SKU needs a yaml change.

This implements the long-term solution tracked in https://github.com/sonic-net/sonic-mgmt/issues/26048.

#### How did you do it?
The `skip_if_packet_trimming_not_supported` fixture in `tests/packet_trimming/conftest.py` already checks the runtime `SWITCH_TRIMMING_CAPABLE` capability (plus SPC1/2/3 and SPC4 platform-specific checks), which accurately reflects whether the running image supports trimming.

Drop the Mellanox hwskus from the conditional_mark allowlist and exempt Mellanox via `asic_type not in ['mellanox']`, so Mellanox platforms rely on the fixture and no longer need a yaml change per new SKU. Non-Mellanox platforms remain gated by the Arista 7060X6 allowlist. The `release in ['202505']` and `asic_type in ['vs']` static guards are kept (cheap collection-time skip, not covered reliably by the runtime check).

#### How did you verify/test it?
Verified on `Mellanox-SN6600_LD-P128C2` (platform `x86_64-nvidia_sn6600_ld-r0`, 202605_RC image):
```
$ redis-cli -n 6 HGET "SWITCH_CAPABILITY|switch" "SWITCH_TRIMMING_CAPABLE"
"true"
```
So the fixture correctly allows trimming tests to run on this SKU without any allowlist entry.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A