### PR TITLE
[202511] fix: pass KVM_BUILD_ID as template parameter through pre_defined_pr_test pipeline chain (#23061)

### DIFF
--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -70,6 +70,10 @@ parameters:
   type: string
   default: $(BUILD_BRANCH)
 
+- name: KVM_BUILD_ID
+  type: string
+  default: ""
+
 jobs:
   - job: get_impacted_area
     displayName: "Get impacted area"
@@ -133,6 +137,7 @@ jobs:
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
           KVM_IMAGE_BRANCH: ${{ parameters.KVM_IMAGE_BRANCH }}
+          KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
           MGMT_BRANCH: ${{ parameters.MGMT_BRANCH }}
           COMMON_EXTRA_PARAMS: "--disable_sai_validation "
           ${{ each param in parameters.OVERRIDE_PARAMS }}:
@@ -218,6 +223,7 @@ jobs:
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
           KVM_IMAGE_BRANCH: ${{ parameters.KVM_IMAGE_BRANCH }}
+          KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
           MGMT_BRANCH: ${{ parameters.MGMT_BRANCH }}
           COMMON_EXTRA_PARAMS: "--disable_sai_validation "
           ${{ each param in parameters.OVERRIDE_PARAMS }}:
@@ -440,6 +446,7 @@ jobs:
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
           KVM_IMAGE_BRANCH: ${{ parameters.KVM_IMAGE_BRANCH }}
+          KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
           MGMT_BRANCH: ${{ parameters.MGMT_BRANCH }}
           COMMON_EXTRA_PARAMS: "--disable_sai_validation "
           ${{ each param in parameters.OVERRIDE_PARAMS }}:

--- a/.azure-pipelines/pre_defined_pr_test.yml
+++ b/.azure-pipelines/pre_defined_pr_test.yml
@@ -34,6 +34,10 @@ parameters:
   type: object
   default: {}
 
+- name: KVM_BUILD_ID
+  type: string
+  default: ""
+
 stages:
 - stage: Test
   variables:
@@ -54,3 +58,4 @@ stages:
         TEST_PLAN_STOP_ON_FAILURE: ${{ parameters.TEST_PLAN_STOP_ON_FAILURE }}
         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
         IMPACT_AREA_INFO: ${{ parameters.IMPACT_AREA_INFO }}
+        KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -192,6 +192,10 @@ parameters:
     type: string
     default: ""
 
+  - name: KVM_BUILD_ID
+    type: string
+    default: ""
+
   - name: EXPECTED_RESULT
     type: string
     default: ""
@@ -285,8 +289,8 @@ steps:
       --max-worker ${{ parameters.MAX_WORKER }} \
       --lock-wait-timeout-seconds ${{ parameters.LOCK_WAIT_TIMEOUT_SECONDS }} \
       --test-set ${{ parameters.TEST_SET }} \
-      --kvm-build-id $(KVM_BUILD_ID) \
-      --kvm-image-branch "${{ parameters.KVM_IMAGE_BRANCH }}" \
+      --kvm-build-id ${{ parameters.KVM_BUILD_ID }} \
+      --kvm-image-branch ${{ parameters.KVM_IMAGE_BRANCH }} \
       --setup-container-params "${{ parameters.SETUP_CONTAINER_PARAMS }}" \
       --kvm-image-build-pipeline-id ${{ parameters.KVM_IMAGE_BUILD_PIPELINE_ID }} \
       --skip-remove-add-topo-for-nightly ${{ parameters.SKIP_REMOVE_ADD_TOPO_FOR_NIGHTLY }} \

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -331,6 +331,9 @@ class TestPlanManager(object):
         if BUILDIMAGE_REPO_FLAG in kwargs.get("source_repo"):
             kvm_image_build_id = build_id
             kvm_image_branch = ""
+        # kvm_image_build_id and kvm_image_branch are mutually exclusive; build id takes precedence
+        if kvm_image_build_id:
+            kvm_image_branch = ""
         affinity = json.loads(kwargs.get("affinity", "[]"))
         payload = {
             "name": test_plan_name,


### PR DESCRIPTION
Cherry-pick of #23061 to `202511`.

### Description of PR

Summary:
When triggering pipeline `pre_defined_pr_test` (pipeline 3320) programmatically to run PR binary search tests against specific pre-built VS images, `KVM_BUILD_ID` was always empty inside the pipeline.

Root cause: `run-test-elastictest-template.yml` used `$(KVM_BUILD_ID)` (pipeline variable macro), but the `SONiC-Elastictest` variable group loaded at stage scope in `pre_defined_pr_test.yml` overrides pipeline variables at job level, causing `$(KVM_BUILD_ID)` to always expand to empty.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

The PR binary search tool (`pr_binary_search`) pre-builds VS images for specific sonic-buildimage commits and then triggers `pre_defined_pr_test` with a specific `KVM_BUILD_ID` to run tests against each image. Without this fix, the build ID is silently dropped and the pipeline always picks a fresh image, making binary search ineffective.

#### How did you do it?

Thread `KVM_BUILD_ID` as a **template parameter** (compile-time `${{ parameters.KVM_BUILD_ID }}`) through the full pipeline chain:

```
pre_defined_pr_test.yml → pr_test_template.yml → run-test-elastictest-template.yml
```

Template parameters are resolved at compile time and are immune to variable group scope overrides, unlike runtime `$(VAR)` macros.

Also fixed `test_plan.py` to enforce mutual exclusivity: if `kvm_image_build_id` is set, `kvm_image_branch` is cleared before building the elastictest API payload (the API rejects requests that supply both fields).

**Files changed:**
- `run-test-elastictest-template.yml`: Add `KVM_BUILD_ID` template parameter (default `""`); pass `${{ parameters.KVM_BUILD_ID }}` and `${{ parameters.KVM_IMAGE_BRANCH }}` to `test_plan.py`
- `pr_test_template.yml`: Add `KVM_BUILD_ID` parameter; pass it to all `run-test-elastictest-template.yml` calls (active and commented-out jobs)
- `pre_defined_pr_test.yml`: Add `KVM_BUILD_ID` parameter; pass it to `pr_test_template.yml`
- `test_plan.py`: If `kvm_image_build_id` is non-empty, clear `kvm_image_branch` to satisfy the mutual exclusivity constraint

#### How did you verify/test it?

Triggered pipeline 3320 from this PR branch with `KVM_BUILD_ID=1062607` as a `templateParameter` via the ADO Runs API. Confirmed in the "Trigger Test" step log:
- `--kvm-build-id 1062607` was present in the `test_plan.py` command
- `kvm_build_id='1062607'` appeared in the elastictest create-plan payload

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

No documentation update required — this is an internal pipeline fix.