### PR TITLE
Ignore repeated syncd collectData port attr logs

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -509,7 +509,7 @@ r, ".* ERR swss\d*#orchagent:.*getPortLinkTrainingFailure: Failed to get LT fail
 # https://github.com/sonic-net/sonic-mgmt/issues/24023
 r, ".* ERR syncd\d*#syncd:.*SAI_API_PORT:brcm_sai_get_port_attribute_cmn:\d+ RX signal detect status get \d+ attrib \d+ failed with error Feature unavailable \(0xfffffff0\).*"
 r, ".* ERR syncd\d*#syncd:.*SAI_API_PORT:brcm_sai_get_port_attribute_cmn:\d+ bcm_port_phy_control_get rx snr failed with error Feature unavailable \(0xfffffff0\).*"
-r, ".* ERR syncd\d*#syncd: :- collectData: Failed to get port attr for VID 0x[0-9a-fA-F]+, RID:0x[0-9a-fA-F]+: -\d+.*"
+r, ".* ERR syncd\d*#syncd:.* :- collectData: Failed to get port attr for VID 0x[0-9a-fA-F]+, RID:0x[0-9a-fA-F]+: -\d+.*"
 
 # https://github.com/sonic-net/sonic-mgmt/issues/19347
 r, ".* ERR auditd.*: queue to plugins is full - dropping event"


### PR DESCRIPTION
### Description of PR
Ignore the syslog-compressed form of the known benign syncd `collectData: Failed to get port attr` PORT_PHY_ATTR polling message. The existing loganalyzer common ignore handled the raw message but not `message repeated N times: [ ... ]`, causing QoS SAI tests to fail in teardown on Arista 7060X6 202511 runs.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://dev.azure.com/msazure/One/_workitems/edit/38753982
Failure type: regression

### Tested branch
<!-- Select each branch where the change was tested. -->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result
N/A - validated by code inspection / log analysis; see Approach > "How did you verify/test it?".

### Approach
#### What is the motivation for this PR?
Nightly PBI 38753982 tracks `qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize` failing during loganalyzer teardown because syslog reports the already-known benign syncd collectData port attribute error using the compressed `message repeated` format.

#### How did you do it?
Relax the existing common ignore pattern from `syncd#syncd: :- collectData...` to `syncd#syncd:.* :- collectData...` so it matches both the direct syslog line and the syslog-compressed repeated-message wrapper.

#### How did you verify/test it?
Regex change only. Verified the new pattern matches both:
- `ERR syncd#syncd: :- collectData: Failed to get port attr ...`
- `ERR syncd#syncd: message repeated 20 times: [ :- collectData: Failed to get port attr ...]`

#### Any platform specific information?
Observed on Arista-7060X6-64PE 202511 T1/ft2/lt2 nightly runs.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
