### PR TITLE
fill_leakout_plus_one for cisco-8000 in pfc_xoff_probing

### DIFF
--- a/tests/saitests/probe/pfc_xoff_probing_executor.py
+++ b/tests/saitests/probe/pfc_xoff_probing_executor.py
@@ -56,6 +56,28 @@ except ImportError:
     port_list = {"src": {}}
 
 
+def _get_fill_leakout_plus_one():
+    """
+    Lazy import of fill_leakout_plus_one at call time.
+
+    Module-load-time imports failed silently in some deployments (probably a
+    sys.path ordering issue between the probe/ and py3/ directories). By the
+    time an executor's check() runs, the probing test module has already
+    imported sai_qos_tests successfully, so this lookup is reliable.
+
+    Returns the function on success, or None with the real exception written
+    to stderr on failure (so we can diagnose instead of silently no-op'ing).
+    """
+    try:
+        from sai_qos_tests import fill_leakout_plus_one as _fn
+        return _fn
+    except Exception as e:  # noqa: BLE001 — we want to see the actual error
+        sys.stderr.write(
+            f"[PFC Xoff Executor] lazy import of fill_leakout_plus_one failed: "
+            f"{type(e).__name__}: {e}\n")
+        return None
+
+
 @ExecutorRegistry.register(probe_type='pfc_xoff', executor_env='physical')
 class PfcXoffProbingExecutor:
     """
@@ -145,6 +167,35 @@ class PfcXoffProbingExecutor:
                     self.ptftest.buffer_ctrl.hold_buffer([dst_port])     # Simulate congestion condition
                     time.sleep(PORT_TX_CTRL_DELAY)
 
+                # ===== Step 1.5: Leakout compensation (cisco-8000) =====
+                # Mirror PfcStdTest's compensation stack for cisco-8000:
+                #   1. fill_leakout_plus_one() primes the queue with ~1 cell (dynamic
+                #      "initial burst" leakout).
+                #   2. Add pkts_num_leak_out (static per-platform value from qos.yaml)
+                #      to compensate for the ongoing trickle-out during the burst.
+                # Net effect: after send, buffer occupancy ~= `value` cells.
+                # Use substring match to cover variants like 'cisco-8000-gr2'.
+                # Skipped for incremental (drain_buffer=False) sends since the buffer
+                # is already primed from a prior drained iteration.
+                send_count = value
+                asic_type = getattr(self.ptftest, 'asic_type', '') or ''
+                fill_leakout_fn = _get_fill_leakout_plus_one()
+                if (drain_buffer and value > 0
+                        and 'cisco-8000' in asic_type
+                        and fill_leakout_fn is not None):
+                    pkt = self.ptftest.stream_mgr.get_packet(
+                        src_port, dst_port, **traffic_keys)
+                    if pkt is not None:
+                        pkts_num_leak_out = int(getattr(self.ptftest, 'pkts_num_leak_out', 0) or 0)
+                        fill_leakout_fn(
+                            self.ptftest, src_port, dst_port, pkt,
+                            traffic_keys.get('pg', 0), asic_type)
+                        # Compensation math:
+                        #   -1  : fill_leakout_plus_one primed the queue with 1 cell
+                        #   +pkts_num_leak_out : ongoing leakout absorbs this many
+                        #                        cells during the burst
+                        send_count = max(0, value + pkts_num_leak_out - 1)
+
                 # ===== Step 2: Baseline measurement =====
                 sport_cnt_base, _ = sai_thrift_read_port_counters(
                     self.ptftest.src_client,
@@ -153,8 +204,8 @@ class PfcXoffProbingExecutor:
                 )
 
                 # ===== Step 3: Traffic injection =====
-                if value > 0:
-                    self.ptftest.buffer_ctrl.send_traffic(src_port, dst_port, value, **traffic_keys)
+                if send_count > 0:
+                    self.ptftest.buffer_ctrl.send_traffic(src_port, dst_port, send_count, **traffic_keys)
 
                 # ===== Step 4: Wait for counter refresh =====
                 time.sleep(PFC_TRIGGER_DELAY)
@@ -173,7 +224,7 @@ class PfcXoffProbingExecutor:
                     self.observer.trace(
                         f"[PFC Xoff Executor] Verification {attempt + 1}/{attempts}: "
                         f"src={src_port}, dst={dst_port}, value={value}, "
-                        f"pfc_triggered={pfc_triggered}")
+                        f"send_count={send_count}, pfc_triggered={pfc_triggered}")
 
             # Result analysis based on attempts
             return_result = (True, results[0])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

pfc_xoff_probing failed in cisco G200 due to ~184 packets in leakout.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
Fix pfc_xoff_probing failure in cisco G200 due to ~184 packets in leakout.

#### How did you do it?
Add fill_leakout_plus_one for cisco devices.

#### How did you verify/test it?
Ran it on cisco G200.
```
============================================================================ PASSES ============================================================================
_____________________________________________________ TestQosProbe.testQosPfcXoffProbe[single_asic-xoff_1] _____________________________________________________
-------------------------- generated xml file: /tmp/qos/test_qos_probe.py::TestQosProbe::testQosPfcXoffProbe_2026-07-09-22-12-07.xml ---------------------------
INFO:root:Can not get Allure report URL. Please check logs
-------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------
10/07/2026 00:01:30 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
=================================================================== short test summary info ====================================================================
PASSED qos/test_qos_probe.py::TestQosProbe::testQosPfcXoffProbe[single_asic-xoff_1]
```
```
root@9fb080a47389:~# bash PfcXoffProbing.sh 
Using packet manipulation module: ptf.packet_scapy
pfc_xoff_probing.PfcXoffProbing
Template method defining the probing workflow. ... switch_init asic_type= cisco-8000
Platform-specific: packet_length=64, cell_occupancy=1
Probing uses: packet_length=64, cell_occupancy=1
================================================================================
[pfc_xoff] Starting threshold probing
  src_port=3, dst_port=10
  pool_size=428032
  precision_target_ratio=0.05
  enable_precise_detection=False
  executor_env=physical
================================================================================
fill_leakout_plus_one: Success, sent 236 packets, queue occupancy bytes rose from 0 to 512

Upper Bound Probing

| Iter     | Lower     | Candidate | Upper     | Step  | PfcXoff      | Time(s)  | Total(s)  |
|----------|-----------|-----------|-----------|-------|--------------|----------|-----------|
| 1.1      | NA        | NA        | 428032    | init  | reached      | 10.24    | 10.24     |
fill_leakout_plus_one: Success, sent 235 packets, queue occupancy bytes rose from 0 to 512

Lower Bound Probing

| Iter     | Lower     | Candidate | Upper     | Step  | PfcXoff      | Time(s)  | Total(s)  |
|----------|-----------|-----------|-----------|-------|--------------|----------|-----------|
| 2.1      | 214016    | NA        | 428032    | init  | reached      | 8.70     | 8.70      |
fill_leakout_plus_one: Success, sent 237 packets, queue occupancy bytes rose from 0 to 512
| 2.2      | 107008    | NA        | 428032    | /2    | unreached    | 7.99     | 16.68     |
fill_leakout_plus_one: Success, sent 257 packets, queue occupancy bytes rose from 0 to 512
fill_leakout_plus_one: Success, sent 237 packets, queue occupancy bytes rose from 0 to 512

Threshold Range Probing

| Iter     | Lower     | Candidate | Upper     | Step  | PfcXoff      | Time(s)  | Total(s)  |
|----------|-----------|-----------|-----------|-------|--------------|----------|-----------|
| 3.1      | 107008    | 267520    | 428032    | init  | reached      | 17.81    | 17.81     |
fill_leakout_plus_one: Success, sent 237 packets, queue occupancy bytes rose from 0 to 512
fill_leakout_plus_one: Success, sent 237 packets, queue occupancy bytes rose from 0 to 512
| 3.2      | 107008    | 187264    | 267520    | <-U   | reached      | 18.26    | 36.07     |
fill_leakout_plus_one: Success, sent 237 packets, queue occupancy bytes rose from 0 to 512
fill_leakout_plus_one: Success, sent 251 packets, queue occupancy bytes rose from 0 to 512
| 3.3      | 107008    | 147136    | 187264    | <-U   | unreached    | 18.49    | 54.56     |
fill_leakout_plus_one: Success, sent 251 packets, queue occupancy bytes rose from 0 to 512
fill_leakout_plus_one: Success, sent 249 packets, queue occupancy bytes rose from 0 to 512
| 3.4      | 147137    | 167200    | 187264    | L->   | unreached    | 16.09    | 70.65     |
fill_leakout_plus_one: Success, sent 248 packets, queue occupancy bytes rose from 0 to 512
fill_leakout_plus_one: Success, sent 237 packets, queue occupancy bytes rose from 0 to 512
| 3.5      | 167201    | 177232    | 187264    | L->   | reached      | 16.94    | 87.59     |
fill_leakout_plus_one: Success, sent 237 packets, queue occupancy bytes rose from 0 to 512
fill_leakout_plus_one: Success, sent 236 packets, queue occupancy bytes rose from 0 to 512
| 3.6      | 167201    | 172216    | 177232    | <-U   | reached      | 17.40    | 104.99    |
| 3.7      | 167201    | 169708    | 172216    | <-U   | skipped      | 0.00     | 104.99    |
PFC XOFF probing result: range [167201, 172216] pkt
[PASS] PFC XOFF threshold, range check passed:
  Expected       : 172035 pkt
  Precision ratio: 5.0%
  Lower bound    : 167201 pkt
  Candidate      : 169708 pkt
  Upper bound    : 172216 pkt
  Range size     : (Upper bound - Lower bound) = 5015 pkt <= 8602 pkt (Expected * Precision ratio)
ok

----------------------------------------------------------------------
Ran 1 test in 169.006s

OK
root@9fb080a47389:~# 
```

#### Any platform specific information?
cisco-8000.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
