### PR TITLE
[acl] Fix one_vlan_a dst-IP vs rule_id mismatch in test_dest_ip_match tests

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -378,8 +378,8 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_selected_front_end_dut, ran
     elif tbinfo['topo']['type'] in ['t0']:
         try:
             vlan_config = tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']['default_vlan_config']
-            if vlan_config == 'two_vlan_a':
-                logging.info("topo {} has 2 vlans".format(tbinfo['topo']['name']))
+            if vlan_config in ('one_vlan_a', 'two_vlan_a'):
+                logging.info("topo {} vlan_config {}".format(tbinfo['topo']['name'], vlan_config))
                 DOWNSTREAM_DST_IP = DOWNSTREAM_DST_IP_VLAN2000 if vlan_name == "Vlan2000" else DOWNSTREAM_DST_IP_VLAN
                 DOWNSTREAM_IP_TO_ALLOW = DOWNSTREAM_IP_TO_ALLOW_VLAN2000 if vlan_name == "Vlan2000" \
                     else DOWNSTREAM_IP_TO_ALLOW_VLAN

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -1846,8 +1846,9 @@ class TestMultiBindingAcl(TestBasicAcl):
                      dest=dut_conf_file_path)
         dut.command(
             f"config mirror_session add everflow_session {SRC_IP} {DST_IP} {DSCP} {TTL} {GRE_TYPE}")
-        dut.command(f"acl-loader update full {dut_conf_file_path} --table_name {table_name} \
-                    --session_name everflow_session")
+        dut.command(
+            f"acl-loader update full {dut_conf_file_path} --table_name {table_name} "
+            "--session_name everflow_session")
 
     def test_ingress_unmatched_blocked(self, setup, direction, ptfadapter, ip_version, stage):
         pytest.skip("Not applicable for multi binding ACL")


### PR DESCRIPTION
### Description of PR

Summary:
On a `t0` testbed whose `default_vlan_config` is `one_vlan_a`, the ACL
`test_dest_ip_match_forwarded` / `test_dest_ip_match_dropped` tests fail their
class-scoped `counters_sanity_check` teardown with `0 should be greater than 0`
across every ACL test class.

Root cause: PR #25087 extended `test_dest_ip_match_forwarded/dropped` to select
the VLAN rule (`rule_id` 33/34) for the `one_vlan_a` config, but the `setup`
fixture only overrides `DOWNSTREAM_IP_TO_ALLOW` / `DOWNSTREAM_IP_TO_BLOCK` to the
VLAN IPs (`.122` / `.121`) for `two_vlan_a`. On a `t0` / `one_vlan_a` testbed the
downstream packet is therefore still sent to the module default `.252` (which
matches `RULE_2`), while the test asserts on `RULE_33` (`.122`). `RULE_33`'s
counter never increments, so the teardown sanity check fails.

Fix: extend the `t0` override in the `setup` fixture so it handles `one_vlan_a` in
addition to `two_vlan_a`, making the downstream IPs line up with the `rule_id` the
tests assert on.

Tracking issue/work item for backport/cherry-pick request:
ADO: 38778317
https://msazure.visualstudio.com/One/_workitems/edit/38778317

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Observed on the internal `202605` nightly (image `SONiC.20260510.04`,
`Arista-7060CX-32S-C32`, `t0` / `one_vlan_a`). No triage-bot ADO item was filed for
this subtest; the failure was self-diagnosed and the fix verified on the same
platform/topology (see verification below).
Failure type: day-one issue (setup override was never extended when `one_vlan_a`
`rule_id` selection was added in #25087).

### Approach
#### What is the motivation for this PR?

`acl/test_acl.py` fails deterministically on `t0` / `one_vlan_a` testbeds because
the downstream destination IP used in `test_dest_ip_match_*` does not match the
`rule_id` those tests assert on, leaving the expected ACL rule counter at 0 and
failing the `counters_sanity_check` teardown for every ACL class.

#### How did you do it?

In the `setup` fixture's `t0` branch, changed the VLAN-IP override condition from
`if vlan_config == 'two_vlan_a':` to `if vlan_config in ('one_vlan_a', 'two_vlan_a'):`
so `DOWNSTREAM_IP_TO_ALLOW` / `DOWNSTREAM_IP_TO_BLOCK` resolve to the VLAN IPs on
`one_vlan_a` as well. Two-line change, no behavior change for any other topology.

#### How did you verify/test it?

Verified on a real `Arista-7060CX-32S-C32` `t0` / `one_vlan_a` testbed
(`testbed-bjw2-can-t0-7060-10`), image `SONiC.20260510.04` (`internal-202605`),
running the fix branch.

**Single functional run** (Elastictest plan `6a50c2c408377a690d68897d`) — full
`acl/test_acl.py` (5 ACL test classes): all selected cases passed, pretest clean,
`RULE_33` counter incremented as expected, and every class-scoped
`counters_sanity_check` teardown passed (the original `0 should be greater than 0`
failure is gone).

**Repeat ×5 stability run** (Elastictest plan `6a50f57aba15e559a9fa636a`) —
`acl/test_acl.py` re-run 5× on the same testbed (`retry_times=0`,
`repeat_times=5`). Every repeat was green:

| Repeat | Passed | Failed | Errors | Skipped (topology-gated) |
|:------:|:------:|:------:|:------:|:------------------------:|
| 1 | 192 | 0 | 0 | 808 |
| 2 | 192 | 0 | 0 | 808 |
| 3 | 192 | 0 | 0 | 808 |
| 4 | 192 | 0 | 0 | 808 |
| 5 | 192 | 0 | 0 | 808 |

Total across all 5 repeats: **960 passed / 0 failed / 0 errors**. Pretest passed
on every run. (The 808 skips per repeat are the non-`t0`/`one_vlan_a` case
combinations gated out by topology — expected.)

#### Any platform specific information?

The affected code path is the `t0` VLAN-config override; the fix is platform
agnostic. Verified on Broadcom `Arista-7060CX-32S-C32`.

#### Supported testbed topology if it's a new test case?

Not a new test case — `t0` (`one_vlan_a` and `two_vlan_a`).

### Documentation

No documentation changes required.


