### PR TITLE
[upgrade_path] Re-install TLS certs after base-image reboot in test_upgrade_gnoi

### DIFF
--- a/tests/common/fixtures/grpc_fixtures.py
+++ b/tests/common/fixtures/grpc_fixtures.py
@@ -169,31 +169,50 @@ class GnmiFixture:
     gnmic: Optional[PtfGnmic]   # None for UDS transport
     transport: str = 'tls'      # 'tls' or 'uds'
     _duthost: object = None  # For post-reboot reconfiguration
+    _ptfhost: object = None  # For post-upgrade cert redistribution
+    _cert_dir: Optional[str] = None  # Local cert dir used during setup
 
     def reconfigure_after_reboot(self):
         """
-        Reconfigure gNMI server after a DUT reboot.
-
-        After a COLD or WARM reboot, the gNMI server may start with default
-        configuration. This method re-applies the TLS configuration and
-        restarts the server so the existing client can reconnect.
-
-        Usage:
-            # After reboot completes and DUT is back up:
-            gnmi_tls.reconfigure_after_reboot()
-            # Now gNOI calls work again:
-            status = gnmi_tls.gnoi.reboot_status()
+        Re-apply TLS config + restart server after a reboot so the client can
+        reconnect. Certs survive the reboot, so they are reused (not regenerated).
         """
+        # Reboot/upgrade helpers need the stored duthost reference.
         if self._duthost is None:
             raise RuntimeError("GnmiFixture was not initialized with duthost reference")
+        # Plaintext transport has no TLS server to reconfigure.
         if not self.tls:
             logger.info("Plaintext mode - no TLS reconfiguration needed")
             return
 
         logger.info("Reconfiguring gNMI server after reboot")
-        _configure_gnoi_tls_server(self._duthost)
-        _restart_gnoi_server(self._duthost)
+        # regen_certs=False: rootfs (and cert files) survived the reboot.
+        _establish_gnoi_tls_handshake(self._duthost, regen_certs=False)
         logger.info("Post-reboot TLS reconfiguration completed")
+
+    def reinstall_certs_after_upgrade(self):
+        """
+        Regenerate certs + re-apply TLS config after an image upgrade. An upgrade
+        replaces the rootfs, wiping the cert files, so reconfigure alone is not
+        enough; certs must be recreated and redistributed to DUT and PTF.
+        """
+        # Cert regen needs duthost, ptfhost and the local cert dir.
+        if self._duthost is None or self._ptfhost is None or self._cert_dir is None:
+            raise RuntimeError(
+                "GnmiFixture was not initialized with duthost/ptfhost/cert_dir "
+                "references required for post-upgrade cert reinstall"
+            )
+        # Plaintext transport has no TLS certs to reinstall.
+        if not self.tls:
+            logger.info("Plaintext mode - no TLS cert reinstall needed")
+            return
+
+        logger.info("Reinstalling gNOI TLS certificates after upgrade")
+        # regen_certs=True: upgrade wiped the certs, so recreate them.
+        _establish_gnoi_tls_handshake(
+            self._duthost, ptfhost=self._ptfhost, cert_dir=self._cert_dir, regen_certs=True
+        )
+        logger.info("Post-upgrade TLS cert reinstall completed")
 
 
 @pytest.fixture(scope="function")
@@ -245,17 +264,10 @@ def gnmi_tls(request, duthosts, ptfhost):
     create_checkpoint(duthost, checkpoint_name)
 
     try:
-        # 2. Generate and distribute certificates
-        _create_gnoi_certs(duthost, ptfhost, cert_dir)
-
-        # 3. Configure server for TLS mode
-        _configure_gnoi_tls_server(duthost)
-
-        # 4. Restart gNOI server process
-        _restart_gnoi_server(duthost)
-
-        # 5. Verify TLS connectivity
-        _verify_gnoi_tls_connectivity(duthost, ptfhost)
+        # 2-5. Generate/distribute certs, configure + restart server, verify handshake
+        _establish_gnoi_tls_handshake(
+            duthost, ptfhost=ptfhost, cert_dir=cert_dir, regen_certs=True, verify=True
+        )
 
         # Build coupled client with the exact config we just set up
         host = duthost.mgmt_ip
@@ -294,6 +306,8 @@ def gnmi_tls(request, duthosts, ptfhost):
             gnmic=gnmic_client,
             transport='tls',
             _duthost=duthost,
+            _ptfhost=ptfhost,
+            _cert_dir=cert_dir,
         )
 
         logger.info("Constructed PtfGnmic client: %s", gnmic_client)
