### PR TITLE
[dhcp_relay]: Fix dual-tor option82 Remote-ID MAC in VRF DHCPv4 relay ptf test

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -205,7 +205,8 @@ class DHCPTest(DataplaneBaseTest):
         #  Byte 0: Suboption number, always set to 2
         #  Byte 1: Length of suboption data in bytes
         #  Bytes 2+: Suboption data
-        # Our remote_id string simply consists of the MAC address of the port that received the request
+        # remote_id (suboption 2) is the switch base MAC. On dual-ToR the VLAN carries a virtual MAC,
+        # so the relay stamps the base MAC (uplink_mac); on single-ToR relay_iface_mac already equals it.
         remote_id_string = self.uplink_mac if self.dual_tor else self.relay_iface_mac
         self.option82 += struct.pack('BB', self.REMOTE_ID_SUBOPTION, len(remote_id_string))
         self.option82 += remote_id_string.encode('utf-8')

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -206,7 +206,7 @@ class DHCPTest(DataplaneBaseTest):
         #  Byte 1: Length of suboption data in bytes
         #  Bytes 2+: Suboption data
         # Our remote_id string simply consists of the MAC address of the port that received the request
-        remote_id_string = self.relay_iface_mac
+        remote_id_string = self.uplink_mac if self.dual_tor else self.relay_iface_mac
         self.option82 += struct.pack('BB', self.REMOTE_ID_SUBOPTION, len(remote_id_string))
         self.option82 += remote_id_string.encode('utf-8')
 


### PR DESCRIPTION
### Description of PR
Summary:
`test_dhcp_relay_with_different_non_default_vrf` (and `..._non_default_vrf`) fail **only on
dual-tor** with `discover packet counts are not equal 0 != 48`. The relay forwards every DISCOVER
correctly; the ptf **expected** Option-82 does not byte-match the relay's actual packet.

This PR fixes one of two independent dual-tor expectation bugs: the **Option-82 Remote-ID
(SubOption 2) MAC**. Companion fix (a duplicate LINK_SELECTION SubOption 5) is in #26033 — both are
required for the dual-tor VRF discover check to pass.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): ADO 38757669
Failure type: day-one issue (test-side dual-tor Remote-ID MAC expectation defect)

### Approach
#### What is the motivation for this PR?
The expected Remote-ID was built from the VLAN interface MAC (`relay_iface_mac`, read from
`/sys/class/net/<vlan>/address`). On dual-tor the VLAN carries a **virtual** MAC, so the expected
Remote-ID bytes differ from the relay's and the whole Option-82 byte-compare fails (0 matched
discovers). On single-tor the VLAN MAC already equals the base MAC, which is why this is
dual-tor-only.

The relay stamps Remote-ID with the switch/host **base** MAC, not the VLAN MAC. In
`sonic-net/sonic-dhcp-relay`,
[`dhcp4relay/src/dhcp4relay.cpp`](https://github.com/sonic-net/sonic-dhcp-relay/blob/master/dhcp4relay/src/dhcp4relay.cpp)
(master line numbers at this writing):

```cpp
L504  /* Encode remote ID sub-option: | 2 | 6 | my_mac | */
L512  encode_tlv(... OPTION82_SUBOPT_REMOTE_ID, MAC_ADDR_STR_LEN,
L513                 (uint8_t *)(m_config.host_mac_addr.c_str()));
```

`host_mac_addr` is the switch base MAC, which the ptf already knows as `uplink_mac`.

#### How did you do it?
`remote_id_string = self.uplink_mac if self.dual_tor else self.relay_iface_mac` — no-op on
single-tor (VLAN MAC == base MAC there).

#### How did you verify/test it?
On a dual-tor 7260 testbed, the DUT's actual relayed Remote-ID byte-equals `uplink_mac` (not the
virtual VLAN MAC). With this plus #26033, the discover verification passes (count 48 == 48).

**Target-branch (202605) validation** — on `internal-202605`, image `20260510.05` (BJW dual-ToR
hardware), as part of the combined dhcpv4-relay PTF-expectation fix stack:
- `test_dhcp_relay_default` — **2/2 passed** (`isc-relay-agent` + `sonic-relay-agent`).
- `test_dhcp_relay_unicast_mac` — **2/2 passed** (both relay implementations).

#### Any platform specific information?
Dual-tor topology specific (virtual VLAN MAC).

#### Supported testbed topology if it's a new test case?
N/A (existing test fix).

### Documentation
N/A

Microsoft ADO: 38757669
