### PR TITLE
Fix type error in test_show_version_serial_numbers_bmc

### DIFF
--- a/tests/platform_tests/cli/test_show_bmc.py
+++ b/tests/platform_tests/cli/test_show_bmc.py
@@ -446,14 +446,14 @@ def test_show_version_serial_numbers_bmc(duthosts, enum_rand_one_per_hwsku_hostn
     inv_files = get_inventory_files(request)
     bmc_inv_serial = get_host_visible_vars(inv_files, duthost.hostname).get('serial')
     if bmc_inv_serial:
-        pytest_assert(bmc_inv_serial == bmc_serial,
+        pytest_assert(str(bmc_inv_serial).strip() == bmc_serial,
                       "BMC `Serial Number` ({!r}) from `show version` does not match inventory `serial:` "
                       "for {} ({!r})".format(bmc_serial, duthost.hostname, bmc_inv_serial))
 
     switch_host = get_switch_host_or_skip_test(duthost)
     sw_inv_serial = get_host_visible_vars(inv_files, switch_host.hostname).get('serial')
     if sw_inv_serial:
-        pytest_assert(sw_inv_serial == sw_serial,
+        pytest_assert(str(sw_inv_serial).strip() == sw_serial,
                       "`Switch-Host Serial Number` ({!r}) from `show version` does not match inventory "
                       "`serial:` for paired switch {} ({!r})".format(sw_serial, switch_host.hostname, sw_inv_serial))
 


### PR DESCRIPTION
Summary: Fix type error in test_show_version_serial_numbers_bmc
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
The `test_show_version_serial_numbers_bmc` compared the inventory serial against the serial parsed from `show version`, but the two can have different types:

- bmc_serial: From DUT `show version` output, always a str, e.g. '1331826040003'.
- bmc_inv_serial: From the ansible inventory via get_host_visible_vars(inv_files, host).get('serial'). ansible strips the surrounding quotes and runs ast.literal_eval on the value, so a purely-numeric serial is parsed as an int, e.g. 1331826040003.

#### How did you do it?
Convert the inventory serial to str before comparing.

#### How did you verify/test it?
Regression pass

#### Any platform specific information?
BMC

#### Supported testbed topology if it's a new test case?
BMC

### Documentation
N/A
