### PR TITLE
[cSONiC] Fix flaky "0 routes" for T0-leaf neighbors: keep exabgp injector out of PEER_V4/V6

### DIFF
--- a/ansible/roles/sonic/templates/configdb-t0-leaf.j2
+++ b/ansible/roles/sonic/templates/configdb-t0-leaf.j2
@@ -1,4 +1,10 @@
 {% set host = configuration[hostname] %}
+{# #25898 follow-up: exabgp iBGP injector must live in BGP_INTERNAL_NEIGHBOR    #}
+{# (separate INTERNAL_PEER_V4/V6 group), NOT BGP_NEIGHBOR, else it poisons      #}
+{# PEER_V4/V6 as internal and FRR rejects the eBGP DUT peer                     #}
+{# ("Peer-group members must be all internal or all external") -> 0 routes.     #}
+{% set exabgp_asn = host['bgp']['asn'] %}
+{% set _lo0 = host['interfaces'].get('Loopback0', {}) %}
 {
     "PORT": {
 {% set port_comma = joiner(",") %}
@@ -50,6 +56,18 @@
 {% endif %}
 {% endif %}
 {% endfor %}
+{# Synthetic Loopback4096 required by bgpcfgd's internal peer manager (used for #}
+{# the exabgp iBGP injector in BGP_INTERNAL_NEIGHBOR). Reuses Loopback0 addrs.  #}
+{{ loopback_comma() }}
+        "Loopback4096": {}
+{% if _lo0['ipv4'] is defined %}
+{{ loopback_comma() }}
+        "Loopback4096|{{ _lo0['ipv4'] }}": {}
+{% endif %}
+{% if _lo0['ipv6'] is defined %}
+{{ loopback_comma() }}
+        "Loopback4096|{{ _lo0['ipv6'] }}": {}
+{% endif %}
     },
 {% set has_portchannel = [] %}
 {% for name, iface in host['interfaces'].items() %}
@@ -150,20 +168,33 @@
         }
 {% endfor %}
 {% endfor %}
-{{ bgp_comma() }}
+    },
+    "BGP_INTERNAL_NEIGHBOR": {
+{% set bgp_int_comma = joiner(",") %}
+{# exabgp route-injector as iBGP (own ASN) in the INTERNAL peer-group, so the   #}
+{# DUT never sees exabgp and PEER_V4/V6 stays uniformly eBGP. local_addr binds  #}
+{# the session to the neighbor's Loopback0 (fallback backplane) address.        #}
+{% if props.nhipv4 is defined and props.nhipv4 %}
+{{ bgp_int_comma() }}
         "{{ props.nhipv4 }}": {
-            "asn": "{{ host['bgp']['asn'] }}",
+            "asn": "{{ exabgp_asn }}",
             "name": "exabgp_v4",
-            "admin_status": "up",
-            "holdtime": "10",
-            "keepalive": "3"
-        },
-        "{{ props.nhipv6 }}": {
-            "asn": "{{ host['bgp']['asn'] }}",
-            "name": "exabgp_v6",
+            "local_addr": "{{ (_lo0['ipv4'] | default(host['bp_interface']['ipv4'], true)).split('/')[0] }}",
             "admin_status": "up",
             "holdtime": "10",
             "keepalive": "3"
         }
+{% endif %}
+{% if props.nhipv6 is defined and props.nhipv6 %}
+{{ bgp_int_comma() }}
+        "{{ props.nhipv6 }}": {
+            "asn": "{{ exabgp_asn }}",
+            "name": "exabgp_v6",
+            "local_addr": "{{ (_lo0['ipv6'] | default(host['bp_interface']['ipv6'], true)).split('/')[0] }}",
+            "admin_status": "up",
+            "holdtime": "10",
+            "keepalive": "3"
+        }
+{% endif %}
     }
 }

--- a/ansible/roles/sonic/templates/tests/test_configdb_t0_leaf.py
+++ b/ansible/roles/sonic/templates/tests/test_configdb_t0_leaf.py
@@ -23,7 +23,7 @@ or under pytest.
 import json
 import os
 
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 TEMPLATES_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TEMPLATE_NAME = "configdb-t0-leaf.j2"
@@ -43,7 +43,7 @@ def _host():
 def _render(host=None, props=None):
     host = host or _host()
     props = props or {"swrole": "leaf", "nhipv4": "10.10.246.254", "nhipv6": "fc0a::ff"}
-    env = Environment(loader=FileSystemLoader(TEMPLATES_DIR))
+    env = Environment(loader=FileSystemLoader(TEMPLATES_DIR), autoescape=select_autoescape())
     ctx = {
         "configuration": {"n": host},
         "hostname": "n",

--- a/ansible/roles/sonic/templates/tests/test_configdb_t0_leaf.py
+++ b/ansible/roles/sonic/templates/tests/test_configdb_t0_leaf.py
@@ -1,0 +1,101 @@
+"""Unit tests for the T0-leaf CONFIG_DB Jinja2 template (configdb-t0-leaf.j2).
+
+These render the template with a synthetic T0-leaf neighbor configuration and
+assert on the produced CONFIG_DB JSON. They lock in the fix that keeps the
+exabgp route-injector out of the shared PEER_V4/V6 peer-group:
+
+  * the output is always valid JSON (comma/joiner handling),
+  * the exabgp injector (props.nhipv4 / props.nhipv6) is emitted in
+    BGP_INTERNAL_NEIGHBOR (iBGP, own ASN) and NOT in BGP_NEIGHBOR, so bgpcfgd
+    renders it into the separate INTERNAL_PEER_V4/V6 group and PEER_V4/V6 stay
+    uniformly eBGP (avoids FRR "Peer-group members must be all internal or all
+    external" -> 0 routes advertised),
+  * the real DUT peers remain in BGP_NEIGHBOR,
+  * a synthetic Loopback4096 (required by bgpcfgd's internal peer manager) is
+    added to LOOPBACK_INTERFACE, reusing Loopback0 addresses.
+
+Runs standalone (jinja2 only):
+
+    python3 ansible/roles/sonic/templates/tests/test_configdb_t0_leaf.py
+
+or under pytest.
+"""
+import json
+import os
+
+from jinja2 import Environment, FileSystemLoader
+
+TEMPLATES_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TEMPLATE_NAME = "configdb-t0-leaf.j2"
+
+
+def _host():
+    return {
+        "bgp": {"asn": "64600", "peers": {"65100": ["10.0.0.58", "FC00::75"]}},
+        "interfaces": {
+            "Loopback0": {"ipv4": "100.1.0.29/32", "ipv6": "2064:100::1d/128"},
+            "Ethernet1": {"ipv4": "10.0.0.59/31"},
+        },
+        "bp_interface": {"ipv4": "10.1.0.32/24", "ipv6": "fc00::1/64"},
+    }
+
+
+def _render(host=None, props=None):
+    host = host or _host()
+    props = props or {"swrole": "leaf", "nhipv4": "10.10.246.254", "nhipv6": "fc0a::ff"}
+    env = Environment(loader=FileSystemLoader(TEMPLATES_DIR))
+    ctx = {
+        "configuration": {"n": host},
+        "hostname": "n",
+        "props": props,
+        "topo": "t0",
+        "snmp_rocommunity": "public",
+        "configuration_properties": {"common": {}},
+    }
+    return env.get_template(TEMPLATE_NAME).render(**ctx)
+
+
+def test_output_is_valid_json():
+    json.loads(_render())
+
+
+def test_injector_in_internal_neighbor_not_bgp_neighbor():
+    d = json.loads(_render())
+    internal = d.get("BGP_INTERNAL_NEIGHBOR", {})
+    neighbor = d.get("BGP_NEIGHBOR", {})
+    # injector v4/v6 live in BGP_INTERNAL_NEIGHBOR ...
+    assert "10.10.246.254" in internal, internal
+    assert "fc0a::ff" in internal, internal
+    # ... and NOT in BGP_NEIGHBOR
+    assert "10.10.246.254" not in neighbor, neighbor
+    assert "fc0a::ff" not in neighbor, neighbor
+    # injector is iBGP (own ASN)
+    assert internal["10.10.246.254"]["asn"] == "64600"
+
+
+def test_dut_peers_remain_in_bgp_neighbor():
+    d = json.loads(_render())
+    neighbor = d.get("BGP_NEIGHBOR", {})
+    assert "10.0.0.58" in neighbor, neighbor
+    assert "FC00::75" in neighbor, neighbor
+
+
+def test_loopback4096_present():
+    d = json.loads(_render())
+    lo = d.get("LOOPBACK_INTERFACE", {})
+    assert "Loopback4096" in lo, lo
+    assert "Loopback4096|100.1.0.29/32" in lo, lo
+
+
+def test_injector_absent_when_undefined():
+    # when no exabgp next-hop is provided, BGP_INTERNAL_NEIGHBOR is empty and JSON stays valid
+    d = json.loads(_render(props={"swrole": "leaf"}))
+    assert d.get("BGP_INTERNAL_NEIGHBOR", {}) == {}
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print("ok:", name)
+    print("ALL PASSED")


### PR DESCRIPTION
### Problem

#25898 moved the exabgp route-injector into `BGP_INTERNAL_NEIGHBOR` (a separate `INTERNAL_PEER_V4/V6` group) so it can no longer poison the shared `PEER_V4/V6` peer-group as internal and make FRR reject the eBGP DUT peer (`% Peer-group members must be all internal or all external`) -> 0 routes advertised.

That fix only landed in `configdb-csonic.j2`. But T0 cSONiC neighbors have `props.swrole == 'leaf'`, and `roles/sonic/tasks/csonic_config.yml` selects the neighbor template via `first_found` (`configdb-{topo}-{swrole}.j2` wins over `configdb-csonic.j2`). So those neighbors actually render from **`configdb-t0-leaf.j2`**, which still placed the injector (own ASN = iBGP) in `BGP_NEIGHBOR` and therefore still poisoned `PEER_V4/V6`. Result: 1-2 of 4 neighbors flap to 0 prefixes depending on bind order.

### Fix

Apply #25898's treatment to `configdb-t0-leaf.j2`:
- emit the injector (`props.nhipv4/nhipv6`) in `BGP_INTERNAL_NEIGHBOR` with the neighbor's own ASN + a Loopback0-derived `local_addr`;
- remove it from `BGP_NEIGHBOR` (only real DUT peers remain);
- add the synthetic `Loopback4096` that bgpcfgd's internal peer manager requires.

Adds `test_configdb_t0_leaf.py` mirroring `test_configdb_csonic.py`.

### Validation

Live on 3 T0 cSONiC benches: **all 4/4 ARISTA neighbors advertise the full 6400-prefix set deterministically** after this change (previously 1-2 of 4 stuck at 0). Unit tests pass standalone and under pytest.


### Running the unit tests

Both tests are self-contained (only need `jinja2`; no testbed/DUT). From `ansible/roles/sonic/templates/tests/`:

```bash
# standalone (prints ALL PASSED on success)
python3 test_configdb_t0_leaf.py
python3 test_configdb_csonic.py

# or under pytest
pytest test_configdb_t0_leaf.py test_configdb_csonic.py
```

Each renders the corresponding template against sample configs and asserts the exabgp injector lands in `BGP_INTERNAL_NEIGHBOR` (not `PEER_V4/V6`), real DUT peers stay in `BGP_NEIGHBOR`, `Loopback4096` is present, and the output is valid JSON.