@@ -445,8 +459,34 @@ def ptf_gnoi(ptf_grpc):
 
 
 # ---------------------------------------------------------------------------
-# Internal helpers (unchanged)
+# Internal helpers
 # ---------------------------------------------------------------------------
+
+def _establish_gnoi_tls_handshake(duthost, ptfhost=None, cert_dir=None,
+                                  regen_certs=True, verify=False):
+    """
+    Bring the gNOI TLS server into a state where the PTF client can connect.
+    Single source of truth called at setup, after reboot, and after upgrade.
+
+    regen_certs: recreate + redistribute certs (needs ptfhost, cert_dir).
+    verify: check TLS connectivity afterwards (needs ptfhost).
+    """
+    if regen_certs:
+        # Certs are gone (fresh setup / upgrade wiped rootfs) - recreate them.
+        if ptfhost is None or cert_dir is None:
+            raise RuntimeError("regen_certs=True requires ptfhost and cert_dir")
+        duthost.shell(f"mkdir -p {grpc_config.DUT_CERT_DIR}")  # ensure DUT cert dir exists
+        _create_gnoi_certs(duthost, ptfhost, cert_dir)         # gen + copy to DUT/PTF
+
+    _configure_gnoi_tls_server(duthost)  # write TLS settings into CONFIG_DB
+    _restart_gnoi_server(duthost)        # restart so server picks up new config
+
+    if verify:
+        # Confirm the client can actually complete a TLS call before returning.
+        if ptfhost is None:
+            raise RuntimeError("verify=True requires ptfhost")
+        _verify_gnoi_tls_connectivity(duthost, ptfhost)
+
 
 def _create_gnoi_certs(duthost, ptfhost, cert_dir):
     """

--- a/tests/upgrade_path/test_upgrade_gnoi.py
+++ b/tests/upgrade_path/test_upgrade_gnoi.py
@@ -61,6 +61,12 @@ def test_upgrade_via_gnoi(
         duthost.shell("sudo config save -y")
         setup_upgrade_test(duthost, localhost, from_image, to_image, tbinfo,
                            upgrade_type)
+        # Installing the base image replaces the DUT rootfs, so the gnmi_tls
+        # fixture's server certs under /etc/sonic/telemetry/ and its CONFIG_DB
+        # entries are lost. Re-push certs and re-apply TLS config so the
+        # subsequent gNOI TransferToRemote/SetPackage calls can validate the
+        # server cert (which needs the DUT mgmt IP in its SAN).
+        gnmi_tls.reinstall_certs_after_upgrade()
 
     perform_gnoi_upgrade(
         ptf_gnoi=gnmi_tls.gnoi,


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (issue)

`test_upgrade_via_gnoi` was failing on the `gnoi.file.File/TransferToRemote` gRPC call
with `x509: cannot validate certificate for <mgmt-ip> because it doesn't contain any IP
SANs`. Installing the base image replaces the DUT rootfs, wiping
`/etc/sonic/telemetry/*.cer` and the `GNMI|*` CONFIG_DB entries that the `gnmi_tls`
fixture pushes. The existing `reconfigure_after_reboot()` only re-applies CONFIG_DB
(assuming the cert files survive), so it is insufficient for image-install reboots.

This PR adds `GnmiFixture.reinstall_certs_after_upgrade()`, which regenerates certs,
redistributes them to the DUT and PTF via the existing `_create_gnoi_certs` helper, then
reconfigures and restarts the gNMI server. `test_upgrade_gnoi.py` calls it right after
`setup_upgrade_test()` boots the DUT into the base image.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: regression

### Approach
#### What is the motivation for this PR?

`test_upgrade_via_gnoi` failed immediately after the base-image cold reboot with an
`x509 ... doesn't contain any IP SANs` error, because the freshly installed image
wipes the gNMI/gNOI TLS server certs and CONFIG_DB settings.

#### How did you do it?

Added `GnmiFixture.reinstall_certs_after_upgrade()` and had `GnmiFixture` carry
`_ptfhost` and `_cert_dir` references (populated by the `gnmi_tls` fixture). The method
regenerates and redistributes certs to DUT and PTF, then reconfigures and restarts the
gNMI server. `test_upgrade_gnoi.py` invokes it after `setup_upgrade_test()`.

#### How did you verify/test it?

Verified on a t0-7060 testbed. Before this change, the test failed with the IP SAN error
right after the base-image cold reboot. After this change, TransferToRemote / SetPackage
/ System.Reboot all complete and the DUT comes up on the target image.

#### Any platform specific information?

None.

#### Supported testbed topology if it's a new test case?

N/A (existing test fix).

### Documentation

No documentation changes required.
